### PR TITLE
Add testid to ExpressionEditorTextfield>ErrorMessageContainer

### DIFF
--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -598,7 +598,9 @@ class ExpressionEditorTextfield extends React.Component<
           />
         </EditorContainer>
         {errorMessage && hasChanges && (
-          <ErrorMessageContainer>{errorMessage.message}</ErrorMessageContainer>
+          <ErrorMessageContainer data-testid="expression-editor-error-message">
+            {errorMessage.message}
+          </ErrorMessageContainer>
         )}
         <ExpressionEditorHelpText
           target={helpTextTarget}


### PR DESCRIPTION
I am debugging the `notebook.cy.spec` e2e test and will need a test-id to get the error message.