### PR TITLE
render waterfall series

### DIFF
--- a/frontend/src/metabase/lib/types.ts
+++ b/frontend/src/metabase/lib/types.ts
@@ -19,3 +19,10 @@ export const checkNotNull = <T>(value: T | null | undefined): T => {
     throw new TypeError();
   }
 };
+
+export const checkNumber = (value: any) => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new TypeError(`value ${value} is not a non-NaN number`);
+  }
+  return value;
+};

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.tsx
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.tsx
@@ -1,9 +1,9 @@
 import { init } from "echarts";
 
 import { getCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model";
-import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesian/option";
 import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 import type { IsomorphicStaticChartProps } from "metabase/static-viz/containers/IsomorphicStaticChart/types";
+import { getWaterfallOption } from "metabase/visualizations/echarts/cartesian/waterfall/option";
 
 import { computeStaticComboChartSettings } from "../ComboChart/settings";
 
@@ -27,7 +27,7 @@ export function WaterfallChart({
     computedVisualizationSettings,
     renderingContext,
   );
-  const option = getCartesianChartOption(
+  const option = getWaterfallOption(
     chartModel,
     null,
     [],

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -22,6 +22,7 @@ import {
   getYAxesModels,
 } from "metabase/visualizations/echarts/cartesian/model/axis";
 import { getScatterPlotDataset } from "metabase/visualizations/echarts/cartesian/scatter/model";
+import { getWaterfallDataset } from "metabase/visualizations/echarts/cartesian/waterfall/model";
 
 const SUPPORTED_AUTO_SPLIT_TYPES = ["line", "area", "bar", "combo"];
 
@@ -90,10 +91,17 @@ export const getCartesianChartModel = (
     ? unsortedSeriesModels
     : getSortedSeriesModels(unsortedSeriesModels, settings);
 
-  const dataset =
-    rawSeries[0].card.display === "scatter"
-      ? getScatterPlotDataset(rawSeries, cardsColumns)
-      : getJoinedCardsDataset(rawSeries, cardsColumns);
+  let dataset;
+  switch (rawSeries[0].card.display) {
+    case "scatter":
+      dataset = getScatterPlotDataset(rawSeries, cardsColumns);
+      break;
+    case "waterfall":
+      dataset = getWaterfallDataset(rawSeries[0].data.rows, cardsColumns[0]);
+      break;
+    default:
+      dataset = getJoinedCardsDataset(rawSeries, cardsColumns);
+  }
 
   const transformedDataset = getTransformedDataset(
     dataset,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -226,11 +226,7 @@ export const buildEChartsSeries = (
             renderingContext,
           );
         case "waterfall":
-          return buildEChartsWaterfallSeries(
-            seriesModel,
-            chartModel.dimensionModel.dataKey,
-            yAxisIndex,
-          );
+          return buildEChartsWaterfallSeries();
       }
     })
     .filter(isNotNull);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -229,5 +229,6 @@ export const buildEChartsSeries = (
           return buildEChartsWaterfallSeries();
       }
     })
+    .flat()
     .filter(isNotNull);
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/constants.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/constants.ts
@@ -1,0 +1,7 @@
+export const DATASET_DIMENSIONS = {
+  dimension: "dimension",
+  barOffset: "barOffset",
+  increase: "increase",
+  decrease: "decrease",
+  total: "total",
+} as const;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model.ts
@@ -6,6 +6,7 @@ import {
 } from "metabase/visualizations/lib/graph/columns";
 
 import type { WaterfallDatum } from "./types";
+import { DATASET_DIMENSIONS } from "./constants";
 
 function createDatum({
   dimension,
@@ -21,11 +22,11 @@ function createDatum({
   total?: number;
 }): WaterfallDatum {
   return {
-    dimension,
-    barOffset: barOffset ?? 0,
-    increase: increase ?? null,
-    decrease: decrease ?? null,
-    total: total ?? null,
+    [DATASET_DIMENSIONS.dimension]: dimension,
+    [DATASET_DIMENSIONS.barOffset]: barOffset ?? 0,
+    [DATASET_DIMENSIONS.increase]: increase ?? null,
+    [DATASET_DIMENSIONS.decrease]: decrease ?? null,
+    [DATASET_DIMENSIONS.total]: total ?? null,
   };
 }
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model.ts
@@ -1,0 +1,87 @@
+import type { RowValues } from "metabase-types/api";
+import { checkNumber } from "metabase/lib/types";
+import {
+  assertMultiMetricColumns,
+  type CartesianChartColumns,
+} from "metabase/visualizations/lib/graph/columns";
+
+import type { WaterfallDatum } from "./types";
+
+function createDatum({
+  dimension,
+  barOffset,
+  increase,
+  decrease,
+  total,
+}: {
+  dimension: string;
+  barOffset?: number | null;
+  increase?: number | null;
+  decrease?: number | null;
+  total?: number;
+}): WaterfallDatum {
+  return {
+    dimension,
+    barOffset: barOffset ?? 0,
+    increase: increase ?? null,
+    decrease: decrease ?? null,
+    total: total ?? null,
+  };
+}
+
+export function getWaterfallDataset(
+  rows: RowValues[],
+  cardColumns: CartesianChartColumns,
+): WaterfallDatum[] {
+  const columns = assertMultiMetricColumns(cardColumns);
+  const dataset: WaterfallDatum[] = [];
+
+  rows.forEach((row, index) => {
+    const dimension = String(row[columns.dimension.index]);
+    const value = checkNumber(row[columns.metrics[0].index]);
+
+    let increase: number | null = null;
+    let decrease: number | null = null;
+    if (value >= 0) {
+      increase = value;
+    } else {
+      decrease = value;
+    }
+
+    if (index === 0) {
+      dataset.push(createDatum({ dimension, increase, decrease }));
+      return;
+    }
+
+    const {
+      barOffset: prevBarOffset,
+      increase: prevIncrease,
+      decrease: prevDecrease,
+    } = dataset[dataset.length - 1];
+
+    let barOffset: number | null = null;
+    // case 1: increase following increase
+    if (increase !== null && prevIncrease !== null) {
+      barOffset = prevBarOffset + prevIncrease;
+    }
+    // case 2: decrease following increase
+    else if (decrease !== null && prevIncrease !== null) {
+      barOffset = prevBarOffset + prevIncrease - decrease;
+    }
+    // case 3: decrease following decrease
+    else if (decrease !== null && prevDecrease !== null) {
+      barOffset = prevBarOffset - decrease;
+    }
+    // case 4: increase following decrease
+    else if (increase !== null && prevDecrease !== null) {
+      barOffset = prevBarOffset;
+    }
+
+    dataset.push(createDatum({ dimension, barOffset, increase, decrease }));
+  });
+
+  // TODO handle negatives
+  // TODO total
+
+  return dataset;
+}

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option.ts
@@ -1,0 +1,32 @@
+import type { EChartsOption } from "echarts";
+import type { DatasetOption } from "echarts/types/dist/shared";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+
+import type { CartesianChartModel } from "../model/types";
+import { getCartesianChartOption } from "../option";
+import { DATASET_DIMENSIONS } from "./constants";
+
+export function getWaterfallOption(
+  chartModel: CartesianChartModel,
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+): EChartsOption {
+  const option = getCartesianChartOption(
+    chartModel,
+    settings,
+    renderingContext,
+  );
+
+  // TODO remove typecast
+  (option.dataset as DatasetOption[])[0].dimensions =
+    Object.values(DATASET_DIMENSIONS);
+  // TODO full yAxis options
+  option.yAxis = {
+    type: "value",
+  };
+
+  return option;
+}

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option.ts
@@ -4,19 +4,27 @@ import type {
   ComputedVisualizationSettings,
   RenderingContext,
 } from "metabase/visualizations/types";
+import type { TimelineEventId } from "metabase-types/api";
 
 import type { CartesianChartModel } from "../model/types";
 import { getCartesianChartOption } from "../option";
+import type { TimelineEventsModel } from "../timeline-events/types";
 import { DATASET_DIMENSIONS } from "./constants";
 
 export function getWaterfallOption(
   chartModel: CartesianChartModel,
+  timelineEventsModel: TimelineEventsModel | null,
+  selectedTimelineEventsIds: TimelineEventId[],
   settings: ComputedVisualizationSettings,
+  isAnimated: boolean,
   renderingContext: RenderingContext,
 ): EChartsOption {
   const option = getCartesianChartOption(
     chartModel,
+    timelineEventsModel,
+    selectedTimelineEventsIds,
     settings,
+    isAnimated,
     renderingContext,
   );
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/series.ts
@@ -1,11 +1,51 @@
 import type { RegisteredSeriesOption } from "echarts/types/dist/shared";
 
-export function buildEChartsWaterfallSeries(): RegisteredSeriesOption["bar"] {
-  return {
-    type: "bar",
-    encode: {
-      y: "increase",
-      x: "dimension",
+import { DATASET_DIMENSIONS } from "./constants";
+
+export function buildEChartsWaterfallSeries(): RegisteredSeriesOption["bar"][] {
+  return [
+    {
+      type: "bar",
+      stack: "waterfall_stack",
+      silent: true,
+      itemStyle: {
+        borderColor: "transparent",
+        color: "transparent",
+      },
+      emphasis: {
+        itemStyle: {
+          borderColor: "transparent",
+          color: "transparent",
+        },
+      },
+      encode: {
+        x: DATASET_DIMENSIONS.dimension,
+        y: "barOffset",
+      },
     },
-  };
+    {
+      type: "bar",
+      stack: "waterfall_stack",
+      encode: {
+        x: DATASET_DIMENSIONS.dimension,
+        y: DATASET_DIMENSIONS.increase,
+      },
+    },
+    {
+      type: "bar",
+      stack: "waterfall_stack",
+      encode: {
+        x: DATASET_DIMENSIONS.dimension,
+        y: DATASET_DIMENSIONS.decrease,
+      },
+    },
+    {
+      type: "bar",
+      stack: "waterfall_stack",
+      encode: {
+        x: DATASET_DIMENSIONS.dimension,
+        y: DATASET_DIMENSIONS.total,
+      },
+    },
+  ];
 }

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/series.ts
@@ -1,18 +1,11 @@
 import type { RegisteredSeriesOption } from "echarts/types/dist/shared";
 
-import type { DataKey, SeriesModel } from "../model/types";
-
-export function buildEChartsWaterfallSeries(
-  seriesModel: SeriesModel,
-  dimensionDataKey: DataKey,
-  yAxisIndex: number,
-): RegisteredSeriesOption["bar"] {
+export function buildEChartsWaterfallSeries(): RegisteredSeriesOption["bar"] {
   return {
     type: "bar",
-    yAxisIndex,
     encode: {
-      y: seriesModel.dataKey,
-      x: dimensionDataKey,
+      y: "increase",
+      x: "dimension",
     },
   };
 }

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/types.ts
@@ -1,0 +1,7 @@
+export type WaterfallDatum = {
+  dimension: string;
+  barOffset: number;
+  increase: number | null;
+  decrease: number | null;
+  total: number | null;
+};

--- a/frontend/src/metabase/visualizations/lib/graph/columns.ts
+++ b/frontend/src/metabase/visualizations/lib/graph/columns.ts
@@ -68,6 +68,16 @@ export type CartesianChartColumns =
   | MultipleMetricsChartColumns
   | ScatterPlotColumns;
 
+export function assertMultiMetricColumns(
+  chartColumns: CartesianChartColumns,
+): MultipleMetricsChartColumns {
+  if (Object.keys(chartColumns).includes("breakout")) {
+    throw Error("Given `chartColumns` has breakout");
+  }
+
+  return chartColumns as MultipleMetricsChartColumns;
+}
+
 export const getCartesianChartColumns = (
   columns: RemappingHydratedDatasetColumn[],
   settings: Pick<


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35810

### Description

Renders the base waterfall series. This does not include additional settings, such as the total bar, increase/decrease colors, etc. Those will be implemented in later PRs. Y-axis options will also be added later, so in this PR the y-axis styles will look different.

### How to verify

1. Create a waterfall chart
2. Add to a dashboard
3. Send a subscription
4. Confirm it looks correct

### Demo

![Screenshot 2023-12-17 at 1.34.23 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/9008ed15-e5c0-4dcb-a885-8e6602a41c2a.png)


### Checklist

- [n/a] Tests have been added/updated to cover changes in this PR

The story added in the previous PR suffices to test the changes in this one.