### PR TITLE
Add field values search info

### DIFF
--- a/frontend/src/metabase-lib/fields.ts
+++ b/frontend/src/metabase-lib/fields.ts
@@ -77,7 +77,7 @@ export function legacyRef(
 /**
  * Info about FieldValues/remapping for the purposes of powering search widgets in filter modals.
  */
-function fieldValuesSearchInfo(
+export function fieldValuesSearchInfo(
   metadataProviderable: MetadataProvider | Query,
   column: ColumnMetadata,
 ): FieldValuesSearchInfo {

--- a/frontend/src/metabase-lib/fields.ts
+++ b/frontend/src/metabase-lib/fields.ts
@@ -3,6 +3,7 @@ import type { FieldReference } from "metabase-types/api";
 import type {
   Clause,
   ColumnMetadata,
+  MetadataProvider,
   MetricMetadata,
   Query,
   SegmentMetadata,
@@ -72,3 +73,22 @@ export function legacyRef(
 ): FieldReference {
   return ML.legacy_ref(column);
 }
+
+/**
+ * Info about FieldValues/remapping for the purposes of powering search widgets in filter modals.
+ */
+function fieldValuesSearchInfo(
+  metadataProviderable: MetadataProvider | Query,
+  column: ColumnMetadata,
+): FieldValuesSearchInfo {
+  return ML.field_values_search_info(metadataProviderable, column);
+}
+
+type FieldValuesSearchInfo = {
+  // null means that the underlying field was not found
+  fieldId: number | null;
+  // a note for it below
+  searchFieldId: number | null;
+  // corresponds to has_field_values property, or "none" if the field is not found
+  hasFieldValues: "list" | "search" | "none";
+};

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -4,6 +4,7 @@
    [compojure.core :refer [DELETE GET POST PUT]]
    [metabase.api.common :as api]
    [metabase.db.metadata-queries :as metadata-queries]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.models.dimension :refer [Dimension]]
    [metabase.models.field :as field :refer [Field]]
    [metabase.models.field-values :as field-values :refer [FieldValues]]
@@ -140,7 +141,7 @@
    semantic_type      [:maybe ms/FieldSemanticOrRelationTypeKeywordOrString]
    coercion_strategy  [:maybe ms/CoercionStrategyKeywordOrString]
    visibility_type    [:maybe FieldVisibilityType]
-   has_field_values   [:maybe (into [:enum] (map name field/has-field-values-options))]
+   has_field_values   [:maybe ::lib.schema.metadata/column.has-field-values]
    settings           [:maybe ms/Map]
    nfc_path           [:maybe [:sequential ms/NonBlankString]]
    json_unfolding     [:maybe :boolean]}
@@ -267,10 +268,10 @@
      :has_more_values (not (str/blank? query))
      :field_id        field-id}))
 
-;; TODO -- not sure `has_field_values` actually has to be `:list` -- see code above.
 (api/defendpoint GET "/:id/values"
-  "If a Field's value of `has_field_values` is `:list`, return a list of all the distinct values of the Field (or remapped Field), and (if
-  defined by a User) a map of human-readable remapped values."
+  "If a Field's value of `has_field_values` is `:list`, return a list of all the distinct values of the Field (or
+  remapped Field), and (if defined by a User) a map of human-readable remapped values. If `has_field_values` is not
+  `:list`, checks whether we should create FieldValues for this Field; if so, creates and returns them."
   [id]
   {id ms/PositiveInt}
   (let [field (api/read-check (t2/select-one Field :id id))]

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -46,7 +46,7 @@
             (lib.metadata.calculation/display-name query stage-number card-metadata :long))
           (fallback-display-name source-card)))))
 
-(mu/defn ^:private infer-returned-columns :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
+(mu/defn ^:private infer-returned-columns :- [:maybe [:sequential ::lib.schema.metadata/column]]
   [metadata-providerable :- lib.metadata/MetadataProviderable
    card-query            :- :map]
   (when (some? card-query)
@@ -64,7 +64,7 @@
   nominal refs so as to not completely destroy the FE. Once we port more stuff over maybe we can fix this."
   true)
 
-(mu/defn ->card-metadata-column :- lib.metadata/ColumnMetadata
+(mu/defn ->card-metadata-column :- ::lib.schema.metadata/column
   "Massage possibly-legacy Card results metadata into MLv2 ColumnMetadata."
   ([metadata-providerable col]
    (->card-metadata-column metadata-providerable nil col))
@@ -103,7 +103,7 @@
 
 (def ^:private CardColumnMetadata
   [:merge
-   lib.metadata/ColumnMetadata
+   ::lib.schema.metadata/column
    [:map
     [:lib/source [:= :source/card]]]])
 

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -29,6 +29,9 @@
    [metabase.util :as u]
    [metabase.util.humanization :as u.humanization]
    [metabase.util.log :as log]
+   [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.util.malli.registry :as mr]
+   [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util.malli :as mu]))
 
 (defn- normalize-binning-options [opts]
@@ -723,3 +726,66 @@
   "Return true if field is a JSON field, false if not."
   [field]
   (some? (:nfc-path field)))
+
+;;; yes, this is intentionally different from the version in `:metabase.lib.schema.metadata/column.has-field-values`.
+;;; The FE isn't supposed to need to worry about the distinction between `:auto-list` and `:list` for filter purposes.
+;;; See [[infer-has-field-values]] for more info.
+(mr/def ::field-values-search-info.has-field-values
+  [:enum :list :search :none])
+
+(mr/def ::field-values-search-info
+  [:map
+   [:field-id         [:maybe [:ref ::lib.schema.id/field]]]
+   [:search-field-id  [:maybe [:ref ::lib.schema.id/field]]]
+   [:has-field-values [:ref ::field-values-search-info.has-field-values]]])
+
+(mu/defn infer-has-field-values :- ::field-values-search-info.has-field-values
+  "Determine the value of `:has-field-values` we should return for column metadata for frontend consumption to power
+  filter search widgets, either when returned by the the REST API or in MLv2 with [[field-values-search-info]].
+
+  Note that this value not necessarily the same as the value of `has_field_values` in the application database.
+  `has_field_values` may be unset, in which case we will try to infer it. `:auto-list` is not currently understood by
+  the FE filter stuff, so we will instead return `:list`; the distinction is not important to it anyway."
+  [{:keys [has-field-values], :as field} :- [:map
+                                             ;; this doesn't use `::lib.schema.metadata/column` because it's stricter
+                                             ;; than we need and the REST API calls this function with optimized Field
+                                             ;; maps that don't include some keys like `:name`
+                                             [:base-type        {:optional true} [:maybe ::lib.schema.common/base-type]]
+                                             [:effective-type   {:optional true} [:maybe ::lib.schema.common/base-type]]
+                                             [:has-field-values {:optional true} [:maybe ::lib.schema.metadata/column.has-field-values]]]]
+  (cond
+    ;; if `has_field_values` is set in the DB, use that value; but if it's `auto-list`, return the value as `list` to
+    ;; avoid confusing FE code, which can remain blissfully unaware that `auto-list` is a thing
+    (= has-field-values :auto-list)   :list
+    has-field-values                  has-field-values
+    ;; otherwise if it does not have value set in DB we will infer it
+    (lib.types.isa/searchable? field) :search
+    :else                             :none))
+
+(mu/defn ^:private remapped-field :- [:maybe ::lib.schema.metadata/column]
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   column                :- ::lib.schema.metadata/column]
+  (when-let [remap-field-id (get-in column [:lib/external-remap :field-id])]
+    (lib.metadata/field metadata-providerable remap-field-id)))
+
+(mu/defn ^:private search-field :- [:maybe ::lib.schema.metadata/column]
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   column                :- ::lib.schema.metadata/column]
+  ;; ignore remappings for PK columns.
+  (let [col (or (when (lib.types.isa/primary-key? column)
+                  column)
+                (remapped-field metadata-providerable column)
+                column)]
+    (when (lib.types.isa/searchable? col)
+      col)))
+
+(mu/defn field-values-search-info :- ::field-values-search-info
+  "Info about whether the column in question has FieldValues associated with it for purposes of powering a search
+  widget in the QB filter modals."
+  [metadata-providerable :- ::lib.schema.metadata/metadata-providerable
+   column                :- ::lib.schema.metadata/column]
+  {:field-id         (:id column)
+   :search-field-id  (:id (search-field metadata-providerable column))
+   :has-field-values (if column
+                       (infer-has-field-values column)
+                       :none)})

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -19,20 +19,20 @@
    [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.schema.temporal-bucketing
     :as lib.schema.temporal-bucketing]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
