### PR TITLE
Introduce mechanism for explicitly marking settings for export in their definition

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -418,7 +418,7 @@
 
               (testing "for settings"
                 (let [settings (get @entities "Setting")]
-                  (is (every? @#'setting/exported-settings
+                  (is (every? @#'setting/export?
                               (set (map (comp symbol :key) settings))))
                   (is (= (into {} (for [{:keys [key value]} settings]
                                     [key value]))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -323,7 +323,11 @@
    ;; should be used for most non-sensitive settings, and will log the value returned by its getter, which may be a
    ;; the default getter or a custom one.
    ;; (default: `:no-value`)
-   :audit       (s/maybe (s/enum :never :no-value :raw-value :getter))})
+   :audit       (s/maybe (s/enum :never :no-value :raw-value :getter))
+
+   ;; TODO: make this required and deprecate setting/exported-setting
+   (s/optional-key :export?)     s/Bool ; should this setting be serialized?
+   })
 
 (defonce ^{:doc "Map of loaded defsettings"}
   registered-settings

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -168,7 +168,7 @@
   [:key])
 
 (def ^:private exported-settings
-  '#{application-colors
+  '#{#_application-colors
      application-favicon-url
      application-font
      application-font-files

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -167,7 +167,7 @@
   [_setting]
   [:key])
 
-(def ^:private exported-settings
+(def ^:private ^:dynamic *exported-settings*
   '#{#_application-colors
      application-favicon-url
      application-font
@@ -1253,9 +1253,10 @@
   (some? (env-var-value setting)))
 
 (defn- export? [setting-name]
-  (or (:export? (core/get @registered-settings (keyword setting-name)))
-      ;; deprecated, we want to move to always setting this explicitly in the defsetting declaration
-      (contains? exported-settings (symbol setting-name))))
+  (u/or-with some?
+    (:export? (core/get @registered-settings (keyword setting-name)))
+    ;; deprecated, we want to move to always setting this explicitly in the defsetting declaration
+    (contains? *exported-settings* (symbol setting-name))))
 
 (defn- user-facing-info
   [{:keys [default description], k :name, :as setting} & {:as options}]

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -377,6 +377,7 @@
          "You might need to refresh your browser to see your changes take effect.")
     (application-name-for-setting-descriptions))
   :visibility :public
+  :export?    true
   :type       :json
   :feature    :whitelabel
   :default    {}

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1190,6 +1190,29 @@
                             :new-value      "AUDIT ME"}}
                  (mt/latest-audit-log-entry :setting-update))))))))
 
+(defsetting exported-setting
+  "This setting would be serialized"
+  :export? true)
+
+(defsetting non-exported-setting
+  "This setting would not be serialized"
+  :export? false)
+
+(deftest export?-test
+  (testing "The :export? property is exposed"
+    (is (#'setting/export? :exported-setting))
+    (is (not (#'setting/export? :non-exported-setting))))
+
+  (testing "Fallback to using a globally defined list"
+    (binding [setting/*exported-settings* #{'test-setting-1}]
+      (is (#'setting/export? :test-setting-1))
+      (is (not (#'setting/export? :test-setting-3)))
+      (is (not (#'setting/export? :non-existent-setting)))))
+
+  (testing "The explicit property takes precedence over the deprecated var"
+    (binding [setting/*exported-settings* #{:non-exported-setting}]
+      (is (not (#'setting/export? :non-exported-setting))))))
+
 (deftest realize-throwing-test
   (testing "The realize function ensures all nested lazy values are calculated"
     (let [ok (lazy-seq (cons 1 (lazy-seq (list 2))))


### PR DESCRIPTION
Closes #36240 

### Description

This change starts the deprecation of `setting/exported-settings` in favor of a more explicit `:export?` key in the definition of the setting. The rationale is that it's too easy to forget to add new settings to this set.

The idea is to require an explicit true or false value for this key in the macro, in a subsequent PR. That step is deferred to avoid adding a large amount of noise to this PR.

~~I'm not thrilled about using metadata for filtering, but I wasn't thrilled about the other options I thought of either - looking to discuss offline with @calherries as there's a lot to say on the matter.~~ We selected another approach.

### How to verify

~~I'm not sure whether there is sufficient test coverage for this, it's probably worth adding more.~~ While it would be nice to have an e2e test, the new unit tests should give us enough confidence to merge.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
