### PR TITLE
[MLv2] Fix an edge case where a join-alias is needed on a field ref

### DIFF
--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -445,7 +445,7 @@ describeEE("formatting > sandboxes", () => {
       cy.wait("@dataset");
       cy.log("Reported failing on v1.36.4");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Category is Doohickey");
+      cy.findByText("Products → Category is Doohickey");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("97.44"); // Subtotal for order #10
     });

--- a/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
@@ -613,8 +613,6 @@ describe("scenarios > visualizations > table column settings", () => {
       _addColumn(testData);
     });
 
-    // TODO: This is currently broken by some subtleties of `:lib/source` in MLv2.
-    // This is still better than it used to be, so skip this test and fix it later. See #32373.
     it("should be able to show and hide fields from a nested query with joins and fields (metabase#32373)", () => {
       cy.createQuestion(tableQuestionWithJoinAndFields).then(
         ({ body: card }) => {
@@ -640,14 +638,7 @@ describe("scenarios > visualizations > table column settings", () => {
 
       _addColumn(testData2);
 
-      // // TODO: Once #33972 is fixed in the QP, this test will start failing.
-      // // The correct display name is "Products -> Category", but the QP is incorrectly marking this column as coming
-      // // from the implicit join (so it's using PRODUCT_ID -> "Product", not the table name "Products").
-      _addColumn({
-        ...testData,
-        column: "Products → Category",
-        columnName: "Product → Category",
-      });
+      _addColumn(testData);
     });
 
     it("should be able to show and hide implicitly joinable fields for a nested query with joins and fields", () => {

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -420,6 +420,14 @@
         options           (merge {:lib/uuid       (str (random-uuid))
                                   :base-type      (:base-type metadata)
                                   :effective-type (column-metadata-effective-type metadata)}
+                                 ;; This one deliberately comes first so it will be overwritten by current-join-alias.
+                                 ;; We don't want both :source-field and :join-alias, though.
+                                 (when-let [source-alias (and (not inherited-column?)
+                                                              (not (:fk-field-id metadata))
+                                                              (not= :source/implicitly-joinable
+                                                                    (:lib/source metadata))
+                                                              (:source-alias metadata))]
+                                   {:join-alias source-alias})
                                  (when-let [join-alias (lib.join.util/current-join-alias metadata)]
                                    {:join-alias join-alias})
                                  (when-let [temporal-unit (::temporal-unit metadata)]


### PR DESCRIPTION
The QP sometimes provides a `:source-alias` and no `:join-alias` for
a joined column. Then its MLv2 ref would be missing a `:join-alias` and
it would not match its own column under
`lib.equality/find-matching-column`.

Fixes #36861.
