### PR TITLE
Api key update, regenerate, and list

### DIFF
--- a/src/metabase/api/api_key.clj
+++ b/src/metabase/api/api_key.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.api-key
   "/api/api-key endpoints for CRUD management of API Keys"
   (:require
-   [compojure.core :refer [POST GET]]
+   [compojure.core :refer [POST GET PUT]]
    [metabase.api.common :as api]
    [metabase.models.api-key :as api-key]
    [metabase.models.permissions-group :as perms-group]
@@ -41,9 +41,9 @@
                                             :name         name
                                             :unhashed_key api-key
                                             :created_by   api/*current-user-id*})
-            (select-keys [:created_at :updated_at :id])
+            (t2/hydrate :group_name)
+            (select-keys [:created_at :updated_at :id :group_name])
             (assoc :name name
-                   :group_id group_id
                    :unmasked_key api-key
                    :masked_key (api-key/mask api-key)))))))
 
@@ -52,5 +52,45 @@
   [:as _body]
   (api/check-superuser)
   (t2/count :model/ApiKey))
+
+(api/defendpoint PUT "/:id"
+  "Update an API key by changing either its group or its name"
+  [id :as {{:keys [group_id name] :as _body} :body}]
+  {id       ms/PositiveInt
+   group_id [:maybe ms/PositiveInt]
+   name     [:maybe ms/NonBlankString]}
+  (api/check-superuser)
+  (let [api-key-before (t2/select-one :model/ApiKey :id id)]
+    (when name
+      (t2/with-transaction [_conn]
+        ;; A bit of a pain to keep these in sync, but oh well.
+        (t2/update! :model/User (:user_id api-key-before) {:first_name name})
+        (t2/update! :model/ApiKey id {:name name})))
+    (when group_id
+      (let [user (-> api-key-before (t2/hydrate :user) :user)]
+        (user/set-permissions-groups! user [(perms-group/all-users) {:id group_id}])))
+    (-> (t2/select-one :model/ApiKey :id id)
+        (t2/hydrate :group_name)
+        (select-keys [:created_at :updated_at :id :name :masked_key :group_name]))))
+
+(api/defendpoint PUT "/:id/regenerate"
+  "Regenerate an API Key"
+  [id]
+  {id ms/PositiveInt}
+  (api/check-superuser)
+  (let [unhashed-key (key-with-unique-prefix)
+        [id] (t2/update-returning-pks! :model/ApiKey :id id {:unhashed_key unhashed-key})]
+    (-> (t2/select-one :model/ApiKey id)
+        (t2/hydrate :group_name)
+        (select-keys [:created_at :updated_at :id :name :group_name])
+        (assoc :unmasked_key unhashed-key
+               :masked_key (api-key/mask unhashed-key)))))
+
+(api/defendpoint GET "/"
+  "Get a list of API keys. Non-paginated."
+  []
+  (api/check-superuser)
+  (let [api-keys (t2/hydrate (t2/select :model/ApiKey) :group_name)]
+    (map #(select-keys % [:created_at :updated_at :id :name :group_name]) api-keys)))
 
 (api/define-routes)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -199,3 +199,12 @@
 (methodical/defmethod events/publish-event! ::settings-changed-event
   [topic event]
   (audit-log/record-event! topic event))
+
+(derive ::api-key-event ::event)
+(derive :event/api-key-create ::api-key-event)
+(derive :event/api-key-update ::api-key-event)
+(derive :event/api-key-regenerate ::api-key-event)
+
+(methodical/defmethod events/publish-event! ::api-key-event
+  [topic event]
+  (audit-log/record-event! topic event))

--- a/src/metabase/models/api_key.clj
+++ b/src/metabase/models/api_key.clj
@@ -31,7 +31,7 @@
                                :join [[:permissions_group_membership :pgm]
                                       [:= :pgm.group_id :pg.id]
                                       :api_key [:= :api_key.user_id :pgm.user_id]]
-                               :where [:in :api_key.id (map u/the-id (t2/select :model/ApiKey))]}))
+                               :where [:in :api_key.id (map u/the-id api-keys)]}))
           api-key-id->group-name
           (fn [api-key-id]
             (->> (api-key-id->permissions-groups api-key-id)

--- a/src/metabase/models/api_key.clj
+++ b/src/metabase/models/api_key.clj
@@ -1,5 +1,8 @@
 (ns metabase.models.api-key
   (:require [crypto.random :as crypto-random]
+            [metabase.models.interface :as mi]
+            [metabase.models.permissions-group :as perms-group]
+            [metabase.util :as u]
             [metabase.util.password :as u.password]
             [methodical.core :as methodical]
             [toucan2.core :as t2]))
@@ -11,6 +14,31 @@
 (def ^:private bytes-key-length 32)
 
 (methodical/defmethod t2/table-name :model/ApiKey [_model] :api_key)
+
+(mi/define-batched-hydration-method add-group-name
+  :group_name
+  "Add to each ApiKey a single group_name. Assume that each ApiKey is a member of either zero or one groups other than
+  the 'All Users' group."
+  [api-keys]
+  (when (seq api-keys)
+    (let [api-key-id->permissions-groups
+          (group-by :api-key-id
+                    (t2/query {:select [[:pg.name :group-name]
+                                        [:pg.id :group-id]
+                                        [:api_key.id :api-key-id]]
+                               :from [[:permissions_group :pg]]
+                               :join [[:permissions_group_membership :pgm]
+                                      [:= :pgm.group_id :pg.id]
+                                      :api_key [:= :api_key.user_id :pgm.user_id]]
+                               :where [:in :api_key.id (map u/the-id (t2/select :model/ApiKey))]}))
+          api-key-id->group-name
+          (fn [api-key-id]
+            (->> (api-key-id->permissions-groups api-key-id)
+                 (sort-by #(= (:group-id %) (u/the-id (perms-group/all-users))))
+                 first
+                 :group-name))]
+      (for [api-key api-keys]
+        (assoc api-key :group_name (api-key-id->group-name (u/the-id api-key)))))))
 
 (doto :model/ApiKey
   (derive :metabase/model)
@@ -25,17 +53,19 @@
   (cond-> api-key
     unhashed_key (assoc :key_prefix (prefix unhashed_key))))
 
-(defn mask
-  "Given an API key, returns a string of the same length with all but the prefix masked with `*`s"
-  [key]
-  (->> (concat (prefix key) (repeat "*"))
-       (take (count key))
-       (apply str)))
-
 (defn generate-key
   "Generates a new API key - a random base64 string prefixed with `mb_`"
   []
   (str "mb_" (crypto-random/base64 bytes-key-length)))
+
+(def ^:private string-key-length (count (generate-key)))
+
+(defn mask
+  "Given an API key, returns a string of the same length with all but the prefix masked with `*`s"
+  [key]
+  (->> (concat (prefix key) (repeat "*"))
+       (take string-key-length)
+       (apply str)))
 
 (defn- add-key
   "Adds the `key` based on the `unhashed_key` passed in."
@@ -55,3 +85,13 @@
   (-> api-key
       add-prefix
       add-key))
+
+(defn- add-masked-key [api-key]
+  (if-let [prefix (:key_prefix api-key)]
+    (assoc api-key :masked_key (mask prefix))
+    api-key))
+
+(t2/define-after-select :model/ApiKey
+  [api-key]
+  (-> api-key
+      add-masked-key))

--- a/src/metabase/models/api_key.clj
+++ b/src/metabase/models/api_key.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.api-key
   (:require [crypto.random :as crypto-random]
+            [metabase.models.audit-log :as audit-log]
             [metabase.models.interface :as mi]
             [metabase.models.permissions-group :as perms-group]
             [metabase.util :as u]
@@ -95,3 +96,7 @@
   [api-key]
   (-> api-key
       add-masked-key))
+
+(defmethod audit-log/model-details :model/ApiKey
+  [entity _event-type]
+  (select-keys entity [:name :group_name :key_prefix]))

--- a/test/metabase/api/api_key_test.clj
+++ b/test/metabase/api/api_key_test.clj
@@ -6,6 +6,7 @@
    [metabase.models.api-key :as api-key]
    [metabase.models.permissions-group :as perms-group]
    [metabase.test :as mt]
+   [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (deftest api-key-creation-test
@@ -15,13 +16,14 @@
             resp (mt/user-http-request :crowberto :post 200 "api-key"
                                        {:group_id group-id
                                         :name     name})]
-        (is (= #{:name :group_id :unmasked_key :masked_key :id :created_at :updated_at}
+        (is (= #{:name :group_name :unmasked_key :masked_key :id :created_at :updated_at}
                (-> resp keys set)))
+        (is (= "Cool Friends" (:group_name resp)))
         (is (= name (:name resp)))))
     (testing "Trying to create another API key with the same name fails"
       (let [key-name (str (random-uuid))]
         ;; works once...
-        (is (= #{:unmasked_key :masked_key :group_id :name :id :created_at :updated_at}
+        (is (= #{:unmasked_key :masked_key :group_name :name :id :created_at :updated_at}
                (set (keys (mt/user-http-request :crowberto :post 200 "api-key"
                                                 {:group_id group-id
                                                  :name     key-name})))))
@@ -71,7 +73,11 @@
     (testing "The group can be 'All Users'"
       (is (mt/user-http-request :crowberto :post 200 "api-key"
                                 {:group_id (:id (perms-group/all-users))
-                                 :name     (str (random-uuid))})))
+                                 :name     (str (random-uuid))}))
+      (is (= "All Users"
+             (:group_name (mt/user-http-request :crowberto :post 200 "api-key"
+                                                {:group_id (:id (perms-group/all-users))
+                                                 :name (str (random-uuid))})))))
     (testing "A non-empty name is required"
       (is (= {:errors          {:name "value must be a non-blank string."}
               :specific-errors {:name ["should be at least 1 characters, received: \"\"" "non-blank string, received: \"\""]}}
@@ -109,3 +115,84 @@
       (is (client/client :get 200 "user/current" {:request-options {:headers {"x-api-key" api-key}}}))
       (is (= "Unauthenticated"
              (client/client :get 401 "user/current" {:request-options {:headers {"x-api-key" "mb_not_an_api_key"}}}))))))
+
+(deftest api-keys-can-be-updated
+  (t2.with-temp/with-temp [:model/PermissionsGroup {group-id-1 :id} {:name "Cool Friends"}
+                           :model/PermissionsGroup {group-id-2 :id} {:name "Uncool Friends"}]
+    ;; create the API Key
+    (let [{id :id :as create-resp}
+          (mt/user-http-request :crowberto
+                                :post 200 "api-key"
+                                {:group_id group-id-1
+                                 :name     (str (random-uuid))})
+          _ (is (= "Cool Friends" (:group_name create-resp)))
+          api-user-id (:id (:user (t2/hydrate (t2/select-one :model/ApiKey :id id) :user)))
+          member-of-group? (fn [group-id]
+                             (t2/exists? :model/PermissionsGroupMembership
+                                         :user_id api-user-id
+                                         :group_id group-id))]
+      (is (member-of-group? group-id-1))
+      (is (not (member-of-group? group-id-2)))
+      (testing "You can change the group of an API key"
+        (is (= "Uncool Friends"
+               (:group_name (mt/user-http-request :crowberto :put 200 (format "api-key/%s" id) {:group_id group-id-2}))))
+        (is (not (member-of-group? group-id-1)))
+        (is (member-of-group? group-id-2))))
+    (testing "You can change the name of an API key"
+      (let [name-1 (str "My First Name" (random-uuid))
+            name-2 (str "My Second Name" (random-uuid))
+            {id :id} (mt/user-http-request :crowberto
+                                           :post 200 "api-key"
+                                           {:group_id group-id-1
+                                            :name name-1})
+            api-user-id (-> (t2/select-one :model/ApiKey :id id) (t2/hydrate :user) :user :id)]
+        (testing "before the change..."
+          (is (= name-1 (:common_name (t2/select-one :model/User api-user-id)))))
+        (testing "after the change..."
+          (mt/user-http-request :crowberto :put 200 (str "api-key/" id)
+                                {:name name-2})
+          (is (= name-2 (:common_name (t2/select-one :model/User api-user-id)))))))))
+
+(deftest api-keys-can-be-regenerated
+  (testing "You can regenerate an API key"
+    (t2.with-temp/with-temp [:model/PermissionsGroup {group-id :id} {:name "Cool Friends"}]
+      (let [{id :id old-key :unmasked_key}
+            (mt/user-http-request :crowberto
+                                  :post 200 "api-key"
+                                  {:group_id group-id
+                                   :name (str (random-uuid))})
+            _ (is (client/client :get 200 "user/current" {:request-options {:headers {"x-api-key" old-key}}}))
+            {:as resp new-key :unmasked_key}
+            (mt/user-http-request :crowberto
+                                  :put 200 (format "api-key/%s/regenerate" id))]
+        ;; NOTE: This is missing `group_id`.
+        (is (= #{:created_at :updated_at :id :name :unmasked_key :masked_key :group_name}
+               (set (keys resp))))
+        (is (client/client :get 401 "user/current" {:request-options {:headers {"x-api-key" old-key}}}))
+        (is (client/client :get 200 "user/current" {:request-options {:headers {"x-api-key" new-key}}}))))))
+
+(deftest api-keys-can-be-listed
+  (mt/with-empty-h2-app-db
+    (t2.with-temp/with-temp [:model/PermissionsGroup {group-id :id} {:name "Cool Friends"}]
+      (is (= [] (mt/user-http-request :crowberto :get 200 "api-key")))
+
+      (mt/user-http-request :crowberto
+                            :post 200 "api-key"
+                            {:group_id group-id
+                             :name     "My First API Key"})
+      (is (= [{:name       "My First API Key"
+               :group_name "Cool Friends"}]
+             (map #(select-keys % [:name :group_name])
+                  (mt/user-http-request :crowberto :get 200 "api-key"))))
+
+      (mt/user-http-request :crowberto
+                            :post 200 "api-key"
+                            {:group_id (:id (perms-group/all-users))
+                             :name "My Second API Key"})
+
+      (is (= [{:name "My First API Key"
+               :group_name "Cool Friends"}
+              {:name "My Second API Key"
+               :group_name "All Users"}]
+             (map #(select-keys % [:name :group_name])
+                  (mt/user-http-request :crowberto :get 200 "api-key")))))))


### PR DESCRIPTION
While implementing this, I realized that I made a mistake when
implementing the Create endpoint - I returned a `group_id` instead of
the `group_name` that frontend had requested to get back from the List
endpoint. I think for consistency's sake it's best to return
`group_name` from both endpoints.

To achieve this, I added a hydration method to the ApiKey. It adds the
name of a single group to each ApiKey, preferring group names that
aren't "All Users".

Beyond that, the 3 new endpoints are pretty straightforward.

The update and regenerate endpoints are audit logged, and I added audit logging to the Create endpoint as well.

Resolves #36998, #36999, #37000 