### PR TITLE
Fix isEditable check

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -137,7 +137,8 @@ class StructuredQuery extends AtomicQuery {
    * @returns true if we have metadata for the root source table loaded
    */
   hasMetadata(): boolean {
-    return this.metadata() != null && this.rootTable() != null;
+    const metadata = this.metadata();
+    return metadata != null && metadata.table(this._sourceTableId()) != null;
   }
 
   // Whether the user can modify and run this query


### PR DESCRIPTION
Context https://metaboat.slack.com/archives/C0645JP1W81/p1705076059720359

Calling `rootTable` in MLv1 would break our changes to `databaseId` method because it would try to create a query from a card that doesn't have `dataset_query`. Cannot repro locally.