### PR TITLE
Finally introduce the `mt/test-helpers-set-global-values!` pattern

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -565,7 +565,6 @@
    metabase.test/with-log-messages-for-level                                                                                 hooks.common/with-ignored-first-arg
    metabase.test/with-non-admin-groups-no-root-collection-perms                                                              hooks.common/do*
    metabase.test/with-temp                                                                                                   hooks.toucan2.tools.with-temp/with-temp
-   metabase.test/with-temp!                                                                                                  hooks.toucan2.tools.with-temp/with-temp
    metabase.test/with-temp-file                                                                                              hooks.metabase.test.util/with-temp-file
    metabase.test/with-temporary-setting-values                                                                               hooks.metabase.test.util/with-temporary-setting-values}
 

--- a/.clj-kondo/hooks/clojure/test.clj
+++ b/.clj-kondo/hooks/clojure/test.clj
@@ -50,7 +50,6 @@
      metabase.test/with-all-users-permission
      metabase.test/with-column-remappings
      metabase.test/with-discarded-collections-perms-changes
-     metabase.test/with-ensure-with-temp-no-transaction!
      metabase.test/with-env-keys-renamed-by
      metabase.test/with-expected-messages
      metabase.test/with-fake-inbox
@@ -64,7 +63,6 @@
      metabase.test/with-persistence-enabled
      metabase.test/with-single-admin-user
      metabase.test/with-system-timezone-id
