### PR TITLE
Handle an error of building UI parameters during dashboard fetching

### DIFF
--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -140,9 +140,15 @@ function buildFieldFilterUiParameter(
   const mappedFields = mappingsForParameter.map(mapping => {
     const { target, card } = mapping;
     const question = new Question(card, metadata);
-    const field = getTargetFieldFromCard(target, card, metadata);
 
-    return { field, shouldResolveFkField: !question.isNative() };
+    try {
+      const field = getTargetFieldFromCard(target, card, metadata);
+
+      return { field, shouldResolveFkField: !question.isNative() };
+    } catch (e) {
+      console.error("Error getting a field from a card", { card });
+      throw e;
+    }
   });
 
   const hasVariableTemplateTagTarget = mappingsForParameter.some(mapping => {


### PR DESCRIPTION
related issue https://github.com/metabase/metabase/issues/37779

### Description

It's not possible to understand which card has failed during fetching dashcards, so let's have another try/catch and log some useful info
