### PR TITLE
Restore GET /api/dashboard endpoint

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -59,10 +59,13 @@
     (filter mi/can-read? <>)))
 
 (api/defendpoint GET "/"
-  "Get `Dashboards`. With filter option `f` (default `all`), restrict results as follows:
+  "This endpoint is currently unused by the Metabase frontend and may be out of date with the rest of the application.
+  It only exists for backwards compatibility and may be removed in the future.
+
+  Get `Dashboards`. With filter option `f` (default `all`), restrict results as follows:
   *  `all`      - Return all Dashboards.
   *  `mine`     - Return Dashboards created by the current user.
-  *  `archived` - Return Dashboards that have been archived. (By default, these are *excluded*.)"
+  *  `archived` - Return Dashboards that have been archived. (By default, these are *excluded*.)""
   [f]
   {f [:maybe [:enum "all" "mine" "archived"]]}
   (let [dashboards (dashboards-list f)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -65,7 +65,7 @@
   Get `Dashboards`. With filter option `f` (default `all`), restrict results as follows:
   *  `all`      - Return all Dashboards.
   *  `mine`     - Return Dashboards created by the current user.
-  *  `archived` - Return Dashboards that have been archived. (By default, these are *excluded*.)""
+  *  `archived` - Return Dashboards that have been archived. (By default, these are *excluded*.)"
   [f]
   {f [:maybe [:enum "all" "mine" "archived"]]}
   (let [dashboards (dashboards-list f)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -49,6 +49,31 @@
 
 (set! *warn-on-reflection* true)
 
+(defn- dashboards-list [filter-option]
+  (as-> (t2/select :model/Dashboard {:where    [:and (case (or (keyword filter-option) :all)
+                                                      (:all :archived)  true
+                                                      :mine [:= :creator_id api/*current-user-id*])
+                                                [:= :archived (= (keyword filter-option) :archived)]]
+                                     :order-by [:%lower.name]}) <>
+    (t2/hydrate <> :creator)
+    (filter mi/can-read? <>)))
+
+(api/defendpoint GET "/"
+  "Get `Dashboards`. With filter option `f` (default `all`), restrict results as follows:
+  *  `all`      - Return all Dashboards.
+  *  `mine`     - Return Dashboards created by the current user.
+  *  `archived` - Return Dashboards that have been archived. (By default, these are *excluded*.)"
+  [f]
+  {f [:maybe [:enum "all" "mine" "archived"]]}
+  (let [dashboards (dashboards-list f)
+        edit-infos (:dashboard (last-edit/fetch-last-edited-info {:dashboard-ids (map :id dashboards)}))]
+    (into []
+          (map (fn [{:keys [id] :as dashboard}]
+                 (if-let [edit-info (get edit-infos id)]
+                   (assoc dashboard :last-edit-info edit-info)
+                   dashboard)))
+          dashboards)))
+
 (defn- hydrate-dashboard-details
   "Get dashboard details for the complete dashboard, including tabs, dashcards, params, etc."
   [{dashboard-id :id :as dashboard}]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -58,7 +58,7 @@
     (t2/hydrate <> :creator)
     (filter mi/can-read? <>)))
 
-(api/defendpoint GET "/"
+(api/defendpoint ^:deprecated GET "/"
   "This endpoint is currently unused by the Metabase frontend and may be out of date with the rest of the application.
   It only exists for backwards compatibility and may be removed in the future.
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37455

Restores the GET /api/dashboard endpoint that was removed in 48 (https://github.com/metabase/metabase/pull/35235) with no modifications.

No guarantees will be made to keep it up-to-date with the officially supported alternative, which is to use GET /api/collection to get the list of collections, and for each collection use GET `/api/collection/:id/items?models=dashboard`, and finally GET `/api/dashboard/:id` to get a specific dashboard.

I've added the following warning for users of GET /api/dashboard to its docstring:

"This endpoint is currently unused by the Metabase frontend and may be out of date with the rest of the application. It only exists for backwards compatibility and may be removed in the future."