### PR TITLE
docs - add max query rows limits

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -436,7 +436,7 @@ Secret key used to sign JSON Web Tokens for requests to /api/embed endpoints.
 
 The secret should be kept safe (treated like a password) and recommended to be a 64 character string.
 
-This is for Static embedding, and has nothing to do with JWT SSO authentication, which is [MB*JWT*\*](#mb_jwt_enabled).
+This is for Static embedding, and has nothing to do with JWT SSO authentication (see [`MB_JWT_ENABLED`](#mb_jwt_enabled)).
 
 ### `MB_EMOJI_IN_LOGS`
 

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -882,6 +882,20 @@ Default: `"https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"`
 
 The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.
 
+### `MB_MAX_AGGREGATED_QUERY_ROW_LIMIT`
+
+Type: integer<br>
+Default: 10000 
+
+Maximum number of rows to return for aggregated queries via the API.
+
+### `MB_MAX_UNAGGREGATED_QUERY_ROW_LIMIT`
+
+Type: integer<br>
+Default: 2000
+
+Maximum number of rows to return specifically on `:rows`-type queries via the API.
+
 ### `MB_NATIVE_QUERY_AUTOCOMPLETE_MATCH_STYLE`
 
 Type: string (`"substring"`, `"prefix"`, `"off"`)<br>
@@ -1350,3 +1364,11 @@ Default: `null`<br>
 Since: v41.0
 
 Allowed email address domain(s) for new Subscriptions and Alerts. Specify multiple domain comma-separated. When not defined, all domains are allowed.
+
+### `MB_UNAGGREGATED_QUERY_ROW_LIMIT`
+
+Type: integer<br>
+Default: 2000 
+
+Maximum number of rows to return specifically on `:rows`-type queries via the API.
+

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -887,14 +887,14 @@ The map tile server URL template used in map visualizations, for example from Op
 Type: integer<br>
 Default: 10000 
 
-Maximum number of rows to return for aggregated queries via the API.
+Maximum number of rows to return for aggregated queries via the API. Must less than 1048575.
 
 ### `MB_MAX_UNAGGREGATED_QUERY_ROW_LIMIT`
 
 Type: integer<br>
 Default: 2000
 
-Maximum number of rows to return specifically on `:rows`-type queries via the API.
+Maximum number of rows to return specifically on `:rows`-type queries via the API. Must be less than 1048575.
 
 ### `MB_NATIVE_QUERY_AUTOCOMPLETE_MATCH_STYLE`
 

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -436,7 +436,7 @@ Secret key used to sign JSON Web Tokens for requests to /api/embed endpoints.
 
 The secret should be kept safe (treated like a password) and recommended to be a 64 character string.
 
-This is for Static embedding, and has nothing to do with JWT SSO authentication, which is [MB_JWT_*](#mb_jwt_enabled).
+This is for Static embedding, and has nothing to do with JWT SSO authentication, which is [MB*JWT*\*](#mb_jwt_enabled).
 
 ### `MB_EMOJI_IN_LOGS`
 
@@ -885,7 +885,7 @@ The map tile server URL template used in map visualizations, for example from Op
 ### `MB_MAX_AGGREGATED_QUERY_ROW_LIMIT`
 
 Type: integer<br>
-Default: 10000 
+Default: 10000
 
 Maximum number of rows to return for aggregated queries via the API. Must less than 1048575.
 
@@ -1364,11 +1364,3 @@ Default: `null`<br>
 Since: v41.0
 
 Allowed email address domain(s) for new Subscriptions and Alerts. Specify multiple domain comma-separated. When not defined, all domains are allowed.
-
-### `MB_UNAGGREGATED_QUERY_ROW_LIMIT`
-
-Type: integer<br>
-Default: 2000 
-
-Maximum number of rows to return specifically on `:rows`-type queries via the API.
-

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -57,6 +57,13 @@ Default: `null`
 
 The email address users should be referred to if they encounter a problem.
 
+### `MB_AGGREGATED_QUERY_ROW_LIMIT`
+
+Type: integer<br>
+Default: 10000
+
+Maximum number of rows to return for aggregated queries via the API. Must less than 1048575. See also [`MB_UNAGGREGATED_QUERY_ROW_LIMIT`](#mb_unaggregated_query_row_limit).
+
 ### `MB_ANON_TRACKING_ENABLED`
 
 Type: boolean<br>
@@ -882,20 +889,6 @@ Default: `"https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"`
 
 The map tile server URL template used in map visualizations, for example from OpenStreetMaps or MapBox.
 
-### `MB_MAX_AGGREGATED_QUERY_ROW_LIMIT`
-
-Type: integer<br>
-Default: 10000
-
-Maximum number of rows to return for aggregated queries via the API. Must less than 1048575.
-
-### `MB_MAX_UNAGGREGATED_QUERY_ROW_LIMIT`
-
-Type: integer<br>
-Default: 2000
-
-Maximum number of rows to return specifically on `:rows`-type queries via the API. Must be less than 1048575.
-
 ### `MB_NATIVE_QUERY_AUTOCOMPLETE_MATCH_STYLE`
 
 Type: string (`"substring"`, `"prefix"`, `"off"`)<br>
@@ -1364,3 +1357,10 @@ Default: `null`<br>
 Since: v41.0
 
 Allowed email address domain(s) for new Subscriptions and Alerts. Specify multiple domain comma-separated. When not defined, all domains are allowed.
+
+### `MB_UNAGGREGATED_QUERY_ROW_LIMIT`
+
+Type: integer<br>
+Default: 2000
+
+Maximum number of rows to return specifically on `:rows`-type queries via the API. Must be less than 1048575. See also [`MB_AGGREGATED_QUERY_ROW_LIMIT`](#mb_aggregated_query_row_limit).

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -62,8 +62,9 @@ The email address users should be referred to if they encounter a problem.
 Type: integer<br>
 Default: 10000
 
-Maximum number of rows to return for aggregated queries via the API. Must be less than 1048575. See also [`MB_UNAGGREGATED_QUERY_ROW_LIMIT`](#mb_unaggregated_query_row_limit).
-This environment variable also affects how many rows are returned in the subscription attachments.
+Maximum number of rows to return for aggregated queries via the API. Must be less than 1048575. This environment variable also affects how many rows Metabase includes in dashboard subscription attachments.
+
+See also [`MB_UNAGGREGATED_QUERY_ROW_LIMIT`](#mb_unaggregated_query_row_limit).
 
 ### `MB_ANON_TRACKING_ENABLED`
 
@@ -1364,5 +1365,6 @@ Allowed email address domain(s) for new Subscriptions and Alerts. Specify multip
 Type: integer<br>
 Default: 2000
 
-Maximum number of rows to return specifically on `:rows`-type queries via the API. Must be less than 1048575 and also less than the number configured in MB_AGGREGATED_QUERY_ROW_LIMIT. See also [`MB_AGGREGATED_QUERY_ROW_LIMIT`](#mb_aggregated_query_row_limit).
-This environment variable also affects how many rows are returned in the subscription attachments.
+Maximum number of rows to return specifically on `:rows`-type queries via the API. Must be less than 1048575, and less than the number configured in `MB_AGGREGATED_QUERY_ROW_LIMIT`. This environment variable also affects how many rows Metabase returns in dashboard subscription attachments.
+
+See also [`MB_AGGREGATED_QUERY_ROW_LIMIT`](#mb_aggregated_query_row_limit).

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -62,7 +62,8 @@ The email address users should be referred to if they encounter a problem.
 Type: integer<br>
 Default: 10000
 
-Maximum number of rows to return for aggregated queries via the API. Must less than 1048575. See also [`MB_UNAGGREGATED_QUERY_ROW_LIMIT`](#mb_unaggregated_query_row_limit).
+Maximum number of rows to return for aggregated queries via the API. Must be less than 1048575. See also [`MB_UNAGGREGATED_QUERY_ROW_LIMIT`](#mb_unaggregated_query_row_limit).
+This environment variable also affects how many rows are returned in the subscription attachments.
 
 ### `MB_ANON_TRACKING_ENABLED`
 
@@ -1363,4 +1364,5 @@ Allowed email address domain(s) for new Subscriptions and Alerts. Specify multip
 Type: integer<br>
 Default: 2000
 
-Maximum number of rows to return specifically on `:rows`-type queries via the API. Must be less than 1048575. See also [`MB_AGGREGATED_QUERY_ROW_LIMIT`](#mb_aggregated_query_row_limit).
+Maximum number of rows to return specifically on `:rows`-type queries via the API. Must be less than 1048575 and also less than the number configured in MB_AGGREGATED_QUERY_ROW_LIMIT. See also [`MB_AGGREGATED_QUERY_ROW_LIMIT`](#mb_aggregated_query_row_limit).
+This environment variable also affects how many rows are returned in the subscription attachments.


### PR DESCRIPTION
Adds new env vars:

- `MB_AGGREGATED_QUERY_ROW_LIMIT`
- `MB_UNAGGREGATED_QUERY_ROW_LIMIT`