### PR TITLE
36797 partial permission graph

### DIFF
--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -491,6 +491,30 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
           ["Reviews", "Unrestricted", "Yes"],
         ]);
       });
+
+      it("should show a modal when a revision changes while an admin is editing", () => {
+        cy.intercept("/api/permissions/graph/group/1").as("graph");
+        cy.visit("/admin/permissions");
+
+        selectSidebarItem("collection");
+
+        modifyPermission(
+          "Sample Database",
+          DATA_ACCESS_PERMISSION_INDEX,
+          "Unrestricted",
+        );
+
+        cy.get("@graph").then(data => {
+          cy.request("PUT", "/api/permissions/graph", {
+            groups: {},
+            revision: data.response.body.revision,
+          }).then(() => {
+            selectSidebarItem("data");
+
+            modal().findByText("Someone just changed permissions");
+          });
+        });
+      });
     });
 
     context("database focused view", () => {
@@ -596,6 +620,30 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
           ["nosql", "Unrestricted", "No"],
           ["readonly", "Unrestricted", "Yes"],
         ]);
+      });
+      it("should show a modal when a revision changes while an admin is editing", () => {
+        cy.intercept("/api/permissions/graph/group/1").as("graph");
+        cy.visit("/admin/permissions/");
+
+        selectSidebarItem("collection");
+
+        modifyPermission(
+          "Sample Database",
+          DATA_ACCESS_PERMISSION_INDEX,
+          "Unrestricted",
+        );
+
+        cy.get("@graph").then(data => {
+          cy.request("PUT", "/api/permissions/graph", {
+            groups: {},
+            revision: data.response.body.revision,
+          }).then(() => {
+            cy.get("label").contains("Databases").click();
+            selectSidebarItem("Sample Database");
+
+            modal().findByText("Someone just changed permissions");
+          });
+        });
       });
     });
   });

--- a/frontend/src/metabase-types/store/admin.ts
+++ b/frontend/src/metabase-types/store/admin.ts
@@ -30,7 +30,7 @@ export interface AdminState {
     saveError?: string;
     isHelpReferenceOpen: boolean;
     hasRevisionChanged: {
-      revision: number;
+      revision: number | null;
       hasChanged: boolean;
     };
   };

--- a/frontend/src/metabase-types/store/admin.ts
+++ b/frontend/src/metabase-types/store/admin.ts
@@ -29,6 +29,10 @@ export interface AdminState {
     originalCollectionPermissions: CollectionPermissions;
     saveError?: string;
     isHelpReferenceOpen: boolean;
+    hasRevisionChanged: {
+      revision: number;
+      hasChanged: boolean;
+    };
   };
   settings: {
     settings: SettingDefinition[];

--- a/frontend/src/metabase-types/store/mocks/admin.ts
+++ b/frontend/src/metabase-types/store/mocks/admin.ts
@@ -26,6 +26,10 @@ export const createMockPermissionsState = (
     collectionPermissions: {},
     originalCollectionPermissions: {},
     isHelpReferenceOpen: false,
+    hasRevisionChanged: {
+      revision: null,
+      hasChanged: false,
+    },
     ...opts,
   };
 };

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
@@ -10,6 +10,13 @@ import { LeaveConfirmationModal } from "metabase/components/LeaveConfirmationMod
 import Modal from "metabase/components/Modal";
 import ModalContent from "metabase/components/ModalContent";
 
+import {
+  Modal as NewModal,
+  Text,
+  Button as NewButton,
+  Group,
+} from "metabase/ui";
+
 import type { PermissionsGraph } from "metabase-types/api";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
@@ -28,6 +35,7 @@ import {
   toggleHelpReference,
 } from "../../permissions";
 import { ToolbarButton } from "../ToolbarButton";
+import { showRevisionChangedModal } from "../../selectors/data-permissions/revision";
 import { PermissionsTabs } from "./PermissionsTabs";
 
 import { PermissionsEditBar } from "./PermissionsEditBar";
