### PR TITLE
Permissions schema migrations

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5322,6 +5322,16 @@ databaseChangeLog:
             relativeToChangelogFile: true
       rollback:
 
+  - changeSet:
+      id: v49.2024-01-10T03:27:31
+      author: noahmoss
+      comment: Migrate native-query-editing permissions from `permissions` to `permissions_v2`
+      changes:
+        - sqlFile:
+            path: permissions/native_query_editing.sql
+            relativeToChangelogFile: true
+      rollback:
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5340,6 +5340,16 @@ databaseChangeLog:
             relativeToChangelogFile: true
       rollback:
 
+  # - changeSet:
+  #     id: v49.2024-01-10T03:27:33
+  #     author: noahmoss
+  #     comment: Migrate manage-data-metadata permissions from `permissions` to `data_permissions`
+  #     changes:
+  #       - sqlFile:
+  #           path: permissions/manage_table_metadata.sql
+  #           relativeToChangelogFile: true
+  #     rollback:
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5340,15 +5340,25 @@ databaseChangeLog:
             relativeToChangelogFile: true
       rollback:
 
-  # - changeSet:
-  #     id: v49.2024-01-10T03:27:33
-  #     author: noahmoss
-  #     comment: Migrate manage-data-metadata permissions from `permissions` to `data_permissions`
-  #     changes:
-  #       - sqlFile:
-  #           path: permissions/manage_table_metadata.sql
-  #           relativeToChangelogFile: true
-  #     rollback:
+  - changeSet:
+      id: v49.2024-01-10T03:27:33
+      author: noahmoss
+      comment: Migrate manage-data-metadata permissions from `permissions` to `data_permissions`
+      changes:
+        - sqlFile:
+            path: permissions/manage_table_metadata.sql
+            relativeToChangelogFile: true
+      rollback:
+
+  - changeSet:
+      id: v49.2024-01-10T03:27:34
+      author: noahmoss
+      comment: Migrate manage-database permissions from `permissions` to `data_permissions`
+      changes:
+        - sqlFile:
+            path: permissions/manage_database.sql
+            relativeToChangelogFile: true
+      rollback:
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5330,6 +5330,16 @@ databaseChangeLog:
             relativeToChangelogFile: true
       rollback:
 
+  - changeSet:
+      id: v49.2024-01-10T03:27:32
+      author: noahmoss
+      comment: Migrate download-results permissions from `permissions` to `data_permissions`
+      changes:
+        - sqlFile:
+            path: permissions/download_results.sql
+            relativeToChangelogFile: true
+      rollback:
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5312,6 +5312,15 @@ databaseChangeLog:
                   name: group_id
             indexName: idx_data_permissions_group_id
 
+  - changeSet:
+      id: v49.2024-01-10T03:27:30
+      author: noahmoss
+      comment: Migrate data-access permissions from `permissions` to `permissions_v2`
+      changes:
+        - sqlFile:
+            path: permissions/data_access.sql
+            relativeToChangelogFile: true
+      rollback:
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5234,7 +5234,7 @@ databaseChangeLog:
                     deleteCascade: true
               - column:
                   remarks: The type of the permission (e.g. "data", "collection", "download"...)
-                  name: type
+                  name: perm_type
                   type: varchar(64)
                   constraints:
                     nullable: false
@@ -5250,7 +5250,7 @@ databaseChangeLog:
                     deleteCascade: true
               - column:
                   remarks: A schema name, for table-level permissions
-                  name: schema
+                  name: schema_name
                   type: varchar(254)
                   constraints:
                     nullable: true
@@ -5265,9 +5265,7 @@ databaseChangeLog:
                     foreignKeyName: fk_data_permissions_ref_table_id
                     deleteCascade: true
               - column:
-                  remarks: >-
-                    The value this permission is set to. I wanted to call this 'value' but that's a reserved word
-                    in H2 which makes migrations a little more difficult.
+                  remarks: The value this permission is set to.
                   name: perm_value
                   type: varchar(64)
                   constraints:
@@ -5315,7 +5313,7 @@ databaseChangeLog:
   - changeSet:
       id: v49.2024-01-10T03:27:30
       author: noahmoss
-      comment: Migrate data-access permissions from `permissions` to `permissions_v2`
+      comment: Migrate data-access permissions from `permissions` to `data_permissions`
       changes:
         - sqlFile:
             path: permissions/data_access.sql
@@ -5325,7 +5323,7 @@ databaseChangeLog:
   - changeSet:
       id: v49.2024-01-10T03:27:31
       author: noahmoss
-      comment: Migrate native-query-editing permissions from `permissions` to `permissions_v2`
+      comment: Migrate native-query-editing permissions from `permissions` to `data_permissions`
       changes:
         - sqlFile:
             path: permissions/native_query_editing.sql

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5316,7 +5316,12 @@ databaseChangeLog:
       comment: Migrate data-access permissions from `permissions` to `data_permissions`
       changes:
         - sqlFile:
+            dbms: postgresql,h2
             path: permissions/data_access.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: permissions/mysql_data_access.sql
             relativeToChangelogFile: true
       rollback:
 
@@ -5336,7 +5341,12 @@ databaseChangeLog:
       comment: Migrate download-results permissions from `permissions` to `data_permissions`
       changes:
         - sqlFile:
+            dbms: postgresql,h2
             path: permissions/download_results.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: permissions/mysql_download_results.sql
             relativeToChangelogFile: true
       rollback:
 
@@ -5346,7 +5356,12 @@ databaseChangeLog:
       comment: Migrate manage-data-metadata permissions from `permissions` to `data_permissions`
       changes:
         - sqlFile:
+            dbms: postgresql,h2
             path: permissions/manage_table_metadata.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: permissions/mysql_manage_table_metadata.sql
             relativeToChangelogFile: true
       rollback:
 

--- a/resources/migrations/permissions/data_access.sql
+++ b/resources/migrations/permissions/data_access.sql
@@ -1,0 +1,44 @@
+INSERT INTO permissions_v2 (group_id, type, db_id, schema, table_id, object_id, "VALUE")
+SELECT
+    pg.id AS group_id,
+    'data-access' AS type,
+    mt.db_id,
+    mt.schema AS schema,
+    mt.id AS table_id,
+    NULL AS object_id,
+    CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM permissions p
+            WHERE
+                p.group_id = pg.id AND
+                (
+                    p.object = CONCAT('/db/', mt.db_id, '/') OR
+                    p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/') OR
+                    p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/') OR
+                    p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/') OR
+                    p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/segmented/')
+                )
+        ) THEN 'unrestricted'
+        WHEN EXISTS (
+            SELECT 1
+            FROM permissions p
+            WHERE
+                p.group_id = pg.id AND
+                p.object = CONCAT('/block/db/', mt.db_id, '/')
+        ) THEN 'block'
+        ELSE 'no-self-service'
+    END AS "VALUE"
+FROM
+    permissions_group pg
+CROSS JOIN
+    metabase_table mt
+WHERE
+    pg.name != 'Administrators'
+AND NOT EXISTS (
+    SELECT 1 FROM permissions_v2 pv2
+    WHERE
+        pv2.group_id = pg.id AND
+        pv2.table_id = mt.id AND
+        pv2.type = 'data-access'
+);

--- a/resources/migrations/permissions/data_access.sql
+++ b/resources/migrations/permissions/data_access.sql
@@ -1,90 +1,87 @@
 -- Insert DB-level permissions with a check for table-level permissions
