### PR TITLE
Modify type metabase_field.database_required to bit(1) in mysql

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5122,6 +5122,28 @@ databaseChangeLog:
         - dbms:
             type: mysql,mariadb
 
+  - changeSet:
+      id: v49.00-060
+      author: qnkhuat
+      comment: >-
+        Added 0.49.0 - modify type of metabase_field.database_partitioned
+        from boolean to ${boolean.type} on mysql,mariadb
+      dbms: mysql,mariadb
+      changes:
+        - modifyDataType:
+            tableName: metabase_table
+            columnName: database_require_filter
+            newDataType: ${boolean.type}
+      rollback:
+        - modifyDataType:
+            tableName: metabase_table
+            columnName: database_require_filter
+            newDataType: boolean
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql,mariadb
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5131,13 +5131,13 @@ databaseChangeLog:
       dbms: mysql,mariadb
       changes:
         - modifyDataType:
-            tableName: metabase_table
-            columnName: database_require_filter
+            tableName: metabase_field
+            columnName: database_partitioned
             newDataType: ${boolean.type}
       rollback:
         - modifyDataType:
-            tableName: metabase_table
-            columnName: database_require_filter
+            tableName: metabase_field
+            columnName: database_partitioned
             newDataType: boolean
       preConditions:
         - onFail: MARK_RAN

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -761,7 +761,7 @@
 (deftest no-tiny-int-columns
   (mt/test-driver :mysql
     (testing "All boolean columns in mysql, mariadb should be bit(1)"
-      (is (= [{:table_name "databasechangeloglock" :column_name "LOCKED"}] ;; outlier because this is liquibase's table
+      (is (= [{:table_name "DATABASECHANGELOGLOCK" :column_name "LOCKED"}] ;; outlier because this is liquibase's table
              (t2/query
               (format "SELECT table_name, column_name FROM information_schema.columns WHERE data_type LIKE 'tinyint%%' AND table_schema = '%s';"
                       (-> (mdb.connection/data-source) .getConnection .getCatalog))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -757,3 +757,11 @@
         (is (t2/exists? :pulse :id dash-subscription-id))
         (is (t2/exists? :pulse :id alert-id))
         (is (not (t2/exists? :pulse :id legacy-pulse-id)))))))
+
+(deftest no-tiny-int-columns
+  (mt/test-driver :mysql
+    (testing "All boolean columns in mysql, mariadb should be bit(1)"
+      (is (= [{:table_name "databasechangeloglock" :column_name "LOCKED"}] ;; outlier because this is liquibase's table
+             (t2/query
+              (format "SELECT table_name, column_name FROM information_schema.columns WHERE data_type LIKE 'tinyint%%' AND table_schema = '%s';"
+                      (-> (mdb.connection/data-source) .getConnection .getCatalog))))))))


### PR DESCRIPTION
We change all of the boolean field in MySQL to `bit(1)` in https://github.com/metabase/metabase/pull/36964, but this is a missing case.

Also added a test.