### PR TITLE
Fix embedding flaky test

### DIFF
--- a/e2e/test/scenarios/sharing/public-sharing.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing.cy.spec.js
@@ -73,7 +73,7 @@ describe("scenarios > admin > settings > public sharing", () => {
       .should("not.be.checked");
   });
 
-  it("should see public dashboards", { tags: "@flaky" }, () => {
+  it("should see public dashboards", () => {
     const expectedDashboardName = "Public dashboard";
     const expectedDashboardSlug = "public-dashboard";
     cy.createQuestionAndDashboard({
@@ -119,9 +119,14 @@ describe("scenarios > admin > settings > public sharing", () => {
 
     cy.get("@dashboardId").then(dashboardId => {
       cy.findByText(expectedDashboardName).click();
+      cy.log(
+        "Sometimes the URL will be updated with the tab ID, so we need to account for that",
+      );
       cy.url().should(
-        "eq",
-        `${location.origin}/dashboard/${dashboardId}-${expectedDashboardSlug}`,
+        "match",
+        new RegExp(
+          `${location.origin}/dashboard/${dashboardId}-${expectedDashboardSlug}*`,
+        ),
       );
       cy.visit("/admin/settings/public-sharing");
     });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36679

### Description

The reason was that sometimes the dashboard URL would be updated with the tab ID, so we need to ignore the tab slug by matching with Regular expression

### How to verify

The E2E stress test workflow passes

**master run**: https://github.com/metabase/metabase/actions/runs/7207764080/job/19635261151#step:9:161
**This PR run**: https://github.com/metabase/metabase/actions/runs/7207817521/job/19635429316#step:9:161

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
