### PR TITLE
Add required field to the template tag parameter

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -41,6 +41,7 @@ export function getTemplateTagParameter(
     name: tag["display-name"],
     slug: tag.name,
     default: tag.default,
+    required: tag.required,
     options: tag.options,
     values_query_type: config?.values_query_type,
     values_source_type: config?.values_source_type,

--- a/src/metabase/mbql/schema.cljc
+++ b/src/metabase/mbql/schema.cljc
@@ -1630,18 +1630,19 @@
    [:type ParameterType]
    ;; TODO -- these definitely SHOULD NOT be optional but a ton of tests aren't passing them in like they should be.
    ;; At some point we need to go fix those tests and then make these keys required
-   [:id      {:optional true} NonBlankString]
-   [:target  {:optional true} ParameterTarget]
+   [:id       {:optional true} NonBlankString]
+   [:target   {:optional true} ParameterTarget]
    ;; not specified if the param has no value. TODO - make this stricter; type of `:value` should be validated based
    ;; on the [[ParameterType]]
-   [:value   {:optional true} :any]
+   [:value    {:optional true} :any]
    ;; the name of the parameter we're trying to set -- this is actually required now I think, or at least needs to get
    ;; merged in appropriately
-   [:name    {:optional true} NonBlankString]
+   [:name     {:optional true} NonBlankString]
    ;; The following are not used by the code in this namespace but may or may not be specified depending on what the
    ;; code that constructs the query params is doing. We can go ahead and ignore these when present.
-   [:slug    {:optional true} NonBlankString]
-   [:default {:optional true} :any]])
+   [:slug     {:optional true} NonBlankString]
+   [:default  {:optional true} :any]
+   [:required {:optional true} :any]])
 
 (def ParameterList
   "Schema for a list of `:parameters` as passed in to a query."

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -271,7 +271,8 @@
                 [:variable  [:template-tag (:name tag)]])
      :name    (:display-name tag)
      :slug    (:name tag)
-     :default (:default tag)}))
+     :default (:default tag)
+     :required (:required tag)}))
 
 (defn- check-field-filter-fields-are-from-correct-database
   "Check that all native query Field filter parameters reference Fields belonging to the Database the query points

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -261,18 +261,18 @@
         :when                         (and tag-type
                                            (or (contains? mbql.s/raw-value-template-tag-types tag-type)
                                                (and (= tag-type :dimension) widget-type (not= widget-type :none))))]
-    {:id      (:id tag)
-     :type    (or widget-type (cond (= tag-type :date)   :date/single
-                                    (= tag-type :string) :string/=
-                                    (= tag-type :number) :number/=
-                                    :else                :category))
-     :target  (if (= tag-type :dimension)
-                [:dimension [:template-tag (:name tag)]]
-                [:variable  [:template-tag (:name tag)]])
-     :name    (:display-name tag)
-     :slug    (:name tag)
-     :default (:default tag)
-     :required (:required tag)}))
+    {:id       (:id tag)
+     :type     (or widget-type (cond (= tag-type :date)   :date/single
+                                     (= tag-type :string) :string/=
+                                     (= tag-type :number) :number/=
+                                     :else                :category))
+     :target   (if (= tag-type :dimension)
+                 [:dimension [:template-tag (:name tag)]]
+                 [:variable  [:template-tag (:name tag)]])
+     :name     (:display-name tag)
+     :slug     (:name tag)
+     :default  (:default tag)
+     :required (boolean (:required tag))}))
 
 (defn- check-field-filter-fields-are-from-correct-database
   "Check that all native query Field filter parameters reference Fields belonging to the Database the query points

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -249,6 +249,7 @@
                  :slug "c",
                                     ;; order importance: the default from template-tag is in the final result
                  :default "C TAG"
+                 :required false
                  :values_source_type    "static-list"
                  :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}
                                     ;; the parameter id = "d" is in template-tags, but not card.parameters,
@@ -258,7 +259,8 @@
                  :target ["variable" ["template-tag" "d"]],
                  :name "d",
                  :slug "d",
-                 :default "D TAG"}]
+                 :default "D TAG"
+                 :required false}]
                (:parameters (client/client :get 200 (card-url card)))))))))
 
 (deftest parameters-should-include-relevant-template-tags-only
@@ -270,7 +272,8 @@
                  :id "a",
                  :default "A TAG",
                  :target ["variable" ["template-tag" "a"]],
-                 :slug "a"}]
+                 :slug "a"
+                 :required false}]
                (:parameters (client/client :get 200 (card-url card)))))))))
 
 ;;; ------------------------- GET /api/embed/card/:token/query (and JSON/CSV/XLSX variants) --------------------------

