### PR TITLE
Disable CYPRESS_FE_HEALTHCHECK for test-cypress-open

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
     "test": "yarn test-unit && yarn test-timezones && yarn test-cypress",
     "test-cljs": "yarn && shadow-cljs compile test && node target/node-tests.js",
     "test-cypress": "yarn build && ./bin/build-for-test && yarn test-cypress-run",
-    "test-cypress-open": "./bin/build-for-test && CYPRESS_FE_HEALTHCHECK=true yarn test-cypress-run --e2e --open",
+    "test-cypress-open": "./bin/build-for-test && CYPRESS_FE_HEALTHCHECK=false yarn test-cypress-run --e2e --open",
     "test-cypress-open-no-backend": "E2E_HOST='http://localhost:3000' yarn test-cypress-run --e2e --open",
     "test-cypress-open-qa": "yarn test-qa-dbs:up && QA_DB_ENABLED=true TZ='US/Pacific' yarn test-cypress-open",
     "test-cypress-run": "node ./e2e/runner/run_cypress_tests.js",


### PR DESCRIPTION
This is a temporary fix for the `CYPRESS_FE_HEALTHCHECK`, which doesn't work as expected (hangs) when ran with `yarn build-watch` instead of `yarn build-hot`. 

