### PR TITLE
Trend charts — Compact formatting viz setting

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -201,16 +201,19 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     cy.findByTestId("chartsettings-sidebar").findByText("Display").click();
 
     cy.findByTestId("scalar-container").findByText("3,440,000");
+    cy.findByTestId("scalar-previous-value").findByText("5,270,000");
 
     cy.findByTestId("chartsettings-sidebar")
       .findByLabelText("Compact number")
       .click();
     cy.findByTestId("scalar-container").findByText("3.4M");
+    cy.findByTestId("scalar-previous-value").findByText("5.3M");
 
     cy.findByTestId("chartsettings-sidebar")
       .findByLabelText("Compact number")
       .click();
     cy.findByTestId("scalar-container").findByText("3,440,000");
+    cy.findByTestId("scalar-previous-value").findByText("5,270,000");
   });
 
   it("should work regardless of column order (metabase#13710)", () => {

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -140,6 +140,7 @@ export type VisualizationSettings = {
   "scalar.comparisons"?: SmartScalarComparison;
   "scalar.field"?: string;
   "scalar.switch_positive_negative"?: boolean;
+  "scalar.compact_primary_number"?: boolean;
 
   [key: string]: any;
 };

--- a/frontend/src/metabase/visualizations/lib/scalar_utils.ts
+++ b/frontend/src/metabase/visualizations/lib/scalar_utils.ts
@@ -1,10 +1,17 @@
 import { formatValue } from "metabase/lib/formatting";
 import type { OptionsType } from "metabase/lib/formatting/types";
 
-// used below to determine whether we show compact formatting
 export const COMPACT_MAX_WIDTH = 250;
 export const COMPACT_WIDTH_PER_DIGIT = 25;
 export const COMPACT_MIN_LENGTH = 6;
+
+function checkShouldCompact(fullValue: string, width: number) {
+  const expectedCompactWidth = fullValue.length * COMPACT_WIDTH_PER_DIGIT;
+  return (
+    fullValue.length > COMPACT_MIN_LENGTH &&
+    (width < COMPACT_MAX_WIDTH || width < expectedCompactWidth)
+  );
+}
 
 export function compactifyValue(
   value: number,
@@ -15,21 +22,18 @@ export function compactifyValue(
     ...formatOptions,
     compact: false,
   });
-  const compactScalarValue = formatValue(value, {
-    ...formatOptions,
-    compact: true,
-  });
 
-  // use the compact version of formatting if the component is narrower than
-  // the cutoff and the formatted value is longer than the cutoff
-  // also if the width is less than a certain multiplier of the number of digits
-  const displayCompact =
-    fullScalarValue !== null &&
-    typeof fullScalarValue === "string" &&
-    fullScalarValue.length > COMPACT_MIN_LENGTH &&
-    (width < COMPACT_MAX_WIDTH ||
-      width < COMPACT_WIDTH_PER_DIGIT * fullScalarValue.length);
-  const displayValue = displayCompact ? compactScalarValue : fullScalarValue;
+  const canCompact = typeof fullScalarValue === "string";
+  if (!canCompact) {
+    return { displayValue: fullScalarValue, fullScalarValue };
+  }
+
+  const displayValue = checkShouldCompact(fullScalarValue, width)
+    ? formatValue(value, {
+        ...formatOptions,
+        compact: true,
+      })
+    : fullScalarValue;
 
   return { displayValue, fullScalarValue };
 }

--- a/frontend/src/metabase/visualizations/lib/scalar_utils.ts
+++ b/frontend/src/metabase/visualizations/lib/scalar_utils.ts
@@ -28,12 +28,13 @@ export function compactifyValue(
     return { displayValue: fullScalarValue, fullScalarValue };
   }
 
-  const displayValue = checkShouldCompact(fullScalarValue, width)
-    ? formatValue(value, {
-        ...formatOptions,
-        compact: true,
-      })
-    : fullScalarValue;
+  const displayValue =
+    formatOptions.compact || checkShouldCompact(fullScalarValue, width)
+      ? formatValue(value, {
+          ...formatOptions,
+          compact: true,
+        })
+      : fullScalarValue;
 
   return { displayValue, fullScalarValue };
 }

