### PR TITLE
Add uniqueness constraint on the logical identity of field values

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/params/field_values_test.clj
@@ -1,6 +1,6 @@
 (ns metabase-enterprise.sandbox.models.params.field-values-test
   (:require
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest testing is]]
    [java-time :as t]
    [metabase-enterprise.sandbox.models.group-table-access-policy
     :refer [GroupTableAccessPolicy]]

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5155,16 +5155,24 @@ databaseChangeLog:
   - changeSet:
       id: v49.2024-01-16T12:50:35
       author: crisptruski
-      comment: Add unique constraint on fieldvalues
+      comment: Prepare  fieldvalues
       changes:
         - modifyDataType:
             tableName: metabase_fieldvalues
             columnName: hash_key
+            # we only need 11 characters to fit any 32 bit number, but we leave space in case the hash scheme changes
             newDataType: varchar(32)
-#        - modifyDataType:
-#            tableName: metabase_fieldvalues
-#            columnName: hash_key
-#            newDataType: integer
+      rollback:
+        - modifyDataType:
+            tableName: metabase_fieldvalues
+            columnName: hash_key
+            newDataType: ${text.type}
+
+  - changeSet:
+      id: v49.2024-01-17T13:55:14
+      author: crisptruski
+      comment: Add unique constraint on fieldvalues
+      changes:
         - addUniqueConstraint:
             tableName: metabase_fieldvalues
             constraintName: unique_metabase_fieldvalues_field_id_type_hash_key
@@ -5173,10 +5181,6 @@ databaseChangeLog:
         - dropUniqueConstraint:
             tableName: metabase_fieldvalues
             constraintName: unique_metabase_fieldvalues_field_id_type_hash_key
-        - modifyDataType:
-            tableName: metabase_fieldvalues
-            columnName: hash_key
-            newDataType: ${text.type}
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5170,6 +5170,31 @@ databaseChangeLog:
 
   - changeSet:
       id: v49.2024-01-17T13:55:14
+      author: crisptrutski
+      comment: Prepare  fieldvalues
+      changes:
+        - sql:
+            sql: UPDATE metabase_fieldvalues SET hash_key = '' WHERE hash_key IS NULL;
+      rollback:
+        - sql:
+            sql: UPDATE metabase_fieldvalues SET hash_key = NULL WHERE hash_key = '';
+
+  - changeSet:
+      id: v49.2024-01-17T13:55:16
+      author: crisptrutski
+      comment: Prepare  fieldvalues
+      changes:
+        - addNotNullConstraint:
+            tableName: metabase_fieldvalues
+            columnName: hash_key
+            defaultNullValue: ""
+      rollback:
+        - dropNotNullConstraint:
+            tableName: metabase_fieldvalues
+            columnName: hash_key
+
+  - changeSet:
+      id: v49.2024-01-17T14:11:05
       author: crisptruski
       comment: Add unique constraint on fieldvalues
       changes:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5152,6 +5152,32 @@ databaseChangeLog:
         - dbms:
             type: mysql,mariadb
 
+  - changeSet:
+      id: v49.2024-01-16T12:50:35
+      author: crisptruski
+      comment: Add unique constraint on fieldvalues
+      changes:
+        - modifyDataType:
+            tableName: metabase_fieldvalues
+            columnName: hash_key
+            newDataType: varchar(32)
+#        - modifyDataType:
+#            tableName: metabase_fieldvalues
+#            columnName: hash_key
+#            newDataType: integer
+        - addUniqueConstraint:
+            tableName: metabase_fieldvalues
+            constraintName: unique_metabase_fieldvalues_field_id_type_hash_key
+            columnNames: field_id,type,hash_key
+      rollback:
+        - dropUniqueConstraint:
+            tableName: metabase_fieldvalues
+            constraintName: unique_metabase_fieldvalues_field_id_type_hash_key
+        - modifyDataType:
+            tableName: metabase_fieldvalues
+            columnName: hash_key
+            newDataType: ${text.type}
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5187,11 +5187,13 @@ databaseChangeLog:
         - addNotNullConstraint:
             tableName: metabase_fieldvalues
             columnName: hash_key
+            columnDataType: varchar(32)
             defaultNullValue: ""
       rollback:
         - dropNotNullConstraint:
             tableName: metabase_fieldvalues
             columnName: hash_key
