### PR TITLE
API Keys: Handle Groups UI

### DIFF
--- a/e2e/support/helpers/e2e-api-key-helpers.ts
+++ b/e2e/support/helpers/e2e-api-key-helpers.ts
@@ -1,0 +1,6 @@
+export const createApiKey = (name: string, group_id: number) => {
+  return cy.request("POST", "/api/api-key", {
+    name,
+    group_id,
+  });
+};

--- a/e2e/support/helpers/index.js
+++ b/e2e/support/helpers/index.js
@@ -1,4 +1,5 @@
 export * from "./e2e-action-helpers";
+export * from "./e2e-api-key-helpers";
 export * from "./e2e-setup-helpers";
 export * from "./e2e-ui-elements-helpers";
 export * from "./e2e-dashboard-helpers";

--- a/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
@@ -1,11 +1,9 @@
 import {
-  popover,
   restore,
   visitDashboard,
   visitQuestion,
   createApiKey,
 } from "e2e/support/helpers";
-import type { ApiKey } from "metabase-types/api";
 
 import {
   ALL_USERS_GROUP_ID,

--- a/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/api-keys.cy.spec.ts
@@ -1,4 +1,11 @@
-import { restore, visitDashboard, visitQuestion } from "e2e/support/helpers";
+import {
+  popover,
+  restore,
+  visitDashboard,
+  visitQuestion,
+  createApiKey,
+} from "e2e/support/helpers";
+import type { ApiKey } from "metabase-types/api";
 
 import {
   ALL_USERS_GROUP_ID,
@@ -263,13 +270,6 @@ describe("scenarios > admin > settings > API keys", () => {
     });
   });
 });
