### PR TITLE
Fix nested `a` tags dashboard card action panel

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/ChartSettingsButton/ChartSettingsButton.tsx
@@ -32,6 +32,7 @@ export function ChartSettingsButton({
       tall
       triggerElement={
         <DashCardActionButton
+          as="div"
           tooltip={t`Visualization options`}
           aria-label={t`Show visualization options`}
         >

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/DashCardActionButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/DashCardActionButton.tsx
@@ -1,25 +1,30 @@
-import * as React from "react";
-
+import type { ElementType, HTMLAttributes } from "react";
+import { forwardRef } from "react";
 import Tooltip from "metabase/core/components/Tooltip";
-
 import {
   ActionIcon,
   StyledAnchor,
   HEADER_ICON_SIZE,
 } from "./DashCardActionButton.styled";
 
-interface Props extends React.HTMLAttributes<HTMLAnchorElement> {
+interface Props extends HTMLAttributes<HTMLAnchorElement> {
+  as?: ElementType;
   tooltip?: string;
   analyticsEvent?: string;
 }
 
-const DashActionButton = React.forwardRef<HTMLAnchorElement, Props>(
+const DashActionButton = forwardRef<HTMLAnchorElement, Props>(
   function DashActionButton(
-    { tooltip, analyticsEvent, children, ...props },
+    { as, tooltip, analyticsEvent, children, ...props },
     ref,
   ) {
     return (
-      <StyledAnchor {...props} data-metabase-event={analyticsEvent} ref={ref}>
+      <StyledAnchor
+        {...props}
+        as={as}
+        data-metabase-event={analyticsEvent}
+        ref={ref}
+      >
         <Tooltip tooltip={tooltip}>{children}</Tooltip>
       </StyledAnchor>
     );


### PR DESCRIPTION
Fixes two nested `a` tags for the "Visualization settings" button in the dashboard card action panel. This resulted in the following error:

<details>
<summary>Stacktrace</summary>

```
Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
    in a (created by StyledAnchor)
    in StyledAnchor (created by ForwardRef(DashActionButton))
    in ForwardRef(DashActionButton) (created by ChartSettingsButton)
    in a (created by Trigger)
    in Trigger (created by Triggerable[Modal])
    in Triggerable[Modal] (created by ChartSettingsButton)
    in ChartSettingsButton (created by DashCardActionsPanel)
    in span (created by DashCardActionButtonsContainer)
    in DashCardActionButtonsContainer (created by DashCardActionsPanel)
    in div (created by DashCardActionsPanelContainer)
    in DashCardActionsPanelContainer (created by DashCardActionsPanel)
    in DashCardActionsPanel (created by DashCardInner)
```

</details>

<img src="https://github.com/metabase/metabase/assets/17258145/6dca167f-5b77-4048-97dd-fc012dc76226" alt="Dashboard card UI" width="500px" />