+            columnDataType: varchar(32)
 
   - changeSet:
       id: v49.2024-01-17T14:11:05

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -45,7 +45,7 @@
   30)
 
 (def ^Long auto-list-cardinality-threshold
-  "Fields with less than this many distincy values should be given a `has_field_values` value of `list`, which means
+  "Fields with less than this many distinct values should be given a `has_field_values` value of `list`, which means
   the Field should have FieldValues."
   1000)
 

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -154,9 +154,8 @@
 
 (t2/define-before-insert :model/FieldValues
   [{:keys [field_id] :as field-values}]
-  (u/prog1 (merge {:type :full :hash_key ""}
-                  field-values)
-    (assert-valid-human-readable-values field-values)
+  (u/prog1 (update (merge {:type :full} field-values) :hash_key str)
+           (assert-valid-human-readable-values field-values)
     (assert-valid-field-values-type field-values)
     ;; if inserting a new full fieldvalues, make sure all the advanced field-values of this field is deleted
     (when (= (:type <>) :full)

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -152,6 +152,10 @@
   [field-or-id]
   (t2/delete! FieldValues :field_id (u/the-id field-or-id)))
 
+(t2/define-before-select :model/FieldValues
+  [field-values]
+  (update field-values :hash_key str))
+
 (t2/define-before-insert :model/FieldValues
   [{:keys [field_id] :as field-values}]
   (u/prog1 (update (merge {:type :full} field-values) :hash_key str)
@@ -410,7 +414,6 @@
                     :field_id              (u/the-id field)
                     :has_more_values       has_more_values
                     :values                values
-                    :hash_key ""
                     :human_readable_values human-readable-values)
         ::fv-created)
 

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -129,7 +129,7 @@
                        :stauts-code 400})))
 
     (when (and (= type :full)
-               hash_key)
+               (not (str/blank? hash_key)))
       (throw (ex-info (tru "Full FieldValues shouldn't have hash_key.")
                       {:type        type
                        :hash_key    hash_key
@@ -154,7 +154,7 @@
 
 (t2/define-before-insert :model/FieldValues
   [{:keys [field_id] :as field-values}]
-  (u/prog1 (merge {:type :full}
+  (u/prog1 (merge {:type :full :hash_key ""}
                   field-values)
     (assert-valid-human-readable-values field-values)
     (assert-valid-field-values-type field-values)
@@ -411,6 +411,7 @@
                     :field_id              (u/the-id field)
                     :has_more_values       has_more_values
                     :values                values
+                    :hash_key ""
                     :human_readable_values human-readable-values)
         ::fv-created)
 

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -549,7 +549,7 @@
     m))
 
 (defn index-of
-  "Return index of the first element in `coll` for which `pred` reutrns true."
+  "Return index of the first element in `coll` for which `pred` returns true."
   [pred coll]
   (first (keep-indexed (fn [i x]
                          (when (pred x) i))
@@ -562,7 +562,7 @@
        (re-matches #"[0-9a-f]{64}" new-value)))
 
 (defn topological-sort
-  "Topologically sorts vertexs in graph g. Graph is a map of vertexs to edges. Optionally takes an
+  "Topologically sorts vertexes in graph g. Graph is a map of vertexes to edges. Optionally takes an
    additional argument `edges-fn`, a function used to extract edges. Returns data in the same shape
    (a graph), only sorted.
 

--- a/test/metabase/actions_test.clj
+++ b/test/metabase/actions_test.clj
@@ -1,6 +1,6 @@
 (ns metabase.actions-test
   (:require
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest is testing]]
    [metabase.actions :as actions]
    [metabase.actions.execution :as actions.execution]
    [metabase.api.common :refer [*current-user-permissions-set*]]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3104,7 +3104,7 @@
 (deftest chain-filter-should-use-cached-field-values-test
   (testing "Chain filter endpoints should use cached FieldValues if applicable (#13832)"
     ;; ignore the cache entries added by #23699
-    (mt/with-temp-vals-in-db FieldValues (t2/select-one-pk FieldValues :field_id (mt/id :categories :name) :hash_key "") {:values ["Good" "Bad"]}
+    (mt/with-temp-vals-in-db FieldValues (t2/select-one-pk FieldValues :field_id (mt/id :categories :name)) {:values ["Good" "Bad"]}
       (with-chain-filter-fixtures [{:keys [dashboard]}]
         (testing "GET /api/dashboard/:id/params/:param-key/values"
           (mt/let-url [url (chain-filter-values-url dashboard "_CATEGORY_NAME_")]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4,7 +4,7 @@
    [cheshire.core :as json]
    [clojure.set :as set]
    [clojure.string :as str]
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest is testing use-fixtures]]
    [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.analytics.snowplow-test :as snowplow-test]
@@ -3104,7 +3104,7 @@
 (deftest chain-filter-should-use-cached-field-values-test
   (testing "Chain filter endpoints should use cached FieldValues if applicable (#13832)"
     ;; ignore the cache entries added by #23699
-    (mt/with-temp-vals-in-db FieldValues (t2/select-one-pk FieldValues :field_id (mt/id :categories :name) :hash_key nil) {:values ["Good" "Bad"]}
+    (mt/with-temp-vals-in-db FieldValues (t2/select-one-pk FieldValues :field_id (mt/id :categories :name) :hash_key "") {:values ["Good" "Bad"]}
       (with-chain-filter-fixtures [{:keys [dashboard]}]
         (testing "GET /api/dashboard/:id/params/:param-key/values"
           (mt/let-url [url (chain-filter-values-url dashboard "_CATEGORY_NAME_")]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3104,7 +3104,7 @@
 (deftest chain-filter-should-use-cached-field-values-test
   (testing "Chain filter endpoints should use cached FieldValues if applicable (#13832)"
     ;; ignore the cache entries added by #23699
-    (mt/with-temp-vals-in-db FieldValues (t2/select-one-pk FieldValues :field_id (mt/id :categories :name)) {:values ["Good" "Bad"]}
+    (mt/with-temp-vals-in-db FieldValues (t2/select-one-pk FieldValues :field_id (mt/id :categories :name) :type :full) {:values ["Good" "Bad"]}
       (with-chain-filter-fixtures [{:keys [dashboard]}]
         (testing "GET /api/dashboard/:id/params/:param-key/values"
           (mt/let-url [url (chain-filter-values-url dashboard "_CATEGORY_NAME_")]

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -157,13 +157,16 @@
 
 (deftest normalize-human-readable-values-test
   (testing "If FieldValues were saved as a map, normalize them to a sequence on the way out"
-    (t2.with-temp/with-temp [FieldValues fv {:field_id (mt/id :venues :id)
-                                             :values   (json/generate-string ["1" "2" "3"])}]
-      (is (t2/query-one {:update :metabase_fieldvalues
-                         :set    {:human_readable_values (json/generate-string {"1" "a", "2" "b", "3" "c"})}
-                         :where  [:= :id (:id fv)]}))
-      (is (= ["a" "b" "c"]
-             (:human_readable_values (t2/select-one FieldValues :id (:id fv))))))))
+    (let [field-id (mt/id :venues :id)]
+      ;; hack: clean up from previous tests
+      (t2/delete! FieldValues :field_id field-id)
+      (t2.with-temp/with-temp [FieldValues fv {:field_id field-id
+                                               :values   (json/generate-string ["1" "2" "3"])}]
+        (is (t2/query-one {:update :metabase_fieldvalues
+                           :set    {:human_readable_values (json/generate-string {"1" "a", "2" "b", "3" "c"})}
+                           :where  [:= :id (:id fv)]}))
+        (is (= ["a" "b" "c"]
+               (:human_readable_values (t2/select-one FieldValues :id (:id fv)))))))))
 
 (deftest update-human-readable-values-test
   (testing "Test \"fixing\" of human readable values when field values change"

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -4,7 +4,7 @@
    [cheshire.core :as json]
    [clojure.java.jdbc :as jdbc]
    [clojure.string :as str]
-   [clojure.test :refer :all]
+   [clojure.test :refer [deftest is testing]]
    [java-time.api :as t]
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -605,12 +605,14 @@
           fvs              (t2/select FieldValues :field_id field-id)]
       (t2/delete! FieldValues :field_id field-id)
       ;; switch to "list" to prevent [[field-values/create-or-update-full-field-values!]]
-      ;; from changing this to `nil` if the field is `auto-list` and exceeds threshholds
+      ;; from changing this to `nil` if the field is `auto-list` and exceeds thresholds
       (t2/update! Field field-id {:has_field_values "list"})
       (try
         (thunk)
         (finally
          (t2/update! Field field-id {:has_field_values has_field_values})
+         ;; paranoia due to https://github.com/metabase/metabase/actions/runs/7559357145/job/20583009098?pr=37794
+         (t2/delete! FieldValues :field_id field-id)
          (t2/insert! FieldValues fvs))))))
 
 (defmacro ^:private with-clean-field-values-for-field

--- a/test/metabase/models/params/chain_filter_test.clj
+++ b/test/metabase/models/params/chain_filter_test.clj
@@ -603,10 +603,10 @@
     (let [field-id         (u/the-id field-or-field-id)
           has_field_values (t2/select-one-fn :has_field_values Field :id field-id)
           fvs              (t2/select FieldValues :field_id field-id)]
+      (t2/delete! FieldValues :field_id field-id)
       ;; switch to "list" to prevent [[field-values/create-or-update-full-field-values!]]
       ;; from changing this to `nil` if the field is `auto-list` and exceeds threshholds
       (t2/update! Field field-id {:has_field_values "list"})
-      (t2/delete! FieldValues :field_id field-id)
       (try
         (thunk)
         (finally

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -97,25 +97,25 @@
                                       [;; expired sandbox fieldvalues
                                        {:field_id   field-id
                                         :type       "sandbox"
-                                        :hash_key   "random-hash"
+                                        :hash_key   "random-hash-1"
                                         :created_at expired-created-at
                                         :updated_at expired-created-at}
                                        ;; expired linked-filter fieldvalues
                                        {:field_id   field-id
                                         :type       "linked-filter"
-                                        :hash_key   "random-hash"
+                                        :hash_key   "random-hash-2"
                                         :created_at expired-created-at
                                         :updated_at expired-created-at}
                                        ;; valid sandbox fieldvalues
                                        {:field_id   field-id
                                         :type       "sandbox"
-                                        :hash_key   "random-hash"
+                                        :hash_key   "random-hash-3"
                                         :created_at now
                                         :updated_at now}
                                        ;; valid linked-filter fieldvalues
                                        {:field_id   field-id
                                         :type       "linked-filter"
-                                        :hash_key   "random-hash"
+                                        :hash_key   "random-hash-4"
                                         :created_at now
                                         :updated_at now}
                                        ;; old full fieldvalues

--- a/test/metabase/sync/field_values_test.clj
+++ b/test/metabase/sync/field_values_test.clj
@@ -93,39 +93,39 @@
            valid-linked-filter-id
            old-full-id
            new-full-id]             (t2/insert-returning-pks!
-                                      (t2/table-name FieldValues)
+                                      FieldValues
                                       [;; expired sandbox fieldvalues
                                        {:field_id   field-id
-                                        :type       "sandbox"
+                                        :type       :sandbox
                                         :hash_key   "random-hash-1"
                                         :created_at expired-created-at
                                         :updated_at expired-created-at}
                                        ;; expired linked-filter fieldvalues
                                        {:field_id   field-id
-                                        :type       "linked-filter"
+                                        :type       :linked-filter
                                         :hash_key   "random-hash-2"
                                         :created_at expired-created-at
                                         :updated_at expired-created-at}
                                        ;; valid sandbox fieldvalues
                                        {:field_id   field-id
-                                        :type       "sandbox"
+                                        :type       :sandbox
                                         :hash_key   "random-hash-3"
                                         :created_at now
                                         :updated_at now}
                                        ;; valid linked-filter fieldvalues
                                        {:field_id   field-id
-                                        :type       "linked-filter"
+                                        :type       :linked-filter
                                         :hash_key   "random-hash-4"
                                         :created_at now
                                         :updated_at now}
                                        ;; old full fieldvalues
                                        {:field_id   field-id
-                                        :type       "full"
+                                        :type       :full
                                         :created_at expired-created-at
                                         :updated_at expired-created-at}
                                        ;; new full fieldvalues
                                        {:field_id   field-id
-                                        :type       "full"
+                                        :type       :full
                                         :created_at now
                                         :updated_at now}])]
       (is (= (repeat 2 {:deleted 2})

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -249,7 +249,8 @@
   ;; now copy the FieldValues as well.
   (let [old-field-id->name (t2/select-pk->fn :name Field :table_id old-table-id)
         new-field-name->id (t2/select-fn->pk :name Field :table_id new-table-id)
-        old-field-values   (t2/select FieldValues :field_id [:in (set (keys old-field-id->name))])]
+        old-field-values (t2/select FieldValues :field_id [:in (set (keys old-field-id->name))])
+        old-field-values (map #(update % :hash_key str) old-field-values)]
     (t2/insert! FieldValues
       (for [{old-field-id :field_id, :as field-values} old-field-values
             :let                                       [field-name (get old-field-id->name old-field-id)]]

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -249,8 +249,7 @@
   ;; now copy the FieldValues as well.
   (let [old-field-id->name (t2/select-pk->fn :name Field :table_id old-table-id)
         new-field-name->id (t2/select-fn->pk :name Field :table_id new-table-id)
-        old-field-values (t2/select FieldValues :field_id [:in (set (keys old-field-id->name))])
-        old-field-values (map #(update % :hash_key str) old-field-values)]
+        old-field-values (t2/select FieldValues :field_id [:in (set (keys old-field-id->name))])]
     (t2/insert! FieldValues
       (for [{old-field-id :field_id, :as field-values} old-field-values
             :let                                       [field-name (get old-field-id->name old-field-id)]]


### PR DESCRIPTION
### Description

Refs https://github.com/metabase/metabase/issues/668

This adds a uniqueness constraint over the columns encapsulating the context for a given set of field values.

In practice the `hash_key` should always be a 32 bit integer, at least for rows created by recent versions of the code (and old rows should be pruned), but out of an abundance of caution and lack of necessity we have kept it as a string type, merely giving it fixed width to enable the creation of the index. In any case H2 does not allow a direct conversion from text to integer, and would need to be made a varchar first.

This PR has been created so far simply to run CI as a smoke test to find code paths that create redundant rows.

### How to verify

...