### PR TITLE
Fix admin landing page e2e test flakes

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -286,53 +286,35 @@ describeEE("formatting > whitelabel", () => {
   describe("Landing Page", () => {
     beforeEach(() => {
       cy.intercept("PUT", "/api/setting/landing-page").as("putLandingPage");
+      cy.signInAsAdmin();
+      cy.visit("/admin/settings/whitelabel");
     });
 
     it("should allow users to provide internal urls", () => {
-      cy.signInAsAdmin();
+      cy.findByTestId("landing-page").click().clear().type("/test-1").blur();
+      cy.wait("@putLandingPage");
 
-      cy.visit("/admin/settings/whitelabel");
-      cy.location("origin").then(origin => {
-        // test root / path
-        testValidLandingPageInput({ input: "/", expected: origin + "/" });
-
-        // test relative url
-        testValidLandingPageInput({
-          input: "/test-1",
-          expected: origin + "/test-1",
-        });
-
-        // test no input
-        testValidLandingPageInput({ input: "", expected: origin + "/" });
-
-        // test absolute url matching the page's origin
-        testValidLandingPageInput({
-          input: origin + "/test-2",
-          expected: origin + "/test-2",
-        });
-      });
+      cy.findByTestId("landing-page-error").should("not.exist");
+      cy.findByRole("navigation").findByText("Exit admin").click();
+      cy.url().should("include", "/test-1");
     });
 
     it("should not allow users to provide external urls", () => {
-      cy.signInAsAdmin();
-      cy.visit("/admin/settings/whitelabel");
+      cy.findByTestId("landing-page").click().clear().type("/test-2").blur();
+      cy.wait("@putLandingPage");
 
-      cy.location("origin").then(origin => {
-        // first set to a valid value
-        testValidLandingPageInput({ input: "/", expected: origin + "/" });
+      // set to valid value then test invalid value is not persisted
+      cy.findByTestId("landing-page")
+        .click()
+        .clear()
+        .type("https://google.com")
+        .blur();
+      cy.findByTestId("landing-page-error")
+        .findByText("This field must be a relative URL.")
+        .should("exist");
 
-        // test that setting invalid value errors and is not persisted
-        cy.visit("/admin/settings/whitelabel");
-        cy.findByTestId("landing-page")
-          .click()
-          .type("{selectAll}" + "{backspace}" + "https://google.com")
-          .blur();
-        cy.findByTestId("landing-page-error")
-          .findByText("This field must be a relative URL.")
-          .should("exist");
-        cy.findByText("Exit admin").click();
-        cy.url().should("eq", origin + "/");
-      });
+      cy.findByRole("navigation").findByText("Exit admin").click();
+      cy.url().should("include", "/test-2");
     });
   });
 });
@@ -355,20 +337,3 @@ const helpLink = () => popover().findByRole("link", { name: "Help" });
 
 const getHelpLinkCustomDestinationInput = () =>
   cy.findByPlaceholderText("Enter a URL it should go to");
-
-const testValidLandingPageInput = ({ input, expected }) => {
-  cy.visit("/admin/settings/whitelabel");
-
-  const field = cy.findByTestId("landing-page");
-  field.click().clear();
-  if (input) {
-    field.type(input);
-  }
-  field.blur();
-
-  cy.findByTestId("landing-page").click().clear();
-  cy.wait("@putLandingPage");
-  cy.findByTestId("landing-page-error").should("not.exist");
-  cy.findByText("Exit admin").click();
-  cy.url().should("eq", expected);
-};

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -286,13 +286,14 @@ describeEE("formatting > whitelabel", () => {
   describe("Landing Page", () => {
     beforeEach(() => {
       cy.intercept("PUT", "/api/setting/landing-page").as("putLandingPage");
+      cy.intercept("GET", "/api/setting").as("getSettings");
       cy.signInAsAdmin();
       cy.visit("/admin/settings/whitelabel");
     });
 
     it("should allow users to provide internal urls", () => {
       cy.findByTestId("landing-page").click().clear().type("/test-1").blur();
-      cy.wait("@putLandingPage");
+      cy.wait(["@putLandingPage", "@getSettings"]);
 
       cy.findByTestId("landing-page-error").should("not.exist");
       cy.findByRole("navigation").findByText("Exit admin").click();
@@ -301,7 +302,7 @@ describeEE("formatting > whitelabel", () => {
 
     it("should not allow users to provide external urls", () => {
       cy.findByTestId("landing-page").click().clear().type("/test-2").blur();
-      cy.wait("@putLandingPage");
+      cy.wait(["@putLandingPage", "@getSettings"]);
 
       // set to valid value then test invalid value is not persisted
       cy.findByTestId("landing-page")


### PR DESCRIPTION
### Description

This PR should solve the e2e flakiness introduced in  #37322.

I reduce the tests to only test a single input and make sure to wait for the full settings refetch query before continuing the test. Unit tests should cover a greater breadth of inputs, so reducing the test size should be fine. I believe there was a race condition due to rapidly setting inputs & not waiting for the settings request to return a result. Waiting for both requests should solve.

### How to verify

- e2e tests should pass consistently in CI

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
