### PR TITLE
Don't break pivot tables when column widths are set (#37726)

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -706,6 +706,11 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
         });
 
         it("should display pivot table in an embed URL", () => {
+          // Since the question is transient, it needs to be saved
+          if (test.case === "question") {
+            cy.button("Save").click();
+          }
+
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText(/Embed in your application/).click();
 

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -678,6 +678,11 @@ describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
         });
 
         it("should display pivot table in a public link", () => {
+          // Since the question is transient, it needs to be saved
+          if (test.case === "question") {
+            cy.button("Save").click();
+          }
+
           // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
           cy.findByText("Public link")
             .parent()

--- a/e2e/test/scenarios/visualizations-tabular/reproductions/37726-pivot-table-add-column.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/reproductions/37726-pivot-table-add-column.cy.spec.js
@@ -1,0 +1,85 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { main, restore } from "e2e/support/helpers";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const PIVOT_QUESTION = {
+  name: "Pivot table with custom column width",
+  display: "pivot",
+  query: {
+    "source-table": ORDERS_ID,
+    breakout: [
+      [
+        "field",
+        ORDERS.TOTAL,
+        { "base-type": "type/Float", binnig: { strategy: "default" } },
+      ],
+    ],
+    aggregation: [
+      ["distinct", ["field", ORDERS.ID, { "base-type": "type/BigInteger" }]],
+    ],
+  },
+  visualization_settings: {
+    "pivot_table.column_split": {
+      rows: [
+        [
+          "field",
+          ORDERS.TOTAL,
+          {
+            "base-type": "type/Float",
+            binnig: {
+              strategy: "num-bins",
+              "min-value": 0,
+              "max-value": 160,
+              "num-bins": 8,
+              "bin-width": 20,
+            },
+          },
+        ],
+      ],
+      columns: [],
+      values: [["aggregation", 0]],
+    },
+    "pivot_table.column_widths": {
+      leftHeaderWidths: [80],
+      totalLeftHeaderWidths: 80,
+      valueHeaderWidths: { 0: 193 },
+    },
+  },
+};
+
+describe("issue 37726", function () {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not result in an error when you add a column after resizing an existing one (#37726)", () => {
+    cy.intercept("POST", "/api/dataset/pivot").as("pivot");
+
+    // The important data point in this question is that it has custom
+    // leftHeaderWidths as if a user had dragged them to change the defaults.
+    cy.createQuestion(PIVOT_QUESTION, { visitQuestion: true });
+
+    // Now, add in another column to the pivot table
+    cy.button("Summarize").click();
+
+    cy.findByRole("listitem", { name: "Category" })
+      .realHover()
+      .button("Add dimension")
+      .click();
+
+    // Wait for the pivot call to return
+    cy.wait("@pivot");
+
+    // Refresh the page -- this loads the question using the transient value
+    cy.reload();
+
+    // Look for the new column name in the resulting pivot table.
+    // Note that before this fix, the page would error out and this elements,
+    // along with the rest of the pivot table, would not appear.
+    // Instead, you got a nice ⚠️ icon and a "Something's gone wrong" tooltip.
+    main().within(() => {
+      cy.findByText("Product → Category");
+    });
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.tsx
@@ -208,23 +208,37 @@ function PivotTable({
       setHeaderWidths({
         leftHeaderWidths: null,
         totalLeftHeaderWidths: null,
-        valueHeaderWidths: {},
+        valueHeaderWidths,
       });
       return;
     }
 
     if (columnsChanged) {
-      setHeaderWidths({
-        ...getLeftHeaderWidths({
-          rowIndexes: pivoted?.rowIndexes,
-          getColumnTitle: idx => getColumnTitle(idx),
-          leftHeaderItems: pivoted?.leftHeaderItems,
-          fontFamily: fontFamily,
-        }),
-        valueHeaderWidths: {},
+      const newLeftHeaderWidths = getLeftHeaderWidths({
+        rowIndexes: pivoted?.rowIndexes,
+        getColumnTitle: idx => getColumnTitle(idx),
+        leftHeaderItems: pivoted?.leftHeaderItems,
+        fontFamily: fontFamily,
+      });
+
+      setHeaderWidths({ ...newLeftHeaderWidths, valueHeaderWidths });
+
+      onUpdateVisualizationSettings({
+        "pivot_table.column_widths": {
+          ...newLeftHeaderWidths,
+          valueHeaderWidths,
+        },
       });
     }
-  }, [pivoted, fontFamily, getColumnTitle, columnsChanged, setHeaderWidths]);
+  }, [
+    onUpdateVisualizationSettings,
+    valueHeaderWidths,
+    pivoted,
+    fontFamily,
+    getColumnTitle,
+    columnsChanged,
+    setHeaderWidths,
+  ]);
 
   const handleColumnResize = (
     columnType: "value" | "leftHeader",


### PR DESCRIPTION
* Don't break pivot tables when column widths are set

As per the repro on #37083, if a pivot table column is resized then another column is added from the "Summarize" button, the FE will break if either the question is refreshed or saved then reloaded.

This fixes that behavior by following the same pattern of calling `onUpdateVisualizationSettings` _after_ the relevant visualization settings are recomputed in the column changed `useEffect` as is done in `handleColumnResize`.

In addition to updating the left header widths, `valueHeaderWidths` is also preserved from its `useState` definition. This fixes the subtle behavior in which the UI resets the value header column width when a new breakout is added. Now all existing values are preserved.

* Adding e2e test.

* Preserving initial valueHeaderWidths logic

This PR had originally preserved valueHeaderWidths if they existed. However, if several new columns are added, it appears that the widths are narrow, so the initial logic is preserved.

* Adding `confirmSave` to `openStaticEmbeddingModal` helper

In some cases, if a question has been modified but not saved, when you got to do a static embed, it will ask you to save the question. This commit adds a param to allow you to save the question.

This affects the "should display pivot table in an embed URL" test in `e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js`. To fix, `TEST_CASES` now includes a `confirmSave` param that is passed into `openStaticEmbeddingModal`.

* Removing extra comma

(cherry picked from commit 280b7cb839d407083ff4ae33c2cead34f6d943bb)
