### PR TITLE
Add last_name to ApiKey users

### DIFF
--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -336,7 +336,7 @@
    [:email      ms/Email]
    [:first_name [:maybe ms/NonBlankString]]])
 
-(mu/defn insert-new-user!
+(mu/defn ^:private insert-new-user!
   "Creates a new user, defaulting the password when not provided"
   [new-user :- NewUser]
   (first (t2/insert-returning-instances! User (update new-user :password #(or % (str (random-uuid)))))))


### PR DESCRIPTION
When we generate a `:common_name` on Users, we check for the presence of both `first_name` and `last_name`. If either is `nil`, we don't generate a `common_name`.

ApiKey users only have one name (the name of the ApiKey itself) but we should set the `last_name` to an empty string. This way, the common name will still be generated.

Because the `metabase.models.user/insert-new-user!` function requires a NonBlankString for `first_name` and `last_name` if they're present, I went back to calling `t2/insert-returning-instances!` directly.
