### PR TITLE
add eslint rule to avoid typos in paid feature test files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -197,6 +197,34 @@
       "rules": {
         "jest/valid-title": ["error", { "ignoreTypeOfDescribeName": true }]
       }
-    }
+    },
+    {
+      "files": [
+        "premium.*.spec.ts"
+      ],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "Literal[value=/EE without token/]",
+            "message": "premium.* should test the scenario with the token"
+          }
+        ]
+      }
+    },
+    {
+      "files": [
+        "enterprise.*.spec.ts"
+      ],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "Literal[value=/EE with token/]",
+            "message": "enterprise.* test files should test the scenario without the token"
+          }
+        ]
+      }
+    },
   ]
 }

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -23,6 +23,7 @@ frontend_sources: &frontend_sources
   - "**/tsconfig*.json"
   - "package.json"
   - "babel.config.json"
+  - ".eslintrc"
   - "postcss.config.js"
   - "webpack.config.js"
   - "webpack.static-viz.config.js"


### PR DESCRIPTION
## Description
We're adding more tests to paid features, which involves having 3 almost equal files (see [notion](https://www.notion.so/metabase/Testing-paid-features-49e03e1b2a3b41ffb4ebdc7616a93d90?pvs=4)).

The easiest way is writing the first file and then copy pasting, and it's easy to forget to change the descriptions of the tests (it happened recently in a pr).

Is this taking eslint too far or would you say it's okay?
We can always remove the rules without consequences if they end up creating more issues than they're solving.


## How to verify:
The ci should fail in this PR as there's one of those typos already on master