### PR TITLE
disable static charts animation

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -48,6 +48,7 @@ export const ComboChart = ({
     null,
     [],
     computedVisualizationSettings,
+    false,
     renderingContext,
   );
 

--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -45,6 +45,7 @@ export function ScatterPlot({
     null,
     [],
     computedVisualizationSettings,
+    false,
     renderingContext,
   );
   chart.setOption(option);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
@@ -15,7 +15,7 @@ export const CHART_STYLE = {
   axisNameMargin: 12,
   padding: {
     x: 8,
-    y: 8,
+    y: 12,
   },
   timelineEvents: {
     height: 14,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -19,6 +19,7 @@ export const getCartesianChartOption = (
   timelineEventsModel: TimelineEventsModel | null,
   selectedTimelineEventsIds: TimelineEventId[],
   settings: ComputedVisualizationSettings,
+  isAnimated: boolean,
   renderingContext: RenderingContext,
 ): EChartsOption => {
   const hasTimelineEvents = timelineEventsModel != null;
@@ -68,6 +69,7 @@ export const getCartesianChartOption = (
   ];
 
   return {
+    animation: isAnimated,
     toolbox: {
       show: false,
     },

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -107,6 +107,7 @@ export function CartesianChart({
         timelineEventsModel,
         selectedTimelineEventIds,
         settings,
+        true,
         renderingContext,
       ),
     [


### PR DESCRIPTION
### Description

Static scatter chart do not render if the option object has `animation: true` which is the default value.

### How to verify

Run storybook, check static scatter stories work.
Run the Metabase app, check dynamic combo chart works.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
