### PR TITLE
Fix non-showing loading dashcard when switching tabs

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -94,10 +94,21 @@ export function editDashboard() {
 export function saveDashboard({
   buttonLabel = "Save",
   editBarText = "You're editing this dashboard.",
+  waitForDashcard = false,
 } = {}) {
+  if (waitForDashcard) {
+    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+      "saveDashboardDashcardQuery",
+    );
+  }
+
   cy.button(buttonLabel).click();
   cy.findByText(editBarText).should("not.exist");
   cy.wait(1); // this is stupid but necessary to due to the dashboard resizing and detaching elements
+
+  if (waitForDashcard) {
+    cy.wait("@saveDashboardDashcardQuery");
+  }
 }
 
 export function checkFilterLabelAndValue(label, value) {

--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -94,21 +94,12 @@ export function editDashboard() {
 export function saveDashboard({
   buttonLabel = "Save",
   editBarText = "You're editing this dashboard.",
-  waitForDashcard = false,
+  waitMs = 1,
 } = {}) {
-  if (waitForDashcard) {
-    cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-      "saveDashboardDashcardQuery",
-    );
-  }
-
   cy.button(buttonLabel).click();
   cy.findByText(editBarText).should("not.exist");
-  cy.wait(1); // this is stupid but necessary to due to the dashboard resizing and detaching elements
-
-  if (waitForDashcard) {
-    cy.wait("@saveDashboardDashcardQuery");
-  }
+  // the default 1 is stupid but necessary to due to the dashboard resizing and detaching elements
+  cy.wait(waitMs);
 }
 
 export function checkFilterLabelAndValue(label, value) {

--- a/e2e/support/helpers/e2e-request-helpers.js
+++ b/e2e/support/helpers/e2e-request-helpers.js
@@ -28,19 +28,3 @@ export function spyRequestFinished(name = "requestFinishedSpy") {
     spy,
   };
 }
-
-/**
- * When you need to postpone a response (to check for loading spinners or alike),
- * use this:
- *
- * `cy.intercept('POST', path, delayResponse(1000)).as('delayed')`
- *
- * `cy.wait('@delayed')` - you'll have 1000 ms until this resolves
- */
-export function delayResponse(delayMs) {
-  return function (req) {
-    req.on("response", res => {
-      res.setDelay(delayMs);
-    });
-  };
-}

--- a/e2e/support/helpers/e2e-request-helpers.js
+++ b/e2e/support/helpers/e2e-request-helpers.js
@@ -28,3 +28,18 @@ export function spyRequestFinished(name = "requestFinishedSpy") {
     spy,
   };
 }
+
+/**
+ * When you need to postpone a request (to check for loading spinners or alike),
+ * use this:
+ *
+ * `cy.intercept('POST', path, postponeRequest(1000)).as('postponedRequest')`
+ *
+ * `cy.wait('@postponedRequest')` - you'll have 1000 ms until this resolves
+ *
+ */
+export function postponeRequest(delayMs) {
+  return function delayedInterceptor(req) {
+    return new Promise(resolve => setTimeout(() => resolve(req), delayMs));
+  };
+}

--- a/e2e/support/helpers/e2e-request-helpers.js
+++ b/e2e/support/helpers/e2e-request-helpers.js
@@ -30,16 +30,17 @@ export function spyRequestFinished(name = "requestFinishedSpy") {
 }
 
 /**
- * When you need to postpone a request (to check for loading spinners or alike),
+ * When you need to postpone a response (to check for loading spinners or alike),
  * use this:
  *
- * `cy.intercept('POST', path, postponeRequest(1000)).as('postponedRequest')`
+ * `cy.intercept('POST', path, delayResponse(1000)).as('delayed')`
  *
- * `cy.wait('@postponedRequest')` - you'll have 1000 ms until this resolves
- *
+ * `cy.wait('@delayed')` - you'll have 1000 ms until this resolves
  */
