### PR TITLE
fix stacked bars and areas labels not showing total, fix positioning of negative bar labels

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
@@ -63,6 +63,13 @@ BarOrdinalXScale.args = {
   renderingContext,
 };
 
+export const BarStackedTotalFormattedValues = Template.bind({});
+BarStackedTotalFormattedValues.args = {
+  rawSeries: data.barStackedTotalFormattedValues as any,
+  dashcardSettings: {},
+  renderingContext,
+};
+
 export const SplitYAxis = Template.bind({});
 SplitYAxis.args = {
   rawSeries: data.autoYSplit as any,

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -33,8 +33,6 @@ export const ComboChart = ({
     renderingContext,
   );
 
-  console.log(JSON.stringify(rawSeries));
-
   const chartModel = getCartesianChartModel(
     rawSeries,
     computedVisualizationSettings,

--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -33,6 +33,8 @@ export const ComboChart = ({
     renderingContext,
   );
 
+  console.log(JSON.stringify(rawSeries));
+
   const chartModel = getCartesianChartModel(
     rawSeries,
     computedVisualizationSettings,

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-stacked-total-formatted-values.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-stacked-total-formatted-values.json
@@ -1,0 +1,679 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 5,
+      "result_metadata": [
+        {
+          "description": "The date and time an order was submitted.",
+          "semantic_type": "type/CreationTimestamp",
+          "coercion_strategy": null,
+          "unit": "year",
+          "name": "CREATED_AT",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            38,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "year"
+            }
+          ],
+          "effective_type": "type/DateTime",
+          "id": 38,
+          "visibility_type": "normal",
+          "display_name": "Created At",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 10001,
+              "nil%": 0
+            },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2022-04-30T18:56:13.352Z",
+                "latest": "2026-04-19T14:07:15.657Z"
+              }
+            }
+          },
+          "base_type": "type/DateTime"
+        },
+        {
+          "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+          "semantic_type": "type/Category",
+          "coercion_strategy": null,
+          "name": "CATEGORY",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            64,
+            {
+              "base-type": "type/Text",
+              "source-field": 37
+            }
+          ],
+          "effective_type": "type/Text",
+          "id": 64,
+          "visibility_type": "normal",
+          "display_name": "Product → Category",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 4,
+              "nil%": 0
+            },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 6.375
+              }
+            }
+          },
+          "base_type": "type/Text"
+        },
+        {
+          "display_name": "Average of Total with negative",
+          "field_ref": [
+            "aggregation",
+            0
+          ],
+          "name": "avg",
+          "base_type": "type/Float",
+          "effective_type": "type/Float",
+          "semantic_type": null,
+          "fingerprint": {
+            "global": {
+              "distinct-count": 20,
+              "nil%": 0
+            },
+            "type": {
+              "type/Number": {
+                "min": -25.01883071513849,
+                "q1": -8.265793584324337,
+                "q3": 36.15967901936148,
+                "max": 41.1472155869155,
+                "sd": 23.54601680410227,
+                "avg": 17.204487651704788
+              }
+            }
+          }
+        }
+      ],
+      "database_id": 1,
+      "enable_embedding": false,
+      "collection_id": null,
+      "query_type": "query",
+      "name": "stacked bar labels with mixed sign and empty values and formatting",
+      "creator_id": 1,
+      "updated_at": "2024-01-15T18:28:04.205464-03:00",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "database": 1,
+        "type": "query",
+        "query": {
+          "source-table": 5,
+          "expressions": {
+            "Total with negative": [
+              "case",
+              [
+                [
+                  [
+                    ">",
+                    [
+                      "field",
+                      39,
+                      {
+                        "base-type": "type/Float"
+                      }
+                    ],
+                    78
+                  ],
+                  [
+                    "field",
+                    39,
+                    {
+                      "base-type": "type/Float"
+                    }
+                  ]
+                ]
+              ],
+              {
+                "default": [
+                  "-",
+                  0,
+                  [
+                    "field",
+                    39,
+                    {
+                      "base-type": "type/Float"
+                    }
+                  ]
+                ]
+              }
+            ]
+          },
+          "aggregation": [
+            [
+              "avg",
+              [
+                "expression",
+                "Total with negative"
+              ]
+            ]
+          ],
+          "breakout": [
+            [
+              "field",
+              38,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "year"
+              }
+            ],
+            [
+              "field",
+              64,
+              {
+                "base-type": "type/Text",
+                "source-field": 37
+              }
+            ]
+          ]
+        }
+      },
+      "id": 153,
+      "parameter_mappings": [],
+      "display": "bar",
+      "entity_id": "FvkdBkSLWFGWHJAy6FjvH",
+      "collection_preview": true,
+      "visualization_settings": {
+        "graph.show_goal": false,
+        "graph.show_values": true,
+        "graph.series_order_dimension": "CATEGORY",
+        "graph.y_axis.scale": "linear",
+        "graph.label_value_frequency": "fit",
+        "graph.metrics": [
+          "avg"
+        ],
+        "graph.label_value_formatting": "auto",
+        "graph.series_order": [
+          {
+            "key": "Doohickey",
+            "color": "#88BF4D",
+            "enabled": true,
+            "name": "Doohickey"
+          },
+          {
+            "key": "Gizmo",
+            "color": "#A989C5",
+            "enabled": true,
+            "name": "Gizmo"
+          },
+          {
+            "key": "Gadget",
+            "color": "#F9D45C",
+            "enabled": true,
+            "name": "Gadget"
+          },
+          {
+            "key": "Widget",
+            "color": "#F2A86F",
+            "enabled": true,
+            "name": "Widget"
+          }
+        ],
+        "column_settings": {
+          "[\"name\",\"avg\"]": {
+            "prefix": "[",
+            "scale": 15,
+            "number_separators": ".’",
+            "suffix": "]"
+          }
+        },
+        "series_settings": {
+          "Gizmo": {
+            "display": "bar",
+            "axis": "left",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": true
+          },
+          "Gadget": {
+            "display": "bar",
+            "axis": "left",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": true
+          },
+          "Doohickey": {
+            "axis": null,
+            "display": "bar",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": true
+          },
+          "Widget": {
+            "display": "bar",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": true
+          },
+          "0  –  20": {
+            "axis": "right"
+          },
+          "20  –  40": {
+            "axis": "right"
+          },
+          "40  –  60": {
+            "axis": "right"
+          }
+        },
+        "graph.dimensions": [
+          "CREATED_AT",
+          "CATEGORY"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "metabase_version": "v1.48.1-SNAPSHOT (6934865)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2024-01-15T18:26:00.933624-03:00",
+      "public_uuid": null
+    },
+    "data": {
+      "cols": [
+        {
+          "description": "The date and time an order was submitted.",
+          "semantic_type": "type/CreationTimestamp",
+          "table_id": 5,
+          "coercion_strategy": null,
+          "unit": "year",
+          "name": "CREATED_AT",
+          "settings": null,
+          "source": "breakout",
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            38,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "year"
+            }
+          ],
+          "effective_type": "type/DateTime",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 38,
+          "position": 7,
+          "visibility_type": "normal",
+          "display_name": "Created At",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 10001,
+              "nil%": 0
+            },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2022-04-30T18:56:13.352Z",
+                "latest": "2026-04-19T14:07:15.657Z"
+              }
+            }
+          },
+          "base_type": "type/DateTime"
+        },
+        {
+          "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+          "semantic_type": "type/Category",
+          "table_id": 8,
+          "coercion_strategy": null,
+          "name": "CATEGORY",
+          "settings": null,
+          "source": "breakout",
+          "fk_target_field_id": null,
+          "fk_field_id": 37,
+          "field_ref": [
+            "field",
+            64,
+            {
+              "base-type": "type/Text",
+              "source-field": 37
+            }
+          ],
+          "effective_type": "type/Text",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 64,
+          "position": 3,
+          "visibility_type": "normal",
+          "display_name": "Product → Category",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 4,
+              "nil%": 0
+            },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 6.375
+              }
+            }
+          },
+          "base_type": "type/Text",
+          "source_alias": "PRODUCTS__via__PRODUCT_ID"
+        },
+        {
+          "base_type": "type/Float",
+          "name": "avg",
+          "display_name": "Average of Total with negative",
+          "source": "aggregation",
+          "field_ref": [
+            "aggregation",
+            0
+          ],
+          "aggregation_index": 0,
+          "effective_type": "type/Float"
+        }
+      ],
+      "native_form": {
+        "query": "SELECT DATE_TRUNC('year', \"source\".\"CREATED_AT\") AS \"CREATED_AT\", \"source\".\"PRODUCTS__via__PRODUCT_ID__CATEGORY\" AS \"PRODUCTS__via__PRODUCT_ID__CATEGORY\", AVG(\"source\".\"Total with negative\") AS \"avg\" FROM (SELECT \"PUBLIC\".\"ORDERS\".\"PRODUCT_ID\" AS \"PRODUCT_ID\", \"PUBLIC\".\"ORDERS\".\"TOTAL\" AS \"TOTAL\", \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" AS \"CREATED_AT\", CASE WHEN \"PUBLIC\".\"ORDERS\".\"TOTAL\" > 78 THEN \"PUBLIC\".\"ORDERS\".\"TOTAL\" ELSE 0 - \"PUBLIC\".\"ORDERS\".\"TOTAL\" END AS \"Total with negative\", \"PRODUCTS__via__PRODUCT_ID\".\"CATEGORY\" AS \"PRODUCTS__via__PRODUCT_ID__CATEGORY\", \"PRODUCTS__via__PRODUCT_ID\".\"ID\" AS \"PRODUCTS__via__PRODUCT_ID__ID\" FROM \"PUBLIC\".\"ORDERS\" LEFT JOIN \"PUBLIC\".\"PRODUCTS\" AS \"PRODUCTS__via__PRODUCT_ID\" ON \"PUBLIC\".\"ORDERS\".\"PRODUCT_ID\" = \"PRODUCTS__via__PRODUCT_ID\".\"ID\") AS \"source\" GROUP BY DATE_TRUNC('year', \"source\".\"CREATED_AT\"), \"source\".\"PRODUCTS__via__PRODUCT_ID__CATEGORY\" ORDER BY DATE_TRUNC('year', \"source\".\"CREATED_AT\") ASC, \"source\".\"PRODUCTS__via__PRODUCT_ID__CATEGORY\" ASC",
+        "params": null
+      },
+      "viz-settings": {
+        "graph.show_goal": false,
+        "graph.show_values": true,
+        "metabase.shared.models.visualization-settings/column-settings": {
+          "{:metabase.shared.models.visualization-settings/column-name \"avg\"}": {
+            "metabase.shared.models.visualization-settings/prefix": "[",
+            "metabase.shared.models.visualization-settings/scale": 15,
+            "metabase.shared.models.visualization-settings/number-separators": ".’",
+            "metabase.shared.models.visualization-settings/suffix": "]"
+          }
+        },
+        "graph.series_order_dimension": "CATEGORY",
+        "graph.y_axis.scale": "linear",
+        "graph.label_value_frequency": "fit",
+        "graph.metrics": [
+          "avg"
+        ],
+        "graph.label_value_formatting": "auto",
+        "graph.series_order": [
+          {
+            "key": "Doohickey",
+            "color": "#88BF4D",
+            "enabled": true,
+            "name": "Doohickey"
+          },
+          {
+            "key": "Gizmo",
+            "color": "#A989C5",
+            "enabled": true,
+            "name": "Gizmo"
+          },
+          {
+            "key": "Gadget",
+            "color": "#F9D45C",
+            "enabled": true,
+            "name": "Gadget"
+          },
+          {
+            "key": "Widget",
+            "color": "#F2A86F",
+            "enabled": true,
+            "name": "Widget"
+          }
+        ],
+        "metabase.shared.models.visualization-settings/global-column-settings": {},
+        "series_settings": {
+          "Gizmo": {
+            "display": "bar",
+            "axis": "left"
+          },
+          "Gadget": {
+            "display": "bar",
+            "axis": "left"
+          },
+          "Doohickey": {
+            "axis": null,
+            "display": "bar"
+          },
+          "Widget": {
+            "display": "bar"
+          },
+          "0  –  20": {
+            "axis": "right"
+          },
+          "20  –  40": {
+            "axis": "right"
+          },
+          "40  –  60": {
+            "axis": "right"
+          }
+        },
+        "graph.dimensions": [
+          "CREATED_AT",
+          "CATEGORY"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "results_timezone": "America/Montevideo",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": "The date and time an order was submitted.",
+            "semantic_type": "type/CreationTimestamp",
+            "coercion_strategy": null,
+            "unit": "year",
+            "name": "CREATED_AT",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": [
+              "field",
+              38,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "year"
+              }
+            ],
+            "effective_type": "type/DateTime",
+            "id": 38,
+            "visibility_type": "normal",
+            "display_name": "Created At",
+            "fingerprint": {
+              "global": {
+                "distinct-count": 10001,
+                "nil%": 0
+              },
+              "type": {
+                "type/DateTime": {
+                  "earliest": "2022-04-30T18:56:13.352Z",
+                  "latest": "2026-04-19T14:07:15.657Z"
+                }
+              }
+            },
+            "base_type": "type/DateTime"
+          },
+          {
+            "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+            "semantic_type": "type/Category",
+            "coercion_strategy": null,
+            "name": "CATEGORY",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": [
+              "field",
+              64,
+              {
+                "base-type": "type/Text",
+                "source-field": 37
+              }
+            ],
+            "effective_type": "type/Text",
+            "id": 64,
+            "visibility_type": "normal",
+            "display_name": "Product → Category",
+            "fingerprint": {
+              "global": {
+                "distinct-count": 4,
+                "nil%": 0
+              },
+              "type": {
+                "type/Text": {
+                  "percent-json": 0,
+                  "percent-url": 0,
+                  "percent-email": 0,
+                  "percent-state": 0,
+                  "average-length": 6.375
+                }
+              }
+            },
+            "base_type": "type/Text"
+          },
+          {
+            "display_name": "Average of Total with negative",
+            "field_ref": [
+              "aggregation",
+              0
+            ],
+            "name": "avg",
+            "base_type": "type/Float",
+            "effective_type": "type/Float",
+            "semantic_type": null,
+            "fingerprint": {
+              "global": {
+                "distinct-count": 20,
+                "nil%": 0
+              },
+              "type": {
+                "type/Number": {
+                  "min": -25.01883071513849,
+                  "q1": -8.265793584324337,
+                  "q3": 36.15967901936148,
+                  "max": 41.1472155869155,
+                  "sd": 23.54601680410227,
+                  "avg": 17.204487651704788
+                }
+              }
+            }
+          }
+        ]
+      },
+      "insights": null,
+      "rows": [
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Doohickey",
+          -17.223465277480326
+        ],
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Gadget",
+          -13.551016151218196
+        ],
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Gizmo",
+          11.766175703905454
+        ],
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Widget",
+          -8.300098001441754
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Doohickey",
+          -25.01883071513849
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Gadget",
+          -8.482822417191935
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Gizmo",
+          -8.23148916720692
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Widget",
+          -6.791809016018082
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Doohickey",
+          29.87776597143223
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Gadget",
+          34.939040051113736
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Gizmo",
+          35.505214703850605
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Widget",
+          36.81414333487234
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Doohickey",
+          24.60392384643569
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Gadget",
+          40.43924528814757
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Gizmo",
+          38.63242829314229
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Widget",
+          33.47069332869943
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Doohickey",
+          31.835187705698154
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Gadget",
+          41.1472155869155
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Gizmo",
+          32.76309655012521
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Widget",
+          39.8951534154533
+        ]
+      ]
+    }
+  }
+]

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/index.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/index.ts
@@ -3,6 +3,7 @@ import lineLinearXScaleUnsorted from "./line-linear-x-scale-unsorted.json";
 import barLinearXScale from "./bar-linear-x-scale.json";
 import barHistogramXScale from "./bar-histogram-x-scale.json";
 import barOrdinalXScale from "./bar-ordinal-x-scale.json";
