### PR TITLE
mobile admin view menu icon is now a button

### DIFF
--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 import { useSelector } from "metabase/lib/redux";
 import { getIsPaidPlan } from "metabase/selectors/settings";
 import LogoIcon from "metabase/components/LogoIcon";
-import { Icon } from "metabase/ui";
+import { Button, Icon } from "metabase/ui";
 import type { User } from "metabase-types/api";
 import type { AdminPath } from "metabase-types/store";
 import StoreLink from "../StoreLink";
@@ -84,11 +84,13 @@ const MobileNavbar = ({ adminPaths, currentPath }: AdminMobileNavbarProps) => {
 
   return (
     <AdminMobileNavbar>
-      <Icon
-        name="burger"
-        size={32}
+      <Button
         onClick={() => setMobileNavOpen(prev => !prev)}
-      />
+        variant="subtle"
+        p="0.25rem"
+      >
+        <Icon name="burger" size={32} color="white" />
+      </Button>
       {mobileNavOpen && (
         <AdminMobileNavBarItems>
           {adminPaths.map(({ name, key, path }) => (


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/24160

### Description
Previously the menu icon in the mobile view of the admin app was simply an icon. This change wraps this icon in a button for more semantically correct HTML, as well as giving us a proper hover state when using a pointer.

### How to verify

1. Go to the admin app and shrink your screen until you hit the mobile breakpoint
2. Hover over the menu button. It should so a pointer rather than the default cursor

### Demo
![chrome_XuM849ahKH](https://github.com/metabase/metabase/assets/1328979/87c7f5ce-2328-43b9-b904-8e1dcfd818fd)

### Checklist
I did not add any tests as this is purely a presentation change
