### PR TITLE
UserCollectionList usePagination Flake

### DIFF
--- a/frontend/src/metabase/containers/UserCollectionList.tsx
+++ b/frontend/src/metabase/containers/UserCollectionList.tsx
@@ -16,7 +16,7 @@ import {
   PERSONAL_COLLECTIONS,
 } from "metabase/entities/collections";
 
-import { usePeopleQuery } from "metabase/admin/people/hooks/use-people-query";
+import { usePagination } from "metabase/hooks/use-pagination";
 import {
   CardContent,
   ListGridItem,
@@ -26,8 +26,7 @@ import {
 const PAGE_SIZE = 27;
 
 export const UserCollectionList = () => {
-  const { query, handleNextPage, handlePreviousPage } =
-    usePeopleQuery(PAGE_SIZE);
+  const { page, handleNextPage, handlePreviousPage } = usePagination();
 
   const {
     data: users = [],
@@ -35,8 +34,8 @@ export const UserCollectionList = () => {
     metadata,
   } = useUserListQuery({
     query: {
-      limit: query.pageSize,
-      offset: query.pageSize * query.page,
+      limit: PAGE_SIZE,
+      offset: PAGE_SIZE * page,
     },
   });
 
@@ -89,7 +88,7 @@ export const UserCollectionList = () => {
       </Box>
       <Flex justify="end">
         <PaginationControls
-          page={query.page}
+          page={page}
           pageSize={PAGE_SIZE}
           total={metadata?.total}
           itemsLength={PAGE_SIZE}

--- a/frontend/src/metabase/containers/UserCollectionList.unit.spec.tsx
+++ b/frontend/src/metabase/containers/UserCollectionList.unit.spec.tsx
@@ -36,7 +36,8 @@ describe("UserCollectionList", () => {
 
     expect(await screen.findByText("28 - 54")).toBeInTheDocument();
 
-    expect(await screen.findByText("big boi 29")).toBeInTheDocument();
     expect(await screen.findByTestId("previous-page-btn")).toBeEnabled();
+
+    expect(await screen.findByText("big boi 29")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
### Description
The `usePeopleQuery` hook has a useEffect that will set the page to 0 after 300ms of mounting the component, which is what was causing the flake. 300ms was enough time to start the test and click the next button, but it was possible that the page would set back to 0 before any assertions on the new page were finished, and in the real world situation it's so little time that it's probably not enough to notice. The solution here was to simply use the `usePagination()` hook directly, since we don't care about accounting for searching for users.

### How to verify
Green CI

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
