### PR TITLE
Fix dashcard-filter connection edge cases

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -7,6 +7,10 @@ export function selectDashboardFilter(selection, filterName) {
   popover().contains(filterName).click({ force: true });
 }
 
+export function disconnectDashboardFilter(selection) {
+  selection.findByLabelText("Disconnect").click();
+}
+
 export function getDashboardCards() {
   return cy.get(".DashCard");
 }

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -7,6 +7,7 @@ import {
   sidebar,
   getDashboardCard,
   selectDashboardFilter,
+  disconnectDashboardFilter,
   saveDashboard,
   updateDashboardCards,
   visitDashboardAndCreateTab,
@@ -31,6 +32,23 @@ const { ORDERS_ID, ORDERS, PRODUCTS, PRODUCTS_ID, REVIEWS_ID } =
   SAMPLE_DATABASE;
 
 describe("scenarios > dashboard > parameters", () => {
+  const cards = [
+    {
+      card_id: ORDERS_COUNT_QUESTION_ID,
+      row: 0,
+      col: 0,
+      size_x: 5,
+      size_y: 4,
+    },
+    {
+      card_id: ORDERS_COUNT_QUESTION_ID,
+      row: 0,
+      col: 5,
+      size_x: 5,
+      size_y: 4,
+    },
+  ];
+
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
@@ -43,22 +61,7 @@ describe("scenarios > dashboard > parameters", () => {
       // add the same question twice
       updateDashboardCards({
         dashboard_id: id,
-        cards: [
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 4,
-            size_x: 5,
-            size_y: 4,
-          },
-        ],
+        cards,
       });
 
       visitDashboard(id);
@@ -608,6 +611,69 @@ describe("scenarios > dashboard > parameters", () => {
     });
   });
 
+  describe.only("when parameters are (un)mapped to dashcards", () => {
+    beforeEach(() => {
+      createDashboardWithCards({ cards }).then(dashboardId =>
+        visitDashboard(dashboardId),
+      );
+
+      // editDashboard();
+      // setFilter("Time", "Relative Date");
+      // cy.findByTestId("dashboard-header")
+      //   .findByText("Default value")
+      //   .next()
+      //   .click();
+      // popover().contains("Past 7 days").click({ force: true });
+      // saveDashboard();
+
+      console.log("YAYA 31");
+
+      // cy.intercept(
+      //   "POST",
+      //   "/api/dashboard/*/dashcard/*/card/*/query",
+      //   cy.spy().as("dashcardQuerySpy"),
+      // ).as("dashcardQuery");
+    });
+
+    it.only("should not fetch dashcard data when filter is unmapped", () => {
+      // cy.get("@dashcardQuerySpy").should("not.have.been.called");
+    });
+
+    // it("should fetch dashcard data after save when parameter is mapped", () => {
+    //   // Connect filter to 2 cards
+    //   editDashboard();
+    //   cy.findByTestId("dashboard-header").findByText("Relative Date").click();
+    //   selectDashboardFilter(getDashboardCard(0), "Created At");
+    //   saveDashboard();
+
+    //   cy.get("@dashcardQuery.all").should("have.length", 2);
+    // });
+
+    // it("should fetch dashcard data when parameter mapping is removed", () => {
+    //   // Connect filter to 1 card only
+    //   editDashboard();
+    //   cy.findByTestId("dashboard-header").findByText("Relative Date").click();
+    //   selectDashboardFilter(getDashboardCard(0), "Created At");
+    //   disconnectDashboardFilter(getDashboardCard(1));
+    //   saveDashboard();
+
+    //   // Disconnect filter from the 1st card
+    //   editDashboard();
+    //   cy.findByTestId("dashboard-header").findByText("Relative Date").click();
+    //   disconnectDashboardFilter(getDashboardCard(0));
+    //   saveDashboard();
+
+    //   cy.get("@dashcardQuery.all").should("have.length", 2); // TODO find a way to reset it
+    // });
+
+    // it("should not fetch dashcard data when nothing changed on save", () => {
+    //   editDashboard();
+    //   saveDashboard();
+
+    //   cy.get("@dashcardQuery.all").should("have.length", 0);
+    // });
+  });
+
   describe("when auto-wiring parameters across cards with matching fields", () => {
     beforeEach(() => {
       cy.intercept("GET", "/api/dashboard/**").as("dashboard");
@@ -615,24 +681,7 @@ describe("scenarios > dashboard > parameters", () => {
 
     describe("when wiring parameter to all cards for a filter", () => {
       it("should automatically wire parameters to cards with matching fields", () => {
-        createDashboardWithCards({
-          cards: [
-            {
-              card_id: ORDERS_BY_YEAR_QUESTION_ID,
-              row: 0,
-              col: 0,
-              size_x: 5,
-              size_y: 4,
-            },
-            {
-              card_id: ORDERS_COUNT_QUESTION_ID,
-              row: 0,
-              col: 4,
-              size_x: 5,
-              size_y: 4,
-            },
-          ],
-        }).then(dashboardId => {
+        createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });
 
@@ -658,24 +707,7 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should not automatically wire parameters to cards that already have a parameter, despite matching fields", () => {
-        createDashboardWithCards({
-          cards: [
-            {
-              card_id: ORDERS_BY_YEAR_QUESTION_ID,
-              row: 0,
-              col: 0,
-              size_x: 5,
-              size_y: 4,
-            },
-            {
-              card_id: ORDERS_COUNT_QUESTION_ID,
-              row: 0,
-              col: 4,
-              size_x: 5,
-              size_y: 4,
-            },
-          ],
-        }).then(dashboardId => {
+        createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });
 
@@ -757,23 +789,6 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should autowire parameters to cards in different tabs", () => {
-        const cards = [
-          {
-            card_id: ORDERS_BY_YEAR_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 4,
-            size_x: 5,
-            size_y: 4,
-          },
-        ];
-
         createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboardAndCreateTab({
             dashboardId,
@@ -804,23 +819,6 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should undo parameter wiring when 'Undo auto-connection' is clicked", () => {
-        const cards = [
-          {
-            card_id: ORDERS_BY_YEAR_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 4,
-            size_x: 5,
-            size_y: 4,
-          },
-        ];
-
         createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });
@@ -904,23 +902,6 @@ describe("scenarios > dashboard > parameters", () => {
 
     describe("wiring parameters when adding a card", () => {
       it("should automatically wire a parameters to cards that are added to the dashboard", () => {
-        const cards = [
-          {
-            card_id: ORDERS_BY_YEAR_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 5,
-            size_x: 5,
-            size_y: 4,
-          },
-        ];
-
         createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });
@@ -950,23 +931,6 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should automatically wire parameters to cards that are added to the dashboard in a different tab", () => {
-        const cards = [
-          {
-            card_id: ORDERS_BY_YEAR_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 5,
-            size_x: 5,
-            size_y: 4,
-          },
-        ];
-
         createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });
@@ -994,23 +958,6 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should undo parameter wiring when 'Undo auto-connection' is clicked", () => {
-        const cards = [
-          {
-            card_id: ORDERS_BY_YEAR_QUESTION_ID,
-            row: 0,
-            col: 0,
-            size_x: 5,
-            size_y: 4,
-          },
-          {
-            card_id: ORDERS_COUNT_QUESTION_ID,
-            row: 0,
-            col: 5,
-            size_x: 5,
-            size_y: 4,
-          },
-        ];
-
         createDashboardWithCards({ cards }).then(dashboardId => {
           visitDashboard(dashboardId);
         });

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -469,6 +469,8 @@ export const fetchCardData = createThunkAction(
 export const fetchDashboardCardData =
   ({ isRefreshing, ...options } = {}) =>
   (dispatch, getState) => {
+    console.log(`fetchDashboardCardData ${options.source}`);
+
     const dashboard = getDashboardComplete(getState());
     const selectedTabId = getSelectedTabId(getState());
 
@@ -489,6 +491,8 @@ export const fetchDashboardCardData =
         return dashcard.id;
       });
 
+      console.log("IS REFRESHING", loadingIds.concat(newLoadingIds));
+
       dispatch({
         type: FETCH_DASHBOARD_CARD_DATA,
         payload: {
@@ -502,10 +506,14 @@ export const fetchDashboardCardData =
         return dashcard.id;
       });
 
+      console.log("NOT REFRESHING CANCEL", loadingIds);
+
       for (const id of loadingIds) {
         const dashcard = getDashCardById(getState(), id);
         dispatch(cancelFetchCardData(dashcard.card.id, dashcard.id));
       }
+
+      console.log("NOT REFRESHING", newLoadingIds);
 
       dispatch({
         type: FETCH_DASHBOARD_CARD_DATA,

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -469,8 +469,6 @@ export const fetchCardData = createThunkAction(
 export const fetchDashboardCardData =
   ({ isRefreshing, ...options } = {}) =>
   (dispatch, getState) => {
-    console.log(`fetchDashboardCardData ${options.source}`);
-
     const dashboard = getDashboardComplete(getState());
     const selectedTabId = getSelectedTabId(getState());
 
@@ -491,8 +489,6 @@ export const fetchDashboardCardData =
         return dashcard.id;
       });
 
-      console.log("IS REFRESHING", loadingIds.concat(newLoadingIds));
-
       dispatch({
         type: FETCH_DASHBOARD_CARD_DATA,
         payload: {
@@ -506,14 +502,10 @@ export const fetchDashboardCardData =
         return dashcard.id;
       });
 
-      console.log("NOT REFRESHING CANCEL", loadingIds);
-
       for (const id of loadingIds) {
         const dashcard = getDashCardById(getState(), id);
         dispatch(cancelFetchCardData(dashcard.card.id, dashcard.id));
       }
-
-      console.log("NOT REFRESHING", newLoadingIds);
 
       dispatch({
         type: FETCH_DASHBOARD_CARD_DATA,

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -139,7 +139,16 @@ export const updateDashboardAndCards = createThunkAction(
         }),
       ); // disable using query parameters when saving
 
-      dispatch(fetchDashboardCardData({ reload: false, clearCache: false }));
+      // There might have been changes to dashboard card-filter wiring,
+      // which require re-fetching card data (issue #35503). We expect
+      // the fetchDashboardCardData to decide which cards to fetch.
+      dispatch(
+        fetchDashboardCardData({
+          reload: false,
+          clearCache: false,
+          // source: "SAVE",
+        }),
+      );
     };
   },
 );

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -11,7 +11,7 @@ import { clickBehaviorIsValid } from "metabase-lib/parameters/utils/click-behavi
 import { trackDashboardSaved } from "../analytics";
 import { getDashboardBeforeEditing } from "../selectors";
 
-import { fetchDashboard } from "./data-fetching";
+import { fetchDashboard, fetchDashboardCardData } from "./data-fetching";
 import { hasDashboardChanged, haveDashboardCardsChanged } from "./utils";
 
 export const UPDATE_DASHBOARD_AND_CARDS =
@@ -131,13 +131,15 @@ export const updateDashboardAndCards = createThunkAction(
       });
 
       // make sure that we've fully cleared out any dirty state from editing (this is overkill, but simple)
-      dispatch(
+      await dispatch(
         fetchDashboard({
           dashId: dashboard.id,
           queryParams: null,
           options: { preserveParameters: false },
         }),
       ); // disable using query parameters when saving
+
+      dispatch(fetchDashboardCardData({ reload: false, clearCache: false }));
     };
   },
 );

--- a/frontend/src/metabase/dashboard/actions/save.js
+++ b/frontend/src/metabase/dashboard/actions/save.js
@@ -146,7 +146,6 @@ export const updateDashboardAndCards = createThunkAction(
         fetchDashboardCardData({
           reload: false,
           clearCache: false,
-          // source: "SAVE",
         }),
       );
     };

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -152,7 +152,7 @@ export function DashCardCardParameterMapper({
           buttonIcon: (
             <CloseIconButton
               role="button"
-              aria-label="Disconnect"
+              aria-label={t`Disconnect`}
               onClick={e => {
                 handleChangeTarget(null);
                 e.stopPropagation();

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -151,6 +151,8 @@ export function DashCardCardParameterMapper({
           buttonText: formatSelected(selectedMappingOption),
           buttonIcon: (
             <CloseIconButton
+              role="button"
+              aria-label="Disconnect"
               onClick={e => {
                 handleChangeTarget(null);
                 e.stopPropagation();


### PR DESCRIPTION
This is a better than https://github.com/metabase/metabase/pull/36657 way of fixing https://github.com/metabase/metabase/issues/35503

## Description
Instead of changing `Dashboards`'s `componendDidUpdate` where some data fetch actions are issued, a better place is the `UPDATE_DASHBOARD_AND_CARDS` action. At the end of it, we now issue the `FETCH_DASHBOARD_DATA` action, which finds out which dashcards need update and does actual requests.

## How to verify

### Before:
https://github.com/metabase/metabase/assets/2196347/d3c72301-ebe2-4b64-84a0-28e17b01428b

### After:
https://github.com/metabase/metabase/assets/2196347/dfc7400a-fbc9-4ad6-940b-7b1ee620ef89

