### PR TITLE
Remove legacyQuery from DashCardMenu

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -131,11 +131,7 @@ interface QueryDownloadWidgetOpts {
 }
 
 const canEditQuestion = (question: Question) => {
-  return (
-    question.canWrite() &&
-    question.legacyQuery() != null &&
-    question.isQueryEditable()
-  );
+  return question.canWrite() && question.isQueryEditable();
 };
 
 const canDownloadResults = (result?: Dataset) => {


### PR DESCRIPTION
`isQueryEditable` handles missing query (e.g. when you don't have data permissions) under the hood.