### PR TITLE
Write permission changes in parallel to permissions and data_permissions

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -124,16 +124,6 @@
                  (test-db-perms group-id)))
           (is (not (t2/exists? GroupTableAccessPolicy :group_id group-id))))))))
 
-(deftest update-graph-data-perms-should-delete-block-perms-test
-  (testing "granting data permissions should delete existing block permissions"
-    (mt/with-temp [PermissionsGroup {group-id :id} {}
-                   Permissions      _ {:group_id group-id :object (perms/database-block-perms-path (mt/id))}]
-      (is (= {:schemas :block}
-             (test-db-perms group-id)))
-      (perms/update-data-perms-graph! [group-id (mt/id) :data :schemas] {"public" {(mt/id :venues) {:read :all}}})
-      (is (= {:schemas {"public" {(mt/id :venues) {:read :all}}}}
-             (test-db-perms group-id))))))
-
 (deftest update-graph-disallow-native-query-perms-test
   (testing "Disallow block permissions + native query permissions"
     (mt/with-temp [PermissionsGroup {group-id :id} {}

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -124,6 +124,16 @@
                  (test-db-perms group-id)))
           (is (not (t2/exists? GroupTableAccessPolicy :group_id group-id))))))))
 
+(deftest update-graph-data-perms-should-delete-block-perms-test
+ (testing "granting data permissions should delete existing block permissions"
+   (mt/with-temp [PermissionsGroup {group-id :id} {}
+                  Permissions      _ {:group_id group-id :object (perms/database-block-perms-path (mt/id))}]
+     (is (= {:schemas :block}
+            (test-db-perms group-id)))
+     (perms/update-data-perms-graph! [group-id (mt/id) :data :schemas] {"public" {(mt/id :venues) {:read :all}}})
+     (is (= {:schemas {"public" {(mt/id :venues) {:read :all}}}}
+            (test-db-perms group-id))))))
+
 (deftest update-graph-disallow-native-query-perms-test
   (testing "Disallow block permissions + native query permissions"
     (mt/with-temp [PermissionsGroup {group-id :id} {}

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -229,6 +229,7 @@
       (when (= [:data-access :block] [perm-type value])
         (set-database-permission! group-or-id db-or-id :native-query-editing :no)))))
 
+;; TODO: Update to take multiple tables
 (mu/defn set-table-permission!
   "Sets a single permission to a specified value for a given group and DB or table. If a permission value already exists
   for the specified group and object, it will be updated to the new value.

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -229,85 +229,92 @@
       (when (= [:data-access :block] [perm-type value])
         (set-database-permission! group-or-id db-or-id :native-query-editing :no)))))
 
