### PR TITLE
Support replacing expressions changing types and names

### DIFF
--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -46,6 +46,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.drill-thru :as lib.schema.drill-thru]
+   [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util.malli :as mu]))
 
@@ -69,7 +70,9 @@
       (for [[op label] [[:<  "<"]
                         [:>  ">"]
                         [:=  "="]
-                        [:!= "≠"]]]
+                        [:!= "≠"]]
+            :when (or (not (#{:< :>} op))
+                      (lib.schema.expression/comparable-expressions? field-ref value))]
         {:name   label
          :filter (operator op field-ref value)})
 

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -4,11 +4,10 @@
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.schema.common :as common]
    [metabase.shared.util.i18n :as i18n]
-   [metabase.types]
+   [metabase.types :as types]
+   [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
-
-(comment metabase.types/keep-me)
 
 (defmulti type-of-method
   "Impl for [[type-of]]. Use [[type-of]], but implement [[type-of-method]].
@@ -136,6 +135,22 @@
 (mr/def ::orderable
   (expression-schema orderable-types
                      "an expression that can be compared with :> or :<"))
+
+(defn comparable-expressions?
+  "Returns whether expressions `x` and `y` can be compared.
+
+  Expressions are comparable if their types are comparable.
+  Two types t1 and t2 are comparable if either one is ::type.unknown, or
+  there is an orderable type t such that both `t1` and `t2` are assignable to t."
+  [x y]
+  (some boolean
+        (for [t1 (u/one-or-many (type-of x))
+              t2 (u/one-or-many (type-of y))
+              t orderable-types]
+          (or (= t1 ::type.unknown)
+              (= t2 ::type.unknown)
+              (and (types/assignable? t1 t)
+                   (types/assignable? t2 t))))))
 
 (def equality-comparable-types
   "Set of base types that can be compared with equality."

--- a/src/metabase/lib/schema/filter.cljc
+++ b/src/metabase/lib/schema/filter.cljc
@@ -10,8 +10,7 @@
 
 (defn- tuple-clause-of-comparables-schema
   "Helper intended for use with [[define-mbql-clause]]. Create a clause schema with `:tuple` and ensure that
-  `args` can be compared.
-  Use this for fixed-length MBQL clause schemas. Use [[catn-clause-schema]] for variable-length schemas."
+  the elements of `args` at positions specified by the pairs in `compared-position-pairs` can be compared."
   [compared-position-pairs]
   (fn [tag & args]
     {:pre [(simple-keyword? tag)]}

--- a/src/metabase/lib/schema/filter.cljc
+++ b/src/metabase/lib/schema/filter.cljc
@@ -8,6 +8,23 @@
    [metabase.lib.schema.temporal-bucketing :as temporal-bucketing]
    [metabase.util.malli.registry :as mr]))
 
+(defn- tuple-clause-of-comparables-schema
+  "Helper intended for use with [[define-mbql-clause]]. Create a clause schema with `:tuple` and ensure that
+  `args` can be compared.
+  Use this for fixed-length MBQL clause schemas. Use [[catn-clause-schema]] for variable-length schemas."
+  [compared-position-pairs]
+  (fn [tag & args]
+    {:pre [(simple-keyword? tag)]}
+    [:and
+     (apply mbql-clause/tuple-clause-schema tag args)
+     [:fn
+      {:error/message "arguments should be comparable"}
+      (fn [[_tag _opts & args]]
+        (let [argv (vec args)]
+          (every? true? (map (fn [[i j]]
+                               (expression/comparable-expressions? (get argv i) (get argv j)))
+                             compared-position-pairs))))]]))
+
 (doseq [op [:and :or]]
   (mbql-clause/define-catn-mbql-clause op :- :type/Boolean
     [:args [:repeat {:min 2} [:schema [:ref ::expression/boolean]]]]))
@@ -20,21 +37,21 @@
     [:args [:repeat {:min 2} [:schema [:ref ::expression/equality-comparable]]]]))
 
 (doseq [op [:< :<= :> :>=]]
-  (mbql-clause/define-tuple-mbql-clause op :- :type/Boolean
+  (mbql-clause/define-mbql-clause-with-schema-fn (tuple-clause-of-comparables-schema #{[0 1]})
+    op :- :type/Boolean
     #_x [:ref ::expression/orderable]
     #_y [:ref ::expression/orderable]))
 
-(mbql-clause/define-tuple-mbql-clause :between :- :type/Boolean
-  ;; TODO -- we should probably enforce additional constraints that the various arg types have to agree, e.g. it makes
-  ;; no sense to say something like `[:between {} <date> <[:ref ::expression/string]> <integer>]`
-  ;;
+(mbql-clause/define-mbql-clause-with-schema-fn (tuple-clause-of-comparables-schema #{[0 1] [0 2]})
+  :between :- :type/Boolean
   ;; TODO -- should we enforce that min is <= max (for literal number values?)
   #_expr [:ref ::expression/orderable]
   #_min  [:ref ::expression/orderable]
   #_max  [:ref ::expression/orderable])
 
 ;; sugar: a pair of `:between` clauses
-(mbql-clause/define-tuple-mbql-clause :inside :- :type/Boolean
+(mbql-clause/define-mbql-clause-with-schema-fn (tuple-clause-of-comparables-schema #{[0 2] [0 4] [1 3] [1 5]})
+  :inside :- :type/Boolean
   ;; TODO -- should we enforce that lat-min <= lat-max and lon-min <= lon-max? Should we enforce that -90 <= lat 90
   ;; and -180 <= lon 180 ?? (for literal number values)
   #_lat-expr [:ref ::expression/orderable]

--- a/src/metabase/lib/schema/mbql_clause.cljc
+++ b/src/metabase/lib/schema/mbql_clause.cljc
@@ -108,7 +108,9 @@
 
 ;;;; Even more convenient functions!
 
-(defn- define-mbql-clause-with-schema-fn [schema-fn tag & args]
+(defn define-mbql-clause-with-schema-fn
+  "Helper. Combines [[define-mbql-clause]] and the result of applying `schema-fn` to `tag` and `args`."
+  [schema-fn tag & args]
   (let [[return-type & args] (if (= (first args) :-)
                                (cons (second args) (drop 2 args))
                                (cons nil args))

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -428,7 +428,7 @@
             column  (m/find-first #(= (:name %) "count")
                                   (lib/returned-columns orders-count-aggregation-breakout-on-created-at-by-month-query))
             _       (assert column)
-            context (merge (basic-context column "2018-05")
+            context (merge (basic-context column 10)
                            {:row [(basic-context (meta/field-metadata :orders :created-at) "2018-05")
                                   (basic-context column 10)]})]
         (testing (str "\ncontext =\n" (u/pprint-to-str context))

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -12,22 +12,23 @@
   (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :users))
                   (lib/join (-> (lib/join-clause (meta/table-metadata :checkins)
                                                  [(lib/=
-                                                    (meta/field-metadata :checkins :user-id)
-                                                    (meta/field-metadata :users :id))])
+                                                   (meta/field-metadata :checkins :user-id)
+                                                   (meta/field-metadata :users :id))])
                                 (lib/with-join-fields :all)))
                   (lib/join (-> (lib/join-clause (meta/table-metadata :venues)
                                                  [(lib/=
-                                                    (meta/field-metadata :checkins :venue-id)
-                                                    (meta/field-metadata :venues :id))])
+                                                   (meta/field-metadata :checkins :venue-id)
+                                                   (meta/field-metadata :venues :id))])
                                 (lib/with-join-fields :all))))]
     (doseq [col (lib/filterable-columns query)
             op (lib/filterable-column-operators col)
             :let [short-op (:short op)
                   expression-clause (case short-op
-                                      :between (lib/expression-clause short-op [col 123 456] {})
+                                      :between (lib/expression-clause short-op [col col col] {})
                                       (:contains :does-not-contain :starts-with :ends-with) (lib/expression-clause short-op [col "123"] {})
                                       (:is-null :not-null :is-empty :not-empty) (lib/expression-clause short-op [col] {})
                                       :inside (lib/expression-clause short-op [col 12 34 56 78 90] {})
+                                      (:< :>) (lib/expression-clause short-op [col col] {})
                                       (lib/expression-clause short-op [col 123] {}))]]
       (testing (str short-op " with " (lib.types.isa/field-type col))
         (is (=? {:lib/type :mbql/expression-parts

--- a/test/metabase/lib/filter_test.cljc
+++ b/test/metabase/lib/filter_test.cljc
@@ -319,10 +319,11 @@
     (doseq [col (lib/filterable-columns query)
             op (lib/filterable-column-operators col)
             :let [filter-clause (case (:short op)
-                                  :between (lib/filter-clause op col 123 456)
+                                  :between (lib/filter-clause op col col col)
                                   (:contains :does-not-contain :starts-with :ends-with) (lib/filter-clause op col "123")
                                   (:is-null :not-null :is-empty :not-empty) (lib/filter-clause op col)
                                   :inside (lib/filter-clause op col 12 34 56 78 90)
+                                  (:< :>) (lib/filter-clause op col col)
                                   (lib/filter-clause op col 123))]]
       (testing (str (:short op) " with " (lib.types.isa/field-type col))
         (is (= op

--- a/test/metabase/lib/schema/expression/conditional_test.cljc
+++ b/test/metabase/lib/schema/expression/conditional_test.cljc
@@ -88,7 +88,8 @@
                              {:lib/uuid "8c6e099e-b856-4aeb-a8f6-2266b5d3d1e3"}
                              [[[:>
                                 {:lib/uuid "9c4cc3b0-f3c7-4d34-ab53-640ba6e911e5"}
-                                [:field {:lib/uuid "435b08c8-9404-41a5-8c5a-00b415f14da6"} 25]
+                                [:field {:lib/uuid "435b08c8-9404-41a5-8c5a-00b415f14da6", :effective-type :type/Float}
+                                 25]
                                 0]
                                [:field {:lib/uuid "1c93ba8b-6a39-4ef2-a9e6-e3bcff042800"} 32]]]]
 
@@ -97,7 +98,8 @@
                              {:lib/uuid "8c6e099e-b856-4aeb-a8f6-2266b5d3d1e3"}
                              [[[:>
                                 {:lib/uuid "9c4cc3b0-f3c7-4d34-ab53-640ba6e911e5"}
-                                [:field {:lib/uuid "435b08c8-9404-41a5-8c5a-00b415f14da6"} 25]
+                                [:field {:lib/uuid "435b08c8-9404-41a5-8c5a-00b415f14da6", :effective-type :type/Float}
+                                 25]
                                 0]
                                [:field {:lib/uuid "1c93ba8b-6a39-4ef2-a9e6-e3bcff042800"} 32]]]
                              [:field
@@ -110,7 +112,8 @@
                              {:lib/uuid "66101767-c429-4499-b1b3-512e58267ea4"}
                              [[[:<
                                 {:lib/uuid "580d9de8-8ade-4d64-a512-1e43a31fe869"}
-                                [:field {:lib/uuid "347d5337-5da8-47ff-bc05-b11154e8d19c"} 139657]
+                                [:field {:lib/uuid "347d5337-5da8-47ff-bc05-b11154e8d19c", :effective-type :type/Float}
+                                 139657]
                                 2]
                                [:field {:lib/uuid "a9f83548-d590-4dec-b7dd-ad2bbd0bbe9d"} 139657]]]
                              0]}]

--- a/test/metabase/lib/schema/expression_test.cljc
+++ b/test/metabase/lib/schema/expression_test.cljc
@@ -1,0 +1,23 @@
+(ns metabase.lib.schema.expression-test
+  (:require [clojure.test :refer [deftest are testing]]
+            [metabase.lib.core :as lib]
+            [metabase.lib.schema.expression :as lib.schema.expression]
+            [metabase.lib.test-metadata :as meta]))
+
+(deftest ^:parallel comparable-expressions?-test
+  (let [abs-datetime [:absolute-datetime {:lib/uuid (str (random-uuid))}
+                      "2015-06-01T00:00Z" :day]]
+    (testing "positive examples"
+      (are [e0 e1] (lib.schema.expression/comparable-expressions? e0 e1)
+        "hello!" "szia!"
+        19.43 42
+        abs-datetime abs-datetime
+        abs-datetime "2023-01-01"
+        "2023-11-13T20:12:05" abs-datetime
+        (lib/ref (meta/field-metadata :orders :subtotal)) 100))
+    (testing "negative examples"
+      (are [e0 e1] (not (lib.schema.expression/comparable-expressions? e0 e1))
+        "42" 42
+        abs-datetime 42
+        abs-datetime "2023"
+        (lib/ref (meta/field-metadata :orders :subtotal)) "2023-11-13"))))


### PR DESCRIPTION
Fixes #36211.

The idea is that we optimistically replace the target expression with the new one and if there are schema errors, we remove the offending top-level clauses. If the error cannot be fixed this way, we fall back to the old way, i.e. remove all top-level clauses depending on the target expression.

I haven't addressed the problem of updating the automatically generated join aliases, which means that queries can end up with quite meaningless join aliases.

This PR also resolves an old TODO item: it enforces that the various arg types of comparison operators have to agree, e.g. it prevents nonsense like `[:< {} <date> <integer>]`.