### PR TITLE
[MLv2] Fix column-group display-name

### DIFF
--- a/src/metabase/lib/column_group.cljc
+++ b/src/metabase/lib/column_group.cljc
@@ -101,7 +101,7 @@
        ;; This is very intentional: one table might have several FKs to one foreign table, each with different
        ;; meaning (eg. ORDERS.customer_id vs. ORDERS.supplier_id both linking to a PEOPLE table).
        ;; See #30109 for more details.
-       (assoc field-info :fk-reference-name (lib.util/strip-id (:display-name field-info)))))
+       (update field-info :display-name lib.util/strip-id)))
    {:is-from-join           false
     :is-implicitly-joinable true}))
 
@@ -177,3 +177,7 @@
   "Get the columns associated with a column group"
   [column-group :- ColumnGroup]
   (::columns column-group))
+
+(defmethod lib.metadata.calculation/display-name-method :metadata/column-group
+  [query stage-number column-group _display-name-style]
+  (:display-name (lib.metadata.calculation/display-info query stage-number column-group)))

--- a/test/metabase/lib/column_group_test.cljc
+++ b/test/metabase/lib/column_group_test.cljc
@@ -31,17 +31,19 @@
                                              {:name "NAME", :display-name "Name"}]}]
             groups))
     (testing `lib/display-info
-      (is (=? [{:is-from-join           false
-                :is-implicitly-joinable false
-                :name                   "VENUES"
-                :display-name           "Venues"}
-               {:is-from-join           false
-                :is-implicitly-joinable true
-                :name                   "CATEGORY_ID"
-                :display-name           "Category ID"
-                :fk-reference-name      "Category"}]
+      (is (=? [[{:is-from-join           false
+                 :is-implicitly-joinable false
+                 :name                   "VENUES"
+                 :display-name           "Venues"}
+                "Venues"]
+               [{:is-from-join           false
+                 :is-implicitly-joinable true
+                 :name                   "CATEGORY_ID"
+                 :display-name           "Category"}
+                "Category"]]
               (for [group groups]
-                (lib/display-info query group)))))
+                [(lib/display-info query group)
+                 (lib/display-name query group)]))))
     (testing `lib/columns-group-columns
       (is (= columns
              (mapcat lib/columns-group-columns groups))))))
@@ -163,8 +165,7 @@
                {:is-from-join           false
                 :is-implicitly-joinable true
                 :name                   "CATEGORY_ID"
-                :display-name           "Category ID"
-                :fk-reference-name      "Category"}]
+                :display-name           "Category"}]
               (for [group groups]
                 (lib/display-info query group)))))
     (testing `lib/columns-group-columns
@@ -371,16 +372,16 @@
                {:display-name "Mock orders card"
                 :is-from-join true,
                 :is-implicitly-joinable false}
-               {:display-name "Product ID"
+               {:display-name "Product"
                 :is-from-join false,
                 :is-implicitly-joinable true}
-               {:display-name "User ID"
+               {:display-name "User"
                 :is-from-join false,
                 :is-implicitly-joinable true}
-               {:display-name "Product ID"
+               {:display-name "Product"
                 :is-from-join false,
                 :is-implicitly-joinable true}
-               {:display-name "User ID"
+               {:display-name "User"
                 :is-from-join false,
                 :is-implicitly-joinable true}]
               (map #(lib/display-info query %) groups)))


### PR DESCRIPTION
Fixes #37369

Column group display names need to take fk-reference-name into account and fk-reference-name no longer needs to be exposed through display-info.

Also add an implementation of display-name for column-group.
