### PR TITLE
Render Auth Cards when env var is set

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -38,6 +38,7 @@ PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
         noHeader: true,
         widget: SamlAuthCard,
         getHidden: () => !hasPremiumFeature("sso_saml"),
+        forceRenderWidget: true,
       },
       {
         key: "jwt-enabled",

--- a/enterprise/frontend/src/metabase-enterprise/auth/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/auth/index.js
@@ -46,6 +46,7 @@ PLUGIN_ADMIN_SETTINGS_UPDATES.push(sections =>
         noHeader: true,
         widget: JwtAuthCard,
         getHidden: () => !hasPremiumFeature("sso_jwt"),
+        forceRenderWidget: true,
       },
       ...apiKeySettings,
       {

--- a/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.tsx
@@ -6,6 +6,7 @@ import { Button } from "metabase/ui";
 import { isNotNull } from "metabase/lib/types";
 import Modal from "metabase/components/Modal";
 import ModalContent from "metabase/components/ModalContent";
+import type { SettingDefinition } from "metabase-types/api";
 import {
   CardBadge,
   CardDescription,
@@ -15,9 +16,9 @@ import {
   CardTitle,
 } from "./AuthCard.styled";
 
-export interface AuthSetting {
+export type AuthSetting = Omit<SettingDefinition, "value"> & {
   value: boolean | null;
-}
+};
 
 export interface AuthCardProps {
   setting: AuthSetting;
@@ -41,6 +42,8 @@ const AuthCard = ({
   onDeactivate,
 }: AuthCardProps) => {
   const isEnabled = setting.value ?? false;
+  const isEnvSetting = setting.is_env_setting;
+
   const [isOpened, setIsOpened] = useState(false);
 
   const handleOpen = useCallback(() => {
@@ -63,8 +66,9 @@ const AuthCard = ({
       description={description}
       isEnabled={isEnabled}
       isConfigured={isConfigured}
+      setting={setting}
     >
-      {isConfigured && (
+      {isConfigured && !isEnvSetting && (
         <AuthCardMenu
           isEnabled={isEnabled}
           onChange={onChange}
@@ -90,6 +94,7 @@ interface AuthCardBodyProps {
   isConfigured: boolean;
   badgeText?: string;
   buttonText?: string;
+  setting: AuthSetting;
   children?: ReactNode;
 }
 
@@ -101,10 +106,12 @@ export const AuthCardBody = ({
   isConfigured,
   badgeText,
   buttonText,
+  setting,
   children,
 }: AuthCardBodyProps) => {
   const badgeContent = badgeText ?? (isEnabled ? t`Active` : t`Paused`);
   const buttonLabel = buttonText ?? (isConfigured ? t`Edit` : t`Set up`);
+  const { is_env_setting: isEnvSetting, env_name } = setting;
 
   return (
     <CardRoot>
@@ -114,6 +121,9 @@ export const AuthCardBody = ({
           <CardBadge isEnabled={isEnabled} data-testid="card-badge">
             {badgeContent}
           </CardBadge>
+        )}
+        {isEnvSetting && (
+          <CardBadge isEnabled>{t`Set with env var $${env_name}`}</CardBadge>
         )}
         {children}
       </CardHeader>

--- a/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.tsx
@@ -2,11 +2,12 @@ import type { ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 import { Link } from "react-router";
-import { Button } from "metabase/ui";
+import { Button, Anchor, Text } from "metabase/ui";
 import { isNotNull } from "metabase/lib/types";
 import Modal from "metabase/components/Modal";
 import ModalContent from "metabase/components/ModalContent";
 import type { SettingDefinition } from "metabase-types/api";
+import { getEnvVarDocsUrl } from "metabase/admin/settings/utils";
 import {
   CardBadge,
   CardDescription,
@@ -59,14 +60,24 @@ const AuthCard = ({
     handleClose();
   }, [onDeactivate, handleClose]);
 
+  const footer = isEnvSetting ? (
+    <Text>
+      Set with env var{" "}
+      <Anchor
+        href={getEnvVarDocsUrl(setting.env_name)}
+        target="_blank"
+      >{`$${setting.env_name}`}</Anchor>
+    </Text>
+  ) : null;
+
   return (
     <AuthCardBody
       type={type}
       title={title}
       description={description}
       isEnabled={isEnabled}
-      isConfigured={isConfigured}
-      setting={setting}
+      isConfigured={isConfigured && !isEnvSetting}
+      footer={footer}
     >
       {isConfigured && !isEnvSetting && (
         <AuthCardMenu
@@ -94,7 +105,8 @@ interface AuthCardBodyProps {
   isConfigured: boolean;
   badgeText?: string;
   buttonText?: string;
-  setting: AuthSetting;
+  buttonEnabled?: boolean;
+  footer?: ReactNode;
   children?: ReactNode;
 }
 
@@ -106,12 +118,11 @@ export const AuthCardBody = ({
   isConfigured,
   badgeText,
   buttonText,
-  setting,
+  footer,
   children,
 }: AuthCardBodyProps) => {
   const badgeContent = badgeText ?? (isEnabled ? t`Active` : t`Paused`);
   const buttonLabel = buttonText ?? (isConfigured ? t`Edit` : t`Set up`);
-  const { is_env_setting: isEnvSetting, env_name } = setting;
 
   return (
     <CardRoot>
@@ -122,15 +133,16 @@ export const AuthCardBody = ({
             {badgeContent}
           </CardBadge>
         )}
-        {isEnvSetting && (
-          <CardBadge isEnabled>{t`Set with env var $${env_name}`}</CardBadge>
-        )}
         {children}
       </CardHeader>
       <CardDescription>{description}</CardDescription>
-      <Link to={`/admin/settings/authentication/${type}`}>
-        <Button>{buttonLabel}</Button>
-      </Link>
+      {footer ? (
+        footer
+      ) : (
+        <Link to={`/admin/settings/authentication/${type}`}>
+          <Button>{buttonLabel}</Button>
+        </Link>
+      )}
     </CardRoot>
   );
 };

--- a/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.unit.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { createMockSettingDefinition } from "metabase-types/api/mocks";
 import type { AuthSetting, AuthCardProps } from "./AuthCard";
 import AuthCard from "./AuthCard";
 
@@ -54,12 +55,30 @@ describe("AuthCard", () => {
 
     expect(props.onDeactivate).toHaveBeenCalled();
   });
+
+  it("should handle settings set with env vars", () => {
+    const props = getProps({
+      setting: getSetting({
+        value: null,
+        env_name: "MB_JWT_ENABLED",
+        is_env_setting: true,
+      }),
+      isConfigured: true,
+    });
+
+    render(<AuthCard {...props} />);
+
+    expect(screen.getByRole("link")).toHaveTextContent("$MB_JWT_ENABLED");
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("card-badge")).not.toBeInTheDocument();
+  });
 });
 
-const getSetting = (opts?: Partial<AuthSetting>): AuthSetting => ({
-  value: false,
-  ...opts,
-});
+const getSetting = (opts?: Partial<AuthSetting>): AuthSetting =>
+  createMockSettingDefinition({
+    value: false,
+    ...opts,
+  }) as AuthSetting;
 
 const getProps = (opts?: Partial<AuthCardProps>): AuthCardProps => ({
   setting: getSetting(),

--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
@@ -68,7 +68,7 @@ export default class SettingsSetting extends Component {
           <SettingHeader id={settingId} setting={setting} />
         )}
         <SettingContent>
-          {setting.is_env_setting ? (
+          {setting.is_env_setting && !setting.forceRenderWidget ? (
             <SettingEnvVarMessage>
               {jt`This has been set by the ${(
                 <ExternalLink href={getEnvVarDocsUrl(setting.env_name)}>

--- a/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsSetting.jsx
@@ -2,7 +2,6 @@
 import { Component } from "react";
 import PropTypes from "prop-types";
 import { jt } from "ttag";
-import MetabaseSettings from "metabase/lib/settings";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import SettingHeader from "./SettingHeader";
 import { SettingInput } from "./widgets/SettingInput";
@@ -12,7 +11,7 @@ import SettingRadio from "./widgets/SettingRadio";
 import SettingToggle from "./widgets/SettingToggle";
 import SettingSelect from "./widgets/SettingSelect";
 import SettingText from "./widgets/SettingText";
-import { settingToFormFieldId } from "./../../settings/utils";
+import { settingToFormFieldId, getEnvVarDocsUrl } from "./../../settings/utils";
 import {
   SettingContent,
   SettingEnvVarMessage,
@@ -90,10 +89,3 @@ export default class SettingsSetting extends Component {
     );
   }
 }
-
-const getEnvVarDocsUrl = envName => {
-  return MetabaseSettings.docsUrl(
-    "configuring-metabase/environment-variables",
-    envName?.toLowerCase(),
-  );
-};

--- a/frontend/src/metabase/admin/settings/utils.js
+++ b/frontend/src/metabase/admin/settings/utils.js
@@ -1,4 +1,5 @@
 import { t } from "ttag";
+import MetabaseSettings from "metabase/lib/settings";
 
 // in order to prevent collection of identifying information only fields
 // that are explicitly marked as collectable or booleans should show the true value
@@ -18,3 +19,10 @@ export const settingToFormField = setting => ({
 });
 
 export const settingToFormFieldId = setting => `setting-${setting.key}`;
+
+export const getEnvVarDocsUrl = envName => {
+  return MetabaseSettings.docsUrl(
+    "configuring-metabase/environment-variables",
+    envName?.toLowerCase(),
+  );
+};

--- a/frontend/src/metabase/plugins/builtin/auth/ldap.js
+++ b/frontend/src/metabase/plugins/builtin/auth/ldap.js
@@ -19,6 +19,7 @@ PLUGIN_ADMIN_SETTINGS_UPDATES.push(
         description: null,
         noHeader: true,
         widget: LdapAuthCard,
+        forceRenderWidget: true,
       },
     ]),
   sections => ({


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/33264

### Description
Small change to render auth cards in a read only fashion when their enables setting is set with an environment variable. This adds the optional forceRenderWidget prop to the setting definition, and makes changes to the `<AuthCard />` component to see if `setting.is_env_var` has been set to true, and if so provides `<AuthCardBody>` with a message / link to display, rather than a button link.

### How to verify

1. In your local environment, set `$MB_JWT_ENABLED` to true and start the backend
2. Navigate to Admin -> Settings -> Auth. You should see a card that informs you that JWT is set using the environment variable, and a link that will provide more information

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/21fb0241-8eda-446e-9898-ee57d983bad5)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
