### PR TITLE
[MLv2] Use `QueryDisplayInfo` to replace `isEditable` methods on queries [blocked]

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -508,9 +508,13 @@ class Question {
     return (db && db.auto_run_queries) || false;
   }
 
+  /**
+   * @deprecated use MLv2
+   */
   isQueryEditable(): boolean {
-    const query = this.legacyQuery({ useStructuredQuery: true });
-    return query ? query.isEditable() : false;
+    const query = this.query();
+    const { isEditable } = Lib.displayInfo(query, -1, query);
+    return isEditable;
   }
 
   /**

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -42,6 +42,7 @@ import type {
   SegmentDisplayInfo,
   TableDisplayInfo,
   TableMetadata,
+  QueryDisplayInfo,
 } from "./types";
 
 export function metadataProvider(
@@ -143,6 +144,11 @@ declare function DisplayInfoFn(
   stageIndex: number,
   segment: SegmentMetadata,
 ): SegmentDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  queryInfo: Query,
+): QueryDisplayInfo;
 
 // x can be any sort of opaque object, e.g. a clause or metadata map. Values returned depend on what you pass in, but it
 // should always have display_name... see :metabase.lib.metadata.calculation/display-info schema

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -157,13 +157,6 @@ export default class NativeQuery extends AtomicQuery {
     return database && database.engine;
   }
 
-  // Whether the user can modify and run this query
-  // Determined based on availability of database metadata and native database permissions
-  isEditable(): boolean {
-    const database = this._database();
-    return database != null && database.native_permissions === "write";
-  }
-
   /* Methods unique to this query type */
 
   /**

--- a/frontend/src/metabase-lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/queries/Query.ts
@@ -50,13 +50,6 @@ class Query {
   }
 
   /**
-   * Does this query have the sufficient metadata for editing it?
-   */
-  isEditable(): boolean {
-    return true;
-  }
-
-  /**
    * Returns the dataset_query object underlying this Query
    */
   datasetQuery(): DatasetQuery {

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -141,13 +141,6 @@ class StructuredQuery extends AtomicQuery {
     return metadata != null && metadata.table(this._sourceTableId()) != null;
   }
 
-  // Whether the user can modify and run this query
-  // Determined based on availability of database and source table metadata
-  // For queries based on questions expects virtual table metadata for the source card
-  isEditable(): boolean {
-    return this._database() != null && this.hasMetadata();
-  }
-
   /* AtomicQuery superclass methods */
 
   /**

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -507,3 +507,8 @@ export interface FieldValuesSearchInfo {
   searchFieldId: FieldId | null;
   hasFieldValues: FieldValuesType;
 }
+
+export type QueryDisplayInfo = {
+  isNative: boolean;
+  isEditable: boolean;
+};

--- a/frontend/src/metabase/admin/datamodel/components/GuiQueryEditor/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/GuiQueryEditor/GuiQueryEditor.jsx
@@ -78,7 +78,7 @@ export class GuiQueryEditor extends Component {
   }
 
   renderFilters() {
-    const { legacyQuery, features, setDatasetQuery } = this.props;
+    const { legacyQuery, query, features, setDatasetQuery } = this.props;
 
     if (!features.filter) {
       return;
@@ -88,7 +88,9 @@ export class GuiQueryEditor extends Component {
     let filterList;
     let addFilterButton;
 
-    if (legacyQuery.isEditable()) {
+    const { isEditable } = Lib.displayInfo(query, -1, query);
+
+    if (isEditable) {
       enabled = true;
 
       const filters = legacyQuery.filters();
@@ -152,6 +154,7 @@ export class GuiQueryEditor extends Component {
   renderAggregation() {
     const {
       legacyQuery,
+      query,
       features,
       setDatasetQuery,
       supportMultipleAggregations,
@@ -161,8 +164,10 @@ export class GuiQueryEditor extends Component {
       return;
     }
 
+    const { isEditable } = Lib.displayInfo(query, -1, query);
+
     // aggregation clause.  must have table details available
-    if (legacyQuery.isEditable()) {
+    if (isEditable) {
       const aggregations = [...legacyQuery.aggregations()];
 
       if (aggregations.length === 0) {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -41,7 +41,6 @@ import { createMockState } from "metabase-types/store/mocks";
 import { createMockEntitiesState } from "__support__/store";
 import * as Lib from "metabase-lib";
 import type StructuredQuery from "metabase-lib/queries/StructuredQuery";
-import NativeQuery from "metabase-lib/queries/NativeQuery";
 import Question from "metabase-lib/Question";
 
 import * as querying from "../querying";
@@ -618,7 +617,7 @@ describe("QB Actions > initializeQB", () => {
         const clone = { ...card };
 
         jest
-          .spyOn(NativeQuery.prototype, "isEditable")
+          .spyOn(Question.prototype, "isQueryEditable")
           .mockReturnValue(hasDatabaseWritePermission);
 
         Snippets.actions.fetchList = jest.fn();

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -324,17 +324,6 @@ describe("StructuredQuery", () => {
         expect(query.canRun()).toBe(true);
       });
     });
-    describe("isEditable", () => {
-      it("A valid query should be editable", () => {
-        expect(query.isEditable()).toBe(true);
-      });
-
-      it("should be not editable when database object is missing", () => {
-        const q = makeQuery();
-        q._database = () => null;
-        expect(q.isEditable()).toBe(false);
-      });
-    });
   });
 
   describe("AGGREGATION METHODS", () => {

--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -215,6 +215,7 @@
 
   There's no editable flag! Instead, a query is **not** editable if:
   - Database is missing from the metadata (no permissions at all);
+  - Database is present but it doesn't have native write permissions;
   - Database is present but tables (at least the `:source-table`) are missing (missing table permissions); or
   - Similarly, the card specified by `:source-card` is missing from the metadata.
   If metadata for the `:source-table` or `:source-card` can be found, then the query is editable."
@@ -224,4 +225,8 @@
                     (= (:database query) id))
                   (or (and source-table (table query source-table))
                       (and source-card  (card  query source-card))
-                      (= (:lib/type stage0) :mbql.stage/native))))))
+                      (and
+                        (= (:lib/type stage0) :mbql.stage/native)
+                        ;; Couldn't import and use `lib.native/has-write-permissions` here due to a circular dependency
+                        ;; TODO Find a way to unify has-write-permissions and this function?
+                        (= :write (:native-permissions (database query)))))))))


### PR DESCRIPTION
This is the first PR for https://github.com/metabase/metabase/issues/37389.
The final diff would be huge so I decided to break it apart.

This PR does two things (maybe even this could've been broken into two?):
1. Defines the new type for `QueryDisplayInfo` and
2. Removes `isEditable` method from all query classes