### PR TITLE
Upload only failed Replay e2e recordings

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -36,12 +36,12 @@ const defaultConfig = {
      **                        PREPROCESSOR                            **
      ********************************************************************/
 
-
     if (runWithReplay) {
       on = replay.wrapOn(on);
       replay.default(on, config, {
         upload: true,
         apiKey: process.env.REPLAY_API_KEY,
+        filter: r => r.metadata.test?.result === "failed",
       });
     }
 
@@ -112,7 +112,6 @@ const defaultConfig = {
     };
 
     require("@cypress/grep/src/plugin")(config);
-
 
     return config;
   },


### PR DESCRIPTION
A follow up PR after #37228
We should upload only failed recordings.

Before
![image](https://github.com/metabase/metabase/assets/31325167/bc84e493-5217-411d-922b-84ed429acbaf)

After
![image](https://github.com/metabase/metabase/assets/31325167/83522a77-ec11-4676-92b4-8c4cec812e09)

Notes:
Added `no-backport` label because I'll manually backport it together with https://github.com/metabase/metabase/pull/37231