### PR TITLE
[MLv2] Support exclude date filter for filter args display name

### DIFF
--- a/frontend/src/metabase/querying/components/FilterModal/DateFilterEditor/DateFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/DateFilterEditor/DateFilterEditor.unit.spec.tsx
@@ -194,9 +194,7 @@ describe("DateFilterEditor", () => {
         column,
         filter,
       });
-      expect(
-        screen.getByText("Created At excludes the hour of 5 PM"),
-      ).toBeInTheDocument();
+      expect(screen.getByText("5 PM")).toBeInTheDocument();
 
       userEvent.click(screen.getByLabelText("Clear"));
       expect(getNextFilterName()).toBe(null);

--- a/frontend/src/metabase/querying/components/FilterModal/DateFilterEditor/DateFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/DateFilterEditor/DateFilterEditor.unit.spec.tsx
@@ -194,7 +194,7 @@ describe("DateFilterEditor", () => {
         column,
         filter,
       });
-      expect(screen.getByText("5 PM")).toBeInTheDocument();
+      expect(screen.getByText("Excludes 5 PM")).toBeInTheDocument();
 
       userEvent.click(screen.getByLabelText("Clear"));
       expect(getNextFilterName()).toBe(null);

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -86,7 +86,7 @@
       (lib.temporal-bucket/describe-temporal-pair x y)
 
       [:!= _ (x :guard temporal?) (y :guard (some-fn int? string?))]
-      (lib.temporal-bucket/describe-temporal-pair x y)
+      (i18n/tru "Excludes {0}" (lib.temporal-bucket/describe-temporal-pair x y))
 
       [:< _ (x :guard temporal?) (y :guard string?)]
       (i18n/tru "Before {0}" (->temporal-name y))

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -85,6 +85,9 @@
       [:= _ (x :guard temporal?) (y :guard (some-fn int? string?))]
       (lib.temporal-bucket/describe-temporal-pair x y)
 
+      [:!= _ (x :guard temporal?) (y :guard (some-fn int? string?))]
+      (lib.temporal-bucket/describe-temporal-pair x y)
+
       [:< _ (x :guard temporal?) (y :guard string?)]
       (i18n/tru "Before {0}" (->temporal-name y))
 

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -123,6 +123,7 @@
         date-arg-2 "2024-01-03"]
     (are [expected clause] (=? expected (lib/filter-args-display-name lib.tu/venues-query -1 clause))
       "Nov 2, 2023" (lib/= created-at date-arg-1)
+      "Nov 2, 2023" (lib/!= created-at date-arg-1)
       "Nov 2, 2023 – Jan 3, 2024" (lib/between created-at date-arg-1 date-arg-2)
       "After Nov 2, 2023" (lib/> created-at date-arg-1)
       "Before Nov 2, 2023" (lib/< created-at date-arg-1)

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -123,7 +123,8 @@
         date-arg-2 "2024-01-03"]
     (are [expected clause] (=? expected (lib/filter-args-display-name lib.tu/venues-query -1 clause))
       "Nov 2, 2023" (lib/= created-at date-arg-1)
-      "Nov 2, 2023" (lib/!= created-at date-arg-1)
+      "Excludes Nov 2, 2023" (lib/!= created-at date-arg-1)
+      "Excludes Q4" (lib/!= (lib/with-temporal-bucket created-at :quarter-of-year) date-arg-1)
       "Nov 2, 2023 – Jan 3, 2024" (lib/between created-at date-arg-1 date-arg-2)
       "After Nov 2, 2023" (lib/> created-at date-arg-1)
       "Before Nov 2, 2023" (lib/< created-at date-arg-1)


### PR DESCRIPTION
Fixes #37219 

It seems that this filter is largely unsupported by the FE time picker.