### PR TITLE
Fix format-personal-collection-name-length-test

### DIFF
--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -39,8 +39,8 @@
 (deftest format-personal-collection-name-length-test
   (testing "test that an unrealistically long collection name with unicode letters is still less than the max length for a slug (metabase#33917)"
     (mt/with-temporary-setting-values [site-locale "ru"]
-      (is (< (count (#'collection/slugify (collection/format-personal-collection-name (apply str (repeat 34 "\u0411")) ; cyrillic "b" characters
-                                                                                      (apply str (repeat 35 "\u0411"))
+      (is (= (count (#'collection/slugify (collection/format-personal-collection-name (apply str (repeat 34 "Б"))
+                                                                                      (apply str (repeat 35 "Б"))
                                                                                       "MetaBase@metabase.com"
                                                                                       :site)))
              (var-get #'collection/collection-slug-max-length))))))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -39,7 +39,7 @@
 (deftest format-personal-collection-name-length-test
   (testing "test that an unrealistically long collection name with unicode letters is still less than the max length for a slug (metabase#33917)"
     (mt/with-temporary-setting-values [site-locale "ru"]
-      (is (= (count (#'collection/slugify (collection/format-personal-collection-name (apply str (repeat 34 "Б"))
+      (is (< (count (#'collection/slugify (collection/format-personal-collection-name (apply str (repeat 34 "Б"))
                                                                                       (apply str (repeat 35 "Б"))
                                                                                       "MetaBase@metabase.com"
                                                                                       :site)))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -39,8 +39,8 @@
 (deftest format-personal-collection-name-length-test
   (testing "test that an unrealistically long collection name with unicode letters is still less than the max length for a slug (metabase#33917)"
     (mt/with-temporary-setting-values [site-locale "ru"]
-      (is (< (count (#'collection/slugify (collection/format-personal-collection-name (repeat 20 "\u0411") ; Cyrillic "b" character
-                                                                                      (repeat 20 "\u0411")
+      (is (< (count (#'collection/slugify (collection/format-personal-collection-name (apply str (repeat 40 "\u0411")) ; cyrillic "b" characters
+                                                                                      (apply str (repeat 40 "\u0411"))
                                                                                       "MetaBase@metabase.com"
                                                                                       :site)))
              (var-get #'collection/collection-slug-max-length))))))

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -39,8 +39,8 @@
 (deftest format-personal-collection-name-length-test
   (testing "test that an unrealistically long collection name with unicode letters is still less than the max length for a slug (metabase#33917)"
     (mt/with-temporary-setting-values [site-locale "ru"]
-      (is (< (count (#'collection/slugify (collection/format-personal-collection-name (apply str (repeat 40 "\u0411")) ; cyrillic "b" characters
-                                                                                      (apply str (repeat 40 "\u0411"))
+      (is (< (count (#'collection/slugify (collection/format-personal-collection-name (apply str (repeat 34 "\u0411")) ; cyrillic "b" characters
+                                                                                      (apply str (repeat 35 "\u0411"))
                                                                                       "MetaBase@metabase.com"
                                                                                       :site)))
              (var-get #'collection/collection-slug-max-length))))))


### PR DESCRIPTION
This PR fixes an incorrectly implemented test introduced by https://github.com/metabase/metabase/pull/33931.

The test is meant to check that the `collection/collection-slug-max-length` is large enough so that even long, translated names can be stored. 

The test previously constructed a first name and last name with `(repeat 20 "\u0411")`, when it should have been `(apply str (repeat 20 "\u0411"))`. I've also increased the number of chars in the test because to demonstrate the number of characters is actually higher than demonstrated before.