### PR TITLE
Unwrap value expressions when converting to legacy expression

### DIFF
--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1100,7 +1100,7 @@
     (let [legacy-expr (-> an-expression-clause lib.convert/->legacy-MBQL)]
       (clj->js (cond-> legacy-expr
                  (and (vector? legacy-expr)
-                      (= (first legacy-expr) :aggregation-options))
+                      (#{:aggregation-options :value} (first legacy-expr)))
                  (get 1))))))
 
 (defn ^:export field-values-search-info

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -183,8 +183,11 @@
     (let [query lib.tu/venues-query
           legacy-expr 0
           expr (lib.js/expression-clause-for-legacy-expression query 0 legacy-expr)
-          legacy-expr' (lib.js/legacy-expression-for-expression-clause query 0 expr)]
-      (is (= legacy-expr expr legacy-expr')))))
+          legacy-expr' (lib.js/legacy-expression-for-expression-clause query 0 expr)
+          query-with-expr (lib/expression query 0 "expr" expr)
+          expr-from-query (first (lib/expressions query-with-expr 0))
+          legacy-expr-from-query (lib.js/legacy-expression-for-expression-clause query-with-expr 0 expr-from-query)]
+      (is (= legacy-expr expr legacy-expr' legacy-expr-from-query)))))
 
 (deftest ^:parallel filter-drill-details-test
   (testing ":value field on the filter drill"


### PR DESCRIPTION
Fixes #37461.
