### PR TITLE
Updating honeysql alias in dev ns (#36758)

### DIFF
--- a/dev/src/dev.clj
+++ b/dev/src/dev.clj
@@ -40,7 +40,7 @@
    [dev.debug-qp :as debug-qp]
    [dev.model-tracking :as model-tracking]
    [dev.explain :as dev.explain]
-   [honeysql.core :as hsql]
+   [honey.sql :as sql]
    [malli.dev :as malli-dev]
    [metabase.api.common :as api]
    [metabase.config :as config]
@@ -201,7 +201,7 @@
   [driver-or-driver+dataset sql-args]
   (let [[driver dataset] (u/one-or-many driver-or-driver+dataset)
         [sql & params]   (if (map? sql-args)
-                           (hsql/format sql-args)
+                           (sql/format sql-args)
                            (u/one-or-many sql-args))
         canceled-chan    (a/promise-chan)]
     (try


### PR DESCRIPTION
* Updating honeysql alias in dev ns

This just fixes a broken require to align with the work in #36670.

Fixes #36757

(cherry picked from commit b4408e033fae30ea08e53037d73ad1dcac45f4dd)