@@ -70,7 +78,7 @@ function PermissionsPageLayout({
   helpContent,
 }: PermissionsPageLayoutProps) {
   const saveError = useSelector(state => state.admin.permissions.saveError);
-
+  const showRefreshModal = useSelector(showRevisionChangedModal);
   const isHelpReferenceOpen = useSelector(getIsHelpReferenceOpen);
   const dispatch = useDispatch();
 
@@ -132,6 +140,24 @@ function PermissionsPageLayout({
           {helpContent}
         </PermissionPageSidebar>
       )}
+      <NewModal
+        title="Someone just changed permissions"
+        opened={showRefreshModal}
+        size="lg"
+        padding="2.5rem"
+        withCloseButton={false}
+        onClose={() => true}
+      >
+        <Text mb="1rem">
+          To edit permissions, you need to start from the latest version. Please
+          refresh the page.
+        </Text>
+        <Group position="right">
+          <NewButton onClick={() => location.reload()} variant="filled">
+            Refresh the page
+          </NewButton>
+        </Group>
+      </NewModal>
     </PermissionPageRoot>
   );
 }

--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
@@ -8,7 +8,7 @@ import Tables from "metabase/entities/tables";
 import Groups from "metabase/entities/groups";
 import Databases from "metabase/entities/databases";
 
-import { isDefaultGroup } from "metabase/lib/groups";
+import { isAdminGroup, isDefaultGroup } from "metabase/lib/groups";
 import { PermissionsApi } from "metabase/services";
 import { Loader, Center } from "metabase/ui";
 
