### PR TITLE
Bump liquibase

### DIFF
--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -81,7 +81,7 @@
 (defn no-bare-blob-or-text-types?
   "Ensures that no \"text\" or \"blob\" type columns are added in changesets with id later than 320 (i.e. version
   0.42.0).  From that point on, \"${text.type}\" should be used instead, so that MySQL can handle it correctly (by using
-  `LONGTEXT`).  And similarly, from an earlier point, \"${blob.type\" should be used instead of \"blob\"."
+  `LONGTEXT`).  And similarly, from an earlier point, \"${blob.type}\" should be used instead of \"blob\"."
   [change-log]
   (let [problem-cols (atom [])
         walk-fn      (partial assert-no-types-in-change-set #{"blob" "text"} problem-cols)]
@@ -96,6 +96,19 @@
       (walk/postwalk walk-fn change-set))
     (empty? @problem-cols)))
 
+(defn no-bare-boolean-types?
+  "Ensures that no \"boolean\" type columns are added in changesets with id later than v49.00-032. From that point on,
+  \"${boolean.type}\" should be used instead, so that we can consistently use `BIT(1)` for Boolean columns on MySQL."
+  [change-log]
+  (let [problem-cols (atom [])
+        walk-fn      (partial assert-no-types-in-change-set #{"boolean"} problem-cols)]
+    (doseq [{{id :id} :changeSet :as change-set} change-log
+            :when                                (and id
+                                                      (string? id)
+                                                      (> (compare-ids id "v49.00-032") 0))]
+      (walk/postwalk walk-fn change-set))
+    (empty? @problem-cols)))
+
 (s/def ::changeSet
   (s/spec :change-set.strict/change-set))
 
@@ -103,6 +116,7 @@
   (s/and distinct-change-set-ids?
          change-set-ids-in-order?
          no-bare-blob-or-text-types?
+         no-bare-boolean-types?
          (s/+ (s/alt :property              (s/keys :req-un [::property])
                      :objectQuotingStrategy (s/keys :req-un [::objectQuotingStrategy])
                      :changeSet             (s/keys :req-un [::changeSet])))))

--- a/bin/lint-migrations-file/src/lint_migrations_file.clj
+++ b/bin/lint-migrations-file/src/lint_migrations_file.clj
@@ -105,7 +105,7 @@
     (doseq [{{id :id} :changeSet :as change-set} change-log
             :when                                (and id
                                                       (string? id)
-                                                      (> (compare-ids id "v49.00-032") 0))]
+                                                      (pos? (compare-ids id "v49.00-032")))]
       (walk/postwalk walk-fn change-set))
     (empty? @problem-cols)))
 

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -187,7 +187,7 @@
                   :changes [(mock-add-column-changes :columns [(mock-column :type problem-type)])]))))))))
 
 (deftest prevent-bare-boolean-type-test
-  (testing "should allow \"${boolean.type}\" columns from being added"
+  (testing "should allow adding \"${boolean.type}\" columns"
     (is (= :ok
           (validate
            (mock-change-set

--- a/bin/lint-migrations-file/test/lint_migrations_file_test.clj
+++ b/bin/lint-migrations-file/test/lint_migrations_file_test.clj
@@ -175,7 +175,7 @@
           (validate
            (mock-change-set
              :id "v42.00-001"
-             :changes [(mock-add-column-changes :columns [(mock-column :type "${text.type")])]))))
+             :changes [(mock-add-column-changes :columns [(mock-column :type "${text.type}")])]))))
     (doseq [problem-type ["blob" "text"]]
       (testing (format "should prevent \"%s\" columns from being added after ID 320" problem-type)
         (is (thrown-with-msg?
@@ -185,6 +185,22 @@
                 (mock-change-set
                   :id "v42.00-001"
                   :changes [(mock-add-column-changes :columns [(mock-column :type problem-type)])]))))))))