+   [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
    [metabase.shared.util.i18n :as i18n]
    [metabase.shared.util.time :as shared.ut]
    [metabase.util :as u]
    [metabase.util.humanization :as u.humanization]
    [metabase.util.log :as log]
-   [metabase.lib.schema.id :as lib.schema.id]
-   [metabase.util.malli.registry :as mr]
-   [metabase.lib.types.isa :as lib.types.isa]
-   [metabase.util.malli :as mu]))
+   [metabase.util.malli :as mu]
+   [metabase.util.malli.registry :as mr]))
 
 (defn- normalize-binning-options [opts]
   (lib.normalize/normalize-map

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -743,7 +743,7 @@
   "Determine the value of `:has-field-values` we should return for column metadata for frontend consumption to power
   filter search widgets, either when returned by the the REST API or in MLv2 with [[field-values-search-info]].
 
-  Note that this value not necessarily the same as the value of `has_field_values` in the application database.
+  Note that this value is not necessarily the same as the value of `has_field_values` in the application database.
   `has_field_values` may be unset, in which case we will try to infer it. `:auto-list` is not currently understood by
   the FE filter stuff, so we will instead return `:list`; the distinction is not important to it anyway."
   [{:keys [has-field-values], :as field} :- [:map

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -16,6 +16,7 @@
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib.core]
    [metabase.lib.equality :as lib.equality]
+   [metabase.lib.field :as lib.field]
    [metabase.lib.join :as lib.join]
    [metabase.lib.js.metadata :as js.metadata]
    [metabase.lib.metadata :as lib.metadata]
@@ -1115,3 +1116,9 @@
                  (and (vector? legacy-expr)
                       (= (first legacy-expr) :aggregation-options))
                  (get 1))))))
+
+(defn ^:export field-values-search-info
+  "Info about whether the column in question has FieldValues associated with it for purposes of powering a search
+  widget in the QB filter modals."
+  [metadata-providerable column]
+  (clj->js (lib.field/field-values-search-info metadata-providerable column)))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1121,4 +1121,7 @@
   "Info about whether the column in question has FieldValues associated with it for purposes of powering a search
   widget in the QB filter modals."
   [metadata-providerable column]
-  (clj->js (lib.field/field-values-search-info metadata-providerable column)))
+  (-> (lib.field/field-values-search-info metadata-providerable column)
+      (update :has-field-values name)
+      (update-keys cljs-key->js-key)
+      clj->js))

--- a/src/metabase/lib/js/metadata.cljs
+++ b/src/metabase/lib/js/metadata.cljs
@@ -11,13 +11,7 @@
    [metabase.util :as u]
    [metabase.util.log :as log]))
 
