### PR TITLE
Check backport script workflow

### DIFF
--- a/.github/workflows/check-backport-script.yml
+++ b/.github/workflows/check-backport-script.yml
@@ -1,0 +1,20 @@
+name: Prevent backport.sh from being merged
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-backport-script:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Check for backport.sh file
+        run: |
+          if [ -f "./backport.sh" ]; then
+            echo "backport.sh file exists. Please remove it before merging."
+            exit 1
+          else
+            echo "All good."
+          fi


### PR DESCRIPTION
### Description

Since recently even for backports with conflicts we started creating PRs with commits that include the `./backport.sh` script that cherry-picks the right commit and removes itself. This makes it easier to see if there are still not merged backports exist by searching for PRs with `was-backported` label. However, sometimes the `./backport.sh` script can be accidentally left so this PR introduces a workflow that won't let merge PR in that case.

[Slack convo](https://metaboat.slack.com/archives/C010L1Z4F9S/p1704888265083849)
