### PR TITLE
Validate json settings during init (#36182)

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -13,6 +13,7 @@
    [metabase.driver.postgres]
    [metabase.events :as events]
    [metabase.logger :as mb.logger]
+   [metabase.models.setting :as settings]
    [metabase.plugins :as plugins]
    [metabase.plugins.classloader :as classloader]
    [metabase.public-settings :as public-settings]
@@ -106,6 +107,7 @@
   ;; load any plugins as needed
   (plugins/load-plugins!)
   (init-status/set-progress! 0.3)
+  (settings/validate-json-settings!)
   ;; startup database.  validates connection & runs any necessary migrations
   (log/info (trs "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."))
   (mdb/setup-db!)

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -107,7 +107,7 @@
   ;; load any plugins as needed
   (plugins/load-plugins!)
   (init-status/set-progress! 0.3)
-  (settings/validate-json-settings!)
+  (settings/validate-settings-formatting!)
   ;; startup database.  validates connection & runs any necessary migrations
   (log/info (trs "Setting up and migrating Metabase DB. Please sit tight, this may take a minute..."))
   (mdb/setup-db!)

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -98,7 +98,7 @@
   perform various CRUD actions are defined by [[metabase.models.interface/can-read?]] (in the API sense, not in the
   run-query sense) and [[metabase.models.interface/can-write?]] as well as the
   newer [[metabase.models.interface/can-create?]] and [[metabase.models.interface/can-update?]] methods.
-  Implementations for these methods live in `metabase.model.*` namespaces.
+  Implementations for these methods live in `metabase.models.*` namespaces.
 
   The implementation of these methods is up to individual models. The majority of implementations check whether
   [[metabase.api.common/*current-user-permissions-set*]] includes permissions for a given path (action)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -647,7 +647,7 @@
 
 (defmethod get-value-of-type :json
   [_setting-type setting-definition-or-name]
-  (get-raw-value setting-definition-or-name coll? #(json/parse-string % true)))
+  (get-raw-value setting-definition-or-name coll? #(json/parse-string-strict % true)))
 
 (defmethod get-value-of-type :csv
   [_setting-type setting-definition-or-name]

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1383,16 +1383,17 @@
   "Test whether the value configured for a given setting can be parsed as the expected type.
    Returns an map containing the exception if an issue is encountered, or nil if the value passes validation."
   [setting]
-  (try
-    (get-value-of-type (:type setting) setting)
-    nil
-    (catch clojure.lang.ExceptionInfo e
-      (let [parse-error (or (ex-cause e) e)
-            parse-error (redact-sensitive-tokens parse-error setting)
-            env-var? (set-via-env-var? setting)]
-        (assoc (select-keys setting [:name :type])
-          :parse-error parse-error
-          :env-var? env-var?)))))
+  (when (= :json (:type setting))
+    (try
+      (get-value-of-type (:type setting) setting)
+      nil
+      (catch clojure.lang.ExceptionInfo e
+        (let [parse-error (or (ex-cause e) e)
+              parse-error (redact-sensitive-tokens parse-error setting)
+              env-var? (set-via-env-var? setting)]
+          (assoc (select-keys setting [:name :type])
+            :parse-error parse-error
+            :env-var? env-var?))))))
 
 (defn validate-settings-formatting!
   "Check whether there are any issues with the format of application settings, e.g. an invalid JSON string.

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1386,8 +1386,8 @@
   (try
     (get-value-of-type (:type setting) setting)
     nil
-    (catch java.lang.Exception e
-      (let [parse-error (ex-cause e)
+    (catch clojure.lang.ExceptionInfo e
+      (let [parse-error (or (ex-cause e) e)
             parse-error (redact-sensitive-tokens parse-error setting)
             env-var? (set-via-env-var? setting)]
         (assoc (select-keys setting [:name :type])

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1360,5 +1360,5 @@
    Note that this will only validate settings whose defsetting forms have already been evaluated."
   []
   (when-let [invalid-settings (seq (map key (filter (comp has-invalid-json? val) @registered-settings)))]
-    (throw (ex-info (tru "Invalid JSON configuration for settings: {0}" invalid-settings)
+    (throw (ex-info (trs "Invalid JSON configuration for settings: {0}" invalid-settings)
                     {:registered-settings (sort (keys @registered-settings ))}))))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -532,7 +532,7 @@
                       (core/get cache (setting-name setting-definition-or-name))))))]
         (not-empty v)))))
 
-(defn realize
+(defn- realize
   "Parsing a setting may result in a lazy value. Use this to ensure we finish parsing."
   [value]
   (when (coll? value)

--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -133,7 +133,7 @@
           pattern+base-types+semantic-type)))
 
 (def ^:private FieldOrColumn
-  "Schema that allows a `metabase.model.field/Field` or a column from a query resultset"
+  "Schema that allows a `metabase.models.field/Field` or a column from a query resultset"
   [:and
    [:map
     ;; Some DBs such as MSSQL can return columns with blank name

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1197,7 +1197,7 @@
     (let [ok (lazy-seq (cons 1 (lazy-seq (list 2))))
           ok-deep (lazy-seq (cons 1 (lazy-seq (list (lazy-seq (list 2))))))
           shallow (lazy-seq (cons 1 (throw (ex-info "Surprise!" {}))))
-          deep (lazy-seq (cons 1 (cons 2 (lazy-seq (throw (ex-info "Surprise!" {}))))))]
+          deep (lazy-seq (cons 1 (cons 2 (list (lazy-seq (throw (ex-info "Surprise!" {})))))))]
       (is (= '(1 2) (#'setting/realize ok)))
       (is (= '(1 (2)) (#'setting/realize ok-deep)))
       (doseq [x [shallow deep]]

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1208,6 +1208,9 @@
     (let [ex (get-parse-exception "[1, 2,")]
       (is (= "Invalid JSON configuration for setting: test-json-setting" (ex-message ex)))
       ;; TODO it would be safe to expose the raw Jackson exception here, we could improve redaction logic
+      #_(is (= (str "Unexpected end-of-input within/between Array entries\n"
+                  " at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 7]")
+             (ex-message (ex-cause ex))))
       (is (= "Error of type class com.fasterxml.jackson.core.JsonParseException thrown while parsing a setting"
              (ex-message (ex-cause ex)))))))
 

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1190,3 +1190,14 @@
                             :previous-value nil
                             :new-value      "AUDIT ME"}}
                  (mt/latest-audit-log-entry :setting-update))))))))
+
+(deftest valid-json-setting-test
+  (mt/with-temp-env-var-value ["MB_TEST_JSON_SETTING" "[1, 2]"]
+    (is (nil? (setting/validate-settings-formatting!)))))
+
+(deftest invalid-json-setting-test
+  (mt/with-temp-env-var-value ["MB_TEST_JSON_SETTING" "[1, 2,"]
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid JSON configuration for setting: test-json-setting"
+         (setting/validate-settings-formatting!)))))

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1225,5 +1225,11 @@
 
 (deftest safe-exceptions-not-redacted-test
   (testing "An exception known not to contain sensitive info will not be redacted"
-    (let [ex (get-parse-exception "{\"a\": 2")]
-      (is (str/includes? (pr-str ex) "Unexpected end-of-input")))))
+    (let [password "123abc"
+          ex (get-parse-exception "{\"a\": \"123abc\", \"b\": 2")]
+      (is (not (str/includes? (pr-str ex) password)))
+      (is (= "Invalid JSON configuration for setting: test-json-setting" (ex-message ex)))
+      (is (= (str "Unexpected end-of-input: expected close marker for Object (start marker at [Source: REDACTED"
+                  " (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1])\n"
+                  " at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 23]")
+             (ex-message (ex-cause ex)))))))


### PR DESCRIPTION
### Description

Closes #36182 

This change adds a step during initialization to sanity check all JSON settings.

If any issues are found, the process will indicate which settings are to blame and then terminate.

### How to verify

First configure a setting which expects JSON to have an invalid value, for example use the following `.lein-env`:

```clojure
{:mb-custom-formatting "{\"type/Temporal\":{\"time_style\":\"HH:mm\",\"date_abbreviate\":true}"}
```

*This configuration is missing a closing curly brace.*

Then, attempt to start the server:

```bash
clojure -M:run
```

The process should terminate during startup, and print the following exception:

```text
2024-01-05 18:26:42,568 ERROR metabase.core :: Metabase Initialization FAILED
clojure.lang.ExceptionInfo: Invalid JSON configuration for settings: (:custom-formatting) 
  {:registered-settings (:active-users-count :admin-email :aggregated-query-row-limit ...
```

### Potential ideas for improvement

- Expose non-sensitive hints to assist operator fix the config (e.g. "expected closing brace at char 63")
- Avoid repeated fetching and parsing of the configuration values, e.g. cache and reuse these results 
- Make this mechanism extensible for other validation, e.g. can all raw values be read, is integer really positive, etc
