### PR TITLE
Introduce same-column-lists?

### DIFF
--- a/dev/src/dev/fe_helpers.cljs
+++ b/dev/src/dev/fe_helpers.cljs
@@ -28,3 +28,9 @@
   Hack: This relies on a dev-mode-only global property that's set whenever a Question object is converted to MLv2."
   []
   (.-__MLv2_query js/window))
+
+(defn current-query-results
+  "Gets the current query results from the reduce store.
+  This is normally a JS array or result_metadata objects."
+  []
+  (.. (redux-state) -qb -queryResults))

--- a/frontend/src/metabase-lib/comparison.ts
+++ b/frontend/src/metabase-lib/comparison.ts
@@ -36,3 +36,11 @@ export function findColumnIndexesFromLegacyRefs(
     fieldRefs,
   );
 }
+
+export function isSameColumnList(
+  query: Query,
+  returnedColumns: ColumnMetadata[],
+  resultColumns: DatasetColumn[],
+): boolean {
+  return ML.same_column_lists_QMARK_(query, returnedColumns, resultColumns);
+}

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -312,3 +312,87 @@
            :day]
           (lib.js/expression-clause "time-interval" [(meta/field-metadata :products :created-at)
                                                      (lib.js/expression-clause "interval" [10 "day"] nil) "day"] nil)))))
+
+(deftest ^:parallel disambiguated?-test
+  (are [original disambiguated] (do (is (true? (#'lib.js/disambiguated? original disambiguated)))
+                                    (is (false? (#'lib.js/disambiguated? disambiguated original))))
+    "ID" "ID_2"
+    "Orders__ID" "Orders__ID_2")
+  (are [nom1 nom2] (is (false? (#'lib.js/disambiguated? nom1 nom2)))
+    "ID" "ID"
+    nil "ID"
+    "ID" nil
+    "ID" 1
+    "ID" "DI"
+    "ID" "ID_2a"
+    "ID" "ID_a2"))
+
+(deftest ^:parallel same-column-lists?-test
+  (let [query lib.tu/query-with-self-join
+        result-columns #js [#js {:semantic_type "type/PK"
+                                 :name "ID"
+                                 :effective_type "type/BigInteger"
+                                 :id (meta/id :orders :id)
+                                 :display_name "ID"
+                                 :base_type "type/BigInteger"}
+                            #js {:semantic_type nil
+                                 :name "TAX"
+                                 :effective_type "type/Float"
+                                 :id (meta/id :orders :tax)
+                                 :display_name "Tax"
+                                 :base_type "type/Float"}
+                            #js {:semantic_type "type/PK"
+                                 :name "ID_2"
+                                 :effective_type "type/BigInteger"
+                                 :id (meta/id :orders :id)
+                                 :display_name "Orders → ID"
+                                 :base_type "type/BigInteger"
+                                 :source_alias "Orders"}
+                            #js {:semantic_type nil
+                                 :name "TAX_2"
+                                 :effective_type "type/Float"
+                                 :id (meta/id :orders :tax)
+                                 :display_name "Orders → Tax"
+                                 :base_type "type/Float"
+                                 :source_alias "Orders"}]
+        returned-columns #js [{:lib/type :metadata/column
+                               :lib/desired-column-alias "ID"
+                               :lib/source-column-alias "ID"
+                               :name "ID"
+                               :display-name "ID"
+                               :id (meta/id :orders :id)
+                               :effective-type :type/BigInteger
+                               :base-type :type/BigInteger
+                               :semantic-type :type/PK}
+                              {:lib/type :metadata/column
+                               :base-type :type/Float
+                               :semantic-type nil
+                               :name "TAX"
+                               :lib/source-column-alias "TAX"
+                               :effective-type :type/Float
+                               :id (meta/id :orders :tax)
+                               :lib/desired-column-alias "TAX"
+                               :display-name "Tax"}
+                              {:lib/type :metadata/column
+                               :base-type :type/BigInteger
+                               :semantic-type :type/PK
+                               :name "ID"
+                               :lib/source-column-alias "ID"
+                               :effective-type :type/BigInteger
+                               :id (meta/id :orders :id)
+                               :source-alias "Orders"
+                               :lib/desired-column-alias "Orders__ID"
+                               :display-name "ID"
+                               :metabase.lib.join/join-alias "Orders"}
+                              {:lib/type :metadata/column
+                               :base-type :type/Float
+                               :semantic-type nil
+                               :name "TAX"
+                               :lib/source-column-alias "TAX"
+                               :effective-type :type/Float
+                               :id (meta/id :orders :tax)
+                               :source-alias "Orders"
+                               :lib/desired-column-alias "Orders__TAX"
+                               :display-name "Tax"
+                               :metabase.lib.join/join-alias "Orders"}]]
+    (is (true? (lib.js/same-column-lists? query returned-columns result-columns)))))


### PR DESCRIPTION
Fixes #37517.

This function makes it possible for the FE to decide if the query has to be re-run.
For more context, see the Slack [discussion](https://metaboat.slack.com/archives/C04CYTEL9N2/p1705008072684969?thread_ts=1705002980.394099&cid=C04CYTEL9N2).
