### PR TITLE
Deprecate metabase-lib aggregation utils

### DIFF
--- a/frontend/src/metabase-lib/queries/utils/aggregation.js
+++ b/frontend/src/metabase-lib/queries/utils/aggregation.js
@@ -2,7 +2,10 @@ import { STANDARD_AGGREGATIONS } from "metabase-lib/expressions";
 import * as FieldRef from "./field-ref";
 import { add, update, remove, clear } from "./util";
 
-// returns canonical list of Aggregations, i.e. with deprecated "rows" removed
+/**
+ * Returns canonical list of Aggregations, i.e. with deprecated "rows" removed
+ * @deprecated use MLv2
+ */
 export function getAggregations(aggregation) {
   let aggregations;
   if (Array.isArray(aggregation) && Array.isArray(aggregation[0])) {
@@ -16,7 +19,9 @@ export function getAggregations(aggregation) {
   return aggregations.filter(agg => agg && agg[0] && agg[0] !== "rows");
 }
 
-// turns a list of Aggregations into the canonical AggregationClause
+/**
+ * Turns a list of Aggregations into the canonical AggregationClause
+ */
 function getAggregationClause(aggregations) {
   aggregations = getAggregations(aggregations);
   if (aggregations.length === 0) {
@@ -26,25 +31,42 @@ function getAggregationClause(aggregations) {
   }
 }
 
+/**
+ * @deprecated use MLv2
+ */
 export function addAggregation(aggregation, newAggregation) {
   return getAggregationClause(
     add(getAggregations(aggregation), newAggregation),
   );
 }
+
+/**
+ * @deprecated use MLv2
+ */
 export function updateAggregation(aggregation, index, updatedAggregation) {
   return getAggregationClause(
     update(getAggregations(aggregation), index, updatedAggregation),
   );
 }
+
+/**
+ * @deprecated use MLv2
+ */
 export function removeAggregation(aggregation, index) {
   return getAggregationClause(remove(getAggregations(aggregation), index));
 }
+
+/**
+ * @deprecated use MLv2
+ */
 export function clearAggregations(ac) {
   return getAggregationClause(clear());
 }
 
 // MISC
-
+/**
+ * @deprecated use MLv2
+ */
 export function isBareRows(ac) {
   return getAggregations(ac).length === 0;
 }
@@ -52,7 +74,9 @@ export function isBareRows(ac) {
 // AGGREGATION TYPES
 
 // NOTE: these only differentiate between "standard", "metric", and "custom", but do not validate the aggregation
-
+/**
+ * @deprecated use MLv2
+ */
 export function isStandard(aggregation) {
   return (
     Array.isArray(aggregation) &&
@@ -63,10 +87,16 @@ export function isStandard(aggregation) {
   );
 }
 
+/**
+ * @deprecated use MLv2
+ */
 export function isMetric(aggregation) {
   return Array.isArray(aggregation) && aggregation[0] === "metric";
 }
 
+/**
+ * @deprecated use MLv2
+ */
 export function isCustom(aggregation) {
   return !isStandard(aggregation) && !isMetric(aggregation);
 }
@@ -79,15 +109,31 @@ function hasOptions(aggregation) {
 function getOptions(aggregation) {
   return hasOptions(aggregation) && aggregation[2] ? aggregation[2] : {};
 }
+
+/**
+ * @deprecated use MLv2
+ */
 export function getContent(aggregation) {
   return hasOptions(aggregation) ? aggregation[1] : aggregation;
 }
+
+/**
+ * @deprecated use MLv2
+ */
 export function isNamed(aggregation) {
   return !!getName(aggregation);
 }
+
+/**
+ * @deprecated use MLv2
+ */
 export function getName(aggregation) {
   return getOptions(aggregation)["display-name"];
 }
+
+/**
+ * @deprecated use MLv2
+ */
 export function setName(aggregation, name) {
   return [
     "aggregation-options",
@@ -97,6 +143,9 @@ export function setName(aggregation, name) {
 }
 
 // METRIC
+/**
+ * @deprecated use MLv2
+ */
 export function getMetric(aggregation) {
   if (isMetric(aggregation)) {
     return aggregation[1];
@@ -107,7 +156,10 @@ export function getMetric(aggregation) {
 
 // STANDARD
 
-// get the operator from a standard aggregation clause
+/**
+ * Get the operator from a standard aggregation clause
+ * @deprecated use MLv2
+ */
 export function getOperator(aggregation) {
   if (isStandard(aggregation)) {
     return aggregation[0];
@@ -116,7 +168,10 @@ export function getOperator(aggregation) {
   }
 }
 
-// set the fieldId on a standard aggregation clause
+/**
+ * Set the fieldId on a standard aggregation clause
+ * @deprecated use MLv2
+ */
 export function setField(aggregation, fieldRef) {
   if (isStandard(aggregation)) {
     return [aggregation[0], fieldRef];
@@ -126,6 +181,9 @@ export function setField(aggregation, fieldRef) {
   }
 }
 
+/**
+ * @deprecated use MLv2
+ */
 export function isRows(aggregation) {
   return aggregation && aggregation[0] === "rows";
 }

--- a/frontend/src/metabase-lib/queries/utils/breakout.js
+++ b/frontend/src/metabase-lib/queries/utils/breakout.js
@@ -1,11 +1,16 @@
 import { add, update, remove, clear } from "./util";
 
-// returns canonical list of Breakouts, with nulls removed
+/**
+ * Returns canonical list of Breakouts, with nulls removed
+ * @deprecated use MLv2
+ */
 export function getBreakouts(breakouts) {
   return (breakouts || []).filter(b => b != null);
 }
 
-// turns a list of Breakouts into the canonical BreakoutClause
+/**
+ * Turns a list of Breakouts into the canonical BreakoutClause
+ */
 function getBreakoutClause(breakouts) {
   breakouts = getBreakouts(breakouts);
   if (breakouts.length === 0) {
@@ -15,17 +20,32 @@ function getBreakoutClause(breakouts) {
   }
 }
 
+/**
+ * @deprecated use MLv2
+ */
 export function addBreakout(breakout, newBreakout) {
   return getBreakoutClause(add(getBreakouts(breakout), newBreakout));
 }
+
+/**
+ * @deprecated use MLv2
+ */
 export function updateBreakout(breakout, index, updatedBreakout) {
   return getBreakoutClause(
     update(getBreakouts(breakout), index, updatedBreakout),
   );
 }
+
+/**
+ * @deprecated use MLv2
+ */
 export function removeBreakout(breakout, index) {
   return getBreakoutClause(remove(getBreakouts(breakout), index));
 }
+
+/**
+ * @deprecated use MLv2
+ */
 export function clearBreakouts(breakout) {
   return getBreakoutClause(clear());
 }

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -8,31 +8,70 @@ import * as FIELD from "./field";
 import * as FIELD_REF from "./field-ref";
 
 // AGGREGATION
-
+/**
+ * @deprecated use MLv2
+ */
 export const getAggregations = query => A.getAggregations(query.aggregation);
+
+/**
+ * @deprecated use MLv2
+ */
 export const addAggregation = (query, aggregation) =>
   setAggregationClause(query, A.addAggregation(query.aggregation, aggregation));
+
+/**
+ * @deprecated use MLv2
+ */
 export const updateAggregation = (query, index, aggregation) =>
   setAggregationClause(
     query,
     A.updateAggregation(query.aggregation, index, aggregation),
   );
+
+/**
+ * @deprecated use MLv2
+ */
 export const removeAggregation = (query, index) =>
   setAggregationClause(query, A.removeAggregation(query.aggregation, index));
+
+/**
+ * @deprecated use MLv2
+ */
 export const clearAggregations = query =>
   setAggregationClause(query, A.clearAggregations(query.aggregation));
 
+/**
+ * @deprecated use MLv2
+ */
 export const isBareRows = query => A.isBareRows(query.aggregation);
 
 // BREAKOUT
-
+/**
+ * @deprecated use MLv2
+ */
 export const getBreakouts = query => B.getBreakouts(query.breakout);
+
+/**
+ * @deprecated use MLv2
+ */
 export const addBreakout = (query, breakout) =>
   setBreakoutClause(query, B.addBreakout(query.breakout, breakout));
+
+/**
+ * @deprecated use MLv2
+ */
 export const updateBreakout = (query, index, breakout) =>
   setBreakoutClause(query, B.updateBreakout(query.breakout, index, breakout));
+
+/**
+ * @deprecated use MLv2
+ */
 export const removeBreakout = (query, index) =>
   setBreakoutClause(query, B.removeBreakout(query.breakout, index));
+
+/**
+ * @deprecated use MLv2
+ */
 export const clearBreakouts = query =>
   setBreakoutClause(query, B.clearBreakouts(query.breakout));
 


### PR DESCRIPTION
This PR marks aggregation (and related breakout) utilities as deprecated, in favor of using MLv2 CLJS functions.
Resolves https://github.com/metabase/metabase/issues/37462.

As a task for the follow-up PR, we can migrate the existing aggregation/breakout utils in the QB to MLv2, while leaving the deprecated ones in the `/admin` section.