### PR TITLE
Display chart caption even where there is no card title

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
@@ -6,6 +6,8 @@ import {
   editDashboard,
   showDashboardCardActions,
   modal,
+  saveDashboard,
+  getDashboardCardMenu,
 } from "e2e/support/helpers";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
@@ -15,22 +17,30 @@ describe("scenarios > dashboard cards > visualization options", () => {
     cy.signInAsAdmin();
   });
 
-  it("should allow empty card title (metabase#12013)", () => {
+  it("should allow empty card title (metabase#12013, metabase#36788)", () => {
+    const originalCardTitle = "Orders";
     visitDashboard(ORDERS_DASHBOARD_ID);
 
-    cy.findByTextEnsureVisible("Orders");
-    cy.findByTestId("legend-caption").should("exist");
+    cy.findByTestId("legend-caption")
+      .should("contain", originalCardTitle)
+      .and("be.visible");
 
     editDashboard();
     showDashboardCardActions();
     cy.icon("palette").click();
 
     modal().within(() => {
-      cy.findByDisplayValue("Orders").click().clear();
+      cy.findByDisplayValue(originalCardTitle).click().clear();
       cy.button("Done").click();
     });
 
-    cy.findByTestId("legend-caption").should("not.exist");
+    cy.findByTestId("legend-caption").should("not.contain", originalCardTitle);
+    saveDashboard();
+    getDashboardCard().realHover();
+    getDashboardCardMenu().click();
+    popover()
+      .should("contain", "Edit question")
+      .and("contain", "Download results");
   });
 
   it("column reordering should work (metabase#16229)", () => {

--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -39,10 +39,6 @@ const ChartCaption = ({
     });
   }, [card, onChangeCardAndRun]);
 
-  if (!title) {
-    return null;
-  }
-
   return (
     <ChartCaptionRoot
       title={title}

--- a/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
@@ -62,13 +62,13 @@ const setup = (props: Partial<Props> = {}) => {
 };
 
 describe("ChartCaption", () => {
-  it("shouldn't render without title", () => {
+  it("should render without a title (metabase#36788)", () => {
     setup();
 
-    expect(screen.queryByTestId("legend-caption")).not.toBeInTheDocument();
+    expect(screen.getByTestId("legend-caption")).toBeInTheDocument();
   });
 
-  it("should render with title", () => {
+  it("should render with a title", () => {
     setup({
       series: getSeries({ card: createMockCard({ name: "card name" }) }),
       settings: { "card.description": "description" },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36788

### Description

This PR should fix #36788 by removing the condition in which we don't even display chart caption when there is no card title. This prevents users from downloading the card results or from editing a question.

### How to verify
Follow the repro steps from the original issue.
Once you remove the dashcard title and save the dashboard, the `...` menu should still be there and it should be possible to download test results.

### Demo
https://github.com/metabase/metabase/assets/31325167/36613720-c9be-496a-ab30-bb7ae1a8a451

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

### Additional Info
Related issue that is important for historical context is https://github.com/metabase/metabase/issues/12013. I've adapted the repro for it to suit both that issue and this one. The previous assertion was probably too aggresive.
```diff
- cy.findByTestId("legend-caption").should("not.exist");
+ cy.findByTestId("legend-caption").should("not.contain", originalCardTitle);
```
