### PR TITLE
Prevent Admin > People header from "jumping"

### DIFF
--- a/frontend/src/metabase/components/AdminPaneLayout/AdminPaneLayout.styled.tsx
+++ b/frontend/src/metabase/components/AdminPaneLayout/AdminPaneLayout.styled.tsx
@@ -8,7 +8,7 @@ export const Container = styled.section`
 export const HeadingContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: flex-start;
   gap: 0 1rem;
   min-height: 42px;
 `;


### PR DESCRIPTION
Using the `baseline` for the flex `align-items` option is making this header visually jump 
![Kapture 2023-12-27 at 13 58 10](https://github.com/metabase/metabase/assets/31325167/e1004473-735f-4cd0-a293-f0a358e4a539)

For the explanation why and a nice visual representation, please see [this link](https://stackoverflow.com/a/34611670/8815185).

Using `flex-start` keeps all elements in place, regardless of the current view.
![Kapture 2023-12-27 at 14 00 13](https://github.com/metabase/metabase/assets/31325167/80915930-c22f-4084-bf17-8ef6c5d4b660)

Fixes #37129.

