### PR TITLE
Use explicit definition for all exported settings, remove global var

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_config/models/pulse_channel.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_config/models/pulse_channel.clj
@@ -9,6 +9,7 @@
 (defsetting subscription-allowed-domains
   (deferred-tru "Allowed email address domain(s) for new Dashboard Subscriptions and Alerts. To specify multiple domains, separate each domain with a comma, with no space in between. To allow all domains, leave the field empty. This setting doesn’t affect existing subscriptions.")
   :visibility :public
+  :export?    true
   :feature    :email-allow-list
   ;; this is a comma-separated string but we're not using `:csv` because it gets serialized to an array which makes it
   ;; inconvenient to use on the frontend.

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -841,3 +841,60 @@
                            (get-in viz [:column_settings
                                         (format "[\"ref\",[\"field\",%s,null]]" %people.name)
                                         :pivot_table.column_sort_order])))))))))))))
+
+(deftest exported-settings-test
+  ;; this is the only relevant settings namespace that hadn't been imported already
+  (require 'metabase-enterprise.advanced-config.models.pulse-channel)
+  ;; TODO: delete this, it's here as a temporary measure during migration {} to reassure us that we haven't made a mistake
+  (let [expected-exports
+        '#{application-colors
+           application-favicon-url
+           application-font
+           application-font-files
+           application-logo-url
+           application-name
+           available-fonts
+           available-locales
+           available-timezones
+           breakout-bins-num
+           custom-formatting
+           custom-geojson
+           custom-geojson-enabled
+           enable-embedding
+           enable-nested-queries
+           enable-sandboxes?
+           enable-whitelabeling?
+           enable-xrays
+           hide-embed-branding?
+           humanization-strategy
+           landing-page
+           loading-message
+           aggregated-query-row-limit
+           unaggregated-query-row-limit
+           native-query-autocomplete-match-style
+           persisted-models-enabled
+           report-timezone
+           report-timezone-long
+           report-timezone-short
+           search-typeahead-enabled
+           show-homepage-data
+           show-homepage-pin-message
+           show-homepage-xrays
+           show-lighthouse-illustration
+           show-metabot
+           site-locale
+           site-name
+           source-address-header
+           start-of-week
+           subscription-allowed-domains
+           uploads-enabled
+           uploads-database-id
+           uploads-schema-name}]
+    (testing "We have not had a regression around which settings are exported"
+      (is (= expected-exports
+             (->> @setting/registered-settings
+                  (remove (comp #{:internal} :visibility val))
+                  keys
+                  (filter #'setting/export?)
+                  (map symbol)
+                  set))))))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -590,6 +590,7 @@
          "Larger instances can have performance issues matching using substring, so can use prefix matching, "
          " or turn autocompletions off."))
   :visibility :public
+  :export?    true
   :type       :keyword
   :default    :substring
   :audit      :raw-value

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -21,6 +21,7 @@
 (defsetting custom-geojson-enabled
   (deferred-tru "Whether or not the use of custom GeoJSON is enabled.")
   :visibility :admin
+  :export?    true
   :type       :boolean
   :setter     :none
   :default    true
@@ -108,6 +109,7 @@
                  (validate-geojson new-value))
                (setting/set-value-of-type! :json :custom-geojson new-value)))
   :visibility :public
