### PR TITLE
Remove unneeded check in PinnedQuestionLoader

### DIFF
--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionLoader.tsx
@@ -42,10 +42,7 @@ const PinnedQuestionLoader = ({
   return (
     <Questions.Loader id={id} loadingAndErrorWrapper={false}>
       {({ loading, question: loadedQuestion }: QuestionLoaderProps) => {
-        if (
-          loading !== false ||
-          !loadedQuestion.legacyQuery({ useStructuredQuery: true })
-        ) {
+        if (loading !== false) {
           return children({ loading: true });
         }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37513

I've checked several cases, e.g. when the card is populated by search or when the user doesn't have data permissions and it works correct.