### PR TITLE
🚧 Fix `createMockCard` returns a query without a source table

### DIFF
--- a/frontend/src/metabase-types/api/mocks/query.ts
+++ b/frontend/src/metabase-types/api/mocks/query.ts
@@ -5,9 +5,15 @@ import type {
   StructuredQuery,
 } from "metabase-types/api";
 
+// Corresponds to the Sample Database and sample Products table from the built-in preset:
+// https://github.com/metabase/metabase/blob/master/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
+const DEFAULT_DB_ID = 1;
+const DEFAULT_TABLE_ID = 1;
+
 export const createMockStructuredQuery = (
   opts?: Partial<StructuredQuery>,
 ): StructuredQuery => ({
+  "source-table": DEFAULT_TABLE_ID,
   ...opts,
 });
 
@@ -22,7 +28,7 @@ export const createMockStructuredDatasetQuery = (
   opts?: Partial<StructuredDatasetQuery>,
 ): StructuredDatasetQuery => ({
   type: "query",
-  database: 1,
+  database: DEFAULT_DB_ID,
   query: createMockStructuredQuery(),
   ...opts,
 });
@@ -31,7 +37,7 @@ export const createMockNativeDatasetQuery = (
   opts?: Partial<NativeDatasetQuery>,
 ): NativeDatasetQuery => ({
   type: "native",
-  database: 1,
+  database: DEFAULT_DB_ID,
   native: createMockNativeQuery(),
   ...opts,
 });

--- a/frontend/src/metabase-types/api/mocks/query.ts
+++ b/frontend/src/metabase-types/api/mocks/query.ts
@@ -5,15 +5,10 @@ import type {
   StructuredQuery,
 } from "metabase-types/api";
 
-// Corresponds to the Sample Database and sample Products table from the built-in preset:
-// https://github.com/metabase/metabase/blob/master/frontend/src/metabase-types/api/mocks/presets/sample_database.ts
-const DEFAULT_DB_ID = 1;
-const DEFAULT_TABLE_ID = 1;
-
 export const createMockStructuredQuery = (
   opts?: Partial<StructuredQuery>,
 ): StructuredQuery => ({
-  "source-table": DEFAULT_TABLE_ID,
+  "source-table": 1,
   ...opts,
 });
 
@@ -28,7 +23,7 @@ export const createMockStructuredDatasetQuery = (
   opts?: Partial<StructuredDatasetQuery>,
 ): StructuredDatasetQuery => ({
   type: "query",
-  database: DEFAULT_DB_ID,
+  database: 1,
   query: createMockStructuredQuery(),
   ...opts,
 });
@@ -37,7 +32,7 @@ export const createMockNativeDatasetQuery = (
   opts?: Partial<NativeDatasetQuery>,
 ): NativeDatasetQuery => ({
   type: "native",
-  database: DEFAULT_DB_ID,
+  database: 1,
   native: createMockNativeQuery(),
   ...opts,
 });

--- a/frontend/src/metabase/containers/SavedQuestionLoader.unit.spec.js
+++ b/frontend/src/metabase/containers/SavedQuestionLoader.unit.spec.js
@@ -4,18 +4,15 @@ import SavedQuestionLoader from "metabase/containers/SavedQuestionLoader";
 import { renderWithProviders } from "__support__/ui";
 import {
   setupCardEndpoints,
-  setupSchemaEndpoints,
   setupUnauthorizedSchemaEndpoints,
   setupUnauthorizedCardEndpoints,
+  setupDatabaseEndpoints,
 } from "__support__/server-mocks";
-import {
-  createMockCard,
-  createMockColumn,
-  createMockDatabase,
-} from "metabase-types/api/mocks";
+import { createMockCard, createMockColumn } from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 import Question from "metabase-lib/Question";
 
-const databaseMock = createMockDatabase({ id: 1 });
+const databaseMock = createSampleDatabase();
 
 const childrenRenderFn = ({ loading, question, error }) => {
   if (error) {
@@ -48,7 +45,7 @@ const setupQuestion = ({ id, name, hasAccess }) => {
 
 const setup = ({ questionId, hasAccess }) => {
   if (hasAccess) {
-    setupSchemaEndpoints(databaseMock);
+    setupDatabaseEndpoints(databaseMock);
   } else {
     setupUnauthorizedSchemaEndpoints(databaseMock);
   }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
@@ -44,6 +44,7 @@ const TEST_CARD_NATIVE = createMockCard({
 const TEST_CARD_NO_DATA_ACCESS = createMockCard({
   dataset_query: createMockStructuredDatasetQuery({
     database: SAMPLE_DB_ID,
+    query: {},
   }),
 });
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -50,7 +50,11 @@ const setup = options => {
 
 describe("DashCardParameterMapper", () => {
   it("should render an unauthorized state for a card with no dataset query", () => {
-    setup();
+    const card = createMockCard({
+      dataset_query: createMockStructuredDatasetQuery({ query: {} }),
+    });
+    setup({ card });
+
     expect(getIcon("key")).toBeInTheDocument();
     expect(
       screen.getByLabelText(/permission to see this question/i),


### PR DESCRIPTION
🚧 Work in progress — awaiting CI feedback

Apparently, `createMockCard` returns technically invalid card objects by default. It builds a `dataset_query` with `createMockStructuredQuery`, which returns an empty object by default. As a result, if we're testing some code that calls query methods, almost everything will be broken because the query doesn't have a table

Fixed by setting a default `source-table` to 1, corresponding to the sample Products table in our preset.