### PR TITLE
BE analytics events for embedding

### DIFF
--- a/enterprise/backend/test/metabase/embed/settings_test.clj
+++ b/enterprise/backend/test/metabase/embed/settings_test.clj
@@ -1,29 +1,33 @@
 (ns metabase.embed.settings-test
-  (:require [clojure.test :refer :all]
-            [metabase.analytics.snowplow-test :as snowplow-test]
-            [metabase.embed.settings :as embed.settings]
-            [metabase.test :as mt]
-            [toucan2.core :as t2]))
+  (:require
+   [clojure.test :refer :all]
+   [metabase.analytics.snowplow-test :as snowplow-test]
+   [metabase.embed.settings :as embed.settings]
+   [metabase.public-settings.premium-features-test
+    :as premium-features-test]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (deftest enable-embedding-test
   (testing "A snowplow event is sent whenever embedding is enabled or disabled"
    (mt/with-test-user :crowberto
-     (mt/with-temporary-setting-values [enable-embedding     false
-                                        embedding-app-origin "https://example.com"]
-       (let [embedded-dash-count (t2/count :model/Dashboard :enable_embedding true)
-             embedded-card-count (t2/count :model/Card :enable_embedding true)
-             expected-payload    {"embedding_app_origin_set"   true
-                                  "number_embedded_questions"  embedded-card-count
-                                  "number_embedded_dashboards" embedded-dash-count}]
-         (snowplow-test/with-fake-snowplow-collector
-           (embed.settings/enable-embedding! true)
-           (is (= [{:data
-                    (merge expected-payload {"event" "embedding_enabled"})
-                    :user-id (str (mt/user->id :crowberto))}]
-                  (-> (snowplow-test/pop-event-data-and-user-id!))))
+     (premium-features-test/with-premium-features #{:embedding}
+      (mt/with-temporary-setting-values [enable-embedding     false
+                                         embedding-app-origin "https://example.com"]
+        (let [embedded-dash-count (t2/count :model/Dashboard :enable_embedding true)
+              embedded-card-count (t2/count :model/Card :enable_embedding true)
+              expected-payload    {"embedding_app_origin_set"   true
+                                   "number_embedded_questions"  embedded-card-count
+                                   "number_embedded_dashboards" embedded-dash-count}]
+          (snowplow-test/with-fake-snowplow-collector
+            (embed.settings/enable-embedding! true)
+            (is (= [{:data
+                     (merge expected-payload {"event" "embedding_enabled"})
+                     :user-id (str (mt/user->id :crowberto))}]
+                   (-> (snowplow-test/pop-event-data-and-user-id!))))
 
-           (embed.settings/enable-embedding! false)
-           (is (= [{:data
-                    (merge expected-payload {"event" "embedding_disabled"})
-                    :user-id (str (mt/user->id :crowberto))}]
-                  (-> (snowplow-test/pop-event-data-and-user-id!))))))))))
+            (embed.settings/enable-embedding! false)
+            (is (= [{:data
+                     (merge expected-payload {"event" "embedding_disabled"})
+                     :user-id (str (mt/user->id :crowberto))}]
+                   (-> (snowplow-test/pop-event-data-and-user-id!)))))))))))

--- a/enterprise/backend/test/metabase/embed/settings_test.clj
+++ b/enterprise/backend/test/metabase/embed/settings_test.clj
@@ -1,0 +1,29 @@
+(ns metabase.embed.settings-test
+  (:require [clojure.test :refer :all]
+            [metabase.analytics.snowplow-test :as snowplow-test]
+            [metabase.embed.settings :as embed.settings]
+            [metabase.test :as mt]
+            [toucan2.core :as t2]))
+
+(deftest enable-embedding-test
+  (testing "A snowplow event is sent whenever embedding is enabled or disabled"
+   (mt/with-test-user :crowberto
+     (mt/with-temporary-setting-values [enable-embedding     false
+                                        embedding-app-origin "https://example.com"]
+       (let [embedded-dash-count (t2/count :model/Dashboard :enable_embedding true)
+             embedded-card-count (t2/count :model/Card :enable_embedding true)
+             expected-payload    {"embedding_app_origin_set"   true
+                                  "number_embedded_questions"  embedded-card-count
+                                  "number_embedded_dashboards" embedded-dash-count}]
+         (snowplow-test/with-fake-snowplow-collector
+           (embed.settings/enable-embedding! true)
+           (is (= [{:data
+                    (merge expected-payload {"event" "embedding_enabled"})
+                    :user-id (str (mt/user->id :crowberto))}]
+                  (-> (snowplow-test/pop-event-data-and-user-id!))))
+
+           (embed.settings/enable-embedding! false)
+           (is (= [{:data
+                    (merge expected-payload {"event" "embedding_disabled"})
+                    :user-id (str (mt/user->id :crowberto))}]
+                  (-> (snowplow-test/pop-event-data-and-user-id!))))))))))

