### PR TITLE
Fix Replay before:browser:launch ordering

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -37,12 +37,12 @@ const defaultConfig = {
      ********************************************************************/
 
 
-     if (runWithReplay) {
+    if (runWithReplay) {
+      on = replay.wrapOn(on);
       replay.default(on, config, {
         upload: true,
         apiKey: process.env.REPLAY_API_KEY,
       });
-      on = replay.wrapOn(on);
     }
 
     on(

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -36,6 +36,15 @@ const defaultConfig = {
      **                        PREPROCESSOR                            **
      ********************************************************************/
 
+
+     if (runWithReplay) {
+      replay.default(on, config, {
+        upload: true,
+        apiKey: process.env.REPLAY_API_KEY,
+      });
+      on = replay.wrapOn(on);
+    }
+
     on(
       "file:preprocessor",
       createBundler({ plugins: [NodeModulesPolyfillPlugin()] }),
@@ -104,12 +113,6 @@ const defaultConfig = {
 
     require("@cypress/grep/src/plugin")(config);
 
-    if (runWithReplay) {
-      replay.default(on, config, {
-        upload: true,
-        apiKey: process.env.REPLAY_API_KEY,
-      });
-    }
 
     return config;
   },


### PR DESCRIPTION
### Description

The `before:browser:launch` event defined [here](https://github.com/metabase/metabase/blob/ed7295b5d6cdcf26bb81844c9559b3a1eb155b04/e2e/support/config.js#L48-L64) is not being called because the Replay plugin listens to the same event later on and Cypress only supports one handler per event ([issue](https://github.com/cypress-io/cypress/issues/22428))

This PR moves the Replay plugin setup to the top on and wrap's Cypress's native `on` so that it can handle multiple events. 

We're hopeful that this should fix 8 or so tests ([link](https://www.notion.so/replayio/Metabase-test-review-12-14-e0309735d02a428cbd6e0e845ab15f2d)). 

### How to verify

The success rate should not be affected.

