### PR TITLE
Register keywords defined by `mr/def` for LSP

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -566,7 +566,8 @@
    metabase.test/with-non-admin-groups-no-root-collection-perms                                                              hooks.common/do*
    metabase.test/with-temp                                                                                                   hooks.toucan2.tools.with-temp/with-temp
    metabase.test/with-temp-file                                                                                              hooks.metabase.test.util/with-temp-file
-   metabase.test/with-temporary-setting-values                                                                               hooks.metabase.test.util/with-temporary-setting-values}
+   metabase.test/with-temporary-setting-values                                                                               hooks.metabase.test.util/with-temporary-setting-values
+   metabase.util.malli.registry/def                                                                                          hooks.metabase.util.malli.registry/def}
 
   :macroexpand
   {clojurewerkz.quartzite.jobs/build                                            macros.quartz/build-job

--- a/.clj-kondo/hooks/metabase/util/malli/registry.clj
+++ b/.clj-kondo/hooks/metabase/util/malli/registry.clj
@@ -1,0 +1,20 @@
+(ns hooks.metabase.util.malli.registry
+  (:refer-clojure :exclude [def])
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(defn def
+  "Register the schema keyword so LSP can jump to it."
+  [x]
+  (letfn [(update-def-keyword [k]
+            (api/reg-keyword! k 'metabase.util.malli.registry/def))
+          (update-children [[_def k :as children]]
+            (if (api/keyword-node? k)
+              (update (vec children) 1 update-def-keyword)
+              children))
+          (update-node [node]
+            (if (api/list-node? node)
+              (-> (api/list-node (update-children (:children node)))
+                  (with-meta (meta node)))
+              node))]
+    (update x :node update-node)))


### PR DESCRIPTION
In Emacs `M-x lsp-find-declaration` which is the totally convenient keybinding `<super>-l g g` for me jumps to the malli schema definition after adding this hook