### PR TITLE
Add e2e tests for brush filters in map

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -249,9 +249,9 @@ describe("scenarios > visualizations > maps", () => {
       .click();
 
     cy.findByTestId("visualization-root")
-      .trigger("mousedown", 500, 500)
-      .trigger("mousemove", 600, 600)
-      .trigger("mouseup", 600, 600);
+      .trigger("mousedown", 500, 500, { force: true })
+      .trigger("mousemove", 600, 600, { force: true })
+      .trigger("mouseup", 600, 600, { force: true });
 
     cy.wait("@dataset");
 

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -224,4 +224,42 @@ describe("scenarios > visualizations > maps", () => {
       "true",
     );
   });
+
+  it("should apply brush filters by dragging map", () => {
+    visitQuestionAdhoc({
+      dataset_query: {
+        type: "query",
+        database: SAMPLE_DB_ID,
+        query: {
+          "source-table": PEOPLE_ID,
+        },
+      },
+      display: "map",
+      visualization_settings: {
+        "map.region": "us_states",
+        "map.type": "pin",
+        "map.latitude_column": "LATITUDE",
+        "map.longitude_column": "LONGITUDE",
+      },
+    });
+
+    cy.get(".CardVisualization").realHover();
+    cy.findByTestId("visualization-root")
+      .findByText("Draw box to filter")
+      .click();
+
+    cy.findByTestId("visualization-root")
+      .trigger("mousedown", 500, 500)
+      .trigger("mousemove", 600, 600)
+      .trigger("mouseup", 600, 600);
+
+    cy.wait("@dataset");
+
+    cy.get(".leaflet-marker-icon").should("have.length", 30);
+
+    cy.findByTestId("qb-filters-panel").should(
+      "have.text",
+      "Latitude is between 31.698139949769104 and 40.45497993186572 and Longitude is between -132.41854424701123 and -121.55519818468503",
+    );
+  });
 });

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -226,6 +226,8 @@ describe("scenarios > visualizations > maps", () => {
   });
 
   it("should apply brush filters by dragging map", () => {
+    cy.viewport(1280, 800);
+
     visitQuestionAdhoc({
       dataset_query: {
         type: "query",

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -249,17 +249,13 @@ describe("scenarios > visualizations > maps", () => {
       .click();
 
     cy.findByTestId("visualization-root")
-      .trigger("mousedown", 500, 500, { force: true })
-      .trigger("mousemove", 600, 600, { force: true })
-      .trigger("mouseup", 600, 600, { force: true });
+      .trigger("mousedown", 500, 500)
+      .trigger("mousemove", 600, 600)
+      .trigger("mouseup", 600, 600);
 
     cy.wait("@dataset");
 
-    cy.get(".leaflet-marker-icon").should("have.length", 30);
-
-    cy.findByTestId("qb-filters-panel").should(
-      "have.text",
-      "Latitude is between 31.698139949769104 and 40.45497993186572 and Longitude is between -132.41854424701123 and -121.55519818468503",
-    );
+    // selecting area at the map provides different filter values, so the simplified assertion is used
+    cy.findByTestId("filter-pill").should("have.length", 1);
   });
 });


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/37104

### Description

Add e2e tests for map chart filters:

- using dragging to select some area

stress test https://github.com/metabase/metabase/actions/runs/7357464147/job/20029127998
### How to verify

tests should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
