### PR TITLE
New permissions table schema and backend API

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -56,6 +56,7 @@
    "ModelIndexValue"
    "ModerationReview"
    "Permissions"
+   "PermissionsV2"
    "PermissionsGroup"
    "PermissionsGroupMembership"
    "PermissionsRevision"

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -53,6 +53,7 @@
     :model/ModerationReview
     :model/ParameterCard
     :model/Permissions
+    :model/PermissionsV2
     :model/PermissionsGroup
     :model/PermissionsGroupMembership
     :model/PermissionsRevision

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5227,6 +5227,42 @@ databaseChangeLog:
                   constraints:
                     nullable: false
 
+  - changeSet:
+      id: v49.2024-01-09T13:52:21
+      author: noahmoss
+      comment: Index on permissions_v2.table_id
+      changes:
+        - createIndex:
+            tableName: permissions_v2
+            columns:
+              - column:
+                  name: table_id
+            indexName: idx_permissions_v2_table_id
+
+  - changeSet:
+      id: v49.2024-01-09T13:53:50
+      author: noahmoss
+      comment: Index on permissions_v2.db_id
+      changes:
+        - createIndex:
+            tableName: permissions_v2
+            columns:
+              - column:
+                  name: db_id
+            indexName: idx_permissions_v2_db_id
+
+  - changeSet:
+      id: v49.2024-01-09T13:53:54
+      author: noahmoss
+      comment: Index on permissions_v2.group_id
+      changes:
+        - createIndex:
+            tableName: permissions_v2
+            columns:
+              - column:
+                  name: group_id
+            indexName: idx_permissions_v2_group_id
+
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5179,6 +5179,7 @@ databaseChangeLog:
                     referencedTableName: permissions_group
                     referencedColumnNames: id
                     foreignKeyName: fk_permissions_v2_ref_permissions_group
+                    deleteCascade: true
               - column:
                   remarks: The type of the permission (e.g. "data", "collection", "download"...)
                   name: type
@@ -5194,6 +5195,7 @@ databaseChangeLog:
                     referencedTableName: metabase_database
                     referencedColumnNames: id
                     foreignKeyName: fk_permissions_v2_ref_db_id
+                    deleteCascade: true
               - column:
                   remarks: A schema name, for table-level permissions
                   name: schema
@@ -5209,6 +5211,7 @@ databaseChangeLog:
                     referencedTableName: metabase_table
                     referencedColumnNames: id
                     foreignKeyName: fk_permissions_v2_ref_table_id
+                    deleteCascade: true
               - column:
                   remarks: >-
                     The ID of the object this permission is assocaited with, for non-DB and Table permissions.
@@ -5223,20 +5226,6 @@ databaseChangeLog:
                   type: varchar(64)
                   constraints:
                     nullable: false
-            uniqueConstraints:
-              - unique:
-                  columnNames: group_id, type, object_id
-                  name: unique_permissions_v2_group_id_type_object_id
-
-  - changeSet:
-      id: v49.2024-01-04T13:53:29
-      author: noahmoss
-      comment: Add unique constraint to permissions_v2 table on group_id, type, and object_id columns
-      changes:
-        - addUniqueConstraint:
-            tableName: permissions_v2
-            constraintName: unique_permissions_v2_group_id_type_object_id
-            columnNames: group_id, type, object_id
 
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5221,8 +5221,10 @@ databaseChangeLog:
                   constraints:
                     nullable: true
               - column:
-                  remarks: The value this permission is set to
-                  name: value
+                  remarks: >-
+                    The value this permission is set to. I wanted to call this 'value' but that's a reserved word
+                    in H2 which makes migrations a little more difficult.
+                  name: perm_value
                   type: varchar(64)
                   constraints:
                     nullable: false

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5231,6 +5231,7 @@ databaseChangeLog:
       id: v49.2024-01-09T13:52:21
       author: noahmoss
       comment: Index on permissions_v2.table_id
+      rollback: # not necessary, will be removed with the table
       changes:
         - createIndex:
             tableName: permissions_v2
@@ -5243,6 +5244,7 @@ databaseChangeLog:
       id: v49.2024-01-09T13:53:50
       author: noahmoss
       comment: Index on permissions_v2.db_id
+      rollback: # not necessary, will be removed with the table
       changes:
         - createIndex:
             tableName: permissions_v2
@@ -5255,6 +5257,7 @@ databaseChangeLog:
       id: v49.2024-01-09T13:53:54
       author: noahmoss
       comment: Index on permissions_v2.group_id
+      rollback: # not necessary, will be removed with the table
       changes:
         - createIndex:
             tableName: permissions_v2

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5153,7 +5153,7 @@ databaseChangeLog:
             type: mysql,mariadb
 
   - changeSet:
-      id: 2024-01-04T13:52:51
+      id: v49.2024-01-04T13:52:51
       author: noahmoss
       comment: >-
         Permissions v2 schema (proof of concept)
@@ -5229,7 +5229,7 @@ databaseChangeLog:
                   name: unique_permissions_v2_group_id_type_object_id
 
   - changeSet:
-      id: 2024-01-04T13:53:29
+      id: v49.2024-01-04T13:53:29
       author: noahmoss
       comment: Add unique constraint to permissions_v2 table on group_id, type, and object_id columns
       changes:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5174,7 +5174,6 @@ databaseChangeLog:
                   remarks: The ID of the associated permission group
                   name: group_id
                   type: int
-                  autoIncrement: true
                   constraints:
                     nullable: false
                     referencedTableName: permissions_group
@@ -5187,8 +5186,32 @@ databaseChangeLog:
                   constraints:
                     nullable: false
               - column:
+                  remarks: A database ID, for DB and table-level permissions
+                  name: db_id
+                  type: int
+                  constraints:
+                    nullable: true
+                    referencedTableName: metabase_database
+                    referencedColumnNames: id
+                    foreignKeyName: fk_permissions_v2_ref_db_id
+              - column:
+                  remarks: A schema name, for table-level permissions
+                  name: schema
+                  type: varchar(254)
+                  constraints:
+                    nullable: true
+              - column:
+                  remarks: A table ID
+                  name: table_id
+                  type: int
+                  constraints:
+                    nullable: true
+                    referencedTableName: metabase_table
+                    referencedColumnNames: id
+                    foreignKeyName: fk_permissions_v2_ref_table_id
+              - column:
                   remarks: >-
-                    The ID of the object, such as a table or collection, this permission is assocaited with.
+                    The ID of the object this permission is assocaited with, for non-DB and Table permissions.
                     The table this ID references is inferred based on the permission type.
                   name: object_id
                   type: int

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5152,6 +5152,70 @@ databaseChangeLog:
         - dbms:
             type: mysql,mariadb
 
+  - changeSet:
+      id: 2024-01-04T13:52:51
+      author: noahmoss
+      comment: >-
+        Permissions v2 schema (proof of concept)
+      changes:
+        - createTable:
+            tableName: permissions_v2
+            remarks: A table to store permissions in a v2 format
+            columns:
+              - column:
+                  remarks: The ID of the permission
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  remarks: The ID of the associated permission group
+                  name: group_id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    referencedTableName: permissions_group
+                    referencedColumnNames: id
+                    foreignKeyName: fk_permissions_v2_ref_permissions_group
+              - column:
+                  remarks: The type of the permission (e.g. "data", "collection", "download"...)
+                  name: type
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  remarks: >-
+                    The ID of the object, such as a table or collection, this permission is assocaited with.
+                    The table this ID references is inferred based on the permission type.
+                  name: object_id
+                  type: int
+                  constraints:
+                    nullable: true
+              - column:
+                  remarks: The value this permission is set to
+                  name: value
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+            uniqueConstraints:
+              - unique:
+                  columnNames: group_id, type, object_id
+                  name: unique_permissions_v2_group_id_type_object_id
+
+  - changeSet:
+      id: 2024-01-04T13:53:29
+      author: noahmoss
+      comment: Add unique constraint to permissions_v2 table on group_id, type, and object_id columns
+      changes:
+        - addUniqueConstraint:
+            tableName: permissions_v2
+            constraintName: unique_permissions_v2_group_id_type_object_id
+            columnNames: group_id, type, object_id
+
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/cmd/copy.clj
+++ b/src/metabase/cmd/copy.clj
@@ -76,6 +76,7 @@
     :model/PermissionsGroup
     :model/PermissionsGroupMembership
     :model/Permissions
+    :model/PermissionsV2
     :model/PermissionsRevision
     :model/PersistedInfo
     :model/ApplicationPermissionsRevision