-INSERT INTO data_permissions (group_id, type, db_id, schema, table_id, perm_value)
-SELECT
-    pg.id AS group_id,
-    'data-access' AS type,
-    md.id AS db_id,
-    NULL AS schema,
-    NULL AS table_id,
-    CASE
-        WHEN EXISTS (
-            SELECT 1
-            FROM permissions p
-            WHERE p.group_id = pg.id AND p.object = CONCAT('/db/', md.id, '/')
-        ) THEN 'unrestricted'
-        WHEN EXISTS (
-            SELECT 1
-            FROM permissions p
-            WHERE p.group_id = pg.id AND p.object = CONCAT('/block/db/', md.id, '/')
-        ) THEN 'block'
-        WHEN NOT EXISTS (
-            SELECT 1
-            FROM permissions p
-            WHERE p.group_id = pg.id AND p.object LIKE CONCAT('/db/', md.id, '/%')
-        ) THEN 'no-self-service'
-    END AS perm_value
-FROM
-    permissions_group pg
-CROSS JOIN
-    metabase_database md
-WHERE
-    pg.name != 'Administrators'
-AND NOT EXISTS (
-    SELECT 1 FROM data_permissions dp
-    WHERE dp.group_id = pg.id AND dp.db_id = md.id AND dp.type = 'data-access'
-)
--- Filter out rows where perm_value would be NULL
-AND CASE
-        WHEN EXISTS (
-            SELECT 1
-            FROM permissions p
-            WHERE p.group_id = pg.id AND p.object = CONCAT('/db/', md.id, '/')
-        ) THEN TRUE
-        WHEN EXISTS (
-            SELECT 1
-            FROM permissions p
-            WHERE p.group_id = pg.id AND p.object = CONCAT('/block/db/', md.id, '/')
-        ) THEN TRUE
-        WHEN NOT EXISTS (
-            SELECT 1
-            FROM permissions p
-            WHERE p.group_id = pg.id AND p.object LIKE CONCAT('/db/', md.id, '/%')
-        ) THEN TRUE
-        ELSE FALSE
-    END;
+
+INSERT INTO data_permissions (group_id, TYPE, db_id, SCHEMA, table_id, perm_value)
+SELECT pg.id AS group_id,
+       'data-access' AS TYPE,
+       md.id AS db_id,
+       NULL AS SCHEMA,
+       NULL AS table_id,
+       CASE
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND p.object = concat('/db/', md.id, '/') ) THEN 'unrestricted'
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND p.object = concat('/block/db/', md.id, '/') ) THEN 'block'
+           WHEN NOT EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND p.object LIKE concat('/db/', md.id, '/%') ) THEN 'no-self-service'
+       END AS perm_value
+FROM permissions_group pg
+CROSS JOIN metabase_database md
+WHERE pg.name != 'Administrators'
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = md.id
+       AND dp.type = 'data-access' )
+  AND CASE
+          WHEN EXISTS
+                 (SELECT 1
+                  FROM permissions p
+                  WHERE p.group_id = pg.id
+                    AND p.object = concat('/db/', md.id, '/') ) THEN TRUE
+          WHEN EXISTS
+                 (SELECT 1
+                  FROM permissions p
+                  WHERE p.group_id = pg.id
+                    AND p.object = concat('/block/db/', md.id, '/') ) THEN TRUE
+          WHEN NOT EXISTS
+                 (SELECT 1
+                  FROM permissions p
+                  WHERE p.group_id = pg.id
+                    AND p.object LIKE concat('/db/', md.id, '/%') ) THEN TRUE
+          ELSE FALSE
+      END;
 
 -- Insert table-level permissions only where no DB-level permissions exist
-INSERT INTO data_permissions (group_id, type, db_id, schema, table_id, perm_value)
-SELECT
-    pg.id AS group_id,
-    'data-access' AS type,
-    mt.db_id,
-    mt.schema AS schema,
-    mt.id AS table_id,
-    CASE
-        WHEN EXISTS (
-            SELECT 1
-            FROM permissions p
-            WHERE p.group_id = pg.id AND (
-                p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/') OR
-                p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/') OR
-                p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/') OR
-                p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/segmented/')
-            )
-        ) THEN 'unrestricted'
-        ELSE 'no-self-service'
-    END AS perm_value
-FROM
-    permissions_group pg
-CROSS JOIN
-    metabase_table mt
-WHERE
-    pg.name != 'Administrators'
-AND NOT EXISTS (
-    SELECT 1 FROM data_permissions dp
-    WHERE dp.group_id = pg.id AND dp.db_id = mt.db_id AND dp.type = 'data-access'
-)
-AND NOT EXISTS (
-    SELECT 1 FROM data_permissions dp
-    WHERE dp.group_id = pg.id AND dp.db_id = mt.db_id AND dp.table_id IS NULL
-);
+
+INSERT INTO data_permissions (group_id, TYPE, db_id, SCHEMA, table_id, perm_value)
+SELECT pg.id AS group_id,
+       'data-access' AS TYPE,
+       mt.db_id,
+       mt.schema AS SCHEMA,
+       mt.id AS table_id,
+       CASE
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/')
+                          OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/')
+                          OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/')
+                          OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/segmented/')) ) THEN 'unrestricted'
+           ELSE 'no-self-service'
+       END AS perm_value
+FROM permissions_group pg
+CROSS JOIN metabase_table mt
+WHERE pg.name != 'Administrators'
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = mt.db_id
+       AND dp.type = 'data-access' )
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = mt.db_id
+       AND dp.table_id IS NULL );

--- a/resources/migrations/permissions/data_access.sql
+++ b/resources/migrations/permissions/data_access.sql
@@ -1,34 +1,79 @@
-INSERT INTO permissions_v2 (group_id, type, db_id, schema, table_id, object_id, "VALUE")
+-- Insert DB-level permissions with a check for table-level permissions
+INSERT INTO data_permissions (group_id, type, db_id, schema, table_id, perm_value)
+SELECT
+    pg.id AS group_id,
+    'data-access' AS type,
+    md.id AS db_id,
+    NULL AS schema,
+    NULL AS table_id,
+    CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM permissions p
+            WHERE p.group_id = pg.id AND p.object = CONCAT('/db/', md.id, '/')
+        ) THEN 'unrestricted'
+        WHEN EXISTS (
+            SELECT 1
+            FROM permissions p
+            WHERE p.group_id = pg.id AND p.object = CONCAT('/block/db/', md.id, '/')
+        ) THEN 'block'
+        WHEN NOT EXISTS (
+            SELECT 1
+            FROM permissions p
+            WHERE p.group_id = pg.id AND p.object LIKE CONCAT('/db/', md.id, '/%')
+        ) THEN 'no-self-service'
+    END AS perm_value
+FROM
+    permissions_group pg
+CROSS JOIN
+    metabase_database md
+WHERE
+    pg.name != 'Administrators'
+AND NOT EXISTS (
+    SELECT 1 FROM data_permissions dp
+    WHERE dp.group_id = pg.id AND dp.db_id = md.id AND dp.type = 'data-access'
+)
+-- Filter out rows where perm_value would be NULL
+AND CASE
+        WHEN EXISTS (
+            SELECT 1
+            FROM permissions p
+            WHERE p.group_id = pg.id AND p.object = CONCAT('/db/', md.id, '/')
+        ) THEN TRUE
+        WHEN EXISTS (
+            SELECT 1
+            FROM permissions p
+            WHERE p.group_id = pg.id AND p.object = CONCAT('/block/db/', md.id, '/')
+        ) THEN TRUE
+        WHEN NOT EXISTS (
+            SELECT 1
+            FROM permissions p
+            WHERE p.group_id = pg.id AND p.object LIKE CONCAT('/db/', md.id, '/%')
+        ) THEN TRUE
+        ELSE FALSE
+    END;
+
+-- Insert table-level permissions only where no DB-level permissions exist
+INSERT INTO data_permissions (group_id, type, db_id, schema, table_id, perm_value)
 SELECT
     pg.id AS group_id,
     'data-access' AS type,
     mt.db_id,
     mt.schema AS schema,
     mt.id AS table_id,
-    NULL AS object_id,
     CASE
         WHEN EXISTS (
             SELECT 1
             FROM permissions p
-            WHERE
-                p.group_id = pg.id AND
-                (
-                    p.object = CONCAT('/db/', mt.db_id, '/') OR
-                    p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/') OR
-                    p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/') OR
-                    p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/') OR
-                    p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/segmented/')
-                )
+            WHERE p.group_id = pg.id AND (
+                p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/') OR
+                p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/') OR
+                p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/') OR
+                p.object = CONCAT('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/segmented/')
+            )
         ) THEN 'unrestricted'
