### PR TITLE
Handle `metabase/ui/Modal` in e2e `modal` helper

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -16,7 +16,18 @@ export function menu() {
 }
 
 export function modal() {
-  return cy.get(".ModalContainer .ModalContent");
+  const LEGACY_MODAL_SELECTOR = ".ModalContainer .ModalContent";
+  // Will be used when <Modal /> is used without <ModalContent />
+  const LEGACY_MODAL_FALLBACK_SELECTOR = ".Modal";
+
+  const MODAL_SELECTOR = ".emotion-Modal-content[role='dialog']";
+  return cy.get(
+    [
+      MODAL_SELECTOR,
+      LEGACY_MODAL_SELECTOR,
+      LEGACY_MODAL_FALLBACK_SELECTOR,
+    ].join(","),
+  );
 }
 
 export function sidebar() {

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -16,18 +16,9 @@ export function menu() {
 }
 
 export function modal() {
-  const LEGACY_MODAL_SELECTOR = ".ModalContainer .ModalContent";
-  // Will be used when <Modal /> is used without <ModalContent />
-  const LEGACY_MODAL_FALLBACK_SELECTOR = ".Modal";
-
+  const LEGACY_MODAL_SELECTOR = ".Modal";
   const MODAL_SELECTOR = ".emotion-Modal-content[role='dialog']";
-  return cy.get(
-    [
-      MODAL_SELECTOR,
-      LEGACY_MODAL_SELECTOR,
-      LEGACY_MODAL_FALLBACK_SELECTOR,
-    ].join(","),
-  );
+  return cy.get([MODAL_SELECTOR, LEGACY_MODAL_SELECTOR].join(","));
 }
 
 export function sidebar() {

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -123,10 +123,12 @@ describe(
         .findByText("Number")
         .click();
       cy.findByRole("button", { name: "Save" }).click();
-      modal().within(() => {
-        cy.findByLabelText("Name").type("Delete Order");
-        cy.findByRole("button", { name: "Create" }).click();
-      });
+      modal()
+        .eq(1)
+        .within(() => {
+          cy.findByLabelText("Name").type("Delete Order");
+          cy.findByRole("button", { name: "Create" }).click();
+        });
       cy.findByLabelText("Action list")
         .findByText("Delete Order")
         .should("be.visible");
@@ -217,9 +219,7 @@ describe(
         cy.findByRole("button", { name: "Save" }).click();
       });
 
-      modal().within(() => {
-        cy.findByText("Select a model").click();
-      });
+      modal().eq(1).findByText("Select a model").click();
       popover().findByText("Order").click();
       cy.findByRole("button", { name: "Create" }).click();
 
@@ -910,10 +910,12 @@ function disableSharingFor(actionName) {
     cy.findByRole("button", { name: "Action settings" }).click();
     cy.findByLabelText("Make public").should("be.checked").click();
   });
-  modal().within(() => {
-    cy.findByText("Disable this public link?").should("be.visible");
-    cy.findByRole("button", { name: "Yes" }).click();
-  });
+  modal()
+    .eq(1)
+    .within(() => {
+      cy.findByText("Disable this public link?").should("be.visible");
+      cy.findByRole("button", { name: "Yes" }).click();
+    });
   cy.wait("@disableActionSharing");
   cy.findByRole("dialog").within(() => {
     cy.button("Cancel").click();

--- a/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
+++ b/e2e/test/scenarios/sharing/alert/email-alert.cy.spec.js
@@ -2,7 +2,6 @@ import {
   restore,
   setupSMTP,
   visitQuestion,
-  modal,
   openTable,
 } from "e2e/support/helpers";
 
@@ -74,7 +73,7 @@ describe("scenarios > alert > email_alert", { tags: "@external" }, () => {
 
     cy.wait("@saveCard");
 
-    modal().within(() => {
+    cy.findByTestId("alert-education-screen").within(() => {
       cy.findByRole("button", { name: "Set up an alert" }).click();
     });
     cy.findByRole("button", { name: "Done" }).click();

--- a/frontend/src/metabase/query_builder/components/AlertModals.jsx
+++ b/frontend/src/metabase/query_builder/components/AlertModals.jsx
@@ -148,7 +148,7 @@ class CreateAlertModalContentInner extends Component {
     }
     if (!hasSeenEducationalScreen) {
       return (
-        <ModalContent onClose={onCancel}>
+        <ModalContent onClose={onCancel} data-testid="alert-education-screen">
           <AlertEducationalScreen
             onProceed={this.proceedFromEducationalScreen}
           />


### PR DESCRIPTION
Ensures Cypress `modal` helper can select both legacy and new Modal components.
Similar to [how we handled `popover`](https://github.com/metabase/metabase/blob/d3bb48844a3345fef1da4938127040b35648678f/e2e/support/helpers/e2e-ui-elements-helpers.js#L3) earlier.

**To verify:** CI should be green 🟢 