### PR TITLE
Number viz render method properly uses :scalar.field name to render value

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -872,9 +872,20 @@
       [:img {:style (style/style {:display :block :width :100%})
              :src   (:image-src image-bundle)}]]}))
 
+(defn- get-col-by-name
+    [cols name]
+    (let [cm (into {} (map-indexed (fn [idx m] [(:name m) [idx m]]) cols))]
+      (get cm name)))
+
 (s/defmethod render :scalar :- formatter/RenderedPulseCard
   [_chart-type _render-type timezone-id _card _dashcard {:keys [cols rows viz-settings]}]
-  (let [value (format-cell timezone-id (ffirst rows) (first cols) viz-settings)]
+  (let [field-name    (:scalar.field viz-settings)
+        [row-idx col] (or (when field-name
+                            (get-col-by-name cols field-name))
+                          [0 (first cols)])
+        row           (first rows)
+        raw-value     (get row row-idx)
+        value         (format-cell timezone-id raw-value col viz-settings)]
     {:attachments
      nil
 

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -873,9 +873,11 @@
              :src   (:image-src image-bundle)}]]}))
 
 (defn- get-col-by-name
-    [cols name]
-    (let [cm (into {} (map-indexed (fn [idx m] [(:name m) [idx m]]) cols))]
-      (get cm name)))
+    [cols col-name]
+    (->> (map-indexed (fn [idx m] [idx m]) cols)
+         (some (fn [[idx col]]
+                 (when (= col-name (:name col))
+                   [idx col])))))
 
 (s/defmethod render :scalar :- formatter/RenderedPulseCard
   [_chart-type _render-type timezone-id _card _dashcard {:keys [cols rows viz-settings]}]

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -583,14 +583,14 @@
 (deftest number-viz-shows-correct-value
   (testing "Static Viz. Render of 'Number' Visualization shows the correct column's first value #32362."
     (mt/dataset test-data
-      (let [ ;; test card 1 'narrows' the query to a single column (the 'tax' field)
+      (let [ ;; test card 1 'narrows' the query to a single column (the "TAX" field)
             test-card1 {:visualization_settings {:scalar.field "TAX"}
                         :display                :scalar
                         :dataset_query          {:database (mt/id)
                                                  :type     :query
                                                  :query    {:source-table (mt/id :orders)
                                                             :fields       [[:field (mt/id :orders :tax) {:base-type :type/Float}]]}}}
-            ;; test card 2's query returns all cols/rows of the table, but still has 'Number' viz settings (scalar.field "TAX")
+            ;; test card 2's query returns all cols/rows of the table, but still has 'Number' viz settings `{:scalar.field "TAX"}`
             test-card2 {:visualization_settings {:scalar.field "TAX"}
                         :display                :scalar
                         :dataset_query          {:database (mt/id)
@@ -616,5 +616,7 @@
                                                             :enabled      true}
                        PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
                                                 :user_id          (mt/user->id :rasta)}]
+          ;; First value is the scalar returned from card1 (specified "TAX" field directly in the query)
+          ;; Second value is the scalar returned from card2 (scalar field specified only in viz-settings, not the query)
           (is (= ["2.07" "2.07"]
                  (run-pulse-and-return-scalars pulse))))))))

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -559,3 +559,62 @@
             (testing "A question based on a model retains the curated metadata column names but overrides these with any existing visualization_settings"
               (is (= ["IDENTIFIER" "Tax" "Grand Total" "Amount of Discount ($)" "Count" "Tax Rate"]
                      (attachment-name->cols (format "%s.csv" question-card-name)))))))))))