-;; TODO: Update to take multiple tables
-(mu/defn set-table-permission!
-  "Sets a single permission to a specified value for a given group and DB or table. If a permission value already exists
-  for the specified group and object, it will be updated to the new value.
+(mu/defn set-table-permissions!
+  "Sets table permissions to specified values for a given group. If a permission value already exists for a specified
+  group and table, it will be updated to the new value.
 
-  If setting a table-level permission, and the permission is currently set at the database-level, the database-level permission
+  `table-perms` is a map from tables or table ID to the permission value for each table. All tables in the list must
+  belong to the same database.
+
+  If this permission is currently set at the database-level, the database-level permission
   is removed and table-level rows are are added for all of its tables. Similarly, if setting a table-level permission to a value
   that results in all of the database's tables having the same permission, it is replaced with a single database-level row."
+  [group-or-id :- TheIdable
+   perm-type   :- :keyword
+   table-perms :- [:map-of TheIdable :keyword]]
+  (when (not= :model/Table (model-by-perm-type perm-type))
+    (throw (ex-info (tru "Permission type {0} cannot be set on tables." perm-type)
+                    {perm-type (Permissions perm-type)})))
+  (let [values (set (vals table-perms))]
+    (when (values :block)
+      (throw (ex-info (tru "Block permissions must be set at the database-level only.")
+                      {})))
+    (t2/with-transaction [_conn]
+      (let [group-id               (u/the-id group-or-id)
+            new-perms              (map (fn [[table value]]
+                                          (let [{:keys [id db_id schema]}
+                                                (if (map? table)
+                                                  table
+                                                  (t2/select-one [:model/Table :id :db_id :schema] :id table))]
+                                            {:type       perm-type
+                                             :group_id   group-id
+                                             :perm_value value
+                                             :db_id      db_id
+                                             :table_id   id
+                                             :schema     schema}))
+                                        table-perms)
+            _                      (when (not= (count (set (map :db_id new-perms))) 1)
+                                     (throw (ex-info (tru "All tables must belong to the same database.")
+                                                     {:new-perms new-perms})))
+            table-ids              (map :table_id new-perms)
+            db-id                  (:db_id (first new-perms))
+            existing-db-perm       (t2/select-one :model/DataPermissions
+                                                  {:where
+                                                   [:and
+                                                    [:= :type (name perm-type)]
+                                                    [:= :group_id group-id]
+                                                    [:= :db_id db-id]
+                                                    [:= :table_id nil]]})
+            existing-db-perm-value (:perm_value existing-db-perm)]
+        (if existing-db-perm
+          (when (not= values #{existing-db-perm-value})
+            ;; If we're setting any table permissions to a value that is different from the database-level permission,
+            ;; we need to replace it with individual permission rows for every table in the database instead.
+            (let [other-tables    (t2/select :model/Table {:where [:and
+                                                                   [:= :db_id db-id]
+                                                                   [:not [:in :id table-ids]]]})
+                  other-new-perms (map (fn [table]
+                                         {:type       perm-type
+                                          :group_id   group-id
+                                          :perm_value existing-db-perm-value
+                                          :db_id      db-id
+                                          :table_id   (:id table)
+                                          :schema     (:schema table)})
+                                       other-tables)]
+              (t2/delete! :model/DataPermissions :id (:id existing-db-perm))
+              (t2/insert! :model/DataPermissions (concat other-new-perms new-perms))))
+          (let [existing-table-perms (t2/select :model/DataPermissions
+                                                :type (name perm-type)
+                                                :group_id group-id
+                                                :db_id db-id
+                                                {:where [:and
+                                                         [:not= :table_id nil]
+                                                         [:not [:in :table_id table-ids]]]})
+                existing-table-values (set (map :perm_value existing-table-perms))]
+            (if (and (= (count existing-table-values) 1)
+                     (= values existing-table-values))
+              ;; If all tables would have the same permissions after we update these ones, we can replace all of the table
+              ;; perms with a DB-level perm instead.
+              (set-database-permission! group-or-id db-id perm-type (first values))
+              ;; Otherwise, just replace the rows for the individual table perm
+              (do
+                (t2/delete! :model/DataPermissions :type perm-type :group_id group-id {:where [:in :table_id table-ids]})
+                (t2/insert! :model/DataPermissions new-perms)))))))))
+
+(mu/defn set-table-permission!
+  "Sets permissions for a single table to the specified value for a given group."
   [group-or-id :- TheIdable
    table-or-id :- TheIdable
    perm-type   :- :keyword
    value       :- :keyword]
-  (when (not= :model/Table (model-by-perm-type perm-type))
-    (throw (ex-info (tru "Permission type {0} cannot be set on tables." perm-type)
-                    {perm-type (Permissions perm-type)})))
-  (when (= [:data-access :block] [perm-type value])
-    (throw (ex-info (tru "Block permissions must be set at the database-level only.")
-                    {})))
-  (t2/with-transaction [_conn]
-    (let [group-id                  (u/the-id group-or-id)
-          {:keys [id db_id schema]} (if (map? table-or-id)
-                                      table-or-id
-                                      (t2/select-one [:model/Table :id :db_id :schema] :id table-or-id))
-          new-perm                  {:type       perm-type
-                                     :group_id   group-id
-                                     :perm_value value
-                                     :db_id      db_id
-                                     :table_id   id
-                                     :schema     schema}
-          existing-db-perm          (t2/select-one :model/DataPermissions
-                                                   {:where
-                                                    [:and
-                                                     [:= :type (name perm-type)]
-                                                     [:= :group_id group-id]
-                                                     [:= :db_id db_id]
-                                                     [:= :table_id nil]]})
-          existing-db-perm-value    (:perm_value existing-db-perm)]
-      (if existing-db-perm
-        (when (not= value existing-db-perm-value)
-          ;; If we're setting a table permission to a value that is different from the database-level permission, we need
-          ;; to replace it with individual permission rows for every table in the database instead.
-          ;; Important: We only want to do this in the branch where a DB-level perm exists, because otherwise we'd be
-          ;; reading the entire table list for every table-level perm we set.
-          (let [other-tables    (t2/select :model/Table {:where [:and
-                                                                 [:= :db_id db_id]
-                                                                 [:not= :id id]]})
-                other-new-perms (map (fn [table]
-                                       {:type       perm-type
-                                        :group_id   group-id
-                                        :perm_value existing-db-perm-value
-                                        :db_id      db_id
-                                        :table_id   (:id table)
-                                        :schema     (:schema table)})
-                                     other-tables)]
-            (t2/delete! :model/DataPermissions :id (:id existing-db-perm))
-            (t2/insert! :model/DataPermissions (conj other-new-perms new-perm))))
-        (let [existing-table-perms (t2/select :model/DataPermissions
-                                              :type (name perm-type)
-                                              :group_id group-id
-                                              :db_id db_id
-                                              {:where [:and
-                                                       [:not= :table_id nil]
-                                                       [:not= :table_id id]]})
-              existing-table-values (set (map :perm_value existing-table-perms))]
-          (if (and (= (count existing-table-values) 1)
-                   (existing-table-values value))
-            ;; If all tables would have the same permissions after we update this one, we can replace all of the table
-            ;; perms with a DB-level perm instead.
-            (do
-              (t2/delete! :model/DataPermissions {:where [:and
-                                                          [:= :type      (name perm-type)]
-                                                          [:= :group_id  group-id]
-                                                          [:= :db_id     db_id]
-                                                          [:in :table_id (conj (map :table_id existing-table-perms) id)]]})
-              (t2/insert! :model/DataPermissions {:type       perm-type
-                                                  :group_id   group-id
-                                                  :perm_value value
-                                                  :db_id      db_id}))
-            ;; Otherwise, just replace the row for the individual table perm
-            (do
-              (t2/delete! :model/DataPermissions :type perm-type :group_id group-id :table_id id)
-              (t2/insert! :model/DataPermissions new-perm))))))))
+  (set-table-permissions! group-or-id perm-type [{:table table-or-id :value value}]))

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -317,4 +317,4 @@
    table-or-id :- TheIdable
    perm-type   :- :keyword
    value       :- :keyword]
