### PR TITLE
[MLv2] Add `aggregation-column` and `breakout-column`

### DIFF
--- a/src/metabase/lib/aggregation.cljc
+++ b/src/metabase/lib/aggregation.cljc
@@ -13,6 +13,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.aggregation :as lib.schema.aggregation]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.metadata :as lib.schema.metadata]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
@@ -403,3 +404,15 @@
   (let [ags (aggregations query stage-number)]
     (when (> (clojure.core/count ags) index)
       (nth ags index))))
+
+(mu/defn aggregation-column :- [:maybe ::lib.schema.metadata/column]
+  "Returns the column consumed by this aggregation, eg. the column being summed.
+
+  Returns nil for aggregations like `[:count]` that don't specify a column."
+  [query                                         :- ::lib.schema/query
+   stage-number                                  :- :int
+   [_operator _opts column-ref :as _aggregation] :- ::lib.schema.aggregation/aggregation]
+  (when column-ref
+    (->> (lib.util/query-stage query stage-number)
+         (lib.metadata.calculation/visible-columns query stage-number)
+         (lib.equality/find-matching-column column-ref))))

--- a/src/metabase/lib/breakout.cljc
+++ b/src/metabase/lib/breakout.cljc
@@ -135,3 +135,12 @@
       (lib.remove-replace/remove-clause query stage-number a-breakout))
     query
     (existing-breakouts query stage-number column))))
+
+(mu/defn breakout-column :- ::lib.schema.metadata/column
+  "Returns the input column used for this breakout."
+  [query        :- ::lib.schema/query
+   stage-number :- :int
+   breakout-ref :- ::lib.schema.ref/ref]
+  (->> (lib.util/query-stage query stage-number)
+       (lib.metadata.calculation/visible-columns query stage-number)
+       (lib.equality/find-matching-column breakout-ref)))

--- a/src/metabase/lib/core.cljc
+++ b/src/metabase/lib/core.cljc
@@ -69,6 +69,7 @@
  [lib.aggregation
   aggregate
   aggregation-clause
+  aggregation-column
   aggregation-ref
   aggregation-operator-columns
   aggregations
@@ -96,6 +97,7 @@
   with-binning]
  [lib.breakout
   breakout
+  breakout-column
   breakoutable-columns
   breakouts
   breakouts-metadata]

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -266,6 +266,11 @@
   [a-query stage-number x]
   (lib.core/breakout a-query stage-number (lib.core/ref x)))
 
+(defn ^:export breakout-column
+  "Returns the `:metadata/column` corresponding to this breakout clause."
+  [a-query stage-number breakout-clause]
+  (lib.core/breakout-column a-query stage-number breakout-clause))
+
 (defn ^:export binning
   "Retrieve the current binning state of a `:field` clause, field metadata, etc. as an opaque object, or `nil` if it
   does not have binning options set."
@@ -451,6 +456,11 @@
   "Get the aggregations in a given stage of a query."
   [a-query stage-number]
   (to-array (lib.core/aggregations a-query stage-number)))
+
+(defn ^:export aggregation-column
+  "Returns the `:metadata/column` corresponding to this aggregation clause."
+  [a-query stage-number aggregation-clause]
+  (lib.core/aggregation-column a-query stage-number aggregation-clause))
 
 (defn ^:export aggregation-clause
   "Returns a standalone aggregation clause for an `aggregation-operator` and


### PR DESCRIPTION
These are helpers for going from an aggregation or breakout
clause to the relevant `:metadata/column` they are based on.

Eg. the column being `SUM`'d by an aggregation or bucketed by a breakout.

(Nil for top-level aggregations like `:count`.)

Fixes #37120.