+import barStackedTotalFormattedValues from "./bar-stacked-total-formatted-values.json";
 import autoYSplit from "./auto-y-split.json";
 import messedUpAxis from "./messed-up-axis.json";
 import trendSingleSeriesLine from "./trend-single-series-line.json";
@@ -25,6 +26,7 @@ export const data = {
   barLinearXScale,
   barHistogramXScale,
   barOrdinalXScale,
+  barStackedTotalFormattedValues,
   autoYSplit,
   messedUpAxis,
   trendSingleSeriesLine,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
@@ -1,0 +1,2 @@
+export const POSITIVE_STACK_TOTAL_DATA_KEY = "positiveStackTotal";
+export const NEGATIVE_STACK_TOTAL_DATA_KEY = "negativeStackTotal";

--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
@@ -8,6 +8,11 @@ export const CHART_STYLE = {
     size: 12,
     weight: 600,
   },
+  seriesLabels: {
+    weight: 600,
+    size: 12,
+    offset: 4,
+  },
   axisName: {
     size: 14,
     weight: 600,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -25,6 +25,10 @@ import { isNotNull } from "metabase/lib/types";
 import { isMetric, isNumeric } from "metabase-lib/types/utils/isa";
 
 import { getXAxisType } from "../option/axis";
+import {
+  NEGATIVE_STACK_TOTAL_DATA_KEY,
+  POSITIVE_STACK_TOTAL_DATA_KEY,
+} from "metabase/visualizations/echarts/cartesian/constants/dataset";
 
 /**
  * Sums two metric column values.
@@ -329,6 +333,16 @@ export const getTransformedDataset = (
         applySquareRootScaling,
       ),
     },
+    {
+      condition: settings["stackable.stack_type"] != null,
+      fn: datum => {
+        return {
+          ...datum,
+          [POSITIVE_STACK_TOTAL_DATA_KEY]: Number.MIN_VALUE,
+          [NEGATIVE_STACK_TOTAL_DATA_KEY]: -Number.MIN_VALUE,
+        };
+      },
+    },
   ]);
 };
 
@@ -424,7 +438,7 @@ export const getMetricDisplayValueGetter = (
 export const getSortedSeriesModels = (
   seriesModels: SeriesModel[],
   settings: ComputedVisualizationSettings,
-) => {
+): SeriesModel[] => {
   const breakoutSeriesOrder = settings["graph.series_order"];
   if (breakoutSeriesOrder == null || breakoutSeriesOrder.length === 0) {
     return seriesModels;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
@@ -35,7 +35,6 @@ const createMockSeriesModel = (
   columnIndex: index,
 });
 
-
 const createMockDimensionModel = (
   dataKey: DataKey,
   index: number,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -1,13 +1,21 @@
 import type { Insight } from "metabase-types/api/insight";
 
 import type { CardId, DatasetColumn, RowValue } from "metabase-types/api";
+import type {
+  NEGATIVE_STACK_TOTAL_DATA_KEY,
+  POSITIVE_STACK_TOTAL_DATA_KEY,
+} from "metabase/visualizations/echarts/cartesian/constants/dataset";
 
 export type BreakoutValue = RowValue;
 export type ColumnName = string;
 
-export type DataKey =
+export type SeriesDataKey =
   | `${Nullable<CardId>}:${ColumnName}:${BreakoutValue}`
   | `${Nullable<CardId>}:${ColumnName}`;
+export type StackTotalDataKey =
+  | typeof POSITIVE_STACK_TOTAL_DATA_KEY
+  | typeof NEGATIVE_STACK_TOTAL_DATA_KEY;
+export type DataKey = SeriesDataKey | StackTotalDataKey | string;
 
 export type VizSettingsKey = string;
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -15,7 +15,7 @@ export function getGoalLineSeriesOption(
   }
 
   return {
-    type: "line", // type is irreelevant since we don't render any series data
+    type: "line", // type is irrelevant since we don't render any series data
     data: [],
     silent: true,
     markLine: {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -13,6 +13,10 @@ import { getTimelineEventsSeries } from "metabase/visualizations/echarts/cartesi
 import type { TimelineEventId } from "metabase-types/api";
 import { getGoalLineSeriesOption } from "./goal-line";
 import { getTrendLineOptionsAndDatasets } from "./trend-line";
+import {
+  NEGATIVE_STACK_TOTAL_DATA_KEY,
+  POSITIVE_STACK_TOTAL_DATA_KEY,
+} from "metabase/visualizations/echarts/cartesian/constants/dataset";
 
 export const getCartesianChartOption = (
   chartModel: CartesianChartModel,
@@ -52,9 +56,11 @@ export const getCartesianChartOption = (
     getTrendLineOptionsAndDatasets(chartModel, settings, renderingContext);
 
   const seriesOption = [
+    // Data series should always come first for correct labels positioning
+    // since series labelLayout function params return seriesIndex which is used to access label value
+    dataSeriesOptions,
     goalSeriesOption,
     trendSeriesOptions,
-    dataSeriesOptions,
     timelineEventsSeries,
   ].flatMap(option => option ?? []);
 
@@ -62,6 +68,7 @@ export const getCartesianChartOption = (
   const dimensions = [
     chartModel.dimensionModel.dataKey,
     ...chartModel.seriesModels.map(seriesModel => seriesModel.dataKey),
+    ...[POSITIVE_STACK_TOTAL_DATA_KEY, NEGATIVE_STACK_TOTAL_DATA_KEY],
   ];
   const echartsDataset = [
     { source: chartModel.transformedDataset, dimensions },

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
@@ -1,3 +1,5 @@
+import type { RegisteredSeriesOption } from "echarts";
+
 export interface Padding {
   top: number;
   left: number;
@@ -15,3 +17,8 @@ export interface ChartMeasurements {
   padding: Padding;
   ticksDimensions: TicksDimensions;
 }
+
+export type EChartsSeriesOption =
+  | RegisteredSeriesOption["line"]
+  | RegisteredSeriesOption["bar"]
+  | RegisteredSeriesOption["scatter"];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/layout.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/layout.ts
@@ -163,6 +163,12 @@ export const getChartPadding = (
     right: CHART_STYLE.padding.x,
   };
 
+  // Prevent data labels from being rendered outside the chart
+  if (settings["graph.show_values"]) {
+    padding.top +=
+      CHART_STYLE.seriesLabels.size + CHART_STYLE.seriesLabels.offset;
+  }
+
   const yAxisNameTotalWidth =
     CHART_STYLE.axisName.size / 2 + CHART_STYLE.axisNameMargin;
 


### PR DESCRIPTION
### Description

Fixes labels on bar and stacked area/bar charts:
- Negative bar labels should be rendered below the bar
- On stacked charts we need to render only total values at the top/bottom of each positive/negative stack

### How to verify

[Storybook](http://localhost:6006/?path=/story/static-viz-combochart--bar-stacked-total-formatted-values)
or
Using a dataset with negative values
- create a bar chart with data labels enabled and ensure labels positions are correct
- create a stacked bar/area chart with data labels enabled and ensure labels positions are correct

### Demo

Before
<img width="836" alt="Screenshot 2024-01-15 at 6 36 02 PM" src="https://github.com/metabase/metabase/assets/14301985/75b51efd-bd1e-49ec-a094-00edb44d4376">

After
<img width="842" alt="Screenshot 2024-01-15 at 6 33 24 PM" src="https://github.com/metabase/metabase/assets/14301985/0b087968-e9d9-4f57-b7e7-27ceebb75b1a">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