@@ -54,10 +54,18 @@ function DataPermissionsPage({
   const loadPermissions = () => dispatch(loadDataPermissions());
   const savePermissions = () => dispatch(saveDataPermissions());
 
-  const { loading: isLoading } = useAsync(async () => {
+  const { loading: isLoadingAllUsers } = useAsync(async () => {
     const allUsers = groups.find(isDefaultGroup);
     const result = await PermissionsApi.graphForGroup({
       groupId: allUsers?.id,
+    });
+    await dispatch({ type: LOAD_DATA_PERMISSIONS_FOR_GROUP, payload: result });
+  }, []);
+
+  const { loading: isLoadingAdminstrators } = useAsync(async () => {
+    const admins = groups.find(isAdminGroup);
+    const result = await PermissionsApi.graphForGroup({
+      groupId: admins?.id,
     });
     await dispatch({ type: LOAD_DATA_PERMISSIONS_FOR_GROUP, payload: result });
   }, []);
@@ -81,7 +89,7 @@ function DataPermissionsPage({
     fetchTables(params.databaseId);
   }, [params.databaseId, fetchTables]);
 
-  if (isLoading) {
+  if (isLoadingAllUsers || isLoadingAdminstrators) {
     return (
       <Center h="100%">
         <Loader size="lg" />

--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
@@ -18,7 +18,7 @@ import type Database from "metabase-lib/metadata/Database";
 import { getIsDirty, getDiff } from "../../selectors/data-permissions/diff";
 import {
   saveDataPermissions,
-  loadDataPermissions,
+  restoreLoadedPermissions,
   LOAD_DATA_PERMISSIONS_FOR_GROUP,
 } from "../../permissions";
 import PermissionsPageLayout from "../../components/PermissionsPageLayout/PermissionsPageLayout";
@@ -51,7 +51,7 @@ function DataPermissionsPage({
 
   const dispatch = useDispatch();
 
-  const loadPermissions = () => dispatch(loadDataPermissions());
+  const resetPermissions = () => dispatch(restoreLoadedPermissions());
   const savePermissions = () => dispatch(saveDataPermissions());
 
   const { loading: isLoadingAllUsers } = useAsync(async () => {
@@ -100,7 +100,7 @@ function DataPermissionsPage({
   return (
     <PermissionsPageLayout
       tab="data"
-      onLoad={loadPermissions}
+      onLoad={resetPermissions}
       onSave={savePermissions}
       diff={diff}
       isDirty={isDirty}

--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
@@ -65,7 +65,7 @@ function DataPermissionsPage({
   );
 
   useEffect(() => {
-    initialize();
+    //initialize();
   }, [initialize]);
 
   useEffect(() => {

--- a/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback } from "react";
+import { Fragment, useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
 import { bindActionCreators } from "@reduxjs/toolkit";
 import { push } from "react-router-redux";
@@ -6,19 +6,22 @@ import { t } from "ttag";
 import _ from "underscore";
 import { connect } from "react-redux";
 
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import {
   getGroupsDataPermissionEditor,
   getDataFocusSidebar,
   getIsLoadingDatabaseTables,
   getLoadingDatabaseTablesError,
 } from "../../selectors/data-permissions";
-import { updateDataPermission } from "../../permissions";
+import {
+  updateDataPermission,
+  loadDataPermissionsForDB,
+} from "../../permissions";
 
 import { PermissionsSidebar } from "../../components/PermissionsSidebar";
 import {
   PermissionsEditor,
   PermissionsEditorEmptyState,
-  permissionEditorPropTypes,
 } from "../../components/PermissionsEditor";
 import {
   DATABASES_BASE_PATH,
@@ -42,7 +45,7 @@ const mapDispatchToProps = dispatch => ({
 const mapStateToProps = (state, props) => {
   return {
     sidebar: getDataFocusSidebar(state, props),
-    permissionEditor: getGroupsDataPermissionEditor(state, props),
+    // permissionEditor: getGroupsDataPermissionEditor(state, props),
     isSidebarLoading: getIsLoadingDatabaseTables(state, props),
     sidebarError: getLoadingDatabaseTablesError(state, props),
   };
@@ -56,29 +59,38 @@ const propTypes = {
   }),
   children: PropTypes.node,
   sidebar: PropTypes.object,
-  permissionEditor: PropTypes.shape(permissionEditorPropTypes),
+  // permissionEditor: PropTypes.shape(permissionEditorPropTypes),
   navigateToItem: PropTypes.func.isRequired,
   switchView: PropTypes.func.isRequired,
   updateDataPermission: PropTypes.func.isRequired,
   navigateToDatabaseList: PropTypes.func.isRequired,
   isSidebarLoading: PropTypes.bool,
   sidebarError: PropTypes.string,
-  dispatch: PropTypes.func.isRequired,
+  // dispatch: PropTypes.func.isRequired,
 };
 
 function DatabasesPermissionsPage({
   sidebar,
-  permissionEditor,
+  // permissionEditor,
   params,
   children,
   navigateToItem,
   navigateToDatabaseList,
   switchView,
   updateDataPermission,
-  dispatch,
+  // dispatch,
   isSidebarLoading,
   sidebarError,
 }) {
+  const dispatch = useDispatch();
+  const permissionEditor = useSelector(state =>
+    getGroupsDataPermissionEditor(state, { params }),
+  );
+
+  useEffect(() => {
+    dispatch(loadDataPermissionsForDB(params));
+  }, [params, dispatch]);
+
   const handleEntityChange = useCallback(
     entityType => {
       switchView(entityType);

--- a/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
@@ -1,10 +1,11 @@
-import { Fragment, useCallback } from "react";
+import { Fragment, useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
 import { bindActionCreators } from "@reduxjs/toolkit";
 import { push } from "react-router-redux";
 import { t } from "ttag";
 import _ from "underscore";
 import { connect } from "react-redux";
+import { useSelector, useDispatch } from "metabase/lib/redux";
 
 import {
   getDatabasesPermissionEditor,
@@ -12,12 +13,14 @@ import {
   getLoadingDatabaseTablesError,
   getGroupsSidebar,
 } from "../../selectors/data-permissions";
-import { updateDataPermission } from "../../permissions";
+import {
+  updateDataPermission,
+  loadDataPermissionsForGroup,
+} from "../../permissions";
 import { PermissionsSidebar } from "../../components/PermissionsSidebar";
 import {
   PermissionsEditor,
   PermissionsEditorEmptyState,
-  permissionEditorPropTypes,
 } from "../../components/PermissionsEditor";
 import {
   getGroupFocusPermissionsUrl,
@@ -42,7 +45,7 @@ const mapDispatchToProps = dispatch => ({
 const mapStateToProps = (state, props) => {
   return {
     sidebar: getGroupsSidebar(state, props),
-    permissionEditor: getDatabasesPermissionEditor(state, props),
+    // permissionEditor: getDatabasesPermissionEditor(state, props),
     isEditorLoading: getIsLoadingDatabaseTables(state, props),
     editorError: getLoadingDatabaseTablesError(state, props),
   };
@@ -56,7 +59,7 @@ const propTypes = {
   }),
   children: PropTypes.node,
   sidebar: PropTypes.object,
-  permissionEditor: PropTypes.shape(permissionEditorPropTypes),
+  //permissionEditor: PropTypes.shape(permissionEditorPropTypes),
   navigateToItem: PropTypes.func.isRequired,
   switchView: PropTypes.func.isRequired,
   navigateToTableItem: PropTypes.func.isRequired,
@@ -70,15 +73,24 @@ function GroupsPermissionsPage({
   sidebar,
   params,
   children,
-  permissionEditor,
+  //permissionEditor,
   navigateToItem,
   switchView,
   navigateToTableItem,
   updateDataPermission,
   isEditorLoading,
   editorError,
-  dispatch,
+  //dispatch,
 }) {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(loadDataPermissionsForGroup(params));
+  }, [params, dispatch]);
+
+  const permissionEditor = useSelector(state =>
+    getDatabasesPermissionEditor(state, { params }),
+  );
+
   const handleEntityChange = useCallback(
     entityType => {
       switchView(entityType);

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 import { push } from "react-router-redux";
-import { assocIn } from "icepick";
+import { assocIn, merge } from "icepick";
 
 import {
   PLUGIN_DATA_PERMISSIONS,
@@ -46,6 +46,24 @@ export const LOAD_DATA_PERMISSIONS =
 export const loadDataPermissions = createThunkAction(
   LOAD_DATA_PERMISSIONS,
   () => async () => PermissionsApi.graph(),
+);
+
+export const LOAD_DATA_PERMISSIONS_FOR_GROUP =
+  "metabase/admin/permissions/LOAD_DATA_PERMISSIONS_FOR_GROUP";
+export const loadDataPermissionsForGroup = createThunkAction(
+  LOAD_DATA_PERMISSIONS_FOR_GROUP,
+  ({ groupId }) =>
+    async () =>
+      PermissionsApi.graphForGroup({ groupId }),
+);
+
+export const LOAD_DATA_PERMISSIONS_FOR_DB =
+  "metabase/admin/permissions/LOAD_DATA_PERMISSIONS_FOR_GROUP";
+export const loadDataPermissionsForDB = createThunkAction(
+  LOAD_DATA_PERMISSIONS_FOR_GROUP,
+  ({ databaseId }) =>
+    async () =>
+      PermissionsApi.graphForDB({ databaseId }),
 );
 
 const INITIALIZE_COLLECTION_PERMISSIONS =
@@ -230,6 +248,12 @@ const dataPermissions = handleActions(
     [LOAD_DATA_PERMISSIONS]: {
       next: (_state, { payload }) => payload.groups,
     },
+    [LOAD_DATA_PERMISSIONS_FOR_GROUP]: {
+      next: (state, { payload }) => merge(payload.groups, state),
+    },
+    [LOAD_DATA_PERMISSIONS_FOR_DB]: {
+      next: (state, { payload }) => merge(payload.groups, state),
+    },
     [SAVE_DATA_PERMISSIONS]: { next: (_state, { payload }) => payload.groups },
     [UPDATE_DATA_PERMISSION]: {
       next: (state, { payload }) => {
@@ -317,6 +341,12 @@ const originalDataPermissions = handleActions(
     [LOAD_DATA_PERMISSIONS]: {
       next: (_state, { payload }) => payload.groups,
     },
+    [LOAD_DATA_PERMISSIONS_FOR_GROUP]: {
+      next: (state, { payload }) => merge(payload.groups, state),
+    },
+    [LOAD_DATA_PERMISSIONS_FOR_DB]: {
+      next: (state, { payload }) => merge(payload.groups, state),
+    },
     [SAVE_DATA_PERMISSIONS]: {
       next: (_state, { payload }) => payload.groups,
     },
@@ -328,6 +358,12 @@ const dataPermissionsRevision = handleActions(
   {
     [LOAD_DATA_PERMISSIONS]: {
       next: (_state, { payload }) => payload.revision,
+    },
+    [LOAD_DATA_PERMISSIONS_FOR_GROUP]: {
+      next: (state, { payload }) => payload.revision,
+    },
+    [LOAD_DATA_PERMISSIONS_FOR_DB]: {
+      next: (state, { payload }) => payload.revision,
     },
     [SAVE_DATA_PERMISSIONS]: {
       next: (_state, { payload }) => payload.revision,

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -48,6 +48,19 @@ export const loadDataPermissions = createThunkAction(
   () => async () => PermissionsApi.graph(),
 );
 
+export const RESTORE_LOADED_PERMISSIONS =
+  "metabase/admin/permissions/RESTORE_LOADED_PERMISSIONS";
+
+export const restoreLoadedPermissions = createThunkAction(
+  RESTORE_LOADED_PERMISSIONS,
+  () => async (dispatch, getState) => {
+    const state = getState();
+    const groups = state.admin.permissions.originalDataPermissions;
+    const revision = state.admin.permissions.dataPermissionsRevision;
+    dispatch({ type: LOAD_DATA_PERMISSIONS, payload: { groups, revision } });
+  },
+);
+
 export const LOAD_DATA_PERMISSIONS_FOR_GROUP =
   "metabase/admin/permissions/LOAD_DATA_PERMISSIONS_FOR_GROUP";
 

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -50,21 +50,9 @@ export const loadDataPermissions = createThunkAction(
 
 export const LOAD_DATA_PERMISSIONS_FOR_GROUP =
   "metabase/admin/permissions/LOAD_DATA_PERMISSIONS_FOR_GROUP";
-export const loadDataPermissionsForGroup = createThunkAction(
-  LOAD_DATA_PERMISSIONS_FOR_GROUP,
-  ({ groupId }) =>
-    async () =>
-      PermissionsApi.graphForGroup({ groupId }),
-);
 
 export const LOAD_DATA_PERMISSIONS_FOR_DB =
   "metabase/admin/permissions/LOAD_DATA_PERMISSIONS_FOR_GROUP";
-export const loadDataPermissionsForDB = createThunkAction(
-  LOAD_DATA_PERMISSIONS_FOR_GROUP,
-  ({ databaseId }) =>
-    async () =>
-      PermissionsApi.graphForDB({ databaseId }),
-);
 
 const INITIALIZE_COLLECTION_PERMISSIONS =
   "metabase/admin/permissions/INITIALIZE_COLLECTION_PERMISSIONS";
@@ -438,6 +426,40 @@ export const isHelpReferenceOpen = handleActions(
   false,
 );
 
+const checkRevisionChanged = (state, { payload }) => {
+  if (!state.revision) {
+    return {
+      revision: payload.revision,
+      hasChanged: false,
+    };
+  } else if (state.revision === payload.revision && !state.hasChanged) {
+    return state;
+  } else {
+    return {
+      revision: payload.revision,
+      hasChanged: true,
+    };
+  }
+};
+
+const hasRevisionChanged = handleActions(
+  {
+    [LOAD_DATA_PERMISSIONS]: {
+      next: checkRevisionChanged,
+    },
+    [LOAD_DATA_PERMISSIONS_FOR_GROUP]: {
+      next: checkRevisionChanged,
+    },
+    [LOAD_DATA_PERMISSIONS_FOR_DB]: {
+      next: checkRevisionChanged,
+    },
+  },
+  {
+    revision: null,
+    hasChanged: false,
+  },
+);
+
 export default combineReducers({
   saveError,
   dataPermissions,
@@ -447,4 +469,5 @@ export default combineReducers({
   originalCollectionPermissions,
   collectionPermissionsRevision,
   isHelpReferenceOpen,
+  hasRevisionChanged,
 });

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/revision.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/revision.ts
@@ -1,0 +1,12 @@
+import { createSelector } from "@reduxjs/toolkit";
+import type { State } from "metabase-types/store";
+import { getIsDirty } from "./diff";
+
+export const showRevisionChangedModal = createSelector(
+  [
+    getIsDirty,
+    (state: State) => state.admin.permissions.hasRevisionChanged.hasChanged,
+  ],
+
+  (isDirty, hasRevisionChanged) => isDirty && hasRevisionChanged,
+);

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
@@ -8,11 +8,10 @@ import {
 } from "__support__/ui";
 import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
-import { createMockPermissionsGraph } from "metabase-types/api/mocks/permissions";
 import { createMockGroup } from "metabase-types/api/mocks/group";
 import {
   setupDatabasesEndpoints,
-  setupPermissionsGraphEndpoint,
+  setupPermissionsGraphEndpoints,
   setupGroupsEndpoint,
 } from "__support__/server-mocks";
 import DatabasesPermissionsPage from "metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage";
@@ -23,16 +22,15 @@ import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload"
 
 const TEST_DATABASE = createSampleDatabase();
 
-const TEST_GROUPS = [createMockGroup()];
-
-const TEST_PERMISSIONS_GRAPH = createMockPermissionsGraph({
-  groups: TEST_GROUPS,
-  databases: [TEST_DATABASE],
-});
+// Order is important here for test to pass, since admin options aren't editable
+const TEST_GROUPS = [
+  createMockGroup({ name: "All Users" }),
+  createMockGroup({ id: 2, name: "Administrators" }),
+];
 
 const setup = async () => {
   setupDatabasesEndpoints([TEST_DATABASE]);
-  setupPermissionsGraphEndpoint(TEST_PERMISSIONS_GRAPH);
+  setupPermissionsGraphEndpoints(TEST_GROUPS, [TEST_DATABASE]);
   setupGroupsEndpoint(TEST_GROUPS);
 
   fetchMock.get(

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -8,11 +8,10 @@ import {
 } from "__support__/ui";
 import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
-import { createMockPermissionsGraph } from "metabase-types/api/mocks/permissions";
 import { createMockGroup } from "metabase-types/api/mocks/group";
 import {
   setupDatabasesEndpoints,
-  setupPermissionsGraphEndpoint,
+  setupPermissionsGraphEndpoints,
   setupGroupsEndpoint,
 } from "__support__/server-mocks";
 import { PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES } from "metabase/plugins";
@@ -28,14 +27,9 @@ const TEST_GROUPS = [
   createMockGroup({ name: "All Users" }),
 ];
 
-const TEST_PERMISSIONS_GRAPH = createMockPermissionsGraph({
-  groups: TEST_GROUPS,
-  databases: [TEST_DATABASE],
-});
-
 const setup = async () => {
   setupDatabasesEndpoints([TEST_DATABASE]);
-  setupPermissionsGraphEndpoint(TEST_PERMISSIONS_GRAPH);
+  setupPermissionsGraphEndpoints(TEST_GROUPS, [TEST_DATABASE]);
   setupGroupsEndpoint(TEST_GROUPS);
 
   fetchMock.get(

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -452,6 +452,8 @@ export const PermissionsApi = {
   groups: GET("/api/permissions/group"),
   groupDetails: GET("/api/permissions/group/:id"),
   graph: GET("/api/permissions/graph"),
+  graphForGroup: GET("/api/permissions/graph/group/:groupId"),
+  graphForDB: GET("/api/permissions/graph/db/:databaseId"),
   updateGraph: PUT("/api/permissions/graph"),
   createGroup: POST("/api/permissions/group"),
   memberships: GET("/api/permissions/membership"),

--- a/frontend/test/__support__/server-mocks/permissions.ts
+++ b/frontend/test/__support__/server-mocks/permissions.ts
@@ -1,13 +1,34 @@
 import fetchMock from "fetch-mock";
 import type {
   CollectionPermissionsGraph,
-  PermissionsGraph,
+  Group,
+  Database,
 } from "metabase-types/api";
 
-export const setupPermissionsGraphEndpoint = (
-  permissionsGraph: PermissionsGraph,
+import { createMockPermissionsGraph } from "metabase-types/api/mocks/permissions";
+
+export const setupPermissionsGraphEndpoints = (
+  groups: Omit<Group, "members">[],
+  databases: Database[],
 ) => {
-  fetchMock.get("path:/api/permissions/graph", permissionsGraph);
+  fetchMock.get(
+    "path:/api/permissions/graph",
+    createMockPermissionsGraph({ groups, databases }),
+  );
+
+  groups.forEach(group => {
+    fetchMock.get(
+      `path:/api/permissions/graph/group/${group.id}`,
+      createMockPermissionsGraph({ groups: [group], databases }),
+    );
+  });
+
+  databases.forEach(database => {
+    fetchMock.get(
+      `path:/api/permissions/graph/db/${database.id}`,
+      createMockPermissionsGraph({ groups, databases: [database] }),
+    );
+  });
 };
 
 export const setupCollectionPermissionsGraphEndpoint = (


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36797

### Description
This PR leverages 2 new endpoints to work with the permission graph: `/api/permissions/graph/group/:groupId` and `/api/permissions/graph/database/:databaseId`. These endpoints can be called to get specific parts of the permission graph much quicker than getting the whole graph at once from `/api/permissions/graph`, and are useful because the pages that manage data permissions only display 1 group or 1 database at a time.

When navigating to `/admin/permissions/data/group` (or `database`), we will programmatically load the permissions for the All Users and Admin groups, as they're used for some helpful warnings when making edits. From there, as you navigate between groups or databases, we will make fresh API calls and update our internal state with new pieces of the permission graph. Editing and saving the permission graph should work as it always has, but if the revision number changes while you are making edits then a modal will appear and force you to refresh the page. While this is intrusive, it's similar to how trying to save an graph with the wrong revision number simply presents you with an error and forces you to start over. Aside from this new modal and a few new loading states, the end user experience should be largely the same

### How to verify
Go to Admin -> Permissions and Update Group or database permissions as you normally would. Permission override warnings should still work (if the All Users group has access to something, then limiting a specific group to that same thing is pointless), and saving should still work. In another tab if you make a change and save, then return to your original tab, you should see a modal if you continue to navigate around and make edits.

### De
![chrome_eO1IVcf6YL](https://github.com/metabase/metabase/assets/1328979/1b3bee9a-84db-4afb-b1c5-819b070c3a95)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
