### PR TITLE
Use mantine popover in entityMenu

### DIFF
--- a/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.unit.spec.tsx
@@ -16,7 +16,7 @@ describe("AuthCard", () => {
     expect(screen.queryByLabelText("ellipsis icon")).not.toBeInTheDocument();
   });
 
-  it("should pause active authentication", () => {
+  it("should pause active authentication", async () => {
     const props = getProps({
       setting: getSetting({ value: true }),
       isConfigured: true,
@@ -24,12 +24,13 @@ describe("AuthCard", () => {
 
     render(<AuthCard {...props} />);
     userEvent.click(screen.getByLabelText("ellipsis icon"));
+    await screen.findByRole("dialog");
     userEvent.click(screen.getByText("Pause"));
 
     expect(props.onChange).toHaveBeenCalledWith(false);
   });
 
-  it("should resume paused authentication", () => {
+  it("should resume paused authentication", async () => {
     const props = getProps({
       setting: getSetting({ value: false }),
       isConfigured: true,
@@ -37,12 +38,13 @@ describe("AuthCard", () => {
 
     render(<AuthCard {...props} />);
     userEvent.click(screen.getByLabelText("ellipsis icon"));
+    await screen.findByRole("dialog");
     userEvent.click(screen.getByText("Resume"));
 
     expect(props.onChange).toHaveBeenCalledWith(true);
   });
 
-  it("should deactivate authentication", () => {
+  it("should deactivate authentication", async () => {
     const props = getProps({
       setting: getSetting({ value: false }),
       isConfigured: true,
@@ -50,6 +52,7 @@ describe("AuthCard", () => {
 
     render(<AuthCard {...props} />);
     userEvent.click(screen.getByLabelText("ellipsis icon"));
+    await screen.findByRole("dialog");
     userEvent.click(screen.getByText("Deactivate"));
     userEvent.click(screen.getByRole("button", { name: "Deactivate" }));
 

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
@@ -60,7 +60,7 @@ const setup = ({
 
 describe("ActionMenu", () => {
   describe("preview", () => {
-    it("should show an option to hide preview for a pinned question", () => {
+    it("should show an option to hide preview for a pinned question", async () => {
       const item = createMockCollectionItem({
         model: "card",
         collection_position: 1,
@@ -71,12 +71,12 @@ describe("ActionMenu", () => {
       setup({ item });
 
       userEvent.click(getIcon("ellipsis"));
-      userEvent.click(screen.getByText("Don’t show visualization"));
+      userEvent.click(await screen.findByText("Don’t show visualization"));
 
       expect(item.setCollectionPreview).toHaveBeenCalledWith(false);
     });
 
-    it("should show an option to show preview for a pinned question", () => {
+    it("should show an option to show preview for a pinned question", async () => {
       const item = createMockCollectionItem({
         model: "card",
         collection_position: 1,
@@ -87,7 +87,7 @@ describe("ActionMenu", () => {
       setup({ item });
 
       userEvent.click(getIcon("ellipsis"));
-      userEvent.click(screen.getByText("Show visualization"));
+      userEvent.click(await screen.findByText("Show visualization"));
 
       expect(item.setCollectionPreview).toHaveBeenCalledWith(true);
     });
@@ -110,7 +110,7 @@ describe("ActionMenu", () => {
   });
 
   describe("moving and archiving", () => {
-    it("should allow to move and archive regular collections", () => {
+    it("should allow to move and archive regular collections", async () => {
       const item = createMockCollectionItem({
         name: "Collection",
         model: "collection",
@@ -122,11 +122,11 @@ describe("ActionMenu", () => {
       const { onMove } = setup({ item });
 
       userEvent.click(getIcon("ellipsis"));
-      userEvent.click(screen.getByText("Move"));
+      userEvent.click(await screen.findByText("Move"));
       expect(onMove).toHaveBeenCalledWith([item]);
 
       userEvent.click(getIcon("ellipsis"));
-      userEvent.click(screen.getByText("Archive"));
+      userEvent.click(await screen.findByText("Archive"));
       expect(item.setArchived).toHaveBeenCalledWith(true);
     });
 
@@ -165,7 +165,7 @@ describe("ActionMenu", () => {
   });
 
   describe("x-rays", () => {
-    it("should allow to x-ray a model when xrays are enabled", () => {
+    it("should allow to x-ray a model when xrays are enabled", async () => {
       const item = createMockCollectionItem({
         id: 1,
         model: "dataset",
@@ -174,7 +174,7 @@ describe("ActionMenu", () => {
       setup({ item, isXrayEnabled: true });
 
       userEvent.click(getIcon("ellipsis"));
-      expect(screen.getByText("X-ray this")).toBeInTheDocument();
+      expect(await screen.findByText("X-ray this")).toBeInTheDocument();
     });
 
     it("should not allow to x-ray a model when xrays are not enabled", () => {
@@ -237,13 +237,13 @@ describe("ActionMenu", () => {
       });
     };
 
-    it("should allow to ask metabot when it is enabled and there is native write access", () => {
+    it("should allow to ask metabot when it is enabled and there is native write access", async () => {
       setupMetabot(true, {
         native_permissions: "write",
       });
 
       userEvent.click(getIcon("ellipsis"));
-      expect(screen.getByText("Ask Metabot")).toBeInTheDocument();
+      expect(await screen.findByText("Ask Metabot")).toBeInTheDocument();
     });
 
     it("should not allow to ask metabot when it is not enabled but there is native write access", () => {

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/common.unit.spec.tsx
@@ -177,12 +177,12 @@ describe("CollectionHeader", () => {
   });
 
   describe("collection menu", () => {
-    it("should have collection menu options", () => {
+    it("should have collection menu options", async () => {
       const collection = { can_write: true };
       setup({ collection });
 
       userEvent.click(screen.getByLabelText("ellipsis icon"));
-      expect(screen.getByText("Move")).toBeInTheDocument();
+      expect(await screen.findByText("Move")).toBeInTheDocument();
       expect(screen.getByText("Archive")).toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
@@ -72,18 +72,20 @@ describe("instance analytics custom reports collection", () => {
     isAdmin: true,
   };
 
-  it("should not show move button", () => {
+  it("should not show move button", async () => {
     setup(defaultOptions);
     userEvent.click(getIcon("ellipsis"));
+    await screen.findByRole("dialog");
 
     expect(getIcon("lock")).toBeInTheDocument();
     expect(queryIcon("move")).not.toBeInTheDocument();
     expect(screen.queryByText("Move")).not.toBeInTheDocument();
   });
 
-  it("should not show archive button", () => {
+  it("should not show archive button", async () => {
     setup(defaultOptions);
     userEvent.click(getIcon("ellipsis"));
+    await screen.findByRole("dialog");
 
     expect(getIcon("lock")).toBeInTheDocument();
     expect(queryIcon("archive")).not.toBeInTheDocument();

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
@@ -4,7 +4,7 @@ import { getIcon, queryIcon, screen } from "__support__/ui";
 import { setup } from "./setup";
 
 describe("CollectionMenu", () => {
-  it("should be able to edit collection permissions with admin access", () => {
+  it("should be able to edit collection permissions with admin access", async () => {
     setup({
       collection: createMockCollection({
         can_write: true,
@@ -13,7 +13,7 @@ describe("CollectionMenu", () => {
     });
 
     userEvent.click(getIcon("ellipsis"));
-    expect(screen.getByText("Edit permissions")).toBeInTheDocument();
+    expect(await screen.findByText("Edit permissions")).toBeInTheDocument();
   });
 
   it("should not be able to edit collection permissions without admin access", () => {
@@ -53,7 +53,7 @@ describe("CollectionMenu", () => {
     expect(screen.queryByText("Edit permissions")).not.toBeInTheDocument();
   });
 
-  it("should be able to move and archive a collection with write access", () => {
+  it("should be able to move and archive a collection with write access", async () => {
     setup({
       collection: createMockCollection({
         can_write: true,
@@ -61,7 +61,7 @@ describe("CollectionMenu", () => {
     });
 
     userEvent.click(getIcon("ellipsis"));
-    expect(screen.getByText("Move")).toBeInTheDocument();
+    expect(await screen.findByText("Move")).toBeInTheDocument();
     expect(screen.getByText("Archive")).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
@@ -16,7 +16,7 @@ const setupPremium = (opts?: SetupOpts) => {
 };
 
 describe("CollectionMenu", () => {
-  it("should be able to make the collection official", () => {
+  it("should be able to make the collection official", async () => {
     const collection = createMockCollection({
       can_write: true,
     });
@@ -26,13 +26,13 @@ describe("CollectionMenu", () => {
     });
 
     userEvent.click(getIcon("ellipsis"));
-    userEvent.click(screen.getByText("Make collection official"));
+    userEvent.click(await screen.findByText("Make collection official"));
     expect(onUpdateCollection).toHaveBeenCalledWith(collection, {
       authority_level: "official",
     });
   });
 
-  it("should be able to make the collection regular", () => {
+  it("should be able to make the collection regular", async () => {
     const collection = createMockCollection({
       can_write: true,
       authority_level: "official",
@@ -43,7 +43,7 @@ describe("CollectionMenu", () => {
     });
 
     userEvent.click(getIcon("ellipsis"));
-    userEvent.click(screen.getByText("Remove Official badge"));
+    userEvent.click(await screen.findByText("Remove Official badge"));
     expect(onUpdateCollection).toHaveBeenCalledWith(collection, {
       authority_level: null,
     });

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
@@ -100,10 +100,10 @@ describe("PinnedItemCard", () => {
     expect(screen.getByText("A dashboard")).toBeInTheDocument();
   });
 
-  it("should show an action menu when user clicks on the menu icon in the card", () => {
+  it("should show an action menu when user clicks on the menu icon in the card", async () => {
     setup();
     userEvent.click(getIcon("ellipsis"));
-    expect(screen.getByText("Unpin")).toBeInTheDocument();
+    expect(await screen.findByText("Unpin")).toBeInTheDocument();
   });
 
   it("doesn't show model detail page link", () => {

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -65,6 +65,7 @@ class EntityMenu extends Component {
         opened={open}
         className={cx(className, open ? openClassNames : closedClassNames)}
         transitionProps={{ transition: "scale" }}
+        onChange={() => this.toggleMenu()}
         position="bottom-end"
       >
         <Popover.Target>

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -64,7 +64,7 @@ class EntityMenu extends Component {
       <Popover
         opened={open}
         className={cx(className, open ? openClassNames : closedClassNames)}
-        transitionProps={{ transition: "scale" }}
+        transitionProps={{ transition: "pop" }}
         onChange={() => this.toggleMenu()}
         position="bottom-end"
       >

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -62,6 +62,7 @@ class EntityMenu extends Component {
     const { open, menuItemContent } = this.state;
     return (
       <Popover
+        opened={open}
         className={cx(className, open ? openClassNames : closedClassNames)}
         transitionProps={{ transition: "scale" }}
         position="bottom-end"

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -64,7 +64,7 @@ class EntityMenu extends Component {
       <Popover
         opened={open}
         className={cx(className, open ? openClassNames : closedClassNames)}
-        transitionProps={{ transition: "pop" }}
+        transitionProps={{ transition: "fade" }}
         onChange={() => this.toggleMenu()}
         position="bottom-end"
       >

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -1,18 +1,11 @@
 /* eslint-disable react/prop-types */
 import { createRef, Component } from "react";
-import { Motion, spring } from "react-motion";
 import cx from "classnames";
 
-import { isReducedMotionPreferred } from "metabase/lib/dom";
+import { Popover } from "metabase/ui";
 
-import Card from "metabase/components/Card";
 import EntityMenuTrigger from "metabase/components/EntityMenuTrigger";
 import EntityMenuItem from "metabase/components/EntityMenuItem";
-import Popover from "metabase/components/Popover";
-
-import { Container } from "./EntityMenu.styled";
-
-const MENU_SHIFT_Y = 10;
 
 /**
  * @deprecated: use Menu from "metabase/ui"
@@ -52,8 +45,6 @@ class EntityMenu extends Component {
   };
 
   render() {
-    const preferReducedMotion = isReducedMotionPreferred();
-
     const {
       items,
       triggerIcon,
@@ -61,139 +52,90 @@ class EntityMenu extends Component {
       className,
       openClassNames,
       closedClassNames,
-      horizontalAttachments,
       minWidth,
       tooltip,
       trigger,
       renderTrigger,
-      targetOffsetY,
       triggerAriaLabel,
       tooltipPlacement,
     } = this.props;
     const { open, menuItemContent } = this.state;
     return (
-      <Container
+      <Popover
         className={cx(className, open ? openClassNames : closedClassNames)}
-        open={open}
-        ref={this.rootRef}
+        transitionProps={{ transition: "scale" }}
+        position="bottom-end"
       >
-        {renderTrigger ? (
-          renderTrigger({ open, onClick: this.toggleMenu })
-        ) : (
-          <EntityMenuTrigger
-            ariaLabel={triggerAriaLabel}
-            trigger={trigger}
-            icon={triggerIcon}
-            onClick={this.toggleMenu}
-            open={open}
-            tooltip={tooltip}
-            tooltipPlacement={tooltipPlacement}
-            triggerProps={triggerProps}
-          />
-        )}
-        <Popover
-          target={this.rootRef.current}
-          isOpen={open}
-          onClose={this.toggleMenu}
-          hasArrow={false}
-          hasBackground={false}
-          horizontalAttachments={horizontalAttachments}
-          targetOffsetY={targetOffsetY || 0}
-          ignoreTrigger
-        >
-          {/* Note: @kdoh 10/12/17
-           * React Motion has a flow type problem with children see
-           * https://github.com/chenglou/react-motion/issues/375
-           * TODO This can be removed if we upgrade to flow 0.53 and react-motion >= 0.5.1
-           */}
-          <Motion
-            defaultStyle={{
-              opacity: 0,
-              translateY: 0,
-            }}
-            style={{
-              opacity: open ? spring(1) : spring(0),
-              translateY: open ? spring(MENU_SHIFT_Y) : spring(0),
-            }}
-          >
-            {({ opacity, translateY }) => {
-              const motionOpacity = preferReducedMotion
-                ? opacity > 0.5
-                  ? 1
-                  : 0
-                : opacity;
-              const motionY = preferReducedMotion
-                ? translateY > MENU_SHIFT_Y / 2
-                  ? MENU_SHIFT_Y
-                  : 0
-                : translateY;
-              return (
-                <div
-                  style={{
-                    opacity: motionOpacity,
-                    transform: `translateY(${motionY}px)`,
-                  }}
-                >
-                  <Card>
-                    {menuItemContent || (
-                      <ol className="p1" style={{ minWidth: minWidth ?? 184 }}>
-                        {items.map(item => {
-                          if (!item) {
-                            return null;
-                          } else if (item.content) {
-                            return (
-                              <li key={item.title} data-testid={item.testId}>
-                                <EntityMenuItem
-                                  icon={item.icon}
-                                  title={item.title}
-                                  action={() =>
-                                    this.replaceMenuWithItemContent(
-                                      item.content(
-                                        this.toggleMenu,
-                                        this.setFreezeMenu,
-                                      ),
-                                    )
-                                  }
-                                  tooltip={item.tooltip}
-                                />
-                              </li>
-                            );
-                          } else {
-                            return (
-                              <li key={item.title} data-testid={item.testId}>
-                                <EntityMenuItem
-                                  icon={item.icon}
-                                  title={item.title}
-                                  externalLink={item.externalLink}
-                                  action={
-                                    item.action &&
-                                    (e => {
-                                      item.action(e);
-                                      this.toggleMenu();
-                                    })
-                                  }
-                                  event={item.event}
-                                  link={item.link}
-                                  tooltip={item.tooltip}
-                                  disabled={item.disabled}
-                                  onClose={() => {
-                                    this.toggleMenu();
-                                    item?.onClose?.();
-                                  }}
-                                />
-                              </li>
-                            );
-                          }
-                        })}
-                      </ol>
-                    )}
-                  </Card>
-                </div>
-              );
-            }}
-          </Motion>
-        </Popover>
-      </Container>
+        <Popover.Target>
+          <div>
+            {renderTrigger ? (
+              renderTrigger({ open, onClick: this.toggleMenu })
+            ) : (
+              <EntityMenuTrigger
+                ariaLabel={triggerAriaLabel}
+                trigger={trigger}
+                icon={triggerIcon}
+                onClick={this.toggleMenu}
+                open={open}
+                tooltip={tooltip}
+                tooltipPlacement={tooltipPlacement}
+                triggerProps={triggerProps}
+              />
+            )}
+          </div>
+        </Popover.Target>
+        <Popover.Dropdown>
+          {menuItemContent || (
+            <ol className="p1" style={{ minWidth: minWidth ?? 184 }}>
+              {items.map(item => {
+                if (!item) {
+                  return null;
+                } else if (item.content) {
+                  return (
+                    <li key={item.title} data-testid={item.testId}>
+                      <EntityMenuItem
+                        icon={item.icon}
+                        title={item.title}
+                        action={() =>
+                          this.replaceMenuWithItemContent(
+                            item.content(this.toggleMenu, this.setFreezeMenu),
+                          )
+                        }
+                        tooltip={item.tooltip}
+                      />
+                    </li>
+                  );
+                } else {
+                  return (
+                    <li key={item.title} data-testid={item.testId}>
+                      <EntityMenuItem
+                        icon={item.icon}
+                        title={item.title}
+                        externalLink={item.externalLink}
+                        action={
+                          item.action &&
+                          (e => {
+                            item.action(e);
+                            this.toggleMenu();
+                          })
+                        }
+                        event={item.event}
+                        link={item.link}
+                        tooltip={item.tooltip}
+                        disabled={item.disabled}
+                        onClose={() => {
+                          this.toggleMenu();
+                          item?.onClose?.();
+                        }}
+                      />
+                    </li>
+                  );
+                }
+              })}
+            </ol>
+          )}
+        </Popover.Dropdown>
+      </Popover>
     );
   }
 }

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/tests/common.unit.spec.tsx
@@ -13,6 +13,7 @@ describe("DashboardHeader", () => {
     });
 
     userEvent.click(screen.getByLabelText("dashboard-menu-button"));
+    await screen.findByRole("dialog");
 
     const exportPdfButton = within(
       screen.getByTestId("dashboard-export-pdf-button"),
@@ -26,6 +27,7 @@ describe("DashboardHeader", () => {
     });
 
     userEvent.click(screen.getByLabelText("dashboard-menu-button"));
+    await screen.findByRole("dialog");
 
     const exportPdfButton = within(
       screen.getByTestId("dashboard-export-pdf-button"),

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -362,7 +362,7 @@ describe("ModelDetailPage", () => {
         const { model, modelUpdateSpy } = await setup({ model: getModel() });
 
         userEvent.click(getIcon("ellipsis"));
-        userEvent.click(screen.getByText("Archive"));
+        userEvent.click(await screen.findByText("Archive"));
 
         expect(screen.getByRole("dialog")).toBeInTheDocument();
         userEvent.click(screen.getByRole("button", { name: "Archive" }));
@@ -383,13 +383,15 @@ describe("ModelDetailPage", () => {
         });
 
         userEvent.click(getIcon("ellipsis"));
-        userEvent.click(screen.getByText("Move"));
+        userEvent.click(await screen.findByText("Move"));
 
         expect(screen.getByRole("dialog")).toBeInTheDocument();
         userEvent.click(await screen.findByText(COLLECTION_2.name));
         userEvent.click(screen.getByRole("button", { name: "Move" }));
 
-        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        await waitFor(() =>
+          expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+        );
 
         await waitFor(() => {
           expect(modelUpdateSpy).toHaveBeenCalledWith(
@@ -633,7 +635,7 @@ describe("ModelDetailPage", () => {
         await setupActions({ model, actions: [action] });
 
         openActionMenu(action);
-        userEvent.click(screen.getByText("Edit"));
+        userEvent.click(await screen.findByText("Edit"));
 
         expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
       });
@@ -646,12 +648,14 @@ describe("ModelDetailPage", () => {
 
         const listItem = screen.getByRole("listitem", { name: action.name });
         userEvent.click(within(listItem).getByLabelText("ellipsis icon"));
-        userEvent.click(screen.getByText("Archive"));
+        userEvent.click(await screen.findByText("Archive"));
 
         const modal = screen.getByRole("dialog");
         userEvent.click(within(modal).getByRole("button", { name: "Archive" }));
 
-        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+        await waitFor(() =>
+          expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
+        );
         expect(updateActionSpy).toHaveBeenCalledWith({
           id: action.id,
           archived: true,
@@ -677,7 +681,7 @@ describe("ModelDetailPage", () => {
         await setupActions({ model, actions });
 
         userEvent.click(screen.getByLabelText("Actions menu"));
-        userEvent.click(screen.getByText("Disable basic actions"));
+        userEvent.click(await screen.findByText("Disable basic actions"));
         userEvent.click(screen.getByRole("button", { name: "Disable" }));
 
         actions.forEach(action => {
@@ -734,7 +738,7 @@ describe("ModelDetailPage", () => {
 
         openActionMenu(action);
 
-        expect(screen.getByText("View")).toBeInTheDocument();
+        expect(await screen.findByText("View")).toBeInTheDocument();
       });
 
       it("doesn't allow to archive actions", async () => {
@@ -848,7 +852,7 @@ describe("ModelDetailPage", () => {
       await setupActions({ model: modelCard, actions: [action] });
 
       userEvent.click(screen.getByLabelText("Actions menu"));
-      userEvent.click(screen.getByText("Create basic actions"));
+      userEvent.click(await screen.findByText("Create basic actions"));
 
       await waitFor(() => {
         expect(createActionSpy).toHaveBeenCalledWith({

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.unit.spec.tsx
@@ -76,10 +76,10 @@ describe("ProfileLink", () => {
     fetchMock.get("path:/api/util/bug_report_details", "mockBugReportDetails");
   });
   describe("self-hosted", () => {
-    it("should show the proper set of items for normal users", () => {
+    it("should show the proper set of items for normal users", async () => {
       setup({ isAdmin: false });
 
-      openMenu();
+      await openMenu();
 
       REGULAR_ITEMS.forEach(title => {
         expect(screen.getByText(title)).toBeInTheDocument();
@@ -87,10 +87,10 @@ describe("ProfileLink", () => {
       expect(screen.queryByText("Admin settings")).not.toBeInTheDocument();
     });
 
-    it("should show the proper set of items for admin users", () => {
+    it("should show the proper set of items for admin users", async () => {
       setup({ isAdmin: true });
 
-      openMenu();
+      await openMenu();
 
       ADMIN_ITEMS.forEach(title => {
         expect(screen.getByText(title)).toBeInTheDocument();
@@ -99,10 +99,10 @@ describe("ProfileLink", () => {
   });
 
   describe("hosted", () => {
-    it("should show the proper set of items for normal users", () => {
+    it("should show the proper set of items for normal users", async () => {
       setupHosted({ isAdmin: false });
 
-      openMenu();
+      await openMenu();
 
       REGULAR_ITEMS.forEach(title => {
         expect(screen.getByText(title)).toBeInTheDocument();
@@ -110,10 +110,10 @@ describe("ProfileLink", () => {
       expect(screen.queryByText("Admin settings")).not.toBeInTheDocument();
     });
 
-    it("should show the proper set of items for admin users", () => {
+    it("should show the proper set of items for admin users", async () => {
       setupHosted({ isAdmin: true });
 
-      openMenu();
+      await openMenu();
 
       HOSTED_ITEMS.forEach(title => {
         expect(screen.getByText(title)).toBeInTheDocument();
@@ -123,11 +123,11 @@ describe("ProfileLink", () => {
 
   describe("help link", () => {
     describe("when the setting is set to hidden", () => {
-      it("should return not be visible", () => {
+      it("should return not be visible", async () => {
         setup({
           helpLinkSetting: "hidden",
         });
-        openMenu();
+        await openMenu();
 
         const link = screen.queryByRole("link", { name: /help/i });
 
@@ -136,12 +136,12 @@ describe("ProfileLink", () => {
     });
 
     describe("when the setting is `custom`", () => {
-      it("should return  the custom destination", () => {
+      it("should return  the custom destination", async () => {
         setup({
           helpLinkSetting: "custom",
           helpLinkCustomDestinationSetting: "https://custom.example.org/help",
         });
-        openMenu();
+        await openMenu();
 
         const link = screen.getByRole("link", { name: /help/i });
 
@@ -158,7 +158,7 @@ describe("ProfileLink", () => {
             isPaidPlan: true,
             helpLinkSetting: "metabase",
           });
-          openMenu();
+          await openMenu();
           const link = screen.getByRole("link", { name: /help/i });
 
           expect(link).toBeInTheDocument();
@@ -173,13 +173,13 @@ describe("ProfileLink", () => {
       });
 
       describe("when non admin", () => {
-        it("should return the default /help link", () => {
+        it("should return the default /help link", async () => {
           setup({
             isAdmin: false,
             isPaidPlan: true,
             helpLinkSetting: "metabase",
           });
-          openMenu();
+          await openMenu();
           const link = screen.getByRole("link", { name: /help/i });
 
           expect(link).toBeInTheDocument();
@@ -193,5 +193,7 @@ describe("ProfileLink", () => {
   });
 });
 
-const openMenu = () =>
+const openMenu = async () => {
   userEvent.click(screen.getByRole("img", { name: /gear/i }));
+  await screen.findByRole("dialog");
+};

--- a/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QuestionActions.unit.spec.tsx
@@ -82,7 +82,7 @@ describe("QuestionActions", () => {
     },
   );
 
-  it("should allow to edit the model only with write permissions", () => {
+  it("should allow to edit the model only with write permissions", async () => {
     setup({
       card: createMockCard({
         dataset: true,
@@ -91,11 +91,13 @@ describe("QuestionActions", () => {
     });
 
     userEvent.click(getIcon("ellipsis"));
+    await screen.findByRole("dialog");
+
     expect(screen.getByText("Edit query definition")).toBeInTheDocument();
     expect(screen.getByText("Edit metadata")).toBeInTheDocument();
   });
 
-  it("should not allow to edit the model without write permissions", () => {
+  it("should not allow to edit the model without write permissions", async () => {
     setup({
       card: createMockCard({
         dataset: true,
@@ -104,6 +106,8 @@ describe("QuestionActions", () => {
     });
 
     userEvent.click(getIcon("ellipsis"));
+    await screen.findByRole("dialog");
+
     expect(screen.queryByText("Edit query definition")).not.toBeInTheDocument();
     expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
   });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.beforeunload-events.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.beforeunload-events.unit.spec.tsx
@@ -110,7 +110,7 @@ describe("QueryBuilder - beforeunload events", () => {
 
       userEvent.click(screen.getByText("New"));
       userEvent.click(
-        within(screen.getByTestId("popover")).getByText("SQL query"),
+        within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 
@@ -130,7 +130,7 @@ describe("QueryBuilder - beforeunload events", () => {
 
       userEvent.click(screen.getByText("New"));
       userEvent.click(
-        within(screen.getByTestId("popover")).getByText("SQL query"),
+        within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
 
       await waitForLoaderToBeRemoved();

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
@@ -405,7 +405,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       userEvent.click(screen.getByText("New"));
       userEvent.click(
-        within(screen.getByTestId("popover")).getByText("SQL query"),
+        within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 
@@ -425,7 +425,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       userEvent.click(screen.getByText("New"));
       userEvent.click(
-        within(screen.getByTestId("popover")).getByText("SQL query"),
+        within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 
@@ -444,7 +444,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       userEvent.click(screen.getByText("New"));
       userEvent.click(
-        within(screen.getByTestId("popover")).getByText("SQL query"),
+        within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 
@@ -469,7 +469,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       userEvent.click(screen.getByText("New"));
       userEvent.click(
-        within(screen.getByTestId("popover")).getByText("SQL query"),
+        within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 

--- a/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.unit.spec.tsx
@@ -78,12 +78,13 @@ describe("EventCard", () => {
 
     render(<EventCard {...props} />);
     userEvent.click(screen.getByLabelText("ellipsis icon"));
+    await screen.findByRole("dialog");
 
     expect(screen.getByText("Edit event")).toBeInTheDocument();
     expect(screen.getByText("Archive event")).toBeInTheDocument();
   });
 
-  it("should render the menu for an archived event", () => {
+  it("should render the menu for an archived event", async () => {
     const props = getProps({
       timeline: createMockTimeline({
         collection: createMockCollection({
@@ -97,6 +98,7 @@ describe("EventCard", () => {
 
     render(<EventCard {...props} />);
     userEvent.click(screen.getByLabelText("ellipsis icon"));
+    await screen.findByRole("dialog");
 
     expect(screen.getByText("Unarchive event")).toBeInTheDocument();
     expect(screen.getByText("Delete event")).toBeInTheDocument();

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailHeader.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailHeader.tsx
@@ -73,7 +73,6 @@ export function ObjectDetailHeader({
 
           {actionItems.length > 0 && (
             <EntityMenu
-              horizontalAttachments={["right", "left"]}
               items={actionItems}
               triggerIcon="ellipsis"
               triggerProps={{

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
@@ -503,7 +503,7 @@ describe("ObjectDetailView", () => {
 async function findActionInActionMenu({ name }: Pick<WritebackAction, "name">) {
   const actionsMenu = await screen.findByTestId("actions-menu");
   userEvent.click(actionsMenu);
-  const popover = await screen.findByTestId("popover");
+  const popover = await screen.findByRole("dialog");
   const action = within(popover).queryByText(name);
   return action;
 }


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/37343

>[!warning]
> this is a risky change to a component that appears in a lot of places in the app

### Description

Looking into fixing #37343, I didn't really want to muck around hacking a fix into the older of our two deprecated popover implementations. Instead, I updated the component that uses the popover (EntityMenu) to use Mantine's popover.  

I also tried totally rewriting it to use Mantine's Menu, but I got mired in quite a few edge cases (that component is used in a lot of places and has lots of props). I think it's best to do the smallest change necessary to use this new popover implementation.

![popoverScroll](https://github.com/metabase/metabase/assets/30528226/e0e4a8ca-feec-4b6a-bdb9-b9243795c5b0)


**Bonuses 🥳**
- this popover actually updates when you scroll, so it never overflows the viewport
- there's several snazzy animation options
- we don't have to use react-motion (a rarely used or updated library) anymore in this component.


### How to verify

click on the context menu for collection items near the bottom of your screen, see that it never overflows the viewport



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
