### PR TITLE
Fix permissions breadcrumbs for schemaless dbs

### DIFF
--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/breadcrumbs.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/breadcrumbs.unit.spec.ts
@@ -1,0 +1,99 @@
+import {
+  createMockDatabase,
+  createMockSchema,
+  createMockTable,
+} from "metabase-types/api/mocks";
+import { createMockMetadata } from "__support__/metadata";
+import { getGroupsDataEditorBreadcrumbs } from "./breadcrumbs";
+
+describe("admin > permissions > data > breadcrumbs", () => {
+  describe("getGroupsDataEditorBreadcrumbs", () => {
+    const schema = createMockSchema({
+      id: "100:myschema",
+      name: "myschema",
+    });
+
+    const schema2 = createMockSchema({
+      id: "100:myschema2",
+      name: "myschema2",
+    });
+
+    const metadata = createMockMetadata({
+      databases: [
+        createMockDatabase({
+          id: 100,
+          name: "myDatabase",
+          // @ts-expect-error - we have to set this manually for this test to work due to circular object nonsense
+          schemas: [schema, schema2],
+        }),
+        createMockDatabase({
+          id: 101,
+          name: "mySchemalessDatabase",
+          engine: "mysql",
+        }),
+      ],
+      schemas: [schema, schema2],
+      tables: [
+        createMockTable({ id: 300, db_id: 100, display_name: "myTable" }),
+        createMockTable({
+          id: 301,
+          db_id: 101,
+          display_name: "mySchemalessTable",
+        }),
+      ],
+    });
+
+    it("should return breadcrumbs for a database with schema", () => {
+      const breadcrumbs = getGroupsDataEditorBreadcrumbs(
+        {
+          databaseId: 100,
+          schemaName: "public",
+          tableId: 300,
+        },
+        metadata,
+      );
+
+      expect(breadcrumbs).toEqual([
+        {
+          text: "myDatabase",
+          id: 100,
+          url: "/admin/permissions/data/database/100",
+        },
+        {
+          text: "public",
+          id: "100:public",
+          url: "/admin/permissions/data/database/100/schema/public",
+        },
+        {
+          text: "myTable",
+          id: 300,
+        },
+      ]);
+    });
+
+    // from metabase's metadata perspective, there's no such thing as a schemaless database
+    // even mysql has a single unnamed schema
+    it("should return breadcrumbs for a database with only 1 schema", () => {
+      const breadcrumbs = getGroupsDataEditorBreadcrumbs(
+        {
+          databaseId: 101,
+          schemaName: "public",
+          tableId: 301,
+        },
+        metadata,
+      );
+
+      expect(breadcrumbs).toEqual([
+        {
+          text: "mySchemalessDatabase",
+          id: 101,
+          url: "/admin/permissions/data/database/101",
+        },
+        {
+          text: "mySchemalessTable",
+          id: 301,
+        },
+      ]);
+    });
+  });
+});

--- a/frontend/src/metabase/lib/types.ts
+++ b/frontend/src/metabase/lib/types.ts
@@ -3,7 +3,7 @@ export const isNotNull = <T>(value: T | null | undefined): value is T => {
 };
 
 export const isNotFalsy = <T>(
-  value: T | null | undefined | false,
+  value: T | null | undefined | false | "",
 ): value is T => {
   return value != null && value !== false && value !== "";
 };

--- a/frontend/src/metabase/lib/types.ts
+++ b/frontend/src/metabase/lib/types.ts
@@ -5,7 +5,7 @@ export const isNotNull = <T>(value: T | null | undefined): value is T => {
 export const isNotFalsy = <T>(
   value: T | null | undefined | false,
 ): value is T => {
-  return value != null;
+  return value != null && value !== false && value !== "";
 };
 
 export const isNumber = (value: unknown): value is number => {


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/37650

### Description

Don't show an empty breadcrumb section in database permissions for schemaless databases (or databases with only 1 schema)

Before | After
---|---
![Screen Shot 2024-01-15 at 2 10 49 PM](https://github.com/metabase/metabase/assets/30528226/bfd28a58-923e-49c8-a3eb-c8410fafdc5b) | ![Screen Shot 2024-01-15 at 2 10 33 PM](https://github.com/metabase/metabase/assets/30528226/61cfb4fe-a7bb-4f34-bfc3-53a35fc54516)


### How to verify

Visit database permissions for the sample db, don't see extra arrows

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
