### PR TITLE
Sync should log something before it fetches metadata

### DIFF
--- a/src/metabase/sync/sync_metadata.clj
+++ b/src/metabase/sync/sync_metadata.clj
@@ -65,8 +65,8 @@
 (mu/defn sync-db-metadata!
   "Sync the metadata for a Metabase `database`. This makes sure child Table & Field objects are synchronized."
   [database :- i/DatabaseInstance]
-  (let [db-metadata (fetch-metadata/db-metadata database)]
-    (sync-util/sync-operation :sync-metadata database (format "Sync metadata for %s" (sync-util/name-for-logging database))
+  (sync-util/sync-operation :sync-metadata database (format "Sync metadata for %s" (sync-util/name-for-logging database))
+    (let [db-metadata (fetch-metadata/db-metadata database)]
       (u/prog1 (sync-util/run-sync-operation "sync" database (make-sync-steps db-metadata))
         (if (some sync-util/abandon-sync? (map second (:steps <>)))
           (sync-util/set-initial-database-sync-aborted! database)


### PR DESCRIPTION
We should log out ` STARTING: Sync metadata for redshift Database 5` before we call `(fetch-metadata/db-metadata database)` because that could be slow on big DBs