### PR TITLE
Exclude :card from the parameter types which require defaults to be considered fully parameterized 

### DIFF
--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -185,7 +185,7 @@ describeEE("formatting > sandboxes", () => {
       });
     });
 
-    describe("table sandboxed on a saved parametrized SQL question", () => {
+    describe("table sandboxed on a saved parameterized SQL question", () => {
       it("should show filtered categories", () => {
         openPeopleTable();
         cy.get(".TableInteractive-headerCellData").should("have.length", 4);

--- a/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
+++ b/e2e/test/scenarios/sharing/downloads/downloads.cy.spec.js
@@ -114,7 +114,7 @@ describe("scenarios > question > download", () => {
       assertOrdersExport(1);
     });
 
-    it("should allow downloading parametrized cards opened from dashboards as a user with no self-service permission (metabase#20868)", () => {
+    it("should allow downloading parameterized cards opened from dashboards as a user with no self-service permission (metabase#20868)", () => {
       cy.createQuestion({
         name: "20868",
         query: {

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.unit.spec.js
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.unit.spec.js
@@ -20,7 +20,7 @@ describe("parameters/utils/cards", () => {
       expect(getTemplateTags(card)).toEqual([]);
     });
 
-    it("should return an empty array for a non-parametrized query", () => {
+    it("should return an empty array for a non-parameterized query", () => {
       const card = {
         dataset_query: {
           type: "query",

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -75,7 +75,7 @@ export interface CollectionItem {
   copy?: boolean;
   collection_position?: number | null;
   collection_preview?: boolean | null;
-  fully_parametrized?: boolean | null;
+  fully_parameterized?: boolean | null;
   collection?: Collection | null;
   display?: CardDisplayType;
   personal_owner_id?: UserId;

--- a/frontend/src/metabase-types/api/mocks/collection.ts
+++ b/frontend/src/metabase-types/api/mocks/collection.ts
@@ -23,7 +23,7 @@ export const createMockCollectionItem = (
   description: null,
   collection_position: null,
   collection_preview: true,
-  fully_parametrized: true,
+  fully_parameterized: true,
   getIcon: () => ({ name: "question" }),
   getUrl: () => "/question/1",
   ...opts,

--- a/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
+++ b/frontend/src/metabase/collections/components/PinnedQuestionCard/PinnedQuestionCard.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 import {
-  isFullyParametrized,
+  isFullyParameterized,
   isPreviewShown,
 } from "metabase/collections/utils";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -98,7 +98,7 @@ const PinnedQuestionCard = ({
 };
 
 const getSkeletonTooltip = (item: CollectionItem) => {
-  if (!isFullyParametrized(item)) {
+  if (!isFullyParameterized(item)) {
     return t`Open this question and fill in its variables to see it.`;
   } else {
     return undefined;

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -159,15 +159,15 @@ export function canArchiveItem(item: CollectionItem, collection: Collection) {
 }
 
 export function isPreviewShown(item: CollectionItem) {
-  return isPreviewEnabled(item) && isFullyParametrized(item);
+  return isPreviewEnabled(item) && isFullyParameterized(item);
 }
 
 export function isPreviewEnabled(item: CollectionItem) {
   return item.collection_preview ?? true;
 }
 
-export function isFullyParametrized(item: CollectionItem) {
-  return item.fully_parametrized ?? true;
+export function isFullyParameterized(item: CollectionItem) {
+  return item.fully_parameterized ?? true;
 }
 
 export function coerceCollectionId(

--- a/frontend/src/metabase/components/EntityItem/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.jsx
@@ -11,7 +11,7 @@ import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { Icon } from "metabase/ui";
 import {
   isPreviewShown,
-  isFullyParametrized,
+  isFullyParameterized,
   isItemModel,
   isItemPinned,
 } from "metabase/collections/utils";
@@ -102,7 +102,7 @@ function EntityItemMenu({
 }) {
   const isPinned = isItemPinned(item);
   const isPreviewed = isPreviewShown(item);
-  const isParametrized = isFullyParametrized(item);
+  const isParameterized = isFullyParameterized(item);
   const isModel = isItemModel(item);
   const isXrayShown = isModel && isXrayEnabled;
   const isMetabotShown = isModel && canUseMetabot;
@@ -134,10 +134,10 @@ function EntityItemMenu({
             : t`Show visualization`,
           icon: isPreviewed ? "eye_crossed_out" : "eye",
           action: onTogglePreview,
-          tooltip: !isParametrized
+          tooltip: !isParameterized
             ? t`Open this question and fill in its variables to see it.`
             : undefined,
-          disabled: !isParametrized,
+          disabled: !isParameterized,
           event: `${analyticsContext};Entity Item;Preview Item;${item.model}`,
         },
         onMove && {
@@ -172,7 +172,7 @@ function EntityItemMenu({
       isXrayShown,
       isMetabotShown,
       isPreviewed,
-      isParametrized,
+      isParameterized,
       isBookmarked,
       onPin,
       onMove,

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -597,7 +597,7 @@
                   :entity_id           (:entity_id card)
                   :moderated_status    "verified"
                   :model               "card"
-                  :fully_parametrized  true}])
+                  :fully_parameterized  true}])
                (mt/obj->json->obj
                 (:data (mt/user-http-request :crowberto :get 200
                                              (str "collection/" (u/the-id collection) "/items"))))))))))
@@ -666,7 +666,7 @@
                                                  :collection_preview false,           :display     "table", :entity_id true}
                                                 {:name "Dine & Dashboard", :description nil, :model "dashboard", :entity_id true}
                                                 {:name "Electro-Magnetic Pulse", :model "pulse", :entity_id true}])
-                            (assoc-in [1 :fully_parametrized] true))
+                            (assoc-in [1 :fully_parameterized] true))
                         (mt/boolean-ids-and-timestamps
                          (:data (mt/user-http-request :rasta :get 200 (str "collection/" (u/the-id collection) "/items"))))))))
 
@@ -683,7 +683,7 @@
             (is (partial= [(-> {:name               "Birthday Card", :description nil,     :model     "card",
                                 :collection_preview false,           :display     "table", :entity_id true}
                                default-item
-                               (assoc :fully_parametrized true))
+                               (assoc :fully_parameterized true))
                            (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard", :entity_id true})]
                           (mt/boolean-ids-and-timestamps
                            (:data (mt/user-http-request :rasta :get 200 (str "collection/" (u/the-id collection) "/items")
@@ -1187,7 +1187,7 @@
       (is (partial= [(-> {:name               "Birthday Card", :description nil, :model "card",
                           :collection_preview false, :display "table"}
                          default-item
-                         (assoc :fully_parametrized true))
+                         (assoc :fully_parameterized true))
                      (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})
                      (default-item {:name "Electro-Magnetic Pulse", :model "pulse"})]
                     (with-some-children-of-collection nil
@@ -1236,7 +1236,7 @@
             (is (partial= [(-> {:name               "Birthday Card", :description nil, :model "card",
                                 :collection_preview false,           :display     "table"}
                                default-item
-                               (assoc :fully_parametrized true))
+                               (assoc :fully_parameterized true))
                            (default-item {:name "Dine & Dashboard", :description nil, :model "dashboard"})
                            (default-item {:name "Electro-Magnetic Pulse", :model "pulse"})]
                           (-> (:data (mt/user-http-request :rasta :get 200 "collection/root/items"))
@@ -1275,15 +1275,15 @@
                :moderated_status    nil
                :entity_id           (:entity_id card)
                :model               "card"
-               :fully_parametrized  true}]
+               :fully_parameterized  true}]
              (-> (mt/user-http-request :crowberto :get 200
                                        "collection/root/items?archived=true")
                  :data
                  (results-matching {:name "Business Card", :model "card"}))))))))
 
-(deftest fetch-root-items-fully-parametrized-test ; [sic]
+(deftest fetch-root-items-fully-parameterized-test
   (testing "GET /api/collection/root/items"
-    (testing "fully_parametrized of a card"
+    (testing "fully_parameterized of a card"
       (testing "can be false"
         (t2.with-temp/with-temp [Card card {:name          "Business Card"
                                             :dataset_query {:native {:template-tags {:param0 {:default 0}
@@ -1293,7 +1293,7 @@
           (is (partial= [{:name               "Business Card"
                           :entity_id          (:entity_id card)
                           :model              "card"
-                          :fully_parametrized false}]
+                          :fully_parameterized false}]
                         (-> (mt/user-http-request :crowberto :get 200 "collection/root/items")
                             :data
                             (results-matching {:name "Business Card", :model "card"}))))))
@@ -1306,7 +1306,7 @@
           (is (partial= [{:name               "Business Card"
                           :entity_id          (:entity_id card)
                           :model              "card"
-                          :fully_parametrized false}]
+                          :fully_parameterized false}]
                         (-> (mt/user-http-request :crowberto :get 200 "collection/root/items")
                             :data
                             (results-matching {:name "Business Card", :model "card"}))))))
@@ -1319,7 +1319,7 @@
           (is (partial= [{:name               "Business Card"
                           :entity_id          (:entity_id card)
                           :model              "card"
-                          :fully_parametrized false}]
+                          :fully_parameterized false}]
                         (-> (mt/user-http-request :crowberto :get 200 "collection/root/items")
                             :data
                             (results-matching {:name "Business Card", :model "card"}))))))
@@ -1330,7 +1330,7 @@
           (is (partial= [{:name               "Business Card"
                           :entity_id          (:entity_id card)
                           :model              "card"
-                          :fully_parametrized true}]
+                          :fully_parameterized true}]
                         (-> (mt/user-http-request :crowberto :get 200 "collection/root/items")
                             :data
                             (results-matching {:name "Business Card", :model "card"}))))))
@@ -1345,7 +1345,7 @@
           (is (partial= [{:name               "Business Card"
                           :entity_id          (:entity_id card)
                           :model              "card"
-                          :fully_parametrized true}]
+                          :fully_parameterized true}]
                         (-> (mt/user-http-request :crowberto :get 200 "collection/root/items")
                             :data
                             (results-matching {:name "Business Card", :model "card"}))))))
@@ -1365,10 +1365,32 @@
           (is (partial= [{:name               "Business Card"
                           :entity_id          (:entity_id card)
                           :model              "card"
-                          :fully_parametrized true}]
+                          :fully_parameterized true}]
                         (-> (mt/user-http-request :crowberto :get 200 "collection/root/items")
                             :data
-                            (results-matching {:name "Business Card", :model "card"})))))))))
+                            (results-matching {:name "Business Card", :model "card"})))))))
+
+    (testing "a card with only a reference to another card is considered fully parameterized (#25022)"
+      (t2.with-temp/with-temp [Card card-1 {:dataset_query (mt/mbql-query venues)}]
+        (let [card-tag (format "#%d" (u/the-id card-1))]
+          (t2.with-temp/with-temp [Card card-2 {:name "Business Card"
+                                                :dataset_query
+                                                (mt/native-query {:template-tags
+                                                                  {card-tag
+                                                                   {:id (str (random-uuid))
+                                                                    :name card-tag
+                                                                    :display-name card-tag
+                                                                    :type :card
+                                                                    :card-id (u/the-id card-1)}}
+                                                                  :query (format "SELECT * FROM {{#%d}}" (u/the-id card-1))})}]
+            (is (partial= [{:name               "Business Card"
+                            :entity_id          (:entity_id card-2)
+                            :model              "card"
+                            :fully_parameterized true}]
+                          (-> (mt/user-http-request :crowberto :get 200 "collection/root/items")
+                              :data
+                              (results-matching {:name "Business Card", :model "card"}))))))))))
+
 
 ;;; ----------------------------------- Effective Children, Ancestors, & Location ------------------------------------
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/25022

