### PR TITLE
bump hawk to include the :times option

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -228,7 +228,7 @@
     djblue/portal                {:mvn/version "0.51.0"}                    ; ui for inspecting values
     hashp/hashp                  {:mvn/version "0.2.2"}                     ; debugging/spying utility
     io.github.camsaul/humane-are {:mvn/version "1.0.2"}
-    io.github.metabase/hawk      {:sha "539eefaa31a43d52d7c9b5731f471bb6742e7131"}
+    io.github.metabase/hawk      {:sha "46835a0b808e86894f598472351c08d81aeb1910"}
     jonase/eastwood              {:mvn/version "1.4.2"                      ; inspects namespaces and reports possible problems using tools.analyzer
                                   :exclusions
                                   [org.ow2.asm/asm-all]}


### PR DESCRIPTION
Bump hawk so we can stress test to run multiple times with the `:times` option.

using it like so
```bash
clj -X :dev:test :only test-vars :times 10
```
this will run `test-vars` 10 times. 
test-var can be a namespace, or a single test, or a list of tests.

You can also use this option on GA UI, see https://github.com/metabase/metabase/pull/35919 for how


The option was implemented in https://github.com/metabase/hawk/pull/16