### PR TITLE
count `:model/User`, not `:core_user`

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -57,7 +57,7 @@
                  ;; force this to use a new Connection, it seems to be getting called in situations where the Connection
                  ;; is from a different thread and is invalid by the time we get to use it
                  (let [result (binding [t2.conn/*current-connectable* nil]
-                                (t2/count :core_user :is_active true :type "personal"))]
+                                (t2/count :model/User :is_active true :type :personal))]
                    (log/debug (u/colorize :green "=>") result)
                    result))
       memoized (memoize/ttl


### PR DESCRIPTION
I noticed that this was doing a `(t2/count :core_user ...)` instead of `(t2/count :model/User ...)`. I think the only difference is that our transforms aren't being run (which is why we needed to pass `:type "personal"` instead of `:type :personal`).