--- a/enterprise/backend/test/metabase_enterprise/public_settings_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/public_settings_test.clj
@@ -1,8 +1,10 @@
 (ns metabase-enterprise.public-settings-test
   (:require
    [clojure.test :refer :all]
+   [metabase.embed.settings :as embed.settings]
    [metabase.public-settings :as public-settings]
-   [metabase.public-settings.premium-features-test :as premium-features-test]
+   [metabase.public-settings.premium-features-test
+    :as premium-features-test]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.test.util :as tu]))
@@ -34,19 +36,19 @@
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
              #"Setting embedding-app-origin is not enabled because feature :embedding is not available"
-             (public-settings/embedding-app-origin! "https://metabase.com")))
+             (embed.settings/embedding-app-origin! "https://metabase.com")))
 
         (testing "even if env is set, return the default value"
           (mt/with-temp-env-var-value [mb-embedding-app-origin "https://metabase.com"]
-            (is (nil? (public-settings/embedding-app-origin)))))))
+            (is (nil? (embed.settings/embedding-app-origin)))))))
 
     (testing "can change embedding-app-origin if :embedding is enabled"
       (premium-features-test/with-premium-features #{:embedding}
-        (public-settings/embedding-app-origin! "https://metabase.com")
+        (embed.settings/embedding-app-origin! "https://metabase.com")
         (is (= "https://metabase.com"
-               (public-settings/embedding-app-origin)))
+               (embed.settings/embedding-app-origin)))
 
         (testing "it works with env too"
           (mt/with-temp-env-var-value [mb-embedding-app-origin "ssh://metabase.com"]
             (is (= "ssh://metabase.com"
-                   (public-settings/embedding-app-origin)))))))))
+                   (embed.settings/embedding-app-origin)))))))))

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embed-share/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embed-share/jsonschema/1-0-0
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for tracking embedding enabled and disabled events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "embed-share",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "embedding_enabled",
+        "embedding_disabled"
+      ],
+      "maxLength": 1024
+    },
+    "authorized_origins_set": {
+      "description": "Boolean indicating whether authorized origins are set for embedding",
+      "type": "boolean"
+    },
+    "number_embedded_questions": {
+      "description": "The number of embedded questions",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "number_embedded_dashboards": {
+      "description": "The number of embedded dashboards",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    }
+  },
+  "required": ["event_name"],
+  "additionalProperties": true
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embed_share/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embed_share/jsonschema/1-0-0
@@ -20,17 +20,26 @@
     },
     "authorized_origins_set": {
       "description": "Boolean indicating whether authorized origins are set for embedding",
-      "type": "boolean"
+      "type": [
+        "boolean",
+        "null"
+      ],
     },
     "number_embedded_questions": {
       "description": "The number of embedded questions",
-      "type": "integer",
+      "type": [
+        "integer",
+        "null"
+      ],
       "minimum": 0,
       "maximum": 2147483647
     },
     "number_embedded_dashboards": {
       "description": "The number of embedded dashboards",
-      "type": "integer",
+      "type": [
+        "integer",
+        "null"
+      ],
       "minimum": 0,
       "maximum": 2147483647
     }

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/embed_share/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/embed_share/jsonschema/1-0-0
@@ -3,7 +3,7 @@
   "description": "Schema for tracking embedding enabled and disabled events",
   "self": {
     "vendor": "com.metabase",
-    "name": "embed-share",
+    "name": "embed_share",
     "format": "jsonschema",
     "version": "1-0-0"
   },
@@ -35,6 +35,6 @@
       "maximum": 2147483647
     }
   },
-  "required": ["event_name"],
+  "required": ["event"],
   "additionalProperties": true
 }

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -41,7 +41,7 @@
    ::timeline     "1-0-0"
    ::task         "1-0-0"
    ::action       "1-0-0"
