### PR TITLE
don't dismiss search unless location pathname changes

### DIFF
--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -13,12 +13,14 @@ import {
   setTokenFeatures,
   summarize,
   assertIsEllipsified,
+  main,
 } from "e2e/support/helpers";
 import {
   ADMIN_USER_ID,
   NORMAL_USER_ID,
   ORDERS_COUNT_QUESTION_ID,
   ORDERS_QUESTION_ID,
+  ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -206,6 +208,17 @@ describe("scenarios > search", () => {
       cy.findByTestId("result-description")
         .findByRole("img")
         .should("not.exist");
+    });
+
+    it("should not dismiss when a dashboard finishes loading (#35009)", () => {
+      cy.visit(`/dashboard/${ORDERS_DASHBOARD_ID}`);
+
+      // Type as soon as possible, before the dashboard has finished loading
+      getSearchBar().type("ord");
+
+      // Once the dashboard is visible, the search results should not be dismissed
+      main().findByRole("heading", { name: "Loading..." }).should("not.exist");
+      cy.findByTestId("search-results-floating-container").should("exist");
     });
   });
   describe("accessing full page search with `Enter`", () => {

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -138,11 +138,11 @@ function SearchBarView({ location, onSearchActive, onSearchInactive }: Props) {
   }, [previousLocation, location]);
 
   useEffect(() => {
-    if (previousLocation?.pathname !== location.pathname) {
+    if (previousLocation !== location && location.action !== "REPLACE") {
       // deactivate search when page changes
       setInactive();
     }
-  }, [previousLocation?.pathname, location.pathname, setInactive]);
+  }, [previousLocation, location, setInactive]);
 
   const goToSearchApp = useCallback(() => {
     const shouldPersistFilters = isSearchPageLocation(previousLocation);

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx
@@ -138,11 +138,11 @@ function SearchBarView({ location, onSearchActive, onSearchInactive }: Props) {
   }, [previousLocation, location]);
 
   useEffect(() => {
-    if (previousLocation !== location) {
+    if (previousLocation?.pathname !== location.pathname) {
       // deactivate search when page changes
       setInactive();
     }
-  }, [previousLocation, location, setInactive]);
+  }, [previousLocation?.pathname, location.pathname, setInactive]);
 
   const goToSearchApp = useCallback(() => {
     const shouldPersistFilters = isSearchPageLocation(previousLocation);


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35099
Closes https://github.com/metabase/metabase/issues/34226

### Description
Small adjustment to a comparison in `Searchbar.tsx`. Anytime the app location changed it was basically always going to set the search to inactive. This happens when a dashboard loads so that it can add any filter parameters into the URL once it knows what they are (even if there are none, it still technically updates the location). The change switches the comparison from the location object to the location pathname. 

### How to verify

1. open a dashboard
2. Before it's done loading, type something in the search bar
3. the search results popover should no longer spontaneously disappear 

### Demo
![chrome_qqAho1nNDr](https://github.com/metabase/metabase/assets/1328979/4c9610af-499c-48e0-9c8b-ecd5f640ab5a)

### Checklist

- [x ] Tests have been added/updated to cover changes in this PR
