### PR TITLE
rename the embedding setting to "Enable Embedding" as per new design

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -58,7 +58,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
       cy.findByTestId("enable-embedding-setting").within(() => {
         cy.findByText(embeddingDescription);
 
-        cy.findByLabelText("Embedding Enabled").click({ force: true });
+        cy.findByLabelText("Enable Embedding").click({ force: true });
       });
       // The URL should stay the same
       cy.location("pathname").should("eq", embeddingPage);

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingSwitchWidget/EmbeddingSwitchWidget.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingSwitchWidget/EmbeddingSwitchWidget.tsx
@@ -17,7 +17,7 @@ export const EmbeddingSwitchWidget = ({
     <Switch
       labelPosition="left"
       checked={Boolean(setting.value)}
-      label={<strong>{t`Embedding Enabled`}</strong>}
+      label={<strong>{t`Enable Embedding`}</strong>}
       onChange={e => onChange(e.target.checked)}
     />
   </Stack>


### PR DESCRIPTION
This was changed on figma a couple days ago and I didn't notice it.
Slack feedback on it: https://metaboat.slack.com/archives/C063Q3F1HPF/p1703184590866699?thread_ts=1703181370.938379&cid=C063Q3F1HPF