### PR TITLE
CSV appends: Handle _mb_row_id columns

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -4,6 +4,11 @@ title: Driver interface changelog
 
 # Driver Interface Changelog
 
+## Metabase 0.49.0
+
+- The multimethod `metabase.driver/add-column!` has been added. This method is used to add a column to a table.
+  Currently it only needs to be implemented if the database supports the `:uploads` feature.
+
 ## Metabase 0.48.0
 
 - The MBQL schema in `metabase.mbql.schema` now uses [Malli](https://github.com/metosin/malli) instead of

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,7 +6,7 @@ title: Driver interface changelog
 
 ## Metabase 0.49.0
 
-- The multimethod `metabase.driver/add-column!` has been added. This method is used to add a column to a table.
+- The multimethod `metabase.driver/add-columns!` has been added. This method is used to add a column to a table.
   Currently it only needs to be implemented if the database supports the `:uploads` feature.
 
 ## Metabase 0.48.0

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -876,10 +876,6 @@
 ;;; |                                                    Upload                                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(def ^:dynamic *insert-chunk-rows*
-  "The number of rows to insert at a time when uploading data to a database. This can be rebound for testing purposes."
-  nil)
-
 (defmulti table-name-length-limit
   "Return the maximum number of characters allowed in a table name, or `nil` if there is no limit."
   {:changelog-test/ignore true, :added "0.47.0", :arglists '([driver])}

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -876,6 +876,10 @@
 ;;; |                                                    Upload                                                      |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(def ^:dynamic *insert-chunk-rows*
+  "The number of rows to insert at a time when uploading data to a database. This can be rebound for testing purposes."
+  nil)
+
 (defmulti table-name-length-limit
   "Return the maximum number of characters allowed in a table name, or `nil` if there is no limit."
   {:changelog-test/ignore true, :added "0.47.0", :arglists '([driver])}

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -901,6 +901,12 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
+(defmulti add-columns!
+  "Add columns given by `col->type` to a table named `table-name`. If the table doesn't exist it will throw an error."
+  {:added "0.49.0", :arglists '([driver db-id table-name col->type])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
 (defmulti syncable-schemas
   "Returns the set of syncable schemas in the database (as strings)."
   {:added "0.47.0", :arglists '([driver database])}

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -652,7 +652,7 @@
     ::upload/float                    [:double]
     ::upload/boolean                  [:boolean]
     ::upload/date                     [:date]
-    ::upload/datetime                 [:timestamp]
+    ::upload/datetime                 [:datetime]
     ::upload/offset-datetime          [:timestamp]))
 
 (defmethod driver/table-name-length-limit :mysql

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -672,7 +672,7 @@
   to calculate one by hand."
   [driver database ^OffsetDateTime offset-time]
   (let [zone-id (t/zone-id (driver/db-default-timezone driver database))]
-    (t/local-date-time offset-time zone-id )))
+    (t/local-date-time offset-time zone-id)))
 
 (defmulti ^:private value->string
   "Convert a value into a string that's safe for insertion"

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -841,10 +841,11 @@
                                      :columns     (map keyword column-names)
                                      ::from-stdin "''"}
                                     :quoted true
-                                    :dialect (sql.qp/quote-style driver))]
-       ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
-       (doseq [slice-of-values (partition-all 100 values)]
-         (let [tsvs (->> slice-of-values
+                                    :dialect (sql.qp/quote-style driver))
+           ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
+           chunks (partition-all (or driver/*insert-chunk-rows* 100) values)]
+       (doseq [chunk chunks]
+         (let [tsvs (->> chunk
                          (map row->tsv)
                          (str/join "\n")
                          (StringReader.))]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -841,11 +841,10 @@
                                      :columns     (map keyword column-names)
                                      ::from-stdin "''"}
                                     :quoted true
-                                    :dialect (sql.qp/quote-style driver))
-           ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
-           chunks (partition-all (or driver/*insert-chunk-rows* 100) values)]
-       (doseq [chunk chunks]
-         (let [tsvs (->> chunk
+                                    :dialect (sql.qp/quote-style driver))]
+       ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
+       (doseq [slice-of-values (partition-all 100 values)]
+         (let [tsvs (->> slice-of-values
                          (map row->tsv)
                          (str/join "\n")
                          (StringReader.))]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -142,14 +142,12 @@
   [driver db-id table-name column-names values]
   (let [table-name (keyword table-name)
         columns    (map keyword column-names)
-        ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
-        chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
         sqls       (map #(sql/format {:insert-into table-name
                                       :columns     columns
                                       :values      %}
                                      :quoted true
                                      :dialect (sql.qp/quote-style driver))
-                        chunks)]
+                        (partition-all 100 values))]
     ;; We need to partition the insert into multiple statements for both performance and correctness.
     ;;
     ;; On Postgres with a large file, 100 (3.76m) was significantly faster than 50 (4.03m) and 25 (4.27m). 1,000 was a

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -142,12 +142,14 @@
   [driver db-id table-name column-names values]
   (let [table-name (keyword table-name)
         columns    (map keyword column-names)
+        ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
+        chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
         sqls       (map #(sql/format {:insert-into table-name
                                       :columns     columns
                                       :values      %}
                                      :quoted true
                                      :dialect (sql.qp/quote-style driver))
-                        (partition-all 100 values))]
+                        chunks)]
     ;; We need to partition the insert into multiple statements for both performance and correctness.
     ;;
     ;; On Postgres with a large file, 100 (3.76m) was significantly faster than 50 (4.03m) and 25 (4.27m). 1,000 was a

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -158,6 +158,17 @@
     (doseq [sql sqls]
       (qp.writeback/execute-write-sql! db-id sql))))
 
+(defmethod driver/add-columns! :sql-jdbc
+  [driver db-id table-name col->type]
+  (let [table-name (keyword table-name)
+        sql        (first (sql/format {:alter-table (keyword table-name)
+                                       :add-column (map (fn [[name type-spec]]
+                                                          (vec (cons name type-spec)))
+                                                        col->type)}
+                                      :quoted true
+                                      :dialect (sql.qp/quote-style driver)))]
+    (qp.writeback/execute-write-sql! db-id sql)))
+
 (defmethod driver/syncable-schemas :sql-jdbc
   [driver database]
   (sql-jdbc.execute/do-with-connection-with-options

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -160,13 +160,12 @@
 
 (defmethod driver/add-columns! :sql-jdbc
   [driver db-id table-name col->type]
-  (let [table-name (keyword table-name)
-        sql        (first (sql/format {:alter-table (keyword table-name)
-                                       :add-column (map (fn [[name type-spec]]
-                                                          (vec (cons name type-spec)))
-                                                        col->type)}
-                                      :quoted true
-                                      :dialect (sql.qp/quote-style driver)))]
+  (let [sql (first (sql/format {:alter-table (keyword table-name)
+                                :add-column (map (fn [[name type-spec]]
+                                                   (vec (cons name type-spec)))
+                                                 col->type)}
+                               :quoted true
+                               :dialect (sql.qp/quote-style driver)))]
     (qp.writeback/execute-write-sql! db-id sql)))
 
 (defmethod driver/syncable-schemas :sql-jdbc

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -3,14 +3,18 @@
    [clj-bom.core :as bom]
    [clojure.data :as data]
    [clojure.data.csv :as csv]
+   [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]
    [flatland.ordered.set :as ordered-set]
+   [honey.sql :as sql]
    [java-time.api :as t]
    [medley.core :as m]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sync :as driver.s]
    [metabase.driver.util :as driver.u]
    [metabase.mbql.util :as mbql.u]
@@ -557,25 +561,36 @@
           _                  (check-schema (dissoc normed-name->field auto-pk-column-name) header)
           col-upload-types   (map (comp base-type->upload-type :base_type normed-name->field) normed-header)
           parsed-rows        (parse-rows col-upload-types rows)]
-      (try
-        (when create-auto-pk?
-          (driver/add-columns! driver
-                               (:id database)
-                               (table-identifier table)
-                               {(keyword auto-pk-column-name) (driver/upload-type->database-type driver ::auto-incrementing-int-pk)}))
-        (driver/insert-into! driver
+      (when create-auto-pk?
+        (driver/add-columns! driver
                              (:id database)
                              (table-identifier table)
-                             normed-header
-                             parsed-rows)
-        (scan-and-sync-table! database table)
-        (when create-auto-pk?
-          (let [auto-pk-field (table-id->auto-pk-column (:id table))]
-            (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})))
-        {:row-count (count parsed-rows)}
-        (catch Throwable e
-          ;; TODO: insert rows failure handling
-          (throw (ex-info (ex-message e) {:status-code 400})))))))
+                             {(keyword auto-pk-column-name) (driver/upload-type->database-type driver ::auto-incrementing-int-pk)}))
+      (let [max-pk (val (ffirst (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
+                                            (sql/format {:select [[[:max (keyword auto-pk-column-name)]]]
+                                                         :from (keyword (table-identifier table))}
+                                                        {:quoted true
+                                                         :dialect (sql.qp/quote-style driver)}))))]
+        (try
+          (driver/insert-into! driver
+                               (:id database)
+                               (table-identifier table)
+                               normed-header
+                               parsed-rows)
+          {:row-count (count parsed-rows)}
+          (catch Throwable e
+            (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec database)
+                           (sql/format {:delete-from (keyword (table-identifier table))
+                                        :where       [:> (keyword auto-pk-column-name) max-pk]}
+                                       {:quoted  true
+                                        :dialect (sql.qp/quote-style driver)}))
+            (throw (ex-info (or (ex-message (ex-cause e))
+                                (ex-message e))
+                            {:status-code 422})))))
+      (scan-and-sync-table! database table)
+      (when create-auto-pk?
+        (let [auto-pk-field (table-id->auto-pk-column (:id table))]
+          (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)}))))))
 
 (defn- can-append-error
   "Returns an ExceptionInfo object if the user cannot upload to the given database and schema. Returns nil otherwise."

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -562,7 +562,7 @@
           (driver/add-columns! driver
                                (:id database)
                                (table-identifier table)
-                               {:_mb_row_id (driver/upload-type->database-type driver ::auto-incrementing-int-pk)}))
+                               {(keyword auto-pk-column-name) (driver/upload-type->database-type driver ::auto-incrementing-int-pk)}))
         (driver/insert-into! driver
                              (:id database)
                              (table-identifier table)

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -8,6 +8,7 @@
    [flatland.ordered.map :as ordered-map]
    [flatland.ordered.set :as ordered-set]
    [java-time.api :as t]
+   [medley.core :as m]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
@@ -550,10 +551,8 @@
   [table header]
   ;; Assumes table-cols are unique when normalized
   (let [fields (t2/select :model/Field :table_id (:id table))
-        fields-by-normed-name (-> (into {}
-                                        (map (fn [field]
-                                               [(normalize-column-name (:name field)) field]))
-                                        fields))
+        fields-by-normed-name (m/index-by (comp normalize-column-name :name)
+                                          fields)
         normalized-field-names (keys fields-by-normed-name)
         ;; TODO: use this to create nice error messages when there are extra or missing columns
         normalized-header+header (into []

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1078,16 +1078,6 @@
 ;;; |                                           append-csv!                                                          |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn basic-db-definition
-  "This creates a table with an auto-incrementing integer ID column, and a name column."
-  []
-  (mt/dataset-definition
-   (mt/random-name)
-   ["table_one"
-    [;; 'id' is created automatically
-     {:field-name "name", :base-type :type/Text}]
-    [["Obi-Wan Kenobi"]]]))
-
 (defn create-upload-table!
   "Creates a table and syncs it in the current test database, as if it were uploaded as a CSV upload. `col->upload-type` should be an ordered map of column names (keywords) to upload types.
   `rows` should be a vector of vectors of values, one for each row.
@@ -1355,7 +1345,7 @@
     (with-uploads-allowed
       (testing "Append should fail if the CSV file contains duplicate column names"
         (doseq [csv-rows [["name,name" "Luke Skywalker,Darth Vader"]]]
-          (mt/dataset (basic-db-definition)
+          (mt/with-empty-db
             (let [table (create-upload-table!)
                   file  (csv-file-with csv-rows (mt/random-name))]
               (is (= {:message "The CSV file contains duplicate column names."

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1233,30 +1233,30 @@
       (with-mysql-local-infile-on-and-off
         (mt/with-report-timezone-id "UTC"
           (testing "Append should succeed for all possible CSV column types"
-            (let [csv-rows ["biginteger,float,text,boolean,date,datetime,offset_datetime"
-                            "2000000,2.0,some_text,true,2020-02-02,2020-02-02T02:02:02,2020-02-02T02:02:02+02:00"]]
-              (mt/with-empty-db
-                (with-redefs [driver/db-default-timezone (constantly "Z")
-                              upload/current-database    (constantly (mt/db))]
-                  (let [table (create-upload-table!
-                               {:col->upload-type (ordered-map/ordered-map
-                                                   :_mb_row_id      ::upload/auto-incrementing-int-pk
-                                                   :biginteger      ::upload/int
-                                                   :float           ::upload/float
-                                                   :text            ::upload/varchar-255
-                                                   :boolean         ::upload/boolean
-                                                   :date            ::upload/date
-                                                   :datetime        ::upload/datetime
-                                                   :offset_datetime ::upload/offset-datetime)
-                                :rows [[1000000,1.0,"some_text",false,"2020-01-01","2020-01-01T00:00:00","2020-01-01T00:00:00+00:00"]]})
-                        file  (csv-file-with csv-rows (mt/random-name))]
-                    (is (some? (append-csv! {:file     file
-                                             :table-id (:id table)})))
-                    (testing "Check the data was uploaded into the table correctly"
-                      (is (= [[1 1000000 1.0 "some_text" false "2020-01-01T00:00:00Z" "2020-01-01T00:00:00Z" "2020-01-01T00:00:00Z"]
-                              [2 2000000 2.0 "some_text" true "2020-02-02T00:00:00Z" "2020-02-02T02:02:02Z" "2020-02-02T00:02:02Z"]]
-                             (rows-for-table table))))
-                    (io/delete-file file)))))))))))
+            (mt/with-empty-db
+              (with-redefs [driver/db-default-timezone (constantly "Z")
+                            upload/current-database    (constantly (mt/db))]
+                (let [table (create-upload-table!
+                             {:col->upload-type (ordered-map/ordered-map
+                                                 :_mb_row_id      ::upload/auto-incrementing-int-pk
+                                                 :biginteger      ::upload/int
+                                                 :float           ::upload/float
+                                                 :text            ::upload/varchar-255
+                                                 :boolean         ::upload/boolean
+                                                 :date            ::upload/date
+                                                 :datetime        ::upload/datetime
+                                                 :offset_datetime ::upload/offset-datetime)
+                              :rows [[1000000,1.0,"some_text",false,"2020-01-01","2020-01-01T00:00:00","2020-01-01T00:00:00+00:00"]]})
+                      csv-rows ["biginteger,float,text,boolean,date,datetime,offset_datetime"
+                                "2000000,2.0,some_text,true,2020-02-02,2020-02-02T02:02:02,2020-02-02T02:02:02+02:00"]
+                      file  (csv-file-with csv-rows (mt/random-name))]
+                  (is (some? (append-csv! {:file     file
+                                           :table-id (:id table)})))
+                  (testing "Check the data was uploaded into the table correctly"
+                    (is (= [[1 1000000 1.0 "some_text" false "2020-01-01T00:00:00Z" "2020-01-01T00:00:00Z" "2020-01-01T00:00:00Z"]
+                            [2 2000000 2.0 "some_text" true "2020-02-02T00:00:00Z" "2020-02-02T02:02:02Z" "2020-02-02T00:02:02Z"]]
+                           (rows-for-table table))))
+                  (io/delete-file file))))))))))
 
 (deftest append-no-rows-test
   (mt/test-driver :h2

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -424,7 +424,7 @@
                        :base_type :type/Date}
                       (t2/select-one Field :database_position 6 :table_id (:id table))))
               (is (=? {:name      #"(?i)datetime"
-                       :base_type (if (= driver/*driver* :mysql) :type/DateTimeWithLocalTZ :type/DateTime)}
+                       :base_type :type/DateTime}
                       (t2/select-one Field :database_position 7 :table_id (:id table))))
               (testing "Check the data was uploaded into the table"
                 (is (= 2
@@ -450,7 +450,7 @@
               (is (=? {:name #"(?i)upload_test"} table))
               (testing "Check the datetime column the correct base_type"
                 (is (=? {:name      #"(?i)datetime"
-                         :base_type (if (= driver/*driver* :mysql) :type/DateTimeWithLocalTZ :type/DateTime)}
+                         :base_type :type/DateTime}
                       ;; db position is 1; 0 is for the auto-inserted ID
                         (t2/select-one Field :database_position 1 :table_id (:id table)))))
               (is (some? table)))))))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -898,7 +898,7 @@
             (perms/revoke-data-perms! group-id (mt/id))))))))
 
 (defn append-csv!
-  "Wrapper for `append-csv!` that sets `upload/*sync-synchronously?*` to true for test purposes."
+  "Wraps [[upload/append-csv!]] setting [[upload/*sync-synchronously?*]] to `true` for test purposes."
   [& args]
   (binding [upload/*sync-synchronously?* true]
     (apply upload/append-csv! args)))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1259,7 +1259,7 @@
                   (io/delete-file file))))))))))
 
 (deftest append-no-rows-test
-  (mt/test-driver :h2
+  (mt/test-driver (mt/normal-drivers-with-feature :uploads)
     (with-uploads-allowed
       (testing "Append should succeed with a CSV with only the header"
         (let [csv-rows ["name"]]
@@ -1274,7 +1274,7 @@
                        (rows-for-table table))))
               (io/delete-file file))))))))
 
-(deftest append-mb-row-id-1-test
+(deftest append-mb-row-id-csv-only-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (with-uploads-allowed
       (testing "If the table doesn't have _mb_row_id but the CSV does, ignore the CSV _mb_row_id but create the column anyway"
@@ -1302,7 +1302,7 @@
                        (rows-for-table table))))
               (io/delete-file file))))))))
 
-(deftest append-mb-row-id-2-test
+(deftest append-mb-row-id-table-only-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (with-uploads-allowed
       (testing "Append succeeds if the table has _mb_row_id but the CSV doesn't"
@@ -1319,7 +1319,7 @@
                        (rows-for-table table))))
               (io/delete-file file))))))))
 
-(deftest append-mb-row-id-3-test
+(deftest append-mb-row-id-csv-and-table-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (with-uploads-allowed
       (testing "Append succeeds if the table has _mb_row_id and the CSV does too"
@@ -1349,7 +1349,7 @@
                 (io/delete-file file)))))))))
 
 (deftest append-duplicate-header-csv-test
-  (mt/test-driver :h2
+  (mt/test-driver (mt/normal-drivers-with-feature :uploads)
     (with-uploads-allowed
       (testing "Append should fail if the CSV file contains duplicate column names"
         (doseq [csv-rows [["name,name" "Luke Skywalker,Darth Vader"]]]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1246,7 +1246,7 @@
                                                  :date            ::upload/date
                                                  :datetime        ::upload/datetime
                                                  :offset_datetime ::upload/offset-datetime)
-                              :rows [[1000000,1.0,"some_text",false,"2020-01-01","2020-01-01T00:00:00","2020-01-01T00:00:00Z"]]})
+                              :rows [[1000000,1.0,"some_text",false,#t "2020-01-01",#t "2020-01-01T00:00:00",#t "2020-01-01T00:00:00"]]})
                       csv-rows ["biginteger,float,text,boolean,date,datetime,offset_datetime"
                                 "2000000,2.0,some_text,true,2020-02-02,2020-02-02T02:02:02,2020-02-02T02:02:02+02:00"]
                       file  (csv-file-with csv-rows (mt/random-name))]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1324,17 +1324,17 @@
     (with-uploads-allowed
       (testing "Append succeeds if the table has _mb_row_id and the CSV does too"
         (mt/with-empty-db
-          (let [csv-rows ["_mb_row_id,name" "1000,Luke Skywalker"]]
-            (let [table (create-upload-table!)
-                  file  (csv-file-with csv-rows (mt/random-name))]
-              (is (= {:row-count 1}
-                     (append-csv! {:file     file
-                                   :table-id (:id table)})))
-              (testing "Check the data was uploaded into the table, but the _mb_row_id was ignored"
-                (is (= [[1 "Obi-Wan Kenobi"]
-                        [2 "Luke Skywalker"]]
-                       (rows-for-table table))))
-              (io/delete-file file)))
+          (let [csv-rows ["_mb_row_id,name" "1000,Luke Skywalker"]
+                table    (create-upload-table!)
+                file     (csv-file-with csv-rows (mt/random-name))]
+            (is (= {:row-count 1}
+                   (append-csv! {:file     file
+                                 :table-id (:id table)})))
+            (testing "Check the data was uploaded into the table, but the _mb_row_id was ignored"
+              (is (= [[1 "Obi-Wan Kenobi"]
+                      [2 "Luke Skywalker"]]
+                     (rows-for-table table))))
+            (io/delete-file file))
           (testing "with duplicate normalized _mb_row_id columns in the CSV file"
             (let [csv-rows ["_mb_row_id,name,-MB-ROW-ID" "1000,Luke Skywalker,1001"]]
               (let [table (create-upload-table!)
@@ -1364,3 +1364,72 @@
                 (is (= [[1 "Obi-Wan Kenobi"]]
                        (rows-for-table table))))
               (io/delete-file file))))))))
+
+(deftest append-int-type-mismatch-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (with-mysql-local-infile-on-and-off
+      (with-uploads-allowed
+        (mt/with-empty-db
+          (testing "Append fails if the CSV file contains values that don't match the column types"
+            ;; for drivers that insert rows in chunks, we change the chunk size to 1 so that we can test that the
+            ;; inserted rows are rolled back
+            (binding [driver/*insert-chunk-rows* 10]
+              (let [table (create-upload-table! {:col->upload-type (ordered-map/ordered-map
+                                                                    :_mb_row_id ::upload/auto-incrementing-int-pk
+                                                                    :id         ::upload/int
+                                                                    :name       ::upload/varchar-255)
+                                                 :rows             [[10 "Obi-Wan Kenobi"]]})
+                    csv-rows `["id,name" ~@(repeat 50 "20,Darth Vadar") "not an int,Luke Skywalker"]
+                    file  (csv-file-with csv-rows (mt/random-name))]
+                (testing "Check integers"
+                  (is (= {:message "not an int is not a recognizable number"
+                          :data    {:status-code 422}}
+                         (catch-ex-info (append-csv! {:file     file
+                                                      :table-id (:id table)})))))
+                (testing "Check the data was not uploaded into the table"
+                  (is (= [[1 10 "Obi-Wan Kenobi"]]
+                         (rows-for-table table))))
+                (io/delete-file file)))))))))
+
+(deftest append-date-type-mismatch-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (with-mysql-local-infile-on-and-off
+      (with-uploads-allowed
+        (mt/with-empty-db
+          (testing "Append fails if the CSV file contains values that don't match the column types"
+            ;; for drivers that insert rows in chunks, we change the chunk size to 1 so that we can test that the
+            ;; inserted rows are rolled back
+            (binding [driver/*insert-chunk-rows* 1]
+              (testing "dates"
+                (let [table (create-upload-table! {:col->upload-type (ordered-map/ordered-map
+                                                                      :_mb_row_id ::upload/auto-incrementing-int-pk
+                                                                      :date       ::upload/date
+                                                                      :name       ::upload/varchar-255)
+                                                   :rows             [["2021-01-01" "Obi-Wan Kenobi"]]})
+                      csv-rows `["date,name" ~@(repeat 50 "2023-01-01,Obi-Wan") "2023-01-01T00:00:00,Luke Skywalker"]
+                      file  (csv-file-with csv-rows (mt/random-name))]
+                  (is (= {:message "Text '2023-01-01T00:00:00' could not be parsed, unparsed text found at index 10"
+                          :data    {:status-code 422}}
+                         (catch-ex-info (append-csv! {:file     file
+                                                      :table-id (:id table)}))))
+                  (testing "Check the data was not uploaded into the table"
+                    (is (= [[1 "2021-01-01T00:00:00Z" "Obi-Wan Kenobi"]]
+                           (rows-for-table table))))
+                  (io/delete-file file)))
+              (testing "datetimes"
+                (let [table (create-upload-table! {:col->upload-type (ordered-map/ordered-map
+                                                                      :_mb_row_id ::upload/auto-incrementing-int-pk
+                                                                      :datetime   ::upload/datetime
+                                                                      :name       ::upload/varchar-255)
+                                                   :rows             [["2021-01-01T00:00:00" "Obi-Wan Kenobi"]]})
+                      csv-rows `["datetime,name" ~@(repeat 50 "2023-01-01T00:00:00,Obi-Wan") "2024-01-01T00:00:00Z,Luke Skywalker"]
+                      file  (csv-file-with csv-rows (mt/random-name))]
+                  (testing "Check dates"
+                    (is (= {:message "2024-01-01T00:00:00Z is not a recognizable datetime"
+                            :data    {:status-code 422}}
+                           (catch-ex-info (append-csv! {:file     file
+                                                        :table-id (:id table)})))))
+                  (testing "Check the data was not uploaded into the table"
+                    (is (= [[1 "2021-01-01T00:00:00Z" "Obi-Wan Kenobi"]]
+                           (rows-for-table table))))
+                  (io/delete-file file))))))))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1088,7 +1088,7 @@
      {:field-name "name", :base-type :type/Text}]
     [["Obi-Wan Kenobi"]]]))
 
-(defn- create-upload-table!
+(defn create-upload-table!
   "Creates a table and syncs it in the current test database, as if it were uploaded as a CSV upload. `col->upload-type` should be an ordered map of column names (keywords) to upload types.
   `rows` should be a vector of vectors of values, one for each row.
   Returns the table.

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1321,8 +1321,6 @@
                        (rows-for-table table))))
               (io/delete-file file))))))))
 
-(mt/set-test-drivers! [:postgres])
-
 (deftest append-mb-row-id-3-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (with-uploads-allowed

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1246,7 +1246,7 @@
                                                  :date            ::upload/date
                                                  :datetime        ::upload/datetime
                                                  :offset_datetime ::upload/offset-datetime)
-                              :rows [[1000000,1.0,"some_text",false,"2020-01-01","2020-01-01T00:00:00","2020-01-01T00:00:00+00:00"]]})
+                              :rows [[1000000,1.0,"some_text",false,"2020-01-01","2020-01-01T00:00:00","2020-01-01T00:00:00Z"]]})
                       csv-rows ["biginteger,float,text,boolean,date,datetime,offset_datetime"
                                 "2000000,2.0,some_text,true,2020-02-02,2020-02-02T02:02:02,2020-02-02T02:02:02+02:00"]
                       file  (csv-file-with csv-rows (mt/random-name))]


### PR DESCRIPTION
This PR will merge into the feature branch for Merge 1 of Milestone 0 [(PR)](https://github.com/metabase/metabase/pull/36640)

Epic: [Allow appending more data to CSV uploads](https://github.com/metabase/metabase/issues/35614)
[product doc](https://www.notion.so/metabase/Allow-appending-more-data-to-existing-CSV-uploads-f1f13864632d4cfd83522fce762890eb)
[eng doc](https://www.notion.so/metabase/Eng-Allow-appending-more-data-to-CSV-uploads-4c40e06fa64744c699588b8d8576e5df)

This PR implements special behaviour for `_mb_row_id` columns for CSV appends.

It corresponds to the following section of the eng doc ([block link](https://www.notion.so/metabase/Eng-Allow-appending-more-data-to-CSV-uploads-4c40e06fa64744c699588b8d8576e5df?pvs=4#e6549ef0587747039b7e9fc8a0e09ea3)):

### Special behaviour around _mb_row_id:

- If a CSV file with `_mb_row_id` is uploaded, we will ignore the `_mb_row_id` column in the CSV
- If a CSV file without `_mb_row_id` is uploaded, we will create the column anyway
- This column is assumed to be auto-incrementing. We use the max value of this to roll back changes when failures occur during insertion
- [x]  Test: If a CSV file with `_mb_row_id` is uploaded to a table doesn’t have it, we will ignore the `_mb_row_id` column in the CSV but create the column anyway
- [x]  Test: If a CSV file without `_mb_row_id` is uploaded and the table doesn’t have it either, we will create the column anyway
- [x]  Test: If a CSV file without `_mb_row_id` is uploaded and the table does have it, we can upload just fine (it’s not required)