### PR TITLE
Backport: fix serialization when there is a slash in click_behavior id (#37503)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/extract_test.clj
@@ -1,5 +1,6 @@
 (ns ^:mb/once metabase-enterprise.serialization.v2.extract-test
   (:require
+   [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
@@ -1318,10 +1319,19 @@
                                                                   :dashboard_id clickdash-id
                                                                   :visualization_settings
                                                                   ;; Top-level click behavior for the card.
-                                                                  {:click_behavior {:type              "link"
-                                                                                    :linkType          "question"
-                                                                                    :targetId          c3-2-id
-                                                                                    :parameterMappings {}}}}]
+                                                                  (let [dimension [:dimension [:field "something" {:base-type "type/Text"}]]
+                                                                       mapping-id (json/generate-string dimension)]
+                                                                   {:click_behavior {:type     "link"
+                                                                                     :linkType "question"
+                                                                                     :targetId c3-2-id
+                                                                                     :parameterMapping
+                                                                                     {mapping-id {:id     mapping-id
+                                                                                                  :source {:type "column"
+                                                                                                           :id   "whatever"
+                                                                                                           :name "Just to serialize"}
+                                                                                                  :target {:type      "dimension"
+                                                                                                           :id        mapping-id
+                                                                                                           :dimension dimension}}}}})}]
                        ;;; stress-test that exporting various visualization_settings does not break
                        DashboardCard [_                          {:card_id      c3-1-id
                                                                   :dashboard_id clickdash-id

--- a/src/metabase/models/serialization.clj
+++ b/src/metabase/models/serialization.clj
@@ -936,19 +936,22 @@
       (m/update-existing-in [:target :dimension] mbql-fully-qualified-names->ids)))
 
 (defn- export-viz-click-behavior-mappings
-  "The `:parameterMappings` on a `:click_behavior` viz settings is a map of... IDs turned into JSON strings which have
+  "The `:parameterMapping` on a `:click_behavior` viz settings is a map of... IDs turned into JSON strings which have
   been keywordized. Therefore the keys must be converted to strings, parsed, exported, and JSONified. The values are
   ported by [[export-viz-click-behavior-mapping]]."
   [mappings]
   (into {} (for [[kw-key mapping] mappings
-                 :let [k (name kw-key)]]
+                 ;; Mapping keyword shouldn't been a keyword in the first place, it's just how it's processed after
+                 ;; being selected from db. In an ideal world we'd either have different data layout for
+                 ;; click_behavior or not convert it's keys to a keywords. We need its full content here.
+                 :let [k (u/qualified-name kw-key)]]
              (if (mb.viz/dimension-param-mapping? mapping)
                [(json-ids->fully-qualified-names k)
                 (export-viz-click-behavior-mapping mapping)]
                [k mapping]))))
 
 (defn- import-viz-click-behavior-mappings
-  "The exported form of `:parameterMappings` on a `:click_behavior` viz settings is a map of JSON strings which contain
+  "The exported form of `:parameterMapping` on a `:click_behavior` viz settings is a map of JSON strings which contain
   fully qualified names. These must be parsed, imported, JSONified and then turned back into keywords, since that's the
   form used internally."
   [mappings]


### PR DESCRIPTION
Resolves #37555

Backport of #37503