### PR TITLE
CSV appends: permissions checks

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -5,6 +5,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
    [metabase.api.database :as api.database]
+   [metabase.driver :as driver]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.models :refer [Dashboard DashboardCard Database Field FieldValues
                             Permissions Table]]
@@ -731,6 +732,74 @@
                       (upload-csv!)))))
             (with-all-users-data-perms {db-id {:data {:native :write, :schemas ["not_public"]}}}
               (is (some? (upload-csv!))))))))))
+
+(deftest append-csv-data-perms-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (if (driver/database-supports? driver/*driver* :schemas (mt/db))
+      (testing "CSV appends should be blocked without data access to the schema"
+        (mt/with-empty-db
+          (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec (mt/db)) "CREATE SCHEMA \"not_public\";")
+          (let [db-id       (u/the-id (mt/db))
+                table-a     (upload-test/create-upload-table! :schema-name "not_public")
+                table-b     (upload-test/create-upload-table! :schema-name "not_public")
+                append-csv! (fn []
+                              (upload-test/append-csv-with-defaults! :table-id (:id table-a), :user-id (mt/user->id :rasta)))]
+            (doseq [[schema-perms          can-append? test-string]
+                    [[:all                 true        "Data permissions on schema should succeed"]
+                     [:none                false       "No permissions on schema should fail"]
+                     [{(:id table-a) :all} true        "Data permissions on table should succeed"]
+                     [{(:id table-b) :all} false       "Data permissions only on another table in the same schema should fail"]]]
+              (testing test-string
+                (with-all-users-data-perms {db-id {:data {:native :none, :schemas {"public"     :all
+                                                                                   "not_public" schema-perms}}}}
+                  (if can-append?
+                    (is (some? (append-csv!)))
+                    (is (thrown-with-msg?
+                          clojure.lang.ExceptionInfo
+                          #"You don't have permissions to do that\."
+                          (append-csv!))))))))))
+      ;; else if the database doesn't support schemas
+      (testing "CSV appends should be blocked without data access to the database"
+        (mt/with-empty-db
+          (let [db-id       (u/the-id (mt/db))
+                table-a     (upload-test/create-upload-table!)
+                table-b     (upload-test/create-upload-table!)
+                append-csv! (fn [] (upload-test/append-csv-with-defaults! :table-id (:id table-a), :user-id (mt/user->id :rasta)))]
+            (doseq [[perms                 can-append? test-string]
+                    [[:all                 true        "Data permissions for database should succeed"]
+                     [:none                false       "No permissions for database should fail"]
+                     [{(:id table-a) :all} true        "Data permissions for table should succeed"]
+                     [{(:id table-b) :all} false       "Data permissions only for another table in the same database should fail"]]]
+              (testing test-string
+                (with-all-users-data-perms {db-id {:data {:native :none, :schemas {"" perms}}}}
+                  (if can-append?
+                    (is (some? (append-csv!)))
+                    (is (thrown-with-msg?
+                          clojure.lang.ExceptionInfo
+                          #"You don't have permissions to do that\."
+                          (append-csv!)))))))))))))
+
+(deftest append-csv-block-perms-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (testing "Appends should be blocked if the user has blocked data access to the database, unless they have native query editing perms too"
+      (mt/with-empty-db
+        (let [db-id       (u/the-id (mt/db))
+              table-a     (upload-test/create-upload-table!)
+              append-csv! (fn []
+                            (upload-test/append-csv-with-defaults!
+                             :table-id (:id table-a)
+                             :user-id (mt/user->id :rasta)))]
+          (doseq [[perms                              can-append? test-string]
+                  [[{:native :none,  :schemas :block} false       "With blocked perms it should fail"]
+                   [{:native :write, :schemas :block} true        "With native query editing and blocked perms it should succeed"]]]
+            (testing test-string
+              (with-all-users-data-perms {db-id {:data perms}}
+                (if can-append?
+                  (is (some? (append-csv!)))
+                  (is (thrown-with-msg?
+                        clojure.lang.ExceptionInfo
+                        #"You don't have permissions to do that\."
+                        (append-csv!))))))))))))
 
 (deftest get-database-can-upload-test
   (mt/test-drivers (disj (mt/normal-drivers-with-feature :uploads) :mysql) ; MySQL doesn't support schemas

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -742,7 +742,9 @@
           (let [db-id       (u/the-id (mt/db))
                 table-a     (upload-test/create-upload-table! :schema-name "not_public")
                 table-b     (upload-test/create-upload-table! :schema-name "not_public")
-                append-csv! #(upload-test/append-csv-with-defaults! :table-id (:id table-a), :user-id (mt/user->id :rasta))]
+                append-csv! #(upload-test/append-csv-with-defaults!
+                              :table-id (:id table-a)
+                              :user-id (mt/user->id :rasta))]
             (doseq [[schema-perms          can-append? test-string]
                     [[:all                 true        "Data permissions on schema should succeed"]
                      [:none                false       "No permissions on schema should fail"]
@@ -763,7 +765,9 @@
           (let [db-id       (u/the-id (mt/db))
                 table-a     (upload-test/create-upload-table!)
                 table-b     (upload-test/create-upload-table!)
-                append-csv! #(upload-test/append-csv-with-defaults! :table-id (:id table-a), :user-id (mt/user->id :rasta))]
+                append-csv! #(upload-test/append-csv-with-defaults!
+                              :table-id (:id table-a)
+                              :user-id (mt/user->id :rasta))]
             (doseq [[perms                 can-append? test-string]
                     [[:all                 true        "Data permissions for database should succeed"]
                      [:none                false       "No permissions for database should fail"]
@@ -784,10 +788,9 @@
       (mt/with-empty-db
         (let [db-id       (u/the-id (mt/db))
               table-a     (upload-test/create-upload-table!)
-              append-csv! (fn []
-                            (upload-test/append-csv-with-defaults!
-                             :table-id (:id table-a)
-                             :user-id (mt/user->id :rasta)))]
+              append-csv! #(upload-test/append-csv-with-defaults!
+                            :table-id (:id table-a)
+                            :user-id (mt/user->id :rasta))]
           (doseq [[perms                              can-append? test-string]
                   [[{:native :none,  :schemas :block} false       "With blocked perms it should fail"]
                    [{:native :write, :schemas :block} true        "With native query editing and blocked perms it should succeed"]]]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -742,8 +742,7 @@
           (let [db-id       (u/the-id (mt/db))
                 table-a     (upload-test/create-upload-table! :schema-name "not_public")
                 table-b     (upload-test/create-upload-table! :schema-name "not_public")
-                append-csv! (fn []
-                              (upload-test/append-csv-with-defaults! :table-id (:id table-a), :user-id (mt/user->id :rasta)))]
+                append-csv! #(upload-test/append-csv-with-defaults! :table-id (:id table-a), :user-id (mt/user->id :rasta))]
             (doseq [[schema-perms          can-append? test-string]
                     [[:all                 true        "Data permissions on schema should succeed"]
                      [:none                false       "No permissions on schema should fail"]
@@ -764,7 +763,7 @@
           (let [db-id       (u/the-id (mt/db))
                 table-a     (upload-test/create-upload-table!)
                 table-b     (upload-test/create-upload-table!)
-                append-csv! (fn [] (upload-test/append-csv-with-defaults! :table-id (:id table-a), :user-id (mt/user->id :rasta)))]
+                append-csv! #(upload-test/append-csv-with-defaults! :table-id (:id table-a), :user-id (mt/user->id :rasta))]
             (doseq [[perms                 can-append? test-string]
                     [[:all                 true        "Data permissions for database should succeed"]
                      [:none                false       "No permissions for database should fail"]

--- a/enterprise/backend/test/metabase_enterprise/upload_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/upload_test.clj
@@ -12,3 +12,9 @@
             (upload-test/upload-example-csv! {:grant-permission? false
                                               :schema-name       "not_public"
                                               :table-prefix      "uploaded_magic_"}))))))
+
+(deftest appends-disabled-for-sandboxed-user-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (met/with-gtaps-for-user :rasta {:gtaps {:venues {}}}
+      (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
+            (upload-test/append-csv-with-defaults! :user-id (mt/user->id :rasta)))))))

--- a/enterprise/backend/test/metabase_enterprise/upload_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/upload_test.clj
@@ -15,6 +15,11 @@
 
 (deftest appends-disabled-for-sandboxed-user-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (met/with-gtaps-for-user :rasta {:gtaps {:venues {}}}
-      (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
-            (upload-test/append-csv-with-defaults! :user-id (mt/user->id :rasta)))))))
+    (mt/dataset (mt/dataset-definition
+                 (mt/random-name)
+                 ["venues"
+                  [{:field-name "name" :base-type :type/Text}]
+                  [[]]])
+      (met/with-gtaps-for-user :rasta {:gtaps {:venues {}}}
+        (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
+              (upload-test/append-csv-with-defaults! :user-id (mt/user->id :rasta))))))))

--- a/enterprise/backend/test/metabase_enterprise/upload_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/upload_test.clj
@@ -19,7 +19,7 @@
                  (mt/random-name)
                  ["venues"
                   [{:field-name "name" :base-type :type/Text}]
-                  [[]]])
+                  [["something"]]])
       (met/with-gtaps-for-user :rasta {:gtaps {:venues {}}}
-        (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
-              (upload-test/append-csv-with-defaults! :user-id (mt/user->id :rasta))))))))
+          (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
+                (upload-test/append-csv-with-defaults! :user-id (mt/user->id :rasta))))))))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -606,7 +606,7 @@
         (ex-info (tru "The table must be an uploaded table.")
                  {:status-code 422})
 
-        (not (mi/can-write? table))
+        (not (mi/can-read? table))
         (ex-info (tru "You don''t have permissions to do that.")
                  {:status-code 403}))))
 

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1139,8 +1139,7 @@
   (try
     (mt/with-temporary-setting-values [uploads-enabled uploads-enabled]
       (mt/with-current-user user-id
-        (let [table-id (or table-id
-                         (:id (create-upload-table!)))]
+        (let [table-id (or table-id (:id (create-upload-table!)))]
           (t2/update! :model/Table table-id {:is_upload is-upload})
           (append-csv! {:table-id table-id
                         :file     file}))))


### PR DESCRIPTION
This PR will merge into the feature branch for Merge 1 of Milestone 0 [(PR)](https://github.com/metabase/metabase/pull/36640)

Epic: [Allow appending more data to CSV uploads](https://github.com/metabase/metabase/issues/35614)
[product doc](https://www.notion.so/metabase/Allow-appending-more-data-to-existing-CSV-uploads-f1f13864632d4cfd83522fce762890eb)
[eng doc](https://www.notion.so/metabase/Eng-Allow-appending-more-data-to-CSV-uploads-4c40e06fa64744c699588b8d8576e5df)

This PR implements the permissions checks required for appending CSV data to an existing upload table via the endpoint.

It corresponds to the following section of the eng doc ([block link](https://www.notion.so/metabase/Eng-Allow-appending-more-data-to-CSV-uploads-4c40e06fa64744c699588b8d8576e5df?pvs=4#473fd039820a4ab1bf1b4da51b97cbef)):

### Permissions errors (status: 403):
- Message: “You don’t have permissions to do that.”
- Same permissions checks as uploading a CSV (`POST /api/card/from-csv`) and unrestricted data permissions on the table
- [x]  Test: if user has block permissions: native query editing is required to upload CSV
- [x]  Test: if user doesn’t have unrestricted data permissions then upload fails
- [x]  Test: if the user does have unrestricted data permissions but no native query editing permissions then upload succeeds
- [x]  Test: if user is sandboxed then upload fails