### PR TITLE
Use :skip-results-metadata? true in pulse query execution

### DIFF
--- a/src/metabase/pulse/util.clj
+++ b/src/metabase/pulse/util.clj
@@ -25,8 +25,9 @@
               process-query (fn []
                               (binding [qp.perms/*card-id* card-id]
                                 (qp/process-query-and-save-with-max-results-constraints!
-                                 (assoc query :middleware {:process-viz-settings? true
-                                                           :js-int-to-string?     false})
+                                 (assoc query :middleware {:skip-results-metadata? true
+                                                           :process-viz-settings?  true
+                                                           :js-int-to-string?      false})
                                  (merge (cond->
                                           {:executed-by               pulse-creator-id
                                            :context                   :pulse

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -1005,9 +1005,10 @@
                                        :pulse_id     pulse-id
                                        :enabled      true}]
           (metabase.pulse/send-pulse! p)
-          (is (= (-> result-metadata
-                     first
-                     (select-keys [:display_name :description]))
-                 (t2/select-one-fn
-                  (comp #(select-keys % [:display_name :description]) first :result_metadata)
-                  :model/Card :id card-id))))))))
+          (testing "The custom columns defined in the result-metadata (:display_name and :description) are still present after the alert has run."
+              (is (= (-> result-metadata
+                         first
+                         (select-keys [:display_name :description]))
+                     (t2/select-one-fn
+                      (comp #(select-keys % [:display_name :description]) first :result_metadata)
+                      :model/Card :id card-id)))))))))

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -977,3 +977,37 @@
           (#'metabase.pulse/send-notifications! [fake-slack-notification])
           (is (= {:numberOfSuccessfulCallsWithRetryAttempt 1}
                  (get-positive-retry-metrics test-retry)))))))
+
+(deftest alerts-do-not-remove-user-metadata
+  (testing "Alerts that exist on a Model shouldn't remove metadata (#35091)."
+    (mt/dataset test-data
+      (let [q               {:database (mt/id)
+                             :type     :query
+                             :query
+                             {:source-table (mt/id :reviews)
+                              :aggregation  [[:count]]}}
+            result-metadata [{:base_type         :type/Integer
+                              :name              "count"
+                              :display_name      "ASDF Count"
+                              :description       "ASDF Some description"
+                              :semantic_type     :type/Quantity
+                              :source            :aggregation
+                              :field_ref         [:aggregation 0]
+                              :aggregation_index 0}]]
+        (mt/with-temp [Card {card-id :id} {:display         :table
+                                           :dataset_query   q
+                                           :dataset         true
+                                           :result_metadata result-metadata}
+                       Pulse {pulse-id :id :as p} {:name "Test Pulse"}
+                       PulseCard _ {:pulse_id pulse-id
+                                    :card_id  card-id}
+                       PulseChannel _ {:channel_type :email
+                                       :pulse_id     pulse-id
+                                       :enabled      true}]
+          (metabase.pulse/send-pulse! p)
+          (is (= (-> result-metadata
+                     first
+                     (select-keys [:display_name :description]))
+                 (t2/select-one-fn
+                  (comp #(select-keys % [:display_name :description]) first :result_metadata)
+                  :model/Card :id card-id))))))))


### PR DESCRIPTION
Fixes: #35091 

Without this, the results-metadata middleware ends up replacing a model's metadata.

Using the correct flag causes that middleware to just be skipped, preserving whatever metadata already exists on the model.

A test is also added for this case.

My exploration namespace is below:

```clojure
(ns tickets.35091
  "## An alert set on a model reverts the models customized column names

  ### URL: https://github.com/metabase/metabase/issues/35091

  See the comment blocks below for details."
  (:require
   [clojure.string :as str]
   [clojure.test :refer :all]
   [metabase.email :as email]
   [metabase.models :refer [Card Dashboard DashboardCard Pulse PulseCard PulseChannel PulseChannelRecipient]]
   [metabase.models.pulse :as pulse]
   [metabase.pulse]
   [metabase.pulse.render.test-util :as render.tu]
   [metabase.test :as mt]
   [toucan2.core :as t2]))

(defn manual-alert [pulse-id]
  (metabase.pulse/send-pulse! (pulse/retrieve-alert pulse-id)))

;; I reproduced the problem quite easily. I made a card that's just a count of rows.
(defonce simple-model-before
  (t2/select-one :model/Card :id 1136))

#_(manual-alert 672) ;; the pulse-id was taken from the API response
#_(defonce simple-model-after
    (t2/select-one :model/Card :id 1136))

;; The data before:
{:description            nil,
 :archived               false,
 :collection_position    1,
 :table_id               24,
 :result_metadata
 [{:display_name   "Number of Points",
   :semantic_type  :type/Quantity,
   :field_ref      [:aggregation 0],
   :name           "count",
   :base_type      :type/BigInteger,
   :effective_type :type/BigInteger,
   :fingerprint
   {:global {:distinct-count 1, :nil% 0},
    :type   #:type{:Number {:min 12, :q1 12, :q3 12, :max 12, :sd nil, :avg 12}}},
   :description    "The number of points I've collected."}],
 :database_id            2,
 :enable_embedding       false,
 :collection_id          nil,
 :query_type             :query,
 :name                   "Points, Count",
 :creator_id             1,
 :updated_at             #t "2024-01-15T19:22:12.333674Z",
 :made_public_by_id      nil,
 :embedding_params       nil,
 :cache_ttl              nil,
 :dataset_query          {:database 2, :type :query, :query {:source-table 24, :aggregation [[:count]]}},
 :id                     1136,
 :parameter_mappings     [],
 :display                :table,
 :entity_id              "FPTgeFxaZrIKPD1cqTM-e",
 :collection_preview     true,
 :visualization_settings {:table.pivot_column "count"},
 :metabase_version       "v0.48.1-SNAPSHOT (8379151)",
 :parameters             [],
 :dataset                true,
 :created_at             #t "2024-01-15T19:22:12.333674Z",
 :public_uuid            nil}

;; Then I manually sent and retreived the data again, and just used clojure.data/diff in the repl to get the difference.
;; the difference between the data before/after send is this:

{:before
 {:result_metadata
  [{:fingerprint {:type #:type{:Number {:avg 12, :max 12, :q3 12, :q1 12, :min 12}}, :global {:nil% 0}},
    :display_name "Number of Points",
    :description "The number of points I've collected."}]}
 :after
 {:result_metadata
  [{:fingerprint {:type #:type{:Number {:avg 13.0, :max 13.0, :q3 13.0, :q1 13.0, :min 13.0}}, :global {:nil% 0.0}},
    :display_name "Count"}]}}

;; It's clear that the Alert is blowing away the model's metadata.
;; Here's a repl fn that produces the error, which I can just re-run while I explore.

(defn explore
  []
  (mt/dataset test-data
    (let [q               {:database (mt/id)
                           :type     :query
                           :query
                           {:source-table (mt/id :reviews)
                            :aggregation  [[:count]]}}
          result-metadata [{:base_type         :type/Integer
                            :name              "count"
                            :display_name      "ASDF Count"
                            :description       "ASDF Some description"
                            :semantic_type     :type/Quantity
                            :source            :aggregation
                            :field_ref         [:aggregation 0]
                            :aggregation_index 0}]]
      (mt/with-temp [Card {card-id :id} {:display         :table
                                         :dataset_query   q
                                         :dataset         true
                                         :result_metadata result-metadata}
                     Pulse {pulse-id :id :as p} {:name "Test Pulse"}
                     PulseCard _ {:pulse_id pulse-id
                                  :card_id  card-id}
                     PulseChannel _ {:channel_type :email
                                     :pulse_id     pulse-id
                                     :enabled      true}]
        (metabase.pulse/send-pulse! p)
        (t2/select-one-fn
         (comp (juxt :display_name :description) first :result_metadata)
         :model/Card :id card-id)))))

;; we expect the output to be: `["ASDF Count" "ASDF Some description]` but (while broken) it is `["Count" nil]`.

;; Let's follow the send-pulse! chain.
;; `metabase.pulse/send-pulse!` will always run `send-notifications!` when it's an alert because:
;; There is no dashboard so `(not (:archived nil))` always ends up `true` for alerts.

;; `send-notifications!` handles actually sending off the notifications, but doesn't do execution itself.
;; That means we have to follow `pulse->notifications`.

;; `pulse->notifications` branches on whether or not there's a dashboard. We know there isn't, so follow
;; that branch to see that each card in the pulse (in this alert case it's just 1 card) gets run with:

;; `metabase.pulse.util/execute-card` which seems like a likely candidate for the bug.
;; That fn uses the qp, so maybe we have a bug in a metadata middleware?
;; Adding the `:skip-results-metadata?` key to `true` solves the problem.
;; This key is checked in `metabase.query-processor.middleware.results-metadata/record-and-return-metadata!`
;; If we skip, the user-supplied metadata is never overwritten.

;; It's also the case that `:skip-results-metadata?` is set to true in a few places in the api code, so it's likely a fair assumption to use it here too.

;; All tests pass too when that's added, so it seems like a safe and simple change.

;; Assuming it's a good change, I can write a test case now:

(deftest alerts-do-not-remove-user-metadata
  (testing "Alerts that exist on a Model shouldn't remove metadata (#35091)."
    (mt/dataset test-data
      (let [q               {:database (mt/id)
                             :type     :query
                             :query
                             {:source-table (mt/id :reviews)
                              :aggregation  [[:count]]}}
            result-metadata [{:base_type         :type/Integer
                              :name              "count"
                              :display_name      "ASDF Count"
                              :description       "ASDF Some description"
                              :semantic_type     :type/Quantity
                              :source            :aggregation
                              :field_ref         [:aggregation 0]
                              :aggregation_index 0}]]
        (mt/with-temp [Card {card-id :id} {:display         :table
                                           :dataset_query   q
                                           :dataset         true
                                           :result_metadata result-metadata}
                       Pulse {pulse-id :id :as p} {:name "Test Pulse"}
                       PulseCard _ {:pulse_id pulse-id
                                    :card_id  card-id}
                       PulseChannel _ {:channel_type :email
                                       :pulse_id     pulse-id
                                       :enabled      true}]
          (metabase.pulse/send-pulse! p)
          (is (= (-> result-metadata
                     first
                     (select-keys [:display_name :description]))
                 (t2/select-one-fn
                  (comp #(select-keys % [:display_name :description]) first :result_metadata)
                  :model/Card :id card-id))))))))
```