### PR TITLE
waterfall remove unused extent calculation

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -136,18 +136,11 @@ export function getWaterfallChartModel(
   const { dataset: waterfallDataset, negativeTranslation } =
     getWaterfallDataset(rows, cardColumns, settings);
 
-  // y-axis
-  const yAxisExtents: AxisExtents = [
-    getWaterfallExtent(waterfallDataset),
-    null,
-  ];
-
   const waterfallChartModel: WaterfallChartModel = {
     ...baseChartModel,
     waterfallDataset,
     negativeTranslation,
     total,
-    yAxisExtents,
   };
   return waterfallChartModel;
 }


### PR DESCRIPTION
### Description

Removes a redundant y-axis extent calculation that I forgot to delete while rebasing.

### How to verify

Confirm waterfall charts still work, by sending subscription in app and through storybook.

### Demo

![Screenshot 2024-01-04 at 11.18.34 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/323c9f30-b9fa-4bbc-8e3e-69e24ad92c02.png)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

Not needed since there are existing tests.