* Exclude :card from the parameter types which require defaults to be considered fully parameterized to resolve https://github.com/metabase/metabase/issues/25022
* Fix typo across the code base: `parametrized` -> `parameterized`

**Product question:**

We don't want to attempt to render cards that need user input (parameters, required filters, etc). There's no hope of running a query that needs user choices.

In the past, the mechanism that determined if a query was parameterized considered depending on another query as the same as being parameterized. This isn't necessarily true, but checking cards can get expensive, especially in light of the fact that those queries can depend on other queries, which can depend on other queries, which .... So this just bailed at the first nested query and wouldn't run the question (which is the linked issue).

The change here will consider nested queries as _not_ parameterized. This is probably correct in most cases. But we don't have a mechanism to check that all of the nested queries are not paramaterized. This just assumes they aren't. Based on my gut feeling of how many people are using a parameterized query as a nested query (this doesn't work as there's no way to pass parameters down into the nested query) I think we can get away with this.


#### Why we think using a nested, parameterized query is very rare
This type of question will currently be broken no matter what, since there's no way to pass parameters down into the card that is referenced. So just configuring the nested query will show immediately that it's broken, and then it not rendering in the collection pinning is understandable.

So when it's pinned, we show `There was a problem displaying this chart` because the question itself is essentially broken due to product limitations. Is this OK?

<img width="832" alt="image" src="https://github.com/metabase/metabase/assets/32746338/5b90ae1a-e282-4c42-aa63-bf52ba8c5cb0">
