### PR TITLE
Run manage-milestones job regardless of skip-version-info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -614,7 +614,7 @@ jobs:
   manage-milestones:
     permissions: write-all
     runs-on: ubuntu-22.04
-    needs: [draft-release-notes, publish-version-info] # this will ensure that the milestone stays open until the release notes are published
+    needs: [draft-release-notes] # this will ensure that the milestone stays open until the release notes are published
     timeout-minutes: 15
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
[Release v0.48.1](https://github.com/metabase/metabase/actions/runs/7274818324) had a hiccup and skipped step 3 below.

1. Publish GitHub release
2. Publish `version-info.json` to AWS
3. Delete old milestone, and create next milestone

It stopped at step 2 because `inputs.skip-version-info` was enabled, but step 3 should probably be run regardless, so that’s what this PR does.