### PR TITLE
Show dots if tab content is too wide in Filter Modal

### DIFF
--- a/frontend/src/metabase/querying/components/FilterModal/FilterModal.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/FilterModal.tsx
@@ -189,7 +189,7 @@ interface TabListProps {
 
 function TabList({ groupItems }: TabListProps) {
   return (
-    <Tabs.List w="20%" pt="sm" pl="md">
+    <Tabs.List w="25%" pt="sm" pl="md">
       {groupItems.map(groupItem => (
         <Tabs.Tab
           key={groupItem.key}

--- a/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.styled.tsx
+++ b/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.styled.tsx
@@ -15,6 +15,7 @@ export const getTabsOverrides = (): MantineThemeOverride["components"] => ({
       tab: {
         color: theme.colors.text[2],
         padding: TAB_PADDING[orientation],
+        maxWidth: "100%",
         "&:hover": {
           borderColor: theme.colors.bg[1],
           backgroundColor: theme.colors.brand[0],
@@ -32,6 +33,9 @@ export const getTabsOverrides = (): MantineThemeOverride["components"] => ({
         fontSize: theme.fontSizes.md,
         fontWeight: "bold",
         lineHeight: theme.lineHeight,
+        whiteSpace: "nowrap",
+        textOverflow: "ellipsis",
+        overflow: "hidden",
       },
       tabIcon: {
         "&:not(:only-child)": {


### PR DESCRIPTION
### Description

Fixes showing wide content in Filters Modal

Before
<img width="954" alt="image" src="https://github.com/metabase/metabase/assets/125459446/15ff0b4b-08aa-4157-b410-fd363da2d79e">

After
<img width="954" alt="image" src="https://github.com/metabase/metabase/assets/125459446/05ea725f-3a39-405b-94f2-a3f679a5a4c1">


### How to verify

- create new or open old question
- add `summarize by count` and `group by any`
- open `Filter` and check the modal content (change content of the tab with something long)

### Demo


https://github.com/metabase/metabase/assets/125459446/d7d5a615-6962-4790-a346-d7f6c132f479



### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
