### PR TITLE
set select input label to text-medium

### DIFF
--- a/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
+++ b/frontend/src/metabase/ui/components/inputs/Select/Select.styled.tsx
@@ -41,6 +41,7 @@ export const getSelectInputOverrides = (
       },
     },
     label: {
+      color: theme.fn.themeColor("text-medium"),
       ref: getStylesRef("label"),
     },
     description: {


### PR DESCRIPTION
### Description

Currently mantine select inputs are rendering with `text-dark` labels, where other inputs are using `text-medium` labels. this makes them match

before | after
--- | ---
![Screen Shot 2024-01-12 at 9 03 41 AM](https://github.com/metabase/metabase/assets/30528226/22116264-37bd-4c82-bd2e-33233c0957a9) | ![Screen Shot 2024-01-12 at 9 07 29 AM](https://github.com/metabase/metabase/assets/30528226/1e41845b-5348-4499-a928-296a7fc31f2e)


### How to verify

This is noticeable in the "Create api keys" modal that has a mantine input and select next to each other