### PR TITLE
Trend charts — Compare to another column

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -126,6 +126,29 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
       cy.findByLabelText("Back").should("exist");
       cy.findByLabelText("Label").should("have.value", "My Goal");
       cy.findByLabelText("Value").should("have.value", "42000");
+      cy.button("Back").click();
+    });
+
+    // another column
+    menu().findByText("Value from another column…").click();
+    popover().findByText("Mega Count").click();
+    menu().button("Done").click();
+
+    cy.findByTestId("scalar-previous-value").within(() => {
+      cy.findByText("vs. Mega Count:").should("exist");
+      cy.findByText("3,440,000").should("exist"); // goal
+      cy.findByText("99.11%").should("exist"); // down percentage
+    });
+
+    cy.findByTestId("chartsettings-sidebar").findByText("Mega Count").click();
+    menu().findByLabelText("Column").click();
+    popover().findByText("Count").click();
+    menu().button("Done").click();
+
+    cy.findByTestId("scalar-previous-value").within(() => {
+      cy.findByText("vs. Count:").should("exist");
+      cy.findByText("344").should("exist"); // goal
+      cy.findByText("8,841.71%").should("exist"); // up percentage
     });
   });
 

--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -1,6 +1,12 @@
 import Color from "color";
 import { colors } from "metabase/lib/colors";
-import { menu, popover, restore } from "e2e/support/helpers";
+import {
+  menu,
+  popover,
+  restore,
+  rightSidebar,
+  summarize,
+} from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -150,6 +156,80 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
       cy.findByText("344").should("exist"); // goal
       cy.findByText("8,841.71%").should("exist"); // up percentage
     });
