### PR TITLE
Fix filter picker header back button padding

### DIFF
--- a/frontend/src/metabase/querying/components/FilterPicker/FilterPickerHeader/FilterPickerHeader.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterPickerHeader/FilterPickerHeader.tsx
@@ -16,7 +16,9 @@ export function FilterPickerHeader({
   return (
     <FilterHeaderRoot p="sm" justify="space-between">
       {onBack && (
-        <PopoverBackButton onClick={onBack}>{columnName}</PopoverBackButton>
+        <PopoverBackButton pr="md" onClick={onBack}>
+          {columnName}
+        </PopoverBackButton>
       )}
       {children}
     </FilterHeaderRoot>


### PR DESCRIPTION
Fixes a visual regression caused by #36941
Notice there was no space between the back button and the operator picker

| Before | After  |
|--------|-------|
| <img width="356" alt="before" src="https://github.com/metabase/metabase/assets/17258145/5ab2d05d-2425-4fe7-8aad-93f5f5b5961d">            | <img width="361" alt="after" src="https://github.com/metabase/metabase/assets/17258145/02fe8f1c-3c55-4c22-908d-7cbe4cd8ee00">          |

