### PR TITLE
Uncomment audit-v2-views-test except the part that flakes

### DIFF
--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -540,7 +540,6 @@
         (testing "should drop the existing color column"
           (is (not (contains? (t2/select-one :model/Collection :id collection-id) :color))))))))
 
-#_ ;; TODO: this test is flaky so it's commented out for now
 (deftest audit-v2-views-test
   (testing "Migrations v48.00-029 - end"
     ;; Use an open-ended migration range so that we can detect if any migrations added after these views broke the view
@@ -562,6 +561,7 @@
         (doseq [view-name new-view-names]
           (testing (str "View " view-name " should be created")
             (is (= [] (t2/query (str "SELECT 1 FROM " view-name))))))
+        #_#_ ;; TODO: this is commented out temporarily because it flakes for MySQL (metabase#37434)
         (migrate! :down 47)
         (testing "Views should be removed when downgrading"
           (doseq [view-name new-view-names]


### PR DESCRIPTION
Relates to this flake: https://github.com/metabase/metabase/issues/37434

This PR uncomments the previously commented ([PR](https://github.com/metabase/metabase/pull/37796)) test, but leaves the flaky part commented.

This is in response to Ngoc's comment [here](https://github.com/metabase/metabase/pull/37796#issuecomment-1897666340):

> I don’t think it’s safe to comment that test out. It was purposefully added to detect cases where a future migration changed and somehow broke the view

He's right about it not being safe to comment the whole test out. But it's still safe to comment the flaky part out, which is the part that tests the rollback is successful. This is relatively safe to comment because it is unlikely for changes to the rollback to make it past code review, and there is no change that can prevent them from failing in the future.