### PR TITLE
Update database writability on upload settings change

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -46,6 +46,7 @@ describeWithSnowplow(
       const EMPTY_SCHEMA_NAME = "empty_uploads";
 
       cy.intercept("PUT", "/api/setting").as("saveSettings");
+      cy.intercept("GET", "/api/database").as("databaseList");
 
       restore("postgres-writable");
       cy.signInAsAdmin();
@@ -78,7 +79,7 @@ describeWithSnowplow(
         .button("Enable uploads")
         .click();
 
-      cy.wait("@saveSettings");
+      cy.wait(["@saveSettings", "@databaseList"]);
 
       uploadFile(testFile, "postgres");
 

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.tsx
@@ -7,6 +7,7 @@ import _ from "underscore";
 
 import Databases from "metabase/entities/databases";
 import Schemas from "metabase/entities/schemas";
+import { useDispatch } from "metabase/lib/redux";
 
 import { getSetting } from "metabase/selectors/settings";
 import { updateSettings } from "metabase/admin/settings/settings";
@@ -99,6 +100,7 @@ export function UploadSettingsView({
     settings.uploads_table_prefix ?? null,
   );
   const [errorMessage, setErrorMessage] = useState<null | string>(null);
+  const dispatch = useDispatch();
 
   const showSchema = dbId && dbHasSchema(databases, dbId);
   const databaseOptions = getDatabaseOptions(databases);
@@ -135,6 +137,7 @@ export function UploadSettingsView({
         setSchemaName(schemaName);
         setTablePrefix(tablePrefix);
         saveStatusRef?.current?.setSaved();
+        dispatch(Databases.actions.invalidateLists());
       })
       .catch(() => showError(enableErrorMessage));
   };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34078

### Description

When enabling actions, we should refresh the database list to have fresh data about whether we can write to a given database so that after enabling actions, we can upload to a collection without a page refresh.

![uploadsrefresh](https://github.com/metabase/metabase/assets/30528226/411b3f45-5889-4319-a8fb-8563bfb9635d)


### How to verify

_(without refreshing the page)_
1. Make sure uploads are disabled
2. visit a collection
3. click the upload button
4. see the modal that asked if you want to enable uploads
5. visit settings and select a db + schema for uploads
6. click "exit settings"
7. visit a collection again
8. click on the upload button
9. it should let you upload a csv now!


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
