### PR TITLE
Adding replay upload logic for crashes and ~1/10 passes

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -27,6 +27,9 @@ const {
   removeDirectory,
 } = require("./commands/downloads/deleteDownloadsFolder");
 
+const convertStringToInt = string =>
+  string.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0);
+
 const defaultConfig = {
   // This is the functionality of the old cypress-plugins.js file
   setupNodeEvents(on, config) {
@@ -41,7 +44,19 @@ const defaultConfig = {
       replay.default(on, config, {
         upload: true,
         apiKey: process.env.REPLAY_API_KEY,
-        filter: r => r.metadata.test?.result === "failed",
+        filter: r => {
+          const hasCrashed = r.status === "crashed";
+          const hasFailed = r.metadata.test?.result === "failed";
+          const randomlyUploadAll =
+            convertStringToInt(r.metadata.test.run.id) % 10 === 1;
+
+          console.log("upload replay ::", {
+            hasCrashed,
+            hasFailed,
+            randomlyUploadAll,
+          });
+          return hasCrashed || hasFailed || randomlyUploadAll;
+        },
       });
     }
 


### PR DESCRIPTION
Previously, replays were recorded on failure only, as shown here:

```javascript
filter: r => r.metadata.test?.result === "failed"
```

This filter has been enhanced to include crashes as well as an upload in approximately 1/10 passing instances, as shown:

```javascript
filter: r => {
  const hasCrashed = r.status === "crashed";
  const hasFailed = r.metadata.test?.result === "failed";
  const randomlyUploadAll =
    convertStringToInt(r.metadata.test.run.id) % 10 === 1;

    console.log("upload replay ::", {
      hasCrashed,
      hasFailed,
      randomlyUploadAll,
    });
    return hasCrashed || hasFailed || randomlyUploadAll;
},
```

Note that this closely follows the example provided by replay [here](https://github.com/replayio-public/flake/pull/89/files#diff-3f62e885350a48939f240b9daf40f6b06d41da7751f2b613238fc7669ac0a1b2R32).

Closes #37467