-(def ^:private memoized-kebab-key
-  "Calculating the kebab-case version of a key every time is pretty slow (even with the LRU
-  caching [[u/->kebab-case-en]] has), since the keys here are static and finite we can just memoize them forever with
-  regular memoization and get a nice performance boost."
-  (memoize u/->kebab-case-en))
-
-;;; metabase-lib/metadata/Metadata comes in a class like
+;;; metabase-lib/metadata/Metadata comes in a object like
 ;;;
 ;;;    {
 ;;;      databases: {},
@@ -107,7 +101,7 @@
     (comp
      ;; convert keys to kebab-case keywords
      (map (fn [[k v]]
-            [(cond-> (keyword (memoized-kebab-key k))
+            [(cond-> (keyword (u/->kebab-case-en k))
                rename-key (#(or (rename-key %) %)))
              v]))
      ;; remove [[excluded-keys]]
@@ -243,7 +237,7 @@
   [m]
   (obj->clj
    (map (fn [[k v]]
-          (let [k (keyword (memoized-kebab-key k))
+          (let [k (keyword (u/->kebab-case-en k))
                 k (if (= k :binning-strategy)
                     :strategy
                     k)

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -63,8 +63,8 @@
 (methodical/defmethod t2.pipeline/build [#_query-type     :toucan.query-type/select.*
                                          #_model          :metadata/database
                                          #_resolved-query clojure.lang.IPersistentMap]
-  [query-type model parsed-arg honeysql]
-  (merge (next-method query-type model parsed-arg honeysql)
+  [query-type model parsed-args honeysql]
+  (merge (next-method query-type model parsed-args honeysql)
          {:select [:id :engine :name :dbms_version :settings :is_audit :details]}))
 
 (t2/define-after-select :metadata/database
@@ -89,8 +89,8 @@
 (methodical/defmethod t2.pipeline/build [#_query-type     :toucan.query-type/select.*
                                          #_model          :metadata/table
                                          #_resolved-query clojure.lang.IPersistentMap]
-  [query-type model parsed-arg honeysql]
-  (merge (next-method query-type model parsed-arg honeysql)
+  [query-type model parsed-args honeysql]
+  (merge (next-method query-type model parsed-args honeysql)
          {:select [:id :db_id :name :display_name :schema :active :visibility_type]}))
 
 (t2/define-after-select :metadata/table
@@ -131,9 +131,9 @@
 (methodical/defmethod t2.pipeline/build [#_query-type     :toucan.query-type/select.*
                                          #_model          :metadata/column
                                          #_resolved-query clojure.lang.IPersistentMap]
-  [query-type model parsed-arg honeysql]
+  [query-type model parsed-args honeysql]
   (merge
-   (next-method query-type model parsed-arg honeysql)
+   (next-method query-type model parsed-args honeysql)
    {:select    [:field/base_type
                 :field/coercion_strategy
                 :field/database_type
@@ -223,9 +223,9 @@
 (methodical/defmethod t2.pipeline/build [#_query-type     :toucan.query-type/select.*
                                          #_model          :metadata/card
                                          #_resolved-query clojure.lang.IPersistentMap]
-  [query-type model parsed-arg honeysql]
+  [query-type model parsed-args honeysql]
   (merge
-   (next-method query-type model parsed-arg honeysql)
+   (next-method query-type model parsed-args honeysql)
    {:select    [:card/collection_id
                 :card/database_id
                 :card/dataset
@@ -270,13 +270,30 @@
   (classloader/require 'metabase.models.metric)
   model)
 
+(methodical/defmethod t2.query/apply-kv-arg [#_model          :metadata/metric
+                                             #_resolved-query clojure.lang.IPersistentMap
+                                             #_k              :default]
+  [model honeysql k v]
+  (let [k (if (not (qualified-key? k))
+            (keyword "metric" (name k))
+            k)]
+    (next-method model honeysql k v)))
+
 (methodical/defmethod t2.pipeline/build [#_query-type     :toucan.query-type/select.*
                                          #_model          :metadata/metric
                                          #_resolved-query clojure.lang.IPersistentMap]
-  [query-type model parsed-arg honeysql]
+  [query-type model parsed-args honeysql]
   (merge
-   (next-method query-type model parsed-arg honeysql)
-   {:select [:id :table_id :name :description :archived :definition]}))
+   (next-method query-type model parsed-args honeysql)
+   {:select    [:metric/id
+                :metric/table_id
+                :metric/name
+                :metric/description
+                :metric/archived
+                :metric/definition]
+    :from      [[(t2/table-name :model/Metric) :metric]]
+    :left-join [[(t2/table-name :model/Table) :table]
+                [:= :metric/table_id :table/id]]}))
 
 (t2/define-after-select :metadata/metric
   [metric]
@@ -294,13 +311,30 @@
                        'metabase.models.table)
   model)
 
+(methodical/defmethod t2.query/apply-kv-arg [#_model          :metadata/segment
+                                             #_resolved-query clojure.lang.IPersistentMap
+                                             #_k              :default]
+  [model honeysql k v]
+  (let [k (if (not (qualified-key? k))
+            (keyword "segment" (name k))
+            k)]
+    (next-method model honeysql k v)))
+
 (methodical/defmethod t2.pipeline/build [#_query-type     :toucan.query-type/select.*
                                          #_model          :metadata/segment
                                          #_resolved-query clojure.lang.IPersistentMap]
-  [query-type model parsed-arg honeysql]
+  [query-type model parsed-args honeysql]
   (merge
-   (next-method query-type model parsed-arg honeysql)
-   {:select [:id :table_id :name :description :archived :definition]}))
+   (next-method query-type model parsed-args honeysql)
+   {:select    [:segment/id
+                :segment/table_id
+                :segment/name
+                :segment/description
+                :segment/archived
+                :segment/definition]
+    :from      [[(t2/table-name :model/Segment) :segment]]
+    :left-join [[(t2/table-name :model/Table) :table]
+                [:= :segment/table_id :table/id]]}))
 
 (t2/define-after-select :metadata/segment
   [segment]

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -29,7 +29,14 @@
   "Calculating the kebab-case version of a key every time is pretty slow (even with the LRU
   caching [[u/->kebab-case-en]] has), since the keys here are static and finite we can just memoize them forever with
   regular memoization and get a nice performance boost."
-  (memoize u/->kebab-case-en))
+  ;; actually, just using a simple atom like this is 10x faster than [[memoize]], and thus 100x faster
+  ;; than [[metabase.util.memoize/lru]]... see https://metaboat.slack.com/archives/C04CYTEL9N2/p1702610853943109
+  (let [cache (atom (hash-map))]
+    (fn [k]
+      (or (get @cache k)
+          (let [k' (u/->kebab-case-en k)]
+            (swap! cache assoc k k')
+            k')))))
 
 (defn instance->metadata
   "Convert a (presumably) Toucan 2 instance of an application database model with `snake_case` keys to a MLv2 style

--- a/src/metabase/lib/metadata/jvm.clj
+++ b/src/metabase/lib/metadata/jvm.clj
@@ -25,12 +25,18 @@
   (or (qualified-keyword? k)
       (str/includes? k ".")))
 
+(def ^:private memoized-kebab-key
+  "Calculating the kebab-case version of a key every time is pretty slow (even with the LRU
+  caching [[u/->kebab-case-en]] has), since the keys here are static and finite we can just memoize them forever with
+  regular memoization and get a nice performance boost."
+  (memoize u/->kebab-case-en))
+
 (defn instance->metadata
   "Convert a (presumably) Toucan 2 instance of an application database model with `snake_case` keys to a MLv2 style
   metadata instance with `:lib/type` and `kebab-case` keys."
   [instance metadata-type]
   (-> instance
-      (update-keys u/->kebab-case-en)
+      (update-keys memoized-kebab-key)
       (assoc :lib/type metadata-type)
       u.snake-hating-map/snake-hating-map))
 

--- a/src/metabase/lib/schema/metadata.cljc
+++ b/src/metabase/lib/schema/metadata.cljc
@@ -49,6 +49,54 @@
    ;; Not even introduced, but 'visible' because this column is implicitly joinable.
    :source/implicitly-joinable])
 
+;;; The way FieldValues/remapping works is hella confusing, because it involves the FieldValues table and Dimension
+;;; table, and the `has_field_values` column, nobody knows why life is like this TBH. The docstrings
+;;; in [[metabase.models.field-values]], [[metabase.models.params.chain-filter]],
+;;; and [[metabase.query-processor.middleware.add-dimension-projections]] explain this stuff in more detail, read
+;;; those and then maybe you will understand what the hell is going on.
+
+(def column-has-field-values-options
+  "Possible options for column metadata `:has-field-values`. This is used to determine whether we keep FieldValues for a
+  Field (during sync), and which type of widget should be used to pick values of this Field when filtering by it in
+  the Query Builder. Not otherwise used by MLv2 (except for [[metabase.lib.field/field-values-search-info]], which is
+  a frontend convenience) or QP at the time of this writing. For column remapping purposes in the Query Processor and
+  MLv2 we just ignore `has_field_values` and only look for FieldValues/Dimension."
+  ;; AUTOMATICALLY-SET VALUES, SET DURING SYNC
+  ;;
+  ;; `nil` -- means infer which widget to use based on logic in [[metabase.lib.field/infer-has-field-values]]; this
+  ;; will either return `:search` or `:none`.
+  ;;
+  ;; This is the default state for Fields not marked `auto-list`. Admins cannot explicitly mark a Field as
+  ;; `has_field_values` `nil`. This value is also subject to automatically change in the future if the values of a
+  ;; Field change in such a way that it can now be marked `auto-list`. Fields marked `nil` do *not* have FieldValues
+  ;; objects.
+  ;;
+  #{;; The other automatically-set option. Automatically marked as a 'List' Field based on cardinality and other factors
+    ;; during sync. Store a FieldValues object; use the List Widget. If this Field goes over the distinct value
+    ;; threshold in a future sync, the Field will get switched back to `has_field_values = nil`.
+    ;;
+    ;; Note that when this comes back from the REST API or [[metabase.lib.field/field-values-search-info]] we always
+    ;; return this as `:list` instead of `:auto-list`; this is done by [[metabase.lib.field/infer-has-field-values]].
+    ;; I guess this is because the FE isn't supposed to need to care about whether this is `:auto-list` vs `:list`;
+    ;; those distinctions are only important for sync I guess.
+    :auto-list
+    ;;
+    ;; EXPLICITLY-SET VALUES, SET BY AN ADMIN
+    ;;
+    ;; Admin explicitly marked this as a 'Search' Field, which means we should *not* keep FieldValues, and should use
+    ;; Search Widget.
+    :search
+    ;; Admin explicitly marked this as a 'List' Field, which means we should keep FieldValues, and use the List
+    ;; Widget. Unlike `auto-list`, if this Field grows past the normal cardinality constraints in the future, it will
+    ;; remain `List` until explicitly marked otherwise.
+    :list
+    ;; Admin explicitly marked that this Field shall always have a plain-text widget, neither allowing search, nor
+    ;; showing a list of possible values. FieldValues not kept.
+    :none})
+
+(mr/def ::column.has-field-values
+  (into [:enum] (sort column-has-field-values-options)))
+
 ;;; External remapping (Dimension) for a column. From the [[metabase.models.dimension]] with `type = external`
 ;;; associated with a `Field` in the application database.
 ;;; See [[metabase.query-processor.middleware.add-dimension-projections]] for what this means.
@@ -126,8 +174,19 @@
    ;; for [[metabase.lib.field/fieldable-columns]] it means its already present in `:fields`
    [:selected? {:optional true} :boolean]
    ;;
-   ;; REMAPPING
+   ;; REMAPPING & FIELD VALUES
    ;;
+   ;; See notes above for more info. `:has-field-values` comes from the application database and is used to decide
+   ;; whether to sync FieldValues when running sync, and what certain FE QB widgets should
+   ;; do. (See [[metabase.lib.field/field-values-search-info]]). Note that all metadata providers may not return this
+   ;; column. The JVM provider currently does not, since the QP doesn't need it for anything.
+   [:has-field-values {:optional true} [:maybe [:ref ::column.has-field-values]]]
+   ;;
+   ;; these next two keys are derived by looking at `FieldValues` and `Dimension` instances associated with a `Field`;
+   ;; they are used by the Query Processor to add column remappings to query results. To see how this maps to stuff in
+   ;; the application database, look at the implementation for fetching a `:metadata/column`
+   ;; in [[metabase.lib.metadata.jvm]]. I don't think this is really needed on the FE, at any rate the JS metadata
+   ;; provider doesn't add these keys.
    [:lib/external-remap {:optional true} [:maybe [:ref ::column.remapping.external]]]
    [:lib/internal-remap {:optional true} [:maybe [:ref ::column.remapping.internal]]]])
 

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -3,11 +3,9 @@
   (:refer-clojure :exclude [isa? any? boolean? number? string? integer?])
   (:require
    [medley.core :as m]
-   [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.types.constants :as lib.types.constants]
    [metabase.lib.util :as lib.util]
-   [metabase.types]
-   [metabase.util.malli :as mu]))
+   [metabase.types]))
 
 (comment metabase.types/keep-me)
 
@@ -280,12 +278,10 @@
 
 ;;; TODO -- This stuff should probably use the constants in [[metabase.lib.types.constants]], however this logic isn't
 ;;; supposed to include things with semantic type = Category which the `::string` constant define there includes.
-(mu/defn searchable?
+(defn searchable?
   "Is this column on that we should show a search widget for (to search its values) in the QB filter UI? If so, we can
   give it a `has-field-values` value of `:search`."
-  [{:keys [base-type effective-type]} :- [:map
-                                          [:base-type      {:optional true} [:maybe ::lib.schema.common/base-type]]
-                                          [:effective-type {:optional true} [:maybe ::lib.schema.common/base-type]]]]
+  [{:keys [base-type effective-type]}]
   ;; For the time being we will consider something to be "searchable" if it's a text Field since the `starts-with`
   ;; filter that powers the search queries (see [[metabase.api.field/search-values]]) doesn't work on anything else
   (let [column-type (or effective-type base-type)]

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -279,7 +279,7 @@
 ;;; TODO -- This stuff should probably use the constants in [[metabase.lib.types.constants]], however this logic isn't
 ;;; supposed to include things with semantic type = Category which the `::string` constant define there includes.
 (defn searchable?
-  "Is this column on that we should show a search widget for (to search its values) in the QB filter UI? If so, we can
+  "Is this column one that we should show a search widget for (to search its values) in the QB filter UI? If so, we can
   give it a `has-field-values` value of `:search`."
   [{:keys [base-type effective-type]}]
   ;; For the time being we will consider something to be "searchable" if it's a text Field since the `starts-with`

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -275,10 +275,7 @@
   See [[lib.field/infer-has-field-values]] for more info."
   [_model k field]
   (when field
-    (let [has-field-values (lib.field/infer-has-field-values
-                            {:base-type        (:base_type field)
-                             :effective-type   (:effective_type field)
-                             :has-field-values (:has-field-values field)})]
+    (let [has-field-values (lib.field/infer-has-field-values (lib.metadata.jvm/instance->metadata field :metadata/column))]
       (assoc field k has-field-values))))
 
 (methodical/defmethod t2.hydrate/needs-hydration? [#_model :default #_k :has_field_values]

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -5,6 +5,8 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.db.connection :as mdb.connection]
+   [metabase.lib.field :as lib.field]
+   [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.models.dimension :refer [Dimension]]
    [metabase.models.field-values :as field-values :refer [FieldValues]]
    [metabase.models.humanization :as humanization]
@@ -33,37 +35,6 @@
     :hidden         ; Lightweight hiding which removes field as a choice in most of the UI.  should still be returned in queries.
     :sensitive      ; Strict removal of field from all places except data model listing.  queries should error if someone attempts to access.
     :retired})      ; For fields that no longer exist in the physical db.  automatically set by Metabase.  QP should error if encountered in a query.
-
-(def has-field-values-options
-  "Possible options for `has_field_values`. This column is used to determine whether we keep FieldValues for a Field,
-  and which type of widget should be used to pick values of this Field when filtering by it in the Query Builder."
-  ;; AUTOMATICALLY-SET VALUES, SET DURING SYNC
-  ;;
-  ;; `nil` -- means infer which widget to use based on logic in [[infer-has-field-values]]; this will either return
-  ;; `:search` or `:none`.
-  ;;
-  ;; This is the default state for Fields not marked `auto-list`. Admins cannot explicitly mark a Field as
-  ;; `has_field_values` `nil`. This value is also subject to automatically change in the future if the values of a
-  ;; Field change in such a way that it can now be marked `auto-list`. Fields marked `nil` do *not* have FieldValues
-  ;; objects.
-  ;;
-  #{;; The other automatically-set option. Automatically marked as a 'List' Field based on cardinality and other factors
-    ;; during sync. Store a FieldValues object; use the List Widget. If this Field goes over the distinct value
-    ;; threshold in a future sync, the Field will get switched back to `has_field_values = nil`.
-    :auto-list
-    ;;
-    ;; EXPLICITLY-SET VALUES, SET BY AN ADMIN
-    ;;
-    ;; Admin explicitly marked this as a 'Search' Field, which means we should *not* keep FieldValues, and should use
-    ;; Search Widget.
-    :search
-    ;; Admin explicitly marked this as a 'List' Field, which means we should keep FieldValues, and use the List
-    ;; Widget. Unlike `auto-list`, if this Field grows past the normal cardinality constraints in the future, it will
-    ;; remain `List` until explicitly marked otherwise.
-    :list
-    ;; Admin explicitly marked that this Field shall always have a plain-text widget, neither allowing search, nor
-    ;; showing a list of possible values. FieldValues not kept.
-    :none})
 
 
 ;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------
@@ -294,41 +265,21 @@
           :let  [dimension (get id->dimensions (:id field))]]
       (assoc field :dimensions (if dimension [dimension] [])))))
 
-(defn- is-searchable?
-  "Is this `field` a Field that you should be presented with a search widget for (to search its values)? If so, we can
-  give it a `has_field_values` value of `search`."
-  [{base-type :base_type}]
-  ;; For the time being we will consider something to be "searchable" if it's a text Field since the `starts-with`
-  ;; filter that powers the search queries (see `metabase.api.field/search-values`) doesn't work on anything else
-  (or (isa? base-type :type/Text)
-      (isa? base-type :type/TextLike)))
-
-(defn- infer-has-field-values
-  "Determine the value of `has_field_values` we should return for a `Field` As of 0.29.1 this doesn't require any DB
-  calls! :D"
-  [{has-field-values :has_field_values, :as field}]
-  (or
-   ;; if `has_field_values` is set in the DB, use that value; but if it's `auto-list`, return the value as `list` to
-   ;; avoid confusing FE code, which can remain blissfully unaware that `auto-list` is a thing
-   (when has-field-values
-     (if (= (keyword has-field-values) :auto-list)
-       :list
-       has-field-values))
-   ;; otherwise if it does not have value set in DB we will infer it
-   (if (is-searchable? field)
-     :search
-     :none)))
-
 (methodical/defmethod t2.hydrate/simple-hydrate [#_model :default #_k :has_field_values]
   "Infer what the value of the `has_field_values` should be for Fields where it's not set. See documentation for
-  [[has-field-values-options]] above for a more detailed explanation of what these values mean.
+  [[metabase.lib.schema.metadata/column-has-field-values-options]] for a more detailed explanation of what these
+  values mean.
 
   This does one important thing: if `:has_field_values` is already present and set to `:auto-list`, it is replaced by
   `:list` -- presumably because the frontend doesn't need to know `:auto-list` even exists?
-  See [[infer-has-field-values]] for more info."
+  See [[lib.field/infer-has-field-values]] for more info."
   [_model k field]
   (when field
-    (assoc field k (infer-has-field-values field))))
+    (let [has-field-values (lib.field/infer-has-field-values
+                            {:base-type        (:base_type field)
+                             :effective-type   (:effective_type field)
+                             :has-field-values (:has-field-values field)})]
+      (assoc field k has-field-values))))
 
 (methodical/defmethod t2.hydrate/needs-hydration? [#_model :default #_k :has_field_values]
   "Always (re-)hydrate `:has_field_values`. This is used to convert an existing value of `:auto-list` to

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.field-values
-  "FieldValues is used to store a cached list of values of Fields that has `has_field_values=:auto-list or :list`.
-  Check the doc in [[metabase.models.field/has-field-values-options]] for more info about `has_field_values`.
+  "FieldValues is used to store a cached list of values of Fields that has `has_field_values=:auto-list` or `:list`.
+  Check the doc in [[metabase.lib.schema.metadata/column-has-field-values-options]] for more info about
+  `has_field_values`.
 
   There are 2 main classes of FieldValues: Full and Advanced.
   - Full FieldValues store a list of distinct values of a Field without any constraints.
@@ -17,7 +18,10 @@
   - Advanced FieldValues are created on demand: for example the Sandbox FieldValues are created when a user with
     sandboxed permission try to get values of a Field.
     Normally these FieldValues will be deleted after [[advanced-field-values-max-age]] days by the scanning process.
-    But they will also be automatically deleted when the Full FieldValues of the same Field got updated."
+    But they will also be automatically deleted when the Full FieldValues of the same Field got updated.
+
+  There is also more written about how these are used for remapping in the docstrings
+  for [[metabase.models.params.chain-filter]] and [[metabase.query-processor.middleware.add-dimension-projections]]."
   (:require
    [java-time.api :as t]
    [malli.core :as mc]
@@ -344,12 +348,12 @@
         values                    (map first unwrapped-values)
         field-name                (or (:name field) (:id field))]
     (cond
-      ;; If this Field is marked `auto-list`, and the number of values in now over the [[auto-list-cardinality-threshold]] or
-      ;; the accumulated length of all values exceeded the [[*total-max-length*]] threshold
-      ;; we need to unmark it as `auto-list`. Switch it to `has_field_values` = `nil` and delete the FieldValues;
-      ;; this will result in it getting a Search Widget in the UI when `has_field_values` is automatically inferred
-      ;; by the [[metabase.models.field/infer-has-field-values]] hydration function (see that namespace for more detailed
-      ;; discussion)
+      ;; If this Field is marked `auto-list`, and the number of values in now over
+      ;; the [[auto-list-cardinality-threshold]] or the accumulated length of all values exceeded
+      ;; the [[*total-max-length*]] threshold we need to unmark it as `auto-list`. Switch it to `has_field_values` =
+      ;; `nil` and delete the FieldValues; this will result in it getting a Search Widget in the UI when
+      ;; `has_field_values` is automatically inferred by the [[metabase.models.field/infer-has-field-values]] hydration
+      ;; function (see that namespace for more detailed discussion)
       ;;
       ;; It would be nicer if we could do this in analysis where it gets marked `:auto-list` in the first place, but
       ;; Fingerprints don't get updated regularly enough that we could detect the sudden increase in cardinality in a

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -148,9 +148,9 @@
     (m/index-by :table_id (-> (t2/select Field:params-columns-only
                                 :table_id      [:in table-ids]
                                 :semantic_type (mdb.u/isa :type/Name))
-                              ;; run `metabase.models.field/infer-has-field-values` on these Fields so their values of
+                              ;; run [[metabase.lib.field/infer-has-field-values]] on these Fields so their values of
                               ;; `has_field_values` will be consistent with what the FE expects. (e.g. we'll return
-                              ;; `list` instead of `auto-list`.)
+                              ;; `:list` instead of `:auto-list`.)
                               (t2/hydrate :has_field_values)))))
 
 (mi/define-batched-hydration-method add-name-field

--- a/src/metabase/query_processor/store.clj
+++ b/src/metabase/query_processor/store.clj
@@ -241,14 +241,14 @@
 (def ^:private ^{:deprecated "0.48.0"} LegacyFieldMetadata
   [:map
    [:name          ms/NonBlankString]
-   [:table_id      ::lib.schema.common/positive-int]
+   [:table_id      ::lib.schema.id/table]
    [:display_name  ms/NonBlankString]
    [:description   [:maybe :string]]
    [:database_type ms/NonBlankString]
    [:base_type     ms/FieldType]
    [:semantic_type [:maybe ms/FieldSemanticOrRelationType]]
    [:fingerprint   [:maybe :map]]
-   [:parent_id     [:maybe ::lib.schema.common/positive-int]]
+   [:parent_id     [:maybe ::lib.schema.id/field]]
    [:nfc_path      [:maybe [:sequential ms/NonBlankString]]]
    ;; there's a tension as we sometimes store fields from the db, and sometimes store computed fields. ideally we
    ;; would make everything just use base_type.

--- a/src/metabase/sync/analyze/classifiers/category.clj
+++ b/src/metabase/sync/analyze/classifiers/category.clj
@@ -11,7 +11,7 @@
   determined by the cardinality of the Field, like Category status. Thus it is entirely possibly for a Field to be
   both a Category and a `list` Field."
   (:require
-   [metabase.models.field :as field]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.models.field-values :as field-values]
    [metabase.sync.interface :as i]
    [metabase.sync.util :as sync-util]
@@ -47,7 +47,7 @@
 (mu/defn ^:private field-should-be-auto-list? :- [:maybe :boolean]
   "Based on `distinct-count`, should we mark this `field` as `has-field-values` = `auto-list`?"
   [fingerprint :- [:maybe i/Fingerprint]
-   field       :- [:map [:has-field-values {:optional true} [:maybe (into [:enum] field/has-field-values-options)]]]]
+   field       :- [:map [:has-field-values {:optional true} [:maybe ::lib.schema.metadata/column.has-field-values]]]]
   ;; only update has-field-values if it hasn't been set yet. If it's already been set then it was probably done so
   ;; manually by an admin, and we don't want to stomp over their choices.
   (let [distinct-count (get-in fingerprint [:global :distinct-count])]

--- a/src/metabase/util/snake_hating_map.clj
+++ b/src/metabase/util/snake_hating_map.clj
@@ -71,4 +71,4 @@
        (vary-meta assoc :metabase.driver/metadata-type :metabase.driver/metadata-type.mlv2)
        ->SnakeHatingMap))
   ([k v & more]
-   (snake-hating-map (into {} (cons [k v] (partition-all 2 more))))))
+   (snake-hating-map (into {k v} (partition-all 2) more))))

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -664,8 +664,11 @@
                 :type/Category
                 (fn []
                   (narrow-fields ["PRICE" "CATEGORY_ID"]
-                                 (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (mt/id :venues)))))))))
+                                 (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (mt/id :venues))))))))))))
 
+(deftest query-metadata-remappings-test-2
+  (testing "GET /api/table/:id/query_metadata"
+    (mt/with-column-remappings [venues.category_id (values-of categories.name)]
       (testing "Ensure internal remapped dimensions and human_readable_values are returned when type is enum"
         (is (= [{:table_id   (mt/id :venues)
                  :id         (mt/id :venues :category_id)
@@ -682,8 +685,10 @@
                 :type/Enum
                 (fn []
                   (narrow-fields ["PRICE" "CATEGORY_ID"]
-                                 (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (mt/id :venues))))))))))
+                                 (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (mt/id :venues))))))))))))
 
