### PR TITLE
Fix CollectionID type

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -5,7 +5,7 @@ import type { DatabaseId } from "./database";
 
 export type RegularCollectionId = number;
 
-export type CollectionId = RegularCollectionId | "root" | "users";
+export type CollectionId = RegularCollectionId | "root" | "personal" | "users";
 
 export type CollectionContentModel = "card" | "dataset";
 

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -5,7 +5,7 @@ import type { DatabaseId } from "./database";
 
 export type RegularCollectionId = number;
 
-export type CollectionId = RegularCollectionId | "root" | "personal";
+export type CollectionId = RegularCollectionId | "root" | "users";
 
 export type CollectionContentModel = "card" | "dataset";
 


### PR DESCRIPTION
We don't have a special collection id type called "personal", AFAIC.

Ran into this issue when trying to obtain a collection id using `Urls.extractCollectionId(props.params.slug)`.
![image](https://github.com/metabase/metabase/assets/31325167/33f34b82-da6b-4801-98a0-66dfa6008a32)

I think the `personal` type was just a typo.
One way to confirm this is in the UI. Log in as an admin, and then visit these pages:
|route|result|
|-|-|
|`/collection/1`| works|
|`/collection/root`|works|
|`/collection/personal`|fails|
|`/collection/users`|works|

Visiting `/personal` will give you this error
![image](https://github.com/metabase/metabase/assets/31325167/a637b6d0-8ff0-4184-8dd8-db55e0ec9fb8)

Visiting `/users` will list all users personal collections for an admin.