### PR TITLE
Add validation for remaining setting types

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1379,8 +1379,8 @@
     :positive-integer true
     :timestamp true
 
-    (do (log/warn "Redaction criteria not defined for type and obtain an exception of type" (:type setting) (type ex))
-        true)))
+    ;; fallback to redaction if we have not defined behaviour for a given format
+    true))
 
 (defn- redact-sensitive-tokens [ex raw-value]
   (if (may-contain-raw-token? ex raw-value)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1371,6 +1371,8 @@
                 ;; err on the side of caution
                 true))
 
+    :csv (not (instance? java.io.EOFException ex))
+
     ;; TODO: handle the remaining formats explicitly
     true))
 
@@ -1403,7 +1405,7 @@
   (doseq [invalid-setting (keep validate-setting (vals @registered-settings))]
     (if (:env-var? invalid-setting)
       (throw (ex-info (trs "Invalid {0} configuration for setting: {1}"
-                           #_:clj-kondo/ignore (str/upper-case (name (:type invalid-setting)))
+                           (u/upper-case-en (name (:type invalid-setting)))
                            (name (:name invalid-setting)))
                       (dissoc invalid-setting :parse-error)
                       (:parse-error invalid-setting)))

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1374,9 +1374,16 @@
   (symbol "metabase.models.setting-test" (name (validation-setting-symbol format))))
 
 (deftest validation-completeness-test
-  (testing "Every settings format has tests for its validation"
-    (let [string-formats #{:string :metabase.public-settings/uuid-nonce}]
-      (doseq [format (remove string-formats (keys (methods setting/get-value-of-type)))]
+  (let [string-formats #{:string :metabase.public-settings/uuid-nonce}
+        formats-to-check (remove string-formats (keys (methods setting/get-value-of-type)))]
+
+    (testing "Every settings format has its redaction predicate defined"
+      (doseq [format formats-to-check]
+        (testing (format "We have defined a redaction multimethod for the %s format" format)
+          (is (some? (format (methods setting/may-contain-raw-token?)))))))
+
+    (testing "Every settings format has tests for its validation"
+      (doseq [format formats-to-check]
         ;; We operate on trust that tests are added along with this var
         (testing (format "We have defined a setting for the %s validation tests" format)
           (is (var? (resolve (ns-validation-setting-symbol format)))))))))

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1295,7 +1295,6 @@
              " (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1])\n"
              " at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 23]")))))
 
-
 (deftest valid-csv-setting-test
   (testing "Validation is a no-op if the CSV is valid"
     (is (nil? (get-csv-parse-exception "1, 2")))))


### PR DESCRIPTION
### Description

This extends https://github.com/metabase/metabase/pull/37313 to cover the rest of the settings formats, other than `:string`.
