### PR TITLE
Modify Embedded Analytics UTM codes

### DIFF
--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -247,7 +247,7 @@ describe("embed modal display", () => {
         cy.findByTestId("interactive-embedding-cta").should(
           "have.attr",
           "href",
-          "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=CTA&utm_campaign=embed-modal",
+          "https://www.metabase.com/product/embedded-analytics?utm_source=oss&utm_media=static-embed-popover",
         );
       });
     });

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
+import { getPlan } from "metabase/common/utils/plan";
 import Link from "metabase/core/components/Link";
-import { getIsPaidPlan } from "metabase/selectors/settings";
+import { getIsPaidPlan, getSetting } from "metabase/selectors/settings";
 import { Text, Group, Stack, Box } from "metabase/ui";
 import { useSelector } from "metabase/lib/redux";
 import {
@@ -12,6 +13,9 @@ import {
 
 const useCTAText = () => {
   const isPaidPlan = useSelector(getIsPaidPlan);
+  const plan = useSelector(state =>
+    getPlan(getSetting(state, "token-features")),
+  );
 
   if (isPaidPlan) {
     return {
@@ -26,7 +30,7 @@ const useCTAText = () => {
     showProBadge: true,
     description: t`Give your customers the full power of Metabase in your own app, with SSO, advanced permissions, customization, and more.`,
     linkText: t`Learn more`,
-    url: "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=CTA&utm_campaign=embed-modal",
+    url: `https://www.metabase.com/product/embedded-analytics?utm_source=${plan}&utm_media=static-embed-popover`,
     target: "_blank",
   };
 };

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.unit.spec.tsx
@@ -58,7 +58,7 @@ describe("InteractiveEmbeddingCTA", () => {
 
     expect(screen.getByTestId("interactive-embedding-cta")).toHaveAttribute(
       "href",
-      "https://www.metabase.com/product/embedded-analytics?utm_source=product&utm_medium=CTA&utm_campaign=embed-modal",
+      "https://www.metabase.com/product/embedded-analytics?utm_source=oss&utm_media=static-embed-popover",
     );
   });
 });


### PR DESCRIPTION
Changes the UTM codes for the Interactive Embedding URL to match the [product doc](https://www.notion.so/metabase/Setup-flow-for-static-public-embedding-embedding-feature-discoverability-3f7362e71e63440883bfebae48ab54a0?pvs=4#e834f5744b1c421c8aecdd839961ba87https://www.notion.so/metabase/Setup-flow-for-static-public-embedding-embedding-feature-discoverability-3f7362e71e63440883bfebae48ab54a0?pvs=4#e834f5744b1c421c8aecdd839961ba87).