### PR TITLE
Make it easier to track Structured legacy query usages

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/QueryViewer/QueryViewer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/QueryViewer/QueryViewer.tsx
@@ -28,14 +28,11 @@ export function QueryViewer({ datasetQuery }: { datasetQuery: DatasetQuery }) {
   }, [card, dispatch]);
 
   const question = new Question(card, metadata);
-
-  const query = question.legacyQuery({ useStructuredQuery: true });
-
   if (question.isNative()) {
     return (
       <NativeQueryEditor
         question={question}
-        query={query}
+        query={question.legacyQuery()}
         location={{ query: {} }}
         readOnly
         viewHeight={800}
@@ -45,7 +42,8 @@ export function QueryViewer({ datasetQuery }: { datasetQuery: DatasetQuery }) {
     );
   }
 
-  if (query.tables()) {
+  const database = question.database();
+  if (database && database.tables) {
     return <ReadOnlyNotebook question={question} />;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/QueryViewer/QueryViewer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/QueryViewer/QueryViewer.tsx
@@ -29,7 +29,7 @@ export function QueryViewer({ datasetQuery }: { datasetQuery: DatasetQuery }) {
 
   const question = new Question(card, metadata);
 
-  const query = question.legacyQuery();
+  const query = question.legacyQuery({ useStructuredQuery: true });
 
   if (question.isNative()) {
     return (

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.tsx
@@ -335,7 +335,7 @@ const TargetName = ({ policy, target }: TargetNameProps) => {
             }
 
             const dimension = question
-              .legacyQuery()
+              .legacyQuery({ useStructuredQuery: true })
               .parseFieldReference(fieldRef);
             return (
               <span>

--- a/frontend/src/metabase-lib/Dimension.ts
+++ b/frontend/src/metabase-lib/Dimension.ts
@@ -383,7 +383,9 @@ export default class Dimension {
     return null;
   }
 
-  legacyQuery(): StructuredQuery | null | undefined {
+  legacyQuery(
+    _opts: { useStructuredQuery: true } = {},
+  ): StructuredQuery | null | undefined {
     return this._query;
   }
 
@@ -1213,7 +1215,7 @@ export class ExpressionDimension extends Dimension {
 
     if (!baseTypeOption) {
       if (query) {
-        const datasetQuery = query.legacyQuery();
+        const datasetQuery = query.legacyQuery({ useStructuredQuery: true });
         const expressions = datasetQuery?.expressions ?? {};
         const expr = expressions[this.name()];
 

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -180,7 +180,7 @@ class Question {
    *
    * This is just a wrapper object, the data is stored in `this._card.dataset_query` in a format specific to the query type.
    */
-  legacyQuery = _.once((): AtomicQuery => {
+  _legacyQuery = _.once((): AtomicQuery => {
     const datasetQuery = this._card.dataset_query;
 
     for (const QueryClass of [StructuredQuery, NativeQuery, InternalQuery]) {
@@ -194,6 +194,14 @@ class Question {
     !isVirtualDashcard &&
       console.warn("Unknown query type: " + datasetQuery?.type);
   });
+
+  legacyQuery({ useStructuredQuery = false } = {}) {
+    const query = this._legacyQuery();
+    if (query instanceof StructuredQuery && !useStructuredQuery) {
+      throw new Error("StructuredQuery usage is forbidden. Use MLv2");
+    }
+    return query;
+  }
 
   isNative(): boolean {
     return this.legacyQuery() instanceof NativeQuery;

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -195,7 +195,7 @@ class Question {
       console.warn("Unknown query type: " + datasetQuery?.type);
   });
 
-  legacyQuery({ useStructuredQuery = false } = {}) {
+  legacyQuery({ useStructuredQuery }: { useStructuredQuery?: boolean } = {}) {
     const query = this._legacyQuery();
     if (query instanceof StructuredQuery && !useStructuredQuery) {
       throw new Error("StructuredQuery usage is forbidden. Use MLv2");

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -204,11 +204,15 @@ class Question {
   }
 
   isNative(): boolean {
-    return this.legacyQuery() instanceof NativeQuery;
+    return (
+      this.legacyQuery({ useStructuredQuery: true }) instanceof NativeQuery
+    );
   }
 
   isStructured(): boolean {
-    return this.legacyQuery() instanceof StructuredQuery;
+    return (
+      this.legacyQuery({ useStructuredQuery: true }) instanceof StructuredQuery
+    );
   }
 
   /**
@@ -237,7 +241,7 @@ class Question {
    * Returns a list of atomic queries (NativeQuery or StructuredQuery) contained in this question
    */
   atomicQueries(): AtomicQuery[] {
-    const query = this.legacyQuery();
+    const query = this.legacyQuery({ useStructuredQuery: true });
 
     if (query instanceof AtomicQuery) {
       return [query];
@@ -344,7 +348,7 @@ class Question {
       return this;
     }
 
-    const query = this.legacyQuery();
+    const query = this.legacyQuery({ useStructuredQuery: true });
 
     if (query instanceof StructuredQuery) {
       // TODO: move to StructuredQuery?
@@ -424,7 +428,9 @@ class Question {
   }
 
   setDefaultQuery() {
-    return this.legacyQuery().setDefaultQuery().question();
+    return this.legacyQuery({ useStructuredQuery: true })
+      .setDefaultQuery()
+      .question();
   }
 
   settings(): VisualizationSettings {
@@ -453,7 +459,7 @@ class Question {
   }
 
   isEmpty(): boolean {
-    return this.legacyQuery().isEmpty();
+    return this.legacyQuery({ useStructuredQuery: true }).isEmpty();
   }
 
   /**
@@ -467,7 +473,7 @@ class Question {
    * Question is valid (as far as we know) and can be executed
    */
   canRun(): boolean {
-    return this.legacyQuery().canRun();
+    return this.legacyQuery({ useStructuredQuery: true }).canRun();
   }
 
   canWrite(): boolean {
@@ -486,7 +492,7 @@ class Question {
   }
 
   supportsImplicitActions(): boolean {
-    const legacyQuery = this.legacyQuery();
+    const legacyQuery = this.legacyQuery({ useStructuredQuery: true });
     const query = this.query();
 
     // we want to check the metadata for the underlying table, not the model
@@ -505,7 +511,7 @@ class Question {
   }
 
   isQueryEditable(): boolean {
-    const query = this.legacyQuery();
+    const query = this.legacyQuery({ useStructuredQuery: true });
     return query ? query.isEditable() : false;
   }
 
@@ -570,7 +576,11 @@ class Question {
     return (
       this.isStructured() &&
       _.any(
-        QUERY.getAggregations(this.legacyQuery().legacyQuery()),
+        QUERY.getAggregations(
+          this.legacyQuery({ useStructuredQuery: true }).legacyQuery({
+            useStructuredQuery: true,
+          }),
+        ),
         aggregation => AGGREGATION.getMetric(aggregation) === metricId,
       )
     );
@@ -579,9 +589,11 @@ class Question {
   usesSegment(segmentId): boolean {
     return (
       this.isStructured() &&
-      QUERY.getFilters(this.legacyQuery().legacyQuery()).some(
-        filter => FILTER.isSegment(filter) && filter[1] === segmentId,
-      )
+      QUERY.getFilters(
+        this.legacyQuery({ useStructuredQuery: true }).legacyQuery({
+          useStructuredQuery: true,
+        }),
+      ).some(filter => FILTER.isSegment(filter) && filter[1] === segmentId)
     );
   }
 
@@ -619,7 +631,7 @@ class Question {
     previousQuestion,
     previousQuery,
   ) {
-    const query = this.legacyQuery();
+    const query = this.legacyQuery({ useStructuredQuery: true });
 
     if (
       !_.isEqual(
@@ -735,14 +747,15 @@ class Question {
   }
 
   syncColumnsAndSettings(previous, queryResults) {
-    const query = this.legacyQuery();
+    const query = this.legacyQuery({ useStructuredQuery: true });
     const isQueryResultValid = queryResults && !queryResults.error;
 
     if (query instanceof NativeQuery && isQueryResultValid) {
       return this._syncNativeQuerySettings(queryResults);
     }
 
-    const previousQuery = previous && previous.legacyQuery();
+    const previousQuery =
+      previous && previous.legacyQuery({ useStructuredQuery: true });
 
     if (
       query instanceof StructuredQuery &&
@@ -846,7 +859,7 @@ class Question {
   }
 
   table(): Table | null {
-    const query = this.legacyQuery();
+    const query = this.legacyQuery({ useStructuredQuery: true });
     return query && typeof query.table === "function" ? query.table() : null;
   }
 
@@ -997,7 +1010,9 @@ class Question {
     includeDisplayIsLocked = false,
     creationType,
   } = {}) {
-    const query = clean ? this.legacyQuery().clean() : this.legacyQuery();
+    const query = clean
+      ? this.legacyQuery({ useStructuredQuery: true }).clean()
+      : this.legacyQuery({ useStructuredQuery: true });
     const cardCopy = {
       name: this._card.name,
       description: this._card.description,

--- a/frontend/src/metabase-lib/README.md
+++ b/frontend/src/metabase-lib/README.md
@@ -6,7 +6,7 @@
 
 Examples:
 
-- `question().legacyQuery().aggregation()[0].setDimension(dimension)`
+- `question().legacyQuery({ useStructuredQuery: true }) .aggregation()[0].setDimension(dimension)`
 
 Exceptions:
 

--- a/frontend/src/metabase-lib/expressions/__support__/expressions.ts
+++ b/frontend/src/metabase-lib/expressions/__support__/expressions.ts
@@ -121,6 +121,8 @@ export const metadata = createMockMetadata({
   databases: [database],
 });
 
-export const legacyQuery = checkNotNull(metadata.table(TABLE_ID)).legacyQuery();
+export const legacyQuery = checkNotNull(metadata.table(TABLE_ID)).legacyQuery({
+  useStructuredQuery: true,
+});
 export const expressionOpts = { legacyQuery, startRule: "expression" };
 export const aggregationOpts = { legacyQuery, startRule: "aggregation" };

--- a/frontend/src/metabase-lib/expressions/__support__/shared.ts
+++ b/frontend/src/metabase-lib/expressions/__support__/shared.ts
@@ -69,7 +69,7 @@ const segment = checkNotNull(metadata.segment(SEGMENT_ID)).filterClause();
 const metric = checkNotNull(metadata.metric(METRIC_ID)).aggregationClause();
 
 const legacyQuery = checkNotNull(metadata.table(ORDERS_ID))
-  .legacyQuery()
+  .legacyQuery({ useStructuredQuery: true })
   .addExpression("foo", 42);
 
 // shared test cases used in compile, formatter, and syntax tests:

--- a/frontend/src/metabase-lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/metadata/Database.ts
@@ -150,7 +150,9 @@ class Database {
   }
 
   nativeQuery(native: Partial<NativeQuery>) {
-    return this.nativeQuestion(native).legacyQuery();
+    return this.nativeQuestion(native).legacyQuery({
+      useStructuredQuery: true,
+    });
   }
 
   savedQuestionsDatabase() {

--- a/frontend/src/metabase-lib/metadata/Database.ts
+++ b/frontend/src/metabase-lib/metadata/Database.ts
@@ -150,9 +150,7 @@ class Database {
   }
 
   nativeQuery(native: Partial<NativeQuery>) {
-    return this.nativeQuestion(native).legacyQuery({
-      useStructuredQuery: true,
-    });
+    return this.nativeQuestion(native).legacyQuery();
   }
 
   savedQuestionsDatabase() {

--- a/frontend/src/metabase-lib/metadata/Database.unit.spec.ts
+++ b/frontend/src/metabase-lib/metadata/Database.unit.spec.ts
@@ -204,9 +204,7 @@ describe("Database", () => {
       const database = setup();
       const question = database.nativeQuestion();
 
-      expect(question.legacyQuery({ useStructuredQuery: true })).toBeInstanceOf(
-        NativeQuery,
-      );
+      expect(question.legacyQuery()).toBeInstanceOf(NativeQuery);
       expect(question.metadata()).toBe(database.metadata);
     });
 

--- a/frontend/src/metabase-lib/metadata/Database.unit.spec.ts
+++ b/frontend/src/metabase-lib/metadata/Database.unit.spec.ts
@@ -179,7 +179,9 @@ describe("Database", () => {
       const database = setup();
       const question = database.question();
 
-      expect(question.legacyQuery()).toBeInstanceOf(StructuredQuery);
+      expect(question.legacyQuery({ useStructuredQuery: true })).toBeInstanceOf(
+        StructuredQuery,
+      );
       expect(question.metadata()).toEqual(database.metadata);
     });
 
@@ -202,7 +204,9 @@ describe("Database", () => {
       const database = setup();
       const question = database.nativeQuestion();
 
-      expect(question.legacyQuery()).toBeInstanceOf(NativeQuery);
+      expect(question.legacyQuery({ useStructuredQuery: true })).toBeInstanceOf(
+        NativeQuery,
+      );
       expect(question.metadata()).toBe(database.metadata);
     });
 

--- a/frontend/src/metabase-lib/metadata/Field.ts
+++ b/frontend/src/metabase-lib/metadata/Field.ts
@@ -503,7 +503,9 @@ class FieldInner extends Base {
       return [];
     }
 
-    const { fks } = table.legacyQuery().fieldOptions();
+    const { fks } = table
+      .legacyQuery({ useStructuredQuery: true })
+      .fieldOptions();
     return fks
       .filter(({ field }) => field.id === this.id)
       .map(({ field, dimension, dimensions }) => ({

--- a/frontend/src/metabase-lib/metadata/Metric.ts
+++ b/frontend/src/metabase-lib/metadata/Metric.ts
@@ -31,7 +31,9 @@ class Metric {
   /** Underlying query for this metric */
   definitionQuery() {
     return this.table && this.definition
-      ? this.table.legacyQuery().setQuery(this.definition)
+      ? this.table
+          .legacyQuery({ useStructuredQuery: true })
+          .setQuery(this.definition)
       : null;
   }
 

--- a/frontend/src/metabase-lib/metadata/Table.ts
+++ b/frontend/src/metabase-lib/metadata/Table.ts
@@ -86,12 +86,14 @@ class Table {
   }
 
   legacyQuery(query = {}) {
-    return (this.question().legacyQuery() as StructuredQuery).updateQuery(
-      q => ({
-        ...q,
-        ...query,
-      }),
-    );
+    return (
+      this.question().legacyQuery({
+        useStructuredQuery: true,
+      }) as StructuredQuery
+    ).updateQuery(q => ({
+      ...q,
+      ...query,
+    }));
   }
 
   dimensions() {

--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -97,7 +97,7 @@ export function checkDatabaseCanPersistDatasets(database?: Database | null) {
 }
 
 export function checkCanBeModel(question: Question) {
-  const query = question.legacyQuery();
+  const query = question.legacyQuery({ useStructuredQuery: true });
 
   if (!checkDatabaseSupportsModels(question.database())) {
     return false;

--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -97,8 +97,6 @@ export function checkDatabaseCanPersistDatasets(database?: Database | null) {
 }
 
 export function checkCanBeModel(question: Question) {
-  const query = question.legacyQuery({ useStructuredQuery: true });
-
   if (!checkDatabaseSupportsModels(question.database())) {
     return false;
   }
@@ -107,7 +105,7 @@ export function checkCanBeModel(question: Question) {
     return true;
   }
 
-  return (query as NativeQuery)
+  return (question.legacyQuery() as NativeQuery)
     .templateTags()
     .every(isSupportedTemplateTagForModel);
 }

--- a/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
@@ -131,7 +131,7 @@ function notRelativeDateOrRange({ type }: Parameter) {
 }
 
 export function getTargetsForQuestion(question: Question): Target[] {
-  const query = question.legacyQuery();
+  const query = question.legacyQuery({ useStructuredQuery: true });
   return [...query.dimensionOptions().all(), ...query.variables()].map(o => {
     let id, target: ClickBehaviorTarget;
     if (o instanceof TemplateTagVariable || o instanceof TemplateTagDimension) {

--- a/frontend/src/metabase-lib/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/parameters/utils/targets.ts
@@ -27,7 +27,9 @@ export function getParameterTargetField(
   question: Question,
 ) {
   if (isDimensionTarget(target)) {
-    const query = question.legacyQuery() as NativeQuery | StructuredQuery;
+    const query = question.legacyQuery({ useStructuredQuery: true }) as
+      | NativeQuery
+      | StructuredQuery;
     const dimension = Dimension.parseMBQL(target[1], metadata, query);
 
     return dimension?.field();

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -342,7 +342,9 @@ export default class NativeQuery extends AtomicQuery {
     config: ParameterValuesConfig,
   ): NativeQuery {
     const newParameter = getTemplateTagParameter(tag, config);
-    return this.question().setParameter(tag.id, newParameter).legacyQuery();
+    return this.question()
+      .setParameter(tag.id, newParameter)
+      .legacyQuery({ useStructuredQuery: true });
   }
 
   setDatasetQuery(datasetQuery: DatasetQuery): NativeQuery {

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -342,9 +342,7 @@ export default class NativeQuery extends AtomicQuery {
     config: ParameterValuesConfig,
   ): NativeQuery {
     const newParameter = getTemplateTagParameter(tag, config);
-    return this.question()
-      .setParameter(tag.id, newParameter)
-      .legacyQuery({ useStructuredQuery: true });
+    return this.question().setParameter(tag.id, newParameter).legacyQuery();
   }
 
   setDatasetQuery(datasetQuery: DatasetQuery): NativeQuery {

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -549,7 +549,7 @@ class StructuredQuery extends AtomicQuery {
    * @deprecated use metabase-lib v2 to manage joins
    */
   joins = _.once((): JoinWrapper[] => {
-    return Q.getJoins(this.legacyQuery()).map(
+    return Q.getJoins(this.legacyQuery({ useStructuredQuery: true })).map(
       (join, index) => new JoinWrapper(join, index, this),
     );
   });
@@ -574,7 +574,9 @@ class StructuredQuery extends AtomicQuery {
    * @returns an array of MBQL @type {Aggregation}s.
    */
   aggregations = _.once((): AggregationWrapper[] => {
-    return Q.getAggregations(this.legacyQuery()).map(
+    return Q.getAggregations(
+      this.legacyQuery({ useStructuredQuery: true }),
+    ).map(
       (aggregation, index) => new AggregationWrapper(aggregation, index, this),
     );
   });
@@ -715,11 +717,11 @@ class StructuredQuery extends AtomicQuery {
    * @returns An array of MBQL @type {Breakout}s.
    */
   breakouts = _.once((): BreakoutWrapper[] => {
-    if (this.legacyQuery() == null) {
+    if (this.legacyQuery({ useStructuredQuery: true }) == null) {
       return [];
     }
 
-    return Q.getBreakouts(this.legacyQuery()).map(
+    return Q.getBreakouts(this.legacyQuery({ useStructuredQuery: true })).map(
       (breakout, index) => new BreakoutWrapper(breakout, index, this),
     );
   });
@@ -810,7 +812,7 @@ class StructuredQuery extends AtomicQuery {
    * @returns An array of MBQL @type {Filter}s.
    */
   filters = _.once((): FilterWrapper[] => {
-    return Q.getFilters(this.legacyQuery()).map(
+    return Q.getFilters(this.legacyQuery({ useStructuredQuery: true })).map(
       (filter, index) => new FilterWrapper(filter, index, this),
     );
   });
@@ -922,7 +924,7 @@ class StructuredQuery extends AtomicQuery {
    */
   canAddFilter() {
     return (
-      Q.canAddFilter(this.legacyQuery()) &&
+      Q.canAddFilter(this.legacyQuery({ useStructuredQuery: true })) &&
       (this.filterDimensionOptions().count > 0 ||
         this.filterSegmentOptions().length > 0)
     );
@@ -965,7 +967,7 @@ class StructuredQuery extends AtomicQuery {
 
   // EXPRESSIONS
   expressions = _.once((): ExpressionClause => {
-    return Q.getExpressions(this.legacyQuery());
+    return Q.getExpressions(this.legacyQuery({ useStructuredQuery: true }));
   });
 
   addExpression(name, expression) {
@@ -1009,7 +1011,7 @@ class StructuredQuery extends AtomicQuery {
   // FIELDS
   fields() {
     // FIMXE: implement field functions in query lib
-    return this.legacyQuery().fields || [];
+    return this.legacyQuery({ useStructuredQuery: true }).fields || [];
   }
 
   addField(_name, _expression) {
@@ -1325,7 +1327,9 @@ class StructuredQuery extends AtomicQuery {
    * The (wrapped) source query, if any
    */
   sourceQuery = _.once((): StructuredQuery | null | undefined => {
-    const sourceQuery = this.legacyQuery()?.["source-query"];
+    const sourceQuery = this.legacyQuery({ useStructuredQuery: true })?.[
+      "source-query"
+    ];
 
     if (sourceQuery) {
       return new NestedStructuredQuery(
@@ -1378,7 +1382,10 @@ class StructuredQuery extends AtomicQuery {
           .flatMap(q => q.dimensions())
           .find(d => d.isEqual(fieldRef));
 
-        return this.parseFieldReference(fieldRef, dimension?.legacyQuery());
+        return this.parseFieldReference(
+          fieldRef,
+          dimension?.legacyQuery({ useStructuredQuery: true }),
+        );
       }
     }
 
@@ -1429,7 +1436,7 @@ class StructuredQuery extends AtomicQuery {
         return this;
       }
 
-      sourceQuery = sourceQuery.legacyQuery();
+      sourceQuery = sourceQuery.legacyQuery({ useStructuredQuery: true });
     }
 
     // TODO: if the source query is modified in ways that make the parent query invalid we should "clean" those clauses
@@ -1554,6 +1561,8 @@ class NestedStructuredQuery extends StructuredQuery {
   });
 
   parentQuery() {
-    return this._parent.setSourceQuery(this.legacyQuery());
+    return this._parent.setSourceQuery(
+      this.legacyQuery({ useStructuredQuery: true }),
+    );
   }
 }

--- a/frontend/src/metabase-lib/queries/structured/Aggregation.ts
+++ b/frontend/src/metabase-lib/queries/structured/Aggregation.ts
@@ -312,9 +312,17 @@ export default class Aggregation extends MBQLClause {
       switch (this.expressionName()) {
         case "share":
         case "count-where":
-          return new Filter(this[1], null, this.legacyQuery());
+          return new Filter(
+            this[1],
+            null,
+            this.legacyQuery({ useStructuredQuery: true }),
+          );
         case "sum-where":
-          return new Filter(this[2], null, this.legacyQuery());
+          return new Filter(
+            this[2],
+            null,
+            this.legacyQuery({ useStructuredQuery: true }),
+          );
       }
     }
 
@@ -326,7 +334,9 @@ export default class Aggregation extends MBQLClause {
       const metric = this.metric();
       return metric
         ?.filters()
-        .map(filter => filter.setQuery(this.legacyQuery()));
+        .map(filter =>
+          filter.setQuery(this.legacyQuery({ useStructuredQuery: true })),
+        );
     }
 
     return null;

--- a/frontend/src/metabase-lib/queries/structured/Filter.ts
+++ b/frontend/src/metabase-lib/queries/structured/Filter.ts
@@ -132,7 +132,7 @@ export default class Filter extends MBQLClause {
         return true;
       }
 
-      const query = this.legacyQuery();
+      const query = this.legacyQuery({ useStructuredQuery: true });
 
       if (
         !dimension ||

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -97,23 +97,35 @@ class Join extends MBQLObjectClause {
     const sourceTableId = this["source-table"];
     const sourceQuery = this["source-query"];
     return sourceTableId
-      ? new StructuredQuery(this.legacyQuery().question().setDataset(false), {
-          type: "query",
-          query: {
-            "source-table": sourceTableId,
+      ? new StructuredQuery(
+          this.legacyQuery({ useStructuredQuery: true })
+            .question()
+            .setDataset(false),
+          {
+            type: "query",
+            query: {
+              "source-table": sourceTableId,
+            },
           },
-        })
+        )
       : sourceQuery
-      ? new StructuredQuery(this.legacyQuery().question().setDataset(false), {
-          type: "query",
-          query: sourceQuery,
-        })
+      ? new StructuredQuery(
+          this.legacyQuery({ useStructuredQuery: true })
+            .question()
+            .setDataset(false),
+          {
+            type: "query",
+            query: sourceQuery,
+          },
+        )
       : null;
   }
 
   private joinedDimension(dimension: Dimension) {
     if (dimension instanceof FieldDimension) {
-      return dimension.withJoinAlias(this.alias).setQuery(this.legacyQuery());
+      return dimension
+        .withJoinAlias(this.alias)
+        .setQuery(this.legacyQuery({ useStructuredQuery: true }));
     }
 
     console.warn("Don't know how to create joined dimension with:", dimension);
@@ -136,10 +148,14 @@ class Join extends MBQLObjectClause {
       const [, parentDimension, joinDimension] = condition;
       return [
         parentDimension
-          ? this.legacyQuery().parseFieldReference(parentDimension)
+          ? this.legacyQuery({ useStructuredQuery: true }).parseFieldReference(
+              parentDimension,
+            )
           : null,
         joinDimension
-          ? this.legacyQuery().parseFieldReference(joinDimension)
+          ? this.legacyQuery({ useStructuredQuery: true }).parseFieldReference(
+              joinDimension,
+            )
           : null,
       ];
     });
@@ -162,7 +178,9 @@ class Join extends MBQLObjectClause {
     if (this.fields === "all") {
       return this.joinedDimensions();
     } else if (Array.isArray(this.fields)) {
-      return this.fields.map(f => this.legacyQuery().parseFieldReference(f));
+      return this.fields.map(f =>
+        this.legacyQuery({ useStructuredQuery: true }).parseFieldReference(f),
+      );
     } else {
       return [];
     }

--- a/frontend/src/metabase-lib/queries/structured/MBQLClause.ts
+++ b/frontend/src/metabase-lib/queries/structured/MBQLClause.ts
@@ -38,7 +38,7 @@ export default class MBQLArrayClause extends Array {
   /**
    * returns the parent query object
    */
-  legacyQuery(): StructuredQuery {
+  legacyQuery(_opts: { useStructuredQuery: true } = {}): StructuredQuery {
     return this._query;
   }
 

--- a/frontend/src/metabase-lib/queries/utils/actions.js
+++ b/frontend/src/metabase-lib/queries/utils/actions.js
@@ -8,14 +8,14 @@ import { FieldDimension } from "metabase-lib/Dimension";
 // QUESTION DRILL ACTIONS
 
 export function aggregate(question, aggregation) {
-  const query = question.legacyQuery();
+  const query = question.legacyQuery({ useStructuredQuery: true });
   if (query instanceof StructuredQuery) {
     return query.aggregate(aggregation).question().setDefaultDisplay();
   }
 }
 
 export function breakout(question, breakout) {
-  const query = question.legacyQuery();
+  const query = question.legacyQuery({ useStructuredQuery: true });
   if (query instanceof StructuredQuery) {
     return query.breakout(breakout).question().setDefaultDisplay();
   }
@@ -23,7 +23,7 @@ export function breakout(question, breakout) {
 
 // Adds a new filter with the specified operator, column, and value
 export function filter(question, operator, column, value) {
-  const query = question.legacyQuery();
+  const query = question.legacyQuery({ useStructuredQuery: true });
   if (query instanceof StructuredQuery) {
     return query
       .filter([operator, fieldRefForColumn(column), value])

--- a/frontend/src/metabase-lib/queries/utils/nested-card-query-table.ts
+++ b/frontend/src/metabase-lib/queries/utils/nested-card-query-table.ts
@@ -46,7 +46,9 @@ function createVirtualTableUsingQuestionMetadata(question: Question): Table {
   const metadata = question.metadata();
   const questionResultMetadata = question.getResultMetadata();
   const questionDisplayName = question.displayName() as string;
-  const legacyQuery = question.legacyQuery() as StructuredQuery | NativeQuery;
+  const legacyQuery = question.legacyQuery({ useStructuredQuery: true }) as
+    | StructuredQuery
+    | NativeQuery;
   const fields = questionResultMetadata.map((fieldMetadata: any) => {
     const field = metadata.field(fieldMetadata.id);
     const virtualField = field

--- a/frontend/src/metabase-lib/queries/utils/pivot.js
+++ b/frontend/src/metabase-lib/queries/utils/pivot.js
@@ -4,7 +4,9 @@ import { FieldDimension } from "metabase-lib/Dimension";
 export function getPivotColumnSplit(question) {
   const setting = question.setting("pivot_table.column_split");
   const breakout =
-    (question.isStructured() && question.legacyQuery().breakouts()) || [];
+    (question.isStructured() &&
+      question.legacyQuery({ useStructuredQuery: true }).breakouts()) ||
+    [];
   const { rows: pivot_rows, columns: pivot_cols } = _.mapObject(
     setting,
     fieldRefs =>

--- a/frontend/src/metabase-lib/queries/utils/structured-query-table.unit.spec.ts
+++ b/frontend/src/metabase-lib/queries/utils/structured-query-table.unit.spec.ts
@@ -91,7 +91,7 @@ describe("metabase-lib/queries/utils/structured-query-table", () => {
 
     const table = getStructuredQueryTable(
       nestedQuestion,
-      nestedQuestion.legacyQuery(),
+      nestedQuestion.legacyQuery({ useStructuredQuery: true }),
     );
 
     it("should return a table", () => {
@@ -106,7 +106,10 @@ describe("metabase-lib/queries/utils/structured-query-table", () => {
 
   describe("Model card", () => {
     const model = checkNotNull(metadata.question(modelCard.id));
-    const table = getStructuredQueryTable(model, model.legacyQuery());
+    const table = getStructuredQueryTable(
+      model,
+      model.legacyQuery({ useStructuredQuery: true }),
+    );
 
     it("should return a nested card table using the given query's question", () => {
       expect(table?.getPlainObject()).toEqual(
@@ -135,7 +138,7 @@ describe("metabase-lib/queries/utils/structured-query-table", () => {
 
     const table = getStructuredQueryTable(
       sourceQueryQuestion,
-      sourceQueryQuestion.legacyQuery(),
+      sourceQueryQuestion.legacyQuery({ useStructuredQuery: true }),
     );
 
     it("should return a virtual table based on the nested query", () => {
@@ -179,8 +182,8 @@ describe("metabase-lib/queries/utils/structured-query-table", () => {
     const ordersTable = checkNotNull(metadata.table(ORDERS_ID));
 
     const table = getStructuredQueryTable(
-      ordersTable.legacyQuery().question(),
-      ordersTable.legacyQuery(),
+      ordersTable.legacyQuery({ useStructuredQuery: true }).question(),
+      ordersTable.legacyQuery({ useStructuredQuery: true }),
     );
 
     it("should return the concrete table stored on the Metadata object", () => {

--- a/frontend/src/metabase-lib/queries/utils/virtual-table.unit.spec.ts
+++ b/frontend/src/metabase-lib/queries/utils/virtual-table.unit.spec.ts
@@ -16,7 +16,9 @@ describe("metabase-lib/queries/utils/virtual-table", () => {
 
   const productsTable = metadata.table(PRODUCTS_ID) as Table;
 
-  const query = productsTable.newQuestion().legacyQuery() as StructuredQuery;
+  const query = productsTable
+    .newQuestion()
+    .legacyQuery({ useStructuredQuery: true }) as StructuredQuery;
   const field = createVirtualField({
     id: 123,
     metadata,
@@ -40,7 +42,9 @@ describe("metabase-lib/queries/utils/virtual-table", () => {
   });
 
   describe("createVirtualTable", () => {
-    const query = productsTable.newQuestion().legacyQuery() as StructuredQuery;
+    const query = productsTable
+      .newQuestion()
+      .legacyQuery({ useStructuredQuery: true }) as StructuredQuery;
     const field1 = createVirtualField({
       id: 1,
       metadata,

--- a/frontend/src/metabase/admin/datamodel/components/AggregationWidget/AggregationWidget.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/AggregationWidget/AggregationWidget.jsx
@@ -47,7 +47,8 @@ export class AggregationWidget extends Component {
   render() {
     const {
       aggregation,
-      query = aggregation.query && aggregation.legacyQuery(),
+      query = aggregation.query &&
+        aggregation.legacyQuery({ useStructuredQuery: true }),
       children,
       className,
     } = this.props;

--- a/frontend/src/metabase/admin/datamodel/components/FilterPopover/FilterPopover.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/FilterPopover/FilterPopover.tsx
@@ -93,7 +93,7 @@ export function FilterPopover({
   useEffect(() => {
     if (
       filter &&
-      filter.legacyQuery() === previousQuery &&
+      filter.legacyQuery({ useStructuredQuery: true }) === previousQuery &&
       legacyQuery !== previousQuery
     ) {
       setFilter(filter.setQuery(legacyQuery));
@@ -142,13 +142,14 @@ export function FilterPopover({
     const field = dimension?.field();
     const newFilter =
       !filter ||
-      filter.legacyQuery() !== dimension.legacyQuery() ||
+      filter.legacyQuery({ useStructuredQuery: true }) !==
+        dimension.legacyQuery({ useStructuredQuery: true }) ||
       field?.isDate?.()
         ? new Filter(
             [],
             null,
-            dimension.legacyQuery() ||
-              (filter && filter.legacyQuery()) ||
+            dimension.legacyQuery({ useStructuredQuery: true }) ||
+              (filter && filter.legacyQuery({ useStructuredQuery: true })) ||
               legacyQuery,
           )
         : filter;
@@ -212,7 +213,8 @@ export function FilterPopover({
             isTopLevel
               ? legacyQuery.topLevelFilterFieldOptionSections()
               : (
-                  (filter && filter.legacyQuery()) ||
+                  (filter &&
+                    filter.legacyQuery({ useStructuredQuery: true })) ||
                   legacyQuery
                 ).filterFieldOptionSections(filter, {
                   includeSegments: showCustom,

--- a/frontend/src/metabase/admin/datamodel/components/FilterPopover/FilterPopover.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/FilterPopover/FilterPopover.unit.spec.tsx
@@ -26,7 +26,7 @@ const QUERY = Question.create({
   tableId: ORDERS_ID,
   metadata,
 })
-  .legacyQuery()
+  .legacyQuery({ useStructuredQuery: true })
   // eslint-disable-next-line
   // @ts-ignore
   .aggregate(["count"])

--- a/frontend/src/metabase/admin/datamodel/components/GuiQueryEditor/GuiQueryEditor.unit.spec.js
+++ b/frontend/src/metabase/admin/datamodel/components/GuiQueryEditor/GuiQueryEditor.unit.spec.js
@@ -33,7 +33,7 @@ describe("GuiQueryEditor", () => {
       tableId: ORDERS_ID,
       metadata,
     })
-      .legacyQuery()
+      .legacyQuery({ useStructuredQuery: true })
       .aggregate(["count"]);
 
     render(getGuiQueryEditor(legacyQuery));
@@ -50,7 +50,7 @@ describe("GuiQueryEditor", () => {
       tableId: ORDERS_ID,
       metadata,
     })
-      .legacyQuery()
+      .legacyQuery({ useStructuredQuery: true })
       .aggregate(["count"])
       .breakout(["field", ORDERS.TOTAL, null]);
 

--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -55,7 +55,7 @@ class PartialQueryBuilder extends Component {
 
     // only set the query if it doesn't already have an aggregation or filter
     const question = getSegmentOrMetricQuestion(value, table, metadata);
-    if (!question.legacyQuery().isRaw()) {
+    if (!question.legacyQuery({ useStructuredQuery: true }).isRaw()) {
       return;
     }
 
@@ -78,7 +78,7 @@ class PartialQueryBuilder extends Component {
     const { features, value, metadata, table, previewSummary } = this.props;
 
     const question = getSegmentOrMetricQuestion(value, table, metadata);
-    const legacyQuery = question.legacyQuery();
+    const legacyQuery = question.legacyQuery({ useStructuredQuery: true });
     const query = question.query();
     const previewUrl = Urls.serializedQuestion(question.card());
 

--- a/frontend/src/metabase/admin/datamodel/components/QueryDefinition/QueryDefinition.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/QueryDefinition/QueryDefinition.jsx
@@ -11,7 +11,7 @@ function _QueryDefinition({ className, object, metadata }) {
       dataset_query: { type: "query", query: object.definition },
     },
     metadata,
-  ).legacyQuery();
+  ).legacyQuery({ useStructuredQuery: true });
   const aggregations = query.aggregations();
   const filters = query.filters();
   return (

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/BooleanPicker/BooleanPicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/BooleanPicker/BooleanPicker.unit.spec.tsx
@@ -35,7 +35,9 @@ describe("BooleanPicker", () => {
   const field = checkNotNull(metadata.field(1));
 
   const question = new Question(createAdHocCard(), metadata);
-  const query = question.legacyQuery() as StructuredQuery;
+  const query = question.legacyQuery({
+    useStructuredQuery: true,
+  }) as StructuredQuery;
 
   const fieldRef = field.reference();
 

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -19,7 +19,7 @@ const metadata = createMockMetadata({
 });
 
 const ordersTable = checkNotNull(metadata.table(ORDERS_ID));
-const ordersQuery = ordersTable.legacyQuery();
+const ordersQuery = ordersTable.legacyQuery({ useStructuredQuery: true });
 
 // this component does not manage its own filter state, so we need a wrapper to test
 // any state updates because the component's behavior is based on the filter state

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/ExcludeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/ExcludeDatePicker.unit.spec.tsx
@@ -14,7 +14,7 @@ const metadata = createMockMetadata({
 });
 
 const ordersTable = checkNotNull(metadata.table(ORDERS_ID));
-const query = ordersTable.legacyQuery();
+const query = ordersTable.legacyQuery({ useStructuredQuery: true });
 
 const filter = new Filter(
   [null, ["field", ORDERS.CREATED_AT, null]],

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DefaultPicker/DefaultPicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DefaultPicker/DefaultPicker.tsx
@@ -75,7 +75,10 @@ export function DefaultPicker({
   const isBetweenLayout =
     operator.name === "between" && operatorFields.length === 2;
 
-  const visualizationSettings = filter?.legacyQuery()?.question()?.settings();
+  const visualizationSettings = filter
+    ?.legacyQuery({ useStructuredQuery: true })
+    ?.question()
+    ?.settings();
 
   const key = dimension?.column?.()
     ? getColumnKey(dimension.column() as DatasetColumn)

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DefaultPicker/DefaultPicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DefaultPicker/DefaultPicker.unit.spec.tsx
@@ -38,7 +38,7 @@ const makeQuery = (query = {}): StructuredQuery => {
       },
       database: SAMPLE_DB_ID,
     })
-    .legacyQuery() as StructuredQuery;
+    .legacyQuery({ useStructuredQuery: true }) as StructuredQuery;
 };
 
 const numericQuery = makeQuery({

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
@@ -42,7 +42,10 @@ const PinnedQuestionLoader = ({
   return (
     <Questions.Loader id={id} loadingAndErrorWrapper={false}>
       {({ loading, question: loadedQuestion }: QuestionLoaderProps) => {
-        if (loading !== false || !loadedQuestion.legacyQuery()) {
+        if (
+          loading !== false ||
+          !loadedQuestion.legacyQuery({ useStructuredQuery: true })
+        ) {
           return children({ loading: true });
         }
 

--- a/frontend/src/metabase/containers/QuestionLoader.jsx
+++ b/frontend/src/metabase/containers/QuestionLoader.jsx
@@ -25,15 +25,7 @@ import { serializeCardForUrl } from "metabase/lib/card";
  *
  *        { // link to a new question created by adding a filter }
  *        <Link
- *          to={
- *            question.legacyQuery()
- *                    .filter([
- *                      "segment",
- *                      question.legacyQuery().filterSegmentOptions()[0]
- *                    ])
- *                    .question()
- *                    .getUrl()
- *          }
+ *          to={question.getUrl()}
  *        >
  *          View this ad-hoc exploration
  *        </Link>

--- a/frontend/src/metabase/containers/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.unit.spec.tsx
@@ -152,7 +152,9 @@ function getQuestion({
 const EXPECTED_DIRTY_SUGGESTED_NAME = "Orders, Count, Grouped by Total";
 
 function getDirtyQuestion(originalQuestion: Question) {
-  const query = originalQuestion.legacyQuery() as StructuredQuery;
+  const query = originalQuestion.legacyQuery({
+    useStructuredQuery: true,
+  }) as StructuredQuery;
   return query.breakout(["field", ORDERS.TOTAL, null]).question().markDirty();
 }
 
@@ -634,7 +636,7 @@ describe("SaveQuestionModal", () => {
       databaseId: SAMPLE_DB_ID,
       tableId: ORDERS_ID,
       metadata,
-    }).legacyQuery() as StructuredQuery;
+    }).legacyQuery({ useStructuredQuery: true }) as StructuredQuery;
 
     const question = query.aggregate(["count"]).question();
 

--- a/frontend/src/metabase/dashboard/actions/metadata.js
+++ b/frontend/src/metabase/dashboard/actions/metadata.js
@@ -25,7 +25,9 @@ const loadMetadataForCards = cards => (dispatch, getState) => {
 
   return dispatch(
     loadMetadataForQueries(
-      questions.map(question => question.legacyQuery()),
+      questions.map(question =>
+        question.legacyQuery({ useStructuredQuery: true }),
+      ),
       questions.map(question => question.dependentMetadata()),
     ),
   );

--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -286,7 +286,9 @@ function loadQuestionMetadata(getQuestion) {
       fetch() {
         const { question, loadMetadataForQuery } = this.props;
         if (question) {
-          loadMetadataForQuery(question.legacyQuery());
+          loadMetadataForQuery(
+            question.legacyQuery({ useStructuredQuery: true }),
+          );
         }
       }
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -150,7 +150,8 @@ DashCardMenu.shouldRender = ({
   isPublic,
   isEditing,
 }: QueryDownloadWidgetOpts) => {
-  const isInternalQuery = question.legacyQuery() instanceof InternalQuery;
+  const isInternalQuery =
+    question.legacyQuery({ useStructuredQuery: true }) instanceof InternalQuery;
   if (isEmbed) {
     return isEmbed;
   }

--- a/frontend/src/metabase/metabot/components/MetabotQueryEditor/MetabotQueryEditor.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotQueryEditor/MetabotQueryEditor.tsx
@@ -60,7 +60,7 @@ const MetabotQueryEditor = ({
     <NativeQueryEditor
       cancelQueryOnLeave={false}
       question={question}
-      query={question.legacyQuery()}
+      query={question.legacyQuery({ useStructuredQuery: true })}
       viewHeight={height}
       resizable={false}
       hasParametersList={false}

--- a/frontend/src/metabase/metabot/selectors.ts
+++ b/frontend/src/metabase/metabot/selectors.ts
@@ -2,7 +2,7 @@ import { createSelector } from "@reduxjs/toolkit";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { State } from "metabase-types/store";
 import Question from "metabase-lib/Question";
-import NativeQuery from "metabase-lib/queries/NativeQuery";
+import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import { DEFAULT_TABLE_SETTINGS } from "./constants";
 
 export const getEntityId = (state: State) => {
@@ -57,8 +57,9 @@ export const getFeedbackType = (state: State) => {
 };
 
 export const getNativeQueryText = createSelector([getQuestion], question => {
-  const query = question?.legacyQuery({ useStructuredQuery: true });
-  return query instanceof NativeQuery ? query.queryText() : undefined;
+  return question?.isNative()
+    ? (question.legacyQuery() as NativeQuery).queryText()
+    : undefined;
 });
 
 export const getPromptTemplateVersions = (state: State) =>

--- a/frontend/src/metabase/metabot/selectors.ts
+++ b/frontend/src/metabase/metabot/selectors.ts
@@ -57,7 +57,7 @@ export const getFeedbackType = (state: State) => {
 };
 
 export const getNativeQueryText = createSelector([getQuestion], question => {
-  const query = question?.legacyQuery();
+  const query = question?.legacyQuery({ useStructuredQuery: true });
   return query instanceof NativeQuery ? query.queryText() : undefined;
 });
 

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -188,7 +188,11 @@ export const apiCreateQuestion = question => {
     const resultsMetadata = getResultsMetadata(getState());
     const isResultDirty = getIsResultDirty(getState());
     const questionToCreate = questionWithVizSettings
-      .setLegacyQuery(question.legacyQuery().clean({ skipFilters: true }))
+      .setLegacyQuery(
+        question
+          .legacyQuery({ useStructuredQuery: true })
+          .clean({ skipFilters: true }),
+      )
       .setResultsMetadata(isResultDirty ? null : resultsMetadata);
     const createdQuestion = await reduxCreateQuestion(
       questionToCreate,
@@ -254,7 +258,10 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
       // as calling table() method down the line would bring unwanted consequences
       // such as dropping joins (as joins are treated differently between pure questions and datasets)
       .setLegacyQuery(
-        question.setDataset(false).legacyQuery().clean({ skipFilters: true }),
+        question
+          .setDataset(false)
+          .legacyQuery({ useStructuredQuery: true })
+          .clean({ skipFilters: true }),
       )
       .setResultsMetadata(isResultDirty ? null : resultsMetadata);
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -81,12 +81,16 @@ function getCardForBlankQuestion({
 
   if (databaseId && tableId) {
     if (segment) {
-      question = (question.legacyQuery() as StructuredQuery)
+      question = (
+        question.legacyQuery({ useStructuredQuery: true }) as StructuredQuery
+      )
         .filter(["segment", parseInt(segment)])
         .question();
     }
     if (metric) {
-      question = (question.legacyQuery() as StructuredQuery)
+      question = (
+        question.legacyQuery({ useStructuredQuery: true }) as StructuredQuery
+      )
         .aggregate(["metric", parseInt(metric)])
         .question();
     }

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -707,7 +707,9 @@ describe("QB Actions > initializeQB", () => {
       });
 
       const question = new Question(result.card, metadata);
-      const query = question.legacyQuery() as StructuredQuery;
+      const query = question.legacyQuery({
+        useStructuredQuery: true,
+      }) as StructuredQuery;
 
       return {
         question,

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -32,7 +32,7 @@ import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 function hasNewColumns(question: Question, queryResult: Dataset) {
   // NOTE: this assume column names will change
   // technically this is wrong because you could add and remove two columns with the same name
-  const query = question.legacyQuery();
+  const query = question.legacyQuery({ useStructuredQuery: true });
   const previousColumns =
     (queryResult && queryResult.data.cols.map(col => col.name)) || [];
   const nextColumns =
@@ -166,7 +166,11 @@ export const updateQuestion = (
     if (wasPivot || isPivot) {
       const hasBreakouts =
         newQuestion.isStructured() &&
-        (newQuestion.legacyQuery() as StructuredQuery).hasBreakouts();
+        (
+          newQuestion.legacyQuery({
+            useStructuredQuery: true,
+          }) as StructuredQuery
+        ).hasBreakouts();
 
       // compute the pivot setting now so we can query the appropriate data
       if (isPivot && hasBreakouts) {
@@ -232,12 +236,16 @@ export const updateQuestion = (
     const currentDependencies = currentQuestion
       ? [
           ...currentQuestion.dependentMetadata(),
-          ...currentQuestion.legacyQuery().dependentMetadata(),
+          ...currentQuestion
+            .legacyQuery({ useStructuredQuery: true })
+            .dependentMetadata(),
         ]
       : [];
     const nextDependencies = [
       ...newQuestion.dependentMetadata(),
-      ...newQuestion.legacyQuery().dependentMetadata(),
+      ...newQuestion
+        .legacyQuery({ useStructuredQuery: true })
+        .dependentMetadata(),
     ];
     try {
       if (!_.isEqual(currentDependencies, nextDependencies)) {

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -216,7 +216,7 @@ function DatasetEditor(props) {
       return INITIAL_NOTEBOOK_EDITOR_HEIGHT;
     }
     return calcInitialEditorHeight({
-      query: dataset.legacyQuery(),
+      query: dataset.legacyQuery({ useStructuredQuery: true }),
       viewHeight: height,
     });
   }, [dataset, height]);
@@ -405,7 +405,7 @@ function DatasetEditor(props) {
   );
 
   const canSaveChanges = useMemo(() => {
-    if (dataset.legacyQuery().isEmpty()) {
+    if (dataset.legacyQuery({ useStructuredQuery: true }).isEmpty()) {
       return false;
     }
     const everyFieldHasDisplayName = fields.every(field => field.display_name);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -216,7 +216,7 @@ function DatasetEditor(props) {
       return INITIAL_NOTEBOOK_EDITOR_HEIGHT;
     }
     return calcInitialEditorHeight({
-      query: dataset.legacyQuery({ useStructuredQuery: true }),
+      query: dataset.legacyQuery(),
       viewHeight: height,
     });
   }, [dataset, height]);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
@@ -65,7 +65,7 @@ const renderDatasetEditor = (card: Card | UnsavedCard) => {
     <DatasetEditor
       {...defaultDatasetEditorProps}
       question={question}
-      query={question.legacyQuery()}
+      query={question.legacyQuery({ useStructuredQuery: true })}
     />,
   );
 };

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.unit.spec.tsx
@@ -63,7 +63,7 @@ const setup = async ({
   });
   const metadata = getMetadata(storeInitialState);
   const question = checkNotNull(metadata.question(card.id));
-  const query = question.legacyQuery();
+  const query = question.legacyQuery({ useStructuredQuery: true });
   const DatasetQueryEditor = await importDatasetQueryEditor();
 
   const { rerender } = renderWithProviders(

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.tsx
@@ -31,7 +31,7 @@ interface PreviewQueryButtonOpts {
 }
 
 PreviewQueryButton.shouldRender = ({ question }: PreviewQueryButtonOpts) => {
-  const query = question.legacyQuery();
+  const query = question.legacyQuery({ useStructuredQuery: true });
 
   return (
     question.canRun() &&

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import Tooltip from "metabase/core/components/Tooltip";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import type Question from "metabase-lib/Question";
-import NativeQuery from "metabase-lib/queries/NativeQuery";
+import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import { PreviewButton, PreviewButtonIcon } from "./PreviewQueryButton.styled";
 
 interface PreviewQueryButtonProps {
@@ -31,11 +31,9 @@ interface PreviewQueryButtonOpts {
 }
 
 PreviewQueryButton.shouldRender = ({ question }: PreviewQueryButtonOpts) => {
-  const query = question.legacyQuery({ useStructuredQuery: true });
-
   return (
     question.canRun() &&
-    query instanceof NativeQuery &&
-    query.hasVariableTemplateTags()
+    question.isNative() &&
+    (question.legacyQuery() as NativeQuery).hasVariableTemplateTags()
   );
 };

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -165,8 +165,8 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
 
   const isStructuredQuery = question.isStructured();
   const query = isStructuredQuery
-    ? question.legacyQuery().rootQuery()
-    : question.legacyQuery();
+    ? question.legacyQuery({ useStructuredQuery: true }).rootQuery()
+    : question.legacyQuery({ useStructuredQuery: true });
 
   const hasDataPermission = question.isQueryEditable();
   if (!hasDataPermission) {

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -166,7 +166,7 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
   const isStructuredQuery = question.isStructured();
   const query = isStructuredQuery
     ? question.legacyQuery({ useStructuredQuery: true }).rootQuery()
-    : question.legacyQuery({ useStructuredQuery: true });
+    : question.legacyQuery();
 
   const hasDataPermission = question.isQueryEditable();
   if (!hasDataPermission) {

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
@@ -246,7 +246,7 @@ function getAdHocNestedQuestion({ isMultiSchemaDB } = {}) {
     },
   });
 
-  question.legacyQuery().table = () =>
+  question.legacyQuery({ useStructuredQuery: true }).table = () =>
     getNestedQuestionTableMock(isMultiSchemaDB);
 
   return question;
@@ -264,7 +264,7 @@ function getSavedNestedQuestion({ isMultiSchemaDB } = {}) {
     },
   });
 
-  question.legacyQuery().table = () =>
+  question.legacyQuery({ useStructuredQuery: true }).table = () =>
     getNestedQuestionTableMock(isMultiSchemaDB);
 
   return question;
@@ -408,15 +408,19 @@ describe("QuestionDataSource", () => {
         });
 
         it("shows nothing if a user doesn't have data permissions", () => {
-          const originalMethod = question.legacyQuery()._database;
-          question.legacyQuery()._database = () => null;
+          const originalMethod = question.legacyQuery({
+            useStructuredQuery: true,
+          })._database;
+          question.legacyQuery({ useStructuredQuery: true })._database = () =>
+            null;
 
           setup({ question });
           expect(
             screen.getByTestId("head-crumbs-container"),
           ).toBeEmptyDOMElement();
 
-          question.legacyQuery()._database = originalMethod;
+          question.legacyQuery({ useStructuredQuery: true })._database =
+            originalMethod;
         });
       });
     });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -417,7 +417,9 @@ function ViewTitleHeaderRightSide(props) {
     question.canExploreResults() &&
     MetabaseSettings.get("enable-nested-queries");
 
-  const isNewQuery = !question.legacyQuery().hasData();
+  const isNewQuery = !question
+    .legacyQuery({ useStructuredQuery: true })
+    .hasData();
   const hasSaveButton =
     !isDataset &&
     !!isDirty &&

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.unit.spec.js
@@ -27,7 +27,7 @@ const setup = props => {
   render(
     <ChartTypeSidebar
       question={question}
-      query={question.legacyQuery()}
+      query={question.legacyQuery({ useStructuredQuery: true })}
       result={{ data: DATA }}
       {...props}
     />,

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -37,7 +37,6 @@ import {
   normalizeParameterValue,
 } from "metabase-lib/parameters/utils/parameter-values";
 import { getIsPKFromTablePredicate } from "metabase-lib/types/utils/isa";
-import NativeQuery from "metabase-lib/queries/NativeQuery";
 import Question from "metabase-lib/Question";
 import { isAdHocModelQuestion } from "metabase-lib/metadata/utils/models";
 
@@ -715,9 +714,7 @@ export const getVisualizationSettings = createSelector(
  */
 export const getIsNative = createSelector(
   [getQuestion],
-  question =>
-    question &&
-    question.legacyQuery({ useStructuredQuery: true }) instanceof NativeQuery,
+  question => question && question.isNative(),
 );
 
 /**

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -572,7 +572,7 @@ export const getIsSavedQuestionChanged = createSelector(
 
 export const getQuery = createSelector(
   [getQuestion],
-  question => question && question.legacyQuery(),
+  question => question && question.legacyQuery({ useStructuredQuery: true }),
 );
 
 export const getIsRunnable = createSelector(
@@ -715,7 +715,9 @@ export const getVisualizationSettings = createSelector(
  */
 export const getIsNative = createSelector(
   [getQuestion],
-  question => question && question.legacyQuery() instanceof NativeQuery,
+  question =>
+    question &&
+    question.legacyQuery({ useStructuredQuery: true }) instanceof NativeQuery,
 );
 
 /**

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -15,9 +15,11 @@ export const loadMetadataForCard =
   (dispatch: Dispatch, getState: GetState) => {
     const metadata = getMetadata(getState());
     const question = new Question(card, metadata);
-    const queries = [question.legacyQuery()];
+    const queries = [question.legacyQuery({ useStructuredQuery: true })];
     if (question.isDataset()) {
-      queries.push(question.composeDataset().legacyQuery());
+      queries.push(
+        question.composeDataset().legacyQuery({ useStructuredQuery: true }),
+      );
     }
     return dispatch(
       loadMetadataForQueries(queries, question.dependentMetadata(), options),

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -159,7 +159,7 @@ export default class LeafletMap extends Component {
     const question = new Question(card);
     if (question.isStructured()) {
       const nextCard = updateLatLonFilter(
-        question.legacyQuery(),
+        question.legacyQuery({ useStructuredQuery: true }),
         latitudeColumn,
         longitudeColumn,
         bounds,

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -365,7 +365,9 @@ function makeBrushChangeFunctions({ series, onChangeCardAndRun }) {
     if (range) {
       const column = series[0].data.cols[0];
       const card = series[0].card;
-      const query = new Question(card).legacyQuery();
+      const query = new Question(card).legacyQuery({
+        useStructuredQuery: true,
+      });
       const [start, end] = range;
       if (isDimensionTimeseries(series)) {
         onChangeCardAndRun({

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.unit.spec.js
@@ -61,7 +61,9 @@ const setup = () => {
                 ["2016-01-01T00:00:00-04:00", 500],
                 ["2017-01-01T00:00:00-04:00", 1500],
               ],
-              cols: question.legacyQuery().columns(),
+              cols: question
+                .legacyQuery({ useStructuredQuery: true })
+                .columns(),
             },
           },
         ]}

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.js
@@ -63,7 +63,7 @@ const setup = () => {
               // Need to add missing sources so that the setting displays
               cols: [
                 ...question
-                  .legacyQuery()
+                  .legacyQuery({ useStructuredQuery: true })
                   .columns()
                   .map(c => ({ ...c, source: c.source || "breakout" })),
                 {

--- a/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Dimension.unit.spec.js
@@ -724,7 +724,7 @@ describe("Dimension", () => {
         describe("when an expression dimension has a query that relies on a nested card", () => {
           it("should return a field inferred from the expression", () => {
             const question = new Question(nestedQuestionCard, null);
-            const query = question.legacyQuery();
+            const query = question.legacyQuery({ useStructuredQuery: true });
             const dimension = Dimension.parseMBQL(
               ["expression", "Foobar"], // "Foobar" does not exist in the metadata
               null,
@@ -740,7 +740,7 @@ describe("Dimension", () => {
 
           it("should return a field inferred from the expression (from metadata)", () => {
             const question = new Question(nestedQuestionCard, metadata);
-            const query = question.legacyQuery();
+            const query = question.legacyQuery({ useStructuredQuery: true });
             const dimension = Dimension.parseMBQL(
               ["expression", "Foo"],
               metadata,
@@ -784,7 +784,7 @@ describe("Dimension", () => {
         const dimension = Dimension.parseMBQL(
           ["expression", 42],
           metadata,
-          question.legacyQuery(),
+          question.legacyQuery({ useStructuredQuery: true }),
         );
         expect(dimension.dimensions().length).toEqual(5); // 5 different binnings for a number
       });
@@ -1020,7 +1020,7 @@ describe("Dimension", () => {
     const dimension = Dimension.parseMBQL(
       ["field", "boolean", { "base-type": "type/Boolean" }],
       metadata,
-      question.legacyQuery(),
+      question.legacyQuery({ useStructuredQuery: true }),
     );
 
     describe("INSTANCE METHODS", () => {

--- a/frontend/test/metabase-lib/lib/Question.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/Question.unit.spec.js
@@ -307,8 +307,12 @@ describe("Question", () => {
       });
 
       it("contains an empty structured query", () => {
-        expect(question.legacyQuery().constructor).toBe(StructuredQuery);
-        expect(question.legacyQuery().constructor).toBe(StructuredQuery);
+        expect(
+          question.legacyQuery({ useStructuredQuery: true }).constructor,
+        ).toBe(StructuredQuery);
+        expect(
+          question.legacyQuery({ useStructuredQuery: true }).constructor,
+        ).toBe(StructuredQuery);
       });
 
       it("defaults to table display", () => {
@@ -345,19 +349,28 @@ describe("Question", () => {
     describe("legacyQuery()", () => {
       it("returns a correct class instance for structured query", () => {
         // This is a bit wack, and the repetitive naming is pretty confusing.
-        const query = orders_raw_question.legacyQuery();
+        const query = orders_raw_question.legacyQuery({
+          useStructuredQuery: true,
+        });
         expect(query instanceof StructuredQuery).toBe(true);
       });
       it("returns a correct class instance for native query", () => {
-        const query = native_orders_count_question.legacyQuery();
+        const query = native_orders_count_question.legacyQuery({
+          useStructuredQuery: true,
+        });
         expect(query instanceof NativeQuery).toBe(true);
       });
     });
     describe("setQuery(query)", () => {
       it("updates the dataset_query of card", () => {
-        const rawQuery = native_orders_count_question.legacyQuery();
+        const rawQuery = native_orders_count_question.legacyQuery({
+          useStructuredQuery: true,
+        });
         const newRawQuestion = orders_raw_question.setLegacyQuery(rawQuery);
-        expect(newRawQuestion.legacyQuery() instanceof NativeQuery).toBe(true);
+        expect(
+          newRawQuestion.legacyQuery({ useStructuredQuery: true }) instanceof
+            NativeQuery,
+        ).toBe(true);
       });
     });
     describe("setDatasetQuery(datasetQuery)", () => {
@@ -366,7 +379,10 @@ describe("Question", () => {
           native_orders_count_question.datasetQuery(),
         );
 
-        expect(rawQuestion.legacyQuery() instanceof NativeQuery).toBe(true);
+        expect(
+          rawQuestion.legacyQuery({ useStructuredQuery: true }) instanceof
+            NativeQuery,
+        ).toBe(true);
       });
     });
   });
@@ -557,7 +573,7 @@ describe("Question", () => {
       it("returns the correct query for a summarization of a raw data table", () => {
         const summarizedQuestion = orders_raw_question.aggregate(["count"]);
         expect(summarizedQuestion.canRun()).toBe(true);
-        // if I actually call the .legacyQuery() method below, this blows up garbage collection =/
+        // if I actually call the .legacyQuery({ useStructuredQuery: true })  method below, this blows up garbage collection =/
         expect(summarizedQuestion.datasetQuery()).toEqual(
           orders_count_card.dataset_query,
         );

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
@@ -19,18 +19,16 @@ const ordersTable = metadata.table(ORDERS_ID);
 describe("StructuredQuery", () => {
   describe("clean", () => {
     it("should not return a new instance of the same query", () => {
-      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
+      const q = ordersTable.legacyQuery();
       expect(q.clean() === q).toBe(true);
     });
 
     describe("filters", () => {
       it("should not remove filter referencing valid field ID", () => {
         const q = ordersTable
-          .legacyQuery({ useStructuredQuery: true })
+          .legacyQuery()
           .filter(["=", ["field", ORDERS.TOTAL, null], 42]);
-        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-          q.legacyQuery({ useStructuredQuery: true }),
-        );
+        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
         expect(q.clean() === q).toBe(true);
       });
     });
@@ -38,21 +36,15 @@ describe("StructuredQuery", () => {
     describe("aggregations", () => {
       describe("standard aggregations", () => {
         it("should not remove count", () => {
-          const q = ordersTable
-            .legacyQuery({ useStructuredQuery: true })
-            .aggregate(["count"]);
-          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-            q.legacyQuery({ useStructuredQuery: true }),
-          );
+          const q = ordersTable.legacyQuery().aggregate(["count"]);
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
         it("should not remove aggregation referencing valid field ID", () => {
           const q = ordersTable
-            .legacyQuery({ useStructuredQuery: true })
+            .legacyQuery()
             .aggregate(["avg", ["field", ORDERS.TOTAL, null]]);
-          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-            q.legacyQuery({ useStructuredQuery: true }),
-          );
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
       });
@@ -60,49 +52,37 @@ describe("StructuredQuery", () => {
       describe("named aggregations", () => {
         it("should not remove valid named aggregations", () => {
           const q = ordersTable
-            .legacyQuery({ useStructuredQuery: true })
+            .legacyQuery()
             .aggregate([
               "aggregation-options",
               ["count"],
               { "display-name": "foo" },
             ]);
-          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-            q.legacyQuery({ useStructuredQuery: true }),
-          );
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
       });
 
       describe("metric aggregations", () => {
         it("should not remove valid metrics", () => {
-          const q = ordersTable
-            .legacyQuery({ useStructuredQuery: true })
-            .aggregate(["metric", 1]);
-          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-            q.legacyQuery({ useStructuredQuery: true }),
-          );
+          const q = ordersTable.legacyQuery().aggregate(["metric", 1]);
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
       });
 
       describe("custom aggregations", () => {
         it("should not remove count + 1", () => {
-          const q = ordersTable
-            .legacyQuery({ useStructuredQuery: true })
-            .aggregate(["+", ["count"], 1]);
-          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-            q.legacyQuery({ useStructuredQuery: true }),
-          );
+          const q = ordersTable.legacyQuery().aggregate(["+", ["count"], 1]);
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
 
         it("should not remove custom aggregation referencing valid field ID", () => {
           const q = ordersTable
-            .legacyQuery({ useStructuredQuery: true })
+            .legacyQuery()
             .aggregate(["+", ["avg", ["field", ORDERS.TOTAL, null]], 1]);
-          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-            q.legacyQuery({ useStructuredQuery: true }),
-          );
+          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
           expect(q.clean() === q).toBe(true);
         });
       });
@@ -111,34 +91,28 @@ describe("StructuredQuery", () => {
     describe("breakouts", () => {
       it("should not remove breakout referencing valid field ID", () => {
         const q = ordersTable
-          .legacyQuery({ useStructuredQuery: true })
+          .legacyQuery()
           .breakout(["field", ORDERS.TOTAL, null]);
-        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-          q.legacyQuery({ useStructuredQuery: true }),
-        );
+        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
         expect(q.clean() === q).toBe(true);
       });
       it("should not remove breakout referencing valid expressions", () => {
         const q = ordersTable
-          .legacyQuery({ useStructuredQuery: true })
+          .legacyQuery()
           .addExpression("foo", ["field", ORDERS.TOTAL, null])
           .breakout(["expression", "foo"]);
-        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-          q.legacyQuery({ useStructuredQuery: true }),
-        );
+        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
         expect(q.clean() === q).toBe(true);
       });
       it("should not remove breakout referencing valid fk", () => {
         const q = ordersTable
-          .legacyQuery({ useStructuredQuery: true })
+          .legacyQuery()
           .breakout([
             "field",
             PRODUCTS.TITLE,
             { "source-field": ORDERS.PRODUCT_ID },
           ]);
-        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-          q.legacyQuery({ useStructuredQuery: true }),
-        );
+        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
         expect(q.clean() === q).toBe(true);
       });
     });
@@ -146,7 +120,7 @@ describe("StructuredQuery", () => {
     describe("nested", () => {
       it("shouldn't modify valid nested queries", () => {
         const q = ordersTable
-          .legacyQuery({ useStructuredQuery: true })
+          .legacyQuery()
           .aggregate(["count"])
           .breakout(["field", ORDERS.PRODUCT_ID, null])
           .nest()
@@ -155,22 +129,20 @@ describe("StructuredQuery", () => {
             ["field", "count", { "base-type": "type/Integer" }],
             42,
           ]);
-        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
-          q.legacyQuery({ useStructuredQuery: true }),
-        );
+        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
         expect(q.clean() === q).toBe(true);
       });
 
       it("should remove unnecessary layers of nesting via legacyQuery()", () => {
-        const q = ordersTable.legacyQuery({ useStructuredQuery: true }).nest();
-        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual({
+        const q = ordersTable.legacyQuery().nest();
+        expect(q.clean().legacyQuery()).toEqual({
           "source-table": ORDERS_ID,
         });
       });
 
       it("should remove unnecessary layers of nesting via question()", () => {
-        const q = ordersTable.legacyQuery({ useStructuredQuery: true }).nest();
-        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual({
+        const q = ordersTable.legacyQuery().nest();
+        expect(q.clean().legacyQuery()).toEqual({
           "source-table": ORDERS_ID,
         });
       });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-clean.unit.spec.js
@@ -19,16 +19,18 @@ const ordersTable = metadata.table(ORDERS_ID);
 describe("StructuredQuery", () => {
   describe("clean", () => {
     it("should not return a new instance of the same query", () => {
-      const q = ordersTable.legacyQuery();
+      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
       expect(q.clean() === q).toBe(true);
     });
 
     describe("filters", () => {
       it("should not remove filter referencing valid field ID", () => {
         const q = ordersTable
-          .legacyQuery()
+          .legacyQuery({ useStructuredQuery: true })
           .filter(["=", ["field", ORDERS.TOTAL, null], 42]);
-        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+          q.legacyQuery({ useStructuredQuery: true }),
+        );
         expect(q.clean() === q).toBe(true);
       });
     });
@@ -36,15 +38,21 @@ describe("StructuredQuery", () => {
     describe("aggregations", () => {
       describe("standard aggregations", () => {
         it("should not remove count", () => {
-          const q = ordersTable.legacyQuery().aggregate(["count"]);
-          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+          const q = ordersTable
+            .legacyQuery({ useStructuredQuery: true })
+            .aggregate(["count"]);
+          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+            q.legacyQuery({ useStructuredQuery: true }),
+          );
           expect(q.clean() === q).toBe(true);
         });
         it("should not remove aggregation referencing valid field ID", () => {
           const q = ordersTable
-            .legacyQuery()
+            .legacyQuery({ useStructuredQuery: true })
             .aggregate(["avg", ["field", ORDERS.TOTAL, null]]);
-          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+            q.legacyQuery({ useStructuredQuery: true }),
+          );
           expect(q.clean() === q).toBe(true);
         });
       });
@@ -52,37 +60,49 @@ describe("StructuredQuery", () => {
       describe("named aggregations", () => {
         it("should not remove valid named aggregations", () => {
           const q = ordersTable
-            .legacyQuery()
+            .legacyQuery({ useStructuredQuery: true })
             .aggregate([
               "aggregation-options",
               ["count"],
               { "display-name": "foo" },
             ]);
-          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+            q.legacyQuery({ useStructuredQuery: true }),
+          );
           expect(q.clean() === q).toBe(true);
         });
       });
 
       describe("metric aggregations", () => {
         it("should not remove valid metrics", () => {
-          const q = ordersTable.legacyQuery().aggregate(["metric", 1]);
-          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+          const q = ordersTable
+            .legacyQuery({ useStructuredQuery: true })
+            .aggregate(["metric", 1]);
+          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+            q.legacyQuery({ useStructuredQuery: true }),
+          );
           expect(q.clean() === q).toBe(true);
         });
       });
 
       describe("custom aggregations", () => {
         it("should not remove count + 1", () => {
-          const q = ordersTable.legacyQuery().aggregate(["+", ["count"], 1]);
-          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+          const q = ordersTable
+            .legacyQuery({ useStructuredQuery: true })
+            .aggregate(["+", ["count"], 1]);
+          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+            q.legacyQuery({ useStructuredQuery: true }),
+          );
           expect(q.clean() === q).toBe(true);
         });
 
         it("should not remove custom aggregation referencing valid field ID", () => {
           const q = ordersTable
-            .legacyQuery()
+            .legacyQuery({ useStructuredQuery: true })
             .aggregate(["+", ["avg", ["field", ORDERS.TOTAL, null]], 1]);
-          expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+          expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+            q.legacyQuery({ useStructuredQuery: true }),
+          );
           expect(q.clean() === q).toBe(true);
         });
       });
@@ -91,28 +111,34 @@ describe("StructuredQuery", () => {
     describe("breakouts", () => {
       it("should not remove breakout referencing valid field ID", () => {
         const q = ordersTable
-          .legacyQuery()
+          .legacyQuery({ useStructuredQuery: true })
           .breakout(["field", ORDERS.TOTAL, null]);
-        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+          q.legacyQuery({ useStructuredQuery: true }),
+        );
         expect(q.clean() === q).toBe(true);
       });
       it("should not remove breakout referencing valid expressions", () => {
         const q = ordersTable
-          .legacyQuery()
+          .legacyQuery({ useStructuredQuery: true })
           .addExpression("foo", ["field", ORDERS.TOTAL, null])
           .breakout(["expression", "foo"]);
-        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+          q.legacyQuery({ useStructuredQuery: true }),
+        );
         expect(q.clean() === q).toBe(true);
       });
       it("should not remove breakout referencing valid fk", () => {
         const q = ordersTable
-          .legacyQuery()
+          .legacyQuery({ useStructuredQuery: true })
           .breakout([
             "field",
             PRODUCTS.TITLE,
             { "source-field": ORDERS.PRODUCT_ID },
           ]);
-        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+          q.legacyQuery({ useStructuredQuery: true }),
+        );
         expect(q.clean() === q).toBe(true);
       });
     });
@@ -120,7 +146,7 @@ describe("StructuredQuery", () => {
     describe("nested", () => {
       it("shouldn't modify valid nested queries", () => {
         const q = ordersTable
-          .legacyQuery()
+          .legacyQuery({ useStructuredQuery: true })
           .aggregate(["count"])
           .breakout(["field", ORDERS.PRODUCT_ID, null])
           .nest()
@@ -129,31 +155,41 @@ describe("StructuredQuery", () => {
             ["field", "count", { "base-type": "type/Integer" }],
             42,
           ]);
-        expect(q.clean().legacyQuery()).toEqual(q.legacyQuery());
+        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual(
+          q.legacyQuery({ useStructuredQuery: true }),
+        );
         expect(q.clean() === q).toBe(true);
       });
 
       it("should remove unnecessary layers of nesting via legacyQuery()", () => {
-        const q = ordersTable.legacyQuery().nest();
-        expect(q.clean().legacyQuery()).toEqual({ "source-table": ORDERS_ID });
+        const q = ordersTable.legacyQuery({ useStructuredQuery: true }).nest();
+        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual({
+          "source-table": ORDERS_ID,
+        });
       });
 
       it("should remove unnecessary layers of nesting via question()", () => {
-        const q = ordersTable.legacyQuery().nest();
-        expect(q.clean().legacyQuery()).toEqual({ "source-table": ORDERS_ID });
+        const q = ordersTable.legacyQuery({ useStructuredQuery: true }).nest();
+        expect(q.clean().legacyQuery({ useStructuredQuery: true })).toEqual({
+          "source-table": ORDERS_ID,
+        });
       });
     });
   });
 
   describe("cleanNesting", () => {
     it("should not modify empty queries with no source-query", () => {
-      expect(db.question().legacyQuery().cleanNesting().datasetQuery()).toEqual(
-        {
-          type: "query",
-          database: SAMPLE_DB_ID,
-          query: { "source-table": undefined },
-        },
-      );
+      expect(
+        db
+          .question()
+          .legacyQuery({ useStructuredQuery: true })
+          .cleanNesting()
+          .datasetQuery(),
+      ).toEqual({
+        type: "query",
+        database: SAMPLE_DB_ID,
+        query: { "source-table": undefined },
+      });
     });
   });
 });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-filters.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-filters.unit.spec.js
@@ -18,44 +18,56 @@ const FILTER = ["=", ["field", ORDERS.TOTAL, null], 42];
 describe("StructuredQuery", () => {
   describe("hasFilters", () => {
     it("should return false for queries without filters", () => {
-      const q = ordersTable.legacyQuery();
+      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
       expect(q.hasFilters()).toBe(false);
     });
     it("should return true for queries with filters", () => {
-      const q = ordersTable.legacyQuery().filter(FILTER);
+      const q = ordersTable
+        .legacyQuery({ useStructuredQuery: true })
+        .filter(FILTER);
       expect(q.hasFilters()).toBe(true);
     });
   });
   describe("filters", () => {
     it("should work as raw MBQL", () => {
-      const q = ordersTable.legacyQuery().filter(FILTER);
+      const q = ordersTable
+        .legacyQuery({ useStructuredQuery: true })
+        .filter(FILTER);
       const f = q.filters()[0];
       expect(JSON.stringify(f)).toEqual(JSON.stringify(FILTER));
     });
     describe("dimension()", () => {
       it("should return the correct dimension", () => {
-        const q = ordersTable.legacyQuery().filter(FILTER);
+        const q = ordersTable
+          .legacyQuery({ useStructuredQuery: true })
+          .filter(FILTER);
         const f = q.filters()[0];
         expect(f.dimension().mbql()).toEqual(["field", ORDERS.TOTAL, null]);
       });
     });
     describe("field()", () => {
       it("should return the correct field", () => {
-        const q = ordersTable.legacyQuery().filter(FILTER);
+        const q = ordersTable
+          .legacyQuery({ useStructuredQuery: true })
+          .filter(FILTER);
         const f = q.filters()[0];
         expect(f.field().id).toEqual(ORDERS.TOTAL);
       });
     });
     describe("operator()", () => {
       it("should return the correct operator", () => {
-        const q = ordersTable.legacyQuery().filter(FILTER);
+        const q = ordersTable
+          .legacyQuery({ useStructuredQuery: true })
+          .filter(FILTER);
         const f = q.filters()[0];
         expect(f.operator().name).toEqual("=");
       });
     });
     describe("filterOperators", () => {
       it("should return the valid operators for number filter", () => {
-        const q = ordersTable.legacyQuery().filter(FILTER);
+        const q = ordersTable
+          .legacyQuery({ useStructuredQuery: true })
+          .filter(FILTER);
         const f = q.filters()[0];
         expect(f.filterOperators()).toHaveLength(9);
         expect(f.filterOperators()[0].name).toEqual("=");
@@ -63,13 +75,17 @@ describe("StructuredQuery", () => {
     });
     describe("isOperator", () => {
       it("should return true for the same operator", () => {
-        const q = ordersTable.legacyQuery().filter(FILTER);
+        const q = ordersTable
+          .legacyQuery({ useStructuredQuery: true })
+          .filter(FILTER);
         const f = q.filters()[0];
         expect(f.isOperator("=")).toBe(true);
         expect(f.isOperator(f.filterOperators()[0])).toBe(true);
       });
       it("should return false for different operators", () => {
-        const q = ordersTable.legacyQuery().filter(FILTER);
+        const q = ordersTable
+          .legacyQuery({ useStructuredQuery: true })
+          .filter(FILTER);
         const f = q.filters()[0];
         expect(f.isOperator("!=")).toBe(false);
         expect(f.isOperator(f.filterOperators()[1])).toBe(false);
@@ -77,7 +93,9 @@ describe("StructuredQuery", () => {
     });
     describe("isDimension", () => {
       it("should return true for the same dimension", () => {
-        const q = ordersTable.legacyQuery().filter(FILTER);
+        const q = ordersTable
+          .legacyQuery({ useStructuredQuery: true })
+          .filter(FILTER);
         const f = q.filters()[0];
         expect(f.isDimension(["field", ORDERS.TOTAL, null])).toBe(true);
         expect(
@@ -85,7 +103,9 @@ describe("StructuredQuery", () => {
         ).toBe(true);
       });
       it("should return false for different dimensions", () => {
-        const q = ordersTable.legacyQuery().filter(FILTER);
+        const q = ordersTable
+          .legacyQuery({ useStructuredQuery: true })
+          .filter(FILTER);
         const f = q.filters()[0];
         expect(f.isDimension(["field", PRODUCTS.TITLE, null])).toBe(false);
         expect(

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-joins.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-joins.unit.spec.js
@@ -14,7 +14,7 @@ const productsTable = metadata.table(PRODUCTS_ID);
 describe("StructuredQuery nesting", () => {
   describe("dimensionOptions", () => {
     it("should include joined table's fields", () => {
-      const q = productsTable.legacyQuery().join({
+      const q = productsTable.legacyQuery({ useStructuredQuery: true }).join({
         alias: "join0",
         "source-table": ORDERS_ID,
       });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-nesting.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-nesting.unit.spec.js
@@ -27,21 +27,23 @@ describe("StructuredQuery nesting", () => {
   describe("nest", () => {
     it("should nest correctly", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery();
-      expect(q.legacyQuery()).toEqual({ "source-table": ORDERS_ID });
-      expect(q.nest().legacyQuery()).toEqual({
+      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
+      expect(q.legacyQuery({ useStructuredQuery: true })).toEqual({
+        "source-table": ORDERS_ID,
+      });
+      expect(q.nest().legacyQuery({ useStructuredQuery: true })).toEqual({
         "source-query": { "source-table": ORDERS_ID },
       });
     });
 
     it("should be able to modify the outer question", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery();
+      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
       expect(
         q
           .nest()
           .filter(["=", ["field", ORDERS.TOTAL, null], 42])
-          .legacyQuery(),
+          .legacyQuery({ useStructuredQuery: true }),
       ).toEqual({
         "source-query": { "source-table": ORDERS_ID },
         filter: ["=", ["field", ORDERS.TOTAL, null], 42],
@@ -50,14 +52,14 @@ describe("StructuredQuery nesting", () => {
 
     it("should be able to modify the source question", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery();
+      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
       expect(
         q
           .nest()
           .sourceQuery()
           .filter(["=", ["field", ORDERS.TOTAL, null], 42])
           .parentQuery()
-          .legacyQuery(),
+          .legacyQuery({ useStructuredQuery: true }),
       ).toEqual({
         "source-query": {
           "source-table": ORDERS_ID,
@@ -69,7 +71,7 @@ describe("StructuredQuery nesting", () => {
     it("should return a table with correct dimensions", () => {
       const { ordersTable } = setup();
       const q = ordersTable
-        .legacyQuery()
+        .legacyQuery({ useStructuredQuery: true })
         .aggregate(["count"])
         .breakout(["field", ORDERS.PRODUCT_ID, null]);
       expect(
@@ -87,30 +89,43 @@ describe("StructuredQuery nesting", () => {
   describe("topLevelQuery", () => {
     it("should return the query if it's summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery();
-      expect(q.topLevelQuery().legacyQuery()).toEqual({
+      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
+      expect(
+        q.topLevelQuery().legacyQuery({ useStructuredQuery: true }),
+      ).toEqual({
         "source-table": ORDERS_ID,
       });
     });
     it("should return the query if it's not summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery().aggregate(["count"]);
-      expect(q.topLevelQuery().legacyQuery()).toEqual({
+      const q = ordersTable
+        .legacyQuery({ useStructuredQuery: true })
+        .aggregate(["count"]);
+      expect(
+        q.topLevelQuery().legacyQuery({ useStructuredQuery: true }),
+      ).toEqual({
         "source-table": ORDERS_ID,
         aggregation: [["count"]],
       });
     });
     it("should return last stage if none are summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery().nest();
-      expect(q.topLevelQuery().legacyQuery()).toEqual({
+      const q = ordersTable.legacyQuery({ useStructuredQuery: true }).nest();
+      expect(
+        q.topLevelQuery().legacyQuery({ useStructuredQuery: true }),
+      ).toEqual({
         "source-query": { "source-table": ORDERS_ID },
       });
     });
     it("should return last summarized stage if any is summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery().aggregate(["count"]).nest();
-      expect(q.topLevelQuery().legacyQuery()).toEqual({
+      const q = ordersTable
+        .legacyQuery({ useStructuredQuery: true })
+        .aggregate(["count"])
+        .nest();
+      expect(
+        q.topLevelQuery().legacyQuery({ useStructuredQuery: true }),
+      ).toEqual({
         "source-table": ORDERS_ID,
         aggregation: [["count"]],
       });
@@ -138,7 +153,9 @@ describe("StructuredQuery nesting", () => {
       const metadata = ordersTable.metadata;
       const question = ordersTable.question();
       const dataset = question.setId(1).setDataset(true);
-      const nestedDatasetQuery = dataset.composeDataset().legacyQuery();
+      const nestedDatasetQuery = dataset
+        .composeDataset()
+        .legacyQuery({ useStructuredQuery: true });
       expect(
         // get a list of all dimension options for the nested query
         nestedDatasetQuery

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-nesting.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-nesting.unit.spec.js
@@ -27,23 +27,23 @@ describe("StructuredQuery nesting", () => {
   describe("nest", () => {
     it("should nest correctly", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
-      expect(q.legacyQuery({ useStructuredQuery: true })).toEqual({
+      const q = ordersTable.legacyQuery();
+      expect(q.legacyQuery()).toEqual({
         "source-table": ORDERS_ID,
       });
-      expect(q.nest().legacyQuery({ useStructuredQuery: true })).toEqual({
+      expect(q.nest().legacyQuery()).toEqual({
         "source-query": { "source-table": ORDERS_ID },
       });
     });
 
     it("should be able to modify the outer question", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
+      const q = ordersTable.legacyQuery();
       expect(
         q
           .nest()
           .filter(["=", ["field", ORDERS.TOTAL, null], 42])
-          .legacyQuery({ useStructuredQuery: true }),
+          .legacyQuery(),
       ).toEqual({
         "source-query": { "source-table": ORDERS_ID },
         filter: ["=", ["field", ORDERS.TOTAL, null], 42],
@@ -52,14 +52,14 @@ describe("StructuredQuery nesting", () => {
 
     it("should be able to modify the source question", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
+      const q = ordersTable.legacyQuery();
       expect(
         q
           .nest()
           .sourceQuery()
           .filter(["=", ["field", ORDERS.TOTAL, null], 42])
           .parentQuery()
-          .legacyQuery({ useStructuredQuery: true }),
+          .legacyQuery(),
       ).toEqual({
         "source-query": {
           "source-table": ORDERS_ID,
@@ -71,7 +71,7 @@ describe("StructuredQuery nesting", () => {
     it("should return a table with correct dimensions", () => {
       const { ordersTable } = setup();
       const q = ordersTable
-        .legacyQuery({ useStructuredQuery: true })
+        .legacyQuery()
         .aggregate(["count"])
         .breakout(["field", ORDERS.PRODUCT_ID, null]);
       expect(
@@ -89,43 +89,30 @@ describe("StructuredQuery nesting", () => {
   describe("topLevelQuery", () => {
     it("should return the query if it's summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
-      expect(
-        q.topLevelQuery().legacyQuery({ useStructuredQuery: true }),
-      ).toEqual({
+      const q = ordersTable.legacyQuery();
+      expect(q.topLevelQuery().legacyQuery()).toEqual({
         "source-table": ORDERS_ID,
       });
     });
     it("should return the query if it's not summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable
-        .legacyQuery({ useStructuredQuery: true })
-        .aggregate(["count"]);
-      expect(
-        q.topLevelQuery().legacyQuery({ useStructuredQuery: true }),
-      ).toEqual({
+      const q = ordersTable.legacyQuery().aggregate(["count"]);
+      expect(q.topLevelQuery().legacyQuery()).toEqual({
         "source-table": ORDERS_ID,
         aggregation: [["count"]],
       });
     });
     it("should return last stage if none are summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable.legacyQuery({ useStructuredQuery: true }).nest();
-      expect(
-        q.topLevelQuery().legacyQuery({ useStructuredQuery: true }),
-      ).toEqual({
+      const q = ordersTable.legacyQuery().nest();
+      expect(q.topLevelQuery().legacyQuery()).toEqual({
         "source-query": { "source-table": ORDERS_ID },
       });
     });
     it("should return last summarized stage if any is summarized", () => {
       const { ordersTable } = setup();
-      const q = ordersTable
-        .legacyQuery({ useStructuredQuery: true })
-        .aggregate(["count"])
-        .nest();
-      expect(
-        q.topLevelQuery().legacyQuery({ useStructuredQuery: true }),
-      ).toEqual({
+      const q = ordersTable.legacyQuery().aggregate(["count"]).nest();
+      expect(q.topLevelQuery().legacyQuery()).toEqual({
         "source-table": ORDERS_ID,
         aggregation: [["count"]],
       });

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -115,7 +115,9 @@ function makeQueryWithoutNumericFields() {
     ],
   });
 
-  return new Question(questionDetail, metadata).legacyQuery();
+  return new Question(questionDetail, metadata).legacyQuery({
+    useStructuredQuery: true,
+  });
 }
 
 // no numeric fields, but have linked table (FK) with a numeric field
@@ -172,7 +174,9 @@ function makeQueryWithLinkedTable() {
     ],
   });
 
-  return new Question(questionDetail, metadata).legacyQuery();
+  return new Question(questionDetail, metadata).legacyQuery({
+    useStructuredQuery: true,
+  });
 }
 
 const getShortName = aggregation => aggregation.short;
@@ -296,7 +300,9 @@ describe("StructuredQuery", () => {
     });
     describe("query", () => {
       it("returns the wrapper for the query dictionary", () => {
-        expect(query.legacyQuery()["source-table"]).toBe(ORDERS_ID);
+        expect(
+          query.legacyQuery({ useStructuredQuery: true })["source-table"],
+        ).toBe(ORDERS_ID);
       });
     });
     describe("setDatabase", () => {
@@ -433,7 +439,9 @@ describe("StructuredQuery", () => {
 
     describe("addAggregation", () => {
       it("adds an aggregation", () => {
-        expect(query.aggregate(["count"]).legacyQuery()).toEqual({
+        expect(
+          query.aggregate(["count"]).legacyQuery({ useStructuredQuery: true }),
+        ).toEqual({
           "source-table": ORDERS_ID,
           aggregation: [["count"]],
         });

--- a/frontend/test/metabase-lib/lib/queries/structured/Aggregation.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Aggregation.unit.spec.js
@@ -18,7 +18,9 @@ const metadata = createMockMetadata({
   metrics: [TOTAL_ORDER_VALUE_METRIC],
 });
 
-const query = metadata.table(ORDERS_ID).legacyQuery();
+const query = metadata
+  .table(ORDERS_ID)
+  .legacyQuery({ useStructuredQuery: true });
 
 function aggregationForMBQL(mbql) {
   return new Aggregation(mbql, 0, query);

--- a/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/structured/Filter.unit.spec.js
@@ -16,7 +16,7 @@ const metadata = createMockMetadata({
 
 const ordersTable = metadata.table(ORDERS_ID);
 
-const query = ordersTable.legacyQuery();
+const query = ordersTable.legacyQuery({ useStructuredQuery: true });
 
 function filter(mbql) {
   return new Filter(mbql, 0, query);
@@ -187,7 +187,7 @@ describe("Filter", () => {
       ).toEqual([null, ["field", ORDERS.TOTAL, null]]);
     });
     it("should set joined-field for new filter clause", () => {
-      const q = ordersTable.legacyQuery().join({
+      const q = ordersTable.legacyQuery({ useStructuredQuery: true }).join({
         alias: "foo",
         "source-table": PEOPLE_ID,
       });

--- a/frontend/test/metabase/lib/dataset.unit.spec.js
+++ b/frontend/test/metabase/lib/dataset.unit.spec.js
@@ -40,7 +40,7 @@ describe("metabase/util/dataset", () => {
         });
 
       const newQuestion = prevQuestion
-        .legacyQuery()
+        .legacyQuery({ useStructuredQuery: true })
         .aggregate(["sum", ["field", PRODUCTS.PRICE, null]])
         .question()
         .syncColumnsAndSettings(prevQuestion);
@@ -63,7 +63,7 @@ describe("metabase/util/dataset", () => {
         });
 
       const newQuestion = prevQuestion
-        .legacyQuery()
+        .legacyQuery({ useStructuredQuery: true })
         .removeAggregation(1)
         .question()
         .syncColumnsAndSettings(prevQuestion);
@@ -83,7 +83,7 @@ describe("metabase/util/dataset", () => {
         });
 
       const newQuestion = prevQuestion
-        .legacyQuery()
+        .legacyQuery({ useStructuredQuery: true })
         .breakout(["field", PRODUCTS.VENDOR, null])
         .question()
         .syncColumnsAndSettings(prevQuestion);
@@ -92,7 +92,9 @@ describe("metabase/util/dataset", () => {
         "count",
         "sum",
       ]);
-      expect(newQuestion.legacyQuery().columns()).toHaveLength(4);
+      expect(
+        newQuestion.legacyQuery({ useStructuredQuery: true }).columns(),
+      ).toHaveLength(4);
     });
 
     it("removes columns from table.columns when a column is removed from a query", () => {
@@ -126,7 +128,7 @@ describe("metabase/util/dataset", () => {
         });
 
       const newQuestion = prevQuestion
-        .legacyQuery()
+        .legacyQuery({ useStructuredQuery: true })
         .removeField(2)
         .question()
         .syncColumnsAndSettings(prevQuestion);
@@ -162,7 +164,7 @@ describe("metabase/util/dataset", () => {
         });
 
       const newQuestion = prevQuestion
-        .legacyQuery()
+        .legacyQuery({ useStructuredQuery: true })
         .addField(["field", PRODUCTS.VENDOR, null])
         .question()
         .syncColumnsAndSettings(prevQuestion);


### PR DESCRIPTION
Currently it's hard to track `StructuredQuery` usage via `legacyQuery` because it could be `NativeQuery` and we don't migrate it to MLv2 now. The idea is to require `useStructuredQuery` flag in `legacyQuery` call:
```
legacyQuery({ useStructuredQuery: true })
```
otherwise it would throw an exception. If this approach gets approved I'll add `useStructuredQuery` to all places where `legacyQuery` is called, and we can migrate them one by one.
 