### PR TITLE
Migrate `_serializeForUrl` method to MLv2

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -995,14 +995,13 @@ class Question {
     includeDisplayIsLocked = false,
     creationType,
   } = {}) {
-    const query = clean
-      ? this.legacyQuery({ useStructuredQuery: true }).clean()
-      : this.legacyQuery({ useStructuredQuery: true });
+    const query = clean ? Lib.dropStageIfEmpty(this.query()) : this.query();
+
     const cardCopy = {
       name: this._card.name,
       description: this._card.description,
       collection_id: this._card.collection_id,
-      dataset_query: query.datasetQuery(),
+      dataset_query: Lib.toLegacyQuery(query),
       display: this._card.display,
       parameters: this._card.parameters,
       dataset: this._card.dataset,

--- a/frontend/src/metabase-lib/queries/utils/card.js
+++ b/frontend/src/metabase-lib/queries/utils/card.js
@@ -2,6 +2,7 @@ import _ from "underscore";
 import { updateIn } from "icepick";
 
 import { copy } from "metabase/lib/utils";
+import * as Lib from "metabase-lib";
 import { normalizeParameterValue } from "metabase-lib/parameters/utils/parameter-values";
 import { deriveFieldOperatorFromParameter } from "metabase-lib/parameters/utils/operators";
 import * as Q_DEPRECATED from "metabase-lib/queries/utils"; // legacy
@@ -20,7 +21,7 @@ function cardVisualizationIsEquivalent(cardA, cardB) {
 export function cardQueryIsEquivalent(cardA, cardB) {
   cardA = updateIn(cardA, ["dataset_query", "parameters"], p => p || []);
   cardB = updateIn(cardB, ["dataset_query", "parameters"], p => p || []);
-  return _.isEqual(
+  return Lib.areLegacyQueriesEqual(
     _.pick(cardA, "dataset_query"),
     _.pick(cardB, "dataset_query"),
   );


### PR DESCRIPTION
This PR migrates `_serializeForUrl` method to the MLv2.

Resolves #37508