-  (set-table-permissions! group-or-id perm-type [{:table table-or-id :value value}]))
+  (set-table-permissions! group-or-id perm-type {table-or-id value}))

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -219,10 +219,6 @@
    db-or-id    :- TheIdable
    perm-type   :- :keyword
    value       :- :keyword]
-  (when (and (not= :model/Database (model-by-perm-type perm-type))
-             (not= [:data-access :block] [perm-type value]))
-    (throw (ex-info (tru "Permission type {0} cannot be set on databases." perm-type)
-                    {perm-type (Permissions perm-type)})))
   (t2/with-transaction [_conn]
     (let [group-id (u/the-id group-or-id)
           db-id    (u/the-id db-or-id)]

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -106,15 +106,15 @@
       (update-table-level-download-permissions! group-id db-id table-id schema table-perm))
     (let [tables (db/select :model/Table :db_id db-id :schema schema)]
       (doseq [table tables]
-       (case new-schema-perms
-         :full
-         (data-perms/set-table-permission! group-id table :download-results :one-million-rows)
+        (case new-schema-perms
+          :full
+          (data-perms/set-table-permission! group-id table :download-results :one-million-rows)
 
-         :limited
-         (data-perms/set-table-permission! group-id table :download-results :ten-thousand-rows)
+          :limited
+          (data-perms/set-table-permission! group-id table :download-results :ten-thousand-rows)
 
-         :none
-         (data-perms/set-table-permission! group-id table :download-results :no))))))
+          :none
+          (data-perms/set-table-permission! group-id table :download-results :no))))))
 
 ; ;; TODO: Make sure we update download perm enforcement to infer native download permissions, since
 ; ;; we'll no longer be setting them explicitly in the database.
