### PR TITLE
Attempt to fix pivot table not collapsing on public/static embedding

### DIFF
--- a/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.jsx
@@ -216,11 +216,6 @@ class PublicQuestionInner extends Component {
                     ["visualization_settings"],
                     previousSettings => ({ ...previousSettings, ...settings }),
                   ),
-                  result: updateIn(
-                    result,
-                    ["card", "visualization_settings"],
-                    previousSettings => ({ ...previousSettings, ...settings }),
-                  ),
                 })
               }
               gridUnit={12}

--- a/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.jsx
@@ -211,10 +211,15 @@ class PublicQuestionInner extends Component {
               className="full flex-full z1"
               onUpdateVisualizationSettings={settings =>
                 this.setState({
+                  card: updateIn(
+                    card,
+                    ["visualization_settings"],
+                    previousSettings => ({ ...previousSettings, ...settings }),
+                  ),
                   result: updateIn(
                     result,
                     ["card", "visualization_settings"],
-                    s => ({ ...s, ...settings }),
+                    previousSettings => ({ ...previousSettings, ...settings }),
                   ),
                 })
               }


### PR DESCRIPTION
This is a PoC of the fix for #21847

### Description

Seems the visualization settings passed to the `Visualization` component in public/static question isn't updated. Pivot table collapsing is recorded in `pivot_table.collapsed_rows`.

The visualization settings for public/static question is in the state `card` of `PublicQuestion`. Updating that seems to solve this particular bug.

I've tested that this bug doesn't happen on public dashboards like mentioned in the original issue.

### How to verify

Follow the repro in #21847

### Demo

https://www.loom.com/share/2974cbdc5aec4eeaaad1558fd70e62d0

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
