### PR TITLE
remove BE waterfall code

### DIFF
--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -595,42 +595,6 @@
          :render/text (str (format-cell timezone-id last-value metric-col viz-settings)
                            "\n" (trs "Nothing to compare to."))}))))
 
-(s/defmethod render :waterfall :- formatter/RenderedPulseCard
-  [_ render-type _timezone-id card _dashcard {:keys [rows cols viz-settings] :as data}]
-  (let [[x-axis-rowfn
-         y-axis-rowfn] (formatter/graphing-column-row-fns card data)
-        [x-col y-col]  ((juxt x-axis-rowfn y-axis-rowfn) cols)
-        rows           (map (juxt x-axis-rowfn y-axis-rowfn)
-                            (formatter/row-preprocess x-axis-rowfn y-axis-rowfn rows))
-        labels         (x-and-y-axis-label-info x-col y-col viz-settings)
-        waterfall-type (if (isa? (-> cols x-axis-rowfn :effective_type) :type/Temporal)
-                         :timeseries
-                         :categorical)
-        show-total     (if (nil? (:waterfall.show_total viz-settings))
-                         true
-                         (:waterfall.show_total viz-settings))
-        settings       (-> (->js-viz x-col y-col viz-settings)
-                           (update :colors assoc
-                                   :waterfallTotal (:waterfall.total_color viz-settings)
-                                   :waterfallPositive (:waterfall.increase_color viz-settings)
-                                   :waterfallNegative (:waterfall.decrease_color viz-settings))
-                           (assoc :showTotal show-total)
-                           (assoc :show_values (boolean (:graph.show_values viz-settings))))
-        image-bundle   (image-bundle/make-image-bundle
-                        render-type
-                        (js-svg/waterfall rows
-                                          labels
-                                          settings
-                                          waterfall-type))]
-    {:attachments
-     (when image-bundle
-       (image-bundle/image-bundle->attachment image-bundle))
-
-     :content
-     [:div
-      [:img {:style (style/style {:display :block :width :100%})
-             :src   (:image-src image-bundle)}]]}))
-
 (s/defmethod render :funnel :- formatter/RenderedPulseCard
   [_ render-type _timezone-id card _dashcard {:keys [rows cols viz-settings] :as data}]
   (let [[x-axis-rowfn

--- a/src/metabase/pulse/render/js_svg.clj
+++ b/src/metabase/pulse/render/js_svg.clj
@@ -111,17 +111,6 @@
 (defn- svg-string->bytes [s]
   (-> s parse-svg-string render-svg))
 
-(defn waterfall
-  "Clojure entrypoint to render a timeseries or categorical waterfall chart. Rows should be tuples of [datetime numeric-value]. Labels is
-  a map of {:left \"left-label\" :botton \"bottom-label\". Returns a byte array of a png file."
-  [rows labels settings waterfall-type]
-  (let [svg-string (.asString (js/execute-fn-name (context) "waterfall" rows
-                                                  (map (fn [[k v]] [(name k) v]) labels)
-                                                  (json/generate-string settings)
-                                                  (name waterfall-type)
-                                                  (json/generate-string (public-settings/application-colors))))]
-    (svg-string->bytes svg-string)))
-
 (defn funnel
   "Clojure entrypoint to render a funnel chart. Data should be vec of [[Step Measure]] where Step is {:name name :format format-options} and Measure is {:format format-options} and you go and look to frontend/src/metabase/static-viz/components/FunnelChart/types.ts for the actual format options.
   Returns a byte array of a png file."

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -410,35 +410,6 @@
 (defn has-inline-image? [rendered]
   (some #{:img} (flatten-html-data rendered)))
 
-(defn- render-waterfall [results]
-  (body/render :waterfall :inline pacific-tz render.tu/test-card nil results))
-
-(deftest render-waterfall-test
-  (testing "Render a waterfall graph with non-nil values for the x and y axis"
-    (is (has-inline-image?
-         (render-waterfall {:cols default-columns
-                            :rows         [[10.0 1] [5.0 10] [2.50 20] [1.25 30]]
-                            :viz-settings {}}))))
-  (testing "Render a waterfall graph with bigdec, bigint values for the x and y axis"
-    (is (has-inline-image?
-         (render-waterfall {:cols         default-columns
-                            :rows         [[10.0M 1M] [5.0 10N] [2.50 20N] [1.25M 30]]
-                            :viz-settings {}}))))
-  (testing "Check to make sure we allow nil values for the y-axis"
-    (is (has-inline-image?
-         (render-waterfall {:cols         default-columns
-                            :rows         [[10.0 1] [5.0 10] [2.50 20] [1.25 nil]]
-                            :viz-settings {}}))))
-  (testing "Check to make sure we allow nil values for the x-axis"
-    (is (has-inline-image?
-         (render-waterfall {:cols         default-columns
-                            :rows         [[10.0 1] [5.0 10] [2.50 20] [nil 30]]
-                            :viz-settings {}}))))
-  (testing "Check to make sure we allow nil values for both x and y on different rows"
-    (is (has-inline-image?
-         (render-waterfall {:cols         default-columns
-                            :rows         [[10.0 1] [5.0 10] [nil 20] [1.25 nil]]
-                            :viz-settings {}})))))
 (defn- render-funnel [results]
   (body/render :funnel :inline pacific-tz render.tu/test-card nil results))
 

--- a/test/metabase/pulse/render/js_svg_test.clj
+++ b/test/metabase/pulse/render/js_svg_test.clj
@@ -78,37 +78,6 @@
       (is (no-html-elements tag-set) (str "Contained html elements: "
                                           (set/intersection #{"div" "span" "p"}))))))
 
-(deftest waterfall-test
-  (testing "Timeseries Waterfall renders"
-    (let [rows           [[#t "2020" 2]
-                          [#t "2021" 3]]
-          labels         {:left "count" :bottom "year"}
-          settings       (json/generate-string {:y {:prefix   "prefix"
-                                                    :decimals 4}})
-          waterfall-type (name :timeseries)]
-      (testing "It returns bytes"
-        (let [svg-bytes (js-svg/waterfall rows labels settings waterfall-type)]
-          (is (bytes? svg-bytes))))
-      (let [svg-string (.asString (js/execute-fn-name context "waterfall"
-                                                      rows labels settings waterfall-type
-                                                      (json/generate-string {})))]
-        (testing "it returns a valid svg string (no html in it)"
-          (validate-svg-string :timelineseries-waterfall svg-string)))))
-  (testing "Categorical Waterfall renders"
-    (let [rows           [["One" 20]
-                          ["Two" 30]]
-          labels         {:left "count" :bottom "process step"}
-          settings       (json/generate-string {})
-          waterfall-type (name :categorical)]
-      (testing "It returns bytes"
-        (let [svg-bytes (js-svg/waterfall rows labels settings waterfall-type)]
-          (is (bytes? svg-bytes))))
-      (let [svg-string (.asString (js/execute-fn-name context "waterfall"
-                                                      rows labels settings waterfall-type
-                                                      (json/generate-string {})))]
-        (testing "it returns a valid svg string (no html in it)"
-          (validate-svg-string :categorical-waterfall svg-string))))))
-
 (deftest categorical-donut-test
   (let [rows [["apples" 2]
               ["bananas" 3]]

--- a/test/metabase/pulse/render_test.clj
+++ b/test/metabase/pulse/render_test.clj
@@ -76,7 +76,7 @@
                                               :rows [["A" 2]
                                                      ["B" 3]]})))))
   (testing "Various Single-Series display-types return correct chart-types."
-    (doseq [chart-type [:row :funnel :progress :table :waterfall]]
+    (doseq [chart-type [:row :funnel :progress :table]]
       (is (= chart-type
              (render/detect-pulse-chart-type {:display chart-type}
                                              {}


### PR DESCRIPTION
### Description

Removing the now unused clojure waterfall chart code.

### Demo

![Screenshot 2024-01-11 at 12.13.42 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/31e52555-39cb-449b-ab2c-53a9fbb56f7a.png)


![Screenshot 2024-01-11 at 12.13.35 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/521c4e3c-d3e6-47d1-9582-53b6015da1a2.png)

Confirmed both dynamic and static charts are still working