-
-const createApiKey = (name: string, group_id: number) => {
-  return cy.request("POST", "/api/api-key", {
-    name,
-    group_id,
-  });
-};
 
 const createQuestionForApiKey = (apiKey: string) => {
   cy.signOut();

--- a/e2e/test/scenarios/admin-2/people/group-managers.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people/group-managers.cy.spec.js
@@ -192,5 +192,5 @@ function confirmLosingAbilityToManageGroup() {
 function removeFirstGroup() {
   cy.icon("ellipsis").eq(0).click();
   cy.findByText("Remove Group").click();
-  cy.button("Yes").click();
+  cy.button("Remove group").click();
 }

--- a/e2e/test/scenarios/admin-2/people/group-managers.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people/group-managers.cy.spec.js
@@ -170,7 +170,7 @@ describeEE("scenarios > admin > people", () => {
   });
 
   it("after removing the last group redirects to the home page", () => {
-    cy.findByTextEnsureVisible("Groups").click();
+    cy.findByTestId("admin-left-nav-pane").findByText("Groups").click();
 
     removeFirstGroup();
     cy.url().should("match", /\/admin\/people\/groups$/);

--- a/e2e/test/scenarios/admin-2/people/people.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/people/people.cy.spec.js
@@ -7,10 +7,14 @@ import {
   describeEE,
   getFullName,
   setTokenFeatures,
+  createApiKey,
 } from "e2e/support/helpers";
 import { USERS, USER_GROUPS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { NORMAL_USER_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  NORMAL_USER_ID,
+  COLLECTION_GROUP_ID,
+} from "e2e/support/cypress_sample_instance_data";
 
 const { normal, admin, nocollection } = USERS;
 const { ALL_USERS_GROUP, DATA_GROUP } = USER_GROUPS;
@@ -31,6 +35,8 @@ const normalUserName = getFullName(normal);
 
 describe("scenarios > admin > people", () => {
   beforeEach(() => {
+    cy.intercept("GET", "/api/permissions/group").as("getGroups");
+    cy.intercept("GET", "/api/api-key").as("getApiKeys");
     restore();
     cy.signInAsAdmin();
   });
@@ -318,6 +324,57 @@ describe("scenarios > admin > people", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(`${TOTAL_USERS} people found`);
       assertTableRowsCount(TOTAL_USERS);
+    });
+
+    it("should allow group creation and deletion", () => {
+      cy.intercept("POST", "/api/permissions/group").as("createGroup");
+      cy.intercept("DELETE", "/api/permissions/group/*").as("deleteGroup");
+
+      cy.visit("/admin/people/groups");
+      cy.wait(["@getGroups", "@getApiKeys"]);
+
+      cy.findByTestId("admin-panel").within(() => {
+        cy.button("Create a group").click();
+        cy.findByPlaceholderText(/something like/i).type("My New Group");
+        cy.button("Add").click();
+        cy.wait(["@createGroup", "@getGroups"]);
+
+        cy.findByText("My New Group").closest("tr").icon("ellipsis").click();
+      });
+
+      popover().findByText("Remove Group").click();
+      modal().button("Remove group").click();
+
+      cy.wait(["@deleteGroup", "@getGroups"]);
+      cy.findByTestId("admin-panel")
+        .findByText("My New Group")
+        .should("not.exist");
+    });
+
+    it("should display api keys included in a group and display a warning when deleting the group", () => {
+      createApiKey("MyApiKey", COLLECTION_GROUP_ID);
+      cy.visit("/admin/people/groups");
+      cy.wait(["@getGroups", "@getApiKeys"]);
+
+      cy.findByTestId("admin-panel")
+        .findByText("collection")
+        .closest("tr")
+        .findByText("(includes 1 API key)");
+
+      cy.findByTestId("admin-panel")
+        .findByText("collection")
+        .closest("tr")
+        .icon("ellipsis")
+        .click();
+
+      popover().findByText("Remove Group").click();
+
+      modal().within(() => {
+        cy.findByText(
+          "Are you sure you want remove this group and its API key?",
+        );
+        cy.button("Remove group and API key");
+      });
     });
 
     it("should display more than 50 groups (metabase#17200)", () => {

--- a/enterprise/frontend/src/metabase-enterprise/group_managers/components/UserTypeCell/UserTypeCell.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/group_managers/components/UserTypeCell/UserTypeCell.styled.tsx
@@ -10,7 +10,6 @@ export const ChangeTypeButton = styled.button`
 
 export const UserTypeCellRoot = styled.td`
   text-transform: capitalize;
-  text-decoration: underline;
   font-size: 14px;
   font-weight: bold;
   color: ${color("text-medium")};

--- a/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import { Tooltip } from "metabase/ui";
+import { Tooltip, Text } from "metabase/ui";
 import { isAdminGroup, isDefaultGroup } from "metabase/lib/groups";
 import { getFullName } from "metabase/lib/user";
 import { Icon } from "metabase/core/components/Icon";
@@ -223,14 +223,16 @@ function getName(user: IUser): string {
 const ApiKeyRow = ({ apiKey }: { apiKey: ApiKey }) => {
   return (
     <tr>
-      <td className="text-bold">{apiKey.name}</td>
-      <td></td>
+      <td>
+        <Text weight="bold">{apiKey.name}</Text>
+      </td>
+      <td>
+        <Text weight="bold" color="text.1">{t`API Key`}</Text>
+      </td>
+      <td>{/* api keys don't have emails */}</td>
       <td className="text-right">
         <Link to="/admin/settings/authentication/api-keys">
-          <Tooltip
-            label={t`Manage API keys on Settings \\ Authentication page`}
-            position="left"
-          >
+          <Tooltip label={t`Manage API keys`} position="left">
             <Icon name="link" size={16} />
           </Tooltip>
         </Link>

--- a/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
+++ b/frontend/src/metabase/admin/people/components/GroupMembersTable/GroupMembersTable.tsx
@@ -62,7 +62,7 @@ function GroupMembersTable({
   reload,
 }: GroupMembersTableProps) {
   const { loading, value: apiKeys } = useAsync(
-    () => ApiKeysApi.list(),
+    () => ApiKeysApi.list() as Promise<ApiKey[]>,
     [group.id],
   );
 
@@ -110,7 +110,7 @@ function GroupMembersTable({
             onDone={handleAddUser}
           />
         )}
-        {apiKeys.map((apiKey: ApiKey) => (
+        {apiKeys?.map((apiKey: ApiKey) => (
           <ApiKeyRow key={`apiKey-${apiKey.id}`} apiKey={apiKey} />
         ))}
         {groupUsers.map((user: IUser) => {

--- a/frontend/src/metabase/admin/people/components/GroupsListing.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.jsx
@@ -64,33 +64,39 @@ function DeleteGroupModal({
   onConfirm = () => {},
   onClose = () => {},
 }) {
-  const numApiKeys = apiKeys.length;
-  const hasApiKeys = numApiKeys > 0;
+  const apiKeysCount = apiKeys.length;
+  const hasApiKeys = apiKeys.length > 0;
+
+  const modalTitle =
+    apiKeysCount === 0
+      ? t`Remove this group?`
+      : apiKeysCount === 1
+      ? t`Are you sure you want remove this group and its API key?`
+      : t`Are you sure you want remove this group and its API keys?`;
+
+  const confirmButtonText =
+    apiKeysCount === 0
+      ? t`Remove group`
+      : apiKeysCount === 1
+      ? t`Remove group and API key`
+      : t`Remove group and API keys`;
+
   return (
-    <ModalContent
-      title={
-        numApiKeys === 0
-          ? t`Remove this group?`
-          : numApiKeys === 1
-          ? t`Are you sure you want remove this group and its API Key?`
-          : t`Are you sure you want remove this group and its API Keys?`
-      }
-      onClose={onClose}
-    >
+    <ModalContent title={modalTitle} onClose={onClose}>
       <Stack spacing="xl">
         <Text>
           {hasApiKeys
-            ? jt`All members of this group will lose any permissions settings they have based on this group, and its related API Keys will be deleted. You can ${(
+            ? jt`All members of this group will lose any permissions settings they have based on this group, and its related API keys will be deleted. You can ${(
                 <Link
                   to="/admin/settings/authentication/api-keys"
                   variant="brand"
-                >{t`move the API Keys to another group`}</Link>
+                >{t`move the API keys to another group`}</Link>
               )}.`
             : t`Are you sure? All members of this group will lose any permissions settings they have based on this group.
                 This can't be undone.`}
         </Text>
         <Group spacing="md" position="right">
-          <Button onClick={onClose}>{hasApiKeys ? t`Cancel` : t`No`}</Button>
+          <Button onClick={onClose}>{t`Cancel`}</Button>
           <Button
             variant="filled"
             color="error.0"
@@ -99,7 +105,7 @@ function DeleteGroupModal({
               onConfirm(group);
             }}
           >
-            {hasApiKeys ? t`Remove group and API Key` : t`Yes`}
+            {confirmButtonText}
           </Button>
         </Group>
       </Stack>
@@ -220,13 +226,7 @@ function GroupRow({
       </td>
       <td>
         {group.member_count || 0}
-        <span className="text-light">
-          {apiKeys.length === 1
-            ? t` (Includes 1 API Key)`
-            : apiKeys.length > 1
-            ? t` (Includes ${apiKeys.length} API Keys)`
-            : null}
-        </span>
+        <ApiKeyCount apiKeys={apiKeys} />
       </td>
       <td className="text-right">
         {showActionsButton ? (
@@ -241,6 +241,19 @@ function GroupRow({
     </tr>
   );
 }
+
+const ApiKeyCount = ({ apiKeys }) => {
+  if (!apiKeys?.length) {
+    return null;
+  }
+  return (
+    <span className="text-light">
+      {apiKeys.length === 1
+        ? t` (includes 1 API key)`
+        : t` (includes ${apiKeys.length} API keys)`}
+    </span>
+  );
+};
 
 const getGroupRowColors = () => [
   color("error"),
@@ -286,7 +299,7 @@ function GroupsTable({
             key={group.id}
             group={group}
             index={index}
-            apiKeys={apiKeys.filter(apiKey => apiKey.group_id === group.id)}
+            apiKeys={apiKeys.filter(apiKey => apiKey.group.id === group.id)}
             groupBeingEdited={groupBeingEdited}
             onEditGroupClicked={onEditGroupClicked}
             onDeleteGroupClicked={onDeleteGroupClicked}

--- a/frontend/src/metabase/admin/people/components/GroupsListing.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.jsx
@@ -301,7 +301,11 @@ function GroupsTable({
             key={group.id}
             group={group}
             index={index}
-            apiKeys={apiKeys.filter(apiKey => apiKey.group.id === group.id)}
+            apiKeys={
+              isDefaultGroup(group)
+                ? apiKeys
+                : apiKeys.filter(apiKey => apiKey.group.id === group.id)
+            }
             groupBeingEdited={groupBeingEdited}
             onEditGroupClicked={onEditGroupClicked}
             onDeleteGroupClicked={onDeleteGroupClicked}

--- a/frontend/src/metabase/admin/people/components/GroupsListing.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.jsx
@@ -303,8 +303,8 @@ function GroupsTable({
             index={index}
             apiKeys={
               isDefaultGroup(group)
-                ? apiKeys
-                : apiKeys.filter(apiKey => apiKey.group.id === group.id)
+                ? apiKeys ?? []
+                : apiKeys?.filter(apiKey => apiKey.group.id === group.id) ?? []
             }
             groupBeingEdited={groupBeingEdited}
             onEditGroupClicked={onEditGroupClicked}

--- a/frontend/src/metabase/admin/people/components/GroupsListing.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.jsx
@@ -1,10 +1,11 @@
 /* eslint-disable react/prop-types */
-import { Component, useState, useEffect } from "react";
+import { Component } from "react";
 
 import _ from "underscore";
 import cx from "classnames";
 
 import { jt, t } from "ttag";
+import { useAsync } from "react-use";
 import Link from "metabase/core/components/Link";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { Stack, Text, Group, Button } from "metabase/ui";
@@ -27,6 +28,7 @@ import UserAvatar from "metabase/components/UserAvatar";
 
 import AdminContentTable from "metabase/components/AdminContentTable";
 import AdminPaneLayout from "metabase/components/AdminPaneLayout";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 
 import { AddRow } from "./AddRow";
 import { DeleteModalTrigger, EditGroupButton } from "./GroupsListing.styled";
@@ -277,11 +279,11 @@ function GroupsTable({
   onEditGroupCancelClicked,
   onEditGroupDoneClicked,
 }) {
-  const [apiKeys, setApiKeys] = useState([]);
+  const { loading, value: apiKeys } = useAsync(() => ApiKeysApi.list(), []);
 
-  useEffect(() => {
-    ApiKeysApi.list().then(setApiKeys);
-  }, []);
+  if (loading) {
+    return <LoadingAndErrorWrapper loading={loading} />;
+  }
 
   return (
     <AdminContentTable columnTitles={[t`Group name`, t`Members`]}>

--- a/frontend/src/metabase/components/AdminPaneLayout/AdminPaneLayout.jsx
+++ b/frontend/src/metabase/components/AdminPaneLayout/AdminPaneLayout.jsx
@@ -52,7 +52,7 @@ const AdminPaneLayout = ({
   buttonLink,
   headingContent,
 }) => (
-  <div className="wrapper">
+  <div className="wrapper" data-testid="admin-panel">
     <AdminPaneTitle
       title={title}
       description={description}

--- a/frontend/src/metabase/components/LeftNavPane/LeftNavPane.jsx
+++ b/frontend/src/metabase/components/LeftNavPane/LeftNavPane.jsx
@@ -43,6 +43,7 @@ export function LeftNavPaneItemBack({ path }) {
 export function LeftNavPane({ children, fullHeight = true }) {
   return (
     <div
+      data-testid="admin-left-nav-pane"
       className={cx("MetadataEditor-table-list AdminList flex-no-shrink", {
         "full-height": fullHeight,
       })}


### PR DESCRIPTION
Groups UI now shows whether a group has api keys in it:

![Screen Shot 2024-01-04 at 12 31 06 PM](https://github.com/metabase/metabase/assets/30528226/acbe5914-9df9-4e3b-b56a-9d4c649e3ddb)

If you try to delete a group with api keys, you get some special text in your delete modal:

with api key | without api key
---|---
![Screen Shot 2024-01-04 at 12 32 19 PM](https://github.com/metabase/metabase/assets/30528226/c29fcf30-fbc6-44c0-a05a-8096b784b30a) | ![Screen Shot 2024-01-04 at 12 32 10 PM](https://github.com/metabase/metabase/assets/30528226/a2a9ed71-fb43-496f-86dc-031f1ee4aea1)
