### PR TITLE
Fix bad translation string

### DIFF
--- a/src/metabase/sync/sync_metadata/sync_timezone.clj
+++ b/src/metabase/sync/sync_metadata/sync_timezone.clj
@@ -39,7 +39,7 @@
   [database :- i/DatabaseInstance]
   (let [driver  (driver.u/database->driver database)
         zone-id (driver/db-default-timezone driver database)]
-    (log/infof (i18n/trs "{0} database {1} default timezone is {2}" driver (pr-str (:id database)) (pr-str zone-id)))
+    (log/infof "%s database %s default timezone is %s" driver (pr-str (:id database)) (pr-str zone-id))
     (validate-zone-id driver zone-id)
     (let [zone-id (some-> zone-id str)
           zone-id (if (= zone-id "Z") "UTC" zone-id)]

--- a/src/metabase/sync/sync_metadata/sync_timezone.clj
+++ b/src/metabase/sync/sync_metadata/sync_timezone.clj
@@ -39,7 +39,7 @@
   [database :- i/DatabaseInstance]
   (let [driver  (driver.u/database->driver database)
         zone-id (driver/db-default-timezone driver database)]
-    (log/infof "%s database %s default timezone is %s" driver (pr-str (:id database)) (pr-str zone-id))
+    (log/infof "%s database %s default timezone is %s" driver (:id database) (pr-str zone-id))
     (validate-zone-id driver zone-id)
     (let [zone-id (some-> zone-id str)
           zone-id (if (= zone-id "Z") "UTC" zone-id)]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/37730

Removes the translation of the problematic log message.

The translated french string is wrong anyway, since the format string args don’t line up. The french string has 2 args and the english has 3:
```
en: {0} database {1} default timezone is {2}
fr: Le fuseau horaire par défaut de la base de données {0} est {1}
```
Since we’re okay removing the translation of log messages in 49, I assume it’s also okay in 48 to remove translating this log message.