### PR TITLE
Serdes for DashboardCardSeries

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -32,6 +32,7 @@
    "DashboardTab"
    "Dimension"
    "ParameterCard"
+   "DashboardCardSeries"
    "TimelineEvent"])
 
 (def excluded-models
@@ -46,7 +47,6 @@
    "CollectionPermissionGraphRevision"
    "ConnectionImpersonation"
    "DashboardBookmark"
-   "DashboardCardSeries"
    "GroupTableAccessPolicy"
    "HTTPAction"
    "ImplicitAction"

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -576,6 +576,32 @@
                       (serdes/extract-all "Dashboard")
                       (by-model "Dashboard")))))))))
 
+(deftest dashboard-card-series-test
+  (mt/with-empty-h2-app-db
+    (ts/with-temp-dpc
+      [:model/Collection {coll-id :id, coll-eid :entity_id} {:name "Some Collection"}
+       :model/Card {c1-id :id, c1-eid :entity_id} {:name "Some Question", :collection_id coll-id}
+       :model/Card {c2-id :id, c2-eid :entity_id} {:name "Series Question A", :collection_id coll-id}
+       :model/Card {c3-id :id, c3-eid :entity_id} {:name "Series Question B", :collection_id coll-id}
+       :model/Dashboard {dash-id :id, dash-eid :entity_id} {:name "Shared Dashboard", :collection_id coll-id}
+       :model/DashboardCard {dc1-id :id, dc1-eid :entity_id} {:card_id c1-id, :dashboard_id dash-id}
+       :model/DashboardCard {dc2-eid :entity_id}             {:card_id c1-id, :dashboard_id dash-id}
+       :model/DashboardCardSeries _ {:card_id c3-id, :dashboardcard_id dc1-id, :position 1}
+       :model/DashboardCardSeries _ {:card_id c2-id, :dashboardcard_id dc1-id, :position 0}]
+      (testing "Inlined dashcards include their series' card entity IDs"
+        (let [ser (serdes/extract-one "Dashboard" {} (t2/select-one Dashboard :id dash-id))]
+          (is (=? {:entity_id dash-eid
+                   :dashcards [{:entity_id dc1-eid, :series (mt/exactly=? [{:card_id c2-eid} {:card_id c3-eid}])}
+                               {:entity_id dc2-eid, :series []}]}
+                  ser))
+
+          (testing "and depend on all referenced cards, including cards from dashboard cards' series"
+            (is (= #{[{:model "Card"       :id c1-eid}]
+                     [{:model "Card"       :id c2-eid}]
+                     [{:model "Card"       :id c3-eid}]
+                     [{:model "Collection" :id coll-eid}]}
+                   (set (serdes/dependencies ser))))))))))
+
 (deftest dimensions-test
   (mt/with-empty-h2-app-db
     (ts/with-temp-dpc [;; Simple case: a singular field, no human-readable field.

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1131,7 +1131,7 @@
          (ts/with-dest-db
            (serdes.load/load-metabase! (ingestion-in-memory extract1))
            (ts/with-source-db
-            ;; delete the 1st series and update the 3rd series to have position 0, and the 2nd series to have position 1
+             ;; delete the 1st series and update the 3rd series to have position 0, and the 2nd series to have position 1
              (t2/delete! :model/DashboardCardSeries (:id series1s))
              (t2/update! :model/DashboardCardSeries (:id series3s) {:position 0})
              (t2/update! :model/DashboardCardSeries (:id series2s) {:position 1})

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1126,7 +1126,7 @@
              dashcard1s    (ts/create! :model/DashboardCard :card_id (:id card1s) :dashboard_id (:id dash1s) :dashboard_tab_id (:id tab1s))
              series1s      (ts/create! :model/DashboardCardSeries :dashboardcard_id (:id dashcard1s) :card_id (:id series-card1s) :position 0)
              series2s      (ts/create! :model/DashboardCardSeries :dashboardcard_id (:id dashcard1s) :card_id (:id series-card2s) :position 1)
-             series3s      (ts/create! :model/DashboardCardSeries :dashboardcard_id (:id dashcard1s) :card_id (:id series-card3s) :position 1)
+             series3s      (ts/create! :model/DashboardCardSeries :dashboardcard_id (:id dashcard1s) :card_id (:id series-card3s) :position 2)
              extract1      (into [] (serdes.extract/extract {}))]
          (ts/with-dest-db
            (serdes.load/load-metabase! (ingestion-in-memory extract1))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -1113,6 +1113,55 @@
             (is (not= (:entity_id @tab1s)
                       (:entity_id @tab2d)))))))))
 
