### PR TITLE
Remove `setDefaultQuery()` method for queries

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -427,9 +427,7 @@ class Question {
   }
 
   setDefaultQuery() {
-    return this.legacyQuery({ useStructuredQuery: true })
-      .setDefaultQuery()
-      .question();
+    return this.legacyQuery({ useStructuredQuery: true }).question();
   }
 
   settings(): VisualizationSettings {

--- a/frontend/src/metabase-lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/queries/Query.ts
@@ -106,10 +106,6 @@ class Query {
     return [];
   }
 
-  setDefaultQuery(): Query {
-    return this;
-  }
-
   parseFieldReference(fieldRef, query = this): Dimension | null | undefined {
     return Dimension.parseMBQL(fieldRef, this._metadata, query);
   }

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -266,49 +266,6 @@ class StructuredQuery extends AtomicQuery {
   }
 
   /**
-   *
-   */
-  setDefaultQuery(): StructuredQuery {
-    const table = this.table();
-
-    const query = this.getMLv2Query();
-    const isEmpty = Lib.databaseID(query) == null;
-
-    // NOTE: special case for Google Analytics which doesn't allow raw queries:
-    if (
-      table &&
-      table.entity_type === "entity/GoogleAnalyticsTable" &&
-      !isEmpty &&
-      !this.hasAnyClauses()
-    ) {
-      // NOTE: shold we check that a
-      const dateField = _.findWhere(table.fields, {
-        name: "ga:date",
-      });
-
-      if (dateField) {
-        return this.filter([
-          "time-interval",
-          ["field", dateField.id, null],
-          -365,
-          "day",
-        ])
-          .aggregate(["metric", "ga:users"])
-          .aggregate(["metric", "ga:pageviews"])
-          .breakout([
-            "field",
-            dateField.id,
-            {
-              "temporal-unit": "week",
-            },
-          ]);
-      }
-    }
-
-    return this;
-  }
-
-  /**
    * @returns the table object, if a table is selected and loaded.
    */
   table = _.once((): Table | null => {


### PR DESCRIPTION
This removes the `setDefaultQuery()` method for both
- StructuredQuery and
- Query

Resolves #37506