### PR TITLE
Design Fixes for Setup Flow

### DIFF
--- a/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
@@ -153,8 +153,6 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
     cy.signInAsNormalUser();
     visitQuestion(ORDERS_QUESTION_ID);
 
-    cy.icon("download").click();
-
     downloadAndAssert(
       { fileType: "xlsx", questionId: ORDERS_QUESTION_ID },
       assertSheetRowsCount(10000),
@@ -182,14 +180,10 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       cy.get("@nativeQuestionId").then(id => {
         visitQuestion(id);
 
-        cy.icon("download").click();
-
         downloadAndAssert(
           { fileType: "xlsx", questionId: id },
           assertSheetRowsCount(18760),
         );
-
-        cy.icon("download").click();
 
         // Make sure we can download results from an ad-hoc nested query based on a native question
         cy.findByText("Explore results").click();
@@ -201,8 +195,6 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
         cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
 
         visitQuestion(id);
-
-        cy.icon("download").click();
 
         downloadAndAssert(
           { fileType: "xlsx", questionId: id },
@@ -247,8 +239,6 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       cy.get("@nativeQuestionId").then(id => {
         visitQuestion(id);
 
-        cy.icon("download").click();
-
         downloadAndAssert(
           { fileType: "xlsx", questionId: id },
           assertSheetRowsCount(10000),
@@ -258,16 +248,12 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
         cy.findByText("Explore results").click();
         cy.wait("@dataset");
 
-        cy.icon("download").click();
-
         downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(10000));
 
         // Convert question to a model, which should also have a download row limit
         cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
 
         visitQuestion(id);
-
-        cy.icon("download").click();
 
         downloadAndAssert(
           { fileType: "xlsx", questionId: id },

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -132,21 +132,6 @@ describe("scenarios > public > dashboard", () => {
     });
   });
 
-  it("should see a tooltip prompting the user to ask their admin to create a public link", () => {
-    cy.signInAsNormalUser();
-    cy.get("@dashboardId").then(id => {
-      visitDashboard(id);
-    });
-
-    cy.findByTestId("dashboard-header").icon("share").realHover();
-
-    cy.wait(1000);
-
-    cy.findByRole("tooltip")
-      .findByText("Ask your admin to create a public link")
-      .should("be.visible");
-  });
-
   Object.entries(USERS).map(([userType, setUser]) =>
     describe(`${userType}`, () => {
       it(`should be able to view public dashboards`, () => {

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -139,11 +139,12 @@ describe("scenarios > public > dashboard", () => {
     });
 
     cy.findByTestId("dashboard-header").icon("share").realHover();
-    cy.findByRole("tooltip").within(() => {
-      cy.findByText("Ask your admin to create a public link").should(
-        "be.visible",
-      );
-    });
+
+    cy.wait(1000);
+
+    cy.findByRole("tooltip")
+      .findByText("Ask your admin to create a public link")
+      .should("be.visible");
   });
 
   Object.entries(USERS).map(([userType, setUser]) =>

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -119,21 +119,6 @@ describe("scenarios > public > question", () => {
     });
   });
 
-  it("should see a tooltip prompting the user to ask their admin to create a public link", () => {
-    cy.signInAsNormalUser();
-    cy.get("@questionId").then(id => {
-      visitQuestion(id);
-    });
-
-    cy.findByTestId("dashboard-embed-button").realHover();
-
-    cy.wait(1000);
-
-    cy.findByRole("tooltip")
-      .findByText("Ask your admin to create a public link")
-      .should("be.visible");
-  });
-
   Object.entries(USERS).map(([userType, setUser]) =>
     describe(`${userType}`, () => {
       it(`should be able to view public questions`, () => {

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -125,7 +125,7 @@ describe("scenarios > public > question", () => {
       visitQuestion(id);
     });
 
-    cy.findByTestId("view-footer").icon("share").realHover();
+    cy.findByTestId("dashboard-embed-button").realHover();
     cy.findByRole("tooltip").within(() => {
       cy.findByText("Ask your admin to create a public link").should(
         "be.visible",

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -87,7 +87,6 @@ describe("scenarios > public > question", () => {
       cy.get(".cellData").contains("Winner");
 
       // Make sure we can download the public question (metabase#21993)
-      cy.icon("download").click();
       cy.get("@uuid").then(publicUid => {
         downloadAndAssert(
           { fileType: "xlsx", questionId: id, publicUid },

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -126,11 +126,12 @@ describe("scenarios > public > question", () => {
     });
 
     cy.findByTestId("dashboard-embed-button").realHover();
-    cy.findByRole("tooltip").within(() => {
-      cy.findByText("Ask your admin to create a public link").should(
-        "be.visible",
-      );
-    });
+
+    cy.wait(1000);
+
+    cy.findByRole("tooltip")
+      .findByText("Ask your admin to create a public link")
+      .should("be.visible");
   });
 
   Object.entries(USERS).map(([userType, setUser]) =>

--- a/frontend/src/metabase/components/ButtonBar/ButtonBar.styled.tsx
+++ b/frontend/src/metabase/components/ButtonBar/ButtonBar.styled.tsx
@@ -30,6 +30,7 @@ export interface ButtonBarRightProps {
 export const ButtonBarRight = styled.div<ButtonBarRightProps>`
   display: flex;
   flex: ${props => (props.center ? "1 0 0" : "")};
+  gap: 0.5rem;
   justify-content: flex-end;
   align-items: center;
   margin-left: ${props => (props.center ? "" : "auto")};

--- a/frontend/src/metabase/components/ButtonBar/ButtonBar.styled.tsx
+++ b/frontend/src/metabase/components/ButtonBar/ButtonBar.styled.tsx
@@ -30,7 +30,7 @@ export interface ButtonBarRightProps {
 export const ButtonBarRight = styled.div<ButtonBarRightProps>`
   display: flex;
   flex: ${props => (props.center ? "1 0 0" : "")};
-  gap: 0.5rem;
+  gap: 1rem;
   justify-content: flex-end;
   align-items: center;
   margin-left: ${props => (props.center ? "" : "auto")};

--- a/frontend/src/metabase/dashboard/components/DashboardEmbedHeaderButton/DashboardEmbedHeaderButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardEmbedHeaderButton/DashboardEmbedHeaderButton.tsx
@@ -40,7 +40,7 @@ export const DashboardEmbedHeaderButton = forwardRef(
         py="0.6rem"
         px="0.75rem"
         bg="bg.3"
-        offset={hasBackground ? 4 : -4}
+        offset={4}
         label={
           <Text c="inherit" size="sm" fw={700}>
             {tooltipLabel}

--- a/frontend/src/metabase/dashboard/components/DashboardEmbedHeaderButton/DashboardEmbedHeaderButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardEmbedHeaderButton/DashboardEmbedHeaderButton.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from "react";
 import { useSelector } from "metabase/lib/redux";
 import { getSetting } from "metabase/selectors/settings";
 import { DashboardHeaderButton } from "metabase/dashboard/components/DashboardHeader/DashboardHeader.styled";
-import { Tooltip, Text, Box } from "metabase/ui";
+import { Tooltip, Text, Flex } from "metabase/ui";
 
 export type DashboardEmbedHeaderButtonProps = {
   onClick?: () => void;
@@ -40,7 +40,7 @@ export const DashboardEmbedHeaderButton = forwardRef(
         py="0.6rem"
         px="0.75rem"
         bg="bg.3"
-        offset={hasBackground ? 4 : 0}
+        offset={hasBackground ? 4 : -4}
         label={
           <Text c="inherit" size="sm" fw={700}>
             {tooltipLabel}
@@ -49,7 +49,7 @@ export const DashboardEmbedHeaderButton = forwardRef(
         withArrow
         arrowSize={10}
       >
-        <Box>
+        <Flex>
           <DashboardHeaderButton
             data-disabled={disabled}
             data-testid="dashboard-embed-button"
@@ -59,7 +59,7 @@ export const DashboardEmbedHeaderButton = forwardRef(
             ref={ref}
             hasBackground={hasBackground}
           />
-        </Box>
+        </Flex>
       </Tooltip>
     );
   },

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.styled.tsx
@@ -18,9 +18,17 @@ export const DashboardHeaderButton = styled(Button)<{
   visibleOnSmallScreen?: boolean;
   hasBackground?: boolean;
 }>`
-  padding: 0.25rem 0.5rem;
-  height: 2rem;
-  min-width: 2rem;
+  ${({ hasBackground }) =>
+    hasBackground
+      ? css`
+          padding: 0.25rem 0.5rem;
+          height: 2rem;
+          min-width: 2rem;
+        `
+      : css`
+          padding: 0;
+        `}
+
   color: ${props => (props.isActive ? color("brand") : color("text-medium"))};
   font-size: 1rem;
 

--- a/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.tsx
@@ -30,7 +30,9 @@ export const AdminEmbedMenu = ({
     getSetting(state, "enable-embedding"),
   );
 
-  const target = <DashboardEmbedHeaderButton />;
+  const target = (
+    <DashboardEmbedHeaderButton hasBackground={resourceType === "dashboard"} />
+  );
 
   if (menuMode === "public-link-popover") {
     return resourceType === "dashboard" ? (

--- a/frontend/src/metabase/dashboard/components/EmbedMenu/NonAdminEmbedMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/EmbedMenu/NonAdminEmbedMenu.tsx
@@ -28,6 +28,7 @@ export const NonAdminEmbedMenu = ({
 
   const target = (
     <DashboardEmbedHeaderButton
+      hasBackground={resourceType === "dashboard"}
       onClick={() => setIsOpen(!isOpen)}
       disabled={isDisabled}
       tooltip={isDisabled ? tooltipLabel : null}

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.tsx
@@ -56,8 +56,6 @@ export const PublicLinkCopyPanel = ({
               }
             >
               <RemoveLinkAnchor
-                inline
-                lh="1"
                 fz="sm"
                 c="error.0"
                 fw={700}

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.tsx
@@ -63,8 +63,12 @@ export const PublicLinkPopover = ({
           data-testid="public-link-popover-content"
           mih={getMinDropdownHeight()}
         >
-          <Title order={4}>{t`Public link`}</Title>
-          <Text>{t`Anyone can view this if you give them the link.`}</Text>
+          <Title color="text.1" order={4}>{t`Public link`}</Title>
+          <Text
+            color="text.1"
+            size="sm"
+            mb="xs"
+          >{t`Anyone can view this if you give them the link.`}</Text>
           <PublicLinkCopyPanel
             loading={loading}
             url={url}

--- a/frontend/src/metabase/public/components/widgets/SharingPane/SharingPaneButton/SharingPaneButton.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/SharingPaneButton/SharingPaneButton.styled.tsx
@@ -16,12 +16,15 @@ export const SharingPaneButtonContent = styled(Paper)<
 
 export const SharingPaneButtonTitle = styled(Title)<SharingPaneElementProps>`
   ${({ disabled, theme }) =>
-    !disabled &&
-    css`
-      ${SharingPaneButtonContent}:hover & {
-        color: ${theme.colors.brand[1]};
-      }
-    `}
+    !disabled
+      ? css`
+          ${SharingPaneButtonContent}:hover & {
+            color: ${theme.colors.brand[1]};
+          }
+        `
+      : css`
+          color: ${theme.colors.text[0]};
+        `}
 `;
 
 export const SharingPaneActionButton = styled(Button)<

--- a/frontend/src/metabase/public/components/widgets/SharingPane/SharingPaneButton/SharingPaneButton.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/SharingPaneButton/SharingPaneButton.styled.tsx
@@ -8,8 +8,10 @@ type SharingPaneElementProps = {
   disabled?: boolean;
 };
 
-export const SharingPaneButtonContent = styled(Paper)<PaperProps>`
-  cursor: pointer;
+export const SharingPaneButtonContent = styled(Paper)<
+  PaperProps & { disabled?: boolean }
+>`
+  cursor: ${({ disabled }) => (disabled ? "default" : "pointer")};
 `;
 
 export const SharingPaneButtonTitle = styled(Title)<SharingPaneElementProps>`

--- a/frontend/src/metabase/public/components/widgets/SharingPane/SharingPaneButton/SharingPaneButton.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/SharingPaneButton/SharingPaneButton.tsx
@@ -1,4 +1,4 @@
-import type { MouseEventHandler, ReactNode } from "react";
+import type { MouseEvent, MouseEventHandler, ReactNode } from "react";
 import {
   SharingPaneButtonContent,
   SharingPaneButtonTitle,
@@ -22,11 +22,15 @@ export const SharingPaneButton = ({
   disabled,
   onClick,
 }: SharingOptionProps) => (
-  <SharingPaneButtonContent withBorder>
-    <Center h="22.5rem" p="8rem" onClick={onClick}>
+  <SharingPaneButtonContent withBorder disabled={disabled}>
+    <Center
+      h="22.5rem"
+      p="8rem"
+      onClick={(event: MouseEvent) => !disabled && onClick?.(event)}
+    >
       <Stack w="17.5rem" justify="center" align="center">
         {illustration}
-        <SharingPaneButtonTitle disabled={disabled}>
+        <SharingPaneButtonTitle fz="xl" disabled={disabled}>
           {header}
         </SharingPaneButtonTitle>
         <Text>{description}</Text>

--- a/frontend/src/metabase/public/components/widgets/SharingPane/icons/PublicEmbedIcon/PublicEmbedIcon.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/icons/PublicEmbedIcon/PublicEmbedIcon.styled.tsx
@@ -7,13 +7,12 @@ interface PublicEmbedIconRootProps {
 }
 
 export const PublicEmbedIconRoot = styled.svg<PublicEmbedIconRootProps>`
-  ${({ theme }) => css`
-    .outerFill {
-      stroke: ${theme.colors.bg[1]};
-    }
+  ${({ theme, disabled }) => css`
+    color: ${theme.colors.bg[1]};
 
     .innerFill {
-      stroke: ${theme.colors.text[2]};
+      stroke: ${disabled ? theme.colors.text[0] : theme.colors.bg[2]};
+      opacity: ${disabled ? 0.5 : 1};
     }
   `}
 
@@ -21,9 +20,7 @@ export const PublicEmbedIconRoot = styled.svg<PublicEmbedIconRootProps>`
     !disabled &&
     css`
       ${SharingPaneButtonContent}:hover & {
-        .outerFill {
-          stroke: ${theme.colors.brand[0]};
-        }
+        color: ${theme.colors.bg[2]};
 
         .innerFill {
           stroke: ${theme.colors.brand[1]};

--- a/frontend/src/metabase/public/components/widgets/SharingPane/icons/PublicEmbedIcon/PublicEmbedIcon.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/icons/PublicEmbedIcon/PublicEmbedIcon.tsx
@@ -18,17 +18,16 @@ export const PublicEmbedIcon = ({ disabled }: PublicEmbedIconProps) => (
       width="37.5"
       height="29.5"
       rx="2.75"
-      className="outerFill"
+      stroke="currentColor"
       strokeWidth="2.5"
     />
     <path
-      opacity="0.5"
       d="M6 11C6 10.4477 6.44772 10 7 10H33C33.5523 10 34 10.4477 34 11V18C34 18.5523 33.5523 19 33 19H7C6.44772 19 6 18.5523 6 18V11Z"
       className="innerFill"
       strokeWidth="2"
     />
-    <rect x="5" y="5" width="30" height="2" className="outerFill" />
-    <rect x="5" y="22" width="30" height="2" className="outerFill" />
-    <rect x="5" y="26" width="30" height="2" className="outerFill" />
+    <rect x="5" y="5" width="30" height="2" fill="currentColor" />
+    <rect x="5" y="22" width="30" height="2" fill="currentColor" />
+    <rect x="5" y="26" width="30" height="2" fill="currentColor" />
   </PublicEmbedIconRoot>
 );

--- a/frontend/src/metabase/public/components/widgets/SharingPane/icons/StaticEmbedIcon/StaticEmbedIcon.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/icons/StaticEmbedIcon/StaticEmbedIcon.styled.tsx
@@ -5,29 +5,19 @@ import { SharingPaneButtonContent } from "metabase/public/components/widgets/Sha
 export const StaticEmbedIconRoot = styled.svg`
   ${({ theme }) =>
     css`
-      rect.outerFill {
-        stroke: ${theme.colors.bg[1]};
-      }
-
-      path.outerFill {
-        fill: ${theme.colors.bg[1]};
-      }
+      color: ${theme.colors.bg[1]};
 
       .innerFill {
-        fill: ${theme.colors.text[2]};
+        fill: ${theme.colors.bg[2]};
+        fill-opacity: 0.5;
       }
 
       ${SharingPaneButtonContent}:hover & {
-        rect.outerFill {
-          stroke: ${theme.colors.brand[0]};
-        }
-
-        path.outerFill {
-          fill: ${theme.colors.brand[0]};
-        }
+        color: ${theme.colors.focus};
 
         .innerFill {
           fill: ${theme.colors.brand[1]};
+          fill-opacity: 1;
         }
       }
     `}

--- a/frontend/src/metabase/public/components/widgets/SharingPane/icons/StaticEmbedIcon/StaticEmbedIcon.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/icons/StaticEmbedIcon/StaticEmbedIcon.tsx
@@ -14,30 +14,24 @@ export const StaticEmbedIcon = () => (
       width="37.5"
       height="29.5"
       rx="2.75"
-      className="outerFill"
+      stroke="currentColor"
       strokeWidth="2.5"
     />
     <path
       className="innerFill"
       d="M14 12C14 10.8954 14.8954 10 16 10H33C34.1046 10 35 10.8954 35 12V17H14V12Z"
-      fillOpacity="0.5"
     />
     <path
       className="innerFill"
       d="M14 19H23V28H16C14.8954 28 14 27.1046 14 26V19Z"
-      fillOpacity="0.5"
     />
     <path
       className="innerFill"
       d="M25 19H35V26C35 27.1046 34.1046 28 33 28H25V19Z"
-      fillOpacity="0.5"
     />
+    <path fill="currentColor" d="M5 10H11V28H7C5.89543 28 5 27.1046 5 26V10Z" />
     <path
-      className="outerFill"
-      d="M5 10H11V28H7C5.89543 28 5 27.1046 5 26V10Z"
-    />
-    <path
-      className="outerFill"
+      fill="currentColor"
       d="M5 6C5 4.89543 5.89543 4 7 4H33C34.1046 4 35 4.89543 35 6V8H5V6Z"
     />
   </StaticEmbedIconRoot>

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.styled.tsx
@@ -7,5 +7,6 @@ export const DownloadIcon = styled(Icon)`
 
   &:hover {
     color: ${color("brand")};
+    cursor: pointer;
   }
 `;

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
@@ -1,13 +1,14 @@
 import { connect } from "react-redux";
 import { useAsyncFn } from "react-use";
 import { t } from "ttag";
+import { useState } from "react";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import Tooltip from "metabase/core/components/Tooltip";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
-import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import type { DownloadQueryResultsOpts } from "metabase/query_builder/actions";
 import { downloadQueryResults } from "metabase/query_builder/actions";
 import type { Dataset, VisualizationSettings } from "metabase-types/api";
+import { Flex, Popover } from "metabase/ui";
 import type Question from "metabase-lib/Question";
 import QueryDownloadPopover from "../QueryDownloadPopover";
 import { DownloadIcon } from "./QueryDownloadWidget.styled";
@@ -44,6 +45,8 @@ const QueryDownloadWidget = ({
   visualizationSettings,
   onDownload,
 }: QueryDownloadWidgetProps) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
   const [{ loading }, handleDownload] = useAsyncFn(
     async (type: string) => {
       await onDownload({
@@ -61,34 +64,36 @@ const QueryDownloadWidget = ({
   );
 
   return (
-    <TippyPopoverWithTrigger
-      triggerClasses={className}
-      triggerContent={
-        loading ? (
-          <Tooltip tooltip={t`Downloading…`}>
-            <LoadingSpinner size={18} />
-          </Tooltip>
-        ) : (
-          <Tooltip tooltip={t`Download full results`}>
-            <DownloadIcon
-              name="download"
-              size={20}
-              data-testid="download-button"
-            />
-          </Tooltip>
-        )
-      }
-      popoverContent={({ closePopover }) => (
+    <Popover opened={isPopoverOpen} onClose={() => setIsPopoverOpen(false)}>
+      <Popover.Target>
+        <Flex className={className}>
+          {loading ? (
+            <Tooltip tooltip={t`Downloading…`}>
+              <LoadingSpinner size={18} />
+            </Tooltip>
+          ) : (
+            <Tooltip tooltip={t`Download full results`}>
+              <DownloadIcon
+                onClick={() => setIsPopoverOpen(!isPopoverOpen)}
+                name="download"
+                size={20}
+                data-testid="download-button"
+              />
+            </Tooltip>
+          )}
+        </Flex>
+      </Popover.Target>
+      <Popover.Dropdown>
         <QueryDownloadPopover
           question={question}
           result={result}
           onDownload={type => {
-            closePopover();
+            setIsPopoverOpen(false);
             handleDownload(type);
           }}
         />
-      )}
-    />
+      </Popover.Dropdown>
+    </Popover>
   );
 };
 

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -103,18 +103,18 @@ const ViewFooter = ({
           QuestionRowCount.shouldRender({
             result,
             isObjectDetail,
-          }) && <QuestionRowCount key="row_count" className="mx1" />,
+          }) && <QuestionRowCount key="row_count" />,
           QuestionLastUpdated.shouldRender({ result }) && (
             <QuestionLastUpdated
               key="last-updated"
-              className="mx1 hide sm-show"
+              className="hide sm-show"
               result={result}
             />
           ),
           QueryDownloadWidget.shouldRender({ result }) && (
             <QueryDownloadWidget
               key="download"
-              className="mx1 hide sm-show"
+              className="hide sm-show"
               question={question}
               result={result}
               visualizationSettings={visualizationSettings}
@@ -128,7 +128,7 @@ const ViewFooter = ({
           }) && (
             <QuestionAlertWidget
               key="alerts"
-              className="mx1 hide sm-show"
+              className="hide sm-show"
               canManageSubscriptions={canManageSubscriptions}
               question={question}
               questionAlerts={questionAlerts}
@@ -155,7 +155,7 @@ const ViewFooter = ({
           QuestionTimelineWidget.shouldRender({ isTimeseries }) && (
             <QuestionTimelineWidget
               key="timelines"
-              className="mx1 hide sm-show"
+              className="hide sm-show"
               isShowingTimelineSidebar={isShowingTimelineSidebar}
               onOpenTimelines={onOpenTimelines}
               onCloseTimelines={onCloseTimelines}


### PR DESCRIPTION
Context: [Small Issues in Embedding Flow Refactoring](https://www.loom.com/share/c7b18c090d0f4e45ac00bdb658196bc0)

The PR fixes the following:
#### Inconsistent gaps and padding among icons within the `ViewFooter` (footer in the Query Builder)
_Before_

<img width="283" alt="image" src="https://github.com/metabase/metabase/assets/25306947/d94aedca-e1e2-42d2-b699-e14287303057">


_After_ (look at the cloud icon, it's now aligned with the rest)
<img width="819" alt="image" src="https://github.com/metabase/metabase/assets/25306947/461f906d-bf3a-4408-91a8-8a53b7971820">


#### Font sizes + colors in the public link popover (the header and info text were 16px and 14px respectively, now it's 14px and 12px)
_Before_

<img width="456" alt="image" src="https://github.com/metabase/metabase/assets/25306947/9437e07d-e8eb-4e88-ac01-f5efc93e12c5">


_After_
<img width="453" alt="image" src="https://github.com/metabase/metabase/assets/25306947/3d90efcd-57bb-4a90-993e-f3388ec66d26">


#### When public sharing is disabled, the Public Embed option on the embed modal has zero click behavior now
_Before_

https://github.com/metabase/metabase/assets/25306947/d244c360-d681-4a38-b335-4668b708166b



_After_

https://github.com/metabase/metabase/assets/25306947/03a0af95-5323-4881-99cc-70952c7b929d



#### The titles within the public embed modal are smaller to match the designs (now the title is the `XL` font size in Mantine)

_Before_
<img width="548" alt="image" src="https://github.com/metabase/metabase/assets/25306947/8d7f28bc-85cc-4015-b619-68f316c8d6ad">


_After_
<img width="552" alt="image" src="https://github.com/metabase/metabase/assets/25306947/536a12fe-431c-4c6f-9b3a-116e806ca509">
