### PR TITLE
Trend Charts: Handle missing date unit (i.e. for native queries)

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -107,9 +107,18 @@ export function SmartScalar({
   }
   const { unit } = insight;
   const lastDate = lastRow[dimensionIndex];
-  const lastPeriod = formatDateTimeRangeWithUnit([lastDate], unit, {
-    compact: true,
-  });
+
+  const dateColumn = cols[dimensionIndex];
+  const dateColumnSettings = settings.column(dateColumn) ?? {};
+
+  const lastPeriod = unit
+    ? formatDateTimeRangeWithUnit([lastDate], unit, {
+        compact: true,
+      })
+    : formatValue(lastDate, {
+        ...dateColumnSettings,
+        column: dateColumn,
+      });
 
   const lastValue = insight["last-value"];
   const formatOptions = settings.column(column);


### PR DESCRIPTION
Closes (after backport)
- https://github.com/metabase/metabase/issues/36895

**Prior to Fix**

![image](https://github.com/metabase/metabase/assets/22608765/8963063f-ef7c-4a99-a064-5b9e9b31b507)


**Fixed**
_If missing `dateUnit`, display date based on column settings_

![image](https://github.com/metabase/metabase/assets/22608765/23038847-71fd-4323-959e-ae09959517bb)

---
Query to Reproduce:
```sql
SELECT '2022-12-01'::DATE as date, null as percent
union
select '2023-12-01'::DATE, 0.05
```