### PR TITLE
Fix flaky e2e notebook / "should process ... when pressing Enter"

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -179,7 +179,13 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Custom Expression").click();
 
-    cy.get("@formula").clear().type("[Price] > 1 AND [Price] < 5{enter}");
+    cy.get("@formula")
+      .invoke("val", "") // this is a more reliable .clear()
+      .type("[Price] > 1 AND [Price] < 5{enter}");
+
+    // In case it does exist, it usually is an error in expression (caused by not clearing
+    // the input properly before typing), and this check helps to highlight that.
+    cy.findByTestId("expression-editor-textfield").should("not.exist");
 
     getNotebookStep("filter")
       .contains("Price is greater than 1")


### PR DESCRIPTION
This addresses the most frequently failing e2e test, part of the https://github.com/metabase/metabase/issues/36683

<img width="1565" alt="Screenshot 2023-12-21 at 16 03 26" src="https://github.com/metabase/metabase/assets/2196347/a65d7853-100c-436a-9b27-28505fc41079">

## Confirmation that the flake is fixed

- https://github.com/metabase/metabase/actions/runs/7290033665/job/19865927994 (search for "when pressing Enter" in results)
- https://github.com/metabase/metabase/actions/runs/7289876708 - the entire suite is passing

## How it is fixed
When we call `clear` on an input in Cypress, is [actually invokes](https://docs.cypress.io/api/commands/clear) `.type('{selectall}{backspace}')`. 

And it is unreliable as it turns out. The reason is either the way Cypress simulates native events, or the code we use for handling them (likely somewhere deep in Mantine core) or something else.

Instead, we're programmatically changing the input's `value` - by doing `invoke('val', '')` - which is arguably slightly different but **is not something** we should believe would break any time soon. Like if backspace (which we were checking before) stops working in an input, no matter what's under the hood of it, you have much more serious problems than a single flaky e2e test.

Prior to this working approach I tried waiting for multiple things, triggering the popup differently, etc - all this is available in the [history of the other PR](https://github.com/metabase/metabase/pull/37020). 

## Next steps
I'll need to investigate further. In case we have other flaky tests _and_ they're unreliable because of the same root cause, I might create a new cypress wrapper/helper and a lint rule to enforce its usage. Not part of this PR though.