--- a/test/metabase/api/preview_embed_test.clj
+++ b/test/metabase/api/preview_embed_test.clj
@@ -47,12 +47,13 @@
                                                                         :b {:type "date", :name "b", :display_name "b" :id "b"}
                                                                         :c {:type "date", :name "c", :display_name "c" :id "c"}
                                                                         :d {:type "date", :name "d", :display_name "d" :id "d"}}}}}]
-            (is (= [{:id      "d"
-                     :type    "date/single"
-                     :target  ["variable" ["template-tag" "d"]]
-                     :name    "d"
-                     :slug    "d"
-                     :default nil}]
+            (is (= [{:id       "d"
+                     :type     "date/single"
+                     :target   ["variable" ["template-tag" "d"]]
+                     :name     "d"
+                     :slug     "d"
+                     :default  nil
+                     :required false}]
                    (-> (mt/user-http-request :crowberto :get 200 (card-url card {:_embedding_params {:a "locked"
                                                                                                       :b "disabled"
                                                                                                       :c "enabled"

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -218,14 +218,16 @@
                  :id           "a",
                  :default      "A TAG",
                  :target       ["variable" ["template-tag" "a"]],
-                 :slug         "a"}
+                 :slug         "a"
+                 :required     false}
                 {:type         "date/single",
                  :name         "b",
                  :display_name "b",
                  :id           "b",
                  :default      "B TAG",
                  :target       ["variable" ["template-tag" "b"]],
-                 :slug         "b"}
+                 :slug         "b"
+                 :required     false}
                 ;; the parameter with id = "c" exists in both card.parameters and tempalte-tags should have info
                 ;; merge of both places
                 {:type                 "date/single",
@@ -234,18 +236,20 @@
                  :slug                 "c",
                  ;; order importance: the default from template-tag is in the final result
                  :default              "C TAG",
+                 :required             false
                  :values_source_type   "static-list",
                  :id                   "c",
                  :target               ["variable" ["template-tag" "c"]],
                  :values_source_config {:values ["BBQ" "Bakery" "Bar"]}}
                 ;; the parameter id = "d" is in template-tags, but not card.parameters,
                 ;; when fetching card we should get it returned
-                {:id      "d",
-                 :type    "date/single",
-                 :target  ["variable" ["template-tag" "d"]],
-                 :name    "d",
-                 :slug    "d",
-                 :default "D TAG"}]
+                {:id       "d",
+                 :type     "date/single",
+                 :target   ["variable" ["template-tag" "d"]],
+                 :name     "d",
+                 :slug     "d",
+                 :default  "D TAG"
+                 :required false}]
                (:parameters (client/client :get 200 (str "public/card/" (:public_uuid card))))))))))
 
 (deftest get-card-parameters-should-exclude-non-parameter-template-tags
@@ -262,7 +266,8 @@
                  :id           "a",
                  :default      "A TAG",
                  :target       ["variable" ["template-tag" "a"]],
-                 :slug         "a"}]
+                 :slug         "a"
+                 :required     false}]
                (:parameters (client/client :get 200 (str "public/card/" (:public_uuid card))))))))))
 
 ;;; ------------------------- GET /api/public/card/:uuid/query (and JSON/CSV/XSLX versions) --------------------------

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -336,7 +336,8 @@
                :target [:dimension [:template-tag "date"]],
                :name "Check-In Date",
                :slug "date",
-               :default nil}]
+               :default nil
+               :required false}]
              (card/template-tag-parameters card)))))
   (testing "Card with a non-Field-filter parameter"
     (mt/with-temp [:model/Card card {:dataset_query (qp.card-test/non-field-filter-query)}]
@@ -345,7 +346,8 @@
                :target [:variable [:template-tag "id"]],
                :name "Order ID",
                :slug "id",
-               :default "1"}]
+               :default "1"
+               :required true}]
              (card/template-tag-parameters card)))))
   (testing "Should ignore native query snippets and source card IDs"
     (mt/with-temp [:model/Card card {:dataset_query (qp.card-test/non-parameter-template-tag-query)}]
@@ -354,7 +356,8 @@
                :target [:variable [:template-tag "id"]],
                :name "Order ID",
                :slug "id",
-               :default "1"}]
+               :default "1"
+               :required true}]
              (card/template-tag-parameters card))))))
 
 (deftest validate-template-tag-field-ids-test


### PR DESCRIPTION
Part of the milestone 1 (required parameters in native queries), epic https://github.com/metabase/metabase/issues/36524

As we need to make parameters in native queries required, this is the first step. I am making a separate PR so that it's easier to track which tests fail (quite a few do on the BE) — and either merge it separately, or at least merge it back to the original PR.