### PR TITLE
CSV uploads: Use DATETIME instead of TIMESTAMP for datetime columns with MySQL

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -649,7 +649,7 @@
     ::upload/float                    [:double]
     ::upload/boolean                  [:boolean]
     ::upload/date                     [:date]
-    ::upload/datetime                 [:timestamp]
+    ::upload/datetime                 [:datetime]
     ::upload/offset-datetime          [:timestamp]))
 
 (defmethod driver/table-name-length-limit :mysql

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -282,7 +282,7 @@
         (when (not (str/blank? value))
           (parser value))))))
 
-(mu/defn ^:private column-types-from-rows :- [:sequential (into [:enum] column-types)]
+(mu/defn column-types-from-rows :- [:sequential (into [:enum] column-types)]
   "Returns a sequence of types, given the unparsed rows in the CSV file"
   [settings column-count rows]
   (->> rows

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -179,7 +179,7 @@
     (let [settings   {:number-separators (or seps ".,")}
           value-type (#'upload/value->type string-value settings)
           ;; get the type of the column, if it were filled with only that value
-          col-type   (first (#'upload/column-types-from-rows settings 1 [[string-value]]))
+          col-type   (first (upload/column-types-from-rows settings 1 [[string-value]]))
           parser     (upload-parsing/upload-type->parser col-type settings)]
       (testing (format "\"%s\" is a %s" string-value type)
         (is (= expected-type
@@ -435,7 +435,7 @@
                        :base_type :type/Date}
                       (t2/select-one Field :database_position 6 :table_id (:id table))))
               (is (=? {:name      #"(?i)datetime"
-                       :base_type (if (= driver/*driver* :mysql) :type/DateTimeWithLocalTZ :type/DateTime)}
+                       :base_type :type/DateTime}
                       (t2/select-one Field :database_position 7 :table_id (:id table))))
               (testing "Check the data was uploaded into the table"
                 (is (= 2
@@ -461,7 +461,7 @@
               (is (=? {:name #"(?i)upload_test"} table))
               (testing "Check the datetime column the correct base_type"
                 (is (=? {:name      #"(?i)datetime"
-                         :base_type (if (= driver/*driver* :mysql) :type/DateTimeWithLocalTZ :type/DateTime)}
+                         :base_type :type/DateTime}
                       ;; db position is 1; 0 is for the auto-inserted ID
                         (t2/select-one Field :database_position 1 :table_id (:id table)))))
               (is (some? table)))))))))


### PR DESCRIPTION
Fixes #36761

The fix was really simple, just replace `timestamp` with `datetime` and remove the special cases for MySQL in tests.