### PR TITLE
Add function to generate data perms graph based on permissions_v2 table

### DIFF
--- a/src/metabase/models/permissions_v2.clj
+++ b/src/metabase/models/permissions_v2.clj
@@ -108,7 +108,7 @@
                     {perm-type (Permissions perm-type)}))))
 
 
-;;; ---------------------------------------- Fetching permissions -----------------------------------------------------
+;;; ---------------------------------------- Fetching a user's permissions --------------------------------------------
 
 (defmulti coalesce
   "Coalesce a set of permission values into a single value. This is used to determine the permission to enforce for a
@@ -154,6 +154,49 @@
 
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
+
+
+;;; ---------------------------------------- Fetching the data permissions graph --------------------------------------
+
+(comment
+  ;; General hierarchy of the data access permissions graph
+  {#_:group-id 1
+   {#_:db-id 1
+    {#_:perm-type :data-access
+     {#_:schema-name "PUBLIC"
+      {#_:table-id 1 :unrestricted}}}}})
+
+(defn data-permissions-graph
+  "Returns a tree representation of all data permissions. Can be optionally filtered by group ID, database ID,
+  and/or permission type. This is intended to power the permissions editor in the admin panel, and should not be used
+  for permission enforcement, as it will read much more data than necessary."
+  [& {:keys [group-id db-id perm-type]}]
+  (let [data-perms (t2/select [:model/PermissionsV2
+                               :type
+                               [:group_id :group-id]
+                               :value
+                               [:db_id :db-id]
+                               :schema
+                               [:table_id :table-id]]
+                              {:where [:and
+                                       (when db-id [:= :db_id db-id])
+                                       (when group-id [:= :group_id group-id])
+                                       (when perm-type [:= :type (name perm-type)])]})]
+    (reduce
+     (fn [graph {group-id  :group-id
+                 perm-type :type
+                 value     :value
+                 db-id     :db-id
+                 schema    :schema
+                 table-id  :table-id}]
+       (let [schema   (or schema "")
+             db-perm? (= :model/Database (model-by-perm-type perm-type))
+             path     (if db-perm?
+                        [group-id db-id perm-type]
+                        [group-id db-id perm-type schema table-id])]
+         (assoc-in graph path value)))
+     {}
+     data-perms)))
 
 
 ;;; --------------------------------------------- Updating permissions ------------------------------------------------
@@ -233,7 +276,7 @@
   (defn do-try-catch-message [thunk] (try (thunk) (catch Exception e (ex-message e))))
   (defmacro tcm [& body] `(do-try-catch-message (fn [] ~@body)))
 
-  (set-permission! :data-access 2 :no-self-service 2 1 "PUBLIC")
+  (set-permission! :data-access 1 :unrestricted 3 1 "PUBLIC")
   (set-permission! :data-access 1 :no-self-service {:id 2})
   (set-permission! :data-access {:id 1} :no-self-service 3)
   (set-permission! :data-access {:id 1} :no-self-service {:id 4})

--- a/src/metabase/models/permissions_v2/graph.clj
+++ b/src/metabase/models/permissions_v2/graph.clj
@@ -1,0 +1,2 @@
+(ns metabase.models.permissions-v2.graph
+  "Code for building and manipulating permission graphs for the v2 permission system.")

--- a/src/metabase/models/permissions_v2/graph.clj
+++ b/src/metabase/models/permissions_v2/graph.clj
@@ -1,2 +1,0 @@
-(ns metabase.models.permissions-v2.graph
-  "Code for building and manipulating permission graphs for the v2 permission system.")

--- a/test/metabase/models/permissions_v2_test.clj
+++ b/test/metabase/models/permissions_v2_test.clj
@@ -170,3 +170,95 @@
              ExceptionInfo
              #"Permission type :collection requires an object ID"
              (perms-v2/permission-for-user user-id :collection)))))))
+
+(deftest data-permissions-graph-test
+  (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
+                 :model/PermissionsGroup {group-id-2 :id}      {}
+                 :model/Database         {database-id-1 :id}   {}
+                 :model/Database         {database-id-2 :id}   {}
+                 :model/Table            {table-id-1 :id}      {:db_id database-id-1
+                                                                :schema "PUBLIC"}
+                 :model/Table            {table-id-2 :id}      {:db_id database-id-1
+                                                                :schema "PUBLIC"}
+                 :model/Table            {table-id-3 :id}      {:db_id database-id-2
+                                                                :schema nil}]
+    (with-restored-perms-for-groups! [group-id-1 group-id-2]
+      (testing "Data access and native query permissions can be fetched as a graph"
+        (perms-v2/set-permission! :data-access group-id-1 :unrestricted table-id-1 database-id-1 "PUBLIC")
+        (perms-v2/set-permission! :data-access group-id-1 :unrestricted table-id-2 database-id-1 "PUBLIC")
+        (perms-v2/set-permission! :data-access group-id-1 :unrestricted table-id-3 database-id-2 nil)
+        (perms-v2/set-permission! :native-query-editing group-id-1 :yes database-id-1)
+        (perms-v2/set-permission! :native-query-editing group-id-1 :no database-id-2)
+        (perms-v2/set-permission! :data-access group-id-2 :no-self-service table-id-1 database-id-1 "PUBLIC")
+        (is (partial=
+             {group-id-1
+              {database-id-1 {:data-access
+                              {"PUBLIC"
+                               {table-id-1 :unrestricted
+                                table-id-2 :unrestricted}}
+                              :native-query-editing :yes}
+               database-id-2 {:data-access
+                              {""
+                               {table-id-3 :unrestricted}}
+                              :native-query-editing :no}}
+              group-id-2
+              {database-id-1 {:data-access
+                              {"PUBLIC"
+                               {table-id-1 :no-self-service}}}}}
+             (perms-v2/data-permissions-graph))))
+
+      (testing "Additional data permissions are included when set"
+        (perms-v2/set-permission! :download-results group-id-1 :one-million-rows table-id-3 database-id-2 nil)
+        (perms-v2/set-permission! :manage-table-metadata group-id-1 :yes table-id-1 database-id-1 "PUBLIC")
+        (perms-v2/set-permission! :manage-database group-id-1 :yes database-id-2)
+        (is (partial=
+             {group-id-1
+              {database-id-1 {:manage-table-metadata
+                              {"PUBLIC"
+                               {table-id-1 :yes}}}
+               database-id-2 {:download-results
+                              {""
+                               {table-id-3 :one-million-rows}}
+                              :manage-database :yes}}}
+             (perms-v2/data-permissions-graph))))
+
+      (testing "Data permissions graph can be filtered by group ID, databse ID, and permission type"
+        (is (= {group-id-1
+                {database-id-1 {:data-access
+                                {"PUBLIC"
+                                 {table-id-1 :unrestricted
+                                  table-id-2 :unrestricted}}
+                                :native-query-editing :yes
+                                :manage-table-metadata
+                                {"PUBLIC"
+                                 {table-id-1 :yes}}}
+                 database-id-2 {:data-access
+                                {""
+                                 {table-id-3 :unrestricted}}
+                                :download-results
+                                {""
+                                 {table-id-3 :one-million-rows}}
+                                :manage-database :yes
+                                :native-query-editing :no}}}
+               (perms-v2/data-permissions-graph :group-id group-id-1)))
+
+        (is (= {group-id-1
+                {database-id-1 {:data-access
+                                {"PUBLIC"
+                                 {table-id-1 :unrestricted
+                                  table-id-2 :unrestricted}}
+                                :native-query-editing :yes
+                                :manage-table-metadata
+                                {"PUBLIC"
+                                 {table-id-1 :yes}}}}}
+               (perms-v2/data-permissions-graph :group-id group-id-1
+                                                :db-id database-id-1)))
+
+        (is (= {group-id-1
+                {database-id-1 {:data-access
+                                {"PUBLIC"
+                                 {table-id-1 :unrestricted
+                                  table-id-2 :unrestricted}}}}}
+               (perms-v2/data-permissions-graph :group-id group-id-1
+                                                :db-id database-id-1
+                                                :perm-type :data-access)))))))


### PR DESCRIPTION
The PR adds a function `data-permissions-graph` which returns a graph of all data perms constructed from the rows in the `permissions_v2`

This is _not_ the graph which we can return directly to the FE without further modification, since the DB rows use different permission names than the FE currently expects in the graph. The backend graph->API graph conversion will come in a later PR.