### PR TITLE
CSV appends: better header mismatch error messages

### DIFF
--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1086,7 +1086,7 @@
                (catch Exception e
                  (is (= {:status-code 422}
                         (ex-data e)))
-                 (is (re-matches #"^ public is not syncable\.$"
+                 (is (re-matches #"^The schema public is not syncable\.$"
                                  (.getMessage e))))))
         (testing "\nThe table should be deleted"
           (is (false? (let [details (mt/dbdef->connection-details driver/*driver* :db {:database-name (:name (mt/db))})]


### PR DESCRIPTION
This PR will merge into the feature branch for Merge 1 of Milestone 0 [(PR)](https://github.com/metabase/metabase/pull/36640)

Epic: [Allow appending more data to CSV uploads](https://github.com/metabase/metabase/issues/35614)
[product doc](https://www.notion.so/metabase/Allow-appending-more-data-to-existing-CSV-uploads-f1f13864632d4cfd83522fce762890eb)
[eng doc](https://www.notion.so/metabase/Eng-Allow-appending-more-data-to-CSV-uploads-4c40e06fa64744c699588b8d8576e5df)

This PR makes the error message more specific when the headers of the CSV file don't match the field names of the table being uploaded to. The exact error message wasn't specified in the product doc, so I've taken the liberty to write them myself.

It corresponds to the following section of the eng doc ([block link](https://www.notion.so/metabase/Eng-Allow-appending-more-data-to-CSV-uploads-4c40e06fa64744c699588b8d8576e5df?pvs=4#c5b9b0babfbf48a9ab133e04896c5fc9)):

### Columns mismatch (status: 422):
- Message: “The columns of the uploaded CSV file don’t match the columns of the table. Extra columns: …. Missing columns: …” (or something like that)
- Details:
  - All columns in the table need to be present in the CSV file, with exact string comparison on the normalized column name, unless they are autogenerated by the database (such as the autogenerated `id` column we make for upload tables)
  - The order of the columns doesn’t matter
  - There must be no duplicate column names in the CSV file
  - There must be no extra columns in the CSV file that are not present in the table.
  - If these conditions aren’t satisfied, throw a columns mismatch error (see next section)
    - [x]  Test: If there are extra columns AND/XOR missing columns, return an appropriate error
    - [x]  Test: If the columns in the append CSV are in a different order to the originally uploaded table, the upload should succeed
    - [x]  Test: If the column names are different when unnormalized but are the same normalized, the upload should succeed
    - [x]  Test: If there are duplicate columns, return an appropriate error