### PR TITLE
Publish Releases Granularly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           ./version.properties
 
   upload-to-s3:
-    if: ${{ !inputs.skip-s3 != true }}
+    if: ${{ inputs.skip-s3 != true }}
     runs-on: ubuntu-22.04
     needs: download-uberjar
     timeout-minutes: 15

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           ./version.properties
 
   upload-to-s3:
-    if: ${{ inputs.skip-s3 != true }}
+    if: ${{ !inputs.skip-s3 != true }}
     runs-on: ubuntu-22.04
     needs: download-uberjar
     timeout-minutes: 15
@@ -614,7 +614,7 @@ jobs:
   manage-milestones:
     permissions: write-all
     runs-on: ubuntu-22.04
-    needs: [publish-version-info, draft-release-notes]
+    needs: push-tags
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,26 @@ on:
       commit:
         description: 'A full-length commit SHA-1 hash'
         required: true
+      skip-docker:
+        description: 'Skip Docker image publishing'
+        type: boolean
+        default: false
+      skip-s3:
+        description: 'Skip S3 artifact publishing'
+        type: boolean
+        default: false
+      skip-version-info:
+        description: 'Skip publishing version-info.json'
+        type: boolean
+        default: false
+      skip-tag:
+        description: 'Skip tagging the release'
+        type: boolean
+        default: false
+      skip-release-notes:
+        description: 'Skip publishing release notes'
+        type: boolean
+        default: false
 
 jobs:
   check-version:
@@ -140,6 +160,7 @@ jobs:
           ./version.properties
 
   upload-to-s3:
+    if: ${{ inputs.skip-s3 !== true }}
     runs-on: ubuntu-22.04
     needs: download-uberjar
     timeout-minutes: 15
@@ -217,6 +238,7 @@ jobs:
 
 
   verify-s3-download:
+    if: ${{ inputs.skip-s3 !== true }}
     runs-on: ubuntu-22.04
     needs: upload-to-s3
     timeout-minutes: 15
@@ -250,6 +272,7 @@ jobs:
       run: grep -q $(sha256sum ./metabase-downloaded.jar) SHA256.sum && echo "checksums match" || exit 1
 
   containerize:
+    if: ${{ inputs.skip-docker !== true }}
     runs-on: ubuntu-22.04
     needs: [check-version, download-uberjar]
     timeout-minutes: 15
@@ -359,6 +382,7 @@ jobs:
         echo "Finished!"
 
   verify-docker-pull:
+    if: ${{ inputs.skip-docker !== true }}
     runs-on: ubuntu-22.04
     needs: containerize
     timeout-minutes: 15
@@ -407,6 +431,7 @@ jobs:
       timeout-minutes: 3
 
   push-tags:
+    if: ${{ inputs.skip-tag !== true }}
     permissions: write-all
     needs: [verify-s3-download, verify-docker-pull, check-version]
     runs-on: ubuntu-22.04
@@ -457,6 +482,7 @@ jobs:
         $GITHUB_WORKSPACE/release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
 
   trigger-docs-update:
+    if: ${{ inputs.skip-release-notes !== true }}
     needs: push-tags
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -475,6 +501,7 @@ jobs:
             });
 
   draft-release-notes:
+    if: ${{ inputs.skip-release-notes !== true }}
     needs: push-tags
     runs-on: ubuntu-22.04
     timeout-minutes: 15
@@ -526,6 +553,7 @@ jobs:
             });
 
   publish-version-info:
+    if: ${{ inputs.skip-version-info !== true }}
     runs-on: ubuntu-22.04
     needs: [push-tags, check-version]
     timeout-minutes: 15
@@ -583,7 +611,7 @@ jobs:
         --distribution-id ${{ vars.AWS_CLOUDFRONT_STATIC_ID }} \
         --paths "/version-info.json" "/version-info-ee.json"
 
-  manage-issues:
+  manage-milestones:
     permissions: write-all
     runs-on: ubuntu-22.04
     needs: [publish-version-info, draft-release-notes]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
           ./version.properties
 
   upload-to-s3:
-    if: ${{ inputs.skip-s3 !== true }}
+    if: ${{ inputs.skip-s3 != true }}
     runs-on: ubuntu-22.04
     needs: download-uberjar
     timeout-minutes: 15
@@ -238,7 +238,7 @@ jobs:
 
 
   verify-s3-download:
-    if: ${{ inputs.skip-s3 !== true }}
+    if: ${{ inputs.skip-s3 != true }}
     runs-on: ubuntu-22.04
     needs: upload-to-s3
     timeout-minutes: 15
@@ -272,7 +272,7 @@ jobs:
       run: grep -q $(sha256sum ./metabase-downloaded.jar) SHA256.sum && echo "checksums match" || exit 1
 
   containerize:
-    if: ${{ inputs.skip-docker !== true }}
+    if: ${{ inputs.skip-docker != true }}
     runs-on: ubuntu-22.04
     needs: [check-version, download-uberjar]
     timeout-minutes: 15
@@ -382,7 +382,7 @@ jobs:
         echo "Finished!"
 
   verify-docker-pull:
-    if: ${{ inputs.skip-docker !== true }}
+    if: ${{ inputs.skip-docker != true }}
     runs-on: ubuntu-22.04
     needs: containerize
     timeout-minutes: 15
@@ -431,7 +431,7 @@ jobs:
       timeout-minutes: 3
 
   push-tags:
-    if: ${{ inputs.skip-tag !== true }}
+    if: ${{ inputs.skip-tag != true }}
     permissions: write-all
     needs: [verify-s3-download, verify-docker-pull, check-version]
     runs-on: ubuntu-22.04
@@ -482,7 +482,7 @@ jobs:
         $GITHUB_WORKSPACE/release/reorder-tags.sh ${{ needs.check-version.outputs.ee }} ${{ inputs.commit }}
 
   trigger-docs-update:
-    if: ${{ inputs.skip-release-notes !== true }}
+    if: ${{ inputs.skip-release-notes != true }}
     needs: push-tags
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -501,7 +501,7 @@ jobs:
             });
 
   draft-release-notes:
-    if: ${{ inputs.skip-release-notes !== true }}
+    if: ${{ inputs.skip-release-notes != true }}
     needs: push-tags
     runs-on: ubuntu-22.04
     timeout-minutes: 15
@@ -553,7 +553,7 @@ jobs:
             });
 
   publish-version-info:
-    if: ${{ inputs.skip-version-info !== true }}
+    if: ${{ inputs.skip-version-info != true }}
     runs-on: ubuntu-22.04
     needs: [push-tags, check-version]
     timeout-minutes: 15


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36808

### Description

This adds the option to our release process to skip various steps. @nemanjaglumac and I had actually discussed implementing this a while ago. This simply adds a few boolean variables to this job trigger and skips the selected steps.

This is risky and you should only do this if you know what you're doing.

![Screen Shot 2023-12-14 at 11 42 53 AM](https://github.com/metabase/metabase/assets/30528226/4ed9dcc4-2061-47ad-8fa0-b280ceecd335)

### How to verify

Fork test job 1:  ✅  https://github.com/iethree/metabase/actions/runs/7213104907
![Screen Shot 2023-12-14 at 11 46 48 AM](https://github.com/metabase/metabase/assets/30528226/e4ba88e4-e644-48f4-b836-7154fde5425e)

Fork test job 2:  ✅  https://github.com/iethree/metabase/actions/runs/7213181662

![Screen Shot 2023-12-14 at 11 50 31 AM](https://github.com/metabase/metabase/assets/30528226/5e453f95-c25e-4d4f-8ad2-19f5b21e2e65)


