### PR TITLE
Add unique constraint on databasechangelog if it's not existed

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4195,6 +4195,8 @@ databaseChangeLog:
                     nullable: true
                   remarks: 'Hash of normalized query, calculated in middleware.cache'
 
+  # this index was added in migration 95, but during our split migration work in #34400 we didn't include this index
+  # in the sql initialization, so we need to recreate one here for new instances running 48+
   - changeSet:
       id: v48.00-067
       author: qnkhuat

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4204,14 +4204,24 @@ databaseChangeLog:
         # If we're dumping the migration as a SQL file or trying to force-migrate we can't check the preconditions
         # so just go ahead and skip the entire thing. This is a non-critical migration
         - onUpdateSQL: IGNORE
-        - and:
+        - or:
           - sqlCheck:
               expectedResult: 0
               sql: SELECT count(*) FROM (SELECT count(*) FROM DATABASECHANGELOG GROUP BY ID, AUTHOR, FILENAME HAVING count(*) > 1) t1
-          - not:
-            - indexExists:
-                tableName: ${databasechangelog.name}
-                indexName: idx_databasechangelog_id_author_filename
+          - or:
+            - and:
+              - dbms: h2
+              - not:
+                - indexExists:
+                    tableName: ${databasechangelog.name}
+                    indexName: IDX_DATABASECHANGELOG_ID_AUTHOR_FILENAME
+            - and:
+              - dbms: mysql,mariadb,postgresql
+              - not:
+                - indexExists:
+                    tableName: ${databasechangelog.name}
+                    indexName: idx_databasechangelog_id_author_filename
+
       changes:
         - addUniqueConstraint:
             constraintName: idx_databasechangelog_id_author_filename

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4196,6 +4196,29 @@ databaseChangeLog:
                   remarks: 'Hash of normalized query, calculated in middleware.cache'
 
   - changeSet:
+      id: v48.00-067
+      author: qnkhuat
+      comment: 'Add unique constraint idx_databasechangelog_id_author_filename'
+      preConditions:
+        - onFail: MARK_RAN
+        # If we're dumping the migration as a SQL file or trying to force-migrate we can't check the preconditions
+        # so just go ahead and skip the entire thing. This is a non-critical migration
+        - onUpdateSQL: IGNORE
+        - and:
+          - sqlCheck:
+              expectedResult: 0
+              sql: SELECT count(*) FROM (SELECT count(*) FROM DATABASECHANGELOG GROUP BY ID, AUTHOR, FILENAME HAVING count(*) > 1) t1
+          - not:
+            - indexExists:
+                tableName: ${databasechangelog.name}
+                indexName: idx_databasechangelog_id_author_filename
+      changes:
+        - addUniqueConstraint:
+            constraintName: idx_databasechangelog_id_author_filename
+            tableName: ${databasechangelog.name}
+            columnNames: id, author, filename
+
+  - changeSet:
       id: v49.00-000
       author: qnkhuat
       comment: Remove leagcy pulses

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4212,17 +4212,35 @@ databaseChangeLog:
               sql: SELECT count(*) FROM (SELECT count(*) FROM DATABASECHANGELOG GROUP BY ID, AUTHOR, FILENAME HAVING count(*) > 1) t1
           - or:
             - and:
-              - dbms: h2
-              - not:
-                - indexExists:
-                    tableName: ${databasechangelog.name}
-                    indexName: IDX_DATABASECHANGELOG_ID_AUTHOR_FILENAME
+              - dbms:
+                  type: postgresql
+              - sqlCheck:
+                  expectedResult: 0
+                  sql: >-
+                    SELECT COUNT(*)
+                    FROM pg_indexes
+                    WHERE tablename = 'databasechangelog' AND
+                          indexname = 'idx_databasechangelog_id_author_filename';
             - and:
-              - dbms: mysql,mariadb,postgresql
-              - not:
-                - indexExists:
-                    tableName: ${databasechangelog.name}
-                    indexName: idx_databasechangelog_id_author_filename
+              - dbms:
+                  type: h2
+              - sqlCheck:
+                  expectedResult: 0
+                  sql: >-
+                    SELECT COUNT(*)
+                    FROM INFORMATION_SCHEMA.INDEXES
+                    WHERE TABLE_NAME = 'DATABASECHANGELOG' AND
+                          INDEX_NAME = 'IDX_DATABASECHANGELOG_ID_AUTHOR_FILENAME_INDEX_1';
+            - and:
+              - dbms:
+                  type: mysql,mariadb
+              - sqlCheck:
+                  expectedResult: 0
+                  sql: >-
+                    SELECT COUNT(*)
+                    FROM INFORMATION_SCHEMA.STATISTICS
+                    WHERE TABLE_NAME = 'DATABASECHANGELOG' AND
+                          INDEX_NAME = 'idx_databasechangelog_id_author_filename';
 
       changes:
         - addUniqueConstraint:

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4206,7 +4206,7 @@ databaseChangeLog:
         # If we're dumping the migration as a SQL file or trying to force-migrate we can't check the preconditions
         # so just go ahead and skip the entire thing. This is a non-critical migration
         - onUpdateSQL: IGNORE
