### PR TITLE
Remove `isEmpty` method in `StructuredQuery`

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -129,13 +129,6 @@ class StructuredQuery extends AtomicQuery {
   /* Query superclass methods */
 
   /**
-   * @returns true if this is new query that hasn't been modified yet.
-   */
-  isEmpty() {
-    return !this._databaseId();
-  }
-
-  /**
    * @returns true if this query is in a state where it can be run.
    */
   canRun() {
@@ -278,11 +271,14 @@ class StructuredQuery extends AtomicQuery {
   setDefaultQuery(): StructuredQuery {
     const table = this.table();
 
+    const query = this.getMLv2Query();
+    const isEmpty = Lib.databaseID(query) == null;
+
     // NOTE: special case for Google Analytics which doesn't allow raw queries:
     if (
       table &&
       table.entity_type === "entity/GoogleAnalyticsTable" &&
-      !this.isEmpty() &&
+      !isEmpty &&
       !this.hasAnyClauses()
     ) {
       // NOTE: shold we check that a

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -6,6 +6,7 @@ import _ from "underscore";
 import { merge } from "icepick";
 import { usePrevious } from "react-use";
 
+import * as Lib from "metabase-lib";
 import ActionButton from "metabase/components/ActionButton";
 import Button from "metabase/core/components/Button";
 import DebouncedFrame from "metabase/components/DebouncedFrame";
@@ -411,7 +412,11 @@ function DatasetEditor(props) {
   );
 
   const canSaveChanges = useMemo(() => {
-    if (dataset.legacyQuery({ useStructuredQuery: true }).isEmpty()) {
+    const isEmpty = dataset.isStructured()
+      ? Lib.databaseID(dataset.query()) == null
+      : dataset.legacyQuery().isEmpty();
+
+    if (isEmpty) {
       return false;
     }
     const everyFieldHasDisplayName = fields.every(field => field.display_name);

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -335,11 +335,6 @@ describe("StructuredQuery", () => {
         expect(q.isEditable()).toBe(false);
       });
     });
-    describe("isEmpty", () => {
-      it("tells that a non-empty query is not empty", () => {
-        expect(query.isEmpty()).toBe(false);
-      });
-    });
   });
 
   describe("AGGREGATION METHODS", () => {


### PR DESCRIPTION
This PR resolves #37515 by migrating the `isEmpty` check for models (datasets) in `DatasetEditor` component.

After that migration, it's now possible to completely remove `isEmpty()` method from the StructuredQuery class.
This PR achieves that.