### PR TITLE
Consistent formatting of all columns in Excel exports

### DIFF
--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -149,7 +149,7 @@
   (:type/Number global-column-settings {}))
 
 (defmethod global-type-settings :type/Currency [_ {::mb.viz/keys [global-column-settings] :as _viz-settings}]
-  (:type/Currency global-column-settings {}))
+  (:type/Currency global-column-settings {::mb.viz/number-style "currency"}))
 
 (defmethod global-type-settings :default [_ _viz-settings]
   {})

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -1,6 +1,7 @@
 (ns metabase.query-processor.streaming.common
   "Shared util fns for various export (download) streaming formats."
   (:require
+   [clojure.string :as str]
    [java-time.api :as t]
    [metabase.public-settings :as public-settings]
    [metabase.query-processor.store :as qp.store]
@@ -69,7 +70,7 @@
   "Merge format settings defined in the localization preferences into the format settings
   for a single column."
   [format-settings global-settings-key]
-  (let [global-settings (global-settings-key (public-settings/custom-formatting))
+  (let [global-settings (get (public-settings/custom-formatting) global-settings-key)
         normalized      (mb.viz/db->norm-column-settings-entries global-settings)]
     (merge normalized format-settings)))
 
@@ -112,3 +113,65 @@
       (if (and is-currency? (::mb.viz/currency-in-header merged-settings true))
         (str column-title " (" (currency-identifier merged-settings) ")")
         column-title))))