--- a/src/metabase/models/permissions_v2.clj
+++ b/src/metabase/models/permissions_v2.clj
@@ -1,0 +1,231 @@
+(ns metabase.models.permissions-v2
+  "Model namespace for the V2 permissions system. This is not based on permission paths (as in V1), but rather explicit
+  permission types and associated values for every object (table/collection) or capability on the system."
+  (:require
+   [malli.core :as mc]
+   [metabase.models.interface :as mi]
+   [metabase.util :as u]
+   [metabase.util.i18n :refer [tru]]
+   [methodical.core :as methodical]
+   [toucan2.core :as t2]))
+
+(methodical/defmethod t2/table-name :model/PermissionsV2 [_model] :permissions_v2)
+
+(doto :model/PermissionsV2
+  (derive :metabase/model))
+
+(t2/deftransforms :model/PermissionsV2
+  {:type mi/transform-keyword
+   :value mi/transform-keyword})
+
+
+;;; ---------------------------------------- Permission definitions ---------------------------------------------------
+
+;; IMPORTANT: If you add a new permission type, `:values` must be ordered from *most* permissive to *least* permissive.
+;;
+;;  - When fetching a user's permissions, the default behavior is to return the *most* permissive value from any group the
+;;    user is in. This can be overridden by definding a custom implementation of `coalesce`.
+;;
+;;  - If a user does not have any value for the permission when it is fetched, the *least* permissive value is used as a
+;;    fallback.
+
+;; Permissions which apply to individual databases or tables
+(def ^:private DataPermissions
+  {:data-access           {:values [:unrestricted :no-self-service :block]
+                           :model  :model/Table}
+   :native-query-editing  {:values [:yes :no]
+                           :model  :model/Database}
+   :download-results      {:values [:one-million-rows :ten-thousand-rows :no]
+                           :model  :model/Table}
+   :manage-table-metadata {:values [:yes :no]
+                           :model  :model/Table}
+   :manage-database       {:values [:yes :no]
+                           :model  :model/Database}})
+
+;; Permissions which apply to collections
+(def ^:private CollectionPermissions
+  {:collection {:values [:curate :view :no-access]
+                :model  :model/Collection}})
+
+;; Permissions which apply to the application as a whole, rather than being linked to a specific model
+(def ^:private ApplicationPermissions
+  {:settings-access          {:values [:yes :no]}
+   :monitoring-access        {:values [:yes :no]}
+   :subscriptions-and-alerts {:values [:yes :no]}})
+
+(def ^:private Permissions
+  (merge DataPermissions
+         CollectionPermissions
+         ApplicationPermissions))
+
+(def PermissionType
+  "Malli spec for valid permission types."
+  (into [:enum] (keys Permissions)))
+
+
+;;; ------------------------------------------- Misc Utils ------------------------------------------------------------
+
+(defn- least-permissive-value
+  "The *least* permissive value for a given perm type. This value is used as a fallback when a user does not have a
+  value for the permission in the database."
+  [perm-type]
+  (-> Permissions perm-type :values last))
+
+(defn- most-permissive-value
+  "The *most* permissive value for a given perm type. This is the default value for superusers."
+  [perm-type]
+  (-> Permissions perm-type :values first))
+
+(defn- assert-required-object-id
+  "Takes a permission type and a possibly-nil object ID, and throws an exception if the permission type requires an
+  object ID and the object ID is nil."
+  [perm-type object-id]
+  (when (and (get-in Permissions [perm-type :model])
+             (not object-id))
+    (throw (ex-info (tru "Permission type {0} requires an object ID" perm-type)
+                    {perm-type (Permissions perm-type)}))))
+
+(def perm-types-by-model
+  "A map from model identifiers to a list of permission types that apply to that model."
+  (reduce-kv
+   (fn [m perm-type {:keys [model]}]
+     (when model (update m model (fnil conj #{}) perm-type)))
+   {}
+   Permissions))
+
+
+;;; ---------------------------------------- Fetching permissions -----------------------------------------------------
+
+(defmulti coalesce
+  "Coalesce a set of permission values into a single value. This is used to determine the permission to enforce for a
+  user in multiple groups with conflicting permissions. By default, this returns the *most* permissive value that the
+  user has in any group.
+
+  For instance,
+    #{} -> :yes
+    #{:view :no-access} -> :view"
+  {:arglists '([perm-type perm-values])}
+  (fn [perm-type _perm-values] perm-type))
+
+(defmethod coalesce :default
+  [perm-type perm-values]
+  (let [ordered-values (-> Permissions perm-type :values)]
+    (first (filter (set perm-values) ordered-values))))
+
+(defn permission-for-user
+  "Returns the effective permission value for a given user, permission type, and (optional) object ID. If the user has
+  multiple permissions for the given type in different groups, they are coalesced into a single value."
+  [user-id perm-type & [object-or-id]]
+  (assert-required-object-id perm-type object-or-id)
+  (when (t2/select-one-fn :is_superuser :model/User :id user-id)
+    (most-permissive-value perm-type))
+  (let [object-id (when object-or-id (u/the-id object-or-id))
+        perm-values (t2/select-fn-set :value
+                                      :model/PermissionsV2
+                                      {:select [:p.value]
+                                       :from [[:permissions_group_membership :pgm]]
+                                       :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                                              [:permissions_v2 :p]     [:= :p.group_id :pg.id]]
+                                       :where [:and
+                                               [:= :pgm.user_id user-id]
+                                               [:= :p.type (name perm-type)]
+                                               (when object-id [:= :p.object_id object-id])]})]
+    (or (coalesce perm-type perm-values)
+        (least-permissive-value perm-type))))
+
+#_(defn permissions-graph
+    "Returns a map representing all permissions on the Metabase instance. Can be optionally be scoped by `group-id`
+  and/or `perm-type`."
+    [& {:keys [group-id perm-type]}]
+    [group-id perm-type]
+    (let [permissions (t2/select :model/PermissionsV2
+                                 {:where [:and
+                                          (when group-id [:= :group_id group-id])
+                                          (when perm-type [:= :type (name perm-type)])]})]
+      permissions))
+
+(defn data-permissions-graph
+  "Returns a tree representation of all data permissions on the instance."
+  [user-id]
+  (let [table-level-permissions
+        (t2/select :model/PermissionsV2
+                   {:select [:p.type :p.value [:p.object_id :table_id] [:mt.db_id :db-id] :mt.schema]
+                    :from   [[:permissions_group_membership :pgm]]
+                    :join   [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                             [:permissions_v2 :p]     [:= :p.group_id :pg.id]
+                             [:metabase_table :mt]    [:and
+                                                       [:= :mt.id :p.object_id]
+                                                       [:in :p.type (map name (perm-types-by-model :model/Table))]]]
+                    :where  [:= :pgm.user_id user-id]})
+        db-level-permissions
+        (t2/select :model/PermissionsV2
+                   {:select [:p.type :p.value [:p.object_id :object-id] [:md.id :db_id]]
+                    :from   [[:permissions_group_membership :pgm]]
+                    :join   [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                             [:permissions_v2 :p]     [:= :p.group_id :pg.id]
+                             [:metabase_database :md] [:and
+                                                       [:= :md.id :p.object_id]
+                                                       [:in :p.type (map name (perm-types-by-model :model/Database))]]]
+                    :where  [:= :pgm.user_id user-id]})]
+    ;; TODO: build graph
+    [table-level-permissions db-level-permissions]))
+
+
+;;; --------------------------------------------- Updating permissions ------------------------------------------------
+
+(t2/define-before-insert :model/PermissionsV2
+  [{perm-type :type, object-id :object_id :as permission}]
+  (when-not (mc/validate PermissionType perm-type)
+    (throw (ex-info (tru "Invalid permission type: {0}" perm-type)
+                    permission)))
+  (assert-required-object-id perm-type object-id)
+  permission)
+
+(defn set-permission!
+  "Sets a single permission to a specified value for a given group. Optionally takes an `object-or-id` representing the
+  object (e.g. table or collection) that this permission applies to. If a permission value already exists for the
+  specified group and object, it will be updated to the new value. Returns the number of permission rows added."
+  [perm-type group-or-id value & [object-or-id]]
+  (t2/with-transaction [_conn]
+    (let [group-id         (u/the-id group-or-id)
+          object-id        (when object-or-id (u/the-id object-or-id))
+          new-perm         {:type       perm-type
+                            :group_id   group-id
+                            :object_id  object-id
+                            :value      value}
+          existing-perm-id (t2/select-one-pk :model/PermissionsV2
+                                             :type perm-type
+                                             :group_id group-id
+                                             :object_id object-id)]
+      (if existing-perm-id
+        (t2/update! :model/PermissionsV2 existing-perm-id new-perm)
+        (t2/insert! :model/PermissionsV2 new-perm)))))
+
+(defn set-permissions!
+  "For a single group and permission type, sets permissions for multiple objects at onces (e.g. tables or collections).
+  Takes a map of `object-or-id` -> `value` pairs. Returns the number of permission rows added."
+  [perm-type group-id object-or-id->value]
+  (let [object-id->value (update-keys object-or-id->value u/the-id)
+        permissions      (for [[object-id value] object-id->value]
+                           {:type       perm-type
+                            :group_id   group-id
+                            :object_id  object-id
+                            :value      value})]
+    (t2/with-transaction [_conn]
+      (t2/delete! :model/PermissionsV2
+                  :type perm-type
+                  :group_id group-id
+                  {:where [:in :object_id (keys object-id->value)]})
+      (t2/insert! :model/PermissionsV2 permissions))))
+
+;; TODO
+;; - Function that takes a DB and perm type, and sets permissions for all tables to a given value
+;; - Similar function for a single schema
+
+(comment
+  (set-permission! :data-access 1 :no-self-service 1)
+  (set-permission! :settings-access 1 :yes)
+  (t2/delete! :model/PermissionsV2
+              :type :data-access
+              :group_id 1
+              {:where [:in :object_id (keys {3 :unrestricted})]}))

--- a/src/metabase/models/permissions_v2.clj
+++ b/src/metabase/models/permissions_v2.clj
@@ -267,36 +267,3 @@
       (if existing-perm-id
         (t2/update! :model/PermissionsV2 existing-perm-id new-perm)
         (t2/insert! :model/PermissionsV2 new-perm)))))
