### PR TITLE
[MLv2] Visible columns should not see breakout binning or bucketing

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -116,7 +116,6 @@ const QUERY_FILTER_CREATED_AT = [
     ORDERS.CREATED_AT,
     {
       "base-type": "type/DateTime",
-      "temporal-unit": "month",
     },
   ],
   "2022-08-01",

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -1,6 +1,7 @@
 (ns metabase.lib.breakout
   (:require
    [clojure.string :as str]
+   [metabase.lib.binning :as lib.binning]
    [metabase.lib.equality :as lib.equality]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.ref :as lib.ref]
@@ -82,10 +83,14 @@
                                                (when-let [col (lib.equality/find-matching-column
                                                                query stage-number a-breakout cols
                                                                {:generous? true})]
-                                                 [col index]))
+                                                 [col [index a-breakout]]))
                                              (or (breakouts query stage-number) [])))]
-         (mapv #(let [pos (matching %)]
+         (mapv #(let [[pos a-breakout] (matching %)
+                      binning (lib.binning/binning a-breakout)
+                      {:keys [unit]} (lib.temporal-bucket/temporal-bucket a-breakout)]
                   (cond-> %
+                    binning (lib.binning/with-binning binning)
+                    unit (lib.temporal-bucket/with-temporal-bucket unit)
                     pos (assoc :breakout-position pos)))
                cols))))))
 

--- a/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_geographic.cljc
@@ -103,24 +103,31 @@
   [query                      :- ::lib.schema/query
    stage-number               :- :int
    {:keys [row], :as context} :- ::lib.schema.drill-thru/context]
-  (let [columns (lib.metadata.calculation/visible-columns query stage-number (lib.util/query-stage query stage-number))]
-    (when-let [lat-column (m/find-first lib.types.isa/latitude? columns)]
-      (when-let [lon-column (m/find-first lib.types.isa/longitude? columns)]
-        (letfn [(same-column? [col-x col-y]
-                  (if (:id col-x)
-                    (= (:id col-x) (:id col-y))
-                    (= (:lib/desired-column-alias col-x) (:lib/desired-column-alias col-y))))
-                (column-value [column]
-                  (some
-                   (fn [row-value]
-                     (when (same-column? column (:column row-value))
-                       (:value row-value)))
-                   row))]
-          (assoc context
-                 :lat-column lat-column
-                 :lon-column lon-column
-                 :lat-value (column-value lat-column)
-                 :lon-value (column-value lon-column)))))))
+  (let [stage (lib.util/query-stage query stage-number)
+        ;; First check returned columns in case we breakout by lat/lon so we maintain the binning, othwerwise check visible.
+        [lat-column lon-column] (some
+                                  (fn [columns]
+                                    (when-let [lat-column (m/find-first lib.types.isa/latitude? columns)]
+                                      (when-let [lon-column (m/find-first lib.types.isa/longitude? columns)]
+                                        [lat-column lon-column])))
+                                  [(lib.metadata.calculation/returned-columns query stage-number stage)
+                                   (lib.metadata.calculation/visible-columns query stage-number stage)])]
+    (when (and lat-column lon-column)
+      (letfn [(same-column? [col-x col-y]
+                (if (:id col-x)
+                  (= (:id col-x) (:id col-y))
+                  (= (:lib/desired-column-alias col-x) (:lib/desired-column-alias col-y))))
+              (column-value [column]
+                (some
+                  (fn [row-value]
+                    (when (same-column? column (:column row-value))
+                      (:value row-value)))
+                  row))]
+        (assoc context
+               :lat-column lat-column
+               :lon-column lon-column
+               :lat-value (column-value lat-column)
+               :lon-value (column-value lon-column))))))
 
 ;;;
 ;;; available-drill-thrus

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -251,13 +251,13 @@
   [query stage-number _stage {:keys [unique-name-fn include-implicitly-joinable?], :as options}]
   (let [query            (ensure-previous-stages-have-metadata query stage-number)
         existing-columns (existing-visible-columns query stage-number options)]
-    (->> (concat
-           existing-columns
-           ;; add implicitly joinable columns if desired
-           (when (and include-implicitly-joinable?
-                      (or (not (:source-card (lib.util/query-stage query stage-number)))
-                          (:include-implicitly-joinable-for-source-card? options)))
-             (lib.metadata.calculation/implicitly-joinable-columns query stage-number existing-columns unique-name-fn))))))
+    (concat
+      existing-columns
+      ;; add implicitly joinable columns if desired
+      (when (and include-implicitly-joinable?
+                 (or (not (:source-card (lib.util/query-stage query stage-number)))
+                     (:include-implicitly-joinable-for-source-card? options)))
+        (lib.metadata.calculation/implicitly-joinable-columns query stage-number existing-columns unique-name-fn)))))
 
 ;;; Return results metadata about the expected columns in an MBQL query stage. If the query has
 ;;; aggregations/breakouts, then return those and the fields columns. Otherwise if there are fields columns return

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -4,7 +4,6 @@
    [clojure.string :as str]
    [medley.core :as m]
    [metabase.lib.aggregation :as lib.aggregation]
