### PR TITLE
waterfall axis options

### DIFF
--- a/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.stories.tsx
@@ -34,3 +34,17 @@ WithoutTotal.args = {
   dashcardSettings: {},
   renderingContext,
 };
+
+export const OrdinalXScale = Template.bind({});
+OrdinalXScale.args = {
+  rawSeries: data.ordinalXScale as any,
+  dashcardSettings: {},
+  renderingContext,
+};
+
+export const TimeSeriesDataAsOrdinalXScale = Template.bind({});
+TimeSeriesDataAsOrdinalXScale.args = {
+  rawSeries: data.timeSeriesDataAsOrdinalXScale as any,
+  dashcardSettings: {},
+  renderingContext,
+};

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/index.ts
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/index.ts
@@ -1,5 +1,9 @@
 import withoutTotal from "./without-total.json";
+import ordinalXScale from "./ordinal-x-scale.json";
+import timeSeriesDataAsOrdinalXScale from "./timeseries-data-as-ordinal-x-scale.json";
 
 export const data = {
   withoutTotal,
+  ordinalXScale,
+  timeSeriesDataAsOrdinalXScale,
 };

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/ordinal-x-scale.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/ordinal-x-scale.json
@@ -1,0 +1,219 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 161,
+      "result_metadata": [
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "name": "stage",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1544, null],
+          "effective_type": "type/Text",
+          "id": 1544,
+          "visibility_type": "normal",
+          "display_name": "Stage",
+          "fingerprint": {
+            "global": { "distinct-count": 1, "nil%": 0 },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 8
+              }
+            }
+          },
+          "base_type": "type/Text"
+        },
+        {
+          "display_name": "Count",
+          "semantic_type": "type/Quantity",
+          "field_ref": ["aggregation", 0],
+          "name": "count",
+          "base_type": "type/BigInteger",
+          "effective_type": "type/BigInteger",
+          "fingerprint": {
+            "global": { "distinct-count": 5, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": 225,
+                "q1": 393.75,
+                "q3": 6250,
+                "max": 10000,
+                "sd": 4138.447776642832,
+                "avg": 3435
+              }
+            }
+          }
+        }
+      ],
+      "include_xls": false,
+      "database_id": 2,
+      "enable_embedding": false,
+      "collection_id": 10,
+      "query_type": "query",
+      "name": "Waterfall Ordinal - User Flow",
+      "creator_id": 1,
+      "updated_at": "2023-12-16T19:07:05.257577Z",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "database": 2,
+        "type": "query",
+        "query": {
+          "aggregation": [["count"]],
+          "breakout": [["field", "stage", { "base-type": "type/Text" }]],
+          "source-table": "card__157"
+        }
+      },
+      "id": 158,
+      "parameter_mappings": [],
+      "include_csv": false,
+      "display": "waterfall",
+      "entity_id": "yPXayfKmEAVssfjS7X7K1",
+      "collection_preview": true,
+      "visualization_settings": {
+        "waterfall.show_total": false,
+        "graph.dimensions": ["stage"],
+        "graph.metrics": ["count"]
+      },
+      "metabase_version": "v1.47.1-SNAPSHOT (b37c32d)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2023-12-16T19:07:05.257577Z",
+      "public_uuid": null
+    },
+    "data": {
+      "results_timezone": "America/Los_Angeles",
+      "download_perms": "full",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "name": "stage",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1544, null],
+            "effective_type": "type/Text",
+            "id": 1544,
+            "visibility_type": "normal",
+            "display_name": "Stage",
+            "fingerprint": {
+              "global": { "distinct-count": 1, "nil%": 0 },
+              "type": {
+                "type/Text": {
+                  "percent-json": 0,
+                  "percent-url": 0,
+                  "percent-email": 0,
+                  "percent-state": 0,
+                  "average-length": 8
+                }
+              }
+            },
+            "base_type": "type/Text"
+          },
+          {
+            "display_name": "Count",
+            "semantic_type": "type/Quantity",
+            "field_ref": ["aggregation", 0],
+            "name": "count",
+            "base_type": "type/BigInteger",
+            "effective_type": "type/BigInteger",
+            "fingerprint": {
+              "global": { "distinct-count": 5, "nil%": 0 },
+              "type": {
+                "type/Number": {
+                  "min": 225,
+                  "q1": 393.75,
+                  "q3": 6250,
+                  "max": 10000,
+                  "sd": 4138.447776642832,
+                  "avg": 3435
+                }
+              }
+            }
+          }
+        ]
+      },
+      "rows": [
+        ["cart", 1500],
+        ["checkout", 450],
+        ["homepage", 10000],
+        ["product_page", 5000],
+        ["purchase", 225]
+      ],
+      "cols": [
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 161,
+          "coercion_strategy": null,
+          "name": "stage",
+          "settings": null,
+          "source": "breakout",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1544, null],
+          "effective_type": "type/Text",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1544,
+          "position": 2,
+          "visibility_type": "normal",
+          "display_name": "Stage",
+          "fingerprint": {
+            "global": { "distinct-count": 1, "nil%": 0 },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 8
+              }
+            }
+          },
+          "base_type": "type/Text"
+        },
+        {
+          "base_type": "type/BigInteger",
+          "name": "count",
+          "display_name": "Count",
+          "semantic_type": "type/Quantity",
+          "source": "aggregation",
+          "field_ref": ["aggregation", 0],
+          "aggregation_index": 0,
+          "effective_type": "type/BigInteger"
+        }
+      ],
+      "viz-settings": {
+        "waterfall.show_total": false,
+        "graph.dimensions": ["stage"],
+        "graph.metrics": ["count"],
+        "metabase.shared.models.visualization-settings/column-settings": {
+          "{:metabase.shared.models.visualization-settings/field-id 1542}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1543}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1544}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1545}": {}
+        },
+        "metabase.shared.models.visualization-settings/global-column-settings": {}
+      },
+      "native_form": {
+        "query": "SELECT \"source\".\"stage\" AS \"stage\", COUNT(*) AS \"count\" FROM (SELECT \"csv_upload_data\".\"csv_upload_simple_user_flow_funnel_20231216110456\".\"_mb_row_id\" AS \"_mb_row_id\", \"csv_upload_data\".\"csv_upload_simple_user_flow_funnel_20231216110456\".\"user_id\" AS \"user_id\", \"csv_upload_data\".\"csv_upload_simple_user_flow_funnel_20231216110456\".\"stage\" AS \"stage\", \"csv_upload_data\".\"csv_upload_simple_user_flow_funnel_20231216110456\".\"conversion\" AS \"conversion\" FROM \"csv_upload_data\".\"csv_upload_simple_user_flow_funnel_20231216110456\") AS \"source\" GROUP BY \"source\".\"stage\" ORDER BY \"source\".\"stage\" ASC",
+        "params": null
+      },
+      "is_sandboxed": false,
+      "dataset": true,
+      "insights": null
+    }
+  }
+]

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/timeseries-data-as-ordinal-x-scale.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/timeseries-data-as-ordinal-x-scale.json
@@ -1,0 +1,340 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 154,
+      "result_metadata": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1416, null],
+          "effective_type": "type/BigInteger",
+          "id": 1416,
+          "visibility_type": "normal",
+          "display_name": "Mb Row ID",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": "type/CreationDate",
+          "coercion_strategy": null,
+          "unit": "default",
+          "name": "date",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1417, { "temporal-unit": "default" }],
+          "effective_type": "type/Date",
+          "id": 1417,
+          "visibility_type": "normal",
+          "display_name": "Date",
+          "fingerprint": {
+            "global": { "distinct-count": 1460, "nil%": 0 },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2014-01-01",
+                "latest": "2017-12-31"
+              }
+            }
+          },
+          "base_type": "type/Date"
+        },
+        {
+          "description": null,
+          "semantic_type": "type/Quantity",
+          "coercion_strategy": null,
+          "name": "total_accident",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1418, null],
+          "effective_type": "type/BigInteger",
+          "id": 1418,
+          "visibility_type": "normal",
+          "display_name": "Total Accident",
+          "fingerprint": {
+            "global": { "distinct-count": 310, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": 128,
+                "q1": 333.7211770961825,
+                "q3": 425.76625335908,
+                "max": 567,
+                "sd": 67.95279959530245,
+                "avg": 378.49486652977413
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "include_xls": false,
+      "database_id": 2,
+      "enable_embedding": false,
+      "collection_id": 10,
+      "query_type": "query",
+      "name": "Waterfall Timeseries as Ordinal - UK Car Accidents",
+      "creator_id": 1,
+      "updated_at": "2023-12-16T19:17:18.845612Z",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "database": 2,
+        "type": "query",
+        "query": {
+          "source-table": "card__101",
+          "filter": [
+            "between",
+            ["field", 1417, { "base-type": "type/Date" }],
+            "2016-12-01",
+            "2016-12-31"
+          ]
+        }
+      },
+      "id": 155,
+      "parameter_mappings": [],
+      "include_csv": false,
+      "display": "waterfall",
+      "entity_id": "QRXpTscKiDPmS2Gn_TB1r",
+      "collection_preview": true,
+      "visualization_settings": {
+        "table.column_widths": [null, 226],
+        "graph.show_values": false,
+        "graph.series_order_dimension": null,
+        "graph.y_axis.scale": "linear",
+        "graph.metrics": ["total_accident"],
+        "graph.series_order": null,
+        "series_settings": { "total_accident": { "color": "#227FD2" } },
+        "graph.x_axis.scale": "ordinal",
+        "graph.dimensions": ["date"],
+        "waterfall.show_total": true
+      },
+      "metabase_version": "v1.47.1-SNAPSHOT (b37c32d)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2023-12-16T18:47:52.067605Z",
+      "public_uuid": null
+    },
+    "data": {
+      "results_timezone": "America/Los_Angeles",
+      "download_perms": "full",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": null,
+            "semantic_type": "type/PK",
+            "coercion_strategy": null,
+            "name": "_mb_row_id",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1416, null],
+            "effective_type": "type/BigInteger",
+            "id": 1416,
+            "visibility_type": "normal",
+            "display_name": "Mb Row ID",
+            "fingerprint": null,
+            "base_type": "type/BigInteger"
+          },
+          {
+            "description": null,
+            "semantic_type": "type/CreationDate",
+            "coercion_strategy": null,
+            "unit": "default",
+            "name": "date",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1417, { "temporal-unit": "default" }],
+            "effective_type": "type/Date",
+            "id": 1417,
+            "visibility_type": "normal",
+            "display_name": "Date",
+            "fingerprint": {
+              "global": { "distinct-count": 1460, "nil%": 0 },
+              "type": {
+                "type/DateTime": {
+                  "earliest": "2014-01-01",
+                  "latest": "2017-12-31"
+                }
+              }
+            },
+            "base_type": "type/Date"
+          },
+          {
+            "description": null,
+            "semantic_type": "type/Quantity",
+            "coercion_strategy": null,
+            "name": "total_accident",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1418, null],
+            "effective_type": "type/BigInteger",
+            "id": 1418,
+            "visibility_type": "normal",
+            "display_name": "Total Accident",
+            "fingerprint": {
+              "global": { "distinct-count": 310, "nil%": 0 },
+              "type": {
+                "type/Number": {
+                  "min": 128,
+                  "q1": 333.7211770961825,
+                  "q3": 425.76625335908,
+                  "max": 567,
+                  "sd": 67.95279959530245,
+                  "avg": 378.49486652977413
+                }
+              }
+            },
+            "base_type": "type/BigInteger"
+          }
+        ]
+      },
+      "rows": [
+        [1066, "2016-12-01T00:00:00-08:00", 537],
+        [1067, "2016-12-02T00:00:00-08:00", 487],
+        [1068, "2016-12-03T00:00:00-08:00", 331],
+        [1069, "2016-12-04T00:00:00-08:00", 333],
+        [1070, "2016-12-05T00:00:00-08:00", 394],
+        [1071, "2016-12-06T00:00:00-08:00", 402],
+        [1072, "2016-12-07T00:00:00-08:00", 487],
+        [1073, "2016-12-08T00:00:00-08:00", 472],
+        [1074, "2016-12-09T00:00:00-08:00", 519],
+        [1075, "2016-12-10T00:00:00-08:00", 322],
+        [1076, "2016-12-11T00:00:00-08:00", 322],
+        [1077, "2016-12-12T00:00:00-08:00", 377],
+        [1078, "2016-12-13T00:00:00-08:00", 439],
+        [1079, "2016-12-14T00:00:00-08:00", 437],
+        [1080, "2016-12-15T00:00:00-08:00", 410],
+        [1081, "2016-12-16T00:00:00-08:00", 486],
+        [1082, "2016-12-17T00:00:00-08:00", 294],
+        [1083, "2016-12-18T00:00:00-08:00", 265],
+        [1084, "2016-12-19T00:00:00-08:00", 372],
+        [1085, "2016-12-20T00:00:00-08:00", 383],
+        [1086, "2016-12-21T00:00:00-08:00", 411],
+        [1087, "2016-12-22T00:00:00-08:00", 419],
+        [1088, "2016-12-23T00:00:00-08:00", 356],
+        [1089, "2016-12-24T00:00:00-08:00", 274],
+        [1090, "2016-12-25T00:00:00-08:00", 138],
+        [1091, "2016-12-26T00:00:00-08:00", 187],
+        [1092, "2016-12-27T00:00:00-08:00", 261],
+        [1093, "2016-12-28T00:00:00-08:00", 286],
+        [1094, "2016-12-29T00:00:00-08:00", 295],
+        [1095, "2016-12-30T00:00:00-08:00", 249],
+        [1096, "2016-12-31T00:00:00-08:00", 201]
+      ],
+      "cols": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "table_id": 154,
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1416, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1416,
+          "position": 0,
+          "visibility_type": "normal",
+          "display_name": "Mb Row ID",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": "type/CreationDate",
+          "table_id": 154,
+          "coercion_strategy": null,
+          "unit": "default",
+          "name": "date",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1417, { "temporal-unit": "default" }],
+          "effective_type": "type/Date",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1417,
+          "position": 1,
+          "visibility_type": "normal",
+          "display_name": "Date",
+          "fingerprint": {
+            "global": { "distinct-count": 1460, "nil%": 0 },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2014-01-01",
+                "latest": "2017-12-31"
+              }
+            }
+          },
+          "base_type": "type/Date"
+        },
+        {
+          "description": null,
+          "semantic_type": "type/Quantity",
+          "table_id": 154,
+          "coercion_strategy": null,
+          "name": "total_accident",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1418, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1418,
+          "position": 2,
+          "visibility_type": "normal",
+          "display_name": "Total Accident",
+          "fingerprint": {
+            "global": { "distinct-count": 310, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": 128,
+                "q1": 333.7211770961825,
+                "q3": 425.76625335908,
+                "max": 567,
+                "sd": 67.95279959530245,
+                "avg": 378.49486652977413
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "viz-settings": {
+        "table.column_widths": [null, 226],
+        "graph.show_values": false,
+        "metabase.shared.models.visualization-settings/column-settings": {
+          "{:metabase.shared.models.visualization-settings/field-id 1416}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1417}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1418}": {}
+        },
+        "graph.series_order_dimension": null,
+        "graph.y_axis.scale": "linear",
+        "graph.metrics": ["total_accident"],
+        "graph.series_order": null,
+        "metabase.shared.models.visualization-settings/global-column-settings": {},
+        "series_settings": { "total_accident": { "color": "#227FD2" } },
+        "graph.x_axis.scale": "ordinal",
+        "graph.dimensions": ["date"],
+        "waterfall.show_total": true
+      },
+      "native_form": {
+        "query": "SELECT \"source\".\"_mb_row_id\" AS \"_mb_row_id\", \"source\".\"date\" AS \"date\", \"source\".\"total_accident\" AS \"total_accident\" FROM (SELECT \"csv_upload_data\".\"csv_upload_uk_car_accidents_20231202102102\".\"_mb_row_id\" AS \"_mb_row_id\", \"csv_upload_data\".\"csv_upload_uk_car_accidents_20231202102102\".\"date\" AS \"date\", \"csv_upload_data\".\"csv_upload_uk_car_accidents_20231202102102\".\"total_accident\" AS \"total_accident\" FROM \"csv_upload_data\".\"csv_upload_uk_car_accidents_20231202102102\") AS \"source\" WHERE (\"source\".\"date\" >= timestamp with time zone '2016-12-01 00:00:00.000-08:00') AND (\"source\".\"date\" < timestamp with time zone '2017-01-01 00:00:00.000-08:00') LIMIT 2000",
+        "params": null
+      },
+      "is_sandboxed": false,
+      "dataset": true,
+      "insights": null
+    }
+  }
+]

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -36,7 +36,7 @@ const getCustomAxisRange = (
   return { min: finalMin, max: finalMax };
 };
 
