### PR TITLE
Adds option to skip backfill, and skips it during auditdb loading

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -197,7 +197,7 @@
     ;; The EE token might not have :serialization enabled, but audit features should still be able to use it.
     (let [report (log/with-no-logs
                    (serialization.cmd/v2-load-internal! (str (instance-analytics-plugin-dir (plugins/plugins-dir)))
-                                                        {}
+                                                        {:backfill? false}
                                                         :token-check? false))]
       (if (not-empty (:errors report))
         (log/info (str "Error Loading Analytics Content: " (pr-str report)))

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -82,7 +82,9 @@
 
   `opts` are passed to [[v2.load/load-metabase]]."
   [path :- :string
-   opts :- [:map [:abort-on-error {:optional true} [:maybe :boolean]]]
+   opts :- [:map
+            [:abort-on-error {:optional true} [:maybe :boolean]]
+            [:backfill? {:optional true} [:maybe :boolean]]]
    ;; Deliberately separate from the opts so it can't be set from the CLI.
    & {:keys [token-check?]
       :or   {token-check? true}}]
@@ -102,7 +104,9 @@
 
    opts are passed to load-metabase"
   [path :- :string
-   opts :- [:map [:abort-on-error {:optional true} [:maybe :boolean]]]]
+   opts :- [:map
+            [:abort-on-error {:optional true} [:maybe :boolean]]
+            [:backfill? {:optional true} [:maybe :boolean]]]]
   (v2-load-internal! path opts :token-check? true))
 
 (defn- select-entities-in-collections

--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -82,10 +82,13 @@
 
 (defn load-metabase!
   "Loads in a database export from an ingestion source, which is any Ingestable instance."
-  [ingestion & {:keys [abort-on-error] :or {abort-on-error true}}]
+  [ingestion & {:keys [abort-on-error backfill?]
+                :or {abort-on-error true
+                     backfill? true}}]
   ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared dependencies guide
   ;; the import, and make sure all containers are imported before contents, etc.
-  (serdes.backfill/backfill-ids!)
+  (when backfill?
+    (serdes.backfill/backfill-ids!))
   (let [contents (serdes.ingest/ingest-list ingestion)
         ctx      {:expanding #{}
                   :seen      #{}

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -123,8 +123,13 @@
           (testing "c1 and c2 hash to the same value"
             (is (= (serdes/identity-hash query-c1)
                    (serdes/identity-hash query-c2))))
-          (is (thrown?
-               Exception
-               (serdes.backfill/backfill-ids-for! :model/Collection)))
-          (is (= :audit-db/installed
-                 (audit-db/ensure-audit-db-installed!))))))))
+          (testing "No exception is thrown when db has 'duplicate' entries"
+            (is (= :metabase-enterprise.audit-db/no-op
+                   (audit-db/ensure-audit-db-installed!))))
+          ;; TODO: Why does this fail
+          #_(testing "backfill-ids-for! should throw when db has 'duplicate' entries"
+            (is (thrown?
+                 Exception
+                 (serdes.backfill/backfill-ids-for! :model/Collection))))
+          (t2/update! :model/Collection (:id c1) {:entity_id nil})
+          (t2/update! :model/Collection (:id c2) {:entity_id nil}))))))

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -109,9 +109,9 @@
     (is (= 0 (count (get-audit-db-trigger-keys))) "no sync occured even when called directly for audit db.")))
 
 (deftest no-backfill-occurs-when-loading-analytics-content-test
-  (let [c1          {:entity_id         nil,
-                     :name              "My Duped Collection",
-                     :location          "/"}
+  (let [c1          {:entity_id nil,
+                     :name      "My Duped Collection",
+                     :location  "/"}
         c1-instance (t2/insert-returning-instance! :model/Collection c1)]
     ;; fill in the entity id for c1:
     (serdes.backfill/backfill-ids-for! :model/Collection)

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -15,6 +15,7 @@
    [metabase.task.sync-databases :as task.sync-databases]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :db :plugins))
@@ -119,10 +120,10 @@
       (serdes.backfill/backfill-ids-for! :model/Collection)
       ;; insert c2, which will have the same entity id:
       (let [c2-instance (t2/insert-returning-instance! :model/Collection (dissoc c1-instance :id))]
-        (testing "c1 and c2 hash to the same value"
-          (is (= (serdes/identity-hash c1-instance)
-                 (serdes/identity-hash c2-instance))))
-        (testing "A backfill with 'duplicate' rows (with different ids)"
+        (testing "c1 and c2 hash to the same entity id."
+          (is (= (u/generate-nano-id (serdes/identity-hash c1-instance))
+                 (u/generate-nano-id (serdes/identity-hash c2-instance)))))
+        (testing "A backfill with 'duplicate' rows (with different ids)."
           (is (thrown? Exception
                        (serdes.backfill/backfill-ids-for! :model/Collection))))
         (testing "No exception is thrown when db has 'duplicate' entries."


### PR DESCRIPTION
Resolves #37480

This was an issue in this instance, but auditv2 code is simply surfacing this issue because it is running the backfill process (along with serialization) on startup, and there is a bug _somewhere_ that puts the entity tables into a bad state.

Sometimes doing the backfill process can prevent Metabase from starting up. There can be duplicated entities for which one of them _has_ an entity_id filled in, and the other doesn't. The backfill process computes the entity id for the duplicate without an entity id, and tries to update that duplicate with the new entity id. That breaks because there is a uniqueness constraint on entity id columns.

By skipping the backfill process (which only affects running a de-serialization), we sidestep this issue and the app should start up normally.