### PR TITLE
prevent milestone from closing before release notes are generated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -614,7 +614,7 @@ jobs:
   manage-milestones:
     permissions: write-all
     runs-on: ubuntu-22.04
-    needs: push-tags
+    needs: [draft-release-notes, publish-version-info] # this will ensure that the milestone stays open until the release notes are published
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Description

#36816 introduced a race condition which would allow a milestone to be closed before release notes were generated, and this in fact happened.

![Screen Shot 2023-12-18 at 4 08 22 PM](https://github.com/metabase/metabase/assets/30528226/80e9b928-5c75-480d-bf17-a98c317a2d1b)

17 seconds later, the release notes found no open milestone for v48.0

![Screen Shot 2023-12-18 at 4 08 42 PM](https://github.com/metabase/metabase/assets/30528226/25b359dd-39fd-4b7f-af32-e03063aeadc9)

This change makes the close-milestone step require both publishing version info and release notes. This change somewhat diminishes the value of skipping those steps (you'll have to manually manage the milestone) but that should be a pretty rare occurrence.

## Testing

Unfortunately, I can't test this in my fork since it has some weird permission problem with pushing tags 😬 

