### PR TITLE
Serdes: tidy model lists

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -52,9 +52,9 @@
    "GroupTableAccessPolicy"            ; permissions are not serialized
    "HTTPAction"                        ; HTTP actions are not fully implemented, and if they were they would be inlined into Action
    "LoginHistory"                      ; login history is not serialized
-   "MetricImportantField"              ; ???
-   "ModelIndex"                        ; Why are model indexes not verified???
-   "ModelIndexValue"                   ; Why are model indexes not verified???
+   "MetricImportantField"              ; ??? Cal: I'm not sure what this is
+   "ModelIndex"                        ; ??? Cal: Why are model indexes not serialized
+   "ModelIndexValue"                   ; ??? Cal: Why are model indexes not serialized
    "ModerationReview"                  ; Which content is verified is not serialized
    "Permissions"                       ; permissions are not serialized
    "PermissionsGroup"                  ; permissions are not serialized

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -21,20 +21,20 @@
   "The list of all models exported by serialization by default. Used for production code and by tests."
   (concat data-model
           content
-          ["FieldValues"
-           "Setting"]))
+          ["Setting"]))
 
 (def inlined-models
   "An additional list of models which are inlined into parent entities for serialization.
   These are not extracted and serialized separately, but they may need some processing done.
   For example, the models should also have their entity_id fields populated (if they have one)."
-  ["ImplicitAction"      ; inlined into Action
-   "QueryAction"         ; inlined into Action
-   "DashboardCard"       ; inlined into Dashboard
+  ["DashboardCard"       ; inlined into Dashboard
+   "DashboardCardSeries" ; inlined into Dashboard
    "DashboardTab"        ; inlined into Dashboard
    "Dimension"           ; inlined into Field
+   "FieldValues"         ; inlined into Field
+   "ImplicitAction"      ; inlined into Action
    "ParameterCard"       ; inlined into Card
-   "DashboardCardSeries" ; inlined into Dashboard
+   "QueryAction"         ; inlined into Action
    "TimelineEvent"])     ; inlined into Timeline
 
 (def excluded-models

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/models.clj
@@ -28,51 +28,51 @@
   "An additional list of models which are inlined into parent entities for serialization.
   These are not extracted and serialized separately, but they may need some processing done.
   For example, the models should also have their entity_id fields populated (if they have one)."
-  ["DashboardCard"
-   "DashboardTab"
-   "Dimension"
-   "ParameterCard"
-   "DashboardCardSeries"
-   "TimelineEvent"])
+  ["ImplicitAction"      ; inlined into Action
+   "QueryAction"         ; inlined into Action
+   "DashboardCard"       ; inlined into Dashboard
+   "DashboardTab"        ; inlined into Dashboard
+   "Dimension"           ; inlined into Field
+   "ParameterCard"       ; inlined into Card
+   "DashboardCardSeries" ; inlined into Dashboard
+   "TimelineEvent"])     ; inlined into Timeline
 
 (def excluded-models
   "List of models which are not going to be serialized ever."
-  ["Activity"
-   "ApiKey"
-   "ApplicationPermissionsRevision"
-   "AuditLog"
-   "BookmarkOrdering"
-   "CardBookmark"
-   "CollectionBookmark"
-   "CollectionPermissionGraphRevision"
-   "ConnectionImpersonation"
-   "DashboardBookmark"
-   "GroupTableAccessPolicy"
-   "HTTPAction"
-   "ImplicitAction"
-   "LoginHistory"
-   "MetricImportantField"
-   "ModelIndex"
-   "ModelIndexValue"
-   "ModerationReview"
-   "Permissions"
-   "PermissionsGroup"
-   "PermissionsGroupMembership"
-   "PermissionsRevision"
-   "PersistedInfo"
-   "Pulse"
-   "PulseCard"
-   "PulseChannel"
-   "PulseChannelRecipient"
-   "Query"
-   "QueryAction"
-   "QueryCache"
-   "QueryExecution"
-   "RecentViews"
-   "Revision"
-   "Secret"
-   "Session"
-   "TablePrivileges"
-   "TaskHistory"
-   "User"
-   "ViewLog"])
+  ["Activity"                          ; activity is not serialized
+   "ApiKey"                            ; api keys are not serialized
+   "ApplicationPermissionsRevision"    ; permissions are not serialized
+   "AuditLog"                          ; audit log is not serialized
+   "BookmarkOrdering"                  ; bookmarks are not serialized
+   "CardBookmark"                      ; bookmarks are not serialized
+   "CollectionBookmark"                ; bookmarks are not serialized
+   "CollectionPermissionGraphRevision" ; permissions are not serialized
+   "ConnectionImpersonation"           ; permissions are not serialized
+   "DashboardBookmark"                 ; bookmarks are not serialized
+   "GroupTableAccessPolicy"            ; permissions are not serialized
+   "HTTPAction"                        ; HTTP actions are not fully implemented, and if they were they would be inlined into Action
+   "LoginHistory"                      ; login history is not serialized
+   "MetricImportantField"              ; ???
+   "ModelIndex"                        ; Why are model indexes not verified???
+   "ModelIndexValue"                   ; Why are model indexes not verified???
+   "ModerationReview"                  ; Which content is verified is not serialized
+   "Permissions"                       ; permissions are not serialized
+   "PermissionsGroup"                  ; permissions are not serialized
+   "PermissionsGroupMembership"        ; permissions are not serialized
+   "PermissionsRevision"               ; permissions are not serialized
+   "PersistedInfo"                     ; ??? Cal: this could potentially be a bug, because the persistence is a state machine
+   "Pulse"                             ; subscriptions/alerts are not serialized
+   "PulseCard"                         ; subscriptions/alerts are not serialized
+   "PulseChannel"                      ; subscriptions/alerts are not serialized
+   "PulseChannelRecipient"             ; subscriptions/alerts are not serialized
+   "Query"                             ; queries are not serialized
+   "QueryCache"                        ; query cache data is not serialized
+   "QueryExecution"                    ; query executions is not serialized
+   "RecentViews"                       ; view history is not serialized
+   "Revision"                          ; revisions are not serializaed
+   "Secret"                            ; secrets are not serialized
+   "Session"                           ; sessions are not serialized
+   "TablePrivileges"                   ; table privileges are not serialized
+   "TaskHistory"                       ; task history is not serialized
+   "User"                              ; users are not serialized
+   "ViewLog"])                         ; view history is not serialized

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -34,11 +34,7 @@
   - exported as a child of something else (eg. timeline_event under timeline)
   so they don't need a generated entity_id."
   (set (map #(keyword "model" %)
-            (concat
-             ;; These are not exported at all
-             serdes.models/excluded-models
-             ;; These are exported as children of something else
-             serdes.models/inlined-models))))
+            (concat serdes.models/excluded-models serdes.models/inlined-models))))
 
 (deftest ^:parallel comprehensive-entity-id-test
   (doseq [model (->> (v2.entity-ids/toucan-models)

--- a/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/models/entity_id_test.clj
@@ -8,6 +8,7 @@
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase-enterprise.serialization.v2.entity-ids :as v2.entity-ids]
+   [metabase-enterprise.serialization.v2.models :as serdes.models]
    #_{:clj-kondo/ignore [:deprecated-namespace]}
    [metabase.models]
    [metabase.models.revision-test]
@@ -32,48 +33,12 @@
   - not exported in serialization; or
   - exported as a child of something else (eg. timeline_event under timeline)
   so they don't need a generated entity_id."
-  #{:model/ApiKey
-    :model/HTTPAction
-    :model/ImplicitAction
-    :model/QueryAction
-    :model/Activity
-    :model/ApplicationPermissionsRevision
-    :model/AuditLog
-    :model/BookmarkOrdering
-    :model/CardBookmark
-    :model/CollectionBookmark
-    :model/DashboardBookmark
-    :model/CollectionPermissionGraphRevision
-    :model/DashboardCardSeries
-    :model/LoginHistory
-    :model/FieldValues
-    :model/MetricImportantField
-    :model/ModelIndex
-    :model/ModelIndexValue
-    :model/ModerationReview
-    :model/ParameterCard
-    :model/Permissions
-    :model/PermissionsGroup
-    :model/PermissionsGroupMembership
-    :model/PermissionsRevision
-    :model/PersistedInfo
-    :model/PulseCard
-    :model/PulseChannel
-    :model/PulseChannelRecipient
-    :model/Query
-    :model/QueryCache
-    :model/QueryExecution
-    :model/RecentViews
-    :model/Revision
-    :model/Secret
-    :model/Session
-    :model/TablePrivileges
-    :model/TaskHistory
-    :model/TimelineEvent
-    :model/User
-    :model/ViewLog
-    :model/GroupTableAccessPolicy
-    :model/ConnectionImpersonation})
+  (set (map #(keyword "model" %)
+            (concat
+             ;; These are not exported at all
+             serdes.models/excluded-models
+             ;; These are exported as children of something else
+             serdes.models/inlined-models))))
 
 (deftest ^:parallel comprehensive-entity-id-test
   (doseq [model (->> (v2.entity-ids/toucan-models)


### PR DESCRIPTION
WIP

This [recent issue](https://github.com/metabase/metabase/issues/37232) about not serializing `DashboardCardSeries` could have been prevented if we had checked the list of `excluded-models` to only exclude models that should actually be excluded from serialization.

This PR does a few things:
- adds comments to the `inlined-models` list explaining which model the model is inlined under
- adds comments to the `excluded-models` list explaining why each model is excluded
- changes `metabase-enterprise.models.entity-id-test/entities-not-exported` to use these lists instead of maintaining its own list