### PR TITLE
remove initial slow animation & lags

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -49,7 +49,6 @@ export const ComboChart = ({
     [],
     computedVisualizationSettings,
     WIDTH,
-    false,
     renderingContext,
   );
 

--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -46,7 +46,6 @@ export function ScatterPlot({
     [],
     computedVisualizationSettings,
     WIDTH,
-    false,
     renderingContext,
   );
   chart.setOption(option);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -11,12 +11,12 @@ import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/
 import type { TimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
 import { getTimelineEventsSeries } from "metabase/visualizations/echarts/cartesian/timeline-events/option";
 import type { TimelineEventId } from "metabase-types/api";
-import { getGoalLineSeriesOption } from "./goal-line";
-import { getTrendLineOptionsAndDatasets } from "./trend-line";
 import {
   NEGATIVE_STACK_TOTAL_DATA_KEY,
   POSITIVE_STACK_TOTAL_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import { getGoalLineSeriesOption } from "./goal-line";
+import { getTrendLineOptionsAndDatasets } from "./trend-line";
 
 export const getCartesianChartOption = (
   chartModel: CartesianChartModel,
@@ -24,7 +24,6 @@ export const getCartesianChartOption = (
   selectedTimelineEventsIds: TimelineEventId[],
   settings: ComputedVisualizationSettings,
   chartWidth: number,
-  isAnimated: boolean,
   renderingContext: RenderingContext,
 ): EChartsOption => {
   const hasTimelineEvents = timelineEventsModel != null;
@@ -78,7 +77,8 @@ export const getCartesianChartOption = (
   ];
 
   return {
-    animation: isAnimated,
+    animation: true,
+    animationDuration: 0,
     toolbox: {
       show: false,
     },

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
@@ -19,7 +19,6 @@ export function getWaterfallOption(
   selectedTimelineEventsIds: TimelineEventId[],
   settings: ComputedVisualizationSettings,
   chartWidth: number,
-  isAnimated: boolean,
   renderingContext: RenderingContext,
 ): EChartsOption {
   const baseOption = getCartesianChartOption(
@@ -28,7 +27,6 @@ export function getWaterfallOption(
     selectedTimelineEventsIds,
     settings,
     chartWidth,
-    isAnimated,
     renderingContext,
   );
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -39,7 +39,7 @@ export function CartesianChart(props: VisualizationProps) {
     actionButtons,
     isQueryBuilder,
     isFullscreen,
-    selectedTimelineEventIds = [],
+    selectedTimelineEventIds,
     hovered,
     visualizationIsClickable,
     onChangeCardAndRun,
@@ -128,7 +128,7 @@ export function CartesianChart(props: VisualizationProps) {
             if (
               hasSelectedTimelineEvents(
                 clickedTimelineEvents,
-                selectedTimelineEventIds,
+                selectedTimelineEventIds ?? [],
               )
             ) {
               onDeselectTimelineEvents?.();

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -22,8 +22,8 @@ export function useModelsAndOption({
   card,
   fontFamily,
   width,
-  timelineEvents = [],
-  selectedTimelineEventIds = [],
+  timelineEvents,
+  selectedTimelineEventIds,
 }: VisualizationProps) {
   const seriesToRender = useMemo(
     () => (isPlaceholder ? transformedSeries : rawSeries),
@@ -61,7 +61,7 @@ export function useModelsAndOption({
     () =>
       getTimelineEventsModel(
         chartModel,
-        timelineEvents,
+        timelineEvents ?? [],
         settings,
         width,
         renderingContext,
@@ -75,7 +75,7 @@ export function useModelsAndOption({
         return getWaterfallOption(
           checkWaterfallChartModel(chartModel),
           timelineEventsModel,
-          selectedTimelineEventIds,
+          selectedTimelineEventIds ?? [],
           settings,
           width,
           renderingContext,
@@ -84,7 +84,7 @@ export function useModelsAndOption({
         return getCartesianChartOption(
           chartModel,
           timelineEventsModel,
-          selectedTimelineEventIds,
+          selectedTimelineEventIds ?? [],
           settings,
           width,
           renderingContext,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -78,7 +78,6 @@ export function useModelsAndOption({
           selectedTimelineEventIds,
           settings,
           width,
-          true,
           renderingContext,
         );
       default:
@@ -88,7 +87,6 @@ export function useModelsAndOption({
           selectedTimelineEventIds,
           settings,
           width,
-          true,
           renderingContext,
         );
     }


### PR DESCRIPTION
### Description

Chart looked too laggy for me on a decent data sizes, the performance was worse than previously with dc.js. Turned out it was due to mistake of using default props arrays in deps arrays. It also caused hovered lags when series got stuck in focused or unfocused states.

I also disabled the initial animation since it did not exist before and it adds a bit of a delay before users can see data.

### How to verify

Verify that initial animation is missing on line/area/bar/combo/waterfall/scatter charts.
Verify the performance when hovering charts or resizing is good.

### Demo

Dashboard with 10 charts:

Before
<img width="1723" alt="Screenshot 2024-01-17 at 11 45 05 PM" src="https://github.com/metabase/metabase/assets/14301985/b8791bc1-8539-4760-8c4d-c113f931347d">

After
<img width="1356" alt="Screenshot 2024-01-18 at 1 40 46 AM" src="https://github.com/metabase/metabase/assets/14301985/d9986989-dd13-4e7a-87cd-cd3d47163e93">

### Checklist

- [] Tests have been added/updated to cover changes in this PR
