### PR TITLE
Fix model metadata remapped field overflow

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/MappedFieldPicker/MappedFieldPicker.tsx
@@ -90,7 +90,7 @@ function MappedFieldPicker({
 
   return (
     <SchemaTableAndFieldDataSelector
-      className="flex flex-full justify-center align-center"
+      className="flex flex-full flex-basis-none justify-center align-center"
       selectedDatabaseId={databaseId}
       selectedTableId={selectedTableId}
       selectedSchemaId={fieldObject?.table?.schema?.id}


### PR DESCRIPTION
### Description
SelectButton's container had a `flex-full` CSS class, which we set to `flex: 1 0 auto`. `flex-basis` (the last value) is set to auto and that is causing the overflow.

Ideally, we need to set the flex-basis to `fit-content` but we don't have such a class. I can create one, if needed.

In meantime, forcing the `flex-basis` to `0` through the class `flex-basis-none` will have the same effect.

Fixes #36163

### How to verify
Follow the original repro steps and make sure that both short label and a very long label always take 100% of the container width. The easiest way to achieve this is by manually altering the inner text of a select button in dev tools.

Regular label
![image](https://github.com/metabase/metabase/assets/31325167/23419208-b205-4aec-890f-41dba9c4ad73)

Long label
![image](https://github.com/metabase/metabase/assets/31325167/d68a2320-62a9-4447-81a6-144641ad6b33)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