-        - or:
+        - and:
           - sqlCheck:
               expectedResult: 0
               sql: SELECT count(*) FROM (SELECT count(*) FROM DATABASECHANGELOG GROUP BY ID, AUTHOR, FILENAME HAVING count(*) > 1) t1

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -4234,19 +4234,19 @@ databaseChangeLog:
             - and:
               - dbms:
                   type: mysql,mariadb
-              - sqlCheck:
-                  expectedResult: 0
-                  sql: >-
-                    SELECT COUNT(*)
-                    FROM INFORMATION_SCHEMA.STATISTICS
-                    WHERE TABLE_NAME = 'DATABASECHANGELOG' AND
-                          INDEX_NAME = 'idx_databasechangelog_id_author_filename';
-
+              - not:
+                - indexExists:
+                    tableName: ${databasechangelog.name}
+                    indexName: idx_databasechangelog_id_author_filename
       changes:
         - addUniqueConstraint:
             constraintName: idx_databasechangelog_id_author_filename
             tableName: ${databasechangelog.name}
             columnNames: id, author, filename
+      rollback:
+        - dropUniqueConstraint:
+            tableName: ${databasechangelog.name}
+            constraintName: idx_databasechangelog_id_author_filename
 
   - changeSet:
       id: v49.00-000

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -767,14 +767,15 @@
 
 (deftest index-database-changelog-test
   (testing "we should have an unique constraint on databasechangelog.(id,author,filename)"
-    (is (= 1
-           (:count
-            (t2/query-one
-             (case (mdb.connection/db-type)
-               :postgres "SELECT COUNT(*) as count FROM pg_indexes WHERE
-                         tablename = 'databasechangelog' AND indexname = 'idx_databasechangelog_id_author_filename';"
-               :mysql    "SELECT COUNT(*) as count FROM INFORMATION_SCHEMA.STATISTICS WHERE
-                         TABLE_NAME = 'DATABASECHANGELOG' AND INDEX_NAME = 'idx_databasechangelog_id_author_filename';"
-               ;; h2 has a strange way of naming constraint
-               :h2       "SELECT COUNT(*) as count FROM information_schema.indexes
-                         WHERE TABLE_NAME = 'DATABASECHANGELOG' AND INDEX_NAME = 'IDX_DATABASECHANGELOG_ID_AUTHOR_FILENAME_INDEX_1';")))))))
+    (impl/test-migrations "v49.00-000" [migrate!]
+      (migrate!)
+      (is (pos?
+             (:count
+              (t2/query-one
+               (case (mdb.connection/db-type)
+                 :postgres "SELECT COUNT(*) as count FROM pg_indexes WHERE
+                           tablename = 'databasechangelog' AND indexname = 'idx_databasechangelog_id_author_filename';"
+                 :mysql    "SELECT COUNT(*) as count FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_NAME = 'DATABASECHANGELOG' AND INDEX_NAME = 'idx_databasechangelog_id_author_filename';"
+                 ;; h2 has a strange way of naming constraint
+                 :h2       "SELECT COUNT(*) as count FROM information_schema.indexes
+                           WHERE TABLE_NAME = 'DATABASECHANGELOG' AND INDEX_NAME = 'IDX_DATABASECHANGELOG_ID_AUTHOR_FILENAME_INDEX_1';"))))))))

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -764,3 +764,17 @@
              (t2/query
               (format "SELECT table_name, column_name FROM information_schema.columns WHERE data_type LIKE 'tinyint%%' AND table_schema = '%s';"
                       (-> (mdb.connection/data-source) .getConnection .getCatalog))))))))
+
+(deftest index-database-changelog-test
+  (testing "we should have an unique constraint on databasechangelog.(id,author,filename)"
+    (is (= 1
+           (:count
+            (t2/query-one
+             (case (mdb.connection/db-type)
+               :postgres "SELECT COUNT(*) as count FROM pg_indexes WHERE
+                         tablename = 'databasechangelog' AND indexname = 'idx_databasechangelog_id_author_filename';"
+               :mysql    "SELECT COUNT(*) as count FROM INFORMATION_SCHEMA.STATISTICS WHERE
+                         TABLE_NAME = 'DATABASECHANGELOG' AND INDEX_NAME = 'idx_databasechangelog_id_author_filename';"
+               ;; h2 has a strange way of naming constraint
+               :h2       "SELECT COUNT(*) as count FROM information_schema.indexes
+                         WHERE TABLE_NAME = 'DATABASECHANGELOG' AND INDEX_NAME = 'IDX_DATABASECHANGELOG_ID_AUTHOR_FILENAME_INDEX_1';")))))))


### PR DESCRIPTION
Closes #37552

Preconditions for this migration:
- [x] skip if have duplicated rows
- [x] skip if the index existsed