### PR TITLE
Routine dependency bumps

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -19,15 +19,15 @@
                                                            org.bouncycastle/bcprov-jdk18on]}
   buddy/buddy-sign                          {:mvn/version "3.5.351"}            ; JSON Web Tokens; High-Level message signing library
   camel-snake-kebab/camel-snake-kebab       {:mvn/version "0.4.3"}              ; util functions for converting between camel, snake, and kebob case
-  cheshire/cheshire                         {:mvn/version "5.11.0"}             ; fast JSON encoding (used by Ring JSON middleware)
+  cheshire/cheshire                         {:mvn/version "5.12.0"}             ; fast JSON encoding (used by Ring JSON middleware)
   clj-bom/clj-bom                           {:mvn/version "0.1.2"}              ; handle BOMs in imported CSVs
   clj-commons/iapetos                       {:mvn/version "0.1.13"}             ; prometheus metrics
   clj-http/clj-http                         {:mvn/version "3.12.3"              ; HTTP client
                                              :exclusions  [commons-codec/commons-codec
                                                            commons-io/commons-io
                                                            slingshot/slingshot]}
-  clojure.java-time/clojure.java-time       {:mvn/version "1.3.0"}              ; java.time utilities
-  clojurewerkz/quartzite                    {:mvn/version "2.1.0"               ; scheduling library
+  clojure.java-time/clojure.java-time       {:mvn/version "1.4.2"}              ; java.time utilities
+  clojurewerkz/quartzite                    {:mvn/version "2.2.0"               ; scheduling library
                                              :exclusions  [c3p0/c3p0
                                                            org.quartz-scheduler/quartz]}
   colorize/colorize                         {:mvn/version "0.1.1"               ; string output with ANSI color codes (for logging)
@@ -36,29 +36,29 @@
                                              :exclusions  [it.unimi.dsi/fastutil
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
-  com.github.seancorfield/honeysql          {:mvn/version "2.4.1066"}           ; Honey SQL 2. SQL generation from Clojure data maps
+  com.github.seancorfield/honeysql          {:mvn/version "2.5.1103"}           ; Honey SQL 2. SQL generation from Clojure data maps
   com.github.seancorfield/next.jdbc         {:git/url "https://github.com/seancorfield/next-jdbc.git"
                                              :sha     "abd926cde3730087d3729dcea0ce0ab7ef1194f2"} ; for https://github.com/seancorfield/next-jdbc/issues/245; when this makes it to a release we can switch to that.
   com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.4.1"}            ; Telemetry library
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.4"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
   com.google.guava/guava                    {:mvn/version "32.1.3-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.fasterxml.jackson.core/jackson-databind
-                                            {:mvn/version "2.15.2"}             ; JSON processor used by snowplow-java-tracker
+                                            {:mvn/version "2.16.0"}             ; JSON processor used by snowplow-java-tracker
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "6.5.1"}              ; trans dep of commons-codec (pinned version due to CVE-2022-40151)
-  com.h2database/h2                         {:mvn/version "2.1.214"}            ; embedded SQL database
+  com.h2database/h2                         {:mvn/version "2.2.224"}            ; embedded SQL database
   com.gfredericks/test.chuck                {:mvn/version "0.2.14"}             ; generating strings from regex
   com.snowplowanalytics/snowplow-java-tracker
-                                            {:mvn/version "1.0.0"               ; Snowplow analytics
+                                            {:mvn/version "1.0.1"               ; Snowplow analytics
                                              :exclusions [com.fasterxml.jackson.core/jackson-databind]}
-  com.taoensso/nippy                        {:mvn/version "3.2.0"}              ; Fast serialization (i.e., GZIP) library for Clojure
+  com.taoensso/nippy                        {:mvn/version "3.3.0"}              ; Fast serialization (i.e., GZIP) library for Clojure
   com.vladsch.flexmark/flexmark             {:mvn/version "0.64.8"}             ; Markdown parsing
   com.vladsch.flexmark/flexmark-ext-autolink
                                             {:mvn/version "0.64.8"}             ; Flexmark extension for auto-linking bare URLs
   commons-fileupload/commons-fileupload     {:mvn/version "1.5"}                ; ring/ring-core 1.9.6 uses v1.4, but we want 1.5 due to a CVE. When we upgrade to the forthcoming ring/ring-core 1.10.0 we can remove this.
   commons-codec/commons-codec               {:mvn/version "1.16.0"}             ; Apache Commons -- useful codec util fns
-  commons-io/commons-io                     {:mvn/version "2.13.0"}             ; Apache Commons -- useful IO util fns
-  commons-net/commons-net                   {:mvn/version "3.9.0"}              ; Apache Commons -- useful network utils. Transitive dep of Snowplow, pinned due to CVE-2021-37533
-  commons-validator/commons-validator       {:mvn/version "1.7"                 ; Apache Commons -- useful validation util fns
+  commons-io/commons-io                     {:mvn/version "2.15.1"}             ; Apache Commons -- useful IO util fns
+  commons-net/commons-net                   {:mvn/version "3.10.0"}              ; Apache Commons -- useful network utils. Transitive dep of Snowplow, pinned due to CVE-2021-37533
+  commons-validator/commons-validator       {:mvn/version "1.8.0"                 ; Apache Commons -- useful validation util fns
                                              :exclusions  [commons-beanutils/commons-beanutils
                                                            commons-digester/commons-digester
                                                            commons-logging/commons-logging]}
@@ -71,14 +71,15 @@
   environ/environ                           {:mvn/version "1.2.0"}              ; env vars/Java properties abstraction
   hiccup/hiccup                             {:mvn/version "1.0.5"}              ; HTML templating
   inflections/inflections                   {:mvn/version "0.14.1"}             ; Clojure/Script library used for prularizing words
-  info.sunng/ring-jetty9-adapter            {:mvn/version "0.22.3"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver.
+  info.sunng/ring-jetty9-adapter            {:mvn/version "0.30.3"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver.
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
   clj-commons/clj-yaml                      {:mvn/version "1.0.27"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.535"}
-  io.github.eerohele/pp                     {:git/tag "2023-10-05.5"            ; super fast pretty-printing library
-                                             :git/sha "7059eec"}
+  io.github.eerohele/pp                     {:git/tag "2023-11-25.47"            ; super fast pretty-printing library
+                                             :git/sha "d3210d3"
+                                             :git/url "https://github.com/eerohele/pp"}
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
-  io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1"}              ; Support for retrying operations
+  io.github.resilience4j/resilience4j-retry {:mvn/version "2.1.0"}              ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   io.prometheus/simpleclient_jetty          {:mvn/version "0.16.0"}             ; prometheus jetty collector
   javax.servlet/servlet-api                 {:mvn/version "2.5"}                ; used by ring's multipart-params (file upload)
@@ -94,7 +95,7 @@
                                                           org.bouncycastle/bcpkix-jdk18on
                                                           org.bouncycastle/bcprov-jdk18on]}
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
-  metosin/malli                             {:mvn/version "0.11.0"}             ; Data-driven Schemas for Clojure/Script and babashka
+  metosin/malli                             {:mvn/version "0.13.0"}             ; Data-driven Schemas for Clojure/Script and babashka
   nano-id/nano-id                           {:mvn/version "1.0.0"}              ; NanoID generator for generating entity_ids
   net.cgrand/macrovich                      {:mvn/version "0.2.2"}              ; utils for writing macros for both Clojure & ClojureScript
   net.clojars.wkok/openai-clojure           {:mvn/version "0.14.0"
@@ -109,20 +110,20 @@
   net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20230409"} ; Java implementation of the JQ json query language
   org.apache.commons/commons-compress       {:mvn/version "1.25.0"}             ; compression utils
   org.apache.commons/commons-lang3          {:mvn/version "3.14.0"}             ; helper methods for working with java.lang stuff
-  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.20.0"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-api        {:mvn/version "2.20.0"}             ; add compatibility with log4j 1.2
-  org.apache.logging.log4j/log4j-core       {:mvn/version "2.20.0"}             ; apache logging framework
-  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.20.0"}             ; allows the commons-logging API to work with log4j 2
-  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.20.0"}             ; java.util.logging (JUL) -> Log4j2 adapter
+  org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.22.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-api        {:mvn/version "2.22.0"}             ; add compatibility with log4j 1.2
+  org.apache.logging.log4j/log4j-core       {:mvn/version "2.22.0"}             ; apache logging framework
+  org.apache.logging.log4j/log4j-jcl        {:mvn/version "2.22.0"}             ; allows the commons-logging API to work with log4j 2
+  org.apache.logging.log4j/log4j-jul        {:mvn/version "2.22.0"}             ; java.util.logging (JUL) -> Log4j2 adapter
   org.apache.logging.log4j/log4j-slf4j2-impl
-                                            {:mvn/version "2.20.0"}             ; allows the slf4j2 API to work with log4j 2
+                                            {:mvn/version "2.22.0"}             ; allows the slf4j2 API to work with log4j 2
   org.apache.logging.log4j/log4j-layout-template-json
-                                            {:mvn/version "2.20.0"}             ; allows the custom json logging format
-  org.apache.poi/poi                        {:mvn/version "5.2.4"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
-  org.apache.poi/poi-ooxml                  {:mvn/version "5.2.3"
+                                            {:mvn/version "2.22.0"}             ; allows the custom json logging format
+  org.apache.poi/poi                        {:mvn/version "5.2.5"}              ; Work with Office documents (e.g. Excel spreadsheets) -- newer version than one specified by Docjure
+  org.apache.poi/poi-ooxml                  {:mvn/version "5.2.5"
                                              :exclusions  [org.bouncycastle/bcpkix-jdk15on
                                                            org.bouncycastle/bcprov-jdk15on]}
-  org.apache.sshd/sshd-core                 {:mvn/version "2.10.0"              ; ssh tunneling and test server
+  org.apache.sshd/sshd-core                 {:mvn/version "2.11.0"              ; ssh tunneling and test server
                                              :exclusions  [org.slf4j/slf4j-api
                                                            org.slf4j/jcl-over-slf4j]}
   org.apache.xmlgraphics/batik-all          {:mvn/version "1.17"}               ; SVG -> image
@@ -146,22 +147,22 @@
   org.clojure/tools.logging                 {:mvn/version "1.2.4"}              ; logging framework
   org.clojure/tools.macro                   {:mvn/version "0.1.5"}              ; local macros
   org.clojure/tools.namespace               {:mvn/version "1.4.4"}
-  org.clojure/tools.reader                  {:mvn/version "1.3.6"}
+  org.clojure/tools.reader                  {:mvn/version "1.3.7"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.17"}            ; web server
+  org.eclipse.jetty/jetty-server            {:mvn/version "12.0.4"}            ; web server
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.4"}             ; JavaScript engine
-  org.liquibase/liquibase-core              {:mvn/version "4.21.1"              ; migration management (Java lib)
+  org.liquibase/liquibase-core              {:mvn/version "4.25.0"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
   ;; The 3.X line of development for mariadb-java-client only supports the jdbc:mariadb protocol, so use 2.X for now.
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.10"}             ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
-  org.postgresql/postgresql                 {:mvn/version "42.6.0"}             ; Postgres driver
+  org.postgresql/postgresql                 {:mvn/version "42.7.1"}             ; Postgres driver
   org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.
-  org.slf4j/slf4j-api                       {:mvn/version "2.0.7"}              ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
+  org.slf4j/slf4j-api                       {:mvn/version "2.0.9"}              ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath
   org.threeten/threeten-extra               {:mvn/version "1.7.2"}              ; extra Java 8 java.time classes like DayOfMonth and Quarter
-  potemkin/potemkin                         {:mvn/version "0.4.6"               ; utility macros & fns
+  potemkin/potemkin                         {:mvn/version "0.4.7"               ; utility macros & fns
                                              :exclusions  [riddley/riddley]}
   pretty/pretty                             {:mvn/version "1.0.5"}              ; protocol for defining how custom types should be pretty printed
   prismatic/schema                          {:mvn/version "1.4.1"}              ; Data schema declaration and validation library
@@ -220,13 +221,13 @@
                                  {:mvn/version "1.1.1"}                     ; Enables local profiling and heat map generation
     clj-http-fake/clj-http-fake  {:mvn/version "1.0.4"
                                   :exclusions  [slingshot/slingshot]}
-    clj-kondo/clj-kondo          {:mvn/version "2023.09.07"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
+    clj-kondo/clj-kondo          {:mvn/version "2023.12.15"}                ; this is not for RUNNING kondo, but so we can hack on custom hooks code from the REPL.
     cloverage/cloverage          {:mvn/version "1.2.4"}
     com.gfredericks/test.chuck   {:mvn/version "0.2.14"}                    ; generating strings from regexes (useful with malli)
-    djblue/portal                {:mvn/version "0.46.0"}                    ; ui for inspecting values
+    djblue/portal                {:mvn/version "0.51.0"}                    ; ui for inspecting values
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
     io.github.metabase/hawk      {:sha "539eefaa31a43d52d7c9b5731f471bb6742e7131"}
-    jonase/eastwood              {:mvn/version "1.4.0"                      ; inspects namespaces and reports possible problems using tools.analyzer
+    jonase/eastwood              {:mvn/version "1.4.2"                      ; inspects namespaces and reports possible problems using tools.analyzer
                                   :exclusions
                                   [org.ow2.asm/asm-all]}
     lambdaisland/deep-diff2      {:mvn/version "2.10.211"}                  ; way better diffs
@@ -340,17 +341,18 @@
   {:extra-paths ["test"]
    :extra-deps
    {binaryage/devtools                 {:mvn/version "1.0.7"}
-    cider/cider-nrepl                  {:mvn/version "0.37.0"}
+    cider/cider-nrepl                  {:mvn/version "0.44.0"}
     cider/piggieback                   {:mvn/version "0.5.3"}
     cljs-bean/cljs-bean                {:mvn/version "1.9.0"}
     com.lambdaisland/glogi             {:mvn/version "1.3.169"}
-    io.github.metabase/hawk            {:sha "9c97bcb6d4de116325e651b40973fd0a75b7ae21"}
+    io.github.metabase/hawk            {:git/url "https://github.com/metabase/hawk"
+                                        :git/sha "539eefaa31a43d52d7c9b5731f471bb6742e7131"}
     org.clojars.mmb90/cljs-cache       {:mvn/version "0.1.4"}
     ;; Forcibly targeting a newer release than ships by default with shadow-cljs 2.20.20.
     ;; It fixes an issue where TypeScript can't parse the `cljs_env.js` output file.
     org.clojure/google-closure-library {:mvn/version "0.0-20230227-c7c0a541"}
-    refactor-nrepl/refactor-nrepl      {:mvn/version "3.9.0"}
-    thheller/shadow-cljs               {:mvn/version "2.25.7"}}}
+    refactor-nrepl/refactor-nrepl      {:mvn/version "3.9.1"}
+    thheller/shadow-cljs               {:mvn/version "2.26.2"}}}
 
   ;; for local dev -- include the drivers locally with :dev:drivers
   :drivers
@@ -534,7 +536,7 @@
     com.github.seancorfield/depstar   {:mvn/version "2.1.303"}
     expound/expound                   {:mvn/version "0.9.0"}                    ; better output of spec validation errors
     io.github.borkdude/grasp          {:mvn/version "0.1.4"}
-    io.github.clojure/tools.build     {:mvn/version "0.9.5"}
+    io.github.clojure/tools.build     {:mvn/version "0.9.6"}
     org.clojure/data.xml              {:mvn/version "0.2.0-alpha8"}
     org.clojure/tools.deps.alpha      {:mvn/version "0.15.1254"}
     org.fedorahosted.tennera/jgettext {:mvn/version "0.15.1"}}
@@ -649,7 +651,7 @@
   ;;
   ;; clojure -M:dev:nrepl (etc.)
   :nrepl
-  {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}}
+  {:extra-deps {nrepl/nrepl {:mvn/version "1.1.0"}}
    :main-opts  ["-m" "nrepl.cmdline" "-p" "50605"]}
 
   ;; - start a Socket REPL on port 50505 that you can connect your editor to:

--- a/deps.edn
+++ b/deps.edn
@@ -152,7 +152,7 @@
   org.eclipse.jetty/jetty-server            {:mvn/version "11.0.17"}            ; web server
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.4"}             ; JavaScript engine
-  org.liquibase/liquibase-core              {:mvn/version "4.25.0"              ; migration management (Java lib)
+  org.liquibase/liquibase-core              {:mvn/version "4.21.1"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
   ;; The 3.X line of development for mariadb-java-client only supports the jdbc:mariadb protocol, so use 2.X for now.
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.10"}             ; MySQL/MariaDB driver

--- a/deps.edn
+++ b/deps.edn
@@ -45,7 +45,7 @@
   com.fasterxml.jackson.core/jackson-databind
                                             {:mvn/version "2.16.0"}             ; JSON processor used by snowplow-java-tracker
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "6.5.1"}              ; trans dep of commons-codec (pinned version due to CVE-2022-40151)
-  com.h2database/h2                         {:mvn/version "2.2.224"}            ; embedded SQL database
+  com.h2database/h2                         {:mvn/version "2.1.214"}            ; embedded SQL database
   com.gfredericks/test.chuck                {:mvn/version "0.2.14"}             ; generating strings from regex
   com.snowplowanalytics/snowplow-java-tracker
                                             {:mvn/version "1.0.1"               ; Snowplow analytics

--- a/deps.edn
+++ b/deps.edn
@@ -57,8 +57,8 @@
   commons-fileupload/commons-fileupload     {:mvn/version "1.5"}                ; ring/ring-core 1.9.6 uses v1.4, but we want 1.5 due to a CVE. When we upgrade to the forthcoming ring/ring-core 1.10.0 we can remove this.
   commons-codec/commons-codec               {:mvn/version "1.16.0"}             ; Apache Commons -- useful codec util fns
   commons-io/commons-io                     {:mvn/version "2.15.1"}             ; Apache Commons -- useful IO util fns
-  commons-net/commons-net                   {:mvn/version "3.10.0"}              ; Apache Commons -- useful network utils. Transitive dep of Snowplow, pinned due to CVE-2021-37533
-  commons-validator/commons-validator       {:mvn/version "1.8.0"                 ; Apache Commons -- useful validation util fns
+  commons-net/commons-net                   {:mvn/version "3.10.0"}             ; Apache Commons -- useful network utils. Transitive dep of Snowplow, pinned due to CVE-2021-37533
+  commons-validator/commons-validator       {:mvn/version "1.8.0"               ; Apache Commons -- useful validation util fns
                                              :exclusions  [commons-beanutils/commons-beanutils
                                                            commons-digester/commons-digester
                                                            commons-logging/commons-logging]}
@@ -75,11 +75,11 @@
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
   clj-commons/clj-yaml                      {:mvn/version "1.0.27"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.535"}
-  io.github.eerohele/pp                     {:git/tag "2023-11-25.47"            ; super fast pretty-printing library
+  io.github.eerohele/pp                     {:git/tag "2023-11-25.47"           ; super fast pretty-printing library
                                              :git/sha "d3210d3"
                                              :git/url "https://github.com/eerohele/pp"}
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
-  io.github.resilience4j/resilience4j-retry {:mvn/version "2.1.0"}              ; Support for retrying operations
+  io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1"}              ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   io.prometheus/simpleclient_jetty          {:mvn/version "0.16.0"}             ; prometheus jetty collector
   javax.servlet/servlet-api                 {:mvn/version "2.5"}                ; used by ring's multipart-params (file upload)
@@ -89,7 +89,7 @@
   lambdaisland/uri                          {:mvn/version "1.16.134"}           ; Used by opanai-clojure. security bump
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
-  metabase/saml20-clj                       {:mvn/version "2.2.4"              ; EE SAML integration.
+  metabase/saml20-clj                       {:mvn/version "2.2.4"               ; EE SAML integration.
                                              :exclusions [org.bouncycastle/bcpkix-jdk15on
                                                           org.bouncycastle/bcprov-jdk15on
                                                           org.bouncycastle/bcpkix-jdk18on
@@ -149,7 +149,7 @@
   org.clojure/tools.namespace               {:mvn/version "1.4.4"}
   org.clojure/tools.reader                  {:mvn/version "1.3.7"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "12.0.4"}            ; web server
+  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.17"}            ; web server
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.4"}             ; JavaScript engine
   org.liquibase/liquibase-core              {:mvn/version "4.25.0"              ; migration management (Java lib)
@@ -173,7 +173,7 @@
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
   user-agent/user-agent                     {:mvn/version "0.1.1"}              ; User-Agent string parser, for Login History page & elsewhere
-  weavejester/dependency                    {:mvn/version "0.2.1"}}              ; Dependency graphs and topological sorting
+  weavejester/dependency                    {:mvn/version "0.2.1"}}             ; Dependency graphs and topological sorting
 
 
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/deps.edn
+++ b/deps.edn
@@ -71,7 +71,7 @@
   environ/environ                           {:mvn/version "1.2.0"}              ; env vars/Java properties abstraction
   hiccup/hiccup                             {:mvn/version "1.0.5"}              ; HTML templating
   inflections/inflections                   {:mvn/version "0.14.1"}             ; Clojure/Script library used for prularizing words
-  info.sunng/ring-jetty9-adapter            {:mvn/version "0.30.3"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver.
+  info.sunng/ring-jetty9-adapter            {:mvn/version "0.22.3"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver.
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
   clj-commons/clj-yaml                      {:mvn/version "1.0.27"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.535"}
@@ -173,8 +173,8 @@
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure
   user-agent/user-agent                     {:mvn/version "0.1.1"}              ; User-Agent string parser, for Login History page & elsewhere
-  weavejester/dependency                    {:mvn/version "0.2.1"}              ; Dependency graphs and topological sorting
-  }
+  weavejester/dependency                    {:mvn/version "0.2.1"}}              ; Dependency graphs and topological sorting
+
 
  ;; !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
  ;; !!         PLEASE KEEP NEW DEPENDENCIES ABOVE ALPHABETICALLY ORGANIZED AND ADD COMMENTS EXPLAINING THEM.         !!

--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -5,5 +5,5 @@
  {"athena" {:url "https://s3.amazonaws.com/maven-athena"}}
 
  :deps
- {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.543"}
+ {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.619"}
   com.metabase/athena-jdbc {:mvn/version "2.0.35"}}}

--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -3,6 +3,6 @@
 
  :deps
  ;; TODO: figure out how to be able to leave off this version string and use the version from the BOM
- {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.34.2"}
+ {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.35.0"}
   com.google.code.gson/gson                   {:mvn/version "2.10.1"}
   com.google.oauth-client/google-oauth-client {:mvn/version "1.34.1"}}}

--- a/modules/drivers/presto-jdbc/deps.edn
+++ b/modules/drivers/presto-jdbc/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources"]
 
  :deps
- {com.facebook.presto/presto-jdbc {:mvn/version "0.283"}}
+ {com.facebook.presto/presto-jdbc {:mvn/version "0.285"}}
 
  :metabase.driver/parents
  #{:sql-jdbc}}

--- a/modules/drivers/redshift/deps.edn
+++ b/modules/drivers/redshift/deps.edn
@@ -5,4 +5,4 @@
  {"redshift" {:url "https://s3.amazonaws.com/redshift-maven-repository/release"}}
 
  :deps
- {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.1.0.18"}}}
+ {com.amazon.redshift/redshift-jdbc42 {:mvn/version "2.1.0.24"}}}

--- a/modules/drivers/snowflake/deps.edn
+++ b/modules/drivers/snowflake/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {net.snowflake/snowflake-jdbc {:mvn/version "3.14.1"}}}
+ {net.snowflake/snowflake-jdbc {:mvn/version "3.14.4"}}}

--- a/modules/drivers/sqlite/deps.edn
+++ b/modules/drivers/sqlite/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {org.xerial/sqlite-jdbc {:mvn/version "3.43.0.0"}}}
+ {org.xerial/sqlite-jdbc {:mvn/version "3.44.1.0"}}}

--- a/modules/drivers/sqlserver/deps.edn
+++ b/modules/drivers/sqlserver/deps.edn
@@ -2,4 +2,4 @@
  ["src" "resources"]
 
  :deps
- {com.microsoft.sqlserver/mssql-jdbc {:mvn/version "12.4.1.jre11"}}}
+ {com.microsoft.sqlserver/mssql-jdbc {:mvn/version "12.4.2.jre11"}}}

--- a/modules/drivers/vertica/deps.edn
+++ b/modules/drivers/vertica/deps.edn
@@ -2,7 +2,7 @@
  ["src" "resources-ee"]
 
  :deps
- {com.vertica.jdbc/vertica-jdbc {:mvn/version "12.0.4-0"}}
+ {com.vertica.jdbc/vertica-jdbc {:mvn/version "23.4.0-0"}}
 
  :aliases
  {:oss

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -20,7 +20,6 @@
    (liquibase Contexts LabelExpression Liquibase RuntimeEnvironment Scope Scope$Attr Scope$ScopedRunner)
    (liquibase.change.custom CustomChangeWrapper)
    (liquibase.changelog ChangeLogIterator ChangeSet ChangeSet$ExecType)
-   (liquibase.changelog.filter ChangeSetFilter)
    (liquibase.changelog.visitor AbstractChangeExecListener ChangeExecListener UpdateVisitor)
    (liquibase.database Database DatabaseFactory)
    (liquibase.database.jvm JdbcConnection)
@@ -255,7 +254,7 @@
      :or {change-set-filters []}}]
    (let [change-log     (.getDatabaseChangeLog liquibase)
          database       (.getDatabase liquibase)
-         log-iterator   (ChangeLogIterator. change-log ^List (into-array ChangeSetFilter change-set-filters))
+         log-iterator   (ChangeLogIterator. change-log change-set-filters)
          update-visitor (UpdateVisitor. database ^ChangeExecListener exec-listener)
          runtime-env    (RuntimeEnvironment. database (Contexts.) nil)]
      (run-in-scope-locked

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -17,9 +17,10 @@
   (:import
    (java.io StringWriter)
    (java.util List Map)
-   (liquibase Contexts LabelExpression Liquibase Scope Scope$Attr Scope$ScopedRunner RuntimeEnvironment)
+   (liquibase Contexts LabelExpression Liquibase RuntimeEnvironment Scope Scope$Attr Scope$ScopedRunner)
    (liquibase.change.custom CustomChangeWrapper)
    (liquibase.changelog ChangeLogIterator ChangeSet ChangeSet$ExecType)
+   (liquibase.changelog.filter ChangeSetFilter)
    (liquibase.changelog.visitor AbstractChangeExecListener ChangeExecListener UpdateVisitor)
    (liquibase.database Database DatabaseFactory)
    (liquibase.database.jvm JdbcConnection)
@@ -254,7 +255,7 @@
      :or {change-set-filters []}}]
    (let [change-log     (.getDatabaseChangeLog liquibase)
          database       (.getDatabase liquibase)
-         log-iterator   (ChangeLogIterator. change-log (into-array liquibase.changelog.filter.ChangeSetFilter change-set-filters))
+         log-iterator   (ChangeLogIterator. change-log ^List (into-array ChangeSetFilter change-set-filters))
          update-visitor (UpdateVisitor. database ^ChangeExecListener exec-listener)
          runtime-env    (RuntimeEnvironment. database (Contexts.) nil)]
      (run-in-scope-locked

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -20,6 +20,7 @@
    (liquibase Contexts LabelExpression Liquibase RuntimeEnvironment Scope Scope$Attr Scope$ScopedRunner)
    (liquibase.change.custom CustomChangeWrapper)
    (liquibase.changelog ChangeLogIterator ChangeSet ChangeSet$ExecType)
+   (liquibase.changelog.filter ChangeSetFilter)
    (liquibase.changelog.visitor AbstractChangeExecListener ChangeExecListener UpdateVisitor)
    (liquibase.database Database DatabaseFactory)
    (liquibase.database.jvm JdbcConnection)
@@ -254,7 +255,7 @@
      :or {change-set-filters []}}]
    (let [change-log     (.getDatabaseChangeLog liquibase)
          database       (.getDatabase liquibase)
-         log-iterator   (ChangeLogIterator. change-log change-set-filters)
+         log-iterator   (ChangeLogIterator. change-log (into-array ChangeSetFilter change-set-filters))
          update-visitor (UpdateVisitor. database ^ChangeExecListener exec-listener)
          runtime-env    (RuntimeEnvironment. database (Contexts.) nil)]
      (run-in-scope-locked


### PR DESCRIPTION
Routine dependency bumps for the start of the 49 cycle.

A few dependencies are excluded:
* Jetty, `info.sunng/ring-jetty9-adapter`, and `io.github.resilience4j/resilience4j-retry` are not bumped because the newer versions do not support Java 11
* H2 is not bumped because of another format upgrade between 2.1 and 2.2 ([Slack thread with more details](https://metaboat.slack.com/archives/C97M2U8M6/p1701904521480389))
* Liquibase is not bumped because it causes mysterious failures in (mostly) migration tests. Will investigate this separately. https://github.com/metabase/metabase/issues/36877

There also seems to be issues with the [new version of the Redshift driver](https://metaboat.slack.com/archives/C04DN5VRQM6/p1702506133795809) but I'm still bumping it here, [per Luis's comment](https://metaboat.slack.com/archives/CKZEMT1MJ/p1702665259619859?thread_ts=1677871576.302359&cid=CKZEMT1MJ)