### PR TITLE
Incorporate sandboxes into perms graph based on the `sandboxes` table

### DIFF
--- a/e2e/support/commands/permissions/sandboxTable.js
+++ b/e2e/support/commands/permissions/sandboxTable.js
@@ -20,13 +20,6 @@ Cypress.Commands.add(
       const attr = Object.keys(attribute_remappings).join(", "); // Account for the possiblity of passing multiple user attributes
 
       cy.log(`Sandbox "${name}" table on "${attr}"`);
-      cy.request("POST", "/api/mt/gtap", {
-        attribute_remappings,
-        card_id,
-        group_id,
-        table_id,
-      });
-
       cy.updatePermissionsSchemas({
         schemas: {
           [schema]: {
@@ -35,6 +28,12 @@ Cypress.Commands.add(
         },
         user_group: group_id,
         database_id: db_id,
+      });
+      cy.request("POST", "/api/mt/gtap", {
+        attribute_remappings,
+        card_id,
+        group_id,
+        table_id,
       });
     });
   },

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
@@ -44,12 +44,6 @@
                 :expected-perms   (fn []
                                     {:schemas {:PUBLIC {(mt/id :users) "all"}}})}
 
-               "when revoking segmented query permissions for Table"
-               {:updated-db-perms (fn []
-                                    {:native :none, :schemas {:PUBLIC {(mt/id :venues) {:read :all}}}})
-                :expected-perms   (fn []
-                                    {:schemas {:PUBLIC {(mt/id :venues) {:read "all"}}}})}
-
                "when changing permissions for DB to unrestricted access"
                {:updated-db-perms (constantly {:native :none, :schemas :all})
                 :expected-perms   (constantly {:schemas "all"})}
@@ -67,7 +61,7 @@
           (testing message
             (testing "sanity check"
               (testing "perms graph endpoint should return segmented perms for Venues table"
-                (is (= {:query "segmented"}
+                (is (= {:read "all" :query "segmented"}
                        (get-in (mt/user-http-request :crowberto :get 200 "permissions/graph")
                                (venues-perms-graph-keypath &group)))))
               (testing "GTAP should exist in application DB"

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
@@ -128,7 +128,7 @@
 
 (deftest add-sandboxes-to-permissions-graph-test
   (testing "Sandbox definitions in the DB are automatically added to the permissions graph"
-    (premium-features-test/with-premium-features #{:sandboxes}
+    (mt/with-premium-features #{:sandboxes}
       (mt/with-temp [GroupTableAccessPolicy _gtap {:table_id (mt/id :venues)
                                                    :group_id (u/the-id (perms-group/all-users))}]
         (is (= {(u/the-id (perms-group/all-users))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer :all]
    [metabase-enterprise.sandbox.models.group-table-access-policy
+    :as sandboxes
     :refer [GroupTableAccessPolicy]]
    [metabase.models :refer [Card]]
    [metabase.models.permissions-group :as perms-group]
@@ -124,3 +125,16 @@
                    (f
                     (-> (vec (qp/query->expected-cols (mt/mbql-query venues)))
                         (assoc-in [0 :base_type] :type/BigInteger)))))))))))
+
+(deftest add-sandboxes-to-permissions-graph-test
+  (testing "Sandbox definitions in the DB are automatically added to the permissions graph"
+    (premium-features-test/with-premium-features #{:sandboxes}
+      (mt/with-temp [GroupTableAccessPolicy _gtap {:table_id (mt/id :venues)
+                                                   :group_id (u/the-id (perms-group/all-users))}]
+        (is (= {(u/the-id (perms-group/all-users))
+                {(mt/id)
+                 {:data
+                  {:schemas
+                   {"PUBLIC"
+                    {(mt/id :venues) {:query :segmented :read :all}}}}}}}
+               (sandboxes/add-sandboxes-to-permissions-graph {})))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
@@ -136,5 +136,7 @@
                  {:data
                   {:schemas
                    {"PUBLIC"
-                    {(mt/id :venues) {:query :segmented :read :all}}}}}}}
+                    {(mt/id :venues)
+                     {:query :segmented
+                      :read :all}}}}}}}
                (sandboxes/add-sandboxes-to-permissions-graph {})))))))

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -634,6 +634,12 @@
   [graph]
   graph)
 
+(defenterprise add-sandboxes-to-permissions-graph
+  "Augment the permissions graph with active connection impersonation policies. OSS implementation returns graph as-is."
+  metabase-enterprise.sandbox.models.group-table-access-policy
+  [graph]
+  graph)
+
 (defn- post-process-graph [graph]
   (->>
    graph
@@ -651,6 +657,7 @@
               (all-permissions db-ids)
               (:db permissions-graph)))))
        post-process-graph
+       add-sandboxes-to-permissions-graph
        add-impersonations-to-permissions-graph))
 
 (defn ->v1-paths


### PR DESCRIPTION
This PR adds a `defendpoint` function which updates the permissions graph to indicate that tables are sandboxed based explicitly on the entries in the `sandboxes` table, rather than relying on the paths in `permissions`.

The `sandboxes` table was made the source of truth for sandboxing enforcement in https://github.com/metabase/metabase/pull/27985 but the graph was still based entirely on the `permissions` table. This should be a no-op, because they should be consistent, but if we eventually move away from the current permission path format we'd need to make this change anyway.  

See the similar function `add-impersonations-to-permissions-graph` for comparison. Sandboxes and Impersonations are very similar: they both describe modifications to queries which happen _after_ our normal permission checks, so it makes sense for their sources of truth to be different tables than the normal `permissions` table.