### PR TITLE
fix two y-axis each render splitlines

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
@@ -56,6 +56,20 @@ BarOrdinalXScale.args = {
   renderingContext,
 };
 
+export const BarTwoAxesStackedWithNegativeValues = Template.bind({});
+BarTwoAxesStackedWithNegativeValues.args = {
+  rawSeries: data.barTwoAxesStackedWithNegativeValues as any,
+  dashcardSettings: {},
+  renderingContext,
+};
+
+export const BarBreakoutWithLineSeriesStackedRightAxisOnly = Template.bind({});
+BarBreakoutWithLineSeriesStackedRightAxisOnly.args = {
+  rawSeries: data.barBreakoutWithLineSeriesStackedRightAxisOnly as any,
+  dashcardSettings: {},
+  renderingContext,
+};
+
 export const SplitYAxis = Template.bind({});
 SplitYAxis.args = {
   rawSeries: data.autoYSplit as any,

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-breakout-with-line-series-stacked-right-axis-only.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-breakout-with-line-series-stacked-right-axis-only.json
@@ -1,0 +1,647 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 5,
+      "result_metadata": [
+        {
+          "description": "The date and time an order was submitted.",
+          "semantic_type": "type/CreationTimestamp",
+          "coercion_strategy": null,
+          "unit": "year",
+          "name": "CREATED_AT",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            38,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "year"
+            }
+          ],
+          "effective_type": "type/DateTime",
+          "id": 38,
+          "visibility_type": "normal",
+          "display_name": "Created At",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 10001,
+              "nil%": 0
+            },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2022-04-30T18:56:13.352Z",
+                "latest": "2026-04-19T14:07:15.657Z"
+              }
+            }
+          },
+          "base_type": "type/DateTime"
+        },
+        {
+          "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+          "semantic_type": "type/Category",
+          "coercion_strategy": null,
+          "name": "CATEGORY",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            64,
+            {
+              "base-type": "type/Text",
+              "source-field": 37
+            }
+          ],
+          "effective_type": "type/Text",
+          "id": 64,
+          "visibility_type": "normal",
+          "display_name": "Product → Category",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 4,
+              "nil%": 0
+            },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 6.375
+              }
+            }
+          },
+          "base_type": "type/Text"
+        },
+        {
+          "display_name": "Average of Total with negative",
+          "field_ref": [
+            "aggregation",
+            0
+          ],
+          "name": "avg",
+          "base_type": "type/Float",
+          "effective_type": "type/Float",
+          "semantic_type": null,
+          "fingerprint": {
+            "global": {
+              "distinct-count": 20,
+              "nil%": 0
+            },
+            "type": {
+              "type/Number": {
+                "min": -25.01883071513849,
+                "q1": -8.265793584324337,
+                "q3": 36.15967901936148,
+                "max": 41.1472155869155,
+                "sd": 23.54601680410227,
+                "avg": 17.204487651704788
+              }
+            }
+          }
+        }
+      ],
+      "database_id": 1,
+      "enable_embedding": false,
+      "collection_id": null,
+      "query_type": "query",
+      "name": "bar-breakout-with-line-series-stacked-right-axis-only",
+      "creator_id": 1,
+      "updated_at": "2024-01-16T21:07:48.772419-03:00",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "database": 1,
+        "type": "query",
+        "query": {
+          "source-table": 5,
+          "expressions": {
+            "Total with negative": [
+              "case",
+              [
+                [
+                  [
+                    ">",
+                    [
+                      "field",
+                      39,
+                      {
+                        "base-type": "type/Float"
+                      }
+                    ],
+                    78
+                  ],
+                  [
+                    "field",
+                    39,
+                    {
+                      "base-type": "type/Float"
+                    }
+                  ]
+                ]
+              ],
+              {
+                "default": [
+                  "-",
+                  0,
+                  [
+                    "field",
+                    39,
+                    {
+                      "base-type": "type/Float"
+                    }
+                  ]
+                ]
+              }
+            ]
+          },
+          "aggregation": [
+            [
+              "avg",
+              [
+                "expression",
+                "Total with negative"
+              ]
+            ]
+          ],
+          "breakout": [
+            [
+              "field",
+              38,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "year"
+              }
+            ],
+            [
+              "field",
+              64,
+              {
+                "base-type": "type/Text",
+                "source-field": 37
+              }
+            ]
+          ]
+        }
+      },
+      "id": 163,
+      "parameter_mappings": [],
+      "display": "bar",
+      "entity_id": "WssADU9jAHUrp3N_Gv-15",
+      "collection_preview": true,
+      "visualization_settings": {
+        "graph.show_goal": false,
+        "graph.show_values": true,
+        "graph.series_order_dimension": "CATEGORY",
+        "graph.y_axis.scale": "linear",
+        "graph.label_value_frequency": "fit",
+        "graph.metrics": [
+          "avg"
+        ],
+        "graph.label_value_formatting": "auto",
+        "graph.series_order": [
+          {
+            "key": "Doohickey",
+            "color": "#88BF4D",
+            "enabled": true,
+            "name": "Doohickey"
+          },
+          {
+            "key": "Gadget",
+            "color": "#F9D45C",
+            "enabled": true,
+            "name": "Gadget"
+          },
+          {
+            "key": "Gizmo",
+            "color": "#A989C5",
+            "enabled": true,
+            "name": "Gizmo"
+          },
+          {
+            "key": "Widget",
+            "color": "#F2A86F",
+            "enabled": true,
+            "name": "Widget"
+          }
+        ],
+        "series_settings": {
+          "Gizmo": {
+            "display": "line",
+            "axis": "right",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": true
+          },
+          "Gadget": {
+            "display": "bar",
+            "axis": "right",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": true
+          },
+          "Doohickey": {
+            "axis": "right",
+            "display": "bar",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": true
+          },
+          "Widget": {
+            "axis": "right",
+            "display": "bar",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": true
+          }
+        },
+        "graph.dimensions": [
+          "CREATED_AT",
+          "CATEGORY"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "metabase_version": "v1.48.1-SNAPSHOT (6934865)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2024-01-16T21:06:36.564582-03:00",
+      "public_uuid": null
+    },
+    "data": {
+      "cols": [
+        {
+          "description": "The date and time an order was submitted.",
+          "semantic_type": "type/CreationTimestamp",
+          "table_id": 5,
+          "coercion_strategy": null,
+          "unit": "year",
+          "name": "CREATED_AT",
+          "settings": null,
+          "source": "breakout",
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            38,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "year"
+            }
+          ],
+          "effective_type": "type/DateTime",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 38,
+          "position": 7,
+          "visibility_type": "normal",
+          "display_name": "Created At",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 10001,
+              "nil%": 0
+            },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2022-04-30T18:56:13.352Z",
+                "latest": "2026-04-19T14:07:15.657Z"
+              }
+            }
+          },
+          "base_type": "type/DateTime"
+        },
+        {
+          "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+          "semantic_type": "type/Category",
+          "table_id": 8,
+          "coercion_strategy": null,
+          "name": "CATEGORY",
+          "settings": null,
+          "source": "breakout",
+          "fk_target_field_id": null,
+          "fk_field_id": 37,
+          "field_ref": [
+            "field",
+            64,
+            {
+              "base-type": "type/Text",
+              "source-field": 37
+            }
+          ],
+          "effective_type": "type/Text",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 64,
+          "position": 3,
+          "visibility_type": "normal",
+          "display_name": "Product → Category",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 4,
+              "nil%": 0
+            },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 6.375
+              }
+            }
+          },
+          "base_type": "type/Text",
+          "source_alias": "PRODUCTS__via__PRODUCT_ID"
+        },
+        {
+          "base_type": "type/Float",
+          "name": "avg",
+          "display_name": "Average of Total with negative",
+          "source": "aggregation",
+          "field_ref": [
+            "aggregation",
+            0
+          ],
+          "aggregation_index": 0,
+          "effective_type": "type/Float"
+        }
+      ],
+      "native_form": {
+        "query": "SELECT DATE_TRUNC('year', \"source\".\"CREATED_AT\") AS \"CREATED_AT\", \"source\".\"PRODUCTS__via__PRODUCT_ID__CATEGORY\" AS \"PRODUCTS__via__PRODUCT_ID__CATEGORY\", AVG(\"source\".\"Total with negative\") AS \"avg\" FROM (SELECT \"PUBLIC\".\"ORDERS\".\"PRODUCT_ID\" AS \"PRODUCT_ID\", \"PUBLIC\".\"ORDERS\".\"TOTAL\" AS \"TOTAL\", \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" AS \"CREATED_AT\", CASE WHEN \"PUBLIC\".\"ORDERS\".\"TOTAL\" > 78 THEN \"PUBLIC\".\"ORDERS\".\"TOTAL\" ELSE 0 - \"PUBLIC\".\"ORDERS\".\"TOTAL\" END AS \"Total with negative\", \"PRODUCTS__via__PRODUCT_ID\".\"CATEGORY\" AS \"PRODUCTS__via__PRODUCT_ID__CATEGORY\", \"PRODUCTS__via__PRODUCT_ID\".\"ID\" AS \"PRODUCTS__via__PRODUCT_ID__ID\" FROM \"PUBLIC\".\"ORDERS\" LEFT JOIN \"PUBLIC\".\"PRODUCTS\" AS \"PRODUCTS__via__PRODUCT_ID\" ON \"PUBLIC\".\"ORDERS\".\"PRODUCT_ID\" = \"PRODUCTS__via__PRODUCT_ID\".\"ID\") AS \"source\" GROUP BY DATE_TRUNC('year', \"source\".\"CREATED_AT\"), \"source\".\"PRODUCTS__via__PRODUCT_ID__CATEGORY\" ORDER BY DATE_TRUNC('year', \"source\".\"CREATED_AT\") ASC, \"source\".\"PRODUCTS__via__PRODUCT_ID__CATEGORY\" ASC",
+        "params": null
+      },
+      "viz-settings": {
+        "graph.show_goal": false,
+        "graph.show_values": true,
+        "metabase.shared.models.visualization-settings/column-settings": {},
+        "graph.series_order_dimension": "CATEGORY",
+        "graph.y_axis.scale": "linear",
+        "graph.label_value_frequency": "fit",
+        "graph.metrics": [
+          "avg"
+        ],
+        "graph.label_value_formatting": "auto",
+        "graph.series_order": [
+          {
+            "key": "Doohickey",
+            "color": "#88BF4D",
+            "enabled": true,
+            "name": "Doohickey"
+          },
+          {
+            "key": "Gadget",
+            "color": "#F9D45C",
+            "enabled": true,
+            "name": "Gadget"
+          },
+          {
+            "key": "Gizmo",
+            "color": "#A989C5",
+            "enabled": true,
+            "name": "Gizmo"
+          },
+          {
+            "key": "Widget",
+            "color": "#F2A86F",
+            "enabled": true,
+            "name": "Widget"
+          }
+        ],
+        "metabase.shared.models.visualization-settings/global-column-settings": {},
+        "series_settings": {
+          "Gizmo": {
+            "display": "line",
+            "axis": "right"
+          },
+          "Gadget": {
+            "display": "bar",
+            "axis": "right"
+          },
+          "Doohickey": {
+            "axis": "right"
+          },
+          "Widget": {
+            "axis": "right",
+            "display": "bar"
+          }
+        },
+        "graph.dimensions": [
+          "CREATED_AT",
+          "CATEGORY"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "results_timezone": "America/Montevideo",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": "The date and time an order was submitted.",
+            "semantic_type": "type/CreationTimestamp",
+            "coercion_strategy": null,
+            "unit": "year",
+            "name": "CREATED_AT",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": [
+              "field",
+              38,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "year"
+              }
+            ],
+            "effective_type": "type/DateTime",
+            "id": 38,
+            "visibility_type": "normal",
+            "display_name": "Created At",
+            "fingerprint": {
+              "global": {
+                "distinct-count": 10001,
+                "nil%": 0
+              },
+              "type": {
+                "type/DateTime": {
+                  "earliest": "2022-04-30T18:56:13.352Z",
+                  "latest": "2026-04-19T14:07:15.657Z"
+                }
+              }
+            },
+            "base_type": "type/DateTime"
+          },
+          {
+            "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+            "semantic_type": "type/Category",
+            "coercion_strategy": null,
+            "name": "CATEGORY",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": [
+              "field",
+              64,
+              {
+                "base-type": "type/Text",
+                "source-field": 37
+              }
+            ],
+            "effective_type": "type/Text",
+            "id": 64,
+            "visibility_type": "normal",
+            "display_name": "Product → Category",
+            "fingerprint": {
+              "global": {
+                "distinct-count": 4,
+                "nil%": 0
+              },
+              "type": {
+                "type/Text": {
+                  "percent-json": 0,
+                  "percent-url": 0,
+                  "percent-email": 0,
+                  "percent-state": 0,
+                  "average-length": 6.375
+                }
+              }
+            },
+            "base_type": "type/Text"
+          },
+          {
+            "display_name": "Average of Total with negative",
+            "field_ref": [
+              "aggregation",
+              0
+            ],
+            "name": "avg",
+            "base_type": "type/Float",
+            "effective_type": "type/Float",
+            "semantic_type": null,
+            "fingerprint": {
+              "global": {
+                "distinct-count": 20,
+                "nil%": 0
+              },
+              "type": {
+                "type/Number": {
+                  "min": -25.01883071513849,
+                  "q1": -8.265793584324337,
+                  "q3": 36.15967901936148,
+                  "max": 41.1472155869155,
+                  "sd": 23.54601680410227,
+                  "avg": 17.204487651704788
+                }
+              }
+            }
+          }
+        ]
+      },
+      "insights": null,
+      "rows": [
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Doohickey",
+          -17.223465277480326
+        ],
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Gadget",
+          -13.551016151218196
+        ],
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Gizmo",
+          11.766175703905454
+        ],
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Widget",
+          -8.300098001441754
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Doohickey",
+          -25.01883071513849
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Gadget",
+          -8.482822417191935
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Gizmo",
+          -8.23148916720692
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Widget",
+          -6.791809016018082
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Doohickey",
+          29.87776597143223
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Gadget",
+          34.939040051113736
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Gizmo",
+          35.505214703850605
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Widget",
+          36.81414333487234
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Doohickey",
+          24.60392384643569
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Gadget",
+          40.43924528814757
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Gizmo",
+          38.63242829314229
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Widget",
+          33.47069332869943
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Doohickey",
+          31.835187705698154
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Gadget",
+          41.1472155869155
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Gizmo",
+          32.76309655012521
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Widget",
+          39.8951534154533
+        ]
+      ]
+    }
+  }
+]

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-two-axes-stacked-with-negative-values.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-two-axes-stacked-with-negative-values.json
@@ -1,0 +1,624 @@
+[
+  {
+    "card": {
+      "description": null,
+      "archived": false,
+      "collection_position": null,
+      "table_id": 5,
+      "result_metadata": [
+        {
+          "description": "The date and time an order was submitted.",
+          "semantic_type": "type/CreationTimestamp",
+          "coercion_strategy": null,
+          "unit": "year",
+          "name": "CREATED_AT",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            38,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "year"
+            }
+          ],
+          "effective_type": "type/DateTime",
+          "id": 38,
+          "visibility_type": "normal",
+          "display_name": "Created At",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 10001,
+              "nil%": 0
+            },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2022-04-30T18:56:13.352Z",
+                "latest": "2026-04-19T14:07:15.657Z"
+              }
+            }
+          },
+          "base_type": "type/DateTime"
+        },
+        {
+          "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+          "semantic_type": "type/Category",
+          "coercion_strategy": null,
+          "name": "CATEGORY",
+          "settings": null,
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            64,
+            {
+              "base-type": "type/Text",
+              "source-field": 37
+            }
+          ],
+          "effective_type": "type/Text",
+          "id": 64,
+          "visibility_type": "normal",
+          "display_name": "Product → Category",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 4,
+              "nil%": 0
+            },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 6.375
+              }
+            }
+          },
+          "base_type": "type/Text"
+        },
+        {
+          "display_name": "Average of Total with negative",
+          "field_ref": [
+            "aggregation",
+            0
+          ],
+          "name": "avg",
+          "base_type": "type/Float",
+          "effective_type": "type/Float",
+          "semantic_type": null,
+          "fingerprint": {
+            "global": {
+              "distinct-count": 20,
+              "nil%": 0
+            },
+            "type": {
+              "type/Number": {
+                "min": -25.01883071513849,
+                "q1": -8.265793584324337,
+                "q3": 36.15967901936148,
+                "max": 41.1472155869155,
+                "sd": 23.54601680410227,
+                "avg": 17.204487651704788
+              }
+            }
+          }
+        }
+      ],
+      "database_id": 1,
+      "enable_embedding": false,
+      "collection_id": null,
+      "query_type": "query",
+      "name": "bar-two-axes-stacked-with-negative-values-stacked",
+      "creator_id": 1,
+      "updated_at": "2024-01-16T21:07:48.754757-03:00",
+      "made_public_by_id": null,
+      "embedding_params": null,
+      "cache_ttl": null,
+      "dataset_query": {
+        "database": 1,
+        "type": "query",
+        "query": {
+          "source-table": 5,
+          "expressions": {
+            "Total with negative": [
+              "case",
+              [
+                [
+                  [
+                    ">",
+                    [
+                      "field",
+                      39,
+                      {
+                        "base-type": "type/Float"
+                      }
+                    ],
+                    78
+                  ],
+                  [
+                    "field",
+                    39,
+                    {
+                      "base-type": "type/Float"
+                    }
+                  ]
+                ]
+              ],
+              {
+                "default": [
+                  "-",
+                  0,
+                  [
+                    "field",
+                    39,
+                    {
+                      "base-type": "type/Float"
+                    }
+                  ]
+                ]
+              }
+            ]
+          },
+          "aggregation": [
+            [
+              "avg",
+              [
+                "expression",
+                "Total with negative"
+              ]
+            ]
+          ],
+          "breakout": [
+            [
+              "field",
+              38,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "year"
+              }
+            ],
+            [
+              "field",
+              64,
+              {
+                "base-type": "type/Text",
+                "source-field": 37
+              }
+            ]
+          ]
+        }
+      },
+      "id": 162,
+      "parameter_mappings": [],
+      "display": "bar",
+      "entity_id": "uVJnyVECmRpZCBB1kHQ1R",
+      "collection_preview": true,
+      "visualization_settings": {
+        "graph.show_goal": false,
+        "graph.show_values": true,
+        "graph.series_order_dimension": "CATEGORY",
+        "graph.y_axis.scale": "linear",
+        "graph.label_value_frequency": "fit",
+        "graph.metrics": [
+          "avg"
+        ],
+        "graph.label_value_formatting": "auto",
+        "graph.series_order": [
+          {
+            "key": "Doohickey",
+            "color": "#88BF4D",
+            "enabled": true,
+            "name": "Doohickey"
+          },
+          {
+            "key": "Gadget",
+            "color": "#F9D45C",
+            "enabled": true,
+            "name": "Gadget"
+          },
+          {
+            "key": "Gizmo",
+            "color": "#A989C5",
+            "enabled": true,
+            "name": "Gizmo"
+          },
+          {
+            "key": "Widget",
+            "color": "#F2A86F",
+            "enabled": true,
+            "name": "Widget"
+          }
+        ],
+        "series_settings": {
+          "Gizmo": {
+            "display": "bar",
+            "axis": "right",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": true
+          },
+          "Gadget": {
+            "display": "bar",
+            "axis": "right",
+            "line.interpolate": "linear",
+            "line.marker_enabled": null,
+            "line.missing": "interpolate",
+            "show_series_values": true
+          }
+        },
+        "graph.dimensions": [
+          "CREATED_AT",
+          "CATEGORY"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "metabase_version": "v1.48.1-SNAPSHOT (6934865)",
+      "parameters": [],
+      "dataset": false,
+      "created_at": "2024-01-16T21:02:28.348713-03:00",
+      "public_uuid": null
+    },
+    "data": {
+      "cols": [
+        {
+          "description": "The date and time an order was submitted.",
+          "semantic_type": "type/CreationTimestamp",
+          "table_id": 5,
+          "coercion_strategy": null,
+          "unit": "year",
+          "name": "CREATED_AT",
+          "settings": null,
+          "source": "breakout",
+          "fk_target_field_id": null,
+          "field_ref": [
+            "field",
+            38,
+            {
+              "base-type": "type/DateTime",
+              "temporal-unit": "year"
+            }
+          ],
+          "effective_type": "type/DateTime",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 38,
+          "position": 7,
+          "visibility_type": "normal",
+          "display_name": "Created At",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 10001,
+              "nil%": 0
+            },
+            "type": {
+              "type/DateTime": {
+                "earliest": "2022-04-30T18:56:13.352Z",
+                "latest": "2026-04-19T14:07:15.657Z"
+              }
+            }
+          },
+          "base_type": "type/DateTime"
+        },
+        {
+          "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+          "semantic_type": "type/Category",
+          "table_id": 8,
+          "coercion_strategy": null,
+          "name": "CATEGORY",
+          "settings": null,
+          "source": "breakout",
+          "fk_target_field_id": null,
+          "fk_field_id": 37,
+          "field_ref": [
+            "field",
+            64,
+            {
+              "base-type": "type/Text",
+              "source-field": 37
+            }
+          ],
+          "effective_type": "type/Text",
+          "nfc_path": null,
+          "parent_id": null,
+          "id": 64,
+          "position": 3,
+          "visibility_type": "normal",
+          "display_name": "Product → Category",
+          "fingerprint": {
+            "global": {
+              "distinct-count": 4,
+              "nil%": 0
+            },
+            "type": {
+              "type/Text": {
+                "percent-json": 0,
+                "percent-url": 0,
+                "percent-email": 0,
+                "percent-state": 0,
+                "average-length": 6.375
+              }
+            }
+          },
+          "base_type": "type/Text",
+          "source_alias": "PRODUCTS__via__PRODUCT_ID"
+        },
+        {
+          "base_type": "type/Float",
+          "name": "avg",
+          "display_name": "Average of Total with negative",
+          "source": "aggregation",
+          "field_ref": [
+            "aggregation",
+            0
+          ],
+          "aggregation_index": 0,
+          "effective_type": "type/Float"
+        }
+      ],
+      "native_form": {
+        "query": "SELECT DATE_TRUNC('year', \"source\".\"CREATED_AT\") AS \"CREATED_AT\", \"source\".\"PRODUCTS__via__PRODUCT_ID__CATEGORY\" AS \"PRODUCTS__via__PRODUCT_ID__CATEGORY\", AVG(\"source\".\"Total with negative\") AS \"avg\" FROM (SELECT \"PUBLIC\".\"ORDERS\".\"PRODUCT_ID\" AS \"PRODUCT_ID\", \"PUBLIC\".\"ORDERS\".\"TOTAL\" AS \"TOTAL\", \"PUBLIC\".\"ORDERS\".\"CREATED_AT\" AS \"CREATED_AT\", CASE WHEN \"PUBLIC\".\"ORDERS\".\"TOTAL\" > 78 THEN \"PUBLIC\".\"ORDERS\".\"TOTAL\" ELSE 0 - \"PUBLIC\".\"ORDERS\".\"TOTAL\" END AS \"Total with negative\", \"PRODUCTS__via__PRODUCT_ID\".\"CATEGORY\" AS \"PRODUCTS__via__PRODUCT_ID__CATEGORY\", \"PRODUCTS__via__PRODUCT_ID\".\"ID\" AS \"PRODUCTS__via__PRODUCT_ID__ID\" FROM \"PUBLIC\".\"ORDERS\" LEFT JOIN \"PUBLIC\".\"PRODUCTS\" AS \"PRODUCTS__via__PRODUCT_ID\" ON \"PUBLIC\".\"ORDERS\".\"PRODUCT_ID\" = \"PRODUCTS__via__PRODUCT_ID\".\"ID\") AS \"source\" GROUP BY DATE_TRUNC('year', \"source\".\"CREATED_AT\"), \"source\".\"PRODUCTS__via__PRODUCT_ID__CATEGORY\" ORDER BY DATE_TRUNC('year', \"source\".\"CREATED_AT\") ASC, \"source\".\"PRODUCTS__via__PRODUCT_ID__CATEGORY\" ASC",
+        "params": null
+      },
+      "viz-settings": {
+        "graph.show_goal": false,
+        "graph.show_values": true,
+        "metabase.shared.models.visualization-settings/column-settings": {},
+        "graph.series_order_dimension": "CATEGORY",
+        "graph.y_axis.scale": "linear",
+        "graph.label_value_frequency": "fit",
+        "graph.metrics": [
+          "avg"
+        ],
+        "graph.label_value_formatting": "auto",
+        "graph.series_order": [
+          {
+            "key": "Doohickey",
+            "color": "#88BF4D",
+            "enabled": true,
+            "name": "Doohickey"
+          },
+          {
+            "key": "Gadget",
+            "color": "#F9D45C",
+            "enabled": true,
+            "name": "Gadget"
+          },
+          {
+            "key": "Gizmo",
+            "color": "#A989C5",
+            "enabled": true,
+            "name": "Gizmo"
+          },
+          {
+            "key": "Widget",
+            "color": "#F2A86F",
+            "enabled": true,
+            "name": "Widget"
+          }
+        ],
+        "metabase.shared.models.visualization-settings/global-column-settings": {},
+        "series_settings": {
+          "Gizmo": {
+            "display": "bar",
+            "axis": "right"
+          },
+          "Gadget": {
+            "display": "bar",
+            "axis": "right"
+          }
+        },
+        "graph.dimensions": [
+          "CREATED_AT",
+          "CATEGORY"
+        ],
+        "stackable.stack_type": "stacked"
+      },
+      "results_timezone": "America/Montevideo",
+      "results_metadata": {
+        "columns": [
+          {
+            "description": "The date and time an order was submitted.",
+            "semantic_type": "type/CreationTimestamp",
+            "coercion_strategy": null,
+            "unit": "year",
+            "name": "CREATED_AT",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": [
+              "field",
+              38,
+              {
+                "base-type": "type/DateTime",
+                "temporal-unit": "year"
+              }
+            ],
+            "effective_type": "type/DateTime",
+            "id": 38,
+            "visibility_type": "normal",
+            "display_name": "Created At",
+            "fingerprint": {
+              "global": {
+                "distinct-count": 10001,
+                "nil%": 0
+              },
+              "type": {
+                "type/DateTime": {
+                  "earliest": "2022-04-30T18:56:13.352Z",
+                  "latest": "2026-04-19T14:07:15.657Z"
+                }
+              }
+            },
+            "base_type": "type/DateTime"
+          },
+          {
+            "description": "The type of product, valid values include: Doohicky, Gadget, Gizmo and Widget",
+            "semantic_type": "type/Category",
+            "coercion_strategy": null,
+            "name": "CATEGORY",
+            "settings": null,
+            "fk_target_field_id": null,
+            "field_ref": [
+              "field",
+              64,
+              {
+                "base-type": "type/Text",
+                "source-field": 37
+              }
+            ],
+            "effective_type": "type/Text",
+            "id": 64,
+            "visibility_type": "normal",
+            "display_name": "Product → Category",
+            "fingerprint": {
+              "global": {
+                "distinct-count": 4,
+                "nil%": 0
+              },
+              "type": {
+                "type/Text": {
+                  "percent-json": 0,
+                  "percent-url": 0,
+                  "percent-email": 0,
+                  "percent-state": 0,
+                  "average-length": 6.375
+                }
+              }
+            },
+            "base_type": "type/Text"
+          },
+          {
+            "display_name": "Average of Total with negative",
+            "field_ref": [
+              "aggregation",
+              0
+            ],
+            "name": "avg",
+            "base_type": "type/Float",
+            "effective_type": "type/Float",
+            "semantic_type": null,
+            "fingerprint": {
+              "global": {
+                "distinct-count": 20,
+                "nil%": 0
+              },
+              "type": {
+                "type/Number": {
+                  "min": -25.01883071513849,
+                  "q1": -8.265793584324337,
+                  "q3": 36.15967901936148,
+                  "max": 41.1472155869155,
+                  "sd": 23.54601680410227,
+                  "avg": 17.204487651704788
+                }
+              }
+            }
+          }
+        ]
+      },
+      "insights": null,
+      "rows": [
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Doohickey",
+          -17.223465277480326
+        ],
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Gadget",
+          -13.551016151218196
+        ],
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Gizmo",
+          11.766175703905454
+        ],
+        [
+          "2022-01-01T00:00:00-03:00",
+          "Widget",
+          -8.300098001441754
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Doohickey",
+          -25.01883071513849
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Gadget",
+          -8.482822417191935
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Gizmo",
+          -8.23148916720692
+        ],
+        [
+          "2023-01-01T00:00:00-03:00",
+          "Widget",
+          -6.791809016018082
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Doohickey",
+          29.87776597143223
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Gadget",
+          34.939040051113736
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Gizmo",
+          35.505214703850605
+        ],
+        [
+          "2024-01-01T00:00:00-03:00",
+          "Widget",
+          36.81414333487234
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Doohickey",
+          24.60392384643569
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Gadget",
+          40.43924528814757
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Gizmo",
+          38.63242829314229
+        ],
+        [
+          "2025-01-01T00:00:00-03:00",
+          "Widget",
+          33.47069332869943
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Doohickey",
+          31.835187705698154
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Gadget",
+          41.1472155869155
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Gizmo",
+          32.76309655012521
+        ],
+        [
+          "2026-01-01T00:00:00-03:00",
+          "Widget",
+          39.8951534154533
+        ]
+      ]
+    }
+  }
+]

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/index.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/index.ts
@@ -2,6 +2,8 @@ import lineLinearXScale from "./line-linear-x-scale.json";
 import barLinearXScale from "./bar-linear-x-scale.json";
 import barHistogramXScale from "./bar-histogram-x-scale.json";
 import barOrdinalXScale from "./bar-ordinal-x-scale.json";
