### PR TITLE
Fix `onLeftEdge` prop getting into a plain DOM element

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.styled.tsx
@@ -41,42 +41,6 @@ export const DashCardRoot = styled.div<DashCardRootProps>`
     shouldForceHiddenBackground && hiddenBackgroundStyle}
 `;
 
-export const DashboardCardActionsPanel = styled.div<{
-  isDashCardTabMenuOpen: boolean;
-  onLeftEdge: boolean;
-}>`
-  padding: 0.125em 0.25em;
-  position: absolute;
-  background: white;
-  transform: translateY(-50%);
-  top: 0;
-  right: 20px;
-  border-radius: 8px;
-  box-shadow: 0px 1px 3px rgb(0 0 0 / 13%);
-  cursor: default;
-  transition: opacity 200ms;
-  opacity: ${({ isDashCardTabMenuOpen }) => (isDashCardTabMenuOpen ? 1 : 0)};
-  pointer-events: ${({ isDashCardTabMenuOpen }) =>
-    isDashCardTabMenuOpen ? "all" : "none"};
-  // react-resizable covers panel, we have to override it
-  z-index: 2;
-  // left align on small cards on the left edge to not make the actions go out of the viewport
-  @container DashboardCard (max-width: 12rem) {
-    ${({ onLeftEdge }) => onLeftEdge && "right: unset;"}
-    ${({ onLeftEdge }) => onLeftEdge && "left: 20px;"}
-  }
-
-  .Card:hover &,
-  .Card:focus-within & {
-    opacity: 1;
-    pointer-events: all;
-  }
-
-  .Dash--dragging & {
-    display: none;
-  }
-`;
-
 export const VirtualDashCardOverlayRoot = styled.div`
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.styled.tsx
@@ -1,11 +1,25 @@
 import styled from "@emotion/styled";
+import { css } from "@emotion/react";
+import isPropValid from "@emotion/is-prop-valid";
 
 import { color } from "metabase/lib/colors";
 
-export const DashCardActionsPanelContainer = styled.div<{
+type DashCardActionsPanelContainer = {
   isDashCardTabMenuOpen: boolean;
   onLeftEdge: boolean;
-}>`
+};
+
+function shouldForwardProp(propName: string) {
+  return (
+    isPropValid(propName) &&
+    propName !== "isDashCardTabMenuOpen" &&
+    propName !== "onLeftEdge"
+  );
+}
+
+export const DashCardActionsPanelContainer = styled("div", {
+  shouldForwardProp,
+})<DashCardActionsPanelContainer>`
   padding: 0.125em 0.25em;
   position: absolute;
   background: white;
@@ -19,13 +33,19 @@ export const DashCardActionsPanelContainer = styled.div<{
   opacity: ${({ isDashCardTabMenuOpen }) => (isDashCardTabMenuOpen ? 1 : 0)};
   pointer-events: ${({ isDashCardTabMenuOpen }) =>
     isDashCardTabMenuOpen ? "all" : "none"};
+
   // react-resizable covers panel, we have to override it
   z-index: 2;
+
   // left align on small cards on the left edge to not make the actions go out of the viewport
-  @container (max-width: 12rem) {
-    ${({ onLeftEdge }) => onLeftEdge && "right: unset;"}
-    ${({ onLeftEdge }) => onLeftEdge && "left: 20px;"}
-  }
+  ${({ onLeftEdge }) =>
+    onLeftEdge &&
+    css`
+      @container (max-width: 12rem) {
+        right: unset;
+        left: 20px;
+      }
+    `}
 
   .Card:hover &,
   .Card:focus-within & {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.styled.tsx
@@ -4,7 +4,7 @@ import isPropValid from "@emotion/is-prop-valid";
 
 import { color } from "metabase/lib/colors";
 
-type DashCardActionsPanelContainer = {
+type DashCardActionsPanelContainerProps = {
   isDashCardTabMenuOpen: boolean;
   onLeftEdge: boolean;
 };
@@ -19,7 +19,7 @@ function shouldForwardProp(propName: string) {
 
 export const DashCardActionsPanelContainer = styled("div", {
   shouldForwardProp,
-})<DashCardActionsPanelContainer>`
+})<DashCardActionsPanelContainerProps>`
   padding: 0.125em 0.25em;
   position: absolute;
   background: white;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.styled.tsx
@@ -41,7 +41,7 @@ export const DashCardActionsPanelContainer = styled("div", {
   ${({ onLeftEdge }) =>
     onLeftEdge &&
     css`
-      @container (max-width: 12rem) {
+      @container DashboardCard (max-width: 12rem) {
         right: unset;
         left: 20px;
       }


### PR DESCRIPTION
A React component prop got into a plain DOM element and caused some warnings. Fixed by implementing `shouldForwardProp`. Also removes an unused `DashboardCardActionsPanel` component