### PR TITLE
Rename `Question.query()` to `Question.legacyQuery()`

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
@@ -334,7 +334,9 @@ const TargetName = ({ policy, target }: TargetNameProps) => {
               return null;
             }
 
-            const dimension = question.query().parseFieldReference(fieldRef);
+            const dimension = question
+              .legacyQuery()
+              .parseFieldReference(fieldRef);
             return (
               <span>
                 <strong>{dimension?.render()}</strong> field

--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -383,7 +383,7 @@ export default class Dimension {
     return null;
   }
 
-  query(): StructuredQuery | null | undefined {
+  legacyQuery(): StructuredQuery | null | undefined {
     return this._query;
   }
 
@@ -1213,7 +1213,7 @@ export class ExpressionDimension extends Dimension {
 
     if (!baseTypeOption) {
       if (query) {
-        const datasetQuery = query.query();
+        const datasetQuery = query.legacyQuery();
         const expressions = datasetQuery?.expressions ?? {};
         const expr = expressions[this.name()];
 

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -179,7 +179,7 @@ class Question {
    *
    * This is just a wrapper object, the data is stored in `this._card.dataset_query` in a format specific to the query type.
    */
-  query = _.once((): AtomicQuery => {
+  legacyQuery = _.once((): AtomicQuery => {
     const datasetQuery = this._card.dataset_query;
 
     for (const QueryClass of [StructuredQuery, NativeQuery, InternalQuery]) {
@@ -195,11 +195,11 @@ class Question {
   });
 
   isNative(): boolean {
-    return this.query() instanceof NativeQuery;
+    return this.legacyQuery() instanceof NativeQuery;
   }
 
   isStructured(): boolean {
-    return this.query() instanceof StructuredQuery;
+    return this.legacyQuery() instanceof StructuredQuery;
   }
 
   /**
@@ -228,7 +228,7 @@ class Question {
    * Returns a list of atomic queries (NativeQuery or StructuredQuery) contained in this question
    */
   atomicQueries(): AtomicQuery[] {
-    const query = this.query();
+    const query = this.legacyQuery();
 
     if (query instanceof AtomicQuery) {
       return [query];
@@ -335,7 +335,7 @@ class Question {
       return this;
     }
 
-    const query = this.query();
+    const query = this.legacyQuery();
 
     if (query instanceof StructuredQuery) {
       // TODO: move to StructuredQuery?
@@ -415,7 +415,7 @@ class Question {
   }
 
   setDefaultQuery() {
-    return this.query().setDefaultQuery().question();
+    return this.legacyQuery().setDefaultQuery().question();
   }
 
   settings(): VisualizationSettings {
@@ -444,7 +444,7 @@ class Question {
   }
 
   isEmpty(): boolean {
-    return this.query().isEmpty();
+    return this.legacyQuery().isEmpty();
   }
 
   /**
@@ -458,7 +458,7 @@ class Question {
    * Question is valid (as far as we know) and can be executed
    */
   canRun(): boolean {
-    return this.query().canRun();
+    return this.legacyQuery().canRun();
   }
 
   canWrite(): boolean {
@@ -477,7 +477,7 @@ class Question {
   }
 
   supportsImplicitActions(): boolean {
-    const query = this.query();
+    const query = this.legacyQuery();
 
     // we want to check the metadata for the underlying table, not the model
     const table = query.sourceTable();
@@ -496,7 +496,7 @@ class Question {
   }
 
   isQueryEditable(): boolean {
-    const query = this.query();
+    const query = this.legacyQuery();
     return query ? query.isEditable() : false;
   }
 
@@ -561,7 +561,7 @@ class Question {
     return (
       this.isStructured() &&
       _.any(
-        QUERY.getAggregations(this.query().query()),
+        QUERY.getAggregations(this.legacyQuery().legacyQuery()),
         aggregation => AGGREGATION.getMetric(aggregation) === metricId,
       )
     );
@@ -570,7 +570,7 @@ class Question {
   usesSegment(segmentId): boolean {
     return (
       this.isStructured() &&
-      QUERY.getFilters(this.query().query()).some(
+      QUERY.getFilters(this.legacyQuery().legacyQuery()).some(
         filter => FILTER.isSegment(filter) && filter[1] === segmentId,
       )
     );
@@ -610,7 +610,7 @@ class Question {
     previousQuestion,
     previousQuery,
   ) {
-    const query = this.query();
+    const query = this.legacyQuery();
 
     if (
       !_.isEqual(
@@ -726,14 +726,14 @@ class Question {
   }
 
   syncColumnsAndSettings(previous, queryResults) {
-    const query = this.query();
+    const query = this.legacyQuery();
     const isQueryResultValid = queryResults && !queryResults.error;
 
     if (query instanceof NativeQuery && isQueryResultValid) {
       return this._syncNativeQuerySettings(queryResults);
     }
 
-    const previousQuery = previous && previous.query();
+    const previousQuery = previous && previous.legacyQuery();
 
     if (
       query instanceof StructuredQuery &&
@@ -824,7 +824,7 @@ class Question {
   }
 
   database(): Database | null | undefined {
-    const query = this.query();
+    const query = this.legacyQuery();
     return query && typeof query.database === "function"
       ? query.database()
       : null;
@@ -836,7 +836,7 @@ class Question {
   }
 
   table(): Table | null | undefined {
-    const query = this.query();
+    const query = this.legacyQuery();
     return query && typeof query.table === "function" ? query.table() : null;
   }
 
@@ -987,7 +987,7 @@ class Question {
     includeDisplayIsLocked = false,
     creationType,
   } = {}) {
-    const query = clean ? this.query().clean() : this.query();
+    const query = clean ? this.legacyQuery().clean() : this.legacyQuery();
     const cardCopy = {
       name: this._card.name,
       description: this._card.description,
@@ -1103,7 +1103,7 @@ class Question {
       this.isNative() &&
       this.isSaved() &&
       this.parameters().length === 0 &&
-      this.query().canNest() &&
+      this.legacyQuery().canNest() &&
       this.isQueryEditable() // originally "canRunAdhocQuery"
     );
   }

--- a/frontend/src/metabase-lib/README.md
+++ b/frontend/src/metabase-lib/README.md
@@ -6,7 +6,7 @@
 
 Examples:
 
-- `question().query().aggregation()[0].setDimension(dimension)`
+- `question().legacyQuery().aggregation()[0].setDimension(dimension)`
 
 Exceptions:
 

--- a/frontend/src/metabase-lib/expressions/__support__/expressions.ts
+++ b/frontend/src/metabase-lib/expressions/__support__/expressions.ts
@@ -121,6 +121,6 @@ export const metadata = createMockMetadata({
   databases: [database],
 });
 
-export const legacyQuery = checkNotNull(metadata.table(TABLE_ID)).query();
+export const legacyQuery = checkNotNull(metadata.table(TABLE_ID)).legacyQuery();
 export const expressionOpts = { legacyQuery, startRule: "expression" };
 export const aggregationOpts = { legacyQuery, startRule: "aggregation" };

--- a/frontend/src/metabase-lib/expressions/__support__/shared.ts
+++ b/frontend/src/metabase-lib/expressions/__support__/shared.ts
@@ -69,7 +69,7 @@ const segment = checkNotNull(metadata.segment(SEGMENT_ID)).filterClause();
 const metric = checkNotNull(metadata.metric(METRIC_ID)).aggregationClause();
 
 const legacyQuery = checkNotNull(metadata.table(ORDERS_ID))
-  .query()
+  .legacyQuery()
   .addExpression("foo", 42);
 
 // shared test cases used in compile, formatter, and syntax tests:

--- a/frontend/src/metabase-lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/metadata/Database.ts
@@ -150,7 +150,7 @@ class Database {
   }
 
   nativeQuery(native: Partial<NativeQuery>) {
-    return this.nativeQuestion(native).query();
+    return this.nativeQuestion(native).legacyQuery();
   }
 
   savedQuestionsDatabase() {

--- a/frontend/src/metabase-lib/metadata/Database.unit.spec.ts
+++ b/frontend/src/metabase-lib/metadata/Database.unit.spec.ts
@@ -179,7 +179,7 @@ describe("Database", () => {
       const database = setup();
       const question = database.question();
 
-      expect(question.query()).toBeInstanceOf(StructuredQuery);
+      expect(question.legacyQuery()).toBeInstanceOf(StructuredQuery);
       expect(question.metadata()).toEqual(database.metadata);
     });
 
@@ -202,7 +202,7 @@ describe("Database", () => {
       const database = setup();
       const question = database.nativeQuestion();
 
-      expect(question.query()).toBeInstanceOf(NativeQuery);
+      expect(question.legacyQuery()).toBeInstanceOf(NativeQuery);
       expect(question.metadata()).toBe(database.metadata);
     });
 
@@ -210,7 +210,7 @@ describe("Database", () => {
       const database = setup();
       const question = database.nativeQuestion({ query: "SELECT 1" });
 
-      const query = question.query() as NativeQuery;
+      const query = question.legacyQuery() as NativeQuery;
       expect(query.queryText()).toBe("SELECT 1");
     });
   });

--- a/frontend/src/metabase-lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/metadata/Field.ts
@@ -503,7 +503,7 @@ class FieldInner extends Base {
       return [];
     }
 
-    const { fks } = table.query().fieldOptions();
+    const { fks } = table.legacyQuery().fieldOptions();
     return fks
       .filter(({ field }) => field.id === this.id)
       .map(({ field, dimension, dimensions }) => ({

--- a/frontend/src/metabase-lib/metadata/Metric.ts
+++ b/frontend/src/metabase-lib/metadata/Metric.ts
@@ -31,7 +31,7 @@ class Metric {
   /** Underlying query for this metric */
   definitionQuery() {
     return this.table && this.definition
-      ? this.table.query().setQuery(this.definition)
+      ? this.table.legacyQuery().setQuery(this.definition)
       : null;
   }
 

--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -85,11 +85,13 @@ class Table {
     return match ? parseInt(match[1]) : null;
   }
 
-  query(query = {}) {
-    return (this.question().query() as StructuredQuery).updateQuery(q => ({
-      ...q,
-      ...query,
-    }));
+  legacyQuery(query = {}) {
+    return (this.question().legacyQuery() as StructuredQuery).updateQuery(
+      q => ({
+        ...q,
+        ...query,
+      }),
+    );
   }
 
   dimensions() {

--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -97,7 +97,7 @@ export function checkDatabaseCanPersistDatasets(database?: Database | null) {
 }
 
 export function checkCanBeModel(question: Question) {
-  const query = question.query();
+  const query = question.legacyQuery();
 
   if (!checkDatabaseSupportsModels(query.database())) {
     return false;

--- a/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
@@ -131,7 +131,7 @@ function notRelativeDateOrRange({ type }: Parameter) {
 }
 
 export function getTargetsForQuestion(question: Question): Target[] {
-  const query = question.query();
+  const query = question.legacyQuery();
   return [...query.dimensionOptions().all(), ...query.variables()].map(o => {
     let id, target: ClickBehaviorTarget;
     if (o instanceof TemplateTagVariable || o instanceof TemplateTagDimension) {

--- a/frontend/src/metabase-lib/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/parameters/utils/targets.ts
@@ -26,7 +26,7 @@ export function getParameterTargetField(
   question: Question,
 ) {
   if (isDimensionTarget(target)) {
-    const query = question.query() as NativeQuery | StructuredQuery;
+    const query = question.legacyQuery() as NativeQuery | StructuredQuery;
     const dimension = Dimension.parseMBQL(target[1], metadata, query);
 
     return dimension?.field();

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -342,7 +342,7 @@ export default class NativeQuery extends AtomicQuery {
     config: ParameterValuesConfig,
   ): NativeQuery {
     const newParameter = getTemplateTagParameter(tag, config);
-    return this.question().setParameter(tag.id, newParameter).query();
+    return this.question().setParameter(tag.id, newParameter).legacyQuery();
   }
 
   setDatasetQuery(datasetQuery: DatasetQuery): NativeQuery {

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -211,7 +211,7 @@ class StructuredQuery extends AtomicQuery {
   /**
    * @returns the underlying MBQL query object
    */
-  query(): StructuredQueryObject {
+  legacyQuery(): StructuredQueryObject {
     return this._structuredDatasetQuery.query;
   }
 
@@ -254,7 +254,7 @@ class StructuredQuery extends AtomicQuery {
    * @returns the table ID, if a table is selected.
    */
   sourceTableId(): TableId | null | undefined {
-    return this.query()?.["source-table"];
+    return this.legacyQuery()?.["source-table"];
   }
 
   sourceTable(): Table | null | undefined {
@@ -578,7 +578,7 @@ class StructuredQuery extends AtomicQuery {
    * @deprecated use metabase-lib v2 to manage joins
    */
   joins = _.once((): JoinWrapper[] => {
-    return Q.getJoins(this.query()).map(
+    return Q.getJoins(this.legacyQuery()).map(
       (join, index) => new JoinWrapper(join, index, this),
     );
   });
@@ -603,7 +603,7 @@ class StructuredQuery extends AtomicQuery {
    * @returns an array of MBQL @type {Aggregation}s.
    */
   aggregations = _.once((): AggregationWrapper[] => {
-    return Q.getAggregations(this.query()).map(
+    return Q.getAggregations(this.legacyQuery()).map(
       (aggregation, index) => new AggregationWrapper(aggregation, index, this),
     );
   });
@@ -744,11 +744,11 @@ class StructuredQuery extends AtomicQuery {
    * @returns An array of MBQL @type {Breakout}s.
    */
   breakouts = _.once((): BreakoutWrapper[] => {
-    if (this.query() == null) {
+    if (this.legacyQuery() == null) {
       return [];
     }
 
-    return Q.getBreakouts(this.query()).map(
+    return Q.getBreakouts(this.legacyQuery()).map(
       (breakout, index) => new BreakoutWrapper(breakout, index, this),
     );
   });
@@ -835,7 +835,7 @@ class StructuredQuery extends AtomicQuery {
    * @returns An array of MBQL @type {Filter}s.
    */
   filters = _.once((): FilterWrapper[] => {
-    return Q.getFilters(this.query()).map(
+    return Q.getFilters(this.legacyQuery()).map(
       (filter, index) => new FilterWrapper(filter, index, this),
     );
   });
@@ -955,7 +955,7 @@ class StructuredQuery extends AtomicQuery {
    */
   canAddFilter() {
     return (
-      Q.canAddFilter(this.query()) &&
+      Q.canAddFilter(this.legacyQuery()) &&
       (this.filterDimensionOptions().count > 0 ||
         this.filterSegmentOptions().length > 0)
     );
@@ -1001,7 +1001,7 @@ class StructuredQuery extends AtomicQuery {
    * @deprecated use the orderBys function from metabase-lib v2
    */
   sorts = _.once((): OrderBy[] => {
-    return Q.getOrderBys(this.query());
+    return Q.getOrderBys(this.legacyQuery());
   });
 
   // LIMIT
@@ -1024,7 +1024,7 @@ class StructuredQuery extends AtomicQuery {
 
   // EXPRESSIONS
   expressions = _.once((): ExpressionClause => {
-    return Q.getExpressions(this.query());
+    return Q.getExpressions(this.legacyQuery());
   });
 
   addExpression(name, expression) {
@@ -1068,7 +1068,7 @@ class StructuredQuery extends AtomicQuery {
   // FIELDS
   fields() {
     // FIMXE: implement field functions in query lib
-    return this.query().fields || [];
+    return this.legacyQuery().fields || [];
   }
 
   addField(_name, _expression) {
@@ -1384,7 +1384,7 @@ class StructuredQuery extends AtomicQuery {
    * The (wrapped) source query, if any
    */
   sourceQuery = _.once((): StructuredQuery | null | undefined => {
-    const sourceQuery = this.query()?.["source-query"];
+    const sourceQuery = this.legacyQuery()?.["source-query"];
 
     if (sourceQuery) {
       return new NestedStructuredQuery(
@@ -1456,7 +1456,7 @@ class StructuredQuery extends AtomicQuery {
           .flatMap(q => q.dimensions())
           .find(d => d.isEqual(fieldRef));
 
-        return this.parseFieldReference(fieldRef, dimension?.query());
+        return this.parseFieldReference(fieldRef, dimension?.legacyQuery());
       }
     }
 
@@ -1507,7 +1507,7 @@ class StructuredQuery extends AtomicQuery {
         return this;
       }
 
-      sourceQuery = sourceQuery.query();
+      sourceQuery = sourceQuery.legacyQuery();
     }
 
     // TODO: if the source query is modified in ways that make the parent query invalid we should "clean" those clauses
@@ -1632,6 +1632,6 @@ class NestedStructuredQuery extends StructuredQuery {
   });
 
   parentQuery() {
-    return this._parent.setSourceQuery(this.query());
+    return this._parent.setSourceQuery(this.legacyQuery());
   }
 }

--- a/frontend/src/metabase-lib/queries/structured/Aggregation.ts
+++ b/frontend/src/metabase-lib/queries/structured/Aggregation.ts
@@ -312,9 +312,9 @@ export default class Aggregation extends MBQLClause {
       switch (this.expressionName()) {
         case "share":
         case "count-where":
-          return new Filter(this[1], null, this.query());
+          return new Filter(this[1], null, this.legacyQuery());
         case "sum-where":
-          return new Filter(this[2], null, this.query());
+          return new Filter(this[2], null, this.legacyQuery());
       }
     }
 
@@ -324,7 +324,9 @@ export default class Aggregation extends MBQLClause {
   metricFilters(): Filter[] | null {
     if (this.isMetric()) {
       const metric = this.metric();
-      return metric?.filters().map(filter => filter.setQuery(this.query()));
+      return metric
+        ?.filters()
+        .map(filter => filter.setQuery(this.legacyQuery()));
     }
 
     return null;

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -132,7 +132,7 @@ export default class Filter extends MBQLClause {
         return true;
       }
 
-      const query = this.query();
+      const query = this.legacyQuery();
 
       if (
         !dimension ||

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -201,7 +201,7 @@ class Join extends MBQLObjectClause {
    */
   isValid() {
     // MLv2 should ensure there's a valid condition, etc.
-    const parentTable = this.query?.().table?.();
+    const parentTable = this.legacyQuery?.().table?.();
     return !!parentTable && !!this.joinedTable();
   }
 }

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -97,14 +97,14 @@ class Join extends MBQLObjectClause {
     const sourceTableId = this["source-table"];
     const sourceQuery = this["source-query"];
     return sourceTableId
-      ? new StructuredQuery(this.query().question().setDataset(false), {
+      ? new StructuredQuery(this.legacyQuery().question().setDataset(false), {
           type: "query",
           query: {
             "source-table": sourceTableId,
           },
         })
       : sourceQuery
-      ? new StructuredQuery(this.query().question().setDataset(false), {
+      ? new StructuredQuery(this.legacyQuery().question().setDataset(false), {
           type: "query",
           query: sourceQuery,
         })
@@ -113,7 +113,7 @@ class Join extends MBQLObjectClause {
 
   private joinedDimension(dimension: Dimension) {
     if (dimension instanceof FieldDimension) {
-      return dimension.withJoinAlias(this.alias).setQuery(this.query());
+      return dimension.withJoinAlias(this.alias).setQuery(this.legacyQuery());
     }
 
     console.warn("Don't know how to create joined dimension with:", dimension);
@@ -136,9 +136,11 @@ class Join extends MBQLObjectClause {
       const [, parentDimension, joinDimension] = condition;
       return [
         parentDimension
-          ? this.query().parseFieldReference(parentDimension)
+          ? this.legacyQuery().parseFieldReference(parentDimension)
           : null,
-        joinDimension ? this.query().parseFieldReference(joinDimension) : null,
+        joinDimension
+          ? this.legacyQuery().parseFieldReference(joinDimension)
+          : null,
       ];
     });
   }
@@ -160,7 +162,7 @@ class Join extends MBQLObjectClause {
     if (this.fields === "all") {
       return this.joinedDimensions();
     } else if (Array.isArray(this.fields)) {
-      return this.fields.map(f => this.query().parseFieldReference(f));
+      return this.fields.map(f => this.legacyQuery().parseFieldReference(f));
     } else {
       return [];
     }

--- a/frontend/src/metabase-lib/queries/structured/MBQLClause.ts
+++ b/frontend/src/metabase-lib/queries/structured/MBQLClause.ts
@@ -38,7 +38,7 @@ export default class MBQLArrayClause extends Array {
   /**
    * returns the parent query object
    */
-  query(): StructuredQuery {
+  legacyQuery(): StructuredQuery {
     return this._query;
   }
 
@@ -92,7 +92,7 @@ export class MBQLObjectClause {
   /**
    * returns the parent query object
    */
-  query(): StructuredQuery {
+  legacyQuery(): StructuredQuery {
     return this._query;
   }
 

--- a/frontend/src/metabase-lib/queries/utils/actions.js
+++ b/frontend/src/metabase-lib/queries/utils/actions.js
@@ -8,14 +8,14 @@ import { FieldDimension } from "metabase-lib/Dimension";
 // QUESTION DRILL ACTIONS
 
 export function aggregate(question, aggregation) {
-  const query = question.query();
+  const query = question.legacyQuery();
   if (query instanceof StructuredQuery) {
     return query.aggregate(aggregation).question().setDefaultDisplay();
   }
 }
 
 export function breakout(question, breakout) {
-  const query = question.query();
+  const query = question.legacyQuery();
   if (query instanceof StructuredQuery) {
     return query.breakout(breakout).question().setDefaultDisplay();
   }
@@ -23,7 +23,7 @@ export function breakout(question, breakout) {
 
 // Adds a new filter with the specified operator, column, and value
 export function filter(question, operator, column, value) {
-  const query = question.query();
+  const query = question.legacyQuery();
   if (query instanceof StructuredQuery) {
     return query
       .filter([operator, fieldRefForColumn(column), value])

--- a/frontend/src/metabase-lib/queries/utils/native-query-table.unit.spec.ts
+++ b/frontend/src/metabase-lib/queries/utils/native-query-table.unit.spec.ts
@@ -98,7 +98,7 @@ describe("metabase-lib/queries/utils/native-query-table", () => {
     ) as Question;
 
     const table = getNativeQueryTable(
-      nativeQuestionWithCollection.query() as NativeQuery,
+      nativeQuestionWithCollection.legacyQuery() as NativeQuery,
     );
 
     it("should return the concrete `table` associated with the given collection name", () => {
@@ -108,7 +108,9 @@ describe("metabase-lib/queries/utils/native-query-table", () => {
 
   describe("basic native query question", () => {
     const nativeQuestion = metadata.question(card.id) as Question;
-    const table = getNativeQueryTable(nativeQuestion.query() as NativeQuery);
+    const table = getNativeQueryTable(
+      nativeQuestion.legacyQuery() as NativeQuery,
+    );
 
     it("should not return a table", () => {
       expect(table).toBeNull();

--- a/frontend/src/metabase-lib/queries/utils/nested-card-query-table.ts
+++ b/frontend/src/metabase-lib/queries/utils/nested-card-query-table.ts
@@ -38,7 +38,7 @@ export function getDatasetTable(
   const question = query.question();
   const composedDatasetQuestion = question.composeDataset();
   const composedQuestionQuery =
-    composedDatasetQuestion.query() as StructuredQuery;
+    composedDatasetQuestion.legacyQuery() as StructuredQuery;
   return getNestedCardTable(composedQuestionQuery);
 }
 
@@ -46,7 +46,7 @@ function createVirtualTableUsingQuestionMetadata(question: Question): Table {
   const metadata = question.metadata();
   const questionResultMetadata = question.getResultMetadata();
   const questionDisplayName = question.displayName() as string;
-  const query = question.query() as StructuredQuery | NativeQuery;
+  const query = question.legacyQuery() as StructuredQuery | NativeQuery;
   const fields = questionResultMetadata.map((fieldMetadata: any) => {
     const field = metadata.field(fieldMetadata.id);
     const virtualField = field

--- a/frontend/src/metabase-lib/queries/utils/pivot.js
+++ b/frontend/src/metabase-lib/queries/utils/pivot.js
@@ -4,7 +4,7 @@ import { FieldDimension } from "metabase-lib/Dimension";
 export function getPivotColumnSplit(question) {
   const setting = question.setting("pivot_table.column_split");
   const breakout =
-    (question.isStructured() && question.query().breakouts()) || [];
+    (question.isStructured() && question.legacyQuery().breakouts()) || [];
   const { rows: pivot_rows, columns: pivot_cols } = _.mapObject(
     setting,
     fieldRefs =>

--- a/frontend/src/metabase-lib/queries/utils/segments.js
+++ b/frontend/src/metabase-lib/queries/utils/segments.js
@@ -2,7 +2,7 @@ import Question from "metabase-lib/Question";
 
 export function getSegmentOrMetricQuestion(query, table, metadata) {
   return table
-    ? metadata.table(table.id).query(query).question()
+    ? metadata.table(table.id).legacyQuery(query).question()
     : Question.create({ metadata });
 }
 

--- a/frontend/src/metabase-lib/queries/utils/structured-query-table.unit.spec.ts
+++ b/frontend/src/metabase-lib/queries/utils/structured-query-table.unit.spec.ts
@@ -91,7 +91,7 @@ describe("metabase-lib/queries/utils/structured-query-table", () => {
     const virtualTable = metadata.table(cardTable.id) as Table;
 
     const table = getStructuredQueryTable(
-      nestedQuestion.query() as StructuredQuery,
+      nestedQuestion.legacyQuery() as StructuredQuery,
     );
 
     it("should return a table", () => {
@@ -107,7 +107,9 @@ describe("metabase-lib/queries/utils/structured-query-table", () => {
   describe("Model card", () => {
     const model = metadata.question(modelCard.id) as Question;
 
-    const table = getStructuredQueryTable(model.query() as StructuredQuery);
+    const table = getStructuredQueryTable(
+      model.legacyQuery() as StructuredQuery,
+    );
 
     it("should return a nested card table using the given query's question", () => {
       expect(table?.getPlainObject()).toEqual(
@@ -135,7 +137,7 @@ describe("metabase-lib/queries/utils/structured-query-table", () => {
     const productsTable = metadata.table(PRODUCTS_ID) as Table;
 
     const table = getStructuredQueryTable(
-      sourceQueryQuestion.query() as StructuredQuery,
+      sourceQueryQuestion.legacyQuery() as StructuredQuery,
     );
 
     it("should return a virtual table based on the nested query", () => {
@@ -179,7 +181,7 @@ describe("metabase-lib/queries/utils/structured-query-table", () => {
     const ordersTable = metadata.table(ORDERS_ID) as Table;
 
     const table = getStructuredQueryTable(
-      ordersTable.query() as StructuredQuery,
+      ordersTable.legacyQuery() as StructuredQuery,
     );
 
     it("should return the concrete table stored on the Metadata object", () => {

--- a/frontend/src/metabase-lib/queries/utils/virtual-table.unit.spec.ts
+++ b/frontend/src/metabase-lib/queries/utils/virtual-table.unit.spec.ts
@@ -16,7 +16,7 @@ describe("metabase-lib/queries/utils/virtual-table", () => {
 
   const productsTable = metadata.table(PRODUCTS_ID) as Table;
 
-  const query = productsTable.newQuestion().query() as StructuredQuery;
+  const query = productsTable.newQuestion().legacyQuery() as StructuredQuery;
   const field = createVirtualField({
     id: 123,
     metadata,
@@ -40,7 +40,7 @@ describe("metabase-lib/queries/utils/virtual-table", () => {
   });
 
   describe("createVirtualTable", () => {
-    const query = productsTable.newQuestion().query() as StructuredQuery;
+    const query = productsTable.newQuestion().legacyQuery() as StructuredQuery;
     const field1 = createVirtualField({
       id: 1,
       metadata,

--- a/frontend/src/metabase-lib/urls.ts
+++ b/frontend/src/metabase-lib/urls.ts
@@ -77,7 +77,7 @@ export function getUrlWithParameters(
     });
   }
 
-  const query = question.query() as NativeQuery;
+  const query = question.legacyQuery() as NativeQuery;
   return getUrl(question, {
     clean,
     query: remapParameterValuesToTemplateTags(

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
@@ -136,7 +136,10 @@ function QueryActionContextProvider({
 
   const [question, setQuestion] = useState(initialQuestion);
 
-  const query = useMemo(() => question.query() as NativeQuery, [question]);
+  const query = useMemo(
+    () => question.legacyQuery() as NativeQuery,
+    [question],
+  );
 
   const [formSettings, setFormSettings] = useState(initialFormSettings);
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/utils.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/utils.ts
@@ -52,11 +52,11 @@ export const setTemplateTagTypesFromFieldSettings = (
   settings: ActionFormSettings,
 ): Question => {
   const fields = settings.fields || {};
-  const query = question.query() as NativeQuery;
+  const query = question.legacyQuery() as NativeQuery;
   let tempQuestion = question.clone();
 
   query.variableTemplateTags().forEach((tag: TemplateTag) => {
-    const currentQuery = tempQuestion.query() as NativeQuery;
+    const currentQuery = tempQuestion.legacyQuery() as NativeQuery;
     const fieldType = fields[tag.id]?.fieldType ?? "string";
     const nextTag = {
       ...tag,

--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -56,7 +56,7 @@ class PartialQueryBuilder extends Component {
 
     // only set the query if it doesn't already have an aggregation or filter
     const question = getSegmentOrMetricQuestion(value, table, metadata);
-    if (!question.query().isRaw()) {
+    if (!question.legacyQuery().isRaw()) {
       return;
     }
 
@@ -79,7 +79,7 @@ class PartialQueryBuilder extends Component {
     const { features, value, metadata, table, previewSummary } = this.props;
 
     const question = getSegmentOrMetricQuestion(value, table, metadata);
-    const query = question.query();
+    const query = question.legacyQuery();
     const previewUrl = Urls.serializedQuestion(question.card());
 
     return (

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
@@ -42,7 +42,7 @@ const PinnedQuestionLoader = ({
   return (
     <Questions.Loader id={id} loadingAndErrorWrapper={false}>
       {({ loading, question: loadedQuestion }: QuestionLoaderProps) => {
-        if (loading !== false || !loadedQuestion.query()) {
+        if (loading !== false || !loadedQuestion.legacyQuery()) {
           return children({ loading: true });
         }
 

--- a/frontend/src/metabase/containers/QuestionLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionLoader.jsx
@@ -26,10 +26,10 @@ import { serializeCardForUrl } from "metabase/lib/card";
  *        { // link to a new question created by adding a filter }
  *        <Link
  *          to={
- *            question.query()
+ *            question.legacyQuery()
  *                    .filter([
  *                      "segment",
- *                      question.query().filterSegmentOptions()[0]
+ *                      question.legacyQuery().filterSegmentOptions()[0]
  *                    ])
  *                    .question()
  *                    .getUrl()

--- a/frontend/src/metabase/containers/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.unit.spec.tsx
@@ -152,7 +152,7 @@ function getQuestion({
 const EXPECTED_DIRTY_SUGGESTED_NAME = "Orders, Count, Grouped by Total";
 
 function getDirtyQuestion(originalQuestion: Question) {
-  const query = originalQuestion.query() as StructuredQuery;
+  const query = originalQuestion.legacyQuery() as StructuredQuery;
   return query.breakout(["field", ORDERS.TOTAL, null]).question().markDirty();
 }
 
@@ -634,7 +634,7 @@ describe("SaveQuestionModal", () => {
       databaseId: SAMPLE_DB_ID,
       tableId: ORDERS_ID,
       metadata,
-    }).query() as StructuredQuery;
+    }).legacyQuery() as StructuredQuery;
 
     const question = query.aggregate(["count"]).question();
 

--- a/frontend/src/metabase/dashboard/actions/metadata.js
+++ b/frontend/src/metabase/dashboard/actions/metadata.js
@@ -25,7 +25,7 @@ const loadMetadataForCards = cards => (dispatch, getState) => {
 
   return dispatch(
     loadMetadataForQueries(
-      questions.map(question => question.query()),
+      questions.map(question => question.legacyQuery()),
       questions.map(question => question.dependentMetadata()),
     ),
   );

--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -286,7 +286,7 @@ function loadQuestionMetadata(getQuestion) {
       fetch() {
         const { question, loadMetadataForQuery } = this.props;
         if (question) {
-          loadMetadataForQuery(question.query());
+          loadMetadataForQuery(question.legacyQuery());
         }
       }
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -133,7 +133,7 @@ interface QueryDownloadWidgetOpts {
 const canEditQuestion = (question: Question) => {
   return (
     question.canWrite() &&
-    question.query() != null &&
+    question.legacyQuery() != null &&
     question.isQueryEditable()
   );
 };
@@ -154,7 +154,7 @@ DashCardMenu.shouldRender = ({
   isPublic,
   isEditing,
 }: QueryDownloadWidgetOpts) => {
-  const isInternalQuery = question.query() instanceof InternalQuery;
+  const isInternalQuery = question.legacyQuery() instanceof InternalQuery;
   if (isEmbed) {
     return isEmbed;
   }

--- a/frontend/src/metabase/metabot/components/MetabotQueryEditor/MetabotQueryEditor.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotQueryEditor/MetabotQueryEditor.tsx
@@ -60,7 +60,7 @@ const MetabotQueryEditor = ({
     <NativeQueryEditor
       cancelQueryOnLeave={false}
       question={question}
-      query={question.query()}
+      query={question.legacyQuery()}
       viewHeight={height}
       resizable={false}
       hasParametersList={false}

--- a/frontend/src/metabase/metabot/selectors.ts
+++ b/frontend/src/metabase/metabot/selectors.ts
@@ -57,7 +57,7 @@ export const getFeedbackType = (state: State) => {
 };
 
 export const getNativeQueryText = createSelector([getQuestion], question => {
-  const query = question?.query();
+  const query = question?.legacyQuery();
   return query instanceof NativeQuery ? query.queryText() : undefined;
 });
 

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -99,7 +99,7 @@ function ModelDetailPage({
     database != null && database.hasFeature("nested-queries");
 
   const mainTable = useMemo(
-    () => (model.isStructured() ? model.query().sourceTable() : null),
+    () => (model.isStructured() ? model.legacyQuery().sourceTable() : null),
     [model],
   );
 

--- a/frontend/src/metabase/parameters/utils/mapping-options.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.js
@@ -89,12 +89,12 @@ export function getParameterMappingOptions(
   }
 
   const question = new Question(card, metadata);
-  const query = question.query();
+  const query = question.legacyQuery();
   const options = [];
   if (question.isDataset()) {
     // treat the dataset/model question like it is already composed so that we can apply
     // dataset/model-specific metadata to the underlying dimension options
-    const composedDatasetQuery = question.composeDataset().query();
+    const composedDatasetQuery = question.composeDataset().legacyQuery();
     options.push(
       ...composedDatasetQuery
         .dimensionOptions(

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -188,7 +188,7 @@ export const apiCreateQuestion = question => {
     const resultsMetadata = getResultsMetadata(getState());
     const isResultDirty = getIsResultDirty(getState());
     const questionToCreate = questionWithVizSettings
-      .setQuery(question.query().clean({ skipFilters: true }))
+      .setQuery(question.legacyQuery().clean({ skipFilters: true }))
       .setResultsMetadata(isResultDirty ? null : resultsMetadata);
     const createdQuestion = await reduxCreateQuestion(
       questionToCreate,
@@ -253,7 +253,9 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
       // Before we clean the query, we make sure question is not treated as a dataset
       // as calling table() method down the line would bring unwanted consequences
       // such as dropping joins (as joins are treated differently between pure questions and datasets)
-      .setQuery(question.setDataset(false).query().clean({ skipFilters: true }))
+      .setQuery(
+        question.setDataset(false).legacyQuery().clean({ skipFilters: true }),
+      )
       .setResultsMetadata(isResultDirty ? null : resultsMetadata);
 
     // When viewing a dataset, its dataset_query is swapped with a clean query using the dataset as a source table

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -81,12 +81,12 @@ function getCardForBlankQuestion({
 
   if (databaseId && tableId) {
     if (segment) {
-      question = (question.query() as StructuredQuery)
+      question = (question.legacyQuery() as StructuredQuery)
         .filter(["segment", parseInt(segment)])
         .question();
     }
     if (metric) {
-      question = (question.query() as StructuredQuery)
+      question = (question.legacyQuery() as StructuredQuery)
         .aggregate(["metric", parseInt(metric)])
         .question();
     }
@@ -320,7 +320,7 @@ async function handleQBInit(
   }
 
   if (question.isNative() && question.isQueryEditable()) {
-    const query = question.query() as NativeQuery;
+    const query = question.legacyQuery() as NativeQuery;
     const newQuery = await updateTemplateTagNames(query, getState, dispatch);
     question = question.setQuery(newQuery);
   }

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -644,7 +644,7 @@ describe("QB Actions > initializeQB", () => {
             },
           });
           const formattedQuestion = new Question(result.card, metadata);
-          const query = formattedQuestion.query() as NativeQuery;
+          const query = formattedQuestion.legacyQuery() as NativeQuery;
 
           expect(query.queryText().toLowerCase()).toBe(
             "select * from orders {{snippet: bar}}",
@@ -706,7 +706,7 @@ describe("QB Actions > initializeQB", () => {
       });
 
       const question = new Question(result.card, metadata);
-      const query = question.query() as StructuredQuery;
+      const query = question.legacyQuery() as StructuredQuery;
 
       return {
         question,
@@ -724,7 +724,7 @@ describe("QB Actions > initializeQB", () => {
 
       const { result, metadata } = await setupBlank({ db: SAMPLE_DB_ID });
       const question = new Question(result.card, metadata);
-      const query = question.query() as StructuredQuery;
+      const query = question.legacyQuery() as StructuredQuery;
 
       expect(result.card).toEqual(expectedCard);
       expect(query.sourceTableId()).toBe(null);

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -32,7 +32,7 @@ import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 function hasNewColumns(question: Question, queryResult: Dataset) {
   // NOTE: this assume column names will change
   // technically this is wrong because you could add and remove two columns with the same name
-  const query = question.query();
+  const query = question.legacyQuery();
   const previousColumns =
     (queryResult && queryResult.data.cols.map(col => col.name)) || [];
   const nextColumns =
@@ -86,10 +86,10 @@ function shouldTemplateTagEditorBeVisible({
     return isVisible;
   }
   const previousTags = currentQuestion?.isNative()
-    ? (currentQuestion.query() as NativeQuery).variableTemplateTags()
+    ? (currentQuestion.legacyQuery() as NativeQuery).variableTemplateTags()
     : [];
   const nextTags = newQuestion.isNative()
-    ? (newQuestion.query() as NativeQuery).variableTemplateTags()
+    ? (newQuestion.legacyQuery() as NativeQuery).variableTemplateTags()
     : [];
   if (nextTags.length > previousTags.length) {
     return true;
@@ -166,7 +166,7 @@ export const updateQuestion = (
     if (wasPivot || isPivot) {
       const hasBreakouts =
         newQuestion.isStructured() &&
-        (newQuestion.query() as StructuredQuery).hasBreakouts();
+        (newQuestion.legacyQuery() as StructuredQuery).hasBreakouts();
 
       // compute the pivot setting now so we can query the appropriate data
       if (isPivot && hasBreakouts) {
@@ -232,12 +232,12 @@ export const updateQuestion = (
     const currentDependencies = currentQuestion
       ? [
           ...currentQuestion.dependentMetadata(),
-          ...currentQuestion.query().dependentMetadata(),
+          ...currentQuestion.legacyQuery().dependentMetadata(),
         ]
       : [];
     const nextDependencies = [
       ...newQuestion.dependentMetadata(),
-      ...newQuestion.query().dependentMetadata(),
+      ...newQuestion.legacyQuery().dependentMetadata(),
     ];
     try {
       if (!_.isEqual(currentDependencies, nextDependencies)) {

--- a/frontend/src/metabase/query_builder/actions/native.ts
+++ b/frontend/src/metabase/query_builder/actions/native.ts
@@ -149,7 +149,7 @@ export const insertSnippet =
     if (!question) {
       return;
     }
-    const query = question.query() as NativeQuery;
+    const query = question.legacyQuery() as NativeQuery;
     const nativeEditorCursorOffset = getNativeEditorCursorOffset(getState());
     const nativeEditorSelectedText = getNativeEditorSelectedText(getState());
     const selectionStart =
@@ -174,7 +174,7 @@ export const setTemplateTag = createThunkAction(
       if (!question) {
         return;
       }
-      const query = question.query() as NativeQuery;
+      const query = question.legacyQuery() as NativeQuery;
       const newQuestion = query.setTemplateTag(tag.name, tag).question();
       dispatch(updateQuestion(newQuestion));
     };
@@ -190,7 +190,7 @@ export const setTemplateTagConfig = createThunkAction(
       if (!question) {
         return;
       }
-      const query = question.query() as NativeQuery;
+      const query = question.legacyQuery() as NativeQuery;
       const newQuestion = query.setTemplateTagConfig(tag, parameter).question();
       dispatch(updateQuestion(newQuestion));
     };

--- a/frontend/src/metabase/query_builder/components/AggregationWidget.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationWidget.jsx
@@ -44,7 +44,7 @@ export default class AggregationWidget extends Component {
   render() {
     const {
       aggregation,
-      query = aggregation.query && aggregation.query(),
+      query = aggregation.query && aggregation.legacyQuery(),
       children,
       className,
     } = this.props;

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -216,7 +216,7 @@ function DatasetEditor(props) {
       return INITIAL_NOTEBOOK_EDITOR_HEIGHT;
     }
     return calcInitialEditorHeight({
-      query: dataset.query(),
+      query: dataset.legacyQuery(),
       viewHeight: height,
     });
   }, [dataset, height]);
@@ -405,7 +405,7 @@ function DatasetEditor(props) {
   );
 
   const canSaveChanges = useMemo(() => {
-    if (dataset.query().isEmpty()) {
+    if (dataset.legacyQuery().isEmpty()) {
       return false;
     }
     const everyFieldHasDisplayName = fields.every(field => field.display_name);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.unit.spec.tsx
@@ -63,7 +63,7 @@ const setup = async ({
   });
   const metadata = getMetadata(storeInitialState);
   const question = checkNotNull(metadata.question(card.id));
-  const query = question.query();
+  const query = question.legacyQuery();
   const DatasetQueryEditor = await importDatasetQueryEditor();
 
   const { rerender } = renderWithProviders(

--- a/frontend/src/metabase/query_builder/components/GuiQueryEditor.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/GuiQueryEditor.unit.spec.js
@@ -32,7 +32,7 @@ describe("GuiQueryEditor", () => {
       tableId: ORDERS_ID,
       metadata,
     })
-      .query()
+      .legacyQuery()
       .aggregate(["count"]);
 
     render(getGuiQueryEditor(query));
@@ -49,7 +49,7 @@ describe("GuiQueryEditor", () => {
       tableId: ORDERS_ID,
       metadata,
     })
-      .query()
+      .legacyQuery()
       .aggregate(["count"])
       .breakout(["field", ORDERS.TOTAL, null]);
 

--- a/frontend/src/metabase/query_builder/components/QueryDefinition.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryDefinition.jsx
@@ -12,7 +12,7 @@ function QueryDefinition({ className, object, metadata }) {
       dataset_query: { type: "query", query: object.definition },
     },
     metadata,
-  ).query();
+  ).legacyQuery();
   const aggregations = query.aggregations();
   const filters = query.filters();
   return (

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -25,7 +25,7 @@ export default class QueryVisualization extends Component {
 
   _getStateFromProps(props) {
     return {
-      lastRunDatasetQuery: copy(props.question.query().datasetQuery()),
+      lastRunDatasetQuery: copy(props.question.legacyQuery().datasetQuery()),
       lastRunParameterValues: copy(props.parameterValues),
     };
   }

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -90,7 +90,7 @@ const QuestionActions = ({
     canWrite &&
     isSaved &&
     isDataset &&
-    checkDatabaseCanPersistDatasets(question.query().database());
+    checkDatabaseCanPersistDatasets(question.legacyQuery().database());
 
   const handleEditQuery = useCallback(() => {
     setQueryBuilderMode("dataset", {

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
@@ -89,7 +89,7 @@ export function FilterPopover({
   useEffect(() => {
     if (
       filter &&
-      filter.query() === previousQuery &&
+      filter.legacyQuery() === previousQuery &&
       legacyQuery !== previousQuery
     ) {
       setFilter(filter.setQuery(legacyQuery));
@@ -137,11 +137,15 @@ export function FilterPopover({
   const handleDimensionChange = (dimension: FieldDimension) => {
     const field = dimension?.field();
     const newFilter =
-      !filter || filter.query() !== dimension.query() || field?.isDate?.()
+      !filter ||
+      filter.legacyQuery() !== dimension.legacyQuery() ||
+      field?.isDate?.()
         ? new Filter(
             [],
             null,
-            dimension.query() || (filter && filter.query()) || legacyQuery,
+            dimension.legacyQuery() ||
+              (filter && filter.legacyQuery()) ||
+              legacyQuery,
           )
         : filter;
 
@@ -204,7 +208,7 @@ export function FilterPopover({
             isTopLevel
               ? legacyQuery.topLevelFilterFieldOptionSections()
               : (
-                  (filter && filter.query()) ||
+                  (filter && filter.legacyQuery()) ||
                   legacyQuery
                 ).filterFieldOptionSections(filter, {
                   includeSegments: showCustom,

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.unit.spec.tsx
@@ -26,7 +26,7 @@ const QUERY = Question.create({
   tableId: ORDERS_ID,
   metadata,
 })
-  .query()
+  .legacyQuery()
   // eslint-disable-next-line
   // @ts-ignore
   .aggregate(["count"])

--- a/frontend/src/metabase/query_builder/components/filters/pickers/BooleanPicker/BooleanPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/BooleanPicker/BooleanPicker.unit.spec.tsx
@@ -35,7 +35,7 @@ describe("BooleanPicker", () => {
   const field = checkNotNull(metadata.field(1));
 
   const question = new Question(createAdHocCard(), metadata);
-  const query = question.query() as StructuredQuery;
+  const query = question.legacyQuery() as StructuredQuery;
 
   const fieldRef = field.reference();
 

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -19,7 +19,7 @@ const metadata = createMockMetadata({
 });
 
 const ordersTable = checkNotNull(metadata.table(ORDERS_ID));
-const ordersQuery = ordersTable.query();
+const ordersQuery = ordersTable.legacyQuery();
 
 // this component does not manage its own filter state, so we need a wrapper to test
 // any state updates because the component's behavior is based on the filter state

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DatePicker/ExcludeDatePicker.unit.spec.tsx
@@ -14,7 +14,7 @@ const metadata = createMockMetadata({
 });
 
 const ordersTable = checkNotNull(metadata.table(ORDERS_ID));
-const query = ordersTable.query();
+const query = ordersTable.legacyQuery();
 
 const filter = new Filter(
   [null, ["field", ORDERS.CREATED_AT, null]],

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker/DefaultPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker/DefaultPicker.tsx
@@ -75,7 +75,7 @@ export function DefaultPicker({
   const isBetweenLayout =
     operator.name === "between" && operatorFields.length === 2;
 
-  const visualizationSettings = filter?.query()?.question()?.settings();
+  const visualizationSettings = filter?.legacyQuery()?.question()?.settings();
 
   const key = dimension?.column?.()
     ? getColumnKey(dimension.column() as DatasetColumn)

--- a/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker/DefaultPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/pickers/DefaultPicker/DefaultPicker.unit.spec.tsx
@@ -38,7 +38,7 @@ const makeQuery = (query = {}): StructuredQuery => {
       },
       database: SAMPLE_DB_ID,
     })
-    .query() as StructuredQuery;
+    .legacyQuery() as StructuredQuery;
 };
 
 const numericQuery = makeQuery({

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -55,7 +55,7 @@ const Notebook = ({ className, updateQuestion, ...props }: NotebookProps) => {
     );
 
     // MLv2 doesn't clean up redundant stages, so we do it with MLv1 for now
-    const query = cleanQuestion.query() as StructuredQuery;
+    const query = cleanQuestion.legacyQuery() as StructuredQuery;
     cleanQuestion = cleanQuestion.setQuery(query.clean({ skipFilters: true }));
 
     if (cleanQuestion.display() === "table") {
@@ -97,7 +97,7 @@ const Notebook = ({ className, updateQuestion, ...props }: NotebookProps) => {
 };
 
 function getSourceQuestionId(question: Question) {
-  const query = question.query();
+  const query = question.legacyQuery();
   if (query instanceof StructuredQuery) {
     const sourceTableId = query.sourceTableId();
     if (isVirtualCardId(sourceTableId)) {

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
@@ -77,7 +77,7 @@ function NotebookSteps({
       } else {
         const updatedLegacyQuery = Lib.toLegacyQuery(query);
         const updatedQuestion = question.setDatasetQuery(updatedLegacyQuery);
-        const updatedQuery = updatedQuestion.query() as StructuredQuery;
+        const updatedQuery = updatedQuestion.legacyQuery() as StructuredQuery;
         const cleanQuestion = updatedQuery.cleanNesting().question();
         await updateQuestion(cleanQuestion);
       }

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
@@ -146,7 +146,7 @@ export function getQuestionSteps(question: Question, openSteps = {}) {
   const allSteps: NotebookStep[] = [];
 
   if (question.isStructured()) {
-    let query = question.query() as StructuredQuery;
+    let query = question.legacyQuery() as StructuredQuery;
 
     let topLevelQuery = query.rootQuery().question()._getMLv2Query();
 
@@ -245,7 +245,7 @@ function getStageSteps(
             current.previous &&
             current.previous.stageIndex < current.stageIndex
           ) {
-            newQuery = current.query.setSourceQuery(newQuery.query());
+            newQuery = current.query.setSourceQuery(newQuery.legacyQuery());
           }
           newQuery = current.clean(
             newQuery,

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.unit.spec.js
@@ -49,7 +49,7 @@ const getQuestionStepsForMBQLQuery = query =>
     metadata
       .database(SAMPLE_DB_ID)
       .question()
-      .query()
+      .legacyQuery()
       .setQuery(query)
       .question(),
   );
@@ -87,21 +87,21 @@ describe("filtered and summarized query", () => {
   });
   describe("query", () => {
     it("should be the full query for data step", () => {
-      expect(steps[0].query.query()).toEqual(filteredAndSummarizedQuery);
+      expect(steps[0].query.legacyQuery()).toEqual(filteredAndSummarizedQuery);
     });
     it("should be the full query for filter step", () => {
-      expect(steps[1].query.query()).toEqual(filteredAndSummarizedQuery);
+      expect(steps[1].query.legacyQuery()).toEqual(filteredAndSummarizedQuery);
     });
     it("should be the full query for summarize step", () => {
-      expect(steps[2].query.query()).toEqual(filteredAndSummarizedQuery);
+      expect(steps[2].query.legacyQuery()).toEqual(filteredAndSummarizedQuery);
     });
   });
   describe("previewQuery", () => {
     it("shouldn't include filter, summarize for data step", () => {
-      expect(steps[0].previewQuery.query()).toEqual(rawDataQuery);
+      expect(steps[0].previewQuery.legacyQuery()).toEqual(rawDataQuery);
     });
     it("shouldn't include summarize for filter step", () => {
-      expect(steps[1].previewQuery.query()).toEqual(filteredQuery);
+      expect(steps[1].previewQuery.legacyQuery()).toEqual(filteredQuery);
     });
   });
   describe("update", () => {
@@ -109,19 +109,19 @@ describe("filtered and summarized query", () => {
       const newQuery = steps[0].update(
         steps[0].query.setTableId(PRODUCTS_ID).datasetQuery(),
       );
-      expect(newQuery.query()).toEqual({ "source-table": PRODUCTS_ID });
+      expect(newQuery.legacyQuery()).toEqual({ "source-table": PRODUCTS_ID });
     });
     it("shouldn't remove summarize when removing filter", () => {
       const newQuery = steps[1].update(
         steps[1].revert(steps[1].query).datasetQuery(),
       );
-      expect(newQuery.query()).toEqual(summarizedQuery);
+      expect(newQuery.legacyQuery()).toEqual(summarizedQuery);
     });
     it("shouldn't remove filter when removing summarize", () => {
       const newQuery = steps[2].update(
         steps[2].revert(steps[2].query).datasetQuery(),
       );
-      expect(newQuery.query()).toEqual(filteredQuery);
+      expect(newQuery.legacyQuery()).toEqual(filteredQuery);
     });
   });
 });
@@ -140,27 +140,29 @@ describe("filtered and summarized query with post-aggregation filter", () => {
   });
   describe("query", () => {
     it("should be the source-query for data step", () => {
-      expect(steps[0].query.query()).toEqual(filteredAndSummarizedQuery);
+      expect(steps[0].query.legacyQuery()).toEqual(filteredAndSummarizedQuery);
     });
     it("should be the source-query for filter step", () => {
-      expect(steps[1].query.query()).toEqual(filteredAndSummarizedQuery);
+      expect(steps[1].query.legacyQuery()).toEqual(filteredAndSummarizedQuery);
     });
     it("should be the source-query for summarize step", () => {
-      expect(steps[2].query.query()).toEqual(filteredAndSummarizedQuery);
+      expect(steps[2].query.legacyQuery()).toEqual(filteredAndSummarizedQuery);
     });
     it("should be the original query for post-aggregation filter step", () => {
-      expect(steps[3].query.query()).toEqual(postAggregationFilterQuery);
+      expect(steps[3].query.legacyQuery()).toEqual(postAggregationFilterQuery);
     });
   });
   describe("previewQuery", () => {
     it("shouldn't include filter, summarize, or post-aggregation filter for data step", () => {
-      expect(steps[0].previewQuery.query()).toEqual(rawDataQuery);
+      expect(steps[0].previewQuery.legacyQuery()).toEqual(rawDataQuery);
     });
     it("shouldn't include summarize or post-aggregation filter filter step", () => {
-      expect(steps[1].previewQuery.query()).toEqual(filteredQuery);
+      expect(steps[1].previewQuery.legacyQuery()).toEqual(filteredQuery);
     });
     it("should be the original query for post-aggregation filter step", () => {
-      expect(steps[3].previewQuery.query()).toEqual(postAggregationFilterQuery);
+      expect(steps[3].previewQuery.legacyQuery()).toEqual(
+        postAggregationFilterQuery,
+      );
     });
   });
   describe("update", () => {
@@ -168,13 +170,13 @@ describe("filtered and summarized query with post-aggregation filter", () => {
       const newQuery = steps[0].update(
         steps[0].query.setTableId(PRODUCTS_ID).datasetQuery(),
       );
-      expect(newQuery.query()).toEqual({ "source-table": PRODUCTS_ID });
+      expect(newQuery.legacyQuery()).toEqual({ "source-table": PRODUCTS_ID });
     });
     it("shouldn't remove summarize or post-aggregation filter when removing filter", () => {
       const newQuery = steps[1].update(
         steps[1].revert(steps[1].query).datasetQuery(),
       );
-      expect(newQuery.query()).toEqual({
+      expect(newQuery.legacyQuery()).toEqual({
         ...postAggregationFilterQuery,
         "source-query": summarizedQuery,
       });
@@ -183,13 +185,13 @@ describe("filtered and summarized query with post-aggregation filter", () => {
       const newQuery = steps[2].update(
         steps[2].revert(steps[2].query).datasetQuery(),
       );
-      expect(newQuery.query()).toEqual(filteredQuery);
+      expect(newQuery.legacyQuery()).toEqual(filteredQuery);
     });
     it("should remove empty layer of nesting but not remove filter or summarize when removing post-aggregation filter", () => {
       const newQuery = steps[3].update(
         steps[3].revert(steps[3].query).datasetQuery(),
       );
-      expect(newQuery.query()).toEqual(filteredAndSummarizedQuery);
+      expect(newQuery.legacyQuery()).toEqual(filteredAndSummarizedQuery);
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -89,7 +89,7 @@ const setup = async (
 
 const setupEmptyQuery = () => {
   const question = Question.create({ databaseId: SAMPLE_DB_ID });
-  const legacyQuery = question.query() as StructuredQuery;
+  const legacyQuery = question.legacyQuery() as StructuredQuery;
   const query = question._getMLv2Query();
   return setup(
     createMockNotebookStep({ query: legacyQuery, topLevelQuery: query }),

--- a/frontend/src/metabase/query_builder/components/notebook/test-utils.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/test-utils.ts
@@ -15,7 +15,8 @@ export const metadata = createMockMetadata({
 });
 
 export const DEFAULT_QUESTION = checkNotNull(metadata.question(1));
-export const DEFAULT_LEGACY_QUERY = DEFAULT_QUESTION.query() as StructuredQuery;
+export const DEFAULT_LEGACY_QUERY =
+  DEFAULT_QUESTION.legacyQuery() as StructuredQuery;
 export const DEFAULT_QUERY = DEFAULT_QUESTION._getMLv2Query();
 
 export function createMockNotebookStep({

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.tsx
@@ -31,7 +31,7 @@ interface PreviewQueryButtonOpts {
 }
 
 PreviewQueryButton.shouldRender = ({ question }: PreviewQueryButtonOpts) => {
-  const query = question.query();
+  const query = question.legacyQuery();
 
   return (
     question.canRun() &&

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -27,7 +27,7 @@ QuestionDataSource.propTypes = {
 };
 
 function isMaybeBasedOnDataset(question) {
-  const tableId = question.query().sourceTableId();
+  const tableId = question.legacyQuery().sourceTableId();
   return isVirtualCardId(tableId);
 }
 
@@ -44,7 +44,7 @@ function QuestionDataSource({ question, originalQuestion, subHead, ...props }) {
     );
   }
 
-  const sourceTable = question.query().sourceTableId();
+  const sourceTable = question.legacyQuery().sourceTableId();
   const sourceQuestionId = getQuestionIdFromVirtualTableId(sourceTable);
 
   if (originalQuestion?.id() === sourceQuestionId) {
@@ -162,8 +162,8 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
 
   const isStructuredQuery = question.isStructured();
   const query = isStructuredQuery
-    ? question.query().rootQuery()
-    : question.query();
+    ? question.legacyQuery().rootQuery()
+    : question.legacyQuery();
 
   const hasDataPermission = question.isQueryEditable();
   if (!hasDataPermission) {

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
@@ -246,7 +246,8 @@ function getAdHocNestedQuestion({ isMultiSchemaDB } = {}) {
     },
   });
 
-  question.query().table = () => getNestedQuestionTableMock(isMultiSchemaDB);
+  question.legacyQuery().table = () =>
+    getNestedQuestionTableMock(isMultiSchemaDB);
 
   return question;
 }
@@ -263,7 +264,8 @@ function getSavedNestedQuestion({ isMultiSchemaDB } = {}) {
     },
   });
 
-  question.query().table = () => getNestedQuestionTableMock(isMultiSchemaDB);
+  question.legacyQuery().table = () =>
+    getNestedQuestionTableMock(isMultiSchemaDB);
 
   return question;
 }
@@ -406,15 +408,15 @@ describe("QuestionDataSource", () => {
         });
 
         it("shows nothing if a user doesn't have data permissions", () => {
-          const originalMethod = question.query().database;
-          question.query().database = () => null;
+          const originalMethod = question.legacyQuery().database;
+          question.legacyQuery().database = () => null;
 
           setup({ question });
           expect(
             screen.getByTestId("head-crumbs-container"),
           ).toBeEmptyDOMElement();
 
-          question.query().database = originalMethod;
+          question.legacyQuery().database = originalMethod;
         });
       });
     });

--- a/frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx
@@ -12,7 +12,7 @@ const QuestionDescription = ({
   isObjectDetail,
   onClick,
 }) => {
-  const query = question.query();
+  const query = question.legacyQuery();
   if (query instanceof StructuredQuery) {
     const topQuery = query.topLevelQuery();
     const aggregations = topQuery.aggregations();

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters/QuestionFilters.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters/QuestionFilters.tsx
@@ -98,7 +98,7 @@ export function FilterHeader({
 
   const handleQueryChange = (nextQuery: Lib.Query) => {
     const nextQuestion = question.setDatasetQuery(Lib.toLegacyQuery(nextQuery));
-    onQueryChange(nextQuestion.query() as LegacyQuery);
+    onQueryChange(nextQuestion.legacyQuery() as LegacyQuery);
   };
 
   if (filters.length === 0 || !expanded) {
@@ -198,7 +198,7 @@ const shouldRender = ({
   queryBuilderMode === "view" &&
   question.isStructured() &&
   question.isQueryEditable() &&
-  (question.query() as LegacyQuery).topLevelFilters().length > 0 &&
+  (question.legacyQuery() as LegacyQuery).topLevelFilters().length > 0 &&
   !isObjectDetail;
 
 FilterHeader.shouldRender = shouldRender;

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -184,7 +184,7 @@ function getRowCountMessage(result: Dataset): string {
 }
 
 function getDatabaseId(state: State, { question }: OwnProps & StateProps) {
-  return question.query().databaseId();
+  return question.legacyQuery().databaseId();
 }
 
 const ConnectedQuestionRowCount = _.compose(

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
@@ -51,7 +51,7 @@ function patchQuestion(question: Question) {
     const nextQuery = Lib.orderBy(query, 0, sampleColumn);
     return question.setDatasetQuery(Lib.toLegacyQuery(nextQuery));
   } else {
-    const query = question.query() as NativeQuery;
+    const query = question.legacyQuery() as NativeQuery;
     return query.setQueryText("SELECT * FROM __ORDERS__").question();
   }
 }

--- a/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
@@ -70,6 +70,6 @@ QuestionSummarizeWidget.shouldRender = ({
   question &&
   question.isStructured() &&
   question.isQueryEditable() &&
-  question.query().table() &&
+  question.legacyQuery().table() &&
   !isObjectDetail &&
   isActionListVisible;

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -94,7 +94,7 @@ class View extends Component {
 
     if (isShowingSummarySidebar) {
       const query = question._getMLv2Query();
-      const legacyQuery = question.query();
+      const legacyQuery = question.legacyQuery();
       return (
         <SummarizeSidebar
           query={query}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -93,8 +93,10 @@ export function ViewTitleHeader(props) {
       return;
     }
 
-    const filtersCount = question.query().filters().length;
-    const previousFiltersCount = previousQuestion.query().filters().length;
+    const filtersCount = question.legacyQuery().filters().length;
+    const previousFiltersCount = previousQuestion
+      .legacyQuery()
+      .filters().length;
 
     if (filtersCount > previousFiltersCount) {
       expandFilters();
@@ -107,7 +109,7 @@ export function ViewTitleHeader(props) {
   const isDataset = question.isDataset();
 
   const isSummarized =
-    isStructured && question.query().topLevelQuery().hasAggregations();
+    isStructured && question.legacyQuery().topLevelQuery().hasAggregations();
 
   const onQueryChange = useCallback(
     newQuery => {
@@ -416,7 +418,7 @@ function ViewTitleHeaderRightSide(props) {
     question.canExploreResults() &&
     MetabaseSettings.get("enable-nested-queries");
 
-  const isNewQuery = !question.query().hasData();
+  const isNewQuery = !question.legacyQuery().hasData();
   const hasSaveButton =
     !isDataset &&
     !!isDirty &&

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
@@ -27,7 +27,7 @@ const setup = props => {
   render(
     <ChartTypeSidebar
       question={question}
-      query={question.query()}
+      query={question.legacyQuery()}
       result={{ data: DATA }}
       {...props}
     />,

--- a/frontend/src/metabase/query_builder/containers/QueryViewer.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryViewer.tsx
@@ -31,7 +31,7 @@ export default function QueryViewer({
 
   const question = new Question(card, metadata);
 
-  const query = question.query();
+  const query = question.legacyQuery();
 
   if (question.isNative()) {
     return (

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -572,7 +572,7 @@ export const getIsSavedQuestionChanged = createSelector(
 
 export const getQuery = createSelector(
   [getQuestion],
-  question => question && question.query(),
+  question => question && question.legacyQuery(),
 );
 
 export const getIsRunnable = createSelector(
@@ -715,7 +715,7 @@ export const getVisualizationSettings = createSelector(
  */
 export const getIsNative = createSelector(
   [getQuestion],
-  question => question && question.query() instanceof NativeQuery,
+  question => question && question.legacyQuery() instanceof NativeQuery,
 );
 
 /**

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -15,9 +15,9 @@ export const loadMetadataForCard =
   (dispatch: Dispatch, getState: GetState) => {
     const metadata = getMetadata(getState());
     const question = new Question(card, metadata);
-    const queries = [question.query()];
+    const queries = [question.legacyQuery()];
     if (question.isDataset()) {
-      queries.push(question.composeDataset().query());
+      queries.push(question.composeDataset().legacyQuery());
     }
     return dispatch(
       loadMetadataForQueries(queries, question.dependentMetadata(), options),

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -159,7 +159,7 @@ export default class LeafletMap extends Component {
     const question = new Question(card);
     if (question.isStructured()) {
       const nextCard = updateLatLonFilter(
-        question.query(),
+        question.legacyQuery(),
         latitudeColumn,
         longitudeColumn,
         bounds,

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -365,7 +365,7 @@ function makeBrushChangeFunctions({ series, onChangeCardAndRun }) {
     if (range) {
       const column = series[0].data.cols[0];
       const card = series[0].card;
-      const query = new Question(card).query();
+      const query = new Question(card).legacyQuery();
       const [start, end] = range;
       if (isDimensionTimeseries(series)) {
         onChangeCardAndRun({

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.unit.spec.js
@@ -61,7 +61,7 @@ const setup = () => {
                 ["2016-01-01T00:00:00-04:00", 500],
                 ["2017-01-01T00:00:00-04:00", 1500],
               ],
-              cols: question.query().columns(),
+              cols: question.legacyQuery().columns(),
             },
           },
         ]}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.js
@@ -63,7 +63,7 @@ const setup = () => {
               // Need to add missing sources so that the setting displays
               cols: [
                 ...question
-                  .query()
+                  .legacyQuery()
                   .columns()
                   .map(c => ({ ...c, source: c.source || "breakout" })),
                 {

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -724,7 +724,7 @@ describe("Dimension", () => {
         describe("when an expression dimension has a query that relies on a nested card", () => {
           it("should return a field inferred from the expression", () => {
             const question = new Question(nestedQuestionCard, null);
-            const query = question.query();
+            const query = question.legacyQuery();
             const dimension = Dimension.parseMBQL(
               ["expression", "Foobar"], // "Foobar" does not exist in the metadata
               null,
@@ -740,7 +740,7 @@ describe("Dimension", () => {
 
           it("should return a field inferred from the expression (from metadata)", () => {
             const question = new Question(nestedQuestionCard, metadata);
-            const query = question.query();
+            const query = question.legacyQuery();
             const dimension = Dimension.parseMBQL(
               ["expression", "Foo"],
               metadata,
@@ -784,7 +784,7 @@ describe("Dimension", () => {
         const dimension = Dimension.parseMBQL(
           ["expression", 42],
           metadata,
-          question.query(),
+          question.legacyQuery(),
         );
         expect(dimension.dimensions().length).toEqual(5); // 5 different binnings for a number
       });
@@ -1020,7 +1020,7 @@ describe("Dimension", () => {
     const dimension = Dimension.parseMBQL(
       ["field", "boolean", { "base-type": "type/Boolean" }],
       metadata,
-      question.query(),
+      question.legacyQuery(),
     );
 
     describe("INSTANCE METHODS", () => {

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -307,8 +307,8 @@ describe("Question", () => {
       });
 
       it("contains an empty structured query", () => {
-        expect(question.query().constructor).toBe(StructuredQuery);
-        expect(question.query().constructor).toBe(StructuredQuery);
+        expect(question.legacyQuery().constructor).toBe(StructuredQuery);
+        expect(question.legacyQuery().constructor).toBe(StructuredQuery);
       });
 
       it("defaults to table display", () => {
@@ -342,22 +342,22 @@ describe("Question", () => {
   });
 
   describe("At the heart of a question is an MBQL query.", () => {
-    describe("query()", () => {
+    describe("legacyQuery()", () => {
       it("returns a correct class instance for structured query", () => {
         // This is a bit wack, and the repetitive naming is pretty confusing.
-        const query = orders_raw_question.query();
+        const query = orders_raw_question.legacyQuery();
         expect(query instanceof StructuredQuery).toBe(true);
       });
       it("returns a correct class instance for native query", () => {
-        const query = native_orders_count_question.query();
+        const query = native_orders_count_question.legacyQuery();
         expect(query instanceof NativeQuery).toBe(true);
       });
     });
     describe("setQuery(query)", () => {
       it("updates the dataset_query of card", () => {
-        const rawQuery = native_orders_count_question.query();
+        const rawQuery = native_orders_count_question.legacyQuery();
         const newRawQuestion = orders_raw_question.setQuery(rawQuery);
-        expect(newRawQuestion.query() instanceof NativeQuery).toBe(true);
+        expect(newRawQuestion.legacyQuery() instanceof NativeQuery).toBe(true);
       });
     });
     describe("setDatasetQuery(datasetQuery)", () => {
@@ -366,7 +366,7 @@ describe("Question", () => {
           native_orders_count_question.datasetQuery(),
         );
 
-        expect(rawQuestion.query() instanceof NativeQuery).toBe(true);
+        expect(rawQuestion.legacyQuery() instanceof NativeQuery).toBe(true);
       });
     });
   });
@@ -557,7 +557,7 @@ describe("Question", () => {
       it("returns the correct query for a summarization of a raw data table", () => {
         const summarizedQuestion = orders_raw_question.aggregate(["count"]);
         expect(summarizedQuestion.canRun()).toBe(true);
-        // if I actually call the .query() method below, this blows up garbage collection =/
+        // if I actually call the .legacyQuery() method below, this blows up garbage collection =/
         expect(summarizedQuestion.datasetQuery()).toEqual(
           orders_count_card.dataset_query,
         );

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
@@ -19,16 +19,16 @@ const ordersTable = metadata.table(ORDERS_ID);
 describe("StructuredQuery", () => {
   describe("clean", () => {
     it("should not return a new instance of the same query", () => {
-      const q = ordersTable.query();
+      const q = ordersTable.legacyQuery();
       expect(q.clean() === q).toBe(true);
     });
 
     describe("filters", () => {
       it("should not remove filter referencing valid field ID", () => {
         const q = ordersTable
-          .query()
+          .legacyQuery()
           .filter(["=", ["field", ORDERS.TOTAL, null], 42]);
-        expect(q.clean().query()).toEqual(q.query());
+        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
         expect(q.clean() === q).toBe(true);
       });
     });
@@ -36,15 +36,15 @@ describe("StructuredQuery", () => {
     describe("aggregations", () => {
       describe("standard aggregations", () => {
         it("should not remove count", () => {
-          const q = ordersTable.query().aggregate(["count"]);
-          expect(q.clean().query()).toEqual(q.query());
+          const q = ordersTable.legacyQuery().aggregate(["count"]);
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
         it("should not remove aggregation referencing valid field ID", () => {
           const q = ordersTable
-            .query()
+            .legacyQuery()
             .aggregate(["avg", ["field", ORDERS.TOTAL, null]]);
-          expect(q.clean().query()).toEqual(q.query());
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
       });
@@ -52,37 +52,37 @@ describe("StructuredQuery", () => {
       describe("named aggregations", () => {
         it("should not remove valid named aggregations", () => {
           const q = ordersTable
-            .query()
+            .legacyQuery()
             .aggregate([
               "aggregation-options",
               ["count"],
               { "display-name": "foo" },
             ]);
-          expect(q.clean().query()).toEqual(q.query());
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
       });
 
       describe("metric aggregations", () => {
         it("should not remove valid metrics", () => {
-          const q = ordersTable.query().aggregate(["metric", 1]);
-          expect(q.clean().query()).toEqual(q.query());
+          const q = ordersTable.legacyQuery().aggregate(["metric", 1]);
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
       });
 
       describe("custom aggregations", () => {
         it("should not remove count + 1", () => {
-          const q = ordersTable.query().aggregate(["+", ["count"], 1]);
-          expect(q.clean().query()).toEqual(q.query());
+          const q = ordersTable.legacyQuery().aggregate(["+", ["count"], 1]);
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
 
         it("should not remove custom aggregation referencing valid field ID", () => {
           const q = ordersTable
-            .query()
+            .legacyQuery()
             .aggregate(["+", ["avg", ["field", ORDERS.TOTAL, null]], 1]);
-          expect(q.clean().query()).toEqual(q.query());
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
       });
@@ -90,27 +90,29 @@ describe("StructuredQuery", () => {
 
     describe("breakouts", () => {
       it("should not remove breakout referencing valid field ID", () => {
-        const q = ordersTable.query().breakout(["field", ORDERS.TOTAL, null]);
-        expect(q.clean().query()).toEqual(q.query());
+        const q = ordersTable
+          .legacyQuery()
+          .breakout(["field", ORDERS.TOTAL, null]);
+        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
         expect(q.clean() === q).toBe(true);
       });
       it("should not remove breakout referencing valid expressions", () => {
         const q = ordersTable
-          .query()
+          .legacyQuery()
           .addExpression("foo", ["field", ORDERS.TOTAL, null])
           .breakout(["expression", "foo"]);
-        expect(q.clean().query()).toEqual(q.query());
+        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
         expect(q.clean() === q).toBe(true);
       });
       it("should not remove breakout referencing valid fk", () => {
         const q = ordersTable
-          .query()
+          .legacyQuery()
           .breakout([
             "field",
             PRODUCTS.TITLE,
             { "source-field": ORDERS.PRODUCT_ID },
           ]);
-        expect(q.clean().query()).toEqual(q.query());
+        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
         expect(q.clean() === q).toBe(true);
       });
     });
@@ -118,7 +120,7 @@ describe("StructuredQuery", () => {
     describe("nested", () => {
       it("shouldn't modify valid nested queries", () => {
         const q = ordersTable
-          .query()
+          .legacyQuery()
           .aggregate(["count"])
           .breakout(["field", ORDERS.PRODUCT_ID, null])
           .nest()
@@ -127,52 +129,54 @@ describe("StructuredQuery", () => {
             ["field", "count", { "base-type": "type/Integer" }],
             42,
           ]);
-        expect(q.clean().query()).toEqual(q.query());
+        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
         expect(q.clean() === q).toBe(true);
       });
 
-      it("should remove unnecessary layers of nesting via query()", () => {
-        const q = ordersTable.query().nest();
-        expect(q.clean().query()).toEqual({ "source-table": ORDERS_ID });
+      it("should remove unnecessary layers of nesting via legacyQuery()", () => {
+        const q = ordersTable.legacyQuery().nest();
+        expect(q.clean().legacyQuery()).toEqual({ "source-table": ORDERS_ID });
       });
 
       it("should remove unnecessary layers of nesting via question()", () => {
-        const q = ordersTable.query().nest();
-        expect(q.clean().query()).toEqual({ "source-table": ORDERS_ID });
+        const q = ordersTable.legacyQuery().nest();
+        expect(q.clean().legacyQuery()).toEqual({ "source-table": ORDERS_ID });
       });
     });
   });
 
   describe("cleanNesting", () => {
     it("should not modify empty queries with no source-query", () => {
-      expect(db.question().query().cleanNesting().datasetQuery()).toEqual({
-        type: "query",
-        database: SAMPLE_DB_ID,
-        query: { "source-table": undefined },
-      });
+      expect(db.question().legacyQuery().cleanNesting().datasetQuery()).toEqual(
+        {
+          type: "query",
+          database: SAMPLE_DB_ID,
+          query: { "source-table": undefined },
+        },
+      );
     });
     it("should remove outer empty queries", () => {
       expect(
         ordersTable
-          .query()
+          .legacyQuery()
           .updateLimit(10)
           .nest()
           .nest()
           .nest()
           .cleanNesting()
-          .query(),
+          .legacyQuery(),
       ).toEqual({ "source-table": ORDERS_ID, limit: 10 });
     });
     it("should remove intermediate empty queries", () => {
       expect(
         ordersTable
-          .query()
+          .legacyQuery()
           .nest()
           .nest()
           .nest()
           .updateLimit(10)
           .cleanNesting()
-          .query(),
+          .legacyQuery(),
       ).toEqual({ "source-query": { "source-table": ORDERS_ID }, limit: 10 });
     });
   });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-filters.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-filters.unit.spec.js
@@ -18,44 +18,44 @@ const FILTER = ["=", ["field", ORDERS.TOTAL, null], 42];
 describe("StructuredQuery", () => {
   describe("hasFilters", () => {
     it("should return false for queries without filters", () => {
-      const q = ordersTable.query();
+      const q = ordersTable.legacyQuery();
       expect(q.hasFilters()).toBe(false);
     });
     it("should return true for queries with filters", () => {
-      const q = ordersTable.query().filter(FILTER);
+      const q = ordersTable.legacyQuery().filter(FILTER);
       expect(q.hasFilters()).toBe(true);
     });
   });
   describe("filters", () => {
     it("should work as raw MBQL", () => {
-      const q = ordersTable.query().filter(FILTER);
+      const q = ordersTable.legacyQuery().filter(FILTER);
       const f = q.filters()[0];
       expect(JSON.stringify(f)).toEqual(JSON.stringify(FILTER));
     });
     describe("dimension()", () => {
       it("should return the correct dimension", () => {
-        const q = ordersTable.query().filter(FILTER);
+        const q = ordersTable.legacyQuery().filter(FILTER);
         const f = q.filters()[0];
         expect(f.dimension().mbql()).toEqual(["field", ORDERS.TOTAL, null]);
       });
     });
     describe("field()", () => {
       it("should return the correct field", () => {
-        const q = ordersTable.query().filter(FILTER);
+        const q = ordersTable.legacyQuery().filter(FILTER);
         const f = q.filters()[0];
         expect(f.field().id).toEqual(ORDERS.TOTAL);
       });
     });
     describe("operator()", () => {
       it("should return the correct operator", () => {
-        const q = ordersTable.query().filter(FILTER);
+        const q = ordersTable.legacyQuery().filter(FILTER);
         const f = q.filters()[0];
         expect(f.operator().name).toEqual("=");
       });
     });
     describe("filterOperators", () => {
       it("should return the valid operators for number filter", () => {
-        const q = ordersTable.query().filter(FILTER);
+        const q = ordersTable.legacyQuery().filter(FILTER);
         const f = q.filters()[0];
         expect(f.filterOperators()).toHaveLength(9);
         expect(f.filterOperators()[0].name).toEqual("=");
@@ -63,13 +63,13 @@ describe("StructuredQuery", () => {
     });
     describe("isOperator", () => {
       it("should return true for the same operator", () => {
-        const q = ordersTable.query().filter(FILTER);
+        const q = ordersTable.legacyQuery().filter(FILTER);
         const f = q.filters()[0];
         expect(f.isOperator("=")).toBe(true);
         expect(f.isOperator(f.filterOperators()[0])).toBe(true);
       });
       it("should return false for different operators", () => {
-        const q = ordersTable.query().filter(FILTER);
+        const q = ordersTable.legacyQuery().filter(FILTER);
         const f = q.filters()[0];
         expect(f.isOperator("!=")).toBe(false);
         expect(f.isOperator(f.filterOperators()[1])).toBe(false);
@@ -77,7 +77,7 @@ describe("StructuredQuery", () => {
     });
     describe("isDimension", () => {
       it("should return true for the same dimension", () => {
-        const q = ordersTable.query().filter(FILTER);
+        const q = ordersTable.legacyQuery().filter(FILTER);
         const f = q.filters()[0];
         expect(f.isDimension(["field", ORDERS.TOTAL, null])).toBe(true);
         expect(
@@ -85,7 +85,7 @@ describe("StructuredQuery", () => {
         ).toBe(true);
       });
       it("should return false for different dimensions", () => {
-        const q = ordersTable.query().filter(FILTER);
+        const q = ordersTable.legacyQuery().filter(FILTER);
         const f = q.filters()[0];
         expect(f.isDimension(["field", PRODUCTS.TITLE, null])).toBe(false);
         expect(

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-joins.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-joins.unit.spec.js
@@ -14,7 +14,7 @@ const productsTable = metadata.table(PRODUCTS_ID);
 describe("StructuredQuery nesting", () => {
   describe("dimensionOptions", () => {
     it("should include joined table's fields", () => {
-      const q = productsTable.query().join({
+      const q = productsTable.legacyQuery().join({
         alias: "join0",
         "source-table": ORDERS_ID,
       });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-nesting.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-nesting.unit.spec.js
@@ -27,21 +27,21 @@ describe("StructuredQuery nesting", () => {
   describe("nest", () => {
     it("should nest correctly", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.query();
-      expect(q.query()).toEqual({ "source-table": ORDERS_ID });
-      expect(q.nest().query()).toEqual({
+      const q = ordersTable.legacyQuery();
+      expect(q.legacyQuery()).toEqual({ "source-table": ORDERS_ID });
+      expect(q.nest().legacyQuery()).toEqual({
         "source-query": { "source-table": ORDERS_ID },
       });
     });
 
     it("should be able to modify the outer question", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.query();
+      const q = ordersTable.legacyQuery();
       expect(
         q
           .nest()
           .filter(["=", ["field", ORDERS.TOTAL, null], 42])
-          .query(),
+          .legacyQuery(),
       ).toEqual({
         "source-query": { "source-table": ORDERS_ID },
         filter: ["=", ["field", ORDERS.TOTAL, null], 42],
@@ -50,14 +50,14 @@ describe("StructuredQuery nesting", () => {
 
     it("should be able to modify the source question", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.query();
+      const q = ordersTable.legacyQuery();
       expect(
         q
           .nest()
           .sourceQuery()
           .filter(["=", ["field", ORDERS.TOTAL, null], 42])
           .parentQuery()
-          .query(),
+          .legacyQuery(),
       ).toEqual({
         "source-query": {
           "source-table": ORDERS_ID,
@@ -69,7 +69,7 @@ describe("StructuredQuery nesting", () => {
     it("should return a table with correct dimensions", () => {
       const { ordersTable } = setup();
       const q = ordersTable
-        .query()
+        .legacyQuery()
         .aggregate(["count"])
         .breakout(["field", ORDERS.PRODUCT_ID, null]);
       expect(
@@ -88,7 +88,7 @@ describe("StructuredQuery nesting", () => {
     it("should return filters for the last two stages", () => {
       const { ordersTable } = setup();
       const q = ordersTable
-        .query()
+        .legacyQuery()
         .aggregate(["count"])
         .filter(["=", ["field", ORDERS.PRODUCT_ID, null], 1])
         .nest()
@@ -107,30 +107,30 @@ describe("StructuredQuery nesting", () => {
   describe("topLevelQuery", () => {
     it("should return the query if it's summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.query();
-      expect(q.topLevelQuery().query()).toEqual({
+      const q = ordersTable.legacyQuery();
+      expect(q.topLevelQuery().legacyQuery()).toEqual({
         "source-table": ORDERS_ID,
       });
     });
     it("should return the query if it's not summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.query().aggregate(["count"]);
-      expect(q.topLevelQuery().query()).toEqual({
+      const q = ordersTable.legacyQuery().aggregate(["count"]);
+      expect(q.topLevelQuery().legacyQuery()).toEqual({
         "source-table": ORDERS_ID,
         aggregation: [["count"]],
       });
     });
     it("should return last stage if none are summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.query().nest();
-      expect(q.topLevelQuery().query()).toEqual({
+      const q = ordersTable.legacyQuery().nest();
+      expect(q.topLevelQuery().legacyQuery()).toEqual({
         "source-query": { "source-table": ORDERS_ID },
       });
     });
     it("should return last summarized stage if any is summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.query().aggregate(["count"]).nest();
-      expect(q.topLevelQuery().query()).toEqual({
+      const q = ordersTable.legacyQuery().aggregate(["count"]).nest();
+      expect(q.topLevelQuery().legacyQuery()).toEqual({
         "source-table": ORDERS_ID,
         aggregation: [["count"]],
       });
@@ -140,7 +140,7 @@ describe("StructuredQuery nesting", () => {
   describe("topLevelDimension", () => {
     it("should return same dimension if not nested", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.query();
+      const q = ordersTable.legacyQuery();
       const d = q.topLevelDimension(
         q.parseFieldReference(["field", ORDERS.TOTAL, null]),
       );
@@ -149,7 +149,7 @@ describe("StructuredQuery nesting", () => {
     it("should return underlying dimension for a nested query", () => {
       const { ordersTable } = setup();
       const q = ordersTable
-        .query()
+        .legacyQuery()
         .aggregate(["count"])
         .breakout(["field", ORDERS.TOTAL, null])
         .nest();
@@ -185,7 +185,7 @@ describe("StructuredQuery nesting", () => {
       const metadata = ordersTable.metadata;
       const question = ordersTable.question();
       const dataset = question.setId(1).setDataset(true);
-      const nestedDatasetQuery = dataset.composeDataset().query();
+      const nestedDatasetQuery = dataset.composeDataset().legacyQuery();
       expect(
         // get a list of all dimension options for the nested query
         nestedDatasetQuery

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -114,7 +114,7 @@ function makeQueryWithoutNumericFields() {
     ],
   });
 
-  return new Question(questionDetail, metadata).query();
+  return new Question(questionDetail, metadata).legacyQuery();
 }
 
 // no numeric fields, but have linked table (FK) with a numeric field
@@ -171,7 +171,7 @@ function makeQueryWithLinkedTable() {
     ],
   });
 
-  return new Question(questionDetail, metadata).query();
+  return new Question(questionDetail, metadata).legacyQuery();
 }
 
 const getShortName = aggregation => aggregation.short;
@@ -295,7 +295,7 @@ describe("StructuredQuery", () => {
     });
     describe("query", () => {
       it("returns the wrapper for the query dictionary", () => {
-        expect(query.query()["source-table"]).toBe(ORDERS_ID);
+        expect(query.legacyQuery()["source-table"]).toBe(ORDERS_ID);
       });
     });
     describe("setDatabase", () => {
@@ -443,7 +443,7 @@ describe("StructuredQuery", () => {
 
     describe("addAggregation", () => {
       it("adds an aggregation", () => {
-        expect(query.aggregate(["count"]).query()).toEqual({
+        expect(query.aggregate(["count"]).legacyQuery()).toEqual({
           "source-table": ORDERS_ID,
           aggregation: [["count"]],
         });

--- a/frontend/test/metabase-lib/lib/queries/structured/Aggregation.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Aggregation.unit.spec.js
@@ -18,7 +18,7 @@ const metadata = createMockMetadata({
   metrics: [TOTAL_ORDER_VALUE_METRIC],
 });
 
-const query = metadata.table(ORDERS_ID).query();
+const query = metadata.table(ORDERS_ID).legacyQuery();
 
 function aggregationForMBQL(mbql) {
   return new Aggregation(mbql, 0, query);

--- a/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
@@ -16,7 +16,7 @@ const metadata = createMockMetadata({
 
 const ordersTable = metadata.table(ORDERS_ID);
 
-const query = ordersTable.query();
+const query = ordersTable.legacyQuery();
 
 function filter(mbql) {
   return new Filter(mbql, 0, query);
@@ -187,7 +187,7 @@ describe("Filter", () => {
       ).toEqual([null, ["field", ORDERS.TOTAL, null]]);
     });
     it("should set joined-field for new filter clause", () => {
-      const q = ordersTable.query().join({
+      const q = ordersTable.legacyQuery().join({
         alias: "foo",
         "source-table": PEOPLE_ID,
       });

--- a/frontend/test/metabase/lib/dataset.unit.spec.js
+++ b/frontend/test/metabase/lib/dataset.unit.spec.js
@@ -30,7 +30,7 @@ describe("metabase/util/dataset", () => {
   describe("syncColumnsAndSettings", () => {
     it("should automatically add new metrics when a new aggregrate column is added", () => {
       const prevQuestion = productsTable
-        .query({
+        .legacyQuery({
           aggregation: [["count"]],
           breakout: [["field", PRODUCTS.CATEGORY, null]],
         })
@@ -40,7 +40,7 @@ describe("metabase/util/dataset", () => {
         });
 
       const newQuestion = prevQuestion
-        .query()
+        .legacyQuery()
         .aggregate(["sum", ["field", PRODUCTS.PRICE, null]])
         .question()
         .syncColumnsAndSettings(prevQuestion);
@@ -53,7 +53,7 @@ describe("metabase/util/dataset", () => {
 
     it("should automatically remove metrics from settings when an aggregrate column is removed", () => {
       const prevQuestion = productsTable
-        .query({
+        .legacyQuery({
           aggregation: [["sum", ["field", PRODUCTS.PRICE, null]], ["count"]],
           breakout: [["field", PRODUCTS.CATEGORY, null]],
         })
@@ -63,7 +63,7 @@ describe("metabase/util/dataset", () => {
         });
 
       const newQuestion = prevQuestion
-        .query()
+        .legacyQuery()
         .removeAggregation(1)
         .question()
         .syncColumnsAndSettings(prevQuestion);
@@ -73,7 +73,7 @@ describe("metabase/util/dataset", () => {
 
     it("Adding a breakout should not affect graph.metrics", () => {
       const prevQuestion = productsTable
-        .query({
+        .legacyQuery({
           aggregation: [["sum", ["field", PRODUCTS.PRICE, null]], ["count"]],
           breakout: [["field", PRODUCTS.CATEGORY, null]],
         })
@@ -83,7 +83,7 @@ describe("metabase/util/dataset", () => {
         });
 
       const newQuestion = prevQuestion
-        .query()
+        .legacyQuery()
         .breakout(["field", PRODUCTS.VENDOR, null])
         .question()
         .syncColumnsAndSettings(prevQuestion);
@@ -92,12 +92,12 @@ describe("metabase/util/dataset", () => {
         "count",
         "sum",
       ]);
-      expect(newQuestion.query().columns()).toHaveLength(4);
+      expect(newQuestion.legacyQuery().columns()).toHaveLength(4);
     });
 
     it("removes columns from table.columns when a column is removed from a query", () => {
       const prevQuestion = productsTable
-        .query({
+        .legacyQuery({
           fields: [
             ["field", PRODUCTS.ID, null],
             ["field", PRODUCTS.CATEGORY, null],
@@ -126,7 +126,7 @@ describe("metabase/util/dataset", () => {
         });
 
       const newQuestion = prevQuestion
-        .query()
+        .legacyQuery()
         .removeField(2)
         .question()
         .syncColumnsAndSettings(prevQuestion);
@@ -139,7 +139,7 @@ describe("metabase/util/dataset", () => {
 
     it("adds columns to table.columns when a column is added to a query", () => {
       const prevQuestion = productsTable
-        .query({
+        .legacyQuery({
           fields: [
             ["field", PRODUCTS.ID, null],
             ["field", PRODUCTS.CATEGORY, null],
@@ -162,7 +162,7 @@ describe("metabase/util/dataset", () => {
         });
 
       const newQuestion = prevQuestion
-        .query()
+        .legacyQuery()
         .addField(["field", PRODUCTS.VENDOR, null])
         .question()
         .syncColumnsAndSettings(prevQuestion);


### PR DESCRIPTION
The motivation for this change is to make it easier to spot legacy query usages.

If this changes goes well, we can migrate `_getMLv2Query` to `query`.