### PR TITLE
docs - sections on cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 [![codecov](https://codecov.io/gh/metabase/metabase/branch/master/graph/badge.svg)](https://codecov.io/gh/metabase/metabase)
 ![Docker Pulls](https://img.shields.io/docker/pulls/metabase/metabase)
 
+## Get started
+
+The easiest way to get started with Metabase is to sign up for a free trial of [Metabase Cloud](https://store.metabase.com/checkout). You get support, backups, upgrades, an SMTP server, SSL certificate, SoC2 Type 2 security auditing, and more (plus your money goes toward improving Metabase). Check out our quick overview of [cloud vs self-hosting](https://www.metabase.com/docs/latest/cloud/cloud-vs-self-hosting). If you need to, you can always switch to [self-hosting](https://www.metabase.com/docs/latest/installation-and-operation/installing-metabase) Metabase at any time (or vice versa).
+
 ## Features
 
 - [Set up in five minutes](https://www.metabase.com/docs/latest/setting-up-metabase.html) (we're not kidding).
@@ -29,7 +33,7 @@ Take a [tour of Metabase](https://www.metabase.com/learn/getting-started/tour-of
 
 ## Installation
 
-Metabase can be run just about anywhere. Check out our [Installation Guides](https://www.metabase.com/docs/latest/operations-guide/installing-metabase.html).
+Metabase can be run just about anywhere. Check out our [Installation Guides](https://www.metabase.com/docs/latest/operations-guide/installing-metabase).
 
 ## Contributing
 
@@ -54,7 +58,7 @@ $ yarn build
 To build and run with hot-reload:
 
 ```
-$ yarn build-hot 
+$ yarn build-hot
 ```
 
 ### Backend  quick setup

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,9 +15,13 @@ Metabase is an open-source business intelligence platform. You can use Metabase 
 
 ## First steps
 
+### Metabase Cloud
+
+The easiest way to get started with Metabase is to sign up for a free trial of [Metabase Cloud](https://store.metabase.com/checkout). You get support, backups, upgrades, an SMTP server, SSL certificate, SoC2 Type 2 security auditing, and more (plus your money goes toward improving Metabase). Check out our quick overview of [cloud vs self-hosting](https://www.metabase.com/docs/latest/cloud/cloud-vs-self-hosting). If you need to, you can always switch to [self-hosting](./installation-and-operation/installing-metabase) Metabase at any time (or vice versa).
+
 ### [Installing Metabase](./installation-and-operation/installing-metabase.md)
 
-Run as a JAR, using Docker, or on Metabase Cloud.
+Run as a JAR, using Docker, or on [Metabase Cloud](https://store.metabase.com/checkout).
 
 ### [Setting up Metabase](./configuring-metabase/setting-up-metabase.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Metabase is an open-source business intelligence platform. You can use Metabase 
 
 ### Metabase Cloud
 
-The easiest way to get started with Metabase is to sign up for a free trial of [Metabase Cloud](https://store.metabase.com/checkout). You get support, backups, upgrades, an SMTP server, SSL certificate, SoC2 Type 2 security auditing, and more (plus your money goes toward improving Metabase). Check out our quick overview of [cloud vs self-hosting](https://www.metabase.com/docs/latest/cloud/cloud-vs-self-hosting). If you need to, you can always switch to [self-hosting](./installation-and-operation/installing-metabase) Metabase at any time (or vice versa).
+The easiest way to get started with Metabase is to sign up for a free trial of [Metabase Cloud](https://store.metabase.com/checkout). You get support, backups, upgrades, an SMTP server, SSL certificate, SoC2 Type 2 security auditing, and more (plus your money goes toward improving Metabase). Check out our quick overview of [cloud vs self-hosting](https://www.metabase.com/docs/latest/cloud/cloud-vs-self-hosting). If you need to, you can always switch to [self-hosting](./installation-and-operation/installing-metabase.md) Metabase at any time (or vice versa).
 
 ### [Installing Metabase](./installation-and-operation/installing-metabase.md)
 

--- a/docs/installation-and-operation/installing-metabase.md
+++ b/docs/installation-and-operation/installing-metabase.md
@@ -8,29 +8,31 @@ redirect_from:
 
 Metabase is built and packaged as a Java JAR file and can be run anywhere that Java is available.
 
-If you're not sure which way is right for you, check out [How to run Metabase in production](https://www.metabase.com/blog/how-to-run-metabase-in-production).
+## [Metabase Cloud](https://store.metabase.com/checkout)
 
-## [Running the Jar File](running-the-metabase-jar-file.md)
+The easiest way to run Metabase. All you need to do is [sign up for a free trial](https://store.metabase.com/checkout), and you're off to the races.
 
-The simplest and most basic way of running Metabase.
+## Self-hosting Metabase
 
-## [Running on Docker](running-metabase-on-docker.md)
+For an overview on how to self-host Metabase, check out [how to run Metabase in production](https://www.metabase.com/learn/administration/metabase-in-production).
+
+### [Running the Jar File](running-the-metabase-jar-file.md)
+
+Metabase can run anywhere Java is available.
+
+### [Running on Docker](running-metabase-on-docker.md)
 
 If you prefer to use a Docker container, we've got you covered.
 
-## [Running on Podman](running-metabase-on-podman.md)
+### [Running on Podman](running-metabase-on-podman.md)
 
 Our Docker image is also compatible with Podman.
 
-## [Metabase Cloud](https://www.metabase.com/pricing)
-
-Our official hosted version, [Metabase Cloud](https://www.metabase.com/pricing). All you need to do is sign up for a free trial, and you're off to the races.
-
-## [Building Metabase from source](../developers-guide/start.md)
+### [Building Metabase from source](../developers-guide/start.md)
 
 To run a development branch of Metabase, check out our [developer's guide](../developers-guide/start.md).
 
-## Other installation options
+### Other installation options
 
 - [Running on Azure Web Apps](running-metabase-on-azure.md)
 - [Running on Debian as a service](running-metabase-on-debian.md)
@@ -39,6 +41,6 @@ To run a development branch of Metabase, check out our [developer's guide](../de
 
 See [Upgrading Metabase](upgrading-metabase.md).
 
-*** 
+## Connect with a Metabase Expert
 
 If you’d like more technical resources to set up your data stack with Metabase, connect with a [Metabase Expert](https://www.metabase.com/partners/).


### PR DESCRIPTION
Updates readmes to mention Cloud up front (as Cloud is the easiest way for people to get started with Metabase).

I'm repeating text here as the repo's README lives on GitHub, and the docs README lives on the website.

Additionally, I shuffled the installation page to frontload Cloud so people who want to just start moving can click through, and updated the "How to run Metabase in production" link to the new article.

## Feedback requested

- Are these the correct links? E.g., do we want to send people to the checkout page? (Note: links from the repo README differ slightly than those on the website, as we exclude that readme from the website).
- Just general tone and info. Anything else we should include, omit, or emphasize?