### PR TITLE
HK: remove noPopover and unnecessary function from ParameterValueWidget

### DIFF
--- a/frontend/src/metabase/components/TextWidget/TextWidget.tsx
+++ b/frontend/src/metabase/components/TextWidget/TextWidget.tsx
@@ -35,8 +35,6 @@ export class TextWidget extends Component<Props, State> {
     };
   }
 
-  static noPopover = true;
-
   UNSAFE_componentWillMount() {
     this.UNSAFE_componentWillReceiveProps(this.props);
   }

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -292,7 +292,7 @@ Widget.propTypes = {
 function hasNoPopover(parameter) {
   // This is needed because isTextWidget check isn't complete,
   // and returns true for dates too.
-  if (isDateParameter(parameter.type)) {
+  if (isDateParameter(parameter)) {
     return false;
   }
   return isTextWidget(parameter);

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -99,7 +99,7 @@ class ParameterValueWidget extends Component {
     } = this.props;
     const { isFocused } = this.state;
     const hasValue = value != null;
-    const { noPopover } = getWidgetDefinition(parameter);
+    const noPopover = isTextWidget(parameter);
     const parameterTypeIcon = getParameterIconName(parameter);
     const showTypeIcon = !isEditing && !hasValue && !isFocused;
 
@@ -127,7 +127,7 @@ class ParameterValueWidget extends Component {
           <WidgetStatusIcon
             isFullscreen={isFullscreen}
             hasValue={hasValue}
-            noPopover={!!noPopover}
+            noPopover={noPopover}
             isFocused={isFocused}
             setValue={setValue}
           />
@@ -170,7 +170,7 @@ class ParameterValueWidget extends Component {
               <WidgetStatusIcon
                 isFullscreen={isFullscreen}
                 hasValue={hasValue}
-                noPopover={!!noPopover}
+                noPopover={noPopover}
                 isFocused={isFocused}
                 setValue={setValue}
               />
@@ -288,20 +288,6 @@ Widget.propTypes = {
   onPopoverClose: PropTypes.func.isRequired,
   onFocusChanged: PropTypes.func.isRequired,
 };
-
-function getWidgetDefinition(parameter) {
-  if (DATE_WIDGETS[parameter.type]) {
-    return DATE_WIDGETS[parameter.type];
-  } else if (isTextWidget(parameter)) {
-    return TextWidget;
-  } else if (isNumberParameter(parameter)) {
-    return NumberInputWidget;
-  } else if (isFieldWidget(parameter)) {
-    return ParameterFieldWidget;
-  } else {
-    return StringInputWidget;
-  }
-}
 
 function isTextWidget(parameter) {
   const canQuery = getQueryType(parameter) !== "none";

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -99,7 +99,7 @@ class ParameterValueWidget extends Component {
     } = this.props;
     const { isFocused } = this.state;
     const hasValue = value != null;
-    const noPopover = isTextWidget(parameter);
+    const noPopover = hasNoPopover(parameter);
     const parameterTypeIcon = getParameterIconName(parameter);
     const showTypeIcon = !isEditing && !hasValue && !isFocused;
 
@@ -288,6 +288,15 @@ Widget.propTypes = {
   onPopoverClose: PropTypes.func.isRequired,
   onFocusChanged: PropTypes.func.isRequired,
 };
+
+function hasNoPopover(parameter) {
+  // This is needed because isTextWidget check isn't complete,
+  // and returns true for dates too.
+  if (DATE_WIDGETS[parameter.type]) {
+    return false;
+  }
+  return isTextWidget(parameter);
+}
 
 function isTextWidget(parameter) {
   const canQuery = getQueryType(parameter) !== "none";

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -292,7 +292,7 @@ Widget.propTypes = {
 function hasNoPopover(parameter) {
   // This is needed because isTextWidget check isn't complete,
   // and returns true for dates too.
-  if (DATE_WIDGETS[parameter.type]) {
+  if (isDateParameter(parameter.type)) {
     return false;
   }
   return isTextWidget(parameter);


### PR DESCRIPTION
This logic was a leftover from the time when `Widget` wasn't used. Now this component implements the Widget type selection logic and `getWidgetDefinition` is no longer needed.