@@ -162,7 +162,7 @@
   (if (map? new-schema-perms)
     (doseq [[table-id table-perm] new-schema-perms]
       (update-table-level-data-access-permissions! group-id db-id table-id schema table-perm))
-    (let [tables (db/select :model/Table :db_id db-id :schema schema)]
+    (let [tables (db/select :model/Table :db_id db-id :schema (not-empty schema))]
       (doseq [table tables]
        (case new-schema-perms
          :all

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -141,11 +141,12 @@
         (-> new-table-perms
             (update-vals (fn [table-perm]
                            (if (map? table-perm)
-                             (when (#{:all :segmented} (table-perm :query))
+                             (if (#{:all :segmented} (table-perm :query))
                                ;; `:segmented` indicates that the table is sandboxed, but we should set :data-access
                                ;; permissions to :unrestricted and rely on the `sandboxes` table as the source of truth
                                ;; for sandboxing.
-                               :unrestricted)
+                               :unrestricted
+                               :no-self-service)
                              (case table-perm
                                :all  :unrestricted
                                :none :no-self-service))))

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -16,7 +16,6 @@
      :manage-table-metadata :data-model
 
      :native-query-editing  :native
-     :native-downloads      :native
      :manage-database       :details})
 
 #_(def ^:private db->api-vals
@@ -24,14 +23,12 @@
                              :no-self-service nil
                              :block           :block}
      :download-results      {:one-million-rows  :full
-                             :ten-thousand-rows :partial
+                             :ten-thousand-rows :limited
                              :no                 nil}
      :manage-table-metadata {:yes :all
                              :no nil}
 
      :native-query-editing  {:yes :full
-                             :no nil}
-     :native-downloads      {:yes :write
                              :no nil}
      :manage-database       {:yes :yes
                              :no  :no}})
@@ -64,7 +61,7 @@
   (if (map? new-schema-perms)
     (doseq [[table-id table-perm] new-schema-perms]
       (update-table-level-metadata-permissions! group-id db-id table-id schema table-perm))
-    (let [tables (db/select :model/Table :db_id db-id :schema schema)]
+    (let [tables (db/select :model/Table :db_id db-id :schema (not-empty schema))]
       (doseq [table tables]
        (case new-schema-perms
          :all
@@ -104,7 +101,7 @@
   (if (map? new-schema-perms)
     (doseq [[table-id table-perm] new-schema-perms]
       (update-table-level-download-permissions! group-id db-id table-id schema table-perm))
-    (let [tables (db/select :model/Table :db_id db-id :schema schema)]
+    (let [tables (db/select :model/Table :db_id db-id :schema (not-empty schema))]
       (doseq [table tables]
         (case new-schema-perms
           :full

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -1,0 +1,206 @@
+(ns metabase.models.data-permissions.graph
+  "Code involving reading and writing the API-style data permission graph. This is the graph which we use to represent
+  permissions when communicating with the frontend, which has different keys and a slightly different structure
+  from the one returned by `metabase.models.permissions-v2/data-permissions-graph`, which is based directly on the
+  keys and values stored in the `permissions_v2` table.
+
+  Essentially, this is a translation layer between the graph used by the v1 permissions system and the v2 permissions
+  system."
+  (:require
+   [metabase.models.data-permissions :as data-perms]
+   [toucan2.core :as db]))
+
+#_(def ^:private db->api-keys
+    {:data-access           :data
+     :download-results      :download
+     :manage-table-metadata :data-model
+
+     :native-query-editing  :native
+     :native-downloads      :native
+     :manage-database       :details})
+
+#_(def ^:private db->api-vals
+    {:data-access           {:unrestricted    :all
+                             :no-self-service nil
+                             :block           :block}
+     :download-results      {:one-million-rows  :full
+                             :ten-thousand-rows :partial
+                             :no                 nil}
+     :manage-table-metadata {:yes :all
+                             :no nil}
+
+     :native-query-editing  {:yes :full
+                             :no nil}
+     :native-downloads      {:yes :write
+                             :no nil}
+     :manage-database       {:yes :yes
+                             :no  :no}})
+
+;; TODO
+(defn db-graph->api-graph
+  "Converts the backend representation of the data permissions graph to the representation we send over the API. Mainly
+  renames permission types and values from the names stored in the database to the ones expected by the frontend."
+  [graph]
+  ;; 1. Convert DB key names to API key names
+  ;; 2. Nest table-level perms under :native and :schemas keys
+  ;; 3. Walk tree and convert values to API values
+  ;; 4. Add sandboxed entries to graph (maybe do this a level up?)
+  graph)
+
+;;; ---------------------------------------- Updating permissions -----------------------------------------------------
+
+(defn- update-table-level-metadata-permissions!
+  [group-id db-id table-id schema new-table-perms]
+  (let [table {:id table-id :db_id db-id :schema schema}]
+    (case new-table-perms
+      :all
+      (data-perms/set-table-permission! group-id table :manage-table-metadata :yes)
+
+      :none
+      (data-perms/set-table-permission! group-id table :manage-table-metadata :no))))
+
+(defn- update-schema-level-metadata-permissions!
+  [group-id db-id schema new-schema-perms]
+  (if (map? new-schema-perms)
+    (doseq [[table-id table-perm] new-schema-perms]
+      (update-table-level-metadata-permissions! group-id db-id table-id schema table-perm))
+    (let [tables (db/select :model/Table :db_id db-id :schema schema)]
+      (doseq [table tables]
+       (case new-schema-perms
+         :all
+         (data-perms/set-table-permission! group-id table :manage-table-metadata :yes)
+
+         :none
+         (data-perms/set-table-permission! group-id table :manage-table-metadata :no))))))
+
+(defn- update-db-level-metadata-permissions!
+  [group-id db-id new-db-perms]
+  (when-let [schemas (:schemas new-db-perms)]
+    (if (map? schemas)
+      (doseq [[schema schema-changes] schemas]
+        (update-schema-level-metadata-permissions! group-id db-id schema schema-changes))
+      (case schemas
+        :all
+        (data-perms/set-database-permission! group-id db-id :manage-table-metadata :yes)
+
+        :none
+        (data-perms/set-database-permission! group-id db-id :manage-table-metadata :no)))))
+
+(defn- update-table-level-download-permissions!
+  [group-id db-id table-id schema new-table-perms]
+  (let [table {:id table-id :db_id db-id :schema schema}]
+    (case new-table-perms
+      :full
+      (data-perms/set-table-permission! group-id table :download-results :one-million-rows)
+
+      :limited
+      (data-perms/set-table-permission! group-id table :download-results :ten-thousand-rows)
+
+      :none
+      (data-perms/set-table-permission! group-id table :download-results :no))))
+
+(defn- update-schema-level-download-permissions!
+  [group-id db-id schema new-schema-perms]
+  (if (map? new-schema-perms)
+    (doseq [[table-id table-perm] new-schema-perms]
+      (update-table-level-download-permissions! group-id db-id table-id schema table-perm))
+    (let [tables (db/select :model/Table :db_id db-id :schema schema)]
+      (doseq [table tables]
+       (case new-schema-perms
+         :full
+         (data-perms/set-table-permission! group-id table :download-results :one-million-rows)
+
+         :limited
+         (data-perms/set-table-permission! group-id table :download-results :ten-thousand-rows)
+
+         :none
+         (data-perms/set-table-permission! group-id table :download-results :no))))))
+
+; ;; TODO: Make sure we update download perm enforcement to infer native download permissions, since
+; ;; we'll no longer be setting them explicitly in the database.
+; ;; i.e. you should only be able to download the results of a native query at the most limited level
+; ;; you have for any table in the DB
+(defn- update-db-level-download-permissions!
+  [group-id db-id new-db-perms]
+  (when-let [schemas (:schemas new-db-perms)]
+    (if (map? schemas)
+      (doseq [[schema schema-changes] schemas]
+        (update-schema-level-download-permissions! group-id db-id schema schema-changes))
+      (case schemas
+        :full
+        (data-perms/set-database-permission! group-id db-id :download-results :one-million-rows)
+
+        :limited
+        (data-perms/set-database-permission! group-id db-id :download-results :ten-thousand-rows)
+
+        :none
+        (data-perms/set-database-permission! group-id db-id :download-results :no)))))
+
+(defn- update-native-data-access-permissions!
+  [group-id db-id new-native-perms]
+  (data-perms/set-database-permission! group-id db-id :native-query-editing (case new-native-perms
+                                                                              :write :yes
+                                                                              :none  :no)))
+
+(defn- update-table-level-data-access-permissions!
+  [group-id db-id table-id schema table-perm]
+  (let [table {:id table-id :db_id db-id :schema schema}]
+    (case table-perm
+      :all
+      (data-perms/set-table-permission! group-id table :data-access :unrestricted)
+
+      ;; This indicates that the table is sandboxed, but we should set :data-access permissions to :unrestricted
+      ;; and rely on the `sandboxes` table as the source of truth for sandboxing.
+      {:read :all :query :segmented}
+      (data-perms/set-table-permission! group-id table :data-access :unrestricted)
+
+      :none
+      (data-perms/set-table-permission! group-id table :data-access :no-self-service))))
+
+(defn- update-schema-level-data-access-permissions!
+  [group-id db-id schema new-schema-perms]
+  (if (map? new-schema-perms)
+    (doseq [[table-id table-perm] new-schema-perms]
+      (update-table-level-data-access-permissions! group-id db-id table-id schema table-perm))
+    (let [tables (db/select :model/Table :db_id db-id :schema schema)]
+      (doseq [table tables]
+       (case new-schema-perms
+         :all
+         (data-perms/set-table-permission! group-id table :data-access :unrestricted)
+
+         :none
+         (data-perms/set-table-permission! group-id table :data-access :no-self-service))))))
+
+(defn- update-db-level-data-access-permissions!
+  [group-id db-id new-db-perms]
+  (when-let [new-native-perms (:native new-db-perms)]
+    (update-native-data-access-permissions! group-id db-id new-native-perms))
+  (when-let [schemas (:schemas new-db-perms)]
+    (if (map? schemas)
+      (doseq [[schema schema-changes] schemas]
+        (update-schema-level-data-access-permissions! group-id db-id schema schema-changes))
+      (case schemas
+        (:all :impersonated)
+        (data-perms/set-database-permission! group-id db-id :data-access :unrestricted)
+
+        :none
+        (data-perms/set-database-permission! group-id db-id :data-access :no-self-service)
+
+        :block
+        (data-perms/set-database-permission! group-id db-id :data-access :block)))))
+
+(defn- update-details-perms!
+  [group-id db-id value]
+  (data-perms/set-database-permission! group-id db-id :manage-database value))
+
+(defn update-data-perms-graph!
+  "Takes an API-style perms graph and sets the permissions in the database accordingly."
+  [graph]
+  (doseq [[group-id group-changes] graph]
+    (doseq [[db-id db-changes] group-changes
+            [perm-type new-perms] db-changes]
+      (case perm-type
+        :data       (update-db-level-data-access-permissions! group-id db-id new-perms)
+        :download   (update-db-level-download-permissions! group-id db-id new-perms)
+        :data-model (update-db-level-metadata-permissions! group-id db-id new-perms)
+        :details    (update-details-perms! group-id db-id new-perms)))))

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -176,12 +176,12 @@
    [metabase.api.common :refer [*current-user-id*]]
    [metabase.api.permission-graph :as api.permission-graph]
    [metabase.config :as config]
+   [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.interface :as mi]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.permissions-revision
     :as perms-revision
     :refer [PermissionsRevision]]
-   [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.permissions.parse :as perms-parse]
    [metabase.permissions.util :as perms.u]
    [metabase.plugins.classloader :as classloader]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -181,6 +181,7 @@
    [metabase.models.permissions-revision
     :as perms-revision
     :refer [PermissionsRevision]]
+   [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.permissions.parse :as perms-parse]
    [metabase.permissions.util :as perms.u]
    [metabase.plugins.classloader :as classloader]
@@ -1288,6 +1289,7 @@
        (t2/with-transaction [_conn]
         (doseq [[group-id changes] new]
           (update-group-permissions! group-id changes))
+        (data-perms.graph/update-data-perms-graph! new)
         (save-perms-revision! PermissionsRevision (:revision old-graph) old new)
         (delete-impersonations-if-needed-after-permissions-change! new)
         (delete-gtaps-if-needed-after-permissions-change! new)))))

--- a/test/metabase/models/data_permissions/graph_test.clj
+++ b/test/metabase/models/data_permissions/graph_test.clj
@@ -1,0 +1,78 @@
+(ns metabase.models.data-permissions.graph-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.models.data-permissions :as data-perms]
+   [metabase.models.data-permissions.graph :as data-perms.graph]
+   [metabase.test :as mt]))
+
+(deftest update-db-level-data-access-permissions!-test
+  (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
+                 :model/Database         {database-id-1 :id}   {}
+                 :model/Table            {table-id-1 :id}      {:db_id database-id-1
+                                                                :schema "PUBLIC"}
+                 :model/Table            {table-id-2 :id}      {:db_id database-id-1
+                                                                :schema "PUBLIC"}
+                 :model/Table            {table-id-3 :id}      {:db_id database-id-1
+                                                                :schema nil}]
+    (testing "data-access permissions can be updated via API-style graph"
+      (are [api-graph db-graph] (= db-graph
+                                   (do
+                                     (data-perms.graph/update-data-perms-graph! api-graph)
+                                     (data-perms/data-permissions-graph :group-id group-id-1)))
+
+        ;; Setting granular data access permissions
+        {group-id-1
+         {database-id-1
+          {:data
+           {:native :none
+            :schemas {"PUBLIC"
+                      {table-id-1 :all
+                       table-id-2 :none}
+                      ""
+                      {table-id-3 :all}}}}}}
+        {group-id-1
+         {database-id-1
+          {:native-query-editing :no
+           :data-access {"PUBLIC"
+                         {table-id-1 :unrestricted
+                          table-id-2 :no-self-service}
+                         ""
+                         {table-id-3 :unrestricted}}}}}
+
+        ;; Restoring full data access and native query permissions
+        {group-id-1
+         {database-id-1
+          {:data
+           {:native :write
+            :schemas :all}}}}
+        {group-id-1
+         {database-id-1
+          {:native-query-editing :yes
+           :data-access :unrestricted}}}
+
+        ;; Setting data access permissions at the schema-level
+        {group-id-1
+         {database-id-1
+          {:data
+           {:native :none
+            :schemas {"PUBLIC" :all
+                      ""       :none}}}}}
+        {group-id-1
+         {database-id-1
+          {:native-query-editing :no
+           :data-access {"PUBLIC"
+                         {table-id-1 :unrestricted
+                          table-id-2 :unrestricted}
+                         ""
+                         {table-id-3 :no-self-service}}}}}
+
+        ;; Setting block permissions for the database
+        {group-id-1
+         {database-id-1
+          {:data
+           {:native :none
+            :schemas :block}}}}
+        {group-id-1
+          {database-id-1
+           {:native-query-editing :no
+            :data-access :block}}}))))

--- a/test/metabase/models/data_permissions/graph_test.clj
+++ b/test/metabase/models/data_permissions/graph_test.clj
@@ -19,7 +19,6 @@
                                    (do
                                      (data-perms.graph/update-data-perms-graph! api-graph)
                                      (data-perms/data-permissions-graph :group-id group-id-1)))
-
         ;; Setting granular data access permissions
         {group-id-1
          {database-id-1
@@ -76,3 +75,155 @@
           {database-id-1
            {:native-query-editing :no
             :data-access :block}}}))))
