### PR TITLE
Fix stress-test workflow

### DIFF
--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -45,6 +45,7 @@ jobs:
     env:
       DISPLAY: ""
       QA_DB_ENABLED: true
+      CYPRESS_REPLAYIO_ENABLED: 1
       CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
       CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
       MB_SNOWPLOW_AVAILABLE: true

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -82,7 +82,6 @@ jobs:
           java-version: 11
           distribution: "temurin"
       - name: Prepare Cypress environment
-        id: cypress-prep
         uses: ./.github/actions/prepare-cypress
       - name: Run Snowplow micro
         uses: ./.github/actions/run-snowplow-micro
@@ -95,7 +94,7 @@ jobs:
           --spec '${{ github.event.inputs.spec }}' \
           --env burn=${{ github.event.inputs.burn_in }},grep='${{ github.event.inputs.grep }}' \
           --config-file e2e/support/cypress-stress-test.config.js \
-          --browser ${{ steps.cypress-prep.outputs.chrome-path }}
+          --browser 'replay-chromium'
 
       - name: Upload Cypress Artifacts upon failure
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
I forgot to update stress-test workflow in #37228, which broke this workflow as it still expects some custom chromium browser to run tests on. That browser doesn't exist anymore.

The solution is to use `replay-chromium' browser for these tests as well. This gives us a bit more confidence because we're using the same browser in both "regular" and "stress-test" runs.

### Hot to test?
This run is based off of this branch, and it should pass
https://github.com/metabase/metabase/actions/runs/7409050949