### PR TITLE
Fix e2e test for serdes dashcardseries

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -635,14 +635,14 @@
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
     (ts/with-source-and-dest-dbs
       (ts/with-source-db
-        (t2.with-temp/with-temp
+        (mt/with-temp
           [:model/Collection {coll-id :id} {:name "Some Collection"}
            :model/Card {c1-id :id :as c1} {:name "Some Question", :collection_id coll-id}
            :model/Card {c2-id :id :as c2} {:name "Series Question A", :collection_id coll-id}
            :model/Card {c3-id :id :as c3} {:name "Series Question B", :collection_id coll-id}
            :model/Dashboard {dash-id :id :as dash} {:name "Shared Dashboard", :collection_id coll-id}
            :model/DashboardCard {dc1-id :id} {:card_id c1-id, :dashboard_id dash-id}
-           :model/DashboardCard _ {:card_id c1-id, :dashboard_id dash-id}
+           :model/DashboardCard _dc2 {:card_id c2-id, :dashboard_id dash-id}
            :model/DashboardCardSeries _ {:card_id c3-id, :dashboardcard_id dc1-id, :position 1}
            :model/DashboardCardSeries _ {:card_id c2-id, :dashboardcard_id dc1-id, :position 0}]
           (testing "extract and store"
@@ -654,19 +654,26 @@
                 (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
                     "successful"))
               (testing "Series are loaded correctly"
-                (let [new-dc1-id (t2/select-one-pk :model/DashboardCard :card_id (:id c1))
-                      new-dc2-id (t2/select-one-pk :model/DashboardCard :card_id (:id c2))
+                (let [new-c1-id  (t2/select-one-pk :model/Card :name (:name c1))
                       new-c2-id  (t2/select-one-pk :model/Card :name (:name c2))
                       new-c3-id  (t2/select-one-pk :model/Card :name (:name c3))
+                      new-dc1-id (t2/select-one-pk :model/DashboardCard :card_id new-c1-id)
+                      new-dc2-id (t2/select-one-pk :model/DashboardCard :card_id new-c2-id)
                       hydrated-dashcards (-> (t2/select-one :model/Dashboard :name (:name dash))
                                              (t2/hydrate [:dashcards :series])
                                              :dashcards
                                              (->> (m/index-by :id)))]
+                  (is (some? new-c1-id))
+                  (is (some? new-c2-id))
+                  (is (some? new-c3-id))
+                  (is (some? new-dc1-id))
+                  (is (some? new-dc2-id))
                   (testing "Series hydrate on the dashboard correctly"
-                    (is (=? {new-dc1-id {:series [{:id new-c2-id}
-                                                  {:id new-c3-id}]}}
-                            hydrated-dashcards))
-                    (is (not (contains? (hydrated-dashcards new-dc2-id) :series)))))))))))))
+                    (is (= [new-c2-id new-c3-id]
+                           (->> (get-in hydrated-dashcards [new-dc1-id :series])
+                                (map :id))))
+                    (is (= []
+                           (get-in hydrated-dashcards [new-dc2-id :series])))))))))))))
 
 (deftest dashboard-with-tabs-test
   (testing "Dashboard with tabs must be deserialized correctly"


### PR DESCRIPTION
This PR fixes an e2e test that I added in https://github.com/metabase/metabase/pull/37271

The test currently passes only accidentally, relying on the order in which objects are created in the database based on serialization export and import implementations.

I discovered this when I tried to backport it to 47 on this PR https://github.com/metabase/metabase/pull/37737, where the test broke. I've already fixed it on that PR, so this only needs backporting to 48