### PR TITLE
[MLv2] Introduce a `queryDisplayInfo` abstraction

### DIFF
--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -202,3 +202,7 @@ export function fromLegacyColumn(
 ): ColumnMetadata {
   return ML.legacy_column__GT_metadata(query, stageIndex, columnOrField);
 }
+
+export function queryDisplayInfo(query: Query): QueryDisplayInfo {
+  return displayInfo(query, -1, query);
+}

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -140,18 +140,6 @@ declare function DisplayInfoFn(
   stageIndex: number,
   segment: SegmentMetadata,
 ): SegmentDisplayInfo;
-/**
- * Even though it seems weird to pass the same query two times,
- * this function follows the same pattern as the other displayInfo functions.
- * The first two parameters are always a query, and a stage.
- * The third parameter is what you would like to have info about.
- * It just only happens that the thing we're examining is (again) the query itself.
- */
-declare function DisplayInfoFn(
-  _query: Query,
-  _stageIndex: number,
-  query: Query,
-): QueryDisplayInfo;
 
 // x can be any sort of opaque object, e.g. a clause or metadata map. Values returned depend on what you pass in, but it
 // should always have display_name... see :metabase.lib.metadata.calculation/display-info schema
@@ -203,6 +191,15 @@ export function fromLegacyColumn(
   return ML.legacy_column__GT_metadata(query, stageIndex, columnOrField);
 }
 
+/**
+ * Even though it seems weird to pass the same query two times,
+ * this function follows the same pattern as the other displayInfo functions.
+ * The first two parameters are always a query, and a stage.
+ * The third parameter is what you would like to have info about.
+ * It just only happens that the thing we're examining is (again) the query itself.
+ *
+ * Rather than adding another overload, we're introducing a special-case, named abstraction.
+ */
 export function queryDisplayInfo(query: Query): QueryDisplayInfo {
-  return displayInfo(query, -1, query);
+  return ML.display_info(query, -1, query);
 }

--- a/frontend/src/metabase-lib/metadata.ts
+++ b/frontend/src/metabase-lib/metadata.ts
@@ -191,15 +191,13 @@ export function fromLegacyColumn(
   return ML.legacy_column__GT_metadata(query, stageIndex, columnOrField);
 }
 
-/**
- * Even though it seems weird to pass the same query two times,
- * this function follows the same pattern as the other displayInfo functions.
- * The first two parameters are always a query, and a stage.
- * The third parameter is what you would like to have info about.
- * It just only happens that the thing we're examining is (again) the query itself.
- *
- * Rather than adding another overload, we're introducing a special-case, named abstraction.
- */
 export function queryDisplayInfo(query: Query): QueryDisplayInfo {
+  /**
+   * Even though it seems weird to pass the same query two times,
+   * this function follows the same pattern as the other display_info overloads.
+   * The first two parameters are always a query, and a stage index.
+   * The third parameter is what you would like to have the info about.
+   * It just only happens that the thing we're examining is (again) the query itself.
+   */
   return ML.display_info(query, -1, query);
 }


### PR DESCRIPTION
This PR introduces a FE-only abstraction called `queryDisplayInfo`.
Rather than doing another function overload, we're introducing a named export.

The original CLJS function accepts three parameters. The first two are always the query and the stage index. The third one is what we're trying to get the info about. In this case that is the query.

It's weird and cumbersome to always have to type `Lib.displayInfo(query, -1, query)`. That's the main motivation behind this abstraction.

### Usage
This function can be used in code to determine whether or not a query is editable and whether it is a native query.
```js
const { isEditable, isNative } = Lib.queryDisplayInfo(query);
```