### PR TITLE
Migrate `ViewTitleHeader` to MLv2

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { t } from "ttag";
 import { usePrevious } from "react-use";
 
+import * as Lib from "metabase-lib";
 import * as Urls from "metabase/lib/urls";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { SERVER_ERROR_TYPES } from "metabase/lib/errors";
@@ -88,28 +89,26 @@ export function ViewTitleHeader(props) {
 
   const previousQuestion = usePrevious(question);
 
+  const query = question.query();
+  const previousQuery = usePrevious(query);
+
   useEffect(() => {
     if (!question.isStructured() || !previousQuestion?.isStructured()) {
       return;
     }
 
-    const filtersCount = question.legacyQuery().filters().length;
-    const previousFiltersCount = previousQuestion
-      .legacyQuery()
-      .filters().length;
+    const filtersCount = Lib.filters(query, -1).length;
+    const previousFiltersCount = Lib.filters(previousQuery, -1).length;
 
     if (filtersCount > previousFiltersCount) {
       expandFilters();
     }
-  }, [previousQuestion, question, expandFilters]);
+  }, [previousQuestion, question, expandFilters, previousQuery, query]);
 
-  const isStructured = question.isStructured();
   const isNative = question.isNative();
   const isSaved = question.isSaved();
   const isDataset = question.isDataset();
-
-  const isSummarized =
-    isStructured && question.legacyQuery().topLevelQuery().hasAggregations();
+  const isSummarized = Lib.aggregations(query, -1).length > 0;
 
   const onQueryChange = useCallback(
     newQuery => {


### PR DESCRIPTION
This PR deals with the first task in #37227. It migrates **only the code inside the `ViewTitleHeader` function** to MLv2 .

There is one more place in `frontend/src/metabase/query_builder/components/view/ViewHeader.jsx` where MLv1 is used, but it's currently not possible to migrate it because MLv2 only works for structured queries for now. We need a support for native queries in order to fully migrate this file.

### Demo
- Number of filters should still be updated instantly
- If collapsed,
    - it should stay collapsed when removing filters in the next query
    - it should expand when adding filters to the query

https://github.com/metabase/metabase/assets/31325167/8dda684a-3250-4b24-bffd-1451f3929ce2

