### PR TITLE
Drop the test which was mistakenly backported

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -224,40 +224,4 @@ describe("scenarios > visualizations > maps", () => {
       "true",
     );
   });
-
-  it("should apply brush filters by dragging map", { tags: "@flaky" }, () => {
-    cy.viewport(1280, 800);
-
-    visitQuestionAdhoc({
-      dataset_query: {
-        type: "query",
-        database: SAMPLE_DB_ID,
-        query: {
-          "source-table": PEOPLE_ID,
-        },
-      },
-      display: "map",
-      visualization_settings: {
-        "map.region": "us_states",
-        "map.type": "pin",
-        "map.latitude_column": "LATITUDE",
-        "map.longitude_column": "LONGITUDE",
-      },
-    });
-
-    cy.get(".CardVisualization").realHover();
-    cy.findByTestId("visualization-root")
-      .findByText("Draw box to filter")
-      .click();
-
-    cy.findByTestId("visualization-root")
-      .trigger("mousedown", 500, 500)
-      .trigger("mousemove", 600, 600)
-      .trigger("mouseup", 600, 600);
-
-    cy.wait("@dataset");
-
-    // selecting area at the map provides different filter values, so the simplified assertion is used
-    cy.findByTestId("filter-pill").should("have.length", 1);
-  });
 });


### PR DESCRIPTION
revert of https://github.com/metabase/metabase/pull/37174, it shouldn't have been backported as other filter related PRs weren't backported