### PR TITLE
Add TypeScript wrappers around native CLJS functions

### DIFF
--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -28,6 +28,13 @@ export function templateTags(query: Query): string {
   return ML.template_tags(query);
 }
 
+export function extractTemplateTags(
+  queryText: string,
+  existingTags?: string,
+): string | null {
+  return ML.extract_template_tags(queryText, existingTags);
+}
+
 /**
  * Returns the extra keys that are required for this database's native queries, for example `:collection` name is
  *  needed for MongoDB queries.

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -31,7 +31,7 @@ export function templateTags(query: Query): TemplateTags {
 export function extractTemplateTags(
   queryText: string,
   existingTags?: TemplateTags,
-): TemplateTags | Record<string, never> {
+): TemplateTags {
   return ML.extract_template_tags(queryText, existingTags);
 }
 

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -47,6 +47,10 @@ export function withDifferentDatabase(
   return ML.with_different_database(query, databaseId, metadata);
 }
 
+export function engine(query: Query): string {
+  return ML.engine(query);
+}
+
 /**
  * Returns the extra keys that are required for this database's native queries, for example `:collection` name is
  *  needed for MongoDB queries.

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -12,6 +12,10 @@ export function nativeQuery(
   return ML.native_query(databaseId, metadata, innerQuery);
 }
 
+export function rawNativeQuery(query: Query): string {
+  return ML.raw_native_query(query);
+}
+
 /**
  * Returns the extra keys that are required for this database's native queries, for example `:collection` name is
  *  needed for MongoDB queries.

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -39,6 +39,14 @@ export function hasWritePermission(query: Query): boolean {
   return ML.has_write_permission(query);
 }
 
+export function withDifferentDatabase(
+  query: Query,
+  databaseId: DatabaseId,
+  metadata: MetadataProvider,
+): unknown {
+  return ML.with_different_database(query, databaseId, metadata);
+}
+
 /**
  * Returns the extra keys that are required for this database's native queries, for example `:collection` name is
  *  needed for MongoDB queries.

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -1,6 +1,6 @@
 import * as ML from "cljs/metabase.lib.js";
 
-import type { DatabaseId } from "metabase-types/api";
+import type { DatabaseId, TemplateTags } from "metabase-types/api";
 
 import type { MetadataProvider, Query } from "./types";
 
@@ -20,18 +20,18 @@ export function withNativeQuery(query: Query, innerQuery: string): Query {
   return ML.with_native_query(query, innerQuery);
 }
 
-export function withTemplateTags(query: Query, tags: string[]): Query {
+export function withTemplateTags(query: Query, tags: TemplateTags): Query {
   return ML.with_template_tags(query, tags);
 }
 
-export function templateTags(query: Query): string {
+export function templateTags(query: Query): TemplateTags {
   return ML.template_tags(query);
 }
 
 export function extractTemplateTags(
   queryText: string,
-  existingTags?: string,
-): string | null {
+  existingTags?: TemplateTags,
+): TemplateTags | Record<string, never> {
   return ML.extract_template_tags(queryText, existingTags);
 }
 
@@ -43,7 +43,7 @@ export function withDifferentDatabase(
   query: Query,
   databaseId: DatabaseId,
   metadata: MetadataProvider,
-): unknown {
+): Query {
   return ML.with_different_database(query, databaseId, metadata);
 }
 

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -20,6 +20,10 @@ export function withNativeQuery(query: Query, innerQuery: string): Query {
   return ML.with_native_query(query, innerQuery);
 }
 
+export function withTemplateTags(query: Query, tags: string[]): Query {
+  return ML.with_template_tags(query, tags);
+}
+
 /**
  * Returns the extra keys that are required for this database's native queries, for example `:collection` name is
  *  needed for MongoDB queries.

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -35,6 +35,10 @@ export function extractTemplateTags(
   return ML.extract_template_tags(queryText, existingTags);
 }
 
+export function hasWritePermission(query: Query): boolean {
+  return ML.has_write_permission(query);
+}
+
 /**
  * Returns the extra keys that are required for this database's native queries, for example `:collection` name is
  *  needed for MongoDB queries.

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -24,6 +24,10 @@ export function withTemplateTags(query: Query, tags: string[]): Query {
   return ML.with_template_tags(query, tags);
 }
 
+export function templateTags(query: Query): string {
+  return ML.template_tags(query);
+}
+
 /**
  * Returns the extra keys that are required for this database's native queries, for example `:collection` name is
  *  needed for MongoDB queries.

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -4,6 +4,14 @@ import type { DatabaseId } from "metabase-types/api";
 
 import type { MetadataProvider, Query } from "./types";
 
+export function nativeQuery(
+  databaseId: DatabaseId,
+  metadata: MetadataProvider,
+  innerQuery: string,
+): Query {
+  return ML.native_query(databaseId, metadata, innerQuery);
+}
+
 /**
  * Returns the extra keys that are required for this database's native queries, for example `:collection` name is
  *  needed for MongoDB queries.

--- a/frontend/src/metabase-lib/native.ts
+++ b/frontend/src/metabase-lib/native.ts
@@ -16,6 +16,10 @@ export function rawNativeQuery(query: Query): string {
   return ML.raw_native_query(query);
 }
 
+export function withNativeQuery(query: Query, innerQuery: string): Query {
+  return ML.with_native_query(query, innerQuery);
+}
+
 /**
  * Returns the extra keys that are required for this database's native queries, for example `:collection` name is
  *  needed for MongoDB queries.

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { assoc, assocIn, chain, getIn, updateIn } from "icepick";
 import _ from "underscore";
 import slugg from "slugg";
-import * as ML from "cljs/metabase.lib.js";
+import * as Lib from "metabase-lib";
 import type {
   Card,
   DatabaseId,
@@ -431,7 +431,7 @@ export default class NativeQuery extends AtomicQuery {
    */
   private _getUpdatedTemplateTags(queryText: string): TemplateTags {
     return queryText && this.supportsNativeParameters()
-      ? ML.extract_template_tags(queryText, this.templateTagsMap())
+      ? Lib.extractTemplateTags(queryText, this.templateTagsMap())
       : {};
   }
 


### PR DESCRIPTION
This PR adds the remaining TS wrappers for the native CLJS functions that are registered in `core.cljc`
For the full list, please see #37504 

It also [replaces the direct usage of a ML function with a new wrapper](https://github.com/metabase/metabase/pull/37518/commits/ab624f6517f7416391d55381e78abfd9592eaa0b).

### Hint (from something I learned today)
To compare the types, check the assigned Malli schemas in https://github.com/metabase/metabase/blob/master/src/metabase/lib/native.cljc

Resolves #37504.

---
### Outstanding questions
- Should I add some thing layer of unit tests around these wrappers before merging this PR? cc @metabase/querying-components 