### PR TITLE
Fix flaking database-schema-filtering-test for bigquery

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -427,7 +427,7 @@
                                  (apply str (take 4 dataset-id)))))
             include-prefix (first prefixes)
             inclusion-patterns (str include-prefix "*")
-            exclusion-patterns (str/join "," (map #(str % "*") (rest prefixes)))]
+            exclusion-patterns (str/join "," (map #(str % "*") (set (rest prefixes))))]
         (testing " with an inclusion filter"
           (sync-and-assert-filtered-tables {:name    "BigQuery Test DB with dataset inclusion filters"
                                             :engine  :bigquery-cloud-sdk

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -154,7 +154,8 @@
          driver)))
 
 (deftest database-schema-filtering-test
-  ;; BigQuery is tested in metabase.driver.bigquery-cloud-sdk-test/dataset-filtering-test
+  ;; BigQuery is tested separately in `metabase.driver.bigquery-cloud-sdk-test/dataset-filtering-test`, because
+  ;; otherwise this test takes too long and flakes intermittently
   (mt/test-drivers (disj (schema-filtering-drivers) :bigquery-cloud-sdk)
     (let [driver             (driver.u/database->driver (mt/db))
           schema-filter-prop (find-schema-filters-prop driver)

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -154,7 +154,8 @@
          driver)))
 
 (deftest database-schema-filtering-test
-  (mt/test-drivers (schema-filtering-drivers)
+  ;; BigQuery is tested in metabase.driver.bigquery-cloud-sdk-test/dataset-filtering-test
+  (mt/test-drivers (disj (schema-filtering-drivers) :bigquery-cloud-sdk)
     (let [driver             (driver.u/database->driver (mt/db))
           schema-filter-prop (find-schema-filters-prop driver)
           filter-type-prop   (keyword (str (:name schema-filter-prop) "-type"))


### PR DESCRIPTION
Fixes BE flake https://github.com/metabase/metabase/issues/36891

My theory is the flake happens because the test takes so long to run, that there's a race condition and some datasets are changed while it's running. Running it locally it takes so long I didn't want to wait for it to finish, so I don't know exactly how long it takes.

There are two changes to tests:
1. I removed bigquery from the tested drivers in `metabase.driver.bigquery-cloud-sdk-test/database-schema-filtering-test`. The implementation of this test takes forever to run and was flaking out for bigquery, because the number of test datasets on our test DB is huge (181 by last count), and we were creating and syncing tables for almost every table in every test dataset.
2. I fixed the existing equivalent test for bigquery `metabase.driver.bigquery-cloud-sdk-test/dataset-filtering-test`, which wasn't actually testing anything before due to a bug in its implementation.