+(deftest dashcard-series-test
+  (ts/with-source-and-dest-dbs
+    (testing "Dashcard series are updated and deleted correctly"
+     (ts/with-source-db
+       (let [dash1s        (ts/create! :model/Dashboard :name "My Dashboard")
+             tab1s         (ts/create! :model/DashboardTab :name "Tab 1" :dashboard_id (:id dash1s))
+             card1s        (ts/create! Card :name "The Card")
+             series-card1s (ts/create! Card :name "The Series Card 1")
+             series-card2s (ts/create! Card :name "The Series Card 2")
+             series-card3s (ts/create! Card :name "The Series Card 3")
+             dashcard1s    (ts/create! :model/DashboardCard :card_id (:id card1s) :dashboard_id (:id dash1s) :dashboard_tab_id (:id tab1s))
+             series1s      (ts/create! :model/DashboardCardSeries :dashboardcard_id (:id dashcard1s) :card_id (:id series-card1s) :position 0)
+             series2s      (ts/create! :model/DashboardCardSeries :dashboardcard_id (:id dashcard1s) :card_id (:id series-card2s) :position 1)
+             series3s      (ts/create! :model/DashboardCardSeries :dashboardcard_id (:id dashcard1s) :card_id (:id series-card3s) :position 1)
+             extract1      (into [] (serdes.extract/extract {}))]
+         (ts/with-dest-db
+           (serdes.load/load-metabase! (ingestion-in-memory extract1))
+           (ts/with-source-db
+            ;; delete the 1st series and update the 3rd series to have position 0, and the 2nd series to have position 1
+             (t2/delete! :model/DashboardCardSeries (:id series1s))
+             (t2/update! :model/DashboardCardSeries (:id series3s) {:position 0})
+             (t2/update! :model/DashboardCardSeries (:id series2s) {:position 1})
+             (let [extract2 (into [] (serdes.extract/extract {}))]
+               (ts/with-dest-db
+                 (let [series-card2d        (t2/select-one :model/Card :entity_id (:entity_id series-card2s))
+                       series-card3d        (t2/select-one :model/Card :entity_id (:entity_id series-card3s))
+                       ;; we deleted the card that corresponds to `series1s`, so a shortcut is to get the one with position=0
+                       series-to-be-deleted (t2/select-one :model/DashboardCardSeries :position 0)]
+                   (testing "Sense check: there are 3 series for the dashboard card initially"
+                     (is (= 3
+                            (t2/count :model/DashboardCardSeries :dashboardcard_id (:dashboardcard_id series-to-be-deleted)))))
+                   (serdes.load/load-metabase! (ingestion-in-memory extract2))
+                   (let [dash1d (-> (t2/select-one :model/Dashboard :name "My Dashboard")
+                                    (t2/hydrate [:dashcards :series]))]
+                     (testing "Dashboard cards have the same entity ID"
+                       (is (= (:entity_id dashcard1s)
+                              (get-in dash1d [:dashcards 0 :entity_id]))))
+                     (testing "The dashboard's series is updated"
+                       (is (=? [{:id (:id series-card3d)}
+                                {:id (:id series-card2d)}]
+                               (get-in dash1d [:dashcards 0 :series]))))
+                     (testing "Dashboard card series are correctly updated/deleted in the database"
+                       (is (=? [{:position 0
+                                 :card_id  (:id series-card3d)}
+                                {:position 1
+                                 :card_id  (:id series-card2d)}]
+                               (->> (t2/select :model/DashboardCardSeries :dashboardcard_id (:dashboardcard_id series-to-be-deleted))
+                                    (sort-by :position))))))))))))))))
+
 (deftest extraneous-keys-test
   (let [serialized (atom nil)
         eid (u/generate-nano-id)]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -569,11 +569,10 @@
 (defn export-dashboard-card-series
   "Given the hydrated `:series` of a DashboardCard, as a vector of maps, converts it to a portable form with
   the card IDs replaced with their entity IDs."
-  [serieses]
-  (->> serieses
-       (sort-by :position)
-       (map (fn [series]
-              {:card_id (serdes/*export-fk* (:id series) :model/Card)}))))
+  [cards]
+  (mapv (fn [card]
+          {:card_id (serdes/*export-fk* (:id card) :model/Card)})
+        cards))
 
 (defn- extract-dashcard
   [dashcard]

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -660,7 +660,7 @@
        (concat (serdes/visualization-settings-deps visualization_settings))
        (concat (when card_id   #{[{:model "Card"   :id card_id}]}))
        (concat (when action_id #{[{:model "Action" :id action_id}]}))
-       (concat (when (seq series) (for [s series] [{:model "Card" :id (:card_id s)}])))
+       (concat (for [s series] [{:model "Card" :id (:card_id s)}]))
        set))
 
 (defmethod serdes/dependencies "Dashboard"

--- a/src/metabase/models/dashboard.clj
+++ b/src/metabase/models/dashboard.clj
@@ -609,7 +609,7 @@
   [dash]
   (-> dash
       serdes/load-xform-basics
-      ;; Deliberately not doing anything to :dashcards - they get handled by load-insert! and load-update! below.
+      ;; Deliberately not doing anything to :dashcards - they get handled by load-one! below.
       (update :collection_id     serdes/*import-fk* Collection)
       (update :parameters        serdes/import-parameters)
       (update :creator_id        serdes/*import-user*)

--- a/src/metabase/models/dashboard_card_series.clj
+++ b/src/metabase/models/dashboard_card_series.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.dashboard-card-series
   (:require
-   [metabase.models.serialization :as serdes]
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
@@ -12,14 +11,4 @@
 (methodical/defmethod t2/table-name :model/DashboardCardSeries [_model] :dashboardcard_series)
 
 (doto :model/DashboardCardSeries
-  (derive :metabase/model)
-  (derive :hook/entity-id))
-
-(defn- dashboard-card [{:keys [dashboardcard_id]}]
-  (t2/select-one :model/DashboardCardSeries :id dashboardcard_id))
-
-(defmethod serdes/hash-fields :model/DashboardCardSeries
-  [_dashboard-card-series]
-  [(comp serdes/identity-hash dashboard-card)
-   (serdes/hydrated-hash :card)
-   :position])
+  (derive :metabase/model))

--- a/src/metabase/models/dashboard_card_series.clj
+++ b/src/metabase/models/dashboard_card_series.clj
@@ -12,7 +12,8 @@
 (methodical/defmethod t2/table-name :model/DashboardCardSeries [_model] :dashboardcard_series)
 
 (doto :model/DashboardCardSeries
- (derive :metabase/model))
+  (derive :metabase/model)
+  (derive :hook/entity-id))
 
 (defn- dashboard-card [{:keys [dashboardcard_id]}]
   (t2/select-one :model/DashboardCardSeries :id dashboardcard_id))

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -964,38 +964,57 @@
 
 (deftest descendants-test
   (testing "dashboard which have parameter's source is another card"
-    (t2.with-temp/with-temp [Field     field     {:name "A field"}
-                             Card      card      {:name "A card"}
-                             Dashboard dashboard {:name       "A dashboard"
-                                                  :parameters [{:id "abc"
-                                                                :type "category"
-                                                                :values_source_type "card"
-                                                                :values_source_config {:card_id     (:id card)
-                                                                                       :value_field [:field (:id field) nil]}}]}]
+    (mt/with-temp
+      [Field     field     {:name "A field"}
+       Card      card      {:name "A card"}
+       Dashboard dashboard {:name       "A dashboard"
+                            :parameters [{:id "abc"
+                                          :type "category"
+                                          :values_source_type "card"
+                                          :values_source_config {:card_id     (:id card)
+                                                                 :value_field [:field (:id field) nil]}}]}]
       (is (= #{["Card" (:id card)]}
              (serdes/descendants "Dashboard" (:id dashboard))))))
 
   (testing "dashboard which has a dashcard with an action"
     (mt/with-actions [{:keys [action-id]} {}]
-      (mt/with-temp [Dashboard dashboard {:name "A dashboard"}
-                     DashboardCard _ {:action_id          action-id
-                                      :dashboard_id       (:id dashboard)
-                                      :parameter_mappings []}]
+      (mt/with-temp
+        [Dashboard dashboard {:name "A dashboard"}
+         DashboardCard _ {:action_id          action-id
+                          :dashboard_id       (:id dashboard)
+                          :parameter_mappings []}]
         (is (= #{["Action" action-id]}
                (serdes/descendants "Dashboard" (:id dashboard)))))))
 
   (testing "dashboard in which its dashcards has parameter_mappings to a card"
-    (t2.with-temp/with-temp [Card          card1     {:name "Card attached to dashcard"}
-                             Card          card2     {:name "Card attached to parameters"}
-                             Dashboard     dashboard {:parameters [{:name "Category Name"
-                                                                    :slug "category_name"
-                                                                    :id   "_CATEGORY_NAME_"
-                                                                    :type "category"}]}
-                             DashboardCard _         {:card_id            (:id card1)
-                                                      :dashboard_id       (:id dashboard)
-                                                      :parameter_mappings [{:parameter_id "_CATEGORY_NAME_"
-                                                                            :card_id      (:id card2)
-                                                                            :target       [:dimension (mt/$ids $categories.name)]}]}]
+    (mt/with-temp
+      [Card          card1     {:name "Card attached to dashcard"}
+       Card          card2     {:name "Card attached to parameters"}
+       Dashboard     dashboard {:parameters [{:name "Category Name"
+                                              :slug "category_name"
+                                              :id   "_CATEGORY_NAME_"
+                                              :type "category"}]}
+       DashboardCard _         {:card_id            (:id card1)
+                                :dashboard_id       (:id dashboard)
+                                :parameter_mappings [{:parameter_id "_CATEGORY_NAME_"
+                                                      :card_id      (:id card2)
+                                                      :target       [:dimension (mt/$ids $categories.name)]}]}]
       (is (= #{["Card" (:id card1)]
                ["Card" (:id card2)]}
+             (serdes/descendants "Dashboard" (:id dashboard))))))
+
+  (testing "dashboard in which its dashcards have series"
+    (mt/with-temp
+      [Card                card1     {:name "Card attached to dashcard"}
+       Card                card2     {:name "Card attached to series in 1st position"}
+       Card                card3     {:name "Card attached to series in 2nd position"}
+       Dashboard           dashboard {:parameters [{:name "Category Name"
+                                                    :slug "category_name"
+                                                    :id   "_CATEGORY_NAME_"
+                                                    :type "category"}]}
+       DashboardCard       dashcard {:card_id (:id card1), :dashboard_id (:id dashboard)}
+       DashboardCardSeries _        {:dashboardcard_id (:id dashcard), :card_id (:id card2), :position 0}
+       DashboardCardSeries _        {:dashboardcard_id (:id dashcard), :card_id (:id card3), :position 1}]
+      (is (= (set (for [card [card1 card2 card3]]
+                    ["Card" (:id card)]))
              (serdes/descendants "Dashboard" (:id dashboard)))))))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -301,6 +301,7 @@
 
 ;; Rename this instead of using `import-vars` to make it clear that it's related to `=?`
 (p/import-fn hawk.approx/malli malli=?)
+(p/import-fn hawk.approx/exactly exactly=?)
 
 (alter-meta! #'with-temp update :doc str "\n\n  Note: by default, this will execute its body inside a transaction, making
   it thread safe. If it is wrapped in a call to [[metabase.test/test-helpers-set-global-values!]], it will affect the


### PR DESCRIPTION
Closes this escalated issue https://github.com/metabase/metabase/issues/37232

This PR implements serialization for dashboard card series entities.

Previously they were ignored. This wasn't picked up in tests because `DashboardCardSeries` was mistakenly added to the list of models to exclude from serialization: `metabase-enterprise.serialization.v2.models/excluded-models`

Key design decisions:
- During extraction, DashboardCardSeries are inlined under dashcards under the `:series` key, which are themselves inlined under dashboards. This mirrors regular dashboard hydration. The `:series` value is a vector of maps, where each map has the shape `{:card_id <card-id>}`.
- During loading, every DashboardCardSeries instance is deleted and new ones are inserted if present
- There is no implementation of `:serdes/meta` for DashboardCardSeries entities, because there are no entities that depend on them so there's no need to create a path to identify them. Instead of calling `serdes/load-one!` on a DashboardCardSeries we call `serdes/load-insert!` directly, because `serdes/load-one!` dispatches on the model in the `:serdes/meta` path, which doesn't exist.