### PR TITLE
Add `updated_by` to API Keys

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4391,6 +4391,52 @@ databaseChangeLog:
                   remarks: 'If true, the table requires a filter to be able to query it'
 
   - changeSet:
+      id: v49.00-013
+      author: johnswanson
+      comment: Add `api_key.updated_by_id`
+      rollback: # will be removed with the table
+      changes:
+        - addColumn:
+            tableName: api_key
+            columns:
+              - column:
+                  remarks: The ID of the user that last updated this API key
+                  name: updated_by_id
+                  type: integer
+                  constraints:
+                    # no default and nullable: false for a new column? yikes! But this should probably be ok, because
+                    # we don't yet have any UI for creating a new API key.
+                    nullable: false
+                    referencedTableName: core_user
+                    referencedColumnNames: id
+                    foreignKeyName: fk_api_key_updated_by_id_user_id
+
+  - changeSet:
+      id: v49.00-014
+      author: johnswanson
+      comment: Add an index on `api_key.updated_by_id`
+      rollback: # not necessary, will be removed with the table
+      changes:
+        - createIndex:
+            tableName: api_key
+            indexName: idx_api_key_updated_by_id
+            columns:
+              column:
+                name: updated_by_id
+
+  - changeSet:
+      id: v49.00-015
+      author: johnswanson
+      comment: Rename `created_by` to `creator_id`
+      rollback: # not necessary, will be removed with the table
+      changes:
+        - renameColumn:
+            tableName: api_key
+            columnDataType: integer
+            oldColumnName: created_by
+            newColumnName: creator_id
+
+  - changeSet:
       id: v49.00-016
       author: noahmoss
       comment: >-