+
+(deftest prevent-bare-boolean-type-test
+  (testing "should allow \"${boolean.type}\" columns from being added"
+    (is (= :ok
+          (validate
+           (mock-change-set
+             :id "v49.00-033"
+             :changes [(mock-add-column-changes :columns [(mock-column :type "${boolean.type}")])]))))
+    (testing (format "should prevent \"boolean\" columns from being added after ID v49.00-033")
+      (is (thrown-with-msg?
+            clojure.lang.ExceptionInfo
+            #"(?s)^.*no-bare-boolean-types\\?.*$"
+            (validate
+              (mock-change-set
+                :id "v49.00-033"
+                :changes [(mock-add-column-changes :columns [(mock-column :type "boolean")])])))))))
 
 (deftest require-rollback-test
   (testing "change types with no automatic rollback support"

--- a/deps.edn
+++ b/deps.edn
@@ -153,7 +153,7 @@
   org.eclipse.jetty/jetty-server            {:mvn/version "11.0.17"}            ; web server
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.4"}             ; JavaScript engine
-  org.liquibase/liquibase-core              {:mvn/version "4.21.1"              ; migration management (Java lib)
+  org.liquibase/liquibase-core              {:mvn/version "4.25.1"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
   ;; The 3.X line of development for mariadb-java-client only supports the jdbc:mariadb protocol, so use 2.X for now.
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.10"}             ; MySQL/MariaDB driver

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4742,28 +4742,6 @@ databaseChangeLog:
         - dbms:
             type: mysql,mariadb
 
-  - changeSet:
-      id: v49.00-032
-      author: noahmoss
-      comment: >-
-        Added 0.49.0 - modify type of DATABASECHANGELOGLOCK.LOCKED
-        from boolean to ${boolean.type} on mysql,mariadb
-      dbms: mysql,mariadb
-      changes:
-        - modifyDataType:
-            tableName: DATABASECHANGELOGLOCK
-            columnName: LOCKED
-            newDataType: ${boolean.type}
-      rollback:
-        - modifyDataType:
-            tableName: DATABASECHANGELOGLOCK
-            columnName: LOCKED
-            newDataType: boolean
-      preConditions:
-        - onFail: MARK_RAN
-        - dbms:
-            type: mysql,mariadb
-
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -33,6 +33,15 @@ databaseChangeLog:
       name: databasechangelog.name
       value: databasechangelog
       dbms: postgresql
+  # in MySQL, use bit(1) for booleans instead of tinyint
+  - property:
+      name: boolean.type
+      value: boolean
+      dbms: postgresql,h2
+  - property:
+      name: boolean.type
+      value: bit(1)
+      dbms: mysql,mariadb
 
   - objectQuotingStrategy: QUOTE_ALL_OBJECTS
 
@@ -4380,6 +4389,363 @@ databaseChangeLog:
                   constraints:
                     nullable: true
                   remarks: 'If true, the table requires a filter to be able to query it'
+
+  - changeSet:
+      id: v49.00-013
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of action.archived from boolean to
+        ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: action
+            columnName: archived
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: action
+            columnName: archived
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-014
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of metabase_field.json_unfolding from
+        boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: metabase_field
+            columnName: json_unfolding
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: metabase_field
+            columnName: json_unfolding
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-015
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of database_is_auto_increment.metabase_field
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: metabase_field
+            columnName: database_is_auto_increment
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: metabase_field
+            columnName: database_is_auto_increment
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-016
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of report_dashboard.auto_apply_filters
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: report_dashboard
+            columnName: auto_apply_filters
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: report_dashboard
+            columnName: auto_apply_filters
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-017
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of metabase_database.is_audit
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: metabase_database
+            columnName: is_audit
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: metabase_database
+            columnName: is_audit
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-018
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of metabase_table.is_upload
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: metabase_table
+            columnName: is_upload
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: metabase_table
+            columnName: is_upload
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-019
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of revision.most_recent
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: revision
+            columnName: most_recent
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: revision
+            columnName: most_recent
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-020
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of revision.most_recent
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: revision
+            columnName: most_recent
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: revision
+            columnName: most_recent
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-021
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of table_privileges.select
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: table_privileges
+            columnName: select
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: table_privileges
+            columnName: select
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-022
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of table_privileges.update
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: table_privileges
+            columnName: update
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: table_privileges
+            columnName: update
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-023
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of table_privileges.insert
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: table_privileges
+            columnName: insert
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: table_privileges
+            columnName: insert
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-024
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of table_privileges.delete
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: table_privileges
+            columnName: delete
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: table_privileges
+            columnName: delete
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-025
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of query_execution.is_sandboxed
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: query_execution
+            columnName: is_sandboxed
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: query_execution
+            columnName: is_sandboxed
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-026
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of view_log.has_access
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: view_log
+            columnName: has_access
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: view_log
+            columnName: has_access
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-027
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of metabase_field.database_indexed
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: metabase_field
+            columnName: database_indexed
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: metabase_field
+            columnName: database_indexed
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-028
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of metabase_table.database_require_filter
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: metabase_table
+            columnName: database_require_filter
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: metabase_table
+            columnName: database_require_filter
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-029
+      author: noahmoss
+      comment: >-
+        Added 0.49.0 - modify type of DATABASECHANGELOGLOCK.LOCKED
+        from boolean to ${boolean.type} on mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: DATABASECHANGELOGLOCK
+            columnName: LOCKED
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: DATABASECHANGELOGLOCK
+            columnName: LOCKED
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4415,6 +4415,35 @@ databaseChangeLog:
   - changeSet:
       id: v49.00-017
       author: noahmoss
+      comment: Add NOT NULL constraint to action.archived
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: action
+            columnName: archived
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-018
+      author: noahmoss
+      comment: Add default value to action.archived
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: action
+            columnName: archived
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-019
+      author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of metabase_field.json_unfolding from
         boolean to ${boolean.type} on mysql,mariadb
@@ -4435,10 +4464,39 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-018
+      id: v49.00-020
+      author: noahmoss
+      comment: Add NOT NULL constraint to metabase_field.json_unfolding
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: metabase_field
+            columnName: json_unfolding
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-021
+      author: noahmoss
+      comment: Add default value to metabase_field.json_unfolding
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: metabase_field
+            columnName: json_unfolding
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-022
       author: noahmoss
       comment: >-
-        Added 0.49.0 - modify type of database_is_auto_increment.metabase_field
+        Added 0.49.0 - modify type of metabase_field.database_is_auto_increment
         from boolean to ${boolean.type} on mysql,mariadb
       dbms: mysql,mariadb
       changes:
@@ -4457,7 +4515,36 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-019
+      id: v49.00-023
+      author: noahmoss
+      comment: Add NOT NULL constraint to metabase_field.database_is_auto_increment
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: metabase_field
+            columnName: database_is_auto_increment
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-024
+      author: noahmoss
+      comment: Add default value to metabase_field.database_is_auto_increment
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: metabase_field
+            columnName: database_is_auto_increment
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-025
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of report_dashboard.auto_apply_filters
@@ -4479,7 +4566,36 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-020
+      id: v49.00-026
+      author: noahmoss
+      comment: Add NOT NULL constraint to report_dashboard.auto_apply_filters
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: report_dashboard
+            columnName: auto_apply_filters
+            defaultNullValue: true
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-027
+      author: noahmoss
+      comment: Add default value to report_dashboard.auto_apply_filters
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: true
+            tableName: report_dashboard
+            columnName: auto_apply_filters
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-028
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of metabase_database.is_audit
@@ -4501,7 +4617,36 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-021
+      id: v49.00-029
+      author: noahmoss
+      comment: Add NOT NULL constraint to metabase_database.is_audit
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: metabase_database
+            columnName: is_audit
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-030
+      author: noahmoss
+      comment: Add default value to metabase_database.is_audit
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: metabase_database
+            columnName: is_audit
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-031
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of metabase_table.is_upload
@@ -4523,7 +4668,36 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-022
+      id: v49.00-032
+      author: noahmoss
+      comment: Add NOT NULL constraint to metabase_table.is_upload
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: metabase_table
+            columnName: is_upload
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-033
+      author: noahmoss
+      comment: Add default value to metabase_table.is_upload
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: metabase_table
+            columnName: is_upload
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-034
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of revision.most_recent
@@ -4545,7 +4719,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-023
+      id: v49.00-035
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of revision.most_recent
@@ -4567,7 +4741,36 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-024
+      id: v49.00-036
+      author: noahmoss
+      comment: Add NOT NULL constraint to revision.most_recent
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: revision
+            columnName: most_recent
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-037
+      author: noahmoss
+      comment: Add default value to revision.most_recent
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: revision
+            columnName: most_recent
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-038
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of table_privileges.select
@@ -4589,7 +4792,36 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-025
+      id: v49.00-039
+      author: noahmoss
+      comment: Add NOT NULL constraint to table_privileges.select
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: table_privileges
+            columnName: select
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-040
+      author: noahmoss
+      comment: Add default value to table_privileges.select
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: table_privileges
+            columnName: select
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-041
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of table_privileges.update
@@ -4611,7 +4843,36 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-026
+      id: v49.00-042
+      author: noahmoss
+      comment: Add NOT NULL constraint to table_privileges.update
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: table_privileges
+            columnName: update
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-043
+      author: noahmoss
+      comment: Add default value to table_privileges.update
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: table_privileges
+            columnName: update
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-044
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of table_privileges.insert
@@ -4633,7 +4894,36 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-027
+      id: v49.00-045
+      author: noahmoss
+      comment: Add NOT NULL constraint to table_privileges.insert
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: table_privileges
+            columnName: insert
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-046
+      author: noahmoss
+      comment: Add default value to table_privileges.insert
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: table_privileges
+            columnName: insert
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-047
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of table_privileges.delete
@@ -4655,7 +4945,36 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-028
+      id: v49.00-048
+      author: noahmoss
+      comment: Add NOT NULL constraint to table_privileges.delete
+      changes:
+        - addNotNullConstraint:
+            columnDataType: ${boolean.type}
+            tableName: table_privileges
+            columnName: delete
+            defaultNullValue: false
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-049
+      author: noahmoss
+      comment: Add default value to table_privileges.delete
+      changes:
+        - addDefaultValue:
+            defaultValueBoolean: false
+            tableName: table_privileges
+            columnName: delete
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
+  - changeSet:
+      id: v49.00-050
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of query_execution.is_sandboxed
@@ -4677,7 +4996,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-029
+      id: v49.00-051
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of view_log.has_access
@@ -4699,7 +5018,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-030
+      id: v49.00-052
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of metabase_field.database_indexed
@@ -4721,7 +5040,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-031
+      id: v49.00-053
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of metabase_table.database_require_filter

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4396,6 +4396,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of action.archived from boolean to
         ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: action
@@ -4417,6 +4418,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of metabase_field.json_unfolding from
         boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: metabase_field
@@ -4438,6 +4440,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of database_is_auto_increment.metabase_field
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: metabase_field
@@ -4459,6 +4462,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of report_dashboard.auto_apply_filters
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: report_dashboard
@@ -4480,6 +4484,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of metabase_database.is_audit
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: metabase_database
@@ -4501,6 +4506,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of metabase_table.is_upload
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: metabase_table
@@ -4522,6 +4528,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of revision.most_recent
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: revision
@@ -4543,6 +4550,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of revision.most_recent
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: revision
@@ -4564,6 +4572,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of table_privileges.select
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: table_privileges
@@ -4585,6 +4594,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of table_privileges.update
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: table_privileges
@@ -4606,6 +4616,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of table_privileges.insert
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: table_privileges
@@ -4627,6 +4638,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of table_privileges.delete
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: table_privileges
@@ -4648,6 +4660,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of query_execution.is_sandboxed
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: query_execution
@@ -4669,6 +4682,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of view_log.has_access
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: view_log
@@ -4690,6 +4704,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of metabase_field.database_indexed
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: metabase_field
@@ -4711,6 +4726,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of metabase_table.database_require_filter
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: metabase_table
@@ -4732,6 +4748,7 @@ databaseChangeLog:
       comment: >-
         Added 0.49.0 - modify type of DATABASECHANGELOGLOCK.LOCKED
         from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
       changes:
         - modifyDataType:
             tableName: DATABASECHANGELOGLOCK

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4391,7 +4391,7 @@ databaseChangeLog:
                   remarks: 'If true, the table requires a filter to be able to query it'
 
   - changeSet:
-      id: v49.00-013
+      id: v49.00-016
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of action.archived from boolean to
@@ -4412,7 +4412,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-014
+      id: v49.00-017
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of metabase_field.json_unfolding from
@@ -4433,7 +4433,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-015
+      id: v49.00-018
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of database_is_auto_increment.metabase_field
@@ -4454,7 +4454,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-016
+      id: v49.00-019
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of report_dashboard.auto_apply_filters
@@ -4475,7 +4475,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-017
+      id: v49.00-020
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of metabase_database.is_audit
@@ -4496,7 +4496,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-018
+      id: v49.00-021
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of metabase_table.is_upload
@@ -4517,7 +4517,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-019
+      id: v49.00-022
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of revision.most_recent
@@ -4538,7 +4538,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-020
+      id: v49.00-023
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of revision.most_recent
@@ -4559,7 +4559,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-021
+      id: v49.00-024
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of table_privileges.select
@@ -4580,7 +4580,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-022
+      id: v49.00-025
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of table_privileges.update
@@ -4601,7 +4601,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-023
+      id: v49.00-026
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of table_privileges.insert
@@ -4622,7 +4622,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-024
+      id: v49.00-027
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of table_privileges.delete
@@ -4643,7 +4643,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-025
+      id: v49.00-028
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of query_execution.is_sandboxed
@@ -4664,7 +4664,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-026
+      id: v49.00-029
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of view_log.has_access
@@ -4685,7 +4685,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-027
+      id: v49.00-030
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of metabase_field.database_indexed
@@ -4706,7 +4706,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-028
+      id: v49.00-031
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of metabase_table.database_require_filter
@@ -4727,7 +4727,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: v49.00-029
+      id: v49.00-032
       author: noahmoss
       comment: >-
         Added 0.49.0 - modify type of DATABASECHANGELOGLOCK.LOCKED

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -255,7 +255,7 @@
      :or {change-set-filters []}}]
    (let [change-log     (.getDatabaseChangeLog liquibase)
          database       (.getDatabase liquibase)
-         log-iterator   (ChangeLogIterator. change-log (into-array ChangeSetFilter change-set-filters))
+         log-iterator   (ChangeLogIterator. change-log ^"[Lliquibase.changelog.filter.ChangeSetFilter;" (into-array ChangeSetFilter change-set-filters))
          update-visitor (UpdateVisitor. database ^ChangeExecListener exec-listener)
          runtime-env    (RuntimeEnvironment. database (Contexts.) nil)]
      (run-in-scope-locked

--- a/test/metabase/db/liquibase_test.clj
+++ b/test/metabase/db/liquibase_test.clj
@@ -53,7 +53,7 @@
          (testing "Make sure the first line actually matches the shape we're testing against"
            (is (= (str "CREATE TABLE liquibase_test.DATABASECHANGELOGLOCK ("
                        "ID INT NOT NULL, "
-                       "`LOCKED` BIT(1) NOT NULL, "
+                       "`LOCKED` TINYINT NOT NULL, "
                        "LOCKGRANTED datetime NULL, "
                        "LOCKEDBY VARCHAR(255) NULL, "
                        "CONSTRAINT PK_DATABASECHANGELOGLOCK PRIMARY KEY (ID)"

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -458,7 +458,7 @@
 
 (deftest add-revision-most-recent-test
   (testing "Migrations v48.00-008-v48.00-009: add `revision.most_recent`"
-    (impl/test-migrations ["v48.00-007" "v48.00-009"] [migrate!]
+    (impl/test-migrations ["v48.00-007"] [migrate!]
       (let [user-id          (:id (create-raw-user! (tu.random/random-email)))
             old              (t/minus (t/local-date-time) (t/hours 1))
             rev-dash-1-old (first (t2/insert-returning-pks! (t2/table-name :model/Revision)


### PR DESCRIPTION
Bump to liquibase 4.25.1.

The main issue was the fact that Boolean columns on MySQL/MariaDB were now being created as `tinyint(4)` instead of `bit(1)` as was previously the case (see [this PR](https://github.com/liquibase/liquibase/pull/5130)). `tinyint(4)` is not recognized by the MySQL JDBC driver as a Boolean type, so these fields were being returned as integers (0 or 1) when queried by Metabase instead of Booleans as expected. See [this Slack thread](https://metaboat.slack.com/archives/CKZEMT1MJ/p1703098896963729) for more discussion.

Our workaround is to create a Liquibase property that aliases `${boolean.type}` to `bit(1)` on MySQL, as we've previously done for some other types like `${text.type}` being an alias for `longtext`. This also required migrations to change all existing Boolean columns that would be created as `boolean` on a new installation (i.e. anything in `001_update_migrations` but not in the SQL initialization file) to use `${boolean.type}` instead.