### PR TITLE
remove `@flaky` tag for a test that is not failing anymore

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -137,111 +137,107 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
       dashboard: ORDERS_DASHBOARD_ID,
     };
     ["question", "dashboard"].forEach(object => {
-      it(
-        `should be able to publish/embed and then unpublish a ${object} without filters`,
-        { tags: "@flaky" },
-        () => {
-          const embeddableObject = object === "question" ? "card" : "dashboard";
-          const objectName =
-            object === "question" ? "Orders" : "Orders in a dashboard";
+      it(`should be able to publish/embed and then unpublish a ${object} without filters`, () => {
+        const embeddableObject = object === "question" ? "card" : "dashboard";
+        const objectName =
+          object === "question" ? "Orders" : "Orders in a dashboard";
 
-          cy.intercept("PUT", `/api/${embeddableObject}/${ids[object]}`).as(
-            "embedObject",
+        cy.intercept("PUT", `/api/${embeddableObject}/${ids[object]}`).as(
+          "embedObject",
+        );
+        cy.intercept("GET", `/api/${embeddableObject}/embeddable`).as(
+          "currentlyEmbeddedObject",
+        );
+
+        visitAndEnableSharing(object);
+
+        modal().within(() => {
+          cy.findByRole("tab", { name: "Appearance" }).click();
+
+          cy.findByText("Background");
+          cy.findByText("Dashboard title");
+          cy.findByText("Border");
+          cy.findByText(
+            (_, element) =>
+              element.textContent ===
+              "You can change the font with a paid plan.",
           );
-          cy.intercept("GET", `/api/${embeddableObject}/embeddable`).as(
-            "currentlyEmbeddedObject",
-          );
+          cy.findByText("Download data").should("not.exist");
 
-          visitAndEnableSharing(object);
+          cy.findByRole("tab", { name: "Parameters" }).click();
 
-          modal().within(() => {
-            cy.findByRole("tab", { name: "Appearance" }).click();
-
-            cy.findByText("Background");
-            cy.findByText("Dashboard title");
-            cy.findByText("Border");
-            cy.findByText(
-              (_, element) =>
-                element.textContent ===
-                "You can change the font with a paid plan.",
-            );
-            cy.findByText("Download data").should("not.exist");
-
-            cy.findByRole("tab", { name: "Parameters" }).click();
-
-            cy.findByText(
-              `This ${object} doesn't have any parameters to configure yet.`,
-            );
-
-            cy.findByText(
-              `You will need to publish this ${object} before you can embed it in another application.`,
-            );
-
-            cy.button("Publish changes").click();
-
-            cy.wait("@embedObject");
-          });
-
-          visitIframe();
-
-          cy.findByTestId("embed-frame").within(() => {
-            cy.findByRole("heading", { name: objectName });
-            cy.get(".cellData").contains("37.65");
-          });
-
-          cy.findByRole("contentinfo").within(() => {
-            cy.findByRole("link")
-              .should("have.text", "Powered by Metabase")
-              .and("have.attr", "href")
-              .and("eq", "https://metabase.com/");
-          });
-
-          cy.log(
-            `Make sure the ${object} shows up in the standalone embeds page`,
-          );
-          cy.signInAsAdmin();
-          cy.visit(standalonePath);
-          cy.wait("@currentlyEmbeddedObject");
-
-          const sectionTestId = {
-            dashboard: "-embedded-dashboards-setting",
-            question: "-embedded-questions-setting",
-          }[object];
-
-          cy.findByTestId(sectionTestId)
-            .find("tbody tr")
-            .should("have.length", 1)
-            .and("contain", objectName);
-
-          cy.log(`Unpublish ${object}`);
-          visitAndEnableSharing(object);
-
-          modal().within(() => {
-            cy.findByText(
-              `This ${object} is published and ready to be embedded.`,
-            );
-            cy.button("Unpublish").click();
-
-            cy.wait("@embedObject");
-
-            cy.findByRole("tab", { name: "Parameters" }).click();
-          });
-
-          visitIframe();
-
-          cy.findByTestId("embed-frame").findByText(
-            "Embedding is not enabled for this object.",
+          cy.findByText(
+            `This ${object} doesn't have any parameters to configure yet.`,
           );
 
-          cy.signInAsAdmin();
-          cy.visit(standalonePath);
-          cy.wait("@currentlyEmbeddedObject");
+          cy.findByText(
+            `You will need to publish this ${object} before you can embed it in another application.`,
+          );
 
-          mainPage()
-            .findAllByText(/No (questions|dashboards) have been embedded yet./)
-            .should("have.length", 2);
-        },
-      );
+          cy.button("Publish changes").click();
+
+          cy.wait("@embedObject");
+        });
+
+        visitIframe();
+
+        cy.findByTestId("embed-frame").within(() => {
+          cy.findByRole("heading", { name: objectName });
+          cy.get(".cellData").contains("37.65");
+        });
+
+        cy.findByRole("contentinfo").within(() => {
+          cy.findByRole("link")
+            .should("have.text", "Powered by Metabase")
+            .and("have.attr", "href")
+            .and("eq", "https://metabase.com/");
+        });
+
+        cy.log(
+          `Make sure the ${object} shows up in the standalone embeds page`,
+        );
+        cy.signInAsAdmin();
+        cy.visit(standalonePath);
+        cy.wait("@currentlyEmbeddedObject");
+
+        const sectionTestId = {
+          dashboard: "-embedded-dashboards-setting",
+          question: "-embedded-questions-setting",
+        }[object];
+
+        cy.findByTestId(sectionTestId)
+          .find("tbody tr")
+          .should("have.length", 1)
+          .and("contain", objectName);
+
+        cy.log(`Unpublish ${object}`);
+        visitAndEnableSharing(object);
+
+        modal().within(() => {
+          cy.findByText(
+            `This ${object} is published and ready to be embedded.`,
+          );
+          cy.button("Unpublish").click();
+
+          cy.wait("@embedObject");
+
+          cy.findByRole("tab", { name: "Parameters" }).click();
+        });
+
+        visitIframe();
+
+        cy.findByTestId("embed-frame").findByText(
+          "Embedding is not enabled for this object.",
+        );
+
+        cy.signInAsAdmin();
+        cy.visit(standalonePath);
+        cy.wait("@currentlyEmbeddedObject");
+
+        mainPage()
+          .findAllByText(/No (questions|dashboards) have been embedded yet./)
+          .should("have.length", 2);
+      });
     });
 
     it("should regenerate embedding token and invalidate previous embed url", () => {


### PR DESCRIPTION
This test doesn't seem to be flaky anymore, according to this dashboard linked in [this thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1704888813165949) out of 240+ runs on master done this year it never failed.

Closes https://github.com/metabase/metabase/issues/36688

I added the backport label because the auto formatter changed quite a few lines of code and it would create conflicts on prs on that test otherwise