### PR TITLE
Fix embed error message to make sense for cards

### DIFF
--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -332,8 +332,6 @@
 (defn- check-embedding-enabled-for-object
   "Check that embedding is enabled, that `object` exists, and embedding for `object` is enabled."
   ([entity id]
-   (api/check (pos-int? id)
-              [400 (tru "Dashboard id should be a positive integer.")])
    (check-embedding-enabled-for-object (t2/select-one [entity :enable_embedding] :id id)))
 
   ([object]
@@ -343,13 +341,19 @@
    (api/check (:enable_embedding object)
      [400 (tru "Embedding is not enabled for this object.")])))
 
-(def ^:private ^{:arglists '([dashboard-id])} check-embedding-enabled-for-dashboard
+(defn- check-embedding-enabled-for-dashboard
   "Runs check-embedding-enabled-for-object for a given Dashboard id"
-  (partial check-embedding-enabled-for-object Dashboard))
+  [dashboard-id]
+  (api/check (pos-int? dashboard-id)
+    [400 (tru "Dashboard id should be a positive integer.")])
+  (check-embedding-enabled-for-object Dashboard dashboard-id))
 
-(def ^:private ^{:arglists '([card-id])} check-embedding-enabled-for-card
+(defn- check-embedding-enabled-for-card
   "Runs check-embedding-enabled-for-object for a given Card id"
-  (partial check-embedding-enabled-for-object Card))
+  [card-id]
+  (api/check (pos-int? card-id)
+    [400 (tru "Card id should be a positive integer.")])
+  (check-embedding-enabled-for-object Card card-id))
 
 
 ;;; ------------------------------------------- /api/embed/card endpoints --------------------------------------------

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -332,6 +332,8 @@
 (defn- check-embedding-enabled-for-object
   "Check that embedding is enabled, that `object` exists, and embedding for `object` is enabled."
   ([entity id]
+   (api/check (pos-int? id)
+     [400 (tru "{0} id should be a positive integer." (name entity))])
    (check-embedding-enabled-for-object (t2/select-one [entity :enable_embedding] :id id)))
 
   ([object]
@@ -341,19 +343,13 @@
    (api/check (:enable_embedding object)
      [400 (tru "Embedding is not enabled for this object.")])))
 
-(defn- check-embedding-enabled-for-dashboard
+(def ^:private ^{:arglists '([dashboard-id])} check-embedding-enabled-for-dashboard
   "Runs check-embedding-enabled-for-object for a given Dashboard id"
-  [dashboard-id]
-  (api/check (pos-int? dashboard-id)
-    [400 (tru "Dashboard id should be a positive integer.")])
-  (check-embedding-enabled-for-object Dashboard dashboard-id))
+  (partial check-embedding-enabled-for-object Dashboard))
 
-(defn- check-embedding-enabled-for-card
+(def ^:private ^{:arglists '([card-id])} check-embedding-enabled-for-card
   "Runs check-embedding-enabled-for-object for a given Card id"
-  [card-id]
-  (api/check (pos-int? card-id)
-    [400 (tru "Card id should be a positive integer.")])
-  (check-embedding-enabled-for-object Card card-id))
+  (partial check-embedding-enabled-for-object Card))
 
 
 ;;; ------------------------------------------- /api/embed/card endpoints --------------------------------------------

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -172,6 +172,13 @@
       (is (re= #"Token is expired.*"
                (client/client :get 400 (card-url card {:exp (buddy-util/to-timestamp yesterday)})))))))
 
+(deftest bad-card-id-fails
+  (with-embedding-enabled-and-new-secret-key
+    (let [card-url (str "embed/card/" (sign {:resource {:question "8"}
+                                             :params   {}}))]
+      (is (= "Card id should be a positive integer."
+             (client/client :get 400 card-url))))))
+
 (deftest check-that-the-endpoint-doesn-t-work-if-embedding-isn-t-enabled
   (mt/with-temporary-setting-values [enable-embedding false]
     (with-new-secret-key


### PR DESCRIPTION
### Description

Previously was saying dashboard id fails when for cards, now we change that by having differing behavior if the card endpoint is called.