### PR TITLE
waterfall fix timeseries error

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -54,8 +54,9 @@ function getSortedAggregatedRows(
   cardColumns: CartesianChartColumns,
   settings: ComputedVisualizationSettings,
 ) {
+  let sortedRows = rows;
   if (settings["graph.x_axis.scale"] === "timeseries") {
-    rows.sort((left, right) => {
+    sortedRows = [...rows].sort((left, right) => {
       const leftValue = left[cardColumns.dimension.index];
       const rightValue = right[cardColumns.dimension.index];
 
@@ -71,7 +72,7 @@ function getSortedAggregatedRows(
   const columns = assertMultiMetricColumns(cardColumns);
   const dimensionMetricMap = new Map<RowValue, number>();
 
-  rows.forEach(row => {
+  sortedRows.forEach(row => {
     const dimension = row[columns.dimension.index];
     const rawMetric = row[columns.metrics[0].index];
     if (rawMetric == null) {
@@ -89,7 +90,7 @@ function getSortedAggregatedRows(
   const seenDimensions = new Set();
   const aggregatedRows: RowValues[] = [];
 
-  rows.forEach(row => {
+  sortedRows.forEach(row => {
     const dimension = row[columns.dimension.index];
     if (seenDimensions.has(dimension)) {
       return;


### PR DESCRIPTION
### Description

Fixes an error where timeseries waterfall charts would crash when navigating back to them (e.g. going back to the dashboard after clicking into a question).

### How to verify

1. Create a timeseries waterfall chart
2. Add it to a dashboard
3. Open it from the dashboard
4. Use the button in the top left to go back to the dashboard
5. Confirm the chart still renders without error

### Demo

Before

https://github.com/metabase/metabase/assets/37751258/a22fe291-2b56-4f16-b713-35aa63855de5

After

https://github.com/metabase/metabase/assets/37751258/78cad2e2-c3dd-4d81-ac1e-ba1ab104bcd3





### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
