### PR TITLE
Rename `max-*-query-row-limit` to `*-query-row-limit`

### DIFF
--- a/docs/installation-and-operation/serialization.md
+++ b/docs/installation-and-operation/serialization.md
@@ -241,8 +241,8 @@ custom-geojson-enabled
 start-of-week
 custom-geojson
 available-timezones
-max-unaggregated-query-row-limit
-max-aggregated-query-row-limit
+unaggregated-query-row-limit
+aggregated-query-row-limit
 hide-embed-branding?
 search-typeahead-enabled
 enable-sandboxes?

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -706,5 +706,5 @@
     ;; if the user has set the rowcount-override connection property, it ends up in the details map, but it actually
     ;; needs to be moved over to the settings map (which is where DB local settings go, as per #19399)
     (-> (update database :details #(dissoc % :rowcount-override))
-        (update :settings #(assoc % :max-unaggregated-query-row-limit rowcount-override)))
+        (update :settings #(assoc % :unaggregated-query-row-limit rowcount-override)))
     database))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -188,8 +188,8 @@
      humanization-strategy
      landing-page
      loading-message
-     max-aggregated-query-row-limit
-     max-unaggregated-query-row-limit
+     aggregated-query-row-limit
+     unaggregated-query-row-limit
      native-query-autocomplete-match-style
      persisted-models-enabled
      report-timezone

--- a/src/metabase/query_processor/middleware/constraints.clj
+++ b/src/metabase/query_processor/middleware/constraints.clj
@@ -21,20 +21,20 @@
 ;;
 ;; If we turned the below `const`s into `:default`s on the settings themselves, we would use the default values for
 ;; all queries, whether or not the middleware was applied.
-(def ^:private ^:const default-max-unaggregated-query-row-limit 2000)
-(def ^:private ^:const default-max-aggregated-query-row-limit 10000)
+(def ^:private ^:const default-unaggregated-query-row-limit 2000)
+(def ^:private ^:const default-aggregated-query-row-limit 10000)
 
-;; NOTE: this was changed from a hardcoded var with value of 2000 (now moved to [[default-max-unaggregated-query-row-limit]])
+;; NOTE: this was changed from a hardcoded var with value of 2000 (now moved to [[default-unaggregated-query-row-limit]])
 ;; to a setting in 0.43 the setting, which allows for DB local value, can still be nil, so any places below that used
 ;; to reference the former constant value have to expect it could return nil instead
-(setting/defsetting max-unaggregated-query-row-limit
+(setting/defsetting unaggregated-query-row-limit
   (deferred-tru "Maximum number of rows to return specifically on :rows type queries via the API.")
   :visibility     :authenticated
   :type           :integer
   :database-local :allowed
   :audit          :getter)
 
-(setting/defsetting max-aggregated-query-row-limit
+(setting/defsetting aggregated-query-row-limit
   (deferred-tru "Maximum number of rows to return for aggregated queries via the API.")
   :visibility     :authenticated
   :type           :integer
@@ -43,18 +43,18 @@
 
 (defn query->max-rows
   "Given a query, returns the max rows that should be returned *as defined by settings*. In other words,
-  return `(max-aggregated-query-row-limit)` or `(max-unaggregated-query-row-limit)` depending on whether the query is
+  return `(aggregated-query-row-limit)` or `(unaggregated-query-row-limit)` depending on whether the query is
   aggregated or not."
   [{{aggregations :aggregation} :query}]
   (if-not aggregations
-    (max-unaggregated-query-row-limit)
-    (max-aggregated-query-row-limit)))
+    (unaggregated-query-row-limit)
+    (aggregated-query-row-limit)))
 
 (defn default-query-constraints
   "Default map of constraints that we apply on dataset queries executed by the api."
   []
-  {:max-results           (or (max-aggregated-query-row-limit) default-max-aggregated-query-row-limit)
-   :max-results-bare-rows (or (max-unaggregated-query-row-limit) default-max-unaggregated-query-row-limit)})
+  {:max-results           (or (aggregated-query-row-limit) default-aggregated-query-row-limit)
+   :max-results-bare-rows (or (unaggregated-query-row-limit) default-unaggregated-query-row-limit)})
 
 (defn- ensure-valid-constraints
   "Clamps the value of `max-results-bare-rows` to be less than or equal to the value of `max-results`."

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1811,33 +1811,33 @@
           (is (nil? (settings))))
         (testing "Set initial value"
           (testing "response"
-            (is (partial= {:settings {:max-unaggregated-query-row-limit 1337}}
-                          (set-settings! {:max-unaggregated-query-row-limit 1337}))))
+            (is (partial= {:settings {:unaggregated-query-row-limit 1337}}
+                          (set-settings! {:unaggregated-query-row-limit 1337}))))
           (testing "App DB"
-            (is (= {:max-unaggregated-query-row-limit 1337}
+            (is (= {:unaggregated-query-row-limit 1337}
                    (settings)))))
         (testing "Setting a different value should not affect anything not specified (PATCH-style update)"
           (testing "response"
-            (is (partial= {:settings {:max-unaggregated-query-row-limit   1337
+            (is (partial= {:settings {:unaggregated-query-row-limit   1337
                                       :database-enable-actions true}}
                           (set-settings! {:database-enable-actions true}))))
           (testing "App DB"
-            (is (= {:max-unaggregated-query-row-limit   1337
+            (is (= {:unaggregated-query-row-limit   1337
                     :database-enable-actions true}
                    (settings)))))
         (testing "Update existing value"
           (testing "response"
-            (is (partial= {:settings {:max-unaggregated-query-row-limit   1337
+            (is (partial= {:settings {:unaggregated-query-row-limit   1337
                                       :database-enable-actions false}}
                           (set-settings! {:database-enable-actions false}))))
           (testing "App DB"
-            (is (= {:max-unaggregated-query-row-limit   1337
+            (is (= {:unaggregated-query-row-limit   1337
                     :database-enable-actions false}
                    (settings)))))
         (testing "Unset a value"
           (testing "response"
             (is (partial= {:settings {:database-enable-actions false}}
-                          (set-settings! {:max-unaggregated-query-row-limit nil}))))
+                          (set-settings! {:unaggregated-query-row-limit nil}))))
           (testing "App DB"
             (is (= {:database-enable-actions false}
                    (settings)))))))))

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -76,7 +76,7 @@
                         :name        "testpg"
                         :details     {}
                         :settings    {:database-enable-actions          true   ; visibility: :public
-                                      :max-unaggregated-query-row-limit 2000}  ; visibility: :authenticated
+                                      :unaggregated-query-row-limit 2000}  ; visibility: :authenticated
                         :id          3})]
     (testing "authenticated users should see settings with authenticated visibility"
       (mw.session/with-current-user
@@ -84,7 +84,7 @@
         (is (= {"description" nil
                 "name"        "testpg"
                 "settings"    {"database-enable-actions"          true
-                               "max-unaggregated-query-row-limit" 2000}
+                               "unaggregated-query-row-limit" 2000}
                 "id"          3}
                (encode-decode pg-db)))))
     (testing "non-authenticated users shouldn't see settings with authenticated visibility"

--- a/test/metabase/query_processor/middleware/constraints_test.clj
+++ b/test/metabase/query_processor/middleware/constraints_test.clj
@@ -15,8 +15,8 @@
 (deftest ^:parallel add-constraints-test
   (testing "if it is *truthy* add the constraints"
     (is (= {:middleware  {:add-default-userland-constraints? true},
-            :constraints {:max-results           @#'qp.constraints/default-max-aggregated-query-row-limit
-                          :max-results-bare-rows @#'qp.constraints/default-max-unaggregated-query-row-limit}}
+            :constraints {:max-results           @#'qp.constraints/default-aggregated-query-row-limit
+                          :max-results-bare-rows @#'qp.constraints/default-unaggregated-query-row-limit}}
            (add-default-userland-constraints
             {:middleware {:add-default-userland-constraints? true}})))))
 
@@ -29,7 +29,7 @@
 (deftest ^:parallel dont-overwrite-existing-constraints-test
   (testing "if it already has constraints, don't overwrite those!"
     (is (= {:middleware  {:add-default-userland-constraints? true}
-            :constraints {:max-results           @#'qp.constraints/default-max-aggregated-query-row-limit
+            :constraints {:max-results           @#'qp.constraints/default-aggregated-query-row-limit
                           :max-results-bare-rows 1}}
            (add-default-userland-constraints
             {:constraints {:max-results-bare-rows 1}


### PR DESCRIPTION
@jeff-bruemmer pointed out that these names are redundant in #36723.

Theoretically one could argue that the settings aren't actually setting the "query row limit" - when you make a new question, you can enter whatever limit you like. Instead, they're setting the *maximum* possible "query row limit."

That said, applying two limits is the same as applying the minimum of two limits, so calling it a "query row limit" makes sense too, and might be more clear.