### PR TITLE
Fix handling signals in cleanup

### DIFF
--- a/e2e/runner/run_cypress_tests.js
+++ b/e2e/runner/run_cypress_tests.js
@@ -31,7 +31,11 @@ const cleanup = async (exitCode = 0) => {
     await CypressBackend.stop(server);
   }
 
-  process.exit(exitCode);
+  // We might get a signal code instead, which is a string
+  // and doesn't require process.exit call
+  if (typeof exitCode === "number") {
+    process.exit(exitCode);
+  }
 };
 
 const launch = () =>


### PR DESCRIPTION
When we catch an exist signal from the OS, we shouldn't try to `process.exit(signal)` because it is incorrect and leads to an error, as well as a possibly incomplete shutdown.

<img width="1280" alt="Screenshot 2023-12-20 at 23 07 37" src="https://github.com/metabase/metabase/assets/2196347/ae38d71e-4a17-4d09-93b7-4eb422464165">
