### PR TITLE
Drop the *empty* and unused security holder dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
     "tippy.js": "^6.3.5",
     "ttag": "1.7.21",
     "underscore": "~1.13.3",
-    "yarn.lock": "^0.0.1-security",
     "yup": "^0.32.11",
     "z-index": "0.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -22753,11 +22753,6 @@ yargs@^17.3.1:
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
 
-yarn.lock@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/yarn.lock/-/yarn.lock-0.0.1-security.tgz#8e7117924bfe916671b21f14212ba1bb49dfe0c7"
-  integrity sha512-ZRX6v5zGCJMI1T2aO+BQxJggy1vvorXEwonQhWXIC+brO7lkDB3zWelVNAti183ddH6FmJP8z4UDCJnJlioK4Q==
-
 yauzl@^2.10.0:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"


### PR DESCRIPTION

### Description

https://www.npmjs.com/package/yarn.lock is empty and holded by npm for security reasons. I assume it was added by mistake.