### PR TITLE
Rename the jetty-insecure env var

### DIFF
--- a/src/metabase/server.clj
+++ b/src/metabase/server.clj
@@ -29,7 +29,7 @@
     :trust-password  (config/config-str :mb-jetty-ssl-truststore-password)
     :client-auth     (when (config/config-bool :mb-jetty-ssl-client-auth)
                        :need)
-    :sni-host-check? (when (config/config-str :mb-jetty-sni-check)
+    :sni-host-check? (when (config/config-str :mb-jetty-skip-sni)
                        false)}))
 
 (defn- jetty-config []

--- a/src/metabase/server.clj
+++ b/src/metabase/server.clj
@@ -29,7 +29,7 @@
     :trust-password  (config/config-str :mb-jetty-ssl-truststore-password)
     :client-auth     (when (config/config-bool :mb-jetty-ssl-client-auth)
                        :need)
-    :sni-host-check? (when (config/config-str :mb-jetty-ssl-insecure)
+    :sni-host-check? (when (config/config-str :mb-jetty-sni-check)
                        false)}))
 
 (defn- jetty-config []


### PR DESCRIPTION
Renaming the env var to something more specific, sorry, it was my mistake in the first place