### PR TITLE
Automated release status updates in Slack

### DIFF
--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -1,9 +1,9 @@
-name: Check Release Status
+name: Release Status Check
 
 on:
   workflow_dispatch:
   schedule:
-    - '0 13 * * *' # every day at 8am US eastern time
+    - cron: '0 13 * * *' # every day at 8am US eastern time
 
 jobs:
   check-release-status:
@@ -24,12 +24,17 @@ jobs:
         script: | # js
           const { checkReleaseStatus } = require('${{ github.workspace }}/release/dist/index.cjs');
 
+          if (!process.env.SLACK_BOT_TOKEN) {
+            throw new Error('SLACK_BOT_TOKEN is required');
+          }
+
+          if (!process.env.SLACK_RELEASE_CHANNEL) {
+            throw new Error('SLACK_RELEASE_CHANNEL is required');
+          }
+
           const ossReleased = await checkReleaseStatus({
             github,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            version: versions.oss,
-            channelName: process.env.SLACK_RELEASE_CHANNEL ?? 'bot-testing',
+            channelName: process.env.SLACK_RELEASE_CHANNEL,
           });
-
-

--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -1,0 +1,35 @@
+name: Check Release Status
+
+on:
+  workflow_dispatch:
+  schedule:
+    - '0 13 * * *' # every day at 8am US eastern time
+
+jobs:
+  check-release-status:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        sparse-checkout: release
+    - name: Prepare build scripts
+      run: cd ${{ github.workspace }}/release && yarn && yarn build
+    - name: Check release status and post to Slack
+      uses: actions/github-script@v6
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+      with:
+        script: | # js
+          const { checkReleaseStatus } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+          const ossReleased = await checkReleaseStatus({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            version: versions.oss,
+            channelName: process.env.SLACK_RELEASE_CHANNEL ?? 'bot-testing',
+          });
+
+

--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -14,7 +14,7 @@ jobs:
       with:
         sparse-checkout: release
     - name: Prepare build scripts
-      run: cd ${{ github.workspace }}/release && yarn && yarn build
+      run: cd ${{ github.workspace }}/release && yarn --frozen-lockfile && yarn build
     - name: Check release status and post to Slack
       uses: actions/github-script@v6
       env:

--- a/release/package.json
+++ b/release/package.json
@@ -17,6 +17,8 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@octokit/rest": "^20.0.1",
+    "@slack/web-api": "^6.10.0",
+    "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
     "esbuild": "^0.19.2",
     "node-fetch": "^3.3.2",

