### PR TITLE
Fixing macro scope capture of `with-skip-if-empty-pulse-result`

### DIFF
--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -648,82 +648,82 @@
   pulse, and the queries for two cards. This enables a variety of cases to test the behavior of `:skip_if_empty` based
   on the presence or absence of card data."
   [[result skip-if-empty? query1 query2] & body]
-  `(mt/dataset ~'test-data
-     (mt/with-temp [Card {~'base-card-id :id} {:name          "Card1"
-                                               :dataset_query {:database (mt/id)
-                                                               :type     :query
-                                                               :query    ~query1}}
-                    Card {~'empty-card-id :id} {:name          "Card2"
-                                                :dataset_query {:database (mt/id)
-                                                                :type     :query
-                                                                :query    ~query2}}
-                    Dashboard {~'dash-id :id} {:name "The Dashboard"}
-                    DashboardCard {~'base-dash-card-id :id} {:dashboard_id ~'dash-id
-                                                             :card_id      ~'base-card-id}
-                    DashboardCard {~'empty-dash-card-id :id} {:dashboard_id ~'dash-id
-                                                              :card_id      ~'empty-card-id}
-                    Pulse {~'pulse-id :id :as ~'pulse} {:name          "Only populated pulse"
-                                                        :dashboard_id  ~'dash-id
-                                                        :skip_if_empty ~skip-if-empty?}
-                    PulseCard ~'_ {:pulse_id          ~'pulse-id
-                                   :card_id           ~'base-card-id
-                                   :dashboard_card_id ~'base-dash-card-id
-                                   :include_csv       true}
-                    PulseCard ~'_ {:pulse_id          ~'pulse-id
-                                   :card_id           ~'empty-card-id
-                                   :dashboard_card_id ~'empty-dash-card-id
-                                   :include_csv       true}
-                    PulseChannel {~'pulse-channel-id :id} {:channel_type :email
-                                                           :pulse_id     ~'pulse-id
-                                                           :enabled      true}
-                    PulseChannelRecipient ~'_ {:pulse_channel_id ~'pulse-channel-id
-                                               :user_id          (mt/user->id :rasta)}]
-       (let [~result (run-pulse-and-return-data-tables ~'pulse)]
-         ~@body))))
+  `(mt/with-temp [Card {~'base-card-id :id} {:name          "Card1"
+                                             :dataset_query {:database (mt/id)
+                                                             :type     :query
+                                                             :query    ~query1}}
+                  Card {~'empty-card-id :id} {:name          "Card2"
+                                              :dataset_query {:database (mt/id)
+                                                              :type     :query
+                                                              :query    ~query2}}
+                  Dashboard {~'dash-id :id} {:name "The Dashboard"}
+                  DashboardCard {~'base-dash-card-id :id} {:dashboard_id ~'dash-id
+                                                           :card_id      ~'base-card-id}
+                  DashboardCard {~'empty-dash-card-id :id} {:dashboard_id ~'dash-id
+                                                            :card_id      ~'empty-card-id}
+                  Pulse {~'pulse-id :id :as ~'pulse} {:name          "Only populated pulse"
+                                                      :dashboard_id  ~'dash-id
+                                                      :skip_if_empty ~skip-if-empty?}
+                  PulseCard ~'_ {:pulse_id          ~'pulse-id
+                                 :card_id           ~'base-card-id
+                                 :dashboard_card_id ~'base-dash-card-id
+                                 :include_csv       true}
+                  PulseCard ~'_ {:pulse_id          ~'pulse-id
+                                 :card_id           ~'empty-card-id
+                                 :dashboard_card_id ~'empty-dash-card-id
+                                 :include_csv       true}
+                  PulseChannel {~'pulse-channel-id :id} {:channel_type :email
+                                                         :pulse_id     ~'pulse-id
+                                                         :enabled      true}
+                  PulseChannelRecipient ~'_ {:pulse_channel_id ~'pulse-channel-id
+                                             :user_id          (mt/user->id :rasta)}]
+     (let [~result (run-pulse-and-return-data-tables ~'pulse)]
+       ~@body)))
 
 (deftest skip-if-empty-test
   #_{:clj-kondo/ignore [:unresolved-symbol]}
   (testing "Only send non-empty cards when 'Don't send if there aren't results is enabled' (#34777)"
-    (let [query       {:source-table (mt/id :orders)
-                       :fields       [[:field (mt/id :orders :id) {:base-type :type/BigInteger}]
-                                      [:field (mt/id :orders :tax) {:base-type :type/Float}]]
-                       :limit        2}
-          query2      (merge query {:limit 3})
-          empty-query (merge query
-                             {:filter [:= [:field (mt/id :orders :tax) {:base-type :type/Float}] -1]})]
-      (testing "Cases for when 'Don't send if there aren't results is enabled' is false"
-        (let [skip-if-empty? false]
-          (testing "Everything has results"
-            (with-skip-if-empty-pulse-result [result skip-if-empty? query query2]
-              (testing "Show all the data"
-                (is (= [[["1" "2.07"] ["2" "6.1"]]
-                        [["1" "2.07"] ["2" "6.1"] ["3" "2.9"]]]
-                       result)))))
-          (testing "Not everything has results"
-            (with-skip-if-empty-pulse-result [result skip-if-empty? query empty-query]
-              (testing "The second table is empty since there are no results"
-                (is (= [[["1" "2.07"] ["2" "6.1"]] []] result)))))
-          (testing "No results"
-            (with-skip-if-empty-pulse-result [result skip-if-empty? empty-query empty-query]
-              (testing "We send the email anyways, despite everything being empty due to no results"
-                (is (= [[] []] result)))))))
-      (testing "Cases for when 'Don't send if there aren't results is enabled' is true"
-        (let [skip-if-empty? true]
-          (testing "Everything has results"
-            (with-skip-if-empty-pulse-result [result skip-if-empty? query query2]
-              (testing "When everything has results, we see everything"
-                (is (= 2 (count result))))
-              (testing "Show all the data"
-                (is (= [[["1" "2.07"] ["2" "6.1"]]
-                        [["1" "2.07"] ["2" "6.1"] ["3" "2.9"]]]
-                       result)))))
-          (testing "Not everything has results"
-            (with-skip-if-empty-pulse-result [result skip-if-empty? query empty-query]
-              (testing "We should only see a single data table in the result"
-                (is (= 1 (count result))))
-              (testing "The single result should contain the card with data in it"
-                (is (= [[["1" "2.07"] ["2" "6.1"]]] result)))))
-          (testing "No results"
-            (with-skip-if-empty-pulse-result [result skip-if-empty? empty-query empty-query]
-              (testing "Don't send a pulse if no results at all"
-                (is (nil? result))))))))))
+    (mt/dataset sample-dataset
+      (let [query       {:source-table (mt/id :orders)
+                         :fields       [[:field (mt/id :orders :id) {:base-type :type/BigInteger}]
+                                        [:field (mt/id :orders :tax) {:base-type :type/Float}]]
+                         :limit        2}
+            query2      (merge query {:limit 3})
+            empty-query (merge query
+                               {:filter [:= [:field (mt/id :orders :tax) {:base-type :type/Float}] -1]})]
+        (testing "Cases for when 'Don't send if there aren't results is enabled' is false"
+          (let [skip-if-empty? false]
+            (testing "Everything has results"
+              (with-skip-if-empty-pulse-result [result skip-if-empty? query query2]
+                (testing "Show all the data"
+                  (is (= [[["1" "2.07"] ["2" "6.1"]]
+                          [["1" "2.07"] ["2" "6.1"] ["3" "2.9"]]]
+                         result)))))
+            (testing "Not everything has results"
+              (with-skip-if-empty-pulse-result [result skip-if-empty? query empty-query]
+                (testing "The second table is empty since there are no results"
+                  (is (= [[["1" "2.07"] ["2" "6.1"]] []] result)))))
+            (testing "No results"
+              (with-skip-if-empty-pulse-result [result skip-if-empty? empty-query empty-query]
+                (testing "We send the email anyways, despite everything being empty due to no results"
+                  (is (= [[] []] result)))))))
+        (testing "Cases for when 'Don't send if there aren't results is enabled' is true"
+          (let [skip-if-empty? true]
+            (testing "Everything has results"
+              (with-skip-if-empty-pulse-result [result skip-if-empty? query query2]
+                (testing "When everything has results, we see everything"
+                  (is (= 2 (count result))))
+                (testing "Show all the data"
+                  (is (= [[["1" "2.07"] ["2" "6.1"]]
+                          [["1" "2.07"] ["2" "6.1"] ["3" "2.9"]]]
+                         result)))))
+            (testing "Not everything has results"
+              (with-skip-if-empty-pulse-result [result skip-if-empty? query empty-query]
+                (testing "We should only see a single data table in the result"
+                  (is (= 1 (count result))))
+                (testing "The single result should contain the card with data in it"
+                  (is (= [[["1" "2.07"] ["2" "6.1"]]] result)))))
+            (testing "No results"
+              (with-skip-if-empty-pulse-result [result skip-if-empty? empty-query empty-query]
+                (testing "Don't send a pulse if no results at all"
+                  (is (nil? result)))))))))))

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -683,7 +683,7 @@
 (deftest skip-if-empty-test
   #_{:clj-kondo/ignore [:unresolved-symbol]}
   (testing "Only send non-empty cards when 'Don't send if there aren't results is enabled' (#34777)"
-    (mt/dataset sample-dataset
+    (mt/dataset test-data
       (let [query       {:source-table (mt/id :orders)
                          :fields       [[:field (mt/id :orders :id) {:base-type :type/BigInteger}]
                                         [:field (mt/id :orders :tax) {:base-type :type/Float}]]


### PR DESCRIPTION
As a follow on to #37546, this fixes an issue in which the macroexpansion of `with-skip-if-empty-pulse-result` doesn't capture the scope of the arguments in `skip-if-empty-test`.

The solution is just to _correctly_ wrap all of the `mt/id` functions in `mt/dataset`.