### PR TITLE
add chart debugger hook

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -26,6 +26,7 @@ import type {
 } from "metabase/visualizations/echarts/types";
 import { getSeriesIdFromECharts } from "metabase/visualizations/echarts/cartesian/utils/id";
 import { useModelsAndOption } from "./use-models-and-option";
+import { useChartDebug } from "./use-chart-debug";
 
 export function CartesianChart(props: VisualizationProps) {
   const {
@@ -49,6 +50,7 @@ export function CartesianChart(props: VisualizationProps) {
     onOpenTimelines,
   } = props;
   const { chartModel, timelineEventsModel, option } = useModelsAndOption(props);
+  useChartDebug({ isQueryBuilder, rawSeries, option });
 
   const isBrushing = useRef<boolean>();
   const chartRef = useRef<EChartsType>();

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-debug.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-debug.ts
@@ -1,0 +1,22 @@
+/* eslint-disable no-console */
+import type { EChartsOption } from "echarts";
+import type { RawSeries } from "metabase-types/api";
+import { isProduction } from "metabase/env";
+
+export function useChartDebug({
+  isQueryBuilder,
+  rawSeries,
+  option,
+}: {
+  isQueryBuilder: boolean;
+  rawSeries: RawSeries;
+  option: EChartsOption;
+}) {
+  if (!isQueryBuilder || isProduction) {
+    return;
+  }
+  console.log("-------------- ECHARTS DEBUG INFO START --------------");
+  console.log("rawSeries", rawSeries);
+  console.log("option", option);
+  console.log("-------------- ECHARTS DEBUG INFO END --------------");
+}


### PR DESCRIPTION
### Description

Logs debug info (rawSeries, option) in a hook that only runs in dev and in the query builder, so we don't have to keep adding and removing console log statements.

### How to verify

Open an echarts question in the query builder, confirm data logs. Add the question to a dashboard, confirm it doesn't log.