### PR TITLE
[MLv2] Update types to accommodate `QueryDisplayInfo`

### DIFF
--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -144,6 +144,18 @@ declare function DisplayInfoFn(
   stageIndex: number,
   segment: SegmentMetadata,
 ): SegmentDisplayInfo;
+/**
+ * Even though it seems weird to pass the same query two times,
+ * this function follows the same pattern as the other displayInfo functions.
+ * The first two parameters are always a query, and a stage.
+ * The third parameter is what you would like to have info about.
+ * It just only happens that the thing we're examining is (again) the query itself.
+ *
+ * @example
+ * const query = question.query();
+ * const { isEditable, isNative } = Lib.displayInfo(query, -1, query);
+ *
+ */
 declare function DisplayInfoFn(
   query: Query,
   stageIndex: number,

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -157,8 +157,8 @@ declare function DisplayInfoFn(
  *
  */
 declare function DisplayInfoFn(
-  query: Query,
-  stageIndex: number,
+  _query: Query,
+  _stageIndex: number,
   queryInfo: Query,
 ): QueryDisplayInfo;
 

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -42,6 +42,7 @@ import type {
   SegmentDisplayInfo,
   TableDisplayInfo,
   TableMetadata,
+  QueryDisplayInfo,
 } from "./types";
 
 export function metadataProvider(
@@ -143,6 +144,11 @@ declare function DisplayInfoFn(
   stageIndex: number,
   segment: SegmentMetadata,
 ): SegmentDisplayInfo;
+declare function DisplayInfoFn(
+  query: Query,
+  stageIndex: number,
+  queryInfo: Query,
+): QueryDisplayInfo;
 
 // x can be any sort of opaque object, e.g. a clause or metadata map. Values returned depend on what you pass in, but it
 // should always have display_name... see :metabase.lib.metadata.calculation/display-info schema

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -150,16 +150,11 @@ declare function DisplayInfoFn(
  * The first two parameters are always a query, and a stage.
  * The third parameter is what you would like to have info about.
  * It just only happens that the thing we're examining is (again) the query itself.
- *
- * @example
- * const query = question.query();
- * const { isEditable, isNative } = Lib.displayInfo(query, -1, query);
- *
  */
 declare function DisplayInfoFn(
   _query: Query,
   _stageIndex: number,
-  queryInfo: Query,
+  query: Query,
 ): QueryDisplayInfo;
 
 // x can be any sort of opaque object, e.g. a clause or metadata map. Values returned depend on what you pass in, but it

--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -507,3 +507,8 @@ export interface FieldValuesSearchInfo {
   searchFieldId: FieldId | null;
   hasFieldValues: FieldValuesType;
 }
+
+export type QueryDisplayInfo = {
+  isNative: boolean;
+  isEditable: boolean;
+};


### PR DESCRIPTION
The progress of https://github.com/metabase/metabase/issues/37389 is blocked by https://github.com/metabase/metabase/issues/37765.

The initial attempt was to both add new types and take care of `isEditable` query methods. In order to unblock further work on #37389, I decided to split the tasks into three. This PR is just the first on the three.

It should unblock the work on migrating `isNative` and `isStructured` methods.