### PR TITLE
Use simple `Secret`s for ApiKeys

### DIFF
--- a/src/metabase/api/api_key.clj
+++ b/src/metabase/api/api_key.clj
@@ -10,7 +10,13 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli.schema :as ms]
+   [metabase.util.secret :as u.secret]
    [toucan2.core :as t2]))
+
+(defn- maybe-expose-key [api-key]
+  (if (contains? api-key :unmasked_key)
+    (update api-key :unmasked_key u.secret/expose)
+    api-key))
 
 (defn- present-api-key
   "Takes an ApiKey and hydrates/selects keys as necessary to put it into a standard form for responses"
@@ -25,12 +31,13 @@
                     :unmasked_key
                     :name
                     :masked_key])
+      (maybe-expose-key)
       (update :updated_by #(select-keys % [:common_name :id]))))
 
 (defn- key-with-unique-prefix []
   (u/auto-retry 5
    (let [api-key (api-key/generate-key)
-         prefix (api-key/prefix api-key)]
+         prefix (api-key/prefix (u.secret/expose api-key))]
      ;; we could make this more efficient by generating 5 API keys up front and doing one select to remove any
      ;; duplicates. But a duplicate should be rare enough to just do multiple queries for now.
      (if-not (t2/exists? :model/ApiKey :key_prefix prefix)
@@ -113,7 +120,7 @@
         unhashed-key (key-with-unique-prefix)
         api-key-after (assoc api-key-before
                              :unhashed_key unhashed-key
-                             :key_prefix (api-key/prefix unhashed-key))]
+                             :key_prefix (api-key/prefix (u.secret/expose unhashed-key)))]
     (t2/update! :model/ApiKey :id id (with-updated-by
                                        (select-keys api-key-after [:unhashed_key])))
     (events/publish-event! :event/api-key-regenerate
@@ -123,6 +130,7 @@
     (present-api-key (assoc api-key-after
                             :unmasked_key unhashed-key
                             :masked_key (api-key/mask unhashed-key)))))
+
 
 (api/defendpoint GET "/"
   "Get a list of API keys. Non-paginated."

--- a/src/metabase/api/api_key.clj
+++ b/src/metabase/api/api_key.clj
@@ -131,7 +131,6 @@
                             :unmasked_key unhashed-key
                             :masked_key (api-key/mask unhashed-key)))))
 
-
 (api/defendpoint GET "/"
   "Get a list of API keys. Non-paginated."
   []

--- a/src/metabase/util/secret.clj
+++ b/src/metabase/util/secret.clj
@@ -1,0 +1,27 @@
+(ns metabase.util.secret
+  (:import (java.io Writer)))
+
+(set! *warn-on-reflection* true)
+
+;; Define a protocol for secrets to make things harder to accidentally expose.
+(defprotocol ISecret
+  (expose [this] "Expose the secret"))
+
+(defrecord Secret [value-fn]
+  ISecret
+  (expose [_this] (value-fn))
+  Object
+  (toString [_this] "<< REDACTED SECRET >>"))
+
+(defmethod print-method Secret
+  [^Secret secret ^Writer writer]
+  (.write writer (.toString secret)))
+
+(defmethod print-dup Secret
+  [^Secret secret ^Writer w]
+  (.write w (.toString secret)))
+
+(defn secret
+  "Create a `Secret` that can't be accidentally read without calling the `expose` method on it."
+  [value]
+  (->Secret (constantly value)))

--- a/src/metabase/util/secret.clj
+++ b/src/metabase/util/secret.clj
@@ -1,4 +1,6 @@
 (ns metabase.util.secret
+  (:require
+   [metabase.util.i18n :refer [trs]])
   (:import (java.io Writer)))
 
 (set! *warn-on-reflection* true)
@@ -11,7 +13,7 @@
   ISecret
   (expose [_this] (value-fn))
   Object
-  (toString [_this] "<< REDACTED SECRET >>"))
+  (toString [_this] (trs "<< REDACTED SECRET >>")))
 
 (defmethod print-method Secret
   [^Secret secret ^Writer writer]

--- a/test/metabase/api/api_key_test.clj
+++ b/test/metabase/api/api_key_test.clj
@@ -100,13 +100,13 @@
 (deftest api-count-works
   (mt/with-empty-h2-app-db
     (is (zero? (mt/user-http-request :crowberto :get 200 "api-key/count")))
-    (t2.with-temp/with-temp [:model/ApiKey _ {:unhashed_key  "prefix_key"
+    (t2.with-temp/with-temp [:model/ApiKey _ {:unhashed_key  (api-key/generate-key)
                                               :name          "my cool name"
                                               :user_id       (mt/user->id :crowberto)
                                               :creator_id    (mt/user->id :crowberto)
                                               :updated_by_id (mt/user->id :crowberto)}]
       (is (= 1 (mt/user-http-request :crowberto :get 200 "api-key/count")))
-      (t2.with-temp/with-temp [:model/ApiKey _ {:unhashed_key  "some_other_key"
+      (t2.with-temp/with-temp [:model/ApiKey _ {:unhashed_key  (api-key/generate-key)
                                                 :name          "my cool OTHER name"
                                                 :user_id       (mt/user->id :crowberto)
                                                 :creator_id    (mt/user->id :crowberto)

--- a/test/metabase/server/middleware/session_test.clj
+++ b/test/metabase/server/middleware/session_test.clj
@@ -23,6 +23,7 @@
    [metabase.server.middleware.session :as mw.session]
    [metabase.test :as mt]
    [metabase.util.i18n :as i18n]
+   [metabase.util.secret :as u.secret]
    [ring.mock.request :as ring.mock]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
@@ -251,7 +252,7 @@
                                             :user_id       (mt/user->id :lucky)
                                             :creator_id    (mt/user->id :lucky)
                                             :updated_by_id (mt/user->id :lucky)
-                                            :unhashed_key  "mb_foobar"}]
+                                            :unhashed_key  (u.secret/secret "mb_foobar")}]
     (testing "A valid API key works, and user info is added to the request"
       (let [req {:headers {"x-api-key" "mb_foobar"}}]
         (is (= (merge req {:metabase-user-id  (mt/user->id :lucky)
@@ -291,12 +292,12 @@
                                             :user_id       (mt/user->id :lucky)
                                             :creator_id    (mt/user->id :lucky)
                                             :updated_by_id (mt/user->id :lucky)
-                                            :unhashed_key  "mb_foobar"}
+                                            :unhashed_key  (u.secret/secret "mb_foobar")}
                            :model/ApiKey _ {:name          "A superuser API Key"
                                             :user_id       (mt/user->id :crowberto)
                                             :creator_id    (mt/user->id :lucky)
                                             :updated_by_id (mt/user->id :lucky)
-                                            :unhashed_key  "mb_superuser"}]
+                                            :unhashed_key  (u.secret/secret "mb_superuser")}]
     (testing "A valid API key works, and user info is added to the request"
       (is (= {:is-superuser?     false
               :is-group-manager? false


### PR DESCRIPTION
I decided to POC the idea I had here:
https://metaboat.slack.com/archives/CKZEMT1MJ/p1703790833895029

This wraps the generated ApiKeys in a special Secret type. If the object
is accidentally printed, logged, etc. it will appear as "<< REDACTED
SECRET >>" rather than the actual value.

When we're actually *using* the Secret, we call `expose` on it to turn
it into a String.
