### PR TITLE
Drop fk constraint on `sandboxes.permission_id`

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5375,6 +5375,23 @@ databaseChangeLog:
             relativeToChangelogFile: true
       rollback:
 
+  - changeSet:
+      id: v49.2024-01-10T03:27:35
+      author: noahmoss
+      comment: Drop foreign key constraint on sandboxes.permissions_id
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: sandboxes
+            constraintName: fk_sandboxes_ref_permissions
+      rollback:
+        - addForeignKeyConstraint:
+            baseTableName: sandboxes
+            baseColumnNames: permission_id
+            referencedTableName: permissions
+            referencedColumnNames: id
+            constraintName: fk_sandboxes_ref_permissions
+            onDelete: CASCADE
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
Drops the foreign key constraint on `sandboxes.permission_id`. This allows us to safely migrate data permissions out of the `permissions` table without deleting existing sandboxes.

This wasn't actually required for any functionality — we have a `delete-gtaps-if-needed-after-permissions-change!` function which cleans up sandboxes as necessary after the permissions graph changes, so no behavior should change as a result of dropping this constraint.

