### PR TITLE
Fix flaky e2e notebook / should work on custom column with `case`

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -316,11 +316,12 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       getNotebookStep("expression").contains("Example").should("exist");
 
       visualize(() => {
-        cy.findByTestId("TableInteractive-root").within(() => {
-          cy.contains("Example");
-          cy.contains("Big");
-          cy.contains("Small");
-        });
+        // eslint-disable-next-line no-unscoped-text-selectors
+        cy.contains("Example");
+        // eslint-disable-next-line no-unscoped-text-selectors
+        cy.contains("Big");
+        // eslint-disable-next-line no-unscoped-text-selectors
+        cy.contains("Small");
       });
     });
 

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -316,6 +316,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       getNotebookStep("expression").contains("Example").should("exist");
 
       visualize(() => {
+        cy.wait(1000);
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("Example");
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -297,6 +297,9 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
   describe("arithmetic (metabase#13175)", () => {
     beforeEach(() => {
+      // This is required because TableInteractive won't render columns
+      // that don't fit into the viewport
+      cy.viewport(1400, 1000);
       openOrdersTable({ mode: "notebook" });
     });
 
@@ -315,15 +318,14 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       getNotebookStep("expression").contains("Example").should("exist");
 
-      visualize(() => {
-        cy.wait(1000);
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.contains("Example");
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.contains("Big");
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.contains("Small");
-      });
+      visualize();
+
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.contains("Example");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.contains("Big");
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.contains("Small");
     });
 
     it("should work on custom filter", () => {

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -315,12 +315,12 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       getNotebookStep("expression").contains("Example").should("exist");
 
-      visualize();
-
-      cy.findByTestId("TableInteractive-root").within(() => {
-        cy.contains("Example");
-        cy.contains("Big");
-        cy.contains("Small");
+      visualize(() => {
+        cy.findByTestId("TableInteractive-root").within(() => {
+          cy.contains("Example");
+          cy.contains("Big");
+          cy.contains("Small");
+        });
       });
     });
 

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -304,7 +304,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       cy.icon("add_data").click();
 
       enterCustomColumnDetails({
-        formula: "case([Subtotal] + [Tax] > 100, 'Big', 'Small')",
+        formula: "case([Subtotal] + Tax > 100, 'Big', 'Small')",
       });
 
       cy.findByPlaceholderText("Something nice and descriptive")
@@ -316,11 +316,11 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       getNotebookStep("expression").contains("Example").should("exist");
 
       visualize(() => {
-        // eslint-disable-next-line no-unscoped-text-selectors
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("Example");
-        // eslint-disable-next-line no-unscoped-text-selectors
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("Big");
-        // eslint-disable-next-line no-unscoped-text-selectors
+        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("Small");
       });
     });

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -317,12 +317,11 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
       visualize();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Example");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Big");
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Small");
+      cy.findByTestId("TableInteractive-root").within(() => {
+        cy.contains("Example");
+        cy.contains("Big");
+        cy.contains("Small");
+      });
     });
 
     it("should work on custom filter", () => {

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -304,7 +304,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       cy.icon("add_data").click();
 
       enterCustomColumnDetails({
-        formula: "case([Subtotal] + Tax > 100, 'Big', 'Small')",
+        formula: "case([Subtotal] + [Tax] > 100, 'Big', 'Small')",
       });
 
       cy.findByPlaceholderText("Something nice and descriptive")


### PR DESCRIPTION
Fixes part of the `notebook.spec.cy` flakiness, part of https://github.com/metabase/metabase/pull/37020 and https://github.com/metabase/metabase/issues/36683

## Problem
The default viewport size for cypress is `1000x660px`. This wasn't enough for a wide table that this test is about to fit into screen _sometimes_, perhaps because of some inherent non-determinism in text rendering or something like that.

1000x660 | 1440x1000
---|---
<img width="931" alt="Screenshot 2023-12-22 at 13 15 52" src="https://github.com/metabase/metabase/assets/2196347/0919b83d-affd-44fd-8e14-06c9064bf5c7"> | <img width="935" alt="Screenshot 2023-12-22 at 13 15 27" src="https://github.com/metabase/metabase/assets/2196347/cf1a6256-5268-45e6-b1d8-20a21814eeba">


## Solution
Increase the viewport size and add a comment so it is clear that it's important. May not keep the test afloat forever, but is good enough.

## Proof that it's passing
- Isolated run: https://github.com/metabase/metabase/actions/runs/7300207727/job/19894415958
- The entire `arithmetic (metabase#13175)` - https://github.com/metabase/metabase/actions/runs/7300516481/job/19895310689