### PR TITLE
Fix one flaky [SparkSQL?] fingerprinting test

### DIFF
--- a/src/metabase/driver/ddl/interface.clj
+++ b/src/metabase/driver/ddl/interface.clj
@@ -15,7 +15,7 @@
 
 (mu/defn schema-name :- ::lib.schema.common/non-blank-string
   "Returns a schema name for persisting models. Needs the database to use the db id and the site-uuid to ensure that
-  multiple connections from multiple metabae remain distinct. The UUID will have the first character of each section taken.
+  multiple connections from multiple metabases remain distinct. The UUID will have the first character of each section taken.
 
   (schema-name {:id 234} \"143dd8ce-e116-4c7f-8d6d-32e99eaefbbc\") ->  \"metabase_cache_1e483_1\""
   [{:keys [id] :as _database} :- [:map [:id ::lib.schema.id/database]]

--- a/test/metabase/sync/analyze/fingerprint_test.clj
+++ b/test/metabase/sync/analyze/fingerprint_test.clj
@@ -280,10 +280,11 @@
         (is (= (fingerprint/empty-stats-map 0)
                (fingerprint/fingerprint-fields-for-db! fake-db [(t2/select-one Table :id (data/id :venues))] (fn [_ _]))))))))
 
-(deftest ^:parallel fingerprint-test
+(deftest fingerprint-test
   (mt/test-drivers (mt/normal-drivers)
     (testing "Fingerprints should actually get saved with the correct values"
       (testing "Text fingerprints"
+        (fingerprint/fingerprint-fields! (t2/select-one Table :id (data/id :venues)))
         (is (=? {:global {:distinct-count 100
                           :nil%           0.0}
                  :type   {:type/Text {:percent-json   0.0


### PR DESCRIPTION
This started because of issue #37296, which it does not solve. But while investigating that I realized I could get `metabase.sync.analyze.fingerprint-test/fingerprint-test` to fail pretty frequently while running the ns from the command line. It seems to assume that `fingerprint-fields!` has been called, and usually it *had* been called due to dirty testing state, but on my computer the race was finishing the wrong way.