### PR TITLE
Trend charts — Misc fixes and polish

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/smartscalar-trend.cy.spec.js
@@ -127,7 +127,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
       cy.findByText("42,000").should("exist"); // goal
       cy.findByText("26.76%").should("exist"); // down percentage
     });
-    cy.findByTestId("chartsettings-sidebar").findByText("My Goal").click();
+    cy.findByTestId("chartsettings-sidebar").findByText("(My Goal)").click();
     menu().within(() => {
       cy.findByLabelText("Back").should("exist");
       cy.findByLabelText("Label").should("have.value", "My Goal");
@@ -146,7 +146,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
       cy.findByText("99.11%").should("exist"); // down percentage
     });
 
-    cy.findByTestId("chartsettings-sidebar").findByText("Mega Count").click();
+    cy.findByTestId("chartsettings-sidebar").findByText("(Mega Count)").click();
     menu().findByLabelText("Column").click();
     popover().findByText("Count").click();
     menu().button("Done").click();
@@ -268,7 +268,7 @@ describe("scenarios > visualizations > trend chart (SmartScalar)", () => {
     // Selecting the main column ("Mega Count") to be the comparison column
     // The comparison should be reset to "previous period"
     cy.findByTestId("chartsettings-sidebar").within(() => {
-      cy.findByText("Mega Count").should("exist");
+      cy.findByText("(Mega Count)").should("exist");
       cy.findByText("Count").click();
     });
     popover().findByText("Mega Count").click();

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/ComparisonPicker.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/ComparisonPicker.tsx
@@ -1,9 +1,9 @@
 import type { MouseEvent } from "react";
 import { useCallback, useState } from "react";
-import { t } from "ttag";
+import { jt, t } from "ttag";
 import _ from "underscore";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
-import { Button, Menu, Stack, Text } from "metabase/ui";
+import { Menu, Stack, Text } from "metabase/ui";
 import type {
   DatasetColumn,
   SmartScalarComparison,
@@ -16,6 +16,8 @@ import { StaticNumberForm } from "./StaticNumberForm";
 import { AnotherColumnForm } from "./AnotherColumnForm";
 import { MenuItemStyled } from "./MenuItem.styled";
 import {
+  ComparisonPickerButton,
+  ComparisonPickerSecondaryText,
   DragHandleIcon,
   ExpandIcon,
   RemoveIcon,
@@ -46,11 +48,8 @@ export function ComparisonPicker({
   );
   const [editedValue, setEditedValue] = useState(selectedValue);
 
-  const selectedOption = options.find(
-    ({ type }) => type === selectedValue.type,
-  );
+  const selectedOption = options.find(({ type }) => type === editedValue.type);
 
-  const displayName = getDisplayName(selectedValue, selectedOption);
   const isDisabled = options.length === 1;
 
   const handleRemoveClick = useCallback(
@@ -145,7 +144,7 @@ export function ComparisonPicker({
       closeOnItemClick={false}
     >
       <Menu.Target>
-        <Button
+        <ComparisonPickerButton
           disabled={isDisabled}
           leftIcon={<DragHandleIcon name="grabber" />}
           rightIcon={
@@ -166,9 +165,9 @@ export function ComparisonPicker({
             inner: { justifyContent: "space-between" },
           }}
         >
-          <span>{displayName}</span>
+          <DisplayName value={editedValue} option={selectedOption} />
           <ExpandIcon name="chevrondown" size={14} />
-        </Button>
+        </ComparisonPickerButton>
       </Menu.Target>
 
       <Menu.Dropdown miw="18.25rem">
@@ -186,22 +185,6 @@ function getTabForComparisonType(type: SmartScalarComparisonType): Tab {
     return "staticNumber";
   }
   return null;
-}
-
-function getDisplayName(
-  value: SmartScalarComparison,
-  option?: ComparisonMenuOption,
-) {
-  if (value.type === COMPARISON_TYPES.PERIODS_AGO) {
-    return `${value.value} ${option?.name}`;
-  }
-  if (
-    value.type === COMPARISON_TYPES.ANOTHER_COLUMN ||
-    value.type === COMPARISON_TYPES.STATIC_NUMBER
-  ) {
-    return value.label;
-  }
-  return option?.name;
 }
 
 type HandleEditedValueChangeType = (
@@ -265,4 +248,32 @@ function renderMenuOption({
       </Text>
     </MenuItemStyled>
   );
+}
+
+function DisplayName({
+  value,
+  option,
+}: {
+  value: SmartScalarComparison;
+  option?: ComparisonMenuOption;
+}) {
+  if (value.type === COMPARISON_TYPES.PERIODS_AGO) {
+    return <span>{`${value.value} ${option?.name}`}</span>;
+  }
+
+  if (value.type === COMPARISON_TYPES.ANOTHER_COLUMN) {
+    const columnName = (
+      <ComparisonPickerSecondaryText key="column-name">{`(${value.label})`}</ComparisonPickerSecondaryText>
+    );
+    return <span>{jt`Column ${columnName}`}</span>;
+  }
+
+  if (value.type === COMPARISON_TYPES.STATIC_NUMBER) {
+    const label = (
+      <ComparisonPickerSecondaryText key="label">{`(${value.label})`}</ComparisonPickerSecondaryText>
+    );
+    return <span>{jt`Custom value ${label}`}</span>;
+  }
+
+  return <span>{option?.name}</span>;
 }

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
@@ -1,7 +1,7 @@
 import type { HTMLAttributes } from "react";
 import styled from "@emotion/styled";
-import type { ButtonProps as BaseButtonProps } from "metabase/ui";
-import { Button } from "metabase/ui";
+import type { ButtonProps as BaseButtonProps, TextProps } from "metabase/ui";
+import { Button, Text } from "metabase/ui";
 import { Icon } from "metabase/core/components/Icon";
 import { color } from "metabase/lib/colors";
 
@@ -21,6 +21,28 @@ export const AddComparisonButton = styled(Button)<ButtonProps>`
 AddComparisonButton.defaultProps = {
   variant: "subtle",
 };
+
+type ComparisonPickerSecondaryTextProps = TextProps &
+  HTMLAttributes<HTMLSpanElement> & {
+    component?: "span";
+  };
+
+export const ComparisonPickerSecondaryText = styled(
+  Text,
+)<ComparisonPickerSecondaryTextProps>``;
+
+ComparisonPickerSecondaryText.defaultProps = {
+  component: "span",
+  color: "text.0",
+};
+
+export const ComparisonPickerButton = styled(Button)<ButtonProps>`
+  &:hover {
+    ${ComparisonPickerSecondaryText} {
+      color: ${color("brand")};
+    }
+  }
+`;
 
 export const DoneButton = styled(Button)<ButtonProps>`
   align-self: flex-end;

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/SmartScalarSettingsWidgets.styled.tsx
@@ -37,6 +37,8 @@ ComparisonPickerSecondaryText.defaultProps = {
 };
 
 export const ComparisonPickerButton = styled(Button)<ButtonProps>`
+  height: 40px;
+
   &:hover {
     ${ComparisonPickerSecondaryText} {
       color: ${color("brand")};

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SettingsComponents/StaticNumberForm.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { t } from "ttag";
 import {
   Box,
-  Group,
   NumberInput,
   PopoverBackButton,
   Stack,
@@ -53,7 +52,7 @@ export function StaticNumberForm({
         <PopoverBackButton
           onClick={onBack}
         >{t`Custom value`}</PopoverBackButton>
-        <Group spacing="sm">
+        <Stack w="100%" spacing="md">
           <TextInput
             autoFocus
             value={label}
@@ -66,7 +65,7 @@ export function StaticNumberForm({
             label={t`Value`}
             onChange={handleChangeValue}
           />
-        </Group>
+        </Stack>
         <DoneButton type="submit" disabled={!canSubmit}>{t`Done`}</DoneButton>
       </Stack>
     </Box>

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.jsx
@@ -54,8 +54,8 @@ import {
   getChangeWidth,
   getValueHeight,
   getValueWidth,
-  isComparisonValid,
   isPeriodVisible,
+  validateComparisons,
 } from "./utils";
 import { computeTrend, CHANGE_TYPE_OPTIONS } from "./compute";
 
@@ -289,16 +289,10 @@ Object.assign(SmartScalar, {
       section: t`Data`,
       title: t`Comparisons`,
       widget: SmartScalarComparisonWidget,
-      isValid: (series, vizSettings) => {
-        const comparisons = vizSettings["scalar.comparisons"];
-        return comparisons.every(comparison =>
-          isComparisonValid(comparison, series, vizSettings),
-        );
-      },
-      getDefault: (series, vizSettings) => {
-        const comparison = getDefaultComparison(series, vizSettings);
-        return [comparison];
-      },
+      isValid: (series, vizSettings) =>
+        validateComparisons(series, vizSettings),
+      getDefault: (series, vizSettings) =>
+        getDefaultComparison(series, vizSettings),
       getProps: (series, vizSettings) => {
         const cols = series[0].data.cols;
         return {

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.ts
@@ -120,21 +120,25 @@ export function getDefaultComparison(
   )?.unit;
 
   if (!dateUnit) {
-    return {
-      id: uuid(),
-      ...createComparisonMenuOption({
-        type: COMPARISON_TYPES.PREVIOUS_VALUE,
-      }),
-    };
+    return [
+      {
+        id: uuid(),
+        ...createComparisonMenuOption({
+          type: COMPARISON_TYPES.PREVIOUS_VALUE,
+        }),
+      },
+    ];
   }
 
-  return {
-    id: uuid(),
-    ...createComparisonMenuOption({
-      type: COMPARISON_TYPES.PREVIOUS_PERIOD,
-      dateUnit,
-    }),
-  };
+  return [
+    {
+      id: uuid(),
+      ...createComparisonMenuOption({
+        type: COMPARISON_TYPES.PREVIOUS_PERIOD,
+        dateUnit,
+      }),
+    },
+  ];
 }
 
 export function getColumnsForComparison(
@@ -249,6 +253,16 @@ export function isComparisonValid(
   }
 
   return true;
+}
+
+export function validateComparisons(
+  series: RawSeries,
+  settings: VisualizationSettings,
+) {
+  const comparisons = settings["scalar.comparisons"] || [];
+  return comparisons.every(comparison =>
+    isComparisonValid(comparison, series, settings),
+  );
 }
 
 type getMaxPeriodsAgoParameters = {

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/utils.unit.spec.ts
@@ -76,10 +76,12 @@ describe("SmartScalar > utils", () => {
           settings,
         );
 
-        expect(defaultComparison).toEqual({
-          id: expect.any(String),
-          ...COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE,
-        });
+        expect(defaultComparison).toEqual([
+          {
+            id: expect.any(String),
+            ...COMPARISON_SELECTOR_OPTIONS.PREVIOUS_VALUE,
+          },
+        ]);
       });
 
       it("should return previous period as default if there is a dateUnit", () => {
@@ -94,11 +96,13 @@ describe("SmartScalar > utils", () => {
           settings,
         );
 
-        expect(defaultComparison).toEqual({
-          id: expect.any(String),
-          type: COMPARISON_TYPES.PREVIOUS_PERIOD,
-          name: "Previous month",
-        });
+        expect(defaultComparison).toEqual([
+          {
+            id: expect.any(String),
+            type: COMPARISON_TYPES.PREVIOUS_PERIOD,
+            name: "Previous month",
+          },
+        ]);
       });
     });
 


### PR DESCRIPTION
Epic #33411

Various trend charts fixes batched together. Would be easier to review commit-by-commit:

### [1. Use a vertical layout for `StaticNumberForm`](https://github.com/metabase/metabase/commit/46f6d47095bdadc81a23229e137e9ed4b238d576)

<details>
<summary>Screenshots</summary>

**Before**

<img src="https://github.com/metabase/metabase/assets/17258145/95885dbd-3072-47f4-b1e5-dcff810babe9" width="500px" />

**After**

<img src="https://github.com/metabase/metabase/assets/17258145/8ed707a0-25b7-494c-9aa2-fe209feac297" width="500px" />

</details>

### [2. Update comparison picker display name](https://github.com/metabase/metabase/commit/1c1e388e7343afa92d9b50dc21b4e381912be398)

<details>
<summary>Screenshots</summary>

**Before**

![display-names-before](https://github.com/metabase/metabase/assets/17258145/08afb145-82e9-4de4-ba52-03424a6161c0)

**After**

![display-names-after](https://github.com/metabase/metabase/assets/17258145/7f1a6b59-49bc-437a-8b5e-93537d0a2830)

</details>

### [3. Make smart scalar utils easier to use in static viz](https://github.com/metabase/metabase/commit/c53aaa8acfb8abcc2cef39ebd0d1b1aec1b8ecd7)

Followup on @alxnddr's [comment](https://github.com/metabase/metabase/pull/37176#pullrequestreview-1801250739)