### PR TITLE
fix charts brushing broken due to usage of mlv2 query

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -319,7 +319,9 @@ export const getBrushData = (
   if (range) {
     const column = chartModel.dimensionModel.column;
     const card = rawSeries[0].card;
-    const query = new Question(card).query();
+    const query = new Question(card).legacyQuery({
+      useStructuredQuery: true,
+    });
     const [start, end] = range;
     if (isTimeSeries) {
       return {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37542

### Description

Brushing code got updated in master for dc.js charts to explicitly use legacy query instead of mlv2 query for updating filter values. This PR updates brushing functionality for the echarts implementation.

### How to verify

Try brush on timeseries or numeric line/area/bar/combo charts and ensure it works.

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
