### PR TITLE
fix color button when it's disabled

### DIFF
--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/EmbeddingOption.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/EmbeddingOption.tsx
@@ -4,6 +4,7 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_EMBEDDING } from "metabase/plugins";
 import { getSetting } from "metabase/selectors/settings";
+import type { ButtonProps } from "metabase/ui";
 import { Button, Flex, Text, Title } from "metabase/ui";
 import { Label, StyledCard, BoldExternalLink } from "./EmbeddingOption.styled";
 import InteractiveEmbeddingOff from "./InteractiveEmbeddingOff.svg?component";
@@ -69,14 +70,13 @@ export const StaticEmbeddingOptionCard = () => {
         )
       }`}
     >
-      <Button
+      <LinkButton
         variant="default"
         disabled={!enabled}
-        component={Link}
         to={"/admin/settings/embedding-in-other-applications/standalone"}
       >
         {t`Manage`}
-      </Button>
+      </LinkButton>
     </EmbeddingOption>
   );
 };
@@ -109,13 +109,12 @@ export const InteractiveEmbeddingOptionCard = () => {
         {t`Check out our Quick Start`}
       </BoldExternalLink>
       {isEE ? (
-        <Button
-          component={Link}
+        <LinkButton
           to={"/admin/settings/embedding-in-other-applications/full-app"}
           disabled={!enabled}
         >
           {t`Configure`}
-        </Button>
+        </LinkButton>
       ) : (
         <Button
           component={ExternalLink}
@@ -125,5 +124,21 @@ export const InteractiveEmbeddingOptionCard = () => {
         </Button>
       )}
     </EmbeddingOption>
+  );
+};
+
+// component={Link} breaks the styling when the button is disabled
+// disabling a link button doesn't look like a common enough scenario to make an exported component
+const LinkButton = ({
+  to,
+  disabled,
+  ...buttonProps
+}: { to: string; disabled?: boolean } & ButtonProps) => {
+  return disabled ? (
+    <Button disabled={disabled} {...buttonProps} />
+  ) : (
+    <Link to={to}>
+      <Button {...buttonProps} />
+    </Link>
   );
 };


### PR DESCRIPTION
# Description

`<Button component={Link} disabled={true}>` breaks the styling, I believe it's because some css is actually styling the `button` .
The way we usually create "link buttons" seems to just wrap the button anyway (see for example the ["Connect your database"](https://github.com/metabase/metabase/blob/37a620f214eefbdd50c6352d5284f1cc3bc49542/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.tsx#L41-L50) button).

The color is not the same as in figma, but Vitorio is ok with the default disabled color: https://metaboat.slack.com/archives/C063Q3F1HPF/p1703181370938379

The usecase of "link button with possibility of being disabled" looks very small so I created a local component which is basically a ternary.

Before
<img width="955" alt="image" src="https://github.com/metabase/metabase/assets/1914270/39ea66f8-55db-4d0d-9324-7c006b551525">
After:
<img width="943" alt="image" src="https://github.com/metabase/metabase/assets/1914270/6dc8d234-c79c-4c42-94b3-a3826164b8a7">

