### PR TITLE
HK: Change unused vars naming rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -174,7 +174,7 @@
           "error",
           {
             "argsIgnorePattern": "^_",
-            "varsIgnorePattern": "^_.+",
+            "varsIgnorePattern": "^_.*",
             "ignoreRestSiblings": true,
             "destructuredArrayIgnorePattern": "^_"
           }

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
       {
         "vars": "all",
         "args": "none",
-        "varsIgnorePattern": "^_.+",
+        "varsIgnorePattern": "^_.*",
         "ignoreRestSiblings": true
       }
     ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,7 @@
       {
         "vars": "all",
         "args": "none",
-        "varsIgnorePattern": "^_.*",
+        "varsIgnorePattern": "^_",
         "ignoreRestSiblings": true
       }
     ],
@@ -174,7 +174,7 @@
           "error",
           {
             "argsIgnorePattern": "^_",
-            "varsIgnorePattern": "^_.*",
+            "varsIgnorePattern": "^_",
             "ignoreRestSiblings": true,
             "destructuredArrayIgnorePattern": "^_"
           }


### PR DESCRIPTION
Currently, `eslint` expects unused var names _begin_ with an underscore _and_ have at least 1 character after it.
I believe it is unnecessary as naming things with `_` when destructuring is a common pattern.

There's a related slack discussion: https://metaboat.slack.com/archives/C505ZNNH4/p1702922218163009