### PR TITLE
Avoid failing call to /api/model-index

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -32,7 +32,6 @@ import type {
   Parameter as ParameterObject,
   ParameterValues,
   ParameterId,
-  UnsavedCard,
   VisualizationSettings,
 } from "metabase-types/api";
 
@@ -90,7 +89,7 @@ class Question {
    * The plain object presentation of this question, equal to the format that Metabase REST API understands.
    * It is called `card` for both historical reasons and to make a clear distinction to this class.
    */
-  _card: CardObject | UnsavedCard;
+  _card: CardObject;
 
   /**
    * The Question wrapper requires a metadata object because the queries it contains (like {@link StructuredQuery})

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -32,6 +32,7 @@ import type {
   Parameter as ParameterObject,
   ParameterValues,
   ParameterId,
+  UnsavedCard,
   VisualizationSettings,
 } from "metabase-types/api";
 

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -89,7 +89,7 @@ class Question {
    * The plain object presentation of this question, equal to the format that Metabase REST API understands.
    * It is called `card` for both historical reasons and to make a clear distinction to this class.
    */
-  _card: CardObject;
+  _card: CardObject | UnsavedCard;
 
   /**
    * The Question wrapper requires a metadata object because the queries it contains (like {@link StructuredQuery})

--- a/frontend/src/metabase/entities/model-indexes/model-indexes.ts
+++ b/frontend/src/metabase/entities/model-indexes/model-indexes.ts
@@ -21,8 +21,7 @@ export const ModelIndexes = createEntity({
   api: {
     ...ModelIndexApi,
     list: ({ model_id }: { model_id?: string | null }) =>
-      model_id ? ModelIndexApi.list({ model_id }) : null,
-    // TODO: Write unit tests for the case where there should be an api call and the case where there shouldn't be an api call
+      model_id ? ModelIndexApi.list({ model_id }) : { data: [] },
   },
   actions,
   utils,

--- a/frontend/src/metabase/entities/model-indexes/model-indexes.ts
+++ b/frontend/src/metabase/entities/model-indexes/model-indexes.ts
@@ -20,6 +20,9 @@ export const ModelIndexes = createEntity({
   schema: ModelIndexSchema,
   api: {
     ...ModelIndexApi,
+    list: ({ model_id }: { model_id?: string | null }) =>
+      model_id ? ModelIndexApi.list({ model_id }) : null,
+    // TODO: Write unit tests for the case where there should be an api call and the case where there shouldn't be an api call
   },
   actions,
   utils,

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
@@ -1,0 +1,112 @@
+import fetchMock from "fetch-mock";
+import DatasetEditor from "metabase/query_builder/components/DatasetEditor";
+import {
+  setupCollectionsEndpoints,
+  setupDatabasesEndpoints,
+  setupNativeQuerySnippetEndpoints,
+} from "__support__/server-mocks";
+import { createMockEntitiesState } from "__support__/store";
+import { renderWithProviders } from "__support__/ui";
+import type { Card } from "metabase-types/api";
+import {
+  createMockCard,
+  createMockCollection,
+  createMockNativeDatasetQuery,
+} from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import { createMockState } from "metabase-types/store/mocks";
+import { checkNotNull } from "metabase/lib/types";
+import { getMetadata } from "metabase/selectors/metadata";
+
+const TEST_DB = createSampleDatabase();
+
+const TEST_NATIVE_CARD = createMockCard({
+  dataset_query: createMockNativeDatasetQuery({
+    type: "native",
+    database: TEST_DB.id,
+    native: {
+      query: "select * from orders",
+      "template-tags": undefined,
+    },
+  }),
+});
+
+const ROOT_COLLECTION = createMockCollection({ id: "root" });
+
+interface SetupOpts {
+  card?: Card;
+  shouldUnsetCardId?: boolean;
+}
+
+const setup = async ({
+  card = TEST_NATIVE_CARD,
+  shouldUnsetCardId = true,
+}: SetupOpts) => {
+  setupDatabasesEndpoints([TEST_DB]);
+  setupCollectionsEndpoints({ collections: [ROOT_COLLECTION] });
+  setupNativeQuerySnippetEndpoints();
+
+  const storeInitialState = createMockState({
+    entities: createMockEntitiesState({
+      databases: [createSampleDatabase()],
+      questions: [card],
+    }),
+  });
+  const metadata = getMetadata(storeInitialState);
+  const question = checkNotNull(metadata.question(card.id));
+  const query = question._card.dataset_query;
+  if (shouldUnsetCardId) {
+    question._card.id = undefined;
+  }
+
+  const props = {
+    question: question,
+    params: { slug: "query" },
+    datasetEditorTab: "query",
+    isMetadataDirty: false,
+    parameterValues: {},
+    query: question.legacyQuery(),
+    isDirty: false,
+    isRunning: true,
+    setQueryBuilderMode: () => null,
+    setFieldMetadata: () => null,
+    onSave: () => null,
+    onCancelCreateNewModel: () => null,
+    onCancelDatasetChanges: () => null,
+    handleResize: () => null,
+    runQuestionQuery: () => null,
+    onOpenModal: () => null,
+    isShowingTemplateTagsEditor: false,
+    isShowingDataReference: false,
+    isShowingSnippetSidebar: false,
+    toggleTemplateTagsEditor: () => null,
+    toggleDataReference: () => null,
+    toggleSnippetSidebar: () => null,
+  };
+
+  const { rerender } = renderWithProviders(<DatasetEditor {...props} />);
+
+  return { query, question, rerender };
+};
+
+describe("DatasetEditor", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  it("tries to load a model index when a model_id is specified", async () => {
+    fetchMock.get(
+      "path:/api/model-index",
+      (_: any, __: any, request: Request) => {
+        const params = new URL(request.url).searchParams;
+        expect(params.get("model_id")).toBe(`${TEST_NATIVE_CARD.id}`);
+        return { body: { data: [] } };
+      },
+    );
+    await setup({ shouldUnsetCardId: false });
+  });
+  it("does not try to load a model index when model_id is absent", async () => {
+    fetchMock.mock("*", 200);
+    await setup({ shouldUnsetCardId: true });
+    expect(fetchMock.calls("path:/api/model-index")).toHaveLength(0);
+  });
+});

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
@@ -43,7 +43,7 @@ const setup = async ({ card }: { card: Card | UnsavedCard } ) => {
 
   const storeInitialState = createMockState({
     entities: createMockEntitiesState({
-      databases: [createSampleDatabase()],
+      databases: [TEST_DB],
       questions: 'id' in card ? [card] : [],
     }),
   });
@@ -96,7 +96,8 @@ describe("DatasetEditor", () => {
     await setup({ card: mockSavedCard });
   });
   it("does not try to load a model index when model_id is absent", async () => {
-    fetchMock.get("*", () => ({ body: { data: [] } }));
+    //fetchMock.get("*", () => ({ body: { data: [] } }));
+    fetchMock.get("/api/search", () => ({ body: { data: [] } }));
     await setup({ card: mockUnsavedCard });
     expect(fetchMock.calls("path:/api/model-index")).toHaveLength(0);
   });

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
@@ -5,19 +5,15 @@ import {
   setupDatabasesEndpoints,
   setupNativeQuerySnippetEndpoints,
 } from "__support__/server-mocks";
-import { createMockEntitiesState } from "__support__/store";
 import { renderWithProviders } from "__support__/ui";
-import type { Card, UnsavedCard} from "metabase-types/api";
+import type { Card, UnsavedCard } from "metabase-types/api";
 import {
   createMockCard,
   createMockCollection,
   createMockNativeDatasetQuery,
-  createMockUnsavedCard
+  createMockUnsavedCard,
 } from "metabase-types/api/mocks";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
-import { createMockState } from "metabase-types/store/mocks";
-import { checkNotNull } from "metabase/lib/types";
-import { getMetadata } from "metabase/selectors/metadata";
 import Question from "metabase-lib/Question";
 
 const TEST_DB = createSampleDatabase();
@@ -35,17 +31,10 @@ const mockSavedCard = createMockCard({
 });
 const mockUnsavedCard = createMockUnsavedCard();
 
-const setup = ({ card }: { card: Card | UnsavedCard } ) => {
+const renderDatasetEditor = (card: Card | UnsavedCard) => {
   setupDatabasesEndpoints([TEST_DB]);
   setupCollectionsEndpoints({ collections: [ROOT_COLLECTION] });
   setupNativeQuerySnippetEndpoints();
-
-  // createMockState({
-  //   entities: createMockEntitiesState({
-  //     databases: [TEST_DB],
-  //     questions: 'id' in card ? [card] : [],
-  //   }),
-  // });
   const question = new Question(card);
 
   const props = {
@@ -72,10 +61,7 @@ const setup = ({ card }: { card: Card | UnsavedCard } ) => {
     toggleDataReference: () => null,
     toggleSnippetSidebar: () => null,
   };
-
-  const { rerender } = renderWithProviders(<DatasetEditor {...props} />);
-
-  return { question, rerender };
+  renderWithProviders(<DatasetEditor {...props} />);
 };
 
 describe("DatasetEditor", () => {
@@ -87,7 +73,7 @@ describe("DatasetEditor", () => {
     jest.restoreAllMocks();
   });
   it("tries to load a model index when card is already saved", async () => {
-    setup({ card: mockSavedCard });
+    renderDatasetEditor(mockSavedCard);
     const calls = fetchMock.calls("path:/api/model-index");
     expect(calls).toHaveLength(1);
     expect(
@@ -95,8 +81,8 @@ describe("DatasetEditor", () => {
     ).toBe(`${mockSavedCard.id}`);
   });
   it("does not try to load a model index when card is unsaved", async () => {
-    setup({ card: mockUnsavedCard });
+    renderDatasetEditor(mockUnsavedCard);
     const calls = fetchMock.calls("path:/api/model-index");
     expect(calls).toHaveLength(0);
   });
-})
+});

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
@@ -31,37 +31,43 @@ const mockSavedCard = createMockCard({
 });
 const mockUnsavedCard = createMockUnsavedCard();
 
+const noop = () => null;
+const defaultDatasetEditorProps = {
+  datasetEditorTab: "query",
+  isDirty: false,
+  isMetadataDirty: false,
+  isRunning: true,
+  isShowingDataReference: false,
+  isShowingSnippetSidebar: false,
+  isShowingTemplateTagsEditor: false,
+  parameterValues: {},
+  params: { slug: "query" },
+  handleResize: noop,
+  onCancelCreateNewModel: noop,
+  onCancelDatasetChanges: noop,
+  onOpenModal: noop,
+  onSave: noop,
+  runQuestionQuery: noop,
+  setFieldMetadata: noop,
+  setQueryBuilderMode: noop,
+  toggleDataReference: noop,
+  toggleSnippetSidebar: noop,
+  toggleTemplateTagsEditor: noop,
+};
+
 const renderDatasetEditor = (card: Card | UnsavedCard) => {
   setupDatabasesEndpoints([TEST_DB]);
   setupCollectionsEndpoints({ collections: [ROOT_COLLECTION] });
   setupNativeQuerySnippetEndpoints();
   const question = new Question(card);
 
-  const props = {
-    question: question,
-    params: { slug: "query" },
-    datasetEditorTab: "query",
-    isMetadataDirty: false,
-    parameterValues: {},
-    query: question.legacyQuery(),
-    isDirty: false,
-    isRunning: true,
-    setQueryBuilderMode: () => null,
-    setFieldMetadata: () => null,
-    onSave: () => null,
-    onCancelCreateNewModel: () => null,
-    onCancelDatasetChanges: () => null,
-    handleResize: () => null,
-    runQuestionQuery: () => null,
-    onOpenModal: () => null,
-    isShowingTemplateTagsEditor: false,
-    isShowingDataReference: false,
-    isShowingSnippetSidebar: false,
-    toggleTemplateTagsEditor: () => null,
-    toggleDataReference: () => null,
-    toggleSnippetSidebar: () => null,
-  };
-  renderWithProviders(<DatasetEditor {...props} />);
+  renderWithProviders(
+    <DatasetEditor
+      {...defaultDatasetEditorProps}
+      question={question}
+      query={question.legacyQuery()}
+    />,
+  );
 };
 
 describe("DatasetEditor", () => {

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
@@ -21,6 +21,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 import Question from "metabase-lib/Question";
 
 const TEST_DB = createSampleDatabase();
+const ROOT_COLLECTION = createMockCollection({ id: "root" });
 
 const mockSavedCard = createMockCard({
   dataset_query: createMockNativeDatasetQuery({
@@ -34,21 +35,18 @@ const mockSavedCard = createMockCard({
 });
 const mockUnsavedCard = createMockUnsavedCard();
 
-const ROOT_COLLECTION = createMockCollection({ id: "root" });
-
 const setup = ({ card }: { card: Card | UnsavedCard } ) => {
   setupDatabasesEndpoints([TEST_DB]);
   setupCollectionsEndpoints({ collections: [ROOT_COLLECTION] });
   setupNativeQuerySnippetEndpoints();
 
-  const storeInitialState = createMockState({
-    entities: createMockEntitiesState({
-      databases: [TEST_DB],
-      questions: 'id' in card ? [card] : [],
-    }),
-  });
-  const metadata = getMetadata(storeInitialState);
-  const question = new Question(card); //checkNotNull(metadata.question(card.id));
+  // createMockState({
+  //   entities: createMockEntitiesState({
+  //     databases: [TEST_DB],
+  //     questions: 'id' in card ? [card] : [],
+  //   }),
+  // });
+  const question = new Question(card);
 
   const props = {
     question: question,

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
@@ -78,7 +78,7 @@ describe("DatasetEditor", () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
-  it("tries to load a model index when card is already saved", async () => {
+  it("tries to load a model index when card is already saved", () => {
     renderDatasetEditor(mockSavedCard);
     const calls = fetchMock.calls("path:/api/model-index");
     expect(calls).toHaveLength(1);
@@ -86,7 +86,7 @@ describe("DatasetEditor", () => {
       new URL(calls[0]?.request?.url ?? "").searchParams.get("model_id"),
     ).toBe(`${mockSavedCard.id}`);
   });
-  it("does not try to load a model index when card is unsaved", async () => {
+  it("does not try to load a model index when card is unsaved", () => {
     renderDatasetEditor(mockUnsavedCard);
     const calls = fetchMock.calls("path:/api/model-index");
     expect(calls).toHaveLength(0);


### PR DESCRIPTION
Closes #31671

### Description

On master, when creating a new model index, a call is made to `/api/model-index` that returns error code 400. The reason is that there is no model id available, so the call is made without a `model_id` parameter. But the backend expects that parameter. On this branch, if there is no model id, the call is not made.

### How to verify

On master, go to **New** > **Model**, click **Use the notebook editor**, and note in the DevTools Network tab that the frontend calls `/api/model-index`, which returns error 400.

On the story branch, go through the same steps, and note in the DevTools Network tab that the frontend does not call `/api/model-index`.

### Demo

[Demo video (33 seconds, no audio)](https://www.loom.com/share/7df6c28eecb54b2dba26023fc9bde5d9?sid=299c7d74-26e9-46a8-9b3e-f7712ca46254)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

The tests generate some warnings:
* `Warning: Failed prop type: The prop modelIndexes is marked as required in DatasetEditor, but its value is undefined` (in `DatasetEditor`)
* `Warning: Function components cannot be given refs` (in `Resizable`)
* `Warning: Can't perform a React state update on an unmounted component` (in `UnconnectedDataSelector`)

I've left these warnings in for now, but I'd be glad to try to remove them if reviewers wish.