### PR TITLE
Fix search input surfacing views powering audit-db

### DIFF
--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -138,6 +138,12 @@
            (:where (search.filter/build-filters
                     base-search-query "table"  default-search-ctx))))))
 
+(deftest ^:parallel build-table-filter-always-ignores-audit-tables
+  (is (contains?
+         (set (:where (search.filter/build-filters
+                       base-search-query "table"  default-search-ctx)))
+         [:not [:= :table.db_id perms/audit-db-id]])))
+
 (deftest ^:parallel build-filter-with-search-string-test
   (testing "with search string"
     (is (= [:and

--- a/test/metabase/search/filter_test.clj
+++ b/test/metabase/search/filter_test.clj
@@ -1,6 +1,7 @@
 (ns ^:mb/once metabase.search.filter-test
   (:require
    [clojure.test :refer :all]
+   [metabase.models.permissions :as perms]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.search.config :as search.config]
    [metabase.search.filter :as search.filter]
@@ -130,7 +131,10 @@
            (:where (search.filter/build-filters
                     base-search-query "card" default-search-ctx))))
 
-    (is (= [:and [:= :table.active true] [:= :table.visibility_type nil]]
+    (is (= [:and
+            [:= :table.active true]
+            [:= :table.visibility_type nil]
+            [:not [:= :table.db_id perms/audit-db-id]]]
            (:where (search.filter/build-filters
                     base-search-query "table"  default-search-ctx))))))
 


### PR DESCRIPTION
resolves #37896

Indexed "tables" (views in fact) in the audit db were being surfaced by the search input.

Click on the search result rightly gives 403, so noone can see anything they shouldn't, but this PR fixes this inconvenience none-the-less.