### PR TITLE
add `skip-graph` query param to PUT api/permissions/graph

### DIFF
--- a/src/metabase/api/permissions.clj
+++ b/src/metabase/api/permissions.clj
@@ -110,7 +110,7 @@
             impersonations         (when impersonation-updates
                                      (insert-impersonations! impersonation-updates))]
         (merge {:revision (perms-revision/latest-id)}
-               (when skip-graph {:groups (:groups (perms/data-perms-graph))})
+               (when-not skip-graph {:groups (:groups (perms/data-perms-graph))})
                (when sandboxes {:sandboxes sandboxes})
                (when impersonations {:impersonations impersonations}))))))
 

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -896,7 +896,8 @@
   [db-id]
   (let [group-id->permissions (permissions-by-group-ids [:like :object (h2x/literal (str "%/db/" db-id "/%"))])
         group-id->v1-paths (->v1-paths group-id->permissions)]
-    (generate-graph [db-id] group-id->v1-paths)))
+    {:revision (perms-revision/latest-id)
+     :groups (generate-graph [db-id] group-id->v1-paths)}))
 
 (defn data-graph-for-group
   "Efficiently returns a data permissions graph, which has all the permissions info for the permission group at `group-id`."
@@ -904,7 +905,8 @@
   (let [db-ids (t2/select-pks-set :model/Database)
         group-id->permissions (permissions-by-group-ids [:= :group_id group-id])
         group-id->paths (select-keys (->v1-paths group-id->permissions) [group-id])]
-    (generate-graph db-ids group-id->paths)))
+    {:revision (perms-revision/latest-id)
+     :groups (generate-graph db-ids group-id->paths)}))
 
 (defn data-perms-graph-v2
   "Fetch a graph representing the current *data* permissions status for every Group and all permissioned databases.

--- a/src/metabase/util/malli.cljc
+++ b/src/metabase/util/malli.cljc
@@ -1,17 +1,18 @@
 (ns metabase.util.malli
   (:refer-clojure :exclude [fn defn defmethod])
   (:require
-   [clojure.core :as core]
-   [malli.core :as mc]
-   [malli.destructure]
-   [malli.util :as mut]
-   [metabase.shared.util.i18n :as i18n]
    #?@(:clj
        ([metabase.util.i18n]
         [metabase.util.malli.defn :as mu.defn]
         [metabase.util.malli.fn :as mu.fn]
         [net.cgrand.macrovich :as macros]
-        [potemkin :as p])))
+        [potemkin :as p]))
+   [clojure.core :as core]
+   [malli.core :as mc]
+   [malli.destructure]
+   [malli.error :as me]
+   [malli.util :as mut]
+   [metabase.shared.util.i18n :as i18n])
   #?(:cljs (:require-macros [metabase.util.malli])))
 
 #?(:clj
@@ -24,6 +25,12 @@
   [{:keys [value message]}]
   ;; TODO Should this be translated with more complete context? (tru "{0}, received: {1}" message (pr-str value))
   (str message ", " (i18n/tru "received") ": " (pr-str value)))
+
+(core/defn explain
+  "Explains a schema failure, and returns the offending value."
+  [schema value]
+  (-> (mc/explain schema value)
+      (me/humanize {:wrap humanize-include-value})))
 
 (def ^:private Schema
   [:and any?

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -15,7 +15,8 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
-   [ring.adapter.jetty9 :as jetty])
+   [ring.adapter.jetty9 :as jetty]
+   [ring.middleware.params :refer [wrap-params]])
   (:import
    (org.eclipse.jetty.server Server)))
 
@@ -89,6 +90,19 @@
   (let [{:keys [state po-box archipelago]} body]
     (str/join " | " [state po-box archipelago])))
 
