### PR TITLE
Fix transparent embedding menu option text

### DIFF
--- a/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.tsx
@@ -69,15 +69,13 @@ export const AdminEmbedMenu = ({
           onClick={() => setMenuMode("public-link-popover")}
         >
           {isPublicSharingEnabled ? (
-            <Title c="inherit" order={4}>
+            <Title order={4}>
               {hasPublicLink ? t`Public link` : t`Create a public link`}
             </Title>
           ) : (
             <Stack spacing="xs">
-              <Title c="inherit" order={4}>
-                {t`Public links are off`}
-              </Title>
-              <Text size="sm" c="inherit">{t`Enable them in settings`}</Text>
+              <Title order={4}>{t`Public links are off`}</Title>
+              <Text size="sm">{t`Enable them in settings`}</Text>
             </Stack>
           )}
         </Menu.Item>
@@ -94,15 +92,11 @@ export const AdminEmbedMenu = ({
           onClick={onModalOpen}
         >
           {isEmbeddingEnabled ? (
-            <Title c="inherit" order={4}>
-              {t`Embed`}
-            </Title>
+            <Title order={4}>{t`Embed`}</Title>
           ) : (
             <Stack spacing="xs">
-              <Title c="inherit" order={4}>
-                {t`Embedding is off`}
-              </Title>
-              <Text size="sm" c="inherit">{t`Enable it in settings`}</Text>
+              <Title order={4}>{t`Embedding is off`}</Title>
+              <Text size="sm">{t`Enable it in settings`}</Text>
             </Stack>
           )}
         </Menu.Item>

--- a/frontend/src/metabase/ui/components/overlays/Menu/Menu.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Menu/Menu.styled.tsx
@@ -27,6 +27,10 @@ export const getMenuOverrides = (): MantineThemeOverride["components"] => ({
             color: theme.fn.themeColor("brand"),
           },
         },
+
+        "&:disabled": {
+          color: theme.fn.themeColor("text-light"),
+        },
       },
       itemIcon: {
         marginRight: theme.spacing.sm,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37525

### Description

Mantine's `Menu.Item` component sets the `color` attribute based on the `disabled` prop, and uses the default colors to set the color to a lighter version of its default gray. 

From [Mantine's v6 repo for `Menu.Item`](https://github.com/mantinedev/mantine/blob/6b214a5a20afc1d48127a1939514191a061352da/src/mantine-core/src/Menu/MenuItem/MenuItem.styles.ts#L31)
```
	'&:disabled': {
      color: theme.colorScheme === 'dark' ? theme.colors.dark[3] : theme.colors.gray[5],
      pointerEvents: 'none',
      userSelect: 'none',
    },
```

With the introduction of [Use colors by names PR](https://github.com/metabase/metabase/pull/37443), we set all of the default Mantine colors to `transparent`, which causes issues when we use Mantine components which rely on those default colors for the states we haven't accounted for yet, such as the disabled state of the `Menu.Item` component. This PR explicitly states the color for this state to the `text-light` color.



### How to verify

* Disable embedding and public sharing in the admin settings
* Go to a dashboard or a question
* Open the Sharing/Embedding menu
* See that both options are visible and the text is `text-light`, not `transparent`

### Before/After

_**Before** (on master)_ 
<img width="230" alt="image" src="https://github.com/metabase/metabase/assets/25306947/83213138-b130-4cf0-9bc3-3330ed306407">

The CSS on the `Menu.Item:disabled` property
<img width="259" alt="image" src="https://github.com/metabase/metabase/assets/25306947/b917d833-24c0-49ec-8ca5-b2ed2cb294b4">


_**After** (on this PR branch)_

<img width="225" alt="image" src="https://github.com/metabase/metabase/assets/25306947/3f9f9132-4b1a-44df-8a20-cd7122ba9559">

The CSS on the `Menu.Item:disabled` property (notice the override that I put here, which comes from `metabase/ui/components/overlays/Menu/Menu.styled.tsx`)
<img width="238" alt="image" src="https://github.com/metabase/metabase/assets/25306947/de0f87c3-06a0-4e77-9fbb-512284c97793">
