### PR TITLE
Do not autofocus bulk filter search input

### DIFF
--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterFieldSearch.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterFieldSearch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { t } from "ttag";
 
 import {
@@ -29,12 +29,6 @@ export const FieldSearch = ({
     }
     return false;
   };
-
-  useEffect(() => {
-    if (isExpanded) {
-      inputRef.current?.focus();
-    }
-  }, [isExpanded]);
 
   return (
     <SearchContainer


### PR DESCRIPTION
This PR removes the autofocus from the search input field when it is expanded. As explained in #36734, that behavior had some unexpected consequences.

Fixes #36734.

### Tests?
Unfortunately, I wasn't able to expand the input field using Cypress E2E test no matter what I tried (realHover, trigger mouseenter, mouseover, mousemove...)

Here's a recording of how this works now
![Kapture 2023-12-14 at 09 41 31](https://github.com/metabase/metabase/assets/31325167/0cfb404b-1377-4c1d-9df3-7320afa0ff75)
