### PR TITLE
waterfall use constant for empty val

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
@@ -7,7 +7,11 @@ import {
 import { checkNumber } from "metabase/lib/types";
 
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
-import type { WaterfallDataset } from "../types";
+import {
+  WATERFALL_EMPTY_VALUE,
+  type WaterfallDataset,
+  type WaterfallEmptyValue,
+} from "../types";
 
 export function getWaterfallDataset(
   rows: RowValues[],
@@ -47,8 +51,8 @@ export function getWaterfallDataset(
     const dimension = String(rows[i][columns.dimension.index]);
 
     let barOffset = negativeTranslation;
-    let increase: number | "-" = "-";
-    let decrease: number | "-" = "-";
+    let increase: number | WaterfallEmptyValue = WATERFALL_EMPTY_VALUE;
+    let decrease: number | WaterfallEmptyValue = WATERFALL_EMPTY_VALUE;
 
     const prevSum = i !== 0 ? runningSums[i - 1] : 0;
     const currSum = runningSums[i];
@@ -61,7 +65,13 @@ export function getWaterfallDataset(
       decrease = Math.abs(prevSum - currSum);
     }
 
-    dataset.push({ dimension, barOffset, increase, decrease, total: "-" });
+    dataset.push({
+      dimension,
+      barOffset,
+      increase,
+      decrease,
+      total: WATERFALL_EMPTY_VALUE,
+    });
   }
 
   if (!settings["waterfall.show_total"]) {
@@ -94,8 +104,8 @@ export function getWaterfallDataset(
   dataset.push({
     dimension,
     barOffset,
-    increase: "-",
-    decrease: "-",
+    increase: WATERFALL_EMPTY_VALUE,
+    decrease: WATERFALL_EMPTY_VALUE,
     total: Math.abs(total),
   });
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -13,7 +13,11 @@ import type {
 
 import type { Extent } from "../../model/types";
 import { getCardsColumns, getCartesianChartModel } from "../../model";
-import type { WaterfallChartModel, WaterfallDataset } from "../types";
+import {
+  WATERFALL_EMPTY_VALUE,
+  type WaterfallChartModel,
+  type WaterfallDataset,
+} from "../types";
 import { DATASET_DIMENSIONS } from "../constants";
 
 import { getWaterfallDataset } from "./dataset";
@@ -28,11 +32,11 @@ export function getWaterfallExtent(dataset: WaterfallDataset) {
     const total = datum[DATASET_DIMENSIONS.total];
 
     let value: number;
-    if (increase !== "-") {
+    if (increase !== WATERFALL_EMPTY_VALUE) {
       value = barOffset + increase;
-    } else if (decrease !== "-") {
+    } else if (decrease !== WATERFALL_EMPTY_VALUE) {
       value = barOffset - decrease;
-    } else if (total !== "-") {
+    } else if (total !== WATERFALL_EMPTY_VALUE) {
       return;
     } else {
       throw TypeError("Increase, decrease, and total cannot all be empty");

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/types.ts
@@ -4,6 +4,7 @@ import type { CartesianChartModel } from "../model/types";
 // with echarts' `DatasetOption.source` type, which
 // doesn't allow null for some reason
 export type WaterfallEmptyValue = "-";
+export const WATERFALL_EMPTY_VALUE = "-";
 
 export type WaterfallDatum = {
   dimension: string;


### PR DESCRIPTION
### Description

Addresses this [comment]([url](https://github.com/metabase/metabase/pull/36887/files#r1435268433)) on https://github.com/metabase/metabase/pull/36887



### How to verify

Confirm charts still work in subscriptions and storybook.

### Demo

![Screenshot 2024-01-04 at 11.16.01 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/45cbc0aa-ec07-419e-b83f-d6d2473cfe37.png)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

Not needed since there are existing storybook examples.