-        WHEN EXISTS (
-            SELECT 1
-            FROM permissions p
-            WHERE
-                p.group_id = pg.id AND
-                p.object = CONCAT('/block/db/', mt.db_id, '/')
-        ) THEN 'block'
         ELSE 'no-self-service'
-    END AS "VALUE"
+    END AS perm_value
 FROM
     permissions_group pg
 CROSS JOIN
@@ -36,9 +81,10 @@ CROSS JOIN
 WHERE
     pg.name != 'Administrators'
 AND NOT EXISTS (
-    SELECT 1 FROM permissions_v2 pv2
-    WHERE
-        pv2.group_id = pg.id AND
-        pv2.table_id = mt.id AND
-        pv2.type = 'data-access'
+    SELECT 1 FROM data_permissions dp
+    WHERE dp.group_id = pg.id AND dp.db_id = mt.db_id AND dp.type = 'data-access'
+)
+AND NOT EXISTS (
+    SELECT 1 FROM data_permissions dp
+    WHERE dp.group_id = pg.id AND dp.db_id = mt.db_id AND dp.table_id IS NULL
 );

--- a/resources/migrations/permissions/data_access.sql
+++ b/resources/migrations/permissions/data_access.sql
@@ -1,84 +1,84 @@
 -- Insert DB-level permissions with a check for table-level permissions
 
-INSERT INTO data_permissions (group_id, TYPE, db_id, SCHEMA, table_id, perm_value)
-SELECT pg.id AS group_id,
-       'data-access' AS TYPE,
-       md.id AS db_id,
-       NULL AS SCHEMA,
-       NULL AS table_id,
-       CASE
-           WHEN EXISTS
-                  (SELECT 1
-                   FROM permissions p
-                   WHERE p.group_id = pg.id
-                     AND p.object = concat('/db/', md.id, '/') ) THEN 'unrestricted'
-           WHEN EXISTS
-                  (SELECT 1
-                   FROM permissions p
-                   WHERE p.group_id = pg.id
-                     AND p.object = concat('/block/db/', md.id, '/') ) THEN 'block'
-           WHEN NOT EXISTS
-                  (SELECT 1
-                   FROM permissions p
-                   WHERE p.group_id = pg.id
-                     AND p.object LIKE concat('/db/', md.id, '/%') ) THEN 'no-self-service'
-       END AS perm_value
-FROM permissions_group pg
-CROSS JOIN metabase_database md
-WHERE pg.name != 'Administrators'
-  AND NOT EXISTS
-    (SELECT 1
-     FROM data_permissions dp
-     WHERE dp.group_id = pg.id
-       AND dp.db_id = md.id
-       AND dp.type = 'data-access' )
-  AND CASE
-          WHEN EXISTS
-                 (SELECT 1
-                  FROM permissions p
-                  WHERE p.group_id = pg.id
-                    AND p.object = concat('/db/', md.id, '/') ) THEN TRUE
-          WHEN EXISTS
-                 (SELECT 1
-                  FROM permissions p
-                  WHERE p.group_id = pg.id
-                    AND p.object = concat('/block/db/', md.id, '/') ) THEN TRUE
-          WHEN NOT EXISTS
-                 (SELECT 1
-                  FROM permissions p
-                  WHERE p.group_id = pg.id
-                    AND p.object LIKE concat('/db/', md.id, '/%') ) THEN TRUE
-          ELSE FALSE
-      END;
+  INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
+  SELECT pg.id AS group_id,
+         'data-access' AS perm_type,
+         md.id AS db_id,
+         NULL AS schema_name,
+         NULL AS table_id,
+         CASE
+             WHEN EXISTS
+                    (SELECT 1
+                     FROM permissions p
+                     WHERE p.group_id = pg.id
+                       AND p.object = concat('/db/', md.id, '/') ) THEN 'unrestricted'
+             WHEN EXISTS
+                    (SELECT 1
+                     FROM permissions p
+                     WHERE p.group_id = pg.id
+                       AND p.object = concat('/block/db/', md.id, '/') ) THEN 'block'
+             WHEN NOT EXISTS
+                    (SELECT 1
+                     FROM permissions p
+                     WHERE p.group_id = pg.id
+                       AND p.object LIKE concat('/db/', md.id, '/%') ) THEN 'no-self-service'
+         END AS perm_value
+  FROM permissions_group pg
+  CROSS JOIN metabase_database md
+  WHERE pg.name != 'Administrators'
+    AND NOT EXISTS
+      (SELECT 1
+       FROM data_permissions dp
+       WHERE dp.group_id = pg.id
+         AND dp.db_id = md.id
+         AND dp.perm_type = 'data-access' )
+    AND CASE
+            WHEN EXISTS
+                   (SELECT 1
+                    FROM permissions p
+                    WHERE p.group_id = pg.id
+                      AND p.object = concat('/db/', md.id, '/') ) THEN TRUE
+            WHEN EXISTS
+                   (SELECT 1
+                    FROM permissions p
+                    WHERE p.group_id = pg.id
+                      AND p.object = concat('/block/db/', md.id, '/') ) THEN TRUE
+            WHEN NOT EXISTS
+                   (SELECT 1
+                    FROM permissions p
+                    WHERE p.group_id = pg.id
+                      AND p.object LIKE concat('/db/', md.id, '/%') ) THEN TRUE
+            ELSE FALSE
+        END;
 
--- Insert table-level permissions only where no DB-level permissions exist
+  -- Insert table-level permissions only where no DB-level permissions exist
 
