### PR TITLE
waterfall handle unaggregated data

### DIFF
--- a/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.stories.tsx
@@ -56,6 +56,27 @@ TimeSeriesDataAsOrdinalXScale.args = {
   renderingContext,
 };
 
+export const UnaggregatedOrdinal = Template.bind({});
+UnaggregatedOrdinal.args = {
+  rawSeries: data.unaggregatedOrdinal as any,
+  dashcardSettings: {},
+  renderingContext,
+};
+
+export const UnaggregatedOrdinal2 = Template.bind({});
+UnaggregatedOrdinal2.args = {
+  rawSeries: data.unaggregatedOrdinal2 as any,
+  dashcardSettings: {},
+  renderingContext,
+};
+
+export const UnaggregatedTimeseries = Template.bind({});
+UnaggregatedTimeseries.args = {
+  rawSeries: data.unaggregatedTimeseries as any,
+  dashcardSettings: {},
+  renderingContext,
+};
+
 export const MixedAboveZero = Template.bind({});
 MixedAboveZero.args = {
   rawSeries: data.mixedAboveZero as any,

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/index.ts
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/index.ts
@@ -2,6 +2,9 @@ import withoutTotal from "./without-total.json";
 import ordinalXScale from "./ordinal-x-scale.json";
 import timeseriesXScaleUnsorted from "./timeseries-x-scale-unsorted.json";
 import timeSeriesDataAsOrdinalXScale from "./timeseries-data-as-ordinal-x-scale.json";
+import unaggregatedOrdinal from "./unaggregated-ordinal.json";
+import unaggregatedOrdinal2 from "./unaggregated-ordinal-2.json";
+import unaggregatedTimeseries from "./unaggregated-timeseries.json";
 import mixedAboveZero from "./mixed-above-zero.json";
 import mixedBelowZero from "./mixed-below-zero.json";
 import negativeOnly from "./negative-only.json";
@@ -15,6 +18,9 @@ export const data = {
   ordinalXScale,
   timeseriesXScaleUnsorted,
   timeSeriesDataAsOrdinalXScale,
+  unaggregatedOrdinal,
+  unaggregatedOrdinal2,
+  unaggregatedTimeseries,
   mixedAboveZero,
   mixedBelowZero,
   negativeOnly,

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/unaggregated-ordinal-2.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/unaggregated-ordinal-2.json
@@ -1,0 +1,316 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 158,
+      "result_metadata": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1525, null],
+          "effective_type": "type/BigInteger",
+          "id": 1525,
+          "visibility_type": "normal",
+          "display_name": "_mb_row_id",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "name": "x",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1526, null],
+          "effective_type": "type/BigInteger",
+          "id": 1526,
+          "visibility_type": "normal",
+          "display_name": "X",
+          "fingerprint": {
+            "global": { "distinct-count": 10, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": 1,
+                "q1": 3.414213562373095,
+                "q3": 7.414213562373095,
+                "max": 10,
+                "sd": 2.7294688127912363,
+                "avg": 5.375
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "name": "change",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1527, null],
+          "effective_type": "type/BigInteger",
+          "id": 1527,
+          "visibility_type": "normal",
+          "display_name": "Change",
+          "fingerprint": {
+            "global": { "distinct-count": 15, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": -53,
+                "q1": -7.5,
+                "q3": 9.414213562373096,
+                "max": 52,
+                "sd": 21.398500726297,
+                "avg": 1.8125
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "include_xls": false,
+      "database_id": 2,
+      "enable_embedding": false,
+      "collection_id": 10,
+      "query_type": "query",
+      "name": "Waterfall Unaggregated Ordinal - Waterfall Example 2",
+      "creator_id": 1,
+      "updated_at": "2023-12-18T22:33:42.052334Z",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "type": "query",
+        "database": 2,
+        "query": { "source-table": "card__135" }
+      },
+      "id": 136,
+      "parameter_mappings": [],
+      "include_csv": false,
+      "display": "waterfall",
+      "entity_id": "eMYmpA9DiXFVtVhUuBY2F",
+      "collection_preview": true,
+      "visualization_settings": {
+        "graph.dimensions": ["x"],
+        "graph.series_order_dimension": null,
+        "graph.series_order": null,
+        "graph.show_values": true,
+        "graph.metrics": ["change"]
+      },
+      "metabase_version": "v1.47.1-SNAPSHOT (b37c32d)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2023-12-09T23:41:35.110598Z",
+      "public_uuid": null
+    },
+    "data": {
+      "results_timezone": "America/Los_Angeles",
+      "download_perms": "full",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": null,
+            "semantic_type": "type/PK",
+            "coercion_strategy": null,
+            "name": "_mb_row_id",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1525, null],
+            "effective_type": "type/BigInteger",
+            "id": 1525,
+            "visibility_type": "normal",
+            "display_name": "_mb_row_id",
+            "fingerprint": null,
+            "base_type": "type/BigInteger"
+          },
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "name": "x",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1526, null],
+            "effective_type": "type/BigInteger",
+            "id": 1526,
+            "visibility_type": "normal",
+            "display_name": "X",
+            "fingerprint": {
+              "global": { "distinct-count": 10, "nil%": 0 },
+              "type": {
+                "type/Number": {
+                  "min": 1,
+                  "q1": 3.414213562373095,
+                  "q3": 7.414213562373095,
+                  "max": 10,
+                  "sd": 2.7294688127912363,
+                  "avg": 5.375
+                }
+              }
+            },
+            "base_type": "type/BigInteger"
+          },
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "name": "change",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1527, null],
+            "effective_type": "type/BigInteger",
+            "id": 1527,
+            "visibility_type": "normal",
+            "display_name": "Change",
+            "fingerprint": {
+              "global": { "distinct-count": 15, "nil%": 0 },
+              "type": {
+                "type/Number": {
+                  "min": -53,
+                  "q1": -7.5,
+                  "q3": 9.414213562373096,
+                  "max": 52,
+                  "sd": 21.398500726297,
+                  "avg": 1.8125
+                }
+              }
+            },
+            "base_type": "type/BigInteger"
+          }
+        ]
+      },
+      "rows": [
+        [1, 1, 5],
+        [2, 1, 10],
+        [3, 2, 10],
+        [4, 3, 0],
+        [5, 4, 3],
+        [6, 4, -12],
+        [7, 5, -7],
+        [8, 6, 4],
+        [9, 6, 1],
+        [10, 6, 9],
+        [11, 6, -3],
+        [12, 7, -8],
+        [13, 8, -9],
+        [14, 8, 52],
+        [15, 9, 27],
+        [16, 10, -53]
+      ],
+      "cols": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "table_id": 158,
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1525, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1525,
+          "position": 0,
+          "visibility_type": "normal",
+          "display_name": "_mb_row_id",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 158,
+          "coercion_strategy": null,
+          "name": "x",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1526, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1526,
+          "position": 1,
+          "visibility_type": "normal",
+          "display_name": "X",
+          "fingerprint": {
+            "global": { "distinct-count": 10, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": 1,
+                "q1": 3.414213562373095,
+                "q3": 7.414213562373095,
+                "max": 10,
+                "sd": 2.7294688127912363,
+                "avg": 5.375
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 158,
+          "coercion_strategy": null,
+          "name": "change",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1527, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1527,
+          "position": 2,
+          "visibility_type": "normal",
+          "display_name": "Change",
+          "fingerprint": {
+            "global": { "distinct-count": 15, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": -53,
+                "q1": -7.5,
+                "q3": 9.414213562373096,
+                "max": 52,
+                "sd": 21.398500726297,
+                "avg": 1.8125
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "viz-settings": {
+        "graph.dimensions": ["x"],
+        "graph.series_order_dimension": null,
+        "graph.series_order": null,
+        "graph.show_values": true,
+        "graph.metrics": ["change"],
+        "metabase.shared.models.visualization-settings/column-settings": {
+          "{:metabase.shared.models.visualization-settings/field-id 1525}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1526}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1527}": {}
+        },
+        "metabase.shared.models.visualization-settings/global-column-settings": {}
+      },
+      "native_form": {
+        "query": "SELECT \"source\".\"_mb_row_id\" AS \"_mb_row_id\", \"source\".\"x\" AS \"x\", \"source\".\"change\" AS \"change\" FROM (SELECT \"csv_upload_data\".\"csv_upload_waterfall_example_2_20231209153102\".\"_mb_row_id\" AS \"_mb_row_id\", \"csv_upload_data\".\"csv_upload_waterfall_example_2_20231209153102\".\"x\" AS \"x\", \"csv_upload_data\".\"csv_upload_waterfall_example_2_20231209153102\".\"change\" AS \"change\" FROM \"csv_upload_data\".\"csv_upload_waterfall_example_2_20231209153102\") AS \"source\" LIMIT 2000",
+        "params": null
+      },
+      "is_sandboxed": false,
+      "dataset": true,
+      "insights": null
+    }
+  }
+]

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/unaggregated-ordinal.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/unaggregated-ordinal.json
@@ -1,0 +1,307 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 166,
+      "result_metadata": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1558, null],
+          "effective_type": "type/BigInteger",
+          "id": 1558,
+          "visibility_type": "normal",
+          "display_name": "_mb_row_id",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "name": "category",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1559, null],
+          "effective_type": "type/Text",
+          "id": 1559,
+          "visibility_type": "normal",
+          "display_name": "Category",
+          "fingerprint": {
+            "global": { "distinct-count": 4, "nil%": 0 },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 1
+              }
+            }
+          },
+          "base_type": "type/Text"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "name": "change",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1560, null],
+          "effective_type": "type/BigInteger",
+          "id": 1560,
+          "visibility_type": "normal",
+          "display_name": "Change",
+          "fingerprint": {
+            "global": { "distinct-count": 8, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": -5,
+                "q1": -4,
+                "q3": 2,
+                "max": 5,
+                "sd": 3.559026084010437,
+                "avg": -1
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "include_xls": false,
+      "database_id": 2,
+      "enable_embedding": false,
+      "collection_id": 10,
+      "query_type": "query",
+      "name": "Waterfall Unaggregated Ordinal",
+      "creator_id": 1,
+      "updated_at": "2023-12-18T22:34:05.880058Z",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "type": "query",
+        "database": 2,
+        "query": { "source-table": "card__179" }
+      },
+      "id": 180,
+      "parameter_mappings": [],
+      "include_csv": false,
+      "display": "waterfall",
+      "entity_id": "UFptyMO1xVjtCdibPh_nS",
+      "collection_preview": true,
+      "visualization_settings": {
+        "graph.dimensions": ["category"],
+        "graph.series_order_dimension": null,
+        "graph.series_order": null,
+        "graph.show_values": true,
+        "graph.metrics": ["change"]
+      },
+      "metabase_version": "v1.47.1-SNAPSHOT (b37c32d)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2023-12-18T22:32:54.047219Z",
+      "public_uuid": null
+    },
+    "data": {
+      "results_timezone": "America/Los_Angeles",
+      "download_perms": "full",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": null,
+            "semantic_type": "type/PK",
+            "coercion_strategy": null,
+            "name": "_mb_row_id",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1558, null],
+            "effective_type": "type/BigInteger",
+            "id": 1558,
+            "visibility_type": "normal",
+            "display_name": "_mb_row_id",
+            "fingerprint": null,
+            "base_type": "type/BigInteger"
+          },
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "name": "category",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1559, null],
+            "effective_type": "type/Text",
+            "id": 1559,
+            "visibility_type": "normal",
+            "display_name": "Category",
+            "fingerprint": {
+              "global": { "distinct-count": 4, "nil%": 0 },
+              "type": {
+                "type/Text": {
+                  "percent-json": 0,
+                  "percent-url": 0,
+                  "percent-email": 0,
+                  "percent-state": 0,
+                  "average-length": 1
+                }
+              }
+            },
+            "base_type": "type/Text"
+          },
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "name": "change",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1560, null],
+            "effective_type": "type/BigInteger",
+            "id": 1560,
+            "visibility_type": "normal",
+            "display_name": "Change",
+            "fingerprint": {
+              "global": { "distinct-count": 8, "nil%": 0 },
+              "type": {
+                "type/Number": {
+                  "min": -5,
+                  "q1": -4,
+                  "q3": 2,
+                  "max": 5,
+                  "sd": 3.559026084010437,
+                  "avg": -1
+                }
+              }
+            },
+            "base_type": "type/BigInteger"
+          }
+        ]
+      },
+      "rows": [
+        [1, "a", 3],
+        [2, "b", 2],
+        [3, "a", 5],
+        [4, "c", -4],
+        [5, "b", -5],
+        [6, "c", -3],
+        [7, "d", -5],
+        [8, "c", 1],
+        [9, "d", -3],
+        [10, "b", -1]
+      ],
+      "cols": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "table_id": 166,
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1558, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1558,
+          "position": 0,
+          "visibility_type": "normal",
+          "display_name": "_mb_row_id",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 166,
+          "coercion_strategy": null,
+          "name": "category",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1559, null],
+          "effective_type": "type/Text",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1559,
+          "position": 1,
+          "visibility_type": "normal",
+          "display_name": "Category",
+          "fingerprint": {
+            "global": { "distinct-count": 4, "nil%": 0 },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 1
+              }
+            }
+          },
+          "base_type": "type/Text"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 166,
+          "coercion_strategy": null,
+          "name": "change",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1560, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1560,
+          "position": 2,
+          "visibility_type": "normal",
+          "display_name": "Change",
+          "fingerprint": {
+            "global": { "distinct-count": 8, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": -5,
+                "q1": -4,
+                "q3": 2,
+                "max": 5,
+                "sd": 3.559026084010437,
+                "avg": -1
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "viz-settings": {
+        "graph.dimensions": ["category"],
+        "graph.series_order_dimension": null,
+        "graph.series_order": null,
+        "graph.show_values": true,
+        "graph.metrics": ["change"],
+        "metabase.shared.models.visualization-settings/column-settings": {
+          "{:metabase.shared.models.visualization-settings/field-id 1558}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1559}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1560}": {}
+        },
+        "metabase.shared.models.visualization-settings/global-column-settings": {}
+      },
+      "native_form": {
+        "query": "SELECT \"source\".\"_mb_row_id\" AS \"_mb_row_id\", \"source\".\"category\" AS \"category\", \"source\".\"change\" AS \"change\" FROM (SELECT \"csv_upload_data\".\"csv_upload_waterfall_unaggregated_ordinal_20231218143207\".\"_mb_row_id\" AS \"_mb_row_id\", \"csv_upload_data\".\"csv_upload_waterfall_unaggregated_ordinal_20231218143207\".\"category\" AS \"category\", \"csv_upload_data\".\"csv_upload_waterfall_unaggregated_ordinal_20231218143207\".\"change\" AS \"change\" FROM \"csv_upload_data\".\"csv_upload_waterfall_unaggregated_ordinal_20231218143207\") AS \"source\" LIMIT 2000",
+        "params": null
+      },
+      "is_sandboxed": false,
+      "dataset": true,
+      "insights": null
+    }
+  }
+]

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/unaggregated-timeseries.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/unaggregated-timeseries.json
@@ -1,0 +1,307 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 167,
+      "result_metadata": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1561, null],
+          "effective_type": "type/BigInteger",
+          "id": 1561,
+          "visibility_type": "normal",
+          "display_name": "_mb_row_id",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "unit": "default",
+          "name": "category",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1562, { "temporal-unit": "default" }],
+          "effective_type": "type/Date",
+          "id": 1562,
+          "visibility_type": "normal",
+          "display_name": "Date",
+          "fingerprint": {
+            "global": { "distinct-count": 4, "nil%": 0 },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2017-01-01",
+                "latest": "2017-01-04"
+              }
+            }
+          },
+          "base_type": "type/Date"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "name": "change",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1563, null],
+          "effective_type": "type/BigInteger",
+          "id": 1563,
+          "visibility_type": "normal",
+          "display_name": "Change",
+          "fingerprint": {
+            "global": { "distinct-count": 8, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": -5,
+                "q1": -4,
+                "q3": 2,
+                "max": 5,
+                "sd": 3.559026084010437,
+                "avg": -1
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "include_xls": false,
+      "database_id": 2,
+      "enable_embedding": false,
+      "collection_id": 10,
+      "query_type": "query",
+      "name": "Waterfall Unaggregated Timeseries",
+      "creator_id": 1,
+      "updated_at": "2023-12-18T22:41:59.371143Z",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "type": "query",
+        "database": 2,
+        "query": { "source-table": "card__181" }
+      },
+      "id": 182,
+      "parameter_mappings": [],
+      "include_csv": false,
+      "display": "waterfall",
+      "entity_id": "xXJnvo81DWhDWcCzNaJ0e",
+      "collection_preview": true,
+      "visualization_settings": {
+        "table.pivot_column": "category",
+        "table.cell_column": "change",
+        "graph.dimensions": ["category"],
+        "graph.series_order_dimension": null,
+        "graph.series_order": null,
+        "graph.x_axis.scale": "timeseries",
+        "graph.show_values": true,
+        "graph.metrics": ["change"]
+      },
+      "metabase_version": "v1.47.1-SNAPSHOT (b37c32d)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2023-12-18T22:39:09.432279Z",
+      "public_uuid": null
+    },
+    "data": {
+      "results_timezone": "America/Los_Angeles",
+      "download_perms": "full",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": null,
+            "semantic_type": "type/PK",
+            "coercion_strategy": null,
+            "name": "_mb_row_id",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1561, null],
+            "effective_type": "type/BigInteger",
+            "id": 1561,
+            "visibility_type": "normal",
+            "display_name": "_mb_row_id",
+            "fingerprint": null,
+            "base_type": "type/BigInteger"
+          },
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "unit": "default",
+            "name": "category",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1562, { "temporal-unit": "default" }],
+            "effective_type": "type/Date",
+            "id": 1562,
+            "visibility_type": "normal",
+            "display_name": "Date",
+            "fingerprint": {
+              "global": { "distinct-count": 4, "nil%": 0 },
+              "type": {
+                "type/DateTime": {
+                  "earliest": "2017-01-01",
+                  "latest": "2017-01-04"
+                }
+              }
+            },
+            "base_type": "type/Date"
+          },
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "name": "change",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1563, null],
+            "effective_type": "type/BigInteger",
+            "id": 1563,
+            "visibility_type": "normal",
+            "display_name": "Change",
+            "fingerprint": {
+              "global": { "distinct-count": 8, "nil%": 0 },
+              "type": {
+                "type/Number": {
+                  "min": -5,
+                  "q1": -4,
+                  "q3": 2,
+                  "max": 5,
+                  "sd": 3.559026084010437,
+                  "avg": -1
+                }
+              }
+            },
+            "base_type": "type/BigInteger"
+          }
+        ]
+      },
+      "rows": [
+        [2, "2017-01-01T00:00:00-08:00", 3],
+        [4, "2017-01-01T00:00:00-08:00", 5],
+        [1, "2017-01-02T00:00:00-08:00", 2],
+        [6, "2017-01-02T00:00:00-08:00", -5],
+        [10, "2017-01-02T00:00:00-08:00", -1],
+        [5, "2017-01-03T00:00:00-08:00", -4],
+        [7, "2017-01-03T00:00:00-08:00", -3],
+        [8, "2017-01-03T00:00:00-08:00", 1],
+        [3, "2017-01-04T00:00:00-08:00", -5],
+        [9, "2017-01-04T00:00:00-08:00", -3]
+      ],
+      "cols": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "table_id": 167,
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1561, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1561,
+          "position": 0,
+          "visibility_type": "normal",
+          "display_name": "_mb_row_id",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 167,
+          "coercion_strategy": null,
+          "unit": "default",
+          "name": "category",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1562, { "temporal-unit": "default" }],
+          "effective_type": "type/Date",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1562,
+          "position": 1,
+          "visibility_type": "normal",
+          "display_name": "Date",
+          "fingerprint": {
+            "global": { "distinct-count": 4, "nil%": 0 },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2017-01-01",
+                "latest": "2017-01-04"
+              }
+            }
+          },
+          "base_type": "type/Date"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 167,
+          "coercion_strategy": null,
+          "name": "change",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1563, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1563,
+          "position": 2,
+          "visibility_type": "normal",
+          "display_name": "Change",
+          "fingerprint": {
+            "global": { "distinct-count": 8, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": -5,
+                "q1": -4,
+                "q3": 2,
+                "max": 5,
+                "sd": 3.559026084010437,
+                "avg": -1
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "viz-settings": {
+        "graph.show_values": true,
+        "metabase.shared.models.visualization-settings/column-settings": {
+          "{:metabase.shared.models.visualization-settings/field-id 1561}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1562}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1563}": {}
+        },
+        "table.cell_column": "change",
+        "graph.series_order_dimension": null,
+        "graph.metrics": ["change"],
+        "graph.series_order": null,
+        "table.pivot_column": "category",
+        "metabase.shared.models.visualization-settings/global-column-settings": {},
+        "graph.x_axis.scale": "timeseries",
+        "graph.dimensions": ["category"]
+      },
+      "native_form": {
+        "query": "SELECT \"source\".\"_mb_row_id\" AS \"_mb_row_id\", \"source\".\"category\" AS \"category\", \"source\".\"change\" AS \"change\" FROM (SELECT \"csv_upload_data\".\"csv_upload_waterfall_unaggregated_timeseries_20231218143728\".\"_mb_row_id\" AS \"_mb_row_id\", \"csv_upload_data\".\"csv_upload_waterfall_unaggregated_timeseries_20231218143728\".\"category\" AS \"category\", \"csv_upload_data\".\"csv_upload_waterfall_unaggregated_timeseries_20231218143728\".\"change\" AS \"change\" FROM \"csv_upload_data\".\"csv_upload_waterfall_unaggregated_timeseries_20231218143728\") AS \"source\" LIMIT 2000",
+        "params": null
+      },
+      "is_sandboxed": false,
+      "dataset": true,
+      "insights": null
+    }
+  }
+]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36835

### Description

Handles unaggregated data in the waterfall chart by summing all the values for a single dimension key. E.g.

```
["a", 1]
["a", 2]
["b", 5]
["b"-7]
```

becomes

```
["a", 3]
["b", -2]
```

### How to verify

1. Create a waterfall chart using data that has unaggregated dimension values
2. Add to a dashboard
3. Send a subscription
4. Confirms it renders correctly (data should be aggregated)

### Demo

| Before | After |
| ------ | ----- |
| <img width="532" alt="before" src="https://github.com/metabase/metabase/assets/37751258/590a2459-33d5-4814-a74b-6b4e71792e33"> | <img width="524" alt="after" src="https://github.com/metabase/metabase/assets/37751258/e1f57ed6-d169-4176-a997-ac3e912c5f8c"> |

_Ignore the bars overflowing horizontally, I've filed a separate issue for that._

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
