### PR TITLE
Remove deprecated event tracking

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
@@ -5,6 +5,7 @@ import {
   getDashboardCard,
   editDashboard,
   showDashboardCardActions,
+  modal,
 } from "e2e/support/helpers";
 import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
 
@@ -24,8 +25,10 @@ describe("scenarios > dashboard cards > visualization options", () => {
     showDashboardCardActions();
     cy.icon("palette").click();
 
-    cy.findByDisplayValue("Orders").click().clear();
-    cy.get("[data-metabase-event='Chart Settings;Done']").click();
+    modal().within(() => {
+      cy.findByDisplayValue("Orders").click().clear();
+      cy.button("Done").click();
+    });
 
     cy.findByTestId("legend-caption").should("not.exist");
   });

--- a/e2e/test/scenarios/dashboard-filters/reproductions/16112-nodata-should-use-dashboard-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/16112-nodata-should-use-dashboard-filters.cy.spec.js
@@ -1,4 +1,9 @@
-import { restore, popover, visitDashboard } from "e2e/support/helpers";
+import {
+  restore,
+  popover,
+  visitDashboard,
+  editDashboard,
+} from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
 const { REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
@@ -74,7 +79,7 @@ describe("issues 15119 and 16112", () => {
 
         // Actually need to setup the linked filter:
         visitDashboard(dashboard_id);
-        cy.get('[data-metabase-event="Dashboard;Edit"]').click();
+        editDashboard();
         cy.findByText("Rating Filter").click();
         cy.findByText("Linked filters").click();
         // cy.findByText("Reviewer Filter").click();

--- a/frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/ObjectActionSelect.jsx
@@ -42,7 +42,6 @@ export default class ObjectActionsSelect extends Component {
             <li>
               <ActionLink
                 to={"/admin/datamodel/" + objectType + "/" + object.id}
-                data-metabase-event={"Data Model;" + objectType + " Edit Page"}
               >
                 {t`Edit`} {capitalize(objectType)}
               </ActionLink>
@@ -56,7 +55,6 @@ export default class ObjectActionsSelect extends Component {
                   object.id +
                   "/revisions"
                 }
-                data-metabase-event={"Data Model;" + objectType + " History"}
               >
                 {t`Revision History`}
               </ActionLink>

--- a/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
+++ b/frontend/src/metabase/admin/datamodel/components/PartialQueryBuilder.jsx
@@ -97,7 +97,6 @@ class PartialQueryBuilder extends Component {
             <span className="text-bold px3">{previewSummary}</span>
             <Link
               to={previewUrl}
-              data-metabase-event="Data Model;Preview Click"
               target={window.OSX ? null : "_blank"}
               rel="noopener noreferrer"
               className="Button Button--primary"

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
@@ -77,9 +77,6 @@ function NewVersionAvailable({ currentVersion }) {
           {t`You're running ${currentVersion}`}
         </span>
         <ExternalLink
-          data-metabase-event={
-            "Updates Settings; Update link clicked; " + latestVersion
-          }
           className="Button Button--white Button--medium borderless"
           href={
             "https://www.metabase.com/docs/" +

--- a/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.jsx
@@ -13,7 +13,6 @@ import {
   SAVED_QUESTIONS_VIRTUAL_DB_ID,
 } from "metabase-lib/metadata/utils/saved-questions";
 
-import { ANALYTICS_CONTEXT } from "../../constants";
 import { BrowseHeader } from "../BrowseHeader";
 import {
   TableActionLink,
@@ -60,7 +59,6 @@ const TableBrowser = ({
                 to={
                   !isSyncInProgress(table) ? getTableUrl(table, metadata) : ""
                 }
-                data-metabase-event={`${ANALYTICS_CONTEXT};Table Click`}
               >
                 <TableBrowserItem
                   database={database}
@@ -124,10 +122,7 @@ const TableBrowserItemButtons = ({ tableId, dbId, xraysEnabled }) => {
   return (
     <Fragment>
       {xraysEnabled && (
-        <TableActionLink
-          to={`/auto/dashboard/table/${tableId}`}
-          data-metabase-event={`${ANALYTICS_CONTEXT};Table Item;X-ray Click`}
-        >
+        <TableActionLink to={`/auto/dashboard/table/${tableId}`}>
           <Icon
             name="bolt_filled"
             tooltip={t`X-ray this table`}
@@ -135,10 +130,7 @@ const TableBrowserItemButtons = ({ tableId, dbId, xraysEnabled }) => {
           />
         </TableActionLink>
       )}
-      <TableActionLink
-        to={`/reference/databases/${dbId}/tables/${tableId}`}
-        data-metabase-event={`${ANALYTICS_CONTEXT};Table Item;Reference Click`}
-      >
+      <TableActionLink to={`/reference/databases/${dbId}/tables/${tableId}`}>
         <Icon
           name="reference"
           tooltip={t`Learn about this table`}

--- a/frontend/src/metabase/browse/constants.js
+++ b/frontend/src/metabase/browse/constants.js
@@ -1,2 +1,1 @@
-export const ANALYTICS_CONTEXT = "Data Browse";
 export const RELOAD_INTERVAL = 2000;

--- a/frontend/src/metabase/browse/containers/DatabaseBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/DatabaseBrowser.jsx
@@ -12,7 +12,6 @@ import Link from "metabase/core/components/Link";
 
 import { BrowseHeader } from "metabase/browse/components/BrowseHeader";
 
-import { ANALYTICS_CONTEXT } from "metabase/browse/constants";
 import { DatabaseCard, DatabaseGridItem } from "./DatabaseBrowser.styled";
 
 function DatabaseBrowser({ databases }) {
@@ -23,11 +22,7 @@ function DatabaseBrowser({ databases }) {
       <Grid>
         {databases.map(database => (
           <DatabaseGridItem key={database.id}>
-            <Link
-              to={Urls.browseDatabase(database)}
-              data-metabase-event={`${ANALYTICS_CONTEXT};Database Click`}
-              display="block"
-            >
+            <Link to={Urls.browseDatabase(database)} display="block">
               <DatabaseCard>
                 <Icon
                   name="database"

--- a/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
+++ b/frontend/src/metabase/browse/containers/SchemaBrowser.jsx
@@ -13,7 +13,6 @@ import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
 
 import { BrowseHeader } from "metabase/browse/components/BrowseHeader";
-import { ANALYTICS_CONTEXT } from "metabase/browse/constants";
 import { SchemaGridItem, SchemaLink } from "./SchemaBrowser.styled";
 
 function SchemaBrowser(props) {
@@ -48,7 +47,6 @@ function SchemaBrowser(props) {
                     to={`/browse/${dbId}/schema/${encodeURIComponent(
                       schema.name,
                     )}`}
-                    data-metabase-event={`${ANALYTICS_CONTEXT};Schema Click`}
                   >
                     <Card hoverable className="px1">
                       <EntityItem

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 import { connect } from "react-redux";
 import EventSandbox from "metabase/components/EventSandbox";
 import { getSetting } from "metabase/selectors/settings";
-import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
   canArchiveItem,
   canMoveItem,
@@ -121,7 +120,6 @@ function ActionMenu({
         onArchive={canArchive ? handleArchive : null}
         onToggleBookmark={handleToggleBookmark}
         onTogglePreview={canPreview ? handleTogglePreview : null}
-        analyticsContext={ANALYTICS_CONTEXT}
       />
     </EventSandbox>
   );

--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -9,7 +9,6 @@ import Modal from "metabase/components/Modal";
 import { CollectionMoveModal } from "metabase/containers/CollectionMoveModal";
 import CollectionCopyEntityModal from "metabase/collections/components/CollectionCopyEntityModal";
 
-import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import { canArchiveItem, canMoveItem } from "metabase/collections/utils";
 import {
   BulkActionsToast,
@@ -62,14 +61,12 @@ function BulkActions({
                   purple
                   disabled={!canMove}
                   onClick={onMoveStart}
-                  data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Move Items`}
                 >{t`Move`}</CardButton>
                 <CardButton
                   medium
                   purple
                   disabled={!canArchive}
                   onClick={onArchive}
-                  data-metabase-event={`${ANALYTICS_CONTEXT};Bulk Actions;Archive Items`}
                 >{t`Archive`}</CardButton>
               </CardSide>
             </ToastCard>

--- a/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
+++ b/frontend/src/metabase/collections/components/CollectionEmptyState/CollectionEmptyState.tsx
@@ -1,7 +1,6 @@
 import { t } from "ttag";
 import Button from "metabase/core/components/Button";
 import NewItemMenu from "metabase/containers/NewItemMenu";
-import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import type { Collection } from "metabase-types/api";
 import { Text } from "metabase/ui";
 import {
@@ -31,7 +30,6 @@ const CollectionEmptyState = ({
         <NewItemMenu
           trigger={<Button icon="add">{t`Create a new…`}</Button>}
           collectionId={collection?.id}
-          analyticsContext={ANALYTICS_CONTEXT}
         />
       )}
     </EmptyStateRoot>

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -3,7 +3,6 @@ import { t } from "ttag";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import * as Urls from "metabase/lib/urls";
 import EntityMenu from "metabase/components/EntityMenu";
-import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import {
   isInstanceAnalyticsCustomCollection,
   isRootPersonalCollection,
@@ -52,7 +51,6 @@ export const CollectionMenu = ({
       title: t`Edit permissions`,
       icon: "lock",
       link: `${url}/permissions`,
-      event: `${ANALYTICS_CONTEXT};Edit Menu;Edit Permissions`,
     });
   }
 
@@ -61,13 +59,11 @@ export const CollectionMenu = ({
       title: t`Move`,
       icon: "move",
       link: `${url}/move`,
-      event: `${ANALYTICS_CONTEXT};Edit Menu;Move Collection`,
     });
     items.push({
       title: t`Archive`,
       icon: "archive",
       link: `${url}/archive`,
-      event: `${ANALYTICS_CONTEXT};Edit Menu;Archive Collection`,
     });
   }
 

--- a/frontend/src/metabase/collections/components/ItemsTable.jsx
+++ b/frontend/src/metabase/collections/components/ItemsTable.jsx
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
 
-import { ANALYTICS_CONTEXT } from "metabase/collections/constants";
 import PinDropZone from "metabase/collections/components/PinDropZone";
 
 import BaseItemsTable from "./BaseItemsTable";
@@ -11,15 +10,11 @@ Item.propTypes = {
 };
 
 function Item({ item, ...props }) {
-  const metabaseEvent = `${ANALYTICS_CONTEXT};Item Click;${item.model}`;
   return (
     <BaseItemsTable.Item
       key={`${item.model}-${item.id}`}
       {...props}
       item={item}
-      linkProps={{
-        "data-metabase-event": metabaseEvent,
-      }}
     />
   );
 }

--- a/frontend/src/metabase/collections/constants.js
+++ b/frontend/src/metabase/collections/constants.js
@@ -1,1 +1,0 @@
-export const ANALYTICS_CONTEXT = "Collection Landing";

--- a/frontend/src/metabase/components/CollectionItem/CollectionItem.jsx
+++ b/frontend/src/metabase/components/CollectionItem/CollectionItem.jsx
@@ -20,7 +20,7 @@ const propTypes = {
 const CollectionItem = ({ collection, event }) => {
   const icon = getCollectionIcon(collection);
   return (
-    <ItemLink to={collection.getUrl()} data-metabase-event={event}>
+    <ItemLink to={collection.getUrl()}>
       <Card hoverable>
         <CardContent>
           <IconContainer color={icon.color}>

--- a/frontend/src/metabase/components/CollectionList/CollectionList.jsx
+++ b/frontend/src/metabase/components/CollectionList/CollectionList.jsx
@@ -12,7 +12,6 @@ const propTypes = {
   currentUser: PropTypes.shape({
     personal_collection_id: PropTypes.number,
   }),
-  analyticsContext: PropTypes.string,
 };
 
 function mapStateToProps(state) {
@@ -21,17 +20,14 @@ function mapStateToProps(state) {
   };
 }
 
-function CollectionList({ collections, currentUser, analyticsContext }) {
+function CollectionList({ collections, currentUser }) {
   return (
     <Grid>
       {collections
         .filter(c => c.id !== currentUser.personal_collection_id)
         .map(collection => (
           <CollectionGridItem key={collection.id}>
-            <CollectionItem
-              collection={collection}
-              event={`${analyticsContext};Collection List;Collection click`}
-            />
+            <CollectionItem collection={collection} />
           </CollectionGridItem>
         ))}
     </Grid>

--- a/frontend/src/metabase/components/EntityItem/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.jsx
@@ -98,7 +98,6 @@ function EntityItemMenu({
   onToggleBookmark,
   onTogglePreview,
   className,
-  analyticsContext,
 }) {
   const isPinned = isItemPinned(item);
   const isPreviewed = isPreviewShown(item);
@@ -114,19 +113,16 @@ function EntityItemMenu({
           title: isPinned ? t`Unpin` : t`Pin this`,
           icon: isPinned ? "unpin" : "pin",
           action: onPin,
-          event: `${analyticsContext};Entity Item;Pin Item;${item.model}`,
         },
         isMetabotShown && {
           title: t`Ask Metabot`,
           link: Urls.modelMetabot(item.id),
           icon: "insight",
-          event: `${analyticsContext};Entity Item;Ask Metabot;${item.model}`,
         },
         isXrayShown && {
           title: t`X-ray this`,
           link: Urls.xrayModel(item.id),
           icon: "bolt",
-          event: `${analyticsContext};Entity Item;X-ray Item;${item.model}`,
         },
         onTogglePreview && {
           title: isPreviewed
@@ -138,36 +134,30 @@ function EntityItemMenu({
             ? t`Open this question and fill in its variables to see it.`
             : undefined,
           disabled: !isParameterized,
-          event: `${analyticsContext};Entity Item;Preview Item;${item.model}`,
         },
         onMove && {
           title: t`Move`,
           icon: "move",
           action: onMove,
-          event: `${analyticsContext};Entity Item;Move Item;${item.model}`,
         },
         onCopy && {
           title: t`Duplicate`,
           icon: "clone",
           action: onCopy,
-          event: `${analyticsContext};Entity Item;Copy Item;${item.model}`,
         },
         onArchive && {
           title: t`Archive`,
           icon: "archive",
           action: onArchive,
-          event: `${analyticsContext};Entity Item;Archive Item;${item.model}`,
         },
         onToggleBookmark && {
           title: isBookmarked ? t`Remove from bookmarks` : t`Bookmark`,
           icon: "bookmark",
           action: onToggleBookmark,
-          event: `${analyticsContext};Entity Item;Bookmark Item;${item.model}`,
         },
       ].filter(action => action),
     [
       item.id,
-      item.model,
       isPinned,
       isXrayShown,
       isMetabotShown,
@@ -180,7 +170,6 @@ function EntityItemMenu({
       onArchive,
       onTogglePreview,
       onToggleBookmark,
-      analyticsContext,
     ],
   );
   if (actions.length === 0) {
@@ -200,7 +189,6 @@ function EntityItemMenu({
 }
 
 const EntityItem = ({
-  analyticsContext,
   name,
   iconName,
   onPin,
@@ -254,7 +242,6 @@ const EntityItem = ({
           onCopy={onCopy}
           onArchive={onArchive}
           className="ml1"
-          analyticsContext={analyticsContext}
         />
       </EntityItemActions>
     </EntityItemWrapper>

--- a/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.tsx
+++ b/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.tsx
@@ -17,7 +17,6 @@ export interface EntityMenuItemProps {
   externalLink?: boolean;
   tooltip?: ReactNode;
   disabled?: boolean;
-  event?: string;
   onClose?: () => void;
 }
 
@@ -29,7 +28,6 @@ const EntityMenuItem = ({
   externalLink,
   tooltip,
   disabled,
-  event,
   onClose,
 }: EntityMenuItemProps): JSX.Element | null => {
   if (link && action) {
@@ -50,7 +48,6 @@ const EntityMenuItem = ({
         link={link}
         externalLink={externalLink}
         disabled={disabled}
-        event={event}
         tooltip={tooltip}
         onClose={onClose}
         data-testid="entity-menu-link"
@@ -62,12 +59,7 @@ const EntityMenuItem = ({
 
   if (action) {
     return (
-      <ActionMenuItem
-        action={action}
-        tooltip={tooltip}
-        disabled={disabled}
-        event={event}
-      >
+      <ActionMenuItem action={action} tooltip={tooltip} disabled={disabled}>
         {content}
       </ActionMenuItem>
     );

--- a/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.tsx
+++ b/frontend/src/metabase/components/EntityMenuItem/EntityMenuItem.tsx
@@ -80,7 +80,6 @@ interface ActionMenuItemProps {
   action?: (event: MouseEvent<HTMLDivElement>) => void;
   tooltip?: ReactNode;
   disabled?: boolean;
-  event?: string;
   children?: ReactNode;
 }
 
@@ -88,13 +87,10 @@ const ActionMenuItem = ({
   action,
   tooltip,
   disabled,
-  event,
   children,
 }: ActionMenuItemProps) => (
   <Tooltip tooltip={tooltip} placement="right">
-    <div onClick={disabled ? undefined : action} data-metabase-event={event}>
-      {children}
-    </div>
+    <div onClick={disabled ? undefined : action}>{children}</div>
   </Tooltip>
 );
 
@@ -103,7 +99,6 @@ interface LinkMenuItemProps {
   externalLink?: boolean;
   tooltip?: ReactNode;
   disabled?: boolean;
-  event?: string;
   children?: ReactNode;
   onClose?: () => void;
 }
@@ -113,7 +108,6 @@ const LinkMenuItem = ({
   externalLink,
   tooltip,
   disabled,
-  event,
   children,
   onClose,
 }: LinkMenuItemProps): JSX.Element => (
@@ -122,7 +116,6 @@ const LinkMenuItem = ({
       <MenuExternalLink
         href={link}
         target="_blank"
-        data-metabase-event={event}
         onClick={onClose}
         data-testid="entity-menu-link"
       >
@@ -132,7 +125,6 @@ const LinkMenuItem = ({
       <MenuLink
         to={link}
         disabled={disabled}
-        data-metabase-event={event}
         onClick={onClose}
         data-testid="entity-menu-link"
       >

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -22,7 +22,6 @@ export interface NewItemMenuProps {
   trigger?: ReactNode;
   triggerIcon?: string;
   triggerTooltip?: string;
-  analyticsContext?: string;
   hasModels: boolean;
   hasDataAccess: boolean;
   hasNativeWrite: boolean;
@@ -47,7 +46,6 @@ const NewItemMenu = ({
   trigger,
   triggerIcon,
   triggerTooltip,
-  analyticsContext,
   hasModels,
   hasDataAccess,
   hasNativeWrite,
@@ -82,7 +80,6 @@ const NewItemMenu = ({
           creationType: "custom_question",
           collectionId,
         }),
-        event: `${analyticsContext};New Question Click;`,
         onClose: onCloseNavbar,
       });
     }
@@ -96,7 +93,6 @@ const NewItemMenu = ({
           creationType: "native_question",
           collectionId,
         }),
-        event: `${analyticsContext};New SQL Query Click;`,
         onClose: onCloseNavbar,
       });
     }
@@ -106,13 +102,11 @@ const NewItemMenu = ({
         title: t`Dashboard`,
         icon: "dashboard",
         action: () => setModal("new-dashboard"),
-        event: `${analyticsContext};New Dashboard Click;`,
       },
       {
         title: t`Collection`,
         icon: "folder",
         action: () => setModal("new-collection"),
-        event: `${analyticsContext};New Collection Click;`,
       },
     );
     if (hasNativeWrite) {
@@ -124,7 +118,6 @@ const NewItemMenu = ({
         title: t`Model`,
         icon: "model",
         link: `/model/new${collectionQuery}`,
-        event: `${analyticsContext};New Model Click;`,
         onClose: onCloseNavbar,
       });
     }
@@ -134,7 +127,6 @@ const NewItemMenu = ({
         title: t`Action`,
         icon: "bolt",
         action: () => setModal("new-action"),
-        event: `${analyticsContext};New Action Click;`,
       });
     }
 
@@ -142,7 +134,6 @@ const NewItemMenu = ({
   }, [
     hasDataAccess,
     hasNativeWrite,
-    analyticsContext,
     hasModels,
     hasDatabaseWithActionsEnabled,
     collectionId,

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.tsx
@@ -172,11 +172,7 @@ export class AddSeriesModal extends Component<Props, State> {
             >
               {t`Done`}
             </button>
-            <button
-              data-metabase-event="Dashboard;Edit Series Modal;cancel"
-              className="Button ml2"
-              onClick={this.props.onClose}
-            >
+            <button className="Button ml2" onClick={this.props.onClose}>
               {t`Cancel`}
             </button>
           </div>

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/DashCardActionButton.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionButton/DashCardActionButton.tsx
@@ -19,12 +19,7 @@ const DashActionButton = forwardRef<HTMLAnchorElement, Props>(
     ref,
   ) {
     return (
-      <StyledAnchor
-        {...props}
-        as={as}
-        data-metabase-event={analyticsEvent}
-        ref={ref}
-      >
+      <StyledAnchor {...props} as={as} ref={ref}>
         <Tooltip tooltip={tooltip}>{children}</Tooltip>
       </StyledAnchor>
     );

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -65,7 +65,6 @@ export const getDashboardActions = (
             disabled={!canManageSubscriptions}
             onClick={onSharingClick}
             aria-label="subscriptions"
-            data-metabase-event="Dashboard;Subscriptions"
           />
         </Tooltip>,
       );
@@ -83,7 +82,6 @@ export const getDashboardActions = (
     buttons.push(
       <RefreshWidgetButton
         key="refresh"
-        data-metabase-event="Dashboard;Refresh Menu Open"
         period={refreshPeriod}
         setRefreshElapsedHook={setRefreshElapsedHook}
         onChangePeriod={onRefreshPeriodChange}
@@ -97,7 +95,7 @@ export const getDashboardActions = (
         key="night"
         tooltip={isNightMode ? t`Daytime mode` : t`Nighttime mode`}
       >
-        <span data-metabase-event={"Dashboard;Night Mode;" + !isNightMode}>
+        <span>
           <DashboardHeaderButton
             icon={
               <NightModeButtonIcon
@@ -118,9 +116,7 @@ export const getDashboardActions = (
         key="fullscreen"
         tooltip={isFullscreen ? t`Exit fullscreen` : t`Enter fullscreen`}
       >
-        <span
-          data-metabase-event={"Dashboard;Fullscreen Mode;" + !isFullscreen}
-        >
+        <span>
           <DashboardHeaderButton
             icon={<FullScreenButtonIcon isFullscreen={isFullscreen} />}
             onClick={e => onFullscreenChange(!isFullscreen, !e.altKey)}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -293,7 +293,6 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
   getEditingButtons() {
     return [
       <Button
-        data-metabase-event="Dashboard;Cancel Edits"
         key="cancel"
         className="Button Button--small mr1"
         onClick={this.onRequestCancel}
@@ -360,7 +359,6 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
             isActive={activeSidebarName === SIDEBAR_NAME.addQuestion}
             onClick={() => toggleSidebar(SIDEBAR_NAME.addQuestion)}
             aria-label={t`Add questions`}
-            data-metabase-event="Dashboard;Add Card Sidebar"
           />
         </Tooltip>,
       );
@@ -381,10 +379,7 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
       // Add link card button
       buttons.push(
         <Tooltip key="add-link-card" tooltip={t`Add link card`}>
-          <DashboardHeaderButton
-            onClick={() => this.onAddLinkCard()}
-            data-metabase-event={`Dashboard;Add Link Card`}
-          >
+          <DashboardHeaderButton onClick={() => this.onAddLinkCard()}>
             <Icon name="link" size={18} />
           </DashboardHeaderButton>
         </Tooltip>,
@@ -434,7 +429,6 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
               <DashboardHeaderButton
                 onClick={() => this.onAddAction()}
                 aria-label={t`Add action`}
-                data-metabase-event={`Dashboard;Add Action Button`}
               >
                 <Icon name="click" size={18} />
               </DashboardHeaderButton>
@@ -455,7 +449,6 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
       buttons.push(
         <Button
           icon="clone"
-          data-metabase-event="Dashboard;Copy"
           to={`${location.pathname}/copy`}
           as={Link}
         >{t`Make a copy`}</Button>,
@@ -469,7 +462,6 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
             visibleOnSmallScreen={false}
             key="edit"
             aria-label={t`Edit dashboard`}
-            data-metabase-event="Dashboard;Edit"
             icon="pencil"
             onClick={() => this.handleEdit(dashboard)}
           />
@@ -566,7 +558,6 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
         <DashboardHeaderButton
           key="expand"
           aria-label={t`Enter Fullscreen`}
-          data-metabase-event={`Dashboard;Fullscreen Mode;${!isFullscreen}`}
           icon="expand"
           className="text-brand-hover cursor-pointer"
           onClick={e => onFullscreenChange(!isFullscreen, !e.altKey)}

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -240,7 +240,6 @@ const SuggestionsList = ({ suggestions, section }) => (
               key={itemIndex}
               to={item.url}
               className="hover-parent hover--visibility"
-              data-metabase-event={`Auto Dashboard;Click Related;${s}`}
             >
               <Card className="p2" hoverable>
                 <ItemContent>

--- a/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
@@ -68,7 +68,6 @@ const NewModelOptions = (props: NewModelOptionsProps) => {
                 dataset: true,
                 collectionId,
               })}
-              data-metabase-event="New Model; Custom Question Start"
             />
           </OptionsGridItem>
         )}
@@ -86,7 +85,6 @@ const NewModelOptions = (props: NewModelOptionsProps) => {
                 collectionId,
               })}
               width={180}
-              data-metabase-event="New Model; Native Query Start"
             />
           </OptionsGridItem>
         )}

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavItem.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavItem.tsx
@@ -12,11 +12,7 @@ export const AdminNavItem = ({
   currentPath,
 }: AdminNavItemProps) => (
   <li>
-    <AdminNavLink
-      to={path}
-      data-metabase-event={`NavBar;${name}`}
-      isSelected={currentPath.startsWith(path)}
-    >
+    <AdminNavLink to={path} isSelected={currentPath.startsWith(path)}>
       {name}
     </AdminNavLink>
   </li>

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.tsx
@@ -34,7 +34,7 @@ export const AdminNavbar = ({
 
   return (
     <AdminNavbarRoot className="Nav" aria-label={t`Navigation bar`}>
-      <AdminLogoLink to="/admin" data-metabase-event="Navbar;Logo">
+      <AdminLogoLink to="/admin">
         <AdminLogoContainer>
           <LogoIcon className="text-brand my2" dark />
           <AdminLogoText>{t`Metabase Admin`}</AdminLogoText>
@@ -58,7 +58,6 @@ export const AdminNavbar = ({
         {!isPaidPlain && <StoreLink />}
         <AdminExitLink
           to="/"
-          data-metabase-event="Navbar;Exit Admin"
           data-testid="exit-admin"
         >{t`Exit admin`}</AdminExitLink>
       </MobileHide>
@@ -101,9 +100,7 @@ const MobileNavbar = ({ adminPaths, currentPath }: AdminMobileNavbarProps) => {
               currentPath={currentPath}
             />
           ))}
-          <AdminExitLink to="/" data-metabase-event="Navbar;Exit Admin">
-            {t`Exit admin`}
-          </AdminExitLink>
+          <AdminExitLink to="/">{t`Exit admin`}</AdminExitLink>
         </AdminMobileNavBarItems>
       )}
     </AdminMobileNavbar>

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.tsx
@@ -24,7 +24,6 @@ export function AppBarLogo({
       isSmallAppBar={Boolean(isSmallAppBar)}
       onClick={onLogoClick}
       disabled={!isNavBarEnabled}
-      data-metabase-event="Navbar;Logo"
       data-testid="main-logo-link"
     >
       <LogoIcon height={32} />

--- a/frontend/src/metabase/nav/components/NewItemButton/NewItemButton.tsx
+++ b/frontend/src/metabase/nav/components/NewItemButton/NewItemButton.tsx
@@ -11,17 +11,11 @@ const NewItemButton = ({ collectionId }: NewItemButtonProps) => {
   return (
     <NewItemMenu
       trigger={
-        <NewButton
-          primary
-          icon="add"
-          data-metabase-event="NavBar;Create Menu Click"
-          aria-label={t`New`}
-        >
+        <NewButton primary icon="add" aria-label={t`New`}>
           <NewButtonText>{t`New`}</NewButtonText>
         </NewButton>
       }
       collectionId={collectionId}
-      analyticsContext="NavBar"
     />
   );
 };

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -142,7 +142,6 @@ function MainNavbarView({
                 url={BROWSE_URL}
                 isSelected={nonEntityItem?.url?.startsWith(BROWSE_URL)}
                 onClick={onItemSelect}
-                data-metabase-event="NavBar;Data Browse"
               >
                 {t`Browse data`}
               </PaddedSidebarLink>
@@ -154,7 +153,6 @@ function MainNavbarView({
                     ADD_YOUR_OWN_DATA_URL,
                   )}
                   onClick={onItemSelect}
-                  data-metabase-event="NavBar;Add your own data"
                 >
                   {t`Add your own data`}
                 </AddYourOwnDataLink>

--- a/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionIntroModal.jsx
@@ -22,11 +22,7 @@ export default class SavedQuestionIntroModal extends Component {
         <ModalContent title={title} className="Modal-content text-centered py2">
           <div className="px2 pb2 text-paragraph">{message}</div>
           <div className="Form-actions flex justify-center py1">
-            <button
-              data-metabase-event="QueryBuilder;IntroModal"
-              className="Button Button--primary"
-              onClick={onClose}
-            >
+            <button className="Button Button--primary" onClick={onClose}>
               {t`Okay`}
             </button>
           </div>

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp/TagEditorHelp.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorHelp/TagEditorHelp.tsx
@@ -209,7 +209,6 @@ const TagExample = ({ datasetQuery, setDatasetQuery }: TagExampleProps) => (
         <Button
           medium
           className="mt1"
-          data-metabase-event="QueryBuilder;Template Tag Example Query Used"
           onClick={() => setDatasetQuery(datasetQuery, true)}
         >
           {t`Try it`}
@@ -318,7 +317,6 @@ export const TagEditorHelp = ({
               "questions/native-editor/sql-parameters",
             )}
             target="_blank"
-            data-metabase-event="QueryBuilder;Template Tag Documentation Click"
           >{t`Read the full documentation`}</ExternalLink>
         </p>
       )}

--- a/frontend/src/metabase/query_builder/components/view/ConvertQueryButton/ConvertQueryButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ConvertQueryButton/ConvertQueryButton.tsx
@@ -29,11 +29,7 @@ const ConvertQueryButton = ({
 
   return (
     <Tooltip tooltip={tooltip} placement="top">
-      <SqlButton
-        onClick={handleClick}
-        aria-label={tooltip}
-        data-metabase-event="Notebook Mode; Convert to SQL Click"
-      >
+      <SqlButton onClick={handleClick} aria-label={tooltip}>
         <SqlIcon name="sql" />
       </SqlButton>
     </Tooltip>

--- a/frontend/src/metabase/query_builder/components/view/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/FilterHeaderButton.tsx
@@ -23,7 +23,6 @@ export function FilterHeaderButton({
       labelBreakpoint="sm"
       color={color("filter")}
       onClick={() => onOpenModal(MODAL_TYPES.FILTERS)}
-      data-metabase-event="View Mode; Open Filter Modal"
       data-testid="question-filter-header"
     >
       {t`Filter`}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -327,7 +327,6 @@ function AhHocQuestionLeftSide(props) {
             question={question}
             isObjectDetail={isObjectDetail}
             subHead
-            data-metabase-event="Question Data Source Click"
           />
         )}
       </ViewHeaderLeftSubHeading>
@@ -464,7 +463,6 @@ function ViewTitleHeaderRightSide(props) {
           isShowingSummarySidebar={isShowingSummarySidebar}
           onEditSummary={onEditSummary}
           onCloseSummary={onCloseSummary}
-          data-metabase-event="View Mode; Open Summary Widget"
         />
       )}
       {QuestionNotebookButton.shouldRender(props) && (
@@ -474,11 +472,6 @@ function ViewTitleHeaderRightSide(props) {
             question={question}
             isShowingNotebook={isShowingNotebook}
             setQueryBuilderMode={setQueryBuilderMode}
-            data-metabase-event={
-              isShowingNotebook
-                ? `Notebook Mode;Go to View Mode`
-                : `View Mode; Go to Notebook Mode`
-            }
           />
         </ViewHeaderIconButtonContainer>
       )}
@@ -524,11 +517,6 @@ function ViewTitleHeaderRightSide(props) {
             isEnabled: !isEditable,
             placement: "left",
           }}
-          data-metabase-event={
-            isShowingNotebook
-              ? `Notebook Mode; Click Save`
-              : `View Mode; Click Save`
-          }
           onClick={() => onOpenModal("save")}
         >
           {t`Save`}

--- a/frontend/src/metabase/questions/components/CollectionBadge.jsx
+++ b/frontend/src/metabase/questions/components/CollectionBadge.jsx
@@ -9,7 +9,6 @@ const propTypes = {
   className: PropTypes.string,
   collection: PropTypes.object,
   isSingleLine: PropTypes.bool,
-  analyticsContext: PropTypes.string,
 };
 
 const IRREGULAR_ICON_WIDTH = 16;
@@ -21,12 +20,7 @@ const IRREGULAR_ICON_PROPS = {
   targetOffsetX: IRREGULAR_ICON_WIDTH,
 };
 
-function CollectionBadge({
-  className,
-  collection,
-  isSingleLine,
-  analyticsContext,
-}) {
+function CollectionBadge({ className, collection, isSingleLine }) {
   if (!collection) {
     return null;
   }
@@ -44,7 +38,6 @@ function CollectionBadge({
       activeColor={icon.color}
       inactiveColor="text-light"
       isSingleLine={isSingleLine}
-      data-metabase-event={`${analyticsContext};Collection Badge Click`}
     >
       {collection.getName()}
     </Badge>

--- a/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/EditableReferenceHeader.jsx
@@ -75,7 +75,6 @@ const EditableReferenceHeader = ({
                 primary
                 className="flex flex-align-right mr2"
                 style={{ fontSize: 14 }}
-                data-metabase-event={`Data Reference;Entity -> QB click;${type}`}
               >
                 <Link to={headerLink}>{t`See this ${type}`}</Link>
               </Button>

--- a/frontend/src/metabase/reference/components/ReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/ReferenceHeader.jsx
@@ -38,7 +38,6 @@ const ReferenceHeader = ({
             <Link
               to={headerLink}
               className={cx("Button", "Button--borderless", "ml3")}
-              data-metabase-event={`Data Reference;Entity -> QB click;${type}`}
             >
               <div className="flex align-center relative">
                 <span className="mr1 flex-no-shrink">{t`See this ${type}`}</span>

--- a/frontend/src/metabase/visualizations/components/ChartSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.jsx
@@ -438,19 +438,11 @@ const ChartSettingsFooter = ({ onDone, onCancel, onReset }) => (
       <Button
         borderless
         icon="refresh"
-        data-metabase-event="Chart Settings;Reset"
         onClick={onReset}
       >{t`Reset to defaults`}</Button>
     )}
-    <Button
-      onClick={onCancel}
-      data-metabase-event="Chart Settings;Cancel"
-    >{t`Cancel`}</Button>
-    <Button
-      primary
-      onClick={onDone}
-      data-metabase-event="Chart Settings;Done"
-    >{t`Done`}</Button>
+    <Button onClick={onCancel}>{t`Cancel`}</Button>
+    <Button primary onClick={onDone}>{t`Done`}</Button>
   </ChartSettingsFooterRoot>
 );
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -206,12 +206,7 @@ const RuleListing = ({ rules, cols, onEdit, onAdd, onRemove, onMove }) => (
     they meet certain conditions.`}
     </div>
     <div className="mt2">
-      <Button
-        borderless
-        icon="add"
-        onClick={onAdd}
-        data-metabase-event="Chart Settings;Table Formatting;Add Rule"
-      >
+      <Button borderless icon="add" onClick={onAdd}>
         {t`Add a rule`}
       </Button>
     </div>
@@ -523,21 +518,11 @@ const RuleEditor = ({
       ) : null}
       <div className="mt4">
         {rule.columns.length === 0 ? (
-          <Button
-            primary
-            onClick={onRemove}
-            data-metabase-event="Chart Settings;Table Formatting;"
-          >
+          <Button primary onClick={onRemove}>
             {isNew ? t`Cancel` : t`Delete`}
           </Button>
         ) : (
-          <Button
-            primary
-            onClick={onDone}
-            data-metabase-event={`Chart Setttings;Table Formatting;${
-              isNew ? "Add Rule" : "Update Rule"
-            };Rule Type ${rule.type} Color`}
-          >
+          <Button primary onClick={onDone}>
             {isNew ? t`Add rule` : t`Update rule`}
           </Button>
         )}


### PR DESCRIPTION
### Description

see [slack discussion](https://metaboat.slack.com/archives/C505ZNNH4/p1705685026385679)

It has been a while (years?) since we've used these google apps event tracking properties, it's confusing to leave them in the code (see https://github.com/metabase/metabase/pull/37707/files#diff-215a8c269bae26f8f8485250ae3b7998de5df268f32dbc5d9fa7de16662e0f46R108)

### How to verify

- lint + ts checks should pass
