### PR TITLE
Use new docs url for quickstart link

### DIFF
--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
@@ -72,12 +72,15 @@ describe("[OSS] embedding settings", () => {
 
       it("should link to quickstart for interactive embedding", async () => {
         await setupEmbedding({
-          settingValues: { "enable-embedding": false },
+          settingValues: {
+            "enable-embedding": false,
+            version: { tag: "v0.49.3" },
+          },
         });
         expect(getQuickStartLink()).toBeInTheDocument();
         expect(getQuickStartLink()).toHaveProperty(
           "href",
-          "https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html?utm_source=oss&utm_media=embed-settings",
+          "https://www.metabase.com/docs/v0.49/embedding/interactive-embedding-quick-start-guide.html?utm_source=oss&utm_media=embed-settings",
         );
       });
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
@@ -77,7 +77,7 @@ describe("[OSS] embedding settings", () => {
         expect(getQuickStartLink()).toBeInTheDocument();
         expect(getQuickStartLink()).toHaveProperty(
           "href",
-          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=oss&utm_media=embed-settings",
+          "https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html?utm_source=oss&utm_media=embed-settings",
         );
       });
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
@@ -81,12 +81,15 @@ describe("[EE, no token] embedding settings", () => {
 
       it("should link to quickstart for interactive embedding", async () => {
         await setupEnterprise({
-          settingValues: { "enable-embedding": false },
+          settingValues: {
+            "enable-embedding": false,
+            version: { tag: "v1.49.3" },
+          },
         });
         expect(getQuickStartLink()).toBeInTheDocument();
         expect(getQuickStartLink()).toHaveProperty(
           "href",
-          "https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html?utm_source=oss&utm_media=embed-settings",
+          "https://www.metabase.com/docs/v0.49/embedding/interactive-embedding-quick-start-guide.html?utm_source=oss&utm_media=embed-settings",
         );
       });
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
@@ -86,7 +86,7 @@ describe("[EE, no token] embedding settings", () => {
         expect(getQuickStartLink()).toBeInTheDocument();
         expect(getQuickStartLink()).toHaveProperty(
           "href",
-          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=oss&utm_media=embed-settings",
+          "https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html?utm_source=oss&utm_media=embed-settings",
         );
       });
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -67,12 +67,15 @@ describe("[EE, with token] embedding settings", () => {
 
       it("should link to quickstart for interactive embedding", async () => {
         await setupPremium({
-          settingValues: { "enable-embedding": false },
+          settingValues: {
+            "enable-embedding": false,
+            version: { tag: "v1.49.3" },
+          },
         });
         expect(getQuickStartLink()).toBeInTheDocument();
         expect(getQuickStartLink()).toHaveProperty(
           "href",
-          "https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html?utm_source=pro-self-hosted&utm_media=embed-settings",
+          "https://www.metabase.com/docs/v0.49/embedding/interactive-embedding-quick-start-guide.html?utm_source=pro-self-hosted&utm_media=embed-settings",
         );
       });
     });

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -72,7 +72,7 @@ describe("[EE, with token] embedding settings", () => {
         expect(getQuickStartLink()).toBeInTheDocument();
         expect(getQuickStartLink()).toHaveProperty(
           "href",
-          "https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=pro-self-hosted&utm_media=embed-settings",
+          "https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html?utm_source=pro-self-hosted&utm_media=embed-settings",
         );
       });
     });

--- a/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/EmbeddingOption.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/EmbeddingOption/EmbeddingOption.tsx
@@ -3,7 +3,11 @@ import { jt, t } from "ttag";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_EMBEDDING } from "metabase/plugins";
-import { getSetting, getUpgradeUrl } from "metabase/selectors/settings";
+import {
+  getDocsUrlForVersion,
+  getSetting,
+  getUpgradeUrl,
+} from "metabase/selectors/settings";
 import type { ButtonProps } from "metabase/ui";
 import { Button, Flex, Text, Title } from "metabase/ui";
 import { getPlan } from "metabase/common/utils/plan";
@@ -86,6 +90,12 @@ export const InteractiveEmbeddingOptionCard = () => {
     getPlan(getSetting(state, "token-features")),
   );
   const enabled = useSelector(state => getSetting(state, "enable-embedding"));
+  const quickStartUrl = useSelector(state =>
+    getDocsUrlForVersion(
+      getSetting(state, "version"),
+      "embedding/interactive-embedding-quick-start-guide",
+    ),
+  );
 
   return (
     <EmbeddingOption
@@ -108,7 +118,7 @@ export const InteractiveEmbeddingOptionCard = () => {
       )} and people want to create their own questions, dashboards, models, and more, all in their own data sandbox.`}
     >
       <BoldExternalLink
-        href={`https://www.metabase.com/learn/customer-facing-analytics/interactive-embedding-quick-start?utm_source=${plan}&utm_media=embed-settings`}
+        href={`${quickStartUrl}?utm_source=${plan}&utm_media=embed-settings`}
       >
         {t`Check out our Quick Start`}
       </BoldExternalLink>


### PR DESCRIPTION
Part of [[Epic]Embedding settings cleanup and surface interactive embedding Quickstart ](https://github.com/metabase/metabase/issues/36481)

### Description

This PR updates the url as per

https://github.com/metabase/metabase/pull/37430#discussion_r1447576262
> The Quickstart has since moved.
> There is a redirect in place, so in theory there is nothing wrong, but I prefer we link to the correct URL now.

I'm using the util `getUpgradeUrl` to create the new url, the util appends `.html` to the end of the link.

I'm 60/40 if the tests should use a specific version or should just use the default version and end up with `/latest/` urls.
The util is already tested [here](https://github.com/metabase/metabase/blob/ec30700ac7821dfcd02a75008a50d87a8a377ce2/frontend/test/metabase/lib/settings.unit.spec.js#L13), and I've seen other tests that don't specify a version and just test for `/latest/` urls.
I have a slight preference for the actual versions used in test, but I split the changes in two commits so we can revert the tests to check for `/latest` if you prefer that


### Checklist

- [x] Tests have been added/updated to cover changes in this PR

