### PR TITLE
Add :link to Lato Font for the Dashboard Subscription Preview endpoint

### DIFF
--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -290,8 +290,12 @@
    :headers {"Content-Type" "text/html"}
    :body    (preview/style-tag-from-inline-styles
              (html5
-                 [:body [:h2 (format "Backend Artifacts Preview for Dashboard %s" id)]
-                  (preview/render-dashboard-to-html id)]))})
+               [:head
+                [:link {:nonce "%NONCE%" ;; this will be str/replaced by 'style-tag-nonce-middleware
+                        :rel  "stylesheet"
+                        :href "https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"}]]
+               [:body [:h2 (format "Backend Artifacts Preview for Dashboard %s" id)]
+                (preview/render-dashboard-to-html id)]))})
 
 (api/defendpoint GET "/preview_card_info/:id"
   "Get JSON object containing HTML rendering of a Card with `id` and other information."


### PR DESCRIPTION
@kulyk noticed that the Lato font wasn't being used by the preview. This adds the link to the Google Font.