### PR TITLE
Wait for verification request to complete before fetching updated status

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/moderation/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/index.js
@@ -49,11 +49,11 @@ if (hasPremiumFeature("content_verification")) {
               ? t`Verify this model`
               : t`Verify this question`,
             icon: isVerified ? "close" : verifiedIconName,
-            action: () => {
+            action: async () => {
               if (isVerified) {
-                removeReview({ itemId: id, itemType: "card" });
+                await removeReview({ itemId: id, itemType: "card" });
               } else {
-                verifyItem({ itemId: id, itemType: "card" });
+                await verifyItem({ itemId: id, itemType: "card" });
               }
               reload();
             },


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/35597
Fixes https://github.com/metabase/metabase/issues/32505

[Example of the flake on deploysentinel](https://www.deploysentinel.com/ci/runs/6579fb89fcacf3cead6e580b)

✅ [Passed stress test](https://github.com/metabase/metabase/actions/runs/7252514263) (ran 100 times)

## Summary

The “verified” icon next to the question title wasn’t being removed after disabling the verification because we have to wait for the disabling request to complete before fetching the updated status.