### PR TITLE
Migrate dashboard with parameters -> query with filters transformation to MLv2

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -63,7 +63,13 @@ const QUESTION_LINE_CHART = {
   display: "line",
   query: {
     aggregation: [["count"]],
-    breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }]],
+    breakout: [
+      [
+        "field",
+        ORDERS.CREATED_AT,
+        { "base-type": "type/DateTime", "temporal-unit": "month" },
+      ],
+    ],
     "source-table": ORDERS_ID,
     limit: 5,
   },
@@ -105,14 +111,21 @@ const DASHBOARD_FILTER_TIME = createMockActionParameter({
 
 const QUERY_FILTER_CREATED_AT = [
   "between",
-  ["field", ORDERS.CREATED_AT, null],
+  [
+    "field",
+    ORDERS.CREATED_AT,
+    {
+      "base-type": "type/DateTime",
+      "temporal-unit": "month",
+    },
+  ],
   "2022-08-01",
   "2022-08-31",
 ];
 
 const QUERY_FILTER_QUANTITY = [
   "=",
-  ["field", ORDERS.QUANTITY, null],
+  ["field", ORDERS.QUANTITY, { "base-type": "type/Integer" }],
   POINT_COUNT,
 ];
 

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/dash_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/dash_drill.cy.spec.js
@@ -59,7 +59,11 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
             database: SAMPLE_DB_ID,
             query: {
               aggregation: [["count"]],
-              filter: [">", ["field", ORDERS.TOTAL, null], 100],
+              filter: [
+                ">",
+                ["field", ORDERS.TOTAL, { "base-type": "type/Float" }],
+                100,
+              ],
               "source-table": ORDERS_ID,
             },
             type: "query",
@@ -94,8 +98,12 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
               "source-table": PEOPLE_ID,
               aggregation: [["count"]],
               breakout: [
-                ["field", PEOPLE.SOURCE, null],
-                ["field", PEOPLE.CREATED_AT, { "temporal-unit": "month" }],
+                ["field", PEOPLE.SOURCE, { "base-type": "type/Text" }],
+                [
+                  "field",
+                  PEOPLE.CREATED_AT,
+                  { "base-type": "type/DateTime", "temporal-unit": "month" },
+                ],
               ],
             },
             display: "line",

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -979,13 +979,10 @@ class Question {
   _serializeForUrl({
     includeOriginalCardId = true,
     clean = true,
-    cleanFilters = false,
     includeDisplayIsLocked = false,
     creationType,
   } = {}) {
-    const query = clean
-      ? this.query().clean({ skipFilters: !cleanFilters })
-      : this.query();
+    const query = clean ? this.query().clean() : this.query();
     const cardCopy = {
       name: this._card.name,
       description: this._card.description,

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -44,7 +44,7 @@ import { getCardUiParameters } from "metabase-lib/parameters/utils/cards";
 import { utf8_to_b64url } from "metabase/lib/encoding";
 
 import { getTemplateTagParametersFromCard } from "metabase-lib/parameters/utils/template-tags";
-import { fieldFilterParameterToMBQLFilter } from "metabase-lib/parameters/utils/mbql";
+import { fieldFilterParameterToFilter } from "metabase-lib/parameters/utils/mbql";
 import { getQuestionVirtualTableId } from "metabase-lib/metadata/utils/saved-questions";
 import {
   aggregate,
@@ -1028,7 +1028,7 @@ class Question {
     const stageIndex = -1;
     const filters = this.parameters()
       .map(parameter =>
-        fieldFilterParameterToMBQLFilter(query, stageIndex, parameter),
+        fieldFilterParameterToFilter(query, stageIndex, parameter),
       )
       .filter(mbqlFilter => mbqlFilter != null);
 

--- a/frontend/src/metabase-lib/parameters/utils/mbql.js
+++ b/frontend/src/metabase-lib/parameters/utils/mbql.js
@@ -177,8 +177,8 @@ function isFieldFilterParameterConveratableToMBQL(parameter) {
   return hasValue && hasWellFormedTarget && hasFieldDimensionTarget;
 }
 
-/** compiles a parameter with value to an MBQL clause */
-export function fieldFilterParameterToMBQLFilter(query, stageIndex, parameter) {
+/** compiles a parameter with value to MBQL */
+function fieldFilterParameterToMBQL(query, stageIndex, parameter) {
   if (!isFieldFilterParameterConveratableToMBQL(parameter)) {
     return null;
   }
@@ -196,11 +196,21 @@ export function fieldFilterParameterToMBQLFilter(query, stageIndex, parameter) {
 
   const column = columns[columnIndex];
   const fieldRef = Lib.legacyRef(column);
+
   if (isDateParameter(parameter)) {
     return dateParameterValueToMBQL(parameter.value, fieldRef);
   } else if (Lib.isNumeric(column)) {
     return numberParameterValueToMBQL(parameter, fieldRef);
   } else {
     return stringParameterValueToMBQL(parameter, fieldRef);
+  }
+}
+
+export function fieldFilterParameterToFilter(query, stageIndex, parameter) {
+  const mbql = fieldFilterParameterToMBQL(query, stageIndex, parameter);
+  if (mbql) {
+    return Lib.expressionClauseForLegacyExpression(query, stageIndex, mbql);
+  } else {
+    return null;
   }
 }

--- a/frontend/src/metabase-lib/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase-lib/parameters/utils/mbql.unit.spec.js
@@ -1,22 +1,16 @@
 // eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
-import { createMockMetadata } from "__support__/metadata";
-import {
-  createSampleDatabase,
-  PRODUCTS,
-} from "metabase-types/api/mocks/presets";
+import * as Lib from "metabase-lib";
+import { ORDERS, PRODUCTS } from "metabase-types/api/mocks/presets";
 import {
   dateParameterValueToMBQL,
   stringParameterValueToMBQL,
   numberParameterValueToMBQL,
-  fieldFilterParameterToMBQLFilter,
+  fieldFilterParameterToFilter,
 } from "metabase-lib/parameters/utils/mbql";
+import { createQuery } from "metabase-lib/test-helpers";
 
 describe("parameters/utils/mbql", () => {
-  const metadata = createMockMetadata({
-    databases: [createSampleDatabase()],
-  });
-
   describe("dateParameterValueToMBQL", () => {
     const date = () =>
       moment().utc().hours(0).minutes(0).seconds(0).milliseconds(0);
@@ -245,10 +239,13 @@ describe("parameters/utils/mbql", () => {
     });
   });
 
-  describe("fieldFilterParameterToMBQLFilter", () => {
+  describe("fieldFilterParameterToFilter", () => {
+    const query = createQuery();
+    const stageIndex = -1;
+
     it("should return null for parameter targets that are not field dimension targets", () => {
       expect(
-        fieldFilterParameterToMBQLFilter({
+        fieldFilterParameterToFilter(query, stageIndex, {
           target: null,
           type: "category",
           value: ["foo"],
@@ -256,7 +253,7 @@ describe("parameters/utils/mbql", () => {
       ).toBe(null);
 
       expect(
-        fieldFilterParameterToMBQLFilter({
+        fieldFilterParameterToFilter(query, stageIndex, {
           target: [],
           type: "category",
           value: ["foo"],
@@ -264,7 +261,7 @@ describe("parameters/utils/mbql", () => {
       ).toBe(null);
 
       expect(
-        fieldFilterParameterToMBQLFilter({
+        fieldFilterParameterToFilter(query, stageIndex, {
           target: ["dimension"],
           type: "category",
           value: ["foo"],
@@ -272,7 +269,7 @@ describe("parameters/utils/mbql", () => {
       ).toBe(null);
 
       expect(
-        fieldFilterParameterToMBQLFilter({
+        fieldFilterParameterToFilter(query, stageIndex, {
           target: ["dimension", ["template-tag", "foo"]],
           type: "category",
           value: ["foo"],
@@ -281,100 +278,74 @@ describe("parameters/utils/mbql", () => {
     });
 
     it("should return mbql filter for date parameter", () => {
-      expect(
-        fieldFilterParameterToMBQLFilter(
-          {
-            target: ["dimension", ["field", PRODUCTS.CREATED_AT, null]],
-            type: "date/single",
-            value: "01-01-2020",
-          },
-          metadata,
-        ),
-      ).toEqual(["=", ["field", PRODUCTS.CREATED_AT, null], "01-01-2020"]);
+      const filter = fieldFilterParameterToFilter(query, stageIndex, {
+        target: ["dimension", ["field", ORDERS.CREATED_AT, null]],
+        type: "date/single",
+        value: "01-01-2020",
+      });
+      expect(Lib.displayInfo(query, stageIndex, filter)).toMatchObject({
+        displayName: "Created At is on 01-01-2020",
+      });
     });
 
     it("should return mbql filter for string parameter", () => {
-      expect(
-        fieldFilterParameterToMBQLFilter(
-          {
-            target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-            type: "string/contains",
-            value: "foo",
-          },
-          metadata,
-        ),
-      ).toEqual([
-        "contains",
-        ["field", PRODUCTS.CATEGORY, null],
-        "foo",
-        {
-          "case-sensitive": false,
-        },
-      ]);
+      const containsFilter = fieldFilterParameterToFilter(query, stageIndex, {
+        target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+        type: "string/contains",
+        value: "foo",
+      });
+      expect(Lib.displayInfo(query, stageIndex, containsFilter)).toMatchObject({
+        displayName: "Category contains foo",
+      });
 
-      expect(
-        fieldFilterParameterToMBQLFilter(
-          {
-            target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-            type: "string/starts-with",
-            value: ["foo"],
-          },
-          metadata,
-        ),
-      ).toEqual([
-        "starts-with",
-        ["field", PRODUCTS.CATEGORY, null],
-        "foo",
-        { "case-sensitive": false },
-      ]);
+      const startsFilter = fieldFilterParameterToFilter(query, stageIndex, {
+        target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+        type: "string/starts-with",
+        value: ["foo"],
+      });
+      expect(Lib.displayInfo(query, stageIndex, startsFilter)).toMatchObject({
+        displayName: "Category starts with foo",
+      });
     });
 
     it("should return mbql filter for category parameter", () => {
-      expect(
-        fieldFilterParameterToMBQLFilter(
-          {
-            target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
-            type: "category",
-            value: ["foo", "bar"],
-          },
-          metadata,
-        ),
-      ).toEqual(["=", ["field", PRODUCTS.CATEGORY, null], "foo", "bar"]);
+      const filter = fieldFilterParameterToFilter(query, stageIndex, {
+        target: ["dimension", ["field", PRODUCTS.CATEGORY, null]],
+        type: "category",
+        value: ["foo", "bar"],
+      });
+      expect(Lib.displayInfo(query, stageIndex, filter)).toMatchObject({
+        displayName: "Category is 2 selections",
+      });
     });
 
     it("should return mbql filter for number parameter", () => {
-      expect(
-        fieldFilterParameterToMBQLFilter(
-          {
-            target: ["dimension", ["field", PRODUCTS.RATING, null]],
-            type: "number/=",
-            value: [111],
-          },
-          metadata,
-        ),
-      ).toEqual(["=", ["field", PRODUCTS.RATING, null], 111]);
+      const valueFilter = fieldFilterParameterToFilter(query, stageIndex, {
+        target: ["dimension", ["field", PRODUCTS.RATING, null]],
+        type: "number/=",
+        value: 111,
+      });
+      expect(Lib.displayInfo(query, stageIndex, valueFilter)).toMatchObject({
+        displayName: "Rating is equal to 111",
+      });
 
-      expect(
-        fieldFilterParameterToMBQLFilter(
-          {
-            target: ["dimension", ["field", PRODUCTS.RATING, null]],
-            type: "number/=",
-            value: 111,
-          },
-          metadata,
-        ),
-      ).toEqual(["=", ["field", PRODUCTS.RATING, null], 111]);
+      const arrayFilter = fieldFilterParameterToFilter(query, stageIndex, {
+        target: ["dimension", ["field", PRODUCTS.RATING, null]],
+        type: "number/=",
+        value: [111],
+      });
+      expect(Lib.displayInfo(query, stageIndex, arrayFilter)).toMatchObject({
+        displayName: "Rating is equal to 111",
+      });
 
-      expect(
-        fieldFilterParameterToMBQLFilter(
-          {
-            target: ["dimension", ["field", PRODUCTS.RATING, null]],
-            type: "number/between",
-            value: [1, 100],
-          },
-          metadata,
-        ),
-      ).toEqual(["between", ["field", PRODUCTS.RATING, null], 1, 100]);
+      const betweenFilter = fieldFilterParameterToFilter(query, stageIndex, {
+        target: ["dimension", ["field", PRODUCTS.RATING, null]],
+        type: "number/between",
+        value: [1, 100],
+      });
+      expect(Lib.displayInfo(query, stageIndex, betweenFilter)).toMatchObject({
+        displayName: "Rating is between 1 and 100",
+      });
     });
   });
 });

--- a/frontend/src/metabase-lib/parameters/utils/mbql.unit.spec.js
+++ b/frontend/src/metabase-lib/parameters/utils/mbql.unit.spec.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import * as Lib from "metabase-lib";
-import { ORDERS, PRODUCTS } from "metabase-types/api/mocks/presets";
+import { PRODUCTS, PRODUCTS_ID } from "metabase-types/api/mocks/presets";
 import {
   dateParameterValueToMBQL,
   stringParameterValueToMBQL,
@@ -240,7 +240,7 @@ describe("parameters/utils/mbql", () => {
   });
 
   describe("fieldFilterParameterToFilter", () => {
-    const query = createQuery();
+    const query = Lib.withDifferentTable(createQuery(), PRODUCTS_ID);
     const stageIndex = -1;
 
     it("should return null for parameter targets that are not field dimension targets", () => {
@@ -279,7 +279,7 @@ describe("parameters/utils/mbql", () => {
 
     it("should return mbql filter for date parameter", () => {
       const filter = fieldFilterParameterToFilter(query, stageIndex, {
-        target: ["dimension", ["field", ORDERS.CREATED_AT, null]],
+        target: ["dimension", ["field", PRODUCTS.CREATED_AT, null]],
         type: "date/single",
         value: "01-01-2020",
       });

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -373,13 +373,7 @@ class StructuredQuery extends AtomicQuery {
       query = query.setSourceQuery(sourceQuery.clean({ skipFilters }));
     }
 
-    query = query.cleanJoins().cleanExpressions().cleanFields();
-
-    if (!skipFilters) {
-      query = query.cleanFilters();
-    }
-
-    return query.cleanEmpty();
+    return query.cleanJoins().cleanExpressions().cleanFields().cleanEmpty();
   }
 
   /**

--- a/frontend/src/metabase-lib/urls.ts
+++ b/frontend/src/metabase-lib/urls.ts
@@ -14,7 +14,6 @@ type UrlBuilderOpts = {
   includeDisplayIsLocked?: boolean;
   creationType?: string;
   clean?: boolean;
-  cleanFilters?: boolean;
 };
 
 export function getUrl(
@@ -22,7 +21,6 @@ export function getUrl(
   {
     originalQuestion,
     clean = true,
-    cleanFilters = false,
     query,
     includeDisplayIsLocked,
     creationType,
@@ -37,7 +35,6 @@ export function getUrl(
     return Urls.question(null, {
       hash: question._serializeForUrl({
         clean,
-        cleanFilters,
         includeDisplayIsLocked,
         creationType,
       }),
@@ -66,7 +63,6 @@ export function getUrlWithParameters(
 
       return getUrl(questionWithParameters, {
         clean,
-        cleanFilters: true,
         originalQuestion: question,
         includeDisplayIsLocked,
         query: objectId === undefined ? {} : { objectId },

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -1117,7 +1117,14 @@ describe("Question", () => {
 
       expect(questionWithFilters.datasetQuery().query.filter).toEqual([
         "starts-with",
-        ["field", PRODUCTS.CATEGORY, null],
+        [
+          "field",
+          PRODUCTS.CATEGORY,
+          {
+            "base-type": "type/Text",
+            "source-field": ORDERS.PRODUCT_ID,
+          },
+        ],
         "abc",
         { "case-sensitive": false },
       ]);
@@ -1198,7 +1205,7 @@ describe("Question", () => {
           ...assocIn(
             dissoc(card, "id"),
             ["dataset_query", "query", "filter"],
-            ["=", ["field", 1, null], "bar"],
+            ["=", ["field", 1, { "base-type": "type/Text" }], "bar"],
           ),
           original_card_id: card.id,
         };
@@ -1222,7 +1229,7 @@ describe("Question", () => {
             ...assocIn(
               dissoc(card, "id"),
               ["dataset_query", "query", "filter"],
-              ["=", ["field", 2, null], 123],
+              ["=", ["field", 2, { "base-type": "type/Float" }], 123],
             ),
             original_card_id: card.id,
           },
@@ -1241,7 +1248,15 @@ describe("Question", () => {
             ...assocIn(
               dissoc(card, "id"),
               ["dataset_query", "query", "filter"],
-              ["=", ["field", 3, { "temporal-unit": "month" }], "2017-05-01"],
+              [
+                "=",
+                [
+                  "field",
+                  3,
+                  { "base-type": "type/BigInteger", "temporal-unit": "month" },
+                ],
+                "2017-05-01",
+              ],
             ),
             original_card_id: card.id,
           },

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
@@ -31,11 +31,6 @@ describe("StructuredQuery", () => {
         expect(q.clean().query()).toEqual(q.query());
         expect(q.clean() === q).toBe(true);
       });
-
-      it("should remove filters referencing invalid field ID", () => {
-        const q = ordersTable.query().filter(["=", ["field", 12345, null], 42]);
-        expect(q.clean().query()).toEqual({ "source-table": ORDERS_ID });
-      });
     });
 
     describe("aggregations", () => {
@@ -144,22 +139,6 @@ describe("StructuredQuery", () => {
       it("should remove unnecessary layers of nesting via question()", () => {
         const q = ordersTable.query().nest();
         expect(q.clean().query()).toEqual({ "source-table": ORDERS_ID });
-      });
-
-      it("should remove clauses dependent on removed clauses in the parent", () => {
-        const q = ordersTable
-          .query()
-          .breakout(["field", ORDERS.PRODUCT_ID, null])
-          .nest()
-          .filter([
-            "=",
-            ["field", "count", { "base-type": "type/Integer" }],
-            42,
-          ]);
-        expect(q.clean().query()).toEqual({
-          breakout: [["field", ORDERS.PRODUCT_ID, null]],
-          "source-table": ORDERS_ID,
-        });
       });
     });
   });


### PR DESCRIPTION
Modifies `_convertParametersToMbql` to use MLv2 under the hood. The function is used to create MBQL query filters for parameters. It is used to generate a query with filters when clicking on a question with connected parameters in a dashboard.

To make the change simple, uses `expressionClauseForLegacyExpression` and leaves raw mbql manipulation where it was. Dashboard parameters & their widgets heavily rely on (mostly invalid) mbql as their view model, and this is something that cannot be easily changed without migrating dashboard parameter widgets. Example of how it is used below. This is not important for this PR but just for the context. In this example the legacy date picker is used which is also MBQL-based:  https://github.com/metabase/metabase/blob/c8afac24548a9adf346ffff61ebc7d2cf7509184/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx#L31

It should be the last place in the product that creates invalid filter clauses in **simple mode** (we still have notebook steps relying on it). With it gone, we can remove MLv1 filter validation when serializing the query into the URL.