### PR TITLE
feat: allow listing embedded entities when embedding is off

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -671,7 +671,6 @@
   and a signed JWT."
   []
   (validation/check-has-application-permission :setting)
-  (validation/check-embedding-enabled)
   (t2/select [Card :name :id], :enable_embedding true, :archived false))
 
 (api/defendpoint GET "/:id/related"

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -746,7 +746,6 @@
   endpoints and a signed JWT."
   []
   (validation/check-has-application-permission :setting)
-  (validation/check-embedding-enabled)
   (t2/select [:model/Dashboard :name :id], :enable_embedding true, :archived false))
 
 (api/defendpoint GET "/:id/related"


### PR DESCRIPTION
### Description

Part of [[Epic]Embedding settings cleanup and surface interactive embedding Quickstart ](https://github.com/metabase/metabase/issues/36481)

As part of MS1 we need to make the static embedding page work even if the embedding setting is turned off, to do it we need to make these lists to work:
<img width="540" alt="image" src="https://github.com/metabase/metabase/assets/1914270/29aa571a-0c16-41e9-8f2e-f2503c4e814f">

Without this PR they show an error from the backend:

<img width="794" alt="image" src="https://github.com/metabase/metabase/assets/1914270/d6ab71a2-7a03-4793-98e4-b2de0ab30a95">