+
+(defn- run-pulse-and-return-scalars
+  "Simulate sending the pulse email, get the html body of the response and return the scalar value of the card."
+  [pulse]
+  (mt/with-fake-inbox
+    (with-redefs [email/bcc-enabled? (constantly false)]
+      (mt/with-test-user nil
+        (metabase.pulse/send-pulse! pulse)))
+    (let [html-body   (get-in @mt/inbox ["rasta@metabase.com" 0 :body 0 :content])
+          doc         (-> html-body hik/parse hik/as-hickory)
+          data-tables (hik.s/select
+                       (hik.s/class "pulse-body")
+                       doc)]
+      (mapcat
+       (fn [data-table]
+         (->> (hik.s/select
+               hik.s/first-child
+               data-table)
+              (map (comp first :content))))
+       data-tables))))
+
+(deftest number-viz-shows-correct-value
+  (testing "Static Viz. Render of 'Number' Visualization shows the correct column's first value #32362."
+    (mt/dataset test-data
+      (let [ ;; test card 1 'narrows' the query to a single column (the 'tax' field)
+            test-card1 {:visualization_settings {:scalar.field "TAX"}
+                        :display                :scalar
+                        :dataset_query          {:database (mt/id)
+                                                 :type     :query
+                                                 :query    {:source-table (mt/id :orders)
+                                                            :fields       [[:field (mt/id :orders :tax) {:base-type :type/Float}]]}}}
+            ;; test card 2's query returns all cols/rows of the table, but still has 'Number' viz settings (scalar.field "TAX")
+            test-card2 {:visualization_settings {:scalar.field "TAX"}
+                        :display                :scalar
+                        :dataset_query          {:database (mt/id)
+                                                 :type     :query
+                                                 :query    {:source-table (mt/id :orders)}}}]
+        (mt/with-temp [Card          {card-id1 :id} test-card1
+                       Card          {card-id2 :id} test-card2
+                       Dashboard     {dash-id :id} {:name "just dash"}
+                       DashboardCard {dash-card-id1 :id} {:dashboard_id dash-id
+                                                          :card_id      card-id1}
+                       DashboardCard {dash-card-id2 :id} {:dashboard_id dash-id
+                                                          :card_id      card-id2}
+                       Pulse         {pulse-id :id :as pulse} {:name         "Test Pulse"
+                                                               :dashboard_id dash-id}
+                       PulseCard             _             {:pulse_id          pulse-id
+                                                            :card_id           card-id1
+                                                            :dashboard_card_id dash-card-id1}
+                       PulseCard             _             {:pulse_id          pulse-id
+                                                            :card_id           card-id2
+                                                            :dashboard_card_id dash-card-id2}
+                       PulseChannel {pulse-channel-id :id} {:channel_type :email
+                                                            :pulse_id     pulse-id
+                                                            :enabled      true}
+                       PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
+                                                :user_id          (mt/user->id :rasta)}]
+          (is (= ["2.07" "2.07"]
+                 (run-pulse-and-return-scalars pulse))))))))


### PR DESCRIPTION
Fixes: #32362

