### PR TITLE
[MLv2] Add `legacy-column->metadata` for converting `DatasetColumn`

### DIFF
--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -1,6 +1,6 @@
 import * as ML from "cljs/metabase.lib.js";
 import * as ML_MetadataCalculation from "cljs/metabase.lib.metadata.calculation";
-import type { DatabaseId, TableId } from "metabase-types/api";
+import type { DatabaseId, DatasetColumn, TableId } from "metabase-types/api";
 import type Metadata from "./metadata/Metadata";
 import type {
   AggregationClause,
@@ -179,4 +179,12 @@ export function returnedColumns(
   stageIndex: number,
 ): ColumnMetadata[] {
   return ML.returned_columns(query, stageIndex);
+}
+
+export function fromLegacyColumn(
+  query: Query,
+  stageIndex: number,
+  column: DatasetColumn,
+): ColumnMetadata {
+  return ML.legacy_column__GT_metadata(query, stageIndex, column);
 }

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -997,6 +997,16 @@
     ;; We have the UUID for the aggregation in its ref, so use that here.
     (some-> a-ref first (= :aggregation)) (assoc :lib/source-uuid (last a-ref))))
 
+(defn ^:export legacy-column->metadata
+  "Given a JS `DatasetColumn`, return a CLJS `:metadata/column` for the same.
+
+  This properly handles fields, expressions and aggregations."
+  [a-query stage-number ^js js-column]
+  (lib.convert/with-aggregation-list (lib.core/aggregations a-query stage-number)
+    (let [column-ref (when-let [a-ref (.-field_ref js-column)]
+                       (legacy-ref->pMBQL a-ref))]
+      (fix-column-with-ref column-ref (js.metadata/parse-column js-column)))))
+
 (defn- js-cells-by
   "Given a `col-fn`, returns a function that will extract a JS object like
   `{col: {name: \"ID\", ...}, value: 12}` into a CLJS map like


### PR DESCRIPTION
The query and stage are unfortunately required to correctly handle
aggregation references.

Note that the JS version of this name is `legacy_column__GT_metadata`,
with the double underscore.
