### PR TITLE
Change HTMLAttributes in MenuItem to ButtonHTMLAttributes<HTMLButtonElement>

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/Menu/MenuItem/MenuItem.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Menu/MenuItem/MenuItem.tsx
@@ -1,8 +1,9 @@
-import type { HTMLAttributes, MouseEvent } from "react";
+import type { ButtonHTMLAttributes, MouseEvent } from "react";
 import { Menu } from "@mantine/core";
 import type { MenuItemProps as MantineMenuItemProps } from "@mantine/core";
 
-type MenuItemProps = MantineMenuItemProps & HTMLAttributes<HTMLButtonElement>;
+type MenuItemProps = MantineMenuItemProps &
+  ButtonHTMLAttributes<HTMLButtonElement>;
 
 // hack to prevent parent Popover from closing when selecting a Menu.Item
 // check useClickOutside hook in mantine


### PR DESCRIPTION
Fixes the type-check error for `AdminEmbedMenu`:

```
Property 'disabled' does not exist on type 'IntrinsicAttributes & MenuItemProps & HTMLAttributes<HTMLButtonElement>'.
```

Typescript doesn't recognize the `disabled` attribute in `HTMLAttributes<HTMLButtonElement>` so we'll change it to `ButtonHTMLAttributes`