### PR TITLE
waterfall handle nulls

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
@@ -4,7 +4,7 @@ import {
   assertMultiMetricColumns,
   type CartesianChartColumns,
 } from "metabase/visualizations/lib/graph/columns";
-import { checkNumber } from "metabase/lib/types";
+import { isNumber } from "metabase/lib/types";
 
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import {
@@ -24,7 +24,8 @@ export function getWaterfallDataset(
   // Step 1: calculate runningSums, negativeTranslation beforehand
   let runningSums: number[] = [];
   rows.forEach((row, index) => {
-    const value = checkNumber(row[columns.metrics[0].index]);
+    const rawMetric = row[columns.metrics[0].index];
+    const value = isNumber(rawMetric) ? rawMetric : 0;
 
     if (index === 0) {
       runningSums.push(value);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/series.ts
@@ -29,6 +29,10 @@ export function getWaterfallLabelFormatters(
   renderingContext: RenderingContext,
 ) {
   const valueFormatter = (value: unknown) => {
+    if (value == null) {
+      return "";
+    }
+
     const formattedValue = renderingContext.formatValue(
       Math.abs(checkNumber(value)),
       {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -1,4 +1,5 @@
 import _ from "underscore";
+import { t } from "ttag";
 import type {
   CartesianChartModel,
   DataKey,
@@ -130,7 +131,7 @@ export const getEventColumnsData = (
 
       return {
         key: col.display_name, // TODO: use the title from the viz settings
-        value,
+        value: value ?? t`(empty)`,
         col,
       };
     })
@@ -139,11 +140,10 @@ export const getEventColumnsData = (
   if (isBreakoutSeries) {
     eventData.push({
       key: seriesModel.breakoutColumn.display_name,
-      value: seriesModel.breakoutValue,
+      value: seriesModel.breakoutValue ?? t`(empty)`,
       col: seriesModel.breakoutColumn,
     });
   }
-
   return eventData;
 };
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -1,5 +1,4 @@
 import _ from "underscore";
-import { t } from "ttag";
 import type {
   CartesianChartModel,
   DataKey,
@@ -32,6 +31,7 @@ import { dimensionIsTimeseries } from "metabase/visualizations/lib/timeseries";
 import type { TimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
 import { getSeriesIdFromECharts } from "metabase/visualizations/echarts/cartesian/utils/id";
 import { checkWaterfallChartModel } from "metabase/visualizations/echarts/cartesian/waterfall/utils";
+import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 import { isStructured } from "metabase-lib/queries/utils/card";
 import Question from "metabase-lib/Question";
 import {
@@ -131,7 +131,7 @@ export const getEventColumnsData = (
 
       return {
         key: col.display_name, // TODO: use the title from the viz settings
-        value: value ?? t`(empty)`,
+        value: value ?? NULL_DISPLAY_VALUE,
         col,
       };
     })
@@ -140,7 +140,7 @@ export const getEventColumnsData = (
   if (isBreakoutSeries) {
     eventData.push({
       key: seriesModel.breakoutColumn.display_name,
-      value: seriesModel.breakoutValue ?? t`(empty)`,
+      value: seriesModel.breakoutValue ?? NULL_DISPLAY_VALUE,
       col: seriesModel.breakoutColumn,
     });
   }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37288
### Description

We now correctly handle null values in the waterfall chart, so the chart should not crash. In tooltips we display them as "(empty)", and on the chart they do not appear, and there is no data label for them.

Note that the issue also mentions handling aggregations for the tooltip, but it turns out we do not need to do this explicitly, since they are already handled in the underlying `chartModel.dataset` object that the tooltip uses.

### How to verify

1. Create waterfall charts using null values and unaggregated values in columns other than the metric
2. Confirm they display correctly, with correct tooltips

### Demo

<img width="1862" alt="Screenshot 2024-01-11 at 12 06 40 PM" src="https://github.com/metabase/metabase/assets/37751258/f37e6439-9b2b-4219-a5c0-3c4ae63ccdf5">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

Will backfill these cases later as a part of https://github.com/metabase/metabase/issues/36880
