### PR TITLE
Enabling dragging of long-named TabButtons

### DIFF
--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -415,15 +415,9 @@ describe("scenarios > dashboard > tabs", () => {
     createNewTab();
 
     // Assert initial tab order
-    cy.findAllByTestId("tab-button-input-wrapper")
-      .eq(0)
-      .findByText("Tab 1");
-    cy.findAllByTestId("tab-button-input-wrapper")
-      .eq(1)
-      .findByText("Tab 2");
-    cy.findAllByTestId("tab-button-input-wrapper")
-      .eq(2)
-      .findByText("Tab 3");
+    cy.findAllByTestId("tab-button-input-wrapper").eq(0).findByText("Tab 1");
+    cy.findAllByTestId("tab-button-input-wrapper").eq(1).findByText("Tab 2");
+    cy.findAllByTestId("tab-button-input-wrapper").eq(2).findByText("Tab 3");
 
     // Prior to this bugfix, tab containing this text would be too long to drag to the left of either of the other tabs.
     const longName =
@@ -453,13 +447,13 @@ describe("scenarios > dashboard > tabs", () => {
             button: 0,
             clientX: 11,
             clientY: 0,
-            force: true
+            force: true,
           })
           .trigger("mousemove", {
             button: 0,
             clientX: coordsDrag.x,
             clientY: 0,
-            force: true
+            force: true,
           })
           .trigger("mouseup");
       });
