### PR TITLE
Consistent time formatting for `metabase.formatter.datetime`

### DIFF
--- a/e2e/test/scenarios/sharing/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
@@ -51,8 +51,8 @@ describe("issue 10803", () => {
 
       // Excel and CSV will have different formats
       if (fileType === "csv") {
-        expect(sheet["A2"].v).to.eq("2026-06-03T00:00:00");
-        expect(sheet["B2"].v).to.eq("2026-06-03T23:41:23");
+        expect(sheet["A2"].v).to.eq("June 3, 2026, 12:00 AM");
+        expect(sheet["B2"].v).to.eq("June 3, 2026, 12:00 AM");
       } else if (fileType === "xlsx") {
         // We tell the xlsx library to read raw and not parse dates
         // So for the _date_ format we expect an integer

--- a/e2e/test/scenarios/sharing/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/reproductions/10803-timestamp-formatting.cy.spec.js
@@ -52,7 +52,7 @@ describe("issue 10803", () => {
       // Excel and CSV will have different formats
       if (fileType === "csv") {
         expect(sheet["A2"].v).to.eq("June 3, 2026, 12:00 AM");
-        expect(sheet["B2"].v).to.eq("June 3, 2026, 12:00 AM");
+        expect(sheet["B2"].v).to.eq("June 3, 2026, 11:41 PM");
       } else if (fileType === "xlsx") {
         // We tell the xlsx library to read raw and not parse dates
         // So for the _date_ format we expect an integer

--- a/src/metabase/formatter/datetime.clj
+++ b/src/metabase/formatter/datetime.clj
@@ -4,12 +4,13 @@
    [clojure.string :as str]
    [java-time.api :as t]
    [metabase.public-settings :as public-settings]
+   [metabase.shared.formatting.constants :as constants]
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.util.date-2 :as u.date]
-   [metabase.util.i18n :refer [tru]])
+   [metabase.util.i18n :refer [tru]]
+   [metabase.util.log :as log])
   (:import
    (com.ibm.icu.text RuleBasedNumberFormat)
-   (java.time.format DateTimeFormatter)
    (java.util Locale)))
 
 (set! *warn-on-reflection* true)
@@ -52,80 +53,185 @@
 
 (defn- viz-settings-for-col
   "Get the column-settings map for the given column from the viz-settings."
-  [col viz-settings]
-  (let [[_ field-id]    (:field_ref col)
+  [{column-name :name :keys [field_ref]} viz-settings]
+  (let [[_ field-id-or-name] field_ref
         all-cols-settings (-> viz-settings
                               ::mb.viz/column-settings
                               ;; update the keys so that they will have only the :field-id or :column-name
                               ;; and not have any metadata. Since we don't know the metadata, we can never
                               ;; match a key with metadata, even if we do have the correct name or id
                               (update-keys #(select-keys % [::mb.viz/field-id ::mb.viz/column-name])))]
-    (or (all-cols-settings {::mb.viz/field-id field-id})
-        (all-cols-settings {::mb.viz/column-name field-id}))))
+    (or (all-cols-settings {::mb.viz/field-id field-id-or-name})
+        (all-cols-settings {::mb.viz/column-name (or field-id-or-name column-name)}))))
+
+(defn- determine-time-format
+  "Given viz-settings with a time-style and possible time-enabled (precision) entry, create the format string."
+  [{:keys [time-enabled time-style] :or {time-enabled "minutes" time-style "h:mm A"}}]
+  (let [base-time-format (case time-enabled
+                           "minutes" "mm"
+
+                           "seconds" "mm:ss"
+
+                           "milliseconds" "mm:ss.SSS"
+
+                           ;; {::mb.viz/time-enabled nil} indicates that time is explicitly disabled, rather than
+                           ;; defaulting to "minutes"
+                           nil nil)]
+    (if base-time-format
+      (case time-style
+        "HH:mm" (format "HH:%s" base-time-format)
+
+        ;; Deprecated time style which should be already converted to HH:mm when viz settings are
+        ;; normalized, but we'll handle it here too just in case. (#18112)
+        "k:mm" (str "h" base-time-format)
+
+        ("h:mm A" "h:mm a") (format "h:%s a" base-time-format)
+
+        time-style)
+      time-style)))
+
+(defn- fix-time-style
+  "The Java pattern for DateTimeFormatter is `a` for AM/PM and `A` for milli-of-day. However, to reconcile formats with
+  Moment.js on the FE, we use `h:mm A` to denote AM/PM in our code base. This function replaces time format patterns
+  that use the MB 'A' with 'a' so  that DateTimeFormatter properly formats times. We should consider looking into
+  `metabase.shared.util.time` to see if we can eliminate this altogether."
+  [time-style default-time-style]
+  (str/replace (or time-style default-time-style) #"A" "a"))
+
+(defn- post-process-date-style
+  "Potentially modify a date style to abbreviate names or add a different date separator."
+  [date-style {:keys [date-abbreviate date-separator]}]
+  (let [conditional-changes
+        (cond-> (-> date-style (str/replace #"dddd" "EEEE"))
+          date-separator (str/replace #"/" date-separator)
+          date-abbreviate (-> (str/replace #"MMMM" "MMM")
+                         (str/replace #"EEEE" "EEE")
+                         (str/replace #"DDD" "D")))]
+    (-> conditional-changes
+        ;; 'D' formats as Day of year, we want Day of month, which is  'd' (issue #27469)
+        (str/replace #"D" "d"))))
+
+(def ^:private col-type
+  "The dispatch function logic for format format-timestring.
+  Find the first of the unit or highest type of the object."
+  (some-fn :unit :semantic_type :effective_type :base_type))
+
+(defmulti format-timestring
+"Reformat a temporal literal string to the desired format based on column `:unit`, if provided, then on the column type.
+The type is the highest present of semantic, effective, or base type. This is currently expected to be one of:
+- `:type/Time` - The hour, minute, second, etc. portion of a day, not anchored to a date
+- `:type/Date` - A date without hour and minute information
+- `:type/DateTime` - A full date plus hour, minute, seconds, etc.
+If neither a unit nor a temporal type is provided, just bottom out by assuming a date.
+"
+  (fn [_timezone-id _temporal-str col _viz-settings] (col-type col)))
+
+(defmethod format-timestring :minute [timezone-id temporal-str _col {:keys [date-style time-style] :as viz-settings}]
+  (reformat-temporal-str timezone-id temporal-str
+                         (-> (or date-style "MMMM, yyyy")
+                             (str ", " (fix-time-style time-style constants/default-time-style))
+                             (post-process-date-style viz-settings))))
+
+(defmethod format-timestring :hour [timezone-id temporal-str _col {:keys [date-style time-style] :as viz-settings}]
+  (reformat-temporal-str timezone-id temporal-str
+                         (-> (or date-style "MMMM, yyyy")
+                             (str ", " (fix-time-style time-style "h a"))
+                             (post-process-date-style viz-settings))))
+
+(defmethod format-timestring :day [timezone-id temporal-str _col {:keys [date-style] :as viz-settings}]
+  (reformat-temporal-str timezone-id temporal-str
+                         (-> (or date-style "EEEE, MMMM d, YYYY")
+                             (post-process-date-style viz-settings))))
+
+(defmethod format-timestring :week [timezone-id temporal-str _col _viz-settings]
+  (str (tru "Week ") (reformat-temporal-str timezone-id temporal-str "w - YYYY")))
+
+(defmethod format-timestring :month [timezone-id temporal-str _col {:keys [date-style] :as viz-settings}]
+  (reformat-temporal-str timezone-id temporal-str
+                         (-> (or date-style "MMMM, yyyy")
+                             (post-process-date-style viz-settings))))
+
+(defmethod format-timestring :quarter [timezone-id temporal-str _col _viz-settings]
+  (reformat-temporal-str timezone-id temporal-str "QQQ - yyyy"))
+
+(defmethod format-timestring :year [timezone-id temporal-str _col _viz-settings]
+  (reformat-temporal-str timezone-id temporal-str "YYYY"))
+
+(defmethod format-timestring :day-of-week [_timezone-id temporal-str _col {:keys [date-abbreviate]}]
+  (day-of-week (parse-long temporal-str) date-abbreviate))
+
+(defmethod format-timestring :month-of-year [_timezone-id temporal-str _col {:keys [date-abbreviate]}]
+  (month-of-year (parse-long temporal-str) date-abbreviate))
+
+(defmethod format-timestring :quarter-of-year [_timezone-id temporal-str _col _viz-settings]
+  (format "Q%s" temporal-str))
+
+(defmethod format-timestring :hour-of-day [_timezone-id temporal-str _col {:keys [time-style]}]
+  (hour-of-day temporal-str (fix-time-style time-style "h a")))
+
+(defmethod format-timestring :week-of-year [_timezone-id temporal-str _col _viz-settings]
+  (x-of-y (parse-long temporal-str)))
+
+(defmethod format-timestring :minute-of-hour [_timezone-id temporal-str _col _viz-settings]
+  (x-of-y (parse-long temporal-str)))
+
+(defmethod format-timestring :day-of-month [_timezone-id temporal-str _col _viz-settings]
+  (x-of-y (parse-long temporal-str)))
+
+(defmethod format-timestring :day-of-year [_timezone-id temporal-str _col _viz-settings]
+  (x-of-y (parse-long temporal-str)))
+
+(defmethod format-timestring :type/Time [timezone-id temporal-str _col viz-settings]
+  (let [time-style            (fix-time-style (determine-time-format viz-settings) constants/default-time-style)]
+    (reformat-temporal-str timezone-id temporal-str time-style)))
+
+(defmethod format-timestring :type/Date [timezone-id temporal-str _col {:keys [date-style] :as viz-settings}]
+  (let [date-format (post-process-date-style (or date-style "MMMM d, yyyy") viz-settings)]
+    (reformat-temporal-str timezone-id temporal-str date-format)))
+
+(defmethod format-timestring :type/DateTime [timezone-id temporal-str _col {:keys [date-style] :as viz-settings}]
+  (let [date-style            (or date-style "MMMM d, yyyy")
+        time-style            (fix-time-style (determine-time-format viz-settings) constants/default-time-style)
+        date-time-style       (format "%s, %s" date-style time-style)
+        default-format-string (post-process-date-style date-time-style viz-settings)]
+    (t/format default-format-string (u.date/parse temporal-str timezone-id))))
+
+(defmethod format-timestring :default [timezone-id temporal-str {:keys [unit] :as col} {:keys [date-style] :as viz-settings}]
+  (if (= :default unit)
+    ;; When the unit is the `:default` literal we want to retry formatting with the data types contained in col.
+    (format-timestring timezone-id temporal-str (dissoc col :unit) viz-settings)
+    ;; We're making an assumption when we bottom out here that the string is compatible with this default format,
+    ;; 'MMMM d, yyyy'. If the time string isn't compatible with this format, we just return the string.
+    ;; This is not likely to happen IRL since you generally have a useful unit or know the type of the colum. A failure
+    ;; mode that can be reproduced in test is trying to format a time string (e.g.'15:30:45Z') when the column has no
+    ;; type information (e.g. a semantic or effective type of `:type/Time`).
+    (let [date-format (post-process-date-style (or date-style "MMMM d, yyyy") viz-settings)]
+      (try
+        (reformat-temporal-str timezone-id temporal-str date-format)
+        (catch Exception _
+          (log/warnf "Could not format temporal string %s in time zone %s with format %s."
+                     temporal-str
+                     timezone-id
+                     date-format)
+          temporal-str)))))
 
 (defn format-temporal-str
-  "Reformat a temporal literal string `s` (i.e., an ISO-8601 string) with a human-friendly format based on the
-  column `:unit`."
-  ([timezone-id s col] (format-temporal-str timezone-id s col {}))
-  ([timezone-id s {:keys [effective_type base_type] :as col} viz-settings]
+  "Reformat a temporal literal string by combining time zone, column, and viz setting information to create a final
+  desired output format."
+  ([timezone-id temporal-str col] (format-temporal-str timezone-id temporal-str col {}))
+  ([timezone-id temporal-str col {::mb.viz/keys [global-column-settings] :as viz-settings}]
    (Locale/setDefault (Locale. (public-settings/site-locale)))
-   (cond
-     (str/blank? s) ""
-
-     (isa? (or effective_type base_type) :type/DateTime)
-     (t/format DateTimeFormatter/ISO_LOCAL_DATE_TIME (u.date/parse s timezone-id))
-
-     (isa? (or effective_type base_type) :type/Time)
-     (t/format DateTimeFormatter/ISO_LOCAL_TIME (u.date/parse s timezone-id))
-
-     :else
-     (let [col-viz-settings             (viz-settings-for-col col viz-settings)
-           {date-style     :date-style
-            abbreviate     :date-abbreviate
-            date-separator :date-separator
-            time-style     :time-style} (if (seq col-viz-settings)
-                                          (-> col-viz-settings
-                                              (update-keys (comp keyword name)))
-                                          (-> (:type/Temporal (public-settings/custom-formatting))
-                                              (update-keys (fn [k] (-> k name (str/replace #"_" "-") keyword)))))
-           post-process-date-style      (fn [date-style]
-                                          (let [conditional-changes
-                                                (cond-> (-> date-style (str/replace #"dddd" "EEEE"))
-                                                  date-separator (str/replace #"/" date-separator)
-                                                  abbreviate     (-> (str/replace #"MMMM" "MMM")
-                                                                     (str/replace #"EEEE" "EEE")
-                                                                     (str/replace #"DDD" "D")))]
-                                            (-> conditional-changes
-                                                ;; 'D' formats as Day of year, we want Day of month, which is  'd' (issue #27469)
-                                                (str/replace #"D" "d"))))]
-       (case (:unit col)
-         ;; these types have special formatting
-         :minute  (reformat-temporal-str timezone-id s
-                                         (-> (or date-style "MMMM, yyyy")
-                                             (str ", " (str/replace (or time-style "h:mm a") #"A" "a"))
-                                             post-process-date-style))
-         :hour    (reformat-temporal-str timezone-id s
-                                         (-> (or date-style "MMMM, yyyy")
-                                             (str ", " (str/replace (or time-style "h a") #"A" "a"))
-                                             post-process-date-style))
-         :day     (reformat-temporal-str timezone-id s
-                                         (-> (or date-style "EEEE, MMMM d, YYYY")
-                                             post-process-date-style))
-         :week    (str (tru "Week ") (reformat-temporal-str timezone-id s "w - YYYY"))
-         :month   (reformat-temporal-str timezone-id s
-                                         (-> (or date-style "MMMM, yyyy")
-                                             post-process-date-style))
-         :quarter (reformat-temporal-str timezone-id s "QQQ - yyyy")
-         :year    (reformat-temporal-str timezone-id s "YYYY")
-
-         ;; s is just a number as a string here
-         :day-of-week     (day-of-week (parse-long s) abbreviate)
-         :month-of-year   (month-of-year (parse-long s) abbreviate)
-         :quarter-of-year (format "Q%s" s)
-         :hour-of-day     (hour-of-day s (str/replace (or time-style "h a") #"A" "a"))
-
-         (:week-of-year :minute-of-hour :day-of-month :day-of-year) (x-of-y (parse-long s))
-
-         ;; for everything else return in this format
-         (reformat-temporal-str timezone-id s (-> (or date-style "MMMM d, yyyy")
-                                                  post-process-date-style)))))))
+   (let [public-formatting        (-> (:type/Temporal (public-settings/custom-formatting))
+                                      (update-keys (fn [k] (-> k name (str/replace #"_" "-") keyword))))
+         global-temporal-settings (-> (:type/Temporal global-column-settings {})
+                                      (update-keys (comp keyword name)))
+         custom-col-settings      (-> (viz-settings-for-col col viz-settings)
+                                      (update-keys (comp keyword name)))
+         ;; Merge the column settings by order of precedence.
+         merged-viz-settings      (merge
+                                    public-formatting
+                                    global-temporal-settings
+                                    custom-col-settings)]
+     (if (str/blank? temporal-str)
+       ""
+       (format-timestring timezone-id temporal-str col merged-viz-settings)))))

--- a/test/metabase/formatter/datetime_test.clj
+++ b/test/metabase/formatter/datetime_test.clj
@@ -145,6 +145,11 @@
           (is (= "Monday, December 11, 2023, 9:51:57.265 PM"
                  (let [col (assoc col :name "CUSTOM_DATETIME")]
                    (datetime/format-temporal-str "UTC" time-str col common-viz-settings)))))
+        (testing "Column metadata settings are applied"
+          (is (= "Dec 11, 2023, 21:51:57"
+                 (let [col (assoc col :settings {:time_enabled "seconds"
+                                                 :date_abbreviate true})]
+                   (datetime/format-temporal-str "UTC" time-str col common-viz-settings)))))
         (testing "Various settings can be merged"
           (testing "We abbreviate the base case..."
             (is (= "Dec 11, 2023, 21:51"

--- a/test/metabase/formatter/datetime_test.clj
+++ b/test/metabase/formatter/datetime_test.clj
@@ -8,111 +8,191 @@
 (def ^:private now "2020-07-16T18:04:00Z[UTC]")
 
 (deftest format-temporal-str-test
-  (testing "Null values do not blow up"
-    (is (= ""
-           (datetime/format-temporal-str "UTC" nil :now))))
-  (testing "Temporal Units are formatted"
-    (testing :minute
-      (is (= "July, 2020, 6:04 PM"
-             (datetime/format-temporal-str "UTC" now {:unit :minute}))))
-    (testing :hour
-      (is (= "July, 2020, 6 PM"
-             (datetime/format-temporal-str "UTC" now {:unit :hour}))))
-    (testing :day
-      (is (= "Thursday, July 16, 2020"
-             (datetime/format-temporal-str "UTC" now {:unit :day}))))
-    (testing :week
-      (is (= "Week 29 - 2020"
-             (datetime/format-temporal-str "UTC" now {:unit :week}))))
-    (testing :month
-      (is (= "July, 2020"
-             (datetime/format-temporal-str "UTC" now {:unit :month}))))
-    (testing :quarter
-      (is (= "Q3 - 2020"
-             (datetime/format-temporal-str "UTC" now {:unit :quarter}))))
-    (testing :year
-      (is (= "2020"
-             (datetime/format-temporal-str "UTC" now {:unit :year})))))
-  (testing "x-of-y Temporal Units are formatted"
-    (testing :minute-of-hour
-      (is (= "1st"
-             (datetime/format-temporal-str "UTC" "1" {:unit :minute-of-hour}))))
-    (testing :day-of-month
-      (is (= "2nd"
-             (datetime/format-temporal-str "UTC" "2" {:unit :day-of-month}))))
-    (testing :day-of-year
-      (is (= "203rd"
-             (datetime/format-temporal-str "UTC" "203" {:unit :day-of-year}))))
-    (testing :week-of-year
-      (is (= "44th"
-             (datetime/format-temporal-str "UTC" "44" {:unit :week-of-year}))))
-    (testing :day-of-week
-      (is (= "Thursday"
-             (datetime/format-temporal-str "UTC" "4" {:unit :day-of-week}))))
-    (testing :month-of-year
-      (is (= "May"
-             (datetime/format-temporal-str "UTC" "5" {:unit :month-of-year}))))
-    (testing :quarter-of-year
-      (is (= "Q3"
-             (datetime/format-temporal-str "UTC" "3" {:unit :quarter-of-year}))))
-    (testing :hour-of-day
-      (is (= "4 AM"
-             (datetime/format-temporal-str "UTC" "4" {:unit :hour-of-day})))))
-  (testing "Can render time types (#15146)"
-    (is (= "08:05:06"
-           (datetime/format-temporal-str "UTC" "08:05:06Z"
-                                         {:effective_type :type/Time}))))
-  (testing "Can render date time types (Part of resolving #36484)"
-    (is (= "2014-04-01T08:30:00"
-           (datetime/format-temporal-str "UTC" "2014-04-01T08:30:00"
-                                         {:effective_type :type/DateTime})))))
+  (mt/with-temporary-setting-values [custom-formatting nil]
+    (testing "Null values do not blow up"
+      (is (= ""
+             (datetime/format-temporal-str "UTC" nil :now))))
+    (testing "Temporal Units are formatted"
+      (testing :minute
+        (is (= "July, 2020, 6:04 PM"
+               (datetime/format-temporal-str "UTC" now {:unit :minute}))))
+      (testing :hour
+        (is (= "July, 2020, 6 PM"
+               (datetime/format-temporal-str "UTC" now {:unit :hour}))))
+      (testing :day
+        (is (= "Thursday, July 16, 2020"
+               (datetime/format-temporal-str "UTC" now {:unit :day}))))
+      (testing :week
+        (is (= "Week 29 - 2020"
+               (datetime/format-temporal-str "UTC" now {:unit :week}))))
+      (testing :month
+        (is (= "July, 2020"
+               (datetime/format-temporal-str "UTC" now {:unit :month}))))
+      (testing :quarter
+        (is (= "Q3 - 2020"
+               (datetime/format-temporal-str "UTC" now {:unit :quarter}))))
+      (testing :year
+        (is (= "2020"
+               (datetime/format-temporal-str "UTC" now {:unit :year})))))
+    (testing "x-of-y Temporal Units are formatted"
+      (testing :minute-of-hour
+        (is (= "1st"
+               (datetime/format-temporal-str "UTC" "1" {:unit :minute-of-hour}))))
+      (testing :day-of-month
+        (is (= "2nd"
+               (datetime/format-temporal-str "UTC" "2" {:unit :day-of-month}))))
+      (testing :day-of-year
+        (is (= "203rd"
+               (datetime/format-temporal-str "UTC" "203" {:unit :day-of-year}))))
+      (testing :week-of-year
+        (is (= "44th"
+               (datetime/format-temporal-str "UTC" "44" {:unit :week-of-year}))))
+      (testing :day-of-week
+        (is (= "Thursday"
+               (datetime/format-temporal-str "UTC" "4" {:unit :day-of-week}))))
+      (testing :month-of-year
+        (is (= "May"
+               (datetime/format-temporal-str "UTC" "5" {:unit :month-of-year}))))
+      (testing :quarter-of-year
+        (is (= "Q3"
+               (datetime/format-temporal-str "UTC" "3" {:unit :quarter-of-year}))))
+      (testing :hour-of-day
+        (is (= "4 AM"
+               (datetime/format-temporal-str "UTC" "4" {:unit :hour-of-day})))))
+    (testing "Can render time types (#15146)"
+      (is (= "8:05 AM"
+             (datetime/format-temporal-str "UTC" "08:05:06Z"
+                                           {:effective_type :type/Time})))
+      (testing "Can render date time types (Part of resolving #36484)"
+        (is (= "April 1, 2014, 8:30 AM"
+               (datetime/format-temporal-str "UTC" "2014-04-01T08:30:00"
+                                             {:effective_type :type/DateTime})))))))
 
 (deftest format-temporal-str-column-viz-settings-test
-  (testing "Written Date Formatting"
-    (let [fmt (fn [col-viz]
-                (datetime/format-temporal-str "UTC" now {:field_ref      [:column_name "created_at"]
-                                                         :effective_type :type/Date}
-                                              {::mb.viz/column-settings
-                                               {{::mb.viz/column-name "created_at"} col-viz}}))]
-      (doseq [[ date-style normal-result abbreviated-result]
-              [["MMMM D, YYYY" "July 16, 2020" "Jul 16, 2020"]
-               ["D MMMM, YYYY" "16 July, 2020" "16 Jul, 2020"]
-               ["dddd, MMMM D, YYYY" "Thursday, July 16, 2020" "Thu, Jul 16, 2020"] ;; Render datetimes with Day of Week option. (#27105)
-               [nil "July 16, 2020" "Jul 16, 2020"]]] ;; Render abbreviated date styles when no other style data is explicitly set. (#27020)
-        (testing (str "Date style: " date-style " correctly formats.")
-          (is (= normal-result
-                 (fmt (when date-style {::mb.viz/date-style date-style})))))
-        (testing (str "Date style: " date-style " with abbreviation correctly formats.")
-          (is (= abbreviated-result
-                 (fmt (merge {::mb.viz/date-abbreviate true}
-                             (when date-style {::mb.viz/date-style date-style})))))))))
-  (testing "Numerical Date Formatting"
-    (let [fmt (fn [col-viz]
-                (datetime/format-temporal-str "UTC" now {:field_ref      [:column_name "created_at"]
-                                                         :effective_type :type/Date}
-                                              {::mb.viz/column-settings
-                                               {{::mb.viz/column-name "created_at"} col-viz}}))]
-      (doseq [[ date-style slash-result dash-result dot-result]
-              [["M/D/YYYY" "7/16/2020" "7-16-2020" "7.16.2020"]
-               ["D/M/YYYY" "16/7/2020" "16-7-2020" "16.7.2020"]
-               ["YYYY/M/D" "2020/7/16" "2020-7-16" "2020.7.16"]
-               [nil "July 16, 2020" "July 16, 2020" "July 16, 2020"]] ;; nil date-style does not blow up when date-separator exists
-              date-separator ["/" "-" "."]]
-        (testing (str "Date style: " date-style " with '" date-separator "' correctly formats.")
-          (is (= (get {"/" slash-result
-                       "-" dash-result
-                       "." dot-result} date-separator)
-                 (fmt (merge {::mb.viz/date-separator date-separator}
-                             (when date-style {::mb.viz/date-style date-style})))))))
-      (testing "Default date separator is '/'"
-        (is (= "7/16/2020"
-               (fmt {::mb.viz/date-style "M/D/YYYY"}))))))
-  (testing "Custom Formatting options are respected as defaults."
-    (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style "MMMM D, YYYY"
-                                                                                  :date_abbreviate true}}]
-      (is (= "Jul 16, 2020"
-             (datetime/format-temporal-str "UTC" now nil nil))))
-    (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style "M/DD/YYYY"
-                                                                                    :date_separator "-"}}]
-      (is (= "7-16-2020"
-             (datetime/format-temporal-str "UTC" now nil nil))))))
+  (mt/with-temporary-setting-values [custom-formatting nil]
+    (testing "Written Date Formatting"
+      (let [fmt (fn [col-viz]
+                  (datetime/format-temporal-str "UTC" now {:field_ref      [:column_name "created_at"]
+                                                           :effective_type :type/Date}
+                                                {::mb.viz/column-settings
+                                                 {{::mb.viz/column-name "created_at"} col-viz}}))]
+        (doseq [[date-style normal-result abbreviated-result]
+                [["MMMM D, YYYY" "July 16, 2020" "Jul 16, 2020"]
+                 ["D MMMM, YYYY" "16 July, 2020" "16 Jul, 2020"]
+                 ["dddd, MMMM D, YYYY" "Thursday, July 16, 2020" "Thu, Jul 16, 2020"] ;; Render datetimes with Day of Week option. (#27105)
+                 [nil "July 16, 2020" "Jul 16, 2020"]]]     ;; Render abbreviated date styles when no other style data is explicitly set. (#27020)
+          (testing (str "Date style: " date-style " correctly formats.")
+            (is (= normal-result
+                   (fmt (when date-style {::mb.viz/date-style date-style})))))
+          (testing (str "Date style: " date-style " with abbreviation correctly formats.")
+            (is (= abbreviated-result
+                   (fmt (merge {::mb.viz/date-abbreviate true}
+                               (when date-style {::mb.viz/date-style date-style})))))))))
+    (testing "Numerical Date Formatting"
+      (let [fmt (fn [col-viz]
+                  (datetime/format-temporal-str "UTC" now {:field_ref      [:column_name "created_at"]
+                                                           :effective_type :type/Date}
+                                                {::mb.viz/column-settings
+                                                 {{::mb.viz/column-name "created_at"} col-viz}}))]
+        (doseq [[date-style slash-result dash-result dot-result]
+                [["M/D/YYYY" "7/16/2020" "7-16-2020" "7.16.2020"]
+                 ["D/M/YYYY" "16/7/2020" "16-7-2020" "16.7.2020"]
+                 ["YYYY/M/D" "2020/7/16" "2020-7-16" "2020.7.16"]
+                 [nil "July 16, 2020" "July 16, 2020" "July 16, 2020"]] ;; nil date-style does not blow up when date-separator exists
+                date-separator ["/" "-" "."]]
+          (testing (str "Date style: " date-style " with '" date-separator "' correctly formats.")
+            (is (= (get {"/" slash-result
+                         "-" dash-result
+                         "." dot-result} date-separator)
+                   (fmt (merge {::mb.viz/date-separator date-separator}
+                               (when date-style {::mb.viz/date-style date-style})))))))
+        (testing "Default date separator is '/'"
+          (is (= "7/16/2020"
+                 (fmt {::mb.viz/date-style "M/D/YYYY"}))))))
+    (testing "Custom Formatting options are respected as defaults."
+      (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style      "MMMM D, YYYY"
+                                                                            :date_abbreviate true}}]
+        (is (= "Jul 16, 2020"
+               (datetime/format-temporal-str "UTC" now nil nil))))
+      (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_style     "M/DD/YYYY"
+                                                                            :date_separator "-"}}]
+        (is (= "7-16-2020"
+               (datetime/format-temporal-str "UTC" now nil nil)))))))
+
+(deftest format-datetime-test
+  (testing "Testing permutations of a datetime string with different type information and viz settings (#36559)"
+    (mt/with-temporary-setting-values [custom-formatting nil]
+      (let [common-viz-settings {::mb.viz/column-settings
+                                 ;; Settings specific to a certain column
+                                 {{::mb.viz/column-name "CUSTOM_DATETIME"}
+                                  {::mb.viz/date-style   "dddd, MMMM D, YYYY"
+                                   ::mb.viz/time-enabled "milliseconds"
+                                   ::mb.viz/time-style   "h:mm a"}}
+                                 ;; Global settings
+                                 ::mb.viz/global-column-settings
+                                 {:type/Temporal {::mb.viz/time-style "HH:mm"}}}
+            col                 {:name "DATETIME" :base_type :type/DateTime}
+            time-str            "2023-12-11T21:51:57.265914Z"]
+        (testing "Global settings are applied to a :type/DateTimeDateTime"
+          (is (= "December 11, 2023, 21:51"
+                 (datetime/format-temporal-str "UTC" time-str col common-viz-settings))))
+        (testing "A :type/DateTimeDateTimeWithLocalTZ is a :type/DateTimeDateTime"
+          (is (= "December 11, 2023, 21:51"
+                 (let [col (assoc col :base_type :type/DateTimeWithLocalTZ)]
+                   (datetime/format-temporal-str "UTC" time-str col common-viz-settings)))))
+        (testing "Custom settings are applied when the column has them"
+          ;; Note that the time style of the column setting has precedence over the global setting
+          (is (= "Monday, December 11, 2023, 9:51:57.265 PM"
+                 (let [col (assoc col :name "CUSTOM_DATETIME")]
+                   (datetime/format-temporal-str "UTC" time-str col common-viz-settings)))))
+        (testing "Various settings can be merged"
+          (testing "We abbreviate the base case..."
+            (is (= "Dec 11, 2023, 21:51"
+                   (let [common-viz-settings (assoc-in common-viz-settings
+                                                       [::mb.viz/global-column-settings
+                                                        :type/Temporal
+                                                        ::mb.viz/date-abbreviate]
+                                                       true)]
+                     (datetime/format-temporal-str "UTC" time-str col common-viz-settings)))))
+          (testing "...and we abbreviate the custome column formatting as well"
+            (is (= "Mon, Dec 11, 2023, 9:51:57.265 PM"
+                   (let [col                 (assoc col :name "CUSTOM_DATETIME")
+                         common-viz-settings (assoc-in common-viz-settings
+                                                       [::mb.viz/global-column-settings
+                                                        :type/Temporal
+                                                        ::mb.viz/date-abbreviate]
+                                                       true)]
+                     (datetime/format-temporal-str "UTC" time-str col common-viz-settings))))))
+        (testing "The appropriate formatting is applied when the column type is date"
+          (is (= "December 11, 2023"
+                 (let [col (assoc col :effective_type :type/Date)]
+                   (datetime/format-temporal-str "UTC" time-str col common-viz-settings)))))
+        (testing "The appropriate formatting is applied when the column type is time"
+          (is (= "21:51"
+                 (let [col (assoc col :effective_type :type/Time)]
+                   (datetime/format-temporal-str "UTC" time-str col common-viz-settings)))))
+        (testing "Formatting works for times with a custom time-enabled"
+          (is (= "21:51:57.265"
+                 (let [col                 (assoc col :effective_type :type/Time)
+                       common-viz-settings (assoc-in common-viz-settings
+                                                     [::mb.viz/global-column-settings
+                                                      :type/Temporal
+                                                      ::mb.viz/time-enabled]
+                                                     "milliseconds")]
+                   (datetime/format-temporal-str "UTC" time-str col common-viz-settings)))))))))
+
+(deftest format-default-unit-test
+  (testing "When the unit is :default we use the column type."
+    (mt/with-temporary-setting-values [custom-formatting nil]
+      (let [col {:unit           :default
+                 :effective_type :type/Time
+                 :base_type      :type/Time}]
+        (is (= "3:30 PM"
+               (datetime/format-temporal-str "UTC" "15:30:45Z" col nil))))))
+  (testing "Corner case: Return the time string when there is no useful information about it _and_ it's not formattable."
+    ;; This addresses a rare case (might never happen IRL) in which we try to apply the default formatting of
+    ;; "MMMM d, yyyy" to a time, but we don't know it's a time so we error our.
+    (mt/with-temporary-setting-values [custom-formatting nil]
+      (let [col {:unit           :default}]
+        (is (= "15:30:45Z"
+               (datetime/format-temporal-str "UTC" "15:30:45Z" col nil)))))))

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -11,7 +11,8 @@
    [metabase.email :as email]
    [metabase.models :refer [Card Dashboard DashboardCard Pulse PulseCard PulseChannel PulseChannelRecipient]]
    [metabase.pulse]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (defmacro with-metadata-data-cards
   "Provide a fixture that includes:
@@ -258,3 +259,134 @@
                                                 :user_id          (mt/user->id :rasta)}]
           (let [parsed-data (run-pulse-and-return-attached-csv-data pulse)]
             (is (all-pct-2d? (get-in parsed-data ["Query based on model.csv" "Tax Rate"])))))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;; Consistent Date Formatting ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- sql-time-query
+  "Generate a SQL query that produces N identical rows of data, each row containing a variety of different presentations
+  of the input date string. The intent is to provide a wide variety for testing of different data formats."
+  [date-str n]
+  (format
+    "WITH T AS (SELECT CAST('%s' AS TIMESTAMP) AS example_timestamp),
+          SAMPLE AS (SELECT T.example_timestamp                                   AS full_datetime_utc,
+                            T.example_timestamp AT TIME ZONE 'US/Pacific'         AS full_datetime_pacific,
+                            CAST(T.example_timestamp AS TIMESTAMP)                AS example_timestamp,
+                            CAST(T.example_timestamp AS TIMESTAMP WITH TIME ZONE) AS example_timestamp_with_time_zone,
+                            CAST(T.example_timestamp AS DATE)                     AS example_date,
+                            CAST(T.example_timestamp AS TIME)                     AS example_time,
+                            EXTRACT(YEAR FROM T.example_timestamp)                AS example_year,
+                            EXTRACT(MONTH FROM T.example_timestamp)               AS example_month,
+                            EXTRACT(DAY FROM T.example_timestamp)                 AS example_day,
+                            EXTRACT(HOUR FROM T.example_timestamp)                AS example_hour,
+                            EXTRACT(MINUTE FROM T.example_timestamp)              AS example_minute,
+                            EXTRACT(SECOND FROM T.example_timestamp)              AS example_second
+                     FROM T)
+     SELECT *
+     FROM SAMPLE
+              CROSS JOIN
+          generate_series(1, %s);"
+    date-str n))
+
+(defn- model-query [base-card-id]
+  {:fields       [[:field "FULL_DATETIME_UTC" {:base-type :type/DateTimeWithLocalTZ}]
+                  [:field "FULL_DATETIME_PACIFIC" {:base-type :type/DateTimeWithLocalTZ}]
+                  [:field "EXAMPLE_TIMESTAMP" {:base-type :type/DateTime}]
+                  [:field "EXAMPLE_TIMESTAMP_WITH_TIME_ZONE" {:base-type :type/DateTimeWithLocalTZ}]
+                  [:field "EXAMPLE_DATE" {:base-type :type/Date}]
+                  [:field "EXAMPLE_TIME" {:base-type :type/Time}]
+                  [:field "EXAMPLE_YEAR" {:base-type :type/Integer}]
+                  [:field "EXAMPLE_MONTH" {:base-type :type/Integer}]
+                  [:field "EXAMPLE_DAY" {:base-type :type/Integer}]
+                  [:field "EXAMPLE_HOUR" {:base-type :type/Integer}]
+                  [:field "EXAMPLE_MINUTE" {:base-type :type/Integer}]
+                  [:field "EXAMPLE_SECOND" {:base-type :type/Integer}]]
+   :source-table (format "card__%s" base-card-id)})
+
+(deftest consistent-date-formatting-test
+  (mt/with-temporary-setting-values [custom-formatting nil]
+    (let [q (sql-time-query "2023-12-11 15:30:45.123" 20)]
+      (t2.with-temp/with-temp [Card {native-card-id :id} {:name          "NATIVE"
+                                                          :dataset_query {:database (mt/id)
+                                                                          :type     :native
+                                                                          :native   {:query q}}}
+                               Card {model-card-id :id} {:name          "MODEL"
+                                                         :dataset       true
+                                                         :dataset_query {:database (mt/id)
+                                                                         :type     :query
+                                                                         :query    (model-query native-card-id)}}
+                               Card {meta-model-card-id :id} {:name                   "METAMODEL"
+                                                              :dataset                true
+                                                              :dataset_query          {:database (mt/id)
+                                                                                       :type     :query
+                                                                                       :query    {:source-table
+                                                                                                  (format "card__%s" model-card-id)}}
+                                                              :visualization_settings {:table.pivot_column "FULL_DATETIME_UTC",
+                                                                                       :table.cell_column  "EXAMPLE_YEAR",
+                                                                                       :column_settings    {"[\"name\",\"FULL_DATETIME_UTC\"]"
+                                                                                                            {:date_abbreviate true
+                                                                                                             :time_enabled    "milliseconds"
+                                                                                                             :time_style      "HH:mm"}}}}
+                               Dashboard {dash-id :id} {:name "The Dashboard"}
+                               DashboardCard {base-dash-card-id :id} {:dashboard_id dash-id
+                                                                      :card_id      native-card-id}
+                               DashboardCard {model-dash-card-id :id} {:dashboard_id dash-id
+                                                                       :card_id      model-card-id}
+                               DashboardCard {metamodel-dash-card-id :id} {:dashboard_id dash-id
+                                                                           :card_id      meta-model-card-id}
+                               Pulse {pulse-id :id
+                                      :as      pulse} {:name "Consistent Time Formatting Pulse"}
+                               PulseCard _ {:pulse_id          pulse-id
+                                            :card_id           native-card-id
+                                            :dashboard_card_id base-dash-card-id}
+                               PulseCard _ {:pulse_id          pulse-id
+                                            :card_id           model-card-id
+                                            :dashboard_card_id model-dash-card-id}
+                               PulseCard _ {:pulse_id          pulse-id
+                                            :card_id           meta-model-card-id
+                                            :dashboard_card_id metamodel-dash-card-id}
+                               PulseChannel {pulse-channel-id :id} {:channel_type :email
+                                                                    :pulse_id     pulse-id
+                                                                    :enabled      true}
+                               PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
+                                                        :user_id          (mt/user->id :rasta)}]
+        (let [attached-data     (run-pulse-and-return-attached-csv-data pulse)
+              get-res           #(-> attached-data (get %)
+                                     (update-vals first)
+                                     (dissoc "X"))
+              native-results    (get-res "NATIVE.csv")
+              model-results     (get-res "MODEL.csv")
+              metamodel-results (get-res "METAMODEL.csv")]
+          ;; Note that these values are obtained by inspection since the UI formats are in the FE code.
+          (testing "The default export formats conform to the default UI formats"
+            (is (= {"FULL_DATETIME_UTC"                "December 11, 2023, 3:30 PM"
+                    "FULL_DATETIME_PACIFIC"            "December 11, 2023, 3:30 PM"
+                    "EXAMPLE_TIMESTAMP"                "December 11, 2023, 3:30 PM"
+                    "EXAMPLE_TIMESTAMP_WITH_TIME_ZONE" "December 11, 2023, 3:30 PM"
+                    "EXAMPLE_DATE"                     "December 11, 2023"
+                    "EXAMPLE_TIME"                     "3:30 PM"
+                    ;; NOTE -- We don't have a type in our type system for year so this is just an integer.
+                    ;; It might be worth looking into fixing this so that it displays without a comma
+                    "EXAMPLE_YEAR"                     "2,023"
+                    "EXAMPLE_MONTH"                    "12"
+                    "EXAMPLE_DAY"                      "11"
+                    "EXAMPLE_HOUR"                     "15"
+                    "EXAMPLE_MINUTE"                   "30"
+                    "EXAMPLE_SECOND"                   "45"}
+                   native-results)))
+          (testing "An exported model retains the base format, but does use display names for column names."
+            (is (= {"Full Datetime Utc"                "December 11, 2023, 3:30 PM"
+                    "Full Datetime Pacific"            "December 11, 2023, 3:30 PM"
+                    "Example Timestamp"                "December 11, 2023, 3:30 PM"
+                    "Example Timestamp With Time Zone" "December 11, 2023, 3:30 PM"
+                    "Example Date"                     "December 11, 2023"
+                    "Example Time"                     "3:30 PM"
+                    "Example Year"                     "2,023"
+                    "Example Month"                    "12"
+                    "Example Day"                      "11"
+                    "Example Hour"                     "15"
+                    "Example Minute"                   "30"
+                    "Example Second"                   "45"}
+                   model-results)))
+          (testing "Updating column visualization settings updates the output format."
+            (is (=? {"Full Datetime Utc" "Dec 11, 2023, 15:30:45.123"}
+                    metamodel-results))))))))

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -264,7 +264,9 @@
 
 (defn- sql-time-query
   "Generate a SQL query that produces N identical rows of data, each row containing a variety of different presentations
-  of the input date string. The intent is to provide a wide variety for testing of different data formats."
+  of the input date string. The intent is to provide a wide variety for testing of different row data formats. The
+  reason for the duplication of rows is that some logic (e.g. pulses) may not trigger if N is under a certain threshold
+  (e.g. no attachments if less than 10 rows for an email)."
   [date-str n]
   (format
     "WITH T AS (SELECT CAST('%s' AS TIMESTAMP) AS example_timestamp),

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -159,16 +159,16 @@
 
 ;; Basic test that result rows are formatted correctly (dates, floating point numbers etc)
 (deftest format-result-rows
-  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "2014-04-01T08:30:00" "Stout Burgers & Beers"]}
-          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "2014-12-05T15:15:00" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "2014-08-01T12:45:00" "The Gorbals"]}]
+  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
+          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014, 3:15 PM" "The Apple Pan"]}
+          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014, 12:45 PM" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows test-data})))))
 
 ;; Testing the bar-column, which is the % of this row relative to the max of that column
 (deftest bar-column
-  (is (= [{:bar-width (float 85.249), :row [(number "1" 1) (number "34.1" 34.0996) "2014-04-01T08:30:00" "Stout Burgers & Beers"]}
-          {:bar-width (float 85.1015), :row [(number "2" 2) (number "34.04" 34.0406) "2014-12-05T15:15:00" "The Apple Pan"]}
-          {:bar-width (float 85.1185), :row [(number "3" 3) (number "34.05" 34.0474) "2014-08-01T12:45:00" "The Gorbals"]}]
+  (is (= [{:bar-width (float 85.249), :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
+          {:bar-width (float 85.1015), :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014, 3:15 PM" "The Apple Pan"]}
+          {:bar-width (float 85.1185), :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014, 12:45 PM" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows test-data}
                  {:bar-column second, :min-value 0, :max-value 40})))))
 
@@ -209,9 +209,9 @@
 
 ;; Result rows should include only the remapped column value, not the original
 (deftest include-only-remapped-column-name
-  (is (= [[(number "1" 1) (number "34.1" 34.0996) "Bad" "2014-04-01T08:30:00" "Stout Burgers & Beers"]
-          [(number "2" 2) (number "34.04" 34.0406) "Ok" "2014-12-05T15:15:00" "The Apple Pan"]
-          [(number "3" 3) (number "34.05" 34.0474) "Good" "2014-08-01T12:45:00" "The Gorbals"]]
+  (is (= [[(number "1" 1) (number "34.1" 34.0996) "Bad" "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]
+          [(number "2" 2) (number "34.04" 34.0406) "Ok" "December 5, 2014, 3:15 PM" "The Apple Pan"]
+          [(number "3" 3) (number "34.05" 34.0474) "Good" "August 1, 2014, 12:45 PM" "The Gorbals"]]
          (map :row (rest (#'body/prep-for-html-rendering pacific-tz
                            {}
                            {:cols test-columns-with-remapping :rows test-data-with-remapping}))))))
@@ -233,9 +233,9 @@
                                 :coercion_strategy :Coercion/ISO8601->DateTime}))
 
 (deftest cols-with-semantic-types
-  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "2014-04-01T08:30:00" "Stout Burgers & Beers"]}
-          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "2014-12-05T15:15:00" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "2014-08-01T12:45:00" "The Gorbals"]}]
+  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
+          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014, 3:15 PM" "The Apple Pan"]}
+          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014, 12:45 PM" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz
                  {}
                  {:cols test-columns-with-date-semantic-type :rows test-data})))))
@@ -276,7 +276,7 @@
                                          :semantic_type nil}]
                                  :rows [["foo"]]}))))
   (testing "renders date"
-    (is (= "2014-04-01T08:30:00"
+    (is (= "April 1, 2014, 8:30 AM"
            (render-scalar-value {:cols [{:name         "date",
                                          :display_name "DATE",
                                          :base_type    :type/DateTime

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -22,15 +22,14 @@
    (rest (csv/read-csv response))))
 
 (deftest date-columns-should-be-emitted-without-time
-  (mt/with-temporary-setting-values [custom-formatting nil]
-    (is (= [["1" "April 7, 2014" "5" "12"]
-            ["2" "September 18, 2014" "1" "31"]
-            ["3" "September 15, 2014" "8" "56"]
-            ["4" "March 11, 2014" "5" "4"]
-            ["5" "May 5, 2013" "3" "49"]]
-           (let [result (mt/user-http-request :rasta :post 200 "dataset/csv" :query
-                                              (json/generate-string (mt/mbql-query checkins)))]
-             (take 5 (parse-and-sort-csv result)))))))
+  (is (= [["1" "April 7, 2014" "5" "12"]
+          ["2" "September 18, 2014" "1" "31"]
+          ["3" "September 15, 2014" "8" "56"]
+          ["4" "March 11, 2014" "5" "4"]
+          ["5" "May 5, 2013" "3" "49"]]
+         (let [result (mt/user-http-request :rasta :post 200 "dataset/csv" :query
+                                            (json/generate-string (mt/mbql-query checkins)))]
+           (take 5 (parse-and-sort-csv result))))))
 
 (deftest check-an-empty-date-column
   (testing "NULL values should be written correctly"

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -22,14 +22,15 @@
    (rest (csv/read-csv response))))
 
 (deftest date-columns-should-be-emitted-without-time
-  (is (= [["1" "April 7, 2014" "5" "12"]
-          ["2" "September 18, 2014" "1" "31"]
-          ["3" "September 15, 2014" "8" "56"]
-          ["4" "March 11, 2014" "5" "4"]
-          ["5" "May 5, 2013" "3" "49"]]
-         (let [result (mt/user-http-request :rasta :post 200 "dataset/csv" :query
-                                            (json/generate-string (mt/mbql-query checkins)))]
-           (take 5 (parse-and-sort-csv result))))))
+  (mt/with-temporary-setting-values [custom-formatting nil]
+    (is (= [["1" "April 7, 2014" "5" "12"]
+            ["2" "September 18, 2014" "1" "31"]
+            ["3" "September 15, 2014" "8" "56"]
+            ["4" "March 11, 2014" "5" "4"]
+            ["5" "May 5, 2013" "3" "49"]]
+           (let [result (mt/user-http-request :rasta :post 200 "dataset/csv" :query
+                                              (json/generate-string (mt/mbql-query checkins)))]
+             (take 5 (parse-and-sort-csv result)))))))
 
 (deftest check-an-empty-date-column
   (testing "NULL values should be written correctly"
@@ -57,11 +58,11 @@
 (deftest datetime-fields-are-untouched-when-exported
   (let [result (mt/user-http-request :rasta :post 200 "dataset/csv" :query
                                      (json/generate-string (mt/mbql-query users {:order-by [[:asc $id]], :limit 5})))]
-    (is (= [["1" "Plato Yeshua"        "2014-04-01T08:30:00"]
-            ["2" "Felipinho Asklepios" "2014-12-05T15:15:00"]
-            ["3" "Kaneonuskatew Eiran" "2014-11-06T16:15:00"]
-            ["4" "Simcha Yan"          "2014-01-01T08:30:00"]
-            ["5" "Quentin Sören"       "2014-10-03T17:30:00"]]
+    (is (= [["1" "Plato Yeshua" "April 1, 2014, 8:30 AM"]
+            ["2" "Felipinho Asklepios" "December 5, 2014, 3:15 PM"]
+            ["3" "Kaneonuskatew Eiran" "November 6, 2014, 4:15 PM"]
+            ["4" "Simcha Yan" "January 1, 2014, 8:30 AM"]
+            ["5" "Quentin Sören" "October 3, 2014, 5:30 PM"]]
            (parse-and-sort-csv result)))))
 
 (defn- csv-export

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -167,14 +167,16 @@
               (test-results
                (case export-format
                  :csv
+                 ;; With the updates to make CSV exports conform with FE behavior (See #36726) dates and times are now
+                 ;; presented as they are in the FE. This is the eventual design for all exports.
                  {:date           "November 1, 2019"
-                  :datetime       "2019-11-01T00:23:18.331"
-                  :datetime-ltz   "2019-11-01T07:23:18.331"
-                  :datetime-tz    "2019-11-01T07:23:18.331"
-                  :datetime-tz-id "2019-11-01T07:23:18.331"
-                  :time           "00:23:18.331"
-                  :time-ltz       "07:23:18.331"
-                  :time-tz        "07:23:18.331"}
+                  :datetime       "November 1, 2019, 12:23 AM"
+                  :datetime-ltz   "November 1, 2019, 7:23 AM"
+                  :datetime-tz    "November 1, 2019, 7:23 AM"
+                  :datetime-tz-id "November 1, 2019, 7:23 AM"
+                  :time           "12:23 AM"
+                  :time-ltz       "7:23 AM"
+                  :time-tz        "7:23 AM"}
 
                  :json
                  {:date           "2019-11-01"
@@ -211,14 +213,16 @@
               (test-results
                (case export-format
                  :csv
+                 ;; With the updates to make CSV exports conform with FE behavior (See #36726) dates and times are now
+                 ;; presented as they are in the FE. This is the eventual design for all exports.
                  {:date           "November 1, 2019"
-                  :datetime       "2019-11-01T00:23:18.331"
-                  :datetime-ltz   "2019-11-01T00:23:18.331"
-                  :datetime-tz    "2019-11-01T00:23:18.331"
-                  :datetime-tz-id "2019-11-01T00:23:18.331"
-                  :time            "00:23:18.331"
-                  :time-ltz        "23:23:18.331"
-                  :time-tz         "23:23:18.331"}
+                  :datetime       "November 1, 2019, 12:23 AM"
+                  :datetime-ltz   "November 1, 2019, 12:23 AM"
+                  :datetime-tz    "November 1, 2019, 12:23 AM"
+                  :datetime-tz-id "November 1, 2019, 12:23 AM"
+                  :time           "12:23 AM"
+                  :time-ltz       "11:23 PM"
+                  :time-tz        "11:23 PM"}
 
                  :json
                  {:date           "2019-11-01"


### PR DESCRIPTION
This PR makes changes to `metabase.formatter.datetime` so that the output of these functions is as close to what is presented in the Metabase UI as possible. Note that since the codes are currently not on the same rendering path, this may not be 100% possible, but it looks to be correct ATM.

Changes include:
- Refactoring `metabase.formatter.datetime/format-temporal-str` into two clear stages:
  - Merge the viz settings
  - Format the string
- Rather than being a case statement nested in an if, formtting is now a multimethod based on the unit type of the column or the column type, in that order. This seems a lot cleaner and allows for specialization on our type system as desired.
- Dispatches for `:type/Time`, `:type/Date`, and `:type/DateTime` now handle the different formatting options available on the FE for each type.
- Tests are added to the `metabase.formatter.datetime` and `metabase.pulse.pulse-integration-test` nses.

A few important discoveries made in the course of this PR are:

- We have to exercise care in the use of a/A in time formatting strings because of our FE library (Moment.js) uses `a` to mean `am/pm` and `A` to mean `AM/PM`. Meanwhile, Java [DateTimeFormatter](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html) uses `a` for AM/PM and `A` for millseconds of day. So, if `A` in a pattern like `HH:mm A` makes it to a formatter on the BE it is almost certainly a logic error.
- At some point we should collaborate with the metabase lib team to see if we can unify all of this logic. Whatever path we choose must take into account the time zone, column metadata, and viz settings when producing a consistent formatter.
- To get around this, the `metabase.formatter.datetime` ns had a pattern like `(str/replace (or time-style default-time-style) #"A" "a")` to replace `A` with `a`. This was an undocumented feature that might leave you wondering, but is now part of a documented function. Note that this replacement means you really can't use millis of day in most of our code paths, but IDK that you'd ever want this formatting as we generally use it anyways.
- `metabase.shared.util.internal.time/format-unit` has similar, but not identical, logic to the unit-based rendering in `metabase.formatter.datetime` that we might want to consolidate.