### PR TITLE
fix serialization when there is a slash in click_behavior id

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/once metabase-enterprise.serialization.v2.extract-test
   (:require
+   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -1496,14 +1497,23 @@
                                       clickdash-eid :entity_id} {:name          "Dashboard with click behavior"
                                                                  :collection_id coll5-id
                                                                  :creator_id    mark-id}
-                       DashboardCard _                          {:card_id c3-1-id
+                       DashboardCard _                          {:card_id      c3-1-id
                                                                  :dashboard_id clickdash-id
                                                                  :visualization_settings
                                                                  ;; Top-level click behavior for the card.
-                                                                 {:click_behavior {:type "link"
-                                                                                   :linkType "question"
-                                                                                   :targetId c3-2-id
-                                                                                   :parameterMappings {}}}}
+                                                                 (let [dimension  [:dimension [:field "something" {:base-type "type/Text"}]]
+                                                                       mapping-id (json/generate-string dimension)]
+                                                                   {:click_behavior {:type     "link"
+                                                                                     :linkType "question"
+                                                                                     :targetId c3-2-id
+                                                                                     :parameterMapping
+                                                                                     {mapping-id {:id     mapping-id
+                                                                                                  :source {:type "column"
+                                                                                                           :id   "whatever"
+                                                                                                           :name "Just to serialize"}
+                                                                                                  :target {:type      "dimension"
+                                                                                                           :id        mapping-id
+                                                                                                           :dimension dimension}}}}})}
                        ;;; stress-test that exporting various visualization_settings does not break
                        DashboardCard _                          {:card_id c3-1-id
                                                                  :dashboard_id clickdash-id

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1223,7 +1223,9 @@
   ported by [[export-viz-click-behavior-mapping]]."
   [mappings]
   (into {} (for [[kw-key mapping] mappings
-                 :let [k (name kw-key)]]
+                 :let [k (if (namespace kw-key)
+                           (str (namespace kw-key) "/" (name kw-key))
+                           (name kw-key))]]
              (if (mb.viz/dimension-param-mapping? mapping)
                [(json-ids->fully-qualified-names k)
                 (export-viz-click-behavior-mapping mapping)]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1223,9 +1223,7 @@
   ported by [[export-viz-click-behavior-mapping]]."
   [mappings]
   (into {} (for [[kw-key mapping] mappings
-                 :let [k (if (namespace kw-key)
-                           (str (namespace kw-key) "/" (name kw-key))
-                           (name kw-key))]]
+                 :let [k (u/qualified-name kw-key)]]
              (if (mb.viz/dimension-param-mapping? mapping)
                [(json-ids->fully-qualified-names k)
                 (export-viz-click-behavior-mapping mapping)]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1218,7 +1218,7 @@
       (m/update-existing-in [:target :dimension] mbql-fully-qualified-names->ids)))
 
 (defn- export-viz-click-behavior-mappings
-  "The `:parameterMappings` on a `:click_behavior` viz settings is a map of... IDs turned into JSON strings which have
+  "The `:parameterMapping` on a `:click_behavior` viz settings is a map of... IDs turned into JSON strings which have
   been keywordized. Therefore the keys must be converted to strings, parsed, exported, and JSONified. The values are
   ported by [[export-viz-click-behavior-mapping]]."
   [mappings]
@@ -1230,7 +1230,7 @@
                [k mapping]))))
 
 (defn- import-viz-click-behavior-mappings
-  "The exported form of `:parameterMappings` on a `:click_behavior` viz settings is a map of JSON strings which contain
+  "The exported form of `:parameterMapping` on a `:click_behavior` viz settings is a map of JSON strings which contain
   fully qualified names. These must be parsed, imported, JSONified and then turned back into keywords, since that's the
   form used internally."
   [mappings]

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -1223,6 +1223,9 @@
   ported by [[export-viz-click-behavior-mapping]]."
   [mappings]
   (into {} (for [[kw-key mapping] mappings
+                 ;; Mapping keyword shouldn't been a keyword in the first place, it's just how it's processed after
+                 ;; being selected from db. In an ideal world we'd either have different data layout for
+                 ;; click_behavior or not convert it's keys to a keywords. We need its full content here.
                  :let [k (u/qualified-name kw-key)]]
              (if (mb.viz/dimension-param-mapping? mapping)
                [(json-ids->fully-qualified-names k)


### PR DESCRIPTION
An escalation from @Tony-metabase - when a click_behavior id is something like `[:dimension [:field "something" {:base-type "type/Text"}]]`, going through keyword and back is a little bit tricky. Would be nice to stop keywordizing `click_behavior` keys, but that's a much harder problem to solve.

Resolves #37555