### PR TITLE
Change check-can-connect-before-sync-test to help debug flake

### DIFF
--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -155,7 +155,7 @@
               (tx/destroy-db! driver/*driver* dbdef))
             (testing "after deleting a database, sync should fail"
               (testing "1: sync-and-analyze-database! should log a warning and fail early"
-                (is (nil? (cant-sync-log-msg))))
+                (is (some? (cant-sync-log-msg))))
               (testing "2: triggering the sync via the POST /api/database/:id/sync_schema endpoint should fail"
                 (mt/user-http-request :crowberto :post 422 (str "/database/" (u/the-id db) "/sync_schema"))))
             ;; clean up the database

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -115,34 +115,6 @@
             ;; clean up the database
             (t2/delete! :model/Database (u/the-id db))))))))
 
-;; FAIL in metabase.driver-test/check-can-connect-before-sync-test (driver_test.clj:139)
-;; Database sync should short-circuit and fail if the database at the connection has been deleted (metabase#7526)
-;; :bigquery-cloud-sdk
-;;  using dbdef dataset
-;;  sense checks before deleting the database sense check 1: sync-and-analyze-database! should not log a warning
-;; expected: (false? (cant-sync-logged?))
-;;   actual: (not (false? true))
-
-;; FAIL in metabase.driver-test/check-can-connect-before-sync-test (http_client.clj:187)
-;; Database sync should short-circuit and fail if the database at the connection has been deleted (metabase#7526)
-;; :bigquery-cloud-sdk
-;;  using dbdef dataset
-;;  sense checks before deleting the database sense check 2: triggering the sync via the POST /api/database/:id/sync_schema endpoint should succeed
-;; POST /api/database/360/sync_schema expected a status code of 200, got 422.
-;; expected: 200
-;;   actual: 422
-
-
-;; FAIL in metabase.driver-test/check-can-connect-before-sync-test (driver_test.clj:141)
-;; Database sync should short-circuit and fail if the database at the connection has been deleted (metabase#7526)
-;; :bigquery-cloud-sdk
-;;  using dbdef dataset
-;;  sense checks before deleting the database sense check 2: triggering the sync via the POST /api/database/:id/sync_schema endpoint should succeed
-;; expected: {:status "ok"}
-;;   actual: "Timed out after 3.0 s"
-
-(mt/set-test-drivers! [:bigquery-cloud-sdk])
-
 (deftest check-can-connect-before-sync-test
   (testing "Database sync should short-circuit and fail if the database at the connection has been deleted (metabase#7526)"
     (mt/test-drivers (->> (mt/normal-drivers)


### PR DESCRIPTION
This PR changes metabase.driver-test/check-can-connect-before-sync-test to help debugging its flakiness (issue: https://github.com/metabase/metabase/issues/36397).

An example run that fails: https://github.com/metabase/metabase/actions/runs/7488691603/job/20383722724#step:3:945. 
If it fails in the same way after this change, we'll see the logged message in the test output for sense check 1.