### PR TITLE
Do not cache recently viewed items (#35379)

### DIFF
--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -53,6 +53,18 @@ describe("search > recently viewed", () => {
 
     cy.url().should("match", /\/question\/\d+-orders$/);
   });
+
+  it("shows up-to-date list of recently viewed items after another page is visited", () => {
+    openPeopleTable();
+    cy.findByTextEnsureVisible("Address");
+
+    cy.findByPlaceholderText("Search…").click();
+    // cy.findByTestId("loading-spinner").should("not.exist");
+
+    assertRecentlyViewedItem(0, "People", "Table");
+    assertRecentlyViewedItem(1, "Orders in a dashboard", "Dashboard");
+    assertRecentlyViewedItem(2, "Orders", "Question");
+  });
 });
 
 describeEE("search > recently viewed > enterprise features", () => {

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -54,7 +54,7 @@ describe("search > recently viewed", () => {
     cy.url().should("match", /\/question\/\d+-orders$/);
   });
 
-  it("shows up-to-date list of recently viewed items after another page is visited", () => {
+  it("shows up-to-date list of recently viewed items after another page is visited (metabase#36868)", () => {
     openPeopleTable();
     cy.findByTextEnsureVisible("Address");
 

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -71,12 +71,8 @@ describe("search > recently viewed", () => {
 
     cy.findByPlaceholderText("Search…").click();
     cy.wait("@recent");
-    cy.findByTestId("loading-spinner").should("not.exist");
 
     assertRecentlyViewedItem(0, "People", "Table");
-    assertRecentlyViewedItem(1, "Orders in a dashboard", "Dashboard");
-    assertRecentlyViewedItem(2, "Orders", "Question");
-    cy.findAllByTestId("recently-viewed-item-title").should("have.length", 3);
   });
 });
 

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -64,6 +64,8 @@ describe("search > recently viewed", () => {
     assertRecentlyViewedItem(0, "People", "Table");
     assertRecentlyViewedItem(1, "Orders in a dashboard", "Dashboard");
     assertRecentlyViewedItem(2, "Orders", "Question");
+
+    cy.findAllByTestId("recently-viewed-item-title").should("have.length", 3);
   });
 });
 

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -59,7 +59,7 @@ describe("search > recently viewed", () => {
     cy.findByTextEnsureVisible("Address");
 
     cy.findByPlaceholderText("Search…").click();
-    // cy.findByTestId("loading-spinner").should("not.exist");
+    cy.findByTestId("loading-spinner").should("not.exist");
 
     assertRecentlyViewedItem(0, "People", "Table");
     assertRecentlyViewedItem(1, "Orders in a dashboard", "Dashboard");

--- a/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/recently-viewed.cy.spec.js
@@ -55,16 +55,27 @@ describe("search > recently viewed", () => {
   });
 
   it("shows up-to-date list of recently viewed items after another page is visited (metabase#36868)", () => {
-    openPeopleTable();
-    cy.findByTextEnsureVisible("Address");
+    cy.findByPlaceholderText("Search…").click();
+    cy.wait("@recent");
+    cy.findByTestId("loading-spinner").should("not.exist");
+
+    assertRecentlyViewedItem(0, "Orders in a dashboard", "Dashboard");
+    assertRecentlyViewedItem(1, "Orders", "Question");
+    assertRecentlyViewedItem(2, "People", "Table");
+    cy.findAllByTestId("recently-viewed-item-title").should("have.length", 3);
+
+    const recentlyViewedItems = cy.findAllByTestId(
+      "recently-viewed-item-title",
+    );
+    recentlyViewedItems.eq(2).click();
 
     cy.findByPlaceholderText("Search…").click();
+    cy.wait("@recent");
     cy.findByTestId("loading-spinner").should("not.exist");
 
     assertRecentlyViewedItem(0, "People", "Table");
     assertRecentlyViewedItem(1, "Orders in a dashboard", "Dashboard");
     assertRecentlyViewedItem(2, "Orders", "Question");
-
     cy.findAllByTestId("recently-viewed-item-title").should("have.length", 3);
   });
 });

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -207,26 +207,6 @@ describe("scenarios > search", () => {
         .findByRole("img")
         .should("not.exist");
     });
-
-    // it.only("should re-fetch recently viewed items when the user clicks the search bar (metabase#35379)", () => {
-    //   cy.intercept("GET", "/api/activity/recent_views").as("getRecentViews");
-    //   cy.visit("/");
-    //   cy.wait("@getRecentViews");
-    //   getSearchBar().click();
-    //   cy.wait("@getRecentViews");
-    //   cy.findByTestId("search-results-floating-container").within(() => {
-    //     cy.findByText("Orders, Count").should("not.exist");
-    //     cy.findByText("Nothing here").should("exist");
-    //   });
-    //   cy.visit(`/question/${ORDERS_COUNT_QUESTION_ID}`);
-    //   getSearchBar().click();
-    //   cy.wait("@getRecentViews");
-    //   cy.findByTestId("search-results-floating-container", {
-    //     timeout: 10000,
-    //   }).within(() => {
-    //     cy.findByText("Orders, Count").should("exist");
-    //   });
-    // });
   });
 
   describe("accessing full page search with `Enter`", () => {

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -207,7 +207,25 @@ describe("scenarios > search", () => {
         .findByRole("img")
         .should("not.exist");
     });
+
+    it("should re-fetch recently viewed items when the user clicks the search bar (metabase#35379)", () => {
+      cy.intercept("GET", "/api/activity/recent_views").as("getRecentViews");
+      cy.visit("/");
+      cy.wait("@getRecentViews");
+      getSearchBar().click();
+      cy.wait("@getRecentViews");
+      cy.findByTestId("search-results-floating-container").within(() => {
+        cy.findByText("Orders, Count").should("not.exist");
+      });
+      cy.visit(`/question/${ORDERS_COUNT_QUESTION_ID}`);
+      getSearchBar().click();
+      cy.wait("@getRecentViews");
+      cy.findByTestId("search-results-floating-container").within(() => {
+        cy.findByText("Orders, Count").should("exist");
+      });
+    });
   });
