### PR TITLE
[MLv2] Be more forgiving in the schemas for `:=` filter clauses

### DIFF
--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -138,8 +138,14 @@
                      "an expression that can be compared with :> or :<"))
 
 (def equality-comparable-types
-  "Set of base types that can be campared with equality."
-   #{:type/Boolean :type/Text :type/Number :type/Temporal :type/IPAddress :type/MongoBSONID :type/Array})
+  "Set of base types that can be compared with equality."
+  ;; TODO: Adding :type/* here was necessary to prevent type errors for queries where a field's type in the DB could not
+  ;; be determined better than :type/*. See #36841, where a MySQL enum field gets `:base-type :type/*`, and this check
+  ;; would fail on `[:= {} [:field ...] "enum-str"]` without `:type/*` here.
+  ;; This typing of each input should be replaced with an alternative scheme that checks that it's plausible to compare
+  ;; all the args to an `:=` clause. Eg. comparing `:type/*` and `:type/String` is cool. Comparing `:type/IPAddress` to
+  ;; `:type/Boolean` should fail; we can prove it's the wrong thing to do.
+   #{:type/Boolean :type/Text :type/Number :type/Temporal :type/IPAddress :type/MongoBSONID :type/Array :type/*})
 
 (mr/def ::emptyable
   [:or


### PR DESCRIPTION
This is probably not the full story; we should look into overhauling
how we validate plausible comparisons.

Fixes #36841.

