### PR TITLE
[MLv2] Add `isTemporalExtraction` flag to `displayInfo`

### DIFF
--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -113,6 +113,7 @@ export type BucketDisplayInfo = {
   displayName: string;
   default?: boolean;
   selected?: boolean;
+  isTemporalExtraction?: boolean;
 };
 
 export type TableDisplayInfo = {
@@ -188,7 +189,9 @@ export type ClauseDisplayInfo = Pick<
 
 export type AggregationClauseDisplayInfo = ClauseDisplayInfo;
 
-export type BreakoutClauseDisplayInfo = ClauseDisplayInfo;
+export type BreakoutClauseDisplayInfo = ClauseDisplayInfo & {
+  isTemporalExtraction?: boolean;
+};
 
 export type OrderByClauseDisplayInfo = ClauseDisplayInfo & {
   direction: OrderByDirection;

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -381,6 +381,8 @@
         :is-breakout            (= source :source/breakouts)})
      (when-some [selected (:selected? x-metadata)]
        {:selected selected})
+     (when-let [temporal-unit ((some-fn :metabase.lib.field/temporal-unit :temporal-unit) x-metadata)]
+       {:is-temporal-extraction (contains? lib.schema.temporal-bucketing/datetime-extraction-units temporal-unit)})
      (select-keys x-metadata [:breakout-position :order-by-position :filter-positions]))))
 
 (defmethod display-info-method :default

--- a/src/metabase/lib/temporal_bucket.cljc
+++ b/src/metabase/lib/temporal_bucket.cljc
@@ -198,7 +198,9 @@
 (defmethod lib.metadata.calculation/display-info-method :option/temporal-bucketing
   [query stage-number option]
   (merge {:display-name (lib.metadata.calculation/display-name query stage-number option)
-          :short-name (u/qualified-name (raw-temporal-bucket option))}
+          :short-name (u/qualified-name (raw-temporal-bucket option))
+          :is-temporal-extraction (contains? lib.schema.temporal-bucketing/datetime-extraction-units
+                                             (raw-temporal-bucket option))}
          (select-keys option [:default :selected])))
 
 (defmulti available-temporal-buckets-method

--- a/test/metabase/lib/temporal_bucket_test.cljc
+++ b/test/metabase/lib/temporal_bucket_test.cljc
@@ -176,21 +176,22 @@
 
 (deftest ^:parallel short-name-display-info-test
   (let [query lib.tu/venues-query]
-    (is (= #{"minute"
-             "hour"
-             "day"
-             "week"
-             "month"
-             "quarter"
-             "year"
-             "minute-of-hour"
-             "hour-of-day"
-             "day-of-week"
-             "day-of-month"
-             "day-of-year"
-             "week-of-year"
-             "month-of-year"
-             "quarter-of-year"}
-           (into #{}
-                 (map #(:short-name (lib/display-info query -1 %)))
+    (is (= {"minute"          false
+            "hour"            false
+            "day"             false
+            "week"            false
+            "month"           false
+            "quarter"         false
+            "year"            true
+            "minute-of-hour"  true
+            "hour-of-day"     true
+            "day-of-week"     true
+            "day-of-month"    true
+            "day-of-year"     true
+            "week-of-year"    true
+            "month-of-year"   true
+            "quarter-of-year" true}
+           (into {}
+                 (comp (map #(lib/display-info query -1 %))
+                       (map (juxt :short-name :is-temporal-extraction)))
                  (lib.temporal-bucket/available-temporal-buckets query (meta/field-metadata :products :created-at)))))))


### PR DESCRIPTION
That applies to both freestanding temporal buckets and to breakouts with
`:temporal-unit` set.

Fixes #36978.
