### PR TITLE
fix auto y-axis split on native queries

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -291,6 +291,29 @@ describe("scenarios > visualizations > bar chart", () => {
 
       cy.get("g.axis.yr").should("not.exist");
     });
+
+    it("should not split the y-axis on native queries with two numeric columns", () => {
+      visitQuestionAdhoc({
+        display: "bar",
+        dataset_query: {
+          type: "native",
+          native: {
+            query:
+              `SELECT products.category AS "x", COUNT(*) AS "m1", AVG(orders.discount) AS "m2" ` +
+              "FROM orders " +
+              "JOIN products ON orders.product_id = products.id " +
+              "GROUP BY products.category",
+          },
+          database: SAMPLE_DB_ID,
+        },
+        visualization_settings: {
+          "graph.dimensions": ["x"],
+          "graph.metrics": ["m1", "m2"],
+        },
+      });
+
+      cy.get("g.axis.yr").should("be.visible");
+    });
   });
 
   describe("with stacked bars", () => {

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.js
@@ -2,6 +2,7 @@ import { renderWithProviders, screen } from "__support__/ui";
 import registerVisualizations from "metabase/visualizations/register";
 
 import { delay } from "metabase/lib/promise";
+import { createMockCard } from "metabase-types/api/mocks";
 
 import { color } from "metabase/lib/colors";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -27,7 +28,7 @@ describe("Visualization", () => {
     it("should render", async () => {
       await renderViz([
         {
-          card: { display: "scalar" },
+          card: createMockCard({ display: "scalar" }),
           data: { rows: [[1]], cols: [NumberColumn({ name: "Count" })] },
         },
       ]);
@@ -41,7 +42,7 @@ describe("Visualization", () => {
       it("should have correct colors", async () => {
         const { container } = await renderViz([
           {
-            card: { name: "Card", display: "bar" },
+            card: createMockCard({ name: "Card", display: "bar" }),
             data: {
               cols: [
                 StringColumn({ name: "Dimension" }),
@@ -64,7 +65,7 @@ describe("Visualization", () => {
       it("should have correct colors", async () => {
         const { container } = await renderViz([
           {
-            card: { name: "Card", display: "bar" },
+            card: createMockCard({ name: "Card", display: "bar" }),
             data: {
               cols: [
                 StringColumn({ name: "Dimension" }),
@@ -90,7 +91,7 @@ describe("Visualization", () => {
       it("should have correct colors", async () => {
         const { container } = await renderViz([
           {
-            card: { name: "Card", display: "bar" },
+            card: createMockCard({ name: "Card", display: "bar" }),
             data: {
               cols: [
                 StringColumn({ name: "Dimension1" }),
@@ -118,7 +119,7 @@ describe("Visualization", () => {
       it("should have correct colors", async () => {
         const { container } = await renderViz([
           {
-            card: { name: "Card1", display: "bar" },
+            card: createMockCard({ name: "Card1", display: "bar" }),
             data: {
               cols: [
                 StringColumn({ name: "Dimension" }),
@@ -131,7 +132,7 @@ describe("Visualization", () => {
             },
           },
           {
-            card: { name: "Card2", display: "bar" },
+            card: createMockCard({ name: "Card2", display: "bar" }),
             data: {
               cols: [
                 StringColumn({ name: "Dimension" }),

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer-bar.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer-bar.unit.spec.js
@@ -1,5 +1,6 @@
 import "__support__/ui-mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
 import registerVisualizations from "metabase/visualizations/register";
+import { createMockCard } from "metabase-types/api/mocks";
 
 import {
   NumberColumn,
@@ -32,13 +33,13 @@ const DEFAULT_COLUMN_SETTINGS = {
 
 function MainSeries(chartType, settings = {}, { key = "A", value = 1 } = {}) {
   return {
-    card: {
+    card: createMockCard({
       display: chartType,
       visualization_settings: {
         ...DEFAULT_SETTINGS,
         ...settings,
       },
-    },
+    }),
     data: {
       cols: [
         StringColumn({
@@ -61,7 +62,7 @@ function MainSeries(chartType, settings = {}, { key = "A", value = 1 } = {}) {
 
 function ExtraSeries(count = 2) {
   return {
-    card: {},
+    card: createMockCard({}),
     data: {
       cols: [
         StringColumn({

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer-scatter.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer-scatter.unit.spec.js
@@ -1,5 +1,6 @@
 import "__support__/ui-mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
 import registerVisualizations from "metabase/visualizations/register";
+import { createMockCard } from "metabase-types/api/mocks";
 
 import {
   NumberColumn,
@@ -50,10 +51,10 @@ describe("LineAreaBarRenderer-scatter", () => {
       element,
       [
         {
-          card: {
+          card: createMockCard({
             display: "scatter",
             visualization_settings: DEFAULT_SETTINGS,
-          },
+          }),
           data: {
             cols: [
               NumberColumn({ display_name: "A", source: "breakout" }),
@@ -82,10 +83,10 @@ describe("LineAreaBarRenderer-scatter", () => {
       element,
       [
         {
-          card: {
+          card: createMockCard({
             display: "scatter",
             visualization_settings: DEFAULT_SETTINGS,
-          },
+          }),
           data: {
             cols: [
               NumberColumn({ display_name: "A", source: "breakout" }),

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer-waterfall.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer-waterfall.unit.spec.js
@@ -1,5 +1,6 @@
 import "__support__/ui-mocks"; // included explicitly whereas with e2e tests it comes with __support__/e2e
 import registerVisualizations from "metabase/visualizations/register";
+import { createMockCard } from "metabase-types/api/mocks";
 
 import {
   NumberColumn,
@@ -32,13 +33,13 @@ const DEFAULT_COLUMN_SETTINGS = {
 
 function MainSeries(settings, rows) {
   return {
-    card: {
+    card: createMockCard({
       display: "waterfall",
       visualization_settings: {
         ...DEFAULT_SETTINGS,
         ...settings,
       },
-    },
+    }),
     data: {
       cols: [
         StringColumn({

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.tz.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.tz.unit.spec.js
@@ -4,6 +4,7 @@ import _ from "underscore";
 // eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import testAcrossTimezones from "__support__/timezones";
+import { createMockCard } from "metabase-types/api/mocks";
 import {
   NumberColumn,
   DateTimeColumn,
@@ -232,10 +233,10 @@ const DEFAULT_SETTINGS = {
 function renderTimeseries(element, unit, timezone, rows, props = {}) {
   const series = [
     {
-      card: {
+      card: createMockCard({
         display: "bar",
         visualization_settings: { ...DEFAULT_SETTINGS },
-      },
+      }),
       data: {
         results_timezone: timezone,
         cols: [

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.unit.spec.js
@@ -2,6 +2,7 @@ import "__support__/ui-mocks"; // included explicitly whereas with e2e tests it 
 
 import registerVisualizations from "metabase/visualizations/register";
 import { getComputedSettingsForSeries } from "metabase/visualizations/lib/settings/visualization";
+import { createMockCard } from "metabase-types/api/mocks";
 import lineAreaBarRenderer, {
   getDimensionsAndGroupsAndUpdateSeriesDisplayNames,
 } from "metabase/visualizations/lib/LineAreaBarRenderer";
@@ -90,7 +91,10 @@ describe("LineAreaBarRenderer", () => {
       requested_timezone: "US/Pacific",
       results_timezone: "US/Eastern",
     };
-    const card = { display: "line", visualization_settings: {} };
+    const card = createMockCard({
+      display: "line",
+      visualization_settings: {},
+    });
     const onRender = jest.fn();
 
     renderLineAreaBar(element, [{ data, card }], { onRender });
@@ -109,7 +113,7 @@ describe("LineAreaBarRenderer", () => {
         requested_timezone: tz,
         results_timezone: tz,
       },
-      card: { display: "line", visualization_settings: {} },
+      card: createMockCard({ display: "line", visualization_settings: {} }),
     });
     const onRender = jest.fn();
 
@@ -150,7 +154,9 @@ describe("LineAreaBarRenderer", () => {
 
     const cols = [dateColumn, NumberColumn()];
     const chartType = "line";
-    const series = [{ data: { cols, rows }, card: { display: chartType } }];
+    const series = [
+      { data: { cols, rows }, card: createMockCard({ display: chartType }) },
+    ];
     const settings = getComputedSettingsForSeries(series);
     const onHoverChange = jest.fn();
 
@@ -191,10 +197,10 @@ describe("LineAreaBarRenderer", () => {
         date_separator: "-",
       },
     };
-    const card = {
+    const card = createMockCard({
       display: chartType,
       visualization_settings: { column_settings },
-    };
+    });
     const series = [{ data: { cols, rows }, card }];
     const settings = getComputedSettingsForSeries(series);
     const onHoverChange = jest.fn();
@@ -353,13 +359,13 @@ describe("LineAreaBarRenderer", () => {
                 [3, 1],
               ],
             },
-            card: {
+            card: createMockCard({
               display: "bar",
               visualization_settings: {
                 "graph.x_axis.axis_enabled": true,
                 "graph.x_axis.scale": "histogram",
               },
-            },
+            }),
           },
         ],
         {},
@@ -454,7 +460,7 @@ describe("LineAreaBarRenderer", () => {
           cols: [DateTimeColumn({ unit }), NumberColumn()],
           rows: rows,
         },
-        card: {
+        card: createMockCard({
           display: "line",
           visualization_settings: {
             "graph.x_axis.scale": "timeseries",
@@ -462,7 +468,7 @@ describe("LineAreaBarRenderer", () => {
             "graph.colors": ["#000000"],
             ...settings,
           },
-        },
+        }),
       })),
       {
         onHoverChange,
@@ -479,7 +485,7 @@ describe("LineAreaBarRenderer", () => {
           cols: [StringColumn(), NumberColumn()],
           rows: [scalar],
         },
-        card: {
+        card: createMockCard({
           display: "bar",
           visualization_settings: {
             "bar.scalar_series": true,
@@ -488,7 +494,7 @@ describe("LineAreaBarRenderer", () => {
             "graph.x_axis.axis_enabled": true,
             "graph.x_axis.scale": "ordinal",
           },
-        },
+        }),
       })),
       { onHoverChange },
     );

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -11,6 +11,8 @@ import {
 import { formatNullable } from "metabase/lib/formatting/nullable";
 import { datasetContainsNoResults } from "metabase-lib/queries/utils/dataset";
 
+import { isStructured } from "metabase-lib/queries/utils/card";
+import { isNumeric } from "metabase-lib/types/utils/isa";
 import {
   computeTimeseriesDataInverval,
   dimensionIsTimeseries,
@@ -355,13 +357,14 @@ export function xValueForWaterfallTotal({ settings, series }) {
 
 const uniqueCards = series => _.uniq(series.map(({ card }) => card.id)).length;
 
-const aggregateColumns = series => {
+const getMetricColumnsCount = series => {
+  const metricColumnPredicate = isStructured(series[0]?.card)
+    ? column => column.source === "aggregation"
+    : column => isNumeric(column);
+
   return _.uniq(
     series
-      .map(({ data: { cols } }) => {
-        return cols.filter(col => col.source === "aggregation");
-      })
-      .flat()
+      .flatMap(({ data: { cols } }) => cols.filter(metricColumnPredicate))
       .map(({ name }) => name),
   ).length;
 };
@@ -371,13 +374,19 @@ export function shouldSplitYAxis(
   datas,
   yExtents,
 ) {
-  if (
-    isScalarSeries ||
-    chartType === "scatter" ||
-    settings["graph.y_axis.auto_split"] === false ||
-    (uniqueCards(series) < 2 && aggregateColumns(series) < 2) ||
-    isStacked(settings, datas)
-  ) {
+  const isSuitableChartType = !isScalarSeries && chartType !== "scatter";
+  if (!isSuitableChartType) {
+    return false;
+  }
+
+  if (!settings["graph.y_axis.auto_split"]) {
+    return false;
+  }
+
+  const isSingleCardWithSingleMetricColumn =
+    uniqueCards(series) <= 1 && getMetricColumnsCount(series) <= 1;
+
+  if (isSingleCardWithSingleMetricColumn || isStacked(settings, datas)) {
     return false;
   }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35727

### Description

While https://github.com/metabase/metabase/pull/34674 fixed invalid y-axis split on breakout series, it introduced the linked issue for native queries. The y-axis split code assumed if there is only one metric column on one card, we should not apply auto split. However, the check was valid for GUI (aka structured) queries only since it assumed only columns with `source="aggregation"` are metric columns which is not true for native queries for which we should check for column type to be numeric.

### How to verify

1) create a native question
```
SELECT
  products.category AS "x",
  COUNT(*) AS "m1",
  AVG(orders.discount) AS "m2"
FROM
  orders
JOIN products ON orders.product_id = products.id
GROUP BY
  products.category
```
2) change viz type to `combo`
3) set `x` as x-axis column, `m1`, `m2` as y-axis columns
4) Ensure the y-axis is automatically split

### Demo

Before
<img width="1338" alt="Screenshot 2024-01-19 at 1 27 01 AM" src="https://github.com/metabase/metabase/assets/14301985/abd957b4-7230-4d3d-9e74-92b4e3aad31c">

After
<img width="1349" alt="Screenshot 2024-01-19 at 1 26 00 AM" src="https://github.com/metabase/metabase/assets/14301985/e44f4752-aa43-4420-a2e8-d9e20f7b3199">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