+  :export?    true
   :audit      :raw-value)
 
 (def ^:private connection-timeout-ms 8000)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -54,6 +54,7 @@
 (defsetting report-timezone
   (deferred-tru "Connection timezone to use when executing queries. Defaults to system timezone.")
   :visibility :settings-manager
+  :export?    true
   :audit      :getter
   :setter
   (fn [new-value]
@@ -63,6 +64,7 @@
 (defsetting report-timezone-short
   "Current report timezone abbreviation"
   :visibility :public
+  :export?    true
   :setter     :none
   :getter     (fn [] (short-timezone-name (report-timezone)))
   :doc        false)
@@ -70,6 +72,7 @@
 (defsetting report-timezone-long
   "Current report timezone string"
   :visibility :public
+  :export?    true
   :setter     :none
   :getter     (fn [] (long-timezone-name (report-timezone)))
   :doc        false)

--- a/src/metabase/embed/settings.clj
+++ b/src/metabase/embed/settings.clj
@@ -20,6 +20,7 @@
   :type       :boolean
   :default    false
   :visibility :authenticated
+  :export?    true
   :audit      :getter
   :setter     (fn [new-value]
                 (when (not= new-value (setting/get-value-of-type :boolean :enable-embedding))

--- a/src/metabase/models/humanization.clj
+++ b/src/metabase/models/humanization.clj
@@ -81,6 +81,7 @@
   :type       :keyword
   :default    :simple
   :visibility :settings-manager
+  :export?    true
   :audit      :raw-value
   :getter     (fn []
                 (let [strategy (setting/get-value-of-type :keyword :humanization-strategy)

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1245,8 +1245,8 @@
                (when api/*is-superuser?*
                  [:admin]))))
 
-(defn- filtered-user-facing-settings
-  "Docstrings are hard"
+(defn- user-facing-settings-matching
+  "Returns the user facing view of the registered settings satisfying the given predicate"
   [pred options]
   (into
     []
@@ -1270,7 +1270,7 @@
   ;; ignore Database-local values, but not User-local values
   (let [writable-visibilities (current-user-writable-visibilities)]
     (binding [*database-local-values* nil]
-      (filtered-user-facing-settings
+      (user-facing-settings-matching
         (fn [setting]
           (and (contains? writable-visibilities (:visibility setting))
                (not= (:database-local setting) :only)))
@@ -1288,7 +1288,7 @@
   ;; ignore User-local and Database-local values
   (binding [*user-local-values* (delay (atom nil))
             *database-local-values* nil]
-    (filtered-user-facing-settings
+    (user-facing-settings-matching
       (fn [setting]
         (and (not= (:visibility setting) :internal)
              (allows-site-wide-values? setting)))

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -167,51 +167,6 @@
   [_setting]
   [:key])
 
-(def ^:private ^:dynamic *exported-settings*
-  '#{#_application-colors
-     application-favicon-url
-     application-font
-     application-font-files
-     application-logo-url
-     application-name
-     available-fonts
-     available-locales
-     available-timezones
-     breakout-bins-num
-     custom-formatting
-     custom-geojson
-     custom-geojson-enabled
-     enable-embedding
-     enable-nested-queries
-     enable-sandboxes?
-     enable-whitelabeling?
-     enable-xrays
-     hide-embed-branding?
-     humanization-strategy
-     landing-page
-     loading-message
-     aggregated-query-row-limit
-     unaggregated-query-row-limit
-     native-query-autocomplete-match-style
-     persisted-models-enabled
-     report-timezone
-     report-timezone-long
-     report-timezone-short
-     search-typeahead-enabled
-     show-homepage-data
-     show-homepage-pin-message
-     show-homepage-xrays
-     show-lighthouse-illustration
-     show-metabot
-     site-locale
-     site-name
-     source-address-header
-     start-of-week
-     subscription-allowed-domains
-     uploads-enabled
-     uploads-database-id
-     uploads-schema-name})
-
 (declare export?)
 
 (defmethod serdes/extract-all "Setting" [_model _opts]
@@ -1253,10 +1208,7 @@
   (some? (env-var-value setting)))
 
 (defn- export? [setting-name]
-  (u/or-with some?
-    (:export? (core/get @registered-settings (keyword setting-name)))
-    ;; deprecated, we want to move to always setting this explicitly in the defsetting declaration
-    (contains? *exported-settings* (symbol setting-name))))
+  (:export? (core/get @registered-settings (keyword setting-name))))
 
 (defn- user-facing-info
   [{:keys [default description], k :name, :as setting} & {:as options}]

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -26,6 +26,7 @@
 (defsetting application-name
   (deferred-tru "This will replace the word \"Metabase\" wherever it appears.")
   :visibility :public
+  :export?    true
   :type       :string
   :audit      :getter
   :feature    :whitelabel
@@ -96,7 +97,8 @@
                 (application-name-for-setting-descriptions))
   :default    "Metabase"
   :audit      :getter
-  :visibility :settings-manager)
+  :visibility :settings-manager
+  :export?    true)
 
 (defsetting custom-homepage
   (deferred-tru "Pick a dashboard to serve as the homepage. If people lack permissions to view the selected dashboard, Metabase will redirect them to the default homepage. To revert to the default Metabase homepage, simply turn off the toggle.")
@@ -213,6 +215,7 @@
     (application-name-for-setting-descriptions))
   :default    "en"
   :visibility :public
+  :export?    true
   :audit      :getter
   :getter     (fn []
                 (let [value (setting/get-value-of-type :string :site-locale)]
@@ -271,6 +274,7 @@
 (defsetting landing-page
   (deferred-tru "Default page to show people when they log in.")
   :visibility :public
+  :export?    true
   :type       :string
   :default    ""
   :audit      :getter
@@ -294,6 +298,7 @@
   :type       :boolean
   :default    true
   :visibility :authenticated
+  :export?    true
   :audit      :getter)
 
 (defsetting enable-query-caching
@@ -308,6 +313,7 @@
   :type       :boolean
   :default    false
   :visibility :public
+  :export?    true
   :audit      :getter)
 
 (defsetting persisted-model-refresh-cron-schedule
@@ -384,6 +390,7 @@
 (defsetting loading-message
   (deferred-tru "Message to show while a query is running.")
   :visibility :public
+  :export?    true
   :feature    :whitelabel
   :type       :keyword
   :default    :doing-science
@@ -404,6 +411,7 @@
 (defsetting application-font
   (deferred-tru "This will replace “Lato” as the font family.")
   :visibility :public
+  :export?    true
   :type       :string
   :default    "Lato"
   :feature    :whitelabel
@@ -417,6 +425,7 @@
 (defsetting application-font-files
   (deferred-tru "Tell us where to find the file for each font weight. You don’t need to include all of them, but it’ll look better if you do.")
   :visibility :public
+  :export?    true
   :type       :json
   :audit      :getter
   :feature    :whitelabel)
@@ -434,6 +443,7 @@
 (defsetting application-logo-url
   (deferred-tru "For best results, use an SVG file with a transparent background.")
   :visibility :public
+  :export?    true
   :type       :string
   :audit      :getter
   :feature    :whitelabel
@@ -442,6 +452,7 @@
 (defsetting application-favicon-url
   (deferred-tru "The url or image that you want to use as the favicon.")
   :visibility :public
+  :export?    true
   :type       :string
   :audit      :getter
   :feature    :whitelabel
@@ -450,6 +461,7 @@
 (defsetting show-metabot
   (deferred-tru "Enables Metabot character on the home page")
   :visibility :public
+  :export?    true
   :type       :boolean
   :audit      :getter
   :feature    :whitelabel
@@ -458,6 +470,7 @@
 (defsetting show-lighthouse-illustration
   (deferred-tru "Display the lighthouse illustration on the home and login pages.")
   :visibility :public
+  :export?    true
   :type       :boolean
   :audit      :getter
   :feature    :whitelabel
@@ -536,6 +549,7 @@
     (str "When using the default binning strategy and a number of bins is not provided, "
          "this number will be used as the default."))
   :type    :integer
+  :export? true
   :default 8
   :audit   :getter)
 
@@ -550,6 +564,7 @@
 (defsetting custom-formatting
   (deferred-tru "Object keyed by type, containing formatting settings")
   :type       :json
+  :export?    true
   :default    {}
   :visibility :public
   :audit      :getter)
@@ -559,6 +574,7 @@
   :type       :boolean
   :default    true
   :visibility :authenticated
+  :export?    true
   :audit      :getter)
 
 (defsetting show-homepage-data
@@ -568,6 +584,7 @@
   :type       :boolean
   :default    true
   :visibility :authenticated
+  :export?    true
   :audit      :getter)
 
 (defsetting show-homepage-xrays
@@ -577,6 +594,7 @@
   :type       :boolean
   :default    true
   :visibility :authenticated
+  :export?    true
   :audit      :getter)
 
 (defsetting show-homepage-pin-message
@@ -586,12 +604,14 @@
   :type       :boolean
   :default    true
   :visibility :authenticated
+  :export?    true
   :doc        false
   :audit      :getter)
 
 (defsetting source-address-header
   (deferred-tru "Identify the source of HTTP requests by this header's value, instead of its remote address.")
   :default "X-Forwarded-For"
+  :export? true
   :audit   :getter
   :getter  (fn [] (some-> (setting/get-value-of-type :string :source-address-header)
                           u/lower-case-en)))
@@ -608,6 +628,7 @@
 (defsetting available-fonts
   "Available fonts"
   :visibility :public
+  :export?    true
   :setter     :none
   :getter     u.fonts/available-fonts
   :doc        false)
@@ -615,6 +636,7 @@
 (defsetting available-locales
   "Available i18n locales"
   :visibility :public
+  :export?    true
   :setter     :none
   :getter     available-locales-with-names
   :doc        false)
@@ -622,6 +644,7 @@
 (defsetting available-timezones
   "Available report timezone options"
   :visibility :public
+  :export?    true
   :setter     :none
   :getter     (comp sort t/available-zone-ids)
   :doc        false)
@@ -700,6 +723,7 @@
          "It won''t affect most SQL queries, "
          "although it is used to set the WEEK_START session variable in Snowflake."))
   :visibility :public
+  :export?    true
   :type       :keyword
   :default    :sunday
   :audit      :raw-value
@@ -745,6 +769,7 @@
 (defsetting uploads-enabled
   (deferred-tru "Whether or not uploads are enabled")
   :visibility :authenticated
+  :export?    true
   :type       :boolean
   :audit      :getter
   :default    false)
@@ -764,6 +789,7 @@
 (defsetting uploads-database-id
   (deferred-tru "Database ID for uploads")
   :visibility :authenticated
+  :export?    true
   :type       :integer
   :audit      :getter
   :setter     set-uploads-database-id!)
@@ -771,6 +797,7 @@
 (defsetting uploads-schema-name
   (deferred-tru "Schema name for uploads")
   :visibility :authenticated
+  :export?    true
   :type       :string
   :audit      :getter)
 

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -305,13 +305,15 @@
   "Logo Removal and Full App Embedding. Should we hide the 'Powered by Metabase' attribution on the embedding pages?
    `true` if we have a valid premium embedding token."
   :embedding
+  :export? true
   ;; This specific feature DOES NOT require the EE code to be present in order for it to return truthy, unlike
   ;; everything else.
   :getter #(has-feature? :embedding))
 
 (define-premium-feature enable-whitelabeling?
   "Should we allow full whitelabel embedding (reskinning the entire interface?)"
-  :whitelabel)
+  :whitelabel
+  :export? true)
 
 (define-premium-feature enable-audit-app?
   "Should we enable the Audit Logs interface in the Admin UI?"
@@ -331,7 +333,8 @@
 
 (define-premium-feature enable-sandboxes?
   "Should we enable data sandboxes (row-level permissions)?"
-  :sandboxes)
+  :sandboxes
+  :export? true)
 
 (define-premium-feature enable-sso-jwt?
   "Should we enable JWT-based authentication?"

--- a/src/metabase/query_processor/middleware/constraints.clj
+++ b/src/metabase/query_processor/middleware/constraints.clj
@@ -30,6 +30,7 @@
 (setting/defsetting unaggregated-query-row-limit
   (deferred-tru "Maximum number of rows to return specifically on :rows type queries via the API.")
   :visibility     :authenticated
+  :export?        true
   :type           :integer
   :database-local :allowed
   :audit          :getter)
@@ -37,6 +38,7 @@
 (setting/defsetting aggregated-query-row-limit
   (deferred-tru "Maximum number of rows to return for aggregated queries via the API.")
   :visibility     :authenticated
+  :export?        true
   :type           :integer
   :database-local :allowed
   :audit          :getter)

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -17,6 +17,7 @@
   :type       :boolean
   :default    true
   :visibility :authenticated
+  :export?    true
   :audit      :getter)
 
 (def ^:dynamic *db-max-results*

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1192,7 +1192,9 @@
 
 (defsetting exported-setting
   "This setting would be serialized"
-  :export? true)
+  :export? true
+  ;; make sure it's internal so it doesn't interfere with export test
+  :visibility :internal)
 
 (defsetting non-exported-setting
   "This setting would not be serialized"
@@ -1203,15 +1205,8 @@
     (is (#'setting/export? :exported-setting))
     (is (not (#'setting/export? :non-exported-setting))))
 
-  (testing "Fallback to using a globally defined list"
-    (binding [setting/*exported-settings* #{'test-setting-1}]
-      (is (#'setting/export? :test-setting-1))
-      (is (not (#'setting/export? :test-setting-3)))
-      (is (not (#'setting/export? :non-existent-setting)))))
-
-  (testing "The explicit property takes precedence over the deprecated var"
-    (binding [setting/*exported-settings* #{:non-exported-setting}]
-      (is (not (#'setting/export? :non-exported-setting))))))
+  (testing "By default settings are not exported"
+    (is (not (#'setting/export? :test-setting-1)))))
 
 (deftest realize-throwing-test
   (testing "The realize function ensures all nested lazy values are calculated"


### PR DESCRIPTION
### Description

This cleans up a bit after https://github.com/metabase/metabase/pull/37624, getting rid of the deprecated `exported-settings` var.

The addition of explicit `:export? false` annotations, and making the key a required one, will be done in a subsequent PR.

### How to verify

There's a temporary test asserting that we have not diverged from the previous definition. That test is to give the reviewer confidence, and we can delete it before merging.
