### PR TITLE
Renamed columns are displayed correctly in downloads (#18572)

### DIFF
--- a/src/metabase/query_processor/middleware/visualization_settings.clj
+++ b/src/metabase/query_processor/middleware/visualization_settings.clj
@@ -18,20 +18,29 @@
   for visualization settings, and then merge in the card-level column settings."
   [column-viz-settings field-ids]
   ;; Retrieve field-level settings
-  (let [field-id->settings (reduce
-                             (fn [m field-id]
-                               (let [field-settings      (:settings (lib.metadata/field (qp.store/metadata-provider) field-id))
-                                     norm-field-settings (normalize-field-settings field-id field-settings)]
-                                 (assoc m field-id norm-field-settings)))
-                             {}
-                             field-ids)]
-    ;; For each column viz setting, if there is a match on the field settings, merge it in,
-    ;; with the column viz settings being the default in the event of conflicts.
-    (reduce-kv
-      (fn [coll {field-id ::mb.viz/field-id :as k} column-viz-setting]
-        (assoc coll k (merge (get field-id->settings field-id {}) column-viz-setting)))
-      {}
-      column-viz-settings)))
+  (let [field-id->settings      (reduce
+                                  (fn [m field-id]
+                                    (let [field-settings      (:settings (lib.metadata/field (qp.store/metadata-provider) field-id))
+                                          norm-field-settings (normalize-field-settings field-id field-settings)]
+                                      (cond-> m
+                                        (seq norm-field-settings)
+                                        (assoc field-id norm-field-settings))))
+                                  {}
+                                  field-ids)
+        ;; For each column viz setting, if there is a match on the field settings, merge it in,
+        ;; with the column viz settings being the default in the event of conflicts.
+        merged-settings         (reduce-kv
+                                  (fn [coll {field-id ::mb.viz/field-id :as k} column-viz-setting]
+                                    (assoc coll k (merge (get field-id->settings field-id {}) column-viz-setting)))
+                                  {}
+                                  column-viz-settings)
+        ;; The field-ids that are in the merged settings
+        viz-field-ids           (set (map ::mb.viz/field-id (keys merged-settings)))
+        ;; Keep any field settings that aren't in the merged settings and have settings
+        distinct-field-settings (update-keys
+                                  (remove (comp viz-field-ids first) field-id->settings)
+                                  (fn [k] {::mb.viz/field-id k}))]
+    (merge merged-settings distinct-field-settings)))
 
 (defn- viz-settings
   "Pull viz settings from either the query map or the DB"

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -5,6 +5,7 @@
    [metabase.formatter :as formatter]
    [metabase.query-processor.streaming.common :as common]
    [metabase.query-processor.streaming.interface :as qp.si]
+   [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.util.date-2 :as u.date])
   (:import
    (java.io BufferedWriter OutputStream OutputStreamWriter)
@@ -29,11 +30,12 @@
         ordered-formatters (volatile! {})]
     (reify qp.si/StreamingResultsWriter
       (begin! [_ {{:keys [ordered-cols results_timezone]} :data} viz-settings]
-        (vreset! ordered-formatters (mapv (fn [col]
-                                            (formatter/create-formatter results_timezone col viz-settings))
-                                          ordered-cols))
-        (csv/write-csv writer [(map (some-fn :display_name :name) ordered-cols)])
-        (.flush writer))
+        (let [col-names (common/column-titles ordered-cols (::mb.viz/column-settings viz-settings))]
+          (vreset! ordered-formatters (mapv (fn [col]
+                                              (formatter/create-formatter results_timezone col viz-settings))
+                                            ordered-cols))
+          (csv/write-csv writer [col-names])
+          (.flush writer)))
 
       (write-row! [_ row _row-num _ {:keys [output-order]}]
         (let [ordered-row (if output-order

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -2,12 +2,13 @@
   "Impls for JSON-based QP streaming response types. `:json` streams a simple array of maps as opposed to the full
   response with all the metadata for `:api`."
   (:require
-    [cheshire.core :as json]
-    [java-time.api :as t]
-    [metabase.formatter :as formatter]
-    [metabase.query-processor.streaming.common :as common]
-    [metabase.query-processor.streaming.interface :as qp.si]
-    [metabase.util.date-2 :as u.date])
+   [cheshire.core :as json]
+   [java-time.api :as t]
+   [metabase.formatter :as formatter]
+   [metabase.query-processor.streaming.common :as common]
+   [metabase.query-processor.streaming.interface :as qp.si]
+   [metabase.shared.models.visualization-settings :as mb.viz]
+   [metabase.util.date-2 :as u.date])
   (:import
    (java.io BufferedWriter OutputStream OutputStreamWriter)
    (java.nio.charset StandardCharsets)))
@@ -33,7 +34,7 @@
       (begin! [_ {{:keys [ordered-cols results_timezone]} :data} viz-settings]
         ;; TODO -- wouldn't it make more sense if the JSON downloads used `:name` preferentially? Seeing how JSON is
         ;; probably going to be parsed programmatically
-        (vreset! col-names (mapv (some-fn :display_name :name) ordered-cols))
+        (vreset! col-names (common/column-titles ordered-cols (::mb.viz/column-settings viz-settings)))
         (vreset! ordered-formatters (mapv (fn [col]
                                             (formatter/create-formatter results_timezone col viz-settings))
                                           ordered-cols))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -16,7 +16,8 @@
    [metabase.events.view-log-test :as view-log-test]
    [metabase.http-client :as client]
    [metabase.models
-    :refer [CardBookmark
+    :refer [Card
+            CardBookmark
             Collection
             Dashboard
             Database
@@ -1825,6 +1826,91 @@
         (is (= [{(keyword "COUNT(*)") "8"}]
                (mt/user-http-request :rasta :post 200 (format "card/%d/query/json" (u/the-id card))
                                      :parameters encoded-params)))))))
+
+(deftest renamed-column-names-are-applied-to-json-test
+  (testing "JSON downloads should have the same columns as displayed in Metabase (#18572)"
+    (mt/with-temporary-setting-values [custom-formatting nil]
+      (let [query        {:source-table (mt/id :orders)
+                          :fields       [[:field (mt/id :orders :id) {:base-type :type/BigInteger}]
+                                         [:field (mt/id :orders :tax) {:base-type :type/Float}]
+                                         [:field (mt/id :orders :total) {:base-type :type/Float}]
+                                         [:field (mt/id :orders :discount) {:base-type :type/Float}]
+                                         [:field (mt/id :orders :quantity) {:base-type :type/Integer}]
+                                         [:expression "Tax Rate"]],
+                          :expressions  {"Tax Rate" [:/
+                                                     [:field (mt/id :orders :tax) {:base-type :type/Float}]
+                                                     [:field (mt/id :orders :total) {:base-type :type/Float}]]},
+                          :limit        10}
+            viz-settings {:table.cell_column "TAX",
+                          :column_settings   {(format "[\"ref\",[\"field\",%s,null]]" (mt/id :orders :id))
+                                              {:column_title "THE_ID"}
+                                              (format "[\"ref\",[\"field\",%s,{\"base-type\":\"type/Float\"}]]"
+                                                      (mt/id :orders :tax))
+                                              {:column_title "ORDER TAX"}
+                                              (format "[\"ref\",[\"field\",%s,{\"base-type\":\"type/Float\"}]]"
+                                                      (mt/id :orders :total))
+                                              {:column_title "Total Amount"},
+                                              (format "[\"ref\",[\"field\",%s,{\"base-type\":\"type/Float\"}]]"
+                                                      (mt/id :orders :discount))
+                                              {:column_title "Discount Applied"}
+                                              (format "[\"ref\",[\"field\",%s,{\"base-type\":\"type/Integer\"}]]"
+                                                      (mt/id :orders :quantity))
+                                              {:column_title "Amount Ordered"}
+                                              "[\"ref\",[\"expression\",\"Tax Rate\"]]"
+                                              {:column_title "Effective Tax Rate"}}}]
+        (t2.with-temp/with-temp [Card {base-card-id :id} {:dataset_query          {:database (mt/id)
+                                                                                   :type     :query
+                                                                                   :query    query}
+                                                          :visualization_settings viz-settings}
+                                 Card {model-card-id  :id
+                                       model-metadata :result_metadata} {:dataset       true
+                                                                         :dataset_query {:database (mt/id)
+                                                                                         :type     :query
+                                                                                         :query    {:source-table
+                                                                                                    (format "card__%s" base-card-id)}}}
+                                 Card {meta-model-card-id :id} {:dataset         true
+                                                                :dataset_query   {:database (mt/id)
+                                                                                  :type     :query
+                                                                                  :query    {:source-table
+                                                                                             (format "card__%s" model-card-id)}}
+                                                                :result_metadata (mapv
+                                                                                   (fn [{column-name :name :as col}]
+                                                                                     (cond-> col
+                                                                                       (= "DISCOUNT" column-name)
+                                                                                       (assoc :display_name "Amount of Discount")
+                                                                                       (= "TOTAL" column-name)
+                                                                                       (assoc :display_name "Grand Total")
+                                                                                       (= "QUANTITY" column-name)
+                                                                                       (assoc :display_name "N")))
+                                                                                   model-metadata)}
+                                 Card {question-card-id :id} {:dataset_query          {:database (mt/id)
+                                                                                       :type     :query
+                                                                                       :query    {:source-table
+                                                                                                  (format "card__%s" meta-model-card-id)}}
+                                                              :visualization_settings {:table.pivot_column "DISCOUNT",
+                                                                                       :table.cell_column  "TAX",
+                                                                                       :column_settings    {(format
+                                                                                                              "[\"ref\",[\"field\",%s,{\"base-type\":\"type/Integer\"}]]"
+                                                                                                              (mt/id :orders :quantity))
+                                                                                                            {:column_title "Count"}
+                                                                                                            (format
+                                                                                                              "[\"ref\",[\"field\",%s,{\"base-type\":\"type/BigInteger\"}]]"
+                                                                                                              (mt/id :orders :id))
+                                                                                                            {:column_title "IDENTIFIER"}}}}]
+          (letfn [(col-names [card-id]
+                    (->> (mt/user-http-request :rasta :post 200 (format "card/%d/query/json" card-id)) first keys (map name) set))]
+            (testing "Renaming columns via viz settings is correctly applied to the CSV export"
+              (is (= #{"THE_ID" "ORDER TAX" "Total Amount" "Discount Applied ($)" "Amount Ordered" "Effective Tax Rate"}
+                     (col-names base-card-id))))
+            (testing "A question derived from another question does not bring forward any renames"
+              (is (= #{"ID" "Tax" "Total" "Discount ($)" "Quantity" "Tax Rate"}
+                     (col-names model-card-id))))
+            (testing "A model with custom metadata shows the renamed metadata columns"
+              (is (= #{"ID" "Tax" "Grand Total" "Amount of Discount ($)" "N" "Tax Rate"}
+                     (col-names meta-model-card-id))))
+            (testing "A question based on a model retains the curated metadata column names but overrides these with any existing visualization_settings"
+              (is (= #{"IDENTIFIER" "Tax" "Grand Total" "Amount of Discount ($)" "Count" "Tax Rate"}
+                     (col-names question-card-id))))))))))
 
 (defn- parse-xlsx-results [results]
   (->> results

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -422,3 +422,140 @@
           (testing "Setting time-enabled to nil for a time column just returns an empty string"
             (is (= ""
                    (metamodel-results "Example Time")))))))))
