### PR TITLE
Fix "latest" detection for enterprise releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
 
           console.log("Latest version?", isLatest);
 
-          if (isLatest === "true") {
+          if (isLatest) {
             return edition === 'ee' ? 'enterprise/latest' : 'latest';
           }
           return "false";

--- a/release/package.json
+++ b/release/package.json
@@ -11,7 +11,8 @@
     "build": "esbuild src/index.ts --bundle --outfile=dist/index.cjs --platform=node --target=node16",
     "prettier": "prettier --write",
     "release-offline": "tsx release-offline.ts",
-    "test": "jest"
+    "test:unit": "jest --testPathPattern unit",
+    "test:integration": "jest --testPathPattern integration"
   },
   "author": "Metabase",
   "license": "AGPL-3.0-or-later",

--- a/release/src/github.integration.spec.ts
+++ b/release/src/github.integration.spec.ts
@@ -1,0 +1,80 @@
+import "dotenv/config";
+import { Octokit } from "@octokit/rest";
+import { isLatestRelease } from "./github";
+
+const { GITHUB_TOKEN, GITHUB_OWNER, GITHUB_REPO } = process.env as any;
+const github = new Octokit({ auth: GITHUB_TOKEN });
+
+describe("github release helpers", () => {
+  beforeAll(() => {
+    expect(GITHUB_TOKEN).toBeDefined();
+    expect(GITHUB_OWNER).toBeDefined();
+    expect(GITHUB_REPO).toBeDefined();
+  });
+  describe("isLatestRelease", () => {
+    // Note: if we've gotten to metabase v99 🥳 you'll need to update this test
+    it("should always tell you v0.99 is the latest release", async () => {
+      const isLatest = await isLatestRelease({
+        github,
+        owner: GITHUB_OWNER,
+        repo: GITHUB_REPO,
+        version: "v0.99.0",
+      });
+
+      expect(isLatest).toBe(true);
+    });
+
+    it("should always tell you v1.99 is the latest release", async () => {
+      const isLatest = await isLatestRelease({
+        github,
+        owner: GITHUB_OWNER,
+        repo: GITHUB_REPO,
+        version: "v1.99.0",
+      });
+
+      expect(isLatest).toBe(true);
+    });
+
+    it("should never tell you that v0.1 is the latest release", async () => {
+      const isLatest = await isLatestRelease({
+        github,
+        owner: GITHUB_OWNER,
+        repo: GITHUB_REPO,
+        version: "v0.1.0",
+      });
+
+      expect(isLatest).toBe(false);
+    });
+
+    it("should never tell you that v1.1 is the latest release", async () => {
+      const isLatest = await isLatestRelease({
+        github,
+        owner: GITHUB_OWNER,
+        repo: GITHUB_REPO,
+        version: "v1.1.0",
+      });
+
+      expect(isLatest).toBe(false);
+    });
+
+    it("should never tell you that an RC is a latest release", async () => {
+      const isLatestEE = await isLatestRelease({
+        github,
+        owner: GITHUB_OWNER,
+        repo: GITHUB_REPO,
+        version: "v1.99.0-RC9",
+      });
+
+      expect(isLatestEE).toBe(false);
+
+      const isLatestOSS = await isLatestRelease({
+        github,
+        owner: GITHUB_OWNER,
+        repo: GITHUB_REPO,
+        version: "v0.99.0-RC9",
+      });
+
+      expect(isLatestOSS).toBe(false);
+    });
+  });
+});

--- a/release/src/github.ts
+++ b/release/src/github.ts
@@ -1,9 +1,9 @@
 /* eslint-disable no-console */
 import {
-  isEnterpriseVersion,
   getOSSVersion,
   isLatestVersion,
   getNextVersions,
+  isValidVersionString,
 } from "./version-helpers";
 
 import type { ReleaseProps, Issue } from "./types";
@@ -97,18 +97,16 @@ export const getMilestoneIssues = async ({
   return (issues ?? []) as Issue[];
 };
 
-// latest for the purposes of github release notes
 export const isLatestRelease = async ({
   version,
   github,
   owner,
   repo,
-}: ReleaseProps): Promise<"true" | "false"> => {
-  // for the purposes of github releases enterprise versions are never latest
-  if (isEnterpriseVersion(version)) {
-    return "false";
+}: ReleaseProps): Promise<boolean> => {
+  if (!isValidVersionString(version)) {
+    console.warn(`Invalid version string: ${version}`);
+    return false;
   }
-
   const releases = await github.rest.repos.listReleases({
     owner,
     repo,
@@ -118,8 +116,7 @@ export const isLatestRelease = async ({
     (r: { tag_name: string }) => r.tag_name,
   );
 
-  // github needs this to be a string
-  return isLatestVersion(version, releaseNames) ? "true" : "false";
+  return isLatestVersion(version, releaseNames);
 };
 
 export const hasBeenReleased = async ({

--- a/release/src/release-notes.ts
+++ b/release/src/release-notes.ts
@@ -97,6 +97,10 @@ export async function publishRelease({
 
   const issues = await getMilestoneIssues({ version, github, owner, repo });
 
+  const isLatest: 'true' | 'false' = !isEnterpriseVersion(version) && await isLatestRelease({ version, github, owner, repo })
+    ? 'true'
+    : 'false';
+
   const payload = {
     owner,
     repo,
@@ -105,7 +109,7 @@ export async function publishRelease({
     body: generateReleaseNotes({ version, checksum, issues }),
     draft: true,
     prerelease: isRCVersion(version),
-    make_latest: await isLatestRelease({ version, github, owner, repo }),
+    make_latest: isLatest,
   };
 
   return github.rest.repos.createRelease(payload);

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -249,6 +249,13 @@ describe("version-helpers", () => {
       expect(isLatestVersion("v0.25.2", ["v0.25.2", "v0.25.1"])).toEqual(true);
     });
 
+    it("should return true for an equal release of ee/oss", () => {
+      // this is important because if we release 0.25.2 and 1.25.2 at the same time,
+      // they should both be "latest" - and one of them will always be tagged first
+      expect(isLatestVersion("v0.25.2", ["v1.25.2", "v0.25.1"])).toEqual(true);
+      expect(isLatestVersion("v1.25.2", ["v0.25.2", "v0.25.1"])).toEqual(true);
+    });
+
     it("should filter out invalid versions", () => {
       const trueCases: [string, string[]][] = [
         ["v0.25.2.1", ["v0.24", "v0.25.1", "99"]],


### PR DESCRIPTION
### Description

In the 48.0 release I noticed that 48.0 was properly marked latest for OSS, but not EE. This was because "latest" can mean different things in different contexts. 

For the purposes of pushing to s3 and dockerhub, there are 2 "latest" releases, enterprise and open source, both are latest at the same time. However, on the github releases page, there can only be on "latest" release, and this was confused in the code.  

- updates isLatestRelease to return true if it is a latest release of _either_ oss or ee (previously, this function was tailored for us only in github release notes, and only marked OSS releases as latest)
- added github-releases logic to the github release notes specific function
- updates github action to expect a boolean, rather than a string
- adds a unit test for a race condition between oss and ee
- adds a set of integration tests so `isLatestRelease` can really be tested

In a separate PR, I'll make these tests run in CI, they don't currently.

### How to verify

- [x] unit tests pass
- [x] integration tests pass
- [x] fork test: [latest release](https://github.com/iethree/metabase/actions/runs/7268078794/job/19803313071#step:7:36)
- [x] fork test: [not latest release](https://github.com/iethree/metabase/actions/runs/7267901861/job/19802759675#step:7:36)