-INSERT INTO data_permissions (group_id, TYPE, db_id, SCHEMA, table_id, perm_value)
-SELECT pg.id AS group_id,
-       'data-access' AS TYPE,
-       mt.db_id,
-       mt.schema AS SCHEMA,
-       mt.id AS table_id,
-       CASE
-           WHEN EXISTS
-                  (SELECT 1
-                   FROM permissions p
-                   WHERE p.group_id = pg.id
-                     AND (p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/')
-                          OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/')
-                          OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/')
-                          OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/segmented/')) ) THEN 'unrestricted'
-           ELSE 'no-self-service'
-       END AS perm_value
-FROM permissions_group pg
-CROSS JOIN metabase_table mt
-WHERE pg.name != 'Administrators'
-  AND NOT EXISTS
-    (SELECT 1
-     FROM data_permissions dp
-     WHERE dp.group_id = pg.id
-       AND dp.db_id = mt.db_id
-       AND dp.type = 'data-access' )
+  INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
+  SELECT pg.id AS group_id,
+         'data-access' AS perm_type,
+         mt.db_id,
+         mt.schema AS schema_name,
+         mt.id AS table_id,
+         CASE
+             WHEN EXISTS
+                    (SELECT 1
+                     FROM permissions p
+                     WHERE p.group_id = pg.id
+                       AND (p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/')
+                            OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/')
+                            OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/')
+                            OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/segmented/')) ) THEN 'unrestricted'
+             ELSE 'no-self-service'
+         END AS perm_value
+  FROM permissions_group pg
+  CROSS JOIN metabase_table mt
+  WHERE pg.name != 'Administrators'
+    AND NOT EXISTS
+      (SELECT 1
+       FROM data_permissions dp
+       WHERE dp.group_id = pg.id
+         AND dp.db_id = mt.db_id
+         AND dp.perm_type = 'data-access' )
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp

--- a/resources/migrations/permissions/data_access.sql
+++ b/resources/migrations/permissions/data_access.sql
@@ -1,87 +1,91 @@
--- Insert DB-level permissions with a check for table-level permissions
+-- Insert DB-level permissions for cases where no table-level perms are set
 
-  INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
-  SELECT pg.id AS group_id,
-         'data-access' AS perm_type,
-         md.id AS db_id,
-         NULL AS schema_name,
-         NULL AS table_id,
-         CASE
-             WHEN EXISTS
-                    (SELECT 1
-                     FROM permissions p
-                     WHERE p.group_id = pg.id
-                       AND p.object = concat('/db/', md.id, '/') ) THEN 'unrestricted'
-             WHEN EXISTS
-                    (SELECT 1
-                     FROM permissions p
-                     WHERE p.group_id = pg.id
-                       AND p.object = concat('/block/db/', md.id, '/') ) THEN 'block'
-             WHEN NOT EXISTS
-                    (SELECT 1
-                     FROM permissions p
-                     WHERE p.group_id = pg.id
-                       AND p.object LIKE concat('/db/', md.id, '/%') ) THEN 'no-self-service'
-         END AS perm_value
-  FROM permissions_group pg
-  CROSS JOIN metabase_database md
-  WHERE pg.name != 'Administrators'
-    AND NOT EXISTS
-      (SELECT 1
-       FROM data_permissions dp
-       WHERE dp.group_id = pg.id
-         AND dp.db_id = md.id
-         AND dp.perm_type = 'data-access' )
-    AND CASE
-            WHEN EXISTS
-                   (SELECT 1
-                    FROM permissions p
-                    WHERE p.group_id = pg.id
-                      AND p.object = concat('/db/', md.id, '/') ) THEN TRUE
-            WHEN EXISTS
-                   (SELECT 1
-                    FROM permissions p
-                    WHERE p.group_id = pg.id
-                      AND p.object = concat('/block/db/', md.id, '/') ) THEN TRUE
-            WHEN NOT EXISTS
-                   (SELECT 1
-                    FROM permissions p
-                    WHERE p.group_id = pg.id
-                      AND p.object LIKE concat('/db/', md.id, '/%') ) THEN TRUE
-            ELSE FALSE
-        END;
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
+SELECT pg.id AS group_id,
+       'data-access' AS perm_type,
+       md.id AS db_id,
+       NULL AS schema_name,
+       NULL AS table_id,
+       CASE
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object = concat('/db/', md.id, '/')
+                          OR p.object = concat('/db/', md.id, '/schema/'))) THEN 'unrestricted'
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND p.object = concat('/block/db/', md.id, '/') ) THEN 'block'
+           WHEN NOT EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND p.object LIKE concat('/db/', md.id, '/%') ) THEN 'no-self-service'
+       END AS perm_value
+FROM permissions_group pg
+CROSS JOIN metabase_database md
+WHERE pg.name != 'Administrators'
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = md.id
+       AND dp.perm_type = 'data-access' )
+  AND CASE
+          WHEN EXISTS
+                 (SELECT 1
+                  FROM permissions p
+                  WHERE p.group_id = pg.id
+                    AND (p.object = concat('/db/', md.id, '/')
+                         OR p.object = concat('/db/', md.id, '/schema/')) ) THEN TRUE
+          WHEN EXISTS
+                 (SELECT 1
+                  FROM permissions p
+                  WHERE p.group_id = pg.id
+                    AND p.object = concat('/block/db/', md.id, '/') ) THEN TRUE
+          WHEN NOT EXISTS
+                 (SELECT 1
+                  FROM permissions p
+                  WHERE p.group_id = pg.id
+                    AND p.object LIKE concat('/db/', md.id, '/%') ) THEN TRUE
+          ELSE FALSE
+      END;
 
-  -- Insert table-level permissions only where no DB-level permissions exist
+-- Insert table-level permissions only where no DB-level permissions exist
 
-  INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
-  SELECT pg.id AS group_id,
-         'data-access' AS perm_type,
-         mt.db_id,
-         mt.schema AS schema_name,
-         mt.id AS table_id,
-         CASE
-             WHEN EXISTS
-                    (SELECT 1
-                     FROM permissions p
-                     WHERE p.group_id = pg.id
-                       AND (p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/')
-                            OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/')
-                            OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/')
-                            OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/segmented/')) ) THEN 'unrestricted'
-             ELSE 'no-self-service'
-         END AS perm_value
-  FROM permissions_group pg
-  CROSS JOIN metabase_table mt
-  WHERE pg.name != 'Administrators'
-    AND NOT EXISTS
-      (SELECT 1
-       FROM data_permissions dp
-       WHERE dp.group_id = pg.id
-         AND dp.db_id = mt.db_id
-         AND dp.perm_type = 'data-access' )
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
+SELECT pg.id AS group_id,
+       'data-access' AS perm_type,
+       mt.db_id,
+       mt.schema AS schema_name,
+       mt.id AS table_id,
+       CASE
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/')
+                          OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/')
+                          OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/')
+                          OR p.object = concat('/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/query/segmented/')) ) THEN 'unrestricted'
+           ELSE 'no-self-service'
+       END AS perm_value
+FROM permissions_group pg
+CROSS JOIN metabase_table mt
+WHERE pg.name != 'Administrators'
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
-       AND dp.table_id IS NULL );
+       AND dp.table_id = mt.id
+       AND dp.perm_type = 'data-access' )
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = mt.db_id
+       AND dp.table_id IS NULL
+       AND dp.perm_type = 'data-access' );

--- a/resources/migrations/permissions/download_results.sql
+++ b/resources/migrations/permissions/download_results.sql
@@ -1,0 +1,95 @@
+-- Insert DB-level permissions with a check for table-level permissions
+
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
+SELECT pg.id AS group_id,
+       'download-results' AS perm_type,
+       md.id AS db_id,
+       NULL AS schema_name,
+       NULL AS table_id,
+       CASE
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object = concat('/download/db/', md.id, '/')
+                          OR p.object = concat('/download/db/', md.id, '/schema/'))) THEN 'one-million-rows'
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object = concat('/download/limited/db/', md.id, '/')
+                          OR p.object = concat('/download/limited/db/', md.id, '/schema/'))) THEN 'ten-thousand-rows'
+           WHEN NOT EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object like concat('/download/db/', md.id, '/%')
+                          OR p.object like concat('/download/limited/db/', md.id, '/%'))) THEN 'no'
+       END AS perm_value
+FROM permissions_group pg
+CROSS JOIN metabase_database md
+WHERE pg.name != 'Administrators'
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = md.id
+       AND dp.perm_type = 'download-results')
+  AND CASE
+          WHEN EXISTS
+                 (SELECT 1
+                  FROM permissions p
+                  WHERE p.group_id = pg.id
+                    AND (p.object = concat('/download/db/', md.id, '/')
+                         OR p.object = concat('/download/db/', md.id, '/schema/')
+                         OR p.object = concat('/download/limited/db/', md.id, '/')
+                         OR p.object = concat('/download/limited/db/', md.id, '/schema/'))) THEN TRUE
+          WHEN NOT EXISTS
+                 (SELECT 1
+                  FROM permissions p
+                  WHERE p.group_id = pg.id
+                    AND (p.object like concat('/download/db/', md.id, '/%')
+                         OR p.object like concat('/download/limited/db/', md.id, '/%'))) THEN TRUE
+          ELSE FALSE
+      END;
+
+-- Insert table-level permissions only where no DB-level permissions exist
+
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
+SELECT pg.id AS group_id,
+       'download-results' AS perm_type,
+       mt.db_id,
+       mt.schema AS schema_name,
+       mt.id AS table_id,
+       CASE
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object = concat('/download/db/', mt.db_id, '/schema/', mt.schema, '/')
+                          OR p.object = concat('/download/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/'))) THEN 'one-million-rows'
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object = concat('/download/limited/db/', mt.db_id, '/schema/', mt.schema, '/')
+                          OR p.object = concat('/download/limited/db/', mt.db_id, '/schema/', mt.schema, '/table/', mt.id, '/'))) THEN 'ten-thousand-rows'
+           ELSE 'no'
+       END AS perm_value
+FROM permissions_group pg
+CROSS JOIN metabase_table mt
+WHERE pg.name != 'Administrators'
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = mt.db_id
+       AND dp.table_id = mt.id
+       AND dp.perm_type = 'download-results' )
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = mt.db_id
+       AND dp.table_id IS NULL
+       AND dp.perm_type = 'download-results');

