### PR TITLE
Add e2e spyRequestFinished helper

### DIFF
--- a/e2e/support/helpers/e2e-request-helpers.js
+++ b/e2e/support/helpers/e2e-request-helpers.js
@@ -1,0 +1,30 @@
+/**
+ * Some XHR requests might be called but cancelled shortly after.
+ * In case you wouldn't like to count these, use this helper:
+ *
+ *
+ * const { interceptor, spy } = spyRequestFinished("name")
+ * cy.intercept(
+ *              "POST",
+ *              "/api/dashboard/",
+ *              interceptor,
+ * )
+ *
+ * AND use cypress's should
+ *
+ * cy.get("@name").should("have.callCount", 2)
+ *
+ * OR sinon's should directly
+ *
+ * cy.get("@dashcardRequestSpy").should(spy => {
+ *
+ *    expect(spy.getCalls().length).to.eq(2);
+ * });
+ */
+export function spyRequestFinished(name = "requestFinishedSpy") {
+  const spy = cy.spy().as(name);
+  return {
+    interceptor: req => req.continue(res => spy(req, res)),
+    spy,
+  };
+}

--- a/e2e/support/helpers/index.js
+++ b/e2e/support/helpers/index.js
@@ -25,6 +25,7 @@ export * from "./e2e-bi-basics-helpers";
 export * from "./e2e-boolean-helpers";
 export * from "./e2e-embedding-helpers";
 export * from "./e2e-permissions-helpers";
+export * from "./e2e-request-helpers";
 export * from "./e2e-visual-tests-helpers";
 export * from "./e2e-users-helpers";
 export * from "./e2e-viz-settings-helpers";


### PR DESCRIPTION
I have found a handy way of intercepting successful only requests. It may help when some of them are cancelled (this is what dashboards do) but you only need to react to the finished ones.

Used in my other PR: https://github.com/metabase/metabase/pull/36760/files#diff-6ab257b78f063da56720b3a2e8bf5f31f729e852a40062d499450d9ccad3d85cR631-R635

