### PR TITLE
Backend validation for landing-page to disallow external URLs

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -276,7 +276,7 @@
   :audit      :getter
   :setter     (fn [new-landing-page]
                 (when new-landing-page
-                  ;; If the landing page is a valid URL or mailito, sms, or file, then check with if site-url has the same origin.
+                  ;; If the landing page is a valid URL or mailto, sms, or file, then check with if site-url has the same origin.
                   (when (and (or (re-matches #"^(mailto|sms|file):(.*)" new-landing-page) (u/url? new-landing-page))
                              (not (str/starts-with? new-landing-page (site-url))))
                     (throw (ex-info (tru "This field must be a relative URL.") {:status-code 400}))))

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -187,7 +187,6 @@
             (is (= false
                    (public-settings/redirect-all-requests-to-https)))))))))
 
-
 (deftest cloud-gateway-ips-test
   (mt/with-temp-env-var-value [mb-cloud-gateway-ips "1.2.3.4,5.6.7.8"]
     (with-redefs [premium-features/is-hosted? (constantly true)]
@@ -304,3 +303,54 @@
            (public-settings/help-link-custom-destination! "http://www.metabase.com")))
 
       (is (= nil (public-settings/help-link-custom-destination))))))
+
+(deftest landing-page-setting-test
+    (testing "should return relative url for valid inputs"
+      (public-settings/landing-page! "")
+      (is (= "" (public-settings/landing-page)))
+
+      (public-settings/landing-page! "/")
+      (is (= "/" (public-settings/landing-page)))
+
+      (public-settings/landing-page! "/one/two/three/")
+      (is (= "/one/two/three/" (public-settings/landing-page)))
+
+      (public-settings/landing-page! "no-leading-slash")
+      (is (= "/no-leading-slash" (public-settings/landing-page)))
+
+      (public-settings/landing-page! "/pathname?query=param#hash")
+      (is (= "/pathname?query=param#hash" (public-settings/landing-page)))
+
+      (public-settings/landing-page! "#hash")
+      (is (= "/#hash" (public-settings/landing-page)))
+
+      (with-redefs [public-settings/site-url (constantly "http://localhost")]
+        (public-settings/landing-page! "http://localhost/absolute/same-origin")
+        (is (= "/absolute/same-origin" (public-settings/landing-page)))))
+
+    (testing "landing-page cannot be set to URLs with external origin"
+      (is (thrown-with-msg?
+           Exception
+           #"This field must be a relative URL."
+           (public-settings/landing-page! "https://google.com")))
+
+      (is (thrown-with-msg?
+           Exception
+           #"This field must be a relative URL."
+           (public-settings/landing-page! "sms://?&body=Hello")))
+
+      (is (thrown-with-msg?
+           Exception
+           #"This field must be a relative URL."
+           (public-settings/landing-page! "https://localhost/test")))
+
+
+      (is (thrown-with-msg?
+           Exception
+           #"This field must be a relative URL."
+           (public-settings/landing-page! "mailto:user@example.com")))
+
+      (is (thrown-with-msg?
+           Exception
+           #"This field must be a relative URL."
+           (public-settings/landing-page! "file:///path/to/resource")))))

--- a/test/metabase/public_settings_test.clj
+++ b/test/metabase/public_settings_test.clj
@@ -344,7 +344,6 @@
            #"This field must be a relative URL."
            (public-settings/landing-page! "https://localhost/test")))
 
-
       (is (thrown-with-msg?
            Exception
            #"This field must be a relative URL."


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/32585

### Description

Add a setter to `landing-page` to validate URLs that come in. If the `landing-page` is a URL, then check against `site-url`. Note that I do a prefix check for this, so the same port is required.  

Related (FE version): https://github.com/metabase/metabase/pull/37322