### PR TITLE
Support brushing on the combo echart

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -54,6 +54,15 @@ export const getCartesianChartOption = (
   ];
 
   return {
+    toolbox: {
+      show: false,
+    },
+    brush: {
+      toolbox: ["lineX"],
+      xAxisIndex: 0,
+      throttleType: "debounce",
+      throttleDelay: 200,
+    },
     grid: getChartGrid(chartModel, settings),
     dataset: echartsDataset,
     series: seriesOption,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35795

### Description

Support brushing on the new combo chart. It should be available on timeseries and numeric x-axes.

Note: on numeric x-axis after brushing the chart tries to show x-axis as timeseries. I will fix it further, it is not related to brushing because the correct filter is being applied in such cases

### How to verify

Verify brushing functionality on Line/Area/Bar/Combo charts with numeric and timeseries x-axis scales.
Ensure brushing is disabled on ordinal x-axis scales.

### Demo

https://github.com/metabase/metabase/assets/14301985/f4140354-9a08-4950-86bd-4bd4e71f5b82

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
