### PR TITLE
Load tables when db id is present in data permissions pages, e2e test

### DIFF
--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -490,6 +490,18 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
           ["Products", "Unrestricted", "Yes"],
           ["Reviews", "Unrestricted", "Yes"],
         ]);
+
+        // After saving permissions, user should be able to make further edits without refreshing the page
+        // metabase#37811
+        selectSidebarItem("data");
+
+        modifyPermission(
+          "Sample Database",
+          NATIVE_QUERIES_PERMISSION_INDEX,
+          "No",
+        );
+
+        cy.button("Refresh the page").should("not.exist");
       });
 
       it("should show a modal when a revision changes while an admin is editing", () => {

--- a/frontend/src/metabase-types/api/table.ts
+++ b/frontend/src/metabase-types/api/table.ts
@@ -74,6 +74,7 @@ export interface TableListQuery {
   schemaName?: string;
   include_hidden?: boolean;
   include_editable_data_model?: boolean;
+  remove_inactive?: boolean;
 }
 
 export interface ForeignKey {

--- a/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage.tsx
@@ -1,12 +1,12 @@
 import type { ReactNode } from "react";
-import { useEffect, useCallback } from "react";
 import { useAsync } from "react-use";
 import _ from "underscore";
 import type { Route } from "react-router";
 
-import Tables from "metabase/entities/tables";
 import Groups from "metabase/entities/groups";
 import Databases from "metabase/entities/databases";
+
+import { useTableListQuery } from "metabase/common/hooks";
 
 import { isAdminGroup, isDefaultGroup } from "metabase/lib/groups";
 import { PermissionsApi } from "metabase/services";
@@ -70,26 +70,16 @@ function DataPermissionsPage({
     await dispatch({ type: LOAD_DATA_PERMISSIONS_FOR_GROUP, payload: result });
   }, []);
 
-  const fetchTables = useCallback(
-    (dbId: DatabaseId) =>
-      dispatch(
-        Tables.actions.fetchList({
-          dbId,
-          include_hidden: true,
-          remove_inactive: true,
-        }),
-      ),
-    [dispatch],
-  );
+  const { isLoading: isLoadingTables } = useTableListQuery({
+    query: {
+      dbId: params.databaseId,
+      include_hidden: true,
+      remove_inactive: true,
+    },
+    enabled: params.databaseId !== undefined,
+  });
 
-  useEffect(() => {
-    if (params.databaseId == null) {
-      return;
-    }
-    fetchTables(params.databaseId);
-  }, [params.databaseId, fetchTables]);
-
-  if (isLoadingAllUsers || isLoadingAdminstrators) {
+  if (isLoadingAllUsers || isLoadingAdminstrators || isLoadingTables) {
     return (
       <Center h="100%">
         <Loader size="lg" />

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -466,6 +466,12 @@ const hasRevisionChanged = handleActions(
     [LOAD_DATA_PERMISSIONS_FOR_DB]: {
       next: checkRevisionChanged,
     },
+    [SAVE_DATA_PERMISSIONS]: {
+      next: (state, { payload }) => ({
+        revision: payload.revision,
+        hasChanged: false,
+      }),
+    },
   },
   {
     revision: null,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -149,6 +149,8 @@ export const getDatabasesPermissionEditor = createSelector(
   ) => {
     const { groupId, databaseId, schemaName } = params;
 
+    // console.log(schemaName)
+
     if (isLoading || !permissions || groupId == null || !group) {
       return null;
     }
@@ -159,10 +161,12 @@ export const getDatabasesPermissionEditor = createSelector(
     if (!defaultGroup) {
       throw new Error("No default group found");
     }
-
+ 
     const hasSingleSchema =
       databaseId != null &&
       metadata.database(databaseId)?.getSchemas().length === 1;
+
+    // console.log(hasSingleSchema)
 
     const permissionSubject = getPermissionSubject(
       { databaseId, schemaName },
@@ -178,6 +182,8 @@ export const getDatabasesPermissionEditor = createSelector(
     let entities: any = [];
 
     const database = metadata?.database(databaseId);
+
+    
 
     if (database && (schemaName != null || hasSingleSchema)) {
       const schema: Schema = hasSingleSchema

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -149,8 +149,6 @@ export const getDatabasesPermissionEditor = createSelector(
   ) => {
     const { groupId, databaseId, schemaName } = params;
 
-    // console.log(schemaName)
-
     if (isLoading || !permissions || groupId == null || !group) {
       return null;
     }
@@ -161,12 +159,10 @@ export const getDatabasesPermissionEditor = createSelector(
     if (!defaultGroup) {
       throw new Error("No default group found");
     }
- 
+
     const hasSingleSchema =
       databaseId != null &&
       metadata.database(databaseId)?.getSchemas().length === 1;
-
-    // console.log(hasSingleSchema)
 
     const permissionSubject = getPermissionSubject(
       { databaseId, schemaName },
@@ -182,8 +178,6 @@ export const getDatabasesPermissionEditor = createSelector(
     let entities: any = [];
 
     const database = metadata?.database(databaseId);
-
-    
 
     if (database && (schemaName != null || hasSingleSchema)) {
       const schema: Schema = hasSingleSchema

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -82,8 +82,8 @@ describe("GroupsPermissionsPage", function () {
 
       await editDatabasePermission();
 
-      await expect(screen.getByText("Cancel")).toBeInTheDocument();
-      await expect(screen.getByText("Save changes")).toBeInTheDocument();
+      expect(screen.getByText("Cancel")).toBeInTheDocument();
+      expect(screen.getByText("Save changes")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -27,7 +27,9 @@ const TEST_GROUPS = [
   createMockGroup({ name: "All Users" }),
 ];
 
-const setup = async () => {
+const setup = async ({
+  initialRoute = `/admin/permissions/data/group/${TEST_GROUPS[1].id}`,
+} = {}) => {
   setupDatabasesEndpoints([TEST_DATABASE]);
   setupPermissionsGraphEndpoints(TEST_GROUPS, [TEST_DATABASE]);
   setupGroupsEndpoint(TEST_GROUPS);
@@ -50,7 +52,7 @@ const setup = async () => {
     </Route>,
     {
       withRouter: true,
-      initialRoute: `/admin/permissions/data/group/${TEST_DATABASE.id}`,
+      initialRoute,
     },
   );
 
@@ -80,8 +82,16 @@ describe("GroupsPermissionsPage", function () {
 
       await editDatabasePermission();
 
-      expect(screen.getByText("Cancel")).toBeInTheDocument();
-      expect(screen.getByText("Save changes")).toBeInTheDocument();
+      await expect(screen.getByText("Cancel")).toBeInTheDocument();
+      await expect(screen.getByText("Save changes")).toBeInTheDocument();
+    });
+
+    it.only("should be able to render group permissions for a DB when a schema is provided", async () => {
+      await setup({
+        initialRoute: `/admin/permissions/data/group/${TEST_GROUPS[1].id}/database/${TEST_DATABASE.id}/schema/PUBLIC`,
+      });
+
+      screen.logTestingPlaygroundURL();
     });
   });
 

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -85,14 +85,6 @@ describe("GroupsPermissionsPage", function () {
       await expect(screen.getByText("Cancel")).toBeInTheDocument();
       await expect(screen.getByText("Save changes")).toBeInTheDocument();
     });
-
-    it.only("should be able to render group permissions for a DB when a schema is provided", async () => {
-      await setup({
-        initialRoute: `/admin/permissions/data/group/${TEST_GROUPS[1].id}/database/${TEST_DATABASE.id}/schema/PUBLIC`,
-      });
-
-      screen.logTestingPlaygroundURL();
-    });
   });
 
   describe("triggering beforeunload events", () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37774
Closes https://github.com/metabase/metabase/issues/37811

### Description
Due to the way we fetch and manage data in the Groups and Database permissions pages, it was possible to cause the page to error by navigating directly to a permissions schema page. This is because the parent page is responsible for observing the URL, pulling the DB ID out, and getting table information for that database. However, we would still render the children component while that was happening. The children components then call selectors that make assumptions about what is in the entity store based on the URL. In this specific case, we assumed we would find a schema entity based on the URL, but in reality it hadn't been loaded yet

This bug was caused by something kinda weird, in that when dismissing the sandbox permissions modal we would always have a schema in the URL even if there wasn't one previously (this is due to how we determine parent routes in the app). This change ensures that those routes with the schema will load properly.

This PR also adds some test coverage specifically for editing sandbox access in a group focused view (previously, only database focused view was covered).

Edit:
While working on this, I noticed that the impersonated.cy.spec.js suite was failing do to #37811. Because the change was small, I included it in this PR to get CI green. If needed, I can separate it out into it's own PR

### How to verify

1. Go to Admin -> Permissions
2. Select a group, then a database, and select sandboxed access on one of the tables
3. Once the modal opens, simply dismiss it. You should now see a schema present in your URL
4. Refresh the page.

### Demo
![chrome_e2SrAROaew](https://github.com/metabase/metabase/assets/1328979/18f69ac4-7af5-4a3f-ba1c-b1731ee2e265)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
