### PR TITLE
[MLv2] Add `compatible-type?` wrapper that handles JS `DatasetColumn`s

### DIFF
--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -24,6 +24,7 @@
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.order-by :as lib.order-by]
    [metabase.lib.stage :as lib.stage]
+   [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
    [metabase.mbql.js :as mbql.js]
    [metabase.mbql.normalize :as mbql.normalize]
@@ -1178,3 +1179,11 @@
   "Add or update a filter against `temporal-column`. Modify the temporal unit for any breakouts."
   [a-query temporal-column stage-number start end]
   (lib.core/update-temporal-filter a-query temporal-column stage-number start end))
+
+(defn ^:export assignable?
+  "Given two CLJS `:metadata/columns` returns true if the first column's type `[[lib.types.isa/isa?]]` subtype of the
+  second column's type.
+
+  That is, that a value from `src-column` is assignable to `dst-column`."
+  [src-column dst-column]
+  (lib.types.isa/assignable? src-column dst-column))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1190,10 +1190,7 @@
   [a-query temporal-column stage-number start end]
   (lib.core/update-temporal-filter a-query temporal-column stage-number start end))
 
-(defn ^:export assignable?
-  "Given two CLJS `:metadata/columns` returns true if the first column's type `[[lib.types.isa/isa?]]` subtype of the
-  second column's type.
-
-  That is, that a value from `src-column` is assignable to `dst-column`."
+(defn ^:export valid-filter-for?
+  "Given two CLJS `:metadata/columns` returns true if `src-column` is a valid source to use for filtering `dst-column`."
   [src-column dst-column]
-  (lib.types.isa/assignable? src-column dst-column))
+  (lib.types.isa/valid-filter-for? src-column dst-column))

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -308,9 +308,8 @@
     (or (clojure.core/isa? column-type :type/Text)
         (clojure.core/isa? column-type :type/TextLike))))
 
-(defn ^:export assignable?
-  "Given two CLJS `:metadata/columns` returns true if the first column's type `[[lib.types.isa/isa?]]` subtype of the
-  second column's type. That is, that a value from `src-column` is assignable to `dst-column`.
+(defn valid-filter-for?
+  "Given two CLJS `:metadata/columns` returns true if `src-column` is a valid source to use for filtering `dst-column`.
 
   That's the case if both are from the same family (strings, numbers, temporal) or if the `src-column` [[isa?]] subtype
   of `dst-column`."

--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -307,3 +307,16 @@
   (let [column-type (or effective-type base-type)]
     (or (clojure.core/isa? column-type :type/Text)
         (clojure.core/isa? column-type :type/TextLike))))
+
+(defn ^:export assignable?
+  "Given two CLJS `:metadata/columns` returns true if the first column's type `[[lib.types.isa/isa?]]` subtype of the
+  second column's type. That is, that a value from `src-column` is assignable to `dst-column`.
+
+  That's the case if both are from the same family (strings, numbers, temporal) or if the `src-column` [[isa?]] subtype
+  of `dst-column`."
+  [src-column dst-column]
+  (or
+    (and (string? src-column)   (string? dst-column))
+    (and (number? src-column)   (number? dst-column))
+    (and (temporal? src-column) (temporal? dst-column))
+    (clojure.core/isa? (:base-type src-column) (:base-type dst-column))))

--- a/test/metabase/lib/types/isa_test.cljc
+++ b/test/metabase/lib/types/isa_test.cljc
@@ -219,3 +219,25 @@
       (let [primary-key? (lib.types.isa/primary-key-pred "card__1")]
         (is (= ["column0" "column1" "column2"]
                (map :name (filter primary-key? columns))))))))
+
+(deftest ^:parallel valid-filter-for?-test
+  (are [exp base-lhs eff-lhs base-rhs eff-rhs] (= exp (lib.types.isa/valid-filter-for?
+                                                        {:base-type      base-lhs
+                                                         :effective-type eff-lhs}
+                                                        {:base-type      base-rhs
+                                                         :effective-type eff-rhs}))
+    true  :type/String :type/Text    :type/String :type/Text
+    true  :type/String :type/Text    :type/String :type/TextLike
+    true  :type/String :type/Text    :type/String :type/Category
+
+    true  :type/Float   :type/Number    :type/Float :type/Number
+    true  :type/Float   :type/Price     :type/Float :type/Number
+    true  :type/Integer :type/Quantity  :type/Float :type/Number
+    true  :type/Float   :type/Number    :type/Float :type/Price
+
+    true  :type/DateTime :type/Temporal :type/Time  :type/Temporal
+
+    false :type/String   :type/Text      :type/Integer  :type/Number
+    false :type/Integer  :type/Number    :type/String   :type/Text
+    false :type/DateTime :type/Temporal  :type/String   :type/Text
+    false :type/String   :type/Text      :type/DateTime :type/Temporal))


### PR DESCRIPTION
This wraps the logic of `metabase.lib.types.isa/compatible-type?` with
code to convert JS `DatasetColumn` objects into CLJS form.

Fixes #37501. (Unblocks #37438.)