Here's a screenshot of an initial repro:
![image](https://github.com/metabase/metabase/assets/21064735/41a79486-c98b-4eb8-ae31-f6e9e59d0c01)

The first card renders _incorrectly_: as pointed out in the issue, it's just grabbing the first value from the first row. Since that question's query is just getting the rows of the orders table, we see the value 1 which is the first value in the ID column.

The second card demonstrates the workaround: in the Question itself, modify column visibility to only see the column you want to display (in this repro it's the 'tax' column).

This PR fixes this by changing the scalar static viz render code to look up the value by the column specified in the viz settings. The relevant setting is `{:scalar.field "FIELD_NAME"}`.

The test added demonstrates that in both cases (the query has a specified field and the query does not) the 'Number' viz render looks correct after this change.

Below is a Clojure namespace that I used to repro the issue and write the test:

```clojure
(ns tickets.32362
  "## Number Visualisation show wrong field in dashboard subscription

  ### URL: https://github.com/metabase/metabase/issues/32362

  See the comment blocks below for details."
  (:require
   [clojure.test :refer :all]
   [hickory.core :as hik]
   [hickory.select :as hik.s]
   [metabase.email :as email]
   [metabase.models :refer [Card Dashboard DashboardCard Pulse PulseCard PulseChannel PulseChannelRecipient]]
   [metabase.pulse]
   [metabase.test :as mt]
   [toucan2.core :as t2]))

;; This one seems pretty clear, which is nice.
;; When we use just a single number visualization, our Question will show the first result from that column
;; But, when we then send a subscription we just end up showing the first result of the first row instead, which doesn't really make sense.

;; First, I'll repro manually according to Tony's instructions.
;; Then, I'll recreate the repro using the send-pulse test fixture approach and verify the broken behaviour.
;; Once that's set up I can make a failing test and begin fixing the bug, which I think will be somewhere in our process-viz-settings middleware, but don't yet know that for sure.

;; the process-viz-settings DOES end up seeing that viz-settings map, but it's not doing anything
;; perhaps it's in the render code.
;; the render body code pulls the incorrect value.
;; This likely happens because the render :scalar implementation assumes that the query for the card
;; takes care of narrowing down to a single col/row to get the value. In that world, it is true that the value
;; is simply the first value of the first row.
;; However, it's easily possible to construct a question that has a basic query returning all cols/rows
;; And then just narrows based purely on the viz settings {:scalar.field "FIELD_NAME"}.

(defn- run-pulse-and-return-scalars
  "Simulate sending the pulse email, get the html body of the response and return the scalar values of the cards."
  [pulse]
  (mt/with-fake-inbox
    (with-redefs [email/bcc-enabled? (constantly false)]
      (mt/with-test-user nil
        (metabase.pulse/send-pulse! pulse)))
    (let [html-body   (get-in @mt/inbox ["rasta@metabase.com" 0 :body 0 :content])
          doc         (-> html-body hik/parse hik/as-hickory)
          data-tables (hik.s/select
                       (hik.s/class "pulse-body")
                       doc)]
      (mapcat
       (fn [data-table]
         (->> (hik.s/select
               hik.s/first-child
               data-table)
              (map (comp first :content))))
       data-tables))))

;; This is the 'workaround' card that has the "TAX" field baked into the query
(def test-card1
  (mt/dataset test-data
    {:name "scalar-by-query"
     :visualization_settings {:scalar.field "TAX"}
     :display                :scalar
     :dataset_query          {:database (mt/id)
                              :type     :query
                              :query    {:source-table (mt/id :orders)
                                         :fields [[:field (mt/id :orders :tax) {:base-type :type/Float}]]}}}))

;; This is the card that we want to work.
(def test-card2
  (mt/dataset test-data
    {:name "scalar-by-viz"
     :visualization_settings {:scalar.field "TAX"}
     :display                :scalar
     :dataset_query          {:database (mt/id)
                              :type     :query
                              :query    {:source-table (mt/id :orders)}}}))

;; running this function gives the wrong output "a" when it should be 0.1
;; I've turned this into a test

(defn wrong-scalar
  []
  (mt/dataset test-data
    (mt/with-temp [Card          {card-id1 :id} test-card1
                   Card          {card-id2 :id} test-card2
                   Dashboard     {dash-id :id} {:name "just dash"}
                   DashboardCard {dash-card-id1 :id} {:dashboard_id dash-id
                                                      :card_id      card-id1}
                   DashboardCard {dash-card-id2 :id} {:dashboard_id dash-id
                                                      :card_id      card-id2}
                   Pulse         {pulse-id :id :as p} {:name         "Test Pulse"
                                                       :dashboard_id dash-id}
                   PulseCard             _             {:pulse_id          pulse-id
                                                        :card_id           card-id1
                                                        :dashboard_card_id dash-card-id1}
                   PulseCard             _             {:pulse_id          pulse-id
                                                        :card_id           card-id2
                                                        :dashboard_card_id dash-card-id2}
                   PulseChannel {pulse-channel-id :id} {:channel_type :email
                                                        :pulse_id     pulse-id
                                                        :enabled      true}
                   PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
                                            :user_id          (mt/user->id :rasta)}]
      (run-pulse-and-return-scalars p))))

;; here's a test.
(deftest number-viz-shows-correct-value
  (let [ ;; test card 1 'narrows' the query to a single column (the 'tax' field)
        test-card1 {:visualization_settings {:scalar.field "TAX"}
                    :display                :scalar
                    :dataset_query          {:database (mt/id)
                                             :type     :query
                                             :query    {:source-table (mt/id :orders)
                                                        :fields       [[:field (mt/id :orders :tax) {:base-type :type/Float}]]}}}
        ;; test card 2's query returns all cols/rows of the table, but still has 'Number' viz settings (scalar.field "TAX")
        test-card2 {:visualization_settings {:scalar.field "TAX"}
                    :display                :scalar
                    :dataset_query          {:database (mt/id)
                                             :type     :query
                                             :query    {:source-table (mt/id :orders)}}}]
    (testing "Static Viz. Render of 'Number' Visualization shows the correct column's first value #32362."
      (mt/dataset test-data
        (mt/with-temp [Card          {card-id1 :id} test-card1
                       Card          {card-id2 :id} test-card2
                       Dashboard     {dash-id :id} {:name "just dash"}
                       DashboardCard {dash-card-id1 :id} {:dashboard_id dash-id
                                                          :card_id      card-id1}
                       DashboardCard {dash-card-id2 :id} {:dashboard_id dash-id
                                                          :card_id      card-id2}
                       Pulse         {pulse-id :id :as p} {:name         "Test Pulse"
                                                           :dashboard_id dash-id}
                       PulseCard             _             {:pulse_id          pulse-id
                                                            :card_id           card-id1
                                                            :dashboard_card_id dash-card-id1}
                       PulseCard             _             {:pulse_id          pulse-id
                                                            :card_id           card-id2
                                                            :dashboard_card_id dash-card-id2}
                       PulseChannel {pulse-channel-id :id} {:channel_type :email
                                                            :pulse_id     pulse-id
                                                            :enabled      true}
                       PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
                                                :user_id          (mt/user->id :rasta)}]
          (is (= ["2.07" "2.07"]
                 (run-pulse-and-return-scalars p))))))))

;; Solution
;; The render :scalar implementation naively takes the first result from the first row.
;; This works in cases where the Card's query results in exactly the expected value
;; but is wrong in the case where the query is the table results (a simple, unmodified query) and just the viz. has been set.

;; fix in `metabase.pulse.render.body`
#_(defn- get-col-by-name
    [cols name]
    (let [cm (into {} (map-indexed (fn [idx m] [(:name m) [idx m]]) cols))]
      (get cm name)))

#_(s/defmethod render :scalar :- formatter/RenderedPulseCard
  [_chart-type _render-type timezone-id _card _dashcard {:keys [cols rows viz-settings]}]
  (let [field-name    (:scalar.field viz-settings)
        [row-idx col] (or (when field-name
                            (get-col-by-name cols field-name))
                          [0 (first cols)])
        row           (first rows)
        raw-value     (get row row-idx)
        value         (format-cell timezone-id raw-value col viz-settings)]
    {:attachments
     nil

     :content
     [:div {:style (style/style (style/scalar-style))}
      (h value)]
     :render/text (str value)}))

```

