### PR TITLE
Configurable csv delimiter

### DIFF
--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -219,6 +219,8 @@ export const createMockSettings = (
   "uploads-database-id": null,
   "uploads-table-prefix": null,
   "uploads-schema-name": null,
+  "csv-delimiter": null,
+  "csv-quote": null,
   "user-visibility": null,
   "last-acknowledged-version": "v1",
   ...opts,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -278,6 +278,8 @@ export interface Settings {
   "uploads-database-id": number | null;
   "uploads-schema-name": string | null;
   "uploads-table-prefix": string | null;
+  "csv-delimiter": string | null;
+  "csv-quote": string | null;
   "user-visibility": string | null;
   "last-acknowledged-version": string | null;
 }

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
@@ -315,7 +315,6 @@ export function UploadSettingsView({
           onChangeSetting={onChangeSetting}
           reloadSettings={reloadSettings}
           autoFocus={false}
-          settingValues={settings.csv_delimiter}
         />
         <SettingsSetting
           key={quoteSetting.key}
@@ -326,7 +325,6 @@ export function UploadSettingsView({
           onChangeSetting={onChangeSetting}
           reloadSettings={reloadSettings}
           autoFocus={false}
-          settingValues={settings.csv_quote}
         />
       </ul>
     </>

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
@@ -42,8 +42,6 @@ export interface UploadSettings {
   uploads_database_id: number | null;
   uploads_schema_name: string | null;
   uploads_table_prefix: string | null;
-  csv_delimiter: string;
-  csv_quote: string;
 }
 
 export interface UploadSettingProps {
@@ -63,8 +61,6 @@ export interface UploadSettingProps {
     settingElement: SettingElement,
     newValue: SettingValue,
   ) => void;
-  onChangeSetting?: (key: SettingKey, value: SettingValue) => void;
-  reloadSettings: VoidFunction;
 }
 
 const mapStateToProps = (state: State) => ({
@@ -103,8 +99,6 @@ export function UploadSettingsView({
   settings,
   elements,
   updateSetting,
-  onChangeSetting,
-  reloadSettings,
   updateSettings,
   saveStatusRef,
 }: UploadSettingProps) {
@@ -312,8 +306,6 @@ export function UploadSettingsView({
           onChange={(newValue: SettingValue) =>
             updateSetting(delimiterSetting, newValue)
           }
-          onChangeSetting={onChangeSetting}
-          reloadSettings={reloadSettings}
           autoFocus={false}
         />
         <SettingsSetting
@@ -322,8 +314,6 @@ export function UploadSettingsView({
           onChange={(newValue: SettingValue) =>
             updateSetting(quoteSetting, newValue)
           }
-          onChangeSetting={onChangeSetting}
-          reloadSettings={reloadSettings}
           autoFocus={false}
         />
       </ul>

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
@@ -576,4 +576,16 @@ describe("Admin > Settings > UploadSetting", () => {
       screen.getByText(/uploads to the Sample Database are for testing only/i),
     ).toBeInTheDocument();
   });
+
+  it("should display the csv delimiter field", async () => {
+    setup();
+
+    expect(screen.getByText(/csv quote symbol/i)).toBeInTheDocument();
+  });
+
+  it("should display the csv quote field", async () => {
+    setup();
+
+    expect(screen.getByText(/csv field delimiter symbol/i)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
@@ -2,13 +2,14 @@ import userEvent from "@testing-library/user-event";
 
 import { checkNotNull } from "metabase/lib/types";
 import { getMetadata } from "metabase/selectors/metadata";
-import type { Database } from "metabase-types/api";
+import type { Database, SettingKey } from "metabase-types/api";
 import { createMockDatabase, createMockTable } from "metabase-types/api/mocks";
 import { createMockState } from "metabase-types/store/mocks";
 import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { setupSchemaEndpoints } from "__support__/server-mocks";
 
+import { ADMIN_SETTINGS_SECTIONS } from "../../selectors";
 import type { UploadSettings } from "./UploadSettings";
 import { UploadSettingsView } from "./UploadSettings";
 
@@ -77,6 +78,14 @@ function setup({
   const savingSpy = jest.fn();
   const savedSpy = jest.fn();
   const clearSpy = jest.fn();
+  const updateSettingSpy = jest.fn();
+
+  const uploadSectionElements = ADMIN_SETTINGS_SECTIONS.uploads.settings.map(
+    x => ({
+      ...x,
+      key: x.key as SettingKey,
+    }),
+  );
 
   renderWithProviders(
     <UploadSettingsView
@@ -90,6 +99,8 @@ function setup({
           clear: clearSpy,
         } as any,
       }}
+      elements={uploadSectionElements}
+      updateSetting={updateSettingSpy}
     />,
     { storeInitialState: {} },
   );

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingSelectWithOther.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingSelectWithOther.tsx
@@ -20,17 +20,17 @@ const isOtherSelectValue = (selectValue: UnderlyingType) => {
   return selectValue === OTHER_VALUE_PLACEHOLDER;
 };
 
-interface SelectWithOtherProps {
-  className: string;
+export interface SelectWithOtherProps {
+  className?: string;
   setting: {
     value: UnderlyingType;
     default: UnderlyingType;
     options: { value: string; name: string }[];
-    placeholder: string;
+    placeholder?: string;
   };
   autoFocus?: boolean;
   onChange: (newValue: UnderlyingType) => void;
-  disabled: boolean;
+  disabled?: boolean;
 }
 
 /**

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingSelectWithOther.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingSelectWithOther.tsx
@@ -1,0 +1,112 @@
+/* eslint-disable react/prop-types */
+import cx from "classnames";
+import type { ChangeEventHandler } from "react";
+import {
+  useCallback,
+  type FunctionComponent,
+  useState,
+  useEffect,
+} from "react";
+
+import { t } from "ttag";
+import { Select, Stack, TextInput } from "metabase/ui";
+
+import type { SettingElement } from "../../types";
+
+export const OTHER_VALUE_PLACEHOLDER = "__OTHER";
+export const OTHER_LABEL = t`other`;
+
+const isValueIsOther = (value: string | null) => {
+  return value === OTHER_VALUE_PLACEHOLDER;
+};
+
+interface SelectWithOtherProps<T> {
+  className: string;
+  setting: SettingElement & { value: T; default: T };
+  onChange: any;
+  disabled: boolean;
+}
+
+export const SettingSelectWithOther: FunctionComponent<
+  SelectWithOtherProps<string>
+> = ({ className = "", setting, onChange, disabled = false }) => {
+  const coercedOptions = (setting.options || []).map(option => {
+    return { value: option.value as string, label: option.name };
+  });
+
+  const other = {
+    label: OTHER_LABEL,
+    value: OTHER_VALUE_PLACEHOLDER,
+  } as const;
+
+  const populatedOptions = [...coercedOptions, other];
+
+  const valueToSearchInOptions = setting.value ?? setting.default;
+
+  const valueFoundInOptions = coercedOptions.filter(
+    x => x.value === valueToSearchInOptions,
+  )[0]?.value;
+
+  const initSelectValue = valueFoundInOptions ?? OTHER_VALUE_PLACEHOLDER;
+  const initSelectValueAsStr = initSelectValue;
+
+  const [selectValue, setSelectValue] = useState<string>(initSelectValueAsStr);
+  const [textValue, setTextValue] = useState<string>();
+
+  useEffect(() => {
+    setTextValue(valueToSearchInOptions);
+    setSelectValue(initSelectValueAsStr);
+  }, [initSelectValueAsStr, setting.value, valueToSearchInOptions]);
+
+  const handleSelectChange = useCallback(
+    value => {
+      setSelectValue(value);
+      if (!isValueIsOther(value)) {
+        setTextValue(value);
+        onChange(value);
+      }
+    },
+    [onChange],
+  );
+
+  const handleTextInputChange = useCallback<
+    ChangeEventHandler<HTMLInputElement>
+  >(e => {
+    const value = e.target.value;
+    setTextValue(value);
+  }, []);
+
+  const handleTextInputBlur = useCallback<ChangeEventHandler<HTMLInputElement>>(
+    e => {
+      const value = e.target.value;
+      setTextValue(value);
+      if (isValueIsOther(selectValue)) {
+        onChange(value);
+      }
+    },
+    [onChange, selectValue],
+  );
+
+  return (
+    <Stack>
+      <Select
+        className={cx("SettingsInput", className)}
+        placeholder={setting.placeholder}
+        value={selectValue || ""}
+        disabled={disabled}
+        onChange={handleSelectChange}
+        data={populatedOptions}
+      />
+
+      {isValueIsOther(selectValue) && (
+        <TextInput
+          className={cx("SettingsInput", className)}
+          value={textValue || ""}
+          onChange={handleTextInputChange}
+          onBlur={handleTextInputBlur}
+          disabled={disabled}
+        />
+      )}
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingSelectWithOther.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingSelectWithOther.tsx
@@ -34,7 +34,7 @@ export interface SelectWithOtherProps {
 }
 
 /**
- * A widget which allows to choose a value from a list of options or input a different value.
+ * Widget which allows to choose a value from a list of options or input a different value.
  * Under the hood the widget consist of a `Select` component
  * and a `TextInput` shown only if "other" option is selected
  *
@@ -66,9 +66,8 @@ export const SettingSelectWithOther: FunctionComponent<
     },
   ];
 
-  // look up for the raw value in the list of options
-  // raw value might be null which means it should be the default one
-  // in that case look up for the default value
+  // trying to locate the value in the list of options
+  // null value should be treated as the setting's default
   const effectiveValue = value ?? setting.default;
   const valueFoundInOptions = coercedOptions.filter(
     x => x.value === effectiveValue,
@@ -81,7 +80,7 @@ export const SettingSelectWithOther: FunctionComponent<
     useState<UnderlyingType>(initSelectValue);
   const [textValue, setTextValue] = useState<UnderlyingType>(initTextValue);
 
-  // update states when the compo
+  // re-render when the value is changed from the outside
   useEffect(() => {
     setTextValue(initTextValue);
     setSelectValue(initSelectValue);
@@ -92,7 +91,7 @@ export const SettingSelectWithOther: FunctionComponent<
       setSelectValue(newValue);
 
       if (isOtherSelectValue(newValue)) {
-        // display an empty text input to the user when switching to other value
+        // display an empty text input to the user when switching to the "other" value
         setTextValue(null);
       } else {
         onChange(newValue);

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingSelectWithOther.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingSelectWithOther.unit.spec.tsx
@@ -46,7 +46,7 @@ const commonOptions = [
 ];
 
 describe("SettingSelectWithOther", () => {
-  it("should correctly display default value", () => {
+  it("should correctly display the default value", () => {
     const setupOpts: SetupOpts = {
       key: "test",
       value: null,
@@ -64,7 +64,7 @@ describe("SettingSelectWithOther", () => {
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
-  it("should correctly display a value from options", () => {
+  it("should correctly display a value from the options", () => {
     const setupOpts: SetupOpts = {
       key: "test",
       value: "2",
@@ -82,7 +82,7 @@ describe("SettingSelectWithOther", () => {
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
-  it("should correctly display other value", () => {
+  it('should correctly display the "other" value', () => {
     const setupOpts: SetupOpts = {
       key: "test",
       value: "some other",
@@ -101,7 +101,7 @@ describe("SettingSelectWithOther", () => {
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
-  it("should correctly switch from one value from options to another", () => {
+  it("should correctly switch from a value from the options to another one", () => {
     const setupOpts: SetupOpts = {
       key: "test",
       value: null,
@@ -118,7 +118,7 @@ describe("SettingSelectWithOther", () => {
     expect(onChange).toHaveBeenCalledWith("2");
   });
 
-  it('should display textbox when switching to "other" value', () => {
+  it('should display textbox when switching to the "other" value', () => {
     const setupOpts: SetupOpts = {
       key: "test",
       value: null,
@@ -138,7 +138,7 @@ describe("SettingSelectWithOther", () => {
     expect(onChange).toHaveBeenCalledTimes(0);
   });
 
-  it('should not call onChange before finishing inputting "other" value', () => {
+  it("should not call onChange before a user finishes inputting the value into the textbox", () => {
     const setupOpts: SetupOpts = {
       key: "test",
       value: null,
@@ -183,7 +183,7 @@ describe("SettingSelectWithOther", () => {
     expect(onChange).toHaveBeenCalledWith("something");
   });
 
-  it('should correctly switch from the "other" value to the value from options', () => {
+  it('should correctly switch from the "other" value to the value from the options', () => {
     const setupOpts: SetupOpts = {
       key: "test",
       value: "some other",

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingSelectWithOther.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingSelectWithOther.unit.spec.tsx
@@ -1,0 +1,207 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SettingSelectWithOther } from "./SettingSelectWithOther";
+
+type Value = string | null;
+
+interface SetupOpts {
+  key: string;
+  value: Value;
+  defaultValue: string;
+  options: { name: string; value: string }[];
+}
+
+function setup({ key, value, defaultValue, options }: SetupOpts) {
+  const onChange = jest.fn();
+  render(
+    <SettingSelectWithOther
+      key={key}
+      setting={{
+        options: options,
+        default: defaultValue,
+        value: value,
+      }}
+      onChange={onChange}
+      className={""}
+      disabled={false}
+    />,
+  );
+
+  return { onChange };
+}
+
+const commonOptions = [
+  {
+    value: "1",
+    name: "one",
+  },
+  {
+    value: "2",
+    name: "two",
+  },
+  {
+    value: "3",
+    name: "three",
+  },
+];
+
+describe("SettingSelectWithOther", () => {
+  it("should correctly display default value", () => {
+    const setupOpts: SetupOpts = {
+      key: "test",
+      value: null,
+      defaultValue: "1",
+      options: commonOptions,
+    };
+    const { onChange } = setup(setupOpts);
+
+    const searchBox = screen.getByRole("searchbox");
+    const textInput = screen.queryByRole("textbox");
+
+    expect(searchBox).toBeInTheDocument();
+    expect(textInput).not.toBeInTheDocument();
+    expect(searchBox).toHaveValue("one");
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it("should correctly display a value from options", () => {
+    const setupOpts: SetupOpts = {
+      key: "test",
+      value: "2",
+      defaultValue: "1",
+      options: commonOptions,
+    };
+    const { onChange } = setup(setupOpts);
+
+    const searchBox = screen.getByRole("searchbox");
+    const textInput = screen.queryByRole("textbox");
+
+    expect(searchBox).toBeInTheDocument();
+    expect(textInput).not.toBeInTheDocument();
+    expect(searchBox).toHaveValue("two");
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it("should correctly display other value", () => {
+    const setupOpts: SetupOpts = {
+      key: "test",
+      value: "some other",
+      defaultValue: "1",
+      options: commonOptions,
+    };
+    const { onChange } = setup(setupOpts);
+
+    const searchBox = screen.getByRole("searchbox");
+    const textInput = screen.getByRole("textbox");
+
+    expect(searchBox).toBeInTheDocument();
+    expect(textInput).toBeInTheDocument();
+    expect(textInput).toHaveValue("some other");
+    expect(searchBox).toHaveValue("Other");
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it("should correctly switch from one value from options to another", () => {
+    const setupOpts: SetupOpts = {
+      key: "test",
+      value: null,
+      defaultValue: "1",
+      options: commonOptions,
+    };
+    const { onChange } = setup(setupOpts);
+
+    userEvent.click(screen.getByRole("searchbox"));
+    userEvent.click(screen.getByText("two"));
+
+    const textInput = screen.queryByRole("textbox");
+    expect(textInput).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith("2");
+  });
+
+  it('should display textbox when switching to "other" value', () => {
+    const setupOpts: SetupOpts = {
+      key: "test",
+      value: null,
+      defaultValue: "1",
+      options: commonOptions,
+    };
+    const { onChange } = setup(setupOpts);
+
+    userEvent.click(screen.getByRole("searchbox"));
+    userEvent.click(screen.getByText("Other"));
+
+    // do not type anything
+
+    const textInput = screen.getByRole("textbox");
+
+    expect(textInput).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('should not call onChange before finishing inputting "other" value', () => {
+    const setupOpts: SetupOpts = {
+      key: "test",
+      value: null,
+      defaultValue: "1",
+      options: commonOptions,
+    };
+    const { onChange } = setup(setupOpts);
+
+    userEvent.click(screen.getByRole("searchbox"));
+    userEvent.click(screen.getByText("Other"));
+
+    const textInput = screen.getByRole("textbox");
+
+    // input something
+    userEvent.type(textInput, "something");
+    // do no blur
+
+    expect(textInput).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('should call onChange after the "other" value has been input', () => {
+    const setupOpts: SetupOpts = {
+      key: "test",
+      value: null,
+      defaultValue: "1",
+      options: commonOptions,
+    };
+    const { onChange } = setup(setupOpts);
+
+    userEvent.click(screen.getByRole("searchbox"));
+    userEvent.click(screen.getByText("Other"));
+
+    const textInput = screen.getByRole("textbox");
+
+    // input something
+    userEvent.type(textInput, "something");
+    // blur
+    userEvent.tab();
+
+    expect(textInput).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith("something");
+  });
+
+  it('should correctly switch from the "other" value to the value from options', () => {
+    const setupOpts: SetupOpts = {
+      key: "test",
+      value: "some other",
+      defaultValue: "1",
+      options: commonOptions,
+    };
+    const { onChange } = setup(setupOpts);
+
+    const searchBox = screen.getByRole("searchbox");
+
+    userEvent.click(searchBox);
+    userEvent.click(screen.getByText("two"));
+
+    const textInput = screen.queryByRole("textbox");
+
+    expect(searchBox).toBeInTheDocument();
+    expect(textInput).not.toBeInTheDocument();
+    expect(searchBox).toHaveValue("two");
+    expect(onChange).toHaveBeenCalledWith("2");
+  });
+});

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -49,6 +49,7 @@ import {
 } from "./analytics";
 
 import RedirectWidget from "./components/widgets/RedirectWidget";
+import { SettingSelectWithOther } from "./components/widgets/SettingSelectWithOther";
 import {
   InteractiveEmbeddingOptionCard,
   StaticEmbeddingOptionCard,
@@ -413,6 +414,13 @@ export const ADMIN_SETTINGS_SECTIONS = {
         placeholder: ",",
         type: "string",
         required: false,
+        options: [
+          { value: ",", name: t`Comma (default)` },
+          { value: ";", name: t`Semicolon` },
+          { value: "\t", name: t`Tab` },
+          { value: " ", name: t`Space` },
+        ],
+        widget: SettingSelectWithOther,
       },
       {
         key: "csv-quote",
@@ -421,6 +429,11 @@ export const ADMIN_SETTINGS_SECTIONS = {
         placeholder: '"',
         type: "string",
         required: false,
+        options: [
+          { value: '"', name: t`Double quote (default)` },
+          { value: "'", name: t`Single quote` },
+        ],
+        widget: SettingSelectWithOther,
       },
     ],
   },

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -406,6 +406,22 @@ export const ADMIN_SETTINGS_SECTIONS = {
         type: "string",
         required: false,
       },
+      {
+        key: "csv-delimiter",
+        display_name: t`CSV field delimiter symbol`,
+        description: t`Symbol to separate values in the CSV record.`,
+        placeholder: ",",
+        type: "string",
+        required: false,
+      },
+      {
+        key: "csv-quote",
+        display_name: t`CSV quote symbol`,
+        description: t`Symbol which surrounds CSV fields with reserved characters.`,
+        placeholder: '"',
+        type: "string",
+        required: false,
+      },
     ],
   },
 

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -411,7 +411,6 @@ export const ADMIN_SETTINGS_SECTIONS = {
         key: "csv-delimiter",
         display_name: t`CSV field delimiter symbol`,
         description: t`Symbol to separate values in the CSV record.`,
-        placeholder: ",",
         type: "string",
         required: false,
         options: [
@@ -426,7 +425,6 @@ export const ADMIN_SETTINGS_SECTIONS = {
         key: "csv-quote",
         display_name: t`CSV quote symbol`,
         description: t`Symbol which surrounds CSV fields with reserved characters.`,
-        placeholder: '"',
         type: "string",
         required: false,
         options: [

--- a/frontend/src/metabase/admin/settings/types.ts
+++ b/frontend/src/metabase/admin/settings/types.ts
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import type { ReactElement, FunctionComponent } from "react";
 import type {
   SettingDefinition,
   SettingKey,
@@ -23,7 +23,7 @@ export type SettingElement = {
   noHeader?: boolean;
   disableDefaultUpdate?: boolean;
   validations?: [string, string][];
-  widget?: ReactElement;
+  widget?: ReactElement | FunctionComponent<any>;
   warningMessage?: string;
   postUpdateActions?: VoidFunction[];
   getProps?: (setting: SettingDefinition) => Record<string, any>;

--- a/frontend/src/metabase/admin/settings/utils.ts
+++ b/frontend/src/metabase/admin/settings/utils.ts
@@ -1,13 +1,14 @@
 import { t } from "ttag";
+import type { SettingElement } from "./types";
 
 // in order to prevent collection of identifying information only fields
 // that are explicitly marked as collectable or booleans should show the true value
-export const prepareAnalyticsValue = setting =>
+export const prepareAnalyticsValue = (setting: any) =>
   setting.allowValueCollection || setting.type === "boolean"
     ? setting.value
     : "success";
 
-export const settingToFormField = setting => ({
+export const settingToFormField = (setting: any) => ({
   name: setting.key,
   description: setting.description,
   placeholder: setting.is_env_setting
@@ -17,4 +18,14 @@ export const settingToFormField = setting => ({
   autoFocus: setting.autoFocus,
 });
 
-export const settingToFormFieldId = setting => `setting-${setting.key}`;
+export const settingToFormFieldId = (setting: any) => `setting-${setting.key}`;
+
+export function getSettingsElementWithKnownKey(
+  elements: SettingElement[],
+  key: string,
+) {
+  const element = elements.filter(x => x.key === key);
+  // eslint-disable-next-line no-console
+  console.assert(element.length === 1);
+  return element[0];
+}

--- a/frontend/src/metabase/admin/settings/utils.ts
+++ b/frontend/src/metabase/admin/settings/utils.ts
@@ -25,7 +25,11 @@ export function getSettingsElementWithKnownKey(
   key: string,
 ) {
   const element = elements.filter(x => x.key === key);
-  // eslint-disable-next-line no-console
-  console.assert(element.length === 1);
+  if (element.length !== 1) {
+    const allElementKeys = elements.map(x => x.key).join(", ");
+    throw new Error(
+      `Key ${key} was expected to be found in the following list of elements: ${allElementKeys}`,
+    );
+  }
   return element[0];
 }

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -208,7 +208,9 @@
      subscription-allowed-domains
      uploads-enabled
      uploads-database-id
-     uploads-schema-name})
+     uploads-schema-name
+     csv-delimiter
+     csv-quote})
 
 (defmethod serdes/extract-all "Setting" [_model _opts]
   (for [{:keys [key value]} (admin-writable-site-wide-settings

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -245,6 +245,8 @@
 (defmethod default-tag-for-type :double    [_] `Double)
 (defmethod default-tag-for-type :timestamp [_] `Temporal)
 (defmethod default-tag-for-type :keyword   [_] `Keyword)
+(defmethod default-tag-for-type :char      [_] `Character)
+
 
 (defn- validate-default-value-for-type
   "Check whether the `:default` value of a Setting (if provided) agrees with the Setting's `:type` and its `:tag` (which
@@ -640,6 +642,11 @@
   [_setting-type setting-definition-or-name]
   (get-raw-value setting-definition-or-name sequential? (comp first csv/read-csv)))
 
+(defmethod get-value-of-type :char
+  [_setting-type setting-definition-or-name]
+  (get-raw-value setting-definition-or-name char? #(clojure.core/get % 0)))
+
+
 (defn- default-getter-for-type [setting-type]
   (partial get-value-of-type (keyword setting-type)))
 
@@ -825,6 +832,11 @@
 (defmethod set-value-of-type! :csv
   [_setting-type setting-definition-or-name new-value]
   (set-value-of-type! :string setting-definition-or-name (serialize-csv new-value)))
+
+(defmethod set-value-of-type! :char
+  [_setting-type setting-definition-or-name new-value]
+  (set-value-of-type! :string setting-definition-or-name (str new-value)))
+
 
 (defn- default-setter-for-type [setting-type]
   (partial set-value-of-type! (keyword setting-type)))

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -753,3 +753,10 @@
   :visibility :authenticated
   :type       :string
   :audit      :getter)
+
+(defsetting csv-delimiter
+  (deferred-tru "Character used to separate values in the CSV record")
+  :visibility :authenticated
+  :type       :char
+  :audit      :getter
+  :default    \,)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -755,8 +755,15 @@
   :audit      :getter)
 
 (defsetting csv-delimiter
-  (deferred-tru "Character used to separate values in the CSV record")
+  (deferred-tru "Symbol to separate values in the CSV record")
   :visibility :authenticated
   :type       :char
   :audit      :getter
   :default    \,)
+
+(defsetting csv-quote
+  (deferred-tru "Symbol which surrounds CSV fields with reserved characters")
+  :visibility :authenticated
+  :type       :char
+  :audit      :getter
+  :default    \")

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -407,7 +407,7 @@
   "Loads a table from a CSV file. If the table already exists, it will throw an error.
    Returns the file size, number of rows, and number of columns."
   ([driver db-id table-name ^File csv-file]
-   (load-from-csv! driver db-id table-name csv-file))
+   (load-from-csv! driver db-id table-name csv-file {}))
   ([driver db-id table-name ^File csv-file opts]
    (with-open [reader (bom/bom-reader csv-file)]
      (let [{:keys [header rows]}   (read-headers+rows-from-csv reader opts)

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -385,6 +385,19 @@
       auto-pk-indices
       (map (partial remove-indices auto-pk-indices)))))
 
+(defn- read-csv-with-opts
+  "Wraps around the `clojure.data.csv/read-csv` function guarding from nils and values of incorrect types.
+
+   Accepts a map of options with the following possible keys:
+   :delimiter - delimiter symbol
+   :quote     - quote symbol."
+  [input {:keys [delimiter quote]}]
+  (let [delimiter (or delimiter \,)
+        quote (or quote \")]
+    (assert (char? delimiter))
+    (assert (char? quote))
+    (csv/read-csv input :separator delimiter :quote quote)))
+
 (defn- load-from-csv!
   "Loads a table from a CSV file. If the table already exists, it will throw an error.
    Returns the file size, number of rows, and number of columns."

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -67,6 +67,10 @@
   :setter     :none
   :getter     (constantly true))
 
+(defsetting test-char-setting
+  "Test setting - this only shows up in dev (9)"
+  :type       :char)
+
 (def ^:private ^:dynamic *enabled?* false)
 
 (defsetting test-enabled-setting-no-default
@@ -414,6 +418,38 @@
       (is (= false
              (test-boolean-setting))))))
 
+;;; ------------------------------------------------- CHAR SETTINGS --------------------------------------------------
+
+(deftest char-settings-tag-test
+  (testing "Char settings should have correct `:tag` metadata"
+    (test-assert-setting-has-tag #'test-char-setting 'java.lang.Character)))
+
+(deftest char-setting-user-facing-info-test
+  (testing "user-facing info should return `nil` for empty setting "
+   (is (= {:value nil, :is_env_setting false, :env_name "MB_TEST_CHAR_SETTING", :default nil}
+          (user-facing-info-with-db-and-env-var-values :test-char-setting nil nil)))))
+
+(deftest set-char-setting-test
+  (testing "should be able to set char settings with a char value"
+    (is (= "a"
+           (test-char-setting! \a)))
+    (is (= \a
+           (do
+             (test-char-setting! \a)
+             (test-char-setting)))))
+  (testing "should be able to set char settings with a string value"
+    (is (= "a"
+           (test-char-setting! "a")))
+    (is (= \a
+           (do
+             (test-char-setting! "a")
+             (test-char-setting))))
+    (is (= "aaaa"
+           (test-char-setting! "aaaa")))
+    (is (= \a
+           (do
+             (test-char-setting! "aaaa")
+             (test-char-setting))))))
 
 ;;; ------------------------------------------------- JSON SETTINGS --------------------------------------------------
 

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -370,18 +370,18 @@
            [nil \']
            [\; \']]]
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-                     (testing (format "Passing delimiter: '%s' and quote '%s' into the [[upload/detect-schema]] function" delimiter quote)
-                       (is (=? (with-ai-id {:name             vchar-type
-                                            :age              int-type
-                                            :favorite_pokemon vchar-type})
-                               (@#'upload/detect-schema
-                                (csv-file-with (->> ["Name, Age, Favorite Pokémon"
-                                                     "Tim, 12, ___Haunter___"
-                                                     "Ryan, 97, Paras"]
-                                                    (map #(str/replace % "," (str (or delimiter \,))))
-                                                    (map #(str/replace % "___" (str (or quote \"))))))
-                                {:delimiter delimiter
-                                 :quote quote})))))))
+      (testing (format "Passing delimiter: '%s' and quote '%s' into the [[upload/detect-schema]] function" delimiter quote)
+        (is (=? (with-ai-id {:name             vchar-type
+                             :age              int-type
+                             :favorite_pokemon vchar-type})
+                (@#'upload/detect-schema
+                 (csv-file-with (->> ["Name, Age, Favorite Pokémon"
+                                      "Tim, 12, ___Haunter___"
+                                      "Ryan, 97, Paras"]
+                                     (map #(str/replace % "," (str (or delimiter \,))))
+                                     (map #(str/replace % "___" (str (or quote \"))))))
+                 {:delimiter delimiter
+                  :quote quote})))))))
 
 
 (deftest ^:parallel detect-schema-dates-test
@@ -498,54 +498,54 @@
            [\; \']]]
     (testing (format "Passing delimiter: '%s' and quote '%s' into the [[upload/load-from-csv!]] function" delimiter quote)
       (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-                       (with-mysql-local-infile-on-and-off
-                         (mt/with-empty-db
-                           (@#'upload/load-from-csv!
-                            driver/*driver*
-                            (mt/id)
-                            "upload_test"
-                            (csv-file-with (->> ["id    ,nulls,string ,bool ,number       ,date      ,datetime"
-                                                 "2\t   ,,          a ,true ,1.1\t        ,2022-01-01,2022-01-01T00:00:00"
-                                                 "___ 3___,,           b,false,___$ 1000.1___,2022-02-01,2022-02-01T00:00:00"]
-                                                (map #(str/replace % "," (str (or delimiter \,))))
-                                                (map #(str/replace % "___" (str (or quote \"))))))
-                            {:delimiter delimiter
-                             :quote quote})
-                           (testing "Table and Fields exist after sync"
-                             (sync/sync-database! (mt/db))
-                             (let [table (t2/select-one Table :db_id (mt/id))]
-                               (is (=? {:name         #"(?i)upload_test"
-                                        :display_name "Upload Test"}
-                                       table))
-                               (is (=? {:name          #"(?i)_mb_row_id"
-                                        :semantic_type :type/PK
-                                        :base_type     :type/BigInteger}
-                                       (t2/select-one Field :database_position 0 :table_id (:id table))))
-                               (is (=? {:name          #"(?i)id"
-                                        :semantic_type :type/PK
-                                        :base_type     :type/BigInteger}
-                                       (t2/select-one Field :database_position 1 :table_id (:id table))))
-                               (is (=? {:name      #"(?i)nulls"
-                                        :base_type :type/Text}
-                                       (t2/select-one Field :database_position 2 :table_id (:id table))))
-                               (is (=? {:name      #"(?i)string"
-                                        :base_type :type/Text}
-                                       (t2/select-one Field :database_position 3 :table_id (:id table))))
-                               (is (=? {:name      #"(?i)bool"
-                                        :base_type :type/Boolean}
-                                       (t2/select-one Field :database_position 4 :table_id (:id table))))
-                               (is (=? {:name      #"(?i)number"
-                                        :base_type :type/Float}
-                                       (t2/select-one Field :database_position 5 :table_id (:id table))))
-                               (is (=? {:name      #"(?i)date"
-                                        :base_type :type/Date}
-                                       (t2/select-one Field :database_position 6 :table_id (:id table))))
-                               (is (=? {:name      #"(?i)datetime"
-                                        :base_type :type/DateTime}
-                                       (t2/select-one Field :database_position 7 :table_id (:id table))))
-                               (testing "Check the data was uploaded into the table"
-                                 (is (= 2
-                                        (count (rows-for-table table)))))))))))))
+        (with-mysql-local-infile-on-and-off
+          (mt/with-empty-db
+            (@#'upload/load-from-csv!
+             driver/*driver*
+             (mt/id)
+             "upload_test"
+             (csv-file-with (->> ["id    ,nulls,string ,bool ,number       ,date      ,datetime"
+                                  "2\t   ,,          a ,true ,1.1\t        ,2022-01-01,2022-01-01T00:00:00"
+                                  "___ 3___,,           b,false,___$ 1000.1___,2022-02-01,2022-02-01T00:00:00"]
+                                 (map #(str/replace % "," (str (or delimiter \,))))
+                                 (map #(str/replace % "___" (str (or quote \"))))))
+             {:delimiter delimiter
+              :quote quote})
+            (testing "Table and Fields exist after sync"
+              (sync/sync-database! (mt/db))
+              (let [table (t2/select-one Table :db_id (mt/id))]
+                (is (=? {:name         #"(?i)upload_test"
+                         :display_name "Upload Test"}
+                        table))
+                (is (=? {:name          #"(?i)_mb_row_id"
+                         :semantic_type :type/PK
+                         :base_type     :type/BigInteger}
+                        (t2/select-one Field :database_position 0 :table_id (:id table))))
+                (is (=? {:name          #"(?i)id"
+                         :semantic_type :type/PK
+                         :base_type     :type/BigInteger}
+                        (t2/select-one Field :database_position 1 :table_id (:id table))))
+                (is (=? {:name      #"(?i)nulls"
+                         :base_type :type/Text}
+                        (t2/select-one Field :database_position 2 :table_id (:id table))))
+                (is (=? {:name      #"(?i)string"
+                         :base_type :type/Text}
+                        (t2/select-one Field :database_position 3 :table_id (:id table))))
+                (is (=? {:name      #"(?i)bool"
+                         :base_type :type/Boolean}
+                        (t2/select-one Field :database_position 4 :table_id (:id table))))
+                (is (=? {:name      #"(?i)number"
+                         :base_type :type/Float}
+                        (t2/select-one Field :database_position 5 :table_id (:id table))))
+                (is (=? {:name      #"(?i)date"
+                         :base_type :type/Date}
+                        (t2/select-one Field :database_position 6 :table_id (:id table))))
+                (is (=? {:name      #"(?i)datetime"
+                         :base_type :type/DateTime}
+                        (t2/select-one Field :database_position 7 :table_id (:id table))))
+                (testing "Check the data was uploaded into the table"
+                  (is (= 2
+                         (count (rows-for-table table)))))))))))))
 
 (deftest load-from-csv-date-test
   (testing "Upload a CSV file with a datetime column"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.upload-test
   (:require
    [clj-bom.core :as bom]
-   [clojure.data.csv :as csv]
    [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
@@ -26,6 +25,14 @@
    [toucan2.core :as t2])
   (:import
    (java.io File)))
+
+;; CSV parsing functions use csv-delimeter and csv-quote public settings
+;; In order to avoid inconsistent test result based on the repl state
+;; run each test with the default CSV parsing settings
+(use-fixtures :each (fn [f]
+                      (with-redefs
+                       [upload/get-csv-opts (constantly {})]
+                        (f))))
 
 (set! *warn-on-reflection* true)
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/10256

### Description

Provides users with the means to modify CSV parsing behavior.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Make sure uploads are enabled and turned on
2. Prepare a CSV file with non-standard delimiter and (or) quote symbol
2. Navigate to `Admin settings` -> `Uploads`.
3. Adjust the CSV settings (see screenshot) to match the format of the test file
4. Upload the file into a new collection
5. The collection should be populated with the content of the test file 

### Demo

![Screenshot from 2023-12-26 02-18-46](https://github.com/metabase/metabase/assets/1190257/3b82ce63-3cef-44e6-9d40-7e199539aa50)

### Checklist

- [ x] Tests have been added/updated to cover changes in this PR

### Additional notes

As originally requested, this PR introduces two additional public settings: **csv delimiter symbol** and **csv quote symbol**. These settings are located in the Admin section next to the other uploads config.  

Technically it is implemented in the following way:
* A new type of settings has been added: `char` type
* Public settings for the corresponding csv-parser parameters have been added
* The settings are passed to the `csv-reader` in `uploads.clj`
* On the frontend side an additional widget was added to provide some good predefined options for the user to chose from 

All the new logic is covered with tests.

### Further considerations

The current solution provides the functionality requested in the original issue. However I can think of several caveats in regards to the user experience

1. The settings are hidden deep inside the admin panel. When a user uploads a file they have no clear indication of what formatting options is being used
2. An admin access is required every time a user would need to upload a CSV file with a different format.

Here is what I can think of to further deal with the issues above (in order of implementation complexity)

1. Also display the current CSV settings next to the upload button

The easiest solution so far, requiring only cosmetic changes at the frontend 

2. Allow to specify CSV settings every time a user uploads a file

Requires API changes as well as more complex changes to the UI

3. Guess the settings (at least the delimiter symbol) (e.g as implemented in open office)
![Screenshot from 2023-12-26 02-43-43](https://github.com/metabase/metabase/assets/1190257/2dbea8a1-2a62-4f3b-871d-e36782ff5165)

Requires adding new API endpoints and new parsing step. The preview windows needs to be designed and implemented as well.