### PR TITLE
Update first and last name in Google SSO

### DIFF
--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -122,13 +122,13 @@
             (not= last-name (:last_name user)))
     (t2/update! :model/User (:id user) {:first_name first-name
                                         :last_name  last-name}))
-  (dissoc user :first_name :last_name))
+  (assoc user :first_name first-name :last_name last-name))
 
 (mu/defn ^:private google-auth-fetch-or-create-user! :- (mi/InstanceOf User)
   [first-name last-name email]
   (let [existing-user (t2/select-one [User :id :email :last_login :first_name :last_name] :%lower.email (u/lower-case-en email))]
     (if existing-user
-      (update-google-user! existing-user first-name last-name)
+      (maybe-update-google-user! existing-user first-name last-name)
       (google-auth-create-new-user! {:first_name first-name
                                      :last_name  last-name
                                      :email      email}))))

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -115,7 +115,7 @@
   ;; things hairy and only enforce those for non-Google Auth users
   (user/create-new-google-auth-user! new-user))
 
-(defn- update-google-user!
+(defn- maybe-update-google-user!
   "Update google user if the first or list name changed."
   [user first-name last-name]
   (when (or (not= first-name (:first_name user))

--- a/src/metabase/integrations/google.clj
+++ b/src/metabase/integrations/google.clj
@@ -115,12 +115,23 @@
   ;; things hairy and only enforce those for non-Google Auth users
   (user/create-new-google-auth-user! new-user))
 
+(defn- update-google-user!
+  "Update google user if the first or list name changed."
+  [user first-name last-name]
+  (when (or (not= first-name (:first_name user))
+            (not= last-name (:last_name user)))
+    (t2/update! :model/User (:id user) {:first_name first-name
+                                        :last_name  last-name}))
+  (dissoc user :first_name :last_name))
+
 (mu/defn ^:private google-auth-fetch-or-create-user! :- (mi/InstanceOf User)
   [first-name last-name email]
-  (or (t2/select-one [User :id :email :last_login] :%lower.email (u/lower-case-en email))
+  (let [existing-user (t2/select-one [User :id :email :last_login :first_name :last_name] :%lower.email (u/lower-case-en email))]
+    (if existing-user
+      (update-google-user! existing-user first-name last-name)
       (google-auth-create-new-user! {:first_name first-name
                                      :last_name  last-name
-                                     :email      email})))
+                                     :email      email}))))
 
 (defn do-google-auth
   "Call to Google to perform an authentication"

--- a/test/metabase/integrations/google_test.clj
+++ b/test/metabase/integrations/google_test.clj
@@ -159,3 +159,15 @@
                                   "Rasta" "Toucan" "rasta@sf-toucannery.com")))
             (finally
               (t2/delete! User :email "rasta@sf-toucannery.com"))))))))
+
+(deftest google-auth-fetch-or-create-user!-updated-name-test
+  (testing "test that a exisitng user gets an updated name when calling google-auth-fetch-or-create-user!"
+    (mt/with-model-cleanup [:model/User]
+      (et/with-fake-inbox
+        (mt/with-temporary-setting-values [google-auth-auto-create-accounts-domain "sf-toucannery.com"
+                                           admin-email                             "rasta@toucans.com"]
+          (#'google/google-auth-fetch-or-create-user! "Rasta" "Toucan" "rasta@sf-toucannery.com")
+          (#'google/google-auth-fetch-or-create-user! "Basta" "Boucan" "rasta@sf-toucannery.com")
+          (let [user (t2/select-one [User :first_name :last_name] :email "rasta@sf-toucannery.com")]
+            (is (= "Basta" (:first_name user)))
+            (is (= "Boucan" (:last_name user)))))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35628
Closes https://github.com/metabase/metabase/issues/35970

### Description

In `google-auth-fetch-or-create-user!`, if the first or last name fetched by through Google is different than the one we have in Metabase, we update the first and last name.

### How to verify

1. Setup Google SSO, see: https://www.notion.so/metabase/Google-SSO-setup-570a7efb3080417ba1a1483b235d000f
2. Sign in with your Metabase account
3. Change name on Google
4. Re sign into Metabase, see name change
