### PR TITLE
Return “contains” and “does-not-contain” for comment/description

### DIFF
--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -76,10 +76,10 @@
         {:name   label
          :filter (operator op field-ref value)})
 
-      (lib.types.isa/string? column)
-      (for [[op label] [[:=  "="]
-                        [:!= "≠"]
-                        [:contains "contains"]
+      (and (lib.types.isa/string? column)
+           (or (lib.types.isa/comment? column)
+               (lib.types.isa/description? column)))
+      (for [[op label] [[:contains "contains"]
                         [:does-not-contain "does-not-contain"]]]
         {:name   label
          :filter (operator op field-ref value)})

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -182,16 +182,14 @@
                                 (lib/available-drill-thrus query -1 context))]
       (is (=? {:lib/type  :metabase.lib.drill-thru/drill-thru
                :type      :drill-thru/quick-filter
-               :operators [{:name "="}
-                           {:name "≠"}
-                           {:name "contains"}
+               :operators [{:name "contains"}
                            {:name "does-not-contain"}]
                :value     "text"
                :column    {:name "BODY"}}
               drill))
       (testing "Should include :value in the display info (#33560)"
         (is (=? {:type      :drill-thru/quick-filter
-                 :operators ["=" "≠" "contains" "does-not-contain"]
+                 :operators ["contains" "does-not-contain"]
                  :value     "text"}
                 (lib/display-info query drill))))
       (testing "apply drills"

--- a/test/metabase/lib/test_metadata.cljc
+++ b/test/metabase/lib/test_metadata.cljc
@@ -2058,7 +2058,7 @@
   [_table-name _field-name]
   {:description                nil
    :database-type              "CHARACTER VARYING"
-   :semantic-type              nil
+   :semantic-type              :type/Description
    :table-id                   (id :reviews)
    :coercion-strategy          nil
    :name                       "BODY"


### PR DESCRIPTION
Fixes #36856.

`src/metabase/lib/drill_thru/quick_filter.cljc` contains the following in the namespace docstring:
>   - For string columns which have `type/Comment` or `type/Description` semantic type, allow `contains` and
    `does-not-contain` operators.

Because of this, I've removed `:=` and `:!=` from the list of available operators for comments and descriptions.