--- a/resources/migrations/permissions/download_results.sql
+++ b/resources/migrations/permissions/download_results.sql
@@ -93,7 +93,7 @@ WHERE pg.name != 'Administrators'
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id = mt.id
-       AND dp.perm_type = 'download-results' )
+       AND dp.perm_type = 'download-results')
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp

--- a/resources/migrations/permissions/manage_database.sql
+++ b/resources/migrations/permissions/manage_database.sql
@@ -1,0 +1,23 @@
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
+SELECT pg.id AS group_id,
+       'manage-database' AS perm_type,
+       md.id AS db_id,
+       NULL AS schema_name,
+       NULL AS table_id,
+       CASE
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND p.object = concat('/details/db/', md.id, '/')) THEN 'yes'
+           ELSE 'no'
+       END AS perm_value
+FROM permissions_group pg
+CROSS JOIN metabase_database md
+WHERE pg.name != 'Administrators'
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = md.id
+       AND dp.perm_type = 'manage-database');

--- a/resources/migrations/permissions/manage_table_metadata.sql
+++ b/resources/migrations/permissions/manage_table_metadata.sql
@@ -1,10 +1,10 @@
 -- Insert DB-level permissions with a check for table-level permissions
 
-INSERT INTO data_permissions (group_id, perm_type, db_id, SCHEMA_NAME, table_id, perm_value)
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
        'manage-table-metadata' AS perm_type,
        md.id AS db_id,
-       NULL AS SCHEMA_NAME,
+       NULL AS schema_name,
        NULL AS table_id,
        CASE
            WHEN EXISTS
@@ -13,11 +13,7 @@ SELECT pg.id AS group_id,
                    WHERE p.group_id = pg.id
                      AND (p.object = concat('/data-model/db/', md.id, '/')
                           OR p.object = concat('/data-model/db/', md.id, '/schema/'))) THEN 'yes'
-           WHEN NOT EXISTS
-                  (SELECT 1
-                   FROM permissions p
-                   WHERE p.group_id = pg.id
-                     AND (p.object like concat('/data-model/db/', md.id, '/schema/%'))) THEN 'no'
+            ELSE 'no'
        END AS perm_value
 FROM permissions_group pg
 CROSS JOIN metabase_database md
@@ -47,13 +43,13 @@ WHERE pg.name != 'Administrators'
 WITH escaped_schema_table AS (
 SELECT id,
        db_id,
-       SCHEMA,
-       replace(replace(SCHEMA, '\', '\\'), '/', '\/') AS escaped_schema
+       schema,
+       replace(replace(schema, '\', '\\'), '/', '\/') AS escaped_schema
     FROM metabase_table
 )
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'MANAGE-TABLE-metadata' AS perm_type,
+       'manage-table-metadata' AS perm_type,
        mt.db_id,
        mt.schema AS schema_name,
        mt.id AS table_id,
@@ -62,23 +58,23 @@ SELECT pg.id AS group_id,
                   (SELECT 1
                    FROM permissions p
                    WHERE p.group_id = pg.id
-                     AND p.object = concat('/DATA-model/db/', mt.db_id, '/SCHEMA/', mt.escaped_schema, '/TABLE', mt.id, '/'))) THEN 'yes'
-           ELSE 'NO'
+                     AND p.object = concat('/data-model/db/', mt.db_id, '/schema/', mt.escaped_schema, '/table/', mt.id, '/')) THEN 'yes'
+           ELSE 'no'
        END AS perm_value
 FROM permissions_group pg
 CROSS JOIN escaped_schema_table mt
-WHERE pg.name != 'administrators'
+WHERE pg.name != 'Administrators'
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id = mt.id
-       AND dp.perm_type = 'MANAGE-TABLE-metadata')
+       AND dp.perm_type = 'manage-table-metadata')
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id IS NULL
-       AND dp.perm_type = 'MANAGE-TABLE-metadata');
+       AND dp.perm_type = 'manage-table-metadata');

--- a/resources/migrations/permissions/manage_table_metadata.sql
+++ b/resources/migrations/permissions/manage_table_metadata.sql
@@ -1,0 +1,84 @@
+-- Insert DB-level permissions with a check for table-level permissions
+
+INSERT INTO data_permissions (group_id, perm_type, db_id, SCHEMA_NAME, table_id, perm_value)
+SELECT pg.id AS group_id,
+       'manage-table-metadata' AS perm_type,
+       md.id AS db_id,
+       NULL AS SCHEMA_NAME,
+       NULL AS table_id,
+       CASE
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object = concat('/data-model/db/', md.id, '/')
+                          OR p.object = concat('/data-model/db/', md.id, '/schema/'))) THEN 'yes'
+           WHEN NOT EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object like concat('/data-model/db/', md.id, '/schema/%'))) THEN 'no'
+       END AS perm_value
+FROM permissions_group pg
+CROSS JOIN metabase_database md
+WHERE pg.name != 'Administrators'
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = md.id
+       AND dp.perm_type = 'manage-table-metadata')
+  AND CASE
+          WHEN EXISTS
+                 (SELECT 1
+                  FROM permissions p
+                  WHERE p.group_id = pg.id
+                    AND (p.object = concat('/data-model/db/', md.id, '/')
+                         OR p.object = concat('/data-model/db/', md.id, '/schema/'))) THEN TRUE
+          WHEN NOT EXISTS
+                 (SELECT 1
+                  FROM permissions p
+                  WHERE p.group_id = pg.id
+                    AND p.object like concat('/data-model/db/', md.id, '/schema/%')) THEN TRUE
+          ELSE FALSE
+      END;
+
+-- Insert table-level permissions only where no DB-level permissions exist
+WITH escaped_schema_table AS (
+SELECT id,
+       db_id,
+       SCHEMA,
+       replace(replace(SCHEMA, '\', '\\'), '/', '\/') AS escaped_schema
+    FROM metabase_table
+)
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
+SELECT pg.id AS group_id,
+       'MANAGE-TABLE-metadata' AS perm_type,
+       mt.db_id,
+       mt.schema AS schema_name,
+       mt.id AS table_id,
+       CASE
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND p.object = concat('/DATA-model/db/', mt.db_id, '/SCHEMA/', mt.escaped_schema, '/TABLE', mt.id, '/'))) THEN 'yes'
+           ELSE 'NO'
+       END AS perm_value
+FROM permissions_group pg
+CROSS JOIN escaped_schema_table mt
+WHERE pg.name != 'administrators'
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = mt.db_id
+       AND dp.table_id = mt.id
+       AND dp.perm_type = 'MANAGE-TABLE-metadata')
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = mt.db_id
+       AND dp.table_id IS NULL
+       AND dp.perm_type = 'MANAGE-TABLE-metadata');

