### PR TITLE
Apply formatters to JSON streaming results

### DIFF
--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -26,13 +26,12 @@
 (defmethod qp.si/streaming-results-writer :csv
   [_ ^OutputStream os]
   (let [writer             (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
-        ordered-formatters (atom {})]
+        ordered-formatters (volatile! {})]
     (reify qp.si/StreamingResultsWriter
       (begin! [_ {{:keys [ordered-cols results_timezone]} :data} viz-settings]
-        (swap! ordered-formatters (constantly
-                                    (mapv (fn [col]
+        (vreset! ordered-formatters (mapv (fn [col]
                                             (formatter/create-formatter results_timezone col viz-settings))
-                                          ordered-cols)))
+                                          ordered-cols))
         (csv/write-csv writer [(map (some-fn :display_name :name) ordered-cols)])
         (.flush writer))
 

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1817,12 +1817,12 @@
   (testing "no parameters"
     (with-temp-native-card! [_ card]
       (with-cards-in-readable-collection card
-        (is (= [{(keyword "COUNT(*)") 75}]
+        (is (= [{(keyword "COUNT(*)") "75"}]
                (mt/user-http-request :rasta :post 200 (format "card/%d/query/json" (u/the-id card))))))))
   (testing "with parameters"
     (with-temp-native-card-with-params! [_ card]
       (with-cards-in-readable-collection card
-        (is (= [{(keyword "COUNT(*)") 8}]
+        (is (= [{(keyword "COUNT(*)") "8"}]
                (mt/user-http-request :rasta :post 200 (format "card/%d/query/json" (u/the-id card))
                                      :parameters encoded-params)))))))
 

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -122,7 +122,7 @@
      (test-query-results actual)
 
      "/json"
-     (is (= [{:Count 100}]
+     (is (= [{:Count "100"}]
             actual))
 
      "/csv"

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -206,7 +206,7 @@
                  (mt/rows (client/client :get 202 (str "public/card/" uuid "/query"))))))
 
         (testing ":json download response format"
-          (is (= [{:Count 100}]
+          (is (= [{:Count "100"}]
                  (client/client :get 200 (str "public/card/" uuid "/query/json")))))
 
         (testing ":csv download response format"

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -43,15 +43,22 @@
                    :limit    5})]
       (doseq [export-format (qp.streaming/export-formats)]
         (testing (u/colorize :yellow export-format)
-          (if (= :csv export-format)
+          (case export-format
             ;; CSVs round decimals to 2 digits without viz-settings so are not identical to results from expected-results*
-            (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
-                    ["1" "Red Medicine" "4" "10.06" "-165.37" "3"]
-                    ["2" "Stout Burgers & Beers" "11" "34.1" "-118.33" "2"]
-                    ["3" "The Apple Pan" "11" "34.04" "-118.43" "2"]
-                    ["4" "Wurstküche" "29" "34" "-118.47" "2"]
-                    ["5" "Brite Spot Family Restaurant" "20" "34.08" "-118.26" "2"]]
-                   (basic-actual-results* export-format query)))
+            :csv (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
+                         ["1" "Red Medicine" "4" "10.06" "-165.37" "3"]
+                         ["2" "Stout Burgers & Beers" "11" "34.1" "-118.33" "2"]
+                         ["3" "The Apple Pan" "11" "34.04" "-118.43" "2"]
+                         ["4" "Wurstküche" "29" "34" "-118.47" "2"]
+                         ["5" "Brite Spot Family Restaurant" "20" "34.08" "-118.26" "2"]]
+                        (basic-actual-results* export-format query)))
+            ;; Consistent formatting with CSVs and the UI
+            :json (is (= [{"ID" "1" "Name" "Red Medicine" "Category ID" "4" "Latitude" "10.06" "Longitude" "-165.37" "Price" "3"}
+                          {"ID" "2" "Name" "Stout Burgers & Beers" "Category ID" "11" "Latitude" "34.1" "Longitude" "-118.33" "Price" "2"}
+                          {"ID" "3" "Name" "The Apple Pan" "Category ID" "11" "Latitude" "34.04" "Longitude" "-118.43" "Price" "2"}
+                          {"ID" "4" "Name" "Wurstküche" "Category ID" "29" "Latitude" "34" "Longitude" "-118.47" "Price" "2"}
+                          {"ID" "5" "Name" "Brite Spot Family Restaurant" "Category ID" "20" "Latitude" "34.08" "Longitude" "-118.26" "Price" "2"}]
+                         (map #(update-keys % name) (basic-actual-results* export-format query))))
             (is (= (expected-results* export-format query)
                    (basic-actual-results* export-format query)))))))))
 
@@ -65,8 +72,9 @@
 
 (deftest streaming-response-test
   (testing "Test that the actual results going thru the same steps as an API response are correct."
-    ;; CSVs round decimals to 2 digits without viz-settings so are not identical to results from expected-results*
-    (doseq [export-format (disj (qp.streaming/export-formats) :csv)]
+    ;; CSV and JSON exports round decimals to 2 digits to conform to the Metabase UI
+    ;; so are not identical to results from expected-results*
+    (doseq [export-format (disj (qp.streaming/export-formats) :csv :json)]
       (testing (u/colorize :yellow export-format)
         (compare-results export-format (mt/mbql-query venues {:limit 5}))))))
 
@@ -115,9 +123,9 @@
         (is (= true
                (deref complete-promise 1000 ::timed-out)))
         (let [response-str (String. (.toByteArray os) "UTF-8")]
-          (is (= "[{\"num_cans\":2}]"
+          (is (= "[{\"num_cans\":\"2\"}]"
                  (str/replace response-str #"\n+" "")))
-          (is (= [{:num_cans 2}]
+          (is (= [{:num_cans "2"}]
                  (json/parse-string response-str true))))))))
 
 (defmulti ^:private first-row-map
@@ -166,8 +174,8 @@
             (testing "UTC results"
               (test-results
                (case export-format
-                 :csv
-                 ;; With the updates to make CSV exports conform with FE behavior (See #36726) dates and times are now
+                 (:csv :json)
+                 ;; With the updates to make exports conform with FE behavior (See #36726) dates and times are now
                  ;; presented as they are in the FE. This is the eventual design for all exports.
                  {:date           "November 1, 2019"
                   :datetime       "November 1, 2019, 12:23 AM"
@@ -177,16 +185,6 @@
                   :time           "12:23 AM"
                   :time-ltz       "7:23 AM"
                   :time-tz        "7:23 AM"}
-
-                 :json
-                 {:date           "2019-11-01"
-                  :datetime       "2019-11-01T00:23:18.331"
-                  :datetime-ltz   "2019-11-01T07:23:18.331Z"
-                  :datetime-tz    "2019-11-01T07:23:18.331Z"
-                  :datetime-tz-id "2019-11-01T07:23:18.331Z"
-                  :time           "00:23:18.331"
-                  :time-ltz       "07:23:18.331Z"
-                  :time-tz        "07:23:18.331Z"}
 
                  :api
                  {:date           "2019-11-01T00:00:00Z"
@@ -212,8 +210,8 @@
             (mt/with-temporary-setting-values [report-timezone "US/Pacific"]
               (test-results
                (case export-format
-                 :csv
-                 ;; With the updates to make CSV exports conform with FE behavior (See #36726) dates and times are now
+                 (:csv :json)
+                 ;; With the updates to make exports conform with FE behavior (See #36726) dates and times are now
                  ;; presented as they are in the FE. This is the eventual design for all exports.
                  {:date           "November 1, 2019"
                   :datetime       "November 1, 2019, 12:23 AM"
@@ -223,16 +221,6 @@
                   :time           "12:23 AM"
                   :time-ltz       "11:23 PM"
                   :time-tz        "11:23 PM"}
-
-                 :json
-                 {:date           "2019-11-01"
-                  :datetime       "2019-11-01T00:23:18.331"
-                  :datetime-ltz   "2019-11-01T00:23:18.331-07:00"
-                  :datetime-tz    "2019-11-01T00:23:18.331-07:00"
-                  :datetime-tz-id "2019-11-01T00:23:18.331-07:00"
-                  :time           "00:23:18.331"
-                  :time-ltz       "23:23:18.331-08:00"
-                  :time-tz        "23:23:18.331-08:00"}
 
                  :api
                  {:date           "2019-11-01T00:00:00-07:00"
@@ -348,8 +336,8 @@
 
                  :json (fn [results]
                          (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
-                                 [1 "Red Medicine" 4 10.0646 -165.374 3]
-                                 [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2]]
+                                 ["1" "Red Medicine" "4" "10.06" "-165.37" "3"]
+                                 ["2" "Stout Burgers & Beers" "11" "34.1" "-118.33" "2"]]
                                 (parse-json-results results))))
 
                  :xlsx (fn [results]
@@ -382,7 +370,7 @@
 
                  :json (fn [results]
                          (is (= [["Name" "ID" "Category ID" "Price"]
-                                 ["Red Medicine" 1 4 3]]
+                                 ["Red Medicine" "1" "4" "3"]]
                                 (parse-json-results results))))
 
                  :xlsx (fn [results]
@@ -410,7 +398,7 @@
 
                              :json (fn [results]
                                      (is (= [["ID" "Name" col-name "Latitude" "Longitude" "Price"]
-                                             [1 "Red Medicine" "Asian" 10.0646 -165.374 3]]
+                                             ["1" "Red Medicine" "Asian" "10.06" "-165.37" "3"]]
                                             (parse-json-results results))))
 
                              :xlsx (fn [results]
@@ -452,7 +440,7 @@
 
                  :json (fn [results]
                          (is (= [["ID" "Name" "Category ID" "Categories → Name"]
-                                 [1 "Red Medicine" 4 "Asian"]]
+                                 ["1" "Red Medicine" "4" "Asian"]]
                                 (parse-json-results results))))
 
                  :xlsx (fn [results]
@@ -474,7 +462,7 @@
                          ;; Second ID field is omitted since each col is stored in a JSON object rather than an array.
                          ;; TODO we should be able to include the second column if it is renamed.
                          (is (= [["ID" "NAME"]
-                                 [1 "Red Medicine"]]
+                                 ["1" "Red Medicine"]]
                                 (parse-json-results results))))
 
                  :xlsx (fn [results]


### PR DESCRIPTION
As is done in `metabase.query-processor.streaming.csv`, we now use column formatting in `metabase.query-processor.streaming.json`. This was done by creating a formatter for each column in the `:json` implementation of `qp.si/streaming-results-writer` (in the `begin!` function). These formatters were then applied on each row write.

One important design decision that had to be made here was the handling of JSON numeric types. In Metabase, we do several default formats of numbers and allow custom formatting that would alter the basic presentation of a json number. Examples:
- Integers default to showing a comma separator for large numbers
- Decimals round to 2 significant digits
- Percent, scientific, and currency formats may be applied

The only time a raw JSON number will look identical to what is shown in metabase is if formatting is removed for integers and just the right amount of digits are shown for floats.

Since the goal of exports is to preserve the data as shown in Metabase, the ony way to guarantee this outside of a few corner cases is to export all values as strings. Attempting to parse ints and floats after formatting may also cause unexpected behavior, as `3.14159` may be shown as `3.14` in Metabase and exported as this truncated number (if we parsed it). A user most likely would want to see exactly what they see in Metabase (so default to strings) or the original, unmodified value).

This PR also updates the CSV export code to use a `volatile!` rather than an `atom` for consistency.

Fixes #36554 