### PR TITLE
Remove "@flaky" tag from fixed E2E test

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -979,136 +979,130 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("have.text", "Open the drill-through menu");
     });
 
-    it(
-      "should allow setting dashboard and saved question as custom destination for different columns",
-      { tags: "@flaky" },
-      () => {
-        cy.createQuestion(TARGET_QUESTION);
-        cy.createDashboard(
-          {
-            ...TARGET_DASHBOARD,
-            parameters: [DASHBOARD_FILTER_TEXT, DASHBOARD_FILTER_TIME],
-          },
-          {
-            wrapId: true,
-            idAlias: "targetDashboardId",
-          },
-        );
-        cy.createQuestionAndDashboard({ questionDetails }).then(
-          ({ body: card }) => {
-            visitDashboard(card.dashboard_id);
-          },
-        );
+    it("should allow setting dashboard and saved question as custom destination for different columns", () => {
+      cy.createQuestion(TARGET_QUESTION);
+      cy.createDashboard(
+        {
+          ...TARGET_DASHBOARD,
+          parameters: [DASHBOARD_FILTER_TEXT, DASHBOARD_FILTER_TIME],
+        },
+        {
+          wrapId: true,
+          idAlias: "targetDashboardId",
+        },
+      );
+      cy.createQuestionAndDashboard({ questionDetails }).then(
+        ({ body: card }) => {
+          visitDashboard(card.dashboard_id);
+        },
+      );
 
-        editDashboard();
+      editDashboard();
 
-        getDashboardCard().realHover().icon("click").click();
+      getDashboardCard().realHover().icon("click").click();
 
-        (function addCustomDashboardDestination() {
-          cy.log("custom destination (dashboard) behavior for 'Count' column");
+      (function addCustomDashboardDestination() {
+        cy.log("custom destination (dashboard) behavior for 'Count' column");
 
-          getCountToDashboardMapping().should("not.exist");
-          cy.get("aside").findByText(COUNT_COLUMN_NAME).click();
-          addDashboardDestination();
-          cy.get("aside")
-            .findByText("Select a dashboard tab")
-            .should("not.exist");
-          cy.get("aside")
-            .findByText("No available targets")
-            .should("not.exist");
-          addTextParameter();
-          addTimeParameter();
-          cy.get("aside")
-            .findByRole("textbox")
-            .type(`Count: {{${COUNT_COLUMN_ID}}}`, {
-              parseSpecialCharSequences: false,
-            });
-
-          cy.icon("chevronleft").click();
-
-          getCountToDashboardMapping().should("exist");
-          getDashboardCard()
-            .button()
-            .should("have.text", "1 column has custom behavior");
-        })();
-
-        (function addCustomQuestionDestination() {
-          cy.log(
-            "custom destination (question) behavior for 'Created at' column",
-          );
-
-          getCreatedAtToQuestionMapping().should("not.exist");
-          cy.get("aside").findByText(CREATED_AT_COLUMN_NAME).click();
-          /**
-           * TODO: remove the next line when metabase#34845 is fixed
-           * @see https://github.com/metabase/metabase/issues/34845
-           */
-          cy.get("aside").findByText("Unknown").click();
-          addSavedQuestionDestination();
-          addSavedQuestionCreatedAtParameter();
-          addSavedQuestionQuantityParameter();
-          cy.get("aside")
-            .findByRole("textbox")
-            .type(`Created at: {{${CREATED_AT_COLUMN_ID}}}`, {
-              parseSpecialCharSequences: false,
-            });
-
-          cy.icon("chevronleft").click();
-
-          getCreatedAtToQuestionMapping().should("exist");
-          getDashboardCard()
-            .button()
-            .should("have.text", "2 columns have custom behavior");
-        })();
-
-        cy.get("aside").button("Done").click();
-        saveDashboard();
-
-        (function testDashboardDestinationClick() {
-          cy.log("it handles 'Count' column click");
-
-          getTableCell(COLUMN_INDEX.COUNT)
-            .should("have.text", `Count: ${POINT_COUNT}`)
-            .click();
-          cy.findAllByTestId("field-set")
-            .should("have.length", 2)
-            .should("contain.text", POINT_COUNT)
-            .should("contain.text", POINT_CREATED_AT_FORMATTED);
-          cy.get("@targetDashboardId").then(targetDashboardId => {
-            cy.location().should(({ pathname, search }) => {
-              expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
-              expect(search).to.equal(
-                `?${DASHBOARD_FILTER_TEXT.slug}=${POINT_COUNT}&${DASHBOARD_FILTER_TIME.slug}=${POINT_CREATED_AT}`,
-              );
-            });
+        getCountToDashboardMapping().should("not.exist");
+        cy.get("aside").findByText(COUNT_COLUMN_NAME).click();
+        addDashboardDestination();
+        cy.get("aside")
+          .findByText("Select a dashboard tab")
+          .should("not.exist");
+        cy.get("aside").findByText("No available targets").should("not.exist");
+        addTextParameter();
+        addTimeParameter();
+        cy.get("aside")
+          .findByRole("textbox")
+          .type(`Count: {{${COUNT_COLUMN_ID}}}`, {
+            parseSpecialCharSequences: false,
           });
-        })();
 
-        cy.go("back");
+        cy.icon("chevronleft").click();
 
-        (function testQuestionDestinationClick() {
-          cy.log("it handles 'Created at' column click");
+        getCountToDashboardMapping().should("exist");
+        getDashboardCard()
+          .button()
+          .should("have.text", "1 column has custom behavior");
+      })();
 
-          getTableCell(COLUMN_INDEX.CREATED_AT)
-            .should("have.text", `Created at: ${POINT_CREATED_AT_FORMATTED}`)
-            .click();
-          cy.wait("@dataset");
-          cy.findByTestId("qb-filters-panel")
-            .should("contain.text", "Created At is Aug 1–31, 2022")
-            .should("contain.text", "Quantity is equal to 79");
-          cy.location().should(({ hash, pathname }) => {
-            expect(pathname).to.equal("/question");
-            const card = deserializeCardFromUrl(hash);
-            expect(card.name).to.deep.equal(TARGET_QUESTION.name);
-            expect(card.display).to.deep.equal(TARGET_QUESTION.display);
-            expect(card.dataset_query.query).to.deep.equal({
-              ...TARGET_QUESTION.query,
-              filter: ["and", QUERY_FILTER_CREATED_AT, QUERY_FILTER_QUANTITY],
-            });
+      (function addCustomQuestionDestination() {
+        cy.log(
+          "custom destination (question) behavior for 'Created at' column",
+        );
+
+        getCreatedAtToQuestionMapping().should("not.exist");
+        cy.get("aside").findByText(CREATED_AT_COLUMN_NAME).click();
+        /**
+         * TODO: remove the next line when metabase#34845 is fixed
+         * @see https://github.com/metabase/metabase/issues/34845
+         */
+        cy.get("aside").findByText("Unknown").click();
+        addSavedQuestionDestination();
+        addSavedQuestionCreatedAtParameter();
+        addSavedQuestionQuantityParameter();
+        cy.get("aside")
+          .findByRole("textbox")
+          .type(`Created at: {{${CREATED_AT_COLUMN_ID}}}`, {
+            parseSpecialCharSequences: false,
           });
-        })();
-      },
-    );
+
+        cy.icon("chevronleft").click();
+
+        getCreatedAtToQuestionMapping().should("exist");
+        getDashboardCard()
+          .button()
+          .should("have.text", "2 columns have custom behavior");
+      })();
+
+      cy.get("aside").button("Done").click();
+      saveDashboard();
+
+      (function testDashboardDestinationClick() {
+        cy.log("it handles 'Count' column click");
+
+        getTableCell(COLUMN_INDEX.COUNT)
+          .should("have.text", `Count: ${POINT_COUNT}`)
+          .click();
+        cy.findAllByTestId("field-set")
+          .should("have.length", 2)
+          .should("contain.text", POINT_COUNT)
+          .should("contain.text", POINT_CREATED_AT_FORMATTED);
+        cy.get("@targetDashboardId").then(targetDashboardId => {
+          cy.location().should(({ pathname, search }) => {
+            expect(pathname).to.equal(`/dashboard/${targetDashboardId}`);
+            expect(search).to.equal(
+              `?${DASHBOARD_FILTER_TEXT.slug}=${POINT_COUNT}&${DASHBOARD_FILTER_TIME.slug}=${POINT_CREATED_AT}`,
+            );
+          });
+        });
+      })();
+
+      cy.go("back");
+
+      (function testQuestionDestinationClick() {
+        cy.log("it handles 'Created at' column click");
+
+        getTableCell(COLUMN_INDEX.CREATED_AT)
+          .should("have.text", `Created at: ${POINT_CREATED_AT_FORMATTED}`)
+          .click();
+        cy.wait("@dataset");
+        cy.findByTestId("qb-filters-panel")
+          .should("contain.text", "Created At is Aug 1–31, 2022")
+          .should("contain.text", "Quantity is equal to 79");
+        cy.location().should(({ hash, pathname }) => {
+          expect(pathname).to.equal("/question");
+          const card = deserializeCardFromUrl(hash);
+          expect(card.name).to.deep.equal(TARGET_QUESTION.name);
+          expect(card.display).to.deep.equal(TARGET_QUESTION.display);
+          expect(card.dataset_query.query).to.deep.equal({
+            ...TARGET_QUESTION.query,
+            filter: ["and", QUERY_FILTER_CREATED_AT, QUERY_FILTER_QUANTITY],
+          });
+        });
+      })();
+    });
 
     it("should allow setting dashboard tab with parameter for a column", () => {
       cy.createQuestion(TARGET_QUESTION);


### PR DESCRIPTION
Resolves #36681 

I believe the flake was fixed in #34191 by adding `cy.wait` for the `/api/dataset` endpoints. I couldn't find this test in the flaky list (both in DeploySentinel and Cypress Cloud), so it seems to be working well. Unfortunately, I couldn't verify this with a stress test because the CI workflow doesn't handle tests using paid Metabase features. The test is green after running it ~20 times locally with a x6 CPU throttling though.

[CI stress test result](https://github.com/metabase/metabase/actions/runs/7261999147) (20 times)