### PR TITLE
Fix collection/tree giving 500 error when there is only one user

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -59,16 +59,16 @@
 
 (defn- remove-other-users-personal-subcollections
   [user-id collections]
-  (let [personal-ids         (t2/select-fn-set :id :model/Collection
-                                               {:where
-                                                [:and [:!= :personal_owner_id nil] [:!= :personal_owner_id user-id]]})
-        personal-descendant? (comp personal-ids
-                                   first
-                                   collection/location-path->ids
-                                   :location)]
-    (if (nil? personal-ids)
-      collections
-      (remove personal-descendant? collections))))
+  (let [personal-ids         (set (t2/select-fn-set :id :model/Collection
+                                                    {:where
+                                                     [:and [:!= :personal_owner_id nil] [:!= :personal_owner_id user-id]]}))
+        personal-descendant? (fn [collection]
+                               (let [first-parent-collection-id (-> collection
+                                                                    :location
+                                                                    collection/location-path->ids
+                                                                    first)]
+                                 (personal-ids first-parent-collection-id)))]
+    (remove personal-descendant? collections)))
 
 (defn- select-collections
   "Select collections based off certain parameters. If `shallow` is true, we select only the requested collection (or

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -59,14 +59,16 @@
 
 (defn- remove-other-users-personal-subcollections
   [user-id collections]
-  (let [personal-ids        (t2/select-fn-set :id :model/Collection
-                                              {:where
-                                               [:and [:!= :personal_owner_id nil] [:!= :personal_owner_id user-id]]})
+  (let [personal-ids         (t2/select-fn-set :id :model/Collection
+                                               {:where
+                                                [:and [:!= :personal_owner_id nil] [:!= :personal_owner_id user-id]]})
         personal-descendant? (comp personal-ids
                                    first
                                    collection/location-path->ids
                                    :location)]
-    (remove personal-descendant? collections)))
+    (if (nil? personal-ids)
+      collections
+      (remove personal-descendant? collections))))
 
 (defn- select-collections
   "Select collections based off certain parameters. If `shallow` is true, we select only the requested collection (or

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -237,21 +237,27 @@
   (let [personal-collection (collection/user->personal-collection (mt/user->id :lucky))]
     (with-collection-hierarchy [a b c d e f g]
       (collection/move-collection! a (collection/children-location personal-collection))
-      (let [ids            (set (map :id (cons personal-collection [a b c d e f g])))
-            response-rasta (mt/user-http-request :rasta :get 200 "collection/tree" :exclude-other-user-collections true)
-            response-lucky (mt/user-http-request :lucky :get 200 "collection/tree" :exclude-other-user-collections true)]
+      (let [ids                 (set (map :id (cons personal-collection [a b c d e f g])))
+            response-rasta      (mt/user-http-request :rasta :get 200 "collection/tree" :exclude-other-user-collections true)
+            response-lucky      (mt/user-http-request :lucky :get 200 "collection/tree" :exclude-other-user-collections true)
+            expected-lucky-tree [{:name "Lucky Pigeon's Personal Collection",
+                                  :children
+                                  [{:name "A"
+                                    :children
+                                    [{:name "B" :children []}
+                                     {:name "C"
+                                      :children [{:name "D" :children [{:name "E" :children []}]} {:name "F" :children [{:name "G" :children []}]}]}]}]}]]
         (testing "Make sure that user is not able to see other users personal collections"
           (is (= []
                  (collection-tree-view ids response-rasta))))
         (testing "Make sure that user is able to see his own collections"
-          (is (= [{:name "Lucky Pigeon's Personal Collection",
-                   :children
-                   [{:name "A"
-                     :children
-                     [{:name "B" :children []}
-                      {:name "C"
-                       :children [{:name "D" :children [{:name "E" :children []}]} {:name "F" :children [{:name "G" :children []}]}]}]}]}]
-                 (collection-tree-view ids response-lucky))))))))
+          (is (= expected-lucky-tree
+                 (collection-tree-view ids response-lucky))))
+        (testing "Mocking having one user still returns a correct result"
+          (with-redefs [t2/select-fn-set (constantly nil)]
+            (let [response (mt/user-http-request :lucky :get 200 "collection/tree" :exclude-other-user-collections true)]
+              (is (= expected-lucky-tree
+                     (collection-tree-view ids response))))))))))
 
 (deftest collection-tree-shallow-test
   (testing "GET /api/collection/tree?shallow=true"


### PR DESCRIPTION
### Description

`t2/select-fn-set` returns nil when there is the set is empty. This means when we pass collections through `personal-descendant?`,  then we get hit by a NPE.

See: https://metaboat.slack.com/archives/C010L1Z4F9S/p1704702599756839