### PR TITLE
Convert top-level dashboard components to TypeScript

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -1,4 +1,5 @@
 import type { IconName } from "metabase/ui";
+import type { ColorName } from "metabase/lib/colors/types";
 import type { UserId } from "./user";
 import type { CardDisplayType } from "./card";
 import type { DatabaseId } from "./database";
@@ -17,7 +18,7 @@ export type CollectionAuthorityLevelConfig = {
   type: CollectionAuthorityLevel;
   name: string;
   icon: IconName;
-  color?: string;
+  color?: ColorName;
   tooltips?: Record<string, string>;
 };
 

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -1,5 +1,6 @@
 import type {
   Collection,
+  CollectionAuthorityLevel,
   Parameter,
   ParameterId,
   ParameterTarget,
@@ -23,6 +24,7 @@ export interface Dashboard {
   dashcards: (DashboardCard | ActionDashboardCard)[];
   tabs?: DashboardTab[];
   parameters?: Parameter[] | null;
+  collection_authority_level?: CollectionAuthorityLevel;
   can_write: boolean;
   cache_ttl: number | null;
   "last-edit-info": {
@@ -46,6 +48,7 @@ export type BaseDashboardCard = {
   id: DashCardId;
   dashboard_id: DashboardId;
   dashboard_tab_id?: DashboardTabId;
+  collection_authority_level?: CollectionAuthorityLevel;
   size_x: number;
   size_y: number;
   col: number;
@@ -94,7 +97,7 @@ export type DashboardParameterMapping = {
 
 export type DashCardDataMap = Record<
   DashCardId,
-  Record<CardId, Dataset | undefined>
+  Record<CardId, Dataset | null | undefined>
 >;
 
 export type LinkEntity = RestrictedLinkEntity | UnrestrictedLinkEntity;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -37,6 +37,7 @@ export interface Dashboard {
   auto_apply_filters: boolean;
   archived: boolean;
   public_uuid: string | null;
+  embedding_params?: Record<string, string> | null;
 
   /* Indicates whether static embedding for this dashboard has been published */
   enable_embedding: boolean;

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -26,6 +26,7 @@ export const createMockDashboard = (opts?: Partial<Dashboard>): Dashboard => ({
   archived: false,
   public_uuid: null,
   enable_embedding: false,
+  embedding_params: null,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/store/dashboard.ts
+++ b/frontend/src/metabase-types/store/dashboard.ts
@@ -20,7 +20,9 @@ export type DashboardSidebarName =
 
 interface BaseSidebarState {
   name?: DashboardSidebarName;
-  props: Record<string, unknown>;
+  props: Record<string, unknown> & {
+    dashcardId?: DashCardId;
+  };
 }
 
 type ClickBehaviorSidebarProps = {
@@ -33,6 +35,7 @@ export interface ClickBehaviorSidebarState extends BaseSidebarState {
 }
 
 type EditParameterSidebarProps = {
+  dashcardId?: DashCardId;
   parameterId: ParameterId;
 };
 
@@ -40,6 +43,11 @@ export interface EditParameterSidebarState extends BaseSidebarState {
   name: "editParameter";
   props: EditParameterSidebarProps;
 }
+
+export type DashboardSidebarState =
+  | BaseSidebarState
+  | ClickBehaviorSidebarState
+  | EditParameterSidebarState;
 
 export type StoreDashboardTab = DashboardTab & {
   isRemoved?: boolean;
@@ -95,7 +103,7 @@ export interface DashboardState {
 
   slowCards: Record<DashCardId, unknown>;
 
-  sidebar: ClickBehaviorSidebarState | BaseSidebarState;
+  sidebar: DashboardSidebarState;
 
   missingActionParameters: unknown;
 

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.tsx
@@ -4,10 +4,9 @@ import { t } from "ttag";
 
 import type {
   Card,
-  CardId,
+  DashCardDataMap,
   DashCardId,
   DashboardCard,
-  Dataset,
 } from "metabase-types/api";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { color } from "metabase/lib/colors";
@@ -24,7 +23,7 @@ const CAN_REMOVE_SERIES = (seriesIndex: number) => seriesIndex > 0;
 
 export interface Props {
   dashcard: DashboardCard;
-  dashcardData: Record<DashCardId, Record<CardId, Dataset>>;
+  dashcardData: DashCardDataMap;
   fetchCardData: (
     card: Card,
     dashcard: DashboardCard,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -79,15 +79,6 @@ export interface DashCardProps {
   navigateToNewCardFromDashboard?: (
     opts: NavigateToNewCardFromDashboardOpts,
   ) => void;
-  fetchCardData: (
-    card: Card,
-    dashcard: DashboardCard,
-    options: {
-      clearCache?: boolean;
-      ignoreCache?: boolean;
-      reload?: boolean;
-    },
-  ) => Promise<unknown>;
   onReplaceAllVisualizationSettings: (settings: VisualizationSettings) => void;
   onUpdateVisualizationSettings: (settings: VisualizationSettings) => void;
   showClickBehaviorSidebar: (dashCardId: DashCardId | null) => void;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCard.tsx
@@ -27,7 +27,7 @@ import type {
   ParameterId,
   ParameterValueOrArray,
   VisualizationSettings,
-  Dataset,
+  DashCardDataMap,
 } from "metabase-types/api";
 
 import { DASHBOARD_SLOW_TIMEOUT } from "metabase/dashboard/constants";
@@ -54,7 +54,7 @@ export interface DashCardProps {
   dashcard: DashboardCard & { justAdded?: boolean };
   gridItemWidth: number;
   totalNumGridCols: number;
-  dashcardData: Record<DashCardId, Record<CardId, Dataset>>;
+  dashcardData: DashCardDataMap;
   slowCards: Record<CardId, boolean>;
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
   metadata: Metadata;
@@ -79,6 +79,15 @@ export interface DashCardProps {
   navigateToNewCardFromDashboard?: (
     opts: NavigateToNewCardFromDashboardOpts,
   ) => void;
+  fetchCardData: (
+    card: Card,
+    dashcard: DashboardCard,
+    options: {
+      clearCache?: boolean;
+      ignoreCache?: boolean;
+      reload?: boolean;
+    },
+  ) => Promise<unknown>;
   onReplaceAllVisualizationSettings: (settings: VisualizationSettings) => void;
   onUpdateVisualizationSettings: (settings: VisualizationSettings) => void;
   showClickBehaviorSidebar: (dashCardId: DashCardId | null) => void;

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -84,7 +84,6 @@ function setup({
       isEditing={false}
       isEditingParameter={false}
       {...props}
-      fetchCardData={jest.fn()}
       onAddSeries={jest.fn()}
       onReplaceCard={onReplaceCard}
       onRemove={jest.fn()}

--- a/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/Dashcard.unit.spec.tsx
@@ -84,6 +84,7 @@ function setup({
       isEditing={false}
       isEditingParameter={false}
       {...props}
+      fetchCardData={jest.fn()}
       onAddSeries={jest.fn()}
       onReplaceCard={onReplaceCard}
       onRemove={jest.fn()}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -1,7 +1,8 @@
-// TODO: merge with metabase/dashboard/containers/Dashboard.jsx
+import type { ReactNode } from "react";
 import { Component } from "react";
-import PropTypes from "prop-types";
+import type { Route } from "react-router";
 import _ from "underscore";
+import type { Location } from "history";
 
 import { isSmallScreen, getMainElement } from "metabase/lib/dom";
 
@@ -10,12 +11,45 @@ import SyncedParametersList from "metabase/parameters/components/SyncedParameter
 import { FilterApplyButton } from "metabase/parameters/components/FilterApplyButton";
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import { DashboardControls } from "metabase/dashboard/hoc/DashboardControls";
+
+import type {
+  Dashboard as IDashboard,
+  DashboardId,
+  DashCardDataMap,
+  DashCardId,
+  DatabaseId,
+  Parameter,
+  ParameterId,
+  ParameterValueOrArray,
+  CardId,
+  DashboardTabId,
+  ParameterMappingOptions,
+  RowValue,
+  VisualizationSettings,
+  ValuesQueryType,
+  ValuesSourceType,
+  ValuesSourceConfig,
+} from "metabase-types/api";
+import type {
+  DashboardSidebarName,
+  SelectedTabId,
+  State,
+  StoreDashcard,
+} from "metabase-types/store";
+
+import type Database from "metabase-lib/metadata/Database";
+import type { UiParameter } from "metabase-lib/parameters/types";
+import type Metadata from "metabase-lib/metadata/Metadata";
 import { getValuePopulatedParameters } from "metabase-lib/parameters/utils/parameter-values";
 
-import { DashboardSidebars } from "../DashboardSidebars";
-import { DashboardGridConnected } from "../DashboardGrid";
 import { SIDEBAR_NAME } from "../../constants";
+import { DashboardGridConnected } from "../DashboardGrid";
+import { DashboardSidebars } from "../DashboardSidebars";
 
+import {
+  DashboardEmptyState,
+  DashboardEmptyStateWithoutAddPrompt,
+} from "./DashboardEmptyState/DashboardEmptyState";
 import {
   CardsContainer,
   DashboardStyled,
@@ -25,12 +59,127 @@ import {
   ParametersAndCardsContainer,
   ParametersWidgetContainer,
 } from "./Dashboard.styled";
-import {
-  DashboardEmptyState,
-  DashboardEmptyStateWithoutAddPrompt,
-} from "./DashboardEmptyState/DashboardEmptyState";
 
-class DashboardInner extends Component {
+interface DashboardProps {
+  dashboardId: DashboardId;
+  route: Route;
+  params: { slug: string };
+  children?: ReactNode;
+  canManageSubscriptions: boolean;
+  isAdmin: boolean;
+  isNavbarOpen: boolean;
+  isEditing: boolean;
+  isSharing: boolean;
+  dashboardBeforeEditing: IDashboard | null;
+  isEditingParameter: boolean;
+  isDirty: boolean;
+  dashboard: IDashboard;
+  dashcardData: DashCardDataMap;
+  slowCards: Record<DashCardId, unknown>;
+  databases: Record<DatabaseId, Database>;
+  editingParameter?: Parameter | null;
+  parameters: UiParameter[];
+  parameterValues: Record<ParameterId, ParameterValueOrArray>;
+  draftParameterValues: Record<ParameterId, ParameterValueOrArray | null>;
+  metadata: Metadata;
+  loadingStartTime: number | null;
+  clickBehaviorSidebarDashcard: StoreDashcard | null;
+  isAddParameterPopoverOpen: boolean;
+  sidebar: State["dashboard"]["sidebar"];
+  pageFavicon: string | null;
+  documentTitle: string | undefined;
+  isRunning: boolean;
+  isLoadingComplete: boolean;
+  isHeaderVisible: boolean;
+  isAdditionalInfoVisible: boolean;
+  selectedTabId: SelectedTabId;
+  isAutoApplyFilters: boolean;
+  isNavigatingBackToDashboard: boolean;
+  addCardOnLoad?: DashCardId;
+  editingOnLoad?: string | string[];
+  location: Location;
+  isNightMode: boolean;
+  isFullscreen: boolean;
+
+  initialize: (opts?: { clearCache?: boolean }) => void;
+  fetchDashboard: (opts: {
+    dashId: DashboardId;
+    queryParams?: Record<string, unknown>;
+    options?: {
+      clearCache?: boolean;
+      preserveParameters?: boolean;
+    };
+  }) => Promise<{ error?: unknown; payload?: unknown }>;
+  fetchDashboardCardData: (opts?: {
+    reload?: boolean;
+    clearCache?: boolean;
+  }) => Promise<void>;
+  fetchDashboardCardMetadata: () => Promise<void>;
+  cancelFetchDashboardCardData: () => void;
+  loadDashboardParams: () => void;
+  addCardToDashboard: (opts: {
+    dashId: DashboardId;
+    cardId: CardId;
+    tabId: DashboardTabId | null;
+  }) => void;
+  archiveDashboard: (id: DashboardId) => Promise<void>;
+
+  onRefreshPeriodChange: (period: number | null) => void;
+  setEditingDashboard: (dashboard: IDashboard) => void;
+  setDashboardAttributes: (opts: {
+    id: DashboardId;
+    attributes: Partial<IDashboard>;
+  }) => void;
+  setSharing: (isSharing: boolean) => void;
+  toggleSidebar: (sidebarName: DashboardSidebarName) => void;
+  closeSidebar: () => void;
+
+  closeNavbar: () => void;
+  setErrorPage: (error: unknown) => void;
+  onChangeLocation: (location: Location) => void;
+
+  addParameter: (option: ParameterMappingOptions) => void;
+  setParameterName: (id: ParameterId, name: string) => void;
+  setParameterIndex: (id: ParameterId, index: number) => void;
+  setParameterValue: (id: ParameterId, value: RowValue) => void;
+  setParameterDefaultValue: (id: ParameterId, value: RowValue) => void;
+  setEditingParameter: (id: ParameterId) => void;
+  setParameterIsMultiSelect: (id: ParameterId, isMultiSelect: boolean) => void;
+  setParameterQueryType: (id: ParameterId, queryType: ValuesQueryType) => void;
+  setParameterSourceType: (
+    id: ParameterId,
+    sourceType: ValuesSourceType,
+  ) => void;
+  setParameterSourceConfig: (
+    id: ParameterId,
+    config: ValuesSourceConfig,
+  ) => void;
+  setParameterFilteringParameters: (parameters: ParameterId[]) => void;
+  showAddParameterPopover: () => void;
+  removeParameter: (id: ParameterId) => void;
+
+  onReplaceAllDashCardVisualizationSettings: (
+    id: DashCardId,
+    settings: Partial<VisualizationSettings>,
+  ) => void;
+  onUpdateDashCardVisualizationSettings: (
+    id: DashCardId,
+    settings: Partial<VisualizationSettings>,
+  ) => void;
+  onUpdateDashCardColumnSettings: (
+    id: DashCardId,
+    columnKey: string,
+    settings?: Record<string, unknown> | null,
+  ) => void;
+}
+
+interface DashboardState {
+  error: unknown;
+  parametersListLength: number;
+  hasScroll: boolean;
+}
+
+class DashboardInner extends Component<DashboardProps, DashboardState> {
   state = {
     error: null,
     parametersListLength: 0,
@@ -41,11 +190,10 @@ class DashboardInner extends Component {
     isSharing: false,
   };
 
-  constructor(props) {
-    super(props);
-  }
-
-  static getDerivedStateFromProps({ parameters }, { parametersListLength }) {
+  static getDerivedStateFromProps(
+    { parameters }: DashboardProps,
+    { parametersListLength }: DashboardState,
+  ) {
     const visibleParameters = getVisibleParameters(parameters);
     return visibleParameters.length !== parametersListLength
       ? { parametersListLength: visibleParameters.length }
@@ -60,7 +208,7 @@ class DashboardInner extends Component {
     });
   }
 
-  async componentDidUpdate(prevProps) {
+  async componentDidUpdate(prevProps: DashboardProps) {
     if (prevProps.dashboardId !== this.props.dashboardId) {
       await this.loadDashboard(this.props.dashboardId);
       return;
@@ -85,7 +233,7 @@ class DashboardInner extends Component {
     getMainElement().removeEventListener("scroll", this.onMainScroll);
   }
 
-  async loadDashboard(dashboardId) {
+  async loadDashboard(dashboardId: DashboardId) {
     const {
       editingOnLoad,
       addCardOnLoad,
@@ -124,10 +272,11 @@ class DashboardInner extends Component {
         addCardToDashboard({
           dashId: dashboardId,
           cardId: addCardOnLoad,
-          tabId: this.props.dashboard.tabs[0]?.id ?? null,
+          tabId: this.props.dashboard.tabs?.[0]?.id ?? null,
         });
       }
-    } catch (error) {
+    } catch (err) {
+      const error = err as any;
       if (error.status === 404) {
         setErrorPage({ ...error, context: "dashboard" });
       } else {
@@ -137,17 +286,20 @@ class DashboardInner extends Component {
     }
   }
 
-  setEditing = isEditing => {
+  setEditing = (dashboard: IDashboard) => {
     this.props.onRefreshPeriodChange(null);
-    this.props.setEditingDashboard(isEditing);
+    this.props.setEditingDashboard(dashboard);
   };
 
-  setDashboardAttribute = (attribute, value) => {
+  setDashboardAttribute<Key extends keyof IDashboard>(
+    attribute: Key,
+    value: IDashboard[Key],
+  ) {
     this.props.setDashboardAttributes({
       id: this.props.dashboard.id,
       attributes: { [attribute]: value },
     });
-  };
+  }
 
   onCancel = () => {
     this.props.setSharing(false);
@@ -163,7 +315,7 @@ class DashboardInner extends Component {
     this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
   };
 
-  onMainScroll = event => {
+  onMainScroll = (event: any) => {
     this.setState({ hasScroll: event.target.scrollTop > 0 });
   };
 
@@ -292,7 +444,9 @@ class DashboardInner extends Component {
                 {shouldRenderParametersWidgetInEditMode && (
                   <ParametersWidgetContainer
                     data-testid="edit-dashboard-parameters-widget-container"
-                    isEditing={isEditing}
+                    isEditing={!!isEditing}
+                    hasScroll={false}
+                    isSticky={false}
                   >
                     {parametersWidget}
                   </ParametersWidgetContainer>
@@ -310,6 +464,7 @@ class DashboardInner extends Component {
                 {shouldRenderParametersWidgetInViewMode && (
                   <ParametersWidgetContainer
                     data-testid="dashboard-parameters-widget-container"
+                    isEditing={false}
                     hasScroll={hasScroll}
                     isSticky={isParametersWidgetContainersSticky(
                       parametersListLength,
@@ -338,68 +493,7 @@ class DashboardInner extends Component {
   }
 }
 
-DashboardInner.propTypes = {
-  loadDashboardParams: PropTypes.func,
-  location: PropTypes.object,
-
-  isAdmin: PropTypes.bool,
-  isFullscreen: PropTypes.bool,
-  isNightMode: PropTypes.bool,
-  isSharing: PropTypes.bool,
-  isEditing: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]).isRequired,
-  isEditingParameter: PropTypes.bool.isRequired,
-  isNavbarOpen: PropTypes.bool.isRequired,
-  isHeaderVisible: PropTypes.bool,
-  isAdditionalInfoVisible: PropTypes.bool,
-  isNavigatingBackToDashboard: PropTypes.bool,
-
-  dashboard: PropTypes.object,
-  dashboardId: PropTypes.number,
-  dashcardData: PropTypes.object,
-  selectedTabId: PropTypes.number,
-  parameters: PropTypes.array,
-  parameterValues: PropTypes.object,
-  draftParameterValues: PropTypes.object,
-  editingParameter: PropTypes.object,
-
-  editingOnLoad: PropTypes.bool,
-  addCardOnLoad: PropTypes.number,
-  addCardToDashboard: PropTypes.func.isRequired,
-  addParameter: PropTypes.func,
-  archiveDashboard: PropTypes.func.isRequired,
-  cancelFetchDashboardCardData: PropTypes.func.isRequired,
-  fetchDashboard: PropTypes.func.isRequired,
-  fetchDashboardCardData: PropTypes.func.isRequired,
-  fetchDashboardCardMetadata: PropTypes.func.isRequired,
-  initialize: PropTypes.func.isRequired,
-  onRefreshPeriodChange: PropTypes.func,
-  updateDashboardAndCards: PropTypes.func.isRequired,
-  setDashboardAttributes: PropTypes.func.isRequired,
-  setEditingDashboard: PropTypes.func.isRequired,
-  setErrorPage: PropTypes.func,
-  setSharing: PropTypes.func.isRequired,
-  setParameterValue: PropTypes.func.isRequired,
-  setEditingParameter: PropTypes.func.isRequired,
-  setParameterIndex: PropTypes.func.isRequired,
-
-  onUpdateDashCardVisualizationSettings: PropTypes.func.isRequired,
-  onUpdateDashCardColumnSettings: PropTypes.func.isRequired,
-  onReplaceAllDashCardVisualizationSettings: PropTypes.func.isRequired,
-
-  onChangeLocation: PropTypes.func.isRequired,
-  onSharingClick: PropTypes.func,
-  onEmbeddingClick: PropTypes.any,
-  sidebar: PropTypes.shape({
-    name: PropTypes.string,
-    props: PropTypes.object,
-  }).isRequired,
-  toggleSidebar: PropTypes.func.isRequired,
-  closeSidebar: PropTypes.func.isRequired,
-  closeNavbar: PropTypes.func.isRequired,
-  isAutoApplyFilters: PropTypes.bool,
-};
-
-function isParametersWidgetContainersSticky(parameterCount) {
+function isParametersWidgetContainersSticky(parameterCount: number) {
   if (!isSmallScreen()) {
     return true;
   }

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -275,9 +275,8 @@ class DashboardInner extends Component<DashboardProps, DashboardState> {
           tabId: this.props.dashboard.tabs?.[0]?.id ?? null,
         });
       }
-    } catch (err) {
-      const error = err as any;
-      if (error.status === 404) {
+    } catch (error) {
+      if (error instanceof Response && error.status === 404) {
         setErrorPage({ ...error, context: "dashboard" });
       } else {
         console.error(error);

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -314,8 +314,10 @@ class DashboardInner extends Component<DashboardProps, DashboardState> {
     this.props.toggleSidebar(SIDEBAR_NAME.addQuestion);
   };
 
-  onMainScroll = (event: any) => {
-    this.setState({ hasScroll: event.target.scrollTop > 0 });
+  onMainScroll = (event: Event) => {
+    if (event.target instanceof HTMLElement) {
+      this.setState({ hasScroll: event.target.scrollTop > 0 });
+    }
   };
 
   renderContent = () => {

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -291,15 +291,15 @@ class DashboardInner extends Component<DashboardProps, DashboardState> {
     this.props.setEditingDashboard(dashboard);
   };
 
-  setDashboardAttribute<Key extends keyof IDashboard>(
+  setDashboardAttribute = <Key extends keyof IDashboard>(
     attribute: Key,
     value: IDashboard[Key],
-  ) {
+  ) => {
     this.props.setDashboardAttributes({
       id: this.props.dashboard.id,
       attributes: { [attribute]: value },
     });
-  }
+  };
 
   onCancel = () => {
     this.props.setSharing(false);

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -6,7 +6,7 @@ interface DashboardCardProps {
   isAnimationDisabled?: boolean;
 }
 
-export const DashboardCard = styled.div<DashboardCardProps>`
+export const DashboardCardContainer = styled.div<DashboardCardProps>`
   position: relative;
   z-index: 1;
 

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -49,6 +49,7 @@ import type Metadata from "metabase-lib/metadata/Metadata";
 
 import { DashboardCardContainer } from "./DashboardGrid.styled";
 
+import type { DashCardOnChangeCardAndRunHandler } from "./DashCard/types";
 import { GridLayout } from "./grid/GridLayout";
 import { generateMobileLayout } from "./grid/utils";
 
@@ -101,6 +102,7 @@ interface DashboardGridProps {
     dashcardId: DashCardId;
     nextCardId: CardId;
   }) => void;
+  markNewCardSeen: (dashcardId: DashCardId) => void;
 
   setDashCardAttributes: (options: DashboardChangeItem) => void;
   setMultipleDashCardAttributes: (changes: {
@@ -122,18 +124,16 @@ interface DashboardGridProps {
     settings: Partial<VisualizationSettings>,
   ) => void;
 
+  onChangeLocation: (location: LocationDescriptor) => void;
+  navigateToNewCardFromDashboard: DashCardOnChangeCardAndRunHandler;
+
+  showClickBehaviorSidebar: (dashcardId: DashCardId | null) => void;
+
   addUndo: (options: {
     message: string;
     undo: boolean;
     action: () => void;
   }) => void;
-
-  onChangeLocation: (location: LocationDescriptor) => void;
-
-  // TODO
-  showClickBehaviorSidebar: () => void;
-  navigateToNewCardFromDashboard: () => void;
-  markNewCardSeen: () => void;
 }
 
 interface DashboardGridState {

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -494,7 +494,6 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
         dashcardData={this.props.dashcardData}
         parameterValues={this.props.parameterValues}
         slowCards={this.props.slowCards}
-        fetchCardData={this.props.fetchCardData}
         gridItemWidth={gridItemWidth}
         totalNumGridCols={totalNumGridCols}
         markNewCardSeen={this.props.markNewCardSeen}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -153,7 +153,7 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
 
   _pauseAnimationTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(props: DashboardGridProps, context: any) {
+  constructor(props: DashboardGridProps, context: unknown) {
     super(props, context);
 
     const visibleCardIds = getVisibleCardIds(

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -75,7 +75,7 @@ import {
 
 type NewDashCardOpts = {
   dashId: DashboardId;
-  tabId: DashboardTabId;
+  tabId: DashboardTabId | null;
 };
 
 interface OwnProps {
@@ -209,41 +209,33 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
   };
 
   onAddMarkdownBox() {
-    if (this.props.selectedTabId) {
-      this.props.addMarkdownDashCardToDashboard({
-        dashId: this.props.dashboard.id,
-        tabId: this.props.selectedTabId,
-      });
-    }
+    this.props.addMarkdownDashCardToDashboard({
+      dashId: this.props.dashboard.id,
+      tabId: this.props.selectedTabId,
+    });
   }
 
   onAddHeading() {
-    if (this.props.selectedTabId) {
-      this.props.addHeadingDashCardToDashboard({
-        dashId: this.props.dashboard.id,
-        tabId: this.props.selectedTabId,
-      });
-    }
+    this.props.addHeadingDashCardToDashboard({
+      dashId: this.props.dashboard.id,
+      tabId: this.props.selectedTabId,
+    });
   }
 
   onAddLinkCard() {
-    if (this.props.selectedTabId) {
-      this.props.addLinkDashCardToDashboard({
-        dashId: this.props.dashboard.id,
-        tabId: this.props.selectedTabId,
-      });
-    }
+    this.props.addLinkDashCardToDashboard({
+      dashId: this.props.dashboard.id,
+      tabId: this.props.selectedTabId,
+    });
   }
 
   onAddAction() {
-    if (this.props.selectedTabId) {
-      this.props.addActionToDashboard({
-        dashId: this.props.dashboard.id,
-        tabId: this.props.selectedTabId,
-        displayType: "button",
-        action: {},
-      });
-    }
+    this.props.addActionToDashboard({
+      dashId: this.props.dashboard.id,
+      tabId: this.props.selectedTabId,
+      displayType: "button",
+      action: {},
+    });
   }
 
   onDoneEditing() {

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -116,7 +116,6 @@ interface OwnProps {
       preserveParameters?: boolean;
     };
   }) => Promise<void>;
-  fetchPulseFormInput: () => void;
   setDashboardAttribute: <Key extends keyof Dashboard>(
     key: Key,
     value: Dashboard[Key],
@@ -153,6 +152,7 @@ interface StateProps {
 interface DispatchProps {
   createBookmark: (args: { id: DashboardId }) => void;
   deleteBookmark: (args: { id: DashboardId }) => void;
+  fetchPulseFormInput: () => void;
   toggleSidebar: (sidebarName: DashboardSidebarName) => void;
   onChangeLocation: (location: Location) => void;
   addActionToDashboard: (

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -26,7 +26,7 @@ import {
 import { DashboardTabs } from "../../components/DashboardTabs/DashboardTabs";
 
 interface DashboardHeaderViewProps {
-  editingTitle: string;
+  editingTitle?: string;
   editingSubtitle?: string;
   editingButtons?: JSX.Element[];
   editWarning?: string;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -27,10 +27,10 @@ import { DashboardTabs } from "../../components/DashboardTabs/DashboardTabs";
 
 interface DashboardHeaderViewProps {
   editingTitle: string;
-  editingSubtitle: string;
-  editingButtons: JSX.Element[];
-  editWarning: string;
-  headerButtons: React.ReactNode[];
+  editingSubtitle?: string;
+  editingButtons?: JSX.Element[];
+  editWarning?: string;
+  headerButtons?: React.ReactNode[];
   headerClassName: string;
   location: Location;
   isEditing: boolean;
@@ -40,8 +40,11 @@ interface DashboardHeaderViewProps {
   collection: Collection;
   isBadgeVisible: boolean;
   isLastEditInfoVisible: boolean;
-  onLastEditInfoClick: () => null;
-  setDashboardAttribute: (prop: string, value: string) => null;
+  onLastEditInfoClick: () => void;
+  setDashboardAttribute: <Key extends keyof Dashboard>(
+    key: Key,
+    value: Dashboard[Key],
+  ) => void;
 }
 
 export function DashboardHeaderComponent({

--- a/frontend/src/metabase/dashboard/containers/Dashboard.jsx
+++ b/frontend/src/metabase/dashboard/containers/Dashboard.jsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-// TODO: merge with metabase/dashboard/components/Dashboard.jsx
 
 import { Component } from "react";
 import cx from "classnames";

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -178,8 +178,7 @@ const DashboardApp = (props: DashboardAppProps) => {
 
   const options = parseHashOptions(window.location.hash);
   const editingOnLoad = options.edit;
-  const addCardOnLoad =
-    typeof options.add === "string" ? parseInt(options.add) : undefined;
+  const addCardOnLoad = options.add != null ? Number(options.add) : undefined;
 
   const dispatch = useDispatch();
 

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -179,7 +179,7 @@ export const getDraftParameterValues = (state: State) =>
 
 export const getIsAutoApplyFilters = createSelector(
   [getDashboard],
-  dashboard => dashboard?.auto_apply_filters,
+  dashboard => !!dashboard?.auto_apply_filters,
 );
 export const getHasUnappliedParameterValues = createSelector(
   [getParameterValues, getDraftParameterValues],
@@ -329,12 +329,12 @@ export const getParameterMappingOptions = createSelector(
 
 export const getIsHeaderVisible = createSelector(
   [getIsEmbedded, getEmbedOptions],
-  (isEmbedded, embedOptions) => !isEmbedded || embedOptions.header,
+  (isEmbedded, embedOptions) => !isEmbedded || !!embedOptions.header,
 );
 
 export const getIsAdditionalInfoVisible = createSelector(
   [getIsEmbedded, getEmbedOptions],
-  (isEmbedded, embedOptions) => !isEmbedded || embedOptions.additional_info,
+  (isEmbedded, embedOptions) => !isEmbedded || !!embedOptions.additional_info,
 );
 
 export const getTabs = createSelector([getDashboard], dashboard => {

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -78,6 +78,12 @@ export function expandInlineCard(card?: Card) {
   };
 }
 
+export function isDashCardWithQuery(
+  dashcard: BaseDashboardCard,
+): dashcard is DashboardCard {
+  return "card_id" in dashcard && "card" in dashcard;
+}
+
 export function isVirtualDashCard(dashcard: BaseDashboardCard) {
   return _.isObject(dashcard?.visualization_settings?.virtual_card);
 }

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -10,7 +10,6 @@ import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 import type {
   Card,
   CardId,
-  DashCardId,
   Dashboard,
   DashboardCard,
   Database,
@@ -20,6 +19,8 @@ import type {
   StructuredDatasetQuery,
   ActionDashboardCard,
   EmbedDataset,
+  BaseDashboardCard,
+  DashCardDataMap,
 } from "metabase-types/api";
 import type { SelectedTabId } from "metabase-types/store";
 import Question from "metabase-lib/Question";
@@ -77,7 +78,7 @@ export function expandInlineCard(card?: Card) {
   };
 }
 
-export function isVirtualDashCard(dashcard: DashboardCard) {
+export function isVirtualDashCard(dashcard: BaseDashboardCard) {
   return _.isObject(dashcard?.visualization_settings?.virtual_card);
 }
 
@@ -177,7 +178,7 @@ export function getDatasetQueryParams(
 
 export function isDashcardLoading(
   dashcard: DashboardCard,
-  dashcardsData: Record<DashCardId, Record<CardId, Dataset | null>>,
+  dashcardsData: DashCardDataMap,
 ) {
   if (isVirtualDashCard(dashcard)) {
     return false;
@@ -221,7 +222,7 @@ export function getDashcardResultsError(datasets: Dataset[]) {
 }
 
 const isDashcardDataLoaded = (
-  data?: Record<CardId, Dataset | null>,
+  data?: Record<CardId, Dataset | null | undefined>,
 ): data is Record<CardId, Dataset> => {
   return data != null && Object.values(data).every(result => result != null);
 };
@@ -240,8 +241,8 @@ const hasRows = (dashcardData: Record<CardId, Dataset | EmbedDataset>) => {
 };
 
 const shouldHideCard = (
-  dashcard: DashboardCard,
-  dashcardData: Record<CardId, Dataset | null>,
+  dashcard: BaseDashboardCard,
+  dashcardData: Record<CardId, Dataset | null | undefined>,
   wasVisible: boolean,
 ) => {
   const shouldHideEmpty = dashcard.visualization_settings?.["card.hide_empty"];
@@ -263,8 +264,8 @@ const shouldHideCard = (
 };
 
 export const getVisibleCardIds = (
-  cards: DashboardCard[],
-  dashcardsData: Record<DashCardId, Record<CardId, Dataset | null>>,
+  cards: BaseDashboardCard[],
+  dashcardsData: DashCardDataMap,
   prevVisibleCardIds = new Set<number>(),
 ) => {
   return new Set(

--- a/frontend/src/metabase/public/components/EmbedModal/types.ts
+++ b/frontend/src/metabase/public/components/EmbedModal/types.ts
@@ -5,7 +5,7 @@ export type ActivePreviewPane = "preview" | "code";
 export type EmbedType = "application" | null;
 
 export type EmbedResource = (Card | Dashboard) & {
-  embedding_params?: EmbeddingParameters;
+  embedding_params?: EmbeddingParameters | null;
 };
 
 export type EmbedResourceType = "dashboard" | "question";


### PR DESCRIPTION
Converts top-level dashboard components to TypeScript. That should make other dashboard components a bit more reliable as TypeScript would know which props and redux state exist in top-level dashboard components.

Would be easier to review commit-by-commit:

- [convert `DashboardApp` to TypeScript](https://github.com/metabase/metabase/commit/ea30674e9fc43ddd113f809fae707f903a92248c)
- [convert `Dashboard` to TypeScript](https://github.com/metabase/metabase/commit/a4449f6d867910b3c801645d27746cd5e009c5d3)
- [convert `DashboardGrid` to TypeScript](https://github.com/metabase/metabase/commit/3ce5cc3a323add349cfd25b5a71a470976cea773)
- [convert `DashboardHeader` to TypeScript](https://github.com/metabase/metabase/commit/c4254d42fe123851acc3f9710cd7ae637333c906)

**To verify:** CI should be green 🟢