-   [metabase.lib.binning :as lib.binning]
    [metabase.lib.breakout :as lib.breakout]
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.field :as lib.field]
@@ -16,7 +15,6 @@
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
-   [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.util :as lib.util]
    [metabase.shared.util.i18n :as i18n]
    [metabase.util :as u]
@@ -249,30 +247,6 @@
    (when include-joined?
      (lib.join/all-joins-visible-columns query stage-number unique-name-fn))))
 
-(defn- ref-to? [[tag _opts pointer :as clause] column]
-  (case tag
-    :field (if (or (number? pointer) (string? pointer))
-             (= pointer (:id column))
-             (throw (ex-info "unknown type of :field ref in lib.stage/ref-to?"
-                             {:clause clause
-                              :column column})))
-    :expression (= pointer (:name column))
-    (throw (ex-info "unknown clause in lib.stage/ref-to?"
-                    {:clause clause
-                     :column column}))))
-
-(defn- mark-selected-breakouts [query stage-number columns]
-  (if-let [breakouts (:breakout (lib.util/query-stage query stage-number))]
-    (for [column columns]
-      (if-let [match (m/find-first #(ref-to? % column) breakouts)]
-        (let [binning        (lib.binning/binning match)
-              {:keys [unit]} (lib.temporal-bucket/temporal-bucket match)]
-          (cond-> column
-            binning (lib.binning/with-binning binning)
-            unit    (lib.temporal-bucket/with-temporal-bucket unit)))
-        column))
-    columns))
-
 (defmethod lib.metadata.calculation/visible-columns-method ::stage
   [query stage-number _stage {:keys [unique-name-fn include-implicitly-joinable?], :as options}]
   (let [query            (ensure-previous-stages-have-metadata query stage-number)
@@ -283,8 +257,7 @@
            (when (and include-implicitly-joinable?
                       (or (not (:source-card (lib.util/query-stage query stage-number)))
                           (:include-implicitly-joinable-for-source-card? options)))
-             (lib.metadata.calculation/implicitly-joinable-columns query stage-number existing-columns unique-name-fn)))
-         (mark-selected-breakouts query stage-number))))
+             (lib.metadata.calculation/implicitly-joinable-columns query stage-number existing-columns unique-name-fn))))))
 
 ;;; Return results metadata about the expected columns in an MBQL query stage. If the query has
 ;;; aggregations/breakouts, then return those and the fields columns. Otherwise if there are fields columns return

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -251,13 +251,14 @@
   [query stage-number _stage {:keys [unique-name-fn include-implicitly-joinable?], :as options}]
   (let [query            (ensure-previous-stages-have-metadata query stage-number)
         existing-columns (existing-visible-columns query stage-number options)]
-    (concat
-      existing-columns
-      ;; add implicitly joinable columns if desired
-      (when (and include-implicitly-joinable?
-                 (or (not (:source-card (lib.util/query-stage query stage-number)))
-                     (:include-implicitly-joinable-for-source-card? options)))
-        (lib.metadata.calculation/implicitly-joinable-columns query stage-number existing-columns unique-name-fn)))))
+    (->> (concat
+           existing-columns
+           ;; add implicitly joinable columns if desired
+           (when (and include-implicitly-joinable?
+                      (or (not (:source-card (lib.util/query-stage query stage-number)))
+                          (:include-implicitly-joinable-for-source-card? options)))
+             (lib.metadata.calculation/implicitly-joinable-columns query stage-number existing-columns unique-name-fn)))
+         vec)))
 
 ;;; Return results metadata about the expected columns in an MBQL query stage. If the query has
 ;;; aggregations/breakouts, then return those and the fields columns. Otherwise if there are fields columns return

--- a/test/metabase/lib/binning_test.cljc
+++ b/test/metabase/lib/binning_test.cljc
@@ -1,11 +1,11 @@
 (ns metabase.lib.binning-test
   (:require
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [deftest is testing]]
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.core :as lib]
-   [metabase.lib.test-metadata :as meta]
-   metabase.test-runner.assert-exprs.approximately-equal))
+   [metabase.lib.test-metadata :as meta]))
 
 (deftest ^:parallel binning-display-name-for-coordinate-columns-test
   (testing "Include little degree symbols in display names for coordinate columns"

--- a/test/metabase/lib/binning_test.cljc
+++ b/test/metabase/lib/binning_test.cljc
@@ -29,7 +29,7 @@
     (is (= {:bin-width 12.5, :min-value 15, :max-value 27.5}
            (lib.binning/resolve-bin-width query col-quantity 15)))))
 