--- a/resources/migrations/permissions/mysql_data_access.sql
+++ b/resources/migrations/permissions/mysql_data_access.sql
@@ -55,15 +55,15 @@ WHERE pg.name != 'Administrators'
 
 -- Insert table-level permissions only where no DB-level permissions exist
 
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 WITH escaped_schema_table AS (
     SELECT
     mt.id,
     mt.db_id,
     mt.schema,
-    REPLACE(REPLACE(mt.schema, '\', '\\'), '/', '\/') AS escaped_schema
+    REPLACE(REPLACE(mt.schema, '\\', '\\\\'), '/', '\\/') AS escaped_schema
     FROM metabase_table mt
 )
-INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
        'data-access' AS perm_type,
        mt.db_id,

--- a/resources/migrations/permissions/mysql_download_results.sql
+++ b/resources/migrations/permissions/mysql_download_results.sql
@@ -55,15 +55,15 @@ WHERE pg.name != 'Administrators'
 
 -- Insert table-level permissions only where no DB-level permissions exist
 
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 WITH escaped_schema_table AS (
     SELECT
     mt.id,
     mt.db_id,
     mt.schema,
-    REPLACE(REPLACE(mt.schema, '\', '\\'), '/', '\/') AS escaped_schema
+    REPLACE(REPLACE(mt.schema, '\\', '\\\\'), '/', '\\/') AS escaped_schema
     FROM metabase_table mt
 )
-INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
        'download-results' AS perm_type,
        mt.db_id,

--- a/resources/migrations/permissions/mysql_manage_table_metadata.sql
+++ b/resources/migrations/permissions/mysql_manage_table_metadata.sql
@@ -40,14 +40,14 @@ WHERE pg.name != 'Administrators'
       END;
 
 -- Insert table-level permissions only where no DB-level permissions exist
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 WITH escaped_schema_table AS (
 SELECT mt.id,
        mt.db_id,
        mt.schema,
-       replace(replace(mt.schema, '\', '\\'), '/', '\/') AS escaped_schema
+       replace(replace(mt.schema, '\\', '\\\\'), '/', '\\/') AS escaped_schema
     FROM metabase_table mt
 )
-INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
        'manage-table-metadata' AS perm_type,
        mt.db_id,

--- a/resources/migrations/permissions/native_query_editing.sql
+++ b/resources/migrations/permissions/native_query_editing.sql
@@ -1,0 +1,24 @@
+INSERT INTO data_permissions (group_id, TYPE, db_id, SCHEMA, table_id, perm_value)
+SELECT pg.id AS group_id,
+       'native-query-editing' AS TYPE,
+       md.id AS db_id,
+       NULL AS SCHEMA,
+       NULL AS table_id,
+       CASE
+           WHEN EXISTS
+                  (SELECT 1
+                   FROM permissions p
+                   WHERE p.group_id = pg.id
+                     AND (p.object = concat('/db/', md.id, '/')
+                          OR p.object = concat('/db/', md.id, '/native/'))) THEN 'yes'
+           ELSE 'no'
+       END AS perm_value
+FROM permissions_group pg
+CROSS JOIN metabase_database md
+WHERE pg.name != 'Administrators'
+  AND NOT EXISTS
+    (SELECT 1
+     FROM data_permissions dp
+     WHERE dp.group_id = pg.id
+       AND dp.db_id = md.id
+       AND dp.type = 'native-query-editing' );

--- a/resources/migrations/permissions/native_query_editing.sql
+++ b/resources/migrations/permissions/native_query_editing.sql
@@ -1,8 +1,8 @@
-INSERT INTO data_permissions (group_id, TYPE, db_id, SCHEMA, table_id, perm_value)
+INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'native-query-editing' AS TYPE,
+       'native-query-editing' AS perm_type,
        md.id AS db_id,
-       NULL AS SCHEMA,
+       NULL AS schema_name,
        NULL AS table_id,
        CASE
            WHEN EXISTS
@@ -21,4 +21,4 @@ WHERE pg.name != 'Administrators'
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = md.id
-       AND dp.type = 'native-query-editing' );
+       AND dp.perm_type = 'native-query-editing' );

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -15,9 +15,10 @@
 (methodical/defmethod t2/table-name :model/DataPermissions [_model] :data_permissions)
 
 (t2/deftransforms :model/DataPermissions
-  {:type       mi/transform-keyword
+  {:perm_type  mi/transform-keyword
    :perm_value mi/transform-keyword
-   ;; define keyword transformation for :value as well so that we can use it as an alias for :perm_value
+   ;; define keyword transformation for :type and :value as well so that we can use them as aliases
+   :type       mi/transform-keyword
    :value      mi/transform-keyword})
 
 
@@ -113,7 +114,7 @@
                                                 [:data_permissions :p]   [:= :p.group_id :pg.id]]
                                          :where [:and
                                                  [:= :pgm.user_id user-id]
-                                                 [:= :p.type (name perm-type)]
+                                                 [:= :p.perm_type (name perm-type)]
                                                  [:= :p.db_id database-id]]})]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
@@ -135,7 +136,7 @@
                                                 [:data_permissions :p]   [:= :p.group_id :pg.id]]
                                          :where [:and
                                                  [:= :pgm.user_id user-id]
-                                                 [:= :p.type (name perm-type)]
+                                                 [:= :p.perm_type (name perm-type)]
                                                  [:= :p.db_id database-id]
                                                  [:or
                                                   [:= :table_id table-id]
@@ -160,16 +161,16 @@
   for permission enforcement, as it will read much more data than necessary."
   [& {:keys [group-id db-id perm-type]}]
   (let [data-perms (t2/select [:model/DataPermissions
-                               :type
+                               [:perm_type :type]
                                [:group_id :group-id]
                                [:perm_value :value]
                                [:db_id :db-id]
-                               :schema
+                               [:schema_name :schema]
                                [:table_id :table-id]]
                               {:where [:and
                                        (when db-id [:= :db_id db-id])
                                        (when group-id [:= :group_id group-id])
-                                       (when perm-type [:= :type (name perm-type)])]})]
+                                       (when perm-type [:= :perm_type (name perm-type)])]})]
     (reduce
      (fn [graph {group-id  :group-id
                  perm-type :type
@@ -189,10 +190,10 @@
 ;;; --------------------------------------------- Updating permissions ------------------------------------------------
 
 (defn- assert-valid-permission
-  [{:keys [type perm_value] :as permission}]
-  (when-not (mc/validate PermissionType type)
-    (throw (ex-info (str/join (mu/explain PermissionType type)) permission)))
-  (assert-value-matches-perm-type type perm_value))
+  [{:keys [perm_type perm_value] :as permission}]
+  (when-not (mc/validate PermissionType perm_type)
+    (throw (ex-info (str/join (mu/explain PermissionType perm_type)) permission)))
+  (assert-value-matches-perm-type perm_type perm_value))
 
 (t2/define-before-insert :model/DataPermissions
   [permission]
@@ -221,8 +222,8 @@
   (t2/with-transaction [_conn]
     (let [group-id (u/the-id group-or-id)
           db-id    (u/the-id db-or-id)]
-      (t2/delete! :model/DataPermissions :type perm-type :group_id group-id :db_id db-id)
-      (t2/insert! :model/DataPermissions {:type       perm-type
+      (t2/delete! :model/DataPermissions :perm_type perm-type :group_id group-id :db_id db-id)
+      (t2/insert! :model/DataPermissions {:perm_type  perm-type
                                           :group_id   group-id
                                           :perm_value value
                                           :db_id      db-id})
@@ -256,12 +257,12 @@
                                                 (if (map? table)
                                                   table
                                                   (t2/select-one [:model/Table :id :db_id :schema] :id table))]
-                                            {:type       perm-type
-                                             :group_id   group-id
-                                             :perm_value value
-                                             :db_id      db_id
-                                             :table_id   id
-                                             :schema     schema}))
+                                            {:perm_type   perm-type
+                                             :group_id    group-id
+                                             :perm_value  value
+                                             :db_id       db_id
+                                             :table_id    id
+                                             :schema_name schema}))
                                         table-perms)
             _                      (when (not= (count (set (map :db_id new-perms))) 1)
                                      (throw (ex-info (tru "All tables must belong to the same database.")
@@ -271,10 +272,10 @@
             existing-db-perm       (t2/select-one :model/DataPermissions
                                                   {:where
                                                    [:and
-                                                    [:= :type (name perm-type)]
-                                                    [:= :group_id group-id]
-                                                    [:= :db_id db-id]
-                                                    [:= :table_id nil]]})
+                                                    [:= :perm_type (name perm-type)]
+                                                    [:= :group_id  group-id]
+                                                    [:= :db_id     db-id]
+                                                    [:= :table_id  nil]]})
             existing-db-perm-value (:perm_value existing-db-perm)]
         (if existing-db-perm
           (when (not= values #{existing-db-perm-value})
@@ -284,19 +285,19 @@
                                                                    [:= :db_id db-id]
                                                                    [:not [:in :id table-ids]]]})
                   other-new-perms (map (fn [table]
-                                         {:type       perm-type
-                                          :group_id   group-id
-                                          :perm_value existing-db-perm-value
-                                          :db_id      db-id
-                                          :table_id   (:id table)
-                                          :schema     (:schema table)})
+                                         {:perm_type   perm-type
+                                          :group_id    group-id
+                                          :perm_value  existing-db-perm-value
+                                          :db_id       db-id
+                                          :table_id    (:id table)
+                                          :schema_name (:schema table)})
                                        other-tables)]
               (t2/delete! :model/DataPermissions :id (:id existing-db-perm))
               (t2/insert! :model/DataPermissions (concat other-new-perms new-perms))))
           (let [existing-table-perms (t2/select :model/DataPermissions
-                                                :type (name perm-type)
-                                                :group_id group-id
-                                                :db_id db-id
+                                                :perm_type (name perm-type)
+                                                :group_id  group-id
+                                                :db_id     db-id
                                                 {:where [:and
                                                          [:not= :table_id nil]
                                                          [:not [:in :table_id table-ids]]]})
@@ -308,7 +309,7 @@
               (set-database-permission! group-or-id db-id perm-type (first values))
               ;; Otherwise, just replace the rows for the individual table perm
               (do
-                (t2/delete! :model/DataPermissions :type perm-type :group_id group-id {:where [:in :table_id table-ids]})
+                (t2/delete! :model/DataPermissions :perm_type perm-type :group_id group-id {:where [:in :table_id table-ids]})
                 (t2/insert! :model/DataPermissions new-perms)))))))))
 
 (mu/defn set-table-permission!

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -38,8 +38,8 @@
    :download-results      {:model :model/Table :values [:one-million-rows :ten-thousand-rows :no]}
    :manage-table-metadata {:model :model/Table :values [:yes :no]}
 
-   :native-query-editing {:model :model/Database :values [:yes :no]}
-   :manage-database      {:model :model/Database :values [:yes :no]}})
+   :native-query-editing  {:model :model/Database :values [:yes :no]}
+   :manage-database       {:model :model/Database :values [:yes :no]}})
 
 (def PermissionType
   "Malli spec for valid permission types."

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -946,7 +946,7 @@
           (migrate!)
           (is (= "yes" (t2/select-one-fn :perm_value
                                          (t2/table-name :model/DataPermissions)
-                                         :db_id db-id :table_id nil :group_id group-id :type "native-query-editing"))))
+                                         :db_id db-id :table_id nil :group_id group-id :perm_type "native-query-editing"))))
 
         (testing "Native query editing explicitly allowed"
           (clear-permissions!)
@@ -955,11 +955,11 @@
           (migrate!)
           (is (= "yes" (t2/select-one-fn :perm_value
                                          (t2/table-name :model/DataPermissions)
-                                         :db_id db-id :table_id nil :group_id group-id :type "native-query-editing"))))
+                                         :db_id db-id :table_id nil :group_id group-id :perm_type "native-query-editing"))))
 
         (testing "Native query editing not allowed"
           (clear-permissions!)
           (migrate!)
           (is (= "no" (t2/select-one-fn :perm_value
                                         (t2/table-name :model/DataPermissions)
-                                        :db_id db-id :table_id nil :group_id group-id :type "native-query-editing"))))))))
+                                        :db_id db-id :table_id nil :group_id group-id :perm_type "native-query-editing"))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -801,60 +801,131 @@
 (defn- clear-permissions!
   []
   (t2/delete! :model/Permissions {:where [:not= :object "/"]})
-  (t2/delete! :model/PermissionsV2))
+  (t2/delete! :model/DataPermissions))
 