-
-;; TODO
-;; - Function that takes a DB and perm type, and sets permissions for all tables to a given value
-;; - Similar function for a single schema
-
-
-(comment
-  (defn do-try-catch-message [thunk] (try (thunk) (catch Exception e (ex-message e))))
-  (defmacro tcm [& body] `(do-try-catch-message (fn [] ~@body)))
-
-  (set-permission! :data-access 1 :unrestricted 3 1 "PUBLIC")
-  (set-permission! :data-access 1 :no-self-service {:id 2})
-  (set-permission! :data-access {:id 1} :no-self-service 3)
-  (set-permission! :data-access {:id 1} :no-self-service {:id 4})
-
-  (= :no-self-service
-     (permission-for-user 1 :data-access 1)
-     (permission-for-user 1 :data-access {:id 1}))
-
-  (set-permission! :settings-access 1 :no)
-
-  (= :no (permission-for-user 1 :settings-access 1))
-
-  (t2/delete! :model/PermissionsV2
-              :type :data-access
-              :group_id 1
-              {:where [:in :object_id (keys {3 :unrestricted})]})
-
-  (tcm (set-permission! :settings-access 1 :no-self-service))
-  ;; => "Permission type :settings-access cannot be set to :no-self-service"
-
-  (tcm (set-permission! :settings-access 1 :yes)))
-  ;; => "ERROR: insert or update on table \"permissions_v2\" violates foreign key constraint \"fk_permissions_v2_ref_permissions_group\"\n  Detail: Key (group_id)=(10) is not present in table \"permissions_group\"."

--- a/src/metabase/models/permissions_v2.clj
+++ b/src/metabase/models/permissions_v2.clj
@@ -80,7 +80,7 @@
   (-> Permissions perm-type :values first))
 
 (def ^:private model-by-perm-type
-  "A map from permiiion types directly to model identifiers (or `nil`)."
+  "A map from permission types directly to model identifiers (or `nil`)."
   (update-vals Permissions :model))
 
 (defn- assert-value-matches-perm-type

--- a/src/metabase/models/permissions_v2.clj
+++ b/src/metabase/models/permissions_v2.clj
@@ -43,7 +43,7 @@
 
 (def ^:private CollectionPermissions
   "Permissions which apply to collections"
-  {:collection {:model  :model/Collection :values [:curate :view :no-access]}})
+  {:collection {:model :model/Collection :values [:curate :view :no-access]}})
 
 (def ^:private ApplicationPermissions
   "Permissions which apply to the application as a whole, rather than being linked to a specific model"
@@ -65,6 +65,7 @@
   "Malli spec for a keyword that matches any value in [[Permissions]]."
   (into [:enum {:error/message "Invalid permission value"}]
         (distinct (mapcat :values (vals Permissions)))))
+
 
 ;;; ------------------------------------------- Misc Utils ------------------------------------------------------------
 

--- a/src/metabase/models/permissions_v2/graph.clj
+++ b/src/metabase/models/permissions_v2/graph.clj
@@ -1,0 +1,2 @@
+(ns metabase.models.permissions-v2.graph
+  "Code for building and manipulating permission graphs for the v2 permission system.")

--- a/src/metabase/models/permissions_v2/graph.clj
+++ b/src/metabase/models/permissions_v2/graph.clj
@@ -1,2 +1,0 @@
-(ns metabase.models.permissions-v2.graph
-  "Code for building and manipulating permission graphs for the v2 permission system.")

--- a/test/metabase/models/permissions_v2_test.clj
+++ b/test/metabase/models/permissions_v2_test.clj
@@ -1,0 +1,149 @@
+(ns metabase.models.permissions-v2-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.models.permissions-v2 :as perms-v2]
+   [metabase.test :as mt]
+   [toucan2.core :as t2])
+  (:import
+   (clojure.lang ExceptionInfo)))
+
+(defn do-with-restored-perms!
+  "Implementation of `with-restored-perms` and related helper functions. Optionally takes `group-ids` to restore only the
+  permissions for a set of groups."
+  [group-ids thunk]
+  (let [select-condition [(when group-ids [:in :group_id group-ids])]
+        original-perms (t2/select :model/PermissionsV2 {:where select-condition})]
+    (try
+      (thunk)
+      (finally
+        (t2/delete! :model/PermissionsV2 {:where select-condition})
+        (t2/insert! :model/PermissionsV2 original-perms)))))
+
+(defmacro with-restored-perms!
+  "Runs `body`, and restores all permissions to their original state afterwards."
+  [& body]
+  `(do-with-restored-perms! nil (fn [] ~@body)))
+
+(defmacro with-restored-perms-for-group!
+  "Runs `body`, and restores all permissions for `group-id` to their original state afterwards."
+  [group-id & body]
+  `(do-with-restored-perms! [~group-id] (fn [] ~@body)))
+
+(defmacro with-restored-perms-for-groups!
+  "Runs `body`, and restores all permissions for `group-ids` to their original state afterwards."
+  [group-ids & body]
+  `(do-with-restored-perms! ~group-ids (fn [] ~@body)))
+
+(deftest ^:parallel coalesce-test
+  (testing "`coalesce` correctly returns the most permissive value by default"
+    (are [expected args] (= expected (apply perms-v2/coalesce args))
+      :unrestricted    [:data-access #{:unrestricted :restricted :none}]
+      :no-self-service [:data-access #{:no-self-service :none}]
+      :block           [:data-access #{:block}]
+      nil              [:data-access #{}]
+
+      :curate          [:collection #{:curate :view :no-access}]
+      :view            [:collection #{:view :no-access}]
+      :no-access       [:collection #{:no-access}]
+      nil              [:collection #{}]
+
+      :yes             [:settings-access  #{:yes :no}]
+      :no              [:settings-access  #{:no}]
+      nil              [:settings-access  #{}]
+
+      ;; We can also pass in a list
+      :view            [:collection [:view :view :no-access :view :no-access]])))
+
+(deftest set-permission!-test
+  (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                 :model/Table            {table-id :id} {}]
+    (with-restored-perms-for-group! group-id
+      (testing "`set-permission!` can set a new permission"
+        (is (= 1 (perms-v2/set-permission! :data-access group-id :unrestricted table-id)))
+        (is (= :unrestricted (t2/select-one-fn :value
+                                               :model/PermissionsV2
+                                               :type      :data-access
+                                               :group_id  group-id
+                                               :object_id table-id))))
+
+      (testing "`set-permission!` can update an existing permission"
+        (is (= 1 (perms-v2/set-permission! :data-access group-id :no-self-service table-id)))
+        (is (= :no-self-service (t2/select-one-fn :value
+                                                  :model/PermissionsV2
+                                                  :type      :data-access
+                                                  :group_id  group-id
+                                                  :object_id table-id))))
+
+      (testing "A permission associated with a model (e.g. :data-access) cannot be saved without an object_id"
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"Permission type :data-access requires an object ID"
+             (perms-v2/set-permission! :data-access group-id :unrestricted nil))))
+
+      (testing "An invalid permission type cannot be saved"
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"Invalid permission type: :invalid"
+             (perms-v2/set-permission! :invalid group-id :unrestricted nil)))))))
+
+(deftest set-permissions!-test
+  (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}
+                 :model/Table            {table-id-1 :id} {}
+                 :model/Table            {table-id-2 :id} {}]
+    (with-restored-perms-for-group! group-id
+      (testing "`set-permissions!` can set multiple permissions at once"
+        (is (= 2 (perms-v2/set-permissions! :data-access group-id {table-id-1 :unrestricted
+                                                                   table-id-2 :no-self-service})))
+        (is (= [:unrestricted :no-self-service]
+               (t2/select-fn-vec :value :model/PermissionsV2
+                                 :type      :data-access
+                                 :group_id  group-id
+                                 {:order-by [[:object_id :asc]]}))))
+
+      (testing "`set-permissions!` can update an existing permission"
+        (is (= 2 (perms-v2/set-permissions! :data-access group-id {table-id-1 :no-self-service
+                                                                   table-id-2 :no-self-service})))
+        (is (= [:no-self-service :no-self-service]
+               (t2/select-fn-vec :value :model/PermissionsV2
+                                 :type      :data-access
+                                 :group_id  group-id
+                                 {:order-by [[:object_id :asc]]}))))
+
+      (testing "`set-permissions! will not affect permissions for objects which are not specified"
+        (is (= 1 (perms-v2/set-permissions! :data-access group-id {table-id-1 :block})))
+        (is (= [:block :no-self-service]
+               (t2/select-fn-vec :value :model/PermissionsV2
+                                 :type      :data-access
+                                 :group_id  group-id
+                                 {:order-by [[:object_id :asc]]}))))
+
+      (testing "An invalid permission type cannot be saved"
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"Invalid permission type: :invalid"
+             (perms-v2/set-permissions! :invalid group-id {table-id-1 :block})))))))
+
+(deftest permission-for-user-test
+  (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id} {}
+                 :model/PermissionsGroup           {group-id-2 :id} {}
+                 :model/User                       {user-id :id}    {}
+                 :model/PermissionsGroupMembership {}               {:user_id  user-id
+                                                                     :group_id group-id-1}
+                 :model/PermissionsGroupMembership {}               {:user_id  user-id
+                                                                     :group_id group-id-2}]
+    (with-restored-perms-for-groups! [group-id-1 group-id-2]
+      (testing "`permission-for-user` coalesces permissions from all groups a user is in"
+        (perms-v2/set-permission! :native-query-editing group-id-1 :no 1)
+        (is (= :no (perms-v2/permission-for-user user-id :native-query-editing 1)))
+
+        (perms-v2/set-permission! :native-query-editing group-id-2 :yes 1)
+        (is (= :yes (perms-v2/permission-for-user user-id :native-query-editing 1))))
+
+      (testing "`permission-for-user` falls back to the least permissive value if no value exists for the user"
+        (is (= :no (perms-v2/permission-for-user user-id :native-query-editing 2))))
+
+      (testing "`permission-for-user` throws an exception if an object ID is required but not provided"
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"Permission type :native-query-editing requires an object ID"
+             (perms-v2/permission-for-user user-id :native-query-editing)))))))