@@ -471,15 +465,9 @@ describe("scenarios > dashboard > tabs", () => {
     saveDashboard();
 
     // After the long tab is dragged, it is now in the first position
-    cy.findAllByTestId("tab-button-input-wrapper")
-      .eq(0)
-      .findByText( longName);
-    cy.findAllByTestId("tab-button-input-wrapper")
-      .eq(1)
-      .findByText("Tab 1");
-    cy.findAllByTestId("tab-button-input-wrapper")
-      .eq(2)
-      .findByText("Tab 2");
+    cy.findAllByTestId("tab-button-input-wrapper").eq(0).findByText(longName);
+    cy.findAllByTestId("tab-button-input-wrapper").eq(1).findByText("Tab 1");
+    cy.findAllByTestId("tab-button-input-wrapper").eq(2).findByText("Tab 2");
   });
 });
 

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -54,7 +54,7 @@ export interface TabButtonProps<T> extends HTMLAttributes<HTMLDivElement> {
   label: string;
   value: T;
   showMenu?: boolean;
-  menuItems?: TabButtonMenuItem<unknown>[];
+  menuItems?: TabButtonMenuItem<any>[];
   onRename?: ChangeEventHandler<HTMLInputElement>;
   onFinishRenaming?: () => void;
   isRenaming?: boolean;

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -17,6 +17,8 @@ import styled from "@emotion/styled";
 import { t } from "ttag";
 
 import { css } from "@emotion/react";
+import { useSortable } from "@dnd-kit/sortable";
+import type { UniqueIdentifier } from "@dnd-kit/core";
 import ControlledPopoverWithTrigger from "metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger";
 
 import { color, lighten } from "metabase/lib/colors";
@@ -179,12 +181,13 @@ const _TabButton = forwardRef(function TabButton<T>(
 export interface RenameableTabButtonProps<T>
   extends Omit<
     TabButtonProps<T>,
-    "onRename" | "onFinishRenaming" | "isRenaming"
+    "onRename" | "onFinishRenaming" | "isRenaming" | "value"
   > {
   onRename: (newLabel: string) => void;
   renameMenuLabel?: string;
   renameMenuIndex?: number;
   canRename?: boolean;
+  value: UniqueIdentifier;
 }
 
 // These styles need to be here instead of .styled to avoid circular dependency
@@ -212,10 +215,11 @@ export function RenameableTabButton<T>({
   renameMenuLabel = t`Rename`,
   renameMenuIndex = 0,
   canRename = true,
+  value,
   ...props
 }: RenameableTabButtonProps<T>) {
   const { value: selectedValue } = useContext(TabContext);
-  const isSelected = props.value === selectedValue;
+  const isSelected = value === selectedValue;
 
   const [label, setLabel] = useState(labelProp);
   const [prevLabel, setPrevLabel] = useState(label);
@@ -254,9 +258,19 @@ export function RenameableTabButton<T>({
     ...originalMenuItems.slice(renameMenuIndex),
   ];
 
+  const dragLabel = (s: string) => {
+    if (s.length < 20) {
+      return s;
+    } else {
+      return `${s.slice(0, 17)}...`;
+    }
+  };
+
+  const { isDragging } = useSortable({ id: value });
+
   return (
     <RenameableTabButtonStyled
-      label={label}
+      label={isDragging ? dragLabel(label) : label}
       isSelected={isSelected}
       isRenaming={canRename && isRenaming}
       canRename={canRename}
@@ -267,6 +281,7 @@ export function RenameableTabButton<T>({
         menuItems as TabButtonMenuItem<unknown>[] /* workaround for styled component swallowing generic type */
       }
       ref={inputRef}
+      value={value}
       {...props}
     />
   );

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -54,7 +54,7 @@ export interface TabButtonProps<T> extends HTMLAttributes<HTMLDivElement> {
   label: string;
   value: T;
   showMenu?: boolean;
-  menuItems?: TabButtonMenuItem<T>[];
+  menuItems?: TabButtonMenuItem<unknown>[];
   onRename?: ChangeEventHandler<HTMLInputElement>;
   onFinishRenaming?: () => void;
   isRenaming?: boolean;

--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -68,7 +68,7 @@ function TabRowInner<T>({
   // Needed for DnD e2e tests to work
   // See https://github.com/clauderic/dnd-kit/issues/208#issuecomment-824469766
   const mouseSensor = useSensor(MouseSensor, {
-    activationConstraint: { distance: 10 }
+    activationConstraint: { distance: 10 },
   });
 
   const onDragEnd = (event: DragEndEvent) => {

--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -67,7 +67,9 @@ function TabRowInner<T>({
 
   // Needed for DnD e2e tests to work
   // See https://github.com/clauderic/dnd-kit/issues/208#issuecomment-824469766
-  const mouseSensor = useSensor(MouseSensor);
+  const mouseSensor = useSensor(MouseSensor, {
+    activationConstraint: { distance: 10 }
+  });
 
   const onDragEnd = (event: DragEndEvent) => {
     if (!event.over || !handleDragEnd) {

--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -1,5 +1,10 @@
 import { useState, useRef, useEffect } from "react";
-import { DndContext, useSensor, PointerSensor } from "@dnd-kit/core";
+import {
+  DndContext,
+  useSensor,
+  PointerSensor,
+  MouseSensor,
+} from "@dnd-kit/core";
 import type { UniqueIdentifier, DragEndEvent } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -60,6 +65,10 @@ function TabRowInner<T>({
     activationConstraint: { distance: 10 },
   });
 
+  // Needed for DnD e2e tests to work
+  // See https://github.com/clauderic/dnd-kit/issues/208#issuecomment-824469766
+  const mouseSensor = useSensor(MouseSensor);
+
   const onDragEnd = (event: DragEndEvent) => {
     if (!event.over || !handleDragEnd) {
       return;
@@ -77,7 +86,7 @@ function TabRowInner<T>({
       <DndContext
         onDragEnd={onDragEnd}
         modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
-        sensors={[pointerSensor]}
+        sensors={[pointerSensor, mouseSensor]}
       >
         <SortableContext
           items={itemIds ?? []}


### PR DESCRIPTION
The primary change needed to support rearranging of tabs with super long names is the to shorten the names only when dragging. This was achieved by exposing the `isDragging` prop of the `useSortable` hook in the `RenameableTabButtonStyled` component. The label of this component is dynamically shortened if it is very long on a drag operation by the following logic and function:

```
// Update the label prop when dragging
label={isDragging ? dragLabel(label) : label}
```

The `dragLabel` function is as follows:
```
  const dragLabel = (s: string) => {
    if (s.length < 20) {
      return s;
    } else {
      return `${s.slice(0, 17)}...`;
    }
  };
```

The other change needed to support e2e testing for this operation was the addition of the `MouseSensor` hook to the DnDContext. See [this issue comment](https://github.com/clauderic/dnd-kit/issues/208#issuecomment-824469766) for explanation.

Once that change was in place it was possible to do a drag and drop rearrange test in the `"should allow me to rearrange long tabs (#34970)"` spec.

This test:
- Creates a dashboard with 3 tabs
- Ensures their order
- Gives the last tab a super long name that would not be rearrangeable before fix
- Drags that tab to the first position
- Saves the dashboard
- Asserts the new tab order is saved

Note that to ensure tests pass, some additional changes were needed since the base `mouseSensor` hook caused the tests in DashboardTabs.unit.spec.tsx to fail. Adding in the `activationConstraint: { distance: 10 }` prop to the mouseSensor fixed the DashboardTabs.unit.spec.tsx tests, but broke the DnD tests. Based on the docs [here](https://docs.dndkit.com/api-documentation/sensors/mouse) it looks like you need to move a "distance, in pixels, by which the mouse needs to be moved before a drag start event is emitted." So, the DnD test in tabs.cy.spec.js added an addtional mousemove trigger of 11 pixels to activate the mouseSensor. Yeah, it totally makes sense. 😜🤯💢😡😥

Fixes #34970