-(deftest data-access-permissions-schema-migration
+(deftest data-access-permissions-schema-migration-basic-test
   (testing "Data access permissions are correctly migrated from `permissions` to `permissions_v2`"
-   (impl/test-migrations "v49.2024-01-10T03:27:30" [migrate!]
-     (let [group-id (first (t2/insert-returning-pks! (t2/table-name PermissionsGroup) {:name "Test Group"}))
-           db-id    (first (t2/insert-returning-pks! (t2/table-name Database) {:name       "db"
-                                                                               :engine     "postgres"
+    (impl/test-migrations "v49.2024-01-10T03:27:30" [migrate!]
+      (let [group-id   (first (t2/insert-returning-pks! (t2/table-name PermissionsGroup) {:name "Test Group"}))
+            db-id      (first (t2/insert-returning-pks! (t2/table-name Database) {:name       "db"
+                                                                                  :engine     "postgres"
+                                                                                  :created_at :%now
+                                                                                  :updated_at :%now
+                                                                                  :details    "{}"}))
+            table-id-1 (first (t2/insert-returning-pks! (t2/table-name Table) {:db_id      db-id
+                                                                               :name       "Table 2"
                                                                                :created_at :%now
                                                                                :updated_at :%now
-                                                                               :details    "{}"}))
-           table-id (first (t2/insert-returning-pks! (t2/table-name Table) {:db_id      db-id
-                                                                            :name       "Table"
-                                                                            :created_at :%now
-                                                                            :updated_at :%now
-                                                                            :schema     "PUBLIC"
-                                                                            :active     true}))]
-      (testing "Unrestricted data access for a DB"
-       (clear-permissions!)
-       (t2/insert! (t2/table-name Permissions) {:group_id group-id
-                                                :object   (format "/db/%d/" db-id)})
-       (migrate!)
-       (is (= "unrestricted"
-              (t2/select-one-fn :value (t2/table-name :model/PermissionsV2) :table_id table-id :group_id group-id))))
+                                                                               :schema     "PUBLIC"
+                                                                               :active     true}))
+            table-id-2 (first (t2/insert-returning-pks! (t2/table-name Table) {:db_id      db-id
+                                                                               :name       "Table 1"
+                                                                               :created_at :%now
+                                                                               :updated_at :%now
+                                                                               :schema     "PUBLIC"
+                                                                               :active     true}))]
+        (testing "Unrestricted data access for a DB"
+          (clear-permissions!)
+          (t2/insert! (t2/table-name Permissions) {:group_id group-id
+                                                   :object   (format "/db/%d/" db-id)})
+          (migrate!)
+          (is (= "unrestricted" (t2/select-one-fn :perm_value
+                                                  (t2/table-name :model/DataPermissions)
+                                                  :db_id db-id :table_id nil :group_id group-id)))
+          (is (nil? (t2/select-one-fn :perm_value
+                                      (t2/table-name :model/DataPermissions)
+                                      :db_id db-id :table_id table-id-1 :group_id group-id))))
 
-      (testing "Unrestricted data access for a schema"
-       (clear-permissions!)
-       (t2/insert! (t2/table-name Permissions) {:group_id group-id
-                                                :object   (format "/db/%d/schema/PUBLIC/" db-id)})
-       (migrate!)
-       (is (= "unrestricted"
-              (t2/select-one-fn :value (t2/table-name :model/PermissionsV2) :table_id table-id :group_id group-id))))
+        (testing "Unrestricted data access for a schema"
+          (clear-permissions!)
+          (t2/insert! (t2/table-name Permissions) {:group_id group-id
+                                                   :object   (format "/db/%d/schema/PUBLIC/" db-id)})
+          (migrate!)
+          (is (nil? (t2/select-one-fn :perm_value
+                                      (t2/table-name :model/DataPermissions)
+                                      :db_id db-id :table_id nil :group_id group-id)))
+          (is (= "unrestricted"
+                 (t2/select-one-fn :perm_value
+                                   (t2/table-name :model/DataPermissions)
+                                   :db_id db-id :table_id table-id-1 :group_id group-id))))
 
-      (testing "Unrestricted data access for a table"
-       (clear-permissions!)
-       (t2/insert! (t2/table-name Permissions) {:group_id group-id
-                                                :object   (format "/db/%d/schema/PUBLIC/table/%d/" db-id table-id)})
-       (migrate!)
-       (is (= "unrestricted"
-              (t2/select-one-fn :value (t2/table-name :model/PermissionsV2) :table_id table-id :group_id group-id))))
+        (testing "Unrestricted data access for a table"
+          (clear-permissions!)
+          (t2/insert! (t2/table-name Permissions) {:group_id group-id
+                                                   :object   (format "/db/%d/schema/PUBLIC/table/%d/" db-id table-id-1)})
+          (migrate!)
+          (is (nil? (t2/select-one-fn :perm_value
+                                      (t2/table-name :model/DataPermissions)
+                                      :db_id db-id :table_id nil :group_id group-id)))
+          (is (= "unrestricted"
+                 (t2/select-one-fn :perm_value
+                                   (t2/table-name :model/DataPermissions)
+                                   :db_id db-id :table_id table-id-1 :group_id group-id))))
 
-      (testing "Query access to a table"
-       (clear-permissions!)
-       (t2/insert! (t2/table-name Permissions) {:group_id group-id
-                                                :object   (format "/db/%d/schema/PUBLIC/table/%d/query/" db-id table-id)})
-       (migrate!)
-       (is (= "unrestricted"
-              (t2/select-one-fn :value (t2/table-name :model/PermissionsV2) :table_id table-id :group_id group-id))))
+        (testing "Query access to a table"
+          (clear-permissions!)
+          (t2/insert! (t2/table-name Permissions) {:group_id group-id
+                                                   :object   (format "/db/%d/schema/PUBLIC/table/%d/query/" db-id table-id-1)})
+          (migrate!)
+          (is (nil? (t2/select-one-fn :perm_value
+                                      (t2/table-name :model/DataPermissions)
+                                      :db_id db-id :table_id nil :group_id group-id)))
+          (is (= "unrestricted"
+                 (t2/select-one-fn :perm_value
+                                   (t2/table-name :model/DataPermissions)
+                                   :db_id db-id :table_id table-id-1 :group_id group-id))))
 
-      (testing "Segmented query access to a table - maps to unrestricted data access; sandboxing is determined by the
-               `sandboxes` table"
-       (clear-permissions!)
-       (t2/insert! (t2/table-name Permissions) {:group_id group-id
-                                                :object   (format "/db/%d/schema/PUBLIC/table/%d/query/segmented/" db-id table-id)})
-       (migrate!)
-       (is (= "unrestricted"
-              (t2/select-one-fn :value (t2/table-name :model/PermissionsV2) :table_id table-id :group_id group-id))))))))
+        (testing "Segmented query access to a table - maps to unrestricted data access; sandboxing is determined by the
+                                     `sandboxes` table"
+          (clear-permissions!)
+          (t2/insert! (t2/table-name Permissions) {:group_id group-id
+                                                   :object   (format "/db/%d/schema/PUBLIC/table/%d/query/segmented/" db-id table-id-1)})
+          (migrate!)
+          (is (nil? (t2/select-one-fn :perm_value
+                                      (t2/table-name :model/DataPermissions)
+                                      :db_id db-id :table_id nil :group_id group-id)))
+          (is (= "unrestricted"
+                 (t2/select-one-fn :perm_value
+                                   (t2/table-name :model/DataPermissions)
+                                   :db_id db-id :table_id table-id-1 :group_id group-id))))
+
+        (testing "No self service database access"
+          (clear-permissions!)
+          (migrate!)
+          (is (= "no-self-service"
+                 (t2/select-one-fn :perm_value
+                                   (t2/table-name :model/DataPermissions)
+                                   :db_id db-id :table_id nil :group_id group-id)))
+          (is (nil? (t2/select-one-fn :perm_value
+                                      (t2/table-name :model/DataPermissions)
+                                      :db_id db-id :table_id table-id-1 :group_id group-id))))
+
+        (testing "Granular table permissions"
+          (clear-permissions!)
+          (t2/insert! (t2/table-name Permissions) {:group_id group-id
+                                                   :object   (format "/db/%d/schema/PUBLIC/table/%d/" db-id table-id-2)})
+          (migrate!)
+          (is (nil?
+               (t2/select-one-fn :perm_value
+                                 (t2/table-name :model/DataPermissions)
+                                 :db_id db-id :table_id nil :group_id group-id)))
+          (is (= "no-self-service"
+                 (t2/select-one-fn :perm_value
+                                   (t2/table-name :model/DataPermissions)
+                                   :db_id db-id :table_id table-id-1 :group_id group-id)))
+          (is (= "unrestricted"
+                 (t2/select-one-fn :perm_value
+                                   (t2/table-name :model/DataPermissions)
+                                   :db_id db-id :table_id table-id-2 :group_id group-id))))
+
+        (testing "Block permissions for a database"
+          (clear-permissions!)
+          (t2/insert! (t2/table-name Permissions) {:group_id group-id
+                                                   :object   (format "/block/db/%d/" db-id)})
+          (migrate!)
+          (is (= "block" (t2/select-one-fn :perm_value
+                                           (t2/table-name :model/DataPermissions)
+                                           :db_id db-id :table_id nil :group_id group-id)))
+          (is (nil? (t2/select-one-fn :perm_value
+                                      (t2/table-name :model/DataPermissions)
+                                      :db_id db-id :table_id table-id-1 :group_id group-id))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -822,7 +822,7 @@
                                                                                :name       "Table 2"
                                                                                :created_at :%now
                                                                                :updated_at :%now
-                                                                               :schema     "PUBLIC"
+                                                                               :schema     "PUBLIC/with\\slash"
                                                                                :active     true}))]
         (testing "Unrestricted data access for a DB"
           (clear-permissions!)
@@ -915,7 +915,7 @@
         (testing "Granular table permissions"
           (clear-permissions!)
           (t2/insert! (t2/table-name Permissions) {:group_id group-id
-                                                   :object   (format "/db/%d/schema/PUBLIC/table/%d/" db-id table-id-2)})
+                                                   :object   (format "/db/%d/schema/PUBLIC\\/with\\\\slash/table/%d/" db-id table-id-2)})
           (migrate!)
           (is (nil?
                (t2/select-one-fn :perm_value

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -47,9 +47,9 @@
                  :model/Database         {database-id :id} {}]
     (let [perm-value (fn [perm-type] (t2/select-one-fn :perm_value
                                                        :model/DataPermissions
-                                                       :db_id database-id
-                                                       :group_id group-id
-                                                       :type perm-type))]
+                                                       :db_id     database-id
+                                                       :group_id  group-id
+                                                       :perm_type perm-type))]
      (with-restored-perms-for-group! group-id
        (testing "`set-database-permission!` correctly updates an individual database's permissions"
          (data-perms/set-database-permission! group-id database-id :native-query-editing :no)
@@ -78,10 +78,10 @@
                  :model/Table            {table-id-3 :id}    {:db_id database-id}
                  :model/Table            {table-id-4 :id}    {:db_id database-id-2}]
     (let [data-access-perm-value (fn [table-id] (t2/select-one-fn :perm_value :model/DataPermissions
-                                                                  :db_id database-id
-                                                                  :group_id group-id
-                                                                  :table_id table-id
-                                                                  :type :data-access))]
+                                                                  :db_id     database-id
+                                                                  :group_id  group-id
+                                                                  :table_id  table-id
+                                                                  :perm_type :data-access))]
       (with-restored-perms-for-group! group-id
         (testing "`set-table-permissions!` can set individual table permissions to different values"
           (data-perms/set-table-permissions! group-id :data-access {table-id-1 :no-self-service


### PR DESCRIPTION
Adds migrations to migrate data permissions in `permissions` into `data_permissions` with the new schema.

In general, each script:
* Does a cross join between groups and DBs
* For each row, inserts a new DB-level row into `data_permissions`, with the value based on the presence or absence of specific permission paths in `permissions`. It skips rows which should be set at the table-level.
* Then, it does a cross join between tables and DBs
* For each row, it inserts a new table-level row into `data_permissions` with the value based on the presence of absence of specific permission paths in `permissions`. It skips rows which were already set at the DB-level.

This should also be idempotent — it won't update the permission for a particular group & DB if it has already been set in `data_permissions`.

The scripts are duplicated for MySQL & MariaDB to alter these two specific things:
* Backslashes need to be escaped with another backslash
* The `WITH escaped_schema_table` CTE has to be put below the `INSERT INTO data_permissions` clause, rather than above it.
Everything else about the scripts should be the same between Postgres/H2 and MySQL/MariaDB.

I've also changed the names of the columns `type` and `schema` to `perm_type` and `schema_name`, respectively. This is just to avoid conflicts with DB reserved words which make migrations slightly more annoying to write.