### PR TITLE
Remove inconsistency with readOnly and isEditable

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -26,8 +26,6 @@ const {
   PEOPLE,
   REVIEWS,
   REVIEWS_ID,
-  ANALYTIC_EVENTS,
-  ANALYTIC_EVENTS_ID,
 } = SAMPLE_DATABASE;
 
 const QUESTION_NAME = "Cypress Pivot Table";
@@ -1107,23 +1105,11 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
       const query = {
         type: "query",
         query: {
-          "source-table": ANALYTIC_EVENTS_ID,
+          "source-table": PRODUCTS_ID,
           aggregation: [["count"]],
           breakout: [
-            [
-              "field",
-              ANALYTIC_EVENTS.BUTTON_LABEL,
-              { "base-type": "type/Text" },
-            ],
-            ["field", ANALYTIC_EVENTS.PAGE_URL, { "base-type": "type/Text" }],
-            [
-              "field",
-              ANALYTIC_EVENTS.TIMESTAMP,
-              { "base-type": "type/DateTime", "temporal-unit": "day" },
-            ],
-            ["field", ANALYTIC_EVENTS.EVENT, { "base-type": "type/Text" }],
-            ["field", ANALYTIC_EVENTS.ACCOUNT_ID, { "base-type": "type/Text" }],
-            ["field", ANALYTIC_EVENTS.ID, { "base-type": "type/Text" }],
+            ["field", PRODUCTS.CATEGORY, { "base-type": "type/Text" }],
+            ["field", PRODUCTS.EAN, { "base-type": "type/Text" }],
           ],
         },
         database: SAMPLE_DB_ID,
@@ -1135,27 +1121,10 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
         visualization_settings: {
           "pivot_table.column_split": {
             rows: [
-              ["field", ANALYTIC_EVENTS.PAGE_URL, { "base-type": "type/Text" }],
-              [
-                "field",
-                ANALYTIC_EVENTS.BUTTON_LABEL,
-                { "base-type": "type/Text" },
-              ],
-              [
-                "field",
-                ANALYTIC_EVENTS.ACCOUNT_ID,
-                { "base-type": "type/Text" },
-              ],
-              [
-                "field",
-                ANALYTIC_EVENTS.TIMESTAMP,
-                { "base-type": "type/DateTime", "temporal-unit": "day" },
-              ],
-              ["field", ANALYTIC_EVENTS.ID, { "base-type": "type/Text" }],
+              ["field", PRODUCTS.CATEGORY, { "base-type": "type/Text" }],
+              ["field", PRODUCTS.EAN, { "base-type": "type/Text" }],
             ],
-            columns: [
-              ["field", ANALYTIC_EVENTS.EVENT, { "base-type": "type/Text" }],
-            ],
+            columns: [["field", "count", { "base-type": "type/Integer" }]],
             values: [["aggregation", 0]],
           },
         },
@@ -1163,7 +1132,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
       cy.findByTestId("question-row-count").should(
         "have.text",
-        "Showing first 52,711 rows",
+        "Showing 205 rows",
       );
 
       cy.findByTestId("qb-header-action-panel").findByText("Save").click();
@@ -1175,7 +1144,7 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
 
       cy.findByTestId("question-row-count").should(
         "have.text",
-        "Showing first 52,711 rows",
+        "Showing 205 rows",
       );
     },
   );

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -159,7 +159,7 @@ export default class NativeQuery extends AtomicQuery {
   }
 
   // Whether the user can modify and run this query
