### PR TITLE
Make e2e tests less flaky

### DIFF
--- a/e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js
@@ -14,7 +14,7 @@ const { PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
 describe("issue 34382", () => {
   beforeEach(() => {
     restore();
-    cy.signInAsAdmin();
+    cy.signInAsNormalUser();
 
     cy.intercept("POST", "/api/dashboard/*/dashcard/*/card/*/query").as(
       "dashcardQuery",
@@ -44,8 +44,10 @@ describe("issue 34382", () => {
 
       getDashboardCard().within(() => {
         // only products with category "Gizmo" are filtered
-        cy.findAllByTestId("table-row").should("have.length", 8);
-        cy.findAllByText("Gizmo").should("have.length", 8);
+        cy.findAllByTestId("table-row")
+          .find("td")
+          .eq(3)
+          .should("contain", "Gizmo");
       });
     },
   );

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -597,6 +597,12 @@ describe("scenarios > visualizations > line chart", () => {
       cy.wait("@dataset");
 
       cy.findByTestId("filter-pill").should("contain.text", "Created At is");
+
+      const X_AXIS_VALUE = "June 2022";
+      cy.get(".CardVisualization").within(() => {
+        cy.get(".x-axis-label").should("have.text", "Created At");
+        cy.findByText(X_AXIS_VALUE);
+      });
     },
   );
 
@@ -629,6 +635,11 @@ describe("scenarios > visualizations > line chart", () => {
       "contain.text",
       "Quantity is between",
     );
+    const X_AXIS_VALUE = 8;
+    cy.get(".CardVisualization").within(() => {
+      cy.get(".x-axis-label").should("have.text", "Quantity");
+      cy.findByText(X_AXIS_VALUE);
+    });
   });
 });
 

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -578,32 +578,23 @@ describe("scenarios > visualizations > line chart", () => {
     });
   });
 
-  it(
-    "should apply filters to the series selecting area range",
-    { tags: "@flaky" },
-    () => {
-      cy.viewport(1280, 800);
+  it("should apply filters to the series selecting area range", () => {
+    cy.viewport(1280, 800);
 
-      visitQuestionAdhoc({
-        dataset_query: testQuery,
-        display: "line",
-      });
+    visitQuestionAdhoc({
+      dataset_query: testQuery,
+      display: "line",
+    });
 
-      cy.get(".Visualization")
-        .trigger("mousedown", 100, 200)
-        .trigger("mousemove", 230, 200)
-        .trigger("mouseup", 230, 200);
+    cy.get(".Visualization")
+      .trigger("mousedown", 100, 200)
+      .trigger("mousemove", 230, 200)
+      .trigger("mouseup", 230, 200);
 
-      cy.wait("@dataset");
+    cy.wait("@dataset");
 
-      cy.findByTestId("filter-pill").should(
-        "have.text",
-        "Created At is Apr 1, 12:00 AM – Sep 1, 2022, 12:00 AM",
-      );
-
-      cy.get(".Visualization .dot").should("have.length", 6);
-    },
-  );
+    cy.findByTestId("filter-pill").should("contain.text", "Created At is");
+  });
 
   it("should apply filters to the series selecting area range when axis is a number", () => {
     const testQuery = {
@@ -634,8 +625,6 @@ describe("scenarios > visualizations > line chart", () => {
       "contain.text",
       "Quantity is between",
     );
-
-    cy.get(".Visualization .dot").should("have.length", 4);
   });
 });
 

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -578,23 +578,27 @@ describe("scenarios > visualizations > line chart", () => {
     });
   });
 
-  it("should apply filters to the series selecting area range", () => {
-    cy.viewport(1280, 800);
+  it(
+    "should apply filters to the series selecting area range",
+    { tags: "@flaky" },
+    () => {
+      cy.viewport(1280, 800);
 
-    visitQuestionAdhoc({
-      dataset_query: testQuery,
-      display: "line",
-    });
+      visitQuestionAdhoc({
+        dataset_query: testQuery,
+        display: "line",
+      });
 
-    cy.get(".Visualization")
-      .trigger("mousedown", 100, 200)
-      .trigger("mousemove", 230, 200)
-      .trigger("mouseup", 230, 200);
+      cy.get(".Visualization")
+        .trigger("mousedown", 100, 200)
+        .trigger("mousemove", 230, 200)
+        .trigger("mouseup", 230, 200);
 
-    cy.wait("@dataset");
+      cy.wait("@dataset");
 
-    cy.findByTestId("filter-pill").should("contain.text", "Created At is");
-  });
+      cy.findByTestId("filter-pill").should("contain.text", "Created At is");
+    },
+  );
 
   it("should apply filters to the series selecting area range when axis is a number", () => {
     const testQuery = {

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -59,15 +59,11 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
       .trigger("mouseup", 230, 200);
 
     // Note: Test was flaking because apparently mouseup doesn't always happen at the same position.
-    //       It is enough that we assert that the filter exists and that it starts with May 2022.
-    //       The date range formatter sometimes omits the year of the first month (e.g. May–July 2022),
-    //       so checking that 2022 occurs after May ensures that May 2022 is in fact the first date.
-
-    cy.findByTestId("qb-filters-panel")
-      .findByText(
-        "Product → Created At is May 1, 12:00 AM – Jul 1, 2022, 12:00 AM",
-      )
-      .should("exist");
+    //       It is enough that we assert that the filter exists.
+    cy.findByTestId("qb-filters-panel").should(
+      "contain",
+      "Product → Created At is",
+    );
 
     queryBuilderMain().within(() => {
       cy.get(".LineAreaBarChart").findByText("June 2022"); // more granular axis labels


### PR DESCRIPTION
### Description

Since drag&drop is not stable, filter results can vary between runs. So the idea to simplify assertion was discussed ([thread](https://metaboat.slack.com/archives/C5XHN8GLW/p1704299003934219))

nagivating back is flaky because of the number of printed rows, (1-7 vs 1-8), so I made it less dependent on the viewport size

### How to verify

Tests should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
