### PR TITLE
Trend charts — multiple comparisons

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -158,6 +158,85 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     });
   });
 
+  it("should handle up to 3 comparisons", () => {
+    cy.createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: AGGREGATIONS,
+          breakout: [
+            ["field", ORDERS.CREATED_AT, { "temporal-unit": "month" }],
+          ],
+        },
+        display: "smartscalar",
+      },
+      { visitQuestion: true },
+    );
+
+    cy.findByTestId("viz-settings-button").click();
+    cy.findByTestId("comparison-list").children().should("have.length", 1);
+
+    cy.findByTestId("scalar-previous-value").within(() => {
+      cy.findByText("34.72%").should("exist");
+      cy.findByText("vs. previous month:").should("exist");
+      cy.findByText("527").should("exist");
+    });
+
+    cy.button("Add comparison").click();
+    cy.findByTestId("comparison-list")
+      .children()
+      .should("have.length", 2)
+      .last()
+      .click();
+    menu().findByText("2 months ago").click();
+    cy.findAllByTestId("scalar-previous-value")
+      .children()
+      .should("have.length", 2)
+      .last()
+      .within(() => {
+        cy.findByText("36.65%").should("exist");
+        cy.findByText("vs. Feb:").should("exist");
+        cy.findByText("543").should("exist");
+      });
+
+    cy.button("Add comparison").click();
+    cy.findByTestId("comparison-list")
+      .children()
+      .should("have.length", 3)
+      .last()
+      .click();
+    menu().findByText("Previous value").click();
+    cy.findAllByTestId("scalar-previous-value")
+      .children()
+      .should("have.length", 3)
+      .last()
+      .within(() => {
+        cy.findByText("34.72%").should("exist");
+        cy.findByText("vs. Mar:").should("exist");
+        cy.findByText("527").should("exist");
+      });
+
+    cy.button("Add comparison").should("be.disabled");
+
+    cy.findByTestId("comparison-list")
+      .children()
+      .last()
+      .findByLabelText("Remove")
+      .click();
+    cy.findByTestId("comparison-list").children().should("have.length", 2);
+    cy.findByTestId("comparison-list")
+      .findByText("Previous value")
+      .should("not.exist");
+    cy.findAllByTestId("scalar-previous-value")
+      .children()
+      .should("have.length", 2);
+    cy.findAllByTestId("scalar-previous-value")
+      .findByText("vs. Mar:")
+      .should("not.exist");
+
+    cy.button("Add comparison").should("be.enabled");
+  });
+
   it("should reset 'another column' comparison when it becomes invalid", () => {
     cy.createQuestion(
       {

--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -173,6 +173,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
           "scalar.field": "Count",
           "scalar.comparisons": [
             {
+              id: "1",
               type: "anotherColumn",
               column: "Mega Count",
               label: "Mega Count",

--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -171,11 +171,13 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
         display: "smartscalar",
         visualization_settings: {
           "scalar.field": "Count",
-          "scalar.comparisons": {
-            type: "anotherColumn",
-            column: "Mega Count",
-            label: "Mega Count",
-          },
+          "scalar.comparisons": [
+            {
+              type: "anotherColumn",
+              column: "Mega Count",
+              label: "Mega Count",
+            },
+          ],
         },
       },
       { visitQuestion: true },

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -137,7 +137,7 @@ export type VisualizationSettings = {
   "pivot_table.collapsed_rows"?: PivotTableCollapsedRowsSetting;
 
   // Scalar Settings
-  "scalar.comparisons"?: SmartScalarComparison;
+  "scalar.comparisons"?: SmartScalarComparison[];
   "scalar.field"?: string;
   "scalar.switch_positive_negative"?: boolean;
   "scalar.compact_primary_number"?: boolean;

--- a/frontend/src/metabase-types/api/visualization-settings.ts
+++ b/frontend/src/metabase-types/api/visualization-settings.ts
@@ -7,6 +7,7 @@ export type SmartScalarComparisonType =
   | "staticNumber";
 
 interface BaseSmartScalarComparison {
+  id: string; // client-side generated, used for sorting
   type: SmartScalarComparisonType;
 }
 

--- a/frontend/src/metabase/core/components/Sortable/Sortable.tsx
+++ b/frontend/src/metabase/core/components/Sortable/Sortable.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ElementType, ReactNode } from "react";
 import type { UniqueIdentifier } from "@dnd-kit/core";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -6,6 +6,7 @@ import { SortableDiv } from "./Sortable.styled";
 
 interface SortableProps {
   id: UniqueIdentifier;
+  as?: ElementType;
   children: ReactNode;
   disabled?: boolean;
 }
@@ -14,12 +15,18 @@ interface SortableProps {
  * Wrapper to use with dnd-kit's Sortable preset
  * https://docs.dndkit.com/presets/sortable
  */
-export function Sortable({ id, children, disabled = false }: SortableProps) {
+export function Sortable({
+  id,
+  as = "div",
+  children,
+  disabled = false,
+}: SortableProps) {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id, disabled });
 
   return (
     <SortableDiv
+      as={as}
       transform={CSS.Transform.toString(transform)}
       transition={transition}
       ref={setNodeRef}

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/AnotherColumnForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/AnotherColumnForm.tsx
@@ -19,7 +19,7 @@ import { DoneButton } from "./SmartScalarSettingsWidgets.styled";
 interface AnotherColumnFormProps {
   value?: SmartScalarComparisonAnotherColumn;
   columns: DatasetColumn[];
-  onChange: (value: SmartScalarComparisonAnotherColumn) => void;
+  onChange: (value: Omit<SmartScalarComparisonAnotherColumn, "id">) => void;
   onBack: () => void;
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/ComparisonPicker.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/ComparisonPicker.tsx
@@ -1,0 +1,268 @@
+import type { MouseEvent } from "react";
+import { useCallback, useState } from "react";
+import { t } from "ttag";
+import _ from "underscore";
+import IconButtonWrapper from "metabase/components/IconButtonWrapper";
+import { Button, Menu, Stack, Text } from "metabase/ui";
+import type {
+  DatasetColumn,
+  SmartScalarComparison,
+  SmartScalarComparisonType,
+} from "metabase-types/api";
+import { COMPARISON_TYPES } from "../constants";
+import type { ComparisonMenuOption } from "../types";
+import { PeriodsAgoMenuOption } from "./PeriodsAgoMenuOption";
+import { StaticNumberForm } from "./StaticNumberForm";
+import { AnotherColumnForm } from "./AnotherColumnForm";
+import { MenuItemStyled } from "./MenuItem.styled";
+import {
+  DragHandleIcon,
+  ExpandIcon,
+  RemoveIcon,
+} from "./SmartScalarSettingsWidgets.styled";
+
+type Tab = "anotherColumn" | "staticNumber" | null;
+
+interface ComparisonPickerProps {
+  value: SmartScalarComparison;
+  options: ComparisonMenuOption[];
+  comparableColumns: DatasetColumn[];
+  isRemovable?: boolean;
+  onChange: (setting: SmartScalarComparison) => void;
+  onRemove: () => void;
+}
+
+export function ComparisonPicker({
+  onChange,
+  onRemove,
+  options,
+  isRemovable = true,
+  comparableColumns,
+  value: selectedValue,
+}: ComparisonPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<Tab>(
+    getTabForComparisonType(selectedValue.type),
+  );
+  const [editedValue, setEditedValue] = useState(selectedValue);
+
+  const selectedOption = options.find(
+    ({ type }) => type === selectedValue.type,
+  );
+
+  const displayName = getDisplayName(selectedValue, selectedOption);
+  const isDisabled = options.length === 1;
+
+  const handleRemoveClick = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      onRemove();
+    },
+    [onRemove],
+  );
+
+  const handleEditedValueChange: HandleEditedValueChangeType = useCallback(
+    (value: SmartScalarComparison, shouldSubmit = false) => {
+      setEditedValue(value);
+
+      if (shouldSubmit) {
+        onChange(value);
+        setOpen(false);
+      }
+    },
+    [onChange, setEditedValue, setOpen],
+  );
+
+  const handleMenuStateChange = (isOpen: boolean) => {
+    if (isOpen) {
+      setEditedValue(selectedValue);
+      setTab(getTabForComparisonType(selectedValue.type));
+    } else if (!_.isEqual(selectedValue, editedValue)) {
+      onChange(editedValue);
+    }
+    setOpen(isOpen);
+  };
+
+  const renderMenuDropdownContent = () => {
+    if (tab === "anotherColumn") {
+      return (
+        <AnotherColumnForm
+          value={
+            selectedValue.type === COMPARISON_TYPES.ANOTHER_COLUMN
+              ? selectedValue
+              : undefined
+          }
+          columns={comparableColumns}
+          onChange={nextValue => {
+            handleEditedValueChange(
+              { id: selectedValue.id, ...nextValue },
+              true,
+            );
+          }}
+          onBack={() => setTab(null)}
+        />
+      );
+    }
+    if (tab === "staticNumber") {
+      return (
+        <StaticNumberForm
+          value={
+            selectedValue.type === COMPARISON_TYPES.STATIC_NUMBER
+              ? selectedValue
+              : undefined
+          }
+          onChange={nextValue => {
+            handleEditedValueChange(
+              { id: selectedValue.id, ...nextValue },
+              true,
+            );
+          }}
+          onBack={() => setTab(null)}
+        />
+      );
+    }
+    return (
+      <Stack spacing="sm">
+        {options.map(optionArgs =>
+          renderMenuOption({
+            editedValue,
+            selectedValue,
+            optionArgs,
+            onChange: handleEditedValueChange,
+            onChangeTab: setTab,
+          }),
+        )}
+      </Stack>
+    );
+  };
+
+  return (
+    <Menu
+      opened={open}
+      onChange={handleMenuStateChange}
+      position="bottom-start"
+      shadow="sm"
+      closeOnItemClick={false}
+    >
+      <Menu.Target>
+        <Button
+          disabled={isDisabled}
+          leftIcon={<DragHandleIcon name="grabber" />}
+          rightIcon={
+            isRemovable && (
+              <IconButtonWrapper
+                aria-label={t`Remove`}
+                onClick={handleRemoveClick}
+              >
+                <RemoveIcon name="close" />
+              </IconButtonWrapper>
+            )
+          }
+          px="1rem"
+          fullWidth
+          data-testid="comparisons-widget-button"
+          styles={{
+            label: { flex: 1 },
+            inner: { justifyContent: "space-between" },
+          }}
+        >
+          <span>{displayName}</span>
+          <ExpandIcon name="chevrondown" size={14} />
+        </Button>
+      </Menu.Target>
+
+      <Menu.Dropdown miw="18.25rem">
+        {renderMenuDropdownContent()}
+      </Menu.Dropdown>
+    </Menu>
+  );
+}
+
+function getTabForComparisonType(type: SmartScalarComparisonType): Tab {
+  if (type === COMPARISON_TYPES.ANOTHER_COLUMN) {
+    return "anotherColumn";
+  }
+  if (type === COMPARISON_TYPES.STATIC_NUMBER) {
+    return "staticNumber";
+  }
+  return null;
+}
+
+function getDisplayName(
+  value: SmartScalarComparison,
+  option?: ComparisonMenuOption,
+) {
+  if (value.type === COMPARISON_TYPES.PERIODS_AGO) {
+    return `${value.value} ${option?.name}`;
+  }
+  if (
+    value.type === COMPARISON_TYPES.ANOTHER_COLUMN ||
+    value.type === COMPARISON_TYPES.STATIC_NUMBER
+  ) {
+    return value.label;
+  }
+  return option?.name;
+}
+
+type HandleEditedValueChangeType = (
+  value: SmartScalarComparison,
+  shouldSubmit?: boolean,
+) => void;
+
+type RenderMenuOptionProps = {
+  editedValue: SmartScalarComparison;
+  selectedValue: SmartScalarComparison;
+  optionArgs: ComparisonMenuOption;
+  onChange: HandleEditedValueChangeType;
+  onChangeTab: (tab: Tab) => void;
+};
+
+function renderMenuOption({
+  editedValue,
+  selectedValue,
+  optionArgs,
+  onChange,
+  onChangeTab,
+}: RenderMenuOptionProps) {
+  const { type, name } = optionArgs;
+
+  const isSelected = selectedValue.type === type;
+
+  if (type === COMPARISON_TYPES.PERIODS_AGO) {
+    const { maxValue } = optionArgs;
+
+    return (
+      <PeriodsAgoMenuOption
+        key={type}
+        aria-selected={isSelected}
+        type={type}
+        name={name}
+        onChange={(nextValue, submit) =>
+          onChange({ id: selectedValue.id, ...nextValue }, submit)
+        }
+        maxValue={maxValue}
+        editedValue={editedValue.type === type ? editedValue : undefined}
+      />
+    );
+  }
+
+  const handleClick = () => {
+    if (
+      type === COMPARISON_TYPES.ANOTHER_COLUMN ||
+      type === COMPARISON_TYPES.STATIC_NUMBER
+    ) {
+      const tab = getTabForComparisonType(type);
+      onChangeTab(tab);
+    } else {
+      onChange({ id: selectedValue.id, type }, true);
+    }
+  };
+
+  return (
+    <MenuItemStyled key={type} aria-selected={isSelected} onClick={handleClick}>
+      <Text fw="bold" ml="0.5rem">
+        {name}
+      </Text>
+    </MenuItemStyled>
+  );
+}

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/PeriodsAgoMenuOption.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/PeriodsAgoMenuOption.tsx
@@ -5,15 +5,17 @@ import type { SmartScalarComparisonPeriodsAgo } from "metabase-types/api";
 import type { COMPARISON_TYPES } from "metabase/visualizations/visualizations/SmartScalar/constants";
 import { NumberInputStyled } from "./PeriodsAgoMenuOption.styled";
 import { MenuItemStyled } from "./MenuItem.styled";
-import type { HandleEditedValueChangeType } from "./SmartScalarSettingsWidgets";
 
 type PeriodsAgoMenuOptionProps = {
   "aria-selected": boolean;
   editedValue?: SmartScalarComparisonPeriodsAgo;
   maxValue: number;
   name: string;
-  onChange: HandleEditedValueChangeType;
   type: typeof COMPARISON_TYPES.PERIODS_AGO;
+  onChange: (
+    value: Omit<SmartScalarComparisonPeriodsAgo, "id">,
+    submit?: boolean,
+  ) => void;
 };
 
 const MIN_VALUE = 2;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
@@ -5,6 +5,12 @@ import { Button } from "metabase/ui";
 import { Icon } from "metabase/core/components/Icon";
 import { color } from "metabase/lib/colors";
 
+export const ComparisonList = styled.ul`
+  li:not(:first-of-type) {
+    margin-top: 8px;
+  }
+`;
+
 type DoneButtonProps = ButtonProps & HTMLAttributes<HTMLButtonElement>;
 
 export const DoneButton = styled(Button)<DoneButtonProps>`

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
@@ -1,9 +1,11 @@
 import type { HTMLAttributes } from "react";
 import styled from "@emotion/styled";
-import type { ButtonProps } from "metabase/ui";
+import type { ButtonProps as BaseButtonProps } from "metabase/ui";
 import { Button } from "metabase/ui";
 import { Icon } from "metabase/core/components/Icon";
 import { color } from "metabase/lib/colors";
+
+type ButtonProps = BaseButtonProps & HTMLAttributes<HTMLButtonElement>;
 
 export const ComparisonList = styled.ul`
   li:not(:first-of-type) {
@@ -11,9 +13,16 @@ export const ComparisonList = styled.ul`
   }
 `;
 
-type DoneButtonProps = ButtonProps & HTMLAttributes<HTMLButtonElement>;
+export const AddComparisonButton = styled(Button)<ButtonProps>`
+  align-self: flex-start;
+  padding: 0;
+`;
 
-export const DoneButton = styled(Button)<DoneButtonProps>`
+AddComparisonButton.defaultProps = {
+  variant: "subtle",
+};
+
+export const DoneButton = styled(Button)<ButtonProps>`
   align-self: flex-end;
 `;
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
@@ -2,6 +2,8 @@ import type { HTMLAttributes } from "react";
 import styled from "@emotion/styled";
 import type { ButtonProps } from "metabase/ui";
 import { Button } from "metabase/ui";
+import { Icon } from "metabase/core/components/Icon";
+import { color } from "metabase/lib/colors";
 
 type DoneButtonProps = ButtonProps & HTMLAttributes<HTMLButtonElement>;
 
@@ -12,3 +14,16 @@ export const DoneButton = styled(Button)<DoneButtonProps>`
 DoneButton.defaultProps = {
   variant: "filled",
 };
+
+export const DragHandleIcon = styled(Icon)`
+  cursor: grab;
+  color: ${color("text-dark")};
+`;
+
+export const ExpandIcon = styled(Icon)`
+  margin-left: 8px;
+`;
+
+export const RemoveIcon = styled(Icon)`
+  color: ${color("text-dark")};
+`;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -1,5 +1,4 @@
-import type { MouseEvent } from "react";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 import { DndContext, useSensor, PointerSensor } from "@dnd-kit/core";
@@ -15,24 +14,14 @@ import {
 } from "@dnd-kit/modifiers";
 import { uuid } from "metabase/lib/utils";
 import { Sortable } from "metabase/core/components/Sortable";
-import IconButtonWrapper from "metabase/components/IconButtonWrapper";
-import { Button, Menu, Stack, Text } from "metabase/ui";
-import type {
-  DatasetColumn,
-  SmartScalarComparison,
-  SmartScalarComparisonType,
-} from "metabase-types/api";
+import { Stack } from "metabase/ui";
+import type { DatasetColumn, SmartScalarComparison } from "metabase-types/api";
 import { COMPARISON_TYPES } from "../constants";
 import type { ComparisonMenuOption } from "../types";
-import { PeriodsAgoMenuOption } from "./PeriodsAgoMenuOption";
-import { StaticNumberForm } from "./StaticNumberForm";
-import { AnotherColumnForm } from "./AnotherColumnForm";
-import { MenuItemStyled } from "./MenuItem.styled";
+import { ComparisonPicker } from "./ComparisonPicker";
 import {
+  AddComparisonButton,
   ComparisonList,
-  DragHandleIcon,
-  ExpandIcon,
-  RemoveIcon,
 } from "./SmartScalarSettingsWidgets.styled";
 
 type SmartScalarComparisonWidgetProps = {
@@ -42,8 +31,6 @@ type SmartScalarComparisonWidgetProps = {
   value: SmartScalarComparison[];
   maxComparisons: number;
 };
-
-type Tab = "anotherColumn" | "staticNumber" | null;
 
 export function SmartScalarComparisonWidget({
   value,
@@ -118,257 +105,10 @@ export function SmartScalarComparisonWidget({
           </ComparisonList>
         </SortableContext>
       </DndContext>
-      <Button
-        variant="subtle"
+      <AddComparisonButton
         disabled={!canAddComparison}
         onClick={handleAddComparison}
-        p="0"
-        style={{ alignSelf: "flex-start" }}
-      >{t`Add comparison`}</Button>
+      >{t`Add comparison`}</AddComparisonButton>
     </Stack>
-  );
-}
-
-interface ComparisonPickerProps {
-  value: SmartScalarComparison;
-  options: ComparisonMenuOption[];
-  comparableColumns: DatasetColumn[];
-  isRemovable?: boolean;
-  onChange: (setting: SmartScalarComparison) => void;
-  onRemove: () => void;
-}
-
-function ComparisonPicker({
-  onChange,
-  onRemove,
-  options,
-  isRemovable = true,
-  comparableColumns,
-  value: selectedValue,
-}: ComparisonPickerProps) {
-  const [open, setOpen] = useState(false);
-  const [tab, setTab] = useState<Tab>(
-    getTabForComparisonType(selectedValue.type),
-  );
-  const [editedValue, setEditedValue] = useState(selectedValue);
-
-  const selectedOption = options.find(
-    ({ type }) => type === selectedValue.type,
-  );
-
-  const displayName = getDisplayName(selectedValue, selectedOption);
-  const isDisabled = options.length === 1;
-
-  const handleRemoveClick = useCallback(
-    (event: MouseEvent<HTMLButtonElement>) => {
-      event.stopPropagation();
-      onRemove();
-    },
-    [onRemove],
-  );
-
-  const handleEditedValueChange: HandleEditedValueChangeType = useCallback(
-    (value: SmartScalarComparison, shouldSubmit = false) => {
-      setEditedValue(value);
-
-      if (shouldSubmit) {
-        onChange(value);
-        setOpen(false);
-      }
-    },
-    [onChange, setEditedValue, setOpen],
-  );
-
-  const handleMenuStateChange = (isOpen: boolean) => {
-    if (isOpen) {
-      setEditedValue(selectedValue);
-      setTab(getTabForComparisonType(selectedValue.type));
-    } else if (!_.isEqual(selectedValue, editedValue)) {
-      onChange(editedValue);
-    }
-    setOpen(isOpen);
-  };
-
-  const renderMenuDropdownContent = () => {
-    if (tab === "anotherColumn") {
-      return (
-        <AnotherColumnForm
-          value={
-            selectedValue.type === COMPARISON_TYPES.ANOTHER_COLUMN
-              ? selectedValue
-              : undefined
-          }
-          columns={comparableColumns}
-          onChange={nextValue => {
-            handleEditedValueChange(
-              { id: selectedValue.id, ...nextValue },
-              true,
-            );
-          }}
-          onBack={() => setTab(null)}
-        />
-      );
-    }
-    if (tab === "staticNumber") {
-      return (
-        <StaticNumberForm
-          value={
-            selectedValue.type === COMPARISON_TYPES.STATIC_NUMBER
-              ? selectedValue
-              : undefined
-          }
-          onChange={nextValue => {
-            handleEditedValueChange(
-              { id: selectedValue.id, ...nextValue },
-              true,
-            );
-          }}
-          onBack={() => setTab(null)}
-        />
-      );
-    }
-    return (
-      <Stack spacing="sm">
-        {options.map(optionArgs =>
-          renderMenuOption({
-            editedValue,
-            selectedValue,
-            optionArgs,
-            onChange: handleEditedValueChange,
-            onChangeTab: setTab,
-          }),
-        )}
-      </Stack>
-    );
-  };
-
-  return (
-    <Menu
-      opened={open}
-      onChange={handleMenuStateChange}
-      position="bottom-start"
-      shadow="sm"
-      closeOnItemClick={false}
-    >
-      <Menu.Target>
-        <Button
-          disabled={isDisabled}
-          leftIcon={<DragHandleIcon name="grabber" />}
-          rightIcon={
-            isRemovable && (
-              <IconButtonWrapper
-                aria-label={t`Remove`}
-                onClick={handleRemoveClick}
-              >
-                <RemoveIcon name="close" />
-              </IconButtonWrapper>
-            )
-          }
-          px="1rem"
-          fullWidth
-          data-testid="comparisons-widget-button"
-          styles={{
-            label: { flex: 1 },
-            inner: { justifyContent: "space-between" },
-          }}
-        >
-          <span>{displayName}</span>
-          <ExpandIcon name="chevrondown" size={14} />
-        </Button>
-      </Menu.Target>
-
-      <Menu.Dropdown miw="18.25rem">
-        {renderMenuDropdownContent()}
-      </Menu.Dropdown>
-    </Menu>
-  );
-}
-
-function getTabForComparisonType(type: SmartScalarComparisonType): Tab {
-  if (type === COMPARISON_TYPES.ANOTHER_COLUMN) {
-    return "anotherColumn";
-  }
-  if (type === COMPARISON_TYPES.STATIC_NUMBER) {
-    return "staticNumber";
-  }
-  return null;
-}
-
-function getDisplayName(
-  value: SmartScalarComparison,
-  option?: ComparisonMenuOption,
-) {
-  if (value.type === COMPARISON_TYPES.PERIODS_AGO) {
-    return `${value.value} ${option?.name}`;
-  }
-  if (
-    value.type === COMPARISON_TYPES.ANOTHER_COLUMN ||
-    value.type === COMPARISON_TYPES.STATIC_NUMBER
-  ) {
-    return value.label;
-  }
-  return option?.name;
-}
-
-type HandleEditedValueChangeType = (
-  value: SmartScalarComparison,
-  shouldSubmit?: boolean,
-) => void;
-
-type RenderMenuOptionProps = {
-  editedValue: SmartScalarComparison;
-  selectedValue: SmartScalarComparison;
-  optionArgs: ComparisonMenuOption;
-  onChange: HandleEditedValueChangeType;
-  onChangeTab: (tab: Tab) => void;
-};
-
-function renderMenuOption({
-  editedValue,
-  selectedValue,
-  optionArgs,
-  onChange,
-  onChangeTab,
-}: RenderMenuOptionProps) {
-  const { type, name } = optionArgs;
-
-  const isSelected = selectedValue.type === type;
-
-  if (type === COMPARISON_TYPES.PERIODS_AGO) {
-    const { maxValue } = optionArgs;
-
-    return (
-      <PeriodsAgoMenuOption
-        key={type}
-        aria-selected={isSelected}
-        type={type}
-        name={name}
-        onChange={(nextValue, submit) =>
-          onChange({ id: selectedValue.id, ...nextValue }, submit)
-        }
-        maxValue={maxValue}
-        editedValue={editedValue.type === type ? editedValue : undefined}
-      />
-    );
-  }
-
-  const handleClick = () => {
-    if (
-      type === COMPARISON_TYPES.ANOTHER_COLUMN ||
-      type === COMPARISON_TYPES.STATIC_NUMBER
-    ) {
-      const tab = getTabForComparisonType(type);
-      onChangeTab(tab);
-    } else {
-      onChange({ id: selectedValue.id, type }, true);
-    }
-  };
-
-  return (
-    <MenuItemStyled key={type} aria-selected={isSelected} onClick={handleClick}>
-      <Text fw="bold" ml="0.5rem">
-        {name}
-      </Text>
-    </MenuItemStyled>
   );
 }

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { t } from "ttag";
 import _ from "underscore";
 import { Icon } from "metabase/core/components/Icon";
 import { Button, Menu, Stack, Text } from "metabase/ui";
@@ -19,16 +20,24 @@ type SmartScalarComparisonWidgetProps = {
   options: ComparisonMenuOption[];
   comparableColumns: DatasetColumn[];
   value: SmartScalarComparison[];
+  maxComparisons: number;
 };
 
 type Tab = "anotherColumn" | "staticNumber" | null;
 
 export function SmartScalarComparisonWidget({
   value,
+  maxComparisons,
   onChange,
   ...props
 }: SmartScalarComparisonWidgetProps) {
-  const handleChange = useCallback(
+  const canAddComparison = value.length < maxComparisons;
+
+  const handleAddComparison = useCallback(() => {
+    onChange([...value, { type: COMPARISON_TYPES.PREVIOUS_PERIOD }]);
+  }, [value, onChange]);
+
+  const handleChangeComparison = useCallback(
     (index: number, comparison: SmartScalarComparison) => {
       const nextValue = value.map((item, i) =>
         i === index ? comparison : item,
@@ -39,16 +48,25 @@ export function SmartScalarComparisonWidget({
   );
 
   return (
-    <div>
+    <Stack>
       {value.map((comparison, index) => (
         <ComparisonPicker
           {...props}
           key={index}
           value={comparison}
-          onChange={nextComparison => handleChange(index, nextComparison)}
+          onChange={nextComparison =>
+            handleChangeComparison(index, nextComparison)
+          }
         />
       ))}
-    </div>
+      <Button
+        variant="subtle"
+        disabled={!canAddComparison}
+        onClick={handleAddComparison}
+        p="0"
+        style={{ alignSelf: "flex-start" }}
+      >{t`Add comparison`}</Button>
+    </Stack>
   );
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -15,7 +15,11 @@ import { PeriodsAgoMenuOption } from "./PeriodsAgoMenuOption";
 import { StaticNumberForm } from "./StaticNumberForm";
 import { AnotherColumnForm } from "./AnotherColumnForm";
 import { MenuItemStyled } from "./MenuItem.styled";
-import { ExpandIcon, RemoveIcon } from "./SmartScalarSettingsWidgets.styled";
+import {
+  ComparisonList,
+  ExpandIcon,
+  RemoveIcon,
+} from "./SmartScalarSettingsWidgets.styled";
 
 type SmartScalarComparisonWidgetProps = {
   onChange: (setting: SmartScalarComparison[]) => void;
@@ -60,18 +64,21 @@ export function SmartScalarComparisonWidget({
 
   return (
     <Stack>
-      {value.map((comparison, index) => (
-        <ComparisonPicker
-          {...props}
-          key={index}
-          value={comparison}
-          isRemovable={canRemoveComparison}
-          onChange={nextComparison =>
-            handleChangeComparison(index, nextComparison)
-          }
-          onRemove={() => handleRemoveComparison(index)}
-        />
-      ))}
+      <ComparisonList>
+        {value.map((comparison, index) => (
+          <li key={index}>
+            <ComparisonPicker
+              {...props}
+              value={comparison}
+              isRemovable={canRemoveComparison}
+              onChange={nextComparison =>
+                handleChangeComparison(index, nextComparison)
+              }
+              onRemove={() => handleRemoveComparison(index)}
+            />
+          </li>
+        ))}
+      </ComparisonList>
       <Button
         variant="subtle"
         disabled={!canAddComparison}

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.tsx
@@ -15,20 +15,56 @@ import { MenuItemStyled } from "./MenuItem.styled";
 import { AnotherColumnForm } from "./AnotherColumnForm";
 
 type SmartScalarComparisonWidgetProps = {
-  onChange: (setting: SmartScalarComparison) => void;
+  onChange: (setting: SmartScalarComparison[]) => void;
   options: ComparisonMenuOption[];
   comparableColumns: DatasetColumn[];
-  value: SmartScalarComparison;
+  value: SmartScalarComparison[];
 };
 
 type Tab = "anotherColumn" | "staticNumber" | null;
 
 export function SmartScalarComparisonWidget({
-  onChange: onChange,
+  value,
+  onChange,
+  ...props
+}: SmartScalarComparisonWidgetProps) {
+  const handleChange = useCallback(
+    (index: number, comparison: SmartScalarComparison) => {
+      const nextValue = value.map((item, i) =>
+        i === index ? comparison : item,
+      );
+      onChange(nextValue);
+    },
+    [value, onChange],
+  );
+
+  return (
+    <div>
+      {value.map((comparison, index) => (
+        <ComparisonPicker
+          {...props}
+          key={index}
+          value={comparison}
+          onChange={nextComparison => handleChange(index, nextComparison)}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface ComparisonPickerProps {
+  value: SmartScalarComparison;
+  options: ComparisonMenuOption[];
+  comparableColumns: DatasetColumn[];
+  onChange: (setting: SmartScalarComparison) => void;
+}
+
+function ComparisonPicker({
+  onChange,
   options,
   comparableColumns,
   value: selectedValue,
-}: SmartScalarComparisonWidgetProps) {
+}: ComparisonPickerProps) {
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<Tab>(
     getTabForComparisonType(selectedValue.type),

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
@@ -15,7 +15,7 @@ import { DoneButton } from "./SmartScalarSettingsWidgets.styled";
 
 interface StaticNumberFormProps {
   value?: SmartScalarComparisonStaticNumber;
-  onChange: (setting: SmartScalarComparisonStaticNumber) => void;
+  onChange: (value: Omit<SmartScalarComparisonStaticNumber, "id">) => void;
   onBack: () => void;
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -81,7 +81,7 @@ export function SmartScalar({
   if (trend == null) {
     return null;
   }
-  const { value, clicked, comparison, display, formatOptions } = trend;
+  const { value, clicked, comparisons, display, formatOptions } = trend;
 
   const innerHeight = isDashboard ? height - DASHCARD_HEADER_HEIGHT : height;
 
@@ -126,12 +126,16 @@ export function SmartScalar({
       {isPeriodVisible(innerHeight) && (
         <ScalarPeriod lines={1} period={display.date} />
       )}
-
-      <PreviousValueWrapper data-testid="scalar-previous-value">
-        <PreviousValueComparison
-          {...{ comparison, width, fontFamily, formatOptions }}
-        />
-      </PreviousValueWrapper>
+      {comparisons.map((comparison, index) => (
+        <PreviousValueWrapper key={index} data-testid="scalar-previous-value">
+          <PreviousValueComparison
+            comparison={comparison}
+            fontFamily={fontFamily}
+            formatOptions={formatOptions}
+            width={width}
+          />
+        </PreviousValueWrapper>
+      ))}
     </ScalarWrapper>
   );
 }
@@ -213,7 +217,7 @@ function PreviousValueComparison({
     }
 
     return jt`${comparisonDescStr}: ${(
-      <PreviousValueNumber>{valueStr}</PreviousValueNumber>
+      <PreviousValueNumber key="value-str">{valueStr}</PreviousValueNumber>
     )}`;
   });
   const fullDetailDisplay = detailCandidates[0];
@@ -284,9 +288,16 @@ Object.assign(SmartScalar, {
       section: t`Data`,
       title: t`Comparisons`,
       widget: SmartScalarComparisonWidget,
-      isValid: (series, vizSettings) => isComparisonValid(series, vizSettings),
-      getDefault: (series, vizSettings) =>
-        getDefaultComparison(series, vizSettings),
+      isValid: (series, vizSettings) => {
+        const comparisons = vizSettings["scalar.comparisons"];
+        return comparisons.every(comparison =>
+          isComparisonValid(comparison, series, vizSettings),
+        );
+      },
+      getDefault: (series, vizSettings) => {
+        const comparison = getDefaultComparison(series, vizSettings);
+        return [comparison];
+      },
       getProps: (series, vizSettings) => {
         const cols = series[0].data.cols;
         return {

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -30,6 +30,7 @@ import {
   DASHCARD_HEADER_HEIGHT,
   ICON_MARGIN_RIGHT,
   ICON_SIZE,
+  MAX_COMPARISONS,
   SPACING,
   TOOLTIP_ICON_SIZE,
 } from "./constants";
@@ -301,6 +302,7 @@ Object.assign(SmartScalar, {
       getProps: (series, vizSettings) => {
         const cols = series[0].data.cols;
         return {
+          maxComparisons: MAX_COMPARISONS,
           comparableColumns: getColumnsForComparison(cols, vizSettings),
           options: getComparisonOptions(series, vizSettings),
         };

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.unit.spec.js
@@ -25,11 +25,12 @@ const getPeriodsAgoComparison = value => ({
   value,
 });
 
-const series = (
-  { rows, insights, field, comparisonType } = {
-    comparisonType: PREVIOUS_PERIOD_COMPARISON,
-  },
-) => {
+const series = ({
+  rows,
+  insights,
+  field,
+  comparisonType = PREVIOUS_PERIOD_COMPARISON,
+} = {}) => {
   const cols = [
     DateTimeColumn({ name: "Month" }),
     NumberColumn({ name: "Count" }),
@@ -41,7 +42,7 @@ const series = (
         display: "smartscalar",
         visualization_settings: {
           "scalar.field": field,
-          "scalar.comparisons": comparisonType,
+          "scalar.comparisons": [comparisonType],
         },
       },
       data: { cols, rows, insights },

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.unit.spec.js
@@ -13,14 +13,17 @@ const setup = (series, width = 800) =>
   renderWithProviders(<Visualization rawSeries={series} width={width} />);
 
 const PREVIOUS_PERIOD_COMPARISON = {
+  id: "1",
   type: COMPARISON_TYPES.PREVIOUS_PERIOD,
 };
 
 const PREVIOUS_VALUE_COMPARISON = {
+  id: "1",
   type: COMPARISON_TYPES.PREVIOUS_VALUE,
 };
 
 const getPeriodsAgoComparison = value => ({
+  id: "1",
   type: COMPARISON_TYPES.PERIODS_AGO,
   value,
 });

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.unit.spec.js
@@ -205,7 +205,7 @@ describe("SmartScalar > compute", () => {
         createGetComparisonProperties(comparisonType);
       const settings = createMockVisualizationSettings({
         "scalar.field": "Count",
-        "scalar.comparisons": { type: comparisonType },
+        "scalar.comparisons": [{ type: comparisonType }],
       });
 
       const cols = [
@@ -357,7 +357,7 @@ describe("SmartScalar > compute", () => {
           createGetComparisonProperties(comparisonType);
         const settings = createMockVisualizationSettings({
           "scalar.field": "Count",
-          "scalar.comparisons": { type: comparisonType },
+          "scalar.comparisons": [{ type: comparisonType }],
         });
 
         const cols = [
@@ -440,7 +440,7 @@ describe("SmartScalar > compute", () => {
           createGetComparisonProperties(comparisonType);
         const settings = createMockVisualizationSettings({
           "scalar.field": "Count",
-          "scalar.comparisons": { type: comparisonType },
+          "scalar.comparisons": [{ type: comparisonType }],
         });
 
         const cols = [
@@ -637,7 +637,7 @@ describe("SmartScalar > compute", () => {
           const comparisonType = COMPARISON_TYPES.PREVIOUS_PERIOD;
           const settings = createMockVisualizationSettings({
             "scalar.field": "Count",
-            "scalar.comparisons": { type: comparisonType },
+            "scalar.comparisons": [{ type: comparisonType }],
           });
 
           const cols = [
@@ -674,7 +674,7 @@ describe("SmartScalar > compute", () => {
         const createSettings = value =>
           createMockVisualizationSettings({
             "scalar.field": "Count",
-            "scalar.comparisons": { type: comparisonType, value },
+            "scalar.comparisons": [{ type: comparisonType, value }],
           });
 
         const cols = [
@@ -976,7 +976,7 @@ describe("SmartScalar > compute", () => {
           const createSettings = value =>
             createMockVisualizationSettings({
               "scalar.field": "Count",
-              "scalar.comparisons": { type: comparisonType, value },
+              "scalar.comparisons": [{ type: comparisonType, value }],
             });
 
           const cols = [
@@ -1056,7 +1056,7 @@ describe("SmartScalar > compute", () => {
 
         const createSettings = ({ label, value }) => ({
           "scalar.field": "Count",
-          "scalar.comparisons": { type: comparisonType, label, value },
+          "scalar.comparisons": [{ type: comparisonType, label, value }],
         });
 
         const createExpectedTrendObject = ({ changeType, label, value }) => ({
@@ -1169,7 +1169,7 @@ describe("SmartScalar > compute", () => {
 
         const createSettings = ({ column = "Average", label = column }) => ({
           "scalar.field": "Count",
-          "scalar.comparisons": { type: comparisonType, label, column },
+          "scalar.comparisons": [{ type: comparisonType, label, column }],
         });
 
         const insights = [{ unit: "year", col: "Count" }];
@@ -1260,7 +1260,7 @@ describe("SmartScalar > compute", () => {
         const createSettings = type =>
           createMockVisualizationSettings({
             "scalar.field": "Count",
-            "scalar.comparisons": { type },
+            "scalar.comparisons": [{ type }],
           });
 
         const cols = [
@@ -1312,7 +1312,7 @@ describe("SmartScalar > compute", () => {
           createGetComparisonProperties(comparisonType);
         const settings = createMockVisualizationSettings({
           "scalar.field": "Count",
-          "scalar.comparisons": { type: comparisonType },
+          "scalar.comparisons": [{ type: comparisonType }],
         });
 
         const cols = [
@@ -1686,7 +1686,7 @@ describe("SmartScalar > compute", () => {
         const createSettings = value =>
           createMockVisualizationSettings({
             "scalar.field": "Count",
-            "scalar.comparisons": { type: comparisonType, value },
+            "scalar.comparisons": [{ type: comparisonType, value }],
           });
 
         const cols = [
@@ -1975,7 +1975,7 @@ describe("SmartScalar > compute", () => {
       const createSettings = field =>
         createMockVisualizationSettings({
           "scalar.field": field,
-          "scalar.comparisons": { type: comparisonType },
+          "scalar.comparisons": [{ type: comparisonType }],
         });
 
       const COUNT_FIELD = "Count";
@@ -2066,13 +2066,13 @@ describe("SmartScalar > compute", () => {
         createMockVisualizationSettings({
           column: column => ({ column }),
           "scalar.field": "Count",
-          "scalar.comparisons": { type: COMPARISON_TYPES.PREVIOUS_VALUE },
+          "scalar.comparisons": [{ type: COMPARISON_TYPES.PREVIOUS_VALUE }],
           ...settings,
         });
 
       it("should have `compact: false` by default", () => {
         const {
-          comparison: { display: comparisonDisplay },
+          comparisons: [{ display: comparisonDisplay }],
           display,
           formatOptions,
         } = computeTrend(series, insights, createVizSettings());
@@ -2084,7 +2084,7 @@ describe("SmartScalar > compute", () => {
 
       it("should have `compact: true` with `scalar.compact_primary_number` viz setting", () => {
         const {
-          comparison: { display: comparisonDisplay },
+          comparisons: [{ display: comparisonDisplay }],
           display,
           formatOptions,
         } = computeTrend(
@@ -2298,7 +2298,7 @@ function getTrend(trend) {
     return null;
   }
 
-  const { value, display, comparison } = trend;
+  const { value, display, comparisons } = trend;
 
   return {
     value,
@@ -2306,7 +2306,7 @@ function getTrend(trend) {
       value: display.value,
       date: display.date,
     },
-    comparison: getComparison(comparison),
+    comparison: getComparison(comparisons[0]),
   };
 }
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/compute.unit.spec.js
@@ -205,7 +205,7 @@ describe("SmartScalar > compute", () => {
         createGetComparisonProperties(comparisonType);
       const settings = createMockVisualizationSettings({
         "scalar.field": "Count",
-        "scalar.comparisons": [{ type: comparisonType }],
+        "scalar.comparisons": [{ id: "1", type: comparisonType }],
       });
 
       const cols = [
@@ -357,7 +357,7 @@ describe("SmartScalar > compute", () => {
           createGetComparisonProperties(comparisonType);
         const settings = createMockVisualizationSettings({
           "scalar.field": "Count",
-          "scalar.comparisons": [{ type: comparisonType }],
+          "scalar.comparisons": [{ id: "1", type: comparisonType }],
         });
 
         const cols = [
@@ -440,7 +440,7 @@ describe("SmartScalar > compute", () => {
           createGetComparisonProperties(comparisonType);
         const settings = createMockVisualizationSettings({
           "scalar.field": "Count",
-          "scalar.comparisons": [{ type: comparisonType }],
+          "scalar.comparisons": [{ id: "1", type: comparisonType }],
         });
 
         const cols = [
@@ -637,7 +637,7 @@ describe("SmartScalar > compute", () => {
           const comparisonType = COMPARISON_TYPES.PREVIOUS_PERIOD;
           const settings = createMockVisualizationSettings({
             "scalar.field": "Count",
-            "scalar.comparisons": [{ type: comparisonType }],
+            "scalar.comparisons": [{ id: "1", type: comparisonType }],
           });
 
           const cols = [
@@ -674,7 +674,7 @@ describe("SmartScalar > compute", () => {
         const createSettings = value =>
           createMockVisualizationSettings({
             "scalar.field": "Count",
-            "scalar.comparisons": [{ type: comparisonType, value }],
+            "scalar.comparisons": [{ id: "1", type: comparisonType, value }],
           });
 
         const cols = [
@@ -976,7 +976,7 @@ describe("SmartScalar > compute", () => {
           const createSettings = value =>
             createMockVisualizationSettings({
               "scalar.field": "Count",
-              "scalar.comparisons": [{ type: comparisonType, value }],
+              "scalar.comparisons": [{ id: "1", type: comparisonType, value }],
             });
 
           const cols = [
@@ -1056,7 +1056,9 @@ describe("SmartScalar > compute", () => {
 
         const createSettings = ({ label, value }) => ({
           "scalar.field": "Count",
-          "scalar.comparisons": [{ type: comparisonType, label, value }],
+          "scalar.comparisons": [
+            { id: "1", type: comparisonType, label, value },
+          ],
         });
 
         const createExpectedTrendObject = ({ changeType, label, value }) => ({
@@ -1169,7 +1171,9 @@ describe("SmartScalar > compute", () => {
 
         const createSettings = ({ column = "Average", label = column }) => ({
           "scalar.field": "Count",
-          "scalar.comparisons": [{ type: comparisonType, label, column }],
+          "scalar.comparisons": [
+            { id: "1", type: comparisonType, label, column },
+          ],
         });
 
         const insights = [{ unit: "year", col: "Count" }];
@@ -1260,7 +1264,7 @@ describe("SmartScalar > compute", () => {
         const createSettings = type =>
           createMockVisualizationSettings({
             "scalar.field": "Count",
-            "scalar.comparisons": [{ type }],
+            "scalar.comparisons": [{ id: "1", type }],
           });
 
         const cols = [
@@ -1312,7 +1316,7 @@ describe("SmartScalar > compute", () => {
           createGetComparisonProperties(comparisonType);
         const settings = createMockVisualizationSettings({
           "scalar.field": "Count",
-          "scalar.comparisons": [{ type: comparisonType }],
+          "scalar.comparisons": [{ id: "1", type: comparisonType }],
         });
 
         const cols = [
@@ -1686,7 +1690,7 @@ describe("SmartScalar > compute", () => {
         const createSettings = value =>
           createMockVisualizationSettings({
             "scalar.field": "Count",
-            "scalar.comparisons": [{ type: comparisonType, value }],
+            "scalar.comparisons": [{ id: "1", type: comparisonType, value }],
           });
 
         const cols = [
@@ -1975,7 +1979,7 @@ describe("SmartScalar > compute", () => {
       const createSettings = field =>
         createMockVisualizationSettings({
           "scalar.field": field,
-          "scalar.comparisons": [{ type: comparisonType }],
+          "scalar.comparisons": [{ id: "1", type: comparisonType }],
         });
 
       const COUNT_FIELD = "Count";
@@ -2066,7 +2070,9 @@ describe("SmartScalar > compute", () => {
         createMockVisualizationSettings({
           column: column => ({ column }),
           "scalar.field": "Count",
-          "scalar.comparisons": [{ type: COMPARISON_TYPES.PREVIOUS_VALUE }],
+          "scalar.comparisons": [
+            { id: "1", type: COMPARISON_TYPES.PREVIOUS_VALUE },
+          ],
           ...settings,
         });
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/constants.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/constants.ts
@@ -14,6 +14,8 @@ export const PERIOD_HIDE_HEIGHT_THRESHOLD = 70; // determined empirically
 
 export const DASHCARD_HEADER_HEIGHT = 33;
 
+export const MAX_COMPARISONS = 3;
+
 export const COMPARISON_TYPES = {
   ANOTHER_COLUMN: "anotherColumn",
   PREVIOUS_VALUE: "previousValue",

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -16,6 +16,7 @@ import type {
 import { isEmpty } from "metabase/lib/validate";
 import { formatNumber } from "metabase/lib/formatting";
 import { measureText } from "metabase/lib/measure-text";
+import { uuid } from "metabase/lib/utils";
 import { isDate, isNumeric } from "metabase-lib/types/utils/isa";
 
 import {
@@ -119,15 +120,21 @@ export function getDefaultComparison(
   )?.unit;
 
   if (!dateUnit) {
-    return createComparisonMenuOption({
-      type: COMPARISON_TYPES.PREVIOUS_VALUE,
-    });
+    return {
+      id: uuid(),
+      ...createComparisonMenuOption({
+        type: COMPARISON_TYPES.PREVIOUS_VALUE,
+      }),
+    };
   }
 
-  return createComparisonMenuOption({
-    type: COMPARISON_TYPES.PREVIOUS_PERIOD,
-    dateUnit,
-  });
+  return {
+    id: uuid(),
+    ...createComparisonMenuOption({
+      type: COMPARISON_TYPES.PREVIOUS_PERIOD,
+      dateUnit,
+    }),
+  };
 }
 
 export function getColumnsForComparison(
@@ -206,6 +213,10 @@ export function isComparisonValid(
       data: { cols, insights },
     },
   ] = series;
+
+  if (!comparison.id) {
+    return false;
+  }
 
   if (comparison.type === COMPARISON_TYPES.ANOTHER_COLUMN) {
     if (isEmpty(comparison.column) || isEmpty(comparison.label)) {

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -9,6 +9,7 @@ import type {
 } from "metabase-types/api/dataset";
 import type {
   RelativeDatetimeUnit,
+  SmartScalarComparison,
   VisualizationSettings,
 } from "metabase-types/api";
 
@@ -196,24 +197,18 @@ export function getComparisonOptions(
 }
 
 export function isComparisonValid(
+  comparison: SmartScalarComparison,
   series: RawSeries,
   settings: VisualizationSettings,
 ) {
-  const comparison = settings["scalar.comparisons"];
-  const comparisonType = comparison?.type;
-
   const [
     {
       data: { cols, insights },
     },
   ] = series;
 
-  if (comparisonType === COMPARISON_TYPES.ANOTHER_COLUMN) {
-    if (
-      !comparison ||
-      isEmpty(comparison.column) ||
-      isEmpty(comparison.label)
-    ) {
+  if (comparison.type === COMPARISON_TYPES.ANOTHER_COLUMN) {
+    if (isEmpty(comparison.column) || isEmpty(comparison.label)) {
       return false;
     }
 
@@ -226,11 +221,11 @@ export function isComparisonValid(
     return isExistingColumn && isDifferentFromPrimaryColumn;
   }
 
-  if (comparisonType === COMPARISON_TYPES.PREVIOUS_VALUE) {
+  if (comparison.type === COMPARISON_TYPES.PREVIOUS_VALUE) {
     return true;
   }
 
-  if (comparisonType === COMPARISON_TYPES.STATIC_NUMBER) {
+  if (comparison.type === COMPARISON_TYPES.STATIC_NUMBER) {
     return !isEmpty(comparison?.value) && !isEmpty(comparison?.label);
   }
 

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
@@ -6,6 +6,8 @@ import type {
   Insight,
   RelativeDatetimeUnit,
   RowValues,
+  SmartScalarComparisonAnotherColumn,
+  SmartScalarComparisonStaticNumber,
   VisualizationSettings,
 } from "metabase-types/api";
 import {
@@ -212,15 +214,17 @@ describe("SmartScalar > utils", () => {
 
     describe("isComparisonValid", () => {
       it("should always return true if type is previousValue comparison", () => {
+        const comparison = { type: COMPARISON_TYPES.PREVIOUS_VALUE };
         const settings = {
           "scalar.field": FIELD_NAME,
-          "scalar.comparisons": { type: COMPARISON_TYPES.PREVIOUS_VALUE },
+          "scalar.comparisons": [comparison],
         };
         const rows = [
           ["2019-10-01", 100],
           ["2019-11-01", 300],
         ];
         const isValid = isComparisonValid(
+          comparison,
           series({ rows, insights: [] }),
           settings,
         );
@@ -229,7 +233,6 @@ describe("SmartScalar > utils", () => {
       });
 
       it.each([
-        ["missing", undefined],
         [
           COMPARISON_TYPES.PERIODS_AGO,
           { type: COMPARISON_TYPES.PERIODS_AGO, value: 3 },
@@ -243,13 +246,14 @@ describe("SmartScalar > utils", () => {
         (_, comparison) => {
           const settings = {
             "scalar.field": FIELD_NAME,
-            "scalar.comparisons": comparison,
+            "scalar.comparisons": [comparison],
           };
           const rows = [
             ["2019-10-01", 100],
             ["2019-11-01", 300],
           ];
           const isValid = isComparisonValid(
+            comparison,
             series({ rows, insights: [] }),
             settings,
           );
@@ -259,7 +263,6 @@ describe("SmartScalar > utils", () => {
       );
 
       it.each([
-        ["missing", undefined],
         [
           COMPARISON_TYPES.PERIODS_AGO,
           { type: COMPARISON_TYPES.PERIODS_AGO, value: 3 },
@@ -277,7 +280,7 @@ describe("SmartScalar > utils", () => {
         (_, comparison) => {
           const settings = {
             "scalar.field": FIELD_NAME,
-            "scalar.comparisons": comparison,
+            "scalar.comparisons": [comparison],
           };
           const rows = [
             ["2019-10-01", 100],
@@ -285,6 +288,7 @@ describe("SmartScalar > utils", () => {
           ];
           const insights = createInsights("month");
           const isValid = isComparisonValid(
+            comparison,
             series({ rows, insights }),
             settings,
           );
@@ -307,16 +311,18 @@ describe("SmartScalar > utils", () => {
         });
 
         it("should return true when valid", () => {
+          const comparison = {
+            type: COMPARISON_TYPES.ANOTHER_COLUMN,
+            label: "Avg",
+            column: "Average",
+          };
           const settings = {
             "scalar.field": FIELD_NAME,
-            "scalar.comparisons": {
-              type: COMPARISON_TYPES.ANOTHER_COLUMN,
-              label: "Avg",
-              column: "Average",
-            },
+            "scalar.comparisons": [comparison],
           };
 
           const isValid = isComparisonValid(
+            comparison,
             multiSeries,
             settings as VisualizationSettings,
           );
@@ -325,15 +331,17 @@ describe("SmartScalar > utils", () => {
         });
 
         it("should return false when column is missing", () => {
+          const comparison = {
+            type: COMPARISON_TYPES.ANOTHER_COLUMN,
+            label: "Count",
+          };
           const settings = {
             "scalar.field": FIELD_NAME,
-            "scalar.comparisons": {
-              type: COMPARISON_TYPES.ANOTHER_COLUMN,
-              label: "Count",
-            },
+            "scalar.comparisons": [comparison],
           };
 
           const isValid = isComparisonValid(
+            comparison as SmartScalarComparisonAnotherColumn,
             multiSeries,
             settings as VisualizationSettings,
           );
@@ -342,15 +350,17 @@ describe("SmartScalar > utils", () => {
         });
 
         it("should return false when label is missing", () => {
+          const comparison = {
+            type: COMPARISON_TYPES.ANOTHER_COLUMN,
+            column: "Count",
+          };
           const settings = {
             "scalar.field": FIELD_NAME,
-            "scalar.comparisons": {
-              type: COMPARISON_TYPES.ANOTHER_COLUMN,
-              column: "Count",
-            },
+            "scalar.comparisons": [comparison],
           };
 
           const isValid = isComparisonValid(
+            comparison as SmartScalarComparisonAnotherColumn,
             multiSeries,
             settings as VisualizationSettings,
           );
@@ -359,16 +369,18 @@ describe("SmartScalar > utils", () => {
         });
 
         it("should return false when comparison column is the same as primary number", () => {
+          const comparison = {
+            type: COMPARISON_TYPES.ANOTHER_COLUMN,
+            column: FIELD_NAME,
+            label: "Count",
+          };
           const settings = {
             "scalar.field": FIELD_NAME,
-            "scalar.comparisons": {
-              type: COMPARISON_TYPES.ANOTHER_COLUMN,
-              column: FIELD_NAME,
-              label: "Count",
-            },
+            "scalar.comparisons": [comparison],
           };
 
           const isValid = isComparisonValid(
+            comparison,
             multiSeries,
             settings as VisualizationSettings,
           );
@@ -377,16 +389,18 @@ describe("SmartScalar > utils", () => {
         });
 
         it("should return false when column is missing in the series", () => {
+          const comparison = {
+            type: COMPARISON_TYPES.ANOTHER_COLUMN,
+            label: "Missing",
+            column: "Missing",
+          };
           const settings = {
             "scalar.field": FIELD_NAME,
-            "scalar.comparisons": {
-              type: COMPARISON_TYPES.ANOTHER_COLUMN,
-              label: "Missing",
-              column: "Missing",
-            },
+            "scalar.comparisons": [comparison],
           };
 
           const isValid = isComparisonValid(
+            comparison as SmartScalarComparisonAnotherColumn,
             multiSeries,
             settings as VisualizationSettings,
           );
@@ -397,19 +411,21 @@ describe("SmartScalar > utils", () => {
 
       describe("static number comparison", () => {
         it("should return true when valid", () => {
+          const comparison = {
+            type: COMPARISON_TYPES.STATIC_NUMBER,
+            value: 100,
+            label: "Goal",
+          };
           const settings = {
             "scalar.field": FIELD_NAME,
-            "scalar.comparisons": {
-              type: COMPARISON_TYPES.STATIC_NUMBER,
-              value: 100,
-              label: "Goal",
-            },
+            "scalar.comparisons": [comparison],
           };
           const rows = [
             ["2019-10-01", 100],
             ["2019-11-01", 300],
           ];
           const isValid = isComparisonValid(
+            comparison as SmartScalarComparisonStaticNumber,
             series({ rows, insights: [] }),
             settings,
           );
@@ -418,12 +434,13 @@ describe("SmartScalar > utils", () => {
         });
 
         it("should return false when value is missing", () => {
+          const comparison = {
+            type: COMPARISON_TYPES.STATIC_NUMBER,
+            label: "Goal",
+          };
           const settings = {
             "scalar.field": FIELD_NAME,
-            "scalar.comparisons": {
-              type: COMPARISON_TYPES.STATIC_NUMBER,
-              label: "Goal",
-            },
+            "scalar.comparisons": [comparison],
           };
           const rows = [
             ["2019-10-01", 100],
@@ -431,6 +448,7 @@ describe("SmartScalar > utils", () => {
           ];
 
           const isValid = isComparisonValid(
+            comparison as SmartScalarComparisonStaticNumber,
             series({ rows, insights: [] }),
             settings as VisualizationSettings,
           );
@@ -439,12 +457,13 @@ describe("SmartScalar > utils", () => {
         });
 
         it("should return false when label is missing", () => {
+          const comparison = {
+            type: COMPARISON_TYPES.STATIC_NUMBER,
+            value: 100,
+          };
           const settings = {
             "scalar.field": FIELD_NAME,
-            "scalar.comparisons": {
-              type: COMPARISON_TYPES.STATIC_NUMBER,
-              value: 100,
-            },
+            "scalar.comparisons": [comparison],
           };
           const rows = [
             ["2019-10-01", 100],
@@ -452,6 +471,7 @@ describe("SmartScalar > utils", () => {
           ];
 
           const isValid = isComparisonValid(
+            comparison as SmartScalarComparisonStaticNumber,
             series({ rows, insights: [] }),
             settings as VisualizationSettings,
           );

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
@@ -6,6 +6,7 @@ import type {
   Insight,
   RelativeDatetimeUnit,
   RowValues,
+  SmartScalarComparison,
   SmartScalarComparisonAnotherColumn,
   SmartScalarComparisonStaticNumber,
   VisualizationSettings,
@@ -75,9 +76,10 @@ describe("SmartScalar > utils", () => {
           settings,
         );
 
-        expect(defaultComparison).toBe(
-          COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE,
-        );
+        expect(defaultComparison).toEqual({
+          id: expect.any(String),
+          ...COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE,
+        });
       });
 
       it("should return previous period as default if there is a dateUnit", () => {
@@ -93,6 +95,7 @@ describe("SmartScalar > utils", () => {
         );
 
         expect(defaultComparison).toEqual({
+          id: expect.any(String),
           type: COMPARISON_TYPES.PREVIOUS_PERIOD,
           name: "Previous month",
         });
@@ -214,7 +217,7 @@ describe("SmartScalar > utils", () => {
 
     describe("isComparisonValid", () => {
       it("should always return true if type is previousValue comparison", () => {
-        const comparison = { type: COMPARISON_TYPES.PREVIOUS_VALUE };
+        const comparison = { id: "1", type: COMPARISON_TYPES.PREVIOUS_VALUE };
         const settings = {
           "scalar.field": FIELD_NAME,
           "scalar.comparisons": [comparison],
@@ -232,14 +235,33 @@ describe("SmartScalar > utils", () => {
         expect(isValid).toBeTruthy();
       });
 
+      it("should always return false if ID is missing", () => {
+        const comparison = { type: COMPARISON_TYPES.PREVIOUS_VALUE };
+        const settings = {
+          "scalar.field": FIELD_NAME,
+          "scalar.comparisons": [comparison],
+        };
+        const rows = [
+          ["2019-10-01", 100],
+          ["2019-11-01", 300],
+        ];
+        const isValid = isComparisonValid(
+          comparison as SmartScalarComparison,
+          series({ rows, insights: [] }),
+          settings as VisualizationSettings,
+        );
+
+        expect(isValid).toBe(false);
+      });
+
       it.each([
         [
           COMPARISON_TYPES.PERIODS_AGO,
-          { type: COMPARISON_TYPES.PERIODS_AGO, value: 3 },
+          { id: "1", type: COMPARISON_TYPES.PERIODS_AGO, value: 3 },
         ],
         [
           COMPARISON_TYPES.PREVIOUS_PERIOD,
-          { type: COMPARISON_TYPES.PREVIOUS_PERIOD },
+          { id: "1", type: COMPARISON_TYPES.PREVIOUS_PERIOD },
         ],
       ])(
         "should return false for %s comparison when dateUnit is missing",
@@ -265,15 +287,20 @@ describe("SmartScalar > utils", () => {
       it.each([
         [
           COMPARISON_TYPES.PERIODS_AGO,
-          { type: COMPARISON_TYPES.PERIODS_AGO, value: 3 },
+          { id: "1", type: COMPARISON_TYPES.PERIODS_AGO, value: 3 },
         ],
         [
           COMPARISON_TYPES.PREVIOUS_PERIOD,
-          { type: COMPARISON_TYPES.PREVIOUS_PERIOD },
+          { id: "1", type: COMPARISON_TYPES.PREVIOUS_PERIOD },
         ],
         [
           COMPARISON_TYPES.STATIC_NUMBER,
-          { type: COMPARISON_TYPES.STATIC_NUMBER, value: 100, label: "Goal" },
+          {
+            id: "1",
+            type: COMPARISON_TYPES.STATIC_NUMBER,
+            value: 100,
+            label: "Goal",
+          },
         ],
       ])(
         "should return true for %s comparison when dateUnit is supplied",
@@ -312,6 +339,7 @@ describe("SmartScalar > utils", () => {
 
         it("should return true when valid", () => {
           const comparison = {
+            id: "1",
             type: COMPARISON_TYPES.ANOTHER_COLUMN,
             label: "Avg",
             column: "Average",
@@ -370,6 +398,7 @@ describe("SmartScalar > utils", () => {
 
         it("should return false when comparison column is the same as primary number", () => {
           const comparison = {
+            id: "1",
             type: COMPARISON_TYPES.ANOTHER_COLUMN,
             column: FIELD_NAME,
             label: "Count",
@@ -412,6 +441,7 @@ describe("SmartScalar > utils", () => {
       describe("static number comparison", () => {
         it("should return true when valid", () => {
           const comparison = {
+            id: "1",
             type: COMPARISON_TYPES.STATIC_NUMBER,
             value: 100,
             label: "Goal",


### PR DESCRIPTION
Resolves #35555

Allows adding up to three comparisons for a single trend chart. Also, I had to add an `id` to every comparison object because `dndkit` needs stable IDs for sorting. Could be easier to review in order:

* [`fb89155`](https://github.com/metabase/metabase/pull/37176/commits/fb89155ef46581733502560d98933968bbfdfcca) — turns the `scalar.comparisons` setting into an array
* [`b84847e`](https://github.com/metabase/metabase/pull/37176/commits/b84847ed7b8ce920a5c1deb429cfdcf8d92c5b35) — adds an `id` property to comparison objects
* everything else

### Demo

https://github.com/metabase/metabase/assets/17258145/8ca1923d-3cce-42d9-b520-3f7a7817c711