### PR TITLE
Add umbrella isQueryEditable function to ease migration from MLv1 query

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -495,6 +495,11 @@ class Question {
     return (db && db.auto_run_queries) || false;
   }
 
+  isQueryEditable(): boolean {
+    const query = this.query();
+    return query ? query.isEditable() : false;
+  }
+
   /**
    * Returns the type of alert that current question supports
    *
@@ -1103,7 +1108,7 @@ class Question {
       this.isSaved() &&
       this.parameters().length === 0 &&
       this.query().canNest() &&
-      !this.query().readOnly() // originally "canRunAdhocQuery"
+      this.isQueryEditable() // originally "canRunAdhocQuery"
     );
   }
 

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -151,13 +151,6 @@ export default class NativeQuery extends AtomicQuery {
     return database && database.engine;
   }
 
-  /**
-   * Opposite of isEditable
-   */
-  readOnly(): boolean {
-    return !this.isEditable();
-  }
-
   // Whether the user can modify and run this query
   // Determined based on availability of database metadata and native database permissions
   isEditable(): boolean {

--- a/frontend/src/metabase-lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/queries/Query.ts
@@ -83,13 +83,6 @@ class Query {
   }
 
   /**
-   * Returns true if the database metadata (or lack thererof indicates the user can modify and run this query
-   */
-  readOnly(): boolean {
-    return true;
-  }
-
-  /**
    * Dimensions exposed by this query
    * NOTE: Ideally we'd also have `dimensions()` that returns a flat list, but currently StructuredQuery has it's own `dimensions()` for another purpose.
    */

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -199,13 +199,6 @@ class StructuredQuery extends AtomicQuery {
     return database && database.engine;
   }
 
-  /**
-   * Opposite of isEditable
-   */
-  readOnly(): boolean {
-    return !this.isEditable();
-  }
-
   /* Methods unique to this query type */
 
   /**

--- a/frontend/src/metabase-lib/queries/drills/native-drill-fallback.ts
+++ b/frontend/src/metabase-lib/queries/drills/native-drill-fallback.ts
@@ -5,9 +5,8 @@ interface FallbackNativeDrillProps {
 }
 
 export function nativeDrillFallback({ question }: FallbackNativeDrillProps) {
-  const query = question.query();
   const database = question.database();
-  if (!question.isNative() || !query.isEditable() || !database) {
+  if (!question.isNative() || !question.isQueryEditable() || !database) {
     return null;
   }
 

--- a/frontend/src/metabase-lib/urls.ts
+++ b/frontend/src/metabase-lib/urls.ts
@@ -59,7 +59,7 @@ export function getUrlWithParameters(
   if (question.isStructured()) {
     let questionWithParameters = question.setParameters(parameters);
 
-    if (question.query().isEditable()) {
+    if (question.isQueryEditable()) {
       questionWithParameters = questionWithParameters
         .setParameterValues(parameterValues)
         ._convertParametersToMbql();

--- a/frontend/src/metabase/dashboard/actions/navigation.js
+++ b/frontend/src/metabase/dashboard/actions/navigation.js
@@ -51,7 +51,7 @@ export const navigateToNewCardFromDashboard = createThunkAction(
       );
 
       let question = new Question(cardAfterClick, metadata);
-      if (question.query().isEditable()) {
+      if (question.isQueryEditable()) {
         question = question
           .setDisplay(cardAfterClick.display || previousCard.display)
           .setSettings(dashcard.card.visualization_settings)

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -134,7 +134,7 @@ const canEditQuestion = (question: Question) => {
   return (
     question.canWrite() &&
     question.query() != null &&
-    question.query().isEditable()
+    question.isQueryEditable()
   );
 };
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -125,7 +125,7 @@ export function DashCardCardParameterMapper({
     }
 
     const question = new Question(card, metadata);
-    return question.query().isEditable();
+    return question.isQueryEditable();
   }, [card, metadata, isVirtual]);
 
   const { buttonVariant, buttonTooltip, buttonText, buttonIcon } =

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -91,7 +91,7 @@ function ModelDetailPage({
   );
 
   const database = model.database();
-  const hasDataPermissions = model.query().isEditable();
+  const hasDataPermissions = model.isQueryEditable();
   const hasActions = actions.length > 0;
   const hasActionsEnabled = database != null && database.hasActionsEnabled();
   const hasActionsTab = hasActions || hasActionsEnabled;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -319,7 +319,7 @@ async function handleQBInit(
     uiControls.isNativeEditorOpen = isEditing || !question.isSaved();
   }
 
-  if (question.isNative() && !question.query().readOnly()) {
+  if (question.isNative() && question.isQueryEditable()) {
     const query = question.query() as NativeQuery;
     const newQuery = await updateTemplateTagNames(query, getState, dispatch);
     question = question.setQuery(newQuery);

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -607,9 +607,6 @@ describe("QB Actions > initializeQB", () => {
         const clone = { ...card };
 
         jest
-          .spyOn(NativeQuery.prototype, "readOnly")
-          .mockReturnValue(!hasDatabaseWritePermission);
-        jest
           .spyOn(NativeQuery.prototype, "isEditable")
           .mockReturnValue(hasDatabaseWritePermission);
 

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -125,7 +125,7 @@ export const updateQuestion = (
     const shouldTurnIntoAdHoc =
       shouldStartAdHocQuestion &&
       newQuestion.isSaved() &&
-      newQuestion.query().isEditable() &&
+      newQuestion.isQueryEditable() &&
       queryBuilderMode !== "dataset";
 
     if (shouldTurnIntoAdHoc) {

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -179,7 +179,7 @@ export const queryCompleted = (question, queryResults) => {
     const [{ data: prevData }] = getQueryResults(getState()) || [{}];
     const originalQuestion = getOriginalQuestionWithParameterValues(getState());
     const isDirty =
-      question.query().isEditable() &&
+      question.isQueryEditable() &&
       question.isDirtyComparedTo(originalQuestion);
 
     if (isDirty) {

--- a/frontend/src/metabase/query_builder/actions/visualization-settings.js
+++ b/frontend/src/metabase/query_builder/actions/visualization-settings.js
@@ -31,7 +31,7 @@ export const updateCardVisualizationSettings =
     }
 
     // The check allows users without data permission to resize/rearrange columns
-    const hasWritePermissions = question.query().isEditable();
+    const hasWritePermissions = question.isQueryEditable();
     await dispatch(
       updateQuestion(question.updateSettings(settings), {
         run: hasWritePermissions ? "auto" : false,
@@ -46,7 +46,7 @@ export const replaceAllCardVisualizationSettings =
     question = question.setSettings(settings);
 
     // The check allows users without data permission to resize/rearrange columns
-    const hasWritePermissions = question.query().isEditable();
+    const hasWritePermissions = question.isQueryEditable();
     await dispatch(
       updateQuestion(question, {
         run: hasWritePermissions ? "auto" : false,

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -197,7 +197,7 @@ const QuestionActions = ({
     }
   }
 
-  if (!question.query().readOnly()) {
+  if (question.isQueryEditable()) {
     extraButtons.push({
       title: t`Duplicate`,
       icon: "clone",

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -108,7 +108,7 @@ export default class VisualizationResult extends Component {
         this.props,
         ...ALLOWED_VISUALIZATION_PROPS,
       );
-      const hasDrills = this.props.query.isEditable();
+      const hasDrills = question.isQueryEditable();
       return (
         <>
           <Visualization

--- a/frontend/src/metabase/query_builder/components/view/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/FilterHeaderButton.tsx
@@ -45,6 +45,6 @@ FilterHeaderButton.shouldRender = ({
 }: RenderCheckOpts) =>
   queryBuilderMode === "view" &&
   question.isStructured() &&
-  question.query().isEditable() &&
+  question.isQueryEditable() &&
   !isObjectDetail &&
   isActionListVisible;

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -165,7 +165,7 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
     ? question.query().rootQuery()
     : question.query();
 
-  const hasDataPermission = query.isEditable();
+  const hasDataPermission = question.isQueryEditable();
   if (!hasDataPermission) {
     return [];
   }

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters/QuestionFilters.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters/QuestionFilters.tsx
@@ -197,7 +197,7 @@ const shouldRender = ({
 }: RenderCheckOpts) =>
   queryBuilderMode === "view" &&
   question.isStructured() &&
-  question.query().isEditable() &&
+  question.isQueryEditable() &&
   (question.query() as LegacyQuery).topLevelFilters().length > 0 &&
   !isObjectDetail;
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton/QuestionNotebookButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton/QuestionNotebookButton.jsx
@@ -33,6 +33,4 @@ export function QuestionNotebookButton({
 }
 
 QuestionNotebookButton.shouldRender = ({ question, isActionListVisible }) =>
-  question.isStructured() &&
-  question.query().isEditable() &&
-  isActionListVisible;
+  question.isStructured() && question.isQueryEditable() && isActionListVisible;

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -87,8 +87,7 @@ function QuestionRowCount({
     onChangeLimit(limit > 0 ? limit : null);
   };
 
-  const canChangeLimit =
-    question.isStructured() && question.query().isEditable();
+  const canChangeLimit = question.isStructured() && question.isQueryEditable();
 
   const limit = canChangeLimit
     ? Lib.currentLimit(question._getMLv2Query(), -1)

--- a/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
@@ -69,7 +69,7 @@ QuestionSummarizeWidget.shouldRender = ({
   queryBuilderMode === "view" &&
   question &&
   question.isStructured() &&
-  question.query().isEditable() &&
+  question.isQueryEditable() &&
   question.query().table() &&
   !isObjectDetail &&
   isActionListVisible;

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -235,7 +235,7 @@ class View extends Component {
     // So the model is opened as an underlying native question and the query editor becomes visible
     // This check makes it hide the editor in this particular case
     // More details: https://github.com/metabase/metabase/pull/20161
-    if (question.isDataset() && !query.isEditable()) {
+    if (question.isDataset() && !question.isQueryEditable()) {
       return null;
     }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -43,7 +43,7 @@ const ViewFooter = ({
     return null;
   }
 
-  const hasDataPermission = question.query().isEditable();
+  const hasDataPermission = question.isQueryEditable();
   const hideChartSettings = result.error && !hasDataPermission;
 
   return (

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -296,8 +296,7 @@ function AhHocQuestionLeftSide(props) {
   } = props;
 
   const handleTitleClick = () => {
-    const query = question.query();
-    if (!query.readOnly()) {
+    if (question.isQueryEditable()) {
       onOpenModal(MODAL_TYPES.SAVE);
     }
   };
@@ -412,7 +411,7 @@ function ViewTitleHeaderRightSide(props) {
     onModelPersistenceChange,
   } = props;
   const isShowingNotebook = queryBuilderMode === "notebook";
-  const canEditQuery = !question.query().readOnly();
+  const canEditQuery = question.isQueryEditable();
   const hasExploreResultsLink =
     question.canExploreResults() &&
     MetabaseSettings.get("enable-nested-queries");

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
@@ -110,7 +110,7 @@ const ChartTypeSidebar = ({
         }
 
         updateQuestion(newQuestion, {
-          shouldUpdateUrl: question.query().isEditable(),
+          shouldUpdateUrl: question.isQueryEditable(),
         });
         setUIControls({ isShowingRawTable: false });
       }

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -350,7 +350,7 @@ export const getQuestion = createSelector(
 );
 
 function isQuestionEditable(question) {
-  return question.isQueryEditable();
+  return question ? question.isQueryEditable() : false;
 }
 
 function areLegacyQueriesEqual(queryA, queryB, tableMetadata) {

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -350,7 +350,7 @@ export const getQuestion = createSelector(
 );
 
 function isQuestionEditable(question) {
-  return !question?.query().readOnly();
+  return question.isQueryEditable();
 }
 
 function areLegacyQueriesEqual(queryA, queryB, tableMetadata) {
@@ -582,7 +582,7 @@ export const getIsRunnable = createSelector(
       return false;
     }
     if (!question.isSaved() || isDirty) {
-      return question.canRun() && !question.query().readOnly();
+      return question.canRun() && question.isQueryEditable();
     }
     return question.canRun();
   },

--- a/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
@@ -19,7 +19,7 @@ export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
     clicked.value !== undefined ||
     !clicked.column ||
     clicked?.extraData?.isRawTable ||
-    !question.query().isEditable()
+    !question.isQueryEditable()
   ) {
     return [];
   }

--- a/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
@@ -16,7 +16,7 @@ export const HideColumnAction: LegacyDrill = ({
     clicked.value !== undefined ||
     !clicked.column ||
     clicked?.extraData?.isRawTable ||
-    !question.query().isEditable()
+    !question.isQueryEditable()
   ) {
     return [];
   }


### PR DESCRIPTION
We'd like to remove legacy `StructuredQuery` usage across the app. It's often used to check whether the user can edit and run the query. To make migration easier, let's consolidate all `query().isEditable()` calls under one function. Similar to how we call `question.isStructured()` or `question.isNative()`.

I've made it `isQueryEditable` and not `isEditable` because technically read/write permissions of the question itself are based on collection permissions; so let's make it explicit it's about queries.