### PR TITLE
[MLv2] Removing a final JOIN condition removes the whole join

### DIFF
--- a/dev/src/dev/fe_helpers.cljs
+++ b/dev/src/dev/fe_helpers.cljs
@@ -1,15 +1,30 @@
 (ns dev.fe-helpers)
 
-(defn redux-state []
+(defn redux-state
+  "Returns the root Redux state, the JS object holding the complete state of the app.
+
+  This is hacky - it reaches deep into the internals of Redux, and may break in the future. That seems acceptable for a
+  dev time helper."
+  []
   (let [root  (js/document.querySelector "#root")
         store (.. root -_reactRootContainer -_internalRoot -current -child -memoizedProps -store)]
     (.getState store)))
 
-(defn current-card []
+(defn current-card
+  "Retrieves the current query's card from the Redux state.
+
+  Undefined behavior if there is not currently a single question loaded in the UI."
+  []
   (.. (redux-state) -qb -card))
 
-(defn current-legacy-query-js []
+(defn current-legacy-query-js
+  "Gets the legacy query for the currently loaded question."
+  []
   (.-dataset_query (current-card)))
 
-(defn current-query []
+(defn current-query
+  "Gets the MLv2 query for the currently loaded question.
+
+  Hack: This relies on a dev-mode-only global property that's set whenever a Question object is converted to MLv2."
+  []
   (.-__MLv2_query js/window))

--- a/src/metabase/lib/remove_replace.cljc
+++ b/src/metabase/lib/remove_replace.cljc
@@ -32,6 +32,7 @@
 
 (declare remove-local-references)
 (declare remove-stage-references)
+(declare remove-join)
 (declare normalize-fields-clauses)
 
 (defn- find-matching-order-by-index
@@ -118,12 +119,24 @@
                                        (_ :guard #(or (empty? target-opts)
                                                       (set/subset? (set target-opts) (set %))))
                                        target-ref-id] [location clause]))))))
-                   (stage-paths query stage-number))]
-    (reduce
-     (fn [query [location target-clause]]
-       (remove-replace-location query stage-number unmodified-query-for-stage location target-clause #(lib.util/remove-clause %1 %2 %3 stage-number)))
-     query
-     to-remove)))
+                   (stage-paths query stage-number))
+        dead-joins (volatile! (transient []))]
+    (as-> query q
+      (reduce
+        (fn [query [location target-clause]]
+          (remove-replace-location
+            query stage-number unmodified-query-for-stage location target-clause
+            #(try (lib.util/remove-clause %1 %2 %3 stage-number)
+                  (catch #?(:clj Exception :cljs js/Error) e
+                    (let [{:keys [error join]} (ex-data e)]
+                      (if (= error :metabase.lib.util/cannot-remove-final-join-condition)
+                        ;; Return the stage unchanged, but keep track of the dead joins.
+                        (do (vswap! dead-joins conj! join)
+                            %1)
+                        (throw e)))))))
+        q
+        to-remove)
+      (reduce #(remove-join %1 stage-number %2) q (persistent! @dead-joins)))))
 
 (defn- remove-stage-references
   [query previous-stage-number unmodified-query-for-stage target-uuid]
@@ -181,8 +194,6 @@
             (remove-replace-location stage-number query location target-clause remove-replace-fn)
             normalize-fields-clauses)
         query))))
-
-(declare remove-join)
 
 (mu/defn remove-clause :- :metabase.lib.schema/query
   "Removes the `target-clause` from the stage specified by `stage-number` of `query`.


### PR DESCRIPTION
This still throws an exception on trying to directly remove the final
JOIN condition. But if the condition is being removed because a field it
depends on is being removed (eg. a custom column, a breakout, a
previous stage aggregation) then the entire JOIN is also removed, in the
usual cascading fashion.

Fixes #36690.