--- a/test/metabase/models/permissions_v2_test.clj
+++ b/test/metabase/models/permissions_v2_test.clj
@@ -80,11 +80,12 @@
              #"Permission type :data-access requires an object ID"
              (perms-v2/set-permission! :data-access group-id :unrestricted nil))))
 
+
       (testing "An invalid permission type cannot be saved"
         (is (thrown-with-msg?
              ExceptionInfo
-             #"Invalid permission type: :invalid"
-             (perms-v2/set-permission! :invalid group-id :unrestricted nil)))))))
+             #"Permission type :invalid-type cannot be set to :unrestricted"
+             (perms-v2/set-permission! :invalid-type group-id :unrestricted nil)))))))
 
 (deftest set-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}
@@ -120,7 +121,7 @@
       (testing "An invalid permission type cannot be saved"
         (is (thrown-with-msg?
              ExceptionInfo
-             #"Invalid permission type: :invalid"
+             #"Invalid permission type, received: :invalid"
              (perms-v2/set-permissions! :invalid group-id {table-id-1 :block})))))))
 
 (deftest permission-for-user-test

--- a/test/metabase/models/permissions_v2_test.clj
+++ b/test/metabase/models/permissions_v2_test.clj
@@ -99,43 +99,6 @@
              #"Permission type :collection cannot be set to :invalid-value"
              (perms-v2/set-permission! :collection group-id :invalid-value collection-id)))))))
 
