### PR TITLE
new utm tags for embed settings

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -115,7 +115,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
           .should("have.attr", "href")
           .and(
             "eq",
-            "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-oss-cta",
+            "https://www.metabase.com/product/embedded-analytics?utm_source=oss&utm_media=embed-settings",
           );
       });
     });

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -15,7 +15,7 @@ import {
 const embeddingPage = "/admin/settings/embedding-in-other-applications";
 const standalonePath =
   "/admin/settings/embedding-in-other-applications/standalone";
-const pricingUrl = "https://www.metabase.com/pricing";
+const upgradeUrl = "https://www.metabase.com/upgrade";
 const embeddingDescription =
   "Embed dashboards, questions, or the entire Metabase app into your application. Integrate with your server code to create a secure environment, limited to specific users or organizations.";
 
@@ -74,7 +74,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
       cy.findByTestId("-static-embedding-setting").within(() => {
         // FE unit tests are making sure this section doesn't exist when a valid token is provided,
         // so we don't have to do it here usign a conditional logic
-        assertLinkMatchesUrl("upgrade to a paid plan", pricingUrl);
+        assertLinkMatchesUrl("upgrade to a paid plan", upgradeUrl);
 
         cy.findByRole("link", { name: "Manage" })
           .should("have.attr", "href")

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
@@ -39,7 +39,7 @@ describe("[OSS] embedding settings", () => {
           screen.getByRole("link", { name: "upgrade to a paid plan" }),
         ).toHaveProperty(
           "href",
-          "https://www.metabase.com/pricing/?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-oss-cta",
+          "https://www.metabase.com/upgrade?utm_media=embed-settings&utm_source=oss",
         );
       });
     });
@@ -66,7 +66,7 @@ describe("[OSS] embedding settings", () => {
         ).toBeInTheDocument();
         expect(screen.getByRole("link", { name: "Learn More" })).toHaveProperty(
           "href",
-          "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-oss-cta",
+          "https://www.metabase.com/product/embedded-analytics?utm_source=oss&utm_media=embed-settings",
         );
       });
 
@@ -77,11 +77,11 @@ describe("[OSS] embedding settings", () => {
         expect(getQuickStartLink()).toBeInTheDocument();
         expect(getQuickStartLink()).toHaveProperty(
           "href",
-          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-oss-cta",
+          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=oss&utm_media=embed-settings",
         );
       });
 
-      it("should link to https://www.metabase.com/blog/why-full-app-embedding", async () => {
+      it("should link to https://www.metabase.com/blog/why-full-app-embedding?utm_source=oss&utm_media=embed-settings", async () => {
         await setupEmbedding({
           settingValues: { "enable-embedding": false },
         });
@@ -90,7 +90,7 @@ describe("[OSS] embedding settings", () => {
           screen.getByText("offer multi-tenant, self-service analytics"),
         ).toHaveProperty(
           "href",
-          "https://www.metabase.com/blog/why-full-app-embedding",
+          "https://www.metabase.com/blog/why-full-app-embedding?utm_source=oss&utm_media=embed-settings",
         );
       });
     });

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
@@ -48,7 +48,7 @@ describe("[EE, no token] embedding settings", () => {
           screen.getByRole("link", { name: "upgrade to a paid plan" }),
         ).toHaveProperty(
           "href",
-          "https://www.metabase.com/pricing/?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-oss-cta",
+          "https://www.metabase.com/upgrade?utm_media=embed-settings&utm_source=oss",
         );
       });
     });
@@ -75,7 +75,7 @@ describe("[EE, no token] embedding settings", () => {
         ).toBeInTheDocument();
         expect(screen.getByRole("link", { name: "Learn More" })).toHaveProperty(
           "href",
-          "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-oss-cta",
+          "https://www.metabase.com/product/embedded-analytics?utm_source=oss&utm_media=embed-settings",
         );
       });
 
@@ -86,7 +86,7 @@ describe("[EE, no token] embedding settings", () => {
         expect(getQuickStartLink()).toBeInTheDocument();
         expect(getQuickStartLink()).toHaveProperty(
           "href",
-          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-oss-cta",
+          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=oss&utm_media=embed-settings",
         );
       });
 
@@ -99,7 +99,7 @@ describe("[EE, no token] embedding settings", () => {
           screen.getByText("offer multi-tenant, self-service analytics"),
         ).toHaveProperty(
           "href",
-          "https://www.metabase.com/blog/why-full-app-embedding",
+          "https://www.metabase.com/blog/why-full-app-embedding?utm_source=oss&utm_media=embed-settings",
         );
       });
     });

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -72,7 +72,7 @@ describe("[EE, with token] embedding settings", () => {
         expect(getQuickStartLink()).toBeInTheDocument();
         expect(getQuickStartLink()).toHaveProperty(
           "href",
-          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-pro-cta",
+          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=oss&utm_media=embed-settings",
         );
       });
     });

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -15,6 +15,7 @@ const setupPremium = (opts?: SetupOpts) => {
     ...opts,
     hasEnterprisePlugins: true,
     hasEmbeddingFeature: true,
+    hasWhiteLabelFeature: true, // this activates the different utm tag from getPlan
   });
 };
 
