### PR TITLE
Expose MLv2 functions in the browser in dev mode

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1101,6 +1101,7 @@ class Question {
     if (process.env.NODE_ENV === "development") {
       window.__MLv2_metadata = metadata;
       window.__MLv2_query = this.__mlv2Query;
+      window.Lib = Lib;
     }
 
     return this.__mlv2Query;


### PR DESCRIPTION
This is a small change but a huge QoL improvement.
@bshepherdson already exposed mlv2 metadata and the query which made debugging a much more pleasant experience. With this new change, one will now have all of the mlv2 methods in the browser to which one could pass the query and observe the results.

No more console logging. 🎉 

FWIW, working in the REPL still remains superior method, but debugging directly in the browser is as close as it gets to that experience.

Example
![image](https://github.com/metabase/metabase/assets/31325167/109395eb-6be5-447e-b664-94c6c629740b)
