### PR TITLE
Fix `editable?` function so that it respects native write permissions

### DIFF
--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -215,6 +215,7 @@
 
   There's no editable flag! Instead, a query is **not** editable if:
   - Database is missing from the metadata (no permissions at all);
+  - Database is present but it doesn't have native write permissions;
   - Database is present but tables (at least the `:source-table`) are missing (missing table permissions); or
   - Similarly, the card specified by `:source-card` is missing from the metadata.
   If metadata for the `:source-table` or `:source-card` can be found, then the query is editable."
@@ -224,4 +225,8 @@
                     (= (:database query) id))
                   (or (and source-table (table query source-table))
                       (and source-card  (card  query source-card))
-                      (= (:lib/type stage0) :mbql.stage/native))))))
+                      (and
+                        (= (:lib/type stage0) :mbql.stage/native)
+                        ;; Couldn't import and use `lib.native/has-write-permissions` here due to a circular dependency
+                        ;; TODO Find a way to unify has-write-permissions and this function?
+                        (= :write (:native-permissions (database query)))))))))

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -128,19 +128,12 @@
       (let [editable     (lib/native-query (lib.tu/mock-metadata-provider
                                             meta/metadata-provider
                                             {:database (merge (lib.metadata/database meta/metadata-provider) {:native-permissions :write})})
-                                           "select * from x;")
-            bad-db       (assoc editable :database 999999999)
-            none-perm-db (assoc editable :native-permissions :none)
-            no-perm-db   (dissoc editable :native-permissions)]
-        (is (= {:is-native   true
-                :is-editable true}
-               (lib/display-info editable -1 editable)))
-        (is (= {:is-native   true
-                :is-editable false}
-               (lib/display-info bad-db -1 bad-db)))
-        (is (= {:is-native   true
-                :is-editable false}
-               (lib/display-info none-perm-db -1 none-perm-db)))
-        (is (= {:is-native   true
-                :is-editable false}
-               (lib/display-info no-perm-db -1 no-perm-db)))))))
+                                           "select * from x;")]
+        (are [editable? query] (= {:is-native   true
+                                   :is-editable editable?}
+                                  (mu/disable-enforcement
+                                   (lib/display-info query -1 query)))
+          true  editable
+          false (assoc editable :database 999999999)          ; database unknown - no permissions
+          false (assoc editable :native-permissions :none)    ; native-permissions explicitly set to :none
+          false (dissoc editable :native-permissions))))))    ; native-permissions not found on the database

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -123,7 +123,7 @@
                        ; source-card not visible
                        (assoc :source-card 999999999)
                        (dissoc :source-table))))))
-    (testing "on native queries"
+    (testing "on native queries (#37765)"
       (let [editable              (lib/native-query meta/metadata-provider "SELECT * FROM Venues;")
             ;; Logic for the native-query mock borrowed from metabase.lib.native/has-write-permission-test
             mock-db-native-perms #(lib/native-query (lib.tu/mock-metadata-provider

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -2413,6 +2413,7 @@
    :options                     nil
    :engine                      :h2
    :initial-sync-status         "complete"
+   :native-permissions          :write
    :dbms-version                {:flavor "H2", :version "2.1.212 (2022-04-09)", :semantic-version [2 1]}
    :refingerprint               nil
    :points-of-interest          nil


### PR DESCRIPTION
Fixes #37765 and unblocks https://github.com/metabase/metabase/issues/37389

This PR adjusts `editable?` function that now takes native permissions into account.
It also adds a few more test cases where those native permissions are explicitly set to `:none` or are missing altogether.

> [!important]
> This PR alters the test database metadata - it adds `:native-permissions :write` to the map. In other words, the default database assumes native write permissions. This wasn't explicitly set previously which was the equivalent of no native permissions.