### PR TITLE
Add a DELETE endpoint for API Keys

### DIFF
--- a/src/metabase/api/api_key.clj
+++ b/src/metabase/api/api_key.clj
@@ -1,7 +1,7 @@
 (ns metabase.api.api-key
   "/api/api-key endpoints for CRUD management of API Keys"
   (:require
-   [compojure.core :refer [POST GET PUT]]
+   [compojure.core :refer [POST GET PUT DELETE]]
    [metabase.api.common :as api]
    [metabase.events :as events]
    [metabase.models.api-key :as api-key]
@@ -85,7 +85,8 @@
   (api/check-superuser)
   (let [api-key-before (-> (t2/select-one :model/ApiKey :id id)
                            ;; hydrate the group_name for audit logging
-                           (t2/hydrate :group_name))]
+                           (t2/hydrate :group_name)
+                           (api/check-404))]
     (t2/with-transaction [_conn]
       (when group_id
         (let [user (-> api-key-before (t2/hydrate :user) :user)]
@@ -107,7 +108,8 @@
   {id ms/PositiveInt}
   (api/check-superuser)
   (let [api-key-before (-> (t2/select-one :model/ApiKey id)
-                           (t2/hydrate :group_name))
+                           (t2/hydrate :group_name)
+                           (api/check-404))
         unhashed-key (key-with-unique-prefix)
         api-key-after (assoc api-key-before
                              :unhashed_key unhashed-key
@@ -128,5 +130,21 @@
   (api/check-superuser)
   (let [api-keys (t2/hydrate (t2/select :model/ApiKey) :group_name :updated_by)]
     (map present-api-key api-keys)))
+
+(api/defendpoint DELETE "/:id"
+  "Delete an ApiKey"
+  [id]
+  {id ms/PositiveInt}
+  (api/check-superuser)
+  (let [api-key (-> (t2/select-one :model/ApiKey id)
+                    (t2/hydrate :group_name)
+                    (api/check-404))]
+    (t2/with-transaction [_tx]
+      (t2/delete! :model/ApiKey id)
+      (t2/update! :model/User (:user_id api-key) {:is_active false}))
+    (events/publish-event! :event/api-key-delete
+                           {:object api-key
+                            :user-id api/*current-user-id*})
+    api/generic-204-no-content))
 
 (api/define-routes)

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -204,6 +204,7 @@
 (derive :event/api-key-create ::api-key-event)
 (derive :event/api-key-update ::api-key-event)
 (derive :event/api-key-regenerate ::api-key-event)
+(derive :event/api-key-delete ::api-key-event)
 
 (methodical/defmethod events/publish-event! ::api-key-event
   [topic event]

--- a/src/metabase/models/api_key.clj
+++ b/src/metabase/models/api_key.clj
@@ -53,7 +53,8 @@
 
 (defn- add-prefix [{:keys [unhashed_key] :as api-key}]
   (cond-> api-key
-    unhashed_key (assoc :key_prefix (prefix unhashed_key))))
+    (contains? api-key :unhashed_key)
+    (assoc :key_prefix (some-> unhashed_key prefix))))
 
 (defn generate-key
   "Generates a new API key - a random base64 string prefixed with `mb_`"
@@ -73,7 +74,9 @@
   "Adds the `key` based on the `unhashed_key` passed in."
   [{:keys [unhashed_key] :as api-key}]
   (cond-> api-key
-    unhashed_key (assoc :key (u.password/hash-bcrypt unhashed_key))
+    (contains? api-key :unhashed_key)
+    (assoc :key (some-> unhashed_key u.password/hash-bcrypt))
+
     true (dissoc :unhashed_key)))
 
 (defn- add-updated-by-id [api-key]
@@ -109,4 +112,4 @@
 
 (defmethod audit-log/model-details :model/ApiKey
   [entity _event-type]
-  (select-keys entity [:name :group_name :key_prefix]))
+  (select-keys entity [:name :group_name :key_prefix :user_id]))

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -306,6 +306,7 @@
                 :from      :api_key
                 :left-join [[:core_user :user] [:= :api_key.user_id :user.id]]
                 :where     [:and
+                            [:= :user.is_active true]
                             [:= :api_key.key_prefix [:raw "?"]]]
                 :limit     [:inline 1]}
          enable-advanced-permissions?

--- a/test/metabase/api/api_key_test.clj
+++ b/test/metabase/api/api_key_test.clj
@@ -114,14 +114,18 @@
 
 (deftest api-keys-work-e2e
   (testing "We can create a new API key and then use it for authentication"
-    (let [api-key (:unmasked_key
-                   (mt/user-http-request :crowberto :post 200 "api-key"
-                                         {:group_id (:id (perms-group/all-users))
-                                          :name     (str (random-uuid))}))]
+    (let [{api-key :unmasked_key
+           id      :id} (mt/user-http-request :crowberto :post 200 "api-key"
+                                              {:group_id (:id (perms-group/all-users))
+                                               :name     (str (random-uuid))})]
       ;; the exact endpoint here doesn't really matter - we just want to make an API call that requires auth
       (is (client/client :get 200 "user/current" {:request-options {:headers {"x-api-key" api-key}}}))
       (is (= "Unauthenticated"
-             (client/client :get 401 "user/current" {:request-options {:headers {"x-api-key" "mb_not_an_api_key"}}}))))))
+             (client/client :get 401 "user/current" {:request-options {:headers {"x-api-key" "mb_not_an_api_key"}}})))
+      (testing "A deleted API Key can no longer be used"
+        (mt/user-http-request :crowberto :delete 204 (format "api-key/%s" id))
+        (is (= "Unauthenticated"
+               (client/client :get 401 "user/current" {:request-options {:headers {"x-api-key" api-key}}})))))))
 
 (deftest api-keys-can-be-updated
   (t2.with-temp/with-temp [:model/PermissionsGroup {group-id-1 :id} {:name "Cool Friends"}
@@ -163,7 +167,10 @@
         (testing "the shape of the response is correct"
           (is (= #{:created_at :updated_at :updated_by :id :group_name :name :masked_key}
                  (set (keys (mt/user-http-request :crowberto :put 200 (str "api-key/" id)
-                                                  {:name name-1}))))))))))
+                                                  {:name name-1}))))))))
+    (testing "A nonexistent API Key can't be updated"
+      (mt/user-http-request :crowberto
+                            :put 404 (format "api-key/%s/regenerate" (+ 13371337 (rand-int 100)))))))
 
 (deftest api-keys-can-be-regenerated
   (testing "You can regenerate an API key"
@@ -180,7 +187,10 @@
         (is (= #{:created_at :updated_at :id :name :unmasked_key :masked_key :group_name :updated_by}
                (set (keys resp))))
         (is (client/client :get 401 "user/current" {:request-options {:headers {"x-api-key" old-key}}}))
-        (is (client/client :get 200 "user/current" {:request-options {:headers {"x-api-key" new-key}}}))))))
+        (is (client/client :get 200 "user/current" {:request-options {:headers {"x-api-key" new-key}}})))))
+  (testing "A nonexistent API Key can't be regenerated"
+    (mt/user-http-request :crowberto
+                          :put 404 (format "api-key/%s/regenerate" (+ 13371337 (rand-int 100))))))
 
 (deftest api-keys-can-be-listed
   (mt/with-empty-h2-app-db
@@ -209,6 +219,22 @@
              (map #(select-keys % [:name :group_name])
                   (mt/user-http-request :crowberto :get 200 "api-key")))))))
 
+(deftest api-keys-can-be-deleted
+  (mt/with-empty-h2-app-db
+    (is (= [] (mt/user-http-request :crowberto :get 200 "api-key")))
+
+    (let [{id :id} (mt/user-http-request :crowberto
+                                         :post 200 "api-key"
+                                         {:group_id (:id (perms-group/all-users))
+                                          :name     "My First API Key"})]
+      (is (= 1 (count (mt/user-http-request :crowberto :get 200 "api-key"))))
+      (is (= 1 (mt/user-http-request :crowberto :get 200 "api-key/count")))
+      (mt/user-http-request :crowberto :delete 204 (format "api-key/%s" id))
+      (is (zero? (count (mt/user-http-request :crowberto :get 200 "api-key"))))
+      (is (zero? (mt/user-http-request :crowberto :get 200 "api-key/count")))
+      (testing "Deleting a nonexistent API Key returns a 404"
+        (mt/user-http-request :crowberto :delete 404 (format "api-key/%s" id))))))
+
 (deftest api-key-operations-are-audit-logged
   (premium-features-test/with-premium-features #{:audit-app}
     (mt/with-empty-h2-app-db
@@ -224,12 +250,13 @@
               url                          (fn [url] (format url id))]
           (testing "Creation was audit logged"
             (is (=? {:details  {:name       "My API Key"
-                                :group_name "Cool Friends"}
+                                :group_name "Cool Friends"
+                                :user_id    (t2/select-one-fn :user_id :model/ApiKey id)}
                      :model    "ApiKey"
                      :model_id id
                      :user_id  (mt/user->id :crowberto)}
                     (mt/latest-audit-log-entry :api-key-create id)))
-            (is (= #{:name :group_name :key_prefix}
+            (is (= #{:name :group_name :key_prefix :user_id}
                    (-> (mt/latest-audit-log-entry :api-key-create id) :details keys set))))
           (testing "Update is audit logged"
             (mt/user-http-request :crowberto
@@ -254,4 +281,13 @@
                        :model    "ApiKey"
                        :model_id id
                        :user_id  (mt/user->id :crowberto)}
-                      (mt/latest-audit-log-entry :api-key-regenerate id))))))))))
+                      (mt/latest-audit-log-entry :api-key-regenerate id)))))
+          (testing "Deletion is audit logged"
+            (mt/user-http-request :crowberto
+                                  :delete 204 (url "api-key/%s"))
+            (is (=? {:details  {:name       "A New Name"
+                                :group_name "Less Cool Friends"}
+                     :model    "ApiKey"
+                     :model_id id
+                     :user_id  (mt/user->id :crowberto)}
+                    (mt/latest-audit-log-entry :api-key-delete id)))))))))


### PR DESCRIPTION
Don't actually delete them from the database (to keep the invariant that a user with an `:api-key` type will always have an associated ApiKey). Just mark them as `:archived`, and:

- make them invisible to the count endpoint

- make them invisible to the list endpoint

- make them not work for authentication