### PR TITLE
Add tooltip and stacked tooltips support to the dynamic combo chart

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -99,6 +99,7 @@ export const getCardSeriesModels = (
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): SeriesModel[] => {
+  const cardId = card.id ?? null;
   const hasBreakout = "breakout" in columns;
 
   // Charts without breakout have one series per selected metric column.
@@ -130,10 +131,10 @@ export const getCardSeriesModels = (
       return {
         name,
         color,
-        cardId: card.id,
+        cardId,
         column: metric.column,
         columnIndex: metric.index,
-        dataKey: getDatasetKey(metric.column, card.id),
+        dataKey: getDatasetKey(metric.column, cardId),
         vizSettingsKey,
         legacySeriesSettingsObjectKey,
       };
@@ -177,12 +178,12 @@ export const getCardSeriesModels = (
     return {
       name,
       color,
-      cardId: card.id,
+      cardId,
       column: metric.column,
       columnIndex: metric.index,
       vizSettingsKey,
       legacySeriesSettingsObjectKey,
-      dataKey: getDatasetKey(metric.column, card.id, breakoutValue),
+      dataKey: getDatasetKey(metric.column, cardId, breakoutValue),
       breakoutColumnIndex: breakout.index,
       breakoutColumn: breakout.column,
       breakoutValue,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -32,6 +32,7 @@ const buildEChartsLabelOptions = (
   const valueGetter = getMetricDisplayValueGetter(settings);
 
   return {
+    silent: true,
     show: settings["graph.show_values"],
     position: "top",
     fontFamily,
@@ -60,6 +61,7 @@ const buildEChartsBarSeries = (
   dimensionDataKey: string,
   yAxisIndex: number,
   barSeriesCount: number,
+  hasMultipleSeries: boolean,
   renderingContext: RenderingContext,
 ): RegisteredSeriesOption["bar"] => {
   const stackName =
@@ -70,6 +72,20 @@ const buildEChartsBarSeries = (
 
   return {
     id: seriesModel.dataKey,
+    emphasis: {
+      focus: hasMultipleSeries ? "series" : "self",
+      itemStyle: {
+        color: seriesModel.color,
+      },
+    },
+    blur: {
+      label: {
+        show: settings["graph.show_values"] && !hasMultipleSeries,
+      },
+      itemStyle: {
+        opacity: 0.3,
+      },
+    },
     type: "bar",
     yAxisIndex,
     barGap: 0,
@@ -95,6 +111,7 @@ const buildEChartsLineAreaSeries = (
   settings: ComputedVisualizationSettings,
   dimensionDataKey: string,
   yAxisIndex: number,
+  hasMultipleSeries: boolean,
   renderingContext: RenderingContext,
 ): RegisteredSeriesOption["line"] => {
   const display = seriesSettings?.display ?? "line";
@@ -103,6 +120,20 @@ const buildEChartsLineAreaSeries = (
     settings["stackable.stack_type"] != null ? `area_${yAxisIndex}` : undefined;
 
   return {
+    emphasis: {
+      focus: hasMultipleSeries ? "series" : "self",
+      itemStyle: {
+        color: seriesModel.color,
+      },
+    },
+    blur: {
+      label: {
+        show: settings["graph.show_values"] && !hasMultipleSeries,
+      },
+      itemStyle: {
+        opacity: 0.3,
+      },
+    },
     id: seriesModel.dataKey,
     type: "line",
     yAxisIndex,
@@ -151,6 +182,8 @@ export const buildEChartsSeries = (
     seriesSettings => seriesSettings.display === "bar",
   ).length;
 
+  const hasMultipleSeries = chartModel.seriesModels.length > 1;
+
   return chartModel.seriesModels
     .map(seriesModel => {
       const seriesSettings = seriesSettingsByDataKey[seriesModel.dataKey];
@@ -165,6 +198,7 @@ export const buildEChartsSeries = (
             settings,
             chartModel.dimensionModel.dataKey,
             yAxisIndex,
+            hasMultipleSeries,
             renderingContext,
           );
         case "bar":
@@ -175,6 +209,7 @@ export const buildEChartsSeries = (
             chartModel.dimensionModel.dataKey,
             yAxisIndex,
             barSeriesCount,
+            hasMultipleSeries,
             renderingContext,
           );
         case "scatter":


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35793
Closes https://github.com/metabase/metabase/issues/35797

### Description

Support hover events on the new dynamic combo chart:
- Normal tooltips
- Stacked tooltips on stacked charts
- Hover effects on series
- Hover events on legend

### How to verify

Create single & multiseries questions, stacked/non-stacked. Ensure the hover tooltip shows correct values.

### Demo

https://github.com/metabase/metabase/assets/14301985/13fcf71c-1d2e-42db-a963-1ed952eeadf0

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
