### PR TITLE
handle unsorted timeseries data

### DIFF
--- a/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.stories.tsx
@@ -35,6 +35,13 @@ WithoutTotal.args = {
   renderingContext,
 };
 
+export const TimeseriesXScaleUnsorted = Template.bind({});
+TimeseriesXScaleUnsorted.args = {
+  rawSeries: data.timeseriesXScaleUnsorted as any,
+  dashcardSettings: {},
+  renderingContext,
+};
+
 export const OrdinalXScale = Template.bind({});
 OrdinalXScale.args = {
   rawSeries: data.ordinalXScale as any,

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/index.ts
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/index.ts
@@ -1,5 +1,6 @@
 import withoutTotal from "./without-total.json";
 import ordinalXScale from "./ordinal-x-scale.json";
+import timeseriesXScaleUnsorted from "./timeseries-x-scale-unsorted.json";
 import timeSeriesDataAsOrdinalXScale from "./timeseries-data-as-ordinal-x-scale.json";
 import mixedAboveZero from "./mixed-above-zero.json";
 import mixedBelowZero from "./mixed-below-zero.json";
@@ -12,6 +13,7 @@ import startsBelowZeroCrossesEndsBelow from "./starts-below-zero-crosses-ends-be
 export const data = {
   withoutTotal,
   ordinalXScale,
+  timeseriesXScaleUnsorted,
   timeSeriesDataAsOrdinalXScale,
   mixedAboveZero,
   mixedBelowZero,

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/timeseries-x-scale-unsorted.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/timeseries-x-scale-unsorted.json
@@ -1,0 +1,347 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 165,
+      "result_metadata": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1555, null],
+          "effective_type": "type/BigInteger",
+          "id": 1555,
+          "visibility_type": "normal",
+          "display_name": "_mb_row_id",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "unit": "default",
+          "name": "date",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1556, { "temporal-unit": "default" }],
+          "effective_type": "type/Date",
+          "id": 1556,
+          "visibility_type": "normal",
+          "display_name": "Date",
+          "fingerprint": {
+            "global": { "distinct-count": 1460, "nil%": 0 },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2014-01-01",
+                "latest": "2017-12-31"
+              }
+            }
+          },
+          "base_type": "type/Date"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "name": "total_accident",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1557, null],
+          "effective_type": "type/BigInteger",
+          "id": 1557,
+          "visibility_type": "normal",
+          "display_name": "Total Accident",
+          "fingerprint": {
+            "global": { "distinct-count": 310, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": 128,
+                "q1": 333.4336162177404,
+                "q3": 425.67787789723786,
+                "max": 567,
+                "sd": 67.95545465965502,
+                "avg": 378.49486652977413
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "include_xls": false,
+      "database_id": 2,
+      "enable_embedding": false,
+      "collection_id": 10,
+      "query_type": "query",
+      "name": "Waterfall Timeseries Unsorted  - UK Car Accidents Randomized",
+      "creator_id": 1,
+      "updated_at": "2023-12-17T23:53:12.908027Z",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "database": 2,
+        "type": "query",
+        "query": {
+          "source-table": "card__177",
+          "filter": [
+            "between",
+            ["field", "date", { "base-type": "type/Date" }],
+            "2016-12-01",
+            "2016-12-31"
+          ]
+        }
+      },
+      "id": 178,
+      "parameter_mappings": [],
+      "include_csv": false,
+      "display": "waterfall",
+      "entity_id": "2VE4kSr_UpvnmPDM_zhTx",
+      "collection_preview": true,
+      "visualization_settings": {
+        "table.column_widths": [null, 226],
+        "graph.show_values": false,
+        "graph.series_order_dimension": null,
+        "graph.y_axis.scale": "linear",
+        "graph.metrics": ["total_accident"],
+        "graph.series_order": null,
+        "series_settings": {
+          "total_accident": {
+            "color": "#227FD2",
+            "display": "waterfall",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": false
+          }
+        },
+        "graph.dimensions": ["date"],
+        "waterfall.show_total": true
+      },
+      "metabase_version": "v1.47.1-SNAPSHOT (b37c32d)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2023-12-17T23:53:12.908027Z",
+      "public_uuid": null
+    },
+    "data": {
+      "results_timezone": "America/Los_Angeles",
+      "download_perms": "full",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": null,
+            "semantic_type": "type/PK",
+            "coercion_strategy": null,
+            "name": "_mb_row_id",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1555, null],
+            "effective_type": "type/BigInteger",
+            "id": 1555,
+            "visibility_type": "normal",
+            "display_name": "_mb_row_id",
+            "fingerprint": null,
+            "base_type": "type/BigInteger"
+          },
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "unit": "default",
+            "name": "date",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1556, { "temporal-unit": "default" }],
+            "effective_type": "type/Date",
+            "id": 1556,
+            "visibility_type": "normal",
+            "display_name": "Date",
+            "fingerprint": {
+              "global": { "distinct-count": 1460, "nil%": 0 },
+              "type": {
+                "type/DateTime": {
+                  "earliest": "2014-01-01",
+                  "latest": "2017-12-31"
+                }
+              }
+            },
+            "base_type": "type/Date"
+          },
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "name": "total_accident",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1557, null],
+            "effective_type": "type/BigInteger",
+            "id": 1557,
+            "visibility_type": "normal",
+            "display_name": "Total Accident",
+            "fingerprint": {
+              "global": { "distinct-count": 310, "nil%": 0 },
+              "type": {
+                "type/Number": {
+                  "min": 128,
+                  "q1": 333.4336162177404,
+                  "q3": 425.67787789723786,
+                  "max": 567,
+                  "sd": 67.95545465965502,
+                  "avg": 378.49486652977413
+                }
+              }
+            },
+            "base_type": "type/BigInteger"
+          }
+        ]
+      },
+      "rows": [
+        [49, "2016-12-06T00:00:00-08:00", 402],
+        [234, "2016-12-14T00:00:00-08:00", 437],
+        [268, "2016-12-11T00:00:00-08:00", 322],
+        [283, "2016-12-10T00:00:00-08:00", 322],
+        [312, "2016-12-05T00:00:00-08:00", 394],
+        [319, "2016-12-08T00:00:00-08:00", 472],
+        [345, "2016-12-13T00:00:00-08:00", 439],
+        [414, "2016-12-18T00:00:00-08:00", 265],
+        [449, "2016-12-16T00:00:00-08:00", 486],
+        [451, "2016-12-23T00:00:00-08:00", 356],
+        [467, "2016-12-19T00:00:00-08:00", 372],
+        [546, "2016-12-29T00:00:00-08:00", 295],
+        [644, "2016-12-02T00:00:00-08:00", 487],
+        [698, "2016-12-15T00:00:00-08:00", 410],
+        [705, "2016-12-21T00:00:00-08:00", 411],
+        [723, "2016-12-26T00:00:00-08:00", 187],
+        [800, "2016-12-28T00:00:00-08:00", 286],
+        [838, "2016-12-04T00:00:00-08:00", 333],
+        [845, "2016-12-24T00:00:00-08:00", 274],
+        [857, "2016-12-22T00:00:00-08:00", 419],
+        [958, "2016-12-12T00:00:00-08:00", 377],
+        [998, "2016-12-07T00:00:00-08:00", 487],
+        [1058, "2016-12-17T00:00:00-08:00", 294],
+        [1137, "2016-12-01T00:00:00-08:00", 537],
+        [1143, "2016-12-09T00:00:00-08:00", 519],
+        [1195, "2016-12-27T00:00:00-08:00", 261],
+        [1197, "2016-12-30T00:00:00-08:00", 249],
+        [1198, "2016-12-31T00:00:00-08:00", 201],
+        [1342, "2016-12-20T00:00:00-08:00", 383],
+        [1371, "2016-12-25T00:00:00-08:00", 138],
+        [1401, "2016-12-03T00:00:00-08:00", 331]
+      ],
+      "cols": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "table_id": 165,
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1555, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1555,
+          "position": 0,
+          "visibility_type": "normal",
+          "display_name": "_mb_row_id",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 165,
+          "coercion_strategy": null,
+          "unit": "default",
+          "name": "date",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1556, { "temporal-unit": "default" }],
+          "effective_type": "type/Date",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1556,
+          "position": 1,
+          "visibility_type": "normal",
+          "display_name": "Date",
+          "fingerprint": {
+            "global": { "distinct-count": 1460, "nil%": 0 },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2014-01-01",
+                "latest": "2017-12-31"
+              }
+            }
+          },
+          "base_type": "type/Date"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 165,
+          "coercion_strategy": null,
+          "name": "total_accident",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1557, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1557,
+          "position": 2,
+          "visibility_type": "normal",
+          "display_name": "Total Accident",
+          "fingerprint": {
+            "global": { "distinct-count": 310, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": 128,
+                "q1": 333.4336162177404,
+                "q3": 425.67787789723786,
+                "max": 567,
+                "sd": 67.95545465965502,
+                "avg": 378.49486652977413
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "viz-settings": {
+        "table.column_widths": [null, 226],
+        "graph.show_values": false,
+        "metabase.shared.models.visualization-settings/column-settings": {
+          "{:metabase.shared.models.visualization-settings/field-id 1555}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1556}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1557}": {}
+        },
+        "graph.series_order_dimension": null,
+        "graph.y_axis.scale": "linear",
+        "graph.metrics": ["total_accident"],
+        "graph.series_order": null,
+        "metabase.shared.models.visualization-settings/global-column-settings": {},
+        "series_settings": { "total_accident": { "color": "#227FD2" } },
+        "graph.dimensions": ["date"],
+        "waterfall.show_total": true
+      },
+      "native_form": {
+        "query": "SELECT \"source\".\"_mb_row_id\" AS \"_mb_row_id\", \"source\".\"date\" AS \"date\", \"source\".\"total_accident\" AS \"total_accident\" FROM (SELECT \"csv_upload_data\".\"csv_upload_uk_car_accidents_randomized_20231217154908\".\"_mb_row_id\" AS \"_mb_row_id\", \"csv_upload_data\".\"csv_upload_uk_car_accidents_randomized_20231217154908\".\"date\" AS \"date\", \"csv_upload_data\".\"csv_upload_uk_car_accidents_randomized_20231217154908\".\"total_accident\" AS \"total_accident\" FROM \"csv_upload_data\".\"csv_upload_uk_car_accidents_randomized_20231217154908\") AS \"source\" WHERE (\"source\".\"date\" >= timestamp with time zone '2016-12-01 00:00:00.000-08:00') AND (\"source\".\"date\" < timestamp with time zone '2017-01-01 00:00:00.000-08:00') LIMIT 2000",
+        "params": null
+      },
+      "is_sandboxed": false,
+      "dataset": true,
+      "insights": null
+    }
+  }
+]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36834

### Description

For timeseries x-axis, we now sort the rows before creating the dataset for the waterfall chart, so that unsorted data will still look correct on the chart.

### How to verify

1. Create a waterfall chart
2. Add to a dashboard
3. Send a subscription
4. Confirm it looks correct

### Demo

| Before | After |
| ------- | ----- |
| <img width="558" alt="Screenshot 2023-12-17 at 6 14 31 PM" src="https://github.com/metabase/metabase/assets/37751258/c41c5cdc-ea42-4561-9393-955205519ef6"> | <img width="528" alt="Screenshot 2023-12-17 at 6 13 32 PM" src="https://github.com/metabase/metabase/assets/37751258/2986088a-ee60-45ef-8e0b-b35545fe18d6"> |




### Checklist

- [x] Tests have been added/updated to cover changes in this PR