-const getYAxisRange = (
+export const getYAxisRange = (
   axisModel: YAxisModel,
   settings: ComputedVisualizationSettings,
 ) => {
@@ -166,7 +166,7 @@ export const buildDimensionAxis = (
   };
 };
 
-const buildMetricAxis = (
+export const buildMetricAxis = (
   axisModel: YAxisModel,
   ticksWidth: number,
   settings: ComputedVisualizationSettings,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option.ts
@@ -1,5 +1,5 @@
 import type { EChartsOption } from "echarts";
-import type { DatasetOption } from "echarts/types/dist/shared";
+import type { DatasetOption, YAXisOption } from "echarts/types/dist/shared";
 import type {
   ComputedVisualizationSettings,
   RenderingContext,
@@ -8,9 +8,14 @@ import type { TimelineEventId } from "metabase-types/api";
 
 import type { CartesianChartModel } from "../model/types";
 import { getCartesianChartOption } from "../option";
+import { buildMetricAxis } from "../option/axis";
+import { getChartMeasurements } from "../utils/layout";
 import type { TimelineEventsModel } from "../timeline-events/types";
+import type { WaterfallDataset } from "./types";
 import { DATASET_DIMENSIONS } from "./constants";
+import { getWaterfallExtent } from "./model";
 
+// TODO remove all the typecasts
 export function getWaterfallOption(
   chartModel: CartesianChartModel,
   timelineEventsModel: TimelineEventsModel | null,
@@ -28,13 +33,30 @@ export function getWaterfallOption(
     renderingContext,
   );
 
-  // TODO remove typecast
+  // dataset
   (option.dataset as DatasetOption[])[0].dimensions =
     Object.values(DATASET_DIMENSIONS);
-  // TODO full yAxis options
-  option.yAxis = {
-    type: "value",
-  };
+
+  // y-axis
+  if (!chartModel.leftAxisModel) {
+    throw Error("Missing leftAxisModel");
+  }
+  chartModel.leftAxisModel.extent = getWaterfallExtent(
+    chartModel.dataset as WaterfallDataset,
+  );
+  const chartMeasurements = getChartMeasurements(
+    chartModel,
+    settings,
+    timelineEventsModel != null,
+    renderingContext,
+  );
+  option.yAxis = buildMetricAxis(
+    chartModel.leftAxisModel,
+    chartMeasurements.ticksDimensions.yTicksWidthLeft,
+    settings,
+    "left",
+    renderingContext,
+  ) as YAXisOption;
 
   return option;
 }

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option.ts
@@ -1,5 +1,9 @@
 import type { EChartsOption } from "echarts";
-import type { DatasetOption, YAXisOption } from "echarts/types/dist/shared";
+import type {
+  DatasetOption,
+  YAXisOption,
+  XAXisOption,
+} from "echarts/types/dist/shared";
 import type {
   ComputedVisualizationSettings,
   RenderingContext,
@@ -14,6 +18,13 @@ import type { TimelineEventsModel } from "../timeline-events/types";
 import type { WaterfallDataset } from "./types";
 import { DATASET_DIMENSIONS } from "./constants";
 import { getWaterfallExtent } from "./model";
+
+function getXAxisType(settings: ComputedVisualizationSettings) {
+  if (settings["graph.x_axis.scale"] === "timeseries") {
+    return "time";
+  }
+  return "category";
+}
 
 // TODO remove all the typecasts
 export function getWaterfallOption(
@@ -36,6 +47,9 @@ export function getWaterfallOption(
   // dataset
   (option.dataset as DatasetOption[])[0].dimensions =
     Object.values(DATASET_DIMENSIONS);
+
+  // x-axis
+  (option.xAxis as XAXisOption).type = getXAxisType(settings);
 
   // y-axis
   if (!chartModel.leftAxisModel) {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/types.ts
@@ -5,3 +5,5 @@ export type WaterfallDatum = {
   decrease: number | null;
   total: number | null;
 };
+
+export type WaterfallDataset = WaterfallDatum[];


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36828

### Description

Adds axis options to the overall echarts option object for the waterfall chart. Also correctly sets `xAxis.type`, so both timeseries and categorical x-axis scales work. However, timeseries data still needs to be sorted, which I will do in a later PR.

### How to verify

1. Create a waterfall chart
2. Add to a dashboard
3. Send a subscription
4. Confirm it looks correct (y-axis should look like other charts)

### Demo

![Screenshot 2023-12-17 at 1.40.32 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/02b98324-2d0d-45ff-b81a-852925f006c2.png)

![Screenshot 2023-12-17 at 1.43.15 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/1e7ed6d8-90b3-4bd8-ba14-e521ccb5060c.png)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
