### PR TITLE
Tweak Malli schema in `update-users-recent-views!`

### DIFF
--- a/src/metabase/models/recent_views.clj
+++ b/src/metabase/models/recent_views.clj
@@ -47,7 +47,7 @@
 
 (mu/defn update-users-recent-views!
   "Updates the RecentViews table for a given user with a new view, and prunes old views."
-  [user-id  :- ms/PositiveInt
+  [user-id  :- [:maybe ms/PositiveInt]
    model    :- [:or
                 [:enum :model/Card :model/Table :model/Dashboard]
                 :string]


### PR DESCRIPTION
Tweaks the validation to make `user-id` optional, which can happen since this is called from an event handler which listens on generic events like `dashboard-read` and `table-read`, and some events might be sent in e.g. public or embedded contexts when a user ID is not available.

Should resolve https://github.com/metabase/metabase/issues/37030, I think