### PR TITLE
Add environ based suggestion for db config

### DIFF
--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -180,7 +180,19 @@ You could also pass a full conection string in as the `mb.db.connection.uri`:
 "-Dmb.db.connection.uri=postgres://<user>:<password>@localhost:5432/<dbname>"
 ```
 
+Another option is to create a `.lein-env` file within your project directory:
 
+```
+{:mb-db-type   "postgres"
+ :mb-db-host   "localhost"
+ :mb-db-user   "<username>"
+ :mb-db-dbname "<dbname>"
+ :mb-db-pass   ""}
+```
+
+Despite the name, this works fine with `deps.edn` projects, and is read directly by [environ](https://github.com/weavejester/environ).
+
+There is already an entry in `.gitignore` to prevent you accidentally committing this file.
 
 ### Building drivers
 

--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -180,7 +180,9 @@ You could also pass a full conection string in as the `mb.db.connection.uri`:
 "-Dmb.db.connection.uri=postgres://<user>:<password>@localhost:5432/<dbname>"
 ```
 
-Another option is to create a `.lein-env` file within your project directory:
+There is another option besides using environment variables, and instead uses a feature of our configuration library [environ](https://github.com/weavejester/environ) directly.
+
+This approach requires creating a `.lein-env` file within your project directory:
 
 ```
 {:mb-db-type   "postgres"
@@ -190,9 +192,9 @@ Another option is to create a `.lein-env` file within your project directory:
  :mb-db-pass   ""}
 ```
 
-Despite the name, this works fine with `deps.edn` projects, and is read directly by [environ](https://github.com/weavejester/environ).
+An advantage of this approach versus the global `deps.edn` approach is that it is scoped to this project only. Despite the name, this file works fine with `deps.edn` projects.
 
-There is already an entry in `.gitignore` to prevent you accidentally committing this file.
+Only use this for development. This is not supported for production use. There is already entry in `.gitignore` to prevent you accidentally committing this file.
 
 ### Building drivers
 

--- a/docs/developers-guide/devenv.md
+++ b/docs/developers-guide/devenv.md
@@ -180,7 +180,7 @@ You could also pass a full conection string in as the `mb.db.connection.uri`:
 "-Dmb.db.connection.uri=postgres://<user>:<password>@localhost:5432/<dbname>"
 ```
 
-There is another option besides using environment variables, and instead uses a feature of our configuration library [environ](https://github.com/weavejester/environ) directly.
+Besides using environment variables, there is the option to interface with the configuration library [environ](https://github.com/weavejester/environ) directly.
 
 This approach requires creating a `.lein-env` file within your project directory:
 
@@ -192,9 +192,9 @@ This approach requires creating a `.lein-env` file within your project directory
  :mb-db-pass   ""}
 ```
 
-An advantage of this approach versus the global `deps.edn` approach is that it is scoped to this project only. Despite the name, this file works fine with `deps.edn` projects.
+Despite the name, this file works fine with `deps.edn` projects. An advantage of this approach versus the global `deps.edn` approach is that it is scoped to this project only. 
 
-Only use this for development. This is not supported for production use. There is already entry in `.gitignore` to prevent you accidentally committing this file.
+Only use this for development, it is not supported for production use. There is already entry in `.gitignore` to prevent you accidentally committing this file.
 
 ### Building drivers
 


### PR DESCRIPTION
### Description

It's nice for local config to be scoped to a specific project, but still work with non CLI created processes, e.g. via jack-in. 

Added instructions for the approach that I am using - an environ specific dot file.

Describe the overall approach and the problem being solved.

### How to verify

Follow these instructions, and verify that the associated fields are set in `metabase.db.env/env`, and that the H2 warning is no longer printed.
