### PR TITLE
Fixing case of invalid graph.dimension

### DIFF
--- a/src/metabase/util/ui_logic.clj
+++ b/src/metabase/util/ui_logic.clj
@@ -91,7 +91,7 @@
   [card results]
   (let [metrics     (some-> card
                             (get-in [:visualization_settings :graph.metrics]))
-        col-indices (map #(column-name->index % results) metrics)]
+        col-indices (keep #(column-name->index % results) metrics)]
     (when (seq col-indices)
       (fn [row]
         (let [res (vec (for [idx col-indices]
@@ -106,7 +106,7 @@
   [card results]
   (let [dimensions  (some-> card
                             (get-in [:visualization_settings :graph.dimensions]))
-        col-indices (map #(column-name->index % results) dimensions)]
+        col-indices (keep #(column-name->index % results) dimensions)]
     (when (seq col-indices)
       (fn [row]
         (let [res (vec (for [idx col-indices]


### PR DESCRIPTION
When trying to render a card with viz settings containing a nonexistent dimension, an error would result in `mult-x-axis-rowfn` causing a failure to render.

This fix simply replaces `map` with `keep` in `metabase.util.ui-logic/mult-x-axis-rowfn` and `metabase.util.ui-logic/mult-y-axis-rowfn` so that `nil` values are dropped if a bad dimension or metric name is provided.

The following easily shows the broken case (now fixed). Previously, an error was rendered. Now you get the chart.

```clojure
;; REPRO
(comment
  (ns tickets.37266-slack-error
    (:require
     [clojure.test :refer :all]
     [dev.render-png :as render-png]
     [metabase.models :refer [Card]]
     [metabase.pulse.render.body :as body]
     [metabase.query-processor :as qp]
     [metabase.test :as mt]
     [toucan2.core :as t2]))

  (let [busted? true]
    (mt/dataset test-data
      ;; Note that this uses orders since we have that as test data.
      (mt/with-temp [Card {base-card-id :id}
                     {:dataset_query          {:database (mt/id)
                                               :type     :query
                                               :query    {:source-table (mt/id :orders)
                                                          :aggregation  [[:count]]
                                                          :filter       [:between [:field (mt/id :orders :created_at) nil] "2019-05-16" "2019-08-16"]
                                                          :breakout     [:field (mt/id :orders :created_at) {:temporal-unit :week}]}}
                      :display                :line
                      :visualization_settings {:table.pivot_column      "state"
                                               ;; This is also intentionally broken
                                               :graph.metrics           (if busted?
                                                                          ["frooby"]
                                                                          ["count"])
                                               :graph.show_trendline    false
                                               :graph.x_axis.title_text "Week"
                                               :graph.y_axis.title_text "PR Review Activity"
                                               ;; Using a missing dimension name breaks the results
                                               :graph.dimensions        (if busted?
                                                                          ["_sdc_extracted_at"]
                                                                          ["created_at"])
                                               :graph.show_values       false
                                               :table.cell_column       "count"}}]
        (render-png/render-card-to-png base-card-id)))))
```

Fixes #37266