### PR TITLE
Wrap `can-append-test` with mt/with-empty-db to fix seemingly unrelated download perms test

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions_test.clj
@@ -7,8 +7,8 @@
    [metabase-enterprise.advanced-permissions.query-processor.middleware.permissions
     :as ee.qp.perms]
    [metabase.api.dataset :as api.dataset]
-   [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
+   [metabase.permissions.test-util :as perms.test-util]
    [metabase.public-settings.premium-features-test
     :as premium-features-test]
    [metabase.query-processor.reducible :as qp.reducible]
@@ -20,16 +20,12 @@
 
 (defn- do-with-download-perms
   [db-or-id graph f]
-  (let [all-users-group-id           (u/the-id (perms-group/all-users))
-        db-id                        (u/the-id db-or-id)
-        current-download-perms-graph (get-in (perms/data-perms-graph)
-                                             [:groups all-users-group-id db-id :download])]
+  (let [all-users-group-id (u/the-id (perms-group/all-users))
+        db-id              (u/the-id db-or-id)]
     (premium-features-test/with-premium-features #{:advanced-permissions}
-      (ee.perms/update-db-download-permissions! all-users-group-id db-id graph)
-      (try
-        (f)
-        (finally
-          (ee.perms/update-db-download-permissions! all-users-group-id db-id current-download-perms-graph))))))
+      (perms.test-util/with-restored-perms!
+        (ee.perms/update-db-download-permissions! all-users-group-id db-id graph)
+        (f)))))
 
 (defmacro ^:private with-download-perms
   "Runs `f` with the download perms for `db-or-id` set to the values in `graph` for the All Users permissions group."
@@ -130,8 +126,8 @@
              (check-download-permisions (mbql-download-query))))
 
         (testing "No exception is thrown for non-download queries"
-              (let [query (dissoc (mbql-download-query 'venues) :info)]
-                (is (= query (check-download-permisions query))))))))
+          (let [query (dissoc (mbql-download-query 'venues) :info)]
+            (is (= query (check-download-permisions query))))))))
 
   (testing "No exception is thrown if the user has any (full or limited) download permissions for the DB"
     (with-download-perms-for-db (mt/id) :full
@@ -149,8 +145,8 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn- csv-row-count
- [results]
- (count
+  [results]
+  (count
    ;; Ignore first row, since it's the header
    (rest (csv/read-csv results))))
 
@@ -312,8 +308,8 @@
       (streaming-test/do-test
        "A user has limited downloads for a query with a join if they have limited permissions for one of the tables"
        {:query (mt/mbql-query checkins
-                    {:joins [{:source-table $$users
-                              :condition    [:= $user_id 1]}]
-                     :limit 10})
+                 {:joins [{:source-table $$users
+                           :condition    [:= $user_id 1]}]
+                  :limit 10})
         :endpoints  [:card :dataset]
         :assertions {:csv (fn [results] (is (= 3 (csv-row-count results))))}}))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1199,35 +1199,36 @@
 
 (deftest can-append-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (testing "Happy path"
-      (is (= {:row-count 2}
-             (append-csv-with-defaults!))))
-    (testing "Even if the uploads database, schema and table prefix is not set, appends succeed"
-      (mt/with-temporary-setting-values [uploads-database-id nil
-                                         uploads-schema-name nil
-                                         uploads-table-prefix nil]
-        (is (some? (append-csv-with-defaults!)))))
-    (testing "Uploads must be enabled"
-      (is (= {:message "Uploads are not enabled."
-              :data    {:status-code 422}}
-             (catch-ex-info (append-csv-with-defaults! :uploads-enabled false)))))
-    (testing "The table must exist"
-      (is (= {:message "Not found."
-              :data    {:status-code 404}}
-             (catch-ex-info (append-csv-with-defaults! :table-id Integer/MAX_VALUE)))))
-    (testing "The table must be an uploaded table"
-      (is (= {:message "The table must be an uploaded table."
-              :data    {:status-code 422}}
-             (catch-ex-info (append-csv-with-defaults! :is-upload false)))))
-    (testing "The CSV file must not be empty"
-      (is (= {:message "The CSV file contains extra columns that are not in the table: \"name\".",
-              :data    {:status-code 422}}
-             (catch-ex-info (append-csv-with-defaults! :file (csv-file-with [] (mt/random-name)))))))
-    (testing "Uploads must be supported"
-      (with-redefs [driver/database-supports? (constantly false)]
-        (is (= {:message (format "Uploads are not supported on %s databases." (str/capitalize (name driver/*driver*)))
+    (mt/with-empty-db
+      (testing "Happy path"
+        (is (= {:row-count 2}
+               (append-csv-with-defaults!))))
+      (testing "Even if the uploads database, schema and table prefix is not set, appends succeed"
+        (mt/with-temporary-setting-values [uploads-database-id nil
+                                           uploads-schema-name nil
+                                           uploads-table-prefix nil]
+          (is (some? (append-csv-with-defaults!)))))
+      (testing "Uploads must be enabled"
+        (is (= {:message "Uploads are not enabled."
                 :data    {:status-code 422}}
-               (catch-ex-info (append-csv-with-defaults!))))))))
+               (catch-ex-info (append-csv-with-defaults! :uploads-enabled false)))))
+      (testing "The table must exist"
+        (is (= {:message "Not found."
+                :data    {:status-code 404}}
+               (catch-ex-info (append-csv-with-defaults! :table-id Integer/MAX_VALUE)))))
+      (testing "The table must be an uploaded table"
+        (is (= {:message "The table must be an uploaded table."
+                :data    {:status-code 422}}
+               (catch-ex-info (append-csv-with-defaults! :is-upload false)))))
+      (testing "The CSV file must not be empty"
+        (is (= {:message "The CSV file contains extra columns that are not in the table: \"name\".",
+                :data    {:status-code 422}}
+               (catch-ex-info (append-csv-with-defaults! :file (csv-file-with [] (mt/random-name)))))))
+      (testing "Uploads must be supported"
+        (with-redefs [driver/database-supports? (constantly false)]
+          (is (= {:message (format "Uploads are not supported on %s databases." (str/capitalize (name driver/*driver*)))
+                  :data    {:status-code 422}}
+                 (catch-ex-info (append-csv-with-defaults!)))))))))
 
 (defn do-with-uploads-allowed
   "Set uploads-enabled to true, and uses an admin user, run the thunk"


### PR DESCRIPTION
This should fix the last failures in permission-related tests in Cloverage, which I had previously tried to fix in https://github.com/metabase/metabase/pull/37093 and https://github.com/metabase/metabase/pull/37141

Basically the issue was that `metabase.upload-test/can-append-test` was creating new tables in the test database to test CSV uploads. Most tests that did this were already wrapped in `mt/with-empty-db` so that the test database would be reset to its normal state afterwards, but this one didn't.

This caused a download perms test to fail because native query download perms for a DB are essentially derived from the download perms for all of its tables. If _any_ table has no download perms, then there are no download perms for native queries.

So whenever `can-append-test` was run _before_ the download perm tests, extra tables would be created in the test database, which would then cause native download perms for the sample database to be computed to `:none` when they should have been `:limited`, because the extra tables did not have download perms.

Apparently this order of test runs was only encountered when running Cloverage, not during normal test suites, so it only showed up on `master`. 🫠 

I've fixed it by adding `mt/with-empty-db` to `can-append-test`, like all the others in that test namespace. I've also:
* Switched `with-download-perms` to use `perms.test-util/with-restored-perms` from my earlier PR
* Did a couple formatting fixes