### PR TITLE
[MLv2] Properly match aggregations across versions of a query

### DIFF
--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -23,8 +23,9 @@
 (mu/defn column-metadata->aggregation-ref :- :mbql.clause/aggregation
   "Given `:metadata/column` column metadata for an aggregation, construct an `:aggregation` reference."
   [metadata :- lib.metadata/ColumnMetadata]
-  (let [options {:lib/uuid       (str (random-uuid))
-                 :effective-type ((some-fn :effective-type :base-type) metadata)}
+  (let [options {:lib/uuid        (str (random-uuid))
+                 :effective-type  ((some-fn :effective-type :base-type) metadata)
+                 :lib/source-name (:name metadata)}
         ag-uuid (:lib/source-uuid metadata)]
     (assert ag-uuid "Metadata for an aggregation reference should include :lib/source-uuid")
     [:aggregation options ag-uuid]))

--- a/src/metabase/lib/schema/ref.cljc
+++ b/src/metabase/lib/schema/ref.cljc
@@ -79,7 +79,8 @@
    ::common/options
    [:map
     [:name {:optional true} ::common/non-blank-string]
-    [:display-name {:optional true} ::common/non-blank-string]]])
+    [:display-name {:optional true} ::common/non-blank-string]
+    [:lib/source-name {:optional true} ::common/non-blank-string]]])
 
 (mbql-clause/define-mbql-clause :aggregation
   [:tuple


### PR DESCRIPTION
Because aggregation refs are based on `:source-uuid` they are not
comparable between queries, which breaks some logic to find columns
added and removed between two versions of a query.

This adds a fallback based on the newly added `:lib/source-name` option on
aggregation refs.

Fixes #37851.

