### PR TITLE
Improve performance of ExpressionEditor

### DIFF
--- a/e2e/test/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -1,5 +1,11 @@
 import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
-import { restore, popover, visualize, openTable } from "e2e/support/helpers";
+import {
+  restore,
+  popover,
+  visualize,
+  openTable,
+  getNotebookStep,
+} from "e2e/support/helpers";
 
 describe("issue 17963", { tags: "@mongo" }, () => {
   beforeEach(() => {
@@ -18,28 +24,21 @@ describe("issue 17963", { tags: "@mongo" }, () => {
 
   it("should be able to compare two fields using filter expression (metabase#17963)", () => {
     cy.findByRole("button", { name: "Filter" }).click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Add filters to narrow your answer").click();
 
     popover().contains("Custom Expression").click();
 
     typeAndSelect([
       { string: "dis", field: "Discount" },
-      { string: "> qu", field: "Quantity" },
+      { string: "> quan", field: "Quantity" },
     ]);
-    cy.get(".ace_text-input").blur();
 
+    cy.get(".ace_text-input").blur();
     cy.button("Done").click();
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Discount is greater than Quantity");
+    getNotebookStep("filter").findByText("Discount is greater than Quantity");
 
     cy.findByRole("button", { name: "Summarize" }).click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Pick the metric you want to see").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Count of rows").click();
+    popover().findByText("Count of rows").click();
 
     visualize();
 

--- a/frontend/src/metabase-lib/expression.ts
+++ b/frontend/src/metabase-lib/expression.ts
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import * as ML from "cljs/metabase.lib.js";
 import type {
   AggregationClause,
@@ -35,16 +34,12 @@ export function expressions(
   return ML.expressions(query, stageIndex);
 }
 
-const memo_expressionable_columns = _.memoize(
-  ML.expressionable_columns,
-  (...args) => args.join(),
-);
 export function expressionableColumns(
   query: Query,
   stageIndex?: number,
   expressionPosition?: number,
 ): ColumnMetadata[] {
-  return memo_expressionable_columns(query, stageIndex, expressionPosition);
+  return ML.expressionable_columns(query, stageIndex, expressionPosition);
 }
 
 export function expressionParts(

--- a/frontend/src/metabase-lib/expression.ts
+++ b/frontend/src/metabase-lib/expression.ts
@@ -1,3 +1,4 @@
+import _ from "underscore";
 import * as ML from "cljs/metabase.lib.js";
 import type {
   AggregationClause,
@@ -34,12 +35,16 @@ export function expressions(
   return ML.expressions(query, stageIndex);
 }
 
+const memo_expressionable_columns = _.memoize(
+  ML.expressionable_columns,
+  (...args) => args.join(),
+);
 export function expressionableColumns(
   query: Query,
-  stageIndex: number,
+  stageIndex?: number,
   expressionPosition?: number,
 ): ColumnMetadata[] {
-  return ML.expressionable_columns(query, stageIndex, expressionPosition);
+  return memo_expressionable_columns(query, stageIndex, expressionPosition);
 }
 
 export function expressionParts(

--- a/frontend/src/metabase-lib/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/expressions/suggest.ts
@@ -48,6 +48,7 @@ type SuggestArgs = {
   reportTimezone?: string;
   startRule: string;
   targetOffset?: number;
+  expressionPosition?: number;
   getColumnIcon: (column: Lib.ColumnMetadata) => string;
 };
 
@@ -59,6 +60,7 @@ export function suggest({
   metadata,
   reportTimezone,
   startRule,
+  expressionPosition,
   targetOffset = source.length,
 }: SuggestArgs): {
   helpText?: HelpText;
@@ -151,7 +153,7 @@ export function suggest({
 
   if (_.last(matchPrefix) !== "]") {
     suggestions.push(
-      ...Lib.expressionableColumns(query, stageIndex, targetOffset).map(
+      ...Lib.expressionableColumns(query, stageIndex, expressionPosition).map(
         column => {
           const displayInfo = Lib.displayInfo(query, stageIndex, column);
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -1,5 +1,7 @@
+/* eslint-disable react/prop-types */
 import { Component, Fragment } from "react";
 import PropTypes from "prop-types";
+import _ from "underscore";
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/core/components/Icon";
 import { isObscured } from "metabase/lib/dom";
@@ -71,6 +73,10 @@ export default class ExpressionEditorSuggestions extends Component {
     this.props.onSuggestionMouseDown && this.props.onSuggestionMouseDown(index);
   }
 
+  onMouseDownCapture = _.memoize(i => {
+    return event => this.onSuggestionMouseDown(event, i);
+  });
+
   render() {
     const { suggestions, highlightedIndex, target } = this.props;
 
@@ -92,38 +98,48 @@ export default class ExpressionEditorSuggestions extends Component {
             className="pb1"
             data-ignore-outside-clicks
           >
-            {suggestions.map((suggestion, i) => {
-              const isHighlighted = i === highlightedIndex;
-              const { icon } = suggestion;
-              const { normal, highlighted } = colorForIcon(icon);
-
-              const key = `$suggstion-${i}`;
-              const listItem = (
-                <ExpressionListItem
-                  onMouseDownCapture={e => this.onSuggestionMouseDown(e, i)}
-                  isHighlighted={isHighlighted}
-                  className="hover-parent hover--inherit"
-                  data-ignore-outside-clicks
-                >
-                  <Icon
-                    name={icon}
-                    color={isHighlighted ? highlighted : normal}
-                    className="mr1"
-                    data-ignore-outside-clicks
-                  />
-                  <SuggestionSpan
-                    suggestion={suggestion}
-                    isHighlighted={isHighlighted}
-                    data-ignore-outside-clicks
-                  />
-                </ExpressionListItem>
-              );
-
-              return <Fragment key={key}>{listItem}</Fragment>;
-            })}
+            {suggestions.map((suggestion, i) => (
+              <Fragment key={`$suggestion-${i}`}>
+                <ExpressionEditorSuggestionsListItem
+                  suggestion={suggestion}
+                  isHighlighted={i === highlightedIndex}
+                  onMouseDownCapture={this.onMouseDownCapture(i)}
+                />
+              </Fragment>
+            ))}
           </ExpressionList>
         }
       />
     );
   }
+}
+
+function ExpressionEditorSuggestionsListItem({
+  suggestion,
+  isHighlighted,
+  onMouseDownCapture,
+}) {
+  const { icon } = suggestion;
+  const { normal, highlighted } = colorForIcon(icon);
+
+  return (
+    <ExpressionListItem
+      onMouseDownCapture={onMouseDownCapture}
+      isHighlighted={isHighlighted}
+      className="hover-parent hover--inherit"
+      data-ignore-outside-clicks
+    >
+      <Icon
+        name={icon}
+        color={isHighlighted ? highlighted : normal}
+        className="mr1"
+        data-ignore-outside-clicks
+      />
+      <SuggestionSpan
+        suggestion={suggestion}
+        isHighlighted={isHighlighted}
+        data-ignore-outside-clicks
+      />
+    </ExpressionListItem>
+  );
 }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -73,7 +73,7 @@ export default class ExpressionEditorSuggestions extends Component {
     this.props.onSuggestionMouseDown && this.props.onSuggestionMouseDown(index);
   }
 
-  onMouseDownCapture = _.memoize(i => {
+  createOnMouseDownHandler = _.memoize(i => {
     return event => this.onSuggestionMouseDown(event, i);
   });
 
@@ -103,7 +103,7 @@ export default class ExpressionEditorSuggestions extends Component {
                 <ExpressionEditorSuggestionsListItem
                   suggestion={suggestion}
                   isHighlighted={i === highlightedIndex}
-                  onMouseDownCapture={this.onMouseDownCapture(i)}
+                  onMouseDownCapture={this.createOnMouseDownHandler(i)}
                 />
               </Fragment>
             ))}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -57,6 +57,7 @@ interface ExpressionEditorTextfieldProps {
   stageIndex: number;
   metadata: Metadata;
   startRule: string;
+  expressionPosition?: number;
   width?: number;
   reportTimezone?: string;
   textAreaId?: string;
@@ -472,6 +473,7 @@ class ExpressionEditorTextfield extends React.Component<
       reportTimezone,
       stageIndex,
       metadata,
+      expressionPosition,
       startRule = ExpressionEditorTextfield.defaultProps.startRule,
     } = this.props;
     const { source } = this.state;
@@ -480,6 +482,7 @@ class ExpressionEditorTextfield extends React.Component<
       startRule,
       source,
       targetOffset: cursor.column,
+      expressionPosition,
       query,
       stageIndex,
       metadata,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -120,6 +120,8 @@ const mapStateToProps = (state: State) => ({
   metadata: getMetadata(state),
 });
 
+const CURSOR_DEBOUNCE_INTERVAL = 10;
+
 class ExpressionEditorTextfield extends React.Component<
   ExpressionEditorTextfieldProps,
   ExpressionEditorTextfieldState
@@ -451,7 +453,7 @@ class ExpressionEditorTextfield extends React.Component<
     this.handleExpressionChange(this.state.source);
   };
 
-  handleExpressionChange(source: string) {
+  handleExpressionChange = (source: string) => {
     if (source) {
       this.setState({ hasChanges: true });
     }
@@ -460,9 +462,9 @@ class ExpressionEditorTextfield extends React.Component<
     if (this.props.onBlankChange) {
       this.props.onBlankChange(source.length === 0);
     }
-  }
+  };
 
-  handleCursorChange(selection: Ace.Selection) {
+  handleCursorChange = _.debounce((selection: Ace.Selection) => {
     const cursor = selection.getCursor();
 
     const {
@@ -488,7 +490,7 @@ class ExpressionEditorTextfield extends React.Component<
     if (this.state.isFocused) {
       this.updateSuggestions(suggestions);
     }
-  }
+  }, CURSOR_DEBOUNCE_INTERVAL);
 
   errorAsMarkers(errorMessage: ErrorWithMessage | null = null): IMarker[] {
     if (errorMessage) {
@@ -584,8 +586,8 @@ class ExpressionEditorTextfield extends React.Component<
             onBlur={this.handleInputBlur}
             onFocus={this.handleFocus}
             setOptions={ACE_OPTIONS}
-            onChange={source => this.handleExpressionChange(source)}
-            onCursorChange={selection => this.handleCursorChange(selection)}
+            onChange={this.handleExpressionChange}
+            onCursorChange={this.handleCursorChange}
             width="100%"
           />
           <ExpressionEditorSuggestions

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -132,8 +132,6 @@ class ExpressionEditorTextfield extends React.Component<
     startRule: "expression",
   };
 
-  state: ExpressionEditorTextfieldState;
-
   constructor(props: ExpressionEditorTextfieldProps) {
     super(props);
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -44,6 +44,7 @@ export type ExpressionWidgetProps<Clause = Lib.ExpressionClause> = {
   startRule?: string;
   reportTimezone?: string;
   header?: ReactNode;
+  expressionPosition?: number;
 
   onChangeExpression?: (name: string, expression: Expression) => void;
   onChangeClause?: (
@@ -67,6 +68,7 @@ export const ExpressionWidget = <Clause extends object = Lib.ExpressionClause>(
     startRule,
     reportTimezone,
     header,
+    expressionPosition,
     onChangeExpression,
     onChangeClause,
     onRemoveExpression,
@@ -147,6 +149,7 @@ export const ExpressionWidget = <Clause extends object = Lib.ExpressionClause>(
           <ExpressionEditorTextfield
             helpTextTarget={helpTextTargetRef.current}
             expression={expression}
+            expressionPosition={expressionPosition}
             clause={clause}
             startRule={startRule}
             name={name}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
@@ -25,10 +25,11 @@ export const ExpressionStep = ({
       items={expressions}
       renderName={renderExpressionName}
       readOnly={readOnly}
-      renderPopover={({ item }) => (
+      renderPopover={({ item, index: expressionPosition }) => (
         <ExpressionWidget
           query={query}
           stageIndex={stageIndex}
+          expressionPosition={expressionPosition}
           name={
             item
               ? Lib.displayInfo(query, stageIndex, item).displayName

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -128,7 +128,11 @@
   "Return a sequence of Column metadatas about the columns you can add order bys for in a given stage of `a-query.` To
   add an order by, pass the result to [[order-by]]."
   [a-query stage-number]
-  (to-array (lib.order-by/orderable-columns a-query stage-number)))
+  ;; Attaches the cached columns directly to this query, in case it gets called again.
+  (lib.cache/side-channel-cache
+    (keyword "orderable-columns" (str "stage-" stage-number)) a-query
+    (fn [_]
+      (to-array (lib.order-by/orderable-columns a-query stage-number)))))
 
 ;; Display-info =====================================================================================================
 ;; This is a complicated stack of caches and inner functions, so some guidance is in order.
@@ -244,7 +248,11 @@
   To break out by a given column, the corresponding element of the result has to be added to the query using
   [[breakout]]."
   [a-query stage-number]
-  (to-array (lib.core/breakoutable-columns a-query stage-number)))
+  ;; Attaches the cached columns directly to this query, in case it gets called again.
+  (lib.cache/side-channel-cache
+    (keyword "breakoutable-columns" (str "stage-" stage-number)) a-query
+    (fn [_]
+      (to-array (lib.core/breakoutable-columns a-query stage-number)))))
 
 (defn ^:export breakouts
   "Get the breakout clauses (as an array of opaque objects) in `a-query` at a given `stage-number`.
@@ -440,7 +448,11 @@
 (defn ^:export filterable-columns
   "Get the available filterable columns for the stage with `stage-number` of the query `a-query`."
   [a-query stage-number]
-  (to-array (lib.core/filterable-columns a-query stage-number)))
+  ;; Attaches the cached columns directly to this query, in case it gets called again.
+  (lib.cache/side-channel-cache
+    (keyword "filterable-columns" (str "stage-" stage-number)) a-query
+    (fn [_]
+      (to-array (lib.core/filterable-columns a-query stage-number)))))
 
 (defn ^:export filterable-column-operators
   "Returns the operators for which `filterable-column` is applicable."
@@ -526,7 +538,11 @@
 (defn ^:export fieldable-columns
   "Return a sequence of column metadatas for columns that you can specify in the `:fields` of a query."
   [a-query stage-number]
-  (to-array (lib.core/fieldable-columns a-query stage-number)))
+  ;; Attaches the cached columns directly to this query, in case it gets called again.
+  (lib.cache/side-channel-cache
+    (keyword "fieldable-columns" (str "stage-" stage-number)) a-query
+    (fn [_]
+      (to-array (lib.core/fieldable-columns a-query stage-number)))))
 
 (defn ^:export add-field
   "Adds a given field (`ColumnMetadata`, as returned from eg. [[visible-columns]]) to the fields returned by the query.
@@ -560,6 +576,14 @@
   ;; [[lib.convert/legacy-ref->pMBQL]] will handle JS -> Clj conversion as needed
   (lib.core/find-column-for-legacy-ref a-query stage-number a-legacy-ref columns))
 
+(defn- visible-columns*
+  "Inner implementation for [[visible-columns]], which wraps this with caching."
+  [a-query stage-number]
+  (let [stage          (lib.util/query-stage a-query stage-number)
+        vis-columns    (lib.metadata.calculation/visible-columns a-query stage-number stage)
+        ret-columns    (lib.metadata.calculation/returned-columns a-query stage-number stage)]
+    (to-array (lib.equality/mark-selected-columns a-query stage-number vis-columns ret-columns))))
+
 ;; TODO: Added as an expedient to fix metabase/metabase#32373. Due to the interaction with viz-settings, this issue
 ;; was difficult to fix entirely within MLv2. Once viz-settings are ported, this function should not be needed, and the
 ;; FE logic using it should be ported to MLv2 behind more meaningful names.
@@ -568,18 +592,28 @@
 
   Does not pass any options to [[visible-columns]], so it uses the defaults."
   [a-query stage-number]
-  (let [stage          (lib.util/query-stage a-query stage-number)
-        vis-columns    (lib.metadata.calculation/visible-columns a-query stage-number stage)
-        ret-columns    (lib.metadata.calculation/returned-columns a-query stage-number stage)]
-    (to-array (lib.equality/mark-selected-columns a-query stage-number vis-columns ret-columns))))
+  ;; Attaches the cached columns directly to this query, in case it gets called again.
+  (lib.cache/side-channel-cache
+    (keyword "visible-columns" (str "stage-" stage-number)) a-query
+    (fn [_]
+      (visible-columns* a-query stage-number))))
 
-(defn ^:export returned-columns
-  "Return a sequence of column metadatas for columns returned by the query."
+(defn- returned-columns*
+  "Inner implementation for [[returned-columns]], which wraps this with caching."
   [a-query stage-number]
   (let [stage (lib.util/query-stage a-query stage-number)]
     (->> (lib.metadata.calculation/returned-columns a-query stage-number stage)
          (map #(assoc % :selected? true))
          to-array)))
+
+(defn ^:export returned-columns
+  "Return a sequence of column metadatas for columns returned by the query."
+  [a-query stage-number]
+  ;; Attaches the cached columns directly to this query, in case it gets called again.
+  (lib.cache/side-channel-cache
+    (keyword "returned-columns" (str "stage-" stage-number)) a-query
+    (fn [_]
+      (returned-columns* a-query stage-number))))
 
 (defn- normalize-legacy-ref
   [a-ref]
@@ -721,10 +755,15 @@
 (defn ^:export expressionable-columns
   "Return an array of Column metadatas about the columns that can be used in an expression in a given stage of `a-query`.
    Pass the current `expression-position` or `null` for new expressions."
-  ([a-query expression-position]
-   (expressionable-columns a-query expression-position))
-  ([a-query stage-number expression-position]
-   (to-array (lib.core/expressionable-columns a-query stage-number expression-position))))
+  [a-query stage-number expression-position]
+  (lib.cache/side-channel-cache
+    ;; Caching is based on both the stage and expression position, since they can return different sets.
+    ;; TODO: Since these caches are mainly here to avoid expensively recomputing things in rapid succession, it would
+    ;; probably suffice to cache only the last position, and evict if it's different. But the lib.cache system doesn't
+    ;; support that currently.
+    (keyword "expressionable-columns" (str "stage-" stage-number "-" expression-position)) a-query
+    (fn [_]
+      (to-array (lib.core/expressionable-columns a-query stage-number expression-position)))))
 
 (defn ^:export suggested-join-conditions
   "Return suggested default join conditions when constructing a join against `joinable`, e.g. a Table, Saved
@@ -906,6 +945,8 @@
   something [[Joinable]] (i.e., a Table or Card) or manipulating an existing join. When passing in a join, currently
   selected columns (those in the join's `:fields`) will include `:selected true` information."
   [a-query stage-number join-or-joinable]
+  ;; TODO: It's not practical to cache this currently. We need to be able to key off the query and the joinable, which
+  ;; is not supported by the lib.cache system.
   (to-array (lib.core/joinable-columns a-query stage-number join-or-joinable)))
 
 (defn ^:export table-or-card-metadata

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -128,11 +128,7 @@
   "Return a sequence of Column metadatas about the columns you can add order bys for in a given stage of `a-query.` To
   add an order by, pass the result to [[order-by]]."
   [a-query stage-number]
-  ;; Attaches the cached columns directly to this query, in case it gets called again.
-  (lib.cache/side-channel-cache
-    (keyword "orderable-columns" (str "stage-" stage-number)) a-query
-    (fn [_]
-      (to-array (lib.order-by/orderable-columns a-query stage-number)))))
+  (to-array (lib.order-by/orderable-columns a-query stage-number)))
 
 ;; Display-info =====================================================================================================
 ;; This is a complicated stack of caches and inner functions, so some guidance is in order.
@@ -248,11 +244,7 @@
   To break out by a given column, the corresponding element of the result has to be added to the query using
   [[breakout]]."
   [a-query stage-number]
-  ;; Attaches the cached columns directly to this query, in case it gets called again.
-  (lib.cache/side-channel-cache
-    (keyword "breakoutable-columns" (str "stage-" stage-number)) a-query
-    (fn [_]
-      (to-array (lib.core/breakoutable-columns a-query stage-number)))))
+  (to-array (lib.core/breakoutable-columns a-query stage-number)))
 
 (defn ^:export breakouts
   "Get the breakout clauses (as an array of opaque objects) in `a-query` at a given `stage-number`.
@@ -448,11 +440,7 @@
 (defn ^:export filterable-columns
   "Get the available filterable columns for the stage with `stage-number` of the query `a-query`."
   [a-query stage-number]
-  ;; Attaches the cached columns directly to this query, in case it gets called again.
-  (lib.cache/side-channel-cache
-    (keyword "filterable-columns" (str "stage-" stage-number)) a-query
-    (fn [_]
-      (to-array (lib.core/filterable-columns a-query stage-number)))))
+  (to-array (lib.core/filterable-columns a-query stage-number)))
 
 (defn ^:export filterable-column-operators
   "Returns the operators for which `filterable-column` is applicable."
@@ -538,11 +526,7 @@
 (defn ^:export fieldable-columns
   "Return a sequence of column metadatas for columns that you can specify in the `:fields` of a query."
   [a-query stage-number]
-  ;; Attaches the cached columns directly to this query, in case it gets called again.
-  (lib.cache/side-channel-cache
-    (keyword "fieldable-columns" (str "stage-" stage-number)) a-query
-    (fn [_]
-      (to-array (lib.core/fieldable-columns a-query stage-number)))))
+  (to-array (lib.core/fieldable-columns a-query stage-number)))
 
 (defn ^:export add-field
   "Adds a given field (`ColumnMetadata`, as returned from eg. [[visible-columns]]) to the fields returned by the query.
@@ -576,14 +560,6 @@
   ;; [[lib.convert/legacy-ref->pMBQL]] will handle JS -> Clj conversion as needed
   (lib.core/find-column-for-legacy-ref a-query stage-number a-legacy-ref columns))
 
-(defn- visible-columns*
-  "Inner implementation for [[visible-columns]], which wraps this with caching."
-  [a-query stage-number]
-  (let [stage          (lib.util/query-stage a-query stage-number)
-        vis-columns    (lib.metadata.calculation/visible-columns a-query stage-number stage)
-        ret-columns    (lib.metadata.calculation/returned-columns a-query stage-number stage)]
-    (to-array (lib.equality/mark-selected-columns a-query stage-number vis-columns ret-columns))))
-
 ;; TODO: Added as an expedient to fix metabase/metabase#32373. Due to the interaction with viz-settings, this issue
 ;; was difficult to fix entirely within MLv2. Once viz-settings are ported, this function should not be needed, and the
 ;; FE logic using it should be ported to MLv2 behind more meaningful names.
@@ -592,28 +568,18 @@
 
   Does not pass any options to [[visible-columns]], so it uses the defaults."
   [a-query stage-number]
-  ;; Attaches the cached columns directly to this query, in case it gets called again.
-  (lib.cache/side-channel-cache
-    (keyword "visible-columns" (str "stage-" stage-number)) a-query
-    (fn [_]
-      (visible-columns* a-query stage-number))))
+  (let [stage          (lib.util/query-stage a-query stage-number)
+        vis-columns    (lib.metadata.calculation/visible-columns a-query stage-number stage)
+        ret-columns    (lib.metadata.calculation/returned-columns a-query stage-number stage)]
+    (to-array (lib.equality/mark-selected-columns a-query stage-number vis-columns ret-columns))))
 
-(defn- returned-columns*
-  "Inner implementation for [[returned-columns]], which wraps this with caching."
+(defn ^:export returned-columns
+  "Return a sequence of column metadatas for columns returned by the query."
   [a-query stage-number]
   (let [stage (lib.util/query-stage a-query stage-number)]
     (->> (lib.metadata.calculation/returned-columns a-query stage-number stage)
          (map #(assoc % :selected? true))
          to-array)))
-
-(defn ^:export returned-columns
-  "Return a sequence of column metadatas for columns returned by the query."
-  [a-query stage-number]
-  ;; Attaches the cached columns directly to this query, in case it gets called again.
-  (lib.cache/side-channel-cache
-    (keyword "returned-columns" (str "stage-" stage-number)) a-query
-    (fn [_]
-      (returned-columns* a-query stage-number))))
 
 (defn- normalize-legacy-ref
   [a-ref]
@@ -755,15 +721,10 @@
 (defn ^:export expressionable-columns
   "Return an array of Column metadatas about the columns that can be used in an expression in a given stage of `a-query`.
    Pass the current `expression-position` or `null` for new expressions."
-  [a-query stage-number expression-position]
-  (lib.cache/side-channel-cache
-    ;; Caching is based on both the stage and expression position, since they can return different sets.
-    ;; TODO: Since these caches are mainly here to avoid expensively recomputing things in rapid succession, it would
-    ;; probably suffice to cache only the last position, and evict if it's different. But the lib.cache system doesn't
-    ;; support that currently.
-    (keyword "expressionable-columns" (str "stage-" stage-number "-" expression-position)) a-query
-    (fn [_]
-      (to-array (lib.core/expressionable-columns a-query stage-number expression-position)))))
+  ([a-query expression-position]
+   (expressionable-columns a-query expression-position))
+  ([a-query stage-number expression-position]
+   (to-array (lib.core/expressionable-columns a-query stage-number expression-position))))
 
 (defn ^:export suggested-join-conditions
   "Return suggested default join conditions when constructing a join against `joinable`, e.g. a Table, Saved
@@ -945,8 +906,6 @@
   something [[Joinable]] (i.e., a Table or Card) or manipulating an existing join. When passing in a join, currently
   selected columns (those in the join's `:fields`) will include `:selected true` information."
   [a-query stage-number join-or-joinable]
-  ;; TODO: It's not practical to cache this currently. We need to be able to key off the query and the joinable, which
-  ;; is not supported by the lib.cache system.
   (to-array (lib.core/joinable-columns a-query stage-number join-or-joinable)))
 
 (defn ^:export table-or-card-metadata


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/37528

### Description

Memoization will be added on BE side, but on FE we called MLv2 methods too often (3 times for every key down), this PR added debouncing and doesn't allow triggering MLv2 methods too often

### How to verify

Go to notebook editor and add expression - slow down CPU via dev tools

### Demo

After

https://github.com/metabase/metabase/assets/125459446/440a77bb-94cb-4d52-95ca-380ed968b095


Before

https://github.com/metabase/metabase/assets/125459446/e0d8f379-e42b-44f3-85bf-f885c4dbe51a




### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
