### PR TITLE
Migrate `isNative` to MLv2

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/components/QueryViewer/QueryViewer.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/components/QueryViewer/QueryViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from "react";
 import _ from "underscore";
 
+import * as Lib from "metabase-lib";
 import { useSelector, useDispatch } from "metabase/lib/redux";
 import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
 import ReadOnlyNotebook from "metabase/query_builder/components/notebook/ReadOnlyNotebook";
@@ -28,7 +29,9 @@ export function QueryViewer({ datasetQuery }: { datasetQuery: DatasetQuery }) {
   }, [card, dispatch]);
 
   const question = new Question(card, metadata);
-  if (question.isNative()) {
+  const { isNative } = Lib.queryDisplayInfo(question.query());
+
+  if (isNative) {
     return (
       <NativeQueryEditor
         question={question}

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -204,15 +204,12 @@ class Question {
   }
 
   isNative(): boolean {
-    return (
-      this.legacyQuery({ useStructuredQuery: true }) instanceof NativeQuery
-    );
+    const { isNative } = Lib.queryDisplayInfo(this.query());
+    return isNative;
   }
 
   isStructured(): boolean {
-    return (
-      this.legacyQuery({ useStructuredQuery: true }) instanceof StructuredQuery
-    );
+    return !this.isNative();
   }
 
   /**

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -184,7 +184,7 @@ class Question {
     }
 
     const isVirtualDashcard = !this._card.id;
-    // `dataset_query` is null for questions on a dashboard the user don't have access to
+    // The `dataset_query` is null for questions on a dashboard the user doesn't have access to
     !isVirtualDashcard &&
       console.warn("Unknown query type: " + datasetQuery?.type);
   });

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -206,16 +206,9 @@ class Question {
   /**
    * @deprecated use MLv2
    */
-  isNative(): boolean {
-    const { isNative } = Lib.queryDisplayInfo(this.query());
-    return isNative;
-  }
-
-  /**
-   * @deprecated use MLv2
-   */
   isStructured(): boolean {
-    return !this.isNative();
+    const { isNative } = Lib.queryDisplayInfo(this.query());
+    return !isNative;
   }
 
   /**
@@ -1115,9 +1108,10 @@ class Question {
    */
   canExploreResults() {
     const canNest = Boolean(this.database()?.hasFeature("nested-queries"));
+    const { isNative } = Lib.queryDisplayInfo(this.query());
 
     return (
-      this.isNative() &&
+      isNative &&
       this.isSaved() &&
       this.parameters().length === 0 &&
       canNest &&

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -203,11 +203,17 @@ class Question {
     return query;
   }
 
+  /**
+   * @deprecated use MLv2
+   */
   isNative(): boolean {
     const { isNative } = Lib.queryDisplayInfo(this.query());
     return isNative;
   }
 
+  /**
+   * @deprecated use MLv2
+   */
   isStructured(): boolean {
     return !this.isNative();
   }

--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -8,6 +8,7 @@ import type {
   StructuredDatasetQuery,
   FieldId,
 } from "metabase-types/api";
+import * as Lib from "metabase-lib";
 import { getQuestionVirtualTableId } from "metabase-lib/metadata/utils/saved-questions";
 import type Database from "metabase-lib/metadata/Database";
 import type Question from "metabase-lib/Question";
@@ -101,7 +102,9 @@ export function checkCanBeModel(question: Question) {
     return false;
   }
 
-  if (!question.isNative()) {
+  const { isNative } = Lib.queryDisplayInfo(question.query());
+
+  if (!isNative) {
     return true;
   }
 

--- a/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
@@ -134,15 +134,11 @@ function notRelativeDateOrRange({ type }: Parameter) {
 export function getTargetsForQuestion(question: Question): Target[] {
   const { isNative } = Lib.queryDisplayInfo(question.query());
 
-  if (!isNative) {
-    return getTargetsForStructuredQuestion(question);
-  }
-
   if (isNative) {
     return getTargetsForNativeQuestion(question);
   }
 
-  return [];
+  return getTargetsForStructuredQuestion(question);
 }
 
 function getTargetsForStructuredQuestion(question: Question): Target[] {

--- a/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
+++ b/frontend/src/metabase-lib/parameters/utils/click-behavior.ts
@@ -132,11 +132,13 @@ function notRelativeDateOrRange({ type }: Parameter) {
 }
 
 export function getTargetsForQuestion(question: Question): Target[] {
-  if (question.isStructured()) {
+  const { isNative } = Lib.queryDisplayInfo(question.query());
+
+  if (!isNative) {
     return getTargetsForStructuredQuestion(question);
   }
 
-  if (question.isNative()) {
+  if (isNative) {
     return getTargetsForNativeQuestion(question);
   }
 

--- a/frontend/src/metabase-lib/queries/drills/native-drill-fallback.ts
+++ b/frontend/src/metabase-lib/queries/drills/native-drill-fallback.ts
@@ -1,3 +1,4 @@
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/Question";
 
 interface FallbackNativeDrillProps {
@@ -6,7 +7,10 @@ interface FallbackNativeDrillProps {
 
 export function nativeDrillFallback({ question }: FallbackNativeDrillProps) {
   const database = question.database();
-  if (!question.isNative() || !question.isQueryEditable() || !database) {
+  const query = question.query();
+  const { isNative } = Lib.queryDisplayInfo(query);
+
+  if (!isNative || !question.isQueryEditable() || !database) {
     return null;
   }
 

--- a/frontend/src/metabase/dashboard/actions/navigation.js
+++ b/frontend/src/metabase/dashboard/actions/navigation.js
@@ -2,6 +2,7 @@ import { createThunkAction } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
 
 import { openUrl } from "metabase/redux/app";
+import * as Lib from "metabase-lib";
 import { getParametersMappedToDashcard } from "metabase/parameters/utils/dashboards";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getCardAfterVisualizationClick } from "metabase/visualizations/lib/utils";
@@ -14,7 +15,8 @@ export const editQuestion = createThunkAction(
   EDIT_QUESTION,
   question => (dispatch, getState) => {
     const dashboardId = getDashboardId(getState());
-    const mode = question.isNative() ? "view" : "notebook";
+    const { isNative } = Lib.queryDisplayInfo(question.query());
+    const mode = isNative ? "view" : "notebook";
     const url = Urls.question(question.card(), { mode });
 
     dispatch(openUrl(url));
@@ -73,8 +75,12 @@ export const navigateToNewCardFromDashboard = createThunkAction(
       // When building a question URL, it'll usually clean the query and
       // strip clauses referencing fields from tables without metadata
       const previousQuestion = new Question(previousCard, metadata);
+      const { isNative: isPreviousNative } = Lib.queryDisplayInfo(
+        previousQuestion.query(),
+      );
+
       const isDrillingFromNativeModel =
-        previousQuestion.isDataset() && previousQuestion.isNative();
+        previousQuestion.isDataset() && isPreviousNative;
 
       const url = ML_Urls.getUrlWithParameters(
         question,

--- a/frontend/src/metabase/dashboard/components/ClickMappings.jsx
+++ b/frontend/src/metabase/dashboard/components/ClickMappings.jsx
@@ -8,6 +8,7 @@ import { getIn, assocIn, dissocIn } from "icepick";
 import { Icon } from "metabase/ui";
 import Select from "metabase/core/components/Select";
 
+import * as Lib from "metabase-lib";
 import MetabaseSettings from "metabase/lib/settings";
 import { isPivotGroupColumn } from "metabase/lib/data_grid";
 import { GTAPApi } from "metabase/services";
@@ -342,9 +343,10 @@ export function isMappableColumn(column) {
 export function clickTargetObjectType(object) {
   if (!(object instanceof Question)) {
     return "dashboard";
-  } else if (object.isNative()) {
-    return "native";
-  } else {
-    return "gui";
   }
+
+  const query = object.query();
+  const { isNative } = Lib.queryDisplayInfo(query);
+
+  return isNative ? "native" : "gui";
 }

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -96,7 +96,7 @@ export function isLinkDashCard(dashcard: DashboardCard) {
 }
 
 export function isNativeDashCard(dashcard: DashboardCard) {
-  // The `dataset_query` is null for dashboard cards for users without data permissions
+  // The `dataset_query` is null for questions on a dashboard the user doesn't have access to
   return dashcard.card.dataset_query?.type === "native";
 }
 

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -23,7 +23,6 @@ import type {
   DashCardDataMap,
 } from "metabase-types/api";
 import type { SelectedTabId } from "metabase-types/store";
-import Question from "metabase-lib/Question";
 import {
   isDateParameter,
   isNumberParameter,
@@ -97,7 +96,8 @@ export function isLinkDashCard(dashcard: DashboardCard) {
 }
 
 export function isNativeDashCard(dashcard: DashboardCard) {
-  return dashcard.card && new Question(dashcard.card).isNative();
+  // The `dataset_query` is null for dashboard cards for users without data permissions
+  return dashcard.card.dataset_query?.type === "native";
 }
 
 // For a virtual (text) dashcard without any parameters, returns a boolean indicating whether we should display the

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -41,7 +41,7 @@ export function getClickBehaviorDescription(dashcard) {
 export function hasActionsMenu(dashcard) {
   // This seems to work, but it isn't the right logic.
   // The right thing to do would be to check for any drills. However, we'd need a "clicked" object for that.
-  return !dashcard.card.dataset_query?.type === "native";
+  return dashcard.card.dataset_query?.type !== "native";
 }
 
 export function isTableDisplay(dashcard) {

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -41,7 +41,7 @@ export function getClickBehaviorDescription(dashcard) {
 export function hasActionsMenu(dashcard) {
   // This seems to work, but it isn't the right logic.
   // The right thing to do would be to check for any drills. However, we'd need a "clicked" object for that.
-  return dashcard.card.dataset_query?.type !== "native";
+  return dashcard.card.dataset_query?.type === "query";
 }
 
 export function isTableDisplay(dashcard) {

--- a/frontend/src/metabase/lib/click-behavior.js
+++ b/frontend/src/metabase/lib/click-behavior.js
@@ -2,7 +2,6 @@ import { msgid, ngettext, t } from "ttag";
 import { getIn } from "icepick";
 import Questions from "metabase/entities/questions";
 import Dashboards from "metabase/entities/dashboards";
-import Question from "metabase-lib/Question";
 
 export function getClickBehaviorDescription(dashcard) {
   const noBehaviorMessage = hasActionsMenu(dashcard)
@@ -42,7 +41,7 @@ export function getClickBehaviorDescription(dashcard) {
 export function hasActionsMenu(dashcard) {
   // This seems to work, but it isn't the right logic.
   // The right thing to do would be to check for any drills. However, we'd need a "clicked" object for that.
-  return !new Question(dashcard.card).isNative();
+  return !dashcard.card.dataset_query?.type === "native";
 }
 
 export function isTableDisplay(dashcard) {

--- a/frontend/src/metabase/metabot/selectors.ts
+++ b/frontend/src/metabase/metabot/selectors.ts
@@ -1,6 +1,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { getMetadata } from "metabase/selectors/metadata";
 import type { State } from "metabase-types/store";
+import * as Lib from "metabase-lib";
 import Question from "metabase-lib/Question";
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import { DEFAULT_TABLE_SETTINGS } from "./constants";
@@ -57,7 +58,7 @@ export const getFeedbackType = (state: State) => {
 };
 
 export const getNativeQueryText = createSelector([getQuestion], question => {
-  return question?.isNative()
+  return question && Lib.queryDisplayInfo(question.query()).isNative
     ? (question.legacyQuery() as NativeQuery).queryText()
     : undefined;
 });

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelInfoSidePanel/ModelInfoSidePanel.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 
 import type { Card } from "metabase-types/api";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/Question";
 import * as ML_Urls from "metabase-lib/urls";
 import type Table from "metabase-lib/metadata/Table";
@@ -26,6 +27,7 @@ function ModelInfoSidePanel({ model, mainTable, onChangeDescription }: Props) {
 
   const canWrite = model.canWrite();
   const description = model.description();
+  const { isNative } = Lib.queryDisplayInfo(model.query());
 
   return (
     <ModelInfoPanel>
@@ -43,9 +45,7 @@ function ModelInfoSidePanel({ model, mainTable, onChangeDescription }: Props) {
           onChange={onChangeDescription}
         />
       </ModelInfoSection>
-      {!model.isNative() && (
-        <ModelRelationships model={model} mainTable={mainTable} />
-      )}
+      {!isNative && <ModelRelationships model={model} mainTable={mainTable} />}
       {modelCard.creator && (
         <ModelInfoSection>
           <ModelInfoTitle>{t`Created by`}</ModelInfoTitle>

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -100,11 +100,13 @@ function ModelDetailPage({
     database != null && database.hasFeature("nested-queries");
 
   const mainTable = useMemo(() => {
-    if (model.isNative()) {
+    const query = model.query();
+    const { isNative } = Lib.queryDisplayInfo(query);
+
+    if (isNative) {
       return null;
     }
 
-    const query = model.query();
     const sourceTableId = Lib.sourceTableOrCardId(query);
     const table = model.metadata().table(sourceTableId);
     return table;

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -145,7 +145,7 @@ function buildFieldFilterUiParameter(
       return {
         field,
         // The `dataset_query` is null for questions on a dashboard the user doesn't have access to
-        shouldResolveFkField: Boolean(card.dataset_query?.type !== "native"),
+        shouldResolveFkField: card.dataset_query?.type === "query",
       };
     } catch (e) {
       console.error("Error getting a field from a card", { card });

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -22,7 +22,6 @@ import {
 } from "metabase-lib/parameters/utils/targets";
 import type Metadata from "metabase-lib/metadata/Metadata";
 import type Field from "metabase-lib/metadata/Field";
-import Question from "metabase-lib/Question";
 
 type ExtendedMapping = DashboardParameterMapping & {
   dashcard_id: number;
@@ -139,12 +138,15 @@ function buildFieldFilterUiParameter(
   );
   const mappedFields = mappingsForParameter.map(mapping => {
     const { target, card } = mapping;
-    const question = new Question(card, metadata);
 
     try {
       const field = getTargetFieldFromCard(target, card, metadata);
 
-      return { field, shouldResolveFkField: !question.isNative() };
+      return {
+        field,
+        // The `dataset_query` is null for questions on a dashboard the user doesn't have access to
+        shouldResolveFkField: Boolean(card.dataset_query?.type !== "native"),
+      };
     } catch (e) {
       console.error("Error getting a field from a card", { card });
       throw e;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -329,6 +329,8 @@ async function handleQBInit(
   const metadata = getMetadata(getState());
 
   let question = new Question(card, metadata);
+  const query = question.query();
+  const { isNative } = Lib.queryDisplayInfo(query);
 
   if (question.isSaved()) {
     if (!question.isDataset()) {
@@ -342,12 +344,12 @@ async function handleQBInit(
     }
   }
 
-  if (question.isNative()) {
+  if (isNative) {
     const isEditing = getIsEditingInDashboard(getState());
     uiControls.isNativeEditorOpen = isEditing || !question.isSaved();
   }
 
-  if (question.isNative() && question.isQueryEditable()) {
+  if (isNative && question.isQueryEditable()) {
     const query = question.legacyQuery() as NativeQuery;
     const newQuery = await updateTemplateTagNames(query, getState, dispatch);
     question = question.setLegacyQuery(newQuery);

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -74,10 +74,16 @@ function shouldTemplateTagEditorBeVisible({
   if (queryBuilderMode === "dataset") {
     return isVisible;
   }
-  const previousTags = currentQuestion?.isNative()
+  const isCurrentQuestionNative =
+    currentQuestion && Lib.queryDisplayInfo(currentQuestion.query()).isNative;
+  const isNewQuestionNative = Lib.queryDisplayInfo(
+    newQuestion.query(),
+  ).isNative;
+
+  const previousTags = isCurrentQuestionNative
     ? (currentQuestion.legacyQuery() as NativeQuery).variableTemplateTags()
     : [];
-  const nextTags = newQuestion.isNative()
+  const nextTags = isNewQuestionNative
     ? (newQuestion.legacyQuery() as NativeQuery).variableTemplateTags()
     : [];
   if (nextTags.length > previousTags.length) {
@@ -148,9 +154,15 @@ export const updateQuestion = (
     const isPivot = newQuestion.display() === "pivot";
     const wasPivot = currentQuestion?.display() === "pivot";
 
+    const isCurrentQuestionNative =
+      currentQuestion && Lib.queryDisplayInfo(currentQuestion.query()).isNative;
+    const isNewQuestionNative = Lib.queryDisplayInfo(
+      newQuestion.query(),
+    ).isNative;
+
     if (wasPivot || isPivot) {
       const hasBreakouts =
-        newQuestion.isStructured() &&
+        !isNewQuestionNative &&
         Lib.breakouts(newQuestion.query(), -1).length > 0;
 
       // compute the pivot setting now so we can query the appropriate data
@@ -178,7 +190,7 @@ export const updateQuestion = (
     }
 
     // Native query should never be in notebook mode (metabase#12651)
-    if (queryBuilderMode === "notebook" && newQuestion.isNative()) {
+    if (queryBuilderMode === "notebook" && isNewQuestionNative) {
       await dispatch(
         setQueryBuilderMode("view", {
           shouldUpdateUrl: false,
@@ -187,7 +199,7 @@ export const updateQuestion = (
     }
 
     // Sync card's parameters with the template tags;
-    if (newQuestion.isNative()) {
+    if (isNewQuestionNative) {
       const parameters = getTemplateTagParametersFromCard(newQuestion.card());
       newQuestion = newQuestion.setParameters(parameters);
     }
@@ -201,7 +213,7 @@ export const updateQuestion = (
       dispatch(updateUrl(null, { dirty: true }));
     }
 
-    if (currentQuestion?.isNative?.() || newQuestion.isNative()) {
+    if (isCurrentQuestionNative || isNewQuestionNative) {
       const isVisible = getIsShowingTemplateTagsEditor(getState());
       const shouldBeVisible = shouldTemplateTagEditorBeVisible({
         currentQuestion,

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -1,6 +1,7 @@
 import { t } from "ttag";
 import { createAction } from "redux-actions";
 
+import * as Lib from "metabase-lib";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { startTimer } from "metabase/lib/performance";
 import { defer } from "metabase/lib/promise";
@@ -183,7 +184,9 @@ export const queryCompleted = (question, queryResults) => {
       question.isDirtyComparedTo(originalQuestion);
 
     if (isDirty) {
-      if (question.isNative()) {
+      const { isNative } = Lib.queryDisplayInfo(question.query());
+
+      if (isNative) {
         question = question.syncColumnsAndSettings(
           originalQuestion,
           queryResults[0],

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -145,7 +145,9 @@ function getSidebar(
     );
   }
 
-  if (!dataset.isNative()) {
+  const { isNative } = Lib.queryDisplayInfo(dataset.query());
+
+  if (!isNative) {
     return null;
   }
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -14,6 +14,7 @@ import { usePrevious } from "react-use";
 
 import Radio from "metabase/core/components/Radio";
 
+import * as Lib from "metabase-lib";
 import {
   field_visibility_types,
   field_semantic_types,
@@ -82,6 +83,8 @@ function getFormFields({ dataset, field }) {
   const canIndex =
     dataset.isSaved() && ModelIndexes.utils.canIndexField(field, dataset);
 
+  const { isNative } = Lib.queryDisplayInfo(dataset.query());
+
   return formFieldValues =>
     [
       {
@@ -95,7 +98,7 @@ function getFormFields({ dataset, field }) {
         placeholder: t`It’s optional, but oh, so helpful`,
         type: "text",
       },
-      dataset.isNative() && {
+      isNative && {
         name: "id",
         title: t`Database column this maps to`,
         widget: MappedFieldPicker,
@@ -178,7 +181,9 @@ function DatasetFieldMetadataSidebar({
       visibility_type: field.visibility_type || "normal",
       should_index: ModelIndexes.utils.fieldHasIndex(modelIndexes, field),
     };
-    if (dataset.isNative()) {
+    const { isNative } = Lib.queryDisplayInfo(dataset.query());
+
+    if (isNative) {
       values.id = field.id;
     }
     return values;
@@ -308,6 +313,8 @@ function DatasetFieldMetadataSidebar({
     [onFieldMetadataChange],
   );
 
+  const { isNative } = Lib.queryDisplayInfo(dataset.query());
+
   return (
     <SidebarContent>
       <RootForm
@@ -329,7 +336,7 @@ function DatasetFieldMetadataSidebar({
                 onChange={onDescriptionChange}
                 tabIndex={EDITOR_TAB_INDEXES.ESSENTIAL_FORM_FIELD}
               />
-              {dataset.isNative() && (
+              {isNative && (
                 <FormField
                   name="id"
                   tableId={field.table_id}

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
@@ -1,6 +1,7 @@
 import { memo, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import styled from "@emotion/styled";
+import * as Lib from "metabase-lib";
 import NativeQueryEditor from "metabase/query_builder/components/NativeQueryEditor";
 import { isReducedMotionPreferred } from "metabase/lib/dom";
 import ResizableNotebook from "./ResizableNotebook";
@@ -28,6 +29,7 @@ function DatasetQueryEditor({
   // Datasets/models by default behave like they are already nested,
   // so we need to edit the dataset/model question like it is a normal question
   const question = dataset.setDataset(false);
+  const { isNative } = Lib.queryDisplayInfo(question.query());
 
   const [isResizing, setResizing] = useState(false);
 
@@ -64,7 +66,7 @@ function DatasetQueryEditor({
 
   return (
     <QueryEditorContainer isActive={isActive}>
-      {question.isNative() ? (
+      {isNative ? (
         <NativeQueryEditor
           {...props}
           question={question}

--- a/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.tsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationError/VisualizationError.tsx
@@ -2,6 +2,7 @@ import { t } from "ttag";
 import { getIn } from "icepick";
 import cx from "classnames";
 
+import * as Lib from "metabase-lib";
 import MetabaseSettings from "metabase/lib/settings";
 import { getEngineNativeType } from "metabase/lib/engine";
 import { ErrorMessage } from "metabase/components/ErrorMessage";
@@ -49,6 +50,7 @@ export function VisualizationError({
   className,
 }: VisualizationErrorProps) {
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+  const isNative = question && Lib.queryDisplayInfo(question.query()).isNative;
   if (error && typeof error.status === "number") {
     // Assume if the request took more than 15 seconds it was due to a timeout
     // Some platforms like Heroku return a 503 for numerous types of errors so we can't use the status code to distinguish between timeouts and other failures.
@@ -83,7 +85,7 @@ export function VisualizationError({
         </div>
       </div>
     );
-  } else if (question?.isNative()) {
+  } else if (isNative) {
     // always show errors for native queries
     let processedError = error;
     const origSql = getIn(via, [(via || "").length - 1, "ex-data", "sql"]);

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryButton/PreviewQueryButton.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { t } from "ttag";
+import * as Lib from "metabase-lib";
 import Tooltip from "metabase/core/components/Tooltip";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import type Question from "metabase-lib/Question";
@@ -31,9 +32,11 @@ interface PreviewQueryButtonOpts {
 }
 
 PreviewQueryButton.shouldRender = ({ question }: PreviewQueryButtonOpts) => {
+  const { isNative } = Lib.queryDisplayInfo(question.query());
+
   return (
+    isNative &&
     question.canRun() &&
-    question.isNative() &&
     (question.legacyQuery() as NativeQuery).hasVariableTemplateTags()
   );
 };

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -105,7 +105,7 @@ export function ViewTitleHeader(props) {
     }
   }, [previousQuestion, question, expandFilters, previousQuery, query]);
 
-  const isNative = question.isNative();
+  const { isNative } = Lib.queryDisplayInfo(query);
   const isSaved = question.isSaved();
   const isDataset = question.isDataset();
   const isSummarized = Lib.aggregations(query, -1).length > 0;

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -627,7 +627,10 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
       return isDirty || isMetadataDirty;
     }
 
-    if (question?.isNative()) {
+    const isNative =
+      question && Lib.queryDisplayInfo(question.query()).isNative;
+
+    if (isNative) {
       const isNewQuestion = !originalQuestion;
 
       if (isNewQuestion) {
@@ -710,7 +713,7 @@ export const getVisualizationSettings = createSelector(
  */
 export const getIsNative = createSelector(
   [getQuestion],
-  question => question && question.isNative(),
+  question => question && Lib.queryDisplayInfo(question.query()).isNative,
 );
 
 /**

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -4,6 +4,7 @@ import * as Urls from "metabase/lib/urls";
 import { serializeCardForUrl } from "metabase/lib/card";
 import type { Card } from "metabase-types/api";
 import type { DatasetEditorTab, QueryBuilderMode } from "metabase-types/store";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/Question";
 
 interface GetPathNameFromQueryBuilderModeOptions {
@@ -104,7 +105,9 @@ export const isNavigationAllowed = ({
     return isRunningModel || allowedPathnames.includes(pathname);
   }
 
-  if (question.isNative()) {
+  const { isNative } = Lib.queryDisplayInfo(question.query());
+
+  if (isNative) {
     const isRunningQuestion = pathname === "/question" && hash.length > 0;
     return isRunningQuestion;
   }


### PR DESCRIPTION
This PR is just one of the tasks for #37389.
It migrates the old `isNative()` method from the `Question` prototype to MLv2. It ultimately removes it the last commit.

The old way to determine whether a query is native was to check is it an instance of a `NativeQuery` class.
MLv2 provides a direct way to achieve this:
```js
const { isNative } = Lib.queryDisplayInfo(query);
```