+
+(defn normalize-keys
+  "Update map keys to remove namespaces from keywords and convert from snake to kebab case."
+  [m]
+  (update-keys m (fn [k] (-> k name (str/replace #"_" "-") keyword))))
+
+(def col-type
+  "The dispatch function logic for format format-timestring.
+  Find the highest type of the object."
+  (some-fn :semantic_type :effective_type :base_type))
+
+(defmulti global-type-settings
+  "Look up the global viz settings based on the type of the column. A multimethod is used because they match well
+  against type hierarchies."
+  (fn [col _viz-settings] (col-type col)))
+
+(defmethod global-type-settings :type/Temporal [_ {::mb.viz/keys [global-column-settings] :as _viz-settings}]
+  (:type/Temporal global-column-settings {}))
+
+(defmethod global-type-settings :type/Date [_ {::mb.viz/keys [global-column-settings] :as _viz-settings}]
+  (merge
+    (:type/Temporal global-column-settings {})
+    {::mb.viz/time-enabled nil}))
+
+(defmethod global-type-settings :type/Time [_ {::mb.viz/keys [global-column-settings] :as _viz-settings}]
+  (merge
+    (:type/Temporal global-column-settings {})
+    {::mb.viz/time-style "h:mm A"
+     ::mb.viz/date-style ""}))
+
+(defmethod global-type-settings :type/DateTime [_ {::mb.viz/keys [global-column-settings] :as _viz-settings}]
+  (:type/Temporal global-column-settings {}))
+
+(defmethod global-type-settings :type/Number [_ {::mb.viz/keys [global-column-settings] :as _viz-settings}]
+  (:type/Number global-column-settings {}))
+
+(defmethod global-type-settings :type/Currency [_ {::mb.viz/keys [global-column-settings] :as _viz-settings}]
+  (:type/Currency global-column-settings {}))
+
+(defmethod global-type-settings :default [_ _viz-settings]
+  {})
+
+(defn viz-settings-for-col
+  "Get the unified viz settings for a column based on the column's metadata (if any) and user settings (⚙)."
+  [{column-name :name metadata-column-settings :settings :keys [field_ref] :as col} viz-settings]
+  (let [[_ field-id-or-name] field_ref
+        all-cols-settings (-> viz-settings
+                              ::mb.viz/column-settings
+                              ;; update the keys so that they will have only the :field-id or :column-name
+                              ;; and not have any metadata. Since we don't know the metadata, we can never
+                              ;; match a key with metadata, even if we do have the correct name or id
+                              (update-keys #(select-keys % [::mb.viz/field-id ::mb.viz/column-name])))]
+    (merge
+      (global-type-settings col viz-settings)
+      ;; User defined metadata -- Note that this transformation should probably go in
+      ;; `metabase.query-processor.middleware.results-metadata/merge-final-column-metadata
+      ;; to prevent repetition
+      (mb.viz/db->norm-column-settings-entries metadata-column-settings)
+      ;; Column settings coming from the user settings in the ui
+      ;; (E.g. Click the ⚙️on the column)
+      (or (all-cols-settings {::mb.viz/field-id field-id-or-name})
+          (all-cols-settings {::mb.viz/column-name (or field-id-or-name column-name)})))))

--- a/src/metabase/query_processor/streaming/common.clj
+++ b/src/metabase/query_processor/streaming/common.clj
@@ -139,9 +139,8 @@
 
 (defmethod global-type-settings :type/Time [_ {::mb.viz/keys [global-column-settings] :as _viz-settings}]
   (merge
-    (:type/Temporal global-column-settings {})
-    {::mb.viz/time-style "h:mm A"
-     ::mb.viz/date-style ""}))
+    (:type/Temporal global-column-settings {::mb.viz/time-style "h:mm A"})
+    {::mb.viz/date-style ""}))
 
 (defmethod global-type-settings :type/DateTime [_ {::mb.viz/keys [global-column-settings] :as _viz-settings}]
   (:type/Temporal global-column-settings {}))

--- a/src/metabase/query_processor/streaming/csv.clj
+++ b/src/metabase/query_processor/streaming/csv.clj
@@ -27,7 +27,7 @@
 (defmethod qp.si/streaming-results-writer :csv
   [_ ^OutputStream os]
   (let [writer             (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
-        ordered-formatters (volatile! {})]
+        ordered-formatters (volatile! nil)]
     (reify qp.si/StreamingResultsWriter
       (begin! [_ {{:keys [ordered-cols results_timezone]} :data} viz-settings]
         (let [col-names (common/column-titles ordered-cols (::mb.viz/column-settings viz-settings))]

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -29,7 +29,7 @@
   [_ ^OutputStream os]
   (let [writer             (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
         col-names          (volatile! nil)
-        ordered-formatters (volatile! {})]
+        ordered-formatters (volatile! nil)]
     (reify qp.si/StreamingResultsWriter
       (begin! [_ {{:keys [ordered-cols results_timezone]} :data} viz-settings]
         ;; TODO -- wouldn't it make more sense if the JSON downloads used `:name` preferentially? Seeing how JSON is

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -167,7 +167,9 @@
 (defn- add-time-format
   "Adds the appropriate time setting to a date format string if necessary, producing a datetime format string."
   [format-settings unit format-string]
-  (if (or (not unit) (lib.schema.temporal-bucketing/time-bucketing-units unit))
+  (if (or (not unit)
+          (lib.schema.temporal-bucketing/time-bucketing-units unit)
+          (= :default unit))
     (if-let [time-format (time-format format-settings)]
       (cond->> time-format
                (seq format-string)

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -64,13 +64,14 @@
       "name"
       (str base-string "\" " currency-identifier "\""))))
 
-(defn- default-number-format?
+(defn- unformatted-number?
   "Use default formatting for decimal number types that have no other format settings defined
   aside from prefix, suffix or scale."
   [format-settings]
   (and
-   ;; This is a decimal number (not a currency, percentage or scientific notation)
+   ;; This is a decimal or currency number (not a percentage or scientific notation)
    (or (= (::mb.viz/number-style format-settings) "decimal")
+       (= (::mb.viz/number-style format-settings) "currency")
        (not (::mb.viz/number-style format-settings)))
    ;; Custom number formatting options are not set
    (not (seq (dissoc format-settings
@@ -92,7 +93,7 @@
                                 "###0"
                                 "#,##0")
               decimals        (or decimals 2)
-              base-strings    (if (default-number-format? format-settings)
+              base-strings    (if (unformatted-number? format-settings)
                                 ;; [int-format, float-format]
                                 [base-string (str base-string ".##")]
                                 (repeat 2 (apply str base-string (when (> decimals 0) (apply str "." (repeat decimals "0"))))))]

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -51,8 +51,9 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
-   (java.io ByteArrayInputStream)
-   (org.quartz.impl StdSchedulerFactory)))
+    (java.io ByteArrayInputStream)
+    (org.apache.poi.ss.usermodel DataFormatter)
+    (org.quartz.impl StdSchedulerFactory)))
 
 (set! *warn-on-reflection* true)
 
@@ -1934,6 +1935,171 @@
                (parse-xlsx-results
                 (mt/user-http-request :rasta :post 200 (format "card/%d/query/xlsx" (u/the-id card))
                                       :parameters encoded-params))))))))
+
+(defn- parse-xlsx-results-to-strings
+  "Parse an excel response into a 2-D array of formatted values"
+  [results]
+  (let [df (DataFormatter.)]
+    (->> results
+         ByteArrayInputStream.
+         spreadsheet/load-workbook
+         (spreadsheet/select-sheet "Query result")
+         spreadsheet/row-seq
+         (mapv (fn [row]
+                 (mapv (fn [cell] (.formatCellValue df cell)) (spreadsheet/cell-seq row)))))))
+
+(deftest xlsx-timestamp-formatting-test
+  (testing "A timestamp should format correctly in an excel export (#14393)"
+    (t2.with-temp/with-temp [Card card {:dataset_query {:database (mt/id)
+                                                        :type     :native
+                                                        :native   {:query "select (TIMESTAMP '2023-01-01 12:34:56') as T"}}
+                                        :display :table
+                                        :visualization_settings {:table.pivot_column "T",
+                                                                 :column_settings {"[\"name\",\"T\"]" {:date_style "YYYY/M/D",
+                                                                                                       :date_separator "-",
+                                                                                                       :time_enabled nil}}}}]
+      (testing "Removing the time portion of the timestamp should only show the date"
+        (is (= [["T"] ["2023-1-1"]]
+               (parse-xlsx-results-to-strings
+                 (mt/user-http-request :rasta :post 200 (format "card/%d/query/xlsx" (u/the-id card))))))))))
+
+(deftest xlsx-full-formatting-test
+  (testing "Formatting should be applied correctly for all types, including numbers, currencies, exponents, and times. (relates to #14393)"
+    (let [excel-data-query
+          "with t1 as (
+         select *
+         FROM (
+          VALUES
+            (1234.05, 1234.05, 2345.05, 4321.05, 7180.643352291768, 1234.00, 0.053010935820623994, 0.1920, TIMESTAMP '2023-01-01 12:34:56'),
+            (2345.30, 2345.30, 3456.30, 2931.30, 17180.643352291768, 0.00, 8.01623207863001, 0.00, TIMESTAMP '2023-01-01 12:34:56'),
+            (3456.00, 3456.00, 2300.00, 2250.00, 127180.643352291768, 122.00, 95.40200874663908, 0.1158, TIMESTAMP '2023-01-01 12:34:56')
+          )
+        ),
+        t2 as (
+        select
+            c1 as default_currency,
+            c2 as currency1,
+            c3 as currency2,
+            c4 as currency3,
+            c5 as scientific,
+            c6 as hide_me,
+            c7 as percent1,
+            c8 as percent2,
+            c9 as og_creation_timestamp,
+            c9 as creation_timestamp,
+            c9 as creation_timestamp_dup,
+            CAST(c9 AS DATE) as creation_date,
+            CAST(c9 AS TIME) as creation_time,
+            from t1
+        )
+        select * from t2"
+          viz-settings {:table.pivot_column "SCIENTIFIC"
+                        :table.cell_column  "CURRENCY1"
+                        :table.columns      [{:name     "OG_CREATION_TIMESTAMP"
+                                              :fieldRef [:field "OG_CREATION_TIMESTAMP" {:base-type :type/DateTime}]
+                                              :enabled  true}
+                                             {:name     "CREATION_TIMESTAMP"
+                                              :fieldRef [:field "CREATION_TIMESTAMP" {:base-type :type/DateTime}]
+                                              :enabled  true}
+                                             {:name     "CREATION_TIMESTAMP_DUP"
+                                              :fieldRef [:field "CREATION_TIMESTAMP_DUP" {:base-type :type/DateTime}]
+                                              :enabled  true}
+                                             {:name     "CREATION_DATE"
+                                              :fieldRef [:field "CREATION_DATE" {:base-type :type/Date}]
+                                              :enabled  true}
+                                             {:name     "CREATION_TIME"
+                                              :fieldRef [:field "CREATION_TIME" {:base-type :type/Time}]
+                                              :enabled  true}
+                                             {:name     "DEFAULT_CURRENCY"
+                                              :fieldRef [:field "DEFAULT_CURRENCY" {:base-type :type/Decimal}]
+                                              :enabled  true}
+                                             {:name     "CURRENCY1"
+                                              :fieldRef [:field "CURRENCY1" {:base-type :type/Decimal}]
+                                              :enabled  true}
+                                             {:name     "CURRENCY2"
+                                              :fieldRef [:field "CURRENCY2" {:base-type :type/Decimal}]
+                                              :enabled  true}
+                                             {:name     "CURRENCY3"
+                                              :fieldRef [:field "CURRENCY3" {:base-type :type/Decimal}]
+                                              :enabled  true}
+                                             {:name     "SCIENTIFIC"
+                                              :fieldRef [:field "SCIENTIFIC" {:base-type :type/Decimal}]
+                                              :enabled  true}
+                                             {:name     "HIDE_ME"
+                                              :fieldRef [:field "HIDE_ME" {:base-type :type/Decimal}]
+                                              :enabled  false}
+                                             {:name     "PERCENT1"
+                                              :fieldRef [:field "PERCENT1" {:base-type :type/Decimal}]
+                                              :enabled  true}
+                                             {:name     "PERCENT2"
+                                              :fieldRef [:field "PERCENT2" {:base-type :type/Decimal}]
+                                              :enabled  true}]
+                        :column_settings    {"[\"name\",\"OG_CREATION_TIMESTAMP\"]"  {:column_title "No Formatting TS"}
+                                             "[\"name\",\"SCIENTIFIC\"]"             {:number_style "scientific"
+                                                                                      :column_title "EXPO"}
+                                             "[\"name\",\"CREATION_TIME\"]"          {:column_title "Time"}
+                                             "[\"name\",\"CURRENCY3\"]"              {:number_style       "currency"
+                                                                                      :currency_style     "name"
+                                                                                      :number_separators  ".’"
+                                                                                      :column_title       "DOL Col"
+                                                                                      :currency_in_header false}
+                                             "[\"name\",\"PERCENT2\"]"               {:number_style "percent"
+                                                                                      :column_title "3D PCT"
+                                                                                      :decimals     3}
+                                             "[\"name\",\"CURRENCY1\"]"              {:number_style       "currency"
+                                                                                      :currency_in_header false
+                                                                                      :column_title       "Col $"}
+                                             "[\"name\",\"CREATION_TIMESTAMP\"]"     {:time_enabled   nil
+                                                                                      :time_style     "HH:mm"
+                                                                                      :date_style     "YYYY/M/D"
+                                                                                      :date_separator "-"
+                                                                                      :column_title   "DATE-ONLY TS"}
+                                             "[\"name\",\"CREATION_TIMESTAMP_DUP\"]" {:time_enabled   "milliseconds",
+                                                                                      :time_style     "HH:mm",
+                                                                                      :date_style     "D/M/YYYY",
+                                                                                      :date_separator "-",
+                                                                                      :column_title   "TS W/FORMATTING"}
+                                             "[\"name\",\"PERCENT1\"]"               {:number_style "percent"
+                                                                                      :scale        0.01
+                                                                                      :column_title "Scaled PCT"}
+                                             "[\"name\",\"CURRENCY2\"]"              {:number_style       "currency"
+                                                                                      :currency_style     "code"
+                                                                                      :currency_in_header false
+                                                                                      :number_separators  "."
+                                                                                      :column_title       "USD Col"}
+                                             "[\"name\",\"CREATION_DATE\"]"          {:column_title "Date"}
+                                             "[\"name\",\"DEFAULT_CURRENCY\"]"       {:number_style "currency"
+                                                                                      :column_title "Plain Currency"}}}]
+      (t2.with-temp/with-temp [Card card {:dataset_query          {:database (mt/id)
+                                                                   :type     :native
+                                                                   :native   {:query excel-data-query}}
+                                          :display                :table
+                                          :visualization_settings viz-settings}]
+        ;; The following formatting has been applied:
+        ;; - All columns renamed
+        ;; - Column reordering
+        ;; - Column hiding (See "HIDE_ME") above
+        ;; - Base formatting ("No Formatting TS") conforms to standard datetime format
+        ;; - "DATE-ONLY TS" shows only a date-formatted timestamp
+        ;; - "TS W/FORMATTING" shows a timestamp with custom date and time formatting
+        ;; - "Date" shows simple date formatting
+        ;; - "Time" shows simple time formatting
+        ;; - "Plain Currency ($)" formats numbers as regular numbers with no dollar sign in the number column
+        ;; - "Col $" formats currency with leading $. Note that the strings as presented aren't as you'd see in Excel. Excel properly just adds a leading $.
+        ;; - "USD Col" has a leading USD. Again, the formatting of this output is an artifact of POI rendering. It is correct in Excel as "USD 1.23"
+        ;; - "DOL Col" has trailing US dollars
+        ;; - "EXPO" has exponentiated values
+        ;; - "Scaled PCT" multiplies values by 0.01 and presents as percentages
+        ;; - "3D PCT" is a standard percentage with a customization of 3 significant digits
+        (testing "All formatting is applied correctly in a complex situation."
+          (is (= [["No Formatting TS" "DATE-ONLY TS" "TS W/FORMATTING" "Date" "Time" "Plain Currency ($)" "Col $" "USD Col" "DOL Col" "EXPO" "Scaled PCT" "3D PCT"]
+                  ["Jan 1, 2023, 12:34 PM" "2023-1-1" "1-1-2023, 12:34:56.000" "Jan 1, 2023" "12:34 PM" "1,234.05" "[$$]1,234.05" "[$USD] 2345.05" "4,321.05 US dollars" "7180.64E+0" "0.05%" "19.200%"]
+                  ["Jan 1, 2023, 12:34 PM" "2023-1-1" "1-1-2023, 12:34:56.000" "Jan 1, 2023" "12:34 PM" "2,345.30" "[$$]2,345.30" "[$USD] 3456.30" "2,931.30 US dollars" "1.71806E+4" "8.02%" "0.000%"]
+                  ["Jan 1, 2023, 12:34 PM" "2023-1-1" "1-1-2023, 12:34:56.000" "Jan 1, 2023" "12:34 PM" "3,456.00" "[$$]3,456.00" "[$USD] 2300.00" "2,250.00 US dollars" "12.7181E+4" "95.40%" "11.580%"]]
+                 (parse-xlsx-results-to-strings
+                   (mt/user-http-request :rasta :post 200 (format "card/%d/query/xlsx" (u/the-id card)))))))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (deftest download-default-constraints-test
   (t2.with-temp/with-temp [:model/Card card {:dataset_query {:database   (mt/id)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1966,33 +1966,33 @@
 (deftest xlsx-full-formatting-test
   (testing "Formatting should be applied correctly for all types, including numbers, currencies, exponents, and times. (relates to #14393)"
     (let [excel-data-query
-          "with t1 as (
-         select *
-         FROM (
-          VALUES
-            (1234.05, 1234.05, 2345.05, 4321.05, 7180.643352291768, 1234.00, 0.053010935820623994, 0.1920, TIMESTAMP '2023-01-01 12:34:56'),
-            (2345.30, 2345.30, 3456.30, 2931.30, 17180.643352291768, 0.00, 8.01623207863001, 0.00, TIMESTAMP '2023-01-01 12:34:56'),
-            (3456.00, 3456.00, 2300.00, 2250.00, 127180.643352291768, 122.00, 95.40200874663908, 0.1158, TIMESTAMP '2023-01-01 12:34:56')
-          )
-        ),
-        t2 as (
-        select
-            c1 as default_currency,
-            c2 as currency1,
-            c3 as currency2,
-            c4 as currency3,
-            c5 as scientific,
-            c6 as hide_me,
-            c7 as percent1,
-            c8 as percent2,
-            c9 as og_creation_timestamp,
-            c9 as creation_timestamp,
-            c9 as creation_timestamp_dup,
-            CAST(c9 AS DATE) as creation_date,
-            CAST(c9 AS TIME) as creation_time,
-            from t1
-        )
-        select * from t2"
+                       "with t1 as (
+                      select *
+                      FROM (
+                       VALUES
+                         (1234.05, 1234.05, 2345.05, 4321.05, 7180.643352291768, 1234.00, 0.053010935820623994, 0.1920, TIMESTAMP '2023-01-01 12:34:56'),
+                         (2345.30, 2345.30, 3456.30, 2931.30, 17180.643352291768, 0.00, 8.01623207863001, 0.00, TIMESTAMP '2023-01-01 12:34:56'),
+                         (3456.00, 3456.00, 2300.00, 2250.00, 127180.643352291768, 122.00, 95.40200874663908, 0.1158, TIMESTAMP '2023-01-01 12:34:56')
+                       )
+                     ),
+                     t2 as (
+                     select
+                         c1 as default_currency,
+                         c2 as currency1,
+                         c3 as currency2,
+                         c4 as currency3,
+                         c5 as scientific,
+                         c6 as hide_me,
+                         c7 as percent1,
+                         c8 as percent2,
+                         c9 as og_creation_timestamp,
+                         c9 as creation_timestamp,
+                         c9 as creation_timestamp_dup,
+                         CAST(c9 AS DATE) as creation_date,
+                         CAST(c9 AS TIME) as creation_time,
+                         from t1
+                     )
+                     select * from t2"
           viz-settings {:table.pivot_column "SCIENTIFIC"
                         :table.cell_column  "CURRENCY1"
                         :table.columns      [{:name     "OG_CREATION_TIMESTAMP"
@@ -2070,34 +2070,35 @@
                                              "[\"name\",\"CREATION_DATE\"]"          {:column_title "Date"}
                                              "[\"name\",\"DEFAULT_CURRENCY\"]"       {:number_style "currency"
                                                                                       :column_title "Plain Currency"}}}]
-      (t2.with-temp/with-temp [Card card {:dataset_query          {:database (mt/id)
-                                                                   :type     :native
-                                                                   :native   {:query excel-data-query}}
-                                          :display                :table
-                                          :visualization_settings viz-settings}]
-        ;; The following formatting has been applied:
-        ;; - All columns renamed
-        ;; - Column reordering
-        ;; - Column hiding (See "HIDE_ME") above
-        ;; - Base formatting ("No Formatting TS") conforms to standard datetime format
-        ;; - "DATE-ONLY TS" shows only a date-formatted timestamp
-        ;; - "TS W/FORMATTING" shows a timestamp with custom date and time formatting
-        ;; - "Date" shows simple date formatting
-        ;; - "Time" shows simple time formatting
-        ;; - "Plain Currency ($)" formats numbers as regular numbers with no dollar sign in the number column
-        ;; - "Col $" formats currency with leading $. Note that the strings as presented aren't as you'd see in Excel. Excel properly just adds a leading $.
-        ;; - "USD Col" has a leading USD. Again, the formatting of this output is an artifact of POI rendering. It is correct in Excel as "USD 1.23"
-        ;; - "DOL Col" has trailing US dollars
-        ;; - "EXPO" has exponentiated values
-        ;; - "Scaled PCT" multiplies values by 0.01 and presents as percentages
-        ;; - "3D PCT" is a standard percentage with a customization of 3 significant digits
-        (testing "All formatting is applied correctly in a complex situation."
-          (is (= [["No Formatting TS" "DATE-ONLY TS" "TS W/FORMATTING" "Date" "Time" "Plain Currency ($)" "Col $" "USD Col" "DOL Col" "EXPO" "Scaled PCT" "3D PCT"]
-                  ["Jan 1, 2023, 12:34 PM" "2023-1-1" "1-1-2023, 12:34:56.000" "Jan 1, 2023" "12:34 PM" "1,234.05" "[$$]1,234.05" "[$USD] 2345.05" "4,321.05 US dollars" "7180.64E+0" "0.05%" "19.200%"]
-                  ["Jan 1, 2023, 12:34 PM" "2023-1-1" "1-1-2023, 12:34:56.000" "Jan 1, 2023" "12:34 PM" "2,345.30" "[$$]2,345.30" "[$USD] 3456.30" "2,931.30 US dollars" "1.71806E+4" "8.02%" "0.000%"]
-                  ["Jan 1, 2023, 12:34 PM" "2023-1-1" "1-1-2023, 12:34:56.000" "Jan 1, 2023" "12:34 PM" "3,456.00" "[$$]3,456.00" "[$USD] 2300.00" "2,250.00 US dollars" "12.7181E+4" "95.40%" "11.580%"]]
-                 (parse-xlsx-results-to-strings
-                   (mt/user-http-request :rasta :post 200 (format "card/%d/query/xlsx" (u/the-id card)))))))))))
+      (mt/with-temporary-setting-values [custom-formatting {:type/Temporal {:date_abbreviate true}}]
+        (t2.with-temp/with-temp [Card card {:dataset_query          {:database (mt/id)
+                                                                     :type     :native
+                                                                     :native   {:query excel-data-query}}
+                                            :display                :table
+                                            :visualization_settings viz-settings}]
+          ;; The following formatting has been applied:
+          ;; - All columns renamed
+          ;; - Column reordering
+          ;; - Column hiding (See "HIDE_ME") above
+          ;; - Base formatting ("No Formatting TS") conforms to standard datetime format
+          ;; - "DATE-ONLY TS" shows only a date-formatted timestamp
+          ;; - "TS W/FORMATTING" shows a timestamp with custom date and time formatting
+          ;; - "Date" shows simple date formatting
+          ;; - "Time" shows simple time formatting
+          ;; - "Plain Currency ($)" formats numbers as regular numbers with no dollar sign in the number column
+          ;; - "Col $" formats currency with leading $. Note that the strings as presented aren't as you'd see in Excel. Excel properly just adds a leading $.
+          ;; - "USD Col" has a leading USD. Again, the formatting of this output is an artifact of POI rendering. It is correct in Excel as "USD 1.23"
+          ;; - "DOL Col" has trailing US dollars
+          ;; - "EXPO" has exponentiated values
+          ;; - "Scaled PCT" multiplies values by 0.01 and presents as percentages
+          ;; - "3D PCT" is a standard percentage with a customization of 3 significant digits
+          (testing "All formatting is applied correctly in a complex situation."
+            (is (= [["No Formatting TS" "DATE-ONLY TS" "TS W/FORMATTING" "Date" "Time" "Plain Currency ($)" "Col $" "USD Col" "DOL Col" "EXPO" "Scaled PCT" "3D PCT"]
+                    ["Jan 1, 2023, 12:34 PM" "2023-1-1" "1-1-2023, 12:34:56.000" "Jan 1, 2023" "12:34 PM" "1,234.05" "[$$]1,234.05" "[$USD] 2345.05" "4,321.05 US dollars" "7180.64E+0" "0.05%" "19.200%"]
+                    ["Jan 1, 2023, 12:34 PM" "2023-1-1" "1-1-2023, 12:34:56.000" "Jan 1, 2023" "12:34 PM" "2,345.30" "[$$]2,345.30" "[$USD] 3456.30" "2,931.30 US dollars" "1.71806E+4" "8.02%" "0.000%"]
+                    ["Jan 1, 2023, 12:34 PM" "2023-1-1" "1-1-2023, 12:34:56.000" "Jan 1, 2023" "12:34 PM" "3,456.00" "[$$]3,456.00" "[$USD] 2300.00" "2,250.00 US dollars" "12.7181E+4" "95.40%" "11.580%"]]
+                   (parse-xlsx-results-to-strings
+                     (mt/user-http-request :rasta :post 200 (format "card/%d/query/xlsx" (u/the-id card))))))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/test/metabase/formatter_test.clj
+++ b/test/metabase/formatter_test.clj
@@ -25,29 +25,39 @@
       (is (= "2" (format 2 nil))))
     (testing "Currency"
       (testing "defaults to USD and two decimal places and symbol"
-        (is (= "$12,345.54" (fmt {::mb.viz/number-style "currency"}))))
+        (is (= "$12,345.54" (fmt {::mb.viz/number-style "currency"
+                                  ::mb.viz/currency-in-header false}))))
       (testing "Defaults to currency when there is a currency style"
-        (is (= "$12,345.54" (fmt {::mb.viz/currency-style "symbol"}))))
+        (is (= "$12,345.54" (fmt {::mb.viz/currency-style "symbol"
+                                  ::mb.viz/currency-in-header false}))))
       (testing "Defaults to currency when there is a currency"
-        (is (= "$12,345.54" (fmt {::mb.viz/currency "USD"}))))
+        (is (= "$12,345.54" (fmt {::mb.viz/currency "USD"
+                                  ::mb.viz/currency-in-header false}))))
       (testing "respects the number of decimal places when specified"
         (is (= "$12,345.54320" (fmt {::mb.viz/currency "USD"
-                                     ::mb.viz/decimals 5}))))
+                                     ::mb.viz/decimals 5
+                                     ::mb.viz/currency-in-header false}))))
       (testing "Other currencies"
-        (is (= "AED12,345.54" (fmt {::mb.viz/currency "AED"})))
+        (is (= "AED12,345.54" (fmt {::mb.viz/currency "AED"
+                                    ::mb.viz/currency-in-header false})))
         (is (= "12,345.54 Cape Verdean escudos"
                (fmt {::mb.viz/currency       "CVE"
-                     ::mb.viz/currency-style "name"})))
+                     ::mb.viz/currency-style "name"
+                     ::mb.viz/currency-in-header false})))
         (testing "which have no 'cents' and thus no decimal places"
-          (is (= "Af12,346" (fmt {::mb.viz/currency "AFN"})))
-          (is (= "₡12,346" (fmt {::mb.viz/currency "CRC"})))
-          (is (= "ZK12,346" (fmt {::mb.viz/currency "ZMK"})))))
+          (is (= "Af12,346" (fmt {::mb.viz/currency "AFN"
+                                  ::mb.viz/currency-in-header false})))
+          (is (= "₡12,346" (fmt {::mb.viz/currency "CRC"
+                                 ::mb.viz/currency-in-header false})))
+          (is (= "ZK12,346" (fmt {::mb.viz/currency "ZMK"
+                                  ::mb.viz/currency-in-header false})))))
       (testing "Understands name, code, and symbol"
         (doseq [[style expected] [["name" "12,345.54 Czech Republic korunas"]
                                   ["symbol" "Kč12,345.54"]
                                   ["code" "CZK 12,345.54"]]]
           (is (= expected (fmt {::mb.viz/currency       "CZK"
-                                ::mb.viz/currency-style style}))
+                                ::mb.viz/currency-style style
+                                ::mb.viz/currency-in-header false}))
               style))))
     (testing "scientific notation"
       (is (= "1.23E4" (fmt {::mb.viz/number-style "scientific"})))

--- a/test/metabase/formatter_test.clj
+++ b/test/metabase/formatter_test.clj
@@ -75,8 +75,12 @@
       (is (= "10%" (format 0.1 {::mb.viz/number-style "percent"})))
       (is (= "1%" (format 0.01 {::mb.viz/number-style "percent"})))
       (is (= "0%" (format 0.000000 {::mb.viz/number-style "percent"})))
-      ;; This is not zero, so should show decimal places
-      (is (= "0.00%" (format 0.0000001 {::mb.viz/number-style "percent"})))
+      ;; With default formatting (2 digits) and zero trimming, we get 0%
+      (is (= "0%" (format 0.0000001 {::mb.viz/number-style "percent"})))
+      ;; Requiring 2 digits adds zeros
+      (is (= "0.00%" (format 0.0000001 {::mb.viz/number-style "percent"
+                                        ::mb.viz/decimals     2})))
+      ;; You need at least 5 digits (not the scale by 100 for percents) to show the low value
       (is (= "0.00001%" (format 0.0000001 {::mb.viz/number-style "percent"
                                            ::mb.viz/decimals          5}))))
     (testing "Match UI 'natural formatting' behavior for decimal values with no column formatting present"

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -413,8 +413,8 @@
           (testing "Custom column metadata settings are applied"
             (is (= "2023-12-11, 15:30"
                    (metamodel-results "Example Timestamp With Time Zone"))))
-          (testing "Custom column settings metadata takes precedence over visualization settings"
-            (is (= "December 11, 2023, 3:30:45 PM"
+          (testing "Visualization settings overwrite custom metadata column settings"
+            (is (= "December 11, 2023, 3:30:45.123 PM"
                    (metamodel-results "Example Timestamp"))))
           (testing "Setting time-enabled to nil for a date time column results in only showing the date"
             (is (= "December 11, 2023"

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -4,9 +4,7 @@
    [clojure.java.io :as io]
    [clojure.test :refer :all]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
-   [medley.core :as m]
    [metabase.driver :as driver]
-   [metabase.public-settings :as public-settings]
    [metabase.query-processor.streaming.common :as common]
    [metabase.query-processor.streaming.interface :as qp.si]
    [metabase.query-processor.streaming.xlsx :as qp.xlsx]
@@ -29,9 +27,7 @@
   ([format-settings col]
    (let [viz-settings (common/viz-settings-for-col
                         (assoc col :field_ref [:field 1])
-                        {::mb.viz/column-settings {{::mb.viz/field-id 1} format-settings}
-                         ::mb.viz/global-column-settings (m/map-vals mb.viz/db->norm-column-settings-entries
-                                                                     (public-settings/custom-formatting))})
+                        {::mb.viz/column-settings {{::mb.viz/field-id 1} format-settings}})
          format-strings (@#'qp.xlsx/format-settings->format-strings viz-settings col)]
      ;; If only one format string is returned (for datetimes) or both format strings
      ;; are equal, just return a single value to make tests more readable.

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -440,14 +440,14 @@
 
   (testing "Misc format strings are included correctly in exports"
     (is (= ["[$€]#,##0.00"]
-           (second (xlsx-export [{:id 0, :name "Col", :semantic_type :type/Cost}]
+           (second (xlsx-export [{:field_ref [:field 0] :name "Col" :semantic_type :type/Cost}]
                                 {::mb.viz/column-settings {{::mb.viz/field-id 0}
                                                            {::mb.viz/currency "EUR"
                                                             ::mb.viz/currency-in-header false}}}
                                 [[1.23]]
                                 parse-format-strings))))
     (is (= ["yyyy.m.d, h:mm:ss am/pm"]
-           (second (xlsx-export [{:id 0, :name "Col", :effective_type :type/Temporal}]
+           (second (xlsx-export [{:field_ref [:field 0] :name "Col" :effective_type :type/Temporal}]
                                 {::mb.viz/column-settings {{::mb.viz/field-id 0}
                                                            {::mb.viz/date-style "YYYY/M/D",
                                                             ::mb.viz/date-separator ".",

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -431,30 +431,31 @@
          row)))
 
 (deftest export-format-test
-  (testing "Different format strings are used for ints and numbers that round to ints (with 2 decimal places)"
-    (is (= [["#,##0"] ["#,##0.##"] ["#,##0"] ["#,##0.##"] ["#,##0"] ["#,##0.##"]]
-           (rest (xlsx-export [{:id 0, :name "Col", :semantic_type :type/Cost}]
-                              {}
-                              [[1] [1.23] [1.004] [1.005] [10000000000] [10000000000.123]]
-                              parse-format-strings)))))
+  (mt/with-temporary-setting-values [custom-formatting {}]
+    (testing "Different format strings are used for ints and numbers that round to ints (with 2 decimal places)"
+      (is (= [["#,##0"] ["#,##0.##"] ["#,##0"] ["#,##0.##"] ["#,##0"] ["#,##0.##"]]
+             (rest (xlsx-export [{:field_ref [:field 0] :name "Col" :semantic_type :type/Cost}]
+                                {}
+                                [[1] [1.23] [1.004] [1.005] [10000000000] [10000000000.123]]
+                                parse-format-strings)))))
 
-  (testing "Misc format strings are included correctly in exports"
-    (is (= ["[$€]#,##0.00"]
-           (second (xlsx-export [{:field_ref [:field 0] :name "Col" :semantic_type :type/Cost}]
-                                {::mb.viz/column-settings {{::mb.viz/field-id 0}
-                                                           {::mb.viz/currency "EUR"
-                                                            ::mb.viz/currency-in-header false}}}
-                                [[1.23]]
-                                parse-format-strings))))
-    (is (= ["yyyy.m.d, h:mm:ss am/pm"]
-           (second (xlsx-export [{:field_ref [:field 0] :name "Col" :effective_type :type/Temporal}]
-                                {::mb.viz/column-settings {{::mb.viz/field-id 0}
-                                                           {::mb.viz/date-style "YYYY/M/D",
-                                                            ::mb.viz/date-separator ".",
-                                                            ::mb.viz/time-style "h:mm A",
-                                                            ::mb.viz/time-enabled "seconds"}}}
-                                [[#t "2020-03-28T10:12:06.681"]]
-                                parse-format-strings))))))
+    (testing "Misc format strings are included correctly in exports"
+      (is (= ["[$€]#,##0.00"]
+             (second (xlsx-export [{:field_ref [:field 0] :name "Col" :semantic_type :type/Cost}]
+                                  {::mb.viz/column-settings {{::mb.viz/field-id 0}
+                                                             {::mb.viz/currency           "EUR"
+                                                              ::mb.viz/currency-in-header false}}}
+                                  [[1.23]]
+                                  parse-format-strings))))
+      (is (= ["yyyy.m.d, h:mm:ss am/pm"]
+             (second (xlsx-export [{:field_ref [:field 0] :name "Col" :effective_type :type/Temporal}]
+                                  {::mb.viz/column-settings {{::mb.viz/field-id 0}
+                                                             {::mb.viz/date-style     "YYYY/M/D",
+                                                              ::mb.viz/date-separator ".",
+                                                              ::mb.viz/time-style     "h:mm A",
+                                                              ::mb.viz/time-enabled   "seconds"}}}
+                                  [[#t "2020-03-28T10:12:06.681"]]
+                                  parse-format-strings)))))))
 
 (deftest column-order-test
   (testing "Column titles are ordered correctly in the output"


### PR DESCRIPTION
This PR has a set of changes that should provide consistent formatting across exports of Excel, CSV, and JSON files, including formatting applied globally, as metadata, and as visualization-specific settings.

Changes include:
- Consolidation of settings merge logic into `metabase.query-processor.streaming.common` as `viz-settings-for-col`. This is now used for `xlsx`, `csv`, and `json` exports.
  - The `xlsx` still needs to take these settings and produce cell formatters where the `csv` and `json` branches need to produce string formatters. Either way, this is a good incremental step towards a pipeline of all the settings -> unified settings per column -> format -> product of format (cell style or formatter).
  - This also provides a more functional style in which we reach for global settings far less and rely on what is passed in via the unified settings (which get global settings from the `metabase.query-processor.middleware.visualization-settings` qp middleware).
- Modify `metabase.query-processor.streaming.xlsx` to use the same strategy as csv and json exports of computing styles for visible columns only up front then reusing these styles
- Removing trailing zeroes for percentages in CSV and JSON files prior to formatting to conform to the FE. While this gets us close to consistent behavior, we should maybe revisit the idea of default stripping of trailing zeroes.
- Adds consistent seed values of `nil` to the `volatile!` fields used in stream processing for column formatting.
  - Note that this ns still has some potential to be streamlined to remove code that is close to code in the csv/json path but this PR is meant to be a start, not to completely refactor the whole ns.
- Unit tests
  - All existing tests pass. Note that `metabase.query-processor.streaming.xlsx-test/format-string` has been modified to compute a unified settings map to better follow what happens in practice with the qp middleware.
  - Additional smaller and large-scale tests were added to `metabase.api.card-test` to test end to end xlsx exports.

Fixes #14393
Closes #17753