### PR TITLE
Change e2e spec pattern to allow TypeScript extension

### DIFF
--- a/e2e/runner/cypress-runner-run-tests.js
+++ b/e2e/runner/cypress-runner-run-tests.js
@@ -12,7 +12,7 @@ const isFolder = !!folder;
 const isOpenMode = args["--open"];
 
 const getSourceFolder = folder => {
-  return `./e2e/test/scenarios/${folder}/**/*.cy.spec.js`;
+  return `./e2e/test/scenarios/${folder}/**/*.cy.spec.{js,ts}`;
 };
 
 const runCypress = async (baseUrl, exitFunction) => {

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -110,7 +110,7 @@ const defaultConfig = {
   // New `specPattern` is the combination of the old:
   //   1. testFiles and
   //   2. integrationFolder
-  specPattern: "e2e/test/**/*.cy.spec.js",
+  specPattern: "e2e/test/**/*.cy.spec.{js,ts}",
 };
 
 const mainConfig = {
@@ -138,13 +138,13 @@ const snapshotsConfig = {
 const crossVersionSourceConfig = {
   ...defaultConfig,
   baseUrl: "http://localhost:3000",
-  specPattern: "e2e/test/scenarios/cross-version/source/**/*.cy.spec.js",
+  specPattern: "e2e/test/scenarios/cross-version/source/**/*.cy.spec.{js,ts}",
 };
 
 const crossVersionTargetConfig = {
   ...defaultConfig,
   baseUrl: "http://localhost:3001",
-  specPattern: "e2e/test/scenarios/cross-version/target/**/*.cy.spec.js",
+  specPattern: "e2e/test/scenarios/cross-version/target/**/*.cy.spec.{js,ts}",
 };
 
 const stressTestConfig = {

--- a/e2e/validate-e2e-test-files.js
+++ b/e2e/validate-e2e-test-files.js
@@ -5,7 +5,7 @@ const path = require("path");
 const glob = require("glob");
 const chalk = require("chalk");
 
-const E2E_FILE_EXTENSION = ".cy.spec.js";
+const E2E_FILE_EXTENSION = /\.cy\.spec\.(js|ts)$/;
 const E2E_HOME = "e2e/test/";
 
 init();
@@ -16,7 +16,7 @@ function validateE2EFileNames(files) {
   }
 
   const invalidFileNames = files.filter(fullPath => {
-    return !path.basename(fullPath).endsWith(E2E_FILE_EXTENSION);
+    return !path.basename(fullPath).match(E2E_FILE_EXTENSION);
   });
 
   printFeedback(invalidFileNames);


### PR DESCRIPTION
Continuing https://github.com/metabase/metabase/pull/36474

Allow `*.cy.spec.ts` files to be picked up by our Cypress test runner.  I’m adding the first typescript spec here: https://github.com/metabase/metabase/pull/36258