### PR TITLE
Rename `_getMLv2Query` Question method to `query`

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1026,7 +1026,7 @@ class Question {
       return this;
     }
 
-    const query = this._getMLv2Query();
+    const query = this.query();
     const stageIndex = -1;
     const filters = this.parameters()
       .map(parameter =>
@@ -1045,7 +1045,7 @@ class Question {
     return hasQueryBeenAltered ? newQuestion.markDirty() : newQuestion;
   }
 
-  _getMLv2Query(metadata = this._metadata): Query {
+  query(metadata = this._metadata): Query {
     // cache the metadata provider we create for our metadata.
     if (metadata === this._metadata) {
       if (!this.__mlv2MetadataProvider) {
@@ -1085,7 +1085,7 @@ class Question {
   }
 
   generateQueryDescription() {
-    const query = this._getMLv2Query();
+    const query = this.query();
     return ML.suggestedName(query);
   }
 

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -127,7 +127,7 @@ class StructuredQuery extends AtomicQuery {
   }
 
   private getMLv2Query(): Query {
-    return this.question()._getMLv2Query();
+    return this.question().query();
   }
 
   private updateWithMLv2(nextQuery: Query) {

--- a/frontend/src/metabase/query_builder/actions/query-updates.ts
+++ b/frontend/src/metabase/query_builder/actions/query-updates.ts
@@ -13,7 +13,7 @@ export const setLimit =
     if (!question) {
       return;
     }
-    const query = question._getMLv2Query();
+    const query = question.query();
     const nextQuery = Lib.limit(query, -1, limit);
     const nextLegacyQuery = Lib.toLegacyQuery(nextQuery);
     const nextQuestion = question.setDatasetQuery(nextLegacyQuery);

--- a/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
+++ b/frontend/src/metabase/query_builder/components/AggregationPopover/AggregationPopover.jsx
@@ -332,7 +332,7 @@ export default class AggregationPopover extends Component {
       return (
         <ExpressionWidget
           name={AGGREGATION.getName(this.state.aggregation)}
-          query={legacyQuery.question()._getMLv2Query()}
+          query={legacyQuery.question().query()}
           stageIndex={-1}
           legacyQuery={legacyQuery}
           expression={aggregation}

--- a/frontend/src/metabase/query_builder/components/QueryModals.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.tsx
@@ -238,7 +238,7 @@ class QueryModals extends Component<QueryModalsProps> {
       case MODAL_TYPES.FILTERS:
         return (
           <FilterModal
-            query={question._getMLv2Query()}
+            query={question.query()}
             onSubmit={this.onQueryChange}
             onClose={onCloseModal}
           />

--- a/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
+++ b/frontend/src/metabase/query_builder/components/filters/FilterPopover/FilterPopover.tsx
@@ -179,7 +179,7 @@ export function FilterPopover({
     const expression = isExpression(filterMBQL) ? filterMBQL : undefined;
     return (
       <ExpressionWidget
-        query={legacyQuery.question()._getMLv2Query()}
+        query={legacyQuery.question().query()}
         stageIndex={-1}
         expression={expression}
         startRule="boolean"

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -51,7 +51,7 @@ const Notebook = ({ className, updateQuestion, ...props }: NotebookProps) => {
   async function cleanupQuestion() {
     // Converting a query to MLv2 and back performs a clean-up
     let cleanQuestion = question.setDatasetQuery(
-      Lib.toLegacyQuery(Lib.dropEmptyStages(question._getMLv2Query())),
+      Lib.toLegacyQuery(Lib.dropEmptyStages(question.query())),
     );
 
     if (cleanQuestion.display() === "table") {

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
@@ -192,7 +192,7 @@ export function getQuestionSteps(
   const allSteps: NotebookStep[] = [];
 
   let legacyQuery = question.legacyQuery() as StructuredQuery;
-  let query = question._getMLv2Query();
+  let query = question.query();
 
   // strip empty source queries
   legacyQuery = legacyQuery.cleanNesting();

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -90,7 +90,7 @@ const setup = async (
 const setupEmptyQuery = () => {
   const question = Question.create({ databaseId: SAMPLE_DB_ID });
   const legacyQuery = question.legacyQuery() as StructuredQuery;
-  const query = question._getMLv2Query();
+  const query = question.query();
   return setup(
     createMockNotebookStep({ query: legacyQuery, topLevelQuery: query }),
   );

--- a/frontend/src/metabase/query_builder/components/notebook/test-utils.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/test-utils.ts
@@ -17,7 +17,7 @@ export const metadata = createMockMetadata({
 export const DEFAULT_QUESTION = checkNotNull(metadata.question(1));
 export const DEFAULT_LEGACY_QUERY =
   DEFAULT_QUESTION.legacyQuery() as StructuredQuery;
-export const DEFAULT_QUERY = DEFAULT_QUESTION._getMLv2Query();
+export const DEFAULT_QUERY = DEFAULT_QUESTION.query();
 
 export function createMockNotebookStep({
   id = "test-step",

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters/FilterHeader.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters/FilterHeader.unit.spec.tsx
@@ -41,7 +41,7 @@ function setup({
     });
 
     const handleQueryChange = (nextLegacyQuery: StructuredQuery) => {
-      const nextQuery = nextLegacyQuery.question()._getMLv2Query();
+      const nextQuery = nextLegacyQuery.question().query();
       setQuery(nextQuery);
       onChange(nextQuery);
     };

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters/QuestionFilters.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters/QuestionFilters.tsx
@@ -86,7 +86,7 @@ export function FilterHeader({
   expanded,
   onQueryChange,
 }: FilterHeaderProps) {
-  const query = question._getMLv2Query();
+  const query = question.query();
 
   const stageCount = Lib.stageCount(query);
   const lastStageIndex = stageCount - 1;

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -89,9 +89,7 @@ function QuestionRowCount({
 
   const canChangeLimit = question.isStructured() && question.isQueryEditable();
 
-  const limit = canChangeLimit
-    ? Lib.currentLimit(question._getMLv2Query(), -1)
-    : null;
+  const limit = canChangeLimit ? Lib.currentLimit(question.query(), -1) : null;
 
   if (loading) {
     return null;
@@ -153,7 +151,7 @@ const formatRowCount = (count: number) => {
 };
 
 function getLimitMessage(question: Question, result: Dataset): string {
-  const limit = Lib.currentLimit(question._getMLv2Query(), -1);
+  const limit = Lib.currentLimit(question.query(), -1);
   const isValidLimit =
     typeof limit === "number" && limit > 0 && limit < HARD_ROW_LIMIT;
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
@@ -46,7 +46,7 @@ type SetupOpts = {
 
 function patchQuestion(question: Question) {
   if (question.isStructured()) {
-    const query = question._getMLv2Query();
+    const query = question.query();
     const [sampleColumn] = Lib.orderableColumns(query, 0);
     const nextQuery = Lib.orderBy(query, 0, sampleColumn);
     return question.setDatasetQuery(Lib.toLegacyQuery(nextQuery));

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -93,7 +93,7 @@ class View extends Component {
     const isSaved = question.isSaved();
 
     if (isShowingSummarySidebar) {
-      const query = question._getMLv2Query();
+      const query = question.query();
       const legacyQuery = question.legacyQuery();
       return (
         <SummarizeSidebar

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -447,7 +447,7 @@ function ViewTitleHeaderRightSide(props) {
       {FilterHeaderToggle.shouldRender(props) && (
         <FilterHeaderToggle
           className="ml2 mr1"
-          query={question._getMLv2Query()}
+          query={question.query()}
           expanded={areFiltersExpanded}
           onExpand={onExpandFilters}
           onCollapse={onCollapseFilters}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -58,7 +58,7 @@ function setup({
       : new Question(card, metadata);
 
   function Wrapper() {
-    const [query, setQuery] = useState(question._getMLv2Query());
+    const [query, setQuery] = useState(question.query());
 
     return (
       <SummarizeSidebar

--- a/frontend/src/metabase/querying/components/TimeseriesChrome/TimeseriesChrome.tsx
+++ b/frontend/src/metabase/querying/components/TimeseriesChrome/TimeseriesChrome.tsx
@@ -27,7 +27,7 @@ export function TimeseriesChrome({
   question,
   updateQuestion,
 }: TimeseriesChromeProps) {
-  const query = question._getMLv2Query();
+  const query = question.query();
 
   const handleChange = (query: Lib.Query) => {
     updateQuestion(question._setMLv2Query(query), { run: true });

--- a/frontend/src/metabase/querying/utils/drills/query-drill.ts
+++ b/frontend/src/metabase/querying/utils/drills/query-drill.ts
@@ -7,7 +7,7 @@ export function queryDrill(
   question: Question,
   clicked?: Lib.ClickObject,
 ): ClickAction[] {
-  const query = question._getMLv2Query();
+  const query = question.query();
   const stageIndex = -1;
   const drills = Lib.availableDrillThrus(
     query,

--- a/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
@@ -36,7 +36,7 @@ export const HideColumnAction: LegacyDrill = ({
         const columnSettings = getColumnSettingsWithRefs(
           settings?.["table.columns"] || [],
         );
-        const query = question._getMLv2Query();
+        const query = question.query();
 
         const columnSettingIndex = findColumnSettingIndex(
           query,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingAddRemoveColumns/ChartSettingAddRemoveColumns.unit.spec.tsx
@@ -61,7 +61,7 @@ const setup = ({
   renderWithProviders(
     <ChartSettingAddRemoveColumns
       value={value}
-      query={question._getMLv2Query()}
+      query={question.query()}
       onChange={onChange}
     />,
   );

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
@@ -40,7 +40,7 @@ export const ChartSettingTableColumns = ({
   );
 
   if (question?.isStructured()) {
-    const query = question._getMLv2Query();
+    const query = question.query();
 
     return (
       <QueryColumnSelector


### PR DESCRIPTION
This PR is a follow up after #37233.
It is now possible to rename all `_getMLv2Query` references (which was just a temporary placeholder) to the `query`.

This PR updates the method name in the Question class, and updates all references in the codebase to reflect that change.

After this PR
![image](https://github.com/metabase/metabase/assets/31325167/e4d1e118-3c5b-4acc-bc5e-602039f56ae9)
