### PR TITLE
Add e2e front-end healthcheck to cypress

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -17,6 +17,8 @@ const targetVersion = process.env["CROSS_VERSION_TARGET"];
 
 const runWithReplay = process.env["CYPRESS_REPLAYIO_ENABLED"];
 
+const feHealthcheckEnabled = process.env["CYPRESS_FE_HEALTHCHECK"] === "true";
+
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
@@ -92,6 +94,13 @@ const defaultConfig = {
     config.env.SNOWPLOW_MICRO_URL = snowplowMicroUrl;
     config.env.SOURCE_VERSION = sourceVersion;
     config.env.TARGET_VERSION = targetVersion;
+    // Set on local, development-mode runs only
+    config.env.feHealthcheck = {
+      enabled: feHealthcheckEnabled,
+      url: feHealthcheckEnabled
+        ? "http://localhost:8080/webpack-dev-server/"
+        : undefined,
+    };
 
     require("@cypress/grep/src/plugin")(config);
 

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -24,7 +24,7 @@ Cypress.on("test:before:run", () => {
   if (feHealthcheck?.enabled) {
     fetch(feHealthcheck.url).catch(() =>
       alert(
-        `⛔️ ${feHealthcheck.url} is not avaiable.\n\nIs dev server running?`,
+        `⛔️ ${feHealthcheck.url} is not available.\n\nIs dev server running?`,
       ),
     );
   }

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -18,6 +18,18 @@ require("cy-verify-downloads").addCustomCommand();
 
 Cypress.on("uncaught:exception", (err, runnable) => false);
 
+Cypress.on("test:before:run", () => {
+  // Check wether FE is running in dev mode
+  const feHealthcheck = Cypress.env().feHealthcheck;
+  if (feHealthcheck?.enabled) {
+    fetch(feHealthcheck.url).catch(() =>
+      alert(
+        `⛔️ ${feHealthcheck.url} is not avaiable.\n\nIs dev server running?`,
+      ),
+    );
+  }
+});
+
 Cypress.on("test:after:run", (test, runnable) => {
   if (test.state === "failed") {
     const titleToFileName = title => title.replace(/[>]/g, "");

--- a/package.json
+++ b/package.json
@@ -345,7 +345,7 @@
     "test": "yarn test-unit && yarn test-timezones && yarn test-cypress",
     "test-cljs": "yarn && shadow-cljs compile test && node target/node-tests.js",
     "test-cypress": "yarn build && ./bin/build-for-test && yarn test-cypress-run",
-    "test-cypress-open": "./bin/build-for-test && yarn test-cypress-run --e2e --open",
+    "test-cypress-open": "./bin/build-for-test && CYPRESS_FE_HEALTHCHECK=true yarn test-cypress-run --e2e --open",
     "test-cypress-open-no-backend": "E2E_HOST='http://localhost:3000' yarn test-cypress-run --e2e --open",
     "test-cypress-open-qa": "yarn test-qa-dbs:up && QA_DB_ENABLED=true TZ='US/Pacific' yarn test-cypress-open",
     "test-cypress-run": "node ./e2e/runner/run_cypress_tests.js",


### PR DESCRIPTION
**TL;DR:** when you forget to run `yarn build-hot` when running e2e tests locally, you will now see an alert reminding you about it.

<img width="1290" alt="Screenshot 2023-12-15 at 19 39 36" src="https://github.com/metabase/metabase/assets/2196347/1ac60eb3-9636-4342-a677-ee660221bc0c">

## Description

* it's a **safe opt-in option** controlled by the env `CYPRESS_FE_HEALTHCHECK` - see package.json, which **does not affect any runs** other than local ones
* `test:before:run` is run within a test browser and checks if `http://localhost:8080/webpack-dev-server/` is available

It is ok to hardcode the host and port, since it's already done in the backend (grep `localhost:8080`) _and_ it is greppable like that. I don't feel like we need any configs around that.

## Rationale

Yesterday I was caught the 2nd time by not running a front-end dev server via `yarn build-hot` and tinkering with "mysterious" e2e failures for over an hour. Perhaps I was switching branches or doing something like that and at some point killed it. 

Then the suite I was working on started failing with some request timing out. I _was expecting_ request failures in this particular suite and perhaps was a bit fatigued by looking at the tests, so it didn't look unusual and I kept debugging... Until I had almost smashed my head on the wall. Turned out, I wasn't running the dev-server! 

This tiny addition prevents this from happening.

