### PR TITLE
Add MB_ATTACHMENT_TABLE_ROW_LIMIT to docs

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -185,6 +185,14 @@ Since: v35.0
 
 Maximum number of async Jetty threads. If not set, then [MB_JETTY_MAXTHREADS](#mb_jetty_maxthreads) will be used, otherwise it will use the default.
 
+### `MB_ATTACHMENT_TABLE_ROW_LIMIT`
+
+Type: integer<br>
+Default: `20`<br>
+Since: v48.0
+
+Adds the ability to control the row limit for rendered tables in alerts and subscriptions.
+
 ### `MB_AUDIT_MAX_RETENTION_DAYS`
 
 Only available on Metabase [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.<br>

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -189,7 +189,6 @@ Maximum number of async Jetty threads. If not set, then [MB_JETTY_MAXTHREADS](#m
 
 Type: integer<br>
 Default: `20`<br>
-Since: v48.0
 
 Limits the number of rows Metabase will include in tables sent as attachments with dashboard subscriptions and alerts.
 

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -190,7 +190,7 @@ Maximum number of async Jetty threads. If not set, then [MB_JETTY_MAXTHREADS](#m
 Type: integer<br>
 Default: `20`<br>
 
-Limits the number of rows Metabase will include in tables sent as attachments with dashboard subscriptions and alerts.
+Limits the number of rows Metabase will include in tables sent as attachments with dashboard subscriptions and alerts. Range: 1-100.
 
 ### `MB_AUDIT_MAX_RETENTION_DAYS`
 

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -191,7 +191,7 @@ Type: integer<br>
 Default: `20`<br>
 Since: v48.0
 
-Adds the ability to control the row limit for rendered tables in alerts and subscriptions.
+Limits the number of rows Metabase will include in tables sent as attachments with dashboard subscriptions and alerts.
 
 ### `MB_AUDIT_MAX_RETENTION_DAYS`
 


### PR DESCRIPTION
With the default set to 20