### PR TITLE
Fix MLv1 filter validation

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -996,11 +996,12 @@ class Question {
   _serializeForUrl({
     includeOriginalCardId = true,
     clean = true,
+    cleanFilters = false,
     includeDisplayIsLocked = false,
     creationType,
   } = {}) {
     const query = clean
-      ? this.query().clean({ skipFilters: true })
+      ? this.query().clean({ skipFilters: !cleanFilters })
       : this.query();
     const cardCopy = {
       name: this._card.name,

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -999,7 +999,9 @@ class Question {
     includeDisplayIsLocked = false,
     creationType,
   } = {}) {
-    const query = clean ? this.query().clean() : this.query();
+    const query = clean
+      ? this.query().clean({ skipFilters: true })
+      : this.query();
     const cardCopy = {
       name: this._card.name,
       description: this._card.description,

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -374,7 +374,7 @@ class StructuredQuery extends AtomicQuery {
     const sourceQuery = query.sourceQuery();
 
     if (sourceQuery) {
-      query = query.setSourceQuery(sourceQuery.clean());
+      query = query.setSourceQuery(sourceQuery.clean({ skipFilters }));
     }
 
     query = query.cleanJoins().cleanExpressions().cleanFields();

--- a/frontend/src/metabase-lib/urls.ts
+++ b/frontend/src/metabase-lib/urls.ts
@@ -14,6 +14,7 @@ type UrlBuilderOpts = {
   includeDisplayIsLocked?: boolean;
   creationType?: string;
   clean?: boolean;
+  cleanFilters?: boolean;
 };
 
 export function getUrl(
@@ -21,6 +22,7 @@ export function getUrl(
   {
     originalQuestion,
     clean = true,
+    cleanFilters = false,
     query,
     includeDisplayIsLocked,
     creationType,
@@ -35,6 +37,7 @@ export function getUrl(
     return Urls.question(null, {
       hash: question._serializeForUrl({
         clean,
+        cleanFilters,
         includeDisplayIsLocked,
         creationType,
       }),
@@ -63,6 +66,7 @@ export function getUrlWithParameters(
 
       return getUrl(questionWithParameters, {
         clean,
+        cleanFilters: true,
         originalQuestion: question,
         includeDisplayIsLocked,
         query: objectId === undefined ? {} : { objectId },

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -188,7 +188,7 @@ export const apiCreateQuestion = question => {
     const resultsMetadata = getResultsMetadata(getState());
     const isResultDirty = getIsResultDirty(getState());
     const questionToCreate = questionWithVizSettings
-      .setQuery(question.query().clean())
+      .setQuery(question.query().clean({ skipFilters: true }))
       .setResultsMetadata(isResultDirty ? null : resultsMetadata);
     const createdQuestion = await reduxCreateQuestion(
       questionToCreate,
@@ -253,7 +253,7 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
       // Before we clean the query, we make sure question is not treated as a dataset
       // as calling table() method down the line would bring unwanted consequences
       // such as dropping joins (as joins are treated differently between pure questions and datasets)
-      .setQuery(question.setDataset(false).query().clean())
+      .setQuery(question.setDataset(false).query().clean({ skipFilters: true }))
       .setResultsMetadata(isResultDirty ? null : resultsMetadata);
 
     // When viewing a dataset, its dataset_query is swapped with a clean query using the dataset as a source table

--- a/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/modals/BulkFilterModal/BulkFilterModal.tsx
@@ -93,7 +93,7 @@ const BulkFilterModal = ({
 
   const handleApplyQuery = useCallback(() => {
     const preCleanedQuery = fixBetweens(query);
-    onQueryChange(preCleanedQuery.clean());
+    onQueryChange(preCleanedQuery.clean({ skipFilters: false }));
     onClose?.();
   }, [query, onClose, onQueryChange]);
 


### PR DESCRIPTION
After merging MLv2 filters and drills to master it became possible to create filters that are considered invalid in MLv1. Currently it's only possible to add MLv1 filters in the filter modal, so lets skip filter validation in all cases but that modal. 

It should be possible to add filters to questions like this https://stats.metabase.com/question/14939