### PR TITLE
Align pie chart labels and values vertically

### DIFF
--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -96,7 +96,10 @@ export default class LegendVertical extends Component {
               />
               {Array.isArray(title) && (
                 <span
-                  className={cx("LegendItem", "flex-align-right pl1")}
+                  className={cx(
+                    "LegendItem",
+                    "flex align-center flex-align-right pl1",
+                  )}
                   style={{ opacity: isMuted ? 0.4 : 1 }}
                 >
                   {title[1]}


### PR DESCRIPTION
This PR fixes the vertical alignment in pie chart labels and values.

**Before**
![image](https://github.com/metabase/metabase/assets/31325167/b7e76606-72af-46ce-a065-bf1666f7d892)

**Now**
![image](https://github.com/metabase/metabase/assets/31325167/56b29272-cee9-4ec8-9ad1-114c40962dfa)

Fixes #37635

P.S. I'm looking at 48.3 and it seems to be fine there, so I'm adding `no-backport` label
![image](https://github.com/metabase/metabase/assets/31325167/c3d7a26b-7ce0-43c3-8391-07c70c08238f)
