### PR TITLE
Remove flake tag and follow lint rule in recents e2e test

### DIFF
--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -45,9 +45,8 @@ describe("search > recently viewed", () => {
     assertRecentlyViewedItem(2, "People", "Table");
   });
 
-  it("allows to select an item from keyboard", { tags: "@flaky" }, () => {
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Recently viewed");
+  it("allows to select an item from keyboard", () => {
+    cy.findByTestId("recents-list-container").findByText("Recently viewed");
     cy.get("body").trigger("keydown", { key: "ArrowDown" });
     cy.get("body").trigger("keydown", { key: "ArrowDown" });
     cy.get("body").trigger("keydown", { key: "Enter" });


### PR DESCRIPTION
Follow up for #35848 
Closes https://github.com/metabase/metabase/issues/36675

### Description

Flake has been fixed. 7day flake rate is 0%

![Screen Shot 2023-12-12 at 4 53 10 PM](https://github.com/metabase/metabase/assets/30528226/ebd49f9a-5542-4a52-96ea-31b04910b305)
