### PR TITLE
Allow non-admins to see unarchive/delete buttons in archive list

### DIFF
--- a/frontend/src/metabase/archive/containers/ArchiveApp.tsx
+++ b/frontend/src/metabase/archive/containers/ArchiveApp.tsx
@@ -12,7 +12,6 @@ import { isSmallScreen, getMainElement } from "metabase/lib/dom";
 
 import { openNavbar } from "metabase/redux/app";
 import { getIsNavbarOpen } from "metabase/selectors/app";
-import { getUserIsAdmin } from "metabase/selectors/user";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper";
 import { Button } from "metabase/ui";
@@ -37,7 +36,6 @@ const ROW_HEIGHT = 68;
 export function ArchiveApp() {
   const dispatch = useDispatch();
   const isNavbarOpen = useSelector(getIsNavbarOpen);
-  const isAdmin = useSelector(getUserIsAdmin);
   const mainElement = getMainElement();
 
   useEffect(() => {
@@ -98,7 +96,6 @@ export function ArchiveApp() {
                   name={Search.objectSelectors.getName(item)}
                   icon={Search.objectSelectors.getIcon(item).name}
                   color={Search.objectSelectors.getColor(item)}
-                  isAdmin={isAdmin}
                   onUnarchive={() => {
                     dispatch(Search.actions.setArchived(item, false));
                   }}

--- a/frontend/src/metabase/components/ArchivedItem/ArchivedItem.tsx
+++ b/frontend/src/metabase/components/ArchivedItem/ArchivedItem.tsx
@@ -17,7 +17,6 @@ interface ArchivedItemProps {
   model: CollectionItemModel;
   icon: IconName;
   color?: string;
-  isAdmin: boolean;
   onUnarchive?: () => void;
   onDelete?: () => void;
   selected: boolean;
@@ -30,7 +29,6 @@ export const ArchivedItem = ({
   model,
   icon,
   color = c("text-light"),
-  isAdmin = false,
   onUnarchive,
   onDelete,
   selected,
@@ -56,7 +54,7 @@ export const ArchivedItem = ({
       isSwapped={showSelect}
     />
     {name}
-    {isAdmin && (onUnarchive || onDelete) && (
+    {(onUnarchive || onDelete) && (
       <span className="ml-auto mr2">
         {onUnarchive && (
           <Tooltip


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/26169

### Description

Removes a check that only allowed admins to see unarchive or delete buttons in archive list. These are actions they are allowed to take and could do in another places in the UI, so this limitation was arbitrary.

### How to verify

- log in as non-admin
- archive a question
- go to archive page
- hover over an element in the list

### Demo

https://github.com/metabase/metabase/assets/7104357/4bb5fe2c-63bd-432a-a8a8-8aadd9b8e2f9


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
