### PR TITLE
Remove unused method from StructuredQuery

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -126,11 +126,6 @@ class StructuredQuery extends AtomicQuery {
     return this.question().query();
   }
 
-  private updateWithMLv2(nextQuery: Query) {
-    const nextMLv1Query = ML.toLegacyQuery(nextQuery);
-    return this.setDatasetQuery(nextMLv1Query);
-  }
-
   /* Query superclass methods */
 
   /**


### PR DESCRIPTION
This private method has been added nine months ago.
It is not in use today. This PR removes it.