-(deftest ^:parallel binning-and-bucketing-only-show-up-for-breakoutable-columns
+(deftest ^:parallel binning-and-bucketing-only-show-up-for-returned-and-breakoutable-columns
   (testing "Within the stage, binning and bucketing at breakout should be invisible, outside the stage it should be visible"
     (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                     (lib/aggregate (lib/count)))

--- a/test/metabase/lib/binning_test.cljc
+++ b/test/metabase/lib/binning_test.cljc
@@ -4,7 +4,8 @@
    [medley.core :as m]
    [metabase.lib.binning :as lib.binning]
    [metabase.lib.core :as lib]
-   [metabase.lib.test-metadata :as meta]))
+   [metabase.lib.test-metadata :as meta]
+   metabase.test-runner.assert-exprs.approximately-equal))
 
 (deftest ^:parallel binning-display-name-for-coordinate-columns-test
   (testing "Include little degree symbols in display names for coordinate columns"
@@ -27,3 +28,32 @@
     (is (some? col-quantity))
     (is (= {:bin-width 12.5, :min-value 15, :max-value 27.5}
            (lib.binning/resolve-bin-width query col-quantity 15)))))
+
+(deftest ^:parallel binning-and-bucketing-only-show-up-for-breakoutable-columns
+  (testing "Within the stage, binning and bucketing at breakout should be invisible, outside the stage it should be visible"
+    (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                    (lib/aggregate (lib/count)))
+          total-col (m/find-first (comp #{"TOTAL"} :name) (lib/breakoutable-columns query))
+          binned-total (lib/with-binning total-col (first (lib/available-binning-strategies query total-col)))
+          query (lib/breakout query binned-total)
+          created-col (m/find-first (comp #{"CREATED_AT"} :name) (lib/breakoutable-columns query))
+          bucket-created (lib/with-temporal-bucket created-col (first (lib/available-temporal-buckets query created-col)))
+          query (lib/breakout query bucket-created)]
+      (is (=?
+            (complement :metabase.lib.field/binning)
+            (m/find-first (comp #{"TOTAL"} :name) (lib/visible-columns query))))
+      (is (=?
+            {:metabase.lib.field/binning {:strategy :default}}
+            (m/find-first (comp #{"TOTAL"} :name) (lib/breakoutable-columns query))))
+      (is (=?
+            {:metabase.lib.field/binning {:strategy :default}}
+            (m/find-first (comp #{"TOTAL"} :name) (lib/returned-columns query))))
+      (is (=?
+            (complement :metabase.lib.field/temporal-unit)
+            (m/find-first (comp #{"CREATED_AT"} :name) (lib/visible-columns query))))
+      (is (=?
+            {:metabase.lib.field/temporal-unit :minute}
+            (m/find-first (comp #{"CREATED_AT"} :name) (lib/breakoutable-columns query))))
+      (is (=?
+            {:metabase.lib.field/temporal-unit :minute}
+            (m/find-first (comp #{"CREATED_AT"} :name) (lib/returned-columns query)))))))

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -149,7 +149,7 @@
                        :value        (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])}
       :drill-args     ["<"]
       :expected-query {:stages [{:filters [[:< {}
-                                            [:field {:temporal-unit :month} (meta/id :orders :created-at)]
+                                            [:field {} (meta/id :orders :created-at)]
                                             (get-in lib.drill-thru.tu/test-queries ["ORDERS" :aggregated :row "CREATED_AT"])]]}]}})))
 
 (deftest ^:parallel apply-quick-filter-on-correct-level-test-3

--- a/test/metabase/query_processor_test/drill_thru_e2e_test.clj
+++ b/test/metabase/query_processor_test/drill_thru_e2e_test.clj
@@ -28,14 +28,20 @@
               quick-filter-drill (m/find-first #(= (:type %) :drill-thru/quick-filter)
                                                (lib/available-drill-thrus query drill-context))]
           (is (some? quick-filter-drill))
-          (let [query' (lib/drill-thru query -1 quick-filter-drill "=")]
-            (is (=? {:stages [{:filters [[:=
+          (let [query' (lib/drill-thru query -1 quick-filter-drill "<")]
+            (is (=? {:stages [{:filters [[:<
                                           {}
-                                          [:field {:temporal-unit :day} (mt/id :products :created_at)]
+                                          [:field {} (mt/id :products :created_at)]
                                           #t "2016-05-30T00:00Z[UTC]"]]}]}
                     query'))
             (mt/with-native-query-testing-context query'
-              (is (= [["2016-05-30T00:00:00Z" 2]]
+              (is (= [["2016-04-26T00:00:00Z" 1]
+                      ["2016-04-28T00:00:00Z" 1]
+                      ["2016-05-02T00:00:00Z" 1]
+                      ["2016-05-04T00:00:00Z" 1]
+                      ["2016-05-11T00:00:00Z" 1]
+                      ["2016-05-12T00:00:00Z" 1]
+                      ["2016-05-24T00:00:00Z" 1]]
                      (mt/rows (qp/process-query query')))))))))))
 
 (deftest ^:parallel distribution-drill-on-longitude-from-sql-source-card-test


### PR DESCRIPTION
Fixes #37463

Changes #31293 to apply binning and bucketing to columns only on returned/breakoutable columns