### PR TITLE
Manual backport - Fix TypeError when changing click behavior to drill-through menu & default click behavior does not have selected state

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -195,7 +195,21 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
       editDashboard();
 
+      cy.log("doesn't throw when setting default behavior (metabase#35354)");
+      cy.on("uncaught:exception", err => {
+        expect(err.name.includes("TypeError")).to.be.false;
+      });
+
       getDashboardCard().realHover().icon("click").click();
+
+      // When the default menu is selected, it should've visual cue (metabase#34848)
+      cy.get("aside")
+        .findByText("Open the Metabase drill-through menu")
+        .parent()
+        .parent()
+        .should("have.attr", "aria-selected", "true")
+        .should("have.css", "background-color", "rgb(80, 158, 227)");
+
       addDashboardDestination();
       cy.get("aside").findByText("Select a dashboard tab").should("not.exist");
       cy.get("aside").findByText("No available targets").should("exist");
@@ -1226,11 +1240,6 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
         getCreatedAtToUrlMapping().should("not.exist");
         cy.get("aside").findByText(CREATED_AT_COLUMN_NAME).click();
-        /**
-         * TODO: remove the next line when metabase#34845 is fixed
-         * @see https://github.com/metabase/metabase/issues/34845
-         */
-        cy.get("aside").findByText("Unknown").click();
         addUrlDestination();
         modal().within(() => {
           const urlInput = cy.findAllByRole("textbox").eq(0);

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1051,11 +1051,6 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
 
           getCreatedAtToQuestionMapping().should("not.exist");
           cy.get("aside").findByText(CREATED_AT_COLUMN_NAME).click();
-          /**
-           * TODO: remove the next line when metabase#34845 is fixed
-           * @see https://github.com/metabase/metabase/issues/34845
-           */
-          cy.get("aside").findByText("Unknown").click();
           addSavedQuestionDestination();
           addSavedQuestionCreatedAtParameter();
           addSavedQuestionQuantityParameter();

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -125,7 +125,10 @@ export function ClickBehaviorSidebar({
         });
       }
 
-      const changedType = nextClickBehavior.type !== clickBehavior?.type;
+      // nextClickBehavior is `undefined` for drill-through menu
+      const changedType =
+        !!nextClickBehavior && nextClickBehavior.type !== clickBehavior?.type;
+
       if (changedType) {
         // move to next screen
         setTypeSelectorVisible(false);

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebarContent.tsx
@@ -48,6 +48,7 @@ export function ClickBehaviorSidebarContent({
     if (clickBehavior) {
       return clickBehavior;
     }
+    // drill-through menu
     return { type: "actionMenu" };
   }, [clickBehavior]);
 
@@ -65,7 +66,7 @@ export function ClickBehaviorSidebarContent({
     );
   }
 
-  if (isTypeSelectorVisible) {
+  if (isTypeSelectorVisible || finalClickBehavior.type === "actionMenu") {
     return (
       <SidebarContent>
         <TypeSelector

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem/SidebarItem.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/SidebarItem/SidebarItem.tsx
@@ -54,7 +54,13 @@ interface SelectableSidebarItem extends Omit<SidebarItemProps, "as"> {
 }
 
 function SelectableSidebarItem(props: SelectableSidebarItem) {
-  return <SidebarItem {...props} as={SelectableSidebarItemRoot} />;
+  return (
+    <SidebarItem
+      {...props}
+      as={SelectableSidebarItemRoot}
+      aria-selected={props.isSelected}
+    />
+  );
 }
 
 SidebarItem.Selectable = SelectableSidebarItem;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/TypeSelector.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/TypeSelector/TypeSelector.tsx
@@ -18,7 +18,7 @@ import { SidebarItem } from "../SidebarItem";
 import { BehaviorOptionIcon } from "./TypeSelector.styled";
 
 interface BehaviorOptionProps {
-  value: ClickBehaviorType | "menu";
+  value: ClickBehaviorType;
   dashcard: DashboardCard;
   icon: IconName;
   hasNextStep: boolean;
@@ -82,8 +82,8 @@ export function TypeSelector({
   const handleSelect = useCallback(
     value => {
       if (value !== clickBehavior.type) {
-        updateSettings(value === "menu" ? undefined : { type: value });
-      } else if (value !== "menu") {
+        updateSettings(value === "actionMenu" ? undefined : { type: value });
+      } else if (value !== "actionMenu") {
         moveToNextPage();
       }
     },
@@ -101,7 +101,7 @@ export function TypeSelector({
             disabled={value === "crossfilter" && parameters.length === 0}
             onClick={() => handleSelect(value)}
             icon={icon}
-            hasNextStep={value !== "menu"}
+            hasNextStep={value !== "actionMenu"}
           />
         </div>
       ))}

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/hooks.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/hooks.ts
@@ -5,11 +5,11 @@ import { useSelector } from "metabase/lib/redux";
 import { getApplicationName } from "metabase/selectors/whitelabel";
 
 export function useClickBehaviorOptionName(
-  value: ClickBehaviorType | "menu",
+  value: ClickBehaviorType,
   dashcard: DashboardCard,
 ) {
   const applicationName = useSelector(getApplicationName);
-  if (value === "menu") {
+  if (value === "actionMenu") {
     return hasActionsMenu(dashcard)
       ? t`Open the ${applicationName} drill-through menu`
       : t`Do nothing`;

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.ts
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/utils.ts
@@ -9,12 +9,12 @@ import type { IconName } from "metabase/core/components/Icon";
 import { getColumnKey } from "metabase-lib/queries/utils/get-column-key";
 
 type ClickBehaviorOption = {
-  value: ClickBehaviorType | "menu";
+  value: ClickBehaviorType;
   icon: IconName;
 };
 
 export const clickBehaviorOptions: ClickBehaviorOption[] = [
-  { value: "menu", icon: "popover" },
+  { value: "actionMenu", icon: "popover" },
   { value: "link", icon: "link" },
   { value: "crossfilter", icon: "filter" },
 ];


### PR DESCRIPTION
Manual backport of #35863 (which is a fix for #35354 & #34848).