### PR TITLE
[#35961 M4] Add backend verification for accepting embedding legalese

### DIFF
--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -164,6 +164,7 @@ export const createMockSettings = (
   engines: createMockEngines(),
   "has-user-setup": true,
   "hide-embed-branding?": true,
+  "show-static-embed-terms": true,
   "ga-enabled": false,
   "google-auth-auto-create-accounts-domain": null,
   "google-auth-client-id": null,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -280,6 +280,7 @@ export interface Settings {
   "uploads-table-prefix": string | null;
   "user-visibility": string | null;
   "last-acknowledged-version": string | null;
+  "show-static-embed-terms": boolean | null;
 }
 
 export type SettingKey = keyof Settings;

--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -53,7 +53,7 @@ export const UPDATE_SETTING = "metabase/admin/settings/UPDATE_SETTING";
 export const updateSetting = createThunkAction(
   UPDATE_SETTING,
   function (setting) {
-    return async function (dispatch, getState) {
+    return async function (dispatch) {
       try {
         await SettingsApi.put(setting);
       } catch (error) {

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
@@ -47,7 +47,7 @@ const EmbedTitle = ({
 
 export const EmbedModal = ({ children, isOpen, onClose }: EmbedModalProps) => {
   const shouldShowEmbedTerms = useSelector(state =>
-      getSetting(state, "show-static-embed-terms"),
+    getSetting(state, "show-static-embed-terms"),
   );
   const [embedType, setEmbedType] = useState<EmbedModalStep>(null);
   const applicationName = useSelector(getApplicationName);

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
@@ -4,6 +4,7 @@ import {
   EmbedModalHeaderBackIcon,
   EmbedTitleContainer,
 } from "metabase/public/components/EmbedModal/EmbedModal.styled";
+import { getSetting } from "metabase/selectors/settings";
 import { useSelector } from "metabase/lib/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 import Modal from "metabase/components/Modal";
@@ -45,15 +46,16 @@ const EmbedTitle = ({
 };
 
 export const EmbedModal = ({ children, isOpen, onClose }: EmbedModalProps) => {
+  const shouldShowEmbedTerms = useSelector(state =>
+      getSetting(state, "show-static-embed-terms"),
+  );
   const [embedType, setEmbedType] = useState<EmbedModalStep>(null);
   const applicationName = useSelector(getApplicationName);
 
   const goToNextStep = () => {
-    if (embedType === null) {
+    if (embedType === null && shouldShowEmbedTerms) {
       setEmbedType("legalese");
-    }
-
-    if (embedType === "legalese") {
+    } else {
       setEmbedType("application");
     }
   };

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
@@ -18,7 +18,9 @@ const TestEmbedModal = ({
       {({ embedType, goToNextStep, goBackToEmbedModal }) => (
         <Group data-testid="test-embed-modal-content">
           <Button onClick={goBackToEmbedModal}>Previous</Button>
-          <Text data-testid="test-embed-step">{embedType ?? "Embed Landing"}</Text>
+          <Text data-testid="test-embed-step">
+            {embedType ?? "Embed Landing"}
+          </Text>
           <Button onClick={goToNextStep}>Next</Button>
         </Group>
       )}
@@ -59,7 +61,9 @@ describe("EmbedModal", () => {
 
     expect(screen.getByTestId("test-embed-modal-content")).toBeInTheDocument();
 
-    expect(screen.getByTestId("test-embed-step")).toHaveTextContent("Embed Landing");
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "Embed Landing",
+    );
   });
 
   it("should go to the legalese step when `Next` is clicked", () => {
@@ -75,18 +79,22 @@ describe("EmbedModal", () => {
     userEvent.click(screen.getByText("Next"));
     expect(screen.getByTestId("test-embed-step")).toHaveTextContent("legalese");
 
-    userEvent.click(screen.getByText("Next"))
-    expect(screen.getByTestId("test-embed-step")).toHaveTextContent("application");
-  })
+    userEvent.click(screen.getByText("Next"));
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "application",
+    );
+  });
 
   it("should immediately go to the static embedding step if the user has accepted the terms", async () => {
-    setup({ showStaticEmbedTerms: false});
+    setup({ showStaticEmbedTerms: false });
 
     userEvent.click(screen.getByText("Next"));
     expect(
       within(screen.getByTestId("modal-header")).getByText("Static embedding"),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("test-embed-step")).toHaveTextContent("application");
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "application",
+    );
   });
 
   it("returns to the initial embed modal landing when the user clicks the modal title", () => {
@@ -96,7 +104,9 @@ describe("EmbedModal", () => {
     expect(screen.getByTestId("test-embed-step")).toHaveTextContent("legalese");
 
     userEvent.click(screen.getByText("Static embedding"));
-    expect(screen.getByTestId("test-embed-step")).toHaveTextContent("Embed Landing");
+    expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
+      "Embed Landing",
+    );
   });
 
   it("calls onClose when the modal is closed", () => {

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.tsx
@@ -1,6 +1,6 @@
-import {LegaleseStep} from "metabase/public/components/widgets/LegaleseStep/LegaleseStep";
 import { useState } from "react";
 import _ from "underscore";
+import {LegaleseStep} from "metabase/public/components/widgets/LegaleseStep/LegaleseStep";
 import { getSignedPreviewUrl, getSignedToken } from "metabase/public/lib/embed";
 import { getSetting } from "metabase/selectors/settings";
 import { useSelector } from "metabase/lib/redux";

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import _ from "underscore";
-import {LegaleseStep} from "metabase/public/components/widgets/LegaleseStep/LegaleseStep";
+import { LegaleseStep } from "metabase/public/components/widgets/LegaleseStep/LegaleseStep";
 import { getSignedPreviewUrl, getSignedToken } from "metabase/public/lib/embed";
 import { getSetting } from "metabase/selectors/settings";
 import { useSelector } from "metabase/lib/redux";

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.tsx
@@ -10,7 +10,7 @@ import * as MetabaseAnalytics from "metabase/lib/analytics";
 import Link from "metabase/core/components/Link";
 import type { ExportFormatType } from "metabase/dashboard/components/PublicLinkPopover/types";
 
-import type { EmbedResource, EmbedResourceType, EmbedModalStep } from "../types";
+import type { EmbedResource, EmbedResourceType } from "../types";
 import { SharingPaneActionButton } from "./SharingPaneButton/SharingPaneButton.styled";
 import { SharingPaneButton } from "./SharingPaneButton/SharingPaneButton";
 import { PublicEmbedIcon, StaticEmbedIcon } from "./icons";

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
@@ -1,4 +1,6 @@
 import { jt, t } from "ttag";
+import { updateSetting } from "metabase/admin/settings/settings";
+import { useDispatch } from "metabase/lib/redux";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { LegaleseStepDetailsContainer } from "metabase/public/components/widgets/LegaleseStep/LegaleseStep.styled";
 import { Text, Button, Center, Stack, Title } from "metabase/ui";
@@ -7,34 +9,49 @@ export const LegaleseStep = ({
   goToNextStep,
 }: {
   goToNextStep: () => void;
-}) => (
-  <Center bg="white" px="18rem" pt="6.25rem" pb="11.75rem">
-    <Stack align="center" spacing="3rem">
-      <Title order={2} fz="1.25rem">{t`First, some legalese`}</Title>
+}) => {
+  const dispatch = useDispatch();
 
-      <LegaleseStepDetailsContainer p="lg" w="40rem">
-        <Text fw={700}>
-          {jt`By clicking "Agree and continue" you're agreeing to ${(
-            <ExternalLink
-              href="https://metabase.com/license/embedding"
-              target="_blank"
-            >
-              {t`our embedding license.`}
-            </ExternalLink>
-          )}`}
-        </Text>
-        <Text>
-          {t`When you embed charts or dashboards from Metabase in your own application, that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the "Powered by Metabase" visible on those embeds.`}
-        </Text>
-        <Text>
-          {t`You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature.`}
-        </Text>
-      </LegaleseStepDetailsContainer>
+  const onAcceptTerms = () => {
+    dispatch(
+      updateSetting({
+        key: "show-static-embed-terms",
+        value: false,
+      }),
+    );
+    goToNextStep();
+  };
 
-      <Button
-        variant="filled"
-        onClick={goToNextStep}
-      >{t`Agree and continue`}</Button>
-    </Stack>
-  </Center>
-);
+  return (
+    <Center bg="white" px="18rem" pt="6.25rem" pb="11.75rem">
+      <Stack align="center" spacing="3rem">
+        <Title order={2} fz="1.25rem">{t`First, some legalese`}</Title>
+
+        <LegaleseStepDetailsContainer p="lg" w="40rem">
+          <Text fw={700}>
+            {jt`By clicking "Agree and continue" you're agreeing to ${(
+              <ExternalLink
+                  key="embed-license-link"
+                href="https://metabase.com/license/embedding"
+                target="_blank"
+              >
+                {t`our embedding license.`}
+              </ExternalLink>
+            )}`}
+          </Text>
+          <Text>
+            {t`When you embed charts or dashboards from Metabase in your own application that application isn't subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the "Powered by Metabase" visible on those embeds.`}
+          </Text>
+          <Text>
+            {t`You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature.`}
+          </Text>
+        </LegaleseStepDetailsContainer>
+
+        <Button
+          variant="filled"
+          onClick={onAcceptTerms}
+        >{t`Agree and continue`}</Button>
+      </Stack>
+    </Center>
+  );
+};

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.tsx
@@ -31,7 +31,7 @@ export const LegaleseStep = ({
           <Text fw={700}>
             {jt`By clicking "Agree and continue" you're agreeing to ${(
               <ExternalLink
-                  key="embed-license-link"
+                key="embed-license-link"
                 href="https://metabase.com/license/embedding"
                 target="_blank"
               >

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.unit.spec.tsx
@@ -59,6 +59,9 @@ describe("LegaleseStep", () => {
     userEvent.click(screen.getByText("Agree and continue"));
 
     expect(settingPutCalls.calls().length).toBe(1);
+    expect(await settingPutCalls.lastCall()?.request?.json()).toEqual({
+      value: false,
+    });
     expect(goToNextStep).toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.unit.spec.tsx
@@ -1,0 +1,64 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import {
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import {
+  createMockSettingDefinition,
+  createMockSettings,
+} from "metabase-types/api/mocks";
+import { LegaleseStep } from "./LegaleseStep";
+
+const setup = () => {
+  const goToNextStep = jest.fn();
+
+  setupSettingsEndpoints([
+    createMockSettingDefinition({
+      key: "show-static-embed-terms",
+      value: true,
+    }),
+  ]);
+
+  setupPropertiesEndpoints(createMockSettings());
+
+  renderWithProviders(<LegaleseStep goToNextStep={goToNextStep} />);
+
+  return { goToNextStep };
+};
+
+describe("LegaleseStep", () => {
+  it("renders the LegaleseStep component with legalese content", () => {
+    setup();
+
+    expect(screen.getByText("First, some legalese")).toBeInTheDocument();
+    expect(
+      screen.getByText('By clicking "Agree and continue" you\'re agreeing to'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'When you embed charts or dashboards from Metabase in your own application, that application isn\'t subject to the Affero General Public License that covers the rest of Metabase, provided you keep the Metabase logo and the "Powered by Metabase" visible on those embeds.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "You should, however, read the license text linked above as that is the actual license that you will be agreeing to by enabling this feature.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Agree and continue")).toBeInTheDocument();
+  });
+
+  it("calls goToNextStep and updates setting on clicking 'Agree and continue'", async () => {
+    const settingPutCalls = fetchMock.put(
+      "path:/api/setting/show-static-embed-terms",
+      {},
+    );
+
+    const { goToNextStep } = setup();
+    userEvent.click(screen.getByText("Agree and continue"));
+
+    expect(settingPutCalls.calls().length).toBe(1);
+    expect(goToNextStep).toHaveBeenCalled();
+  });
+});

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -107,7 +107,6 @@
   (or (get-in unsigned-token keyseq)
       (throw (ex-info (tru "Token is missing value for keypath {0}" keyseq) {:status-code 400}))))
 
-
 (defsetting show-static-embed-terms
   (deferred-tru "Check if the static embedding licensing should be hidden in the static embedding flow")
   :type    :boolean

--- a/src/metabase/util/embed.clj
+++ b/src/metabase/util/embed.clj
@@ -6,7 +6,8 @@
    [cheshire.core :as json]
    [clojure.string :as str]
    [hiccup.core :refer [html]]
-   [metabase.models.setting :as setting]
+   [metabase.config :as config]
+   [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.public-settings :as public-settings]
    [metabase.util :as u]
    [metabase.util.i18n :refer [deferred-tru trs tru]]
@@ -55,7 +56,7 @@
 
 ;;; ----------------------------------------------- EMBEDDING UTIL FNS -----------------------------------------------
 
-(setting/defsetting embedding-secret-key
+(defsetting embedding-secret-key
   (deferred-tru "Secret key used to sign JSON Web Tokens for requests to `/api/embed` endpoints.")
   :visibility :admin
   :audit :no-value
@@ -105,3 +106,13 @@
   [unsigned-token keyseq]
   (or (get-in unsigned-token keyseq)
       (throw (ex-info (tru "Token is missing value for keypath {0}" keyseq) {:status-code 400}))))
+
+
+(defsetting show-static-embed-terms
+  (deferred-tru "Check if the static embedding licensing should be hidden in the static embedding flow")
+  :type    :boolean
+  :default true
+  :getter  (fn []
+              (if-not config/ee-available?
+                (setting/get-value-of-type :boolean :show-static-embed-terms)
+                false)))

--- a/test/metabase/util/embed_test.clj
+++ b/test/metabase/util/embed_test.clj
@@ -1,8 +1,9 @@
 (ns ^:mb/once metabase.util.embed-test
   (:require
    [buddy.sign.jwt :as jwt]
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest is testing]]
    [crypto.random :as crypto-random]
+   [metabase.config :as config]
    [metabase.test :as mt]
    [metabase.util.embed :as embed]))
 
@@ -21,3 +22,20 @@
            clojure.lang.ExceptionInfo
            #"JWT `alg` cannot be `none`"
            (embed/unsign token-with-alg-none))))))
+
+(deftest show-static-embed-terms-test
+  (mt/with-test-user :crowberto
+    (mt/with-temporary-setting-values [show-static-embed-terms nil]
+      (testing "Check if the user needs to accept the embedding licensing terms before static embedding"
+        (when-not config/ee-available?
+          (testing "should return true when user is OSS and has not accepted licensing terms"
+            (is (= (embed/show-static-embed-terms) true)))
+          (testing "should return false when user is OSS and has already accepted licensing terms"
+            (embed/show-static-embed-terms! false)
+            (is (= (embed/show-static-embed-terms) false))))
+        (when config/ee-available?
+          (testing "should always return false for EE users"
+            (is (= (embed/show-static-embed-terms) false))
+            (embed/show-static-embed-terms! false)
+            (is (= (embed/show-static-embed-terms) false))
+            ))))))

--- a/test/metabase/util/embed_test.clj
+++ b/test/metabase/util/embed_test.clj
@@ -1,7 +1,7 @@
 (ns ^:mb/once metabase.util.embed-test
   (:require
    [buddy.sign.jwt :as jwt]
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer :all]
    [crypto.random :as crypto-random]
    [metabase.config :as config]
    [metabase.test :as mt]
@@ -37,5 +37,4 @@
           (testing "should always return false for EE users"
             (is (= (embed/show-static-embed-terms) false))
             (embed/show-static-embed-terms! false)
-            (is (= (embed/show-static-embed-terms) false))
-            ))))))
+            (is (= (embed/show-static-embed-terms) false))))))))


### PR DESCRIPTION
Epic #35961 - Milestone 4

### Description

Adds the backend code for ensuring that the static embedding licensing terms are only shown once to OSS users. This additional flag will ensure that an OSS user will only see the legalese if they haven't accepted them yet.

### How to verify

_In an EE instance_
* Go to a dashboard/question and access the Embed modal (click the share icon and click the "Embed" option in the menu)
* Click into `Static Embed`
* You should immediately see the options for static embedding. For EE instances, there is no legalese step

_In an OSS instance_
* Go to a dashboard/question and access the Embed modal (click the share icon and click the "Embed" option in the menu)
* Click into `Static Embed`
* You should see a screen containing the licensing terms for static embedding. Clicking `Agree and continue` should take you to the static embedding configuration screen.
* Refresh the page and try the same flow. You should immediately see the options for static embedding, as the user has already accepted the terms


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR _**Backend tests have been written, E2E tests will be solved in a separate PR**_