@@ -66,13 +67,13 @@ describe("[EE, with token] embedding settings", () => {
       });
 
       it("should link to quickstart for interactive embedding", async () => {
-        await setupEmbedding({
+        await setupPremium({
           settingValues: { "enable-embedding": false },
         });
         expect(getQuickStartLink()).toBeInTheDocument();
         expect(getQuickStartLink()).toHaveProperty(
           "href",
-          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=oss&utm_media=embed-settings",
+          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=pro-self-hosted&utm_media=embed-settings",
         );
       });
     });

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -15,7 +15,6 @@ const setupPremium = (opts?: SetupOpts) => {
     ...opts,
     hasEnterprisePlugins: true,
     hasEmbeddingFeature: true,
-    hasWhiteLabelFeature: true, // this activates the different utm tag from getPlan
   });
 };
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/setup.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/setup.tsx
@@ -13,17 +13,20 @@ export type SetupOpts = {
   settingValues?: Partial<Settings>;
   hasEmbeddingFeature?: boolean;
   hasEnterprisePlugins?: boolean;
+  hasWhiteLabelFeature?: boolean;
 };
 
 export const setupEmbedding = async ({
   settingValues,
   hasEmbeddingFeature = false,
   hasEnterprisePlugins = false,
+  hasWhiteLabelFeature = false,
 }: SetupOpts) => {
   const returnedValue = await setup({
     settingValues: createMockSettings(settingValues),
     tokenFeatures: createMockTokenFeatures({
       embedding: hasEmbeddingFeature,
+      whitelabel: hasWhiteLabelFeature,
     }),
     hasEnterprisePlugins,
   });

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/setup.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/setup.tsx
@@ -13,20 +13,17 @@ export type SetupOpts = {
   settingValues?: Partial<Settings>;
   hasEmbeddingFeature?: boolean;
   hasEnterprisePlugins?: boolean;
-  hasWhiteLabelFeature?: boolean;
 };
 
 export const setupEmbedding = async ({
   settingValues,
   hasEmbeddingFeature = false,
   hasEnterprisePlugins = false,
-  hasWhiteLabelFeature = false,
 }: SetupOpts) => {
   const returnedValue = await setup({
     settingValues: createMockSettings(settingValues),
     tokenFeatures: createMockTokenFeatures({
       embedding: hasEmbeddingFeature,
-      whitelabel: hasWhiteLabelFeature,
     }),
     hasEnterprisePlugins,
   });

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/EmbeddingOption.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/EmbeddingOption.tsx
@@ -3,9 +3,10 @@ import { jt, t } from "ttag";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_EMBEDDING } from "metabase/plugins";
-import { getSetting } from "metabase/selectors/settings";
+import { getSetting, getUpgradeUrl } from "metabase/selectors/settings";
 import type { ButtonProps } from "metabase/ui";
 import { Button, Flex, Text, Title } from "metabase/ui";
+import { getPlan } from "metabase/common/utils/plan";
 import { Label, StyledCard, BoldExternalLink } from "./EmbeddingOption.styled";
 import InteractiveEmbeddingOff from "./InteractiveEmbeddingOff.svg?component";
 import InteractiveEmbeddingOn from "./InteractiveEmbeddingOn.svg?component";
@@ -45,15 +46,13 @@ function EmbeddingOption({
 
 export const StaticEmbeddingOptionCard = () => {
   const enabled = useSelector(state => getSetting(state, "enable-embedding"));
+  const upgradeUrl = useSelector(state =>
+    getUpgradeUrl(state, { utm_media: "embed-settings" }),
+  );
   const shouldPromptToUpgrade = !PLUGIN_EMBEDDING.isEnabled();
 
   const upgradeText = jt`A "powered by Metabase" banner appears on static embeds. You can ${(
-    <ExternalLink
-      key="upgrade-link"
-      href={
-        "https://www.metabase.com/pricing/?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-oss-cta"
-      }
-    >
+    <ExternalLink key="upgrade-link" href={upgradeUrl}>
       {t`upgrade to a paid plan`}
     </ExternalLink>
   )} to remove it.`;
@@ -83,6 +82,9 @@ export const StaticEmbeddingOptionCard = () => {
 
 export const InteractiveEmbeddingOptionCard = () => {
   const isEE = PLUGIN_EMBEDDING.isEnabled();
+  const plan = useSelector(state =>
+    getPlan(getSetting(state, "token-features")),
+  );
   const enabled = useSelector(state => getSetting(state, "enable-embedding"));
 
   return (
@@ -98,7 +100,7 @@ export const InteractiveEmbeddingOptionCard = () => {
       label={t`PRO & ENTERPRISE`}
       description={jt`Use interactive embedding when you want to ${(
         <ExternalLink
-          href="https://www.metabase.com/blog/why-full-app-embedding"
+          href={`https://www.metabase.com/blog/why-full-app-embedding?utm_source=${plan}&utm_media=embed-settings`}
           key="why-full-app-embedding"
         >
           {t`offer multi-tenant, self-service analytics`}
@@ -106,11 +108,7 @@ export const InteractiveEmbeddingOptionCard = () => {
       )} and people want to create their own questions, dashboards, models, and more, all in their own data sandbox.`}
     >
       <BoldExternalLink
-        href={
-          isEE
-            ? "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-pro-cta"
-            : "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-oss-cta"
-        }
+        href={`https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=${plan}&utm_media=embed-settings`}
       >
         {t`Check out our Quick Start`}
       </BoldExternalLink>
@@ -124,7 +122,7 @@ export const InteractiveEmbeddingOptionCard = () => {
       ) : (
         <Button
           component={ExternalLink}
-          href="https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=CTA&utm_campaign=embed-settings-oss-cta"
+          href={`https://www.metabase.com/product/embedded-analytics?utm_source=${plan}&utm_media=embed-settings`}
         >
           {t`Learn More`}
         </Button>


### PR DESCRIPTION
[[Epic]Embedding settings cleanup and surface interactive embedding Quickstart ](https://github.com/metabase/metabase/issues/36481)

Slack message with the decision of the new utm tags: https://metaboat.slack.com/archives/C063Q3F1HPF/p1704736520321709?thread_ts=1703159414.478599&cid=C063Q3F1HPF

Changes:
- /pricing is changed back to /upgrade as it was originally in this page
- all utm tags are adjusted to be consistent with the upgrade link
