### PR TITLE
[Epic #35961] Milestone 4 - Add Legalese Step

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -155,10 +155,12 @@ export function openEmbedModalFromMenu() {
  * @param {object} params
  * @param {("overview"|"parameters"|"appearance")} [params.activeTab] - modal tab to open
  * @param {("code"|"preview")} [params.previewMode] - preview mode type to activate
+ * @param {boolean} [params.acceptTerms] - whether we need to go through the legalese step
  */
 export function openStaticEmbeddingModal({
   activeTab,
   previewMode,
+  acceptTerms = true,
   confirmSave,
 } = {}) {
   openEmbedModalFromMenu();
@@ -168,6 +170,10 @@ export function openStaticEmbeddingModal({
   }
 
   cy.findByTestId("sharing-pane-static-embed-button").click();
+
+  if (acceptTerms) {
+    cy.findByTestId("accept-legalese-terms-button").click();
+  }
 
   modal().within(() => {
     if (activeTab) {

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -54,7 +54,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
         visitDashboard(dashboardId);
       });
 
-      openStaticEmbeddingModal({ activeTab: "parameters" });
+      openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: true });
 
       cy.findByLabelText("Enable or lock parameters").as("allParameters");
 
@@ -137,7 +137,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
         visitDashboard(dashboardId);
       });
 
-      openStaticEmbeddingModal({ activeTab: "parameters" });
+      openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: false });
 
       cy.get("@allParameters").findByText("Locked").click();
       popover().contains("Disabled").click();