+(api/defendpoint GET "/with-query-params/"
+  [:as {params :params}]
+  {params [:and
+           ;; decodes the keyword _keys_
+           [:map-of :keyword any?]
+           ;; ^ if you don't care about the shape you can stop there
+           [:map
+            [:bool-key {:optional true} :boolean]
+            [:string-key {:optional true} :string]
+            [:enum-key [:enum :a :b :c]]
+            [:kw-key :keyword]]]}
+  (pr-str params))
+
 (api/defendpoint POST "/accept-thing/:a" [a] {a [:re #"a.*"]} "hit route for a.")
 (api/defendpoint POST "/accept-thing/:b" [b] {b [:re #"b.*"]} "hit route for b.")
 (api/defendpoint POST "/accept-thing/:c" [c] {c [:re #"c.*"]} "hit route for c.")
@@ -99,15 +113,29 @@
 
 (defn- json-mw [handler]
   (fn [req]
-    (update
-     (handler
-      (update req :body #(-> % slurp (json/parse-string true))))
-     :body json/generate-string)))
+    (-> req
+        (update :body #(-> % slurp (json/parse-string true)))
+        handler
+        (update :body json/generate-string))))
 
 (defn exception-mw [handler]
   (fn [req] (try
               (handler req)
               (catch Exception e (mw.exceptions/api-exception-response e)))))
+
+(deftest defendpoint-query-params-test
+  (let [^Server server (jetty/run-jetty (json-mw
+                                         (exception-mw
+                                          (wrap-params #'routes))) {:port 0 :join? false})
+        port   (.. server getURI getPort)
+        get! (fn [route]
+               (http/get (str "http://localhost:" port route)
+                         {:throw-exceptions false
+                          :accept           :json
+                          :as               :json
+                          :coerce           :always}))]
+    (is (= "{:bool-key true, :string-key \"abc\", :enum-key :a, :kw-key :abc}"
+           (:body (get! "/with-query-params/?bool-key=true&string-key=abc&enum-key=a&kw-key=abc"))))))
 
 (deftest defendpoint-test
   (let [^Server server (jetty/run-jetty (json-mw (exception-mw #'routes)) {:port 0 :join? false})

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -127,7 +127,7 @@
   (let [^Server server (jetty/run-jetty (json-mw
                                          (exception-mw
                                           (wrap-params #'routes))) {:port 0 :join? false})
-        port   (.. server getURI getPort)
+        port (.. server getURI getPort)
         get! (fn [route]
                (http/get (str "http://localhost:" port route)
                          {:throw-exceptions false

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -253,6 +253,21 @@
         (is (= {:query {:schemas :all}, :data {:native :write}}
                (get-in (perms/data-perms-graph-v2) [:groups (u/the-id group) db-id])))))))
 
+(deftest update-perms-graph-with-skip-graph-skips-graph-test
+  (testing "PUT /api/permissions/graph"
+    (testing "permissions graph is not returned when skip-graph"
+      (t2.with-temp/with-temp [:model/PermissionsGroup group       {}
+                               :model/Database         {db-id :id} {}]
+        (let [g (perms/data-perms-graph)
+              returned-g (mt/user-http-request :crowberto :put 200 "permissions/graph"
+                                               (assoc-in g [:groups (u/the-id group) db-id :data :schemas] :all))
+              no-returned-g (mt/user-http-request :crowberto :put 200 "permissions/graph?skip-graph=true"
+                                                  (assoc-in g [:groups (u/the-id group) db-id :data :schemas] :all))]
+          (is (perm-test-util/validate-graph-api-output (:groups g)))
+          (is (perm-test-util/validate-graph-api-output (:groups returned-g)))
+          (is (not (perm-test-util/validate-graph-api-output (:groups no-returned-g))))
+          (is (= {} no-returned-g)))))))
+
 (deftest update-perms-graph-group-has-no-permissions-test
   (testing "PUT /api/permissions/graph"
     (testing "permissions when group has no permissions"

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -164,8 +164,8 @@
                                Database         db                          {}]
         (perms/grant-permissions! group (perms/data-perms-path db))
         (let [graph (mt/user-http-request :crowberto :get 200 (format "permissions/graph/group/%s" group-id))]
-          (is (perm-test-util/validate-graph-api-output graph))
-          (is (= #{group-id} (set (keys graph)))))))))
+          (is (perm-test-util/validate-graph-api-groups (:groups graph)))
+          (is (= #{group-id} (set (keys (:groups graph))))))))))
 
 (deftest fetch-perms-graph-by-db-id-test
   (testing "GET /api/permissions/graph"
@@ -174,8 +174,8 @@
                                Database         {db-id :id} {}]
         (perms/grant-permissions! group (perms/data-perms-path db-id))
         (let [graph (mt/user-http-request :crowberto :get 200 (format "permissions/graph/db/%s" db-id))]
-          (is (perm-test-util/validate-graph-api-output graph))
-          (is (= #{db-id} (->> graph vals (mapcat keys) set))))))))
+          (is (perm-test-util/validate-graph-api-groups (:groups graph)))
+          (is (= #{db-id} (->> graph :groups vals (mapcat keys) set))))))))
 
 (deftest fetch-perms-graph-v2-test
   (testing "GET /api/permissions/graph-v2"
@@ -264,10 +264,10 @@
               returned-g     (do-perm-put "permissions/graph")
               returned-g-two (do-perm-put "permissions/graph?skip-graph=false")
               no-returned-g  (do-perm-put "permissions/graph?skip-graph=true")]
-          (is (perm-test-util/validate-graph-api-output (:groups g)))
-          (is (perm-test-util/validate-graph-api-output (:groups returned-g)))
-          (is (perm-test-util/validate-graph-api-output (:groups returned-g-two)))
-          (is (not (perm-test-util/validate-graph-api-output (:groups no-returned-g))))
+          (is (perm-test-util/validate-graph-api-groups (:groups g)))
+          (is (perm-test-util/validate-graph-api-groups (:groups returned-g)))
+          (is (perm-test-util/validate-graph-api-groups (:groups returned-g-two)))
+          (is (not (perm-test-util/validate-graph-api-groups (:groups no-returned-g))))
           (is (= {} no-returned-g)))))))
 
 (deftest update-perms-graph-group-has-no-permissions-test

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -2,6 +2,7 @@
   "Tests for `/api/permissions` endpoints."
   (:require
    [clojure.test :refer :all]
+   [malli.core :as mc]
    [medley.core :as m]
    [metabase.api.permissions :as api.permissions]
    [metabase.api.permissions-test-util :as perm-test-util]
@@ -164,6 +165,7 @@
                                Database         db                          {}]
         (perms/grant-permissions! group (perms/data-perms-path db))
         (let [graph (mt/user-http-request :crowberto :get 200 (format "permissions/graph/group/%s" group-id))]
+          (is (mc/validate nat-int? (:revision graph)))
           (is (perm-test-util/validate-graph-api-groups (:groups graph)))
           (is (= #{group-id} (set (keys (:groups graph))))))))))
 
@@ -174,6 +176,7 @@
                                Database         {db-id :id} {}]
         (perms/grant-permissions! group (perms/data-perms-path db-id))
         (let [graph (mt/user-http-request :crowberto :get 200 (format "permissions/graph/db/%s" db-id))]
+          (is (mc/validate nat-int? (:revision graph)))
           (is (perm-test-util/validate-graph-api-groups (:groups graph)))
           (is (= #{db-id} (->> graph :groups vals (mapcat keys) set))))))))
 
@@ -258,17 +261,28 @@
     (testing "permissions graph is not returned when skip-graph"
       (t2.with-temp/with-temp [:model/PermissionsGroup group       {}
                                :model/Database         {db-id :id} {}]
-        (let [g              (perms/data-perms-graph)
-              do-perm-put    (fn [url] (mt/user-http-request :crowberto :put 200 url
-                                                          (assoc-in g [:groups (u/the-id group) db-id :data :schemas] :all)))
+        (let [do-perm-put    (fn [url] (mt/user-http-request
+                                        :crowberto :put 200 url
+                                        (assoc-in (perms/data-perms-graph)
+                                                  ;; Get a new revision number each time
+                                                  [:groups (u/the-id group) db-id :data :schemas] :all)))
               returned-g     (do-perm-put "permissions/graph")
               returned-g-two (do-perm-put "permissions/graph?skip-graph=false")
               no-returned-g  (do-perm-put "permissions/graph?skip-graph=true")]
-          (is (perm-test-util/validate-graph-api-groups (:groups g)))
-          (is (perm-test-util/validate-graph-api-groups (:groups returned-g)))
-          (is (perm-test-util/validate-graph-api-groups (:groups returned-g-two)))
-          (is (not (perm-test-util/validate-graph-api-groups (:groups no-returned-g))))
-          (is (= {} no-returned-g)))))))
+
+          (testing "returned-g"
+            (is (perm-test-util/validate-graph-api-groups (:groups returned-g)))
+            (is (mc/validate [:map [:revision pos-int?]] returned-g)))
+
+          (testing "return-g-two"
+            (is (perm-test-util/validate-graph-api-groups (:groups returned-g-two)))
+            (is (mc/validate [:map [:revision pos-int?]] returned-g-two)))
+
+          (testing "no returned g"
+            (is (not (perm-test-util/validate-graph-api-groups (:groups no-returned-g))))
+            (is (mc/validate [:map {:closed true}
+                              [:revision pos-int?]] no-returned-g))))))))
+
 
 (deftest update-perms-graph-group-has-no-permissions-test
   (testing "PUT /api/permissions/graph"

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -258,13 +258,15 @@
     (testing "permissions graph is not returned when skip-graph"
       (t2.with-temp/with-temp [:model/PermissionsGroup group       {}
                                :model/Database         {db-id :id} {}]
-        (let [g (perms/data-perms-graph)
-              returned-g (mt/user-http-request :crowberto :put 200 "permissions/graph"
-                                               (assoc-in g [:groups (u/the-id group) db-id :data :schemas] :all))
-              no-returned-g (mt/user-http-request :crowberto :put 200 "permissions/graph?skip-graph=true"
-                                                  (assoc-in g [:groups (u/the-id group) db-id :data :schemas] :all))]
+        (let [g              (perms/data-perms-graph)
+              do-perm-put    (fn [url] (mt/user-http-request :crowberto :put 200 url
+                                                          (assoc-in g [:groups (u/the-id group) db-id :data :schemas] :all)))
+              returned-g     (do-perm-put "permissions/graph")
+              returned-g-two (do-perm-put "permissions/graph?skip-graph=false")
+              no-returned-g  (do-perm-put "permissions/graph?skip-graph=true")]
           (is (perm-test-util/validate-graph-api-output (:groups g)))
           (is (perm-test-util/validate-graph-api-output (:groups returned-g)))
+          (is (perm-test-util/validate-graph-api-output (:groups returned-g-two)))
           (is (not (perm-test-util/validate-graph-api-output (:groups no-returned-g))))
           (is (= {} no-returned-g)))))))
 

--- a/test/metabase/api/permissions_test_util.clj
+++ b/test/metabase/api/permissions_test_util.clj
@@ -9,7 +9,7 @@
 (defn- decode-and-validate [schema value]
   (mc/validate schema (mc/decode schema value (mtx/string-transformer))))
 
-(defn validate-graph-api-output
+(defn validate-graph-api-groups
   "Handles string->keyword transofmrations in DataPerms"
   [graph]
   (decode-and-validate graph-output-schema graph))

--- a/test/metabase/models/permissions_group_test.clj
+++ b/test/metabase/models/permissions_group_test.clj
@@ -111,7 +111,7 @@
   (doseq [group-id (t2/select-fn-set :id :model/PermissionsGroup)]
     (testing (str "testing data-graph-for-group with group-id: [" group-id "].")
       (let [graph (perms/data-graph-for-group group-id)]
-        (is (perm-test-util/validate-graph-api-output graph))
+        (is (perm-test-util/validate-graph-api-groups graph))
         (is (= #{group-id} (set (keys graph))))))))
 
 (defn- perm-object->db [perm-obj]
@@ -123,7 +123,7 @@
     (doseq [db-id (t2/select-fn-set :id :model/Database)]
       (testing (str "testing data-graph-for-db with db-id: [" db-id "].")
         (let [graph (perms/data-graph-for-db db-id)]
-          (is (perm-test-util/validate-graph-api-output graph))
+          (is (perm-test-util/validate-graph-api-groups graph))
           ;; Only check this for dbs with permissions
           (when (contains? dbs-in-perms db-id)
             (is (= #{db-id} (->> graph vals (mapcat keys) set)))))))))

--- a/test/metabase/models/permissions_group_test.clj
+++ b/test/metabase/models/permissions_group_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.permissions-group-test
   (:require
    [clojure.test :refer :all]
+   [malli.core :as mc]
    [metabase.api.permissions-test-util :as perm-test-util]
    [metabase.models.database :refer [Database]]
    [metabase.models.interface :as mi]
@@ -111,8 +112,9 @@
   (doseq [group-id (t2/select-fn-set :id :model/PermissionsGroup)]
     (testing (str "testing data-graph-for-group with group-id: [" group-id "].")
       (let [graph (perms/data-graph-for-group group-id)]
-        (is (perm-test-util/validate-graph-api-groups graph))
-        (is (= #{group-id} (set (keys graph))))))))
+        (is (mc/validate pos-int? (:revision graph)))
+        (is (perm-test-util/validate-graph-api-groups (:groups graph)))
+        (is (= #{group-id} (set (keys (:groups graph)))))))))
 
 (defn- perm-object->db [perm-obj]
   (some-> (re-find #"/db/(\d+)/" perm-obj) second parse-long))
@@ -123,7 +125,8 @@
     (doseq [db-id (t2/select-fn-set :id :model/Database)]
       (testing (str "testing data-graph-for-db with db-id: [" db-id "].")
         (let [graph (perms/data-graph-for-db db-id)]
-          (is (perm-test-util/validate-graph-api-groups graph))
+          (is (mc/validate pos-int? (:revision graph)))
+          (is (perm-test-util/validate-graph-api-groups (:groups graph)))
           ;; Only check this for dbs with permissions
           (when (contains? dbs-in-perms db-id)
-            (is (= #{db-id} (->> graph vals (mapcat keys) set)))))))))
+            (is (= #{db-id} (->> graph :groups vals (mapcat keys) set)))))))))


### PR DESCRIPTION
Resolves #36651 

The `skip-graph` query parameter has no effect if it is left out of the query params, or included in the query params and set to false.

If PUT `api/permissions/graph/&skip-graph=true`, then we do not return the entire permissions graph (which is a potentially expensive operation).