-#_(deftest set-permissions!-test
-    (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}
-                   :model/Table            {table-id-1 :id} {}
-                   :model/Table            {table-id-2 :id} {}]
-      (with-restored-perms-for-group! group-id
-        (testing "`set-permissions!` can set multiple permissions at once"
-          (is (= 2 (perms-v2/set-permissions! :data-access group-id {table-id-1 :unrestricted
-                                                                     table-id-2 :no-self-service})))
-          (is (= [:unrestricted :no-self-service]
-                 (t2/select-fn-vec :value :model/PermissionsV2
-                                   :type      :data-access
-                                   :group_id  group-id
-                                   {:order-by [[:object_id :asc]]}))))
-
-        (testing "`set-permissions!` can update an existing permission"
-          (is (= 2 (perms-v2/set-permissions! :data-access group-id {table-id-1 :no-self-service
-                                                                     table-id-2 :no-self-service})))
-          (is (= [:no-self-service :no-self-service]
-                 (t2/select-fn-vec :value :model/PermissionsV2
-                                   :type      :data-access
-                                   :group_id  group-id
-                                   {:order-by [[:object_id :asc]]}))))
-
-        (testing "`set-permissions! will not affect permissions for objects which are not specified"
-          (is (= 1 (perms-v2/set-permissions! :data-access group-id {table-id-1 :block})))
-          (is (= [:block :no-self-service]
-                 (t2/select-fn-vec :value :model/PermissionsV2
-                                   :type      :data-access
-                                   :group_id  group-id
-                                   {:order-by [[:object_id :asc]]}))))
-
-        (testing "An invalid permission type cannot be saved"
-          (is (thrown-with-msg?
-               ExceptionInfo
-               #"Invalid permission type, received: :invalid"
-               (perms-v2/set-permissions! :invalid group-id {table-id-1 :block})))))))
-
 (deftest permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id} {}
                  :model/PermissionsGroup           {group-id-2 :id} {}

