### PR TITLE
[#35961 M4] Add legalese step without any checks

### DIFF
--- a/frontend/src/metabase/components/ModalContent/ModalContent.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.tsx
@@ -35,7 +35,7 @@ export default class ModalContent extends Component<ModalContentProps> {
   static propTypes = {
     "data-testid": PropTypes.string,
     id: PropTypes.string,
-    title: PropTypes.string,
+    title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
     centeredTitle: PropTypes.bool,
     onClose: PropTypes.func,
     // takes over the entire screen

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
@@ -43,12 +43,13 @@ export const DashboardSharingEmbeddingModal = (
 
   return (
     <EmbedModal isOpen={isOpen} onClose={onClose}>
-      {({ embedType, setEmbedType }) => (
+      {({ embedType, goToNextStep, goToPreviousStep }) => (
         <EmbedModalContent
           {...props}
           isLinkEnabled={isLinkEnabled ?? true}
           embedType={embedType}
-          setEmbedType={setEmbedType}
+          goToNextStep={goToNextStep}
+          goToPreviousStep={goToPreviousStep}
           className={className}
           resource={dashboard}
           resourceParameters={parameters}

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
@@ -2,7 +2,7 @@ import type { Dashboard } from "metabase-types/api";
 import type { EmbedOptions } from "metabase-types/store";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import { EmbedModal } from "metabase/public/components/widgets/EmbedModal";
+import { EmbedModal } from "metabase/public/components/EmbedModal";
 import EmbedModalContent from "metabase/public/components/widgets/EmbedModalContent";
 import { getParameters } from "metabase/dashboard/selectors";
 
@@ -43,13 +43,13 @@ export const DashboardSharingEmbeddingModal = (
 
   return (
     <EmbedModal isOpen={isOpen} onClose={onClose}>
-      {({ embedType, goToNextStep, goToPreviousStep }) => (
+      {({ embedType, goToNextStep, goBackToEmbedModal }) => (
         <EmbedModalContent
           {...props}
           isLinkEnabled={isLinkEnabled ?? true}
           embedType={embedType}
           goToNextStep={goToNextStep}
-          goToPreviousStep={goToPreviousStep}
+          goBackToEmbedModal={goBackToEmbedModal}
           className={className}
           resource={dashboard}
           resourceParameters={parameters}

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.styled.tsx
@@ -3,11 +3,11 @@ import styled from "@emotion/styled";
 import { Group } from "metabase/ui";
 
 export const EmbedTitleContainer = styled(Group)<{
-  isActive?: boolean;
+  onClick?: () => void;
 }>`
-  ${({ isActive, theme }) => {
+  ${({ onClick, theme }) => {
     return (
-      isActive &&
+      onClick &&
       css`
         &:hover * {
           color: ${theme.colors.brand[1]};

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { t } from "ttag";
 import { useSelector } from "metabase/lib/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import { Icon } from "metabase/core/components/Icon";
@@ -7,23 +8,18 @@ import type { WindowModalProps } from "metabase/components/Modal/WindowModal";
 import { Box, Text } from "metabase/ui";
 import { EmbedTitleContainer } from "./EmbedModal.styled";
 
-type EmbedModalStep = "application" | "legalese" | null;
+export type EmbedModalStep = "application" | "legalese" | null;
 
 const EmbedTitle = ({
-  embedStep,
   onClick,
+  label,
 }: {
-  embedStep: EmbedModalStep;
+  label: string;
   onClick?: () => void;
 }) => {
-  const applicationName = useSelector(getApplicationName);
-
-  const label =
-    embedStep === null ? `Embed ${applicationName}` : `Static embedding`;
-
   return (
-    <EmbedTitleContainer isActive={embedStep !== null} onClick={onClick}>
-      {embedStep !== null && <Icon name="chevronleft" />}
+    <EmbedTitleContainer onClick={onClick}>
+      {onClick && <Icon name="chevronleft" />}
       <Text fz="xl" c="text.1">
         {label}
       </Text>
@@ -42,14 +38,15 @@ export const EmbedModal = ({
   children: ({
     embedType,
     goToNextStep,
-    goToPreviousStep,
+    goBackToEmbedModal,
   }: {
     embedType: EmbedModalStep;
     goToNextStep: () => void;
-    goToPreviousStep: () => void;
+    goBackToEmbedModal: () => void;
   }) => JSX.Element;
 } & WindowModalProps) => {
   const [embedType, setEmbedType] = useState<EmbedModalStep>(null);
+  const applicationName = useSelector(getApplicationName);
 
   const goToNextStep = () => {
     if (embedType === null) {
@@ -61,7 +58,7 @@ export const EmbedModal = ({
     }
   };
 
-  const goToPreviousStep = () => {
+  const goBackToEmbedModal = () => {
     setEmbedType(null);
   };
 
@@ -70,20 +67,29 @@ export const EmbedModal = ({
     setEmbedType(null);
   };
 
-  const isFullScreen = embedType === "application";
+  const modalHeaderProps =
+    embedType === null
+      ? {
+          label: t`Embed ${applicationName}`,
+          onClick: undefined,
+        }
+      : {
+          label: t`Static embedding`,
+          onClick: goBackToEmbedModal,
+        };
 
   return (
     <Modal
       isOpen={isOpen}
       onClose={onEmbedClose}
-      title={<EmbedTitle embedStep={embedType} onClick={goToPreviousStep} />}
-      fit={!isFullScreen}
-      full={isFullScreen}
+      title={<EmbedTitle {...modalHeaderProps} />}
+      fit={embedType !== "application"}
+      wide={true}
       formModal={false}
       {...modalProps}
     >
       <Box bg="bg.0" h="100%">
-        {children({ embedType, goToNextStep, goToPreviousStep })}
+        {children({ embedType, goToNextStep, goBackToEmbedModal })}
       </Box>
     </Modal>
   );

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
@@ -1,0 +1,103 @@
+import userEvent from "@testing-library/user-event";
+import { Route } from "react-router";
+import { mockSettings } from "__support__/settings";
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { createMockState } from "metabase-types/store/mocks";
+import { Button, Group, Text } from "metabase/ui";
+import { EmbedModal } from "./EmbedModal";
+
+const TestEmbedModal = ({
+  onClose,
+  isOpen,
+}: {
+  onClose: () => void;
+  isOpen?: boolean;
+}): JSX.Element => {
+  return (
+    <EmbedModal isOpen={isOpen} onClose={onClose}>
+      {({ embedType, goToNextStep, goBackToEmbedModal }) => (
+        <Group data-testid="test-embed-modal-content">
+          <Button onClick={goBackToEmbedModal}>Previous</Button>
+          <Text>{embedType ?? "Embed Landing"}</Text>
+          <Button onClick={goToNextStep}>Next</Button>
+        </Group>
+      )}
+    </EmbedModal>
+  );
+};
+
+const setup = ({ isOpen = true } = {}) => {
+  const onClose = jest.fn();
+
+  renderWithProviders(
+    <Route
+      path="*"
+      component={() => <TestEmbedModal isOpen={isOpen} onClose={onClose} />}
+    ></Route>,
+    {
+      storeInitialState: createMockState({
+        settings: mockSettings({
+          "application-name": "Embed Metabase",
+        }),
+      }),
+      initialRoute: "*",
+      withRouter: true,
+    },
+  );
+
+  return { onClose };
+};
+
+describe("EmbedModal", () => {
+  it("should render header and content", () => {
+    setup();
+
+    expect(
+      within(screen.getByTestId("modal-header")).getByText("Embed Metabase"),
+    ).toBeInTheDocument();
+
+    expect(screen.getByTestId("test-embed-modal-content")).toBeInTheDocument();
+
+    expect(screen.getByText("Embed Landing")).toBeInTheDocument();
+  });
+
+  it("should go to the legalese step when `Next` is clicked", () => {
+    setup();
+
+    userEvent.click(screen.getByText("Next"));
+
+    expect(screen.getByText("legalese")).toBeInTheDocument();
+  });
+
+  it("should go to the static embedding step when `Next` is clicked twice", async () => {
+    // TODO: add logic for this test when we add the API call
+    //  for checking if the user has already accepted the terms
+
+    setup();
+
+    userEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("legalese")).toBeInTheDocument();
+
+    userEvent.click(screen.getByText("Next"));
+    expect(
+      within(screen.getByTestId("modal-header")).getByText("Static embedding"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("application")).toBeInTheDocument();
+  });
+
+  it("returns to the initial embed modal landing when the user clicks the modal title", () => {
+    setup();
+
+    userEvent.click(screen.getByText("Next"));
+    expect(screen.getByText("legalese")).toBeInTheDocument();
+
+    userEvent.click(screen.getByText("Static embedding"));
+    expect(screen.getByText("Embed Landing")).toBeInTheDocument();
+  });
+
+  it("calls onClose when the modal is closed", () => {
+    const { onClose } = setup();
+    userEvent.click(screen.getByLabelText("close icon"));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/metabase/public/components/EmbedModal/index.ts
+++ b/frontend/src/metabase/public/components/EmbedModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./EmbedModal";

--- a/frontend/src/metabase/public/components/widgets/EmbedModal.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModal.styled.tsx
@@ -1,8 +1,19 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { color } from "metabase/lib/colors";
+import { Group } from "metabase/ui";
 
-export const EmbedTitleLabel = styled.span`
-  &:hover {
-    color: ${color("brand")};
-  }
+export const EmbedTitleContainer = styled(Group)<{
+  isActive?: boolean;
+}>`
+  ${({ isActive, theme }) => {
+    return (
+      isActive &&
+      css`
+        &:hover * {
+          color: ${theme.colors.brand[1]};
+          cursor: pointer;
+        }
+      `
+    );
+  }}
 `;

--- a/frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx
@@ -9,6 +9,7 @@ import { getSignedPreviewUrl, getSignedToken } from "metabase/public/lib/embed";
 import { getSetting } from "metabase/selectors/settings";
 import { getUserIsAdmin } from "metabase/selectors/user";
 
+import { LegaleseStep } from "metabase/public/components/widgets/LegaleseStep/LegaleseStep";
 import AdvancedEmbedPane from "./AdvancedEmbedPane";
 import { SharingPane } from "./SharingPane";
 
@@ -100,7 +101,7 @@ class EmbedModalContent extends Component {
       resourceType,
       resourceParameters,
       embedType,
-      setEmbedType,
+      goToNextStep,
     } = this.props;
     const { pane, embeddingParams, parameterValues, displayOptions } =
       this.state;
@@ -111,9 +112,15 @@ class EmbedModalContent extends Component {
       embeddingParams,
     );
 
-    return embedType == null ? (
-      <SharingPane {...this.props} onChangeEmbedType={setEmbedType} />
-    ) : embedType === "application" ? (
+    if (embedType == null) {
+      return <SharingPane {...this.props} goToNextStep={goToNextStep} />;
+    }
+
+    if (embedType === "legalese") {
+      return <LegaleseStep goToNextStep={goToNextStep} />;
+    }
+
+    return embedType === "application" ? (
       <div className="flex flex-full" style={{ height: "100%" }}>
         <AdvancedEmbedPane
           pane={pane}
@@ -181,7 +188,8 @@ EmbedModalContent.propTypes = {
   onUpdateEmbeddingParams: PropTypes.func,
 
   embedType: PropTypes.string,
-  setEmbedType: PropTypes.func.isRequired,
+  goToNextStep: PropTypes.func.isRequired,
+  goToPreviousStep: PropTypes.func.isRequired,
 };
 
 function getDefaultEmbeddingParams(props) {

--- a/frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModalContent.jsx
@@ -189,7 +189,7 @@ EmbedModalContent.propTypes = {
 
   embedType: PropTypes.string,
   goToNextStep: PropTypes.func.isRequired,
-  goToPreviousStep: PropTypes.func.isRequired,
+  goBackToEmbedModal: PropTypes.func.isRequired,
 };
 
 function getDefaultEmbeddingParams(props) {

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.styled.tsx
@@ -1,0 +1,10 @@
+import { css } from "@emotion/react";
+import styled from "@emotion/styled";
+import { Stack } from "metabase/ui";
+
+export const LegaleseStepDetailsContainer = styled(Stack)`
+  ${({ theme }) => css`
+    border: 1px solid ${theme.colors.border[0]};
+    border-radius: ${theme.radius.md};
+  `}
+`;

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
@@ -1,0 +1,43 @@
+import { t } from "ttag";
+import ExternalLink from "metabase/core/components/ExternalLink";
+import { LegaleseStepDetailsContainer } from "metabase/public/components/widgets/LegaleseStep/LegaleseStep.styled";
+import { Text, Button, Center, Stack, Title } from "metabase/ui";
+
+export const LegaleseStep = ({
+  goToNextStep,
+}: {
+  goToNextStep: () => void;
+}) => (
+  <Center bg="white" px="18rem" pt="6.25rem" pb="11.75rem">
+    <Stack align="center" spacing="3rem">
+      <Title order={2} fz="1.25rem">{t`First, some legalese`}</Title>
+
+      <LegaleseStepDetailsContainer p="lg" w="40rem">
+        <Text fw={700}>
+          {t`By clicking “Agree and continue” you're agreeing to`}{" "}
+          <ExternalLink
+            href="https://metabase.com/license/embedding"
+            target="_blank"
+          >
+            {t`our embedding license.`}
+          </ExternalLink>
+        </Text>
+        <Text>
+          {t`When you embed charts or dashboards from Metabase in your own
+          application, that application isn't subject to the Affero General
+          Public License that covers the rest of Metabase, provided you keep the
+          Metabase logo and the "Powered by Metabase" visible on those embeds.`}
+        </Text>
+        <Text>
+          {t`You should, however, read the license text linked above as that is the
+          actual license that you will be agreeing to by enabling this feature.`}
+        </Text>
+      </LegaleseStepDetailsContainer>
+
+      <Button
+        variant="filled"
+        onClick={goToNextStep}
+      >{t`Agree and continue`}</Button>
+    </Stack>
+  </Center>
+);

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
@@ -1,4 +1,4 @@
-import { t } from "ttag";
+import { jt, t } from "ttag";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { LegaleseStepDetailsContainer } from "metabase/public/components/widgets/LegaleseStep/LegaleseStep.styled";
 import { Text, Button, Center, Stack, Title } from "metabase/ui";
@@ -14,23 +14,20 @@ export const LegaleseStep = ({
 
       <LegaleseStepDetailsContainer p="lg" w="40rem">
         <Text fw={700}>
-          {t`By clicking “Agree and continue” you're agreeing to`}{" "}
-          <ExternalLink
-            href="https://metabase.com/license/embedding"
-            target="_blank"
-          >
-            {t`our embedding license.`}
-          </ExternalLink>
+          {jt`By clicking "Agree and continue" you're agreeing to ${(
+            <ExternalLink
+              href="https://metabase.com/license/embedding"
+              target="_blank"
+            >
+              {t`our embedding license.`}
+            </ExternalLink>
+          )}`}
         </Text>
         <Text>
-          {t`When you embed charts or dashboards from Metabase in your own
-          application, that application isn't subject to the Affero General
-          Public License that covers the rest of Metabase, provided you keep the
-          Metabase logo and the "Powered by Metabase" visible on those embeds.`}
+          {t`When you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the "Powered by Metabase" visible on those embeds.`}
         </Text>
         <Text>
-          {t`You should, however, read the license text linked above as that is the
-          actual license that you will be agreeing to by enabling this feature.`}
+          {t`You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature.`}
         </Text>
       </LegaleseStepDetailsContainer>
 

--- a/frontend/src/metabase/public/components/widgets/SharingPane/SharingPane.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/SharingPane.tsx
@@ -26,7 +26,7 @@ interface SharingPaneProps {
   onCreatePublicLink: () => void;
   onDeletePublicLink: () => void;
   getPublicUrl: (resource: Resource, extension?: ExportFormatType) => void;
-  onChangeEmbedType: (embedType: string) => void;
+  goToNextStep: () => void;
   isPublicSharingEnabled: boolean;
 }
 
@@ -36,7 +36,7 @@ function SharingPane({
   onCreatePublicLink,
   onDeletePublicLink,
   getPublicUrl,
-  onChangeEmbedType,
+  goToNextStep,
 }: SharingPaneProps) {
   const iframeSource = getPublicEmbedHTML(getPublicUrl(resource));
 
@@ -118,12 +118,11 @@ function SharingPane({
           header={t`Static embed`}
           description={t`Securely embed this dashboard in your own application’s server code.`}
           illustration={<StaticEmbedIcon />}
-          onClick={() => onChangeEmbedType("application")}
+          onClick={goToNextStep}
         >
           <SharingPaneActionButton
             data-testid="sharing-pane-static-embed-button"
             fullWidth
-            onClick={() => onChangeEmbedType("application")}
           >
             {resource.enable_embedding ? t`Edit settings` : t`Set this up`}
           </SharingPaneActionButton>

--- a/frontend/src/metabase/public/components/widgets/SharingPane/SharingPane.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/SharingPane.unit.spec.tsx
@@ -28,7 +28,7 @@ const setup = ({
   const onCreatePublicLink = jest.fn();
   const onDeletePublicLink = jest.fn();
   const getPublicUrl = jest.fn(resource => resource.public_uuid);
-  const onChangeEmbedType = jest.fn();
+  const goToNextStep = jest.fn();
 
   const { history } = renderWithProviders(
     <Route
@@ -40,7 +40,7 @@ const setup = ({
           onCreatePublicLink={onCreatePublicLink}
           onDeletePublicLink={onDeletePublicLink}
           getPublicUrl={getPublicUrl}
-          onChangeEmbedType={onChangeEmbedType}
+          goToNextStep={goToNextStep}
           isPublicSharingEnabled={isPublicSharingEnabled}
         />
       )}
@@ -58,7 +58,7 @@ const setup = ({
   );
 
   return {
-    onChangeEmbedType,
+    goToNextStep,
     onCreatePublicLink,
     onDeletePublicLink,
     getPublicUrl,
@@ -77,12 +77,12 @@ describe("SharingPane", () => {
         ).toBeInTheDocument();
       });
 
-      it("should call `onChangeEmbedType` with `application` when `Edit settings` is clicked", () => {
-        const { onChangeEmbedType } = setup({ isResourcePublished: true });
+      it("should call `goToNextStep` with `application` when `Edit settings` is clicked", () => {
+        const { goToNextStep } = setup({ isResourcePublished: true });
 
         userEvent.click(screen.getByRole("button", { name: "Edit settings" }));
 
-        expect(onChangeEmbedType).toHaveBeenCalledWith("application");
+        expect(goToNextStep).toHaveBeenCalledWith("application");
       });
     });
 
@@ -95,12 +95,12 @@ describe("SharingPane", () => {
         ).toBeInTheDocument();
       });
 
-      it("should call `onChangeEmbedType` with `application` when `Set this up` is clicked", () => {
-        const { onChangeEmbedType } = setup({ isResourcePublished: false });
+      it("should call `goToNextStep` with `application` when `Set this up` is clicked", () => {
+        const { goToNextStep } = setup({ isResourcePublished: false });
 
         userEvent.click(screen.getByRole("button", { name: "Set this up" }));
 
-        expect(onChangeEmbedType).toHaveBeenCalledWith("application");
+        expect(goToNextStep).toHaveBeenCalledWith("application");
       });
     });
   });

--- a/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
@@ -44,11 +44,12 @@ export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
 
   return (
     <EmbedModal onClose={onClose}>
-      {({ embedType, setEmbedType }) => (
+      {({ embedType, goToNextStep, goToPreviousStep }) => (
         <EmbedModalContent
           {...props}
           embedType={embedType}
-          setEmbedType={setEmbedType}
+          goToNextStep={goToNextStep}
+          goToPreviousStep={goToPreviousStep}
           className={className}
           resource={card}
           resourceType="question"

--- a/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionEmbedWidget/QuestionEmbedWidget.tsx
@@ -3,7 +3,7 @@ import type { EmbedOptions } from "metabase-types/store";
 import type { ExportFormatType } from "metabase/dashboard/components/PublicLinkPopover/types";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { publicQuestion } from "metabase/lib/urls";
-import { EmbedModal } from "metabase/public/components/widgets/EmbedModal";
+import { EmbedModal } from "metabase/public/components/EmbedModal";
 import EmbedModalContent from "metabase/public/components/widgets/EmbedModalContent";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getCardUiParameters } from "metabase-lib/parameters/utils/cards";
@@ -44,12 +44,12 @@ export const QuestionEmbedWidget = (props: QuestionEmbedWidgetProps) => {
 
   return (
     <EmbedModal onClose={onClose}>
-      {({ embedType, goToNextStep, goToPreviousStep }) => (
+      {({ embedType, goToNextStep, goBackToEmbedModal }) => (
         <EmbedModalContent
           {...props}
           embedType={embedType}
           goToNextStep={goToNextStep}
-          goToPreviousStep={goToPreviousStep}
+          goBackToEmbedModal={goBackToEmbedModal}
           className={className}
           resource={card}
           resourceType="question"


### PR DESCRIPTION
Epic #35961 - Milestone 4

### Description

Adds the `Legalese` step to the static embedding modal flow for OSS users. Right now, there are no checks or actions done to indicate whether or not the user has actually accepted the terms - clicking "Agree" simply moves the user to the static embedding settings. This extra behavior (which will most likely require some BE work) will be sorted in #37327 .

### How to verify

* Ensure embedding is enabled. 
* Go to a question/dashboard and click the share dropdown menu, and click `Embed`.
* Click `Static embed`.
* There should be a legalese step. You should see a link to the embedding terms, and clicking `Agree` should take you to the static embedding settings for that question/dashboard


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
