### PR TITLE
run frontend ci tasks when eslint config changes

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -23,6 +23,7 @@ frontend_sources: &frontend_sources
   - "**/tsconfig*.json"
   - "package.json"
   - "babel.config.json"
+  - ".eslintrc"
   - "postcss.config.js"
   - "webpack.config.js"
   - "webpack.static-viz.config.js"


### PR DESCRIPTION
### Description

Currently we don't run the linting job when a pr only contains changes in `.eslintrc`.
To fix it I added the file name under `frontend_sources` even though it's not technically a source file.
Would it be better if we added it to `frontend_all`?

### How to verify

This pr https://github.com/metabase/metabase/pull/37596 contains only a `.eslintrc` change + the changes from this pr.


You can check under the [commits] tab(https://github.com/metabase/metabase/pull/37596/commits) that the job was skipped on the first commit, that didn't have the files-path change, and started (and correctly failed) on the second one)

<img width="1082" alt="image" src="https://github.com/metabase/metabase/assets/1914270/df641d6c-8323-4deb-9ddb-dc3123df4117">