+
+(deftest renamed-column-names-are-applied-test
+  (testing "CSV and JSON attachments should have the same columns as displayed in Metabase (#18572)"
+    (mt/with-temporary-setting-values [custom-formatting nil]
+      (let [query        {:source-table (mt/id :orders)
+                          :fields       [[:field (mt/id :orders :id) {:base-type :type/BigInteger}]
+                                         [:field (mt/id :orders :tax) {:base-type :type/Float}]
+                                         [:field (mt/id :orders :total) {:base-type :type/Float}]
+                                         [:field (mt/id :orders :discount) {:base-type :type/Float}]
+                                         [:field (mt/id :orders :quantity) {:base-type :type/Integer}]
+                                         [:expression "Tax Rate"]],
+                          :expressions  {"Tax Rate" [:/
+                                                     [:field (mt/id :orders :tax) {:base-type :type/Float}]
+                                                     [:field (mt/id :orders :total) {:base-type :type/Float}]]},
+                          :limit        10}
+            viz-settings {:table.cell_column "TAX",
+                          :column_settings   {(format "[\"ref\",[\"field\",%s,null]]" (mt/id :orders :id))
+                                              {:column_title "THE_ID"}
+                                              (format "[\"ref\",[\"field\",%s,{\"base-type\":\"type/Float\"}]]"
+                                                      (mt/id :orders :tax))
+                                              {:column_title "ORDER TAX"}
+                                              (format "[\"ref\",[\"field\",%s,{\"base-type\":\"type/Float\"}]]"
+                                                      (mt/id :orders :total))
+                                              {:column_title "Total Amount"},
+                                              (format "[\"ref\",[\"field\",%s,{\"base-type\":\"type/Float\"}]]"
+                                                      (mt/id :orders :discount))
+                                              {:column_title "Discount Applied"}
+                                              (format "[\"ref\",[\"field\",%s,{\"base-type\":\"type/Integer\"}]]"
+                                                      (mt/id :orders :quantity))
+                                              {:column_title "Amount Ordered"}
+                                              "[\"ref\",[\"expression\",\"Tax Rate\"]]"
+                                              {:column_title "Effective Tax Rate"}}}]
+        (t2.with-temp/with-temp [Card {base-card-name :name
+                                       base-card-id   :id} {:name                   "RENAMED"
+                                                            :dataset_query          {:database (mt/id)
+                                                                                     :type     :query
+                                                                                     :query    query}
+                                                            :visualization_settings viz-settings}
+                                 Card {model-card-name :name
+                                       model-card-id   :id
+                                       model-metadata  :result_metadata} {:name          "MODEL"
+                                                                          :dataset       true
+                                                                          :dataset_query {:database (mt/id)
+                                                                                          :type     :query
+                                                                                          :query    {:source-table
+                                                                                                     (format "card__%s" base-card-id)}}}
+                                 Card {meta-model-card-name :name
+                                       meta-model-card-id   :id} {:name            "MODEL_WITH_META"
+                                                                  :dataset         true
+                                                                  :dataset_query   {:database (mt/id)
+                                                                                    :type     :query
+                                                                                    :query    {:source-table
+                                                                                               (format "card__%s" model-card-id)}}
+                                                                  :result_metadata (mapv
+                                                                                     (fn [{column-name :name :as col}]
+                                                                                       (cond-> col
+                                                                                         (= "DISCOUNT" column-name)
+                                                                                         (assoc :display_name "Amount of Discount")
+                                                                                         (= "TOTAL" column-name)
+                                                                                         (assoc :display_name "Grand Total")
+                                                                                         (= "QUANTITY" column-name)
+                                                                                         (assoc :display_name "N")))
+                                                                                     model-metadata)}
+                                 Card {question-card-name :name
+                                       question-card-id   :id} {:name                   "FINAL_QUESTION"
+                                                                :dataset_query          {:database (mt/id)
+                                                                                         :type     :query
+                                                                                         :query    {:source-table
+                                                                                                    (format "card__%s" meta-model-card-id)}}
+                                                                :visualization_settings {:table.pivot_column "DISCOUNT",
+                                                                                         :table.cell_column  "TAX",
+                                                                                         :column_settings    {(format
+                                                                                                                "[\"ref\",[\"field\",%s,{\"base-type\":\"type/Integer\"}]]"
+                                                                                                                (mt/id :orders :quantity))
+                                                                                                              {:column_title "Count"}
+                                                                                                              (format
+                                                                                                                "[\"ref\",[\"field\",%s,{\"base-type\":\"type/BigInteger\"}]]"
+                                                                                                                (mt/id :orders :id))
+                                                                                                              {:column_title "IDENTIFIER"}}}}
+                                 Dashboard {dash-id :id} {:name "The Dashboard"}
+                                 DashboardCard {base-dash-card-id :id} {:dashboard_id dash-id
+                                                                        :card_id      base-card-id}
+                                 DashboardCard {model-dash-card-id :id} {:dashboard_id dash-id
+                                                                         :card_id      model-card-id}
+                                 DashboardCard {meta-model-dash-card-id :id} {:dashboard_id dash-id
+                                                                              :card_id      meta-model-card-id}
+                                 DashboardCard {question-dash-card-id :id} {:dashboard_id dash-id
+                                                                            :card_id      question-card-id}
+                                 Pulse {pulse-id :id
+                                        :as      pulse} {:name "Consistent Column Names"}
+                                 PulseCard _ {:pulse_id          pulse-id
+                                              :card_id           base-card-id
+                                              :dashboard_card_id base-dash-card-id
+                                              :include_csv       true}
+                                 PulseCard _ {:pulse_id          pulse-id
+                                              :card_id           model-card-id
+                                              :dashboard_card_id model-dash-card-id
+                                              :include_csv       true}
+                                 PulseCard _ {:pulse_id          pulse-id
+                                              :card_id           meta-model-card-id
+                                              :dashboard_card_id meta-model-dash-card-id
+                                              :include_csv       true}
+                                 PulseCard _ {:pulse_id          pulse-id
+                                              :card_id           question-card-id
+                                              :dashboard_card_id question-dash-card-id
+                                              :include_csv       true}
+                                 PulseChannel {pulse-channel-id :id} {:channel_type :email
+                                                                      :pulse_id     pulse-id
+                                                                      :enabled      true}
+                                 PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
+                                                          :user_id          (mt/user->id :rasta)}]
+          (let [attachment-name->cols (mt/with-fake-inbox
+                                        (with-redefs [email/bcc-enabled? (constantly false)]
+                                          (mt/with-test-user nil
+                                            (metabase.pulse/send-pulse! pulse)))
+                                        (->>
+                                          (get-in @mt/inbox ["rasta@metabase.com" 0 :body])
+                                          (keep
+                                            (fn [{:keys [type content-type file-name content]}]
+                                              (when (and
+                                                      (= :attachment type)
+                                                      (= "text/csv" content-type))
+                                                [file-name
+                                                 (first (csv/read-csv (slurp content)))])))
+                                          (into {})))]
+            (testing "Renaming columns via viz settings is correctly applied to the CSV export"
+              (is (= ["THE_ID" "ORDER TAX" "Total Amount" "Discount Applied ($)" "Amount Ordered" "Effective Tax Rate"]
+                     (attachment-name->cols (format "%s.csv" base-card-name)))))
+            (testing "A question derived from another question does not bring forward any renames"
+              (is (= ["ID" "Tax" "Total" "Discount ($)" "Quantity" "Tax Rate"]
+                     (attachment-name->cols (format "%s.csv" model-card-name)))))
+            (testing "A model with custom metadata shows the renamed metadata columns"
+              (is (= ["ID" "Tax" "Grand Total" "Amount of Discount ($)" "N" "Tax Rate"]
+                     (attachment-name->cols (format "%s.csv" meta-model-card-name)))))
+            (testing "A question based on a model retains the curated metadata column names but overrides these with any existing visualization_settings"
+              (is (= ["IDENTIFIER" "Tax" "Grand Total" "Amount of Discount ($)" "Count" "Tax Rate"]
+                     (attachment-name->cols (format "%s.csv" question-card-name)))))))))))

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -424,7 +424,7 @@
                    (metamodel-results "Example Time")))))))))
 
 (deftest renamed-column-names-are-applied-test
-  (testing "CSV and JSON attachments should have the same columns as displayed in Metabase (#18572)"
+  (testing "CSV attachments should have the same columns as displayed in Metabase (#18572)"
     (mt/with-temporary-setting-values [custom-formatting nil]
       (let [query        {:source-table (mt/id :orders)
                           :fields       [[:field (mt/id :orders :id) {:base-type :type/BigInteger}]

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -485,7 +485,7 @@
     ;; Dollar symbol is included by default if semantic type of column derives from :type/Currency
     (is (= ["Col ($)"]
            (first (xlsx-export [{:id 0, :name "Col", :semantic_type :type/Cost}]
-                               {::mb.viz/column-settings {::mb.viz/field-id 0}}
+                               {::mb.viz/column-settings {{::mb.viz/field-id 0} {}}}
                                []))))
     ;; Currency code is used if requested in viz settings
     (is (= ["Col (USD)"]


### PR DESCRIPTION
When custom viz settings or metadata is applied to questions and models, the downloaded artifact labels do not always mirror what is displayed on the tabular view in Metabase. This happens for several reasons:

- The `:visualization_settings` were not applied to CSV and JSON downloads
- `update-card-viz-settings` in `metabase.query-processor.middleware.visualization-settings` did not correctly merge keys, resulting in dropped column names in Excel file
- The logic for reconciling column metadata in a result set and the keys in `:visualization_settings` of a query result is not straightforward

This PR is an attempt to move this consistency in the right direction without fixing all the challenges of field matching as discussed in [this thread](https://metaboat.slack.com/archives/CKZEMT1MJ/p1703091539541279) and [this issue](Duplicated columns in a source query cannot be distinguished #36185) as this sounds like a significant effort.

The following changes were made:

1. Update `metabase.query-processor.middleware.visualization-settings/update-card-viz-settings` to merge field settings, if present, into `column-viz-settings` without introducing new keys, especially ambiguous keys as follows:

```clojure
(defn- update-card-viz-settings
  "For each field, fetch its settings from the QP store, convert the settings into the normalized form
  for visualization settings, and then merge in the card-level column settings."
  [column-viz-settings field-ids]
  ;; Retrieve field-level settings
  (let [field-id->settings (reduce
                             (fn [m field-id]
                               (let [field-settings      (:settings (lib.metadata/field (qp.store/metadata-provider) field-id))
                                     norm-field-settings (normalize-field-settings field-id field-settings)]
                                 (assoc m field-id norm-field-settings)))
                             {}
                             field-ids)]
    ;; For each column viz setting, if there is a match on the field settings, merge it in,
    ;; with the column viz settings being the default in the event of conflicts.
    (reduce-kv
      (fn [coll {field-id ::mb.viz/field-id :as k} column-viz-setting]
        (assoc coll k (merge (get field-id->settings field-id {}) column-viz-setting)))
      {}
      column-viz-settings)))
```

The primary difference is rather than merging in new keys as `{::mb.viz/field-id field-id} -> field-settings` this code will merge settings found by field id with any `column-viz-setting` containing that field id as part of its key. The merge prefers `column-viz-settings`.

This should be an improvement over what already exists.

2. Move `column-titles` from `metabase.query-processor.streaming.xlsx` to `metabase.query-processor.streaming.common` and use this common function for CSV and JSON export names.

Note that the lifted `column-titles` has some erroneous logic:

- It relies on column `:name` or `:id` as unique identifiers -- they are not always unique.
- It expects the `col-settings` key format to be exactly `{::mb.viz/field-id id}` or `{::mb.viz/column-name name}` -- Sometimes these keys have additional keys. One change made to this function is normalizing `col-settings` to conform to the expected format by removing extra keys. While this isn't a perfect solution, it conforms with the intent of what already exists and is an improvement in the majority of cases.

The _right_ thing to do is _probably_ to use `metabase.lib.equality/find-matching-column` to match the column and settings keys, _but_ the `col-settings` keys are in a weird format that isn't really conducive to doing this. I'd rather we make an incremental step forward and try doing this in another effort.

This second change should not make anything that wasn't already problematic worse, while making the general case better.

Fixes #18572