--- a/e2e/test/scenarios/embedding/embedding-downloads-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-downloads-questions.cy.spec.js
@@ -103,7 +103,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
       cy.get("@questionId").then(questionId => {
         visitQuestion(questionId);
 
-        openStaticEmbeddingModal({ activeTab: "appearance" });
+        openStaticEmbeddingModal({ activeTab: "appearance", acceptTerms: false });
 
         cy.log("Disable downloads");
         cy.findByLabelText("Enable users to download data from this embed?")

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -211,7 +211,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
           .and("contain", objectName);
 
         cy.log(`Unpublish ${object}`);
-        visitAndEnableSharing(object);
+        visitAndEnableSharing(object, false);
 
         modal().within(() => {
           cy.findByText(
@@ -331,7 +331,7 @@ function ensureEmbeddingIsDisabled() {
   });
 }
 
-function visitAndEnableSharing(object) {
+function visitAndEnableSharing(object, acceptTerms = true) {
   if (object === "question") {
     visitQuestion(ORDERS_QUESTION_ID);
   }
@@ -340,7 +340,7 @@ function visitAndEnableSharing(object) {
     visitDashboard(ORDERS_DASHBOARD_ID);
   }
 
-  openStaticEmbeddingModal();
+  openStaticEmbeddingModal({acceptTerms});
 }
 
 function sidebar() {

--- a/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-snippets.cy.spec.js
@@ -26,7 +26,8 @@ features.forEach(feature => {
 
     it("dashboard should have the correct embed snippet", () => {
       visitDashboard(ORDERS_DASHBOARD_ID);
-      openStaticEmbeddingModal();
+      console.log("feature", feature);
+      openStaticEmbeddingModal({ acceptTerms: false });
 
       modal().within(() => {
         cy.findByText(
@@ -91,7 +92,8 @@ features.forEach(feature => {
 
     it("question should have the correct embed snippet", () => {
       visitQuestion(ORDERS_QUESTION_ID);
-      openStaticEmbeddingModal();
+      console.log("feature", feature);
+      openStaticEmbeddingModal({ acceptTerms: false });
 
       modal().within(() => {
         cy.findByText(

--- a/e2e/test/scenarios/embedding/reproductions/30535-session-sandboxing.cy.spec.js
+++ b/e2e/test/scenarios/embedding/reproductions/30535-session-sandboxing.cy.spec.js
@@ -41,6 +41,7 @@ describeEE("issue 30535", () => {
     openStaticEmbeddingModal({
       activeTab: "parameters",
       previewMode: "preview",
+      acceptTerms: false,
     });
 
     cy.document().then(doc => {

--- a/e2e/test/scenarios/sharing/reproductions/26988-embedding-dynamic-settings.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/26988-embedding-dynamic-settings.cy.spec.js
@@ -37,6 +37,7 @@ describeEE("issue 26988", () => {
     openStaticEmbeddingModal({
       activeTab: "appearance",
       previewMode: "preview",
+      acceptTerms: false
     });
 
     cy.wait("@dashboard");

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -897,6 +897,7 @@
            show-homepage-xrays
            show-lighthouse-illustration
            show-metabot
+           show-static-embed-terms
            site-locale
            site-name
            source-address-header

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -164,6 +164,7 @@ export const createMockSettings = (
   engines: createMockEngines(),
   "has-user-setup": true,
   "hide-embed-branding?": true,
+  "show-static-embed-terms": true,
   "ga-enabled": false,
   "google-auth-auto-create-accounts-domain": null,
   "google-auth-client-id": null,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -281,6 +281,7 @@ export interface Settings {
   "uploads-table-prefix": string | null;
   "user-visibility": string | null;
   "last-acknowledged-version": string | null;
+  "show-static-embed-terms": boolean | null;
 }
 
 export type SettingKey = keyof Settings;

--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -53,7 +53,7 @@ export const UPDATE_SETTING = "metabase/admin/settings/UPDATE_SETTING";
 export const updateSetting = createThunkAction(
   UPDATE_SETTING,
   function (setting) {
-    return async function (dispatch, getState) {
+    return async function (dispatch) {
       try {
         await SettingsApi.put(setting);
       } catch (error) {

--- a/frontend/src/metabase/components/ModalContent/ModalContent.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.tsx
@@ -35,7 +35,7 @@ export default class ModalContent extends Component<ModalContentProps> {
   static propTypes = {
     "data-testid": PropTypes.string,
     id: PropTypes.string,
-    title: PropTypes.string,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     centeredTitle: PropTypes.bool,
     onClose: PropTypes.func,
     // takes over the entire screen

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
@@ -43,10 +43,10 @@ export const DashboardSharingEmbeddingModal = (
 
   return (
     <EmbedModal isOpen={isOpen} onClose={onClose}>
-      {({ embedType, setEmbedType }) => (
+      {({ embedType, goToNextStep }) => (
         <EmbedModalContent
           embedType={embedType}
-          setEmbedType={setEmbedType}
+          goToNextStep={goToNextStep}
           className={className}
           resource={dashboard}
           resourceParameters={parameters}

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.styled.tsx
@@ -1,6 +1,24 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
+import { Group } from "metabase/ui";
 import { ModalContentActionIcon } from "metabase/components/ModalContent";
 
+export const EmbedTitleContainer = styled(Group)<{
+  onClick?: () => void;
+}>`
+  ${({ onClick, theme }) => {
+    return (
+      onClick &&
+      css`
+        &:hover * {
+          color: ${theme.colors.brand[1]};
+          cursor: pointer;
+        }
+      `
+    );
+  }}
+`;
+
 export const EmbedModalHeaderBackIcon = styled(ModalContentActionIcon)`
-  margin: -0.5rem 0 -0.5rem -0.5rem;
+  padding: 0;
 `;

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
@@ -1,31 +1,66 @@
 import { useState } from "react";
 import { t } from "ttag";
+import {
+  EmbedModalHeaderBackIcon,
+  EmbedTitleContainer,
+} from "metabase/public/components/EmbedModal/EmbedModal.styled";
 import { useSelector } from "metabase/lib/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import Modal from "metabase/components/Modal";
-import { Divider } from "metabase/ui";
+import { Box, Divider, Text } from "metabase/ui";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
+import type { EmbedModalStep } from "./types";
 
-import { EmbedModalHeaderBackIcon } from "./EmbedModal.styled";
-import type { EmbedType } from "./types";
-
-interface EmbedModalProps {
+type EmbedModalProps = {
   isOpen?: boolean;
   onClose: () => void;
   children: ({
     embedType,
-    setEmbedType,
+    goToNextStep,
+    goBackToEmbedModal,
   }: {
-    embedType: EmbedType;
-    setEmbedType: (type: EmbedType) => void;
+    embedType: EmbedModalStep;
+    goToNextStep: () => void;
+    goBackToEmbedModal: () => void;
   }) => JSX.Element;
-}
+};
+
+const EmbedTitle = ({
+  onClick,
+  label,
+}: {
+  label: string;
+  onClick?: () => void;
+}) => {
+  return (
+    <EmbedTitleContainer onClick={onClick}>
+      {onClick && (
+        <EmbedModalHeaderBackIcon name="chevronleft" onClick={onClick} />
+      )}
+      <Text fz="xl" c="text.1">
+        {label}
+      </Text>
+    </EmbedTitleContainer>
+  );
+};
 
 export const EmbedModal = ({ children, isOpen, onClose }: EmbedModalProps) => {
-  const [embedType, setEmbedType] = useState<EmbedType>(null);
+  const [embedType, setEmbedType] = useState<EmbedModalStep>(null);
   const applicationName = useSelector(getApplicationName);
 
-  const isEmbeddingStage = embedType === "application";
+  const goToNextStep = () => {
+    if (embedType === null) {
+      setEmbedType("legalese");
+    }
+
+    if (embedType === "legalese") {
+      setEmbedType("application");
+    }
+  };
+
+  const goBackToEmbedModal = () => {
+    setEmbedType(null);
+  };
 
   const onEmbedClose = () => {
     MetabaseAnalytics.trackStructEvent("Sharing Modal", "Modal Closed");
@@ -33,28 +68,29 @@ export const EmbedModal = ({ children, isOpen, onClose }: EmbedModalProps) => {
     setEmbedType(null);
   };
 
+  const modalHeaderProps =
+    embedType === null
+      ? {
+          label: t`Embed ${applicationName}`,
+          onClick: undefined,
+        }
+      : {
+          label: t`Static embedding`,
+          onClick: goBackToEmbedModal,
+        };
+
   return (
     <Modal
       isOpen={isOpen}
       onClose={onEmbedClose}
-      title={
-        isEmbeddingStage ? (
-          <>
-            <EmbedModalHeaderBackIcon
-              name="chevronleft"
-              onClick={() => setEmbedType(null)}
-            />
-            {t`Static embedding`}
-          </>
-        ) : (
-          t`Embed ${applicationName}`
-        )
-      }
+      title={<EmbedTitle {...modalHeaderProps} />}
       fit
       formModal={false}
     >
       <Divider />
-      {children({ embedType, setEmbedType })}
+      <Box bg="bg.0" h="100%">
+        {children({ embedType, goToNextStep, goBackToEmbedModal })}
+      </Box>
     </Modal>
   );
 };

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
@@ -4,6 +4,7 @@ import {
   EmbedModalHeaderBackIcon,
   EmbedTitleContainer,
 } from "metabase/public/components/EmbedModal/EmbedModal.styled";
+import { getSetting } from "metabase/selectors/settings";
 import { useSelector } from "metabase/lib/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import Modal from "metabase/components/Modal";
@@ -45,15 +46,16 @@ const EmbedTitle = ({
 };
 
 export const EmbedModal = ({ children, isOpen, onClose }: EmbedModalProps) => {
+  const shouldShowEmbedTerms = useSelector(state =>
+    getSetting(state, "show-static-embed-terms"),
+  );
   const [embedType, setEmbedType] = useState<EmbedModalStep>(null);
   const applicationName = useSelector(getApplicationName);
 
   const goToNextStep = () => {
-    if (embedType === null) {
+    if (embedType === null && shouldShowEmbedTerms) {
       setEmbedType("legalese");
-    }
-
-    if (embedType === "legalese") {
+    } else {
       setEmbedType("application");
     }
   };

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
@@ -1,0 +1,103 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { createMockState } from "metabase-types/store/mocks";
+import { Button, Group, Text } from "metabase/ui";
+import { EmbedModal } from "./EmbedModal";
+
+const TestEmbedModal = ({
+  onClose,
+  isOpen,
+}: {
+  onClose: () => void;
+  isOpen?: boolean;
+}): JSX.Element => {
+  return (
+    <EmbedModal isOpen={isOpen} onClose={onClose}>
+      {({ embedType, goToNextStep, goBackToEmbedModal }) => (
+        <Group data-testid="test-embed-modal-content">
+          <Button onClick={goBackToEmbedModal}>Previous</Button>
+          <Text>{embedType ?? "Embed Landing"}</Text>
+          <Button onClick={goToNextStep}>Next</Button>
+        </Group>
+      )}
+    </EmbedModal>
+  );
+};
+
+const setup = ({ isOpen = true } = {}) => {
+  const onClose = jest.fn();
+
+  renderWithProviders(
+    <Route
+      path="*"
+      component={() => <TestEmbedModal isOpen={isOpen} onClose={onClose} />}
+    ></Route>,
+    {
+      storeInitialState: createMockState({
+        settings: mockSettings({
+          "application-name": "Embed Metabase",
+        }),
+      }),
+      initialRoute: "*",
+      withRouter: true,
+    },
+  );
+
+  return { onClose };
+};
+
+describe("EmbedModal", () => {
+  it("should render header and content", () => {
+    setup();
+
+    expect(
+      within(screen.getByTestId("modal-header")).getByText("Embed Metabase"),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId("test-embed-modal-content")).toBeInTheDocument();
+
+    expect(screen.getByText("Embed Landing")).toBeInTheDocument();
+  });
+
+  it("should go to the legalese step when `Next` is clicked", () => {
+    setup();
+
+    userEvent.click(screen.getByText("Next"));
+
+    expect(screen.getByText("legalese")).toBeInTheDocument();
+  });
+
+  it("should go to the static embedding step when `Next` is clicked twice", async () => {
+    // TODO: add logic for this test when we add the API call
+    //  for checking if the user has already accepted the terms
+
+    setup();
+
+    userEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("legalese")).toBeInTheDocument();
+
+    userEvent.click(screen.getByText("Next"));
+    expect(
+      within(screen.getByTestId("modal-header")).getByText("Static embedding"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("application")).toBeInTheDocument();
+  });
+
+  it("returns to the initial embed modal landing when the user clicks the modal title", () => {
+    setup();
+
+    userEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("legalese")).toBeInTheDocument();
+
+    userEvent.click(screen.getByText("Static embedding"));
+    expect(screen.getByText("Embed Landing")).toBeInTheDocument();
+  });
+
+  it("calls onClose when the modal is closed", () => {
+    const { onClose } = setup();
+    userEvent.click(screen.getByLabelText("close icon"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
@@ -18,7 +18,9 @@ const TestEmbedModal = ({
       {({ embedType, goToNextStep, goBackToEmbedModal }) => (
         <Group data-testid="test-embed-modal-content">
           <Button onClick={goBackToEmbedModal}>Previous</Button>
-          <Text>{embedType ?? "Embed Landing"}</Text>
+          <Text data-testid="test-embed-step">
+            {embedType ?? "Embed Landing"}
+          </Text>
           <Button onClick={goToNextStep}>Next</Button>
         </Group>
       )}
@@ -26,7 +28,7 @@ const TestEmbedModal = ({
   );
 };
 
-const setup = ({ isOpen = true } = {}) => {
+const setup = ({ isOpen = true, showStaticEmbedTerms = true } = {}) => {
   const onClose = jest.fn();
 
   renderWithProviders(
@@ -38,6 +40,7 @@ const setup = ({ isOpen = true } = {}) => {
       storeInitialState: createMockState({
         settings: mockSettings({
           "application-name": "Embed Metabase",
+          "show-static-embed-terms": showStaticEmbedTerms,
         }),
       }),
       initialRoute: "*",
@@ -58,7 +61,9 @@ describe("EmbedModal", () => {
 
     expect(screen.getByTestId("test-embed-modal-content")).toBeInTheDocument();
 
-    expect(screen.getByText("Embed Landing")).toBeInTheDocument();
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "Embed Landing",
+    );
   });
 
   it("should go to the legalese step when `Next` is clicked", () => {
@@ -66,33 +71,42 @@ describe("EmbedModal", () => {
 
     userEvent.click(screen.getByText("Next"));
 
-    expect(screen.getByText("legalese")).toBeInTheDocument();
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent("legalese");
   });
 
-  it("should go to the static embedding step when `Next` is clicked twice", async () => {
-    // TODO: add logic for this test when we add the API call
-    //  for checking if the user has already accepted the terms
-
-    setup();
+  it("should go to the legalese step then the static embedding step if the user has not accepted the embedding terms", () => {
+    setup({ showStaticEmbedTerms: true });
+    userEvent.click(screen.getByText("Next"));
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent("legalese");
 
     userEvent.click(screen.getByText("Next"));
-    expect(screen.getByText("legalese")).toBeInTheDocument();
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "application",
+    );
+  });
+
+  it("should immediately go to the static embedding step if the user has accepted the terms", async () => {
+    setup({ showStaticEmbedTerms: false });
 
     userEvent.click(screen.getByText("Next"));
     expect(
       within(screen.getByTestId("modal-header")).getByText("Static embedding"),
     ).toBeInTheDocument();
-    expect(screen.getByText("application")).toBeInTheDocument();
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "application",
+    );
   });
 
   it("returns to the initial embed modal landing when the user clicks the modal title", () => {
     setup();
 
     userEvent.click(screen.getByText("Next"));
-    expect(screen.getByText("legalese")).toBeInTheDocument();
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent("legalese");
 
     userEvent.click(screen.getByText("Static embedding"));
-    expect(screen.getByText("Embed Landing")).toBeInTheDocument();
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "Embed Landing",
+    );
   });
 
   it("calls onClose when the modal is closed", () => {

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.tsx
@@ -1,3 +1,4 @@
+import {LegaleseStep} from "metabase/public/components/widgets/LegaleseStep/LegaleseStep";
 import { useState } from "react";
 import _ from "underscore";
 import { getSignedPreviewUrl, getSignedToken } from "metabase/public/lib/embed";
@@ -15,14 +16,14 @@ import type {
   EmbedResource,
   EmbedResourceParameter,
   EmbedResourceType,
-  EmbedType,
+  EmbedModalStep,
 } from "../types";
 import { SelectEmbedTypePane } from "../SelectEmbedTypePane";
 import { EmbedModalContentStatusBar } from "./EmbedModalContentStatusBar";
 
 export interface EmbedModalContentProps {
-  embedType: EmbedType;
-  setEmbedType: (type: EmbedType) => void;
+  embedType: EmbedModalStep;
+  goToNextStep: () => void;
 
   resource: EmbedResource;
   resourceType: EmbedResourceType;
@@ -43,7 +44,7 @@ export const EmbedModalContent = (
 ): JSX.Element => {
   const {
     embedType,
-    setEmbedType,
+    goToNextStep,
     resource,
     resourceType,
     resourceParameters,
@@ -125,7 +126,7 @@ export const EmbedModalContent = (
     embeddingParams,
   );
 
-  if (!embedType) {
+  if (embedType == null) {
     return (
       <SelectEmbedTypePane
         resource={resource}
@@ -133,9 +134,13 @@ export const EmbedModalContent = (
         onCreatePublicLink={onCreatePublicLink}
         onDeletePublicLink={onDeletePublicLink}
         getPublicUrl={getPublicUrl}
-        onChangeEmbedType={setEmbedType}
+        goToNextStep={goToNextStep}
       />
     );
+  }
+
+  if (embedType === "legalese") {
+    return <LegaleseStep goToNextStep={goToNextStep} />;
   }
 
   const hasSettingsChanges = !_.isEqual(

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.tsx
@@ -1,6 +1,6 @@
-import {LegaleseStep} from "metabase/public/components/widgets/LegaleseStep/LegaleseStep";
 import { useState } from "react";
 import _ from "underscore";
+import { LegaleseStep } from "metabase/public/components/widgets/LegaleseStep/LegaleseStep";
 import { getSignedPreviewUrl, getSignedToken } from "metabase/public/lib/embed";
 import { getSetting } from "metabase/selectors/settings";
 import { useSelector } from "metabase/lib/redux";

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.unit.spec.tsx
@@ -149,7 +149,7 @@ function setup({
   resource = {} as EmbedResource,
   resourceType = "dashboard",
   resourceParameters = [],
-  setEmbedType = jest.fn(),
+  goToNextStep = jest.fn(),
   getPublicUrl = jest.fn(_resource => "some URL"),
   onUpdateEmbeddingParams = jest.fn(),
   onUpdateEnableEmbedding = jest.fn(),
@@ -159,7 +159,7 @@ function setup({
   const view = renderWithProviders(
     <EmbedModalContent
       embedType={embedType}
-      setEmbedType={setEmbedType}
+      goToNextStep={goToNextStep}
       resource={resource}
       resourceType={resourceType}
       resourceParameters={resourceParameters}
@@ -182,7 +182,7 @@ function setup({
 
   return {
     ...view,
-    setEmbedType,
+    goToNextStep,
     getPublicUrl,
     onUpdateEmbeddingParams,
     onUpdateEnableEmbedding,

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -10,7 +10,7 @@ import * as MetabaseAnalytics from "metabase/lib/analytics";
 import Link from "metabase/core/components/Link";
 import type { ExportFormatType } from "metabase/dashboard/components/PublicLinkPopover/types";
 
-import type { EmbedResource, EmbedResourceType, EmbedType } from "../types";
+import type { EmbedResource, EmbedResourceType, EmbedModalStep } from "../types";
 import { SharingPaneActionButton } from "./SharingPaneButton/SharingPaneButton.styled";
 import { SharingPaneButton } from "./SharingPaneButton/SharingPaneButton";
 import { PublicEmbedIcon, StaticEmbedIcon } from "./icons";
@@ -22,7 +22,7 @@ interface SelectEmbedTypePaneProps {
   onCreatePublicLink: () => void;
   onDeletePublicLink: () => void;
   getPublicUrl: (publicUuid: string, extension?: ExportFormatType) => string;
-  onChangeEmbedType: (embedType: EmbedType) => void;
+  goToNextStep: () => void;
 }
 
 export function SelectEmbedTypePane({
@@ -31,7 +31,7 @@ export function SelectEmbedTypePane({
   onCreatePublicLink,
   onDeletePublicLink,
   getPublicUrl,
-  onChangeEmbedType,
+  goToNextStep,
 }: SelectEmbedTypePaneProps) {
   const hasPublicLink = resource.public_uuid != null;
 
@@ -115,12 +115,11 @@ export function SelectEmbedTypePane({
           header={t`Static embed`}
           description={t`Securely embed this dashboard in your own application’s server code.`}
           illustration={<StaticEmbedIcon />}
-          onClick={() => onChangeEmbedType("application")}
+          onClick={goToNextStep}
         >
           <SharingPaneActionButton
             data-testid="sharing-pane-static-embed-button"
             fullWidth
-            onClick={() => onChangeEmbedType("application")}
           >
             {resource.enable_embedding ? t`Edit settings` : t`Set this up`}
           </SharingPaneActionButton>

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -10,7 +10,7 @@ import * as MetabaseAnalytics from "metabase/lib/analytics";
 import Link from "metabase/core/components/Link";
 import type { ExportFormatType } from "metabase/dashboard/components/PublicLinkPopover/types";
 
-import type { EmbedResource, EmbedResourceType, EmbedModalStep } from "../types";
+import type { EmbedResource, EmbedResourceType } from "../types";
 import { SharingPaneActionButton } from "./SharingPaneButton/SharingPaneButton.styled";
 import { SharingPaneButton } from "./SharingPaneButton/SharingPaneButton";
 import { PublicEmbedIcon, StaticEmbedIcon } from "./icons";

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.unit.spec.tsx
@@ -100,7 +100,7 @@ describe("SelectEmbedTypePane", () => {
 
         userEvent.click(screen.getByRole("button", { name: "Set this up" }));
 
-        expect(goToNextStep).toHaveBeenCalledWith();
+        expect(goToNextStep).toHaveBeenCalled();
       });
     });
   });

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.unit.spec.tsx
@@ -29,7 +29,7 @@ const setup = ({
   const onCreatePublicLink = jest.fn();
   const onDeletePublicLink = jest.fn();
   const getPublicUrl = jest.fn(uuid => uuid);
-  const onChangeEmbedType = jest.fn();
+  const goToNextStep = jest.fn();
 
   const { history } = renderWithProviders(
     <Route
@@ -41,7 +41,7 @@ const setup = ({
           onCreatePublicLink={onCreatePublicLink}
           onDeletePublicLink={onDeletePublicLink}
           getPublicUrl={getPublicUrl}
-          onChangeEmbedType={onChangeEmbedType}
+          goToNextStep={goToNextStep}
         />
       )}
     ></Route>,
@@ -58,7 +58,7 @@ const setup = ({
   );
 
   return {
-    onChangeEmbedType,
+    goToNextStep,
     onCreatePublicLink,
     onDeletePublicLink,
     getPublicUrl,
@@ -77,12 +77,12 @@ describe("SelectEmbedTypePane", () => {
         ).toBeInTheDocument();
       });
 
-      it("should call `onChangeEmbedType` with `application` when `Edit settings` is clicked", () => {
-        const { onChangeEmbedType } = setup({ isResourcePublished: true });
+      it("should call `goToNextStep` with `application` when `Edit settings` is clicked", () => {
+        const { goToNextStep } = setup({ isResourcePublished: true });
 
         userEvent.click(screen.getByRole("button", { name: "Edit settings" }));
 
-        expect(onChangeEmbedType).toHaveBeenCalledWith("application");
+        expect(goToNextStep).toHaveBeenCalled();
       });
     });
 
@@ -95,12 +95,12 @@ describe("SelectEmbedTypePane", () => {
         ).toBeInTheDocument();
       });
 
-      it("should call `onChangeEmbedType` with `application` when `Set this up` is clicked", () => {
-        const { onChangeEmbedType } = setup({ isResourcePublished: false });
+      it("should call `goToNextStep` with `application` when `Set this up` is clicked", () => {
+        const { goToNextStep } = setup({ isResourcePublished: false });
 
         userEvent.click(screen.getByRole("button", { name: "Set this up" }));
 
-        expect(onChangeEmbedType).toHaveBeenCalledWith("application");
+        expect(goToNextStep).toHaveBeenCalledWith();
       });
     });
   });

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/AppearanceSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/AppearanceSettings.tsx
@@ -15,7 +15,7 @@ import type {
   EmbeddingParameters,
   EmbedResource,
   EmbedResourceType,
-  EmbedType,
+  EmbedModalStep,
 } from "../types";
 import EmbedCodePane from "./EmbedCodePane";
 import PreviewPane from "./PreviewPane";
@@ -35,7 +35,7 @@ const DEFAULT_THEME = THEME_OPTIONS[0].value;
 export interface AppearanceSettingsProps {
   activePane: ActivePreviewPane;
 
-  embedType: EmbedType;
+  embedType: EmbedModalStep;
   resource: EmbedResource;
   resourceType: EmbedResourceType;
   iframeUrl: string;

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/OverviewSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/OverviewSettings.tsx
@@ -8,7 +8,7 @@ import type {
   EmbeddingParameters,
   EmbedResource,
   EmbedResourceType,
-  EmbedType,
+  EmbedModalStep,
   EmbeddingDisplayOptions,
 } from "../types";
 import EmbedCodePane from "./EmbedCodePane";
@@ -16,7 +16,7 @@ import { SettingsTabLayout } from "./StaticEmbedSetupPane.styled";
 import { StaticEmbedSetupPaneSettingsContentSection } from "./StaticEmbedSetupPaneSettingsContentSection";
 
 export interface OverviewSettingsProps {
-  embedType: EmbedType;
+  embedType: EmbedModalStep;
   resource: EmbedResource;
   resourceType: EmbedResourceType;
   iframeUrl: string;

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
@@ -16,7 +16,7 @@ import type {
   EmbeddingParametersValues,
   EmbeddingDisplayOptions,
   EmbedResource,
-  EmbedType,
+  EmbedModalStep,
   EmbedResourceParameterWithValue,
 } from "../types";
 import EmbedCodePane from "./EmbedCodePane";
@@ -35,7 +35,7 @@ export interface ParametersSettingsProps {
   lockedParameters: EmbedResourceParameter[];
   parameterValues: EmbeddingParametersValues;
 
-  embedType: EmbedType;
+  embedType: EmbedModalStep;
 
   iframeUrl: string;
   token: string;

--- a/frontend/src/metabase/public/components/EmbedModal/types.ts
+++ b/frontend/src/metabase/public/components/EmbedModal/types.ts
@@ -2,7 +2,7 @@ import type { Card, Dashboard } from "metabase-types/api";
 
 export type ActivePreviewPane = "preview" | "code";
 
-export type EmbedType = "application" | null;
+export type EmbedModalStep = "application" | "legalese" | null;
 
 export type EmbedResource = (Card | Dashboard) & {
   embedding_params?: EmbeddingParameters;

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.styled.tsx
@@ -1,0 +1,10 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { Stack } from "metabase/ui";
+
+export const LegaleseStepDetailsContainer = styled(Stack)`
+  ${({ theme }) => css`
+    border: 1px solid ${theme.colors.border[0]};
+    border-radius: ${theme.radius.md};
+  `}
+`;

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
@@ -1,0 +1,40 @@
+import { jt, t } from "ttag";
+import ExternalLink from "metabase/core/components/ExternalLink";
+import { LegaleseStepDetailsContainer } from "metabase/public/components/widgets/LegaleseStep/LegaleseStep.styled";
+import { Text, Button, Center, Stack, Title } from "metabase/ui";
+
+export const LegaleseStep = ({
+  goToNextStep,
+}: {
+  goToNextStep: () => void;
+}) => (
+  <Center bg="white" px="18rem" pt="6.25rem" pb="11.75rem">
+    <Stack align="center" spacing="3rem">
+      <Title order={2} fz="1.25rem">{t`First, some legalese`}</Title>
+
+      <LegaleseStepDetailsContainer p="lg" w="40rem">
+        <Text fw={700}>
+          {jt`By clicking "Agree and continue" you're agreeing to ${(
+            <ExternalLink
+              href="https://metabase.com/license/embedding"
+              target="_blank"
+            >
+              {t`our embedding license.`}
+            </ExternalLink>
+          )}`}
+        </Text>
+        <Text>
+          {t`When you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the "Powered by Metabase" visible on those embeds.`}
+        </Text>
+        <Text>
+          {t`You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature.`}
+        </Text>
+      </LegaleseStepDetailsContainer>
+
+      <Button
+        variant="filled"
+        onClick={goToNextStep}
+      >{t`Agree and continue`}</Button>
+    </Stack>
+  </Center>
+);

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
@@ -1,4 +1,6 @@
 import { jt, t } from "ttag";
+import { updateSetting } from "metabase/admin/settings/settings";
+import { useDispatch } from "metabase/lib/redux";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { LegaleseStepDetailsContainer } from "metabase/public/components/widgets/LegaleseStep/LegaleseStep.styled";
 import { Text, Button, Center, Stack, Title } from "metabase/ui";
@@ -7,34 +9,50 @@ export const LegaleseStep = ({
   goToNextStep,
 }: {
   goToNextStep: () => void;
-}) => (
-  <Center bg="white" px="18rem" pt="6.25rem" pb="11.75rem">
-    <Stack align="center" spacing="3rem">
-      <Title order={2} fz="1.25rem">{t`First, some legalese`}</Title>
+}) => {
+  const dispatch = useDispatch();
 
-      <LegaleseStepDetailsContainer p="lg" w="40rem">
-        <Text fw={700}>
-          {jt`By clicking "Agree and continue" you're agreeing to ${(
-            <ExternalLink
-              href="https://metabase.com/license/embedding"
-              target="_blank"
-            >
-              {t`our embedding license.`}
-            </ExternalLink>
-          )}`}
-        </Text>
-        <Text>
-          {t`When you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the "Powered by Metabase" visible on those embeds.`}
-        </Text>
-        <Text>
-          {t`You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature.`}
-        </Text>
-      </LegaleseStepDetailsContainer>
+  const onAcceptTerms = () => {
+    dispatch(
+      updateSetting({
+        key: "show-static-embed-terms",
+        value: false,
+      }),
+    );
+    goToNextStep();
+  };
 
-      <Button
-        variant="filled"
-        onClick={goToNextStep}
-      >{t`Agree and continue`}</Button>
-    </Stack>
-  </Center>
-);
+  return (
+    <Center bg="white" px="18rem" pt="6.25rem" pb="11.75rem">
+      <Stack align="center" spacing="3rem">
+        <Title order={2} fz="1.25rem">{t`First, some legalese`}</Title>
+
+        <LegaleseStepDetailsContainer p="lg" w="40rem">
+          <Text fw={700}>
+            {jt`By clicking "Agree and continue" you're agreeing to ${(
+              <ExternalLink
+                key="embed-license-link"
+                href="https://metabase.com/license/embedding"
+                target="_blank"
+              >
+                {t`our embedding license.`}
+              </ExternalLink>
+            )}`}
+          </Text>
+          <Text>
+            {t`When you embed charts or dashboards from Metabase in your own application that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the "Powered by Metabase" visible on those embeds.`}
+          </Text>
+          <Text>
+            {t`You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature.`}
+          </Text>
+        </LegaleseStepDetailsContainer>
+
+        <Button
+          variant="filled"
+          onClick={onAcceptTerms}
+          data-testid="accept-legalese-terms-button"
+        >{t`Agree and continue`}</Button>
+      </Stack>
+    </Center>
+  );
+};

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.unit.spec.tsx
@@ -1,0 +1,67 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import {
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockSettingDefinition,
+  createMockSettings,
+} from "metabase-types/api/mocks";
+import { LegaleseStep } from "./LegaleseStep";
+
+const setup = () => {
+  const goToNextStep = jest.fn();
+
+  setupSettingsEndpoints([
+    createMockSettingDefinition({
+      key: "show-static-embed-terms",
+      value: true,
+    }),
+  ]);
+
+  setupPropertiesEndpoints(createMockSettings());
+
+  renderWithProviders(<LegaleseStep goToNextStep={goToNextStep} />);
+
+  return { goToNextStep };
+};
+
+describe("LegaleseStep", () => {
+  it("should render", () => {
+    setup();
+
+    expect(screen.getByText("First, some legalese")).toBeInTheDocument();
+    expect(
+      screen.getByText('By clicking "Agree and continue" you\'re agreeing to'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `When you embed charts or dashboards from Metabase in your own application that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the "Powered by Metabase" visible on those embeds.`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Agree and continue")).toBeInTheDocument();
+  });
+
+  it("calls goToNextStep and updates setting on clicking 'Agree and continue'", async () => {
+    const settingPutCalls = fetchMock.put(
+      "path:/api/setting/show-static-embed-terms",
+      {},
+    );
+
+    const { goToNextStep } = setup();
+    userEvent.click(screen.getByText("Agree and continue"));
+
+    expect(settingPutCalls.calls().length).toBe(1);
+    expect(await settingPutCalls.lastCall()?.request?.json()).toEqual({
+      value: false,
+    });
+    expect(goToNextStep).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
@@ -42,10 +42,10 @@ export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
 
   return (
     <EmbedModal onClose={onClose}>
-      {({ embedType, setEmbedType }) => (
+      {({ embedType, goToNextStep }) => (
         <EmbedModalContent
           embedType={embedType}
-          setEmbedType={setEmbedType}
+          goToNextStep={goToNextStep}
           className={className}
           resource={card}
           resourceType="question"

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -6,8 +6,10 @@
    [cheshire.core :as json]
    [clojure.string :as str]
    [hiccup.core :refer [html]]
-   [metabase.models.setting :as setting]
+   [metabase.config :as config]
+   [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.public-settings :as public-settings]
+   [metabase.public-settings.premium-features :as premium-features]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru trs tru]]
    [ring.util.codec :as codec]))
@@ -55,7 +57,7 @@
 
 ;;; ----------------------------------------------- EMBEDDING UTIL FNS -----------------------------------------------
 
-(setting/defsetting embedding-secret-key
+(defsetting embedding-secret-key
   (deferred-tru "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints.")
   :visibility :admin
   :audit :no-value
@@ -105,3 +107,13 @@
   [unsigned-token keyseq]
   (or (get-in unsigned-token keyseq)
       (throw (ex-info (tru "Token is missing value for keypath {0}" keyseq) {:status-code 400}))))
+
+(defsetting show-static-embed-terms
+  (deferred-tru "Check if the static embedding licensing should be hidden in the static embedding flow")
+  :type    :boolean
+  :default true
+  :export? true
+  :getter  (fn []
+              (if-not (and config/ee-available? (:valid (premium-features/token-status)))
+                (setting/get-value-of-type :boolean :show-static-embed-terms)
+                false)))

--- a/test/metabase/util/embed_test.clj
+++ b/test/metabase/util/embed_test.clj
@@ -3,6 +3,10 @@
    [buddy.sign.jwt :as jwt]
    [clojure.test :refer :all]
    [crypto.random :as crypto-random]
+   [metabase.config :as config]
+   [metabase.public-settings.premium-features :as premium-features]
+   [metabase.public-settings.premium-features-test
+    :as premium-features-test]
    [metabase.test :as mt]
    [metabase.util.embed :as embed]))
 
@@ -21,3 +25,32 @@
            clojure.lang.ExceptionInfo
            #"JWT `alg` cannot be `none`"
            (embed/unsign token-with-alg-none))))))
+
+(deftest show-static-embed-terms-test
+  (mt/with-test-user :crowberto
+    (mt/with-temporary-setting-values [show-static-embed-terms nil]
+      (testing "Check if the user needs to accept the embedding licensing terms before static embedding"
+        (when-not config/ee-available?
+          (testing "should return true when user is OSS and has not accepted licensing terms"
+            (is (= (embed/show-static-embed-terms) true)))
+          (testing "should return false when user is OSS and has already accepted licensing terms"
+            (embed/show-static-embed-terms! false)
+            (is (= (embed/show-static-embed-terms) false))))
+        (when config/ee-available?
+          (testing "should return false when an EE user has a valid token"
+           (with-redefs [premium-features/fetch-token-status (fn [_x]
+                                                               {:valid    true
+                                                                :status   "fake"
+                                                                :features ["test" "fixture"]
+                                                                :trial    false})]
+             (mt/with-temporary-setting-values [premium-embedding-token premium-features-test/random-fake-token]
+              (is (= (embed/show-static-embed-terms) false))
+              (embed/show-static-embed-terms! false)
+              (is (= (embed/show-static-embed-terms) false)))))
+          (testing "when an EE user doesn't have a valid token"
+            (mt/with-temporary-setting-values [premium-embedding-token nil show-static-embed-terms nil]
+              (testing "should return true when the user has not accepted licensing terms"
+                (is (= (embed/show-static-embed-terms) true)))
+              (testing "should return false when the user has already accepted licensing terms"
+                (embed/show-static-embed-terms! false)
+                (is (= (embed/show-static-embed-terms) false))))))))))


### PR DESCRIPTION
Milestone 4 of Epic #35961

### Description

Adds the Legalese step for OSS and EE instances with no token

### How to verify

_In an OSS instances and EE instances without a valid token_
* Go to a dashboard/question and access the Embed modal (click the share icon and click the "Embed" option in the menu)
* Click into `Static Embed`
* You should see a screen containing the licensing terms for static embedding. Clicking `Agree and continue` should take you to the static embedding configuration screen.
* Refresh the page and try the same flow. You should immediately see the options for static embedding, as the user has already accepted the terms

_In an EE instance with a valid token_
* Go to a dashboard/question and access the Embed modal (click the share icon and click the "Embed" option in the menu)
* Click into `Static Embed`
* You should immediately see the options for static embedding. For EE instances, there is no legalese step


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