+import barTwoAxesStackedWithNegativeValues from "./bar-two-axes-stacked-with-negative-values.json";
+import barBreakoutWithLineSeriesStackedRightAxisOnly from "./bar-breakout-with-line-series-stacked-right-axis-only.json";
 import autoYSplit from "./auto-y-split.json";
 import messedUpAxis from "./messed-up-axis.json";
 import trendSingleSeriesLine from "./trend-single-series-line.json";
@@ -23,6 +25,8 @@ export const data = {
   barLinearXScale,
   barHistogramXScale,
   barOrdinalXScale,
+  barTwoAxesStackedWithNegativeValues,
+  barBreakoutWithLineSeriesStackedRightAxisOnly,
   autoYSplit,
   messedUpAxis,
   trendSingleSeriesLine,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -163,7 +163,7 @@ export const buildDimensionAxis = (
     axisLine: {
       show: !!settings["graph.x_axis.axis_enabled"],
       lineStyle: {
-        color: getColor("text-dark"),
+        color: getColor("border"),
       },
     },
   };
@@ -174,6 +174,7 @@ export const buildMetricAxis = (
   ticksWidth: number,
   settings: ComputedVisualizationSettings,
   position: "left" | "right",
+  hasSplitLine: boolean,
   renderingContext: RenderingContext,
 ): CartesianAxisOption => {
   const shouldFlipAxisName = position === "right";
@@ -191,12 +192,14 @@ export const buildMetricAxis = (
       axisModel.label,
       shouldFlipAxisName ? -90 : undefined,
     ),
-    splitLine: {
-      lineStyle: {
-        type: 5,
-        color: renderingContext.getColor("border"),
-      },
-    },
+    splitLine: hasSplitLine
+      ? {
+          lineStyle: {
+            type: 5,
+            color: renderingContext.getColor("border"),
+          },
+        }
+      : undefined,
     position,
     axisLine: {
       show: false,
@@ -229,18 +232,21 @@ const buildMetricsAxes = (
         chartMeasurements.ticksDimensions.yTicksWidthLeft,
         settings,
         "left",
+        true,
         renderingContext,
       ),
     );
   }
 
   if (chartModel.rightAxisModel != null) {
+    const isOnlyAxis = chartModel.leftAxisModel == null;
     axes.push(
       buildMetricAxis(
         chartModel.rightAxisModel,
         chartMeasurements.ticksDimensions.yTicksWidthRight,
         settings,
         "right",
+        isOnlyAxis,
         renderingContext,
       ),
     );


### PR DESCRIPTION
### Description

Fix two y-axis render their own splitlines which looks noisy. Previously, we rendered splitlines only for one axis.
Also closes https://github.com/metabase/metabase/issues/36824

### How to verify

- create a question with multiple series and assign them to different y-axes
- ensure the chart renders split lines only for left y-axis
- assign all series to the right axis
- ensure the chart renders split lines for right y-axis

### Demo

Labels on the screenshot are wrong but they will be fixed by https://github.com/metabase/metabase/pull/37721
<img width="718" alt="Screenshot 2024-01-16 at 9 04 17 PM" src="https://github.com/metabase/metabase/assets/14301985/1f93b7fd-045a-4697-a3bd-b703fde1fbd8">


<img width="992" alt="Screenshot 2024-01-16 at 9 05 58 PM" src="https://github.com/metabase/metabase/assets/14301985/cca9e5c8-0999-46f6-993c-2b79e56d0001">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
