### PR TITLE
Add e2e tests for brush filters in line chart

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -588,7 +588,7 @@ describe("scenarios > visualizations > line chart", () => {
       });
 
       cy.get(".Visualization")
-        .trigger("mousedown", 120, 200)
+        .trigger("mousedown", 110, 200)
         .trigger("mousemove", 230, 200)
         .trigger("mouseup", 230, 200);
 

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -588,7 +588,7 @@ describe("scenarios > visualizations > line chart", () => {
       });
 
       cy.get(".Visualization")
-        .trigger("mousedown", 110, 200)
+        .trigger("mousedown", 100, 200)
         .trigger("mousemove", 230, 200)
         .trigger("mouseup", 230, 200);
 
@@ -596,7 +596,7 @@ describe("scenarios > visualizations > line chart", () => {
 
       cy.findByTestId("filter-pill").should(
         "have.text",
-        "Created At is May 1, 12:00 AM – Sep 1, 2022, 12:00 AM",
+        "Created At is Apr 1, 12:00 AM – Sep 1, 2022, 12:00 AM",
       );
 
       cy.get(".Visualization .dot").should("have.length", 6);

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -590,6 +590,8 @@ describe("scenarios > visualizations > line chart", () => {
         .trigger("mousemove", 230, 200)
         .trigger("mouseup", 230, 200);
 
+      cy.wait("@dataset");
+
       cy.findByTestId("filter-pill").should(
         "have.text",
         "Created At is May 1, 12:00 AM – Sep 1, 2022, 12:00 AM",

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -580,13 +580,7 @@ describe("scenarios > visualizations > line chart", () => {
 
   describe("brush filters", () => {
     it("should apply filters to the series selecting area range", () => {
-      cy.log(
-        "viewport" +
-          " " +
-          Cypress.config("viewportWidth") +
-          " x " +
-          Cypress.config("viewportHeight"),
-      );
+      cy.viewport(1280, 800);
 
       visitQuestionAdhoc({
         dataset_query: testQuery,

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -580,6 +580,8 @@ describe("scenarios > visualizations > line chart", () => {
 
   describe("brush filters", () => {
     it("should apply filters to the series selecting area range", () => {
+      cy.viewport(1280, 800);
+
       visitQuestionAdhoc({
         dataset_query: testQuery,
         display: "line",

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -580,6 +580,14 @@ describe("scenarios > visualizations > line chart", () => {
 
   describe("brush filters", () => {
     it("should apply filters to the series selecting area range", () => {
+      cy.log(
+        "viewport" +
+          " " +
+          Cypress.config("viewportWidth") +
+          " x " +
+          Cypress.config("viewportHeight"),
+      );
+
       visitQuestionAdhoc({
         dataset_query: testQuery,
         display: "line",

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -578,43 +578,27 @@ describe("scenarios > visualizations > line chart", () => {
     });
   });
 
-  describe("brush filters", () => {
-    it("should apply filters to the series selecting area range", () => {
-      cy.viewport(1280, 800);
+  it("should apply filters to the series selecting area range", () => {
+    cy.viewport(1280, 800);
 
-      visitQuestionAdhoc({
-        dataset_query: testQuery,
-        display: "line",
-      });
-
-      cy.get(".Visualization")
-        .trigger("mousedown", 100, 200)
-        .trigger("mousemove", 230, 200)
-        .trigger("mouseup", 230, 200);
-
-      cy.wait("@dataset");
-
-      cy.findByTestId("filter-pill").should(
-        "have.text",
-        "Created At is Apr 1, 12:00 AM – Sep 1, 2022, 12:00 AM",
-      );
-
-      cy.get(".Visualization .dot").should("have.length", 6);
+    visitQuestionAdhoc({
+      dataset_query: testQuery,
+      display: "line",
     });
 
-    it("should apply filter to the series after drilling down", () => {
-      visitQuestionAdhoc({
-        dataset_query: testQuery,
-        display: "line",
-      });
-      cy.get(".Visualization .dot").eq(5).click({ force: true });
+    cy.get(".Visualization")
+      .trigger("mousedown", 100, 200)
+      .trigger("mousemove", 230, 200)
+      .trigger("mouseup", 230, 200);
 
-      popover().findByText("See these Orders").click();
+    cy.wait("@dataset");
 
-      cy.findByTestId("qb-filters-panel")
-        .findByText("Created At is Sep 1–30, 2022")
-        .should("exist");
-    });
+    cy.findByTestId("filter-pill").should(
+      "have.text",
+      "Created At is Apr 1, 12:00 AM – Sep 1, 2022, 12:00 AM",
+    );
+
+    cy.get(".Visualization .dot").should("have.length", 6);
   });
 });
 

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -580,8 +580,6 @@ describe("scenarios > visualizations > line chart", () => {
 
   describe("brush filters", () => {
     it("should apply filters to the series selecting area range", () => {
-      cy.viewport(1280, 800);
-
       visitQuestionAdhoc({
         dataset_query: testQuery,
         display: "line",

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -577,6 +577,41 @@ describe("scenarios > visualizations > line chart", () => {
       cy.get(".y-axis-label").invoke("text").should("eq", "Average of Price");
     });
   });
+
+  describe("brush filters", () => {
+    it("should apply filters to the series selecting area range", () => {
+      visitQuestionAdhoc({
+        dataset_query: testQuery,
+        display: "line",
+      });
+
+      cy.get(".Visualization")
+        .trigger("mousedown", 120, 200)
+        .trigger("mousemove", 230, 200)
+        .trigger("mouseup", 230, 200);
+
+      cy.findByTestId("filter-pill").should(
+        "have.text",
+        "Created At is May 1, 12:00 AM – Sep 1, 2022, 12:00 AM",
+      );
+
+      cy.get(".Visualization .dot").should("have.length", 6);
+    });
+
+    it("should apply filter to the series after drilling down", () => {
+      visitQuestionAdhoc({
+        dataset_query: testQuery,
+        display: "line",
+      });
+      cy.get(".Visualization .dot").eq(5).click({ force: true });
+
+      popover().findByText("See these Orders").click();
+
+      cy.findByTestId("qb-filters-panel")
+        .findByText("Created At is Sep 1–30, 2022")
+        .should("exist");
+    });
+  });
 });
 
 function testPairedTooltipValues(val1, val2) {


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/37104

### Description

Add e2e tests for line chart filters:

- using dragging to select some area
- using drill to select a single dot

Stress test run https://github.com/metabase/metabase/actions/runs/7356917227

### How to verify

tests should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
