### PR TITLE
add delay instead of throttle

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/reproductions/25322-loading-list-values.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/25322-loading-list-values.cy.spec.js
@@ -75,5 +75,5 @@ const throttleFieldValuesRequest = dashboard_id => {
     middleware: true,
   };
 
-  cy.intercept(matcher, req => req.on("response", res => res.setThrottle(10)));
+  cy.intercept(matcher, req => req.on("response", res => res.setDelay(100)));
 };


### PR DESCRIPTION
Fixing a flake analyzed in [this document](https://replayio.notion.site/dashboard-filters-reproductions-25322-loading-list-19324262f19d404ba03787c9f70968ab). 

The test `25322-loading-list-values.cy.spec.js` has become flaky because the period of time to find `loading-spinner` element is too short. This is thanks to API response being fast.

in the past, this was partially remedied by adding `setThrottle()` method to slow the API response down. while it is a good initial approach, it is not resilient to a situation when the data transfer size becomes smaller.

I’m suggesting changing the method to `setTimeout` that will give the test enough time to catch the loading state.

in the future, this particular test would be a good candidate for a component test as it is quite granular