### PR TITLE
Update hardcoded plugins to use MB_PLUGINS_DIR

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -165,7 +165,7 @@
   (if (running-from-jar?)
     (let [path-to-jar (get-jar-path)]
       (log/info "The app is running from a jar, starting copy...")
-      (copy-from-jar! path-to-jar "instance_analytics/" "plugins/")
+      (copy-from-jar! path-to-jar "instance_analytics/" (plugins/plugins-dir))
       (log/info "Copying complete."))
     (let [in-path (fs/path analytics-dir-resource)]
       (log/info "The app is not running from a jar, starting copy...")

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -148,33 +148,34 @@
                   {:name [:upper :name]}))
     (log/infof "Adjusted Audit DB to match host engine: %s" (name mdb.env/db-type))))
 
-(def analytics-dir-resource
+(def ^:private analytics-dir-resource
   "A resource dir containing analytics content created by Metabase to load into the app instance on startup."
   (io/resource "instance_analytics"))
 
 (defn- instance-analytics-plugin-dir
   "The directory analytics content is unzipped or moved to, and subsequently loaded into the app from on startup."
-  []
-  (fs/path (fs/absolutize (plugins/plugins-dir)) "instance_analytics"))
+  [plugins-dir]
+  (fs/path (fs/absolutize plugins-dir) "instance_analytics"))
 
 (defn- ia-content->plugins
   "Load instance analytics content (collections/dashboards/cards/etc.) from resources dir or a zip file
    and copies it into the provided directory (by default, plugins/instance_analytics)."
   [plugins-dir]
-  (when (fs/exists? plugins-dir)
-    (fs/delete-tree plugins-dir))
-  (if (running-from-jar?)
-    (let [path-to-jar (get-jar-path)]
-      (log/info "The app is running from a jar, starting copy...")
-      (copy-from-jar! path-to-jar "instance_analytics/" plugins-dir)
-      (log/info "Copying complete."))
-    (let [in-path (fs/path analytics-dir-resource)]
-      (log/info "The app is not running from a jar, starting copy...")
-      (log/info (str "Copying " in-path " -> " plugins-dir))
-      (fs/copy-tree (u.files/relative-path in-path)
-                    (u.files/relative-path plugins-dir)
-                    {:replace-existing true})
-      (log/info "Copying complete."))))
+  (let [ia-dir (instance-analytics-plugin-dir plugins-dir)]
+    (when (fs/exists? (u.files/relative-path ia-dir))
+      (fs/delete-tree (u.files/relative-path ia-dir)))
+    (if (running-from-jar?)
+      (let [path-to-jar (get-jar-path)]
+        (log/info "The app is running from a jar, starting copy...")
+        (copy-from-jar! path-to-jar "instance_analytics/" plugins-dir)
+        (log/info "Copying complete."))
+      (let [in-path (fs/path analytics-dir-resource)]
+        (log/info "The app is not running from a jar, starting copy...")
+        (log/info (str "Copying " in-path " -> " ia-dir))
+        (fs/copy-tree (u.files/relative-path in-path)
+                      (u.files/relative-path ia-dir)
+                      {:replace-existing true})
+        (log/info "Copying complete.")))))
 
 (defsetting load-analytics-content
   "Whether or not we should load Metabase analytics content on startup. Defaults to true, but can be disabled via environment variable."
@@ -191,11 +192,11 @@
     (ee.internal-user/ensure-internal-user-exists!)
     (adjust-audit-db-to-source! audit-db)
     (log/info "Loading Analytics Content...")
-    (ia-content->plugins (instance-analytics-plugin-dir))
-    (log/info (str "Loading Analytics Content from: " (instance-analytics-plugin-dir)))
+    (ia-content->plugins (plugins/plugins-dir))
+    (log/info (str "Loading Analytics Content from: " (instance-analytics-plugin-dir (plugins/plugins-dir))))
     ;; The EE token might not have :serialization enabled, but audit features should still be able to use it.
     (let [report (log/with-no-logs
-                   (serialization.cmd/v2-load-internal! (str (instance-analytics-plugin-dir))
+                   (serialization.cmd/v2-load-internal! (str (instance-analytics-plugin-dir (plugins/plugins-dir)))
                                                         {}
                                                         :token-check? false))]
       (if (not-empty (:errors report))

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -160,12 +160,12 @@
   "Load instance analytics content (collections/dashboards/cards/etc.) from resources dir or a zip file
    and put it into plugins/instance_analytics"
   []
-  (when (fs/exists? (u.files/relative-path instance-analytics-plugin-dir))
-    (fs/delete-tree (u.files/relative-path instance-analytics-plugin-dir)))
+  (when (fs/exists? instance-analytics-plugin-dir)
+    (fs/delete-tree instance-analytics-plugin-dir))
   (if (running-from-jar?)
     (let [path-to-jar (get-jar-path)]
       (log/info "The app is running from a jar, starting copy...")
-      (copy-from-jar! path-to-jar "instance_analytics/" (plugins/plugins-dir))
+      (copy-from-jar! path-to-jar "instance_analytics/" (str (plugins/plugins-dir)))
       (log/info "Copying complete."))
     (let [in-path (fs/path analytics-dir-resource)]
       (log/info "The app is not running from a jar, starting copy...")

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -8,6 +8,7 @@
    [metabase.core :as mbc]
    [metabase.models.database :refer [Database]]
    [metabase.models.permissions :as perms]
+   [metabase.plugins :as plugins]
    [metabase.task :as task]
    [metabase.task.sync-databases :as task.sync-databases]
    [metabase.test :as mt]
@@ -93,3 +94,7 @@
            #"Cannot sync Database: It is the audit db."
            (#'task.sync-databases/sync-and-analyze-database! "job-context"))))
     (is (= 0 (count (get-audit-db-trigger-keys))) "no sync occured even when called directly for audit db.")))
+
+(deftest plugins-path-is-plugins-str-test
+  (is (= (fs/path (plugins/plugins-dir))
+         (fs/path (str (plugins/plugins-dir))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -78,6 +78,14 @@
            "plugins/instance_analytics/databases"}
          (set (map str (fs/list-dir "plugins/instance_analytics"))))))
 
+(deftest audit-db-instance-analytics-content-is-copied-from-mb-plugins-dir-test
+  (mt/with-temp-env-var-value [mb-plugins-dir "card_catalogue_dir"]
+    (let [plugins-dir (plugins/plugins-dir)]
+      (#'audit-db/ia-content->plugins)
+      (doseq [top-level-plugin-dir (map (comp str fs/absolutize)
+                                        (fs/list-dir (fs/path plugins-dir "instance_analytics")))]
+        (is (str/starts-with? top-level-plugin-dir (str (fs/absolutize plugins-dir))))))))
+
 (defn- get-audit-db-trigger-keys []
   (let [trigger-keys (->> (task/scheduler-info) :jobs (mapcat :triggers) (map :key))
         audit-db? #(str/includes? % (str perms/audit-db-id))]

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -70,16 +70,20 @@
 
 (deftest instance-analytics-content-is-copied-to-mb-plugins-dir-test
   (mt/with-temp-env-var-value [mb-plugins-dir "card_catalogue_dir"]
-    (let [plugins-dir (plugins/plugins-dir)]
-      (#'audit-db/ia-content->plugins)
-      (doseq [top-level-plugin-dir (map (comp str fs/absolutize)
-                                        (fs/list-dir (fs/path plugins-dir "instance_analytics")))]
-        (testing (str top-level-plugin-dir " starts with plugins value")
-          (is (str/starts-with? top-level-plugin-dir (str (fs/absolutize plugins-dir)))))))))
+    (try
+     (let [plugins-dir (plugins/plugins-dir)]
+       (fs/create-dirs plugins-dir)
+       (#'audit-db/ia-content->plugins (#'audit-db/instance-analytics-plugin-dir))
+       (doseq [top-level-plugin-dir (map (comp str fs/absolutize)
+                                         (fs/list-dir (fs/path plugins-dir "instance_analytics")))]
+         (testing (str top-level-plugin-dir " starts with plugins value")
+           (is (str/starts-with? top-level-plugin-dir (str (fs/absolutize plugins-dir)))))))
+     (finally
+       (fs/delete-tree (plugins/plugins-dir))))))
 
 (deftest all-instance-analytics-content-is-copied-from-mb-plugins-dir-test
   (mt/with-temp-env-var-value [mb-plugins-dir "card_catalogue_dir"]
-    (#'audit-db/ia-content->plugins)
+    (#'audit-db/ia-content->plugins (#'audit-db/instance-analytics-plugin-dir))
     (is (= (count (file-seq (io/file (str (fs/path (plugins/plugins-dir) "instance_analytics")))))
            (count (file-seq (io/file (io/resource "instance_analytics"))))))))
 

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -99,7 +99,3 @@
            #"Cannot sync Database: It is the audit db."
            (#'task.sync-databases/sync-and-analyze-database! "job-context"))))
     (is (= 0 (count (get-audit-db-trigger-keys))) "no sync occured even when called directly for audit db.")))
-
-(deftest plugins-path-is-plugins-str-test
-  (is (= (fs/path (plugins/plugins-dir))
-         (fs/path (str (plugins/plugins-dir))))))


### PR DESCRIPTION
We had one last spot hardcoding `"plugins/"`. That's been replaced with a call to `plugins-dir` which reads the path from `MB_PLUGINS_DIR` (and falls back to `"plugins/"`).

To verify:

Build with `bin/build.sh` then launch the app with:

```
MB_PLUGINS_DIR=~/path/to/custom/plugins java -jar metabase.jar
```

And see the logs indicate that:

```
Loading Analytics Content Complete (264) entities loaded.
```

Leaving out MB_PLUGINS_DIR works too.
