### PR TITLE
waterfall color setting

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -154,6 +154,12 @@ export type VisualizationSettings = {
   // Scatter plot settings
   "scatter.bubble"?: string; // col name
 
+  // Waterfall settings
+  "waterfall.increase_color"?: string;
+  "waterfall.decrease_color"?: string;
+  "waterfall.total_color"?: string;
+  "waterfall.show_total"?: boolean;
+
   // Funnel settings
   "funnel.rows"?: SeriesOrderSetting[];
 

--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -36,7 +36,7 @@ import {
 import { getDimensionModel } from "metabase/visualizations/echarts/cartesian/model/series";
 import type { LegacySeriesSettingsObjectKey } from "metabase/visualizations/echarts/cartesian/model/types";
 
-const fillWithDefaultValue = (
+export const fillWithDefaultValue = (
   settings: Record<string, unknown>,
   key: string,
   defaultValue: unknown,

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.stories.tsx
@@ -125,3 +125,10 @@ StartsBelowZeroCrossesEndsBelow.args = {
   dashcardSettings: {},
   renderingContext,
 };
+
+export const CustomColors = Template.bind({});
+CustomColors.args = {
+  rawSeries: data.customColors as any,
+  dashcardSettings: {},
+  renderingContext,
+};

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.tsx
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.tsx
@@ -5,7 +5,7 @@ import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 import { getWaterfallOption } from "metabase/visualizations/echarts/cartesian/waterfall/option";
 import { getWaterfallChartModel } from "metabase/visualizations/echarts/cartesian/waterfall/model";
 
-import { computeStaticComboChartSettings } from "../ComboChart/settings";
+import { computeStaticWaterfallChartSettings } from "./settings";
 
 const WIDTH = 540;
 const HEIGHT = 360;
@@ -17,7 +17,7 @@ export function WaterfallChart({
   width = WIDTH,
   height = HEIGHT,
 }: IsomorphicStaticChartProps) {
-  const computedVisualizationSettings = computeStaticComboChartSettings(
+  const computedVisualizationSettings = computeStaticWaterfallChartSettings(
     rawSeries,
     dashcardSettings,
     renderingContext,

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/settings.ts
@@ -1,0 +1,47 @@
+import type { RawSeries, VisualizationSettings } from "metabase-types/api";
+import type {
+  ComputedVisualizationSettings,
+  RenderingContext,
+} from "metabase/visualizations/types";
+
+import {
+  getDefaultDecreaseColor,
+  getDefaultIncreaseColor,
+  getDefaultShowTotal,
+  getDefaultTotalColor,
+} from "metabase/visualizations/shared/settings/waterfall";
+import {
+  computeStaticComboChartSettings,
+  fillWithDefaultValue,
+} from "../ComboChart/settings";
+
+export function computeStaticWaterfallChartSettings(
+  rawSeries: RawSeries,
+  dashcardSettings: VisualizationSettings,
+  renderingContext: RenderingContext,
+): ComputedVisualizationSettings {
+  const settings = computeStaticComboChartSettings(
+    rawSeries,
+    dashcardSettings,
+    renderingContext,
+  );
+
+  fillWithDefaultValue(
+    settings,
+    "waterfall.increase_color",
+    getDefaultIncreaseColor(renderingContext),
+  );
+  fillWithDefaultValue(
+    settings,
+    "waterfall.decrease_color",
+    getDefaultDecreaseColor(renderingContext),
+  );
+  fillWithDefaultValue(
+    settings,
+    "waterfall.total_color",
+    getDefaultTotalColor(renderingContext),
+  );
+  fillWithDefaultValue(settings, "waterfall.show_total", getDefaultShowTotal());
+
+  return settings;
+}

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/custom-colors.json
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/custom-colors.json
@@ -1,0 +1,307 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 162,
+      "result_metadata": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1546, null],
+          "effective_type": "type/BigInteger",
+          "id": 1546,
+          "visibility_type": "normal",
+          "display_name": "_mb_row_id",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "name": "category",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1547, null],
+          "effective_type": "type/Text",
+          "id": 1547,
+          "visibility_type": "normal",
+          "display_name": "Category",
+          "fingerprint": {
+            "global": { "distinct-count": 6, "nil%": 0 },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 1
+              }
+            }
+          },
+          "base_type": "type/Text"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "coercion_strategy": null,
+          "name": "change",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1548, null],
+          "effective_type": "type/BigInteger",
+          "id": 1548,
+          "visibility_type": "normal",
+          "display_name": "Change",
+          "fingerprint": {
+            "global": { "distinct-count": 6, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": -4,
+                "q1": -2,
+                "q3": 6,
+                "max": 8,
+                "sd": 4.9396356140913875,
+                "avg": 2
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "include_xls": false,
+      "database_id": 2,
+      "enable_embedding": false,
+      "collection_id": 10,
+      "query_type": "query",
+      "name": "Waterfall Custom Colors",
+      "creator_id": 1,
+      "updated_at": "2023-12-19T21:21:52.580391Z",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "type": "query",
+        "database": 2,
+        "query": { "source-table": "card__159" }
+      },
+      "id": 183,
+      "parameter_mappings": [],
+      "include_csv": false,
+      "display": "waterfall",
+      "entity_id": "NdsnmA1s07NH6M5Tfh-LK",
+      "collection_preview": true,
+      "visualization_settings": {
+        "graph.dimensions": ["category"],
+        "graph.series_order_dimension": null,
+        "graph.series_order": null,
+        "waterfall.increase_color": "#8A5EB0",
+        "waterfall.decrease_color": "#F7C41F",
+        "waterfall.total_color": "#69C8C8",
+        "graph.metrics": ["change"]
+      },
+      "metabase_version": "v1.47.1-SNAPSHOT (b37c32d)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2023-12-19T21:21:01.645077Z",
+      "public_uuid": null
+    },
+    "data": {
+      "results_timezone": "America/Los_Angeles",
+      "download_perms": "full",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": null,
+            "semantic_type": "type/PK",
+            "coercion_strategy": null,
+            "name": "_mb_row_id",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1546, null],
+            "effective_type": "type/BigInteger",
+            "id": 1546,
+            "visibility_type": "normal",
+            "display_name": "_mb_row_id",
+            "fingerprint": null,
+            "base_type": "type/BigInteger"
+          },
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "name": "category",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1547, null],
+            "effective_type": "type/Text",
+            "id": 1547,
+            "visibility_type": "normal",
+            "display_name": "Category",
+            "fingerprint": {
+              "global": { "distinct-count": 6, "nil%": 0 },
+              "type": {
+                "type/Text": {
+                  "percent-json": 0,
+                  "percent-url": 0,
+                  "percent-email": 0,
+                  "percent-state": 0,
+                  "average-length": 1
+                }
+              }
+            },
+            "base_type": "type/Text"
+          },
+          {
+            "description": null,
+            "semantic_type": null,
+            "coercion_strategy": null,
+            "name": "change",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": ["field", 1548, null],
+            "effective_type": "type/BigInteger",
+            "id": 1548,
+            "visibility_type": "normal",
+            "display_name": "Change",
+            "fingerprint": {
+              "global": { "distinct-count": 6, "nil%": 0 },
+              "type": {
+                "type/Number": {
+                  "min": -4,
+                  "q1": -2,
+                  "q3": 6,
+                  "max": 8,
+                  "sd": 4.9396356140913875,
+                  "avg": 2
+                }
+              }
+            },
+            "base_type": "type/BigInteger"
+          }
+        ]
+      },
+      "rows": [
+        [1, "A", 5],
+        [2, "B", 6],
+        [3, "C", -2],
+        [4, "D", -1],
+        [5, "E", 8],
+        [6, "F", -4]
+      ],
+      "cols": [
+        {
+          "description": null,
+          "semantic_type": "type/PK",
+          "table_id": 162,
+          "coercion_strategy": null,
+          "name": "_mb_row_id",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1546, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1546,
+          "position": 0,
+          "visibility_type": "normal",
+          "display_name": "_mb_row_id",
+          "fingerprint": null,
+          "base_type": "type/BigInteger"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 162,
+          "coercion_strategy": null,
+          "name": "category",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1547, null],
+          "effective_type": "type/Text",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1547,
+          "position": 1,
+          "visibility_type": "normal",
+          "display_name": "Category",
+          "fingerprint": {
+            "global": { "distinct-count": 6, "nil%": 0 },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 1
+              }
+            }
+          },
+          "base_type": "type/Text"
+        },
+        {
+          "description": null,
+          "semantic_type": null,
+          "table_id": 162,
+          "coercion_strategy": null,
+          "name": "change",
+          "settings": null,
+          "source": "fields",
+          "fk_target_field_id": null,
+          "field_ref": ["field", 1548, null],
+          "effective_type": "type/BigInteger",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 1548,
+          "position": 2,
+          "visibility_type": "normal",
+          "display_name": "Change",
+          "fingerprint": {
+            "global": { "distinct-count": 6, "nil%": 0 },
+            "type": {
+              "type/Number": {
+                "min": -4,
+                "q1": -2,
+                "q3": 6,
+                "max": 8,
+                "sd": 4.9396356140913875,
+                "avg": 2
+              }
+            }
+          },
+          "base_type": "type/BigInteger"
+        }
+      ],
+      "viz-settings": {
+        "waterfall.increase_color": "#8A5EB0",
+        "waterfall.total_color": "#69C8C8",
+        "waterfall.decrease_color": "#F7C41F",
+        "metabase.shared.models.visualization-settings/column-settings": {
+          "{:metabase.shared.models.visualization-settings/field-id 1546}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1547}": {},
+          "{:metabase.shared.models.visualization-settings/field-id 1548}": {}
+        },
+        "graph.series_order_dimension": null,
+        "graph.metrics": ["change"],
+        "graph.series_order": null,
+        "metabase.shared.models.visualization-settings/global-column-settings": {},
+        "graph.dimensions": ["category"]
+      },
+      "native_form": {
+        "query": "SELECT \"source\".\"_mb_row_id\" AS \"_mb_row_id\", \"source\".\"category\" AS \"category\", \"source\".\"change\" AS \"change\" FROM (SELECT \"csv_upload_data\".\"csv_upload_waterfall_mixed_above_0_20231216113933\".\"_mb_row_id\" AS \"_mb_row_id\", \"csv_upload_data\".\"csv_upload_waterfall_mixed_above_0_20231216113933\".\"category\" AS \"category\", \"csv_upload_data\".\"csv_upload_waterfall_mixed_above_0_20231216113933\".\"change\" AS \"change\" FROM \"csv_upload_data\".\"csv_upload_waterfall_mixed_above_0_20231216113933\") AS \"source\" LIMIT 2000",
+        "params": null
+      },
+      "is_sandboxed": false,
+      "dataset": true,
+      "insights": null
+    }
+  }
+]

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/index.ts
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/stories-data/index.ts
@@ -12,6 +12,7 @@ import startsAboveZeroEndsBelow from "./starts-above-zero-ends-below.json";
 import startsBelowZeroEndsAbove from "./starts-below-zero-ends-above.json";
 import startsAboveZeroCrossesEndsAbove from "./starts-above-zero-crosses-ends-above.json";
 import startsBelowZeroCrossesEndsBelow from "./starts-below-zero-crosses-ends-below.json";
