### PR TITLE
[MLv2] Normalize expression-clause

### DIFF
--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -472,7 +472,11 @@
 (defn ^:export expression-clause
   "Returns a standalone clause for an `operator`, `options`, and arguments."
   [an-operator args options]
-  (lib.core/expression-clause (keyword an-operator) args (js->clj options :keywordize-keys true)))
+  (-> (lib.core/expression-clause
+        (keyword an-operator)
+        args
+        (js->clj options :keywordize-keys true))
+      (lib.core/normalize)))
 
 (defn ^:export expression-parts
   "Returns the parts (operator, args, and optionally, options) of `expression-clause`."

--- a/src/metabase/lib/normalize.cljc
+++ b/src/metabase/lib/normalize.cljc
@@ -83,3 +83,51 @@
     (mbql-clause-type x) (default-normalize-mbql-clause x)
     (map-type x)         (normalize-map x)
     :else                x))
+
+(defn- maybe-normalize-token
+  [expression k]
+  (cond-> expression
+    (string? (get expression k)) (update k keyword)))
+
+(defmethod normalize :time-interval
+  [[_ _ _ amount _unit :as expression]]
+  (cond-> (default-normalize-mbql-clause expression)
+    (= "current" amount) (update 3 keyword)
+    :always (maybe-normalize-token 4)))
+
+(defmethod normalize :relative-datetime
+  [[_ _ amount _unit :as expression]]
+  (cond-> (default-normalize-mbql-clause expression)
+    (= "current" amount) (update 2 keyword)
+    :always (maybe-normalize-token 3)))
+
+(defmethod normalize :interval
+  [expression]
+  (-> (default-normalize-mbql-clause expression)
+      (maybe-normalize-token 3)))
+
+(defmethod normalize :datetime-add
+  [expression]
+  (-> (default-normalize-mbql-clause expression)
+      (maybe-normalize-token 4)))
+
+(defmethod normalize :datetime-subtract
+  [expression]
+  (-> (default-normalize-mbql-clause expression)
+      (maybe-normalize-token 4)))
+
+(defmethod normalize :get-week
+  [expression]
+  (-> (default-normalize-mbql-clause expression)
+      (maybe-normalize-token 3)))
+
+(defmethod normalize :temporal-extract
+  [expression]
+  (-> (default-normalize-mbql-clause expression)
+      (maybe-normalize-token 3)
+      (maybe-normalize-token 4)))
+
+(defmethod normalize :datetime-diff
+  [expression]
+  (-> (default-normalize-mbql-clause expression)
+      (maybe-normalize-token 4)))


### PR DESCRIPTION
Fixes #37175 

This ports over some of `mbql.normalize` for particular expressions that take keywords