### PR TITLE
Cleanup flaky tests

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -582,8 +582,6 @@ describe("scenarios > visualizations > line chart", () => {
     "should apply filters to the series selecting area range",
     { tags: "@flaky" },
     () => {
-      cy.viewport(1280, 800);
-
       visitQuestionAdhoc({
         dataset_query: testQuery,
         display: "line",
@@ -616,8 +614,6 @@ describe("scenarios > visualizations > line chart", () => {
       },
       database: SAMPLE_DB_ID,
     };
-
-    cy.viewport(1280, 800);
 
     visitQuestionAdhoc({
       dataset_query: testQuery,

--- a/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/maps.cy.spec.js
@@ -226,8 +226,6 @@ describe("scenarios > visualizations > maps", () => {
   });
 
   it("should apply brush filters by dragging map", () => {
-    cy.viewport(1280, 800);
-
     visitQuestionAdhoc({
       dataset_query: {
         type: "query",
@@ -258,6 +256,9 @@ describe("scenarios > visualizations > maps", () => {
     cy.wait("@dataset");
 
     // selecting area at the map provides different filter values, so the simplified assertion is used
-    cy.findByTestId("filter-pill").should("have.length", 1);
+    cy.findByTestId("filter-pill")
+      .should("contain", "Latitude is between")
+      .should("contain", "Longitude is between");
+    cy.get(".leaflet-marker-icon").should("have.length.greaterThan", 0);
   });
 });


### PR DESCRIPTION
### Description

As were mentioned in the thread, we don't need to specify viewport as the same default value is used

[thread](https://metaboat.slack.com/archives/C5XHN8GLW/p1704358805584909?thread_ts=1704358605.236789&cid=C5XHN8GLW)

config https://github.com/metabase/metabase/blob/master/e2e/support/config.js#L130:L131

### How to verify

- e2e tests should pass
- stress tests should pass

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
