### PR TITLE
adding back events on persist and unpersist

### DIFF
--- a/e2e/test/scenarios/admin/databases/reproductions/26470-model-cache-enable-button.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/reproductions/26470-model-cache-enable-button.cy.spec.js
@@ -1,0 +1,17 @@
+import { restore } from "e2e/support/helpers";
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+
+describe("issue 26470", { tags: "@external" }, () => {
+  beforeEach(() => {
+    restore("postgres_12");
+    cy.signInAsAdmin();
+    cy.request("POST", "/api/persist/enable");
+  });
+
+  it("Model Cache enable / disable button should update button text", () => {
+    cy.visit(`/admin/databases/${WRITABLE_DB_ID}`);
+    cy.button("Turn model caching on").click();
+    //Transition from Done takes 5 seconds, so this gives a 2 second buffer
+    cy.button("Turn model caching off", { timeout: 7000 }).should("exist");
+  });
+});

--- a/e2e/test/scenarios/admin/databases/reproductions/26470-model-cache-enable-button.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/reproductions/26470-model-cache-enable-button.cy.spec.js
@@ -9,9 +9,11 @@ describe("issue 26470", { tags: "@external" }, () => {
   });
 
   it("Model Cache enable / disable button should update button text", () => {
+    cy.clock(Date.now());
     cy.visit(`/admin/databases/${WRITABLE_DB_ID}`);
     cy.button("Turn model caching on").click();
-    //Transition from Done takes 5 seconds, so this gives a 2 second buffer
-    cy.button("Turn model caching off", { timeout: 7000 }).should("exist");
+    cy.button(/Done/).should("exist");
+    cy.tick(6000);
+    cy.button("Turn model caching off").should("exist");
   });
 });

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelCachingControl/ModelCachingControl.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelCachingControl/ModelCachingControl.tsx
@@ -5,9 +5,15 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 import ActionButton from "metabase/components/ActionButton";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 
+import {
+  PERSIST_DATABASE,
+  UNPERSIST_DATABASE,
+} from "metabase/admin/databases/database";
+
 import { MetabaseApi } from "metabase/services";
 
 import MetabaseSettings from "metabase/lib/settings";
+import { useDispatch } from "metabase/lib/redux";
 import type Database from "metabase-lib/metadata/Database";
 import { getModelCacheSchemaName } from "metabase-lib/metadata/utils/models";
 
@@ -51,6 +57,7 @@ function isLackPermissionsError(response: ErrorResponse) {
 
 function ModelCachingControl({ database }: Props) {
   const [error, setError] = useState<string | null>(null);
+  const dispatch = useDispatch();
 
   const databaseId = database.id;
   const isEnabled = database.isPersisted();
@@ -67,8 +74,10 @@ function ModelCachingControl({ database }: Props) {
     try {
       if (isEnabled) {
         await MetabaseApi.db_unpersist({ dbId: databaseId });
+        await dispatch({ type: UNPERSIST_DATABASE });
       } else {
         await MetabaseApi.db_persist({ dbId: databaseId });
+        await dispatch({ type: PERSIST_DATABASE });
       }
     } catch (error) {
       const response = error as ErrorResponse;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/26470

### Description
Back in 2022 we updated the `ModelCachingControl` component to make API requests directly rather than through a redux action. This was done so that the handler in the component would have access to the response and be able to better handle an error state, but it also meant that the proper events were no longer emitted to update state. Now that we have access to the useDispatch hook, it is very easy to emit the proper events after the API request is complete

### How to verify
1. Go to the admin -> databases -> a DB with models enabled
2. Click "Turn Model Caching On/Off". Text should update to saving
3. After a timeout, text should be updated with the proper message

### Demo
![chrome_Kmna99ODqU](https://github.com/metabase/metabase/assets/1328979/0733fb4b-6106-427f-9cc2-e0efd5dd9e64)


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
