### PR TITLE
Skip listing tables for bigquery driver/can-connect? check

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -80,15 +80,8 @@
 (defn- list-tables
   "Fetch all tables (new pages are loaded automatically by the API)."
   (^Iterable [details]
-   (list-tables details {:validate-dataset? false}))
-  (^Iterable [details {:keys [validate-dataset?]}]
    (let [client (database-details->client details)
          dataset-iter (list-datasets details)]
-     (when (and (not= (:dataset-filters-type details) "all")
-                validate-dataset?
-                (zero? (count dataset-iter)))
-       (throw (ex-info (tru "Looks like we cannot find any matching datasets.")
-                       {::driver/can-connect-message? true})))
      (apply concat (for [^DatasetId dataset-id dataset-iter]
                      (-> (.listTables client dataset-id (u/varargs BigQuery$TableListOption))
                          .iterateAll
@@ -96,14 +89,21 @@
                          iterator-seq))))))
 
 (defmethod driver/can-connect? :bigquery-cloud-sdk
-  [_ details-map]
-  ;; check whether we can connect by seeing whether listing tables succeeds
-  (try (some? (list-tables details-map {:validate-dataset? true}))
-       (catch Exception e
-         (when (::driver/can-connect-message? (ex-data e))
-           (throw e))
-         (log/errorf e (trs "Exception caught in :bigquery-cloud-sdk can-connect?"))
-         false)))
+  [_ details]
+  ;; check whether we can connect by seeing whether listing datasets succeeds
+  (let [[success? datasets] (try [true (list-datasets details)]
+                                 (catch Exception e
+                                   (log/errorf e (trs "Exception caught in :bigquery-cloud-sdk can-connect?"))
+                                   [false nil]))]
+    (cond
+      (not success?)
+      false
+      ;; if the datasets are filtered throw an exception with a message that we can show to the user
+      (and (not= (:dataset-filters-type details) "all")
+           (nil? (first datasets)))
+      (throw (Exception. (tru "Looks like we cannot find any matching datasets.")))
+      :else
+      true)))
 
 (def ^:private empty-table-options
   (u/varargs BigQuery$TableOption))

--- a/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
+++ b/modules/drivers/bigquery-cloud-sdk/src/metabase/driver/bigquery_cloud_sdk.clj
@@ -98,7 +98,8 @@
     (cond
       (not success?)
       false
-      ;; if the datasets are filtered throw an exception with a message that we can show to the user
+      ;; if the datasets are filtered and we don't find any matches, throw an exception with a message that we can show
+      ;; to the user
       (and (not= (:dataset-filters-type details) "all")
            (nil? (first datasets)))
       (throw (Exception. (tru "Looks like we cannot find any matching datasets.")))


### PR DESCRIPTION
Hopefully this fixes this flaking test for bigquery https://github.com/metabase/metabase/issues/36397

It seems like bigquery's `driver/can-connect?` check is sometimes timing out over the 3 second limit we set for tests here:
https://github.com/metabase/metabase/blob/b88e75d76c1601189b10922a453f60768614e8ce/src/metabase/driver/util.clj#L123-L129

I could just raise the limit, but I think we can improve the performance of `driver/can-connect?`, because it's doing more work than it needs to.

Currently, the bigquery implementation of `driver/can-connect?` does three checks which all have to pass for it to return true:
1. We check that `.listDatasets` returns without throwing exceptions.
2. If a filter string on datasets is provided (from the admin panel), we check that there is at least one dataset that matches the filter.
3. For each matching dataset, we check that `.listTables` returns without throwing exceptions.

This PR removes check 3, because being able to list tables in every schema is not required by other implementations of `driver/can-connect?` (most just run a `select 1` or something like it), so I don't think it's necessary for bigquery either. I've also optimized check 2 to short-circuit as soon as one dataset is found, which should speed up the average execution.

Testing locally, this reduces the time it takes to execute `driver/can-connect?` from around 2.5-3.5 seconds on the flaking test to around 1.5s.