+import customColors from "./custom-colors.json";
 
 export const data = {
   withoutTotal,
@@ -28,4 +29,5 @@ export const data = {
   startsBelowZeroEndsAbove,
   startsAboveZeroCrossesEndsAbove,
   startsBelowZeroCrossesEndsBelow,
+  customColors,
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -226,7 +226,7 @@ export const buildEChartsSeries = (
             renderingContext,
           );
         case "waterfall":
-          return buildEChartsWaterfallSeries();
+          return buildEChartsWaterfallSeries(settings);
       }
     })
     .flat()

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/series.ts
@@ -1,8 +1,12 @@
 import type { RegisteredSeriesOption } from "echarts/types/dist/shared";
 
+import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
+
 import { DATASET_DIMENSIONS } from "./constants";
 
-export function buildEChartsWaterfallSeries(): RegisteredSeriesOption["bar"][] {
+export function buildEChartsWaterfallSeries(
+  settings: ComputedVisualizationSettings,
+): RegisteredSeriesOption["bar"][] {
   return [
     {
       type: "bar",
@@ -30,6 +34,9 @@ export function buildEChartsWaterfallSeries(): RegisteredSeriesOption["bar"][] {
         x: DATASET_DIMENSIONS.dimension,
         y: DATASET_DIMENSIONS.increase,
       },
+      itemStyle: {
+        color: settings["waterfall.increase_color"],
+      },
     },
     {
       type: "bar",
@@ -38,6 +45,9 @@ export function buildEChartsWaterfallSeries(): RegisteredSeriesOption["bar"][] {
         x: DATASET_DIMENSIONS.dimension,
         y: DATASET_DIMENSIONS.decrease,
       },
+      itemStyle: {
+        color: settings["waterfall.decrease_color"],
+      },
     },
     {
       type: "bar",
@@ -45,6 +55,9 @@ export function buildEChartsWaterfallSeries(): RegisteredSeriesOption["bar"][] {
       encode: {
         x: DATASET_DIMENSIONS.dimension,
         y: DATASET_DIMENSIONS.total,
+      },
+      itemStyle: {
+        color: settings["waterfall.total_color"],
       },
     },
   ];

--- a/frontend/src/metabase/visualizations/shared/settings/waterfall.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/waterfall.ts
@@ -1,0 +1,17 @@
+import type { RenderingContext } from "metabase/visualizations/types";
+
+export function getDefaultIncreaseColor(renderingContext: RenderingContext) {
+  return renderingContext.getColor("accent1");
+}
+
+export function getDefaultDecreaseColor(renderingContext: RenderingContext) {
+  return renderingContext.getColor("accent3");
+}
+
+export function getDefaultTotalColor(renderingContext: RenderingContext) {
+  return renderingContext.getColor("text-dark");
+}
+
+export function getDefaultShowTotal() {
+  return true;
+}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35801 
Closes https://github.com/metabase/metabase/issues/36297

### Description

This PR implements the color settings for the waterfall chart. The default settings computations were added so that by default, the chart will show the correct default colors. When the user changes the color setting manually, they will see their selected colors on the chart.

This PR implements both the series and total color setting for convenience, however we won't see the total color setting yet since we have yet to implement the total bar (will do that in the next PR).

### How to verify

1. Create two waterfall charts, and in one of the them change the colors
2. Add both to a dashboard
3. Send a subscription
4. Confirms it renders correctly (one should have default colors, the other should have the colors the user selected).


### Demo


![Screenshot 2023-12-19 at 1.51.46 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/16c844ce-2564-4753-92db-e67fef66e967.png)

![Screenshot 2023-12-19 at 1.30.59 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/e20d8575-20ce-473d-93ed-ced2133b0213.png)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
