### PR TITLE
make fn-name consistent between mu/defn and mu.fn/fn

### DIFF
--- a/src/metabase/util/malli/defn.clj
+++ b/src/metabase/util/malli/defn.clj
@@ -83,6 +83,6 @@
       `(def ~(vary-meta fn-name merge attr-map)
          ~docstring
          ~(macros/case
-            :clj  (let [error-context {:fn-name (list 'quote (symbol (name (ns-name *ns*)) (name fn-name)))}]
+            :clj  (let [error-context {:fn-name (list 'quote fn-name)}]
                     (mu.fn/instrumented-fn-form error-context parsed))
             :cljs (mu.fn/deparameterized-fn-form parsed))))))

--- a/test/metabase/util/malli/defn_test.clj
+++ b/test/metabase/util/malli/defn_test.clj
@@ -172,12 +172,12 @@
       (binding [mu.fn/*skip-ns-decision-fn* (constantly false)]
         (let [expansion (macroexpand `(mu/defn ~'f :- :int [] "foo"))]
           (is (= '(def f
-           "Inputs: []\n  Return: :int"
-           (clojure.core/let
-            [&f (clojure.core/fn [] "foo")]
-            (clojure.core/fn
-             ([]
-              (try
-               (clojure.core/->> (&f) (metabase.util.malli.fn/validate-output {:fn-name 'user/f} :int))
-               (catch java.lang.Exception error (throw (metabase.util.malli.fn/fixup-stacktrace error))))))))
+                    "Inputs: []\n  Return: :int"
+                    (clojure.core/let
+                        [&f (clojure.core/fn [] "foo")]
+                      (clojure.core/fn
+                        ([]
+                         (try
+                           (clojure.core/->> (&f) (metabase.util.malli.fn/validate-output {:fn-name 'f} :int))
+                           (catch java.lang.Exception error (throw (metabase.util.malli.fn/fixup-stacktrace error))))))))
                  expansion)))))))


### PR DESCRIPTION
We're including the namespace name as a part of the :fn-name in error context which leads to inconsistent macroexpansion depending on the value of *ns*.

We may want to add the namespace into the error context, but that can be done in a seperate PR.