### PR TITLE
Fix card loading state in different tabs when parameters change

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -94,10 +94,11 @@ export function editDashboard() {
 export function saveDashboard({
   buttonLabel = "Save",
   editBarText = "You're editing this dashboard.",
+  waitMs = 1,
 } = {}) {
   cy.button(buttonLabel).click();
   cy.findByText(editBarText).should("not.exist");
-  cy.wait(1); // this is stupid but necessary to due to the dashboard resizing and detaching elements
+  cy.wait(waitMs); // this is stupid but necessary to due to the dashboard resizing and detaching elements
 }
 
 export function checkFilterLabelAndValue(label, value) {

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -215,7 +215,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       cy.get("aside").findByText("No available targets").should("exist");
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       cy.intercept(
         "GET",
@@ -266,7 +266,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -309,7 +309,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTimeParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -369,7 +369,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -443,7 +443,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("not.exist");
       cy.button("Done").should("be.enabled").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.get("@targetDashboardId").then(targetDashboardId => {
@@ -486,7 +486,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .findByLabelText("Select a dashboard tab")
         .should("not.exist");
       cy.button("Done").should("be.enabled").click();
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.get("@targetDashboardId").then(targetDashboardId => {
@@ -603,7 +603,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addSavedQuestionDestination();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       cy.intercept(
         "GET",
@@ -647,7 +647,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addSavedQuestionCreatedAtParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findByTestId("qb-filters-panel").should(
@@ -686,7 +686,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addSavedQuestionQuantityParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.wait("@dataset");
@@ -756,7 +756,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       onNextAnchorClick(anchor => {
         expect(anchor).to.have.attr("href", URL);
@@ -798,7 +798,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       });
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       cy.button(DASHBOARD_FILTER_TEXT.name).click();
       popover().within(() => {
@@ -851,7 +851,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTextParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -894,7 +894,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("contain.text", COUNT_COLUMN_NAME);
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       editDashboard();
       cy.findByTestId("edit-dashboard-parameters-widget-container")
@@ -902,7 +902,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .click();
       cy.get("aside").button("Remove").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -947,7 +947,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       addTimeParameter();
       cy.get("aside").button("Done").click();
 
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       clickLineChartPoint();
       cy.findAllByTestId("field-set")
@@ -1070,7 +1070,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
       })();
 
       cy.get("aside").button("Done").click();
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       (function testDashboardDestinationClick() {
         cy.log("it handles 'Count' column click");
@@ -1168,7 +1168,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("have.text", "1 column has custom behavior");
 
       cy.get("aside").button("Done").click();
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       getTableCell(COLUMN_INDEX.COUNT)
         .should("have.text", String(POINT_COUNT))
@@ -1264,7 +1264,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("have.text", "2 columns have custom behavior");
 
       cy.get("aside").button("Done").click();
-      saveDashboard();
+      saveDashboard({ waitMs: 250 });
 
       (function testUpdateDashboardFiltersClick() {
         cy.log("it handles 'Count' column click");
@@ -1687,7 +1687,7 @@ const testChangingBackToDefaultBehavior = () => {
   cy.get("aside").findByText("Open the Metabase drill-through menu").click();
   cy.get("aside").button("Done").click();
 
-  saveDashboard();
+  saveDashboard({ waitMs: 250 });
   // this is necessary due to query params being reset after saving dashboard
   // with filter applied, which causes dashcard to be refetched
   cy.wait(1);

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -27,6 +27,9 @@ import {
   moveDashCardToTab,
   addTextBoxWhileEditing,
   expectGoodSnowplowEvent,
+  selectDashboardFilter,
+  filterWidget,
+  popover,
 } from "e2e/support/helpers";
 
 import {
@@ -351,6 +354,60 @@ describe("scenarios > dashboard > tabs", () => {
     cy.get("@publicFirstTabQuery").should("have.been.calledOnce");
     cy.get("@publicSecondTabQuery").should("have.been.calledOnce");
   });
+
+  it("should apply filter and show loading spinner when changing tabs", () => {
+    visitDashboard(ORDERS_DASHBOARD_ID);
+    editDashboard();
+    createNewTab();
+    saveDashboard();
+
+    goToTab("Tab 2");
+    editDashboard();
+    openQuestionsSidebar();
+    sidebar().within(() => {
+      cy.findByText("Orders, Count").click();
+    });
+
+    cy.findByTestId("dashboard-header").within(() => {
+      cy.icon("filter").click();
+    });
+
+    popover().within(() => {
+      cy.contains("Time").click();
+      cy.findByText("Relative Date").click();
+    });
+
+    // Auto-connection happens here
+    selectDashboardFilter(getDashboardCard(0), "Created At");
+    saveDashboard();
+
+    cy.intercept(
+      "POST",
+      "/api/dashboard/*/dashcard/*/card/*/query",
+      delayResponse(500),
+    ).as("saveCard");
+
+    filterWidget().contains("Relative Date").click();
+    popover().within(() => {
+      cy.findByText("Today").click();
+    });
+
+    // Loader in the 2nd tab
+    getDashboardCard(0).within(() => {
+      cy.findByTestId("loading-spinner").should("exist");
+      cy.wait("@saveCard");
+      cy.findByText("14").should("exist");
+    });
+
+    // Loader in the 1st tab
+    goToTab("Tab 1");
+    getDashboardCard(0).within(() => {
+      cy.findByTestId("loading-spinner").should("exist");
+      cy.wait("@saveCard");
+      cy.findByText("58.4") // this is total from the first row
+        .should("exist");
+    });
+  });
 });
 
 describeWithSnowplow("scenarios > dashboard > tabs", () => {
@@ -410,3 +467,19 @@ describeWithSnowplow("scenarios > dashboard > tabs", () => {
     );
   });
 });
+
+/**
+ * When you need to postpone a response (to check for loading spinners or alike),
+ * use this:
+ *
+ * `cy.intercept('POST', path, delayResponse(1000)).as('delayed')`
+ *
+ * `cy.wait('@delayed')` - you'll have 1000 ms until this resolves
+ */
+function delayResponse(delayMs) {
+  return function (req) {
+    req.on("response", res => {
+      res.setDelay(delayMs);
+    });
+  };
+}

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -355,7 +355,7 @@ describe("scenarios > dashboard > tabs", () => {
     cy.get("@publicSecondTabQuery").should("have.been.calledOnce");
   });
 
-  it("should apply filter and show loading spinner when changing tabs", () => {
+  it("should apply filter and show loading spinner when changing tabs (#33767)", () => {
     visitDashboard(ORDERS_DASHBOARD_ID);
     editDashboard();
     createNewTab();

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -345,6 +345,8 @@ export const fetchCardData = createThunkAction(
 
       cancelFetchCardData(card.id, dashcard.id);
 
+      // When dashcard parameters change, we need to clean previous (stale)
+      // state so that the loader spinner shows as expected (#33767)
       const hasParametersChanged =
         !lastResult ||
         !equals(

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -325,9 +325,9 @@ export const fetchCardData = createThunkAction(
         dashcard && dashcard.parameter_mappings,
       );
 
+      const lastResult = getIn(dashcardData, [dashcard.id, card.id]);
       if (!reload) {
         // if reload not set, check to see if the last result has the same query dict and return that
-        const lastResult = getIn(dashcardData, [dashcard.id, card.id]);
         if (
           lastResult &&
           equals(
@@ -345,7 +345,14 @@ export const fetchCardData = createThunkAction(
 
       cancelFetchCardData(card.id, dashcard.id);
 
-      if (clearCache) {
+      const hasParametersChanged =
+        !lastResult ||
+        !equals(
+          getDatasetQueryParams(lastResult.json_query).parameters,
+          getDatasetQueryParams(datasetQuery).parameters,
+        );
+
+      if (clearCache || hasParametersChanged) {
         // clears the card data to indicate the card is reloading
         dispatch(clearCardData(card.id, dashcard.id));
       }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/33767

## Description
Unlike https://github.com/metabase/metabase/pull/36910, fixes the issue by reacting to change in _parameters_ in `fetchCardData`, which is the correct way to fix it.

### Before
https://github.com/metabase/metabase/assets/2196347/4180acc8-83f2-4074-8228-87f95a50814b 

### After

https://github.com/metabase/metabase/assets/2196347/1680c2b2-f39b-430e-9c9d-8a3dc55500ba