--- a/frontend/src/metabase/visualizations/lib/scalar_utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/scalar_utils.unit.spec.ts
@@ -88,5 +88,18 @@ describe("scalar utils", () => {
       expect(displayValue).toBe(fullScalarValue);
       expect(displayValue).toBe("10,010,010,010");
     });
+
+    it("displayValue is always compact when formatOptions.compact is true", () => {
+      const value = 10010010010;
+      const width = 350;
+
+      const { displayValue, fullScalarValue } = compactifyValue(value, width, {
+        ...formatOptions,
+        compact: true,
+      }) as { displayValue: string; fullScalarValue: string };
+
+      expect(displayValue).toBe("10.0B");
+      expect(fullScalarValue).toBe("10,010,010,010");
+    });
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -84,8 +84,7 @@ export function SmartScalarComparisonWidget({
                 : undefined
             }
             onChange={nextValue => {
-              onChange(nextValue);
-              setOpen(false);
+              handleEditedValueChange(nextValue, true);
             }}
             onBack={() => setTab(null)}
           />

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -96,11 +96,10 @@ export function SmartScalar({
     }
   };
 
-  const { displayValue, fullScalarValue } = compactifyValue(
-    value,
-    width,
-    formatOptions,
-  );
+  const { displayValue, fullScalarValue } = compactifyValue(value, width, {
+    ...formatOptions,
+    compact: settings["scalar.compact_primary_number"],
+  });
 
   return (
     <ScalarWrapper>
@@ -295,6 +294,13 @@ Object.assign(SmartScalar, {
       title: t`Switch positive / negative colors?`,
       widget: "toggle",
       inline: true,
+    },
+    "scalar.compact_primary_number": {
+      section: t`Display`,
+      title: t`Compact number`,
+      widget: "toggle",
+      inline: true,
+      default: false,
     },
     ...columnSettings({
       section: t`Display`,

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -96,10 +96,11 @@ export function SmartScalar({
     }
   };
 
-  const { displayValue, fullScalarValue } = compactifyValue(value, width, {
-    ...formatOptions,
-    compact: settings["scalar.compact_primary_number"],
-  });
+  const { displayValue, fullScalarValue } = compactifyValue(
+    value,
+    width,
+    formatOptions,
+  );
 
   return (
     <ScalarWrapper>

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
@@ -147,7 +147,10 @@ function getCurrentMetricData({ series, insights, settings }) {
     dateUnit,
   };
 
-  const formatOptions = settings.column?.(metricColumn);
+  const formatOptions = {
+    ...settings.column?.(metricColumn),
+    compact: settings["scalar.compact_primary_number"],
+  };
 
   const clicked = {
     value,

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.unit.spec.js
@@ -1954,51 +1954,55 @@ describe("SmartScalar > compute", () => {
     });
 
     describe("format options", () => {
-      const series = [
-        createMockSingleSeries(
-          {},
-          {
-            data: {
-              rows: [
-                [100, "2023-10-01T00:00:00"],
-                [300, "2024-10-01T00:00:00"],
-              ],
-              cols: [
-                createMockNumberColumn({ name: "Count" }),
-                createMockDateTimeColumn({ name: "Month" }),
-              ],
-            },
-          },
-        ),
+      const countColumn = createMockNumberColumn({ name: "Count" });
+      const monthColumn = createMockDateTimeColumn({ name: "Month" });
+
+      const cols = [countColumn, monthColumn];
+      const rows = [
+        [105000, "2023-10-01T00:00:00"],
+        [210000, "2024-10-01T00:00:00"],
       ];
+
+      const series = [createMockSingleSeries({}, { data: { rows, cols } })];
 
       const insights = [{ unit: "month", col: "Count" }];
 
       const createVizSettings = settings =>
         createMockVisualizationSettings({
+          column: column => ({ column }),
           "scalar.field": "Count",
           "scalar.comparisons": { type: COMPARISON_TYPES.PREVIOUS_VALUE },
           ...settings,
         });
 
       it("should have `compact: false` by default", () => {
-        const { formatOptions } = computeTrend(
-          series,
-          insights,
-          createVizSettings(),
-        );
+        const {
+          comparison: { display: comparisonDisplay },
+          display,
+          formatOptions,
+        } = computeTrend(series, insights, createVizSettings());
+
         expect(formatOptions.compact).toBeFalsy();
+        expect(display.value).toBe("210,000");
+        expect(comparisonDisplay.comparisonValue).toBe("105,000");
       });
 
       it("should have `compact: true` with `scalar.compact_primary_number` viz setting", () => {
-        const { formatOptions } = computeTrend(
+        const {
+          comparison: { display: comparisonDisplay },
+          display,
+          formatOptions,
+        } = computeTrend(
           series,
           insights,
           createVizSettings({
             "scalar.compact_primary_number": true,
           }),
         );
+
         expect(formatOptions.compact).toBe(true);
+        expect(display.value).toBe("210.0k");
+        expect(comparisonDisplay.comparisonValue).toBe("105.0k");
       });
     });
   });
@@ -2214,6 +2218,7 @@ function getTrend(trend) {
 function createMockDateTimeColumn(opts) {
   return createMockColumn({
     base_type: "type/DateTime",
+    effective_type: "type/DateTime",
     semantic_type: null,
     ...opts,
   });
@@ -2222,6 +2227,7 @@ function createMockDateTimeColumn(opts) {
 function createMockNumberColumn(opts) {
   return createMockColumn({
     base_type: "type/Integer",
+    effective_type: "type/Integer",
     semantic_type: "type/Number",
     ...opts,
   });

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.unit.spec.js
@@ -1952,6 +1952,55 @@ describe("SmartScalar > compute", () => {
         },
       );
     });
+
+    describe("format options", () => {
+      const series = [
+        createMockSingleSeries(
+          {},
+          {
+            data: {
+              rows: [
+                [100, "2023-10-01T00:00:00"],
+                [300, "2024-10-01T00:00:00"],
+              ],
+              cols: [
+                createMockNumberColumn({ name: "Count" }),
+                createMockDateTimeColumn({ name: "Month" }),
+              ],
+            },
+          },
+        ),
+      ];
+
+      const insights = [{ unit: "month", col: "Count" }];
+
+      const createVizSettings = settings =>
+        createMockVisualizationSettings({
+          "scalar.field": "Count",
+          "scalar.comparisons": { type: COMPARISON_TYPES.PREVIOUS_VALUE },
+          ...settings,
+        });
+
+      it("should have `compact: false` by default", () => {
+        const { formatOptions } = computeTrend(
+          series,
+          insights,
+          createVizSettings(),
+        );
+        expect(formatOptions.compact).toBeFalsy();
+      });
+
+      it("should have `compact: true` with `scalar.compact_primary_number` viz setting", () => {
+        const { formatOptions } = computeTrend(
+          series,
+          insights,
+          createVizSettings({
+            "scalar.compact_primary_number": true,
+          }),
+        );
+        expect(formatOptions.compact).toBe(true);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
Closes #35554

Adds a new boolean viz setting for trend charts that makes it always use compact number format (1M vs 1,000,000 or 400K vs. 400,000)

### To Verify

1. New > Question > Raw Data > Orders
2. Click "Pick the metric you want to see" > Custom Expression > Use `Count * 10000` as a formula
3. Click "Pick a column to group by" > Created At
4. Visualize, change the visualization to "Trend"
5. Open visualization settings sidebar > Display tab
6. Toggle the "Compact number" option
7. Ensure the value changed to something like "3.4M"

### Demo

https://github.com/metabase/metabase/assets/17258145/948e7500-bc25-4a8d-93e6-00c16026f2d1


