### PR TITLE
Trend Charts — Add static number comparison

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -92,6 +92,31 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
       cy.findByText("vs. Jan:");
       cy.findByText("52,249.59");
     });
+
+    // static number
+    cy.findByTestId("chartsettings-sidebar").findByText("3 months ago").click();
+    menu().within(() => {
+      cy.findByText("Custom value…").click();
+
+      // Test the back button
+      cy.findByLabelText("Back").click();
+      cy.findByText("Custom value…").click();
+
+      cy.findByLabelText("Label").type("My Goal");
+      cy.findByLabelText("Value").type("{selectall}42000");
+      cy.button("Done").click();
+    });
+    cy.findByTestId("scalar-previous-value").within(() => {
+      cy.findByText("vs. my goal:").should("exist");
+      cy.findByText("42,000").should("exist"); // goal
+      cy.findByText("26.76%").should("exist"); // down percentage
+    });
+    cy.findByTestId("chartsettings-sidebar").findByText("My Goal").click();
+    menu().within(() => {
+      cy.findByLabelText("Back").should("exist");
+      cy.findByLabelText("Label").should("have.value", "My Goal");
+      cy.findByLabelText("Value").should("have.value", "42000");
+    });
   });
 
   it("should allow display settings to be changed and display should reflect changes", () => {

--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -183,32 +183,6 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     cy.findByTestId("scalar-container").findByText("Woah: 68’800.0000% ! cool");
   });
 
