### PR TITLE
Do not use API Key names as part of user email

### DIFF
--- a/src/metabase/api/api_key.clj
+++ b/src/metabase/api/api_key.clj
@@ -59,7 +59,7 @@
   (api/checkp (not (t2/exists? :model/ApiKey :name name))
     "name" "An API key with this name already exists.")
   (let [unhashed-key (key-with-unique-prefix)
-        email        (format "api-key-user-%s@api-key.invalid" (u/slugify name))]
+        email        (format "api-key-user-%s@api-key.invalid" (random-uuid))]
     (t2/with-transaction [_conn]
       (let [user (first
                   (t2/insert-returning-instances! :model/User


### PR DESCRIPTION
Originally I had planned on using this to ensure uniqueness of the ApiKey name. However, a) this is no longer a requirement, as we have a uniqueness constraint on `:name` of the ApiKey directly, b) it would be buggy anyway, because email addresses are case insensitive and `u/slugify` will in some cases return the same slug for different names, and c) it causes issues when you attempt to create a new ApiKey with the same name as a deleted ApiKey (because the old user still exists).

The email can just be random - it's an implementation detail that shouldn't be exposed to users.