### PR TITLE
Stress test EE specs by default, and add mb_edition input

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -15,6 +15,10 @@ on:
         description: 'Grep and filter tests to run in isolation'
         type: string
         required: false
+      mb_edition:
+        description: 'set MB_EDITION env var to "ee" (enteprise) or "oss" (open-source, default)'
+        type: string
+        required: false
 
 jobs:
   workflow-summary:
@@ -44,6 +48,7 @@ jobs:
       CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
+      MB_EDITION: ${{ inputs.mb_edition }}
       TERM: xterm
       TZ: US/Pacific # to make node match the instance tz
     steps:

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -16,7 +16,7 @@ on:
         type: string
         required: false
       mb_edition:
-        description: 'set MB_EDITION env var to "ee" (enteprise) or "oss" (open-source, default)'
+        description: 'Set MB_EDITION env var to "ee" (enteprise) or "oss" (open-source)'
         type: string
         required: false
         default: "ee"

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -19,6 +19,7 @@ on:
         description: 'set MB_EDITION env var to "ee" (enteprise) or "oss" (open-source, default)'
         type: string
         required: false
+        default: "ee"
 
 jobs:
   workflow-summary:


### PR DESCRIPTION
We need a way to stress test EE specs