-  // Determined based on availability of database metadata
+  // Determined based on availability of database metadata and native database permissions
   isEditable(): boolean {
     const database = this.database();
     return database != null && database.native_permissions === "write";

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -152,14 +152,14 @@ export default class NativeQuery extends AtomicQuery {
   }
 
   /**
-   * Returns true if the database metadata (or lack thererof indicates the user can modify and run this query
+   * Opposite of isEditable
    */
   readOnly(): boolean {
     return !this.isEditable();
   }
 
-  // This basically just mirrors StructuredQueries `isEditable` method,
-  // so there is no need to do `isStructured ? isEditable() : readOnly()`
+  // Whether the user can modify and run this query
+  // Determined based on availability of database metadata
   isEditable(): boolean {
     const database = this.database();
     return database != null && database.native_permissions === "write";

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -154,15 +154,15 @@ export default class NativeQuery extends AtomicQuery {
   /**
    * Returns true if the database metadata (or lack thererof indicates the user can modify and run this query
    */
-  readOnly() {
-    const database = this.database();
-    return !database || database.native_permissions !== "write";
+  readOnly(): boolean {
+    return !this.isEditable();
   }
 
   // This basically just mirrors StructuredQueries `isEditable` method,
   // so there is no need to do `isStructured ? isEditable() : readOnly()`
-  isEditable() {
-    return !this.readOnly();
+  isEditable(): boolean {
+    const database = this.database();
+    return database != null && database.native_permissions === "write";
   }
 
   /* Methods unique to this query type */

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -154,15 +154,15 @@ class StructuredQuery extends AtomicQuery {
   /**
    * @returns true if we have metadata for the root source table loaded
    */
-  hasMetadata() {
-    return this.metadata() && !!this.rootTable();
+  hasMetadata(): boolean {
+    return this.metadata() != null && this.rootTable() != null;
   }
 
   /**
    * @returns true if this query is in a state where it can be edited. Must have database and table set, and metadata for the table loaded.
    */
-  isEditable() {
-    return !this.readOnly() && this.hasMetadata();
+  isEditable(): boolean {
+    return this.database() != null && this.hasMetadata();
   }
 
   /* AtomicQuery superclass methods */
@@ -202,8 +202,8 @@ class StructuredQuery extends AtomicQuery {
   /**
    * Returns true if the database metadata (or lack thererof indicates the user can modify and run this query
    */
-  readOnly() {
-    return !this.database();
+  readOnly(): boolean {
+    return !this.isEditable();
   }
 
   /* Methods unique to this query type */

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -160,7 +160,7 @@ class StructuredQuery extends AtomicQuery {
 
   // Whether the user can modify and run this query
   // Determined based on availability of database and source table metadata
-  // For queries based on another card expects virtual table metadata for the source card
+  // For queries based on questions expects virtual table metadata for the source card
   isEditable(): boolean {
     return this.database() != null && this.hasMetadata();
   }

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -158,9 +158,9 @@ class StructuredQuery extends AtomicQuery {
     return this.metadata() != null && this.rootTable() != null;
   }
 
-  /**
-   * @returns true if this query is in a state where it can be edited. Must have database and table set, and metadata for the table loaded.
-   */
+  // Whether the user can modify and run this query
+  // Determined based on availability of database and source table metadata
+  // For queries based on another card expects virtual table metadata for the source card
   isEditable(): boolean {
     return this.database() != null && this.hasMetadata();
   }
@@ -200,7 +200,7 @@ class StructuredQuery extends AtomicQuery {
   }
 
   /**
-   * Returns true if the database metadata (or lack thererof indicates the user can modify and run this query
+   * Opposite of isEditable
    */
   readOnly(): boolean {
     return !this.isEditable();

--- a/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
@@ -1,7 +1,11 @@
 import userEvent from "@testing-library/user-event";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { Card, Database } from "metabase-types/api";
-import { createMockCard, createMockNativeCard } from "metabase-types/api/mocks";
+import {
+  createMockCard,
+  createMockNativeCard,
+  createMockTable,
+} from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 import { createMockState } from "metabase-types/store/mocks";
 import { createMockEntitiesState } from "__support__/store";
@@ -41,6 +45,7 @@ function setup({ card, databases = [createSampleDatabase()] }: SetupOpts) {
   const state = createMockState({
     entities: createMockEntitiesState({
       databases,
+      tables: [createMockTable({ id: `card__${card.id}` })],
       questions: [card],
     }),
   });

--- a/frontend/src/metabase/query_builder/selectors.unit.spec.js
+++ b/frontend/src/metabase/query_builder/selectors.unit.spec.js
@@ -7,6 +7,7 @@ import {
   getQuestionDetailsTimelineDrawerState,
 } from "metabase/query_builder/selectors";
 import { createMockEntitiesState } from "__support__/store";
+import { createMockTable } from "metabase-types/api/mocks";
 import {
   createSampleDatabase,
   ORDERS,
@@ -26,7 +27,10 @@ import Join from "metabase-lib/queries/structured/Join";
 
 function getBaseState({ uiControls = {}, ...state } = {}) {
   return createMockState({
-    entities: createMockEntitiesState({ databases: [createSampleDatabase()] }),
+    entities: createMockEntitiesState({
+      databases: [createSampleDatabase()],
+      tables: [createMockTable({ id: "card__1" })],
+    }),
     qb: createMockQueryBuilderState({
       ...state,
       uiControls: createMockQueryBuilderUIControlsState({


### PR DESCRIPTION
Now `isEditable() === !readOnly()` in all cases. Previously there was an edge case with sandboxing where `isEditable()` was `false` and `readOnly` was `false`, which is incorrect. `isEditable` is more strict.