### PR TITLE
support hovers and clicks on timeline events

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
@@ -51,6 +51,7 @@ export const getTimelineEventsSeries = (
       const dataUri = svgToDataUri(iconSvg);
 
       return {
+        name: "timeline-event",
         xAxis: date,
         symbolSize: 16,
         symbolOffset: [0, 12],
@@ -72,7 +73,7 @@ export const getTimelineEventsSeries = (
     });
 
   return {
-    id: "timelineEvents",
+    id: "timeline-events",
     animation: false,
     type: "line",
     data: [],

--- a/frontend/src/metabase/visualizations/echarts/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/types.ts
@@ -1,0 +1,17 @@
+import type { ElementEvent } from "echarts";
+import type { BrushAreaParam } from "echarts/types/src/component/brush/BrushModel";
+import type { ZRRawMouseEvent } from "zrender/lib/core/types";
+
+export type EChartsSeriesMouseEvent = ElementEvent & {
+  event: ElementEvent["event"] & {
+    event: ZRRawMouseEvent;
+  };
+  dataIndex?: number;
+  seriesId?: string;
+  name?: string;
+  value: any;
+};
+
+export type EChartsSeriesBrushEndEvent = EChartsSeriesMouseEvent & {
+  areas: BrushAreaParam[];
+};

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -86,6 +86,7 @@ export interface VisualizationProps {
   onUpdateVisualizationSettings: (settings: VisualizationSettings) => void;
   onSelectTimelineEvents?: (timelineEvents: TimelineEvent[]) => void;
   onDeselectTimelineEvents?: () => void;
+  onOpenTimelines?: () => void;
 
   "graph.dimensions"?: string[];
   "graph.metrics"?: string[];


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/35781

### Description

Adds the support of hovers and clicks on timeline events.

### How to verify

On a chart with timeline events try hovering and clicking on timeline events.
- Hovers should show the timeline events data or multiple timeline events data if it is a group of events. 
- Clicks should open the sidebar make the event selected visually on charts and in the sidebar. Clcik on selected events should deselect them

### Demo

https://github.com/metabase/metabase/assets/14301985/ad89cbe5-6985-44e2-b263-781e317ad047

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
