### PR TITLE
Remove extra clj-kondo library config

### DIFF
--- a/.clj-kondo/com.github.steffan-westcott/clj-otel-api/config.edn
+++ b/.clj-kondo/com.github.steffan-westcott/clj-otel-api/config.edn
@@ -1,3 +1,0 @@
-;!zprint {:width 140}
-
-{:lint-as {steffan-westcott.clj-otel.api.trace.span/with-span-binding clojure.core/let}}


### PR DESCRIPTION
Ignore another clj-kondo library config missed by https://github.com/metabase/metabase/pull/36889

This was causing dirty changes to be left in the repo after running `bin/kondo.sh`. The script should be clean after this change, I think.