-   ::embed-share  "1-0-0"})
+   ::embed_share  "1-0-0"})
 
 (def ^:private event->schema
   "The schema to use for each analytics event."
@@ -66,8 +66,8 @@
    ::csv-upload-successful          ::csvupload
    ::csv-upload-failed              ::csvupload
    ::metabot-feedback-received      ::metabot
-   ::embedding-enabled              ::embed-share
-   ::embedding-disabled             ::embed-share})
+   ::embedding-enabled              ::embed_share
+   ::embedding-disabled             ::embed_share})
 
 (defsetting analytics-uuid
   (deferred-tru

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -24,6 +24,51 @@
 
 (set! *warn-on-reflection* true)
 
+;; Adding or updating a Snowplow schema? Make sure that the two maps below are updated accordingly.
+
+(def ^:private schema->version
+  "The most recent version for each event schema. This should be updated whenever a new version of a schema is added
+  to SnowcatCloud, at the same time that the data sent to the collector is updated."
+  {::account      "1-0-1"
+   ::invite       "1-0-1"
+   ::csvupload    "1-0-0"
+   ::dashboard    "1-1-3"
+   ::database     "1-0-1"
+   ::instance     "1-1-2"
+   ::metabot      "1-0-1"
+   ::search       "1-0-1"
+   ::model        "1-0-0"
+   ::timeline     "1-0-0"
+   ::task         "1-0-0"
+   ::action       "1-0-0"
+   ::embed-share  "1-0-0"})
+
+(def ^:private event->schema
+  "The schema to use for each analytics event."
+  {::new-instance-created           ::account
+   ::new-user-created               ::account
+   ::invite-sent                    ::invite
+   ::index-model-entities-enabled   ::model
+   ::dashboard-created              ::dashboard
+   ::question-added-to-dashboard    ::dashboard
+   ::dashboard-tab-created          ::dashboard
+   ::dashboard-tab-deleted          ::dashboard
+   ::database-connection-successful ::database
+   ::database-connection-failed     ::database
+   ::new-event-created              ::timeline
+   ::new-task-history               ::task
+   ::new-search-query               ::search
+   ::search-results-filtered        ::search
+   ::action-created                 ::action
+   ::action-updated                 ::action
+   ::action-deleted                 ::action
+   ::action-executed                ::action
+   ::csv-upload-successful          ::csvupload
+   ::csv-upload-failed              ::csvupload
+   ::metabot-feedback-received      ::metabot
+   ::embedding-enabled              ::embed-share
+   ::embedding-disabled             ::embed-share})
+
 (defsetting analytics-uuid
   (deferred-tru
     (str "Unique identifier to be used in Snowplow analytics, to identify this instance of Metabase. "
@@ -134,22 +179,6 @@
        ;; Override with localhost IP to avoid logging actual user IP addresses
        (.ipAddress "127.0.0.1"))))
 
-(def ^:private schema->version
-  "The most recent version for each event schema. This should be updated whenever a new version of a schema is added
-  to SnowcatCloud, at the same time that the data sent to the collector is updated."
-  {::account      "1-0-1"
-   ::invite       "1-0-1"
-   ::csvupload    "1-0-0"
-   ::dashboard    "1-1-3"
-   ::database     "1-0-1"
-   ::instance     "1-1-2"
-   ::metabot      "1-0-1"
-   ::search       "1-0-1"
-   ::model        "1-0-0"
-   ::timeline     "1-0-0"
-   ::task         "1-0-0"
-   ::action       "1-0-0"})
-
 (defn- app-db-type
   "Returns the type of the Metabase application database as a string (e.g. PostgreSQL, MySQL)"
   []
@@ -195,30 +224,6 @@
   event data to an in-memory store."
   [tracker event]
   (.track ^Tracker tracker ^SelfDescribing event))
-
-(def ^:private event->schema
-  "The schema to use for each analytics event."
-  {::new-instance-created           ::account
-   ::new-user-created               ::account
-   ::invite-sent                    ::invite
-   ::index-model-entities-enabled   ::model
-   ::dashboard-created              ::dashboard
-   ::question-added-to-dashboard    ::dashboard
-   ::dashboard-tab-created          ::dashboard
-   ::dashboard-tab-deleted          ::dashboard
-   ::database-connection-successful ::database
-   ::database-connection-failed     ::database
-   ::new-event-created              ::timeline
-   ::new-task-history               ::task
-   ::new-search-query               ::search
-   ::search-results-filtered        ::search
-   ::action-created                 ::action
-   ::action-updated                 ::action
-   ::action-deleted                 ::action
-   ::action-executed                ::action
-   ::csv-upload-successful          ::csvupload
-   ::csv-upload-failed              ::csvupload
-   ::metabot-feedback-received      ::metabot})
 
 (defn track-event!
   "Send a single analytics event to the Snowplow collector, if tracking is enabled for this MB instance and a collector

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -12,6 +12,7 @@
    [metabase.db.util :as mdb.u]
    [metabase.driver :as driver]
    [metabase.email :as email]
+   [metabase.embed.settings :as embed.settings]
    [metabase.integrations.google :as google]
    [metabase.integrations.slack :as slack]
    [metabase.models
@@ -141,8 +142,8 @@
    :instance_started         (snowplow/instance-creation)
    :has_sample_data          (t2/exists? Database, :is_sample true)
    :help_link                (public-settings/help-link)
-   :enable_embedding         (public-settings/enable-embedding)
-   :embedding_app_origin_set (boolean (public-settings/embedding-app-origin))})
+   :enable_embedding         (embed.settings/enable-embedding)
+   :embedding_app_origin_set (boolean (embed.settings/embedding-app-origin))})
 
 (defn- user-metrics
   "Get metrics based on user records.

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -126,22 +126,23 @@
 (defn- instance-settings
   "Figure out global info about this instance"
   []
-  {:version              (config/mb-version-info :tag)
-   :running_on           (environment-type)
-   :startup_time_millis  (public-settings/startup-time-millis)
-   :application_database (config/config-str :mb-db-type)
-   :check_for_updates    (public-settings/check-for-updates)
-   :site_name            (not= (public-settings/site-name) "Metabase")
-   :report_timezone      (driver/report-timezone)
+  {:version                  (config/mb-version-info :tag)
+   :running_on               (environment-type)
+   :startup_time_millis      (public-settings/startup-time-millis)
+   :application_database     (config/config-str :mb-db-type)
+   :check_for_updates        (public-settings/check-for-updates)
+   :site_name                (not= (public-settings/site-name) "Metabase")
+   :report_timezone          (driver/report-timezone)
    ; We deprecated advanced humanization but have this here anyways
-   :friendly_names       (= (humanization/humanization-strategy) "advanced")
-   :email_configured     (email/email-configured?)
-   :slack_configured     (slack/slack-configured?)
-   :sso_configured       (google/google-auth-enabled)
-   :instance_started     (snowplow/instance-creation)
-   :has_sample_data      (t2/exists? Database, :is_sample true)
-   :help_link            (public-settings/help-link)
-   :enable_embedding     (public-settings/enable-embedding)})
+   :friendly_names           (= (humanization/humanization-strategy) "advanced")
+   :email_configured         (email/email-configured?)
+   :slack_configured         (slack/slack-configured?)
+   :sso_configured           (google/google-auth-enabled)
+   :instance_started         (snowplow/instance-creation)
+   :has_sample_data          (t2/exists? Database, :is_sample true)
+   :help_link                (public-settings/help-link)
+   :enable_embedding         (public-settings/enable-embedding)
+   :embedding_app_origin_set (boolean (public-settings/embedding-app-origin))})
 
 (defn- user-metrics
   "Get metrics based on user records.

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -140,7 +140,8 @@
    :sso_configured       (google/google-auth-enabled)
    :instance_started     (snowplow/instance-creation)
    :has_sample_data      (t2/exists? Database, :is_sample true)
-   :help_link            (public-settings/help-link)})
+   :help_link            (public-settings/help-link)
+   :enable_embedding     (public-settings/enable-embedding)})
 
 (defn- user-metrics
   "Get metrics based on user records.

--- a/src/metabase/api/common/validation.clj
+++ b/src/metabase/api/common/validation.clj
@@ -3,6 +3,7 @@
    [clojure.string :as str]
    [metabase.api.common :as api]
    [metabase.config :as config]
+   [metabase.embed.settings :as embed.settings]
    [metabase.plugins.classloader :as classloader]
    [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
@@ -19,7 +20,7 @@
 (defn check-embedding-enabled
   "Is embedding of Cards or Objects (secured access via `/api/embed` endpoints with a signed JWT enabled?"
   []
-  (api/check (public-settings/enable-embedding)
+  (api/check (embed.settings/enable-embedding)
              [400 (tru "Embedding is not enabled.")]))
 
 (defn check-has-application-permission

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -36,13 +36,16 @@
    [metabase.query-processor.pivot :as qp.pivot]
    [metabase.util :as u]
    [metabase.util.embed :as embed]
-   [metabase.util.i18n :refer [tru]]
+   [metabase.util.i18n
+    :as i18n
+    :refer [tru]]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
+
 
 ;;; ------------------------------------------------- Param Checking -------------------------------------------------
 

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -46,7 +46,6 @@
 
 (set! *warn-on-reflection* true)
 
-
 ;;; ------------------------------------------------- Param Checking -------------------------------------------------
 
 (defn- check-params-are-allowed

--- a/src/metabase/embed/settings.clj
+++ b/src/metabase/embed/settings.clj
@@ -1,0 +1,33 @@
+(ns metabase.embed.settings
+  "Settings related to embedding Metabase in other applications."
+  (:require
+   [metabase.analytics.snowplow :as snowplow]
+   [metabase.api.common :as api]
+   [metabase.models.setting :as setting :refer [defsetting]]
+   [metabase.util.i18n
+    :as i18n
+    :refer [deferred-tru]]
+   [toucan2.core :as t2]))
+
+(defsetting embedding-app-origin
+  (deferred-tru "Allow this origin to embed the full {0} application"
+                ((resolve 'metabase.public-settings/application-name-for-setting-descriptions)))
+  :feature    :embedding
+  :visibility :public
+  :audit      :getter)
+
+(defsetting enable-embedding
+  (deferred-tru "Allow admins to securely embed questions and dashboards within other applications?")
+  :type       :boolean
+  :default    false
+  :visibility :authenticated
+  :audit      :getter
+  :setter     (fn [new-value]
+                (when (not= new-value (setting/get-value-of-type :boolean :enable-embedding))
+                  (setting/set-value-of-type! :boolean :enable-embedding new-value)
+                  (let [snowplow-payload {:embedding-app-origin-set   (boolean (embedding-app-origin))
+                                          :number-embedded-questions  (t2/count :model/Dashboard :enable_embedding true)
+                                          :number-embedded-dashboards (t2/count :model/Card :enable_embedding true)}]
+                    (if new-value
+                      (snowplow/track-event! ::snowplow/embedding-enabled api/*current-user-id* snowplow-payload)
+                      (snowplow/track-event! ::snowplow/embedding-disabled api/*current-user-id* snowplow-payload))))))

--- a/src/metabase/embed/settings.clj
+++ b/src/metabase/embed/settings.clj
@@ -4,14 +4,13 @@
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.models.setting :as setting :refer [defsetting]]
-   [metabase.util.i18n
-    :as i18n
-    :refer [deferred-tru]]
+   [metabase.public-settings :as public-settings]
+   [metabase.util.i18n :as i18n :refer [deferred-tru]]
    [toucan2.core :as t2]))
 
 (defsetting embedding-app-origin
   (deferred-tru "Allow this origin to embed the full {0} application"
-                ((resolve 'metabase.public-settings/application-name-for-setting-descriptions)))
+                (public-settings/application-name-for-setting-descriptions))
   :feature    :embedding
   :visibility :public
   :audit      :getter)

--- a/src/metabase/embed/settings.clj
+++ b/src/metabase/embed/settings.clj
@@ -25,8 +25,8 @@
                 (when (not= new-value (setting/get-value-of-type :boolean :enable-embedding))
                   (setting/set-value-of-type! :boolean :enable-embedding new-value)
                   (let [snowplow-payload {:embedding-app-origin-set   (boolean (embedding-app-origin))
-                                          :number-embedded-questions  (t2/count :model/Dashboard :enable_embedding true)
-                                          :number-embedded-dashboards (t2/count :model/Card :enable_embedding true)}]
+                                          :number-embedded-questions  (t2/count :model/Card :enable_embedding true)
+                                          :number-embedded-dashboards (t2/count :model/Dashboard :enable_embedding true)}]
                     (if new-value
                       (snowplow/track-event! ::snowplow/embedding-enabled api/*current-user-id* snowplow-payload)
                       (snowplow/track-event! ::snowplow/embedding-disabled api/*current-user-id* snowplow-payload))))))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -271,20 +271,6 @@
   :visibility :authenticated
   :audit      :getter)
 
-(defsetting enable-embedding
-  (deferred-tru "Allow admins to securely embed questions and dashboards within other applications?")
-  :type       :boolean
-  :default    false
-  :visibility :authenticated
-  :audit      :getter)
-
-(defsetting embedding-app-origin
-  (deferred-tru "Allow this origin to embed the full {0} application"
-                (application-name-for-setting-descriptions))
-  :feature    :embedding
-  :visibility :public
-  :audit      :getter)
-
 (defsetting enable-nested-queries
   (deferred-tru "Allow using a saved question or Model as the source for other queries?")
   :type       :boolean

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -6,6 +6,7 @@
    [java-time.api :as t]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.config :as config]
+   [metabase.embed.settings :as embed.settings]
    [metabase.models.setting :refer [defsetting]]
    [metabase.public-settings :as public-settings]
    [metabase.server.request.util :as request.u]
@@ -119,8 +120,8 @@
 
 (defn- embedding-app-origin
   []
-  (when (and (public-settings/enable-embedding) (public-settings/embedding-app-origin))
-    (public-settings/embedding-app-origin)))
+  (when (and (embed.settings/enable-embedding) (embed.settings/embedding-app-origin))
+    (embed.settings/embedding-app-origin)))
 
 (defn- content-security-policy-header-with-frame-ancestors
   [allow-iframes? nonce]

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -10,7 +10,6 @@
    [metabase.models.pulse-card :refer [PulseCard]]
    [metabase.models.pulse-channel :refer [PulseChannel]]
    [metabase.models.query-execution :refer [QueryExecution]]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.util :as qp.util]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
@@ -71,12 +70,12 @@
     "10000+"     100000))
 
 (deftest anonymous-usage-stats-test
-  (with-redefs [email/email-configured?           (constantly false)
-                slack/slack-configured?           (constantly false)
-                public-settings/enable-embedding  (constantly false)]
+  (with-redefs [email/email-configured? (constantly false)
+                slack/slack-configured? (constantly false)]
     (mt/with-temporary-setting-values [site-name          "Test"
                                        startup-time-millis 1234.0
-                                       google-auth-enabled false]
+                                       google-auth-enabled false
+                                       enable-embedding    false]
       (t2.with-temp/with-temp [:model/Database _ {:is_sample true}]
         (let [stats (anonymous-usage-stats)]
           (is (partial= {:running_on               :unknown

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -79,17 +79,18 @@
                                        google-auth-enabled false]
       (t2.with-temp/with-temp [:model/Database _ {:is_sample true}]
         (let [stats (anonymous-usage-stats)]
-          (is (partial= {:running_on          :unknown
-                         :check_for_updates   true
-                         :startup_time_millis 1234.0
-                         :site_name           true
-                         :friendly_names      false
-                         :email_configured    false
-                         :slack_configured    false
-                         :sso_configured      false
-                         :has_sample_data     true
-                         :help_link           :metabase
-                         :enable_embedding    false}
+          (is (partial= {:running_on               :unknown
+                         :check_for_updates        true
+                         :startup_time_millis      1234.0
+                         :site_name                true
+                         :friendly_names           false
+                         :email_configured         false
+                         :slack_configured         false
+                         :sso_configured           false
+                         :has_sample_data          true
+                         :help_link                :metabase
+                         :enable_embedding         false
+                         :embedding_app_origin_set false}
                         stats))
           (is (malli= [:map-of :string ms/IntGreaterThanOrEqualToZero]
                       (-> stats :stats :database :dbms_versions))))))))

--- a/test/metabase/server/middleware/security_test.clj
+++ b/test/metabase/server/middleware/security_test.clj
@@ -86,8 +86,8 @@
                              (filter #(str/starts-with? % "style-src "))
                              first)]
           (testing "The nonce is 10 characters long and alphanumeric"
-            (is (re-matches #"^[a-zA-Z0-9]{10}$" nonce))
+            (is (re-matches #"^[a-zA-Z0-9]{10}$" nonce)))
           (testing "The same nonce is in the CSP header"
            (is (str/includes? style-src (str "nonce-" nonce))))
           (testing "The same nonce is in the body of the rendered page"
-            (is (str/includes? (:body response) nonce)))))))))
+            (is (str/includes? (:body response) nonce))))))))


### PR DESCRIPTION
This PR adds tracking of analytics data related to embedding from the backend as specified in [this product doc](https://www.notion.so/Embedding-settings-cleanup-and-surface-interactive-embedding-Quickstart-7e4ed0b3a47947ac9235e53998db1280).

* A couple new keys are added to anonymous usage tracking
* A new Snowplow namespace and two new events are added, sent whenever embedding is enabled or disabled.

Because the Snowplow calls needed to be added to the setter of `enable-embedding` in `metabase.public-settings`, and the Snowplow namespace needs access to a couple of other unrelated settings, there was a circular dependency that was tricky to untangle. The best solution I could find was to create a new `metabase.embed.settings` namespace for the embed settings, but maybe there's a different potential refactor here I'm overlooking. 