### PR TITLE
remove deprecated event on embedding settings

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingSwitchWidget/EmbeddingSwitchWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingSwitchWidget/EmbeddingSwitchWidget.tsx
@@ -1,5 +1,4 @@
 import { t } from "ttag";
-import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { Stack, Switch, Text } from "metabase/ui";
 
 interface EmbeddingSwitchWidgetProps {
@@ -19,16 +18,7 @@ export const EmbeddingSwitchWidget = ({
       labelPosition="left"
       checked={Boolean(setting.value)}
       label={<strong>{t`Embedding Enabled`}</strong>}
-      onChange={e => {
-        const newValue = e.target.checked;
-        onChange(newValue);
-        if (newValue) {
-          MetabaseAnalytics.trackStructEvent(
-            "Admin Embed Settings",
-            "Embedding Enable Click",
-          );
-        }
-      }}
+      onChange={e => onChange(e.target.checked)}
     />
   </Stack>
 );


### PR DESCRIPTION
### Description
This event is still using GA, which AFAIK doesn't work anymore so we don't need to keep it in the new version of the page.

Slack thread saying we're not using it: https://metaboat.slack.com/archives/C021BPRNNBT/p1702918355743809?thread_ts=1702645844.844169&cid=C021BPRNNBT