+  });
+
+  it("should reset 'another column' comparison when it becomes invalid", () => {
+    cy.createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: AGGREGATIONS,
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+        display: "smartscalar",
+        visualization_settings: {
+          "scalar.field": "Count",
+          "scalar.comparisons": {
+            type: "anotherColumn",
+            column: "Mega Count",
+            label: "Mega Count",
+          },
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    cy.findByTestId("viz-settings-button").click();
+
+    // Selecting the main column ("Mega Count") to be the comparison column
+    // The comparison should be reset to "previous period"
+    cy.findByTestId("chartsettings-sidebar").within(() => {
+      cy.findByText("Mega Count").should("exist");
+      cy.findByText("Count").click();
+    });
+    popover().findByText("Mega Count").click();
+
+    cy.findByTestId("scalar-value").should("have.text", "3,440,000");
+    cy.findByTestId("scalar-previous-value").within(() => {
+      cy.findByText("Sum of Total").should("not.exist");
+      cy.findByText("vs. previous month:").should("exist");
+      cy.findByText("5,270,000").should("exist");
+    });
+
+    cy.findByTestId("chartsettings-sidebar")
+      .findByText("Previous month")
+      .click();
+    menu().findByText("Value from another column…").click();
+    popover().findByText("Sum of Total").click();
+    popover().button("Done").click();
+
+    // Removing the comparison column ("Sum of Total") from the query
+    // The comparison should be reset to "previous period"
+    summarize();
+    rightSidebar().findByLabelText("Sum of Total").icon("close").click();
+
+    cy.findByTestId("scalar-value").should("have.text", "3,440,000");
+    cy.findByTestId("scalar-previous-value").within(() => {
+      cy.findByText("Sum of Total").should("not.exist");
+      cy.findByText("vs. previous month:").should("exist");
+      cy.findByText("5,270,000").should("exist");
+    });
+
+    // Removing the remaining numeric column, so only Count is left
+    // to ensure we no longer offer the "Value from another column…" option
+    rightSidebar().within(() => {
+      cy.findByLabelText("Count").icon("close").click();
+      cy.button("Done").click();
+    });
+
+    cy.findByTestId("viz-settings-button").click();
+    cy.findByTestId("chartsettings-sidebar").within(() => {
+      cy.findByText("Sum of Total").should("not.exist");
+      cy.findByText("Previous month").should("exist").click();
+    });
+    menu().findByText("Value from another column…").should("not.exist");
   });
 
   it("should allow display settings to be changed and display should reflect changes", () => {

--- a/frontend/src/metabase-types/api/visualization-settings.ts
+++ b/frontend/src/metabase-types/api/visualization-settings.ts
@@ -1,22 +1,48 @@
 // SmartScalar (Trend Chart)
-export type SmartScalarComparisonPeriodsAgo = {
+export type SmartScalarComparisonType =
+  | "anotherColumn"
+  | "previousValue"
+  | "previousPeriod"
+  | "periodsAgo"
+  | "staticNumber";
+
+interface BaseSmartScalarComparison {
+  type: SmartScalarComparisonType;
+}
+
+export interface SmartScalarComparisonAnotherColumn
+  extends BaseSmartScalarComparison {
+  type: "anotherColumn";
+  column: string;
+  label: string;
+}
+
+export interface SmartScalarComparisonPeriodsAgo
+  extends BaseSmartScalarComparison {
   type: "periodsAgo";
   value: number;
-};
-type SmartScalarComparisonPreviousPeriod = {
+}
+
+export interface SmartScalarComparisonPreviousPeriod
+  extends BaseSmartScalarComparison {
   type: "previousPeriod";
-};
-type SmartScalarComparisonCompareToPrevious = {
+}
+
+export interface SmartScalarComparisonPreviousValue
+  extends BaseSmartScalarComparison {
   type: "previousValue";
-};
-export type SmartScalarComparisonStaticNumber = {
+}
+
+export interface SmartScalarComparisonStaticNumber
+  extends BaseSmartScalarComparison {
   type: "staticNumber";
   value: number;
   label: string;
-};
+}
 
 export type SmartScalarComparison =
-  | SmartScalarComparisonCompareToPrevious
+  | SmartScalarComparisonAnotherColumn
+  | SmartScalarComparisonPreviousValue
   | SmartScalarComparisonPreviousPeriod
   | SmartScalarComparisonPeriodsAgo
   | SmartScalarComparisonStaticNumber;

--- a/frontend/src/metabase/ui/components/inputs/Autocomplete/Autocomplete.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Autocomplete/Autocomplete.styled.tsx
@@ -17,7 +17,7 @@ export const getAutocompleteOverrides =
         maxDropdownHeight: 512,
       }),
       styles: (theme, _, { size = "md" }) => ({
-        ...getSelectInputOverrides(theme),
+        ...getSelectInputOverrides(theme, size),
         ...getSelectItemsOverrides(theme, size),
       }),
     },

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -33,7 +33,7 @@ export const getMultiSelectOverrides =
         { invalid }: MultiSelectStylesParams,
         { size = "md" },
       ) => ({
-        ...getSelectInputOverrides(theme),
+        ...getSelectInputOverrides(theme, size),
         ...getSelectItemsOverrides(theme, size),
         values: {
           minHeight: getSize({ size, sizes: SIZES }),

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
@@ -21,7 +21,7 @@ export const getSelectOverrides = (): MantineThemeOverride["components"] => ({
       },
     }),
     styles: (theme, _, { size = "md" }) => ({
-      ...getSelectInputOverrides(theme),
+      ...getSelectInputOverrides(theme, size),
       ...getSelectItemsOverrides(theme, size),
     }),
   },
@@ -29,6 +29,7 @@ export const getSelectOverrides = (): MantineThemeOverride["components"] => ({
 
 export const getSelectInputOverrides = (
   theme: MantineTheme,
+  size: MantineSize | number,
 ): Record<string, CSSObject> => {
   return {
     root: {
@@ -42,6 +43,8 @@ export const getSelectInputOverrides = (
     },
     label: {
       ref: getStylesRef("label"),
+      color: theme.colors.text[1],
+      fontSize: getSize({ size, sizes: theme.fontSizes }),
     },
     description: {
       ref: getStylesRef("description"),

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
@@ -52,7 +52,9 @@ export const getSelectInputOverrides = (
     wrapper: {
       ref: getStylesRef("wrapper"),
       color: theme.colors.text[2],
-
+      "&:not(:only-child)": {
+        marginTop: theme.spacing.xs,
+      },
       [`&:has(.${getStylesRef("input")}[data-disabled])`]: {
         opacity: 1,
         pointerEvents: "auto",

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/AnotherColumnForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/AnotherColumnForm.tsx
@@ -1,0 +1,96 @@
+import type { ChangeEvent, FormEvent } from "react";
+import { useMemo, useState } from "react";
+import { t } from "ttag";
+import {
+  Box,
+  Flex,
+  PopoverBackButton,
+  TextInput,
+  Select,
+  Stack,
+} from "metabase/ui";
+import type {
+  DatasetColumn,
+  SmartScalarComparisonAnotherColumn,
+} from "metabase-types/api";
+import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
+import { COMPARISON_TYPES } from "../constants";
+import { DoneButton } from "./SmartScalarSettingsWidgets.styled";
+
+interface AnotherColumnFormProps {
+  value?: SmartScalarComparisonAnotherColumn;
+  columns: DatasetColumn[];
+  onChange: (value: SmartScalarComparisonAnotherColumn) => void;
+  onBack: () => void;
+}
+
+export function AnotherColumnForm({
+  value: selectedValue,
+  columns,
+  onChange,
+  onBack,
+}: AnotherColumnFormProps) {
+  const [label, setLabel] = useState(selectedValue?.label || "");
+  const [columnKey, setColumnKey] = useState(selectedValue?.column || "");
+
+  const canSubmit = label.length > 0 && columnKey.length > 0;
+
+  const columnOptions = useMemo(
+    () =>
+      columns.map(column => ({
+        label: column.display_name,
+        value: getColumnKey(column),
+      })),
+    [columns],
+  );
+
+  const handleChangeColumnKey = (value: string) => {
+    setColumnKey(value);
+    const option = columnOptions.find(option => option.value === value);
+    setLabel(option?.label || "");
+  };
+
+  const handleChangeLabel = (e: ChangeEvent<HTMLInputElement>) => {
+    setLabel(e.target.value);
+  };
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+
+    onChange({
+      type: COMPARISON_TYPES.ANOTHER_COLUMN,
+      label,
+      column: columnKey,
+    });
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit}>
+      <Flex direction="column" align="flex-start" gap="lg">
+        <PopoverBackButton
+          onClick={onBack}
+        >{t`Value from another column`}</PopoverBackButton>
+        <Stack pos="relative" w="100%" spacing="md">
+          <Select
+            autoFocus={!columnKey}
+            value={columnKey}
+            data={columnOptions}
+            label={t`Column`}
+            searchable
+            onChange={handleChangeColumnKey}
+            styles={{ dropdown: { width: "100%" } }}
+            withinPortal={false}
+          />
+          <TextInput
+            value={label}
+            label={t`Label`}
+            onChange={handleChangeLabel}
+          />
+        </Stack>
+        <DoneButton type="submit" disabled={!canSubmit}>
+          {t`Done`}
+        </DoneButton>
+      </Flex>
+    </Box>
+  );
+}

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/AnotherColumnForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/AnotherColumnForm.tsx
@@ -13,7 +13,6 @@ import type {
   DatasetColumn,
   SmartScalarComparisonAnotherColumn,
 } from "metabase-types/api";
-import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 import { COMPARISON_TYPES } from "../constants";
 import { DoneButton } from "./SmartScalarSettingsWidgets.styled";
 
@@ -31,21 +30,21 @@ export function AnotherColumnForm({
   onBack,
 }: AnotherColumnFormProps) {
   const [label, setLabel] = useState(selectedValue?.label || "");
-  const [columnKey, setColumnKey] = useState(selectedValue?.column || "");
+  const [column, setColumn] = useState(selectedValue?.column || "");
 
-  const canSubmit = label.length > 0 && columnKey.length > 0;
+  const canSubmit = label.length > 0 && column.length > 0;
 
   const columnOptions = useMemo(
     () =>
       columns.map(column => ({
         label: column.display_name,
-        value: getColumnKey(column),
+        value: column.name,
       })),
     [columns],
   );
 
   const handleChangeColumnKey = (value: string) => {
-    setColumnKey(value);
+    setColumn(value);
     const option = columnOptions.find(option => option.value === value);
     setLabel(option?.label || "");
   };
@@ -60,7 +59,7 @@ export function AnotherColumnForm({
     onChange({
       type: COMPARISON_TYPES.ANOTHER_COLUMN,
       label,
-      column: columnKey,
+      column,
     });
   };
 
@@ -72,8 +71,8 @@ export function AnotherColumnForm({
         >{t`Value from another column`}</PopoverBackButton>
         <Stack pos="relative" w="100%" spacing="md">
           <Select
-            autoFocus={!columnKey}
-            value={columnKey}
+            autoFocus={!column}
+            value={column}
             data={columnOptions}
             label={t`Column`}
             searchable

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -74,8 +74,7 @@ export function SmartScalarComparisonWidget({
           }
           columns={comparableColumns}
           onChange={nextValue => {
-            onChange(nextValue);
-            setOpen(false);
+            handleEditedValueChange(nextValue, true);
           }}
           onBack={() => setTab(null)}
         />

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -63,6 +63,54 @@ export function SmartScalarComparisonWidget({
     setOpen(isOpen);
   };
 
+  const renderMenuDropdownContent = () => {
+    if (tab === "anotherColumn") {
+      return (
+        <AnotherColumnForm
+          value={
+            selectedValue.type === COMPARISON_TYPES.ANOTHER_COLUMN
+              ? selectedValue
+              : undefined
+          }
+          columns={comparableColumns}
+          onChange={nextValue => {
+            onChange(nextValue);
+            setOpen(false);
+          }}
+          onBack={() => setTab(null)}
+        />
+      );
+    }
+    if (tab === "staticNumber") {
+      return (
+        <StaticNumberForm
+          value={
+            selectedValue.type === COMPARISON_TYPES.STATIC_NUMBER
+              ? selectedValue
+              : undefined
+          }
+          onChange={nextValue => {
+            handleEditedValueChange(nextValue, true);
+          }}
+          onBack={() => setTab(null)}
+        />
+      );
+    }
+    return (
+      <Stack spacing="sm">
+        {options.map(optionArgs =>
+          renderMenuOption({
+            editedValue,
+            selectedValue,
+            optionArgs,
+            onChange: handleEditedValueChange,
+            onChangeTab: setTab,
+          }),
+        )}
+      </Stack>
+    );
+  };
+
   return (
     <Menu
       opened={open}
@@ -85,45 +133,7 @@ export function SmartScalarComparisonWidget({
       </Menu.Target>
 
       <Menu.Dropdown miw="18.25rem">
-        {tab === "anotherColumn" ? (
-          <AnotherColumnForm
-            value={
-              selectedValue.type === COMPARISON_TYPES.ANOTHER_COLUMN
-                ? selectedValue
-                : undefined
-            }
-            columns={comparableColumns}
-            onChange={nextValue => {
-              onChange(nextValue);
-              setOpen(false);
-            }}
-            onBack={() => setTab(null)}
-          />
-        ) : tab === "staticNumber" ? (
-          <StaticNumberForm
-            value={
-              selectedValue.type === COMPARISON_TYPES.STATIC_NUMBER
-                ? selectedValue
-                : undefined
-            }
-            onChange={nextValue => {
-              handleEditedValueChange(nextValue, true);
-            }}
-            onBack={() => setTab(null)}
-          />
-        ) : (
-          <Stack spacing="sm">
-            {options.map(optionArgs =>
-              renderMenuOption({
-                editedValue,
-                selectedValue,
-                optionArgs,
-                onChange: handleEditedValueChange,
-                onChangeTab: setTab,
-              }),
-            )}
-          </Stack>
-        )}
+        {renderMenuDropdownContent()}
       </Menu.Dropdown>
     </Menu>
   );

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -2,28 +2,37 @@ import { useCallback, useState } from "react";
 import _ from "underscore";
 import { Icon } from "metabase/core/components/Icon";
 import { Button, Menu, Stack, Text } from "metabase/ui";
-import type { SmartScalarComparison } from "metabase-types/api";
+import type {
+  DatasetColumn,
+  SmartScalarComparison,
+  SmartScalarComparisonType,
+} from "metabase-types/api";
 import { COMPARISON_TYPES } from "../constants";
 import type { ComparisonMenuOption } from "../types";
 import { PeriodsAgoMenuOption } from "./PeriodsAgoMenuOption";
 import { StaticNumberForm } from "./StaticNumberForm";
 import { MenuItemStyled } from "./MenuItem.styled";
+import { AnotherColumnForm } from "./AnotherColumnForm";
 
 type SmartScalarComparisonWidgetProps = {
   onChange: (setting: SmartScalarComparison) => void;
   options: ComparisonMenuOption[];
+  comparableColumns: DatasetColumn[];
   value: SmartScalarComparison;
 };
 
-type Tab = "staticNumber" | null;
+type Tab = "anotherColumn" | "staticNumber" | null;
 
 export function SmartScalarComparisonWidget({
   onChange: onChange,
   options,
+  comparableColumns,
   value: selectedValue,
 }: SmartScalarComparisonWidgetProps) {
   const [open, setOpen] = useState(false);
-  const [tab, setTab] = useState<Tab>(getTabForValue(selectedValue));
+  const [tab, setTab] = useState<Tab>(
+    getTabForComparisonType(selectedValue.type),
+  );
   const [editedValue, setEditedValue] = useState(selectedValue);
 
   const selectedOption = options.find(
@@ -47,7 +56,7 @@ export function SmartScalarComparisonWidget({
   const handleMenuStateChange = (isOpen: boolean) => {
     if (isOpen) {
       setEditedValue(selectedValue);
-      setTab(getTabForValue(selectedValue));
+      setTab(getTabForComparisonType(selectedValue.type));
     } else if (!_.isEqual(selectedValue, editedValue)) {
       onChange(editedValue);
     }
@@ -76,7 +85,21 @@ export function SmartScalarComparisonWidget({
       </Menu.Target>
 
       <Menu.Dropdown miw="18.25rem">
-        {tab === "staticNumber" ? (
+        {tab === "anotherColumn" ? (
+          <AnotherColumnForm
+            value={
+              selectedValue.type === COMPARISON_TYPES.ANOTHER_COLUMN
+                ? selectedValue
+                : undefined
+            }
+            columns={comparableColumns}
+            onChange={nextValue => {
+              onChange(nextValue);
+              setOpen(false);
+            }}
+            onBack={() => setTab(null)}
+          />
+        ) : tab === "staticNumber" ? (
           <StaticNumberForm
             value={
               selectedValue.type === COMPARISON_TYPES.STATIC_NUMBER
@@ -106,8 +129,11 @@ export function SmartScalarComparisonWidget({
   );
 }
 
-function getTabForValue(value: SmartScalarComparison): Tab {
-  if (value.type === COMPARISON_TYPES.STATIC_NUMBER) {
+function getTabForComparisonType(type: SmartScalarComparisonType): Tab {
+  if (type === COMPARISON_TYPES.ANOTHER_COLUMN) {
+    return "anotherColumn";
+  }
+  if (type === COMPARISON_TYPES.STATIC_NUMBER) {
     return "staticNumber";
   }
   return null;
@@ -120,7 +146,10 @@ function getDisplayName(
   if (value.type === COMPARISON_TYPES.PERIODS_AGO) {
     return `${value.value} ${option?.name}`;
   }
-  if (value.type === COMPARISON_TYPES.STATIC_NUMBER) {
+  if (
+    value.type === COMPARISON_TYPES.ANOTHER_COLUMN ||
+    value.type === COMPARISON_TYPES.STATIC_NUMBER
+  ) {
     return value.label;
   }
   return option?.name;
@@ -167,8 +196,12 @@ function renderMenuOption({
   }
 
   const handleClick = () => {
-    if (type === COMPARISON_TYPES.STATIC_NUMBER) {
-      onChangeTab("staticNumber");
+    if (
+      type === COMPARISON_TYPES.ANOTHER_COLUMN ||
+      type === COMPARISON_TYPES.STATIC_NUMBER
+    ) {
+      const tab = getTabForComparisonType(type);
+      onChangeTab(tab);
     } else {
       onChange({ type }, true);
     }

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -47,6 +47,7 @@ import {
 } from "./SmartScalar.styled";
 import {
   getDefaultComparison,
+  getColumnsForComparison,
   getComparisonOptions,
   formatChangeAutoPrecision,
   getChangeWidth,
@@ -288,14 +289,8 @@ Object.assign(SmartScalar, {
         getDefaultComparison(series, vizSettings),
       getProps: (series, vizSettings) => {
         const cols = series[0].data.cols;
-        const mainColumn = vizSettings["scalar.field"];
-
-        const comparableColumns = cols.filter(
-          col => isNumeric(col) && col.name !== mainColumn,
-        );
-
         return {
-          comparableColumns,
+          comparableColumns: getColumnsForComparison(cols, vizSettings),
           options: getComparisonOptions(series, vizSettings),
         };
       },

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -286,9 +286,20 @@ Object.assign(SmartScalar, {
       isValid: (series, vizSettings) => isComparisonValid(series, vizSettings),
       getDefault: (series, vizSettings) =>
         getDefaultComparison(series, vizSettings),
-      getProps: (series, vizSettings) => ({
-        options: getComparisonOptions(series, vizSettings),
-      }),
+      getProps: (series, vizSettings) => {
+        const cols = series[0].data.cols;
+        const mainColumn = vizSettings["scalar.field"];
+
+        const comparableColumns = cols.filter(
+          col => isNumeric(col) && col.name !== mainColumn,
+        );
+
+        return {
+          comparableColumns,
+          options: getComparisonOptions(series, vizSettings),
+        };
+      },
+      readDependencies: ["scalar.field"],
     },
     "scalar.switch_positive_negative": {
       section: t`Display`,

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
@@ -9,7 +9,6 @@ import { COMPARISON_TYPES } from "metabase/visualizations/visualizations/SmartSc
 import { formatChange } from "metabase/visualizations/visualizations/SmartScalar/utils";
 import { isEmpty } from "metabase/lib/validate";
 import { isDate } from "metabase-lib/types/utils/isa";
-import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 
 export function computeTrend(series, insights, settings) {
   // get current metric data
@@ -198,7 +197,7 @@ function computeTrendAnotherColumn({ currentMetricData, series, settings }) {
   const comparison = settings["scalar.comparisons"];
 
   const columnIndex = cols.findIndex(
-    column => getColumnKey(column) === comparison.column,
+    column => column.name === comparison.column,
   );
   const column = cols[columnIndex];
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.js
@@ -199,9 +199,15 @@ function computeTrendAnotherColumn({ currentMetricData, series, settings }) {
   const columnIndex = cols.findIndex(
     column => column.name === comparison.column,
   );
-  const column = cols[columnIndex];
 
-  // TODO if (!column) { ... }
+  if (columnIndex === -1) {
+    return {
+      comparisonValueStr: t`(No data)`,
+      comparisonDescStr: t`vs. N/A`,
+    };
+  }
+
+  const column = cols[columnIndex];
 
   const lastRow = rows[latestRowIndex];
   const comparisonValue = lastRow[columnIndex];

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/constants.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/constants.ts
@@ -15,6 +15,7 @@ export const PERIOD_HIDE_HEIGHT_THRESHOLD = 70; // determined empirically
 export const DASHCARD_HEADER_HEIGHT = 33;
 
 export const COMPARISON_TYPES = {
+  ANOTHER_COLUMN: "anotherColumn",
   PREVIOUS_VALUE: "previousValue",
   PREVIOUS_PERIOD: "previousPeriod",
   PERIODS_AGO: "periodsAgo",

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/types.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/types.ts
@@ -1,5 +1,9 @@
 import type { COMPARISON_TYPES } from "./constants";
 
+type AnotherColumnMenuOption = {
+  type: typeof COMPARISON_TYPES.ANOTHER_COLUMN;
+  name: string;
+};
 type PreviousValueMenuOption = {
   type: typeof COMPARISON_TYPES.PREVIOUS_VALUE;
   name: string;
@@ -18,6 +22,7 @@ type StaticNumberMenuOption = {
   name: string;
 };
 export type ComparisonMenuOption =
+  | AnotherColumnMenuOption
   | PreviousValueMenuOption
   | PreviousPeriodMenuOption
   | PeriodsAgoMenuOption

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -83,6 +83,10 @@ export const getChangeWidth = (width: number): number => {
 };
 
 export const COMPARISON_SELECTOR_OPTIONS = {
+  ANOTHER_COLUMN: {
+    type: COMPARISON_TYPES.ANOTHER_COLUMN,
+    name: t`Value from another column…`,
+  },
   PREVIOUS_PERIOD: {
     type: COMPARISON_TYPES.PREVIOUS_PERIOD,
   },
@@ -137,8 +141,16 @@ export function getComparisonOptions(
 
   const options: ComparisonMenuOption[] = [
     createComparisonMenuOption({ type: COMPARISON_TYPES.PREVIOUS_VALUE }),
-    createComparisonMenuOption({ type: COMPARISON_TYPES.STATIC_NUMBER }),
   ];
+
+  // TODO Put a condition here
+  options.push(
+    createComparisonMenuOption({ type: COMPARISON_TYPES.ANOTHER_COLUMN }),
+  );
+
+  options.push(
+    createComparisonMenuOption({ type: COMPARISON_TYPES.STATIC_NUMBER }),
+  );
 
   const dateUnit = insights?.find(
     insight => insight.col === settings["scalar.field"],
@@ -184,6 +196,11 @@ export function isComparisonValid(
       data: { insights },
     },
   ] = series;
+
+  // TODO test
+  if (comparisonType === COMPARISON_TYPES.ANOTHER_COLUMN) {
+    return !isEmpty(comparison?.column) && !isEmpty(comparison?.label);
+  }
 
   if (comparisonType === COMPARISON_TYPES.PREVIOUS_VALUE) {
     return true;
@@ -245,6 +262,9 @@ function getMaxPeriodsAgo({
 
 type GetComparisonMenuOptionParameters =
   | {
+      type: typeof COMPARISON_TYPES.ANOTHER_COLUMN;
+    }
+  | {
       type: typeof COMPARISON_TYPES.PREVIOUS_VALUE;
     }
   | {
@@ -264,6 +284,10 @@ function createComparisonMenuOption(
   comparisonParameters: GetComparisonMenuOptionParameters,
 ): ComparisonMenuOption {
   const { type } = comparisonParameters;
+
+  if (type === COMPARISON_TYPES.ANOTHER_COLUMN) {
+    return COMPARISON_SELECTOR_OPTIONS.ANOTHER_COLUMN;
+  }
 
   if (type === COMPARISON_TYPES.PREVIOUS_PERIOD) {
     const { dateUnit } = comparisonParameters;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -15,7 +15,7 @@ import type {
 import { isEmpty } from "metabase/lib/validate";
 import { formatNumber } from "metabase/lib/formatting";
 import { measureText } from "metabase/lib/measure-text";
-import { isDate } from "metabase-lib/types/utils/isa";
+import { isDate, isNumeric } from "metabase-lib/types/utils/isa";
 
 import {
   COMPARISON_TYPES,
@@ -127,6 +127,15 @@ export function getDefaultComparison(
     type: COMPARISON_TYPES.PREVIOUS_PERIOD,
     dateUnit,
   });
+}
+
+export function getColumnsForComparison(
+  columns: DatasetColumn[],
+  settings: VisualizationSettings,
+) {
+  return columns.filter(
+    column => isNumeric(column) && column.name !== settings["scalar.field"],
+  );
 }
 
 export function getComparisonOptions(

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -210,7 +210,11 @@ export function isComparisonValid(
 
   // TODO test
   if (comparisonType === COMPARISON_TYPES.ANOTHER_COLUMN) {
-    return !isEmpty(comparison?.column) && !isEmpty(comparison?.label);
+    return (
+      !isEmpty(comparison?.column) &&
+      !isEmpty(comparison?.label) &&
+      comparison?.column !== settings["scalar.field"]
+    );
   }
 
   if (comparisonType === COMPARISON_TYPES.PREVIOUS_VALUE) {

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -208,7 +208,6 @@ export function isComparisonValid(
     },
   ] = series;
 
-  // TODO test
   if (comparisonType === COMPARISON_TYPES.ANOTHER_COLUMN) {
     return (
       !isEmpty(comparison?.column) &&

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -204,16 +204,26 @@ export function isComparisonValid(
 
   const [
     {
-      data: { insights },
+      data: { cols, insights },
     },
   ] = series;
 
   if (comparisonType === COMPARISON_TYPES.ANOTHER_COLUMN) {
-    return (
-      !isEmpty(comparison?.column) &&
-      !isEmpty(comparison?.label) &&
-      comparison?.column !== settings["scalar.field"]
-    );
+    if (
+      !comparison ||
+      isEmpty(comparison.column) ||
+      isEmpty(comparison.label)
+    ) {
+      return false;
+    }
+
+    const isExistingColumn =
+      cols.find(col => col.name === comparison?.column) != null;
+
+    const isDifferentFromPrimaryColumn =
+      comparison.column !== settings["scalar.field"];
+
+    return isExistingColumn && isDifferentFromPrimaryColumn;
   }
 
   if (comparisonType === COMPARISON_TYPES.PREVIOUS_VALUE) {

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -144,7 +144,7 @@ export function getComparisonOptions(
 ) {
   const [
     {
-      data: { cols, insights, rows },
+      data: { cols, insights = [], rows },
     },
   ] = series;
 
@@ -152,16 +152,18 @@ export function getComparisonOptions(
     createComparisonMenuOption({ type: COMPARISON_TYPES.PREVIOUS_VALUE }),
   ];
 
-  // TODO Put a condition here
-  options.push(
-    createComparisonMenuOption({ type: COMPARISON_TYPES.ANOTHER_COLUMN }),
-  );
+  const comparableColumns = getColumnsForComparison(cols, settings);
+  if (comparableColumns.length > 0) {
+    options.push(
+      createComparisonMenuOption({ type: COMPARISON_TYPES.ANOTHER_COLUMN }),
+    );
+  }
 
   options.push(
     createComparisonMenuOption({ type: COMPARISON_TYPES.STATIC_NUMBER }),
   );
 
-  const dateUnit = insights?.find(
+  const dateUnit = insights.find(
     insight => insight.col === settings["scalar.field"],
   )?.unit;
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
@@ -293,67 +293,69 @@ describe("SmartScalar > utils", () => {
         },
       );
 
-      it("should return true for staticNumber comparison when dateUnit is missing", () => {
-        const settings = {
-          "scalar.field": FIELD_NAME,
-          "scalar.comparisons": {
-            type: COMPARISON_TYPES.STATIC_NUMBER,
-            value: 100,
-            label: "Goal",
-          },
-        };
-        const rows = [
-          ["2019-10-01", 100],
-          ["2019-11-01", 300],
-        ];
-        const isValid = isComparisonValid(
-          series({ rows, insights: [] }),
-          settings,
-        );
+      describe("static number comparison", () => {
+        it("should return true when valid", () => {
+          const settings = {
+            "scalar.field": FIELD_NAME,
+            "scalar.comparisons": {
+              type: COMPARISON_TYPES.STATIC_NUMBER,
+              value: 100,
+              label: "Goal",
+            },
+          };
+          const rows = [
+            ["2019-10-01", 100],
+            ["2019-11-01", 300],
+          ];
+          const isValid = isComparisonValid(
+            series({ rows, insights: [] }),
+            settings,
+          );
 
-        expect(isValid).toBeTruthy();
-      });
+          expect(isValid).toBeTruthy();
+        });
 
-      it("should return false for staticNumber comparison when value is missing", () => {
-        const settings = {
-          "scalar.field": FIELD_NAME,
-          "scalar.comparisons": {
-            type: COMPARISON_TYPES.STATIC_NUMBER,
-            label: "Goal",
-          },
-        };
-        const rows = [
-          ["2019-10-01", 100],
-          ["2019-11-01", 300],
-        ];
+        it("should return false when value is missing", () => {
+          const settings = {
+            "scalar.field": FIELD_NAME,
+            "scalar.comparisons": {
+              type: COMPARISON_TYPES.STATIC_NUMBER,
+              label: "Goal",
+            },
+          };
+          const rows = [
+            ["2019-10-01", 100],
+            ["2019-11-01", 300],
+          ];
 
-        const isValid = isComparisonValid(
-          series({ rows, insights: [] }),
-          settings as VisualizationSettings,
-        );
+          const isValid = isComparisonValid(
+            series({ rows, insights: [] }),
+            settings as VisualizationSettings,
+          );
 
-        expect(isValid).toBeFalsy();
-      });
+          expect(isValid).toBeFalsy();
+        });
 
-      it("should return false for staticNumber comparison when label is missing", () => {
-        const settings = {
-          "scalar.field": FIELD_NAME,
-          "scalar.comparisons": {
-            type: COMPARISON_TYPES.STATIC_NUMBER,
-            value: 100,
-          },
-        };
-        const rows = [
-          ["2019-10-01", 100],
-          ["2019-11-01", 300],
-        ];
+        it("should return false when label is missing", () => {
+          const settings = {
+            "scalar.field": FIELD_NAME,
+            "scalar.comparisons": {
+              type: COMPARISON_TYPES.STATIC_NUMBER,
+              value: 100,
+            },
+          };
+          const rows = [
+            ["2019-10-01", 100],
+            ["2019-11-01", 300],
+          ];
 
-        const isValid = isComparisonValid(
-          series({ rows, insights: [] }),
-          settings as VisualizationSettings,
-        );
+          const isValid = isComparisonValid(
+            series({ rows, insights: [] }),
+            settings as VisualizationSettings,
+          );
 
-        expect(isValid).toBeFalsy();
+          expect(isValid).toBeFalsy();
+        });
       });
     });
   });

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
@@ -375,6 +375,24 @@ describe("SmartScalar > utils", () => {
 
           expect(isValid).toBe(false);
         });
+
+        it("should return false when column is missing in the series", () => {
+          const settings = {
+            "scalar.field": FIELD_NAME,
+            "scalar.comparisons": {
+              type: COMPARISON_TYPES.ANOTHER_COLUMN,
+              label: "Missing",
+              column: "Missing",
+            },
+          };
+
+          const isValid = isComparisonValid(
+            multiSeries,
+            settings as VisualizationSettings,
+          );
+
+          expect(isValid).toBe(false);
+        });
       });
 
       describe("static number comparison", () => {

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
@@ -293,6 +293,90 @@ describe("SmartScalar > utils", () => {
         },
       );
 
+      describe("'another column' comparison", () => {
+        const anotherColumn = createMockColumn(
+          NumberColumn({ name: "Average" }),
+        );
+        const multiSeries = series({
+          cols: [...cols, anotherColumn],
+          rows: [
+            ["2019-10-01", 100, 110],
+            ["2019-11-01", 300, 250],
+          ],
+          insights: [],
+        });
+
+        it("should return true when valid", () => {
+          const settings = {
+            "scalar.field": FIELD_NAME,
+            "scalar.comparisons": {
+              type: COMPARISON_TYPES.ANOTHER_COLUMN,
+              label: "Avg",
+              column: "Average",
+            },
+          };
+
+          const isValid = isComparisonValid(
+            multiSeries,
+            settings as VisualizationSettings,
+          );
+
+          expect(isValid).toBe(true);
+        });
+
+        it("should return false when column is missing", () => {
+          const settings = {
+            "scalar.field": FIELD_NAME,
+            "scalar.comparisons": {
+              type: COMPARISON_TYPES.ANOTHER_COLUMN,
+              label: "Count",
+            },
+          };
+
+          const isValid = isComparisonValid(
+            multiSeries,
+            settings as VisualizationSettings,
+          );
+
+          expect(isValid).toBe(false);
+        });
+
+        it("should return false when label is missing", () => {
+          const settings = {
+            "scalar.field": FIELD_NAME,
+            "scalar.comparisons": {
+              type: COMPARISON_TYPES.ANOTHER_COLUMN,
+              column: "Count",
+            },
+          };
+
+          const isValid = isComparisonValid(
+            multiSeries,
+            settings as VisualizationSettings,
+          );
+
+          expect(isValid).toBe(false);
+        });
+
+        it("should return false when comparison column is the same as primary number", () => {
+          const settings = {
+            "scalar.field": FIELD_NAME,
+            "scalar.comparisons": {
+              type: COMPARISON_TYPES.ANOTHER_COLUMN,
+              column: FIELD_NAME,
+              label: "Count",
+            },
+          };
+
+          const isValid = isComparisonValid(
+            multiSeries,
+            settings as VisualizationSettings,
+          );
+
+          expect(isValid).toBe(false);
+        });
+      });
+
       describe("static number comparison", () => {
         it("should return true when valid", () => {
           const settings = {


### PR DESCRIPTION
Resolves #35553

Adds "another column" comparison type for trend charts

### How to verify

1. New > Question > Raw Data > Sample Database > Products
2. Summarize Count, Min of Price by Created At
3. Set visualization to "trend"
4. Visualization settings > Data tab > Comparisons > Value from another column > Pick "Min of Price"
5. Try different values for "Label" and "Column" and ensure the chart calculates and displays the change as expected

### Demo

https://github.com/metabase/metabase/assets/17258145/51dc5320-7c66-4d92-8a18-7d3063c57d8d