--- a/test/metabase/models/permissions_v2_test.clj
+++ b/test/metabase/models/permissions_v2_test.clj
@@ -170,3 +170,95 @@
              ExceptionInfo
              #"Permission type :collection requires an object ID"
              (perms-v2/permission-for-user user-id :collection)))))))
+
+(deftest data-permissions-graph-test
+  (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
+                 :model/PermissionsGroup {group-id-2 :id}      {}
+                 :model/Database         {database-id-1 :id}   {}
+                 :model/Database         {database-id-2 :id}   {}
+                 :model/Table            {table-id-1 :id}      {:db_id database-id-1
+                                                                :schema "PUBLIC"}
+                 :model/Table            {table-id-2 :id}      {:db_id database-id-1
+                                                                :schema "PUBLIC"}
+                 :model/Table            {table-id-3 :id}      {:db_id database-id-2
+                                                                :schema nil}]
+    (with-restored-perms-for-groups! [group-id-1 group-id-2]
+      (testing "Data access and native query permissions can be fetched as a graph"
+        (perms-v2/set-permission! :data-access group-id-1 :unrestricted table-id-1 database-id-1 "PUBLIC")
+        (perms-v2/set-permission! :data-access group-id-1 :unrestricted table-id-2 database-id-1 "PUBLIC")
+        (perms-v2/set-permission! :data-access group-id-1 :unrestricted table-id-3 database-id-2 nil)
+        (perms-v2/set-permission! :native-query-editing group-id-1 :yes database-id-1)
+        (perms-v2/set-permission! :native-query-editing group-id-1 :no database-id-2)
+        (perms-v2/set-permission! :data-access group-id-2 :no-self-service table-id-1 database-id-1 "PUBLIC")
+        (is (partial=
+             {group-id-1
+              {database-id-1 {:data-access
+                              {"PUBLIC"
+                               {table-id-1 :unrestricted
+                                table-id-2 :unrestricted}}
+                              :native-query-editing :yes}
+               database-id-2 {:data-access
+                              {""
+                               {table-id-3 :unrestricted}}
+                              :native-query-editing :no}}
+              group-id-2
+              {database-id-1 {:data-access
+                              {"PUBLIC"
+                               {table-id-1 :no-self-service}}}}}
+             (perms-v2/data-permissions-graph))))
+
+      (testing "Additional data permissions are included when set"
+        (perms-v2/set-permission! :download-results group-id-1 :one-million-rows table-id-3 database-id-2 nil)
+        (perms-v2/set-permission! :manage-table-metadata group-id-1 :yes table-id-1 database-id-1 "PUBLIC")
+        (perms-v2/set-permission! :manage-database group-id-1 :yes database-id-2)
+        (is (partial=
+             {group-id-1
+              {database-id-1 {:manage-table-metadata
+                              {"PUBLIC"
+                               {table-id-1 :yes}}}
+               database-id-2 {:download-results
+                              {""
+                               {table-id-3 :one-million-rows}}
+                              :manage-database :yes}}}
+             (perms-v2/data-permissions-graph))))
+
+      (testing "Data permissions graph can be filtered by group ID, databse ID, and permission type"
+        (is (= {group-id-1
+                {database-id-1 {:data-access
+                                {"PUBLIC"
+                                 {table-id-1 :unrestricted
+                                  table-id-2 :unrestricted}}
+                                :native-query-editing :yes
+                                :manage-table-metadata
+                                {"PUBLIC"
+                                 {table-id-1 :yes}}}
+                 database-id-2 {:data-access
+                                {""
+                                 {table-id-3 :unrestricted}}
+                                :download-results
+                                {""
+                                 {table-id-3 :one-million-rows}}
+                                :manage-database :yes
+                                :native-query-editing :no}}}
+               (perms-v2/data-permissions-graph :group-id group-id-1)))
+
+        (is (= {group-id-1
+                {database-id-1 {:data-access
+                                {"PUBLIC"
+                                 {table-id-1 :unrestricted
+                                  table-id-2 :unrestricted}}
+                                :native-query-editing :yes
+                                :manage-table-metadata
+                                {"PUBLIC"
+                                 {table-id-1 :yes}}}}}
+               (perms-v2/data-permissions-graph :group-id group-id-1
+                                                :db-id database-id-1)))
+
+        (is (= {group-id-1
+                {database-id-1 {:data-access
+                                {"PUBLIC"
+                                 {table-id-1 :unrestricted
+                                  table-id-2 :unrestricted}}}}}
+               (perms-v2/data-permissions-graph :group-id group-id-1
+                                                :db-id database-id-1
+                                                :perm-type :data-access)))))))

