### PR TITLE
Fix salt in pulse unsub hash

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -308,8 +308,8 @@
   [pulse-id email]
   (codecs/bytes->hex
    (encryption/validate-and-hash-secret-key
-    (json/generate-string {:salt public-settings/site-uuid-for-unsubscribing-url
-                           :email email
+    (json/generate-string {:salt     (public-settings/site-uuid-for-unsubscribing-url)
+                           :email    email
                            :pulse-id pulse-id}))))
 
 (defn- pulse-context [pulse dashboard non-user-email]

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -569,6 +569,11 @@
 
 ;;; ------------------------------------------- TESTS FOR UNSUBSCRIBING NONUSERS STUFF --------------------------------------------
 
+(deftest unsubscribe-hash-test
+  (with-redefs [public-settings/site-uuid-for-unsubscribing-url "08534993-94c6-4bac-a1ad-86c9668ee8f5"]
+    (is (= "691501b28502126a6f59636ce147d26afa9d8fe8e5d0bd41f0de609194c0d9ba0042276d9b23cf10b1c7a4b18b3f946707e511d3e95e08fbe2c456080f619e36"
+           (messages/generate-pulse-unsubscribe-hash :pulse-id "rasta@pasta.com")))))
+
 (deftest unsubscribe-test
   (reset-throttlers!)
   (testing "POST /pulse/unsubscribe"

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -570,19 +570,19 @@
 ;;; ------------------------------------------- TESTS FOR UNSUBSCRIBING NONUSERS STUFF --------------------------------------------
 
 (deftest unsubscribe-hash-test
-  (let [email         "rasta@pasta.com"
-        pulse-id      12345678
-        expected-hash "37bc76b4a24279eb90a71c129a629fb8626ad0089f119d6d095bc5135377f2e2884ad80b037495f1962a283cf57cdbad031fd1f06a21d86a40bba7fe674802dd"]
-    (mt/with-temporary-setting-values [site-uuid-for-unsubscribing-url "08534993-94c6-4bac-a1ad-86c9668ee8f5"]
+  (mt/with-temporary-setting-values [site-uuid-for-unsubscribing-url "08534993-94c6-4bac-a1ad-86c9668ee8f5"]
+    (let [email         "rasta@pasta.com"
+          pulse-id      12345678
+          expected-hash "37bc76b4a24279eb90a71c129a629fb8626ad0089f119d6d095bc5135377f2e2884ad80b037495f1962a283cf57cdbad031fd1f06a21d86a40bba7fe674802dd"]
       (testing "We generate a cryptographic hash to validate unsubscribe URLs"
         (is (= expected-hash (messages/generate-pulse-unsubscribe-hash pulse-id email))))
 
       (testing "The hash value depends on the pulse-id, email, and site-uuid"
         (let [alternate-site-uuid "aa147515-ade9-4298-ac5f-c7e42b69286d"
-              alternate-hashes [(messages/generate-pulse-unsubscribe-hash 87654321 email)
-                                (messages/generate-pulse-unsubscribe-hash pulse-id "hasta@lavista.com")
-                                (mt/with-temporary-setting-values [site-uuid-for-unsubscribing-url alternate-site-uuid]
-                                  (messages/generate-pulse-unsubscribe-hash pulse-id email))]]
+              alternate-hashes    [(messages/generate-pulse-unsubscribe-hash 87654321 email)
+                                   (messages/generate-pulse-unsubscribe-hash pulse-id "hasta@lavista.com")
+                                   (mt/with-temporary-setting-values [site-uuid-for-unsubscribing-url alternate-site-uuid]
+                                     (messages/generate-pulse-unsubscribe-hash pulse-id email))]]
           (is (= 3 (count (distinct (remove #{expected-hash} alternate-hashes))))))))))
 
 (deftest unsubscribe-test

--- a/test/metabase/api/session_test.clj
+++ b/test/metabase/api/session_test.clj
@@ -570,7 +570,7 @@
 ;;; ------------------------------------------- TESTS FOR UNSUBSCRIBING NONUSERS STUFF --------------------------------------------
 
 (deftest unsubscribe-hash-test
-  (with-redefs [public-settings/site-uuid-for-unsubscribing-url "08534993-94c6-4bac-a1ad-86c9668ee8f5"]
+  (with-redefs [public-settings/site-uuid-for-unsubscribing-url (constantly "08534993-94c6-4bac-a1ad-86c9668ee8f5")]
     (is (= "691501b28502126a6f59636ce147d26afa9d8fe8e5d0bd41f0de609194c0d9ba0042276d9b23cf10b1c7a4b18b3f946707e511d3e95e08fbe2c456080f619e36"
            (messages/generate-pulse-unsubscribe-hash :pulse-id "rasta@pasta.com")))))
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37916

### Description

While looking at the `site-uuid` related code, I noticed that this setting was never being read. It looks like we're accidentally using the mangled var name in the relevant payload instead.

I don't think we can merge this as is, as I believe it would break unsubscription links out in the wild. I'm not sure how best we would handle this - perhaps being lenient and accepting both hashes. 

### How to verify

Executing the previous code in the REPL:

```clojure
(json/generate-string 
  {:salt public-settings/site-uuid-for-unsubscribing-url
   :email email
   pulse-id pulse-id}))))
                           
 "{\"salt\":\"metabase.models.setting$setting_fn$setting_getter_STAR___62091@3b698184\",\"email\":\"email\",\"pulse-id\":\"pulse-id\"}"
```

### Checklist

- [x] Confirm this is something worth fixing
- [x] Confirm whether we want to backport
- [x] ~~Make a plan for backwards compatibility, if necessary~~ Not worth it.