### PR TITLE
Increase the request timeout for instance-analytics

### DIFF
--- a/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
+++ b/e2e/test/scenarios/collections/instance-analytics.cy.spec.js
@@ -44,7 +44,7 @@ describeEE("scenarios > Metabase Analytics Collection (AuditV2) ", () => {
 
     it(
       "should default to saving audit content in custom reports collection",
-      { tags: "@flaky" },
+      { requestTimeout: 15000 },
       () => {
         cy.log("saving edited question");
         getItemId(ANALYTICS_COLLECTION_NAME, PEOPLE_MODEL_NAME).then(id => {


### PR DESCRIPTION
This PR fixes a flake that was happening due to the timeout by increasing the `requestTimeout` in that test.

### Stress-test
10/10 ✅ 
https://github.com/metabase/metabase/actions/runs/7490944956