### PR TITLE
Fix append CSV missing column in CSV file error string

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -600,7 +600,7 @@
                             (tru "The CSV file contains extra columns that are not in the table: {0}."
                                  (format-columns extra))
                             missing
-                            (tru "The CSV file contains extra columns that are not in the table: {0}."
+                            (tru "The CSV file is missing columns that are in the table: {0}."
                                  (format-columns missing)))]
         (throw (ex-info error-message {:status-code 422}))))))
 

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1235,7 +1235,7 @@
                 :data    {:status-code 422}}
                (catch-ex-info (append-csv-with-defaults! :is-upload false)))))
       (testing "The CSV file must not be empty"
-        (is (= {:message "The CSV file contains extra columns that are not in the table: \"name\".",
+        (is (= {:message "The CSV file is missing columns that are in the table: \"name\".",
                 :data    {:status-code 422}}
                (catch-ex-info (append-csv-with-defaults! :file (csv-file-with [] (mt/random-name)))))))
       (testing "Uploads must be supported"

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1286,7 +1286,7 @@
                  "The CSV file contains extra columns that are not in the table: \"extra_column_two\", \"extra_column_one\"."
 
                  [""]
-                 "The CSV file contains extra columns that are not in the table: \"id\", \"name\"."
+                 "The CSV file is missing columns that are in the table: \"id\", \"name\"."
 
                  ["_mb_row_id,extra 1, extra 2"]
                  "The CSV file contains extra columns that are not in the table: \"extra_2\", \"extra_1\". The CSV file is missing columns that are in the table: \"id\", \"name\"."}]


### PR DESCRIPTION
The error message was incorrect for when a CSV file is uploaded and the file is missing some columns that are in the table being uploaded to.

See the test for the change.