### PR TITLE
Adjust Malli enforcement to `log/warn` by default and throw in dev

### DIFF
--- a/src/metabase/util/malli/fn.clj
+++ b/src/metabase/util/malli/fn.clj
@@ -5,7 +5,9 @@
    [malli.core :as mc]
    [malli.destructure :as md]
    [malli.error :as me]
+   [metabase.config :as config]
    [metabase.shared.util.i18n :as i18n]
+   [metabase.util.log :as log]
    [metabase.util.malli.humanize :as mu.humanize]
    [metabase.util.malli.registry :as mr]))
 
@@ -148,17 +150,29 @@
 (defn- validate [error-context schema value error-type]
   (when *enforce*
     (when-let [error (mr/explain schema value)]
-      (let [humanized (me/humanize error)]
-        (throw (ex-info (case error-type
-                          ::invalid-input  (i18n/tru "Invalid input: {0}" (pr-str humanized))
-                          ::invalid-output (i18n/tru "Invalid output: {0}" (pr-str humanized)))
-                        (merge
-                         {:type      error-type
-                          :error     error
-                          :humanized humanized
-                          :schema    schema
-                          :value     value}
-                         error-context)))))))
+      (let [humanized (me/humanize error)
+            details   (merge
+                        {:type      error-type
+                         :error     error
+                         :humanized humanized
+                         :schema    schema
+                         :value     value}
+                        error-context)]
+        (if (or config/is-dev?
+              config/is-test?)
+          ;; In dev and test, throw an exception.
+          (throw (ex-info (case error-type
+                            ::invalid-input  (i18n/tru "Invalid input: {0}" (pr-str humanized))
+                            ::invalid-output (i18n/tru "Invalid output: {0}" (pr-str humanized)))
+                          details))
+          ;; In prod, log a warning.
+          (log/warn
+            (case error-type
+              ::invalid-input  (i18n/tru "Invalid input - Please report this as an issue on Github: {0}"
+                                         (pr-str humanized))
+              ::invalid-output (i18n/tru "Invalid output - Please report this as an issue on Github: {0}"
+                                         (pr-str humanized)))
+            details))))))
 
 (defn validate-input
   "Impl for [[metabase.util.malli.fn/fn]]; validates an input argument with `value` against `schema` using a cached


### PR DESCRIPTION
This changes the logic for `mu/defn` Malli validation errors to only throw in dev and test.
In prod, it will `log/warn` instead, with a message asking the user to file a bug.

This is in response to Malli errors breaking users on 48 because the QP is using MLv2 logic now.

Examples:
- #36841 (fixed in #36865 but still an instance of this pattern)
- #36893

We want to take these in as non-blocking P3 bugs so we can fix any gaps in the schema. But validation errors deep in
the QP are not caught nicely or recoverable, so it tends to completely break any use of these queries.

This is safe with respect to Malli use by the API in `defendpoint` and similar because those are explicit Malli calls,
it doesn't rely on `mu/defn` enforcement.
See `defendpoint` [here](https://github.com/metabase/metabase/blob/36975b68d7c6529002dc9bfdd558b17ca7ebf306/src/metabase/api/common/internal.clj#L316)
and the trigger [here](https://github.com/metabase/metabase/blob/ngoc-sync-partition-key/src/metabase/api/common.clj#L355).

I view this as a temporary measure to keep from breaking users with slightly-broken legacy queries and especially where
our schemas don't quite capture every legal combination.
