### PR TITLE
Use UTF8 encoding for dashboard preview page

### DIFF
--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -291,8 +291,7 @@
    :body    (preview/style-tag-from-inline-styles
              (html5
                [:head
-                [:meta {:nonce "%NONCE%" ;; this will be str/replaced by 'style-tag-nonce-middleware
-                        :charset "utf-8"}]
+                [:meta {:charset "utf-8"}]
                 [:link {:nonce "%NONCE%" ;; this will be str/replaced by 'style-tag-nonce-middleware
                         :rel  "stylesheet"
                         :href "https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"}]]

--- a/src/metabase/api/pulse.clj
+++ b/src/metabase/api/pulse.clj
@@ -291,6 +291,8 @@
    :body    (preview/style-tag-from-inline-styles
              (html5
                [:head
+                [:meta {:nonce "%NONCE%" ;; this will be str/replaced by 'style-tag-nonce-middleware
+                        :charset "utf-8"}]
                 [:link {:nonce "%NONCE%" ;; this will be str/replaced by 'style-tag-nonce-middleware
                         :rel  "stylesheet"
                         :href "https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap"}]]


### PR DESCRIPTION
Adds `<meta charset="utf-8" />` to the dashboard subscription preview page