### PR TITLE
Fix failing download perms test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions_test.clj
@@ -18,130 +18,81 @@
 ;;; |                                          Download permissions                                                  |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn- download-perms-by-group-id [group-id]
-  (get-in (perms/data-perms-graph) [:groups group-id (mt/id) :download]))
+(defn- download-perms-by-group-id [group-id db-id]
+  (get-in (perms/data-perms-graph) [:groups group-id db-id :download]))
 
 (deftest update-db-download-permissions-test
   (mt/with-model-cleanup [Permissions]
-    (t2.with-temp/with-temp [PermissionsGroup {group-id :id}]
+    (t2.with-temp/with-temp [:model/Database         {db-id :id}    {}
+                             :model/Table            {table-id-1 :id} {:db_id db-id :schema "PUBLIC"}
+                             :model/Table            {table-id-2 :id} {:db_id db-id :schema "PUBLIC"}
+                             :model/PermissionsGroup {group-id :id} {}]
       (premium-features-test/with-premium-features #{:advanced-permissions}
         (testing "Download perms for all schemas can be set and revoked"
-          (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas :full})
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas :full})
           (is (= {:schemas :full, :native :full}
-                 (download-perms-by-group-id group-id)))
+                 (download-perms-by-group-id group-id db-id)))
 
-          (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas :limited})
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas :limited})
           (is (= {:schemas :limited, :native :limited}
-                 (download-perms-by-group-id group-id)))
+                 (download-perms-by-group-id group-id db-id)))
 
-          (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas :none})
-          (is (nil? (download-perms-by-group-id group-id))))
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas :none})
+          (is (nil? (download-perms-by-group-id group-id db-id))))
 
         (testing "Download perms for individual schemas can be set and revoked"
-          (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas {"PUBLIC" :full}})
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas {"PUBLIC" :full}})
           (is (= {:schemas {"PUBLIC" :full} :native :full}
-                 (download-perms-by-group-id group-id)))
+                 (download-perms-by-group-id group-id db-id)))
 
-          (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas {"PUBLIC" :limited}})
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas {"PUBLIC" :limited}})
           (is (= {:schemas {"PUBLIC" :limited} :native :limited}
-                 (download-perms-by-group-id group-id)))
+                 (download-perms-by-group-id group-id db-id)))
 
-          (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas {"PUBLIC" :none}})
-          (is (nil? (download-perms-by-group-id group-id))))
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas {"PUBLIC" :none}})
+          (is (nil? (download-perms-by-group-id group-id db-id))))
 
         (testing "Download perms for individual tables can be set and revoked"
-          (let [[id-1 id-2 id-3 id-4 id-5 id-6 id-7 id-8] (map u/the-id (database/tables (mt/db)))]
-            (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas {"PUBLIC" {id-1 :full
-                                                                                            id-2 :full
-                                                                                            id-3 :full
-                                                                                            id-4 :full
-                                                                                            id-5 :full
-                                                                                            id-6 :full
-                                                                                            id-7 :full
-                                                                                            id-8 :full}}})
-            (is (= {:schemas {"PUBLIC" {id-1 :full
-                                        id-2 :full
-                                        id-3 :full
-                                        id-4 :full
-                                        id-5 :full
-                                        id-6 :full
-                                        id-7 :full
-                                        id-8 :full}}
-                    :native :full}
-                   (download-perms-by-group-id group-id)))
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas {"PUBLIC" {table-id-1 :full
+                                                                                        table-id-2 :full}}})
+          (is (= {:schemas {"PUBLIC" {table-id-1 :full
+                                      table-id-2 :full}}
+                  :native :full}
+                 (download-perms-by-group-id group-id db-id)))
 
-            (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas {"PUBLIC" {id-1 :limited}}})
-            (is (= {:schemas {"PUBLIC" {id-1 :limited
-                                        id-2 :full
-                                        id-3 :full
-                                        id-4 :full
-                                        id-5 :full
-                                        id-6 :full
-                                        id-7 :full
-                                        id-8 :full}}
-                    :native :limited}
-                   (download-perms-by-group-id group-id)))
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas {"PUBLIC" {table-id-1 :limited
+                                                                                        table-id-2 :full}}})
+          (is (= {:schemas {"PUBLIC" {table-id-1 :limited
+                                      table-id-2 :full}}
+                  :native :limited}
+                 (download-perms-by-group-id group-id db-id)))
 
