### PR TITLE
Comment out flaky audit-v2-views-test

### DIFF
--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -540,6 +540,7 @@
         (testing "should drop the existing color column"
           (is (not (contains? (t2/select-one :model/Collection :id collection-id) :color))))))))
 
+#_ ;; TODO: this test is flaky so it's commented out for now
 (deftest audit-v2-views-test
   (testing "Migrations v48.00-029 - end"
     ;; Use an open-ended migration range so that we can detect if any migrations added after these views broke the view


### PR DESCRIPTION
Temporary fix for https://github.com/metabase/metabase/issues/37434

This PR comments out `metabase.db.schema-migrations-test/audit-v2-views-test`.

Commenting out the test is relatively safe because it is testing a SQL migration, and changes to migrations shouldn't get past PR review.