-  it("should have data settings disabled if only one option to choose from", () => {
-    // create native question with irregular time periods
-    cy.createNativeQuestion(
-      {
-        name: "13710",
-        native: {
-          query:
-            "SELECT '2026-03-01'::date as date, 22 as \"Value\"\nUNION ALL\nSELECT '2026-04-01'::date, 44\nUNION ALL\nSELECT '2026-06-04'::date, 41",
-        },
-        display: "smartscalar",
-      },
-      { visitQuestion: true },
-    );
-
-    cy.findByTestId("viz-settings-button").click();
-    cy.findByTestId("chartsettings-sidebar").findByText("Data").click();
-
-    cy.findByTestId("chartsettings-sidebar").within(() => {
-      // only one primary number option
-      cy.findByTestId("select-button").should("be.disabled");
-
-      // only one comparison option
-      cy.findByTestId("comparisons-widget-button").should("be.disabled");
-    });
-  });
-
   it("should work regardless of column order (metabase#13710)", () => {
     cy.createQuestion(
       {

--- a/frontend/src/metabase-types/api/visualization-settings.ts
+++ b/frontend/src/metabase-types/api/visualization-settings.ts
@@ -9,7 +9,7 @@ type SmartScalarComparisonPreviousPeriod = {
 type SmartScalarComparisonCompareToPrevious = {
   type: "previousValue";
 };
-export type SelectedComparisonStaticNumber = {
+export type SmartScalarComparisonStaticNumber = {
   type: "staticNumber";
   value: number;
   label: string;
@@ -19,4 +19,4 @@ export type SmartScalarComparison =
   | SmartScalarComparisonCompareToPrevious
   | SmartScalarComparisonPreviousPeriod
   | SmartScalarComparisonPeriodsAgo
-  | SelectedComparisonStaticNumber;
+  | SmartScalarComparisonStaticNumber;

--- a/frontend/src/metabase-types/api/visualization-settings.ts
+++ b/frontend/src/metabase-types/api/visualization-settings.ts
@@ -9,8 +9,14 @@ type SmartScalarComparisonPreviousPeriod = {
 type SmartScalarComparisonCompareToPrevious = {
   type: "previousValue";
 };
+export type SelectedComparisonStaticNumber = {
+  type: "staticNumber";
+  value: number;
+  label: string;
+};
 
 export type SmartScalarComparison =
   | SmartScalarComparisonCompareToPrevious
   | SmartScalarComparisonPreviousPeriod
-  | SmartScalarComparisonPeriodsAgo;
+  | SmartScalarComparisonPeriodsAgo
+  | SelectedComparisonStaticNumber;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/MenuItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/MenuItem.styled.tsx
@@ -1,5 +1,5 @@
-import styled from "@emotion/styled";
 import type { HTMLAttributes } from "react";
+import styled from "@emotion/styled";
 import type { MenuItemProps } from "metabase/ui";
 import { Menu } from "metabase/ui";
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
@@ -8,3 +8,7 @@ type DoneButtonProps = ButtonProps & HTMLAttributes<HTMLButtonElement>;
 export const DoneButton = styled(Button)<DoneButtonProps>`
   align-self: flex-end;
 `;
+
+DoneButton.defaultProps = {
+  variant: "filled",
+};

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
@@ -1,0 +1,10 @@
+import type { HTMLAttributes } from "react";
+import styled from "@emotion/styled";
+import type { ButtonProps } from "metabase/ui";
+import { Button } from "metabase/ui";
+
+type DoneButtonProps = ButtonProps & HTMLAttributes<HTMLButtonElement>;
+
+export const DoneButton = styled(Button)<DoneButtonProps>`
+  align-self: flex-end;
+`;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -2,10 +2,7 @@ import { useCallback, useState } from "react";
 import _ from "underscore";
 import { Icon } from "metabase/core/components/Icon";
 import { Button, Menu, Stack, Text } from "metabase/ui";
-import type {
-  SmartScalarComparison,
-  SmartScalarComparisonStaticNumber,
-} from "metabase-types/api";
+import type { SmartScalarComparison } from "metabase-types/api";
 import { COMPARISON_TYPES } from "../constants";
 import type { ComparisonMenuOption } from "../types";
 import { PeriodsAgoMenuOption } from "./PeriodsAgoMenuOption";
@@ -80,7 +77,11 @@ export function SmartScalarComparisonWidget({
       <Menu.Dropdown miw="18.25rem">
         {tab === "staticNumber" ? (
           <StaticNumberForm
-            value={selectedValue as SmartScalarComparisonStaticNumber}
+            value={
+              selectedValue.type === COMPARISON_TYPES.STATIC_NUMBER
+                ? selectedValue
+                : undefined
+            }
             onChange={nextValue => {
               onChange(nextValue);
               setOpen(false);

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -4,7 +4,7 @@ import { Icon } from "metabase/core/components/Icon";
 import { Button, Menu, Stack, Text } from "metabase/ui";
 import type {
   SmartScalarComparison,
-  SelectedComparisonStaticNumber,
+  SmartScalarComparisonStaticNumber,
 } from "metabase-types/api";
 import { COMPARISON_TYPES } from "../constants";
 import type { ComparisonMenuOption } from "../types";
@@ -80,7 +80,7 @@ export function SmartScalarComparisonWidget({
       <Menu.Dropdown miw="18.25rem">
         {tab === "staticNumber" ? (
           <StaticNumberForm
-            value={selectedValue as SelectedComparisonStaticNumber}
+            value={selectedValue as SmartScalarComparisonStaticNumber}
             onChange={nextValue => {
               onChange(nextValue);
               setOpen(false);

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -2,11 +2,14 @@ import { useCallback, useState } from "react";
 import _ from "underscore";
 import { Icon } from "metabase/core/components/Icon";
 import { Button, Menu, Stack, Text } from "metabase/ui";
-import { isEmpty } from "metabase/lib/validate";
-import type { SmartScalarComparison } from "metabase-types/api";
+import type {
+  SmartScalarComparison,
+  SelectedComparisonStaticNumber,
+} from "metabase-types/api";
 import { COMPARISON_TYPES } from "../constants";
 import type { ComparisonMenuOption } from "../types";
 import { PeriodsAgoMenuOption } from "./PeriodsAgoMenuOption";
+import { StaticNumberForm } from "./StaticNumberForm";
 import { MenuItemStyled } from "./MenuItem.styled";
 
 type SmartScalarComparisonWidgetProps = {
@@ -15,16 +18,25 @@ type SmartScalarComparisonWidgetProps = {
   value: SmartScalarComparison;
 };
 
+type Tab = "staticNumber" | null;
+
 export function SmartScalarComparisonWidget({
   onChange: onChange,
   options,
   value: selectedValue,
 }: SmartScalarComparisonWidgetProps) {
   const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<Tab>(getTabForValue(selectedValue));
   const [editedValue, setEditedValue] = useState(selectedValue);
 
+  const selectedOption = options.find(
+    ({ type }) => type === selectedValue.type,
+  );
+
+  const isDisabled = options.length === 1;
+
   const handleEditedValueChange: HandleEditedValueChangeType = useCallback(
-    (value: SmartScalarComparison, shouldSubmit: boolean = false) => {
+    (value: SmartScalarComparison, shouldSubmit = false) => {
       setEditedValue(value);
 
       if (shouldSubmit) {
@@ -35,61 +47,82 @@ export function SmartScalarComparisonWidget({
     [onChange, setEditedValue, setOpen],
   );
 
-  const handleClose = useCallback(() => {
-    if (_.isEqual(selectedValue, editedValue)) {
-      return;
+  const handleMenuStateChange = (isOpen: boolean) => {
+    if (isOpen) {
+      setTab(getTabForValue(selectedValue));
+    } else if (!_.isEqual(selectedValue, editedValue)) {
+      onChange(editedValue);
     }
-
-    onChange(editedValue);
-  }, [editedValue, onChange, selectedValue]);
-
-  const selectedOption = options.find(
-    ({ type }) => type === selectedValue.type,
-  );
-
-  const selectedDisplayName =
-    selectedValue.type === COMPARISON_TYPES.PERIODS_AGO
-      ? `${selectedValue.value ?? ""} ${selectedOption?.name}`
-      : selectedOption?.name;
-
-  const isDisabled = options.length === 1 && !isEmpty(selectedOption);
+    setOpen(isOpen);
+  };
 
   return (
     <Menu
       opened={open}
-      onChange={setOpen}
-      onClose={handleClose}
+      onChange={handleMenuStateChange}
       position="bottom-start"
       shadow="sm"
       closeOnItemClick={false}
     >
       <Menu.Target>
         <Button
-          data-testid="comparisons-widget-button"
-          styles={{ inner: { justifyContent: "space-between" } }}
+          disabled={isDisabled}
           rightIcon={<Icon name="chevrondown" size="12" />}
           px="1rem"
           fullWidth
-          disabled={isDisabled}
+          data-testid="comparisons-widget-button"
+          styles={{ inner: { justifyContent: "space-between" } }}
         >
-          {selectedDisplayName}
+          {getDisplayName(selectedValue, selectedOption)}
         </Button>
       </Menu.Target>
 
       <Menu.Dropdown miw="18.25rem">
-        <Stack spacing="sm">
-          {options.map(optionArgs =>
-            renderMenuOption({
-              editedValue,
-              optionArgs,
-              onChange: handleEditedValueChange,
-              selectedValue,
-            }),
-          )}
-        </Stack>
+        {tab === "staticNumber" ? (
+          <StaticNumberForm
+            value={selectedValue as SelectedComparisonStaticNumber}
+            onChange={nextValue => {
+              onChange(nextValue);
+              setOpen(false);
+            }}
+            onBack={() => setTab(null)}
+          />
+        ) : (
+          <Stack spacing="sm">
+            {options.map(optionArgs =>
+              renderMenuOption({
+                editedValue,
+                selectedValue,
+                optionArgs,
+                onChange: handleEditedValueChange,
+                onChangeTab: setTab,
+              }),
+            )}
+          </Stack>
+        )}
       </Menu.Dropdown>
     </Menu>
   );
+}
+
+function getTabForValue(value: SmartScalarComparison): Tab {
+  if (value.type === COMPARISON_TYPES.STATIC_NUMBER) {
+    return "staticNumber";
+  }
+  return null;
+}
+
+function getDisplayName(
+  value: SmartScalarComparison,
+  option?: ComparisonMenuOption,
+) {
+  if (value.type === COMPARISON_TYPES.PERIODS_AGO) {
+    return `${value.value} ${option?.name}`;
+  }
+  if (value.type === COMPARISON_TYPES.STATIC_NUMBER) {
+    return value.label;
+  }
+  return option?.name;
 }
 
 export type HandleEditedValueChangeType = (
@@ -99,18 +132,22 @@ export type HandleEditedValueChangeType = (
 
 type RenderMenuOptionProps = {
   editedValue: SmartScalarComparison;
-  onChange: HandleEditedValueChangeType;
-  optionArgs: ComparisonMenuOption;
   selectedValue: SmartScalarComparison;
+  optionArgs: ComparisonMenuOption;
+  onChange: HandleEditedValueChangeType;
+  onChangeTab: (tab: Tab) => void;
 };
 
 function renderMenuOption({
   editedValue,
-  onChange,
-  optionArgs,
   selectedValue,
+  optionArgs,
+  onChange,
+  onChangeTab,
 }: RenderMenuOptionProps) {
   const { type, name } = optionArgs;
+
+  const isSelected = selectedValue.type === type;
 
   if (type === COMPARISON_TYPES.PERIODS_AGO) {
     const { maxValue } = optionArgs;
@@ -118,7 +155,7 @@ function renderMenuOption({
     return (
       <PeriodsAgoMenuOption
         key={type}
-        aria-selected={selectedValue.type === type}
+        aria-selected={isSelected}
         type={type}
         name={name}
         onChange={onChange}
@@ -128,16 +165,16 @@ function renderMenuOption({
     );
   }
 
-  const handleSimpleMenuItemClick = () => {
-    onChange({ type }, true);
+  const handleClick = () => {
+    if (type === COMPARISON_TYPES.STATIC_NUMBER) {
+      onChangeTab("staticNumber");
+    } else {
+      onChange({ type }, true);
+    }
   };
 
   return (
-    <MenuItemStyled
-      key={type}
-      aria-selected={selectedValue.type === type}
-      onClick={handleSimpleMenuItemClick}
-    >
+    <MenuItemStyled key={type} aria-selected={isSelected} onClick={handleClick}>
       <Text fw="bold" ml="0.5rem">
         {name}
       </Text>

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -46,6 +46,7 @@ export function SmartScalarComparisonWidget({
 
   const handleMenuStateChange = (isOpen: boolean) => {
     if (isOpen) {
+      setEditedValue(selectedValue);
       setTab(getTabForValue(selectedValue));
     } else if (!_.isEqual(selectedValue, editedValue)) {
       onChange(editedValue);

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { t } from "ttag";
 import {
   Box,
-  Flex,
+  Group,
   NumberInput,
   PopoverBackButton,
   Stack,
@@ -53,7 +53,7 @@ export function StaticNumberForm({
         <PopoverBackButton
           onClick={onBack}
         >{t`Custom value`}</PopoverBackButton>
-        <Flex gap="sm">
+        <Group spacing="sm">
           <TextInput
             autoFocus
             value={label}
@@ -66,7 +66,7 @@ export function StaticNumberForm({
             label={t`Value`}
             onChange={handleChangeValue}
           />
-        </Flex>
+        </Group>
         <DoneButton
           type="submit"
           variant="filled"

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent } from "react";
+import type { ChangeEvent, FormEvent } from "react";
 import { useState } from "react";
 import { t } from "ttag";
 import {
@@ -29,7 +29,7 @@ export function StaticNumberForm({
 
   const canSubmit = label.length > 0;
 
-  const handleChangeLabel = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeLabel = (e: ChangeEvent<HTMLInputElement>) => {
     setLabel(e.target.value);
   };
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
@@ -14,18 +14,18 @@ import { COMPARISON_TYPES } from "../constants";
 import { DoneButton } from "./SmartScalarSettingsWidgets.styled";
 
 interface StaticNumberFormProps {
-  value: Partial<SmartScalarComparisonStaticNumber>;
+  value?: SmartScalarComparisonStaticNumber;
   onChange: (setting: SmartScalarComparisonStaticNumber) => void;
   onBack: () => void;
 }
 
 export function StaticNumberForm({
-  value: selectedValue,
+  value: comparison,
   onChange,
   onBack,
 }: StaticNumberFormProps) {
-  const [label, setLabel] = useState(selectedValue.label || "");
-  const [value, setValue] = useState(selectedValue.value || 0);
+  const [label, setLabel] = useState(comparison?.label || "");
+  const [value, setValue] = useState(comparison?.value || 0);
 
   const canSubmit = label.length > 0;
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   NumberInput,
   PopoverBackButton,
+  Stack,
   TextInput,
 } from "metabase/ui";
 import type { SmartScalarComparisonStaticNumber } from "metabase-types/api";
@@ -48,7 +49,7 @@ export function StaticNumberForm({
 
   return (
     <Box component="form" onSubmit={handleSubmit}>
-      <Flex direction="column" align="flex-start" gap="lg">
+      <Stack align="flex-start" spacing="lg">
         <PopoverBackButton
           onClick={onBack}
         >{t`Custom value`}</PopoverBackButton>
@@ -71,7 +72,7 @@ export function StaticNumberForm({
           variant="filled"
           disabled={!canSubmit}
         >{t`Done`}</DoneButton>
-      </Flex>
+      </Stack>
     </Box>
   );
 }

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
@@ -67,11 +67,7 @@ export function StaticNumberForm({
             onChange={handleChangeValue}
           />
         </Group>
-        <DoneButton
-          type="submit"
-          variant="filled"
-          disabled={!canSubmit}
-        >{t`Done`}</DoneButton>
+        <DoneButton type="submit" disabled={!canSubmit}>{t`Done`}</DoneButton>
       </Stack>
     </Box>
   );

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
@@ -1,0 +1,77 @@
+import type { FormEvent } from "react";
+import { useState } from "react";
+import { t } from "ttag";
+import {
+  Box,
+  Flex,
+  NumberInput,
+  PopoverBackButton,
+  TextInput,
+} from "metabase/ui";
+import type { SelectedComparisonStaticNumber } from "metabase-types/api";
+import { COMPARISON_TYPES } from "../constants";
+import { DoneButton } from "./SmartScalarSettingsWidgets.styled";
+
+interface StaticNumberFormProps {
+  value: Partial<SelectedComparisonStaticNumber>;
+  onChange: (setting: SelectedComparisonStaticNumber) => void;
+  onBack: () => void;
+}
+
+export function StaticNumberForm({
+  value: selectedValue,
+  onChange,
+  onBack,
+}: StaticNumberFormProps) {
+  const [label, setLabel] = useState(selectedValue.label || "");
+  const [value, setValue] = useState(selectedValue.value || 0);
+
+  const canSubmit = label.length > 0;
+
+  const handleChangeLabel = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setLabel(e.target.value);
+  };
+
+  const handleChangeValue = (nextValue: number | "") => {
+    setValue(nextValue || 0);
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+
+    onChange({
+      type: COMPARISON_TYPES.STATIC_NUMBER,
+      label,
+      value,
+    });
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit}>
+      <Flex direction="column" align="flex-start" gap="lg">
+        <PopoverBackButton
+          onClick={onBack}
+        >{t`Custom value`}</PopoverBackButton>
+        <Flex gap="sm">
+          <TextInput
+            autoFocus
+            value={label}
+            label={t`Label`}
+            onChange={handleChangeLabel}
+            data-autofocus
+          />
+          <NumberInput
+            value={value}
+            label={t`Value`}
+            onChange={handleChangeValue}
+          />
+        </Flex>
+        <DoneButton
+          type="submit"
+          variant="filled"
+          disabled={!canSubmit}
+        >{t`Done`}</DoneButton>
+      </Flex>
+    </Box>
+  );
+}

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
@@ -8,13 +8,13 @@ import {
   PopoverBackButton,
   TextInput,
 } from "metabase/ui";
-import type { SelectedComparisonStaticNumber } from "metabase-types/api";
+import type { SmartScalarComparisonStaticNumber } from "metabase-types/api";
 import { COMPARISON_TYPES } from "../constants";
 import { DoneButton } from "./SmartScalarSettingsWidgets.styled";
 
 interface StaticNumberFormProps {
-  value: Partial<SelectedComparisonStaticNumber>;
-  onChange: (setting: SelectedComparisonStaticNumber) => void;
+  value: Partial<SmartScalarComparisonStaticNumber>;
+  onChange: (setting: SmartScalarComparisonStaticNumber) => void;
   onBack: () => void;
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
@@ -100,6 +100,10 @@ function computeComparison({ currentMetricData, series, settings }) {
     });
   }
 
+  if (type === COMPARISON_TYPES.STATIC_NUMBER) {
+    return computeTrendStaticValue({ settings });
+  }
+
   throw Error("Invalid comparison type specified");
 }
 
@@ -172,6 +176,14 @@ function getCurrentMetricData({ series, insights, settings }) {
       latestRowIndex,
     },
     value,
+  };
+}
+
+function computeTrendStaticValue({ settings }) {
+  const { value, label } = settings["scalar.comparisons"];
+  return {
+    comparisonDescStr: t`vs. ${label.toLowerCase()}`,
+    comparisonValue: value,
   };
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.unit.spec.js
@@ -1084,8 +1084,8 @@ describe("SmartScalar > compute", () => {
         ];
 
         const cols = [
-          DateTimeColumn({ name: "Month" }),
-          NumberColumn({ name: "Count" }),
+          createMockDateTimeColumn({ name: "Month" }),
+          createMockNumberColumn({ name: "Count" }),
         ];
 
         const testCases = [

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/constants.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/constants.ts
@@ -18,4 +18,5 @@ export const COMPARISON_TYPES = {
   PREVIOUS_VALUE: "previousValue",
   PREVIOUS_PERIOD: "previousPeriod",
   PERIODS_AGO: "periodsAgo",
+  STATIC_NUMBER: "staticNumber",
 } as const;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/types.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/types.ts
@@ -16,7 +16,6 @@ type PeriodsAgoMenuOption = {
 type StaticNumberMenuOption = {
   type: typeof COMPARISON_TYPES.STATIC_NUMBER;
   name: string;
-  label: string;
 };
 export type ComparisonMenuOption =
   | PreviousValueMenuOption

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/types.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/types.ts
@@ -13,7 +13,13 @@ type PeriodsAgoMenuOption = {
   name: string;
   maxValue: number;
 };
+type StaticNumberMenuOption = {
+  type: typeof COMPARISON_TYPES.STATIC_NUMBER;
+  name: string;
+  label: string;
+};
 export type ComparisonMenuOption =
   | PreviousValueMenuOption
   | PreviousPeriodMenuOption
-  | PeriodsAgoMenuOption;
+  | PeriodsAgoMenuOption
+  | StaticNumberMenuOption;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -93,6 +93,10 @@ export const COMPARISON_SELECTOR_OPTIONS = {
     type: COMPARISON_TYPES.PREVIOUS_VALUE,
     name: t`Previous value`,
   },
+  STATIC_NUMBER: {
+    type: COMPARISON_TYPES.STATIC_NUMBER,
+    name: t`Custom value…`,
+  },
 } as const;
 
 export function getDefaultComparison(
@@ -164,6 +168,7 @@ export function getComparisonOptions(
 
   options.push(
     createComparisonMenuOption({ type: COMPARISON_TYPES.PREVIOUS_VALUE }),
+    createComparisonMenuOption({ type: COMPARISON_TYPES.STATIC_NUMBER }),
   );
 
   return options;
@@ -247,6 +252,9 @@ type GetComparisonMenuOptionParameters =
       type: typeof COMPARISON_TYPES.PERIODS_AGO;
       maxValue: number;
       dateUnit: RelativeDatetimeUnit;
+    }
+  | {
+      type: typeof COMPARISON_TYPES.STATIC_NUMBER;
     };
 
 function createComparisonMenuOption(
@@ -271,6 +279,11 @@ function createComparisonMenuOption(
       name: formatPeriodsAgoOptionName(dateUnit),
       maxValue,
     };
+  }
+
+  if (type === COMPARISON_TYPES.STATIC_NUMBER) {
+    const { name } = COMPARISON_SELECTOR_OPTIONS.STATIC_NUMBER;
+    return { type, name };
   }
 
   return COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -280,8 +280,7 @@ function createComparisonMenuOption(
   }
 
   if (type === COMPARISON_TYPES.STATIC_NUMBER) {
-    const { name } = COMPARISON_SELECTOR_OPTIONS.STATIC_NUMBER;
-    return { type, name };
+    return COMPARISON_SELECTOR_OPTIONS.STATIC_NUMBER;
   }
 
   return COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -135,29 +135,25 @@ export function getComparisonOptions(
     },
   ] = series;
 
+  const options: ComparisonMenuOption[] = [
+    createComparisonMenuOption({ type: COMPARISON_TYPES.PREVIOUS_VALUE }),
+    createComparisonMenuOption({ type: COMPARISON_TYPES.STATIC_NUMBER }),
+  ];
+
   const dateUnit = insights?.find(
     insight => insight.col === settings["scalar.field"],
   )?.unit;
 
   if (!dateUnit) {
-    return [
-      createComparisonMenuOption({ type: COMPARISON_TYPES.PREVIOUS_VALUE }),
-    ];
+    return options;
   }
-
-  const options: ComparisonMenuOption[] = [
-    createComparisonMenuOption({
-      type: COMPARISON_TYPES.PREVIOUS_PERIOD,
-      dateUnit,
-    }),
-  ];
 
   const maxPeriodsAgo = getMaxPeriodsAgo({ cols, rows, dateUnit });
 
   // only add this option is # number of selectable periods ago is >= 2
   // since we already have an option for 1 period ago -> PREVIOUS_PERIOD
   if (maxPeriodsAgo && maxPeriodsAgo >= 2) {
-    options.push(
+    options.unshift(
       createComparisonMenuOption({
         type: COMPARISON_TYPES.PERIODS_AGO,
         dateUnit,
@@ -166,9 +162,11 @@ export function getComparisonOptions(
     );
   }
 
-  options.push(
-    createComparisonMenuOption({ type: COMPARISON_TYPES.PREVIOUS_VALUE }),
-    createComparisonMenuOption({ type: COMPARISON_TYPES.STATIC_NUMBER }),
+  options.unshift(
+    createComparisonMenuOption({
+      type: COMPARISON_TYPES.PREVIOUS_PERIOD,
+      dateUnit,
+    }),
   );
 
   return options;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -176,16 +176,21 @@ export function isComparisonValid(
   series: RawSeries,
   settings: VisualizationSettings,
 ) {
+  const comparison = settings["scalar.comparisons"];
+  const comparisonType = comparison?.type;
+
   const [
     {
       data: { insights },
     },
   ] = series;
 
-  if (
-    settings["scalar.comparisons"]?.type === COMPARISON_TYPES.PREVIOUS_VALUE
-  ) {
+  if (comparisonType === COMPARISON_TYPES.PREVIOUS_VALUE) {
     return true;
+  }
+
+  if (comparisonType === COMPARISON_TYPES.STATIC_NUMBER) {
+    return !isEmpty(comparison?.value) && !isEmpty(comparison?.label);
   }
 
   const dateUnit = insights?.find(

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
@@ -96,7 +96,7 @@ describe("SmartScalar > utils", () => {
         "scalar.field": FIELD_NAME,
       };
 
-      it("should return only previousValue option if no dateUnit", () => {
+      it("should not return 'periods ago' or `previous period` option if no dateUnit", () => {
         const rows = [
           ["2019-10-01", 100],
           ["2019-11-01", 300],
@@ -108,6 +108,7 @@ describe("SmartScalar > utils", () => {
 
         expect(comparisonOptions).toEqual([
           COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE,
+          COMPARISON_SELECTOR_OPTIONS.STATIC_NUMBER,
         ]);
       });
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
@@ -95,6 +95,7 @@ describe("SmartScalar > utils", () => {
       const settings = {
         "scalar.field": FIELD_NAME,
       };
+
       it("should return only previousValue option if no dateUnit", () => {
         const rows = [
           ["2019-10-01", 100],
@@ -110,7 +111,7 @@ describe("SmartScalar > utils", () => {
         ]);
       });
 
-      it("should return only previousValue and previousPeriod if dateUnit is supplied but dataset only ranges 1 period in the past", () => {
+      it("should not return 'periods ago' if dateUnit is supplied but dataset only ranges 1 period in the past", () => {
         const rows = [
           ["2019-10-01", 100],
           ["2019-11-01", 300],
@@ -128,6 +129,7 @@ describe("SmartScalar > utils", () => {
             name: "Previous month",
           },
           COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE,
+          COMPARISON_SELECTOR_OPTIONS.STATIC_NUMBER,
         ]);
       });
 
@@ -156,6 +158,7 @@ describe("SmartScalar > utils", () => {
             maxValue: 3,
           },
           COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE,
+          COMPARISON_SELECTOR_OPTIONS.STATIC_NUMBER,
         ]);
       });
     });


### PR DESCRIPTION
Closes #35552

Adds "static number" comparison type for trend charts

### How to verify

1. New > Question > Raw Data > Sample Database > Products
2. Summarize Count by Created At
3. Set visualization to "trend"
4. Visualization settings > Data tab > Comparisons > Custom Value
5. Try different values for "Label" and "Value" and ensure the chart calculates and displays the change as expected

### Demo

https://github.com/metabase/metabase/assets/17258145/1c41e00d-05a8-44be-8f4f-4f3a746f8914

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
