### PR TITLE
Make the nav sidebar more predictable and discoverable

### DIFF
--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -1,12 +1,12 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import Link from "metabase/core/components/Link";
-import { space } from "metabase/styled-components/theme";
-import { AppBarLeftContainer } from "./AppBarLarge.styled";
 
 export const LogoRoot = styled.div`
-  position: relative;
+  display: flex;
+  align-items: center;
+  column-gap: 0.5rem;
+  padding-left: 0.5rem;
 `;
 
 interface LogoLinkProps {
@@ -20,37 +20,17 @@ export const LogoLink = styled(Link)<LogoLinkProps>`
   align-items: center;
   justify-content: center;
   border-radius: 0.375rem;
-  padding: 0.5rem 1rem;
   transition: opacity 0.3s;
+  width: 2.5rem;
+  height: 2.5rem;
 
   &:hover {
     background-color: ${color("bg-light")};
   }
-
-  ${props =>
-    !props.isSmallAppBar &&
-    css`
-      ${AppBarLeftContainer}:hover & {
-        opacity: ${props.isNavBarEnabled ? 0 : 1};
-        pointer-events: ${props.isNavBarEnabled ? "none" : ""};
-      }
-    `}
 `;
 
 interface ToggleContainerProps {
   isLogoVisible?: boolean;
 }
 
-export const ToggleContainer = styled.div<ToggleContainerProps>`
-  ${props =>
-    props.isLogoVisible
-      ? css`
-          position: absolute;
-          top: 0.625rem;
-          left: 0.9375rem;
-        `
-      : css`
-          padding: ${space(1)} ${space(2)};
-        `}
-  transition: opacity 0.3s;
-`;
+export const ToggleContainer = styled.div<ToggleContainerProps>``;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -6,7 +6,7 @@ export const LogoRoot = styled.div`
   display: flex;
   align-items: center;
   column-gap: 0.5rem;
-  padding-left: 0.5rem;
+  padding: 0 0.5rem;
 `;
 
 interface LogoLinkProps {

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -7,6 +7,7 @@ export const LogoRoot = styled.div`
   align-items: center;
   column-gap: 0.5rem;
   padding: 0 0.5rem;
+  margin-right: 0.25rem;
 `;
 
 interface LogoLinkProps {

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
@@ -21,16 +21,6 @@ const AppBarLogo = ({
 }: AppBarLogoProps): JSX.Element => {
   return (
     <LogoRoot>
-      {isLogoVisible && (
-        <LogoLink
-          isNavBarEnabled={isNavBarEnabled}
-          to="/"
-          onClick={onLogoClick}
-          data-metabase-event="Navbar;Logo"
-        >
-          <LogoIcon height={32} />
-        </LogoLink>
-      )}
       {isNavBarEnabled && (
         <ToggleContainer isLogoVisible={isLogoVisible}>
           <AppBarToggle
@@ -41,6 +31,16 @@ const AppBarLogo = ({
             onToggleClick={onToggleClick}
           />
         </ToggleContainer>
+      )}
+      {isLogoVisible && (
+        <LogoLink
+          isNavBarEnabled={isNavBarEnabled}
+          to="/"
+          onClick={onLogoClick}
+          data-metabase-event="Navbar;Logo"
+        >
+          <LogoIcon height={32} />
+        </LogoLink>
       )}
     </LogoRoot>
   );

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.styled.tsx
@@ -1,8 +1,6 @@
 import styled from "@emotion/styled";
-import { css } from "@emotion/react";
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
-import { AppBarLeftContainer } from "./AppBarLarge.styled";
 
 interface SidebarButtonProps {
   isSmallAppBar?: boolean;
@@ -13,19 +11,6 @@ interface SidebarButtonProps {
 export const SidebarButton = styled.button<SidebarButtonProps>`
   cursor: pointer;
   display: block;
-
-  ${({ isNavBarEnabled, isLogoVisible, isSmallAppBar }) =>
-    isLogoVisible && !isSmallAppBar
-      ? css`
-          opacity: ${isNavBarEnabled ? 0 : 1};
-
-          ${AppBarLeftContainer}:hover & {
-            opacity: ${isNavBarEnabled ? 1 : 0};
-          }
-        `
-      : css`
-          opacity: 1;
-        `}
 `;
 
 interface SidebarIconProps {
@@ -33,17 +18,6 @@ interface SidebarIconProps {
 }
 
 export const SidebarIcon = styled(Icon)<SidebarIconProps>`
-  color: ${color("brand")};
+  color: ${color("text-dark")};
   display: block;
-  transform: translateY(2px) translateX(2px);
-
-  ${props =>
-    !props.isLogoVisible &&
-    css`
-      color: ${color("text-medium")};
-
-      &:hover {
-        color: ${color("brand")};
-      }
-    `}
 `;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
@@ -28,11 +28,7 @@ const AppBarToggle = ({
         data-testid="sidebar-toggle"
         aria-label={t`Toggle sidebar`}
       >
-        <SidebarIcon
-          isLogoVisible={isLogoVisible}
-          size={24}
-          name={isNavBarOpen ? "sidebar_open" : "sidebar_closed"}
-        />
+        <SidebarIcon isLogoVisible={isLogoVisible} size={20} name="burger" />
       </SidebarButton>
     </Tooltip>
   );


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36963

## Summary

Change the logo so that clicking it takes you home, and add a burger icon to toggle the sidebar.

Previously, the logo changed to a sidebar button when hovering.

<img width="369" alt="CleanShot 2023-12-19 at 19 47 13@2x" src="https://github.com/metabase/metabase/assets/116838/892407fa-e734-4605-8aa4-e3ff24db06cb">
