### PR TITLE
[MLv2] Migrate `isEditable` method to MLv2

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -503,11 +503,6 @@ class Question {
     return (db && db.auto_run_queries) || false;
   }
 
-  isQueryEditable(): boolean {
-    const query = this.legacyQuery({ useStructuredQuery: true });
-    return query ? query.isEditable() : false;
-  }
-
   /**
    * Returns the type of alert that current question supports
    *

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1108,14 +1108,14 @@ class Question {
    */
   canExploreResults() {
     const canNest = Boolean(this.database()?.hasFeature("nested-queries"));
-    const { isNative } = Lib.queryDisplayInfo(this.query());
+    const { isNative, isEditable } = Lib.queryDisplayInfo(this.query());
 
     return (
       isNative &&
       this.isSaved() &&
       this.parameters().length === 0 &&
       canNest &&
-      this.isQueryEditable() // originally "canRunAdhocQuery"
+      isEditable // originally "canRunAdhocQuery"
     );
   }
 

--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -161,13 +161,6 @@ export default class NativeQuery extends AtomicQuery {
     return database && database.engine;
   }
 
-  // Whether the user can modify and run this query
-  // Determined based on availability of database metadata and native database permissions
-  isEditable(): boolean {
-    const database = this._database();
-    return database != null && database.native_permissions === "write";
-  }
-
   /* Methods unique to this query type */
 
   /**

--- a/frontend/src/metabase-lib/queries/Query.ts
+++ b/frontend/src/metabase-lib/queries/Query.ts
@@ -51,13 +51,6 @@ class Query {
   }
 
   /**
-   * Does this query have the sufficient metadata for editing it?
-   */
-  isEditable(): boolean {
-    return true;
-  }
-
-  /**
    * Returns the dataset_query object underlying this Query
    */
   datasetQuery(): DatasetQuery {

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -141,14 +141,6 @@ class StructuredQuery extends AtomicQuery {
     return metadata != null && metadata.table(this._sourceTableId()) != null;
   }
 
-  /**
-   * @deprecated use MLv2
-   */
-  isEditable(): boolean {
-    const { isEditable } = Lib.queryDisplayInfo(this.getMLv2Query());
-    return isEditable;
-  }
-
   /* AtomicQuery superclass methods */
 
   /**

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -141,11 +141,12 @@ class StructuredQuery extends AtomicQuery {
     return metadata != null && metadata.table(this._sourceTableId()) != null;
   }
 
-  // Whether the user can modify and run this query
-  // Determined based on availability of database and source table metadata
-  // For queries based on questions expects virtual table metadata for the source card
+  /**
+   * @deprecated use MLv2
+   */
   isEditable(): boolean {
-    return this._database() != null && this.hasMetadata();
+    const { isEditable } = Lib.queryDisplayInfo(this.getMLv2Query());
+    return isEditable;
   }
 
   /* AtomicQuery superclass methods */

--- a/frontend/src/metabase-lib/queries/drills/native-drill-fallback.ts
+++ b/frontend/src/metabase-lib/queries/drills/native-drill-fallback.ts
@@ -8,9 +8,9 @@ interface FallbackNativeDrillProps {
 export function nativeDrillFallback({ question }: FallbackNativeDrillProps) {
   const database = question.database();
   const query = question.query();
-  const { isNative } = Lib.queryDisplayInfo(query);
+  const { isNative, isEditable } = Lib.queryDisplayInfo(query);
 
-  if (!isNative || !question.isQueryEditable() || !database) {
+  if (!isNative || !isEditable || !database) {
     return null;
   }
 

--- a/frontend/src/metabase-lib/urls.ts
+++ b/frontend/src/metabase-lib/urls.ts
@@ -1,3 +1,4 @@
+import * as Lib from "metabase-lib";
 import * as Urls from "metabase/lib/urls";
 import { utf8_to_b64url } from "metabase/lib/encoding";
 import type { ParameterId, ParameterValue } from "metabase-types/api";
@@ -52,11 +53,12 @@ export function getUrlWithParameters(
   { objectId, clean }: { objectId?: string | number; clean?: boolean } = {},
 ): string {
   const includeDisplayIsLocked = true;
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
 
   if (question.isStructured()) {
     let questionWithParameters = question.setParameters(parameters);
 
-    if (question.isQueryEditable()) {
+    if (isEditable) {
       questionWithParameters = questionWithParameters
         .setParameterValues(parameterValues)
         ._convertParametersToMbql();

--- a/frontend/src/metabase/admin/datamodel/components/GuiQueryEditor/GuiQueryEditor.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/GuiQueryEditor/GuiQueryEditor.jsx
@@ -78,7 +78,7 @@ export class GuiQueryEditor extends Component {
   }
 
   renderFilters() {
-    const { legacyQuery, features, setDatasetQuery } = this.props;
+    const { legacyQuery, query, features, setDatasetQuery } = this.props;
 
     if (!features.filter) {
       return;
@@ -88,7 +88,9 @@ export class GuiQueryEditor extends Component {
     let filterList;
     let addFilterButton;
 
-    if (legacyQuery.isEditable()) {
+    const { isEditable } = Lib.queryDisplayInfo(query);
+
+    if (isEditable) {
       enabled = true;
 
       const filters = legacyQuery.filters();
@@ -151,18 +153,19 @@ export class GuiQueryEditor extends Component {
 
   renderAggregation() {
     const {
+      query,
       legacyQuery,
       features,
       setDatasetQuery,
       supportMultipleAggregations,
     } = this.props;
+    const { isEditable } = Lib.queryDisplayInfo(query);
 
     if (!features.aggregation) {
       return;
     }
-
     // aggregation clause.  must have table details available
-    if (legacyQuery.isEditable()) {
+    if (isEditable) {
       const aggregations = [...legacyQuery.aggregations()];
 
       if (aggregations.length === 0) {

--- a/frontend/src/metabase/dashboard/actions/navigation.js
+++ b/frontend/src/metabase/dashboard/actions/navigation.js
@@ -53,7 +53,8 @@ export const navigateToNewCardFromDashboard = createThunkAction(
       );
 
       let question = new Question(cardAfterClick, metadata);
-      if (question.isQueryEditable()) {
+      const { isEditable } = Lib.queryDisplayInfo(question.query());
+      if (isEditable) {
         question = question
           .setDisplay(cardAfterClick.display || previousCard.display)
           .setSettings(dashcard.card.visualization_settings)

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -15,6 +15,7 @@ import type {
   Dataset,
   VisualizationSettings,
 } from "metabase-types/api";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/Question";
 import { CardMenuRoot } from "./DashCardMenu.styled";
 
@@ -130,7 +131,8 @@ interface QueryDownloadWidgetOpts {
 }
 
 const canEditQuestion = (question: Question) => {
-  return question.canWrite() && question.isQueryEditable();
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  return question.canWrite() && isEditable;
 };
 
 const canDownloadResults = (result?: Dataset) => {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -25,6 +25,7 @@ import {
 
 import { isActionDashCard } from "metabase/actions/utils";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
+import * as Lib from "metabase-lib";
 import Question from "metabase-lib/Question";
 import { isVariableTarget } from "metabase-lib/parameters/utils/targets";
 import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
@@ -120,7 +121,8 @@ export function DashCardCardParameterMapper({
     }
 
     const question = new Question(card, metadata);
-    return question.isQueryEditable();
+    const { isEditable } = Lib.queryDisplayInfo(question.query());
+    return isEditable;
   }, [card, metadata, isVirtual]);
 
   const { buttonVariant, buttonTooltip, buttonText, buttonIcon } =

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -92,7 +92,8 @@ function ModelDetailPage({
   );
 
   const database = model.database();
-  const hasDataPermissions = model.isQueryEditable();
+  const { isEditable } = Lib.queryDisplayInfo(model.query());
+  const hasDataPermissions = isEditable;
   const hasActions = actions.length > 0;
   const hasActionsEnabled = database != null && database.hasActionsEnabled();
   const hasActionsTab = hasActions || hasActionsEnabled;

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -330,7 +330,7 @@ async function handleQBInit(
 
   let question = new Question(card, metadata);
   const query = question.query();
-  const { isNative } = Lib.queryDisplayInfo(query);
+  const { isNative, isEditable } = Lib.queryDisplayInfo(query);
 
   if (question.isSaved()) {
     if (!question.isDataset()) {
@@ -349,7 +349,7 @@ async function handleQBInit(
     uiControls.isNativeEditorOpen = isEditing || !question.isSaved();
   }
 
-  if (isNative && question.isQueryEditable()) {
+  if (isNative && isEditable) {
     const query = question.legacyQuery() as NativeQuery;
     const newQuery = await updateTemplateTagNames(query, getState, dispatch);
     question = question.setLegacyQuery(newQuery);

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -116,11 +116,12 @@ export const updateQuestion = (
   return async (dispatch: Dispatch, getState: GetState) => {
     const currentQuestion = getQuestion(getState());
     const queryBuilderMode = getQueryBuilderMode(getState());
+    const { isEditable } = Lib.queryDisplayInfo(newQuestion.query());
 
     const shouldTurnIntoAdHoc =
       shouldStartAdHocQuestion &&
       newQuestion.isSaved() &&
-      newQuestion.isQueryEditable() &&
+      isEditable &&
       queryBuilderMode !== "dataset";
 
     if (shouldTurnIntoAdHoc) {

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -179,9 +179,8 @@ export const queryCompleted = (question, queryResults) => {
     const [{ data }] = queryResults;
     const [{ data: prevData }] = getQueryResults(getState()) || [{}];
     const originalQuestion = getOriginalQuestionWithParameterValues(getState());
-    const isDirty =
-      question.isQueryEditable() &&
-      question.isDirtyComparedTo(originalQuestion);
+    const { isEditable } = Lib.queryDisplayInfo(question.query());
+    const isDirty = isEditable && question.isDirtyComparedTo(originalQuestion);
 
     if (isDirty) {
       const { isNative } = Lib.queryDisplayInfo(question.query());

--- a/frontend/src/metabase/query_builder/actions/visualization-settings.js
+++ b/frontend/src/metabase/query_builder/actions/visualization-settings.js
@@ -1,3 +1,4 @@
+import * as Lib from "metabase-lib";
 import {
   getDatasetEditorTab,
   getPreviousQueryBuilderMode,
@@ -31,7 +32,8 @@ export const updateCardVisualizationSettings =
     }
 
     // The check allows users without data permission to resize/rearrange columns
-    const hasWritePermissions = question.isQueryEditable();
+    const { isEditable } = Lib.queryDisplayInfo(question.query());
+    const hasWritePermissions = isEditable;
     await dispatch(
       updateQuestion(question.updateSettings(settings), {
         shouldUpdateUrl: hasWritePermissions,
@@ -43,7 +45,8 @@ export const replaceAllCardVisualizationSettings =
   (settings, newQuestion) => async (dispatch, getState) => {
     const oldQuestion = getQuestion(getState());
     const updatedQuestion = (newQuestion ?? oldQuestion).setSettings(settings);
-    const hasWritePermissions = updatedQuestion.isQueryEditable();
+    const { isEditable } = Lib.queryDisplayInfo(updatedQuestion.query());
+    const hasWritePermissions = isEditable;
 
     await dispatch(
       updateQuestion(updatedQuestion, {

--- a/frontend/src/metabase/query_builder/components/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.tsx
@@ -20,6 +20,7 @@ import { getSetting } from "metabase/selectors/settings";
 import { canUseMetabotOnDatabase } from "metabase/metabot/utils";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { trackTurnIntoModelClicked } from "metabase/query_builder/analytics";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/Question";
 
 import {
@@ -197,7 +198,8 @@ const QuestionActions = ({
     }
   }
 
-  if (question.isQueryEditable()) {
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  if (isEditable) {
     extraButtons.push({
       title: t`Duplicate`,
       icon: "clone",

--- a/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
+++ b/frontend/src/metabase/query_builder/components/VisualizationResult.jsx
@@ -8,6 +8,7 @@ import { ErrorMessage } from "metabase/components/ErrorMessage";
 import Visualization from "metabase/visualizations/components/Visualization";
 import { CreateAlertModalContent } from "metabase/query_builder/components/AlertModals";
 import Modal from "metabase/components/Modal";
+import * as Lib from "metabase-lib";
 import { datasetContainsNoResults } from "metabase-lib/queries/utils/dataset";
 import { ALERT_TYPE_ROWS } from "metabase-lib/Alert";
 
@@ -108,7 +109,8 @@ export default class VisualizationResult extends Component {
         this.props,
         ...ALLOWED_VISUALIZATION_PROPS,
       );
-      const hasDrills = question.isQueryEditable();
+      const { isEditable } = Lib.queryDisplayInfo(question.query());
+      const hasDrills = isEditable;
       return (
         <>
           <Visualization

--- a/frontend/src/metabase/query_builder/components/view/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/FilterHeaderButton.tsx
@@ -2,6 +2,7 @@ import { t } from "ttag";
 import { color } from "metabase/lib/colors";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
 import type { QueryBuilderMode } from "metabase-types/store";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/Question";
 import { HeaderButton } from "./ViewHeader.styled";
 
@@ -42,9 +43,13 @@ FilterHeaderButton.shouldRender = ({
   queryBuilderMode,
   isObjectDetail,
   isActionListVisible,
-}: RenderCheckOpts) =>
-  queryBuilderMode === "view" &&
-  question.isStructured() &&
-  question.isQueryEditable() &&
-  !isObjectDetail &&
-  isActionListVisible;
+}: RenderCheckOpts) => {
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  return (
+    queryBuilderMode === "view" &&
+    question.isStructured() &&
+    isEditable &&
+    !isObjectDetail &&
+    isActionListVisible
+  );
+};

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -164,7 +164,8 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
     return [];
   }
 
-  const hasDataPermission = question.isQueryEditable();
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  const hasDataPermission = isEditable;
   if (!hasDataPermission) {
     return [];
   }

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
@@ -408,19 +408,15 @@ describe("QuestionDataSource", () => {
         });
 
         it("shows nothing if a user doesn't have data permissions", () => {
-          const originalMethod = question.legacyQuery({
-            useStructuredQuery: true,
-          })._database;
-          question.legacyQuery({ useStructuredQuery: true })._database = () =>
-            null;
+          const databaseId = question.card().dataset_query.database;
+          question.card().dataset_query.database = null;
 
           setup({ question });
           expect(
             screen.getByTestId("head-crumbs-container"),
           ).toBeEmptyDOMElement();
 
-          question.legacyQuery({ useStructuredQuery: true })._database =
-            originalMethod;
+          question.card().dataset_query.database = databaseId;
         });
       });
     });

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.unit.spec.js
@@ -175,28 +175,12 @@ function getMetadata() {
   });
 }
 
-function getQuestion(card) {
-  return new Question(card, getMetadata());
+function getQuestion(card, metadata) {
+  return new Question(card, metadata);
 }
 
 function getAdHocQuestion(overrides) {
   return getQuestion({ ...BASE_GUI_QUESTION, ...overrides });
-}
-
-function getNativeQuestion() {
-  return getQuestion(BASE_NATIVE_QUESTION);
-}
-
-function getSavedGUIQuestion(overrides) {
-  return getQuestion({ ...BASE_GUI_QUESTION, ...SAVED_QUESTION, ...overrides });
-}
-
-function getSavedNativeQuestion(overrides) {
-  return getQuestion({
-    ...BASE_NATIVE_QUESTION,
-    ...SAVED_QUESTION,
-    ...overrides,
-  });
 }
 
 function getAdHocOrdersQuestion() {
@@ -234,42 +218,6 @@ function getNestedQuestionTableMock(isMultiSchemaDB) {
   };
 }
 
-function getAdHocNestedQuestion({ isMultiSchemaDB } = {}) {
-  const dbId = isMultiSchemaDB ? MULTI_SCHEMA_DB_ID : SAMPLE_DB_ID;
-  const question = getAdHocQuestion({
-    dataset_query: {
-      type: "query",
-      database: dbId,
-      query: {
-        "source-table": SOURCE_QUESTION_VIRTUAL_ID,
-      },
-    },
-  });
-
-  question.legacyQuery({ useStructuredQuery: true }).table = () =>
-    getNestedQuestionTableMock(isMultiSchemaDB);
-
-  return question;
-}
-
-function getSavedNestedQuestion({ isMultiSchemaDB } = {}) {
-  const dbId = isMultiSchemaDB ? MULTI_SCHEMA_DB_ID : SAMPLE_DB_ID;
-  const question = getSavedGUIQuestion({
-    dataset_query: {
-      type: "query",
-      database: dbId,
-      query: {
-        "source-table": SOURCE_QUESTION_VIRTUAL_ID,
-      },
-    },
-  });
-
-  question.legacyQuery({ useStructuredQuery: true }).table = () =>
-    getNestedQuestionTableMock(isMultiSchemaDB);
-
-  return question;
-}
-
 class ErrorBoundary extends Component {
   componentDidCatch(...args) {
     console.error(...args);
@@ -282,7 +230,15 @@ class ErrorBoundary extends Component {
 }
 const SOURCE_CARD = createMockCard({ id: SOURCE_QUESTION_ID });
 
-function setup({ question, subHead = false, isObjectDetail = false } = {}) {
+function setup({
+  card,
+  subHead = false,
+  isObjectDetail = false,
+  hasPermissions = true,
+} = {}) {
+  const metadata = hasPermissions ? getMetadata() : createMockMetadata({});
+  const question = card && new Question(card, metadata);
+
   setupCardEndpoints(SOURCE_CARD);
 
   const onError = jest.fn();
@@ -295,7 +251,7 @@ function setup({ question, subHead = false, isObjectDetail = false } = {}) {
       />
     </ErrorBoundary>,
   );
-  return { onError };
+  return { onError, question };
 }
 
 jest.mock("metabase/core/components/Link", () => ({ to: href, ...props }) => (
@@ -305,100 +261,95 @@ jest.mock("metabase/core/components/Link", () => ({ to: href, ...props }) => (
 describe("QuestionDataSource", () => {
   const GUI_TEST_CASE = {
     SAVED_GUI_QUESTION: {
-      question: getSavedGUIQuestion(),
+      card: { ...BASE_GUI_QUESTION, ...SAVED_QUESTION },
       questionType: "saved GUI question",
     },
     AD_HOC_QUESTION: {
-      question: getAdHocQuestion(),
+      card: BASE_GUI_QUESTION,
       questionType: "ad-hoc GUI question",
     },
     SAVED_GUI_PRODUCTS_JOIN: {
-      question: getSavedGUIQuestion({
+      card: {
+        ...BASE_GUI_QUESTION,
+        ...SAVED_QUESTION,
         dataset_query: QUERY_WITH_PRODUCTS_JOIN,
-      }),
+      },
       questionType: "saved GUI question joining a table",
     },
     AD_HOC_PRODUCTS_JOIN: {
-      question: getAdHocQuestion({ dataset_query: QUERY_WITH_PRODUCTS_JOIN }),
+      card: { ...BASE_GUI_QUESTION, dataset_query: QUERY_WITH_PRODUCTS_JOIN },
       questionType: "ad-hoc GUI question joining a table",
     },
     SAVED_GUI_PRODUCTS_PEOPLE_JOIN: {
-      question: getSavedGUIQuestion({
+      card: {
+        ...BASE_GUI_QUESTION,
+        ...SAVED_QUESTION,
         dataset_query: QUERY_WITH_PRODUCTS_PEOPLE_JOIN,
-      }),
+      },
       questionType: "saved GUI question joining a few tables",
     },
     AD_HOC_PRODUCTS_PEOPLE_JOIN: {
-      question: getAdHocQuestion({
+      card: {
+        ...BASE_GUI_QUESTION,
         dataset_query: QUERY_WITH_PRODUCTS_PEOPLE_JOIN,
-      }),
+      },
       questionType: "ad-hoc GUI question joining a few tables",
     },
     SAVED_GUI_MULTI_SCHEMA_DB: {
-      question: getSavedGUIQuestion({
+      card: {
+        ...BASE_GUI_QUESTION,
+        ...SAVED_QUESTION,
         dataset_query: QUERY_IN_MULTI_SCHEMA_DB,
-      }),
+      },
       questionType: "saved GUI question using multi-schema DB",
     },
     AD_HOC_MULTI_SCHEMA_DB: {
-      question: getAdHocQuestion({ dataset_query: QUERY_IN_MULTI_SCHEMA_DB }),
+      card: {
+        ...BASE_GUI_QUESTION,
+        dataset_query: QUERY_IN_MULTI_SCHEMA_DB,
+      },
       questionType: "ad-hoc GUI question using multi-schema DB",
     },
     SAVED_OBJECT_DETAIL: {
-      question: getSavedGUIQuestion({ dataset_query: ORDER_DETAIL_QUERY }),
+      card: {
+        ...BASE_GUI_QUESTION,
+        ...SAVED_QUESTION,
+        dataset_query: ORDER_DETAIL_QUERY,
+      },
       questionType: "saved object detail",
     },
     AD_HOC_OBJECT_DETAIL: {
-      question: getAdHocQuestion({ dataset_query: ORDER_DETAIL_QUERY }),
+      card: { ...BASE_GUI_QUESTION, dataset_query: ORDER_DETAIL_QUERY },
       questionType: "ad-hoc object detail",
     },
   };
 
   const GUI_TEST_CASES = Object.values(GUI_TEST_CASE);
 
-  const NESTED_TEST_CASES = {
-    SAVED: {
-      question: getSavedNestedQuestion({ isMultiSchemaDB: false }),
-      questionType: "saved nested question",
-    },
-    SAVED_MULTI_SCHEMA: {
-      question: getSavedNestedQuestion({ isMultiSchemaDB: true }),
-      questionType: "saved nested question using multi-schema DB",
-    },
-    AD_HOC: {
-      question: getAdHocNestedQuestion({ isMultiSchemaDB: false }),
-      questionType: "ad-hoc nested question",
-    },
-    AD_HOC_MULTI_SCHEMA: {
-      question: getAdHocNestedQuestion({ isMultiSchemaDB: true }),
-      questionType: "ad-hoc nested question using multi-schema DB",
-    },
-  };
-
   const ALL_TEST_CASES = [
     ...GUI_TEST_CASES,
     {
-      question: getNativeQuestion(),
+      card: BASE_NATIVE_QUESTION,
       questionType: "not saved native question",
     },
     {
-      question: getSavedNativeQuestion(),
+      card: { ...BASE_NATIVE_QUESTION, ...SAVED_QUESTION },
       questionType: "saved native question",
     },
   ];
 
   it("does not fail if question is not passed", () => {
-    const { onError } = setup({ question: undefined });
+    const { onError } = setup();
     expect(onError).not.toHaveBeenCalled();
   });
 
   describe("common", () => {
     ALL_TEST_CASES.forEach(testCase => {
-      const { question, questionType } = testCase;
+      const { card, questionType } = testCase;
 
       describe(questionType, () => {
         it("displays database name", () => {
-          setup({ question });
+          const { question } = setup({ card });
           const node = screen.queryByText(question.database().displayName());
           expect(node).toBeInTheDocument();
           expect(node.closest("a")).toHaveAttribute(
@@ -408,15 +359,10 @@ describe("QuestionDataSource", () => {
         });
 
         it("shows nothing if a user doesn't have data permissions", () => {
-          const databaseId = question.card().dataset_query.database;
-          question.card().dataset_query.database = null;
-
-          setup({ question });
+          setup({ card, hasPermissions: false });
           expect(
             screen.getByTestId("head-crumbs-container"),
           ).toBeEmptyDOMElement();
-
-          question.card().dataset_query.database = databaseId;
         });
       });
     });
@@ -424,11 +370,11 @@ describe("QuestionDataSource", () => {
 
   describe("GUI", () => {
     Object.values(GUI_TEST_CASE).forEach(testCase => {
-      const { question, questionType } = testCase;
+      const { card, questionType } = testCase;
 
       describe(questionType, () => {
         it("displays table name", () => {
-          setup({ question });
+          const { question } = setup({ card });
           const node = screen.queryByText(
             new RegExp(question.table().displayName()),
           );
@@ -437,7 +383,7 @@ describe("QuestionDataSource", () => {
         });
 
         it("displays table link in subhead variant", () => {
-          setup({ question, subHead: true });
+          const { question } = setup({ card, subHead: true });
           const node = screen.queryByText(
             new RegExp(question.table().displayName()),
           );
@@ -448,7 +394,7 @@ describe("QuestionDataSource", () => {
         });
 
         it("displays table link in object detail view", () => {
-          setup({ question, isObjectDetail: true });
+          const { question } = setup({ card, isObjectDetail: true });
           const node = screen.queryByText(
             new RegExp(question.table().displayName()),
           );
@@ -466,11 +412,11 @@ describe("QuestionDataSource", () => {
       GUI_TEST_CASE.SAVED_GUI_MULTI_SCHEMA_DB,
       GUI_TEST_CASE.AD_HOC_MULTI_SCHEMA_DB,
     ].forEach(testCase => {
-      const { question, questionType } = testCase;
+      const { card, questionType } = testCase;
 
       describe(questionType, () => {
         it("displays schema name", () => {
-          setup({ question });
+          const { question } = setup({ card });
           const node = screen.queryByText(question.table().schema_name);
           expect(node).toBeInTheDocument();
           expect(node.closest("a")).toHaveAttribute(
@@ -487,11 +433,11 @@ describe("QuestionDataSource", () => {
       GUI_TEST_CASE.SAVED_GUI_PRODUCTS_JOIN,
       GUI_TEST_CASE.AD_HOC_PRODUCTS_JOIN,
     ].forEach(testCase => {
-      const { question, questionType } = testCase;
+      const { card, questionType } = testCase;
 
       describe(questionType, () => {
         it("displays 2 joined tables (metabase#17961)", () => {
-          setup({ question, subHead: true });
+          setup({ card, subHead: true });
 
           const orders = screen.queryByText(/Orders/);
           const products = screen.queryByText(/Products/);
@@ -514,11 +460,11 @@ describe("QuestionDataSource", () => {
       GUI_TEST_CASE.SAVED_GUI_PRODUCTS_PEOPLE_JOIN,
       GUI_TEST_CASE.AD_HOC_PRODUCTS_PEOPLE_JOIN,
     ].forEach(testCase => {
-      const { question, questionType } = testCase;
+      const { card, questionType } = testCase;
 
       describe(questionType, () => {
         it("displays > 2 joined tables (metabase#17961)", () => {
-          setup({ question, subHead: true });
+          setup({ card, subHead: true });
 
           const orders = screen.queryByText(/Orders/);
           const products = screen.queryByText(/Products/);
@@ -544,14 +490,66 @@ describe("QuestionDataSource", () => {
     });
   });
 
-  // Enable when HTTP requests mocking is more reliable than xhr-mock
   describe("Nested", () => {
+    const NESTED_QUESTION = {
+      ...BASE_GUI_QUESTION,
+      dataset_query: {
+        ...BASE_GUI_QUESTION.dataset_query,
+        query: {
+          "source-table": SOURCE_QUESTION_VIRTUAL_ID,
+        },
+      },
+    };
+
+    const SAVED_NESTED_QUESTION = {
+      ...NESTED_QUESTION,
+      ...SAVED_QUESTION,
+    };
+
+    const NESTED_TEST_CASES = {
+      SAVED: {
+        card: SAVED_NESTED_QUESTION,
+        questionType: "saved nested question",
+      },
+      SAVED_MULTI_SCHEMA: {
+        card: {
+          ...SAVED_NESTED_QUESTION,
+          dataset_query: {
+            ...SAVED_NESTED_QUESTION.dataset_query,
+            database: MULTI_SCHEMA_DB_ID,
+          },
+        },
+        questionType: "saved nested question using multi-schema DB",
+      },
+      AD_HOC: {
+        card: NESTED_QUESTION,
+        questionType: "ad-hoc nested question",
+      },
+      AD_HOC_MULTI_SCHEMA: {
+        card: {
+          ...NESTED_QUESTION,
+          dataset_query: {
+            ...NESTED_QUESTION.dataset_query,
+            database: MULTI_SCHEMA_DB_ID,
+          },
+        },
+        questionType: "ad-hoc nested question using multi-schema DB",
+      },
+    };
+
     Object.values(NESTED_TEST_CASES).forEach(testCase => {
-      const { question, questionType } = testCase;
+      const { card, questionType } = testCase;
 
       describe(questionType, () => {
         it("does not display virtual schema (metabase#12616)", () => {
-          setup({ question, subHead: true });
+          const { question } = setup({ card, subHead: true });
+
+          const isMultiSchemaDB =
+            card.dataset_query.database === MULTI_SCHEMA_DB_ID;
+
+          question.legacyQuery({ useStructuredQuery: true }).table = () =>
+            getNestedQuestionTableMock(isMultiSchemaDB);
+
           const node = screen.queryByText(
             SOURCE_QUESTION_COLLECTION_SCHEMA_NAME,
           );

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters/QuestionFilters.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters/QuestionFilters.tsx
@@ -2,7 +2,7 @@ import { FilterPanel, FilterPanelButton } from "metabase/querying";
 
 import type { QueryBuilderMode } from "metabase-types/store";
 
-import type * as Lib from "metabase-lib";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/Question";
 
 interface FilterHeaderToggleProps {
@@ -66,11 +66,15 @@ const shouldRender = ({
   question,
   queryBuilderMode,
   isObjectDetail,
-}: RenderCheckOpts) =>
-  queryBuilderMode === "view" &&
-  question.isStructured() &&
-  question.isQueryEditable() &&
-  !isObjectDetail;
+}: RenderCheckOpts) => {
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  return (
+    queryBuilderMode === "view" &&
+    question.isStructured() &&
+    isEditable &&
+    !isObjectDetail
+  );
+};
 
 FilterHeader.shouldRender = shouldRender;
 FilterHeaderToggle.shouldRender = shouldRender;

--- a/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton/QuestionNotebookButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton/QuestionNotebookButton.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import { t } from "ttag";
 
+import * as Lib from "metabase-lib";
 import Tooltip from "metabase/core/components/Tooltip";
 import { ButtonRoot } from "./QuestionNotebookButton.styled";
 
@@ -32,5 +33,7 @@ export function QuestionNotebookButton({
   );
 }
 
-QuestionNotebookButton.shouldRender = ({ question, isActionListVisible }) =>
-  question.isStructured() && question.isQueryEditable() && isActionListVisible;
+QuestionNotebookButton.shouldRender = ({ question, isActionListVisible }) => {
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  return question.isStructured() && isEditable && isActionListVisible;
+};

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -87,7 +87,9 @@ function QuestionRowCount({
     onChangeLimit(limit > 0 ? limit : null);
   };
 
-  const canChangeLimit = question.isStructured() && question.isQueryEditable();
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+
+  const canChangeLimit = question.isStructured() && isEditable;
 
   const limit = canChangeLimit ? Lib.currentLimit(question.query(), -1) : null;
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import { t } from "ttag";
 
+import * as Lib from "metabase-lib";
 import { color } from "metabase/lib/colors";
 import ViewButton from "./ViewButton";
 import { HeaderButton } from "./ViewHeader.styled";
@@ -65,10 +66,14 @@ QuestionSummarizeWidget.shouldRender = ({
   queryBuilderMode,
   isObjectDetail,
   isActionListVisible,
-}) =>
-  queryBuilderMode === "view" &&
-  question &&
-  question.isStructured() &&
-  question.isQueryEditable() &&
-  !isObjectDetail &&
-  isActionListVisible;
+}) => {
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  return (
+    queryBuilderMode === "view" &&
+    question &&
+    question.isStructured() &&
+    isEditable &&
+    !isObjectDetail &&
+    isActionListVisible
+  );
+};

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -239,7 +239,8 @@ class View extends Component {
     // So the model is opened as an underlying native question and the query editor becomes visible
     // This check makes it hide the editor in this particular case
     // More details: https://github.com/metabase/metabase/pull/20161
-    if (question.isDataset() && !question.isQueryEditable()) {
+    const { isEditable } = Lib.queryDisplayInfo(question.query());
+    if (question.isDataset() && !isEditable) {
       return null;
     }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -2,6 +2,7 @@
 import { t } from "ttag";
 import cx from "classnames";
 
+import * as Lib from "metabase-lib";
 import ButtonBar from "metabase/components/ButtonBar";
 
 import QueryDownloadWidget from "metabase/query_builder/components/QueryDownloadWidget";
@@ -43,7 +44,8 @@ const ViewFooter = ({
     return null;
   }
 
-  const hasDataPermission = question.isQueryEditable();
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  const hasDataPermission = isEditable;
   const hideChartSettings = result.error && !hasDataPermission;
 
   return (

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -297,7 +297,9 @@ function AhHocQuestionLeftSide(props) {
   } = props;
 
   const handleTitleClick = () => {
-    if (question.isQueryEditable()) {
+    const { isEditable } = Lib.queryDisplayInfo(question.query());
+
+    if (isEditable) {
       onOpenModal(MODAL_TYPES.SAVE);
     }
   };
@@ -412,7 +414,7 @@ function ViewTitleHeaderRightSide(props) {
     onModelPersistenceChange,
   } = props;
   const isShowingNotebook = queryBuilderMode === "notebook";
-  const canEditQuery = question.isQueryEditable();
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
   const hasExploreResultsLink =
     question.canExploreResults() &&
     MetabaseSettings.get("enable-nested-queries");
@@ -516,10 +518,10 @@ function ViewTitleHeaderRightSide(props) {
       {hasSaveButton && (
         <SaveButton
           role="button"
-          disabled={!question.canRun() || !canEditQuery}
+          disabled={!question.canRun() || !isEditable}
           tooltip={{
             tooltip: t`You don't have permission to save this question.`,
-            isEnabled: !canEditQuery,
+            isEnabled: !isEditable,
             placement: "left",
           }}
           data-metabase-event={

--- a/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/ChartTypeSidebar.tsx
@@ -10,6 +10,7 @@ import { sanatizeResultData } from "metabase/visualizations/shared/utils/data";
 
 import type { UpdateQuestionOpts } from "metabase/query_builder/actions";
 
+import * as Lib from "metabase-lib";
 import type { Visualization } from "metabase/visualizations/types";
 import type Question from "metabase-lib/Question";
 import type Query from "metabase-lib/queries/Query";
@@ -110,7 +111,7 @@ const ChartTypeSidebar = ({
         }
 
         updateQuestion(newQuestion, {
-          shouldUpdateUrl: question.isQueryEditable(),
+          shouldUpdateUrl: Lib.queryDisplayInfo(question.query()).isEditable,
         });
         setUIControls({ isShowingRawTable: false });
       }

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -349,10 +349,6 @@ export const getQuestion = createSelector(
   },
 );
 
-function isQuestionEditable(question) {
-  return question ? question.isQueryEditable() : false;
-}
-
 function areLegacyQueriesEqual(queryA, queryB, tableMetadata) {
   return Lib.areLegacyQueriesEqual(
     queryA,
@@ -446,10 +442,12 @@ export const getIsResultDirty = createSelector(
     tableMetadata,
   ) => {
     const haveParametersChanged = !_.isEqual(lastParameters, nextParameters);
+    const isEditable =
+      question && Lib.queryDisplayInfo(question.query()).isEditable;
 
     return (
       haveParametersChanged ||
-      (isQuestionEditable(question) &&
+      (isEditable &&
         !areQueriesEquivalent({
           originalQuestion,
           lastRunQuestion,
@@ -577,7 +575,8 @@ export const getIsRunnable = createSelector(
       return false;
     }
     if (!question.isSaved() || isDirty) {
-      return question.canRun() && question.isQueryEditable();
+      const { isEditable } = Lib.queryDisplayInfo(question.query());
+      return question.canRun() && isEditable;
     }
     return question.canRun();
   },

--- a/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/ColumnFormattingAction/ColumnFormattingAction.tsx
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+import * as Lib from "metabase-lib";
 import { getSettingsWidgetsForSeries } from "metabase/visualizations/lib/settings/visualization";
 import ChartSettingsWidget from "metabase/visualizations/components/ChartSettingsWidget";
 import { updateSettings } from "metabase/visualizations/lib/settings";
@@ -14,12 +15,14 @@ import { PopoverRoot } from "./ColumnFormattingAction.styled";
 export const POPOVER_TEST_ID = "column-formatting-settings";
 
 export const ColumnFormattingAction: LegacyDrill = ({ question, clicked }) => {
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+
   if (
     !clicked ||
     clicked.value !== undefined ||
     !clicked.column ||
     clicked?.extraData?.isRawTable ||
-    !question.isQueryEditable()
+    !isEditable
   ) {
     return [];
   }

--- a/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/HideColumnAction/HideColumnAction.tsx
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+import * as Lib from "metabase-lib";
 import type { LegacyDrill } from "metabase/visualizations/types";
 import { onUpdateVisualizationSettings } from "metabase/query_builder/actions";
 import {
@@ -11,12 +12,14 @@ export const HideColumnAction: LegacyDrill = ({
   clicked,
   settings,
 }) => {
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+
   if (
     !clicked ||
     clicked.value !== undefined ||
     !clicked.column ||
     clicked?.extraData?.isRawTable ||
-    !question.isQueryEditable()
+    !isEditable
   ) {
     return [];
   }

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -324,17 +324,6 @@ describe("StructuredQuery", () => {
         expect(query.canRun()).toBe(true);
       });
     });
-    describe("isEditable", () => {
-      it("A valid query should be editable", () => {
-        expect(query.isEditable()).toBe(true);
-      });
-
-      it("should be not editable when database object is missing", () => {
-        const q = makeQuery();
-        q._database = () => null;
-        expect(q.isEditable()).toBe(false);
-      });
-    });
   });
 
   describe("AGGREGATION METHODS", () => {


### PR DESCRIPTION
This PR migrates `isEditable` and `isQueryEditable` methods to MLv2.
It completely removes them from the `Question`, `StructuredQuery` and `NativeQuery` prototypes.

**Please note:**
A commit 6e260a9043afaff8da508d339b7e3717e45c901a was already reviewed separately in https://github.com/metabase/metabase/pull/38058

## Some of the lessons learned while working on this
- Any time we're referencing a question inside a selector, we have to assume it might be `undefined`
- The way to reflect the real-world "missing data permissions" scenario in FE unit tests is to make sure there's no `database` in the mocked `metadata` object