### PR TITLE
remove redundant visibility check

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -69,7 +69,6 @@ export function removeDashboardCard(index = 0) {
   getDashboardCard(index)
     .realHover({ scrollBehavior: "bottom" })
     .findByTestId("dashboardcard-actions-panel")
-    .should("be.visible")
     .icon("close")
     .click();
 }


### PR DESCRIPTION
This is what will make the `dashboard-card-undo.cy.spec.js` stable. this flake was analyzed by looking [at this replay](https://tests.replay.io/recording/e2etestscenariosdashboard-cardsdashboard-card-undocyspecjs--280802af-172b-4206-84b7-7570b87229c5?point=18822076125490706528347043718499305&time=11126&focusWindow=eyJiZWdpbiI6eyJwb2ludCI6IjQ4Njc3NzgzMDcwODQxNDc1ODQ3NDE1NjA2ODU2OTEyOTEiLCJ0aW1lIjozMTI1fSwiZW5kIjp7InBvaW50IjoiMzIxMjczMzY4Mjk5ODY1NzgzODUzMDAwNTU4MTc5ODI1NjMiLCJ0aW1lIjoxNTM0OH19) and was initially flagged to be a timing issue (notion doc from Replay [can be found here](https://www.notion.so/replayio/Metabase-test-review-12-14-e0309735d02a428cbd6e0e845ab15f2d?pvs=4)). the timing issue is real, but the root cause is actually a combination of how the test is written and how elements on page behave.

the test selects an svg icon. that icon is inside a parent element that changes opacity from 0 to 1 when hovered over. (this is the reason changing `.realHover()` to `.trigger('mouseover')` does not really fix the issue). that change of opacity sometimes fails to register. I’m still unsure about the reason for that opacity not changing, because even with failed test, I could clearly see the element, so I’m suspicious that visibility checks might not work properly. I think there might be some conflict between `.realhover()` and `.should('be.visible')` The reason why I’m thinking this is because these two commands use very different methods of interacting with the page (CDP vs js).

If I skip the assertion, test passes consistently, i’ve been burning it for 10 minutes, it’s all green. It’s crazy how this one-line change actually fixes the problem. cc @nemanjaglumac 