### PR TITLE
Pass email and siteURL to metabase.com/help/connect

### DIFF
--- a/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/database-prompt-banner.cy.spec.js
@@ -34,7 +34,10 @@ describeEE("database prompt banner", () => {
 
         cy.findByRole("link", { name: "Get help connecting" })
           .should("have.attr", "href")
-          .and("eq", "https://metabase.com/help/connect");
+          .and(
+            "eq",
+            "https://metabase.com/help/connect?email=admin%40metabase.test&site_url=http%3A%2F%2Flocalhost%3A4000",
+          );
 
         cy.findByRole("link", { name: "Connect your database" }).click();
         cy.url().should("include", "/admin/databases/create");

--- a/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.tsx
+++ b/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.tsx
@@ -1,7 +1,8 @@
 import { t } from "ttag";
 import type { Location } from "history";
 
-import MetabaseSettings from "metabase/lib/settings";
+import { getSetting } from "metabase/selectors/settings";
+import { useSelector } from "metabase/lib/redux";
 
 import Link from "metabase/core/components/Link/Link";
 import { trackDatabasePromptBannerClicked } from "metabase/nav/analytics";
@@ -20,6 +21,13 @@ interface DatabasePromptBannerProps {
 }
 
 export function DatabasePromptBanner({ location }: DatabasePromptBannerProps) {
+  const adminEmail = useSelector(state => getSetting(state, "admin-email"));
+  const siteUrl = useSelector(state => getSetting(state, "site-url"));
+
+  const helpUrl = new URL("https://metabase.com/help/connect");
+  helpUrl.searchParams.set("email", adminEmail || "");
+  helpUrl.searchParams.set("site_url", siteUrl || "");
+
   const shouldShowDatabasePromptBanner = useShouldShowDatabasePromptBanner();
   if (!shouldShowDatabasePromptBanner) {
     return null;
@@ -29,16 +37,12 @@ export function DatabasePromptBanner({ location }: DatabasePromptBannerProps) {
     "/admin/databases/create",
   );
 
-  const adminEmail = MetabaseSettings.get("admin-email");
-  const siteURL = MetabaseSettings.get("site-url");
-  const helpURL = `https://metabase.com/help/connect?email=${adminEmail}&site_url=${siteURL}`;
-
   return (
     <DatabasePromptBannerRoot role="banner">
       <Prompt>{t`Connect to your database to get the most from Metabase.`}</Prompt>
       <CallToActions>
         <GetHelpButton
-          href={helpURL}
+          href={helpUrl.href}
           onClickCapture={() => {
             trackDatabasePromptBannerClicked("help");
           }}

--- a/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.tsx
+++ b/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.tsx
@@ -1,6 +1,8 @@
 import { t } from "ttag";
 import type { Location } from "history";
 
+import MetabaseSettings from "metabase/lib/settings";
+
 import Link from "metabase/core/components/Link/Link";
 import { trackDatabasePromptBannerClicked } from "metabase/nav/analytics";
 import { useShouldShowDatabasePromptBanner } from "metabase/nav/hooks";
@@ -27,12 +29,16 @@ export function DatabasePromptBanner({ location }: DatabasePromptBannerProps) {
     "/admin/databases/create",
   );
 
+  const adminEmail = MetabaseSettings.get("admin-email");
+  const siteURL = MetabaseSettings.get("site-url");
+  const helpURL = `https://metabase.com/help/connect?email=${adminEmail}&site_url=${siteURL}`;
+
   return (
     <DatabasePromptBannerRoot role="banner">
       <Prompt>{t`Connect to your database to get the most from Metabase.`}</Prompt>
       <CallToActions>
         <GetHelpButton
-          href="https://metabase.com/help/connect"
+          href={helpURL}
           onClickCapture={() => {
             trackDatabasePromptBannerClicked("help");
           }}

--- a/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/DatabasePromptBanner/DatabasePromptBanner.unit.spec.tsx
@@ -184,7 +184,7 @@ describe("DatabasePromptBanner", () => {
     expect(getHelpLink).toBeInTheDocument();
     expect(getHelpLink).toHaveAttribute(
       "href",
-      "https://metabase.com/help/connect",
+      "https://metabase.com/help/connect?email=admin%40metabase.test&site_url=http%3A%2F%2Flocalhost%3A3000",
     );
 
     const connectDatabaseLink = screen.getByRole("link", {
@@ -217,7 +217,7 @@ describe("DatabasePromptBanner", () => {
     expect(getHelpLink).toBeInTheDocument();
     expect(getHelpLink).toHaveAttribute(
       "href",
-      "https://metabase.com/help/connect",
+      "https://metabase.com/help/connect?email=admin%40metabase.test&site_url=http%3A%2F%2Flocalhost%3A3000",
     );
 
     expect(


### PR DESCRIPTION
### To verify

1. Use a fresh install of Metabase, or remove all db connections.
2. Use an enterprise token.
3. Hover on "Get help connecting"

![image](https://github.com/metabase/metabase/assets/380816/b9bc3d48-24e4-41fe-8387-7ccc6f1c3f07)

You should see an URL with get params like http://www.metabase.com/help/connect?email=gus@metabase.com&site_url=http://localhost:3000

If you click on it, metabase.com will (for now) redirect the page to Calendly. This will be updated in a separate PR.