### PR TITLE
CSV appends: Use a transaction for inserting data

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -758,7 +758,12 @@
           (with-open [^java.io.Writer writer (jio/writer file-path)]
             (doseq [value (interpose \newline tsvs)]
               (.write writer (str value))))
-          (sql-jdbc.execute/do-with-connection-with-options driver db-id nil (fn [conn] (jdbc/execute! conn sql))))
+          (sql-jdbc.execute/do-with-connection-with-options
+           driver
+           db-id
+           nil
+           (fn [conn]
+             (jdbc/execute! {:connection conn} sql))))
         (finally
           (.delete temp-file))))))
 

--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -745,7 +745,7 @@
   ;; `local_infile` must be turned on per
   ;; https://dev.mysql.com/doc/refman/8.0/en/load-data.html#load-data-local
   (if (not= (get-global-variable db-id "local_infile") "ON")
-      ;; If it isn't turned on, fall back to the generic "INSERT INTO ..." way
+    ;; If it isn't turned on, fall back to the generic "INSERT INTO ..." way
     ((get-method driver/insert-into! :sql-jdbc) driver db-id table-name column-names values)
     (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
       (let [temp-file (File/createTempFile table-name ".tsv")

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -831,25 +831,23 @@
 
 (defmethod driver/insert-into! :postgres
   [driver db-id table-name column-names values]
-  (sql-jdbc.execute/do-with-connection-with-options
-   driver
-   db-id
-   {:write? true}
-   (fn [^java.sql.Connection conn]
-     (let [copy-manager (CopyManager. (.unwrap conn PgConnection))
-           [sql & _]    (sql/format {::copy       (keyword table-name)
-                                     :columns     (map keyword column-names)
-                                     ::from-stdin "''"}
-                                    :quoted true
-                                    :dialect (sql.qp/quote-style driver))
-           ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
-           chunks (partition-all (or driver/*insert-chunk-rows* 100) values)]
-       (doseq [chunk chunks]
-         (let [tsvs (->> chunk
-                         (map row->tsv)
-                         (str/join "\n")
-                         (StringReader.))]
-           (.copyIn copy-manager ^String sql tsvs)))))))
+  (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
+    (let [copy-manager (CopyManager. (.unwrap (:connection conn) PgConnection))
+          [sql & _]    (sql/format {::copy       (keyword table-name)
+                                    :columns     (map keyword column-names)
+                                    ::from-stdin "''"}
+                                   :quoted true
+                                   :dialect (sql.qp/quote-style driver))
+          ;; On Postgres with a large file, 100 (3.76m) was significantly faster than 50 (4.03m) and 25 (4.27m). 1,000 was a
+          ;; little faster but not by much (3.63m), and 10,000 threw an error:
+          ;;     PreparedStatement can have at most 65,535 parameters
+          chunks (partition-all (or driver/*insert-chunk-rows* 1000) values)]
+      (doseq [chunk chunks]
+        (let [tsvs (->> chunk
+                        (map row->tsv)
+                        (str/join "\n")
+                        (StringReader.))]
+          (.copyIn copy-manager ^String sql tsvs))))))
 
 (defmethod driver/current-user-table-privileges :postgres
   [_driver database]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -39,7 +39,7 @@
    [metabase.util.malli :as mu])
   (:import
    (java.io StringReader)
-   (java.sql ResultSet ResultSetMetaData Time Types)
+   (java.sql Connection ResultSet ResultSetMetaData Time Types)
    (java.time LocalDateTime OffsetDateTime OffsetTime)
    (java.util Date UUID)
    (org.postgresql.copy CopyManager)
@@ -832,7 +832,7 @@
 (defmethod driver/insert-into! :postgres
   [driver db-id table-name column-names values]
   (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
-    (let [copy-manager (CopyManager. (.unwrap (:connection conn) PgConnection))
+    (let [copy-manager (CopyManager. (.unwrap ^Connection (:connection conn) PgConnection))
           [sql & _]    (sql/format {::copy       (keyword table-name)
                                     :columns     (map keyword column-names)
                                     ::from-stdin "''"}

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -140,25 +140,26 @@
 
 (defmethod driver/insert-into! :sql-jdbc
   [driver db-id table-name column-names values]
-  (let [table-name (keyword table-name)
-        columns    (map keyword column-names)
-        ;; We need to partition the insert into multiple statements for both performance and correctness.
-        ;;
-        ;; On Postgres with a large file, 100 (3.76m) was significantly faster than 50 (4.03m) and 25 (4.27m). 1,000 was a
-        ;; little faster but not by much (3.63m), and 10,000 threw an error:
-        ;;     PreparedStatement can have at most 65,535 parameters
-        ;; One imagines that `(long (/ 65535 (count columns)))` might be best, but I don't trust the 65K limit to apply
-        ;; across all drivers. With that in mind, 100 seems like a safe compromise.
-        ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
-        chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
-        sqls       (map #(sql/format {:insert-into table-name
-                                      :columns     columns
-                                      :values      %}
-                                     :quoted true
-                                     :dialect (sql.qp/quote-style driver))
-                        chunks)]
-    (doseq [sql sqls]
-      (qp.writeback/execute-write-sql! db-id sql))))
+  (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
+    (let [table-name (keyword table-name)
+          columns    (map keyword column-names)
+          ;; We need to partition the insert into multiple statements for both performance and correctness.
+          ;;
+          ;; On Postgres with a large file, 100 (3.76m) was significantly faster than 50 (4.03m) and 25 (4.27m). 1,000 was a
+          ;; little faster but not by much (3.63m), and 10,000 threw an error:
+          ;;     PreparedStatement can have at most 65,535 parameters
+          ;; One imagines that `(long (/ 65535 (count columns)))` might be best, but I don't trust the 65K limit to apply
+          ;; across all drivers. With that in mind, 100 seems like a safe compromise.
+          ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
+          chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
+          sqls       (map #(sql/format {:insert-into table-name
+                                        :columns     columns
+                                        :values      %}
+                                       :quoted true
+                                       :dialect (sql.qp/quote-style driver))
+                          chunks)]
+      (doseq [sql sqls]
+        (jdbc/execute! conn sql)))))
 
 (defmethod driver/add-columns! :sql-jdbc
   [driver db-id table-name col->type]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -140,24 +140,24 @@
 
 (defmethod driver/insert-into! :sql-jdbc
   [driver db-id table-name column-names values]
-  (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
-    (let [table-name (keyword table-name)
-          columns    (map keyword column-names)
-          ;; We need to partition the insert into multiple statements for both performance and correctness.
-          ;;
-          ;; On Postgres with a large file, 100 (3.76m) was significantly faster than 50 (4.03m) and 25 (4.27m). 1,000 was a
-          ;; little faster but not by much (3.63m), and 10,000 threw an error:
-          ;;     PreparedStatement can have at most 65,535 parameters
-          ;; One imagines that `(long (/ 65535 (count columns)))` might be best, but I don't trust the 65K limit to apply
-          ;; across all drivers. With that in mind, 100 seems like a safe compromise.
-          ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
-          chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
-          sqls       (map #(sql/format {:insert-into table-name
-                                        :columns     columns
-                                        :values      %}
-                                       :quoted true
-                                       :dialect (sql.qp/quote-style driver))
-                          chunks)]
+  (let [table-name (keyword table-name)
+        columns    (map keyword column-names)
+        ;; We need to partition the insert into multiple statements for both performance and correctness.
+        ;;
+        ;; On Postgres with a large file, 100 (3.76m) was significantly faster than 50 (4.03m) and 25 (4.27m). 1,000 was a
+        ;; little faster but not by much (3.63m), and 10,000 threw an error:
+        ;;     PreparedStatement can have at most 65,535 parameters
+        ;; One imagines that `(long (/ 65535 (count columns)))` might be best, but I don't trust the 65K limit to apply
+        ;; across all drivers. With that in mind, 100 seems like a safe compromise.
+        ;; There's nothing magic about 100, but it felt good in testing. There could well be a better number.
+        chunks     (partition-all (or driver/*insert-chunk-rows* 100) values)
+        sqls       (map #(sql/format {:insert-into table-name
+                                      :columns     columns
+                                      :values      %}
+                                     :quoted true
+                                     :dialect (sql.qp/quote-style driver))
+                        chunks)]
+    (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
       (doseq [sql sqls]
         (jdbc/execute! conn sql)))))
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -557,11 +557,6 @@
           _                  (check-schema (dissoc normed-name->field auto-pk-column-name) header)
           col-upload-types   (map (comp base-type->upload-type :base_type normed-name->field) normed-header)
           parsed-rows        (parse-rows col-upload-types rows)]
-      (when create-auto-pk?
-        (driver/add-columns! driver
-                             (:id database)
-                             (table-identifier table)
-                             {(keyword auto-pk-column-name) (driver/upload-type->database-type driver ::auto-incrementing-int-pk)}))
       (try
         (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)
         (catch Throwable e

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -3,18 +3,14 @@
    [clj-bom.core :as bom]
    [clojure.data :as data]
    [clojure.data.csv :as csv]
-   [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
    [flatland.ordered.map :as ordered-map]
    [flatland.ordered.set :as ordered-set]
-   [honey.sql :as sql]
    [java-time.api :as t]
    [medley.core :as m]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.driver :as driver]
-   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
-   [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sync :as driver.s]
    [metabase.driver.util :as driver.u]
    [metabase.mbql.util :as mbql.u]
@@ -566,35 +562,20 @@
                              (:id database)
                              (table-identifier table)
                              {(keyword auto-pk-column-name) (driver/upload-type->database-type driver ::auto-incrementing-int-pk)}))
-      ;; If the insert fails, we need to delete the rows we just inserted. So we:
-      ;; 1. get the max PK value before inserting
-      ;; 2. insert the rows
-      ;; 3. if insertion fails, delete the rows with PKs greater than the max PK value
-      (let [;; 1.
-            max-pk (val (ffirst (jdbc/query (sql-jdbc.conn/db->pooled-connection-spec database)
-                                            (sql/format {:select [[[:max (keyword auto-pk-column-name)]]]
-                                                         :from (keyword (table-identifier table))}
-                                                        {:quoted true
-                                                         :dialect (sql.qp/quote-style driver)}))))]
-        (try
-          ;; 2.
-          (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)
-          (scan-and-sync-table! database table)
-          (let [auto-pk-field (table-id->auto-pk-column (:id table))]
-            (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)}))
-          (catch Throwable e
-            ;; 3.
-            (jdbc/execute! (sql-jdbc.conn/db->pooled-connection-spec database)
-                           (sql/format {:delete-from (keyword (table-identifier table))
-                                        :where       [:> (keyword auto-pk-column-name) max-pk]}
-                                       {:quoted  true
-                                        :dialect (sql.qp/quote-style driver)}))
-            (when create-auto-pk?
-              ;; sync the table again just to pick up the new auto-pk column
-              (scan-and-sync-table! database table)
-              (let [auto-pk-field (table-id->auto-pk-column (:id table))]
-                (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})))
-            (throw (ex-info (ex-message e) {:status-code 422})))))
+      (try
+        (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)
+        (catch Throwable e
+
+          (throw (ex-info (ex-message e) {:status-code 422}))))
+      (when create-auto-pk?
+        (driver/add-columns! driver
+                             (:id database)
+                             (table-identifier table)
+                             {(keyword auto-pk-column-name) (driver/upload-type->database-type driver ::auto-incrementing-int-pk)}))
+      (scan-and-sync-table! database table)
+      (when create-auto-pk?
+        (let [auto-pk-field (table-id->auto-pk-column (:id table))]
+          (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})))
       {:row-count (count parsed-rows)})))
 
 (defn- can-append-error


### PR DESCRIPTION
This PR will merge into the feature branch for Merge 1 of Milestone 0 [(PR)](https://github.com/metabase/metabase/pull/36640)

Epic: [Allow appending more data to CSV uploads](https://github.com/metabase/metabase/issues/35614)
[product doc](https://www.notion.so/metabase/Allow-appending-more-data-to-existing-CSV-uploads-f1f13864632d4cfd83522fce762890eb)
[eng doc](https://www.notion.so/metabase/Eng-Allow-appending-more-data-to-CSV-uploads-4c40e06fa64744c699588b8d8576e5df)

This PR mostly preserves observable behaviour. It replaces the logic I created for handling insertion errors to fake transactions with real transactions. 

Originally I wanted to use `_mb_row_id` for deleting inserted rows if there was a failure, because I thought the reason we weren't using transactions before was to make insertions faster. Turns out I was wrong, using a transaction is actually slightly faster because a transaction doesn't add much overhead but each commit does.

I say "This PR mostly preserves observable behaviour" because it makes one change: if a failure occurs on inserting data and the table didn't have a `_mb_row_id` column before, no `_mb_row_id` column is created. That behaviour can be seen in `append-no-mb-row-id-failure-test`.