+
+(deftest update-db-level-download-permissions!-test
+  (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
+                 :model/Database         {database-id-1 :id}   {}
+                 :model/Table            {table-id-1 :id}      {:db_id database-id-1
+                                                                :schema "PUBLIC"}
+                 :model/Table            {table-id-2 :id}      {:db_id database-id-1
+                                                                :schema "PUBLIC"}
+                 :model/Table            {table-id-3 :id}      {:db_id database-id-1
+                                                                :schema nil}]
+    (testing "download permissions can be updated via API-style graph"
+      (are [api-graph db-graph] (= db-graph
+                                   (do
+                                     (data-perms.graph/update-data-perms-graph! api-graph)
+                                     (data-perms/data-permissions-graph :group-id group-id-1)))
+        ;; Setting granular download permissions
+        {group-id-1
+         {database-id-1
+          {:download
+           {:schemas {"PUBLIC"
+                      {table-id-1 :full
+                       table-id-2 :none}
+                      ""
+                      {table-id-3 :limited}}}}}}
+        {group-id-1
+         {database-id-1
+          {:download-results {"PUBLIC"
+                              {table-id-1 :one-million-rows
+                               table-id-2 :no}
+                              ""
+                              {table-id-3 :ten-thousand-rows}}}}}
+
+        ;; Restoring full download permissions
+        {group-id-1
+         {database-id-1
+          {:download
+           {:schemas :full}}}}
+        {group-id-1
+         {database-id-1
+          {:download-results :one-million-rows}}}
+
+        ;; Setting download permissions at the schema-level
+        {group-id-1
+         {database-id-1
+          {:download
+           {:schemas {"PUBLIC" :full
+                      ""       :none}}}}}
+        {group-id-1
+         {database-id-1
+          {:download-results {"PUBLIC"
+                              {table-id-1 :one-million-rows
+                               table-id-2 :one-million-rows}
+                              ""
+                              {table-id-3 :no}}}}}
+
+        ;; Revoking download permissions for the database
+        {group-id-1
+         {database-id-1
+          {:download
+           {:schemas :none}}}}
+        {group-id-1
+         {database-id-1
+          {:download-results :no}}}))))
+
+(deftest update-db-level-metadata-permissions!-test
+  (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
+                 :model/Database         {database-id-1 :id}   {}
+                 :model/Table            {table-id-1 :id}      {:db_id database-id-1
+                                                                :schema "PUBLIC"}
+                 :model/Table            {table-id-2 :id}      {:db_id database-id-1
+                                                                :schema "PUBLIC"}
+                 :model/Table            {table-id-3 :id}      {:db_id database-id-1
+                                                                :schema nil}]
+    (testing "data model editing permissions can be updated via API-style graph"
+      (are [api-graph db-graph] (= db-graph
+                                   (do
+                                     (data-perms.graph/update-data-perms-graph! api-graph)
+                                     (data-perms/data-permissions-graph :group-id group-id-1)))
+        ;; Setting granular data model editing permissions
+        {group-id-1
+         {database-id-1
+          {:data-model
+           {:schemas
+            {"PUBLIC"
+             {table-id-1 :all
+              table-id-2 :none}
+             ""
+             {table-id-3 :none}}}}}}
+        {group-id-1
+         {database-id-1
+          {:manage-table-metadata
+           {"PUBLIC"
+            {table-id-1 :yes
+             table-id-2 :no}
+            ""
+            {table-id-3 :no}}}}}
+
+        ;; Restoring full data model editing permissions
+        {group-id-1
+         {database-id-1
+          {:data-model
+           {:schemas :all}}}}
+        {group-id-1
+         {database-id-1
+          {:manage-table-metadata :yes}}}
+
+        ;; Setting data model editing permissions at the schema-level
+        {group-id-1
+         {database-id-1
+          {:data-model
+           {:schemas {"PUBLIC" :all
+                      ""       :none}}}}}
+        {group-id-1
+         {database-id-1
+          {:manage-table-metadata {"PUBLIC"
+                                   {table-id-1 :yes
+                                    table-id-2 :yes}
+                                   ""
+                                   {table-id-3 :no}}}}}
+
+        ;; Revoking all data model editing permissions for the database
+        {group-id-1
+         {database-id-1
+          {:data-model
+           {:schemas :none}}}}
+        {group-id-1
+         {database-id-1
+          {:manage-table-metadata :no}}}))))
+
+(deftest update-details-perms!-test
+  (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
+                 :model/Database         {database-id-1 :id}   {}]
+    (testing "database details editing permissions can be updated via API-style graph"
+      (are [api-graph db-graph] (= db-graph
+                                   (do
+                                     (data-perms.graph/update-data-perms-graph! api-graph)
+                                     (data-perms/data-permissions-graph :group-id group-id-1)))
+        ;; Granting permission to edit database details
+        {group-id-1
+         {database-id-1
+          {:details :yes}}}
+        {group-id-1
+         {database-id-1
+          {:manage-database :yes}}}
+
+        ;; Revoking permission to edit database details
+        {group-id-1
+         {database-id-1
+          {:details :no}}}
+        {group-id-1
+         {database-id-1
+          {:manage-database :no}}}))))

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -63,52 +63,62 @@
              #"Permission type :native-query-editing cannot be set to :invalid-value"
              (data-perms/set-database-permission! group-id database-id :native-query-editing :invalid-value)))))))
 