-            (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas {"PUBLIC" {id-2 :none}}})
-            (is (= {:schemas {"PUBLIC" {id-1 :limited
-                                        id-3 :full
-                                        id-4 :full
-                                        id-5 :full
-                                        id-6 :full
-                                        id-7 :full
-                                        id-8 :full}}}
-                   (download-perms-by-group-id group-id)))
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas {"PUBLIC" {table-id-2 :none}}})
+          (is (= {:schemas {"PUBLIC" {table-id-1 :limited}}}
+                 (download-perms-by-group-id group-id db-id)))
 
-            (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas {"PUBLIC" {id-1 :none
-                                                                                            id-3 :none
-                                                                                            id-4 :none
-                                                                                            id-5 :none
-                                                                                            id-6 :none
-                                                                                            id-7 :none
-                                                                                            id-8 :none}}})
-            (is (nil? (download-perms-by-group-id group-id)))
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas {"PUBLIC" {table-id-1 :none
+                                                                                        table-id-2 :none}}})
+          (is (nil? (download-perms-by-group-id group-id db-id)))
 
-            (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas {"PUBLIC" {id-1 :full
-                                                                                            id-2 :full
-                                                                                            id-3 :limited
-                                                                                            id-4 :limited
-                                                                                            id-5 :limited
-                                                                                            id-6 :limited
-                                                                                            id-7 :limited
-                                                                                            id-8 :limited}}})
-            (is (= {:schemas {"PUBLIC" {id-1 :full
-                                        id-2 :full
-                                        id-3 :limited
-                                        id-4 :limited
-                                        id-5 :limited
-                                        id-6 :limited
-                                        id-7 :limited
-                                        id-8 :limited}}
-                    :native :limited}
-                   (download-perms-by-group-id group-id)))
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas {"PUBLIC" {table-id-1 :full
+                                                                                        table-id-2 :limited}}})
+          (is (= {:schemas {"PUBLIC" {table-id-1 :full
+                                      table-id-2 :limited}}
+                  :native :limited}
+                 (download-perms-by-group-id group-id db-id)))
 
-            (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas {"PUBLIC" {id-3 :full
-                                                                                            id-4 :full
-                                                                                            id-5 :full
-                                                                                            id-6 :full
-                                                                                            id-7 :full
-                                                                                            id-8 :full}}})
-            (is (= {:schemas {"PUBLIC" {id-1 :full
-                                        id-2 :full
-                                        id-3 :full
-                                        id-4 :full
-                                        id-5 :full
-                                        id-6 :full
-                                        id-7 :full
-                                        id-8 :full}}
-                    :native :full}
-                   (download-perms-by-group-id group-id)))))
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas {"PUBLIC" {table-id-2 :full}}})
+          (is (= {:schemas {"PUBLIC" {table-id-1 :full
+                                      table-id-2 :full}}
+                  :native :full}
+                 (download-perms-by-group-id group-id db-id))))
 
         (testing "Download perms are revoked when block perms are set"
-          (ee-perms/update-db-download-permissions! group-id (mt/id) {:schemas :full :native :full})
-          (is (= {:schemas :full :native :full} (download-perms-by-group-id group-id)))
-          (@#'perms/update-db-data-access-permissions! group-id (mt/id) {:schemas :block})
-          (is (= nil (download-perms-by-group-id group-id)))))
+          (ee-perms/update-db-download-permissions! group-id db-id {:schemas :full :native :full})
+          (is (= {:schemas :full :native :full} (download-perms-by-group-id group-id db-id)))
+          (@#'perms/update-db-data-access-permissions! group-id db-id {:schemas :block})
+          (is (= nil (download-perms-by-group-id group-id db-id)))))
 
       (premium-features-test/with-premium-features #{}
         (testing "Download permissions cannot be modified without the :advanced-permissions feature flag"


### PR DESCRIPTION
This test just started failing on master when run as part of the Cloverage job, but not otherwise. I think there's an issue with some new permission-related tests modifying the perms of the default test database and not resetting the state, which can then cause other tests to fail if they're run afterwards. And I guess Cloverage must use a different test order than our normal test runs.

Ultimately we need better abstractions for permissions, both in the normal code and in tests. But my shorter-term fix for this failing test is to rewrite it to not rely on the sample dataset at all, but rather temporary DBs and tables created in the test. 