+(deftest query-metadata-remappings-test-3
+  (testing "GET /api/table/:id/query_metadata"
     (mt/with-column-remappings [venues.category_id categories.name]
       (testing "Ensure FK remappings are returned"
         (is (= [{:table_id   (mt/id :venues)

--- a/test/metabase/lib/js/metadata_test.cljs
+++ b/test/metabase/lib/js/metadata_test.cljs
@@ -37,8 +37,8 @@
             :lib/external-remap {:lib/type :metadata.column.remapping/external
                                  :id       72
                                  :name     "Category ID [external remap]"
-                                 :field-id 67}}))
-    (lib.metadata/field metadata-provider 36)))
+                                 :field-id 67}}
+           (lib.metadata/field metadata-provider 36)))))
 
 (def ^:private mock-field-metadata-with-internal-remap
   #js {"id"               33

--- a/test/metabase/lib/js/metadata_test.cljs
+++ b/test/metabase/lib/js/metadata_test.cljs
@@ -1,7 +1,8 @@
 (ns metabase.lib.js.metadata-test
   (:require
    [clojure.test :refer [deftest is]]
-   [metabase.lib.js.metadata :as lib.js.metadata]))
+   [metabase.lib.js.metadata :as lib.js.metadata]
+   [metabase.lib.metadata :as lib.metadata]))
 
 (deftest ^:parallel parse-fields-test
   (let [metadata-fragment #js {:fields #js {"card__1234:5678" #js {:id 0}
@@ -14,3 +15,57 @@
             5678 {:lib/type :metadata/column, :id 1}
             8765 {:lib/type :metadata/column, :id 2}}
            (update-vals parsed-fragment deref)))))