--- a/src/metabase/api/api_key.clj
+++ b/src/metabase/api/api_key.clj
@@ -12,6 +12,21 @@
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
+(defn- present-api-key
+  "Takes an ApiKey and hydrates/selects keys as necessary to put it into a standard form for responses"
+  [api-key]
+  (-> api-key
+      (t2/hydrate :group_name :updated_by)
+      (select-keys [:created_at
+                    :updated_at
+                    :updated_by
+                    :id
+                    :group_name
+                    :unmasked_key
+                    :name
+                    :masked_key])
+      (update :updated_by #(select-keys % [:common_name :id]))))
+
 (defn- key-with-unique-prefix []
   (u/auto-retry 5
    (let [api-key (api-key/generate-key)
@@ -21,6 +36,12 @@
      (if-not (t2/exists? :model/ApiKey :key_prefix prefix)
        api-key
        (throw (ex-info (tru "could not generate key with unique prefix") {}))))))
+
+(defn- with-updated-by [api-key]
+  (assoc api-key :updated_by_id api/*current-user-id*))
+
+(defn- with-creator [api-key]
+  (assoc api-key :creator_id api/*current-user-id*))
 
 (api/defendpoint POST "/"
   "Create a new API key (and an associated `User`) with the provided name and group ID."
@@ -38,18 +59,16 @@
                                          :type       :api-key})]
         (user/set-permissions-groups! user [(perms-group/all-users) group_id])
         (let [api-key (-> (t2/insert-returning-instance! :model/ApiKey
-                                                         {:user_id      (u/the-id user)
-                                                          :name         name
-                                                          :unhashed_key unhashed-key
-                                                          :created_by   api/*current-user-id*})
-                          (t2/hydrate :group_name))]
+                                                         (-> {:user_id       (u/the-id user)
+                                                              :name          name
+                                                              :unhashed_key  unhashed-key}
+                                                             with-creator
+                                                             with-updated-by))
+                          (t2/hydrate :group_name :updated_by))]
           (events/publish-event! :event/api-key-create
                                  {:object  api-key
                                   :user-id api/*current-user-id*})
-          (-> api-key
-              (select-keys [:created_at :updated_at :id :group_name :name])
-              (assoc :unmasked_key unhashed-key
-                     :masked_key (api-key/mask unhashed-key))))))))
+          (present-api-key (assoc api-key :unmasked_key unhashed-key)))))))
 
 (api/defendpoint GET "/count"
   "Get the count of API keys in the DB"
@@ -68,19 +87,19 @@
                            ;; hydrate the group_name for audit logging
                            (t2/hydrate :group_name))]
     (t2/with-transaction [_conn]
+      (when group_id
+        (let [user (-> api-key-before (t2/hydrate :user) :user)]
+          (user/set-permissions-groups! user [(perms-group/all-users) {:id group_id}])))
       (when name
         ;; A bit of a pain to keep these in sync, but oh well.
         (t2/update! :model/User (:user_id api-key-before) {:first_name name})
-        (t2/update! :model/ApiKey id {:name name}))
-      (when group_id
-        (let [user (-> api-key-before (t2/hydrate :user) :user)]
-          (user/set-permissions-groups! user [(perms-group/all-users) {:id group_id}]))))
+        (t2/update! :model/ApiKey id (with-updated-by {:name name}))))
     (let [updated-api-key (-> (t2/select-one :model/ApiKey :id id)
-                              (t2/hydrate :group_name))]
-      (events/publish-event! :event/api-key-update {:object updated-api-key
+                              (t2/hydrate :group_name :updated_by))]
+      (events/publish-event! :event/api-key-update {:object          updated-api-key
                                                     :previous-object api-key-before
-                                                    :user-id api/*current-user-id*})
-      (select-keys updated-api-key [:created_at :updated_at :id :name :masked_key :group_name]))))
+                                                    :user-id         api/*current-user-id*})
+      (present-api-key updated-api-key))))
 
 (api/defendpoint PUT "/:id/regenerate"
   "Regenerate an API Key"
@@ -93,21 +112,21 @@
         api-key-after (assoc api-key-before
                              :unhashed_key unhashed-key
                              :key_prefix (api-key/prefix unhashed-key))]
-    (t2/update! :model/ApiKey :id id (select-keys api-key-after [:unhashed_key]))
+    (t2/update! :model/ApiKey :id id (with-updated-by
+                                       (select-keys api-key-after [:unhashed_key])))
     (events/publish-event! :event/api-key-regenerate
                            {:object api-key-after
                             :previous-object api-key-before
                             :user-id api/*current-user-id*})
-    (-> api-key-after
-        (select-keys [:created_at :updated_at :id :name :group_name])
-        (assoc :unmasked_key unhashed-key
-               :masked_key (api-key/mask unhashed-key)))))
+    (present-api-key (assoc api-key-after
+                            :unmasked_key unhashed-key
+                            :masked_key (api-key/mask unhashed-key)))))
 
 (api/defendpoint GET "/"
   "Get a list of API keys. Non-paginated."
   []
   (api/check-superuser)
-  (let [api-keys (t2/hydrate (t2/select :model/ApiKey) :group_name)]
-    (map #(select-keys % [:created_at :updated_at :id :name :group_name]) api-keys)))
+  (let [api-keys (t2/hydrate (t2/select :model/ApiKey) :group_name :updated_by)]
+    (map present-api-key api-keys)))
 
 (api/define-routes)

--- a/src/metabase/models/api_key.clj
+++ b/src/metabase/models/api_key.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.api-key
   (:require [crypto.random :as crypto-random]
+            [metabase.api.common :as api]
             [metabase.models.audit-log :as audit-log]
             [metabase.models.interface :as mi]
             [metabase.models.permissions-group :as perms-group]
@@ -75,17 +76,26 @@
     unhashed_key (assoc :key (u.password/hash-bcrypt unhashed_key))
     true (dissoc :unhashed_key)))
 
+(defn- add-updated-by-id [api-key]
+  (update api-key :updated_by_id #(or % api/*current-user-id*)))
+
+(defn- add-created-by-id [api-key]
+  (update api-key :creator_id #(or % api/*current-user-id*)))
+
 (t2/define-before-insert :model/ApiKey
   [api-key]
   (-> api-key
       add-prefix
-      add-key))
+      add-key
+      add-updated-by-id
+      add-created-by-id))
 
 (t2/define-before-update :model/ApiKey
   [api-key]
   (-> api-key
       add-prefix
-      add-key))
+      add-key
+      add-updated-by-id))
 
 (defn- add-masked-key [api-key]
   (if-let [prefix (:key_prefix api-key)]

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -41,9 +41,10 @@
   :model/User)
 
 (methodical/defmethod t2/table-name :model/User [_model] :core_user)
-(methodical/defmethod t2/model-for-automagic-hydration [:default :author]  [_original-model _k] :model/User)
-(methodical/defmethod t2/model-for-automagic-hydration [:default :creator] [_original-model _k] :model/User)
-(methodical/defmethod t2/model-for-automagic-hydration [:default :user]    [_original-model _k] :model/User)
+(methodical/defmethod t2/model-for-automagic-hydration [:default :author]     [_original-model _k] :model/User)
+(methodical/defmethod t2/model-for-automagic-hydration [:default :creator]    [_original-model _k] :model/User)
+(methodical/defmethod t2/model-for-automagic-hydration [:default :updated_by] [_original-model _k] :model/User)
+(methodical/defmethod t2/model-for-automagic-hydration [:default :user]       [_original-model _k] :model/User)
 
 (doto :model/User
   (derive :metabase/model)


### PR DESCRIPTION
This required a bit of modification of the DB.

First, I had named the column meant to hold the ID of the user who last updated an API key as `updated_by`. But it seemed like `updated_by` was the natural field to hold the user name that FE wanted, and I didn't want to clobber an existing field with `hydrate`.

So, I renamed the existing column to `updated_by_id` and used `updated_by` to hold the hydrated user that updated the ApiKey.

Second, for consistency, I renamed `created_by` to `creator_id`.

The logic for presenting an ApiKey was getting a bit complicated and spread out over many different endpoints, so I pulled it out into its own function that's called from almost every endpoint defined in the `metabase.api.api-key` namespace. Note that it calls `(t2/hydrate api-key :updated_by :group_name)` - but I verified that this will not result in additional DB calls if the model was already hydrated.