+
   describe("accessing full page search with `Enter`", () => {
     it("should not render full page search if user has not entered a text query", () => {
       cy.intercept("GET", "/api/activity/recent_views").as("getRecentViews");

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -183,13 +183,13 @@ describe("scenarios > search", () => {
         description: `![alt](https://upload.wikimedia.org/wikipedia/commons/a/a2/Cat_outside.jpg)
 
         Lorem ipsum dolor sit amet.
-
+        
         ----
-
+        
         ## Heading 1
-
+        
         This is a [link](https://upload.wikimedia.org/wikipedia/commons/a/a2/Cat_outside.jpg).
-
+        
         Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. `,
       }).then(() => {
         cy.signInAsNormalUser();
@@ -208,7 +208,6 @@ describe("scenarios > search", () => {
         .should("not.exist");
     });
   });
-
   describe("accessing full page search with `Enter`", () => {
     it("should not render full page search if user has not entered a text query", () => {
       cy.intercept("GET", "/api/activity/recent_views").as("getRecentViews");

--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -183,13 +183,13 @@ describe("scenarios > search", () => {
         description: `![alt](https://upload.wikimedia.org/wikipedia/commons/a/a2/Cat_outside.jpg)
 
         Lorem ipsum dolor sit amet.
-        
+
         ----
-        
+
         ## Heading 1
-        
+
         This is a [link](https://upload.wikimedia.org/wikipedia/commons/a/a2/Cat_outside.jpg).
-        
+
         Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. `,
       }).then(() => {
         cy.signInAsNormalUser();
@@ -208,22 +208,25 @@ describe("scenarios > search", () => {
         .should("not.exist");
     });
 
-    it("should re-fetch recently viewed items when the user clicks the search bar (metabase#35379)", () => {
-      cy.intercept("GET", "/api/activity/recent_views").as("getRecentViews");
-      cy.visit("/");
-      cy.wait("@getRecentViews");
-      getSearchBar().click();
-      cy.wait("@getRecentViews");
-      cy.findByTestId("search-results-floating-container").within(() => {
-        cy.findByText("Orders, Count").should("not.exist");
-      });
-      cy.visit(`/question/${ORDERS_COUNT_QUESTION_ID}`);
-      getSearchBar().click();
-      cy.wait("@getRecentViews");
-      cy.findByTestId("search-results-floating-container").within(() => {
-        cy.findByText("Orders, Count").should("exist");
-      });
-    });
+    // it.only("should re-fetch recently viewed items when the user clicks the search bar (metabase#35379)", () => {
+    //   cy.intercept("GET", "/api/activity/recent_views").as("getRecentViews");
+    //   cy.visit("/");
+    //   cy.wait("@getRecentViews");
+    //   getSearchBar().click();
+    //   cy.wait("@getRecentViews");
+    //   cy.findByTestId("search-results-floating-container").within(() => {
+    //     cy.findByText("Orders, Count").should("not.exist");
+    //     cy.findByText("Nothing here").should("exist");
+    //   });
+    //   cy.visit(`/question/${ORDERS_COUNT_QUESTION_ID}`);
+    //   getSearchBar().click();
+    //   cy.wait("@getRecentViews");
+    //   cy.findByTestId("search-results-floating-container", {
+    //     timeout: 10000,
+    //   }).within(() => {
+    //     cy.findByText("Orders, Count").should("exist");
+    //   });
+    // });
   });
 
   describe("accessing full page search with `Enter`", () => {

--- a/frontend/src/metabase/nav/components/search/RecentsList/RecentsList.tsx
+++ b/frontend/src/metabase/nav/components/search/RecentsList/RecentsList.tsx
@@ -28,8 +28,9 @@ export interface WrappedRecentItem extends RecentItem {
 }
 
 export const RecentsList = ({ onClick, className }: RecentsListProps) => {
-  const { data = [], isLoading: isRecentsListLoading } =
-    useRecentItemListQuery();
+  const { data = [], isLoading: isRecentsListLoading } = useRecentItemListQuery(
+    { reload: true },
+  );
 
   const wrappedResults: WrappedRecentItem[] = useMemo(
     () => data.map(item => RecentItems.wrapEntity(item)),


### PR DESCRIPTION
Closes #35379 

### Description

The problem is that recently viewed items are cached in the frontend, but this cache is never invalidated, so the user sees stale data.

### How to verify

Here's an illustration of the behavior, first on `master`, then on this feature branch. I've throttled the connection to "Slow 3G" to make it clearer when data is loading from the network:

https://www.loom.com/share/a686aa2791f0439c946aa0bf94f8d141?sid=f87c9a0d-59be-444c-afcd-dcf7d394eb39

As you can see, on `master`, when I visit a new page, the list of recently viewed items doesn't change. When I switch to this branch (`do-not-cache-recents`), the list changes after I visit a new page.

Since I made my internet deliberately slow, you can also see one downside of this approach, which is that the user must wait for the backend to provide accurate data. @iethree and I had a [discussion about this](https://metaboat.slack.com/archives/C0642RZ0E14/p1702647540969459) on Slack. As he suggested, it might eventually be nice to use the following pattern: the user sees a cached, possibly out-of-date list of recently viewed items right away; this list is then gracefully replaced with an up-to-date list once that information arrives over the network.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
