### PR TITLE
Fix static viz funnel chart rendering by changing row idx values

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -985,8 +985,9 @@
   (let [[x-axis-rowfn
          y-axis-rowfn] (formatter/graphing-column-row-fns card data)
         funnel-rows    (:funnel.rows viz-settings)
-        rows           (cond->> (map (juxt x-axis-rowfn y-axis-rowfn)
-                                     (formatter/row-preprocess x-axis-rowfn y-axis-rowfn rows))
+        raw-rows       (map (juxt x-axis-rowfn y-axis-rowfn)
+                            (formatter/row-preprocess x-axis-rowfn y-axis-rowfn rows))
+        rows           (cond->> raw-rows
                          funnel-rows (mapv (fn [[idx val]]
                                              [(get-in funnel-rows [(dec idx) :key]) val])))
         [x-col y-col]  cols

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -984,14 +984,11 @@
   [_ render-type _timezone-id card _dashcard {:keys [rows cols viz-settings] :as data}]
   (let [[x-axis-rowfn
          y-axis-rowfn] (formatter/graphing-column-row-fns card data)
-        raw-rows       (map (juxt x-axis-rowfn y-axis-rowfn)
-                            (formatter/row-preprocess x-axis-rowfn y-axis-rowfn rows))
         funnel-rows    (:funnel.rows viz-settings)
-        rows           (if funnel-rows
-                           (mapv (fn [[idx val]]
-                                   [(get-in funnel-rows [(dec idx) :key]) val])
-                                 raw-rows)
-                           raw-rows)
+        rows           (cond->> (map (juxt x-axis-rowfn y-axis-rowfn)
+                                     (formatter/row-preprocess x-axis-rowfn y-axis-rowfn rows))
+                         funnel-rows (mapv (fn [[idx val]]
+                                             [(get-in funnel-rows [(dec idx) :key]) val])))
         [x-col y-col]  cols
         settings       (as-> (->js-viz x-col y-col viz-settings) jsviz-settings
                          (assoc jsviz-settings :step    {:name   (:display_name x-col)

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -984,8 +984,14 @@
   [_ render-type _timezone-id card _dashcard {:keys [rows cols viz-settings] :as data}]
   (let [[x-axis-rowfn
          y-axis-rowfn] (formatter/graphing-column-row-fns card data)
-        rows           (map (juxt x-axis-rowfn y-axis-rowfn)
+        raw-rows       (map (juxt x-axis-rowfn y-axis-rowfn)
                             (formatter/row-preprocess x-axis-rowfn y-axis-rowfn rows))
+        funnel-rows    (:funnel.rows viz-settings)
+        rows           (if funnel-rows
+                           (mapv (fn [[idx val]]
+                                   [(get-in funnel-rows [(dec idx) :key]) val])
+                                 raw-rows)
+                           raw-rows)
         [x-col y-col]  cols
         settings       (as-> (->js-viz x-col y-col viz-settings) jsviz-settings
                          (assoc jsviz-settings :step    {:name   (:display_name x-col)

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer :all]
    [clojure.walk :as walk]
    [hiccup.core :refer [html]]
+   [hickory.select :as hik.s]
    [metabase.formatter :as formatter]
    [metabase.models :refer [Card]]
    [metabase.pulse.render.body :as body]
@@ -561,6 +562,45 @@
           {:cols         default-columns
            :rows         [[nil 1] [11.0 nil] [nil nil] [2.50 20] [1.25 30]]
            :viz-settings {}})))))
+
+(defn- render-error?
+  [pulse-body]
+  (let [content (get-in pulse-body [0 :content 0 :content])]
+    (str/includes? content "error occurred")))
+
+(deftest render-funnel-text-row-labels-test
+  (testing "Static-viz Funnel Chart with text keys in viz-settings renders without error (#26944)."
+    (mt/dataset test-data
+      (let [funnel-query {:database (mt/id)
+                          :type     :query
+                          :query
+                          {:source-table (mt/id :orders)
+                           :aggregation  [[:count]]
+                           :breakout     [[:field (mt/id :orders :created_at)
+                                           {:base-type :type/DateTime :temporal-unit :month-of-year}]]}}
+            funnel-card  {:display       :funnel
+                          :dataset_query funnel-query
+                          :visualization_settings
+                          {:funnel.rows
+                           [{:key "December", :name "December", :enabled true}
+                            {:key "November", :name "November", :enabled true}
+                            {:key "October", :name "October", :enabled true}
+                            {:key "September", :name "September", :enabled true}
+                            {:key "August", :name "August", :enabled true}
+                            {:key "July", :name "July", :enabled true}
+                            {:key "June", :name "June", :enabled true}
+                            {:key "May", :name "May", :enabled true}
+                            {:key "April", :name "April", :enabled true}
+                            {:key "March", :name "March", :enabled true}
+                            {:key "February", :name "February", :enabled true}
+                            {:key "January", :name "January", :enabled true}],
+                           :funnel.order_dimension "CREATED_AT"}}]
+        (mt/with-temp [Card {card-id :id} funnel-card]
+          (let [doc        (render.tu/render-card-as-hickory card-id)
+                pulse-body (hik.s/select
+                            (hik.s/class "pulse-body")
+                            doc)]
+            (is (not (render-error? pulse-body)))))))))
 
 (deftest render-categorical-donut-test
   (let [columns [{:name          "category",


### PR DESCRIPTION
Fixes: #26944

Below is a namespace showing the issue and the solution for this bug. The gist of the fix is:

- funnel charts can have :funnel.rows in the viz-settings, which can specify a key to look up a value.
- The js code expects to find values at those key locations if the :funnel.rows key exists, but the funnel render code never adjusted the keys for the rows passed in. They were always numerical indexes.
- Now, when the funnel.rows key exists, the row indexes are adjusted to match the :key for each row specified in viz-settings, and the js code works.

This PR also adds a utility function to help with rendering/asserting on the static viz render output. That is, instead of just checking that a png exists, it's possible to write an assertion that ensures the render is not the "An error occurred" png. Previously, this was opaque and a unit test wouldn't catch the error if it only asserted that a png exists.


The namespace with some more details:


```clojure
(ns tickets.26944
  "## Funnel charts with ' Month of Year ' type dimension and ordering can't render in Static Viz

  ### URL: https://github.com/metabase/metabase/issues/26944

  See the comment block below for details."
  (:require
   [clojure.string :as str]
   [clojure.test :refer :all]
   [clojure.zip :as zip]
   [hiccup.core :as hiccup]
   [hickory.core :as hik]
   [hickory.select :as hik.s]
   [metabase.models :refer [Card]]
   [metabase.pulse]
   [metabase.pulse.render :as render]
   [metabase.pulse.render.image-bundle :as image-bundle]
   [metabase.pulse.render.js-svg :as js-svg]
   [metabase.pulse.render.test-util :as render.tu]
   [metabase.query-processor :as qp]
   [metabase.query-processor.card :as qp.card]
   [metabase.test :as mt]
   [toucan2.core :as t2]))

;;  **Describe the bug**
;;  A Funnel chart with dimension that is grouped by `Month of Year` will fail to render a static viz. This fails because we seem to treat the steps as the index of the month, rather than using the name of the month.
;;
;;  **To Reproduce**
;;  Steps to reproduce the behavior:
;;  1. New Question -> Orders
;;  2. Metric -> Count
;;  3. Group by Created At - Month of Year
;;  4. Click Visualize, and set to funnel chart
;;  5. Reorder the funnel steps and save
;;  6. Add to a dashboard and send static Viz
;;  7. Static viz will display ...

;; The repro steps above are super easy to follow, so I did them and indeed get the same result.
;; So, to repro it in a test, I'll pull that card's query and go from there.

{:database 1
 :type     :query
 :query
 {:source-table 2
  :aggregation  [[:count]]
  :breakout     [[:field 41 {:base-type :type/DateTime :temporal-unit :month-of-year}]]}}

;; And turning that into a test-safe query:
(def broken-funnel-query
  (mt/dataset test-data
    {:database (mt/id)
     :type     :query
     :query
     {:source-table (mt/id :orders)
      :aggregation  [[:count]]
      :breakout     [[:field (mt/id :orders :created_at) {:base-type :type/DateTime :temporal-unit :month-of-year}]]}}))

;; To make things repro properly, I need the `:display` and `:visualization_settings` too:

(def broken-funnel-card
  {:display       :funnel
   :dataset_query broken-funnel-query
   :visualization_settings
   {:funnel.rows
    [{:key "December", :name "December", :enabled true}
     {:key "November", :name "November", :enabled true}
     {:key "October", :name "October", :enabled true}
     {:key "September", :name "September", :enabled true}
     {:key "August", :name "August", :enabled true}
     {:key "July", :name "July", :enabled true}
     {:key "June", :name "June", :enabled true}
     {:key "May", :name "May", :enabled true}
     {:key "April", :name "April", :enabled true}
     {:key "March", :name "March", :enabled true}
     {:key "February", :name "February", :enabled true}
     {:key "January", :name "January", :enabled true}],
    :funnel.order_dimension "CREATED_AT"}})

;; I'll make a couple utility fns here for a moment, to make the namespace easier to copy-paste.
;; In the PR these fns have been added to `metabase.pulse.render-test-util`

;; In the test fn `render-card-as-hickory` we redefine `js-svg/svg-string->bytes` to the `identity` function.
;; This has the effect of putting an svg string into an image tag's src attribute like this:
;; `[:img {:src "<svg>...</svg>"}]`
;; which is not a valid img tag. So, this hiccup tree is malformed and needs to be fixed up.
;; In the render test utils this is handled by also redefnining `image-bundle/make-image-bundle`
;; to transform these image tags into their SVG directly. So this means the svg string is 'unpacked', parsed, and converted to hiccup.

;; This is all done so that you can run the actual static viz rendering but create more fine-grained assertions on the output.
;; This is demonstrated further on by creating an assertion that the pulse-body does NOT contain the string "... an error occurred..."

;; This approach is useful beyond just the funnel chart, of course.

(defn- img-node-with-svg?
  [loc]
  (let [[tag {:keys [src]}] (zip/node loc)]
    (and
     (= tag :img)
     (str/starts-with? src "<svg>"))))

(def ^:private edit-nodes #'render.tu/edit-nodes)
(def ^:private img-node->svg-node #'render.tu/img-node->svg-node)

(defn render-card-as-hickory
  [card-id]
  (let [{:keys [visualization_settings] :as card} (t2/select-one :model/Card :id card-id)
        query                                     (qp.card/query-for-card card [] nil {:process-viz-settings? true} nil)
        results                                   (qp/process-query (assoc query :viz-settings visualization_settings))]
    (with-redefs [js-svg/svg-string->bytes       identity
                  image-bundle/make-image-bundle (fn [_ s]
                                                   {:image-src   s
                                                    :render-type :inline})]
      (let [content (-> (render/render-pulse-card :inline "UTC" card nil results)
                            :content)]
        (-> content
              (edit-nodes img-node-with-svg? img-node->svg-node) ;; replace the :img tag with its parsed SVG.
              hiccup/html
              hik/parse
              hik/as-hickory)))))

(defn broken-funnel
  []
  (mt/dataset test-data
    (mt/with-temp [Card          {card-id1 :id} broken-funnel-card]
      (let [doc        (render-card-as-hickory card-id1)
            pulse-body (hik.s/select
                        (hik.s/class "pulse-body")
                        doc)]
        pulse-body))))

;; The broken-funnel function shows that our funnel render fails because we can see the error message in the returned pulse body.
;; The reason this happens is because our render implementation for funnel charts always passes the results into the js funnel code
;; as a vector of vectors, where the inner vectors are [idx display value]. The idx is always passed in as a number which the js
;; code doesn't always expect.

;; When we also pass in viz-settings with the key :funnel.rows, then the js code will use that data to try look up the funnel values.
;; The :funnel.rows shape is a vector of maps where each map is: `{:key "Field Name" :name "Display Name" :enabled true}`.
;; The error arises when there's a mismatch between the idx and the :key.

;; Therefore, the solution is to adjust what we pass into the js code. Below is how I have fixed the implementation in `metabase.pulse.render.body`.

#_(s/defmethod render :funnel :- formatter/RenderedPulseCard
  [_ render-type _timezone-id card _dashcard {:keys [rows cols viz-settings] :as data}]
  (let [[x-axis-rowfn
         y-axis-rowfn] (formatter/graphing-column-row-fns card data)
        ;; raw-rows has a shape like: [[0 120] [1 245] ...]
        raw-rows       (map (juxt x-axis-rowfn y-axis-rowfn)
                            (formatter/row-preprocess x-axis-rowfn y-axis-rowfn rows))
        ;; funnel rows takes the idx from the viz-settings and turns rows into [["The Key value" 120] ...]
        funnel-rows    (:funnel.rows viz-settings)
        rows           (if funnel-rows
                           (mapv (fn [[idx val]]
                                   [(get-in funnel-rows [(dec idx) :key]) val])
                                 raw-rows)
                           raw-rows)
        [x-col y-col]  cols
        settings       (as-> (->js-viz x-col y-col viz-settings) jsviz-settings
                         (assoc jsviz-settings :step    {:name   (:display_name x-col)
                                                         :format (:x jsviz-settings)}
                                :measure {:format (:y jsviz-settings)}))
        svg            (js-svg/funnel rows settings)
        image-bundle   (image-bundle/make-image-bundle render-type svg)]
    {:attachments
     (image-bundle/image-bundle->attachment image-bundle)

     :content
     [:div
      [:img {:style (style/style {:display :block :width :100%})
             :src   (:image-src image-bundle)}]]}))

;; Here's a failing test before implementing the above fix:

(defn- render-error?
  [pulse-body]
  (let [content (get-in pulse-body [0 :content 0 :content])]
    (str/includes? content "error occurred")))

(deftest funnel-render-test
  (mt/dataset test-data
    (let [funnel-query {:database (mt/id)
                        :type     :query
                        :query
                        {:source-table (mt/id :orders)
                         :aggregation  [[:count]]
                         :breakout     [[:field (mt/id :orders :created_at) {:base-type :type/DateTime :temporal-unit :month-of-year}]]}}
          funnel-card  {:display       :funnel
                        :dataset_query funnel-query
                        :visualization_settings
                        {:funnel.rows
                         [{:key "December", :name "December", :enabled true}
                          {:key "November", :name "November", :enabled true}
                          {:key "October", :name "October", :enabled true}
                          {:key "September", :name "September", :enabled true}
                          {:key "August", :name "August", :enabled true}
                          {:key "July", :name "July", :enabled true}
                          {:key "June", :name "June", :enabled true}
                          {:key "May", :name "May", :enabled true}
                          {:key "April", :name "April", :enabled true}
                          {:key "March", :name "March", :enabled true}
                          {:key "February", :name "February", :enabled true}
                          {:key "January", :name "January", :enabled true}],
                         :funnel.order_dimension "CREATED_AT"}}]
      (mt/with-temp [Card {card-id :id} funnel-card]
        (let [doc        (render-card-as-hickory card-id)
              pulse-body (hik.s/select
                          (hik.s/class "pulse-body")
                          doc)]
          (testing "Static-viz Funnel Chart with non-numeric keys in viz-settings renders without error (#26944)."
            (is (not (render-error? pulse-body)))))))))
```






