### PR TITLE
Fixes clicks, drills on the combined scalars and funnel bar charts

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -44,10 +44,8 @@ export const ComboChart = ({
     renderingContext,
   );
 
-  const { legendItems, isReversed } = getLegendItems(
-    chartModel,
-    computedVisualizationSettings,
-  );
+  const legendItems = getLegendItems(chartModel);
+  const isReversed = computedVisualizationSettings["legend.is_reversed"];
   const { height: legendHeight, items: legendLayoutItems } =
     calculateLegendRows({
       items: legendItems,

--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -11,6 +11,7 @@ import {
   getDefaultIsHistogram,
   getDefaultIsNumeric,
   getDefaultIsTimeSeries,
+  getDefaultLegendIsReversed,
   getDefaultStackDisplayValue,
   getDefaultStackingValue,
   getDefaultXAxisScale,
@@ -242,6 +243,12 @@ export const computeStaticComboChartSettings = (
   );
 
   fillWithDefaultValue(settings, "graph.goal_label", getDefaultGoalLabel());
+
+  fillWithDefaultValue(
+    settings,
+    "legend.is_reversed",
+    getDefaultLegendIsReversed(mainDataset),
+  );
 
   // For scatter plot
   fillWithDefaultValue(

--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -38,10 +38,7 @@ export function ScatterPlot({
     renderingContext,
   );
 
-  const { legendItems } = getLegendItems(
-    chartModel,
-    computedVisualizationSettings,
-  );
+  const legendItems = getLegendItems(chartModel);
   const { height: legendHeight, items: legendLayoutItems } =
     calculateLegendRows({
       items: legendItems,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/legend.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/legend.ts
@@ -1,19 +1,8 @@
-import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
-
 import type { BaseCartesianChartModel } from "./types";
 
-export const getLegendItems = (
-  chartModel: BaseCartesianChartModel,
-  settings: ComputedVisualizationSettings,
-) => {
-  const isReversed = settings["stackable.stack_type"] != null;
-  const legendItems = chartModel.seriesModels.map(seriesModel => ({
+export const getLegendItems = (chartModel: BaseCartesianChartModel) => {
+  return chartModel.seriesModels.map(seriesModel => ({
     name: seriesModel.name,
     color: seriesModel.color,
   }));
-
-  return {
-    legendItems,
-    isReversed,
-  };
 };

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -34,6 +34,7 @@ import {
   getYAxisAutoRangeDefault,
   isStackingValueValid,
   isXAxisScaleValid,
+  getDefaultLegendIsReversed,
   STACKABLE_DISPLAY_TYPES,
 } from "metabase/visualizations/shared/settings/cartesian-chart";
 import {
@@ -323,6 +324,14 @@ export const STACKABLE_SETTINGS = {
   },
 };
 
+export const LEGEND_SETTINGS = {
+  "legend.is_reversed": {
+    getDefault: (_series, settings) => getDefaultLegendIsReversed(settings),
+    hidden: true,
+    readDependencies: ["stackable.stack_display", "stackable.stack_type"],
+  },
+};
+
 export const TOOLTIP_SETTINGS = {
   "graph.tooltip_type": {
     getDefault: (_series, settings) => {
@@ -332,7 +341,7 @@ export const TOOLTIP_SETTINGS = {
       return shouldShowComparisonTooltip ? "series_comparison" : "default";
     },
     hidden: true,
-    readDependencies: ["stackable.stack_display"],
+    readDependencies: ["stackable.stack_display", "stackable.stack_type"],
   },
 };
 

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -176,6 +176,12 @@ export const getDefaultXAxisScale = (
   return "ordinal";
 };
 
+export const getDefaultLegendIsReversed = (
+  vizSettings: ComputedVisualizationSettings,
+) =>
+  vizSettings["stackable.stack_display"] != null &&
+  vizSettings["stackable.stack_type"] != null;
+
 const WATERFALL_UNSUPPORTED_X_AXIS_SCALES = ["pow", "log"];
 export const isXAxisScaleValid = (
   series: RawSeries,

--- a/frontend/src/metabase/visualizations/types/visualization.ts
+++ b/frontend/src/metabase/visualizations/types/visualization.ts
@@ -33,7 +33,7 @@ export interface RenderingContext {
   fontFamily: string;
 }
 
-type OnChangeCardAndRunOpts = {
+export type OnChangeCardAndRunOpts = {
   previousCard?: Card;
   nextCard: Card;
   seriesIndex?: number;

--- a/frontend/src/metabase/visualizations/visualizations/AreaChart/AreaChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/AreaChart/AreaChart.tsx
@@ -17,6 +17,7 @@ import {
   GRAPH_DISPLAY_VALUES_SETTINGS,
   STACKABLE_SETTINGS,
   TOOLTIP_SETTINGS,
+  LEGEND_SETTINGS,
 } from "../../lib/settings/graph";
 import type {
   ComputedVisualizationSettings,
@@ -43,6 +44,7 @@ Object.assign(
       ...GRAPH_DISPLAY_VALUES_SETTINGS,
       ...GRAPH_DATA_SETTINGS,
       ...TOOLTIP_SETTINGS,
+      ...LEGEND_SETTINGS,
     } as any as VisualizationSettingsDefinitions,
     onDisplayUpdate: (settings: ComputedVisualizationSettings) => {
       if (settings["stackable.stack_display"]) {

--- a/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/BarChart/BarChart.tsx
@@ -16,6 +16,7 @@ import {
   GRAPH_DISPLAY_VALUES_SETTINGS,
   STACKABLE_SETTINGS,
   TOOLTIP_SETTINGS,
+  LEGEND_SETTINGS,
 } from "../../lib/settings/graph";
 import type {
   ComputedVisualizationSettings,
@@ -41,6 +42,7 @@ Object.assign(
       ...GRAPH_DISPLAY_VALUES_SETTINGS,
       ...GRAPH_DATA_SETTINGS,
       ...TOOLTIP_SETTINGS,
+      ...LEGEND_SETTINGS,
     } as any as VisualizationSettingsDefinitions,
     onDisplayUpdate: (settings: ComputedVisualizationSettings) => {
       if (settings["stackable.stack_display"]) {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -47,10 +47,7 @@ function _CartesianChart(props: VisualizationProps) {
   const title = settings["card.title"] || card.name;
   const description = settings["card.description"];
 
-  const { legendItems, isReversed } = useMemo(
-    () => getLegendItems(chartModel, settings),
-    [chartModel, settings],
-  );
+  const legendItems = useMemo(() => getLegendItems(chartModel), [chartModel]);
   const hasLegend = legendItems.length > 1;
 
   const handleInit = useCallback((chart: EChartsType) => {
@@ -85,7 +82,7 @@ function _CartesianChart(props: VisualizationProps) {
         />
       )}
       <CartesianChartLegendLayout
-        isReversed={isReversed}
+        isReversed={settings["legend.is_reversed"]}
         hasLegend={hasLegend}
         labels={legendItems.map(item => item.name)}
         colors={legendItems.map(item => item.color)}

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -122,7 +122,9 @@ export const getEventDimensions = (
     });
   }
 
-  return dimensions;
+  return dimensions.filter(
+    dimension => dimension.column.source !== "query-transform",
+  );
 };
 
 export const getEventColumnsData = (

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/funnel-bar-transform.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/funnel-bar-transform.ts
@@ -18,14 +18,13 @@ export const funnelToBarTransform: TransformSeries = (
     col => col.name === settings["funnel.metric"],
   );
 
-  return rows.map((row, index) => {
+  return rows.map(row => {
     const name = renderingContext.formatValue(row[dimensionIndex], {
       column: cols[dimensionIndex],
     });
     return {
       card: {
         ...card,
-        id: index,
         name,
         display: "bar",
         visualization_settings: {
@@ -35,6 +34,8 @@ export const funnelToBarTransform: TransformSeries = (
           "graph.dimensions": [settings["funnel.dimension"]],
           "graph.metrics": [name],
           "graph.y_axis.auto_split": false,
+          "graph.y_axis.title_text": cols[metricIndex].display_name,
+          "legend.is_reversed": false,
         },
       },
       data: {

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/scalars-bar-transform.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/scalars-bar-transform.ts
@@ -22,7 +22,10 @@ export const scalarToBarTransform: TransformSeries = rawSeries => {
           name: "name",
           source: "query-transform",
         },
-        { ...data.cols[metricColumnIndex], name: card.name },
+        {
+          ...data.cols[metricColumnIndex],
+          name: card.name,
+        },
       ],
       rows: [[card.name, data.rows[0][metricColumnIndex]]],
     };
@@ -36,6 +39,7 @@ export const scalarToBarTransform: TransformSeries = rawSeries => {
         "stackable.stack_type": "stacked",
         "graph.dimensions": [transformedDataset.cols[0].name],
         "graph.metrics": [card.name],
+        "legend.is_reversed": false,
       },
     };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37825

### Description

This PR fixes the following cases:

**Funnel bar chart**
- Clicking on the funnel bar legend from a dashboard should open the chart in QB
- Funnel bar dashcard title click should open the chart in QB
- Adds missing y-axis name
- Clicking on a bar shows correct drill popover

**Combined scalars**
- Click on combined scalar legend item opens the clicked scalar card

### How to verify

Verify cases above