-export function postponeRequest(delayMs) {
-  return function delayedInterceptor(req) {
-    return new Promise(resolve => setTimeout(() => resolve(req), delayMs));
+export function delayResponse(delayMs) {
+  return function (req) {
+    req.on("response", res => {
+      res.setDelay(delayMs);
+    });
   };
 }

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -489,7 +489,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.button("Done").should("be.enabled").click();
       saveDashboard({ waitMs: 250 });
 
-      clickLineChartPoint({ waitMs: 250 });
+      clickLineChartPoint();
       cy.get("@targetDashboardId").then(targetDashboardId => {
         cy.location().should(({ pathname, search }) => {
           expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -947,7 +947,13 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTimeParameter();
       cy.get("aside").button("Done").click();
 
+      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
+        "dashcardQuery",
+      );
+
       saveDashboard();
+      // We need to wait so that the query has enough time to get resolved
+      cy.wait("@dashcardQuery");
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -215,7 +215,8 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.get("aside").findByText("No available targets").should("exist");
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      // We need to wait so that the query has enough time to get resolved
+      saveDashboard({ waitMs: 500 });
 
       cy.intercept(
         "GET",
@@ -266,7 +267,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 500 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -369,7 +370,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 500 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -443,7 +444,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("not.exist");
       cy.button("Done").should("be.enabled").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 500 });
 
       clickLineChartPoint();
       cy.get("@targetDashboardId").then(targetDashboardId => {
@@ -488,7 +489,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.button("Done").should("be.enabled").click();
       saveDashboard();
 
-      clickLineChartPoint();
+      clickLineChartPoint({ waitMs: 500 });
       cy.get("@targetDashboardId").then(targetDashboardId => {
         cy.location().should(({ pathname, search }) => {
           expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
@@ -603,7 +604,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addSavedQuestionDestination();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 500 });
 
       cy.intercept(
         "GET",
@@ -647,7 +648,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addSavedQuestionCreatedAtParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 500 });
 
       clickLineChartPoint();
       cy.findByTestId("qb-filters-panel").should(
@@ -686,7 +687,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addSavedQuestionQuantityParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 500 });
 
       clickLineChartPoint();
       cy.wait("@dataset");
@@ -756,7 +757,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 500 });
 
       onNextAnchorClick(anchor => {
         expect(anchor).to.have.attr("href", URL);
@@ -798,7 +799,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 500 });
 
       cy.button(DASHBOARD_FILTER_TEXT.name).click();
       popover().within(() => {
@@ -851,7 +852,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 500 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -902,7 +903,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .click();
       cy.get("aside").button("Remove").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 500 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -947,13 +948,8 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTimeParameter();
       cy.get("aside").button("Done").click();
 
-      cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
-        "dashcardQuery",
-      );
-
-      saveDashboard();
       // We need to wait so that the query has enough time to get resolved
-      cy.wait("@dashcardQuery");
+      saveDashboard({ waitMs: 500 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -1693,10 +1689,7 @@ const testChangingBackToDefaultBehavior = () => {
   cy.get("aside").findByText("Open the Metabase drill-through menu").click();
   cy.get("aside").button("Done").click();
 
-  saveDashboard();
-  // this is necessary due to query params being reset after saving dashboard
-  // with filter applied, which causes dashcard to be refetched
-  cy.wait(1);
+  saveDashboard({ waitMs: 500 });
 
   clickLineChartPoint();
   assertDrillThroughMenuOpen();

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -216,7 +216,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.get("aside").button("Done").click();
 
       // We need to wait so that the query has enough time to get resolved
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       cy.intercept(
         "GET",
@@ -267,7 +267,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -310,7 +310,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTimeParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -370,7 +370,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -444,7 +444,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("not.exist");
       cy.button("Done").should("be.enabled").click();
 
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.get("@targetDashboardId").then(targetDashboardId => {
@@ -487,9 +487,9 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .findByLabelText("Select a dashboard tab")
         .should("not.exist");
       cy.button("Done").should("be.enabled").click();
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
-      clickLineChartPoint({ waitMs: 500 });
+      clickLineChartPoint({ waitMs: 250 });
       cy.get("@targetDashboardId").then(targetDashboardId => {
         cy.location().should(({ pathname, search }) => {
           expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
@@ -604,7 +604,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addSavedQuestionDestination();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       cy.intercept(
         "GET",
@@ -648,7 +648,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addSavedQuestionCreatedAtParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findByTestId("qb-filters-panel").should(
@@ -687,7 +687,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addSavedQuestionQuantityParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.wait("@dataset");
@@ -757,7 +757,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       onNextAnchorClick(anchor => {
         expect(anchor).to.have.attr("href", URL);
@@ -799,7 +799,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       cy.button(DASHBOARD_FILTER_TEXT.name).click();
       popover().within(() => {
@@ -852,7 +852,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -895,7 +895,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("contain.text", COUNT_COLUMN_NAME);
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       editDashboard();
       cy.findByTestId("edit-dashboard-parameters-widget-container")
@@ -903,7 +903,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .click();
       cy.get("aside").button("Remove").click();
 
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -949,7 +949,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.get("aside").button("Done").click();
 
       // We need to wait so that the query has enough time to get resolved
-      saveDashboard({ waitMs: 500 });
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -1072,7 +1072,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       })();
 
       cy.get("aside").button("Done").click();
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       (function testDashboardDestinationClick() {
         cy.log("it handles 'Count' column click");
@@ -1170,7 +1170,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("have.text", "1 column has custom behavior");
 
       cy.get("aside").button("Done").click();
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       getTableCell(COLUMN_INDEX.COUNT)
         .should("have.text", String(POINT_COUNT))
@@ -1266,7 +1266,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("have.text", "2 columns have custom behavior");
 
       cy.get("aside").button("Done").click();
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       (function testUpdateDashboardFiltersClick() {
         cy.log("it handles 'Count' column click");
@@ -1689,7 +1689,7 @@ const testChangingBackToDefaultBehavior = () => {
   cy.get("aside").findByText("Open the Metabase drill-through menu").click();
   cy.get("aside").button("Done").click();
 
-  saveDashboard({ waitMs: 500 });
+  saveDashboard({ waitMs: 250 });
 
   clickLineChartPoint();
   assertDrillThroughMenuOpen();

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -30,7 +30,6 @@ import {
   selectDashboardFilter,
   filterWidget,
   popover,
-  delayResponse,
 } from "e2e/support/helpers";
 
 import {
@@ -468,3 +467,19 @@ describeWithSnowplow("scenarios > dashboard > tabs", () => {
     );
   });
 });
+
+/**
+ * When you need to postpone a response (to check for loading spinners or alike),
+ * use this:
+ *
+ * `cy.intercept('POST', path, delayResponse(1000)).as('delayed')`
+ *
+ * `cy.wait('@delayed')` - you'll have 1000 ms until this resolves
+ */
+function delayResponse(delayMs) {
+  return function (req) {
+    req.on("response", res => {
+      res.setDelay(delayMs);
+    });
+  };
+}

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -30,7 +30,7 @@ import {
   selectDashboardFilter,
   filterWidget,
   popover,
-  postponeRequest,
+  delayResponse,
 } from "e2e/support/helpers";
 
 import {
@@ -385,7 +385,7 @@ describe("scenarios > dashboard > tabs", () => {
     cy.intercept(
       "POST",
       "/api/dashboard/*/dashcard/*/card/*/query",
-      postponeRequest(500),
+      delayResponse(500),
     ).as("saveCard");
 
     filterWidget().contains("Relative Date").click();

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -481,5 +481,5 @@ function saveDashCardVisualizationOptions() {
     cy.findByText("Done").click();
   });
 
-  saveDashboard();
+  saveDashboard({ waitMs: 250 });
 }

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -526,6 +526,7 @@ describe("scenarios > visualizations > line chart", () => {
         });
       cy.button("Save").click();
       cy.findByText("You're editing this dashboard.").should("not.exist");
+      cy.wait(250);
     }
 
     function assertOnLegendItemsValues() {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -162,9 +162,7 @@ function DashCardInner({
   }, [cards, dashcard.id, dashcardData, slowCards]);
 
   const isLoading = useMemo(
-    () =>
-      isDashcardLoading(dashcard, dashcardData) ||
-      loadingDashcardIds.includes(dashcard.id),
+    () => isDashcardLoading(dashcard, dashcardData, loadingDashcardIds),
     [dashcard, dashcardData, loadingDashcardIds],
   );
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -59,6 +59,7 @@ export interface DashCardProps {
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
   metadata: Metadata;
   mode?: Mode;
+  loadingDashcardIds?: number[];
 
   clickBehaviorSidebarDashcard?: DashboardCard | null;
 
@@ -95,6 +96,7 @@ function DashCardInner({
   gridItemWidth,
   totalNumGridCols,
   mode,
+  loadingDashcardIds = [],
   isEditing = false,
   isNightMode = false,
   isFullscreen = false,
@@ -160,8 +162,10 @@ function DashCardInner({
   }, [cards, dashcard.id, dashcardData, slowCards]);
 
   const isLoading = useMemo(
-    () => isDashcardLoading(dashcard, dashcardData),
-    [dashcard, dashcardData],
+    () =>
+      isDashcardLoading(dashcard, dashcardData) ||
+      loadingDashcardIds.includes(dashcard.id),
+    [dashcard, dashcardData, loadingDashcardIds],
   );
 
   const isAction = isActionCard(mainCard);
@@ -308,6 +312,7 @@ function DashCardInner({
           isNightMode={isNightMode}
           isMobile={isMobile}
           isPublic={isPublic}
+          isDashcardDataLoading={isLoading}
           showClickBehaviorSidebar={showClickBehaviorSidebar}
           onUpdateVisualizationSettings={onUpdateVisualizationSettings}
           onChangeCardAndRun={changeCardAndRunHandler}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -76,6 +76,7 @@ interface DashCardVisualizationProps {
   isNightMode?: boolean;
   isPublic?: boolean;
   isXray?: boolean;
+  isDashcardDataLoading?: boolean;
 
   error?: { message?: string; icon?: IconName };
   headerIcon?: IconProps;
@@ -122,6 +123,7 @@ export function DashCardVisualization({
   isNightMode = false,
   isFullscreen = false,
   isMobile = false,
+  isDashcardDataLoading = false,
   isEditingParameter,
   onChangeCardAndRun,
   showClickBehaviorSidebar,
@@ -257,6 +259,7 @@ export function DashCardVisualization({
       isPreviewing={isPreviewing}
       isEditingParameter={isEditingParameter}
       isMobile={isMobile}
+      isDashcardDataLoading={isDashcardDataLoading}
       actionButtons={renderActionButtons()}
       replacementContent={renderVisualizationOverlay()}
       onUpdateVisualizationSettings={onUpdateVisualizationSettings}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -27,13 +27,13 @@ import {
 } from "metabase/lib/dashboard_grid";
 import { ContentViewportContext } from "metabase/core/context/ContentViewportContext";
 import { addUndo } from "metabase/redux/undo";
-import { getLoadingDashCards } from "../selectors";
 
 import {
   MOBILE_HEIGHT_BY_DISPLAY_TYPE,
   MOBILE_DEFAULT_CARD_HEIGHT,
 } from "metabase/visualizations/shared/utils/sizes";
 
+import { getLoadingDashCards } from "../selectors";
 import { DashboardCard } from "./DashboardGrid.styled";
 
 import { GridLayout } from "./grid/GridLayout";

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.jsx
@@ -27,6 +27,8 @@ import {
 } from "metabase/lib/dashboard_grid";
 import { ContentViewportContext } from "metabase/core/context/ContentViewportContext";
 import { addUndo } from "metabase/redux/undo";
+import { getLoadingDashCards } from "../selectors";
+
 import {
   MOBILE_HEIGHT_BY_DISPLAY_TYPE,
   MOBILE_DEFAULT_CARD_HEIGHT,
@@ -40,6 +42,10 @@ import { generateMobileLayout } from "./grid/utils";
 import { AddSeriesModal } from "./AddSeriesModal/AddSeriesModal";
 import { QuestionPickerModal } from "./QuestionPickerModal";
 import { DashCard } from "./DashCard/DashCard";
+
+const mapStateToProps = state => ({
+  loadingDashcardIds: getLoadingDashCards(state).loadingIds,
+});
 
 const mapDispatchToProps = { addUndo };
 
@@ -419,6 +425,7 @@ class DashboardGrid extends Component {
         dashboard={this.props.dashboard}
         showClickBehaviorSidebar={this.props.showClickBehaviorSidebar}
         clickBehaviorSidebarDashcard={this.props.clickBehaviorSidebarDashcard}
+        loadingDashcardIds={this.props.loadingDashcardIds}
       />
     );
   }
@@ -509,5 +516,5 @@ function isEditingTextOrHeadingCard(display, isEditing) {
 
 export const DashboardGridConnected = _.compose(
   ExplicitSize(),
-  connect(null, mapDispatchToProps),
+  connect(mapStateToProps, mapDispatchToProps),
 )(DashboardGrid);

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -89,8 +89,7 @@ export function GridLayout({
     if (isEditing) {
       lowestLayoutCellPoint += Math.ceil(window.innerHeight / cellSize.height);
     }
-    // eslint-disable-next-line no-unused-vars
-    const [horizontalMargin, verticalMargin] = margin;
+    const [_, verticalMargin] = margin;
     return (cellSize.height + verticalMargin) * lowestLayoutCellPoint;
   }, [cellSize.height, layout, margin, isEditing]);
 

--- a/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
+++ b/frontend/src/metabase/dashboard/components/grid/GridLayout.jsx
@@ -44,20 +44,9 @@ export function GridLayout({
     setCurrentBreakpoint(newBreakpoint);
   }, []);
 
-  const margin = useMemo(
-    () => marginMap[currentBreakpoint],
-    [marginMap, currentBreakpoint],
-  );
-
-  const layout = useMemo(
-    () => layouts[currentBreakpoint],
-    [layouts, currentBreakpoint],
-  );
-
-  const cols = useMemo(
-    () => columnsMap[currentBreakpoint],
-    [columnsMap, currentBreakpoint],
-  );
+  const margin = marginMap[currentBreakpoint];
+  const layout = layouts[currentBreakpoint];
+  const cols = columnsMap[currentBreakpoint];
 
   const cellSize = useMemo(() => {
     const marginSlotsCount = cols - 1;

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -178,12 +178,17 @@ export function getDatasetQueryParams(
 export function isDashcardLoading(
   dashcard: DashboardCard,
   dashcardsData: Record<DashCardId, Record<CardId, Dataset | null>>,
+  loadingIds: number[] = [],
 ) {
   if (isVirtualDashCard(dashcard)) {
     return false;
   }
 
   if (dashcardsData[dashcard.id] == null) {
+    return true;
+  }
+
+  if (loadingIds.includes(dashcard.id)) {
     return true;
   }
 

--- a/frontend/src/metabase/dashboard/utils.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/utils.unit.spec.ts
@@ -155,6 +155,18 @@ describe("Dashboard utils", () => {
         }),
       ).toBe(true);
     });
+
+    it("should return true when id is in loadingIds", () => {
+      expect(
+        isDashcardLoading(
+          createMockDashboardCard({ id: 1 }),
+          {
+            1: { 2: createMockDataset() },
+          },
+          [1],
+        ),
+      ).toBe(true);
+    });
   });
 
   describe("getDashcardResultsError", () => {

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -543,16 +543,13 @@ class Visualization extends PureComponent {
 }
 
 function checkIsLoading(series, props) {
-  return (
-    props?.isDashcardDataLoading ||
-    !(
-      series &&
-      series.length > 0 &&
-      _.every(
-        series,
-        s => s.data || _.isObject(s.card.visualization_settings.virtual_card),
-      )
-    )
+  if (props?.isDashcardDataLoading || _.isEmpty(series)) {
+    return true;
+  }
+
+  return !_.every(
+    series,
+    s => s.data || _.isObject(s.card.visualization_settings.virtual_card),
   );
 }
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/33767

## Description

**This is a dirty minimalistic fix.**

Ideally `card` and `dashcard` data and loading states should be held entirely in the store: updated by actions and retrieved by selectors. We currently have `dashboard.loadingDashCards.loadingIds`, but it's not widely used. Our current components instead calculate `isLoading` at various levels ad-hoc, each time using slightly different code.

I am afraid of breaking something - for instance, I already broke Table rendering because the `loading` method in `Visualization` couldn't rely on props when bound to `this`, which may have stale, inappropriate for some lifecycle methods props. At least the bug fix part should be minimal - so I am adding an `OR` to the current conditionals. 

All the rest remains the same except a few tiny readability changes and changes to e2e tests, which were not waiting for dashboards to load and, apparently, checking the stale state (before the re-render when the new data is received).

### Before 
https://github.com/metabase/metabase/assets/2196347/4180acc8-83f2-4074-8228-87f95a50814b 

### After
https://github.com/metabase/metabase/assets/2196347/bb160e6a-999c-4899-8549-118950a78f1a



## Test plan
1. create a dashboard with 2 tabs, multiple cards on each
2. create 1 filter and connect it to all the cards
3. switch between the tabs once to allow initial requests to resolve
4. throttle network in devtools to slow down the requests
5. change the filter value being on one tab
6. without waiting for request to resolve, switch to another tab
7. see there's a loading spinner on the card 