### PR TITLE
Update relative date filter tests for 2024

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -790,14 +790,16 @@ describe("scenarios > dashboard > dashboard drill", () => {
     cy.get(".Table-ID")
       .first()
       // Mid-point check that this cell actually contains ID = 1
-      .contains("3")
+      .contains("1")
       .click();
 
     cy.wait("@dataset").then(xhr => {
       expect(xhr.response.body.error).to.not.exist;
     });
-    cy.findByTestId("object-detail");
-    cy.findAllByText("37.65");
+    cy.findByTestId("object-detail").within(() => {
+      cy.findByText("Subtotal");
+      cy.findByText("37.65");
+    });
   });
 
   it("should display correct tooltip value for multiple series charts on dashboard (metabase#15612)", () => {

--- a/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-date.js
+++ b/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-date.js
@@ -28,6 +28,6 @@ export const DASHBOARD_DATE_FILTERS = {
     value: {
       timeBucket: "years",
     },
-    representativeResult: "78.17",
+    representativeResult: "51.19", // this may change every year
   },
 };

--- a/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-sql-date.js
+++ b/e2e/test/scenarios/dashboard-filters/shared/dashboard-filters-sql-date.js
@@ -37,7 +37,7 @@ export const DASHBOARD_SQL_DATE_FILTERS = {
     value: {
       timeBucket: "years",
     },
-    representativeResult: "Araceli Stiedemann",
+    representativeResult: "Lina Heaney", // this may change every year
   },
 };
 


### PR DESCRIPTION
see discussion: https://metaboat.slack.com/archives/C5XHN8GLW/p1704206165957209

### Description

These tests all use the "past 30 years" filter, which includes (by default) full calendar years. In each of these tests, additional data for the full 2023 calendar year pushed expected results off the first page, leading to test failures.

This simply updates the assertions to get CI moving again. It would be nice to think of some clever way to make relative date tests to work seamlessly for all time in e2e tests, but that also might be more trouble than its worth.