--- a/release/package.json
+++ b/release/package.json
@@ -17,7 +17,7 @@
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@octokit/rest": "^20.0.1",
-    "@slack/web-api": "^6.10.0",
+    "@slack/web-api": "^6.11.1",
     "dayjs": "^1.11.10",
     "dotenv": "^16.3.1",
     "esbuild": "^0.19.2",

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -91,9 +91,9 @@ export const getMilestoneIssues = async ({
   repo,
   state = "closed",
 }: ReleaseProps & { state?: "closed" | "open" }): Promise<Issue[]> => {
-  const milestoneId = await findMilestone({ version, github, owner, repo });
+  const milestone = await findMilestone({ version, github, owner, repo });
 
-  if (!milestoneId) {
+  if (!milestone) {
     return [];
   }
 
@@ -101,7 +101,7 @@ export const getMilestoneIssues = async ({
   const issues = await github.paginate(github.rest.issues.listForRepo, {
     owner,
     repo,
-    milestone: milestoneId.toString(),
+    milestone: String(milestone.number),
     state,
   });
 

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -8,17 +8,27 @@ import {
 
 import type { ReleaseProps, Issue } from "./types";
 
-const findMilestone = async ({
-  version,
+const getMilestones = async ({
   github,
   owner,
   repo,
-}: ReleaseProps) => {
+}: Omit<ReleaseProps, 'version'>) => {
   const milestones = await github.rest.issues.listMilestones({
     owner,
     repo,
     state: "open",
   });
+
+  return milestones.data;
+};
+
+export const findMilestone = async ({
+  version,
+  github,
+  owner,
+  repo,
+}: ReleaseProps) => {
+  const milestones = await getMilestones({ github, owner, repo });
 
   // our milestones don't have the v prefix or a .0 suffix
   const expectedMilestoneName = getOSSVersion(version)
@@ -26,10 +36,10 @@ const findMilestone = async ({
     .replace(/-rc\d+$/i, "") // RC versions use the major version milestone
     .replace(/\.0$/, '');
 
-  return milestones.data.find(
+  return milestones.find(
     (milestone: { title: string; number: number }) =>
       milestone.title === expectedMilestoneName,
-  )?.number;
+  );
 };
 
 export const closeMilestone = async ({
@@ -38,9 +48,9 @@ export const closeMilestone = async ({
   repo,
   version,
 }: ReleaseProps) => {
-  const milestoneId = await findMilestone({ version, github, owner, repo });
+  const milestone = await findMilestone({ version, github, owner, repo });
 
-  if (!milestoneId) {
+  if (!milestone?.number) {
     console.log(`No milestone found for ${version}`);
     return;
   }
@@ -48,7 +58,7 @@ export const closeMilestone = async ({
   await github.rest.issues.updateMilestone({
     owner,
     repo,
-    milestone_number: milestoneId,
+    milestone_number: milestone.number,
     state: "closed",
   });
 };
@@ -79,7 +89,8 @@ export const getMilestoneIssues = async ({
   github,
   owner,
   repo,
-}: ReleaseProps): Promise<Issue[]> => {
+  state = "closed",
+}: ReleaseProps & { state?: "closed" | "open" }): Promise<Issue[]> => {
   const milestoneId = await findMilestone({ version, github, owner, repo });
 
   if (!milestoneId) {
@@ -91,7 +102,7 @@ export const getMilestoneIssues = async ({
     owner,
     repo,
     milestone: milestoneId.toString(),
-    state: "closed",
+    state,
   });
 
   return (issues ?? []) as Issue[];

--- a/release/src/index.ts
+++ b/release/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./github";
 export * from "./release-notes";
+export * from "./slack";
 export * from "./version-helpers";
 export * from "./version-info";

--- a/release/src/index.ts
+++ b/release/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./github";
 export * from "./release-notes";
+export * from "./release-status";
 export * from "./slack";
 export * from "./version-helpers";
 export * from "./version-info";

--- a/release/src/release-status.ts
+++ b/release/src/release-status.ts
@@ -1,0 +1,76 @@
+/* eslint-disable no-console */
+import type { Octokit } from "@octokit/rest";
+import dayjs from "dayjs";
+
+import { getChannelTopic, sendPreReleaseStatus } from "./slack";
+import { getMilestoneIssues, findMilestone } from "./github";
+
+
+const DATE_FORMAT = "ddd, MMM DD";
+// if we're more than 3 days out from a release, don't spam slack
+const MIN_DAYS_TO_RELEASE = 3;
+
+async function getReleaseInfo({
+  channelName
+}: {
+  channelName: string;
+}) {
+  const topic = await getChannelTopic(channelName);
+
+  if (!topic) {
+    throw new Error(`No channel topic found for ${channelName}`);
+  }
+  const matches = Array.from(topic.matchAll(/Next Release\:\s(.+)\son\s(.+)\b/ig));
+
+  if (!matches?.length) {
+    throw new Error("No release date found in channel topic");
+  }
+
+  return matches.map(([, version, date]) => ({
+    version,
+    date: dayjs(date).format(DATE_FORMAT),
+    dateDiff: dayjs(date).diff(dayjs(), 'day')
+  }));
+}
+
+export async function checkReleaseStatus({
+  channelName,
+  github,
+  owner,
+  repo,
+} : {
+  channelName: string,
+  github: Octokit,
+  owner: string,
+  repo: string,
+}) {
+  const releaseInfo = await getReleaseInfo({ channelName });
+  console.log(releaseInfo);
+
+  releaseInfo.forEach(async ({ version, date, dateDiff }) => {
+    if (dateDiff > MIN_DAYS_TO_RELEASE) {
+      return;
+    }
+    const milestone = await findMilestone({ version, github, owner, repo });
+    if (!milestone) {
+      console.log(`No milestone found for ${version}`);
+      return;
+    }
+    const openIssues = await getMilestoneIssues({
+      github,
+      owner,
+      repo,
+      version,
+      state: 'open'
+    });
+
+    await sendPreReleaseStatus({
+      channelName,
+      version,
+      date,
+      openIssues,
+      closedIssueCount: milestone.closed_issues,
+      milestoneId: milestone.number
+    });
+  });
+}

--- a/release/src/slack.ts
+++ b/release/src/slack.ts
@@ -1,0 +1,75 @@
+import { WebClient } from '@slack/web-api';
+import type { Issue } from './types';
+
+const slack = new WebClient(process.env.SLACK_BOT_TOKEN);
+
+export function getChannelTopic(channelName: string) {
+  return slack.conversations.list({
+    types: 'public_channel',
+  }).then(response => {
+    const channel = response?.channels?.find(channel => channel.name === channelName);
+    return channel?.topic?.value;
+  });
+}
+
+export async function sendPreReleaseStatus({
+  channelName, version, date, openIssues, closedIssueCount, milestoneId
+}: {
+  channelName: string,
+  version: string,
+  date: string,
+  openIssues: Issue[],
+  closedIssueCount: number,
+  milestoneId: number,
+}) {
+  const blockerText = `* ${openIssues.length } Blockers*
+${openIssues.map(issue => `  • <${issue.html_url}|#${issue.number} - ${issue.title}> - @${issue.assignee?.login ?? 'unassigned'}`).join("\n")}`;
+
+  const blocks = [
+    {
+			"type": "header",
+			"text": {
+				"type": "plain_text",
+				"text": `:rocket:  ${version} Release Status`,
+				"emoji": true
+			}
+		},
+    {
+			"type": "section",
+			"text": {
+				"type": "mrkdwn",
+				"text": `_<https://github.com/metabase/metabase/milestone/${milestoneId}|:direction-sign: Milestone> targeted for release on ${date}_`,
+			}
+		},
+  ];
+
+  const attachments = [
+    {
+      "color": "#32a852",
+      "blocks": [{
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": `*${closedIssueCount} Closed Issues*`,
+        }
+      }],
+    },
+    {
+      "color": "#a83632",
+      "blocks": [{
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": blockerText,
+        }
+      }],
+    },
+  ];
+
+  return slack.chat.postMessage({
+    channel: channelName,
+    blocks,
+    attachments,
+    text: `${version} is scheduled for release on ${date}`,
+  });
+}

--- a/release/src/types.ts
+++ b/release/src/types.ts
@@ -40,4 +40,5 @@ export type Issue = {
   title: string;
   html_url: string;
   labels: { name: string }[];
+  assignee: { login: string };
 };

--- a/release/yarn.lock
+++ b/release/yarn.lock
@@ -980,6 +980,35 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
+"@slack/logger@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-3.0.0.tgz#b736d4e1c112c22a10ffab0c2d364620aedcb714"
+  integrity sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==
+  dependencies:
+    "@types/node" ">=12.0.0"
+
+"@slack/types@^2.8.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.10.0.tgz#4766c7fb073e55b9b760af46e6f54add5c7f6a71"
+  integrity sha512-JXY9l49rf7dDgvfMZi0maFyugzGkvq0s5u+kDlD68WaRUhjZNLBDKZcsrycMsVVDFfyOK0R1UKkYGmy9Ph069Q==
+
+"@slack/web-api@^6.10.0":
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.10.0.tgz#0316132f3cc455b14c2008464154c7966df03bec"
+  integrity sha512-UTX7EKWEf1MQ6+p//4KX7tNTbvzS2W9dbhd2hYk4Lt0mfXf9khe6ZYRYPnV7QBycYcZ3t6FJRJAB55GTcccZ/A==
+  dependencies:
+    "@slack/logger" "^3.0.0"
+    "@slack/types" "^2.8.0"
+    "@types/is-stream" "^1.1.0"
+    "@types/node" ">=12.0.0"
+    axios "^1.6.0"
+    eventemitter3 "^3.1.0"
+    form-data "^2.5.0"
+    is-electron "2.2.2"
+    is-stream "^1.1.0"
+    p-queue "^6.6.1"
+    p-retry "^4.0.0"
+
 "@types/babel__core@^7.1.14":
   version "7.20.1"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.1.tgz#916ecea274b0c776fec721e333e55762d3a9614b"
@@ -1028,6 +1057,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/is-stream@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
+  integrity sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz#8467d4b3c087805d63580480890791277ce35c44"
@@ -1072,6 +1108,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.9.tgz#c7164e0f8d3f12dfae336af0b1f7fdec8c6b204f"
   integrity sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==
 
+"@types/node@>=12.0.0":
+  version "20.10.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.10.4.tgz#b246fd84d55d5b1b71bf51f964bd514409347198"
+  integrity sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==
+  dependencies:
+    undici-types "~5.26.4"
+
 "@types/node@^18.16.3":
   version "18.17.17"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.17.17.tgz#53cc07ce582c9d7c5850702a3c2cb0af0d7b0ca1"
@@ -1081,6 +1124,11 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@types/ps-tree/-/ps-tree-1.1.2.tgz#5c60773a38ffb1402e049902a7b7a8d3c67cd59a"
   integrity sha512-ZREFYlpUmPQJ0esjxoG1fMvB2HNaD3z+mjqdSosZvd3RalncI9NEur73P8ZJz4YQdL64CmV1w0RuqoRUlhQRBw==
+
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/stack-utils@^2.0.0":
   version "2.0.1"
@@ -1149,6 +1197,20 @@ argparse@^1.0.7:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
+  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -1357,6 +1419,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.6, combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1399,6 +1468,11 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
+dayjs@^1.11.10:
+  version "1.11.10"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
+  integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
+
 debug@^4.1.0, debug@^4.1.1:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -1415,6 +1489,11 @@ deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 deprecation@^2.0.0:
   version "2.3.1"
@@ -1559,6 +1638,16 @@ event-stream@=3.3.4:
     stream-combiner "~0.0.4"
     through "~2.3.1"
 
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
+eventemitter3@^4.0.4:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -1642,6 +1731,29 @@ find-up@^4.0.0, find-up@^4.1.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
+form-data@^2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 formdata-polyfill@^4.0.10:
   version "4.0.10"
@@ -1826,6 +1938,11 @@ is-core-module@^2.13.0:
   dependencies:
     has "^1.0.3"
 
+is-electron@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.2.tgz#3778902a2044d76de98036f5dc58089ac4d80bb9"
+  integrity sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -1857,6 +1974,11 @@ is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+  integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
 
 is-stream@^2.0.0:
   version "2.0.1"
@@ -2389,6 +2511,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2475,6 +2609,11 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
+
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -2495,6 +2634,29 @@ p-locate@^4.1.0:
   integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
   dependencies:
     p-limit "^2.2.0"
+
+p-queue@^6.6.1:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
+  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
+  dependencies:
+    eventemitter3 "^4.0.4"
+    p-timeout "^3.2.0"
+
+p-retry@^4.0.0:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
+
+p-timeout@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2587,6 +2749,11 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 ps-tree@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.2.0.tgz#5e7425b89508736cdd4f2224d028f7bb3f722ebd"
@@ -2649,6 +2816,11 @@ resolve@^1.20.0:
     is-core-module "^2.13.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
+
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -2874,6 +3046,11 @@ typescript@^5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
   integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 universal-user-agent@^6.0.0:
   version "6.0.0"

--- a/release/yarn.lock
+++ b/release/yarn.lock
@@ -987,21 +987,21 @@
   dependencies:
     "@types/node" ">=12.0.0"
 
-"@slack/types@^2.8.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.10.0.tgz#4766c7fb073e55b9b760af46e6f54add5c7f6a71"
-  integrity sha512-JXY9l49rf7dDgvfMZi0maFyugzGkvq0s5u+kDlD68WaRUhjZNLBDKZcsrycMsVVDFfyOK0R1UKkYGmy9Ph069Q==
+"@slack/types@^2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.11.0.tgz#948c556081c3db977dfa8433490cc2ff41f47203"
+  integrity sha512-UlIrDWvuLaDly3QZhCPnwUSI/KYmV1N9LyhuH6EDKCRS1HWZhyTG3Ja46T3D0rYfqdltKYFXbJSSRPwZpwO0cQ==
 
-"@slack/web-api@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.10.0.tgz#0316132f3cc455b14c2008464154c7966df03bec"
-  integrity sha512-UTX7EKWEf1MQ6+p//4KX7tNTbvzS2W9dbhd2hYk4Lt0mfXf9khe6ZYRYPnV7QBycYcZ3t6FJRJAB55GTcccZ/A==
+"@slack/web-api@^6.11.1":
+  version "6.11.1"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.11.1.tgz#a23552d9ee89fb5a727cce30ff58e4a3e3faf9ab"
+  integrity sha512-AU7Sty+NwkMU0qT/cKSIYV1NZ+bGDYqmJ3LAJD/3vtrxJvV9F9DdALgRSV2zRhrRjzjOgLhCRXVuOikQsKQhAg==
   dependencies:
     "@slack/logger" "^3.0.0"
-    "@slack/types" "^2.8.0"
+    "@slack/types" "^2.11.0"
     "@types/is-stream" "^1.1.0"
     "@types/node" ">=12.0.0"
-    axios "^1.6.0"
+    axios "^1.6.3"
     eventemitter3 "^3.1.0"
     form-data "^2.5.0"
     is-electron "2.2.2"
@@ -1203,10 +1203,10 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.6.0:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
-  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
+axios@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.3.tgz#7f50f23b3aa246eff43c54834272346c396613f4"
+  integrity sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==
   dependencies:
     follow-redirects "^1.15.0"
     form-data "^4.0.0"


### PR DESCRIPTION
closes https://github.com/metabase/metabase-private/issues/188

### Description

I've been running this local script to post about upcoming release statuses for a while and it's been useful. This cleans it up and makes it run automatically. It pulls target release date targes from the release slack channel name.

Currently, it follow these rules which are _very_ easy to change, so feedback is welcome:

- It will post about any upcoming release if the release is scheduled within 3 days
- It will post once per day at 1pm UTC (early morning US eastern time)
- It can also be triggered to run manually whenever you want (but still won't post about releases more than 3 days away)

![Screen Shot 2023-12-14 at 2 49 04 PM](https://github.com/metabase/metabase/assets/30528226/94472256-d88b-43a8-be4e-361a13b1f0a2)

## Testing
- [fork test run](https://github.com/iethree/metabase/actions/runs/7267482354/job/19801414893)
- [test slack message](https://metaboat.slack.com/archives/C01BWAZJE0N/p1703019473230009) (doesn't have issues cuz there aren't any in my fork)

