### PR TITLE
Error if DB downgrades are required

### DIFF
--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -126,15 +126,15 @@
             latest-applied (liquibase/latest-applied-major-version conn)]
         ;; `latest-applied` will be `nil` for fresh installs
         (when (and latest-applied (< latest-available latest-applied))
-          (log/info (str (u/format-color 'red (trs "ERROR: Downgrade detected."))
-                         "\n\n"
-                         (trs "Your metabase instance appears to have been downgraded without a corresponding database downgrade.")
-                         "\n\n"
-                         (trs "You must run `java -jar metabase.jar migrate down` from version {0}." latest-applied)
-                         "\n\n"
-                         (trs "Once your database has been downgraded, try running the application again.")
-                         "\n\n"
-                         (trs "See: https://www.metabase.com/docs/latest/installation-and-operation/upgrading-metabase#rolling-back-an-upgrade")))
+          (log/error (str (u/format-color 'red (trs "ERROR: Downgrade detected."))
+                          "\n\n"
+                          (trs "Your metabase instance appears to have been downgraded without a corresponding database downgrade.")
+                          "\n\n"
+                          (trs "You must run `java -jar metabase.jar migrate down` from version {0}." latest-applied)
+                          "\n\n"
+                          (trs "Once your database has been downgraded, try running the application again.")
+                          "\n\n"
+                          (trs "See: https://www.metabase.com/docs/latest/installation-and-operation/upgrading-metabase#rolling-back-an-upgrade")))
           (throw (ex-info (trs "Downgrade detected. Please run `migrate down` from version {0}."
                             latest-applied)
                           {})))))))

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -53,7 +53,6 @@
                    "\n"))
     (throw (Exception. (trs "Database requires manual upgrade.")))))
 
-
 (mu/defn migrate!
   "Migrate the application database specified by `data-source`.
 
@@ -127,8 +126,15 @@
             latest-applied (liquibase/latest-applied-major-version conn)]
         ;; `latest-applied` will be `nil` for fresh installs
         (when (and latest-applied (< latest-available latest-applied))
-          (log/info (u/format-color 'red (trs "Latest applied version: {0}" latest-applied)))
-          (log/info (u/format-color 'red (trs "Latest known version: {0}" latest-available)))
+          (log/info (str (u/format-color 'red (trs "ERROR: Downgrade detected."))
+                         "\n\n"
+                         (trs "Your metabase instance appears to have been downgraded without a corresponding database downgrade.")
+                         "\n\n"
+                         (trs "You must run `java -jar metabase.jar migrate down` from version {0}." latest-applied)
+                         "\n\n"
+                         (trs "Once your database has been downgraded, try running the application again.")
+                         "\n\n"
+                         (trs "See: https://www.metabase.com/docs/latest/installation-and-operation/upgrading-metabase#rolling-back-an-upgrade")))
           (throw (ex-info (trs "Downgrade detected. Please run `migrate down` from version {0}."
                             latest-applied)
                           {})))))))


### PR DESCRIPTION
Before running migrations, check the major versions of:

- the latest database migration that was actually applied (e.g. if v49 ran migrations, this would be 49)

- the latest database migration that liquibase is aware of (e.g. if we're currently running v48, this would be 48)

If the database has executed migrations that we don't know about, throw an exception and exit with a helpful error message telling the user they need to run `migrate down` from the newer version before they can downgrade.

Fixes https://github.com/metabase/metabase/issues/27906