### PR TITLE
add "application-colors" in createMockSettings

### DIFF
--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -133,6 +133,7 @@ export const createMockSettingDefinition = (
 export const createMockSettings = (opts?: Partial<Settings>): Settings => ({
   "admin-email": "admin@metabase.test",
   "anon-tracking-enabled": false,
+  "application-colors": {},
   "application-font": "Lato",
   "application-font-files": [],
   "application-name": "Metabase",

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -1,3 +1,4 @@
+import type { EnterpriseSettings } from "metabase-enterprise/settings/types";
 import type {
   Engine,
   EngineField,
@@ -130,7 +131,9 @@ export const createMockSettingDefinition = (
   ...opts,
 });
 
-export const createMockSettings = (opts?: Partial<Settings>): Settings => ({
+export const createMockSettings = (
+  opts?: Partial<Settings | EnterpriseSettings>,
+): EnterpriseSettings => ({
   "admin-email": "admin@metabase.test",
   "anon-tracking-enabled": false,
   "application-colors": {},

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -193,7 +193,6 @@ export interface Settings {
   "active-users-count"?: number;
   "admin-email": string;
   "anon-tracking-enabled": boolean;
-  "application-colors": Record<string, string>;
   "application-font": string;
   "application-font-files": FontFile[] | null;
   "application-name": string;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -193,6 +193,7 @@ export interface Settings {
   "active-users-count"?: number;
   "admin-email": string;
   "anon-tracking-enabled": boolean;
+  "application-colors": Record<string, string>;
   "application-font": string;
   "application-font-files": FontFile[] | null;
   "application-name": string;


### PR DESCRIPTION
### Description

This setting was not mocked ~nor present in the settings api type~ (it is, in the EnterpriseSettings type).
It was causing a console.error in all jest test that use enterprise plugins
```
console.error
    TypeError: Cannot convert undefined or null to object
        at Function.entries (<anonymous>)
        at entries (/Users/npretto/metabase/metabase/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/whitelabel.js:6:48)
```

### How to reproduce
Run any jest test that uses the EE plugins, for example `yarn jest frontend/src/metabase/selectors/whitelabel/tests/premium.unit.spec.ts`
It should not print that error anymore

⚠️ **I'll be OOO for the next 2 weeks so feel free to take over this PR** 🏝️