### PR TITLE
Use colors by names (as with color utility) instead of indexes in mantine

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.tsx
@@ -130,7 +130,7 @@ const LicenseAndBillingSettings = ({
 
         {!isStoreManagedBilling && (
           <>
-            <Text color="text.1">
+            <Text color="text-medium">
               {t`To manage your billing preferences, please email `}
               <Anchor href="mailto:billing@metabase.com">
                 billing@metabase.com

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkSettings.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/HelpLinkSettings/HelpLinkSettings.tsx
@@ -66,7 +66,7 @@ export const HelpLinkSettings = ({
       {isTextInputVisible && (
         <Stack ml={28} spacing={0}>
           {error && (
-            <Text size="md" color="error.0">
+            <Text size="md" color="error">
               {error}
             </Text>
           )}

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
@@ -24,7 +24,7 @@ const CollectionEmptyState = ({
     <EmptyStateRoot data-testid="collection-empty-state">
       <CollectionEmptyIcon />
       <EmptyStateTitle>{t`This collection is empty`}</EmptyStateTitle>
-      <Text size="1rem" color="text.1" align="center" mb="1.5rem">
+      <Text size="1rem" color="text-medium" align="center" mb="1.5rem">
         {t`Use collections to organize and group dashboards and questions for your team or yourself`}
       </Text>
       {canWrite && (

--- a/frontend/src/metabase/dashboard/components/DashboardEmbedHeaderButton/DashboardEmbedHeaderButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardEmbedHeaderButton/DashboardEmbedHeaderButton.tsx
@@ -39,7 +39,7 @@ export const DashboardEmbedHeaderButton = forwardRef(
       <Tooltip
         py="0.6rem"
         px="0.75rem"
-        bg="bg.3"
+        bg="bg-black"
         offset={4}
         label={
           <Text c="inherit" size="sm" fw={700}>

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.styled.tsx
@@ -10,7 +10,7 @@ export const PublicLinkCopyButton = styled(CopyButton)`
   cursor: pointer;
 
   &:hover {
-    color: ${({ theme }) => theme.colors.brand[1]};
+    color: ${({ theme }) => theme.fn.themeColor("brand")};
   }
 `;
 

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkCopyPanel.tsx
@@ -57,7 +57,7 @@ export const PublicLinkCopyPanel = ({
             >
               <RemoveLinkAnchor
                 fz="sm"
-                c="error.0"
+                c="error"
                 fw={700}
                 onClick={onRemoveLink}
               >
@@ -74,7 +74,7 @@ export const PublicLinkCopyPanel = ({
                 data-testid="extension-option"
                 key={extension}
                 tt="uppercase"
-                c={extension === selectedExtension ? "brand.1" : "text.0"}
+                c={extension === selectedExtension ? "brand" : "text-light"}
                 fw={700}
                 onClick={() =>
                   onChangeExtension?.(

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.tsx
@@ -63,9 +63,9 @@ export const PublicLinkPopover = ({
           data-testid="public-link-popover-content"
           mih={getMinDropdownHeight()}
         >
-          <Title color="text.1" order={4}>{t`Public link`}</Title>
+          <Title color="text-medium" order={4}>{t`Public link`}</Title>
           <Text
-            color="text.1"
+            color="text-medium"
             size="sm"
             mb="xs"
           >{t`Anyone can view this if you give them the link.`}</Text>

--- a/frontend/src/metabase/forms/components/FormErrorMessage/FormErrorMessage.tsx
+++ b/frontend/src/metabase/forms/components/FormErrorMessage/FormErrorMessage.tsx
@@ -16,13 +16,7 @@ export const FormErrorMessage = forwardRef(function FormErrorMessage(
   }
 
   return (
-    <Text
-      {...props}
-      role="alert"
-      aria-label={message}
-      ref={ref}
-      color="error.0"
-    >
+    <Text {...props} role="alert" aria-label={message} ref={ref} color="error">
       {message}
     </Text>
   );

--- a/frontend/src/metabase/forms/components/FormSubmitButton/FormSubmitButton.tsx
+++ b/frontend/src/metabase/forms/components/FormSubmitButton/FormSubmitButton.tsx
@@ -55,9 +55,9 @@ const getSubmitButtonColor = (
 ) => {
   switch (status) {
     case "fulfilled":
-      return "success.0";
+      return "success";
     case "rejected":
-      return "error.0";
+      return "error";
     default:
       return color;
   }

--- a/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.styled.tsx
+++ b/frontend/src/metabase/nav/components/WhatsNewNotification/WhatsNewNotification.styled.tsx
@@ -2,9 +2,9 @@ import styled from "@emotion/styled";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 
 export const DismissIconButtonWrapper = styled(IconButtonWrapper)`
-  color: ${({ theme }) => theme.colors.bg[2]};
+  color: ${({ theme }) => theme.fn.themeColor("bg-dark")};
 
   &:hover {
-    color: ${({ theme }) => theme.colors.text[1]};
+    color: ${({ theme }) => theme.fn.themeColor("text-medium")};
   }
 `;

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.styled.tsx
@@ -85,7 +85,7 @@ export const SearchInput = styled.input<{
 }>`
   background-color: transparent;
   border: none;
-  color: ${({ theme }) => theme.colors.text[2]};
+  color: ${({ theme }) => theme.fn.themeColor("text-dark")};
   font-weight: 700;
   font-size: 0.875rem;
 
@@ -96,7 +96,7 @@ export const SearchInput = styled.input<{
   }
 
   &::placeholder {
-    color: ${({ theme }) => theme.colors.text[2]};
+    color: ${({ theme }) => theme.fn.themeColor("text-dark")};
   }
 
   ${breakpointMinSmall} {

--- a/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.tsx
@@ -51,7 +51,7 @@ export type SearchResultsProps = {
 export const SearchLoadingSpinner = () => (
   <Stack p="xl" align="center">
     <Loader size="lg" data-testid="loading-spinner" />
-    <Text size="xl" color="text.0">
+    <Text size="xl" color="text-light">
       {t`Loading…`}
     </Text>
   </Stack>

--- a/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.styled.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.styled.tsx
@@ -23,8 +23,8 @@ export const SearchResultsContainer = styled(Paper)<PaperProps>`
 `;
 
 const selectedStyles = ({ theme }: { theme: Theme }) => css`
-  color: ${theme.colors.brand[1]};
-  background-color: ${theme.colors.brand[0]};
+  color: ${theme.fn.themeColor("brand")};
+  background-color: ${theme.fn.themeColor("brand-lighter")};
   cursor: pointer;
   transition: all 0.2s ease-in-out;
 `;
@@ -32,7 +32,7 @@ const selectedStyles = ({ theme }: { theme: Theme }) => css`
 export const SearchDropdownFooter = styled(Group, {
   shouldForwardProp: propName => propName !== "isSelected",
 })<{ isSelected?: boolean } & GroupProps>`
-  border-top: 1px solid ${({ theme }) => theme.colors.border[0]};
+  border-top: 1px solid ${({ theme }) => theme.fn.themeColor("border")};
 
   ${({ theme, isSelected }) => isSelected && selectedStyles({ theme })}
   &:hover {

--- a/frontend/src/metabase/public/components/widgets/EmbedModal.tsx
+++ b/frontend/src/metabase/public/components/widgets/EmbedModal.tsx
@@ -72,7 +72,7 @@ export const EmbedModal = ({
       formModal={false}
       {...modalProps}
     >
-      <Box bg="bg.0" h="100%">
+      <Box bg="bg-light" h="100%">
         {children({ embedType, setEmbedType })}
       </Box>
     </Modal>

--- a/frontend/src/metabase/public/components/widgets/SharingPane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.styled.tsx
@@ -11,12 +11,12 @@ export const CTAContainer = styled(Paper)<PaperProps>``;
 
 export const ClickIcon = styled(Icon)`
   ${CTAContainer}:hover & {
-    color: ${({ theme }) => theme.colors.brand[1]};
+    color: ${({ theme }) => theme.fn.themeColor("brand")};
   }
 `;
 
 export const CTAHeader = styled(Title)`
   ${CTAContainer}:hover & {
-    color: ${({ theme }) => theme.colors.brand[1]};
+    color: ${({ theme }) => theme.fn.themeColor("brand")};
   }
 `;

--- a/frontend/src/metabase/public/components/widgets/SharingPane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.tsx
@@ -38,7 +38,7 @@ export const InteractiveEmbeddingCTA = () => {
     // TODO: Check padding because design keeps using non-mantine-standard units
     <Box pos="relative">
       <ProBadge
-        bg="brand.1"
+        bg="brand"
         py="0.125rem"
         px="0.375rem"
         pos="absolute"
@@ -76,7 +76,7 @@ export const InteractiveEmbeddingCTA = () => {
             <Text inline lh="unset" fz="sm">
               {description}
               {"  "}
-              <Text inline inherit span color="brand.1" fw={700}>
+              <Text inline inherit span color="brand" fw={700}>
                 {linkText}
               </Text>
             </Text>

--- a/frontend/src/metabase/public/components/widgets/SharingPane/SharingPaneButton/SharingPaneButton.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/SharingPaneButton/SharingPaneButton.styled.tsx
@@ -19,11 +19,11 @@ export const SharingPaneButtonTitle = styled(Title)<SharingPaneElementProps>`
     !disabled
       ? css`
           ${SharingPaneButtonContent}:hover & {
-            color: ${theme.colors.brand[1]};
+            color: ${theme.fn.themeColor("brand")};
           }
         `
       : css`
-          color: ${theme.colors.text[0]};
+          color: ${theme.fn.themeColor("text-light")};
         `}
 `;
 
@@ -34,7 +34,7 @@ export const SharingPaneActionButton = styled(Button)<
     !disabled &&
     css`
       ${SharingPaneButtonContent}:hover & {
-        background-color: ${theme.colors.brand[1]};
+        background-color: ${theme.fn.themeColor("brand")};
         color: white;
       }
     `}

--- a/frontend/src/metabase/public/components/widgets/SharingPane/icons/PublicEmbedIcon/PublicEmbedIcon.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/icons/PublicEmbedIcon/PublicEmbedIcon.styled.tsx
@@ -8,10 +8,12 @@ interface PublicEmbedIconRootProps {
 
 export const PublicEmbedIconRoot = styled.svg<PublicEmbedIconRootProps>`
   ${({ theme, disabled }) => css`
-    color: ${theme.colors.bg[1]};
+    color: ${theme.fn.themeColor("bg-medium")};
 
     .innerFill {
-      stroke: ${disabled ? theme.colors.text[0] : theme.colors.bg[2]};
+      stroke: ${disabled
+        ? theme.fn.themeColor("text-light")
+        : theme.fn.themeColor("bg-dark")};
       opacity: ${disabled ? 0.5 : 1};
     }
   `}
@@ -20,10 +22,10 @@ export const PublicEmbedIconRoot = styled.svg<PublicEmbedIconRootProps>`
     !disabled &&
     css`
       ${SharingPaneButtonContent}:hover & {
-        color: ${theme.colors.bg[2]};
+        color: ${theme.fn.themeColor("bg-dark")};
 
         .innerFill {
-          stroke: ${theme.colors.brand[1]};
+          stroke: ${theme.fn.themeColor("brand")};
         }
       }
     `}

--- a/frontend/src/metabase/public/components/widgets/SharingPane/icons/StaticEmbedIcon/StaticEmbedIcon.styled.tsx
+++ b/frontend/src/metabase/public/components/widgets/SharingPane/icons/StaticEmbedIcon/StaticEmbedIcon.styled.tsx
@@ -5,18 +5,18 @@ import { SharingPaneButtonContent } from "metabase/public/components/widgets/Sha
 export const StaticEmbedIconRoot = styled.svg`
   ${({ theme }) =>
     css`
-      color: ${theme.colors.bg[1]};
+      color: ${theme.fn.themeColor("bg-medium")};
 
       .innerFill {
-        fill: ${theme.colors.bg[2]};
+        fill: ${theme.fn.themeColor("bg-dark")};
         fill-opacity: 0.5;
       }
 
       ${SharingPaneButtonContent}:hover & {
-        color: ${theme.colors.focus};
+        color: ${theme.fn.themeColor("focus")};
 
         .innerFill {
-          fill: ${theme.colors.brand[1]};
+          fill: ${theme.fn.themeColor("brand")};
           fill-opacity: 1;
         }
       }

--- a/frontend/src/metabase/querying/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.tsx
@@ -127,7 +127,7 @@ export function ExcludeOptionPicker({
         {operatorOptions.map((option, index) => (
           <Button
             key={index}
-            c={option.operator === value?.operator ? "brand.1" : "text.2"}
+            c={option.operator === value?.operator ? "brand" : "text.2"}
             display="block"
             variant="subtle"
             onClick={() => handleChange(option.operator)}

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.tsx
@@ -119,7 +119,7 @@ export function DateIntervalPicker({
       </Flex>
       <Divider />
       <Group px="md" py="sm" position="apart">
-        <Group c="text.1" spacing="sm">
+        <Group c="text-medium" spacing="sm">
           <Icon name="calendar" />
           <Text c="inherit">{dateRangeText}</Text>
         </Group>

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.tsx
@@ -114,7 +114,7 @@ export function DateOffsetIntervalPicker({
       </PickerGrid>
       <Divider />
       <Group px="md" py="sm" spacing="sm" position="apart">
-        <Group c="text.1" spacing="sm">
+        <Group c="text-medium" spacing="sm">
           <Icon name="calendar" />
           <Text c="inherit">{dateRangeText}</Text>
         </Group>

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePickerBody/DateRangePickerBody.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePickerBody/DateRangePickerBody.tsx
@@ -53,7 +53,7 @@ export function DateRangePickerBody({
           aria-label={t`Start date`}
           onChange={handleStartDateChange}
         />
-        <Text c="text.0">{t`and`}</Text>
+        <Text c="text-light">{t`and`}</Text>
         <FlexDateInput
           value={endDate}
           popoverProps={{ opened: false }}
@@ -68,7 +68,7 @@ export function DateRangePickerBody({
             aria-label={t`Start time`}
             onChange={handleStartTimeChange}
           />
-          <Text c="text.0">{t`and`}</Text>
+          <Text c="text-light">{t`and`}</Text>
           <FlexTimeInput
             value={endDate}
             aria-label={t`End time`}

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/TimeToggle/TimeToggle.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/TimeToggle/TimeToggle.tsx
@@ -11,7 +11,7 @@ interface TimeToggleProps extends ButtonProps {
 export function TimeToggle({ hasTime, ...props }: TimeToggleProps) {
   return (
     <Button
-      c="text.1"
+      c="text-medium"
       variant="subtle"
       leftIcon={<Icon name="clock" />}
       {...props}

--- a/frontend/src/metabase/querying/components/FilterModal/FilterColumnName/FilterColumnName.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/FilterColumnName/FilterColumnName.tsx
@@ -32,7 +32,7 @@ export function FilterColumnName({
   return (
     <Group fw="bold" spacing="xs">
       <Text color="text.2">{columnInfo.displayName}</Text>
-      <Text color="text.0">{t`in`}</Text>
+      <Text color="text-light">{t`in`}</Text>
       <Text color="text.2">{columnInfo.table.displayName}</Text>
     </Group>
   );

--- a/frontend/src/metabase/querying/components/FilterModal/FilterModal.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/FilterModal.tsx
@@ -114,7 +114,7 @@ export function FilterModal({
         <ModalFooter p="md" direction="row" justify="space-between">
           <Button
             variant="subtle"
-            color="text.1"
+            color="text-medium"
             disabled={!canRemoveFilters}
             onClick={handleReset}
           >
@@ -176,9 +176,9 @@ function TabContent({
 
 function SearchEmptyState() {
   return (
-    <Stack c="text.0" h="100%" justify="center" align="center">
+    <Stack c="text-light" h="100%" justify="center" align="center">
       <Icon name="search" size={40} />
-      <Text c="text.1" mt="lg" fw="bold">{t`Didn't find anything`}</Text>
+      <Text c="text-medium" mt="lg" fw="bold">{t`Didn't find anything`}</Text>
     </Stack>
   );
 }

--- a/frontend/src/metabase/querying/components/FilterModal/FilterOperatorPicker/FilterOperatorPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/FilterOperatorPicker/FilterOperatorPicker.tsx
@@ -32,7 +32,7 @@ export function FilterOperatorPicker<T extends string>({
         <Button
           variant="subtle"
           disabled={disabled}
-          color="brand.1"
+          color="brand"
           td={disabled ? "none" : "underline"}
           rightIcon={<Icon name="chevrondown" size={8} />}
           p="xs"

--- a/frontend/src/metabase/querying/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.tsx
@@ -77,7 +77,7 @@ export function BooleanFilterPicker({
         </Radio.Group>
         {!isExpanded && (
           <Button
-            c="text.1"
+            c="text-medium"
             variant="subtle"
             aria-label={t`More options`}
             rightIcon={<Icon name="chevrondown" />}

--- a/frontend/src/metabase/querying/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
@@ -94,9 +94,9 @@ function DefaultValuePicker({
             ))}
           </Stack>
         ) : (
-          <Stack c="text.0" justify="center" align="center">
+          <Stack c="text-light" justify="center" align="center">
             <Icon name="search" size={40} />
-            <Text c="text.1" fw="bold">{t`Didn't find anything`}</Text>
+            <Text c="text-medium" fw="bold">{t`Didn't find anything`}</Text>
           </Stack>
         )}
       </Checkbox.Group>

--- a/frontend/src/metabase/search/components/DropdownSidebarFilter/DropdownSidebarFilter.styled.tsx
+++ b/frontend/src/metabase/search/components/DropdownSidebarFilter/DropdownSidebarFilter.styled.tsx
@@ -14,7 +14,9 @@ export const DropdownFieldSet = styled(FieldSet)<{
 
   border: 2px solid
     ${({ theme, fieldHasValueOrFocus }) =>
-      fieldHasValueOrFocus ? theme.colors.brand[1] : theme.colors.border[0]};
+      fieldHasValueOrFocus
+        ? theme.fn.themeColor("brand")
+        : theme.fn.themeColor("border")};
 
   margin: 0;
   padding: 0.5rem 0.75rem;
@@ -38,7 +40,7 @@ export const DropdownFieldSet = styled(FieldSet)<{
   &,
   legend {
     color: ${({ theme, fieldHasValueOrFocus }) =>
-      fieldHasValueOrFocus && theme.colors.brand[1]};
+      fieldHasValueOrFocus && theme.fn.themeColor("brand")};
   }
 `;
 

--- a/frontend/src/metabase/search/components/InfoText/InfoTextAssetLink.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoTextAssetLink.tsx
@@ -19,7 +19,7 @@ type InfoTextAssetLinkProps = {
 };
 
 const LinkSeparator = (
-  <Box component="span" c="text.1">
+  <Box component="span" c="text-medium">
     <Icon name="chevronright" size={8} />
   </Box>
 );

--- a/frontend/src/metabase/search/components/InfoText/InfoTextEditedInfo.styled.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoTextEditedInfo.styled.tsx
@@ -7,14 +7,14 @@ import { breakpointMaxSmall } from "metabase/styled-components/theme";
 export const LastEditedInfoText = styled(LastEditInfoLabel)`
   ${({ theme }) => {
     return css`
-      color: ${theme.colors.text[1]};
+      color: ${theme.fn.themeColor("text-medium")};
       font-size: ${theme.fontSizes.sm};
       font-weight: 500;
 
       cursor: pointer;
 
       &:hover {
-        color: ${theme.colors.brand[1]};
+        color: ${theme.fn.themeColor("brand")};
       }
     `;
   }}

--- a/frontend/src/metabase/search/components/InfoText/InfoTextEditedInfo.tsx
+++ b/frontend/src/metabase/search/components/InfoText/InfoTextEditedInfo.tsx
@@ -24,7 +24,7 @@ const LoadingText = () => (
 );
 
 const InfoTextSeparator = (
-  <Text span size="sm" mx="xs" c="text.1">
+  <Text span size="sm" mx="xs" c="text-medium">
     •
   </Text>
 );
@@ -90,7 +90,7 @@ export const InfoTextEditedInfo = ({
       const formattedDuration = timestamp && getRelativeTime(timestamp);
       return (
         <Tooltip tooltip={<LastEditedInfoTooltip {...lastEditedInfoData} />}>
-          <Text span size="sm" c="text.1" truncate>
+          <Text span size="sm" c="text-medium" truncate>
             {formattedDuration}
           </Text>
         </Tooltip>

--- a/frontend/src/metabase/search/components/SearchFilterPopoverWrapper/SearchFilterPopoverWrapper.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterPopoverWrapper/SearchFilterPopoverWrapper.styled.tsx
@@ -12,7 +12,7 @@ export const DropdownApplyButtonDivider = styled.hr<{ width?: string }>`
   ${({ theme, width }) => {
     const dividerWidth = width ?? "100%";
     return css`
-      border-color: ${theme.colors.border[0]};
+      border-color: ${theme.fn.themeColor("border")};
       width: ${dividerWidth};
     `;
   }}

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.styled.tsx
@@ -24,13 +24,13 @@ export const ResultTitle = styled(Anchor)<
   font-weight: 700;
   font-size: ${({ theme }) => theme.fontSizes.md};
 
-  color: ${({ theme }) => theme.colors.text[2]};
+  color: ${({ theme }) => theme.fn.themeColor("text-dark")};
 
   &:hover,
   &:focus-visible,
   &:focus {
     text-decoration: none;
-    color: ${({ theme }) => theme.colors.brand[1]};
+    color: ${({ theme }) => theme.fn.themeColor("brand")};
     outline: 0;
   }
 `;
@@ -58,24 +58,24 @@ export const SearchResultContainer = styled(Box, {
     isActive &&
     css`
       border-radius: ${theme.radius.md};
-      color: ${isSelected && theme.colors.brand[1]};
-      background-color: ${isSelected && theme.colors.brand[0]};
+      color: ${isSelected && theme.fn.themeColor("brand")};
+      background-color: ${isSelected && theme.fn.themeColor("brand-lighter")};
 
       ${ResultTitle} {
-        color: ${isSelected && theme.colors.brand[1]};
+        color: ${isSelected && theme.fn.themeColor("brand")};
       }
 
       &:hover {
-        background-color: ${theme.colors.brand[0]};
+        background-color: ${theme.fn.themeColor("brand-lighter")};
         cursor: pointer;
 
         ${ResultTitle} {
-          color: ${theme.colors.brand[1]};
+          color: ${theme.fn.themeColor("brand")};
         }
       }
 
       &:focus-within {
-        background-color: ${theme.colors.brand[0]};
+        background-color: ${theme.fn.themeColor("brand-lighter")};
       }
     `}
 `;

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
@@ -128,7 +128,7 @@ export function SearchResult({
           <Group noWrap spacing="sm" data-testid="result-description">
             <DescriptionDivider
               size="md"
-              color="focus.0"
+              color="focus"
               orientation="vertical"
             />
             <SearchResultDescription

--- a/frontend/src/metabase/search/components/SearchResult/components/ItemIcon.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/components/ItemIcon.styled.tsx
@@ -22,7 +22,7 @@ export const IconWrapper = styled.div<{
   active: boolean;
   type: SearchModelType;
 }>`
-  border: ${({ theme }) => `1px solid ${theme.colors.border[0]}`};
+  border: ${({ theme }) => `1px solid ${theme.fn.themeColor("border")}`};
   border-radius: ${({ theme }) => theme.radius.sm};
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/search/components/SearchResultLink/SearchResultLink.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchResultLink/SearchResultLink.styled.tsx
@@ -15,7 +15,7 @@ export const ResultLink = styled.a<ResultLinkProps>`
         &:hover,
         &:focus,
         &:focus-within {
-          color: ${theme.colors.brand[1]};
+          color: ${theme.fn.themeColor("brand")};
           outline: 0;
         }
       `

--- a/frontend/src/metabase/search/components/SearchResultLink/SearchResultLink.tsx
+++ b/frontend/src/metabase/search/components/SearchResultLink/SearchResultLink.tsx
@@ -35,7 +35,7 @@ export const SearchResultLink = ({
         <ResultLink
           {...componentProps}
           span
-          c="text.1"
+          c="text-medium"
           size="sm"
           truncate
           ref={truncatedRef}

--- a/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.styled.tsx
@@ -22,7 +22,7 @@ export const SearchUserPickerContent = styled(Stack)`
 `;
 
 export const SearchUserSelectBox = styled(Stack)`
-  border: ${({ theme }) => theme.colors.border[0]} 1px solid;
+  border: ${({ theme }) => theme.fn.themeColor("border")} 1px solid;
   border-radius: ${({ theme }) => theme.radius.md};
 `;
 
@@ -30,7 +30,7 @@ export const SelectedUserButton = styled(Button)<
   ButtonProps & HTMLAttributes<HTMLButtonElement>
 >`
   ${({ theme }) => {
-    const primaryColor = theme.colors.brand[1];
+    const primaryColor = theme.fn.themeColor("brand");
     const backgroundColor = theme.fn.lighten(primaryColor, 0.8);
     const hoverBackgroundColor = theme.fn.lighten(primaryColor, 0.6);
 

--- a/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.tsx
+++ b/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.tsx
@@ -90,7 +90,7 @@ export const SearchUserPicker = ({
                 <SelectedUserButton
                   data-testid="selected-user-button"
                   key={userId}
-                  c="brand.1"
+                  c="brand"
                   px="md"
                   py="sm"
                   maw="100%"

--- a/frontend/src/metabase/search/components/UserListElement/UserListElement.styled.tsx
+++ b/frontend/src/metabase/search/components/UserListElement/UserListElement.styled.tsx
@@ -7,7 +7,7 @@ export const UserElement = styled(Button)<
   HTMLAttributes<HTMLButtonElement> & ButtonProps
 >`
   &:hover {
-    background-color: ${({ theme }) => theme.colors.brand[0]};
+    background-color: ${({ theme }) => theme.fn.themeColor("brand-lighter")};
   }
 
   & > div {

--- a/frontend/src/metabase/search/components/UserListElement/UserListElement.tsx
+++ b/frontend/src/metabase/search/components/UserListElement/UserListElement.tsx
@@ -20,9 +20,9 @@ export const UserListElement = ({
     px="sm"
     py="xs"
     variant="subtle"
-    bg={isSelected ? "brand.0" : undefined}
+    bg={isSelected ? "brand" : undefined}
   >
-    <Text weight={700} color={isSelected ? "brand.1" : undefined} truncate>
+    <Text weight={700} color={isSelected ? "brand" : undefined} truncate>
       {value.common_name}
     </Text>
   </UserElement>

--- a/frontend/src/metabase/ui/components/buttons/Button/Button.stories.mdx
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.stories.mdx
@@ -21,7 +21,7 @@ export const argTypes = {
     control: { type: "inline-radio" },
   },
   color: {
-    options: { default: undefined, success: "success.0", error: "error.0" },
+    options: { default: undefined, success: "success", error: "error" },
     control: { type: "inline-radio" },
   },
   compact: {
@@ -183,7 +183,7 @@ export const DefaultGrid = GridTemplate.bind({});
 
 export const CustomColorGrid = GridTemplate.bind({});
 CustomColorGrid.args = {
-  color: "error.0",
+  color: "error",
 };
 
 <Canvas>
@@ -266,7 +266,7 @@ CompactGrid.args = {
 
 export const CompactCustomColorGrid = GridTemplate.bind({});
 CompactCustomColorGrid.args = {
-  color: "error.0",
+  color: "error",
   compact: true,
 };
 

--- a/frontend/src/metabase/ui/components/buttons/Button/Button.styled.tsx
+++ b/frontend/src/metabase/ui/components/buttons/Button/Button.styled.tsx
@@ -51,17 +51,17 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
 
         return {
           root: {
-            color: theme.colors.text[2],
-            borderColor: theme.colors.border[0],
+            color: theme.fn.themeColor("text-dark"),
+            borderColor: theme.fn.themeColor("border"),
             backgroundColor: theme.white,
             "&:hover": {
               color: primaryColor,
-              backgroundColor: theme.colors.bg[0],
+              backgroundColor: theme.fn.themeColor("bg-light"),
             },
             "&:disabled": {
-              color: theme.colors.text[0],
-              borderColor: theme.colors.border[0],
-              backgroundColor: theme.colors.bg[0],
+              color: theme.fn.themeColor("text-light"),
+              borderColor: theme.fn.themeColor("border"),
+              backgroundColor: theme.fn.themeColor("bg-light"),
             },
             "&[data-loading]": {
               [`& .${getStylesRef("leftIcon")}`]: {
@@ -85,13 +85,13 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
               backgroundColor: hoverColor,
             },
             "&:disabled": {
-              color: theme.colors.text[0],
-              borderColor: theme.colors.border[0],
-              backgroundColor: theme.colors.bg[0],
+              color: theme.fn.themeColor("text-light"),
+              borderColor: theme.fn.themeColor("border"),
+              backgroundColor: theme.fn.themeColor("bg-light"),
             },
             "&[data-loading]": {
               [`& .${getStylesRef("leftIcon")}`]: {
-                color: theme.colors.focus[0],
+                color: theme.fn.themeColor("focus"),
               },
             },
           },
@@ -112,9 +112,9 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
               backgroundColor,
             },
             "&:disabled": {
-              color: theme.colors.text[0],
-              borderColor: theme.colors.border[0],
-              backgroundColor: theme.colors.bg[0],
+              color: theme.fn.themeColor("text-light"),
+              borderColor: theme.fn.themeColor("border"),
+              backgroundColor: theme.fn.themeColor("bg-light"),
             },
           },
         };
@@ -131,7 +131,7 @@ export const getButtonOverrides = (): MantineThemeOverride["components"] => ({
               backgroundColor: "transparent",
             },
             "&:disabled": {
-              color: theme.colors.text[0],
+              color: theme.fn.themeColor("text-light"),
               borderColor: "transparent",
               backgroundColor: "transparent",
             },

--- a/frontend/src/metabase/ui/components/data-display/Accordion/Accordion.styled.tsx
+++ b/frontend/src/metabase/ui/components/data-display/Accordion/Accordion.styled.tsx
@@ -12,26 +12,26 @@ export const getAccordionOverrides =
             },
           },
           label: {
-            color: theme.colors.brand[1],
+            color: theme.fn.themeColor("brand"),
             fontWeight: 700,
           },
           item: {
-            border: `1px solid ${theme.colors.border}`,
+            border: `1px solid ${theme.fn.themeColor("border")}`,
             borderRadius: theme.spacing.sm,
             "&[data-active]": {
-              border: `1px solid ${theme.colors.border}`,
+              border: `1px solid ${theme.fn.themeColor("border")}`,
             },
             "& + &": {
               marginTop: "0.75rem",
             },
           },
           content: {
-            borderTop: `1px solid ${theme.colors.border}`,
-            color: theme.colors.text[2],
+            borderTop: `1px solid ${theme.fn.themeColor("border")}`,
+            color: theme.fn.themeColor("text-dark"),
           },
           chevron: {
-            color: theme.colors.text[2],
-            border: `1px solid ${theme.colors.border}`,
+            color: theme.fn.themeColor("text-dark"),
+            border: `1px solid ${theme.fn.themeColor("border")}`,
             borderRadius: "100%",
             marginLeft: "1rem",
             height: "1.75rem",

--- a/frontend/src/metabase/ui/components/data-display/Card/Card.styled.tsx
+++ b/frontend/src/metabase/ui/components/data-display/Card/Card.styled.tsx
@@ -5,11 +5,11 @@ export const getCardOverrides = (): MantineThemeOverride["components"] => ({
     styles: (theme: MantineTheme) => {
       return {
         cardSection: {
-          borderTopColor: theme.colors.border[0],
-          borderBottomColor: theme.colors.border[0],
+          borderTopColor: theme.fn.themeColor("border"),
+          borderBottomColor: theme.fn.themeColor("border"),
 
           "&[data-first]": {
-            borderBottomColor: theme.colors.border[0],
+            borderBottomColor: theme.fn.themeColor("border"),
           },
         },
       };

--- a/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Calendar/Calendar.styled.tsx
@@ -7,29 +7,29 @@ export const getCalendarOverrides = (): MantineThemeOverride["components"] => ({
       day: {
         width: rem(40),
         height: rem(40),
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         fontSize: theme.fontSizes.md,
         lineHeight: rem(24),
         borderRadius: theme.radius.xs,
 
         "&:hover": {
-          backgroundColor: theme.colors.bg[0],
+          backgroundColor: theme.fn.themeColor("bg-light"),
         },
         "&[data-disabled]": {
-          color: theme.colors.bg[2],
+          color: theme.fn.themeColor("bg-dark"),
         },
         "&[data-weekend]": {
-          color: theme.colors.text[2],
+          color: theme.fn.themeColor("text-dark"),
         },
         "&[data-outside]": {
-          color: theme.colors.bg[2],
+          color: theme.fn.themeColor("bg-dark"),
         },
         "&[data-in-range]": {
-          color: theme.colors.text[1],
+          color: theme.fn.themeColor("text-medium"),
           borderRadius: 0,
-          backgroundColor: theme.colors.brand[0],
+          backgroundColor: theme.fn.themeColor("brand-lighter"),
           "&:hover": {
-            backgroundColor: theme.colors.brand[0],
+            backgroundColor: theme.fn.themeColor("brand-lighter"),
           },
         },
         "&[data-first-in-range]": {
@@ -42,9 +42,9 @@ export const getCalendarOverrides = (): MantineThemeOverride["components"] => ({
         },
         "&[data-selected]": {
           color: theme.white,
-          backgroundColor: theme.colors.brand[1],
+          backgroundColor: theme.fn.themeColor("brand"),
           "&:hover": {
-            backgroundColor: theme.colors.brand[1],
+            backgroundColor: theme.fn.themeColor("brand"),
           },
         },
       },
@@ -55,7 +55,7 @@ export const getCalendarOverrides = (): MantineThemeOverride["components"] => ({
       weekday: {
         width: rem(40),
         height: rem(32),
-        color: theme.colors.text[0],
+        color: theme.fn.themeColor("text-light"),
         fontSize: theme.fontSizes.sm,
         lineHeight: rem(24),
         textAlign: "center",
@@ -66,7 +66,7 @@ export const getCalendarOverrides = (): MantineThemeOverride["components"] => ({
   PickerControl: {
     styles: theme => ({
       pickerControl: {
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         fontSize: theme.fontSizes.md,
         lineHeight: rem(24),
         width: rem(80),
@@ -74,23 +74,23 @@ export const getCalendarOverrides = (): MantineThemeOverride["components"] => ({
         borderRadius: theme.radius.sm,
 
         "&:hover": {
-          backgroundColor: theme.colors.bg[0],
+          backgroundColor: theme.fn.themeColor("bg-light"),
         },
         "&[data-disabled]": {
-          color: theme.colors.bg[2],
+          color: theme.fn.themeColor("bg-dark"),
         },
         "&[data-weekend]": {
-          color: theme.colors.text[2],
+          color: theme.fn.themeColor("text-dark"),
         },
         "&[data-outside]": {
-          color: theme.colors.bg[2],
+          color: theme.fn.themeColor("bg-dark"),
         },
         "&[data-in-range]": {
-          color: theme.colors.text[1],
+          color: theme.fn.themeColor("text-medium"),
           borderRadius: 0,
-          backgroundColor: theme.colors.brand[0],
+          backgroundColor: theme.fn.themeColor("brand-lighter"),
           "&:hover": {
-            backgroundColor: theme.colors.brand[0],
+            backgroundColor: theme.fn.themeColor("brand-lighter"),
           },
         },
       },
@@ -130,22 +130,22 @@ export const getCalendarOverrides = (): MantineThemeOverride["components"] => ({
       },
       calendarHeaderLevel: {
         height: rem(32),
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         fontSize: theme.fontSizes.md,
         fontWeight: "bold",
         lineHeight: rem(24),
 
         "&:hover": {
-          backgroundColor: theme.colors.bg[0],
+          backgroundColor: theme.fn.themeColor("bg-light"),
         },
       },
       calendarHeaderControl: {
         width: rem(32),
         height: rem(32),
         borderRadius: theme.radius.xs,
-        color: theme.colors.bg[2],
+        color: theme.fn.themeColor("bg-dark"),
         "&:hover": {
-          backgroundColor: theme.colors.bg[0],
+          backgroundColor: theme.fn.themeColor("bg-light"),
         },
       },
     }),

--- a/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Checkbox/Checkbox.styled.tsx
@@ -24,13 +24,13 @@ export const getCheckboxOverrides = (): MantineThemeOverride["components"] => ({
       root: {
         [`&:has(.${getStylesRef("input")}:disabled)`]: {
           [`.${getStylesRef("label")}`]: {
-            color: theme.colors.text[0],
+            color: theme.fn.themeColor("text-light"),
           },
           [`.${getStylesRef("description")}`]: {
-            color: theme.colors.text[0],
+            color: theme.fn.themeColor("text-light"),
           },
           [`.${getStylesRef("icon")}`]: {
-            color: theme.colors.text[0],
+            color: theme.fn.themeColor("text-light"),
           },
         },
       },
@@ -44,36 +44,36 @@ export const getCheckboxOverrides = (): MantineThemeOverride["components"] => ({
         height: getSize({ size, sizes: SIZES }),
         cursor: "pointer",
         borderRadius: theme.radius.xs,
-        border: `1px solid ${theme.colors.bg[2]}`,
+        border: `1px solid ${theme.fn.themeColor("bg-dark")}`,
 
         "&:checked": {
-          borderColor: theme.colors.brand[1],
-          backgroundColor: theme.colors.brand[1],
+          borderColor: theme.fn.themeColor("brand"),
+          backgroundColor: theme.fn.themeColor("brand"),
           [`.${getStylesRef("icon")}`]: {
             color: theme.white,
           },
         },
         "&:disabled": {
-          borderColor: theme.colors.border[0],
-          backgroundColor: theme.colors.border[0],
+          borderColor: theme.fn.themeColor("border"),
+          backgroundColor: theme.fn.themeColor("border"),
         },
       },
       label: {
         ref: getStylesRef("label"),
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         fontSize: theme.fontSizes.md,
         lineHeight: theme.lineHeight,
       },
       description: {
         ref: getStylesRef("description"),
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         fontSize: theme.fontSizes.sm,
         lineHeight: theme.lineHeight,
         marginTop: theme.spacing.xs,
       },
       icon: {
         ref: getStylesRef("icon"),
-        color: theme.colors.text[0],
+        color: theme.fn.themeColor("text-light"),
       },
     }),
     variants: {
@@ -91,7 +91,7 @@ export const getCheckboxOverrides = (): MantineThemeOverride["components"] => ({
         input: {
           "&:after": {
             content: "''",
-            border: `1px solid ${theme.colors.bg[2]}`,
+            border: `1px solid ${theme.fn.themeColor("bg-dark")}`,
             position: "absolute",
             top: rem(-4),
             left: rem(4),
@@ -104,11 +104,11 @@ export const getCheckboxOverrides = (): MantineThemeOverride["components"] => ({
           },
 
           "&:checked:not([disabled]):after": {
-            border: `${rem(2)} solid ${theme.colors.brand[1]}`,
+            border: `${rem(2)} solid ${theme.fn.themeColor("brand")}`,
           },
 
           "&:disabled:after": {
-            border: `${rem(2)} solid ${theme.colors.border[0]}`,
+            border: `${rem(2)} solid ${theme.fn.themeColor("border")}`,
           },
         },
         labelWrapper: {

--- a/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/DateInput/DateInput.styled.tsx
@@ -17,7 +17,7 @@ export const getDateInputOverrides =
           padding: `${theme.spacing.sm} ${theme.spacing.md}`,
         },
         label: {
-          color: theme.colors.text[1],
+          color: theme.fn.themeColor("text-medium"),
           fontSize: getSize({ size, sizes: theme.fontSizes }),
         },
       }),

--- a/frontend/src/metabase/ui/components/inputs/FileInput/FileInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/FileInput/FileInput.styled.tsx
@@ -16,7 +16,7 @@ export const getFileInputOverrides =
           },
         },
         label: {
-          color: theme.colors.text[1],
+          color: theme.fn.themeColor("text-medium"),
           fontSize: getSize({ size, sizes: theme.fontSizes }),
         },
       }),

--- a/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Input/Input.styled.tsx
@@ -18,29 +18,29 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
     },
     styles: (theme, { multiline }: InputStylesParams, { size = "md" }) => ({
       input: {
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         borderRadius: theme.radius.xs,
         height: multiline ? "auto" : getSize({ size, sizes: SIZES }),
         minHeight: getSize({ size, sizes: SIZES }),
         "&::placeholder": {
-          color: theme.colors.text[0],
+          color: theme.fn.themeColor("text-light"),
         },
         "&:disabled": {
-          backgroundColor: theme.colors.bg[0],
+          backgroundColor: theme.fn.themeColor("bg-light"),
         },
         "&[data-invalid]": {
-          color: theme.colors.error[0],
-          borderColor: theme.colors.error[0],
+          color: theme.fn.themeColor("error"),
+          borderColor: theme.fn.themeColor("error"),
           "&::placeholder": {
-            color: theme.colors.error[0],
+            color: theme.fn.themeColor("error"),
           },
         },
       },
       icon: {
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
       },
       rightSection: {
-        color: theme.colors.text[0],
+        color: theme.fn.themeColor("text-light"),
       },
     }),
     sizes: {
@@ -69,9 +69,9 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
               ? rem(rightSectionWidth - BORDER_WIDTH)
               : `calc(${rightSectionWidth} - ${BORDER_WIDTH}px)`
             : rem(PADDING - BORDER_WIDTH),
-          borderColor: theme.colors.border[0],
+          borderColor: theme.fn.themeColor("border"),
           "&:focus": {
-            borderColor: theme.colors.brand[1],
+            borderColor: theme.fn.themeColor("brand"),
           },
           "&[data-with-icon]": {
             paddingLeft: rem(DEFAULT_ICON_WIDTH - BORDER_WIDTH),
@@ -113,23 +113,23 @@ export const getInputOverrides = (): MantineThemeOverride["components"] => ({
     },
     styles: theme => ({
       label: {
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         fontSize: theme.fontSizes.sm,
         fontWeight: "bold",
         lineHeight: theme.lineHeight,
       },
       description: {
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         fontSize: theme.fontSizes.xs,
         lineHeight: theme.lineHeight,
       },
       error: {
-        color: theme.colors.error[0],
+        color: theme.fn.themeColor("error"),
         fontSize: theme.fontSizes.xs,
         lineHeight: theme.lineHeight,
       },
       required: {
-        color: theme.colors.error[0],
+        color: theme.fn.themeColor("error"),
       },
     }),
   },

--- a/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiSelect/MultiSelect.styled.tsx
@@ -45,7 +45,9 @@ export const getMultiSelectOverrides =
         },
         searchInput: {
           "&::placeholder": {
-            color: invalid ? theme.colors.error[0] : theme.colors.text[0],
+            color: invalid
+              ? theme.fn.themeColor("error")
+              : theme.fn.themeColor("text-light"),
           },
           "&::-webkit-search-cancel-button": {
             display: "none",
@@ -58,11 +60,11 @@ export const getMultiSelectOverrides =
           fontWeight: "normal",
           fontSize: theme.fontSizes.xs,
           borderRadius: theme.radius.xs,
-          color: theme.colors.text[2],
-          backgroundColor: theme.colors.bg[1],
+          color: theme.fn.themeColor("text-dark"),
+          backgroundColor: theme.fn.themeColor("bg-medium"),
         },
         defaultValueRemove: {
-          color: theme.colors.text[2],
+          color: theme.fn.themeColor("text-dark"),
           width: rem(12),
           height: rem(12),
           minWidth: rem(12),

--- a/frontend/src/metabase/ui/components/inputs/Radio/Radio.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Radio/Radio.styled.tsx
@@ -22,10 +22,10 @@ export const getRadioOverrides = (): MantineThemeOverride["components"] => ({
       root: {
         [`&:has(.${getStylesRef("input")}:disabled)`]: {
           [`.${getStylesRef("label")}`]: {
-            color: theme.colors.text[0],
+            color: theme.fn.themeColor("text-light"),
           },
           [`.${getStylesRef("description")}`]: {
-            color: theme.colors.text[0],
+            color: theme.fn.themeColor("text-light"),
           },
           [`.${getStylesRef("icon")}`]: {
             color: theme.white,
@@ -41,28 +41,28 @@ export const getRadioOverrides = (): MantineThemeOverride["components"] => ({
         width: getSize({ size, sizes: SIZES }),
         height: getSize({ size, sizes: SIZES }),
         cursor: "pointer",
-        borderColor: theme.colors.text[0],
+        borderColor: theme.fn.themeColor("text-light"),
 
         "&:checked": {
-          borderColor: theme.colors.brand[1],
-          backgroundColor: theme.colors.brand[1],
+          borderColor: theme.fn.themeColor("brand"),
+          backgroundColor: theme.fn.themeColor("brand"),
         },
         "&:disabled": {
           opacity: 0.3,
         },
         "&:disabled:not(:checked)": {
-          borderColor: theme.colors.text[0],
-          backgroundColor: theme.colors.bg[1],
+          borderColor: theme.fn.themeColor("text-light"),
+          backgroundColor: theme.fn.themeColor("bg-medium"),
         },
       },
       label: {
         ref: getStylesRef("label"),
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         fontSize: theme.fontSizes.md,
       },
       description: {
         ref: getStylesRef("description"),
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         fontSize: theme.fontSizes.sm,
         lineHeight: theme.lineHeight,
         marginTop: theme.spacing.xs,

--- a/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/SegmentedControl/SegmentedControl.styled.tsx
@@ -18,7 +18,7 @@ export const getSegmentedControlOverrides =
             fontWeight: "normal",
             lineHeight: "1rem",
             "&[data-active]": {
-              color: theme.colors.text[2],
+              color: theme.fn.themeColor("text-dark"),
             },
           },
         };

--- a/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
@@ -51,25 +51,25 @@ export const getSelectInputOverrides = (
     },
     wrapper: {
       ref: getStylesRef("wrapper"),
-      color: theme.colors.text[2],
+      color: theme.fn.themeColor("text-dark"),
 
       [`&:has(.${getStylesRef("input")}[data-disabled])`]: {
         opacity: 1,
         pointerEvents: "auto",
         [`.${getStylesRef("input")}`]: {
-          color: theme.colors.text[2],
-          backgroundColor: theme.colors.bg[0],
+          color: theme.fn.themeColor("text-dark"),
+          backgroundColor: theme.fn.themeColor("bg-light"),
           "&::placeholder": {
-            color: theme.colors.text[0],
+            color: theme.fn.themeColor("text-light"),
           },
         },
         [`.${getStylesRef("rightSection")}`]: {
-          color: theme.colors.text[0],
+          color: theme.fn.themeColor("text-light"),
         },
       },
       [`&:has(.${getStylesRef("input")}[data-invalid])`]: {
         [`.${getStylesRef("rightSection")}`]: {
-          color: theme.colors.error[0],
+          color: theme.fn.themeColor("error"),
         },
       },
     },
@@ -82,7 +82,7 @@ export const getSelectInputOverrides = (
     },
     rightSection: {
       ref: getStylesRef("rightSection"),
-      color: theme.colors.text[2],
+      color: theme.fn.themeColor("text-dark"),
 
       svg: {
         color: "inherit !important",
@@ -124,16 +124,16 @@ export const getSelectItemsOverrides = (
       padding: "0.75rem",
     },
     item: {
-      color: theme.colors.text[2],
+      color: theme.fn.themeColor("text-dark"),
       fontSize: getSize({ size, sizes: ITEM_FONT_SIZES }),
       lineHeight: getSize({ size, sizes: LINE_HEIGHTS }),
       padding: theme.spacing.sm,
       "&[data-hovered]": {
-        color: theme.colors.brand[1],
-        backgroundColor: theme.colors.brand[0],
+        color: theme.fn.themeColor("brand"),
+        backgroundColor: theme.fn.themeColor("brand-lighter"),
       },
       "&[data-disabled]": {
-        color: theme.colors.text[0],
+        color: theme.fn.themeColor("text-light"),
       },
     },
     separator: {
@@ -145,12 +145,12 @@ export const getSelectItemsOverrides = (
           display: "block",
           marginTop: rem(px(theme.spacing.sm) - 1),
           marginBottom: theme.spacing.xs,
-          borderTop: `1px solid ${theme.colors.border[0]}`,
+          borderTop: `1px solid ${theme.fn.themeColor("border")}`,
         },
       },
     },
     separatorLabel: {
-      color: theme.colors.text[0],
+      color: theme.fn.themeColor("text-light"),
       fontSize: getSize({ size, sizes: SEPARATOR_FONT_SIZES }),
       marginTop: "0 !important",
       paddingTop: theme.spacing.xs,
@@ -161,7 +161,7 @@ export const getSelectItemsOverrides = (
       },
     },
     nothingFound: {
-      color: theme.colors.text[0],
+      color: theme.fn.themeColor("text-light"),
       fontSize: getSize({ size, sizes: ITEM_FONT_SIZES }),
       lineHeight: getSize({ size, sizes: LINE_HEIGHTS }),
       padding: theme.spacing.sm,

--- a/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Switch/Switch.styled.tsx
@@ -71,10 +71,10 @@ export const getSwitchOverrides = (): MantineThemeOverride["components"] => ({
           padding: 0,
           fontSize: getSize({ size, sizes: LABEL_FONT_SIZES }),
           lineHeight: getSize({ size, sizes: LABEL_LINE_HEIGHT }),
-          color: theme.colors.text[2],
+          color: theme.fn.themeColor("text-dark"),
           cursor: "pointer",
           "&[data-disabled]": {
-            color: theme.colors.text[0],
+            color: theme.fn.themeColor("text-light"),
             cursor: "default",
           },
         },
@@ -82,16 +82,16 @@ export const getSwitchOverrides = (): MantineThemeOverride["components"] => ({
           padding: 0,
           marginTop: rem(8),
           fontSize: rem(12),
-          color: theme.colors.text[1],
+          color: theme.fn.themeColor("text-medium"),
         },
         error: {
           padding: 0,
           marginTop: rem(8),
           fontSize: rem(12),
-          color: theme.colors.error[0],
+          color: theme.fn.themeColor("error"),
         },
         track: {
-          backgroundColor: theme.colors.bg[1],
+          backgroundColor: theme.fn.themeColor("bg-medium"),
           border: error ? `1px solid ${color("accent3")}` : "none",
           boxSizing: "border-box",
           borderRadius: rem(24),
@@ -99,7 +99,7 @@ export const getSwitchOverrides = (): MantineThemeOverride["components"] => ({
           width: getSize({ size, sizes: TRACK_WIDTHS }),
           cursor: "pointer",
           [`${getStylesRef("input")}:disabled + &`]: {
-            backgroundColor: theme.colors.bg[1],
+            backgroundColor: theme.fn.themeColor("bg-medium"),
           },
           marginTop: getSize({ size, sizes: TRACK_PADDING_TOP }),
         },
@@ -110,7 +110,7 @@ export const getSwitchOverrides = (): MantineThemeOverride["components"] => ({
           height: getSize({ size, sizes: THUMB_SIZES }),
           width: getSize({ size, sizes: THUMB_SIZES }),
           [`${getStylesRef("input")}:disabled + * > &`]: {
-            backgroundColor: theme.colors.bg[0],
+            backgroundColor: theme.fn.themeColor("bg-light"),
           },
         },
       };

--- a/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextInput/TextInput.styled.tsx
@@ -14,7 +14,7 @@ export const getTextInputOverrides =
           },
         },
         label: {
-          color: theme.colors.text[1],
+          color: theme.fn.themeColor("text-medium"),
           fontSize: getSize({ size, sizes: theme.fontSizes }),
         },
       }),

--- a/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Textarea/Textarea.styled.tsx
@@ -16,7 +16,7 @@ export const getTextareaOverrides = (): MantineThemeOverride["components"] => ({
         },
       },
       label: {
-        color: theme.colors.text[1],
+        color: theme.fn.themeColor("text-medium"),
         fontSize: getSize({ size, sizes: theme.fontSizes }),
       },
     }),

--- a/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.styled.tsx
+++ b/frontend/src/metabase/ui/components/navigation/Tabs/Tabs.styled.tsx
@@ -13,19 +13,19 @@ export const getTabsOverrides = (): MantineThemeOverride["components"] => ({
     },
     styles: (theme, { orientation }: TabsStylesParams) => ({
       tab: {
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         padding: TAB_PADDING[orientation],
         maxWidth: "100%",
         "&:hover": {
-          borderColor: theme.colors.bg[1],
-          backgroundColor: theme.colors.brand[0],
+          borderColor: theme.fn.themeColor("bg-medium"),
+          backgroundColor: theme.fn.themeColor("brand-lighter"),
         },
         "&[data-active]": {
-          color: theme.colors.brand[1],
-          borderColor: theme.colors.brand[1],
+          color: theme.fn.themeColor("brand"),
+          borderColor: theme.fn.themeColor("brand"),
         },
         "&:disabled": {
-          color: theme.colors.text[0],
+          color: theme.fn.themeColor("text-light"),
           opacity: 1,
         },
       },
@@ -43,7 +43,7 @@ export const getTabsOverrides = (): MantineThemeOverride["components"] => ({
         },
       },
       tabsList: {
-        borderColor: theme.colors.bg[1],
+        borderColor: theme.fn.themeColor("bg-medium"),
       },
     }),
   },

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.styled.tsx
@@ -14,17 +14,17 @@ export const getMenuOverrides = (): MantineThemeOverride["components"] => ({
         minWidth: "11.5rem",
       },
       item: {
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         fontSize: theme.fontSizes.md,
         lineHeight: "1.5rem",
         padding: theme.spacing.sm,
 
         "&:hover, &:focus": {
-          color: theme.colors.brand[1],
-          backgroundColor: theme.colors.brand[0],
+          color: theme.fn.themeColor("brand"),
+          backgroundColor: theme.fn.themeColor("brand-lighter"),
 
           [`& .${getStylesRef("itemRightSection")}`]: {
-            color: theme.colors.brand[1],
+            color: theme.fn.themeColor("brand"),
           },
         },
       },
@@ -33,11 +33,11 @@ export const getMenuOverrides = (): MantineThemeOverride["components"] => ({
       },
       itemRightSection: {
         ref: getStylesRef("itemRightSection"),
-        color: theme.colors.text[0],
+        color: theme.fn.themeColor("text-light"),
         marginLeft: theme.spacing.md,
       },
       label: {
-        color: theme.colors.text[0],
+        color: theme.fn.themeColor("text-light"),
         fontSize: theme.fontSizes.sm,
         lineHeight: theme.lineHeight,
         padding: `${theme.spacing.xs} ${theme.spacing.sm}`,
@@ -47,7 +47,7 @@ export const getMenuOverrides = (): MantineThemeOverride["components"] => ({
         marginBottom: theme.spacing.xs,
         marginLeft: theme.spacing.sm,
         marginRight: theme.spacing.sm,
-        borderTopColor: theme.colors.border[0],
+        borderTopColor: theme.fn.themeColor("border"),
       },
     }),
   },

--- a/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx
@@ -9,13 +9,13 @@ export const getModalOverrides = (): MantineThemeOverride["components"] => ({
         fontWeight: 700,
       },
       close: {
-        color: theme.colors.text[0],
+        color: theme.fn.themeColor("text-light"),
         ":hover": {
-          color: theme.colors.text[1],
+          color: theme.fn.themeColor("text-medium"),
         },
       },
       overlay: {
-        backgroundColor: theme.fn.rgba(theme.colors.bg[3], 0.6),
+        backgroundColor: theme.fn.rgba(theme.fn.themeColor("bg-black"), 0.6),
       },
     }),
   },

--- a/frontend/src/metabase/ui/components/typography/Anchor/Anchor.styled.tsx
+++ b/frontend/src/metabase/ui/components/typography/Anchor/Anchor.styled.tsx
@@ -5,9 +5,9 @@ export const getAnchorOverrides = (): MantineThemeOverride["components"] => ({
     styles: theme => {
       return {
         root: {
-          color: theme.colors.brand[1],
+          color: theme.fn.themeColor("brand"),
           "&:active": {
-            color: theme.colors.text[2],
+            color: theme.fn.themeColor("text-dark"),
             textDecoration: "underline",
           },
         },

--- a/frontend/src/metabase/ui/components/utils/Divider/Divider.styled.tsx
+++ b/frontend/src/metabase/ui/components/utils/Divider/Divider.styled.tsx
@@ -4,21 +4,21 @@ export const getDividerOverrides = (): MantineThemeOverride["components"] => ({
   Divider: {
     styles: theme => ({
       horizontal: {
-        borderTopColor: theme.colors.border[0],
+        borderTopColor: theme.fn.themeColor("border"),
       },
       vertical: {
-        borderLeftColor: theme.colors.border[0],
+        borderLeftColor: theme.fn.themeColor("border"),
       },
       label: {
         "&::before": {
-          borderTopColor: theme.colors.border[0],
+          borderTopColor: theme.fn.themeColor("border"),
         },
         "&::after": {
-          borderTopColor: theme.colors.border[0],
+          borderTopColor: theme.fn.themeColor("border"),
         },
       },
       labelDefaultStyles: {
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
       },
     }),
   },

--- a/frontend/src/metabase/ui/components/utils/Paper/Paper.styled.tsx
+++ b/frontend/src/metabase/ui/components/utils/Paper/Paper.styled.tsx
@@ -8,10 +8,10 @@ export const getPaperOverrides = (): MantineThemeOverride["components"] => ({
     },
     styles: (theme, _params: PaperStylesParams) => ({
       root: {
-        color: theme.colors.text[2],
+        color: theme.fn.themeColor("text-dark"),
         backgroundColor: theme.white,
         "&[data-with-border]": {
-          borderColor: theme.colors.border[0],
+          borderColor: theme.fn.themeColor("border"),
         },
       },
     }),

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -1,6 +1,5 @@
-import type { MantineTheme, MantineThemeOverride } from "@mantine/core";
+import type { MantineThemeOverride } from "@mantine/core";
 import { rem } from "@mantine/core";
-import { color } from "metabase/lib/colors";
 import {
   getAccordionOverrides,
   getAnchorOverrides,
@@ -31,37 +30,12 @@ import {
   getTitleOverrides,
   getTooltipOverrides,
 } from "./components";
-
-type ThemeColors = MantineTheme["colors"]["brand"];
-
-const getThemeColors = (colors: string[]): ThemeColors => {
-  return Array.from(
-    { length: 10 },
-    (_, index) => colors[index] ?? "transparent",
-  ) as ThemeColors;
-};
+import { getThemeColors } from "./utils/colors";
 
 export const getThemeOverrides = (): MantineThemeOverride => ({
-  colors: {
-    brand: getThemeColors([color("brand-lighter"), color("brand")]),
-    text: getThemeColors([
-      color("text-light"),
-      color("text-medium"),
-      color("text-dark"),
-    ]),
-    focus: getThemeColors([color("focus")]),
-    border: getThemeColors([color("border")]),
-    bg: getThemeColors([
-      color("bg-light"),
-      color("bg-medium"),
-      color("bg-dark"),
-      color("bg-black"),
-    ]),
-    success: getThemeColors([color("success")]),
-    error: getThemeColors([color("error")]),
-  },
+  colors: getThemeColors(),
   primaryColor: "brand",
-  primaryShade: 1,
+  primaryShade: 0,
   shadows: {
     md: "0px 4px 20px 0px rgba(0, 0, 0, 0.05)",
   },

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -84,7 +84,7 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
   fontFamilyMonospace: "Monaco, monospace",
   focusRingStyles: {
     styles: theme => ({
-      outline: `${rem(2)} solid ${theme.fn.themeColor("focus")}`,
+      outline: `${rem(2)} solid ${theme.colors.focus[0]}`,
       outlineOffset: rem(2),
     }),
   },

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -84,7 +84,7 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
   fontFamilyMonospace: "Monaco, monospace",
   focusRingStyles: {
     styles: theme => ({
-      outline: `${rem(2)} solid ${theme.colors.focus[0]}`,
+      outline: `${rem(2)} solid ${theme.fn.themeColor("focus")}`,
       outlineOffset: rem(2),
     }),
   },

--- a/frontend/src/metabase/ui/utils/colors.ts
+++ b/frontend/src/metabase/ui/utils/colors.ts
@@ -1,0 +1,52 @@
+import type { MantineTheme } from "@mantine/core";
+import { color } from "metabase/lib/colors";
+
+type ColorShades = MantineTheme["colors"]["dark"];
+
+const ORIGINAL_COLORS = [
+  "dark",
+  "gray",
+  "red",
+  "pink",
+  "grape",
+  "violet",
+  "indigo",
+  "blue",
+  "cyan",
+  "green",
+  "lime",
+  "yellow",
+  "orange",
+  "teal",
+];
+
+const CUSTOM_COLORS = [
+  "brand",
+  "brand-lighter",
+  "text-light",
+  "text-medium",
+  "text-dark",
+  "focus",
+  "border",
+  "bg-light",
+  "bg-medium",
+  "bg-dark",
+  "bg-black",
+  "success",
+  "error",
+];
+
+function getColorShades(color: string): ColorShades {
+  return Array(10).fill(color) as ColorShades;
+}
+
+export function getThemeColors(): Record<string, ColorShades> {
+  return {
+    ...Object.fromEntries(
+      ORIGINAL_COLORS.map(name => [name, getColorShades("transparent")]),
+    ),
+    ...Object.fromEntries(
+      CUSTOM_COLORS.map(name => [name, getColorShades(color(name))]),
+    ),
+  };
+}


### PR DESCRIPTION
Allows you to use `<Text color="text-dark" />` instead of `<Text color="text.2" />`; the same with `<Text color="error" />` instead of `<Text color="error.0" />` etc.