### PR TITLE
docs - update minimum version for mysql

### DIFF
--- a/docs/installation-and-operation/migrating-from-h2.md
+++ b/docs/installation-and-operation/migrating-from-h2.md
@@ -25,9 +25,9 @@ You could also choose to run Metabase on a [Metabase Cloud](https://www.metabase
 
 ## Supported databases for storing your Metabase application data
 
-- [PostgreSQL](https://www.postgresql.org/). Minimum version: 9.4.
-- [MySQL](https://www.mysql.com/). Minimum version: 8.0.0 Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
-- [MariaDB](https://mariadb.org/). Minimum version: 10.2.2. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
+- [PostgreSQL](https://www.postgresql.org/). Minimum version: `9.4`.
+- [MySQL](https://www.mysql.com/). Minimum version: `8.0.0`. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
+- [MariaDB](https://mariadb.org/). Minimum version: `10.2.2`. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
 
 Go with whichever database you're familiar with. If you're not familiar with any of these, or not sure which to pick, go with Postgres.
 

--- a/docs/installation-and-operation/migrating-from-h2.md
+++ b/docs/installation-and-operation/migrating-from-h2.md
@@ -26,7 +26,7 @@ You could also choose to run Metabase on a [Metabase Cloud](https://www.metabase
 ## Supported databases for storing your Metabase application data
 
 - [PostgreSQL](https://www.postgresql.org/). Minimum version: 9.4.
-- [MySQL](https://www.mysql.com/). Minimum version: 5.7.7. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
+- [MySQL](https://www.mysql.com/). Minimum version: 8.0.0 Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
 - [MariaDB](https://mariadb.org/). Minimum version: 10.2.2. Required settings (which are the default): `utf8mb4_unicode_ci` collation, `utf8mb4` character set, and `innodb_large_prefix=ON`.
 
 Go with whichever database you're familiar with. If you're not familiar with any of these, or not sure which to pick, go with Postgres.


### PR DESCRIPTION
Updates minimum version of MySQL for appdb to 8.0.0. (MySQL 5.7.7 is End of Life).