### PR TITLE
[MLv2] Drop redundant :fields clauses from stages and joins

### DIFF
--- a/frontend/src/metabase-lib/queries/utils/dataset.js
+++ b/frontend/src/metabase-lib/queries/utils/dataset.js
@@ -43,8 +43,9 @@ export function findColumnIndexForColumnSetting(columns, columnSetting) {
   const fieldRef = normalizeFieldRef(columnSetting.fieldRef);
   // first try to find by fieldRef
   if (fieldRef != null) {
+    const dimension = Dimension.parseMBQL(fieldRef);
     const index = _.findIndex(columns, col =>
-      _.isEqual(fieldRef, normalizeFieldRef(fieldRefForColumn(col))),
+      dimension.isSameBaseDimension(fieldRefForColumn(col)),
     );
     if (index >= 0) {
       return index;

--- a/src/metabase/lib/equality.cljc
+++ b/src/metabase/lib/equality.cljc
@@ -384,3 +384,23 @@
                                         (map #(find-matching-column query stage-number % cols))
                                         selected-refs)]
        (mapv #(assoc % :selected? (contains? matching-selected-cols %)) cols)))))
+
+(mu/defn matching-column-sets? :- :boolean
+  "Returns true if the provided `refs` is the same set as the provided `columns`.
+
+  Order is ignored. Only returns true if each of the `refs` matches a column, and each of the `columns` is matched by
+  exactly 1 of the `refs`. (A bijection, in math terms.)"
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   refs         :- [:sequential ::lib.schema.ref/ref]
+   columns      :- [:sequential ::lib.schema.metadata/column]]
+  ;; The lists match iff:
+  ;; - Each ref matches a column; AND
+  ;; - Each column was matched by exactly one ref
+  ;; So we return true if nil is not a key in the matching, AND all vals in the matching have length 1,
+  ;; AND the matching has as many elements as `columns` (usually the list of columns returned by default).
+  (and (= (count refs) (count columns))
+       (let [matching (group-by #(find-matching-column query stage-number % columns) refs)]
+         (and (not (contains? matching nil))
+              (= (count matching) (count columns))
+              (every? #(= (count %) 1) (vals matching))))))

--- a/test/metabase/lib/remove_replace_test.cljc
+++ b/test/metabase/lib/remove_replace_test.cljc
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.options :as lib.options]
+   [metabase.lib.remove-replace :as lib.remove-replace]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.test-util.macros :as lib.tu.macros]))
@@ -1044,3 +1045,82 @@
                 (lib/replace-clause (first (lib/expressions query))
                                     (lib/with-expression-name 2 "evaluated expr"))
                 lib/expressions)))))
+
+(deftest ^:parallel normalize-fields-clauses-test
+  (testing "queries with no :fields clauses should not be changed"
+    (are [query] (= query (lib.remove-replace/normalize-fields-clauses query))
+      lib.tu/query-with-join
+      lib.tu/query-with-self-join
+      lib.tu/venues-query))
+  (testing "a :fields clause with extras is retained"
+    (let [base     (lib/query meta/metadata-provider (meta/table-metadata :orders))
+          viz      (lib/visible-columns base)
+          category (m/find-first #(= (:name %) "CATEGORY") viz)
+          query    (lib/add-field base 0 category)]
+      (is (= base  (lib.remove-replace/normalize-fields-clauses base)))
+      (is (= query (lib.remove-replace/normalize-fields-clauses query)))))
+  (testing "a :fields clause with a default field removed is retained"
+    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                    (lib/remove-field 0 (assoc (meta/field-metadata :orders :tax)
+                                               :lib/source :source/table-defaults)))]
+      (is (= 8 (-> query :stages first :fields count)))
+      (is (= query (lib.remove-replace/normalize-fields-clauses query)))))
+  (testing "if :fields clause matches the defaults it is dropped"
+    (testing "removing then restoring a field"
+      (let [tax     (assoc (meta/field-metadata :orders :tax)
+                           :lib/source :source/table-defaults)
+            tax-ref (lib/ref tax)
+            query   (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                        (lib/remove-field 0 tax)
+                        ;; Can't use lib/add-field here because it will normalize the :fields clause.
+                        (update-in [:stages 0 :fields] conj tax-ref))]
+        (is (= 9 (-> query :stages first :fields count)))
+        (is (nil? (-> query
+                      lib.remove-replace/normalize-fields-clauses
+                      :stages
+                      first
+                      :fields)))))
+    (testing "adding and dropping and implicit join field"
+      (let [category (assoc (meta/field-metadata :products :category)
+                            :lib/source :source/implicitly-joinable)
+            query    (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                         (lib/add-field 0 category)
+                         ;; Can't use remove-field itself; it will normalize the fields clause.
+                         (update-in [:stages 0 :fields] #(remove (comp #{(meta/id :products :category)} last) %)))]
+        (is (= 9 (-> query :stages first :fields count)))
+        (is (nil? (-> query
+                      lib.remove-replace/normalize-fields-clauses
+                      :stages
+                      first
+                      :fields))))))
+  (testing ":fields clauses on joins"
+    (testing "are preserved if :none or :all"
+      (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                      (lib/join (lib/join-clause (meta/table-metadata :products)
+                                                 [(lib/= (meta/field-metadata :orders :product-id)
+                                                         (meta/field-metadata :products :id))])))
+            none  (assoc-in query [:stages 0 :joins 0 :fields] :none)]
+        (is (= :all (-> query :stages first :joins first :fields)))
+        (is (= query (lib.remove-replace/normalize-fields-clauses query)))
+        (is (= none  (lib.remove-replace/normalize-fields-clauses none)))))
+    (testing "are preserved if they do not match the defaults"
+      (let [join   (-> (lib/join-clause (meta/table-metadata :products)
+                                        [(lib/= (meta/field-metadata :orders :product-id)
+                                                (meta/field-metadata :products :id))])
+                       (lib/with-join-fields (for [field (take 4 (meta/fields :products))]
+                                               (meta/field-metadata :products field))))
+            query  (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                       (lib/join join))]
+        (is (= 4 (-> query :stages first :joins first :fields count)))
+        (is (= query (lib.remove-replace/normalize-fields-clauses query)))))
+    (testing "are replaced with :all if they include all the defaults"
+      (let [join   (-> (lib/join-clause (meta/table-metadata :products)
+                                        [(lib/= (meta/field-metadata :orders :product-id)
+                                                (meta/field-metadata :products :id))])
+                       (lib/with-join-fields (for [field (meta/fields :products)]
+                                               (meta/field-metadata :products field))))
+            query  (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                       (lib/join join))]
+        (is (= 8 (-> query :stages first :joins first :fields count)))
+        (is (= (assoc-in query [:stages 0 :joins 0 :fields] :all)
+               (lib.remove-replace/normalize-fields-clauses query)))))))


### PR DESCRIPTION
If they're equivalent to the default, they can be removed (for stages)
or replaced by `:all` (on joins).