+
+(def ^:private mock-field-metadata-with-external-remap
+  #js {"id"               36
+       "name"             "CATEGORY_ID"
+       "has_field_values" "none"
+       "dimensions"       #js [#js {"id"                      72
+                                    "field_id"                36
+                                    "name"                    "Category ID [external remap]"
+                                    "type"                    "external"
+                                    "human_readable_field_id" 67}]
+       "values"           #js []})
+
+(deftest ^:parallel parse-field-with-external-remap-test
+  (let [metadata          #js {:fields #js {"36" mock-field-metadata-with-external-remap}}
+        metadata-provider (lib.js.metadata/metadata-provider 1 metadata)]
+    (is (= {:lib/type           :metadata/column
+            :id                 36
+            :name               "CATEGORY_ID"
+            :has-field-values   :none
+            :lib/external-remap {:lib/type :metadata.column.remapping/external
+                                 :id       72
+                                 :name     "Category ID [external remap]"
+                                 :field-id 67}}))
+    (lib.metadata/field metadata-provider 36)))
+
+(def ^:private mock-field-metadata-with-internal-remap
+  #js {"id"               33
+       "name"             "ID"
+       "has_field_values" "none"
+       "dimensions"       #js [#js {"id"                      66
+                                    "field_id"                33
+                                    "name"                    "ID [internal remap]"
+                                    "type"                    "internal"
+                                    "human_readable_field_id" nil}]
+       "values"           #js {"has_more_values"       false
+                               "type"                  "full"
+                               "human_readable_values" #js ["African" "BBQ" "Artisan" "American"]
+                               "id"                    17824
+                               "values"                #js [1 4 3 2]
+                               "field_id"              33}})
+
+(deftest ^:parallel parse-field-with-internal-remap-test
+  (let [metadata          #js {:fields #js {"33" mock-field-metadata-with-internal-remap}}
+        metadata-provider (lib.js.metadata/metadata-provider 1 metadata)]
+    (is (= {:lib/type           :metadata/column
+            :id                 33
+            :name               "ID"
+            :has-field-values   :none
+            :lib/internal-remap {:lib/type :metadata.column.remapping/internal
+                                 :id       66
+                                 :name     "ID [internal remap]"
+                                 :values                [1 4 3 2]
+                                 :human-readable-values ["African" "BBQ" "Artisan" "American"]}}
+           (lib.metadata/field metadata-provider 33)))))

