### PR TITLE
Remove empty stages when modifying the list of query columns in viz settings

### DIFF
--- a/e2e/test/scenarios/custom-column/reproductions/19745-cc-nested-query-remove-expressions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/19745-cc-nested-query-remove-expressions.cy.spec.js
@@ -22,13 +22,12 @@ const questionDetails = {
       "source-table": PRODUCTS_ID,
       aggregation: [
         ["count"],
-        ["sum", ["field", PRODUCTS.PRICE, null]],
-        ["sum", ["field", PRODUCTS.RATING, null]],
+        ["sum", ["field", PRODUCTS.PRICE, { "base-type": "type/Float" }]],
       ],
-      breakout: [["field", PRODUCTS.CATEGORY, null]],
+      breakout: [["field", PRODUCTS.CATEGORY, { "base-type": "type/Text" }]],
     },
     fields: [
-      ["field", PRODUCTS.CATEGORY, null],
+      ["field", PRODUCTS.CATEGORY, { "base-type": "type/Text" }],
       ["field", "sum", { "base-type": "type/Float" }],
       ["expression", "Custom Column"],
     ],

--- a/e2e/test/scenarios/custom-column/reproductions/19745-cc-nested-query-remove-expressions.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/19745-cc-nested-query-remove-expressions.cy.spec.js
@@ -9,6 +9,7 @@ import {
   selectDashboardFilter,
   visitDashboard,
   visitQuestion,
+  visualize,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -29,7 +30,6 @@ const questionDetails = {
     fields: [
       ["field", PRODUCTS.CATEGORY, null],
       ["field", "sum", { "base-type": "type/Float" }],
-      ["field", "sum_2", { "base-type": "type/Float" }],
       ["expression", "Custom Column"],
     ],
     expressions: {
@@ -51,17 +51,13 @@ const dashboardDetails = {
   parameters: [filterDetails],
 };
 
-// TODO: unskip both tests when metabase#36574 is resolved
-// @see https://metaboat.slack.com/archives/C04CYTEL9N2/p1702063378269379
-describe.skip("issue 19745", () => {
+describe("issue 19745", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
   });
 
-  // TODO: unskip when metabase#36574 is resolved
-  // @see https://metaboat.slack.com/archives/C04CYTEL9N2/p1702063378269379
-  it.skip("should unwrap the nested query when removing the last expression (metabase#19745)", () => {
+  it("should unwrap the nested query when removing the last expression (metabase#19745)", () => {
     updateQuestionAndSelectFilter(() => removeExpression("Custom Column"));
   });
 
@@ -78,6 +74,10 @@ function updateQuestionAndSelectFilter(updateExpressions) {
       // this should modify the query and remove the second stage
       openNotebook();
       updateExpressions();
+      visualize();
+      cy.findByTestId("viz-settings-button").click();
+      cy.findByRole("button", { name: "Add or remove columns" }).click();
+      cy.findByLabelText("Count").should("not.be.checked").click();
       updateQuestion();
 
       // as we select all columns in the first stage of the query,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/utils.ts
@@ -180,9 +180,10 @@ export const enableColumnInQuery = (
   }
 
   const displayInfo = Lib.displayInfo(query, STAGE_INDEX, metadataColumn);
-  return displayInfo.selected
+  const newQuery = displayInfo.selected
     ? query
     : Lib.addField(query, STAGE_INDEX, metadataColumn);
+  return Lib.dropStageIfEmpty(newQuery, STAGE_INDEX);
 };
 
 export const disableColumnInQuery = (
@@ -193,7 +194,8 @@ export const disableColumnInQuery = (
     return query;
   }
 
-  return Lib.removeField(query, STAGE_INDEX, metadataColumn);
+  const newQuery = Lib.removeField(query, STAGE_INDEX, metadataColumn);
+  return Lib.dropStageIfEmpty(newQuery, STAGE_INDEX);
 };
 
 export const findColumnSettingIndex = (


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36746

When both adding or removing a field we could come up with an empty last stage that needs to be manually dropped. This is needed to be able to filter on query columns in dashboards.