### PR TITLE
polish dynamic combo chart

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.styled.tsx
@@ -2,8 +2,9 @@ import styled from "@emotion/styled";
 import LegendLayout from "metabase/visualizations/components/legend/LegendLayout";
 import { ResponsiveEChartsRenderer } from "metabase/visualizations/components/EChartsRenderer";
 
-export const CartesianChartRoot = styled.div`
-  padding: 0.5rem;
+export const CartesianChartRoot = styled.div<{ isQueryBuilder: boolean }>`
+  padding: ${({ isQueryBuilder }) =>
+    isQueryBuilder ? "1rem 1rem 1rem 2rem" : "0.5rem 1rem"};
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -34,6 +34,8 @@ import {
 
 export function CartesianChart({
   rawSeries,
+  series: transformedSeries,
+  isPlaceholder,
   settings,
   card,
   fontFamily,
@@ -49,8 +51,14 @@ export function CartesianChart({
   onVisualizationClick,
   onChangeCardAndRun,
 }: VisualizationProps) {
+  const seriesToRender = useMemo(
+    () => (isPlaceholder ? transformedSeries : rawSeries),
+    [isPlaceholder, rawSeries, transformedSeries],
+  );
+
   const isBrushing = useRef<boolean>();
   const chartRef = useRef<EChartsType>();
+
   const hasTitle = showTitle && settings["card.title"];
   const title = settings["card.title"] || card.name;
   const description = settings["card.description"];
@@ -66,8 +74,8 @@ export function CartesianChart({
   );
 
   const chartModel = useMemo(
-    () => getCartesianChartModel(rawSeries, settings, renderingContext),
-    [rawSeries, renderingContext, settings],
+    () => getCartesianChartModel(seriesToRender, settings, renderingContext),
+    [seriesToRender, renderingContext, settings],
   );
 
   const legendItems = useMemo(() => getLegendItems(chartModel), [chartModel]);
@@ -135,7 +143,6 @@ export function CartesianChart({
             settings,
             index: seriesIndex,
             datumIndex: dataIndex,
-            seriesId,
             event: event.event.event,
             element: dataIndex != null ? event.event.event.target : null,
             data,
@@ -334,7 +341,7 @@ export function CartesianChart({
   const canSelectTitle = !!onChangeCardAndRun;
 
   return (
-    <CartesianChartRoot>
+    <CartesianChartRoot isQueryBuilder={isQueryBuilder}>
       {hasTitle && (
         <LegendCaption
           title={title}

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/chart-definition.ts
@@ -47,7 +47,10 @@ export const getCartesianChartDefinition = (
       {
         card: {
           display: "line",
-          visualization_settings: {},
+          visualization_settings: {
+            "graph.metrics": ["x"],
+            "graph.dimensions": ["y"],
+          },
           dataset_query: { type: "query" },
         },
         data: {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36294

### Description

- Fixes chart padding in the query builder
- Fixes not showing chart for the placeholder series

### How to verify

1) Paddings
Create line/area/bar/cobmo chart in query builder and ensure the padding around the chart and the legend looks fine. At the same time, on dashcards we show smaller padding due to limited space.

2) Fix placeholder series rendering
Before this change the chart showed an error every time it tried to render placeholder series even for a single tick.
Ensure the following scenario works:
- New Question -> Sample database -> Orders
- Click visualize to show the table with all data
- Summarize -> by Created At
- Ensure it shows the line chart instead of an error

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
