### PR TITLE
Fix broken Percy tests

### DIFF
--- a/e2e/support/helpers/e2e-email-helpers.js
+++ b/e2e/support/helpers/e2e-email-helpers.js
@@ -81,7 +81,7 @@ export const clickSend = () => {
   cy.wait("@emailSent");
 };
 
-export const openAndAddEmailToSubscriptions = recipients => {
+export const openAndAddEmailsToSubscriptions = recipients => {
   cy.findByLabelText("subscriptions").click();
 
   cy.findByText("Email it").click();
@@ -96,7 +96,7 @@ export const openAndAddEmailToSubscriptions = recipients => {
 };
 
 export const setupSubscriptionWithRecipients = recipients => {
-  openAndAddEmailToSubscriptions(recipients);
+  openAndAddEmailsToSubscriptions(recipients);
   sidebar().findByText("Done").click();
 };
 
@@ -110,7 +110,7 @@ export const emailSubscriptionRecipients = () => {
 };
 
 export const sendSubscriptionsEmail = recipient => {
-  openAndAddEmailToSubscriptions(recipient);
+  openAndAddEmailsToSubscriptions([recipient]);
   clickSend();
 };
 


### PR DESCRIPTION
Fix broken helper that is used in Percy tests

![image](https://github.com/metabase/metabase/assets/22608765/ea1f40c5-d8fb-46af-81d3-190f4e6e05f7)

```
TypeError: recipients.forEach is not a function
    at openAndAddEmailToSubscriptions (http://localhost:4000/__cypress/tests?p=e2e/test/visual/static-visualizations/waterfall.cy.spec.js:41170:16)
    at sendSubscriptionsEmail (http://localhost:4000/__cypress/tests?p=e2e/test/visual/static-visualizations/waterfall.cy.spec.js:41176:5)
    at Context.eval (http://localhost:4000/__cypress/tests?p=e2e/test/visual/static-visualizations/waterfall.cy.spec.js:43065:9)
```