### PR TITLE
waterfall rename 'dataset' to 'waterfallDataset'

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -103,14 +103,21 @@ export function getWaterfallChartModel(
     rows,
     cardColumns,
   );
-  const dataset = getWaterfallDataset(rows, cardColumns, negativeTranslation);
+  const waterfallDataset = getWaterfallDataset(
+    rows,
+    cardColumns,
+    negativeTranslation,
+  );
 
   // y-axis
-  const yAxisExtents: AxisExtents = [getWaterfallExtent(dataset), null];
+  const yAxisExtents: AxisExtents = [
+    getWaterfallExtent(waterfallDataset),
+    null,
+  ];
 
   const waterfallChartModel: WaterfallChartModel = {
     ...baseChartModel,
-    dataset,
+    waterfallDataset,
     negativeTranslation,
     yAxisExtents,
   };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option.ts
@@ -63,7 +63,7 @@ export function getWaterfallOption(
   );
 
   const dataset: DatasetOption = {
-    source: chartModel.dataset,
+    source: chartModel.waterfallDataset,
     dimensions: Object.values(DATASET_DIMENSIONS),
   };
   const xAxisType = getXAxisType(settings);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/types.ts
@@ -15,7 +15,7 @@ export type WaterfallDatum = {
 
 export type WaterfallDataset = WaterfallDatum[];
 
-export type WaterfallChartModel = Omit<CartesianChartModel, "dataset"> & {
-  dataset: WaterfallDataset;
+export type WaterfallChartModel = CartesianChartModel & {
+  waterfallDataset: WaterfallDataset;
   negativeTranslation: number;
 };


### PR DESCRIPTION
### Description

Renames the `dataset` property of the waterfall chart model to `waterfallDataset`. We need to preserve the original dataset for dynamic behaviors, such as tooltips and click actions.

### How to verify

Confirm waterfall charts still work. Can use this dashboard on shared app db, and or check the storybook examples. 
