### PR TITLE
Exclude snippet and card template tags from parameters returned from BE endpoints

### DIFF
--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -173,9 +173,9 @@ export function openNewPublicLinkDropdown(resourceType) {
 }
 
 export function createPublicQuestionLink(questionId) {
-  cy.request("POST", `/api/card/${questionId}/public_link`, {});
+  return cy.request("POST", `/api/card/${questionId}/public_link`, {});
 }
 
 export function createPublicDashboardLink(dashboardId) {
-  cy.request("POST", `/api/dashboard/${dashboardId}/public_link`, {});
+  return cy.request("POST", `/api/dashboard/${dashboardId}/public_link`, {});
 }

--- a/e2e/test/scenarios/models/reproductions/20963-can-not-convert-question-with-snippets-to-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20963-can-not-convert-question-with-snippets-to-model.cy.spec.js
@@ -2,6 +2,7 @@ import {
   restore,
   modal,
   openNativeEditor,
+  saveQuestion,
   popover,
   openQuestionActions,
 } from "e2e/support/helpers";
@@ -35,19 +36,7 @@ describe("issue 20963", () => {
 
     cy.get("@editor").type(`{moveToStart}select `);
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save").click();
-    modal().within(() => {
-      // I don't know why the input lost focus, especially when we ran the query before saving.
-      // that'll be worse as the characters we type will go to the query input instead of the
-      // name input.
-      cy.findByLabelText("Name").type(questionName);
-      cy.findByText("Save").click();
-    });
-
-    // dismiss modal
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Not now").click();
+    saveQuestion(questionName, { wrapId: true });
 
     // Convert into to a model
     openQuestionActions();

--- a/e2e/test/scenarios/models/reproductions/20963-can-not-convert-question-with-snippets-to-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20963-can-not-convert-question-with-snippets-to-model.cy.spec.js
@@ -23,8 +23,7 @@ describe("issue 20963", () => {
 
     // Creat a snippet
     cy.icon("snippet").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Create a snippet").click();
+    cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
     modal().within(() => {
       cy.findByLabelText("Enter some SQL here so you can reuse it later").type(

--- a/e2e/test/scenarios/native/reproductions/21550-snippet-scrollbar.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/21550-snippet-scrollbar.cy.spec.js
@@ -14,8 +14,7 @@ describe("issue 21550", () => {
 
     cy.icon("snippet").click();
     cy.wait("@rootCollection");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Create a snippet").click();
+    cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
     modal().within(() => {
       cy.findByLabelText("Enter some SQL here so you can reuse it later").type(

--- a/e2e/test/scenarios/native/snippets/snippet-permissions.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets/snippet-permissions.cy.spec.js
@@ -48,8 +48,7 @@ describeEE("scenarios > question > snippets (EE)", () => {
 
       openNativeEditor();
       cy.icon("snippet").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.contains("Create a snippet").click();
+      cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
       modal().within(() => {
         cy.findByLabelText(

--- a/e2e/test/scenarios/native/snippets/snippets.cy.spec.js
+++ b/e2e/test/scenarios/native/snippets/snippets.cy.spec.js
@@ -24,8 +24,7 @@ describe("scenarios > question > snippets", () => {
 
     // Add a snippet of that text
     cy.icon("snippet").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Create a snippet").click();
+    cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
     modal().within(() => {
       cy.findByLabelText("Give your snippet a name").type("stuff-snippet");

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -2,10 +2,13 @@ import {
   restore,
   filterWidget,
   visitQuestion,
+  saveQuestion,
   downloadAndAssert,
   assertSheetRowsCount,
   openNewPublicLinkDropdown,
   createPublicQuestionLink,
+  modal,
+  openNativeEditor,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
@@ -56,14 +59,10 @@ describe("scenarios > public > question", () => {
     cy.signInAsAdmin();
 
     cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
-
-    cy.createNativeQuestion(questionData).then(({ body: { id } }) => {
-      cy.wrap(id).as("questionId");
-    });
   });
 
   it("adds filters to url as get params and renders the results correctly (metabase#7120, metabase#17033, metabase#21993)", () => {
-    cy.get("@questionId").then(id => {
+    cy.createNativeQuestion(questionData).then(({ body: { id } }) => {
       visitQuestion(id);
 
       // Make sure metadata fully loaded before we continue
@@ -97,24 +96,21 @@ describe("scenarios > public > question", () => {
   });
 
   it("should only allow non-admin users to see a public link if one has already been created", () => {
-    cy.get("@questionId").then(id => {
+    cy.createNativeQuestion(questionData).then(({ body: { id } }) => {
       createPublicQuestionLink(id);
       cy.signOut();
-    });
-
-    cy.signInAsNormalUser().then(() => {
-      cy.get("@questionId").then(id => {
+      cy.signInAsNormalUser().then(() => {
         visitQuestion(id);
-      });
 
-      cy.icon("share").click();
+        cy.icon("share").click();
 
-      cy.findByTestId("public-link-popover-content").within(() => {
-        cy.findByText("Public link").should("be.visible");
-        cy.findByTestId("public-link-input").then($input =>
-          expect($input.val()).to.match(PUBLIC_QUESTION_REGEX),
-        );
-        cy.findByText("Remove public URL").should("not.exist");
+        cy.findByTestId("public-link-popover-content").within(() => {
+          cy.findByText("Public link").should("be.visible");
+          cy.findByTestId("public-link-input").then($input =>
+            expect($input.val()).to.match(PUBLIC_QUESTION_REGEX),
+          );
+          cy.findByText("Remove public URL").should("not.exist");
+        });
       });
     });
   });
@@ -122,7 +118,7 @@ describe("scenarios > public > question", () => {
   Object.entries(USERS).map(([userType, setUser]) =>
     describe(`${userType}`, () => {
       it(`should be able to view public questions`, () => {
-        cy.get("@questionId").then(id => {
+        cy.createNativeQuestion(questionData).then(({ body: { id } }) => {
           cy.request("POST", `/api/card/${id}/public_link`).then(
             ({ body: { uuid } }) => {
               setUser();
@@ -140,6 +136,64 @@ describe("scenarios > public > question", () => {
       });
     }),
   );
+
+  it("should be able to view public questions with snippets", () => {
+    cy.visit("/");
+
+    openNativeEditor();
+
+    // Create a snippet
+    cy.icon("snippet").click();
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Create a snippet").click();
+
+    modal().within(() => {
+      cy.findByLabelText("Enter some SQL here so you can reuse it later").type(
+        `'test'`,
+      );
+      cy.findByLabelText("Give your snippet a name").type("string 'test'");
+      cy.findByText("Save").click();
+    });
+
+    cy.get("@editor").type(`{moveToStart}select `);
+
+    saveQuestion("test question", { wrapId: true });
+    cy.get("@questionId").then(id => {
+      cy.request("POST", `/api/card/${id}/public_link`).then(
+        ({ body: { uuid } }) => {
+          cy.visit(`/public/question/${uuid}`);
+          cy.get(".cellData").contains("test");
+        },
+      );
+    });
+  });
+
+  it("should be able to view public questions with card template tags", () => {
+    cy.createNativeQuestion({
+      name: "Nested Question",
+      native: {
+        query: "SELECT * FROM PEOPLE",
+      },
+    }).then(({ body: { id } }) => {
+      cy.visit("/");
+
+      openNativeEditor();
+
+      cy.get("@editor")
+        .type("select * from {{#")
+        .type(`{leftarrow}{leftarrow}${id}`);
+
+      saveQuestion("test question", { wrapId: true });
+      cy.get("@questionId").then(id => {
+        cy.request("POST", `/api/card/${id}/public_link`).then(
+          ({ body: { uuid } }) => {
+            cy.visit(`/public/question/${uuid}`);
+            cy.get(".cellData").contains("Winner");
+          },
+        );
+      });
+    });
+  });
 });
 
 const visitPublicURL = () => {

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -144,8 +144,7 @@ describe("scenarios > public > question", () => {
 
     // Create a snippet
     cy.icon("snippet").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Create a snippet").click();
+    cy.findByTestId("sidebar-content").findByText("Create a snippet").click();
 
     modal().within(() => {
       cy.findByLabelText("Enter some SQL here so you can reuse it later").type(
@@ -188,7 +187,8 @@ describe("scenarios > public > question", () => {
         cy.request("POST", `/api/card/${id}/public_link`).then(
           ({ body: { uuid } }) => {
             cy.visit(`/public/question/${uuid}`);
-            cy.get(".cellData").contains("Winner");
+            // Check the name of the first person in the PEOPLE table
+            cy.get(".cellData").contains("Hudson Borer");
           },
         );
       });

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -169,7 +169,7 @@ describe("scenarios > public > question", () => {
     cy.createNativeQuestion({
       name: "Nested Question",
       native: {
-        query: "SELECT * FROM PEOPLE",
+        query: "SELECT * FROM PEOPLE LIMIT 5",
       },
     }).then(({ body: { id } }) => {
       cy.visit("/");

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -138,8 +138,6 @@ describe("scenarios > public > question", () => {
   );
 
   it("should be able to view public questions with snippets", () => {
-    cy.visit("/");
-
     openNativeEditor();
 
     // Create a snippet

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -155,13 +155,15 @@ describe("scenarios > public > question", () => {
     cy.get("@editor").type(`{moveToStart}select `);
 
     saveQuestion("test question", { wrapId: true });
+
     cy.get("@questionId").then(id => {
-      cy.request("POST", `/api/card/${id}/public_link`).then(
-        ({ body: { uuid } }) => {
+      createPublicQuestionLink(id).then(({ body: { uuid } }) => {
+        cy.signOut();
+        cy.signInAsNormalUser().then(() => {
           cy.visit(`/public/question/${uuid}`);
           cy.get(".cellData").contains("test");
-        },
-      );
+        });
+      });
     });
   });
 
@@ -172,8 +174,6 @@ describe("scenarios > public > question", () => {
         query: "SELECT * FROM PEOPLE LIMIT 5",
       },
     }).then(({ body: { id } }) => {
-      cy.visit("/");
-
       openNativeEditor();
 
       cy.get("@editor")
@@ -182,13 +182,14 @@ describe("scenarios > public > question", () => {
 
       saveQuestion("test question", { wrapId: true });
       cy.get("@questionId").then(id => {
-        cy.request("POST", `/api/card/${id}/public_link`).then(
-          ({ body: { uuid } }) => {
+        createPublicQuestionLink(id).then(({ body: { uuid } }) => {
+          cy.signOut();
+          cy.signInAsNormalUser().then(() => {
             cy.visit(`/public/question/${uuid}`);
             // Check the name of the first person in the PEOPLE table
             cy.get(".cellData").contains("Hudson Borer");
-          },
-        );
+          });
+        });
       });
     });
   });

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -60,25 +60,21 @@ export function getTemplateTagParameters(
     .filter(
       tag =>
         tag.type != null &&
+        tag.type !== "card" &&
+        tag.type !== "snippet" &&
         ((tag["widget-type"] && tag["widget-type"] !== "none") ||
           tag.type !== "dimension"),
     )
     .map(tag => getTemplateTagParameter(tag, parametersById[tag.id]));
 }
 
-export function getTemplateTagsForParameters(card: Card) {
-  const templateTags: TemplateTag[] =
-    card &&
+export function getTemplateTags(card: Card): TemplateTag[] {
+  return card &&
     card.dataset_query &&
     card.dataset_query.type === "native" &&
     card.dataset_query.native["template-tags"]
-      ? Object.values(card.dataset_query.native["template-tags"])
-      : [];
-
-  return templateTags.filter(
-    // this should only return template tags that define a parameter of the card
-    tag => tag.type !== "card" && tag.type !== "snippet",
-  );
+    ? Object.values(card.dataset_query.native["template-tags"])
+    : [];
 }
 
 export function getParametersFromCard(
@@ -96,7 +92,7 @@ export function getParametersFromCard(
 }
 
 export function getTemplateTagParametersFromCard(card: Card) {
-  const tags = getTemplateTagsForParameters(card);
+  const tags = getTemplateTags(card);
   return getTemplateTagParameters(tags, card.parameters);
 }
 

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -48,7 +48,7 @@ export function getTemplateTagParameter(
   };
 }
 
-// NOTE: this should mirror `template-tag-parameters` in src/metabase/api/embed.clj
+// NOTE: this should mirror `template-tag-parameters` in src/metabase/models/card.clj
 // If this function moves you should update the comment that links to this one
 export function getTemplateTagParameters(
   tags: TemplateTag[],

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -69,9 +69,7 @@ export function getTemplateTagParameters(
 }
 
 export function getTemplateTags(card: Card): TemplateTag[] {
-  return card &&
-    card.dataset_query &&
-    card.dataset_query.type === "native" &&
+  return card?.dataset_query?.type === "native" &&
     card.dataset_query.native["template-tags"]
     ? Object.values(card.dataset_query.native["template-tags"])
     : [];

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.unit.spec.js
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.unit.spec.js
@@ -1,13 +1,14 @@
+import { createMockTemplateTag } from "metabase-types/api/mocks";
 import {
-  getTemplateTagsForParameters,
+  getTemplateTags,
   getTemplateTagParameters,
   remapParameterValuesToTemplateTags,
 } from "metabase-lib/parameters/utils/template-tags";
 
 describe("parameters/utils/cards", () => {
-  describe("getTemplateTagsForParameters", () => {
+  describe("getTemplateTags", () => {
     it("should return an empty array for an invalid card", () => {
-      expect(getTemplateTagsForParameters({})).toEqual([]);
+      expect(getTemplateTags({})).toEqual([]);
     });
 
     it("should return an empty array for a non-native query", () => {
@@ -16,7 +17,7 @@ describe("parameters/utils/cards", () => {
           type: "query",
         },
       };
-      expect(getTemplateTagsForParameters(card)).toEqual([]);
+      expect(getTemplateTags(card)).toEqual([]);
     });
 
     it("should return an empty array for a non-parametrized query", () => {
@@ -28,10 +29,10 @@ describe("parameters/utils/cards", () => {
           },
         },
       };
-      expect(getTemplateTagsForParameters(card)).toEqual([]);
+      expect(getTemplateTags(card)).toEqual([]);
     });
 
-    it("should extract the template tags defining the parameters", () => {
+    it("should extract the template tags", () => {
       const card = {
         dataset_query: {
           type: "native",
@@ -53,11 +54,17 @@ describe("parameters/utils/cards", () => {
           },
         },
       };
-      expect(getTemplateTagsForParameters(card)).toEqual([
+      expect(getTemplateTags(card)).toEqual([
         {
           type: "number",
           name: "stars",
           id: "xyz777",
+        },
+        {
+          id: "abc123",
+          name: "snippet: foo",
+          "snippet-id": 6,
+          type: "snippet",
         },
       ]);
     });
@@ -160,6 +167,38 @@ describe("parameters/utils/cards", () => {
       expect(getTemplateTagParameters(tags)).toEqual(
         parametersWithFieldFilterOperatorTypes,
       );
+    });
+
+    it("should exclude tags that are not parameters", () => {
+      const tags = [
+        createMockTemplateTag({
+          type: "string",
+          id: "1",
+          name: "a",
+          "display-name": "A",
+        }),
+        createMockTemplateTag({
+          type: "card",
+          id: "2",
+          "card-id": 123,
+        }),
+        createMockTemplateTag({
+          type: "snippet",
+          id: "3",
+          "snippet-id": 1,
+          "snippet-name": "C",
+        }),
+      ];
+      expect(getTemplateTagParameters(tags)).toEqual([
+        {
+          default: undefined,
+          id: "1",
+          name: "A",
+          slug: "a",
+          target: ["variable", ["template-tag", "a"]],
+          type: "string/=",
+        },
+      ]);
     });
   });
 

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -250,13 +250,13 @@
   (cond-> card
     (seq (:dataset_query card)) (update :dataset_query mbql.normalize/normalize)))
 
-;; TODO: move this to [[metabase.query-processor.card]]
+;; TODO: move this to [[metabase.query-processor.card]] or MLv2 so the logic can be shared between the backend and frontend
+;; NOTE: this should mirror `getTemplateTagParameters` in frontend/src/metabase-lib/parameters/utils/template-tags.ts
+;; If this function moves you should update the comment that links to this one
 (defn template-tag-parameters
   "Transforms native query's `template-tags` into `parameters`.
   An older style was to not include `:template-tags` onto cards as parameters. I think this is a mistake and they should always be there. Apparently lots of e2e tests are sloppy about this so this is included as a convenience."
   [card]
-  ;; NOTE: this should mirror `getTemplateTagParameters` in frontend/src/metabase-lib/parameters/utils/template-tags.ts
-  ;; If this function moves you should update the comment that links to this one
   (for [[_ {tag-type :type, widget-type :widget-type, :as tag}] (get-in card [:dataset_query :native :template-tags])
         :when                         (and tag-type
                                            (or (contains? mbql.s/raw-value-template-tag-types tag-type)

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -15,6 +15,7 @@
    [metabase.email.messages :as messages]
    [metabase.events :as events]
    [metabase.mbql.normalize :as mbql.normalize]
+   [metabase.mbql.schema :as mbql.s]
    [metabase.models.audit-log :as audit-log]
    [metabase.models.collection :as collection]
    [metabase.models.field-values :as field-values]
@@ -249,6 +250,7 @@
   (cond-> card
     (seq (:dataset_query card)) (update :dataset_query mbql.normalize/normalize)))
 
+;; TODO: move this to [[metabase.query-processor.card]]
 (defn template-tag-parameters
   "Transforms native query's `template-tags` into `parameters`.
   An older style was to not include `:template-tags` onto cards as parameters. I think this is a mistake and they should always be there. Apparently lots of e2e tests are sloppy about this so this is included as a convenience."
@@ -257,8 +259,8 @@
   ;; If this function moves you should update the comment that links to this one
   (for [[_ {tag-type :type, widget-type :widget-type, :as tag}] (get-in card [:dataset_query :native :template-tags])
         :when                         (and tag-type
-                                           (or (and widget-type (not= widget-type :none))
-                                               (not= tag-type :dimension)))]
+                                           (or (contains? mbql.s/raw-value-template-tag-types tag-type)
+                                               (and (= tag-type :dimension) widget-type (not= widget-type :none))))]
     {:id      (:id tag)
      :type    (or widget-type (cond (= tag-type :date)   :date/single
                                     (= tag-type :string) :string/=

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -231,47 +231,87 @@
                                  :default nil}]}
                   (client/client :get 200 (card-url card {:params {:c nil}})))))))))
 
-(deftest parameters-should-include-template-tags
+(def card-with-snippet
+  {:enable_embedding true
+   :dataset_query
+   {:database (mt/id)
+    :type     :native
+    :native   {:query         "select {{snippet: all}} from orders"
+               :collection    "CATEGORIES"
+               :template-tags {:a {:type "date", :name "a", :display_name "a" :id "a" :default "A TAG"}
+                               :category {:name         "category"
+                                          :display-name "Category"
+                                          :type         "dimension"
+                                          :dimension    ["field" (mt/id :categories :name) nil]
+                                          :widget-type  "category"
+                                          :required     true}
+                               "snippet: all" {:type :snippet,
+                                               :name "snippet: all",
+                                               :id "3d64e6a4-e4a3-41d1-bbda-e0ae2ebb0ff2",
+                                               :snippet-name "all",
+                                               :display-name "Snippet: All",
+                                               :snippet-id 1}}}}
+   :parameters       [{:type "date", :name "a", :display_name "a" :id "a" :default "A param"}]
+   :embedding_params {:a "enabled"}})
+
+(def card-with-embedded-params
+  {:enable_embedding true
+   :dataset_query    {:database (mt/id)
+                      :type     :native
+                      :native   {:template-tags {:a {:type "date", :name "a", :display_name "a" :id "a" :default "A TAG"}
+                                                 :b {:type "date", :name "b", :display_name "b" :id "b" :default "B TAG"}
+                                                 :c {:type "date", :name "c", :display_name "c" :id "c" :default "C TAG"}
+                                                 :d {:type "date", :name "d", :display_name "d" :id "d" :default "D TAG"}}}}
+   :parameters       [{:type "date", :name "a", :display_name "a" :id "a" :default "A param"}
+                      {:type "date", :name "b", :display_name "b" :id "b" :default "B param"}
+                      {:type               "date", :name "c", :display_name "c" :id "c" :default "C param"
+                       :values_source_type "static-list" :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}]
+   :embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}})
+
+(defn- parameter-expectations []
+  ;; TODO add case with a "card" template-tag
+  [{:input-card card-with-snippet
+    :expected-parameters-from-api [{:type "date/single",
+                                    :name "a",
+                                    :display_name "a",
+                                    :id "a",
+                                    :default "A TAG",
+                                    :target ["variable" ["template-tag" "a"]],
+                                    :slug "a"}]}
+
+   ;; in 44 we added card.parameters but we didn't migrate template-tags to parameters
+   ;; because doing such migration is costly.
+   ;; so there are cards where some parameters in template-tags does not exist in card.parameters
+   ;; that why we need to keep concat both of them then dedupe by id
+   {:input-card card-with-embedded-params
+    :expected-parameters-from-api [;; the parameter with id = "c" exists in both card.parameters and tempalte-tags should have info
+                                   ;; merge of both places
+                                   {:id "c",
+                                    :type "date/single",
+                                    :display_name "c",
+                                    :target ["variable" ["template-tag" "c"]],
+                                    :name "c",
+                                    :slug "c",
+                                    ;; order importance: the default from template-tag is in the final result
+                                    :default "C TAG"
+                                    :values_source_type    "static-list"
+                                    :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}
+                                    ;; the parameter id = "d" is in template-tags, but not card.parameters,
+                                    ;; when fetching card we should get it returned
+                                   {:id "d",
+                                    :type "date/single",
+                                    :target ["variable" ["template-tag" "d"]],
+                                    :name "d",
+                                    :slug "d",
+                                    :default "D TAG"}]}])
+
+(deftest parameters-should-include-relevant-template-tags-only
   (testing "parameters should get from both template-tags and card.parameters"
-    ;; in 44 we added card.parameters but we didn't migrate template-tags to parameters
-    ;; because doing such migration is costly.
-    ;; so there are cards where some parameters in template-tags does not exist in card.parameters
-    ;; that why we need to keep concat both of them then dedupe by id
-    (with-embedding-enabled-and-new-secret-key
-      (with-temp-card [card {:enable_embedding true
-                             :dataset_query    {:database (mt/id)
-                                                :type     :native
-                                                :native   {:template-tags {:a {:type "date", :name "a", :display_name "a" :id "a" :default "A TAG"}
-                                                                           :b {:type "date", :name "b", :display_name "b" :id "b" :default "B TAG"}
-                                                                           :c {:type "date", :name "c", :display_name "c" :id "c" :default "C TAG"}
-                                                                           :d {:type "date", :name "d", :display_name "d" :id "d" :default "D TAG"}}}}
-                             :parameters       [{:type "date", :name "a", :display_name "a" :id "a" :default "A param"}
-                                                {:type "date", :name "b", :display_name "b" :id "b" :default "B param"}
-                                                {:type "date", :name "c", :display_name "c" :id "c" :default "C param"
-                                                 :values_source_type "static-list"  :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}]
-                             :embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}}]
-        (let [parameters (:parameters (client/client :get 200 (card-url card)))]
-          (is (= [;; the parmeter with id = "c" exists in both card.parameters and tempalte-tags should have info
-                  ;; merge of both places
-                  {:id "c",
-                   :type "date/single",
-                   :display_name "c",
-                   :target ["variable" ["template-tag" "c"]],
-                   :name "c",
-                   :slug "c",
-                   ;; order importance: the default from template-tag is in the final result
-                   :default "C TAG"
-                   :values_source_type    "static-list"
-                   :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}
-                  ;; the parameter id = "d" is in template-tags, but not card.parameters,
-                  ;; when fetching card we should get it returned
-                  {:id "d",
-                   :type "date/single",
-                   :target ["variable" ["template-tag" "d"]],
-                   :name "d",
-                   :slug "d",
-                   :default "D TAG"}]
-                 parameters)))))))
+    (doseq [{:keys [input-card expected-parameters-from-api]} (parameter-expectations)]
+      (with-embedding-enabled-and-new-secret-key
+        (with-temp-card [card input-card]
+          (is (= expected-parameters-from-api
+                 (:parameters (client/client :get 200 (card-url card))))))))))
 
 ;;; ------------------------- GET /api/embed/card/:token/query (and JSON/CSV/XLSX variants) --------------------------
 

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -231,87 +231,47 @@
                                  :default nil}]}
                   (client/client :get 200 (card-url card {:params {:c nil}})))))))))
 
-(def card-with-snippet
-  {:enable_embedding true
-   :dataset_query
-   {:database (mt/id)
-    :type     :native
-    :native   {:query         "select {{snippet: all}} from orders"
-               :collection    "CATEGORIES"
-               :template-tags {:a {:type "date", :name "a", :display_name "a" :id "a" :default "A TAG"}
-                               :category {:name         "category"
-                                          :display-name "Category"
-                                          :type         "dimension"
-                                          :dimension    ["field" (mt/id :categories :name) nil]
-                                          :widget-type  "category"
-                                          :required     true}
-                               "snippet: all" {:type :snippet,
-                                               :name "snippet: all",
-                                               :id "3d64e6a4-e4a3-41d1-bbda-e0ae2ebb0ff2",
-                                               :snippet-name "all",
-                                               :display-name "Snippet: All",
-                                               :snippet-id 1}}}}
-   :parameters       [{:type "date", :name "a", :display_name "a" :id "a" :default "A param"}]
-   :embedding_params {:a "enabled"}})
-
-(def card-with-embedded-params
-  {:enable_embedding true
-   :dataset_query    {:database (mt/id)
-                      :type     :native
-                      :native   {:template-tags {:a {:type "date", :name "a", :display_name "a" :id "a" :default "A TAG"}
-                                                 :b {:type "date", :name "b", :display_name "b" :id "b" :default "B TAG"}
-                                                 :c {:type "date", :name "c", :display_name "c" :id "c" :default "C TAG"}
-                                                 :d {:type "date", :name "d", :display_name "d" :id "d" :default "D TAG"}}}}
-   :parameters       [{:type "date", :name "a", :display_name "a" :id "a" :default "A param"}
-                      {:type "date", :name "b", :display_name "b" :id "b" :default "B param"}
-                      {:type               "date", :name "c", :display_name "c" :id "c" :default "C param"
-                       :values_source_type "static-list" :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}]
-   :embedding_params {:a "locked", :b "disabled", :c "enabled", :d "enabled"}})
-
-(defn- parameter-expectations []
-  ;; TODO add case with a "card" template-tag
-  [{:input-card card-with-snippet
-    :expected-parameters-from-api [{:type "date/single",
-                                    :name "a",
-                                    :display_name "a",
-                                    :id "a",
-                                    :default "A TAG",
-                                    :target ["variable" ["template-tag" "a"]],
-                                    :slug "a"}]}
-
-   ;; in 44 we added card.parameters but we didn't migrate template-tags to parameters
-   ;; because doing such migration is costly.
-   ;; so there are cards where some parameters in template-tags does not exist in card.parameters
-   ;; that why we need to keep concat both of them then dedupe by id
-   {:input-card card-with-embedded-params
-    :expected-parameters-from-api [;; the parameter with id = "c" exists in both card.parameters and tempalte-tags should have info
-                                   ;; merge of both places
-                                   {:id "c",
-                                    :type "date/single",
-                                    :display_name "c",
-                                    :target ["variable" ["template-tag" "c"]],
-                                    :name "c",
-                                    :slug "c",
+(deftest parameters-should-include-legacy-template-tags
+  (testing "parameters should get from both template-tags and card.parameters"
+     ;; in 44 we added card.parameters but we didn't migrate template-tags to parameters
+     ;; because doing such migration is costly.
+     ;; so there are cards where some parameters in template-tags does not exist in card.parameters
+     ;; that why we need to keep concat both of them then dedupe by id
+    (with-embedding-enabled-and-new-secret-key
+      (with-temp-card [card (public-test/card-with-embedded-params)]
+        (is (= [;; the parameter with id = "c" exists in both card.parameters and tempalte-tags should have info
+                ;; merge of both places
+                {:id "c",
+                 :type "date/single",
+                 :display_name "c",
+                 :target ["variable" ["template-tag" "c"]],
+                 :name "c",
+                 :slug "c",
                                     ;; order importance: the default from template-tag is in the final result
-                                    :default "C TAG"
-                                    :values_source_type    "static-list"
-                                    :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}
+                 :default "C TAG"
+                 :values_source_type    "static-list"
+                 :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}
                                     ;; the parameter id = "d" is in template-tags, but not card.parameters,
                                     ;; when fetching card we should get it returned
-                                   {:id "d",
-                                    :type "date/single",
-                                    :target ["variable" ["template-tag" "d"]],
-                                    :name "d",
-                                    :slug "d",
-                                    :default "D TAG"}]}])
+                {:id "d",
+                 :type "date/single",
+                 :target ["variable" ["template-tag" "d"]],
+                 :name "d",
+                 :slug "d",
+                 :default "D TAG"}]
+               (:parameters (client/client :get 200 (card-url card)))))))))
 
 (deftest parameters-should-include-relevant-template-tags-only
-  (testing "parameters should get from both template-tags and card.parameters"
-    (doseq [{:keys [input-card expected-parameters-from-api]} (parameter-expectations)]
-      (with-embedding-enabled-and-new-secret-key
-        (with-temp-card [card input-card]
-          (is (= expected-parameters-from-api
-                 (:parameters (client/client :get 200 (card-url card))))))))))
+  (testing "should work with non-parameter template tags"
+    (with-embedding-enabled-and-new-secret-key
+      (with-temp-card [card (public-test/card-with-snippet-and-card-template-tags)]
+        (is (= [{:type "date/single",
+                 :name "a",
+                 :id "a",
+                 :default "A TAG",
+                 :target ["variable" ["template-tag" "a"]],
+                 :slug "a"}]
+               (:parameters (client/client :get 200 (card-url card)))))))))
 
 ;;; ------------------------- GET /api/embed/card/:token/query (and JSON/CSV/XLSX variants) --------------------------
 

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -9,6 +9,7 @@
    [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.api.card-test :as api.card-test]
    [metabase.api.dashboard-test :as api.dashboard-test]
+   [metabase.api.embed-test :as embed-test]
    [metabase.api.pivots :as api.pivots]
    [metabase.api.public :as api.public]
    [metabase.config :as config]
@@ -165,6 +166,91 @@
              (-> (:param_values (#'api.public/public-card :id (u/the-id card)))
                  (update-in [category-name-id :values] count)
                  (update category-name-id #(into {} %))))))))
+
+(defn- parameter-expectations []
+  [{:input-card embed-test/card-with-embedded-params
+    :expected-parameters-from-api [{:type :date/single,
+                                    :name "a",
+                                    :display_name "a",
+                                    :id "a",
+                                    :default "A TAG",
+                                    :target [:variable [:template-tag "a"]],
+                                    :slug "a"}
+                                   {:type :date/single,
+                                    :name "b",
+                                    :display_name "b",
+                                    :id "b",
+                                    :default "B TAG",
+                                    :target [:variable [:template-tag "b"]],
+                                    :slug "b"}
+                                   {:slug "c",
+                                    :default "C TAG",
+                                    :name "c",
+                                    :type :date/single,
+                                    :values_source_type "static-list",
+                                    :id "c",
+                                    :target [:variable [:template-tag "c"]],
+                                    :values_source_config {:values ["BBQ" "Bakery" "Bar"]},
+                                    :display_name "c"}
+                                   {:id "d",
+                                    :type :date/single,
+                                    :target [:variable [:template-tag "d"]],
+                                    :name "d",
+                                    :slug "d",
+                                    :default "D TAG"}]}
+
+   {:input-card embed-test/card-with-snippet
+    :expected-parameters-from-api [{:type :date/single,
+                                    :name "a",
+                                    :display_name "a",
+                                    :id "a",
+                                    :default "A TAG",
+                                    :target [:variable [:template-tag "a"]],
+                                    :slug "a"}
+                                   {:id      nil,
+                                    :type    :category,
+                                    :target  [:dimension [:template-tag "category"]],
+                                    :name    "Category",
+                                    :slug    "category",
+                                    :default nil}]}])
+
+(deftest get-card-parameters-should-include-relevant-template-tags-only
+  (testing "parameters should get from both template-tags and card.parameters"
+    ;; in 44 we added card.parameters but we didn't migrate template-tags to parameters
+    ;; because doing such migration is costly.
+    ;; so there are cards where some parameters in template-tags does not exist in card.parameters
+    ;; that why we need to keep concat both of them then dedupe by id
+    (doseq [{:keys [input-card expected-parameters-from-api]} (parameter-expectations)]
+      (mt/with-temp [:model/Card card input-card]
+        (is (= expected-parameters-from-api
+               (:parameters (#'api.public/public-card :id (u/the-id card)))))))))
+
+#_(deftest get-card-parameters-should-include-relevant-template-tags
+(let [category-name-id (mt/id :categories :name)]
+  (t2.with-temp/with-temp [Card card {:dataset_query
+                                      {:database (mt/id)
+                                       :type     :native
+                                       :native   {:query         "select {{snippet: all}} from orders"
+                                                  :collection    "CATEGORIES"
+                                                  :template-tags {:category {:name         "category"
+                                                                             :display-name "Category"
+                                                                             :type         "dimension"
+                                                                             :dimension    ["field" category-name-id nil]
+                                                                             :widget-type  "category"
+                                                                             :required     true}
+                                                                  "snippet: all" {:type :snippet,
+                                                                                  :name "snippet: all",
+                                                                                  :id "3d64e6a4-e4a3-41d1-bbda-e0ae2ebb0ff2",
+                                                                                  :snippet-name "all",
+                                                                                  :display-name "Snippet: All",
+                                                                                  :snippet-id 1}}}}}]
+                          (is (= [{:id      nil,
+                                   :type    :category,
+                                   :target  [:dimension [:template-tag "category"]],
+                                   :name    "Category",
+                                   :slug    "category",
+                                   :default nil}]
+                                 (:parameters (#'api.public/public-card :id (u/the-id card))))))))
 
 ;;; ------------------------- GET /api/public/card/:uuid/query (and JSON/CSV/XSLX versions) --------------------------
 

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -10,6 +10,7 @@
    [metabase.models.revision :as revision]
    [metabase.models.serialization :as serdes]
    [metabase.query-processor :as qp]
+   [metabase.query-processor.card-test :as qp.card-test]
    [metabase.test :as mt]
    [metabase.test.util :as tu]
    [metabase.util :as u]
@@ -326,6 +327,35 @@
      (t2.with-temp/with-temp [:model/Card card {:visualization_settings original}]
        (is (= expected
               (t2/select-one-fn :visualization_settings :model/Card :id (u/the-id card))))))))
+
+(deftest template-tag-parameters-test
+  (testing "Card with a Field filter parameter"
+    (t2.with-temp/with-temp [:model/Card card {:dataset_query (qp.card-test/field-filter-query)}]
+      (is (= [{:id "_DATE_",
+               :type :date/all-options,
+               :target [:dimension [:template-tag "date"]],
+               :name "Check-In Date",
+               :slug "date",
+               :default nil}]
+             (card/template-tag-parameters card)))))
+  (testing "Card with a non-Field-filter parameter"
+    (t2.with-temp/with-temp [:model/Card card {:dataset_query (qp.card-test/non-field-filter-query)}]
+      (is (= [{:id "_ID_",
+               :type :number/=,
+               :target [:variable [:template-tag "id"]],
+               :name "Order ID",
+               :slug "id",
+               :default "1"}]
+             (card/template-tag-parameters card)))))
+  (testing "Should ignore native query snippets and source card IDs"
+    (t2.with-temp/with-temp [:model/Card card {:dataset_query (qp.card-test/non-parameter-template-tag-query)}]
+      (is (= [{:id "_ID_",
+               :type :number/=,
+               :target [:variable [:template-tag "id"]],
+               :name "Order ID",
+               :slug "id",
+               :default "1"}]
+             (card/template-tag-parameters card))))))
 
 (deftest validate-template-tag-field-ids-test
   (testing "Disallow saving a Card with native query Field filter template tags referencing a different Database (#14145)"

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -330,7 +330,7 @@
 
 (deftest template-tag-parameters-test
   (testing "Card with a Field filter parameter"
-    (t2.with-temp/with-temp [:model/Card card {:dataset_query (qp.card-test/field-filter-query)}]
+    (mt/with-temp [:model/Card card {:dataset_query (qp.card-test/field-filter-query)}]
       (is (= [{:id "_DATE_",
                :type :date/all-options,
                :target [:dimension [:template-tag "date"]],
@@ -339,7 +339,7 @@
                :default nil}]
              (card/template-tag-parameters card)))))
   (testing "Card with a non-Field-filter parameter"
-    (t2.with-temp/with-temp [:model/Card card {:dataset_query (qp.card-test/non-field-filter-query)}]
+    (mt/with-temp [:model/Card card {:dataset_query (qp.card-test/non-field-filter-query)}]
       (is (= [{:id "_ID_",
                :type :number/=,
                :target [:variable [:template-tag "id"]],
@@ -348,7 +348,7 @@
                :default "1"}]
              (card/template-tag-parameters card)))))
   (testing "Should ignore native query snippets and source card IDs"
-    (t2.with-temp/with-temp [:model/Card card {:dataset_query (qp.card-test/non-parameter-template-tag-query)}]
+    (mt/with-temp [:model/Card card {:dataset_query (qp.card-test/non-parameter-template-tag-query)}]
       (is (= [{:id "_ID_",
                :type :number/=,
                :target [:variable [:template-tag "id"]],

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -55,7 +55,9 @@
                      Card card {:database_id (u/the-id db)}]
         (is (= nil (:cache-ttl (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))))
 
-(defn- field-filter-query []
+(defn field-filter-query
+  "A query with a Field Filter parameter"
+  []
   {:database (mt/id)
    :type     :native
    :native   {:template-tags {"date" {:id           "_DATE_"
@@ -66,7 +68,9 @@
                                       :widget-type  :date/all-options}}
               :query         "SELECT count(*)\nFROM CHECKINS\nWHERE {{date}}"}})
 
-(defn- non-field-filter-query []
+(defn non-field-filter-query
+  "A query with a parameter that is not a Field Filter"
+  []
   {:database (mt/id)
    :type     :native
    :native   {:template-tags {"id"
@@ -78,6 +82,25 @@
                                :default      "1"}}
               :query         "SELECT *\nFROM ORDERS\nWHERE id = {{id}}"}})
 
+(defn non-parameter-template-tag-query
+  "A query with template tags that aren't parameters"
+  []
+  (assoc (non-field-filter-query)
+         "abcdef"
+         {:id           "abcdef"
+          :name         "#1234"
+          :display-name "#1234"
+          :type         :card
+          :card-id      1234}
+
+         "xyz"
+         {:id           "xyz"
+          :name         "snippet: My Snippet"
+          :display-name "Snippet: My Snippet"
+          :type         :snippet
+          :snippet-name "My Snippet"
+          :snippet-id   1}))
+
 (deftest card-template-tag-parameters-test
   (testing "Card with a Field filter parameter"
     (t2.with-temp/with-temp [Card {card-id :id} {:dataset_query (field-filter-query)}]
@@ -88,21 +111,7 @@
       (is (= {"id" :number}
              (#'qp.card/card-template-tag-parameters card-id)))))
   (testing "Should ignore native query snippets and source card IDs"
-    (t2.with-temp/with-temp [Card {card-id :id} {:dataset_query (assoc (non-field-filter-query)
-                                                                       "abcdef"
-                                                                       {:id           "abcdef"
-                                                                        :name         "#1234"
-                                                                        :display-name "#1234"
-                                                                        :type         :card
-                                                                        :card-id      1234}
-
-                                                                       "xyz"
-                                                                       {:id           "xyz"
-                                                                        :name         "snippet: My Snippet"
-                                                                        :display-name "Snippet: My Snippet"
-                                                                        :type         :snippet
-                                                                        :snippet-name "My Snippet"
-                                                                        :snippet-id   1})}]
+    (t2.with-temp/with-temp [Card {card-id :id} {:dataset_query (non-parameter-template-tag-query)}]
       (is (= {"id" :number}
              (#'qp.card/card-template-tag-parameters card-id))))))
 


### PR DESCRIPTION
Fixes #37270

### Explanation of the bug

When snippet or card template tags are used in a native SQL question, the incorrect list of parameters is returned by the endpoint GET `/api/public/card`. There should be no parameters for snippet or card template tags.

example screenshot:
<img width="1728" alt="Screenshot 2024-01-05 at 15 46 57" src="https://github.com/metabase/metabase/assets/8542534/07a23081-271f-4431-a085-0dc5d15f3a2b">

The problem is related to the use of `metabase.models.card/template-tag-parameters`. It was introduced in this PR: [Properly return parameters for card in public and embedding endpoints](https://github.com/metabase/metabase/pull/29233#top).

The BE should mirror the FE and use the logic in `getTemplateTagsForParameters` [here](https://github.com/metabase/metabase/blob/67b3b1454eb85ec33e834c99a9107308307c78e4/frontend/src/metabase-lib/parameters/utils/template-tags.ts#L69) which excludes snippets from the result of `getTemplateTagParametersFromCard`.

### Summary of changes

- FE: 
  - refactoring to match the BE halfway. Previously the logic was split between two functions but now both the BE and FE have it in one
  - added e2e tests for (a) snippets in public questions and (b) card template tags in public questions
- BE: 
  - updated to match the logic on the FE, excluding template tags of type "snippet" and "card"

### What's not included 

`template-tag-parameters` contains duplicated logic with `metabase.query-processor.card/card-template-tag-parameters`. These should probably be merged into a MLv2 function so that logic is not duplicated in different parts of the FE and BE.