--- a/test/metabase/lib/metadata/jvm_test.clj
+++ b/test/metabase/lib/metadata/jvm_test.clj
@@ -157,7 +157,7 @@
                 (map #(lib/display-info agg-query %)
                      (lib.metadata.calculation/returned-columns agg-query))))))))
 
-(deftest ^:synchronized internal-remap-metadata-test
+(deftest ^:synchronized external-remap-metadata-test
   (mt/with-column-remappings [venues.id categories.name]
     (is (=? {:lib/type           :metadata/column
              :name               "ID"
@@ -169,7 +169,7 @@
              (lib.metadata.jvm/application-database-metadata-provider (mt/id))
              (mt/id :venues :id))))))
 
-(deftest ^:synchronized external-remap-metadata-test
+(deftest ^:synchronized internal-remap-metadata-test
   (mt/with-column-remappings [venues.id {1 "African", 2 "American", 3 "Artisan", 4 "BBQ"}]
     (is (=? {:lib/type           :metadata/column
              :name               "ID"

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -2245,7 +2245,7 @@
    :coercion-strategy          nil
    :name                       "id"
    :fingerprint-version        5
-   :has-field-values           "auto-list"
+   :has-field-values           :auto-list
    :settings                   nil
    :caveats                    nil
    :fk-target-field-id         nil
@@ -2279,7 +2279,7 @@
    :coercion-strategy          nil
    :name                       "created_by"
    :fingerprint-version        5
-   :has-field-values           "auto-list"
+   :has-field-values           :auto-list
    :settings                   nil
    :caveats                    nil
    :fk-target-field-id         (id :ic/accounts :id)
@@ -2311,7 +2311,7 @@
    :coercion-strategy          nil
    :name                       "updated_by"
    :fingerprint-version        5
-   :has-field-values           "auto-list"
+   :has-field-values           :auto-list
    :settings                   nil
    :caveats                    nil
    :fk-target-field-id         (id :ic/accounts :id)

--- a/test/metabase/lib/test_util/metadata_providers/remap.cljc
+++ b/test/metabase/lib/test_util/metadata_providers/remap.cljc
@@ -3,17 +3,18 @@
    [metabase.lib.dispatch :as lib.dispatch]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.id :as lib.schema.id]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.test-util.metadata-providers.mock
     :as lib.tu.metadata-providers.mock]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
 
-(mu/defn ^:private external-remapped-column :- lib.metadata/ColumnMetadata
+(mu/defn ^:private external-remapped-column :- ::lib.schema.metadata/column
   "Add an 'external' 'Human Readable Values' remap from values of `original` Field to values of `remapped` Field."
-  [metadata-provider :- lib.metadata/MetadataProvider
-   original          :- lib.metadata/ColumnMetadata
-   remapped          :- [:or lib.metadata/ColumnMetadata ::lib.schema.id/field]]
+  [metadata-provider :- ::lib.schema.metadata/metadata-provider
+   original          :- ::lib.schema.metadata/column
+   remapped          :- [:or ::lib.schema.metadata/column ::lib.schema.id/field]]
   (let [remapped   (if (integer? remapped)
                      (lib.metadata/field metadata-provider remapped)
                      remapped)
@@ -23,9 +24,9 @@
                     :field-id (u/the-id remapped)}]
     (assoc original :lib/external-remap remap-info)))
 
-(mu/defn ^:private internal-remapped-column :- lib.metadata/ColumnMetadata
+(mu/defn ^:private internal-remapped-column :- ::lib.schema.metadata/column
   "Add an 'internal' 'FieldValues' remap from values of `original` Field to hardcoded `remap` values."
-  [original :- lib.metadata/ColumnMetadata
+  [original :- ::lib.schema.metadata/column
    remap    :- [:or
                 [:sequential :any]
                 :map]]
@@ -42,17 +43,17 @@
                          :human-readable-values remapped-values}]
     (assoc original :lib/internal-remap remap-info)))
 
-(mu/defn ^:private remapped-column :- lib.metadata/ColumnMetadata
+(mu/defn ^:private remapped-column :- ::lib.schema.metadata/column
   "Add a remap to an `original` column metadata. Type of remap added depends of value of `remap`:
 
     * Field ID: external remap with values of original replaced by values of remapped Field with ID
     * Field metadata: external remap with values of original replaced by values of remapped Field
     * Sequence of values: internal remap with integer values of original replaced by value at the corresponding index
     * Map of original value => remapped value: internal remap with values replaced with corresponding value in map"
-  [metadata-provider :- lib.metadata/MetadataProvider
-   original          :- [:or lib.metadata/ColumnMetadata ::lib.schema.id/field]
+  [metadata-provider :- ::lib.schema.metadata/metadata-provider
+   original          :- [:or ::lib.schema.metadata/column ::lib.schema.id/field]
    remap             :- [:or
-                         lib.metadata/ColumnMetadata
+                         ::lib.schema.metadata/column
                          ::lib.schema.id/field
                          [:sequential :any]
                          :map]]
@@ -64,14 +65,14 @@
       (external-remapped-column metadata-provider original remap)
       (internal-remapped-column original remap))))
 
-(mu/defn remap-metadata-provider  :- lib.metadata/MetadataProvider
+(mu/defn remap-metadata-provider  :- ::lib.schema.metadata/metadata-provider
   "Composed metadata provider that adds an internal or external remap for `original` Field with [[remapped-column]].
   For QP tests, you may want to use [[metabase.query-processor.test-util/field-values-from-def]] to get values to
   create an internal remap."
-  ([metadata-provider :- lib.metadata/MetadataProvider
-    original          :- [:or lib.metadata/ColumnMetadata ::lib.schema.id/field]
+  ([metadata-provider :- ::lib.schema.metadata/metadata-provider
+    original          :- [:or ::lib.schema.metadata/column ::lib.schema.id/field]
     remap             :- [:or
-                          lib.metadata/ColumnMetadata
+                          ::lib.schema.metadata/column
                           ::lib.schema.id/field
                           [:sequential :any]
                           :map]]

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -36,7 +36,7 @@
            (mt/with-temp [:model/Field field {column unknown-type}]
              field))))))
 
-(deftest identity-hash-test
+(deftest ^:parallel identity-hash-test
   (testing "Field hashes are composed of the name and the table's identity-hash"
     (mt/with-temp [:model/Database db    {:name "field-db" :engine :h2}
                    :model/Table    table {:schema "PUBLIC" :name "widget" :db_id (:id db)}
@@ -46,7 +46,7 @@
                (serdes/raw-hash ["sku" table-hash])
                (serdes/identity-hash field)))))))
 
-(deftest nested-field-names->field-id-test
+(deftest ^:parallel nested-field-names->field-id-test
   (mt/with-temp
     [:model/Database {db-id :id}              {}
      :model/Table    {table-id :id}           {:db_id db-id}

--- a/test/metabase/models/field_test.clj
+++ b/test/metabase/models/field_test.clj
@@ -36,7 +36,7 @@
            (mt/with-temp [:model/Field field {column unknown-type}]
              field))))))
 
-(deftest ^:parallel identity-hash-test
+(deftest identity-hash-test
   (testing "Field hashes are composed of the name and the table's identity-hash"
     (mt/with-temp [:model/Database db    {:name "field-db" :engine :h2}
                    :model/Table    table {:schema "PUBLIC" :name "widget" :db_id (:id db)}
@@ -46,7 +46,7 @@
                (serdes/raw-hash ["sku" table-hash])
                (serdes/identity-hash field)))))))
 
-(deftest ^:parallel nested-field-names->field-id-test
+(deftest nested-field-names->field-id-test
   (mt/with-temp
     [:model/Database {db-id :id}              {}
      :model/Table    {table-id :id}           {:db_id db-id}

--- a/test/metabase/util/snake_hating_map_test.clj
+++ b/test/metabase/util/snake_hating_map_test.clj
@@ -1,0 +1,8 @@
+(ns metabase.util.snake-hating-map-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.util.snake-hating-map :as u.snake-hating-map]))
+
+(deftest ^:parallel create-test
+  (is (= (u.snake-hating-map/snake-hating-map {:a 1, :b 2})
+         (u.snake-hating-map/snake-hating-map :a 1, :b 2))))


### PR DESCRIPTION
Add `fieldValuesSearchInfo()` which is used to power some FE search widget in filters.

As part of this I needed to update the JS metadata provider to parse `:dimensions` and `:values` to `:lib/external-remapping` and :lib/internal-remapping` like the JVM metadata provider already does for corresponding QP stuff. I also moved a lot of the schemas and code that powers some of the hydrated keys that the REST API gives the FE into MLv2 so it can calculate this stuff directly instead of relying on whatever wack version might be in the results metadata. 

This PR also includes a lot of unrelated improvements, I couldn't help myself.

Resolves #36698