--- a/test/metabase/models/permissions_v2_test.clj
+++ b/test/metabase/models/permissions_v2_test.clj
@@ -62,18 +62,18 @@
     (with-restored-perms-for-group! group-id
       (testing "`set-permission!` can set a new permission"
         (is (= 1 (perms-v2/set-permission! :collection group-id :curate collection-id)))
-        (is (= :curate (t2/select-one-fn :value
-                                     :model/PermissionsV2
-                                     :group_id  group-id
-                                     :type      :collection
-                                     :object_id collection-id))))
+        (is (= :curate (t2/select-one-fn :perm_value
+                                         :model/PermissionsV2
+                                         :group_id  group-id
+                                         :type      :collection
+                                         :object_id collection-id))))
 
       (testing "`set-permission!` can update an existing permission"
         (is (= 1 (perms-v2/set-permission! :collection group-id :view collection-id)))
         (is (= 1 (t2/count :model/PermissionsV2
                            :type     :collection
                            :group_id group-id)))
-        (is (= :view (t2/select-one-fn :value
+        (is (= :view (t2/select-one-fn :perm_value
                                        :model/PermissionsV2
                                        :type      :collection
                                        :group_id  group-id
@@ -81,7 +81,7 @@
 
       (testing "`set-permission!` can set a new database-level permission"
         (is (= 1 (perms-v2/set-permission! :manage-database group-id :yes database-id)))
-        (is (= :yes (t2/select-one-fn :value
+        (is (= :yes (t2/select-one-fn :perm_value
                                       :model/PermissionsV2
                                       :group_id  group-id
                                       :type      :manage-database
@@ -92,7 +92,7 @@
         (is (= 1 (t2/count :model/PermissionsV2
                            :type     :manage-database
                            :group_id group-id)))
-        (is (= :no (t2/select-one-fn :value
+        (is (= :no (t2/select-one-fn :perm_value
                                      :model/PermissionsV2
                                      :group_id  group-id
                                      :type      :manage-database
@@ -100,7 +100,7 @@
 
       (testing "`set-permission!` can set a new table-level permission"
         (is (= 1 (perms-v2/set-permission! :data-access group-id :unrestricted table-id database-id "PUBLIC")))
-        (is (= :unrestricted (t2/select-one-fn :value
+        (is (= :unrestricted (t2/select-one-fn :perm_value
                                                :model/PermissionsV2
                                                :group_id  group-id
                                                :type      :data-access
@@ -111,7 +111,7 @@
         (is (= 1 (t2/count :model/PermissionsV2
                            :type     :data-access
                            :group_id group-id)))
-        (is (= :no-self-service (t2/select-one-fn :value
+        (is (= :no-self-service (t2/select-one-fn :perm_value
                                                   :model/PermissionsV2
                                                   :group_id  group-id
                                                   :type      :data-access


### PR DESCRIPTION
Initial PR for my proposal to change the `permissions` table schema and move away from permission paths, as detailed [here](https://www.notion.so/metabase/Design-Doc-New-Permissions-Schema-and-API-2a5ff641e7e848e99f8b49bb412ca83f).

This PR:
- Adds a migration to create a `permissions_v2` table with a new schema
- Creates a `metabase.models.permissions-v2` namespace and bootstraps it with a `set-permission!`, `data-permissions-graph`, and `permission-for-user` functions, as well as a number of related utilities and tests.