-     metabase.test/with-temp!
      metabase.test/with-temp-env-var-value
      metabase.test/with-temp-vals-in-db
      metabase.test/with-temporary-raw-setting-values

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/group_manager_test.clj
@@ -300,13 +300,13 @@
 
 (deftest update-user-api-test
   (testing "PUT /api/user/:id"
-    (mt/with-ensure-with-temp-no-transaction!
+    (mt/test-helpers-set-global-values!
       (mt/with-user-in-groups
         [group {:name "New Group"}
          user  [group]]
         (mt/with-temp [User user-to-update]
           (letfn [(update-user-firstname! [req-user status]
-                    (testing (format "- update users firstname with %s user" (mt/user-descriptor user))
+                    (testing (format "- update users firstname with %s test-user" (mt/user-descriptor user))
                       (mt/user-http-request req-user :put status (format "user/%d" (:id user-to-update))
                                             {:first_name (mt/random-name)})))
                   (add-user-to-group! [req-user status group-to-add]

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -607,39 +607,40 @@
         (mt/user-http-request :rasta :delete 403 (format "database/%d" db-id))))))
 
 (deftest db-operations-test
-  (mt/with-temp! [Database    {db-id :id}     {:engine "h2", :details (:details (mt/db))}
-                  Table       {table-id :id}  {:db_id db-id}
-                  Field       {field-id :id}  {:table_id table-id}
-                  FieldValues {values-id :id} {:field_id field-id, :values [1 2 3 4]}]
-    (with-redefs [api.database/*rescan-values-async* false]
-      (testing "A non-admin can trigger a sync of the DB schema if they have DB details permissions"
-        (with-all-users-data-perms! {db-id {:details :yes}}
-          (mt/user-http-request :rasta :post 200 (format "database/%d/sync_schema" db-id))))
+  (mt/test-helpers-set-global-values!
+    (mt/with-temp [Database    {db-id :id}     {:engine "h2", :details (:details (mt/db))}
+                   Table       {table-id :id}  {:db_id db-id}
+                   Field       {field-id :id}  {:table_id table-id}
+                   FieldValues {values-id :id} {:field_id field-id, :values [1 2 3 4]}]
+      (with-redefs [api.database/*rescan-values-async* false]
+        (testing "A non-admin can trigger a sync of the DB schema if they have DB details permissions"
+          (with-all-users-data-perms! {db-id {:details :yes}}
+            (mt/user-http-request :rasta :post 200 (format "database/%d/sync_schema" db-id))))
 
-      (testing "A non-admin can discard saved field values if they have DB details permissions"
-        (with-all-users-data-perms! {db-id {:details :yes}}
-          (mt/user-http-request :rasta :post 200 (format "database/%d/discard_values" db-id))))
+        (testing "A non-admin can discard saved field values if they have DB details permissions"
+          (with-all-users-data-perms! {db-id {:details :yes}}
+            (mt/user-http-request :rasta :post 200 (format "database/%d/discard_values" db-id))))
 
-      (testing "A non-admin with no data access can discard field values if they have DB details perms"
-        (t2/insert! FieldValues :id values-id :field_id field-id :values [1 2 3 4])
-        (with-all-users-data-perms! {db-id {:data    {:schemas :block :native :none}
-                                            :details :yes}}
-          (mt/user-http-request :rasta :post 200 (format "database/%d/discard_values" db-id)))
-        (is (= nil (t2/select-one-fn :values FieldValues, :field_id field-id)))
-        (mt/user-http-request :crowberto :post 200 (format "database/%d/rescan_values" db-id)))
-
-      ;; Use test database for rescan_values tests so we can verify that scan actually succeeds
-      (testing "A non-admin can trigger a re-scan of field values if they have DB details permissions"
-        (with-all-users-data-perms! {(mt/id) {:details :yes}}
-          (mt/user-http-request :rasta :post 200 (format "database/%d/rescan_values" (mt/id)))))
-
-      (testing "A non-admin with no data access can trigger a re-scan of field values if they have DB details perms"
-        (t2/delete! FieldValues :field_id (mt/id :venues :price))
-        (is (= nil (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))
-        (with-all-users-data-perms! {(mt/id) {:data   {:schemas :block :native :none}
+        (testing "A non-admin with no data access can discard field values if they have DB details perms"
+          (t2/insert! FieldValues :id values-id :field_id field-id :values [1 2 3 4])
+          (with-all-users-data-perms! {db-id {:data    {:schemas :block :native :none}
                                               :details :yes}}
-          (mt/user-http-request :rasta :post 200 (format "database/%d/rescan_values" (mt/id))))
-        (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))))))
+            (mt/user-http-request :rasta :post 200 (format "database/%d/discard_values" db-id)))
+          (is (= nil (t2/select-one-fn :values FieldValues, :field_id field-id)))
+          (mt/user-http-request :crowberto :post 200 (format "database/%d/rescan_values" db-id)))
+
+        ;; Use test database for rescan_values tests so we can verify that scan actually succeeds
+        (testing "A non-admin can trigger a re-scan of field values if they have DB details permissions"
+          (with-all-users-data-perms! {(mt/id) {:details :yes}}
+            (mt/user-http-request :rasta :post 200 (format "database/%d/rescan_values" (mt/id)))))
+
+        (testing "A non-admin with no data access can trigger a re-scan of field values if they have DB details perms"
+          (t2/delete! FieldValues :field_id (mt/id :venues :price))
+          (is (= nil (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))
+          (with-all-users-data-perms! {(mt/id) {:data    {:schemas :block :native :none}
+                                                :details :yes}}
+            (mt/user-http-request :rasta :post 200 (format "database/%d/rescan_values" (mt/id))))
+          (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price)))))))))
 
 (deftest fetch-db-test
   (t2.with-temp/with-temp [Database {db-id :id}]

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/alerts_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/alerts_test.clj
@@ -22,68 +22,69 @@
   (is (= []
          (mt/rows (alerts (mt/random-name)))))
   (let [card-name (mt/random-name)]
-    (mt/with-temp! [Collection {collection-id :id, collection-name :name}]
-      ;; test with both the Root Collection and a non-Root Collection
-      (doseq [{:keys [collection-id collection-name]} [{:collection-id   collection-id
-                                                        :collection-name collection-name}
-                                                       {:collection-id   nil
-                                                        :collection-name "Our analytics"}]]
-        (testing (format "Collection = %d %s" collection-id collection-name)
-          (mt/with-temp [Card                  {card-id :id}      {:name          card-name
-                                                                   :collection_id collection-id}
-                         Pulse                 {pulse-id :id}     {:collection_id   collection-id
-                                                                   :alert_condition "rows"}
-                         PulseCard             _                  {:card_id  card-id
-                                                                   :pulse_id pulse-id}
-                         PulseChannel          {channel-id :id}   {:pulse_id       pulse-id
-                                                                   :channel_type   "email"
-                                                                   :details        {:emails ["amazing@metabase.com"]}
-                                                                   :schedule_type  "monthly"
-                                                                   :schedule_frame "first"
-                                                                   :schedule_day   "mon"
-                                                                   :schedule_hour  8}
-                         PulseChannelRecipient _                  {:pulse_channel_id channel-id
-                                                                   :user_id          (mt/user->id :rasta)}
-                         PulseChannel          {channel-2-id :id} {:pulse_id      pulse-id
-                                                                   :channel_type  "slack"
-                                                                   :details       {:channel "#wow"}
-                                                                   :schedule_type "hourly"}]
-            (is (= {:columns ["card_id"
-                              "card_name"
-                              "pulse_id"
-                              "recipients"
-                              "subscription_type"
-                              "collection_id"
-                              "collection_name"
-                              "frequency"
-                              "creator_id"
-                              "creator_name"
-                              "created_at"
-                              "num_filters"]
-                    ;; sort by newest first.
-                    :rows    [[card-id
-                               card-name
-                               pulse-id
-                               nil
-                               "Slack"
-                               collection-id
-                               collection-name
-                               "Every hour"
-                               (mt/user->id :rasta)
-                               "Rasta Toucan"
-                               (t2/select-one-fn :created_at PulseChannel :id channel-2-id)
-                               0]
-                              [card-id
-                               card-name
-                               pulse-id
-                               2
-                               "Email"
-                               collection-id
-                               collection-name
-                               "At 8:00 AM, on the first Tuesday of the month"
-                               (mt/user->id :rasta)
-                               "Rasta Toucan"
-                               (t2/select-one-fn :created_at PulseChannel :id channel-id)
-                               0]]}
-                   (mt/rows+column-names
-                    (alerts (str/join (rest (butlast card-name)))))))))))))
+    (mt/test-helpers-set-global-values!
+      (mt/with-temp [Collection {collection-id :id, collection-name :name}]
+        ;; test with both the Root Collection and a non-Root Collection
+        (doseq [{:keys [collection-id collection-name]} [{:collection-id   collection-id
+                                                          :collection-name collection-name}
+                                                         {:collection-id   nil
+                                                          :collection-name "Our analytics"}]]
+          (testing (format "Collection = %d %s" collection-id collection-name)
+            (mt/with-temp [Card                  {card-id :id}      {:name          card-name
+                                                                     :collection_id collection-id}
+                           Pulse                 {pulse-id :id}     {:collection_id   collection-id
+                                                                     :alert_condition "rows"}
+                           PulseCard             _                  {:card_id  card-id
+                                                                     :pulse_id pulse-id}
+                           PulseChannel          {channel-id :id}   {:pulse_id       pulse-id
+                                                                     :channel_type   "email"
+                                                                     :details        {:emails ["amazing@metabase.com"]}
+                                                                     :schedule_type  "monthly"
+                                                                     :schedule_frame "first"
+                                                                     :schedule_day   "mon"
+                                                                     :schedule_hour  8}
+                           PulseChannelRecipient _                  {:pulse_channel_id channel-id
+                                                                     :user_id          (mt/user->id :rasta)}
+                           PulseChannel          {channel-2-id :id} {:pulse_id      pulse-id
+                                                                     :channel_type  "slack"
+                                                                     :details       {:channel "#wow"}
+                                                                     :schedule_type "hourly"}]
+              (is (= {:columns ["card_id"
+                                "card_name"
+                                "pulse_id"
+                                "recipients"
+                                "subscription_type"
+                                "collection_id"
+                                "collection_name"
+                                "frequency"
+                                "creator_id"
+                                "creator_name"
+                                "created_at"
+                                "num_filters"]
+                      ;; sort by newest first.
+                      :rows    [[card-id
+                                 card-name
+                                 pulse-id
+                                 nil
+                                 "Slack"
+                                 collection-id
+                                 collection-name
+                                 "Every hour"
+                                 (mt/user->id :rasta)
+                                 "Rasta Toucan"
+                                 (t2/select-one-fn :created_at PulseChannel :id channel-2-id)
+                                 0]
+                                [card-id
+                                 card-name
+                                 pulse-id
+                                 2
+                                 "Email"
+                                 collection-id
+                                 collection-name
+                                 "At 8:00 AM, on the first Tuesday of the month"
+                                 (mt/user->id :rasta)
+                                 "Rasta Toucan"
+                                 (t2/select-one-fn :created_at PulseChannel :id channel-id)
+                                 0]]}
+                     (mt/rows+column-names
+                      (alerts (str/join (rest (butlast card-name))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_app/pages/dashboard_subscriptions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/pages/dashboard_subscriptions_test.clj
@@ -20,69 +20,70 @@
 
 (deftest table-test
   (premium-features-test/with-premium-features #{}
-   (is (= []
-          (mt/rows (dashboard-subscriptions (mt/random-name)))))
-   (let [dashboard-name (mt/random-name)]
-     (mt/with-temp! [Collection {collection-id :id, collection-name :name}]
-       ;; test with both the Root Collection and a non-Root Collection
-       (doseq [{:keys [collection-id collection-name]} [{:collection-id   collection-id
-                                                         :collection-name collection-name}
-                                                        {:collection-id   nil
-                                                         :collection-name "Our analytics"}]]
-         (testing (format "Collection = %d %s" collection-id collection-name)
-           (mt/with-temp! [Dashboard             {dashboard-id :id} {:name          dashboard-name
-                                                                     :collection_id collection-id}
-                           Pulse                 {pulse-id :id}     {:dashboard_id  dashboard-id
-                                                                     :collection_id collection-id}
-                           PulseChannel          {channel-id :id}   {:pulse_id       pulse-id
-                                                                     :channel_type   "email"
-                                                                     :details        {:emails ["amazing@fake.com"]}
-                                                                     :schedule_type  "monthly"
-                                                                     :schedule_frame "first"
-                                                                     :schedule_day   "mon"
-                                                                     :schedule_hour  8}
-                           PulseChannelRecipient _                  {:pulse_channel_id channel-id
-                                                                     :user_id          (mt/user->id :rasta)}
-                           PulseChannel          {channel-2-id :id} {:pulse_id      pulse-id
-                                                                     :channel_type  "slack"
-                                                                     :details       {:channel "#wow"}
-                                                                     :schedule_type "hourly"}]
-             (is (= {:columns ["dashboard_id"
-                               "dashboard_name"
-                               "pulse_id"
-                               "recipients"
-                               "subscription_type"
-                               "collection_id"
-                               "collection_name"
-                               "frequency"
-                               "creator_id"
-                               "creator_name"
-                               "created_at"
-                               "num_filters"]
-                     ;; sort by newest first.
-                     :rows    [[dashboard-id
-                                dashboard-name
-                                pulse-id
-                                nil
-                                "Slack"
-                                collection-id
-                                collection-name
-                                "Every hour"
-                                (mt/user->id :rasta)
-                                "Rasta Toucan"
-                                (t2/select-one-fn :created_at PulseChannel :id channel-2-id)
-                                0]
-                               [dashboard-id
-                                dashboard-name
-                                pulse-id
-                                2
-                                "Email"
-                                collection-id
-                                collection-name
-                                "At 8:00 AM, on the first Tuesday of the month"
-                                (mt/user->id :rasta)
-                                "Rasta Toucan"
-                                (t2/select-one-fn :created_at PulseChannel :id channel-id)
-                                0]]}
-                    (mt/rows+column-names
-                     (dashboard-subscriptions (str/join (rest (butlast dashboard-name))))))))))))))
+    (is (= []
+           (mt/rows (dashboard-subscriptions (mt/random-name)))))
+    (let [dashboard-name (mt/random-name)]
+      (mt/test-helpers-set-global-values!
+        (mt/with-temp [Collection {collection-id :id, collection-name :name}]
+          ;; test with both the Root Collection and a non-Root Collection
+          (doseq [{:keys [collection-id collection-name]} [{:collection-id   collection-id
+                                                            :collection-name collection-name}
+                                                           {:collection-id   nil
+                                                            :collection-name "Our analytics"}]]
+            (testing (format "Collection = %d %s" collection-id collection-name)
+              (mt/with-temp [Dashboard             {dashboard-id :id} {:name          dashboard-name
+                                                                       :collection_id collection-id}
+                             Pulse                 {pulse-id :id}     {:dashboard_id  dashboard-id
+                                                                       :collection_id collection-id}
+                             PulseChannel          {channel-id :id}   {:pulse_id       pulse-id
+                                                                       :channel_type   "email"
+                                                                       :details        {:emails ["amazing@fake.com"]}
+                                                                       :schedule_type  "monthly"
+                                                                       :schedule_frame "first"
+                                                                       :schedule_day   "mon"
+                                                                       :schedule_hour  8}
+                             PulseChannelRecipient _                  {:pulse_channel_id channel-id
+                                                                       :user_id          (mt/user->id :rasta)}
+                             PulseChannel          {channel-2-id :id} {:pulse_id      pulse-id
+                                                                       :channel_type  "slack"
+                                                                       :details       {:channel "#wow"}
+                                                                       :schedule_type "hourly"}]
+                (is (= {:columns ["dashboard_id"
+                                  "dashboard_name"
+                                  "pulse_id"
+                                  "recipients"
+                                  "subscription_type"
+                                  "collection_id"
+                                  "collection_name"
+                                  "frequency"
+                                  "creator_id"
+                                  "creator_name"
+                                  "created_at"
+                                  "num_filters"]
+                        ;; sort by newest first.
+                        :rows    [[dashboard-id
+                                   dashboard-name
+                                   pulse-id
+                                   nil
+                                   "Slack"
+                                   collection-id
+                                   collection-name
+                                   "Every hour"
+                                   (mt/user->id :rasta)
+                                   "Rasta Toucan"
+                                   (t2/select-one-fn :created_at PulseChannel :id channel-2-id)
+                                   0]
+                                  [dashboard-id
+                                   dashboard-name
+                                   pulse-id
+                                   2
+                                   "Email"
+                                   collection-id
+                                   collection-name
+                                   "At 8:00 AM, on the first Tuesday of the month"
+                                   (mt/user->id :rasta)
+                                   "Rasta Toucan"
+                                   (t2/select-one-fn :created_at PulseChannel :id channel-id)
+                                   0]]}
+                       (mt/rows+column-names
+                        (dashboard-subscriptions (str/join (rest (butlast dashboard-name)))))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/entity_ids_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/entity_ids_test.clj
@@ -20,57 +20,61 @@
     (is (true? (v2.entity-ids/seed-entity-ids!))))
   (testing "With a temp Collection with no entity ID"
     (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
-      (mt/with-temp! [Collection c {:name       "No Entity ID Collection"
-                                    :slug       "no_entity_id_collection"
-                                    :created_at now}]
-        (t2/update! Collection (:id c) {:entity_id nil})
-        (letfn [(entity-id []
-                  (some-> (t2/select-one-fn :entity_id Collection :id (:id c)) str/trim))]
-          (is (= nil
-                 (entity-id)))
-          (testing "Should return truthy on success"
-            (is (= true
-                   (v2.entity-ids/seed-entity-ids!))))
-          (is (= "998b109c"
-                 (entity-id))))
-        (testing "Error: duplicate entity IDs"
-          (mt/with-temp! [Collection c2 {:name       "No Entity ID Collection"
-                                         :slug       "no_entity_id_collection"
-                                         :created_at now}]
-            (t2/update! Collection (:id c2) {:entity_id nil})
-            (letfn [(entity-id []
-                      (some-> (t2/select-one-fn :entity_id Collection :id (:id c2)) str/trim))]
-              (is (= nil
-                     (entity-id)))
-              (testing "Should return falsey on error"
-                (is (= false
-                       (v2.entity-ids/seed-entity-ids!))))
-              (is (= nil
-                     (entity-id))))))))))
+      (mt/test-helpers-set-global-values!
+        (mt/with-temp [Collection c {:name       "No Entity ID Collection"
+                                     :slug       "no_entity_id_collection"
+                                     :created_at now}]
+          (t2/update! Collection (:id c) {:entity_id nil})
+          (letfn [(entity-id []
+                    (some-> (t2/select-one-fn :entity_id Collection :id (:id c)) str/trim))]
+            (is (= nil
+                   (entity-id)))
+            (testing "Should return truthy on success"
+              (is (= true
+                     (v2.entity-ids/seed-entity-ids!))))
+            (is (= "998b109c"
+                   (entity-id))))
+          (testing "Error: duplicate entity IDs"
+            (mt/test-helpers-set-global-values!
+              (mt/with-temp [Collection c2 {:name       "No Entity ID Collection"
+                                            :slug       "no_entity_id_collection"
+                                            :created_at now}]
+                (t2/update! Collection (:id c2) {:entity_id nil})
+                (letfn [(entity-id []
+                          (some-> (t2/select-one-fn :entity_id Collection :id (:id c2)) str/trim))]
+                  (is (= nil
+                         (entity-id)))
+                  (testing "Should return falsey on error"
+                    (is (= false
+                           (v2.entity-ids/seed-entity-ids!))))
+                  (is (= nil
+                         (entity-id))))))))))))
 
 (deftest drop-entity-ids-test
   (mt/with-empty-h2-app-db
     (testing "With a temp Collection with an entity ID"
       (let [now (LocalDateTime/of 2022 9 1 12 34 56)]
-        (mt/with-temp! [Collection c {:name       "No Entity ID Collection"
-                                      :slug       "no_entity_id_collection"
-                                      :created_at now}]
-                       (letfn [(entity-id []
-                                 (some-> (t2/select-one-fn :entity_id Collection :id (:id c)) str/trim))]
-                         (is (some? (entity-id)))
-                         (testing "Should return truthy on success"
-                           (is (= true
-                                  (v2.entity-ids/drop-entity-ids!))))
-                         (is (nil? (entity-id)))))))
+        (mt/test-helpers-set-global-values!
+          (mt/with-temp [Collection c {:name       "No Entity ID Collection"
+                                       :slug       "no_entity_id_collection"
+                                       :created_at now}]
+            (letfn [(entity-id []
+                      (some-> (t2/select-one-fn :entity_id Collection :id (:id c)) str/trim))]
+              (is (some? (entity-id)))
+              (testing "Should return truthy on success"
+                (is (= true
+                       (v2.entity-ids/drop-entity-ids!))))
+              (is (nil? (entity-id))))))))
     (testing "empty table"
       (testing "has no entity ids"
-        (mt/with-temp! [Collection _ {:name "No Entity ID Collection"
-                                      :slug "no_entity_id_collection"}]
-                       (is (nil? (t2/select-fn-set :entity-id Dashboard)))
-                       (testing "but doesn't crash drop-entity-ids"
-                         (is (= true
-                                (v2.entity-ids/drop-entity-ids!)))
-                         (is (nil? (t2/select-fn-set :entity-id Dashboard)))))))))
+        (mt/test-helpers-set-global-values!
+          (mt/with-temp [Collection _ {:name "No Entity ID Collection"
+                                       :slug "no_entity_id_collection"}]
+            (is (nil? (t2/select-fn-set :entity-id Dashboard)))
+            (testing "but doesn't crash drop-entity-ids"
+              (is (= true
+                     (v2.entity-ids/drop-entity-ids!)))
+              (is (nil? (t2/select-fn-set :entity-id Dashboard))))))))))
 
 (deftest entity-ids-are-nullable
   (testing "entity_id field should be nullable for model so that drop-entity-ids work (#36365)"

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -56,7 +56,7 @@
       ~@body)))
 
 (defmacro ^:private with-jwt-default-setup [& body]
-  `(mt/with-ensure-with-temp-no-transaction!
+  `(mt/test-helpers-set-global-values!
      (premium-features-test/with-premium-features #{:audit-app}
        (disable-other-sso-types
         (fn []

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -79,7 +79,7 @@
 
 (defmacro with-saml-default-setup [& body]
   ;; most saml tests make actual http calls, so ensuring any nested with-temp doesn't create transaction
-  `(mt/with-ensure-with-temp-no-transaction!
+  `(mt/test-helpers-set-global-values!
     (premium-features-test/with-additional-premium-features #{:sso-saml}
       (call-with-login-attributes-cleared!
        (fn []

--- a/test/metabase/actions/execution_test.clj
+++ b/test/metabase/actions/execution_test.clj
@@ -10,7 +10,7 @@
 
 (deftest fetch-values-save-execution-info-test
   (testing "fetch values for implicit action will save an execution info"
-    (mt/with-ensure-with-temp-no-transaction!
+    (mt/test-helpers-set-global-values!
       (mt/with-actions-enabled
         (let [dataset-query (mt/mbql-query venues {:fields [$id $name]})
               query (assoc

--- a/test/metabase/api/action_test.clj
+++ b/test/metabase/api/action_test.clj
@@ -225,7 +225,7 @@
                                                     {:parameters {:id 1 :source "Twitter"}})))))))))))
 
 (deftest unified-action-create-test
-  (mt/with-ensure-with-temp-no-transaction!
+  (mt/test-helpers-set-global-values!
     (mt/with-actions-enabled
       (mt/with-non-admin-groups-no-root-collection-perms
         (mt/with-actions-test-data-tables #{"users" "categories"}

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -607,72 +607,73 @@
 
 (deftest collection-items-revision-history-and-ordering-test
   (testing "GET /api/collection/:id/items"
-    (mt/with-temp!
-      [Collection {collection-id :id}      {:name "Collection with Items"}
-       User       {user1-id :id}           {:first_name "Test" :last_name "AAAA" :email "aaaa@example.com"}
-       User       {user2-id :id}           {:first_name "Test" :last_name "ZZZZ" :email "zzzz@example.com"}
-       Card       {card1-id :id :as card1} {:name "Card with history 1" :collection_id collection-id}
-       Card       {card2-id :id :as card2} {:name "Card with history 2" :collection_id collection-id}
-       Card       _                        {:name "ZZ" :collection_id collection-id}
-       Card       _                        {:name "AA" :collection_id collection-id}
-       Revision   revision1                {:model    "Card"
-                                            :model_id card1-id
-                                            :user_id  user2-id
-                                            :object   (revision/serialize-instance card1 card1-id card1)}
-       Revision   _revision2               {:model    "Card"
-                                            :model_id card2-id
-                                            :user_id  user1-id
-                                            :object   (revision/serialize-instance card2 card2-id card2)}]
-      ;; need different timestamps and Revision has a pre-update to throw as they aren't editable
-      (is (= 1
-             (t2/query-one {:update :revision
-                            ;; in the past
-                            :set    {:timestamp (.minusHours (ZonedDateTime/now (ZoneId/of "UTC")) 24)}
-                            :where  [:= :id (:id revision1)]})))
-      (testing "Results include last edited information from the `Revision` table"
-        (is (= [{:name "AA"}
-                {:name "Card with history 1",
-                 :last-edit-info
-                 {:id         true,
-                  :email      "zzzz@example.com",
-                  :first_name "Test",
-                  :last_name  "ZZZZ",
-                  :timestamp  true}}
-                {:name "Card with history 2",
-                 :last-edit-info
-                 {:id         true,
-                  :email      "aaaa@example.com",
-                  :first_name "Test",
-                  :last_name  "AAAA",
-                  ;; timestamp collapsed to true, ordinarily a OffsetDateTime
-                  :timestamp  true}}
-                {:name "ZZ"}]
-               (->> (:data (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items")))
-                    mt/boolean-ids-and-timestamps
-                    (map #(select-keys % [:name :last-edit-info]))))))
-      (testing "Results can be ordered by last-edited-at"
-        (testing "ascending"
-          (is (= ["Card with history 1" "Card with history 2" "AA" "ZZ"]
-                 (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited_at&sort_direction=asc"))
-                      :data
-                      (map :name)))))
-        (testing "descending"
-          (is (= ["Card with history 2" "Card with history 1" "AA" "ZZ"]
-                 (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited_at&sort_direction=desc"))
-                      :data
-                      (map :name))))))
-      (testing "Results can be ordered by last-edited-by"
-        (testing "ascending"
-          ;; card with history 2 has user Test AAAA, history 1 user Test ZZZZ
-          (is (= ["Card with history 2" "Card with history 1" "AA" "ZZ"]
-                 (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited_by&sort_direction=asc"))
-                      :data
-                      (map :name)))))
-        (testing "descending"
-          (is (= ["Card with history 1" "Card with history 2" "AA" "ZZ"]
-                 (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited_by&sort_direction=desc"))
-                      :data
-                      (map :name)))))))))
+    (mt/test-helpers-set-global-values!
+     (mt/with-temp
+       [Collection {collection-id :id}      {:name "Collection with Items"}
+        User       {user1-id :id}           {:first_name "Test" :last_name "AAAA" :email "aaaa@example.com"}
+        User       {user2-id :id}           {:first_name "Test" :last_name "ZZZZ" :email "zzzz@example.com"}
+        Card       {card1-id :id :as card1} {:name "Card with history 1" :collection_id collection-id}
+        Card       {card2-id :id :as card2} {:name "Card with history 2" :collection_id collection-id}
+        Card       _                        {:name "ZZ" :collection_id collection-id}
+        Card       _                        {:name "AA" :collection_id collection-id}
+        Revision   revision1                {:model    "Card"
+                                             :model_id card1-id
+                                             :user_id  user2-id
+                                             :object   (revision/serialize-instance card1 card1-id card1)}
+        Revision   _revision2               {:model    "Card"
+                                             :model_id card2-id
+                                             :user_id  user1-id
+                                             :object   (revision/serialize-instance card2 card2-id card2)}]
+       ;; need different timestamps and Revision has a pre-update to throw as they aren't editable
+       (is (= 1
+              (t2/query-one {:update :revision
+                             ;; in the past
+                             :set    {:timestamp (.minusHours (ZonedDateTime/now (ZoneId/of "UTC")) 24)}
+                             :where  [:= :id (:id revision1)]})))
+       (testing "Results include last edited information from the `Revision` table"
+         (is (= [{:name "AA"}
+                 {:name "Card with history 1",
+                  :last-edit-info
+                  {:id         true,
+                   :email      "zzzz@example.com",
+                   :first_name "Test",
+                   :last_name  "ZZZZ",
+                   :timestamp  true}}
+                 {:name "Card with history 2",
+                  :last-edit-info
+                  {:id         true,
+                   :email      "aaaa@example.com",
+                   :first_name "Test",
+                   :last_name  "AAAA",
+                   ;; timestamp collapsed to true, ordinarily a OffsetDateTime
+                   :timestamp  true}}
+                 {:name "ZZ"}]
+                (->> (:data (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items")))
+                     mt/boolean-ids-and-timestamps
+                     (map #(select-keys % [:name :last-edit-info]))))))
+       (testing "Results can be ordered by last-edited-at"
+         (testing "ascending"
+           (is (= ["Card with history 1" "Card with history 2" "AA" "ZZ"]
+                  (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited_at&sort_direction=asc"))
+                       :data
+                       (map :name)))))
+         (testing "descending"
+           (is (= ["Card with history 2" "Card with history 1" "AA" "ZZ"]
+                  (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited_at&sort_direction=desc"))
+                       :data
+                       (map :name))))))
+       (testing "Results can be ordered by last-edited-by"
+         (testing "ascending"
+           ;; card with history 2 has user Test AAAA, history 1 user Test ZZZZ
+           (is (= ["Card with history 2" "Card with history 1" "AA" "ZZ"]
+                  (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited_by&sort_direction=asc"))
+                       :data
+                       (map :name)))))
+         (testing "descending"
+           (is (= ["Card with history 1" "Card with history 2" "AA" "ZZ"]
+                  (->> (mt/user-http-request :rasta :get 200 (str "collection/" collection-id "/items?sort_column=last_edited_by&sort_direction=desc"))
+                       :data
+                       (map :name))))))))))
 
 (deftest collection-items-order-by-model-test
   (testing "GET /api/collection/:id/items"

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -304,7 +304,7 @@
 
 (deftest card-query-test
   (testing "GET /api/embed/card/:token/query and GET /api/embed/card/:token/query/:export-format"
-    (mt/with-ensure-with-temp-no-transaction!
+    (mt/test-helpers-set-global-values!
       (do-response-formats [response-format request-options]
         (testing "check that the endpoint doesn't work if embedding isn't enabled"
           (mt/with-temporary-setting-values [enable-embedding false]
@@ -360,7 +360,7 @@
                    (count (csv/read-csv results))))))))))
 
 (deftest card-locked-params-test
-  (mt/with-ensure-with-temp-no-transaction!
+  (mt/test-helpers-set-global-values!
     (with-embedding-enabled-and-new-secret-key
       (with-temp-card [card {:enable_embedding true, :embedding_params {:venue_id "locked"}}]
         (do-response-formats [response-format request-options]
@@ -395,7 +395,7 @@
                  (client/client :get 400 (str (card-query-url card response-format) "?venue_id=200")))))))))
 
 (deftest card-enabled-params-test
-  (mt/with-ensure-with-temp-no-transaction!
+  (mt/test-helpers-set-global-values!
     (with-embedding-enabled-and-new-secret-key
       (with-temp-card [card {:enable_embedding true, :embedding_params {:venue_id "enabled"}}]
         (do-response-formats [response-format request-options]
@@ -493,13 +493,14 @@
                (client/client :get 200 (str (card-query-url card "/csv") "?date=Q1-2014"))))))))
 
 (deftest csv-forward-url-test
-  (with-embedding-enabled-and-new-secret-key
-    (mt/with-temp! [Card card (card-with-date-field-filter)]
-      ;; make sure the URL doesn't include /api/ at the beginning like it normally would
-      (binding [client/*url-prefix* ""]
-        (mt/with-temporary-setting-values [site-url (str "http://localhost:" (config/config-str :mb-jetty-port) client/*url-prefix*)]
-          (is (= "count\n107\n"
-                 (client/real-client :get 200 (str "embed/question/" (card-token card) ".csv?date=Q1-2014")))))))))
+  (mt/test-helpers-set-global-values!
+   (with-embedding-enabled-and-new-secret-key
+     (mt/with-temp [Card card (card-with-date-field-filter)]
+       ;; make sure the URL doesn't include /api/ at the beginning like it normally would
+       (binding [client/*url-prefix* ""]
+         (mt/with-temporary-setting-values [site-url (str "http://localhost:" (config/config-str :mb-jetty-port) client/*url-prefix*)]
+           (is (= "count\n107\n"
+                  (client/real-client :get 200 (str "embed/question/" (card-token card) ".csv?date=Q1-2014"))))))))))
 
 
 ;;; ---------------------------------------- GET /api/embed/dashboard/:token -----------------------------------------
@@ -696,7 +697,7 @@
   (testing "Tests that embedding download context shows up in the query execution table when downloading cards."
     ;; Clear out the query execution log so that test doesn't read stale state
     (t2/delete! :model/QueryExecution)
-    (mt/with-ensure-with-temp-no-transaction!
+    (mt/test-helpers-set-global-values!
       (with-embedding-enabled-and-new-secret-key
         (with-temp-dashcard [dashcard {:dash {:enable_embedding true}
                                        :card {:dataset_query (mt/mbql-query venues)}}]
@@ -1432,7 +1433,7 @@
 
 (deftest pivot-dashcard-locked-params-test
   (mt/dataset test-data
-    (mt/with-ensure-with-temp-no-transaction!
+    (mt/test-helpers-set-global-values!
       (with-embedding-enabled-and-new-secret-key
         (with-temp-dashcard [dashcard {:dash     {:enable_embedding true
                                                   :embedding_params {:abc "locked"}

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -375,17 +375,18 @@
 
 
 (deftest make-sure-it-also-works-with-the-forwarded-url
-  (mt/with-temporary-setting-values [enable-public-sharing true]
-    (mt/with-temp! [Card {uuid :public_uuid} (card-with-date-field-filter)]
-      ;; make sure the URL doesn't include /api/ at the beginning like it normally would
-      (binding [client/*url-prefix* ""]
-        (mt/with-temporary-setting-values [site-url (str "http://localhost:" (config/config-str :mb-jetty-port) client/*url-prefix*)]
-          (is (= "count\n107\n"
-                 (client/real-client :get 200 (str "public/question/" uuid ".csv")
-                                :parameters (json/encode [{:id     "_DATE_"
-                                                           :type   :date/quarter-year
-                                                           :target [:dimension [:template-tag :date]]
-                                                           :value  "Q1-2014"}])))))))))
+  (mt/test-helpers-set-global-values!
+    (mt/with-temporary-setting-values [enable-public-sharing true]
+      (mt/with-temp [Card {uuid :public_uuid} (card-with-date-field-filter)]
+        ;; make sure the URL doesn't include /api/ at the beginning like it normally would
+        (binding [client/*url-prefix* ""]
+          (mt/with-temporary-setting-values [site-url (str "http://localhost:" (config/config-str :mb-jetty-port) client/*url-prefix*)]
+            (is (= "count\n107\n"
+                   (client/real-client :get 200 (str "public/question/" uuid ".csv")
+                                       :parameters (json/encode [{:id     "_DATE_"
+                                                                  :type   :date/quarter-year
+                                                                  :target [:dimension [:template-tag :date]]
+                                                                  :value  "Q1-2014"}]))))))))))
 
 (defn- card-with-trendline []
   (assoc (shared-obj)

--- a/test/metabase/async/streaming_response_test.clj
+++ b/test/metabase/async/streaming_response_test.clj
@@ -123,7 +123,7 @@
 
 (deftest cancelation-test
   (testing "Make sure canceling a HTTP request ultimately causes the query to be canceled"
-    (mt/with-ensure-with-temp-no-transaction!
+    (mt/test-helpers-set-global-values!
       (with-redefs [streaming-response/async-cancellation-poll-interval-ms 50]
         (with-test-driver-db!
           (reset! canceled? false)

--- a/test/metabase/integrations/common_test.clj
+++ b/test/metabase/integrations/common_test.clj
@@ -83,7 +83,7 @@
              (group-memberships user)))))
 
   (testing "if we attempt to add a user to a group that doesn't exist, does the group sync complete for the other groups?"
-    (mt/with-ensure-with-temp-no-transaction!
+    (mt/test-helpers-set-global-values!
       (with-user-in-groups [group {:name (str ::group)}
                             user    []]
         (integrations.common/sync-group-memberships! user #{Integer/MAX_VALUE group} #{Integer/MAX_VALUE group})

--- a/test/metabase/models/login_history_test.clj
+++ b/test/metabase/models/login_history_test.clj
@@ -40,58 +40,59 @@
 
 (deftest send-email-on-first-login-from-new-device-test
   (testing "User should get an email the first time they log in from a new device (#14313, #15603, #17495)"
-    (mt/with-temp! [User {user-id :id, email :email, first-name :first_name}]
-      (let [device              (str (random-uuid))
-            original-maybe-send (var-get #'login-history/maybe-send-login-from-new-device-email)]
-        (testing "send email on first login from *new* device (but not first login ever)"
-          (mt/with-fake-inbox
-            ;; mock out the IP address geocoding function so we can make sure it handles timezones like PST correctly
-            ;; (#15603)
-            (with-redefs [request.u/geocode-ip-addresses (fn [ip-addresses]
-                                                           (into {} (for [ip-address ip-addresses]
-                                                                      [ip-address
-                                                                       {:description "San Francisco, California, United States"
-                                                                        :timezone    (t/zone-id "America/Los_Angeles")}])))
-                          login-history/maybe-send-login-from-new-device-email
-                          (fn [login-history]
-                            (when-let [futur (original-maybe-send login-history)]
-                              ;; block in tests
-                              (u/deref-with-timeout futur 10000)))]
-              (mt/with-temp [LoginHistory _ {:user_id   user-id
-                                             :device_id (str (random-uuid))}
-                             LoginHistory _ {:user_id   user-id
-                                             :device_id device
-                                             :timestamp #t "2021-04-02T15:52:00-07:00[US/Pacific]"}]
+    (mt/test-helpers-set-global-values!
+      (mt/with-temp [User {user-id :id, email :email, first-name :first_name}]
+        (let [device              (str (random-uuid))
+              original-maybe-send (var-get #'login-history/maybe-send-login-from-new-device-email)]
+          (testing "send email on first login from *new* device (but not first login ever)"
+            (mt/with-fake-inbox
+              ;; mock out the IP address geocoding function so we can make sure it handles timezones like PST correctly
+              ;; (#15603)
+              (with-redefs [request.u/geocode-ip-addresses (fn [ip-addresses]
+                                                             (into {} (for [ip-address ip-addresses]
+                                                                        [ip-address
+                                                                         {:description "San Francisco, California, United States"
+                                                                          :timezone    (t/zone-id "America/Los_Angeles")}])))
+                            login-history/maybe-send-login-from-new-device-email
+                            (fn [login-history]
+                              (when-let [futur (original-maybe-send login-history)]
+                                ;; block in tests
+                                (u/deref-with-timeout futur 10000)))]
+                (mt/with-temp [LoginHistory _ {:user_id   user-id
+                                               :device_id (str (random-uuid))}
+                               LoginHistory _ {:user_id   user-id
+                                               :device_id device
+                                               :timestamp #t "2021-04-02T15:52:00-07:00[US/Pacific]"}]
 
-                (is (malli= [:map-of [:= email]
-                             [:sequential
-                              [:map {:closed true}
-                               [:from ms/Email]
-                               [:to [:= [email]]]
-                               [:subject [:= (format "We've Noticed a New Metabase Login, %s" first-name)]]
-                               [:body [:sequential [:map
-                                                    [:type [:= "text/html; charset=utf-8"]]
-                                                    [:content :string]]]]]]]
-                            @mt/inbox))
-                (let [message (-> @mt/inbox (get email) first :body first :content)
-                      site-url (public-settings/site-url)]
-                  (testing (format "\nMessage = %s\nsite-url = %s" (pr-str message) (pr-str site-url))
-                    (is (string? message))
-                    (when (string? message)
-                      (doseq [expected-str [(format "We've noticed a new login on your <a href=\"%s\">Metabase</a> account."
-                                                    (or site-url ""))
-                                            (format "We noticed a login on your <a href=\"%s\">Metabase</a> account from a new device."
-                                                    (or site-url ""))
-                                            "Browser (Chrome/Windows) - San Francisco, California, United States"
-                                            ;; `format-human-readable` has slightly different output on different JVMs
-                                            (u.date/format-human-readable #t "2021-04-02T15:52:00-07:00[US/Pacific]")]]
-                        (is (str/includes? message expected-str))))))
+                  (is (malli= [:map-of [:= email]
+                               [:sequential
+                                [:map {:closed true}
+                                 [:from ms/Email]
+                                 [:to [:= [email]]]
+                                 [:subject [:= (format "We've Noticed a New Metabase Login, %s" first-name)]]
+                                 [:body [:sequential [:map
+                                                      [:type [:= "text/html; charset=utf-8"]]
+                                                      [:content :string]]]]]]]
+                              @mt/inbox))
+                  (let [message  (-> @mt/inbox (get email) first :body first :content)
+                        site-url (public-settings/site-url)]
+                    (testing (format "\nMessage = %s\nsite-url = %s" (pr-str message) (pr-str site-url))
+                      (is (string? message))
+                      (when (string? message)
+                        (doseq [expected-str [(format "We've noticed a new login on your <a href=\"%s\">Metabase</a> account."
+                                                      (or site-url ""))
+                                              (format "We noticed a login on your <a href=\"%s\">Metabase</a> account from a new device."
+                                                      (or site-url ""))
+                                              "Browser (Chrome/Windows) - San Francisco, California, United States"
+                                              ;; `format-human-readable` has slightly different output on different JVMs
+                                              (u.date/format-human-readable #t "2021-04-02T15:52:00-07:00[US/Pacific]")]]
+                          (is (str/includes? message expected-str))))))
 
-                (testing "don't send email on subsequent login from same device"
-                  (mt/reset-inbox!)
-                  (t2.with-temp/with-temp [LoginHistory _ {:user_id user-id, :device_id device}]
-                    (is (= {}
-                           @mt/inbox)))))))))))
+                  (testing "don't send email on subsequent login from same device"
+                    (mt/reset-inbox!)
+                    (t2.with-temp/with-temp [LoginHistory _ {:user_id user-id, :device_id device}]
+                      (is (= {}
+                             @mt/inbox))))))))))))
 
   (testing "don't send email if the setting is disabled by setting MB_SEND_EMAIL_ON_FIRST_LOGIN_FROM_NEW_DEVICE=FALSE"
     (t2.with-temp/with-temp [User {user-id :id}]

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -384,11 +384,12 @@
       (testing "Invalid ADD operation"
         ;; User should not be removed from the admin group because the attempt to add them to the Integer/MAX_VALUE group
         ;; should fail, causing the entire transaction to fail
-        (mt/with-temp! [User user {:is_superuser true}]
-          (u/ignore-exceptions
-            (user/set-permissions-groups! user #{(perms-group/all-users) Integer/MAX_VALUE}))
-          (is (= true
-                 (t2/select-one-fn :is_superuser User :id (u/the-id user))))))
+        (mt/test-helpers-set-global-values!
+          (mt/with-temp [User user {:is_superuser true}]
+            (u/ignore-exceptions
+              (user/set-permissions-groups! user #{(perms-group/all-users) Integer/MAX_VALUE}))
+            (is (= true
+                   (t2/select-one-fn :is_superuser User :id (u/the-id user)))))))
 
       (testing "Invalid REMOVE operation"
         ;; Attempt to remove someone from All Users + add to a valid group at the same time -- neither should persist

--- a/test/metabase/sync/sync_metadata/fields/sync_instances_test.clj
+++ b/test/metabase/sync/sync_metadata/fields/sync_instances_test.clj
@@ -94,19 +94,20 @@
 
 (deftest reactivate-nested-field-when-parent-is-reactivated-test
   (testing "Nested fields get reactivated if the parent field gets reactivated"
-    (mt/with-temp! [Database db {:engine ::toucanery/toucanery}]
-      ;; do the initial sync
-      (sync-metadata/sync-db-metadata! db)
-      ;; delete our entry for the `transactions.toucan.details.age` field
-      (let [transactions-table-id (u/the-id (t2/select-one-pk Table :db_id (u/the-id db), :name "transactions"))
-            toucan-field-id       (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "toucan"))
-            details-field-id      (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
-            age-field-id          (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "age", :parent_id details-field-id))]
-        (t2/update! Field details-field-id {:active false})
-        ;; now sync again.
+    (mt/test-helpers-set-global-values!
+      (mt/with-temp [Database db {:engine ::toucanery/toucanery}]
+        ;; do the initial sync
         (sync-metadata/sync-db-metadata! db)
-        ;; field should be reactivated
-        (is (t2/select-one-fn :active Field :id age-field-id))))))
+        ;; delete our entry for the `transactions.toucan.details.age` field
+        (let [transactions-table-id (u/the-id (t2/select-one-pk Table :db_id (u/the-id db), :name "transactions"))
+              toucan-field-id       (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "toucan"))
+              details-field-id      (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "details", :parent_id toucan-field-id))
+              age-field-id          (u/the-id (t2/select-one-pk Field :table_id transactions-table-id, :name "age", :parent_id details-field-id))]
+          (t2/update! Field details-field-id {:active false})
+          ;; now sync again.
+          (sync-metadata/sync-db-metadata! db)
+          ;; field should be reactivated
+          (is (t2/select-one-fn :active Field :id age-field-id)))))))
 
 (deftest mark-nested-field-inactive-test
   (testing "Nested fields can be marked inactive"

--- a/test/metabase/task/sync_databases_test.clj
+++ b/test/metabase/task/sync_databases_test.clj
@@ -131,13 +131,14 @@
              (t2/insert! Database {:engine :postgres, k "0 * ABCD"}))))))
 
   (testing "Check that you can't UPDATE a DB's schedule to something invalid"
-    (mt/with-temp! [Database database {:engine :postgres}]
-      (doseq [k [:metadata_sync_schedule :cache_field_values_schedule]]
-        (testing (format "Update %s" k)
-          (is (thrown?
-               Exception
-               (t2/update! Database (u/the-id database)
-                           {k "2 CANS PER DAY"}))))))))
+    (mt/test-helpers-set-global-values!
+      (mt/with-temp [Database database {:engine :postgres}]
+        (doseq [k [:metadata_sync_schedule :cache_field_values_schedule]]
+          (testing (format "Update %s" k)
+            (is (thrown?
+                 Exception
+                 (t2/update! Database (u/the-id database)
+                             {k "2 CANS PER DAY"})))))))))
 
 ;; this is a deftype due to an issue with Clojure. The `org.quartz.JobExecutionContext` interface has a put method and
 ;; defrecord emits a put method and things get

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -38,6 +38,7 @@
    [metabase.test.util.log :as tu.log]
    [metabase.test.util.misc :as tu.misc]
    [metabase.test.util.random :as tu.random]
+   [metabase.test.util.thread-local :as tu.thread-local]
    [metabase.test.util.timezone :as test.tz]
    [pjstadig.humane-test-output :as humane-test-output]
    [potemkin :as p]
@@ -82,6 +83,7 @@
   tu.log/keep-me
   tu.misc/keep-me
   tu.random/keep-me
+  tu.thread-local/keep-me
   tu/keep-me
   tx.env/keep-me
   tx/keep-me)
@@ -211,10 +213,6 @@
   with-temp
   with-temp-defaults]
 
- [test.redefs
-  with-temp!
-  with-ensure-with-temp-no-transaction!]
-
  [tu
   boolean-ids-and-timestamps
   call-with-paused-query
@@ -271,6 +269,9 @@
   random-hash
   random-email]
 
+ [tu.thread-local
+  test-helpers-set-global-values!]
+
  [test.tz
   with-system-timezone-id]
 
@@ -301,4 +302,6 @@
 ;; Rename this instead of using `import-vars` to make it clear that it's related to `=?`
 (p/import-fn hawk.approx/malli malli=?)
 
-(alter-meta! #'with-temp update :doc #(str % "\n\nNote: this version of [[with-temp]] will execute body in a transaction, for cases where that's not desired, use [[mt/with-temp!]]\n"))
+(alter-meta! #'with-temp update :doc str "\n\n  Note: by default, this will execute its body inside a transaction, making
+  it thread safe. If it is wrapped in a call to [[metabase.test/test-helpers-set-global-values!]], it will affect the
+  global state of the application database.")

--- a/test/metabase/test/redefs.clj
+++ b/test/metabase/test/redefs.clj
@@ -4,18 +4,14 @@
   (:require
    [mb.hawk.parallel]
    [metabase.plugins.classloader :as classloader]
+   [metabase.test.util.thread-local :as tu.thread-local]
    [methodical.core :as methodical]
    [toucan2.connection :as t2.connection]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
-(def ^{:dynamic true
-       :private true
-       :doc     "Used to detect whether we're in a nested [[with-temp]]. Default is false."}
-  *in-tx* false)
-
-(def ^{:dynamic true
-       :doc     "Used to control whether [[with-temp]] will run in a transaction. Default is true."}
-  *with-temp-use-transaction* true)
+(def ^:dynamic ^:private *in-tx*
+  "Used to detect whether we're in a nested [[with-temp]]. Default is false."
+  false)
 
 (methodical/defmethod t2.with-temp/do-with-temp* :around :default
   "Initialize the DB before doing the other with-temp stuff.
@@ -26,28 +22,13 @@
   ((resolve 'metabase.test.initialize/initialize-if-needed!) :db)
   ;; so with-temp-defaults are loaded
   (classloader/require 'metabase.test.util)
-
   ;; run `f` in a transaction if it's the top-level with-temp
-  (if (and *with-temp-use-transaction* (not *in-tx*))
+  (if (and tu.thread-local/*thread-local*
+           (not *in-tx*))
     (binding [*in-tx* true]
       (t2.connection/with-transaction [_ t2.connection/*current-connectable* {:rollback-only true}]
         (next-method model attributes f)))
     (next-method model attributes f)))
-
-(defmacro with-temp!
-  "Like [[mt/with-temp]] but does not run body in a transaction that will rollback at the end.
-  Can be used for cases where we test stuffs that can't be on the same thread.
-
-  An example is tests that make real http call with [[mt/user-real-request]]."
-  [& args]
-  `(binding [*with-temp-use-transaction* false]
-     (t2.with-temp/with-temp ~@args)))
-
-(defmacro with-ensure-with-temp-no-transaction!
-  "Run body with [[*with-temp-use-transaction*]] bound to false, ensuring all nested [[mt/with-temp]] will not run in a transaction."
-  [& body]
-  `(binding [*with-temp-use-transaction* false]
-     ~@body))
 
 ;;; wrap `with-redefs-fn` (used by `with-redefs`) so it calls `assert-test-is-not-parallel`
 

--- a/test/metabase/test/util/thread_local.clj
+++ b/test/metabase/test/util/thread_local.clj
@@ -1,0 +1,25 @@
+(ns metabase.test.util.thread-local
+  (:require
+   [clojure.test :as t]
+   [mb.hawk.parallel]
+   [metabase.util :as u]))
+
+(def ^:dynamic *thread-local*
+  "Whether test helpers should set thread-local values for things, as opposed to setting global values."
+  true)
+
+(defn do-test-helpers-set-global-values! [thunk]
+  (if-not *thread-local*
+    (thunk)
+    (binding [*thread-local* false]
+      (mb.hawk.parallel/assert-test-is-not-parallel `test-helpers-set-global-values!)
+      (t/testing (u/colorize :red "\n\n***** metabase.test/test-helpers-set-global-values! ENABLED, TEST HELPERS THAT SUPPORT IT WILL SET VALUES GLOBALLY ***\n\n")
+        (thunk)))))
+
+(defmacro test-helpers-set-global-values!
+  "Tells various test helpers like [[metabase.test/with-temp]] to set values globally in a thread-unsafe manner (e.g.
+  via with [[with-redefs]], or by affecting the global state of the application database) rather than
+  thread-locally (e.g. with [[binding]]). Check docstrings for which helpers support this."
+  {:style/indent 0}
+  [& body]
+  `(do-test-helpers-set-global-values! (^:once fn* [] ~@body)))


### PR DESCRIPTION
#33771 sort of went off the rails when I ran into problems with changes to `report-timezone` triggering Snowflake connection pool resets, I went down a big rabbit hole there trying to get that to work in a thread-safe manner, but utilimately it was too much for one PR.

This PR adds just the new `mt/test-helpers-set-global-values!` pattern from that PR, which we concluded was a good idea in Slack discussions and elsewhere; I'll save actually making `with-temporary-setting-values` and other stuff parallel in follow-on PRs.

As a proof-of-concept application of this new pattern I updated `with-temp` to respect `test-helpers-set-global-values!`, and removed the thread-unsafe `with-temp!` and `with-ensure-with-temp-no-transaction!` and replaced them with usages of `test-helpers-set-global-values!`