### PR TITLE
Fixing case of invalid graph.dimension (#37279)

### DIFF
--- a/src/metabase/util/ui_logic.clj
+++ b/src/metabase/util/ui_logic.clj
@@ -91,7 +91,7 @@
   [card results]
   (let [metrics     (some-> card
                             (get-in [:visualization_settings :graph.metrics]))
-        col-indices (map #(column-name->index % results) metrics)]
+        col-indices (keep #(column-name->index % results) metrics)]
     (when (seq col-indices)
       (fn [row]
         (let [res (vec (for [idx col-indices]
@@ -106,7 +106,7 @@
   [card results]
   (let [dimensions  (some-> card
                             (get-in [:visualization_settings :graph.dimensions]))
-        col-indices (map #(column-name->index % results) dimensions)]
+        col-indices (keep #(column-name->index % results) dimensions)]
     (when (seq col-indices)
       (fn [row]
         (let [res (vec (for [idx col-indices]

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -9,7 +9,9 @@
    [metabase.pulse.render.body :as body]
    [metabase.pulse.render.common :as common]
    [metabase.pulse.render.test-util :as render.tu]
-   [metabase.test :as mt]))
+   [metabase.query-processor :as qp]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
 
 (use-fixtures :each
   (fn warn-possible-rebuild
@@ -41,7 +43,7 @@
     :semantic_type   nil
     :visibility_type :normal}])
 
-(def ^:private test-data
+(def ^:private example-test-data
   [[1 34.0996 "2014-04-01T08:30:00.0000" "Stout Burgers & Beers"]
    [2 34.0406 "2014-12-05T15:15:00.0000" "The Apple Pan"]
    [3 34.0474 "2014-08-01T12:45:00.0000" "The Gorbals"]])
@@ -91,29 +93,29 @@
 ;; Testing the format of headers
 (deftest header-result
   (is (= default-header-result
-         (prep-for-html-rendering' test-columns test-data nil nil nil))))
+         (prep-for-html-rendering' test-columns example-test-data nil nil nil))))
 
 (deftest header-result-2
   (let [cols-with-desc (conj test-columns description-col)
-        data-with-desc (mapv #(conj % "Desc") test-data)]
+        data-with-desc (mapv #(conj % "Desc") example-test-data)]
     (is (= default-header-result
            (prep-for-html-rendering' cols-with-desc data-with-desc nil nil nil)))))
 
 (deftest header-result-3
   (let [cols-with-details (conj test-columns detail-col)
-        data-with-details (mapv #(conj % "Details") test-data)]
+        data-with-details (mapv #(conj % "Details") example-test-data)]
     (is (= default-header-result
            (prep-for-html-rendering' cols-with-details data-with-details nil nil nil)))))
 
 (deftest header-result-4
   (let [cols-with-sensitive (conj test-columns sensitive-col)
-        data-with-sensitive (mapv #(conj % "Sensitive") test-data)]
+        data-with-sensitive (mapv #(conj % "Sensitive") example-test-data)]
     (is (= default-header-result
            (prep-for-html-rendering' cols-with-sensitive data-with-sensitive nil nil nil)))))
 
 (deftest header-result-5
   (let [columns-with-retired (conj test-columns retired-col)
-        data-with-retired    (mapv #(conj % "Retired") test-data)]
+        data-with-retired    (mapv #(conj % "Retired") example-test-data)]
     (is (= default-header-result
            (prep-for-html-rendering' columns-with-retired data-with-retired nil nil nil)))))
 
@@ -151,28 +153,28 @@
 ;; When including a bar column, bar-width is 99%
 (deftest bar-width
   (is (= (assoc-in default-header-result [0 :bar-width] 99)
-         (prep-for-html-rendering' test-columns test-data second 0 40.0))))
+         (prep-for-html-rendering' test-columns example-test-data second 0 40.0))))
 
 ;; When there are too many columns, #'body/prep-for-html-rendering show narrow it
 (deftest narrow-the-columns
   (is (= [{:row [(number "ID" "ID") (number "Latitude" "Latitude")]
            :bar-width 99}
           #{2}]
-         (prep-for-html-rendering' (subvec test-columns 0 2) test-data second 0 40.0))))
+         (prep-for-html-rendering' (subvec test-columns 0 2) example-test-data second 0 40.0))))
 
 ;; Basic test that result rows are formatted correctly (dates, floating point numbers etc)
 (deftest format-result-rows
   (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014" "Stout Burgers & Beers"]}
           {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014" "The Apple Pan"]}
           {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014" "The Gorbals"]}]
-         (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows test-data})))))
+         (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows example-test-data})))))
 
 ;; Testing the bar-column, which is the % of this row relative to the max of that column
 (deftest bar-column
   (is (= [{:bar-width (float 85.249),  :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014" "Stout Burgers & Beers"]}
           {:bar-width (float 85.1015), :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014" "The Apple Pan"]}
           {:bar-width (float 85.1185), :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014" "The Gorbals"]}]
-         (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows test-data}
+         (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows example-test-data}
                                                {:bar-column second, :min-value 0, :max-value 40})))))
 
 (defn- add-rating
@@ -199,7 +201,7 @@
 
 (def ^:private test-data-with-remapping
   (mapv add-rating
-        test-data
+        example-test-data
         [1 2 3]
         ["Bad" "Ok" "Good"]))
 
@@ -241,7 +243,7 @@
           {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz
                                                {}
-                                               {:cols test-columns-with-date-semantic-type :rows test-data})))))
+                 {:cols test-columns-with-date-semantic-type :rows example-test-data})))))
 
 (deftest error-test
   (testing "renders error"
@@ -772,3 +774,28 @@
             to-find        ["14" "2" "-2" "-14"]
             nodes-with-viz (mapv #(last (last (render.tu/nodes-with-text viz-b-render %))) to-find)]
         (is (= ["2" "-2"] (remove nil? nodes-with-viz)))))))
+
+(deftest invalid-graph-dim-render-test
+  (testing "A card with an invalid graph.dimension (or metric) will still render (#37266)"
+    (mt/dataset sample-dataset
+      (mt/with-temp [Card {card-id :id}
+                     {:dataset_query          {:database (mt/id)
+                                               :type     :query
+                                               :query    {:source-table (mt/id :orders)
+                                                          :aggregation  [[:count]]
+                                                          :filter       [:between [:field (mt/id :orders :created_at) nil] "2019-05-16" "2019-08-16"]
+                                                          :breakout     [:field (mt/id :orders :created_at) {:temporal-unit :week}]}}
+                      :display                :line
+                      ;; While not part of the original issue, this fix also handles bad metrics.
+                      :visualization_settings {:graph.metrics    ["frooby"]
+                                               ;; This dimension does not exist and used to break the render
+                                               ;; This test verifies that it now works.
+                                               :graph.dimensions ["_sdc_extracted_at"]}}]
+        (let [{:keys [dataset_query result_metadata dataset] :as card} (t2/select-one :model/Card :id card-id)
+              query-results (qp/process-query
+                              (cond-> dataset_query
+                                dataset
+                                (assoc-in [:info :metadata/dataset-metadata] result_metadata)))
+              {:keys [content]} (body/render :line :inline "UTC" card nil (:data query-results))]
+          (testing "Content is generated (rather than an exception being thrown)"
+            (is (= :div (first content)))))))))


### PR DESCRIPTION
When trying to render a card with viz settings containing a nonexistent dimension, an error would result in `mult-x-axis-rowfn` causing a failure to render.

This fix simply replaces `map` with `keep` in `metabase.util.ui-logic/mult-x-axis-rowfn` and `metabase.util.ui-logic/mult-y-axis-rowfn` so that `nil` values are dropped if a bad dimension or metric name is provided.

The following easily shows the broken case (now fixed). Previously, an error was rendered. Now you get the chart.

```clojure
;; REPRO
(comment
  (ns tickets.37266-slack-error
    (:require
     [clojure.test :refer :all]
     [dev.render-png :as render-png]
     [metabase.models :refer [Card]]
     [metabase.pulse.render.body :as body]
     [metabase.query-processor :as qp]
     [metabase.test :as mt]
     [toucan2.core :as t2]))

  (let [busted? true]
    (mt/dataset test-data
      ;; Note that this uses orders since we have that as test data.
      (mt/with-temp [Card {base-card-id :id}
                     {:dataset_query          {:database (mt/id)
                                               :type     :query
                                               :query    {:source-table (mt/id :orders)
                                                          :aggregation  [[:count]]
                                                          :filter       [:between [:field (mt/id :orders :created_at) nil] "2019-05-16" "2019-08-16"]
                                                          :breakout     [:field (mt/id :orders :created_at) {:temporal-unit :week}]}}
                      :display                :line
                      :visualization_settings {:table.pivot_column      "state"
                                               ;; This is also intentionally broken
                                               :graph.metrics           (if busted?
                                                                          ["frooby"]
                                                                          ["count"])
                                               :graph.show_trendline    false
                                               :graph.x_axis.title_text "Week"
                                               :graph.y_axis.title_text "PR Review Activity"
                                               ;; Using a missing dimension name breaks the results
                                               :graph.dimensions        (if busted?
                                                                          ["_sdc_extracted_at"]
                                                                          ["created_at"])
                                               :graph.show_values       false
                                               :table.cell_column       "count"}}]
        (render-png/render-card-to-png base-card-id)))))
```

(cherry picked from commit 27587264f4e0b4dd3cb617c7f18c319a57e3f4c2)
