### PR TITLE
observe redirect param even when logged in

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.js
@@ -28,6 +28,13 @@ export const createSessionMiddleware = (
 
       let wasLoggedIn = getIsLoggedIn();
 
+      // get the redirect url before refreshing the session because after the refresh the url will be reset
+      const redirectUrl = getRedirectUrl();
+
+      if (wasLoggedIn && !!redirectUrl) {
+        store.dispatch(replace(redirectUrl));
+      }
+
       intervalId = setInterval(async () => {
         const isLoggedIn = getIsLoggedIn();
 
@@ -35,8 +42,6 @@ export const createSessionMiddleware = (
           wasLoggedIn = isLoggedIn;
 
           if (isLoggedIn) {
-            // get the redirect url before refreshing the session because after the refresh the url will be reset
-            const redirectUrl = getRedirectUrl();
             await store.dispatch(refreshSession())?.unwrap();
 
             if (redirectUrl !== null) {

--- a/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/middleware/session-middleware.unit.spec.js
@@ -116,6 +116,29 @@ describe("createSessionMiddleware", () => {
     });
   });
 
+  describe("logged in redirect", () => {
+    beforeEach(() => {
+      changeJSDOMURL(
+        "https://metabase.com/auth/login?redirect=%2Fquestion%2F1%3Fquery%3D5%23hash",
+      );
+    });
+
+    it("should redirect to the redirectUrl", async () => {
+      Cookie.get = jest
+        .fn()
+        .mockImplementationOnce(() => "alive")
+        .mockImplementationOnce(() => "alive");
+
+      const { handleAction, dispatchMock } = setup();
+
+      handleAction(actionStub);
+      clock.tick(COOKIE_POOLING_TIMEOUT);
+
+      expect(dispatchMock).toHaveBeenCalled();
+      expect(replace).toHaveBeenCalledWith("/question/1?query=5#hash");
+    });
+  });
+
   describe("when not logged in", () => {
     beforeEach(() => {
       changeJSDOMURL(


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/14436

### Description

Our `redirect=` parameter only worked when logged out and then logging in. This makes it work even if a user is already logged in.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. while logged in visit a url like `localhost:3000/auth/login?redirect=dashboard/10`
2. see that you get redirected to that dashboard
3. see that it also works if you start logged out.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
