### PR TITLE
Clean up the pulse page

### DIFF
--- a/e2e/test/scenarios/sharing/pulse.cy.spec.js
+++ b/e2e/test/scenarios/sharing/pulse.cy.spec.js
@@ -35,9 +35,6 @@ describe("scenarios > pulse", { tags: "@external" }, () => {
 
     popover().findByText("Orders, Count").click();
 
-    // pulse card preview
-    cy.get("@pulseData").contains("18,760");
-
     cy.findByRole("heading", { name: "Where should this data go?" })
       .parent()
       .within(() => {
@@ -88,8 +85,6 @@ describe("scenarios > pulse", { tags: "@external" }, () => {
       cy.visit("/collection/root");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.contains("pulse title").click({ force: true });
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("18,760");
     });
 
     it("should edit existing pulses", () => {

--- a/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
+++ b/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
@@ -4,10 +4,9 @@ import PropTypes from "prop-types";
 
 import { t } from "ttag";
 import ExternalLink from "metabase/core/components/ExternalLink";
-import LoadingSpinner from "metabase/components/LoadingSpinner";
 import Tooltip from "metabase/core/components/Tooltip";
 
-import { color, alpha } from "metabase/lib/colors";
+import { color } from "metabase/lib/colors";
 import { AttachmentIcon, RemoveIcon } from "./PulseCardPreview.styled";
 
 export default class PulseCardPreview extends Component {
@@ -59,13 +58,14 @@ export default class PulseCardPreview extends Component {
   };
 
   render() {
-    const { cardPreview, attachmentsEnabled } = this.props;
+    const { card, cardPreview, attachmentsEnabled } = this.props;
     const hasAttachment = this.hasAttachment();
     const isAttachmentOnly =
       attachmentsEnabled &&
       hasAttachment &&
       cardPreview &&
       cardPreview.pulse_card_type == null;
+
     return (
       <div
         className="relative full"
@@ -76,12 +76,8 @@ export default class PulseCardPreview extends Component {
         <div
           className="absolute p2 text-light"
           style={{
-            top: 2,
-            right: 2,
-            background: `linear-gradient(to right, ${alpha(
-              color("bg-white"),
-              0.2,
-            )}, white, white)`,
+            top: 1,
+            right: -4,
             paddingLeft: 100,
           }}
         >
@@ -101,37 +97,16 @@ export default class PulseCardPreview extends Component {
               />
             </Tooltip>
           )}
-          <RemoveIcon name="close" size={18} onClick={this.props.onRemove} />
+          <RemoveIcon name="close" onClick={this.props.onRemove} />
         </div>
         <div
           className="bordered rounded bg-white scroll-x"
           style={{ display: !cardPreview && "none" }}
         >
-          {/* Override backend rendering if pulse_card_type == null */}
-          {cardPreview && cardPreview.pulse_card_type == null ? (
-            <RenderedPulseCardPreview href={cardPreview.pulse_card_url}>
-              <RenderedPulseCardPreviewHeader>
-                {cardPreview.pulse_card_name}
-              </RenderedPulseCardPreviewHeader>
-              <RenderedPulseCardPreviewMessage>
-                {isAttachmentOnly
-                  ? t`This question will be added as a file attachment`
-                  : t`This question won't be included in your Pulse`}
-              </RenderedPulseCardPreviewMessage>
-            </RenderedPulseCardPreview>
-          ) : (
-            <div
-              dangerouslySetInnerHTML={{
-                __html: cardPreview && cardPreview.pulse_card_html,
-              }}
-            />
-          )}
+          <p className="ml1" style={{ fontWeight: "bold" }}>
+            {card.name}
+          </p>
         </div>
-        {!cardPreview && (
-          <div className="flex-full flex align-center layout-centered pt1">
-            <LoadingSpinner className="inline-block" />
-          </div>
-        )}
       </div>
     );
   }

--- a/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
+++ b/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 
 import { t } from "ttag";
 import ExternalLink from "metabase/core/components/ExternalLink";
+import LoadingSpinner from "metabase/components/LoadingSpinner";
 import Tooltip from "metabase/core/components/Tooltip";
 
 import { color } from "metabase/lib/colors";
@@ -73,34 +74,43 @@ export default class PulseCardPreview extends Component {
           maxWidth: 379,
         }}
       >
-        <div className="flex flex-row justify-between bordered rounded bg-white px1">
-          <p style={{ fontWeight: "bold" }}>{card.name}</p>
-          <div className="flex flex-row align-center">
-            {attachmentsEnabled && !isAttachmentOnly && (
-              <Tooltip
-                tooltip={
-                  hasAttachment
-                    ? t`Remove attachment`
-                    : t`Attach file with results`
-                }
-              >
-                <AttachmentIcon
-                  name="attachment"
-                  size={18}
-                  hasAttachment={this.hasAttachment()}
-                  onClick={this.toggleAttachment}
-                />
-              </Tooltip>
-            )}
-            <RemoveIcon
-              name="close"
-              onClick={this.props.onRemove}
-              style={{
-                marginLeft: attachmentsEnabled && !isAttachmentOnly ? "4px" : 0,
-              }}
-            />
+        {cardPreview ? (
+          <div className="flex flex-row justify-between bordered rounded bg-white px1">
+            <p style={{ fontWeight: "bold" }}>
+              {card.name || cardPreview.pulse_card_name}
+            </p>
+            <div className="flex flex-row align-center">
+              {attachmentsEnabled && !isAttachmentOnly && (
+                <Tooltip
+                  tooltip={
+                    hasAttachment
+                      ? t`Remove attachment`
+                      : t`Attach file with results`
+                  }
+                >
+                  <AttachmentIcon
+                    name="attachment"
+                    size={18}
+                    hasAttachment={this.hasAttachment()}
+                    onClick={this.toggleAttachment}
+                  />
+                </Tooltip>
+              )}
+              <RemoveIcon
+                name="close"
+                onClick={this.props.onRemove}
+                style={{
+                  marginLeft:
+                    attachmentsEnabled && !isAttachmentOnly ? "4px" : 0,
+                }}
+              />
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="flex-full flex align-center layout-centered pt1">
+            <LoadingSpinner className="inline-block" />
+          </div>
+        )}
       </div>
     );
   }

--- a/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
+++ b/frontend/src/metabase/pulse/components/PulseCardPreview.jsx
@@ -73,39 +73,33 @@ export default class PulseCardPreview extends Component {
           maxWidth: 379,
         }}
       >
-        <div
-          className="absolute p2 text-light"
-          style={{
-            top: 1,
-            right: -4,
-            paddingLeft: 100,
-          }}
-        >
-          {attachmentsEnabled && !isAttachmentOnly && (
-            <Tooltip
-              tooltip={
-                hasAttachment
-                  ? t`Remove attachment`
-                  : t`Attach file with results`
-              }
-            >
-              <AttachmentIcon
-                name="attachment"
-                size={18}
-                hasAttachment={this.hasAttachment()}
-                onClick={this.toggleAttachment}
-              />
-            </Tooltip>
-          )}
-          <RemoveIcon name="close" onClick={this.props.onRemove} />
-        </div>
-        <div
-          className="bordered rounded bg-white scroll-x"
-          style={{ display: !cardPreview && "none" }}
-        >
-          <p className="ml1" style={{ fontWeight: "bold" }}>
-            {card.name}
-          </p>
+        <div className="flex flex-row justify-between bordered rounded bg-white px1">
+          <p style={{ fontWeight: "bold" }}>{card.name}</p>
+          <div className="flex flex-row align-center">
+            {attachmentsEnabled && !isAttachmentOnly && (
+              <Tooltip
+                tooltip={
+                  hasAttachment
+                    ? t`Remove attachment`
+                    : t`Attach file with results`
+                }
+              >
+                <AttachmentIcon
+                  name="attachment"
+                  size={18}
+                  hasAttachment={this.hasAttachment()}
+                  onClick={this.toggleAttachment}
+                />
+              </Tooltip>
+            )}
+            <RemoveIcon
+              name="close"
+              onClick={this.props.onRemove}
+              style={{
+                marginLeft: attachmentsEnabled && !isAttachmentOnly ? "4px" : 0,
+              }}
+            />
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/metabase/pulse/components/PulseCardPreview.styled.tsx
+++ b/frontend/src/metabase/pulse/components/PulseCardPreview.styled.tsx
@@ -18,7 +18,6 @@ export const AttachmentIcon = styled(Icon)<AttachmentIconProps>`
 
 export const RemoveIcon = styled(Icon)`
   cursor: pointer;
-  padding: 0.5rem 0.5rem 0.5rem 0;
 
   &:hover {
     color: ${color("brand")};

--- a/frontend/src/metabase/pulse/components/PulseEditCards.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditCards.jsx
@@ -101,40 +101,6 @@ export default class PulseEditCards extends Component {
     );
   }
 
-  getNotices(card, cardPreview, index) {
-    const showSoftLimitWarning = index === SOFT_LIMIT;
-    const notices = [];
-    const hasAttachment =
-      isAutoAttached(cardPreview) ||
-      (this.props.attachmentsEnabled &&
-        card &&
-        (card.include_csv || card.include_xls));
-    if (cardPreview) {
-      if (isAutoAttached(cardPreview)) {
-        notices.push({
-          type: "warning",
-          head: t`Heads up`,
-          body: t`We'll show the first 10 rows of this table in your Pulse. If you email this, we'll add a file attachment with all columns and up to 2,000 rows.`,
-        });
-      }
-      if (cardPreview.pulse_card_type == null && !hasAttachment) {
-        notices.push({
-          type: "warning",
-          head: t`Heads up`,
-          body: t`Raw data questions can only be included as email attachments`,
-        });
-      }
-    }
-    if (showSoftLimitWarning) {
-      notices.push({
-        type: "warning",
-        head: t`Looks like this pulse is getting big`,
-        body: t`We recommend keeping pulses small and focused to help keep them digestible and useful to the whole team.`,
-      });
-    }
-    return notices;
-  }
-
   render() {
     const { pulse, cardPreviews } = this.props;
 

--- a/frontend/src/metabase/pulse/components/PulseEditCards.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditCards.jsx
@@ -135,23 +135,6 @@ export default class PulseEditCards extends Component {
     return notices;
   }
 
-  renderCardNotices(card, index) {
-    const cardPreview = card && this.props.cardPreviews[card.id];
-    const notices = this.getNotices(card, cardPreview, index);
-    if (notices.length > 0) {
-      return (
-        <div>
-          {notices.map((notice, index) => (
-            <CardNotice key={index} isWarning={notice.type === "warning"}>
-              <h3 className="mb1">{notice.head}</h3>
-              <div className="h4">{notice.body}</div>
-            </CardNotice>
-          ))}
-        </div>
-      );
-    }
-  }
-
   render() {
     const { pulse, cardPreviews } = this.props;
 

--- a/frontend/src/metabase/pulse/components/PulseEditCards.jsx
+++ b/frontend/src/metabase/pulse/components/PulseEditCards.jsx
@@ -76,6 +76,31 @@ export default class PulseEditCards extends Component {
     this.trackPulseEvent("RemoveCard", index);
   }
 
+  maybeRenderAttachmentNotice(card, cardPreview, index) {
+    const hasAttachment =
+      isAutoAttached(cardPreview) ||
+      (this.props.attachmentsEnabled &&
+        card &&
+        (card.include_csv || card.include_xls));
+
+    if (!hasAttachment) {
+      return null;
+    }
+
+    return (
+      <CardNotice>
+        <h3 className="mb1">{t`Attachment`}</h3>
+        <div className="h4">
+          <AttachmentWidget
+            card={card}
+            onChange={card => this.setCard(index, card)}
+            trackPulseEvent={this.trackPulseEvent}
+          />
+        </div>
+      </CardNotice>
+    );
+  }
+
   getNotices(card, cardPreview, index) {
     const showSoftLimitWarning = index === SOFT_LIMIT;
     const notices = [];
@@ -84,18 +109,6 @@ export default class PulseEditCards extends Component {
       (this.props.attachmentsEnabled &&
         card &&
         (card.include_csv || card.include_xls));
-    if (hasAttachment) {
-      notices.push({
-        head: t`Attachment`,
-        body: (
-          <AttachmentWidget
-            card={card}
-            onChange={card => this.setCard(index, card)}
-            trackPulseEvent={this.trackPulseEvent}
-          />
-        ),
-      });
-    }
     if (cardPreview) {
       if (isAutoAttached(cardPreview)) {
         notices.push({
@@ -127,7 +140,7 @@ export default class PulseEditCards extends Component {
     const notices = this.getNotices(card, cardPreview, index);
     if (notices.length > 0) {
       return (
-        <div className="absolute" style={{ width: 400, marginLeft: 420 }}>
+        <div>
           {notices.map((notice, index) => (
             <CardNotice key={index} isWarning={notice.type === "warning"}>
               <h3 className="mb1">{notice.head}</h3>
@@ -190,7 +203,11 @@ export default class PulseEditCards extends Component {
                     />
                   )}
                 </div>
-                {this.renderCardNotices(card, index)}
+                {this.maybeRenderAttachmentNotice(
+                  card,
+                  card && this.props.cardPreviews[card.id],
+                  index,
+                )}
               </div>
             </li>
           ))}


### PR DESCRIPTION
A few visual fixes for the pulse page:

* removed broken card visualizations
* removed floating callouts (absolutely positioned yellow blocks text)

### Demo

| Before | After  |
|--------|-------|
|  <img width="683" src="https://github.com/metabase/metabase/assets/17258145/95d0ed12-290b-40d4-90c7-a064c015e1f1">           |   <img width="657" alt="after" src="https://github.com/metabase/metabase/assets/17258145/fe9cc31a-5360-4698-b383-b9da2a179687">        |

