### PR TITLE
Disallow Filter labels to be any variation of the word 'tab'.

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -141,7 +141,10 @@ function getLabelError({
     return t`Required`;
   }
   if (isParameterSlugUsed(labelValue)) {
-    return t`This label is already in use`;
+    return t`This label is already in use.`;
+  }
+  if (labelValue.toLowerCase() === "tab") {
+    return t`This label is reserved for dashboard tabs.`;
   }
   return null;
 }

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -56,6 +56,33 @@ describe("ParameterSidebar", () => {
     expect(labelInput).toHaveValue("bar");
   });
 
+  it("should not update the label if the input is any variation of the word 'tab'", () => {
+    const { onChangeName } = setup({
+      parameter: createMockUiParameter({
+        name: "foo",
+        type: "string/=",
+        sectionId: "string",
+      }),
+    });
+    const labelInput = screen.getByLabelText("Label");
+    expect(labelInput).toHaveValue("foo");
+    fillValue(labelInput, "tAb");
+    // expect there to be an error message with the text "reserved"
+    expect(screen.getByText(/reserved/i)).toBeInTheDocument();
+    labelInput.blur();
+    // when the input blurs, the value should have reverted to the original
+    expect(onChangeName).not.toHaveBeenCalled();
+    expect(labelInput).toHaveValue("foo");
+    // the error message should disappear
+    expect(screen.queryByText(/reserved/i)).not.toBeInTheDocument();
+
+    // sanity check with a non-blank value
+    fillValue(labelInput, "bar");
+    labelInput.blur();
+    expect(onChangeName).toHaveBeenCalledWith("bar");
+    expect(labelInput).toHaveValue("bar");
+  });
+
   it("should allow to change source settings for location parameters", () => {
     const { onChangeQueryType } = setup({
       parameter: createMockUiParameter({


### PR DESCRIPTION
Fixes: #34784

To prevent ambiguous dashboard URLs, filter labels should not be called 'tab'. 
When editing a filter's label, the UI will prevent you from using any variation of the word 'tab', telling you it's reserved for Dashboard tabs.

This behaviour is similar to when you leave the label text field blank.


https://github.com/metabase/metabase/assets/21064735/791aac96-ae6e-469b-b351-d943a619bb52


 