-(deftest set-table-permission!-test
+(deftest set-table-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}    {}
                  :model/Database         {database-id :id} {}
+                 :model/Database         {database-id-2 :id} {}
                  :model/Table            {table-id-1 :id}  {:db_id database-id}
                  :model/Table            {table-id-2 :id}  {:db_id database-id}
-                 :model/Table            {table-id-3 :id}  {:db_id database-id}]
+                 :model/Table            {table-id-3 :id}  {:db_id database-id}
+                 :model/Table            {table-id-4 :id}  {:db_id database-id-2}]
     (with-restored-perms-for-group! group-id
-      (testing "`set-table-permission!` can set individual table permissions to different values"
-        (data-perms/set-table-permission! group-id table-id-1 :data-access :unrestricted)
-        (data-perms/set-table-permission! group-id table-id-2 :data-access :no-self-service)
-        (data-perms/set-table-permission! group-id table-id-3 :data-access :unrestricted)
-        (is (= :unrestricted (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-1)))
-        (is (= :no-self-service (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-2)))
-        (is (= :unrestricted (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-3))))
+      (testing "`set-table-permissions!` can set individual table permissions to different values"
+        (data-perms/set-table-permissions! group-id :data-access {table-id-1 :no-self-service
+                                                                  table-id-2 :unrestricted
+                                                                  table-id-3 :no-self-service})
+        (is (= :no-self-service (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-1)))
+        (is (= :unrestricted (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-2)))
+        (is (= :no-self-service (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-3))))
 
       (testing "`set-table-permission!` coalesces table perms to a DB-level value if they're all the same"
-        (data-perms/set-table-permission! group-id table-id-2 :data-access :unrestricted)
-        (is (= :unrestricted (t2/select-one-fn :perm_value :model/DataPermissions :db_id database-id :table_id nil)))
+        (data-perms/set-table-permissions! group-id :data-access {table-id-2 :no-self-service})
+        (is (= :no-self-service (t2/select-one-fn :perm_value :model/DataPermissions :db_id database-id :table_id nil)))
         (is (nil? (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-1)))
         (is (nil? (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-2)))
         (is (nil? (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-3))))
 
-      (testing "`set-table-permission!` breaks table perms out again if one is modified"
-        (data-perms/set-table-permission! group-id table-id-1 :data-access :no-self-service)
+      (testing "`set-table-permission!` breaks table perms out again if any are modified"
+        (data-perms/set-table-permissions! group-id :data-access {table-id-2 :unrestricted
+                                                                  table-id-3 :no-self-service})
         (is (nil? (t2/select-one-fn :perm_value :model/DataPermissions :db_id database-id :table_id nil)))
         (is (= :no-self-service (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-1)))
         (is (= :unrestricted (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-2)))
-        (is (= :unrestricted (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-3))))
+        (is (= :no-self-service (t2/select-one-fn :perm_value :model/DataPermissions :table_id table-id-3))))
 
       (testing "A non table-level permission cannot be set"
         (is (thrown-with-msg?
              ExceptionInfo
              #"Permission type :native-query-editing cannot be set on tables."
-             (data-perms/set-table-permission! group-id table-id-1 :native-query-editing :yes))))
+             (data-perms/set-table-permissions! group-id :native-query-editing {table-id-1 :yes}))))
 
       (testing "A table-level permission cannot be set to an invalid value"
         (is (thrown-with-msg?
              ExceptionInfo
              #"Permission type :data-access cannot be set to :invalid"
-             (data-perms/set-table-permission! group-id table-id-1 :data-access :invalid))))
+             (data-perms/set-table-permissions! group-id :data-access {table-id-1 :invalid}))))
 
       (testing "A table-level permission cannot be set to :block"
         (is (thrown-with-msg?
              ExceptionInfo
              #"Block permissions must be set at the database-level only."
-             (data-perms/set-table-permission! group-id table-id-1 :data-access :block))))
+             (data-perms/set-table-permissions! group-id :data-access {table-id-1 :block}))))
+
+      (testing "Table-level permissions can only be set in bulk for tables in the same database"
+        (is (thrown-with-msg?
+             ExceptionInfo
+             #"All tables must belong to the same database."
+             (data-perms/set-table-permissions! group-id :data-access {table-id-3 :unrestricted
+                                                                       table-id-4 :unrestricted}))))
 
       (testing "Setting block permissions at the database level clears table-level data access perms"
         (data-perms/set-database-permission! group-id database-id :data-access :block)

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -47,10 +47,15 @@
                  :model/Database         {database-id :id} {}]
     (with-restored-perms-for-group! group-id
       (testing "`set-database-permission!` correctly updates an individual database's permissions"
-        (data-perms/set-database-permission! group-id database-id :native-query-editing :yes)
-        (is (= :yes (t2/select-one-fn :perm_value :model/DataPermissions :db_id database-id :table_id nil)))
         (data-perms/set-database-permission! group-id database-id :native-query-editing :no)
-        (is (= :no (t2/select-one-fn :perm_value :model/DataPermissions :db_id database-id :table_id nil))))
+        (is (= :no (t2/select-one-fn :perm_value :model/DataPermissions :db_id database-id :type :native-query-editing)))
+        (data-perms/set-database-permission! group-id database-id :native-query-editing :yes)
+        (is (= :yes (t2/select-one-fn :perm_value :model/DataPermissions :db_id database-id :type :native-query-editing))))
+
+      (testing "`set-database-permission!` sets native query permissions to :no if data access is set to :block"
+        (data-perms/set-database-permission! group-id database-id :data-access :block)
+        (is (= :block (t2/select-one-fn :perm_value :model/DataPermissions :db_id database-id :type :data-access)))
+        (is (= :no (t2/select-one-fn :perm_value :model/DataPermissions :db_id database-id :type :native-query-editing))))
 
       (testing "A database-level permission cannot be set to an invalid value"
         (is (thrown-with-msg?

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -52,12 +52,6 @@
         (data-perms/set-database-permission! group-id database-id :native-query-editing :no)
         (is (= :no (t2/select-one-fn :perm_value :model/DataPermissions :db_id database-id :table_id nil))))
 
-      (testing "A non database-level permission cannot be set"
-        (is (thrown-with-msg?
-             ExceptionInfo
-             #"Permission type :data-access cannot be set on databases."
-             (data-perms/set-database-permission! group-id database-id :data-access :unrestricted))))
-
       (testing "A database-level permission cannot be set to an invalid value"
         (is (thrown-with-msg?
              ExceptionInfo


### PR DESCRIPTION
This PR 
* Adds a `update-data-perms-graph!` function which parallels the function with the same name in `metabase.models.permissions`: it takes an API-style graph and recursively traverses it, updating permissions in the DB as it goes. This is already more concise than the existing code because it doesn't need to worry about deleting perms before updating them—this is handled by the lower-level model APIs.
* Adds tests for updating the graph for each permission type
* Fixes a couple bugs in the previous code 