### PR TITLE
Set default audit DB perms

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -7,8 +7,10 @@
    [metabase-enterprise.audit-db :as audit-db]
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase.core :as mbc]
+   [metabase.models.data-permissions :as data-perms]
    [metabase.models.database :refer [Database]]
    [metabase.models.permissions :as perms]
+   [metabase.models.permissions-group :as perms-group]
    [metabase.models.serialization :as serdes]
    [metabase.plugins :as plugins]
    [metabase.task :as task]
@@ -52,8 +54,14 @@
       (is (not= 0 (t2/count :model/Card {:where [:= :database_id perms/audit-db-id]}))
           "Cards should be created for Audit DB when the content is there."))
 
-    (testing "Only admins have data perms for the audit DB after it is installed"
-      (is (not (t2/exists? :model/Permissions {:where [:like :object (str "%" perms/audit-db-id "%")]}))))
+    (testing "Audit DB starts with no permissions for all users"
+      (is (= {:perms/native-query-editing  :no
+              :perms/manage-database       :no
+              :perms/data-access           :no-self-service
+              :perms/download-results      :one-million-rows
+              :perms/manage-table-metadata :no}
+             (-> (data-perms/data-permissions-graph :db-id perms/audit-db-id)
+                 (get-in [(u/the-id (perms-group/all-users)) perms/audit-db-id])))))
 
     (testing "Audit DB does not have scheduled syncs"
       (let [db-has-sync-job-trigger? (fn [db-id]

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -101,10 +101,16 @@
     (let [all-users-group  (perms-group/all-users)
           non-magic-groups (perms-group/non-magic-groups)
           non-admin-groups (conj non-magic-groups all-users-group)]
-      ;; All other permissions are set at the table-level, so they are added when individual tables are synced
-      (data-perms/set-database-permission! all-users-group database :perms/native-query-editing :yes)
-      (doseq [group non-magic-groups]
-        (data-perms/set-database-permission! group database :perms/native-query-editing :no))
+      ;; We only set native-query-editing and manage-database permissions here, because they are only ever set at the
+      ;; database-level. Perms which can have table-level granularity are set in the `define-after-insert` hook for
+      ;; tables.
+      (if (:is_audit database)
+        (doseq [group non-admin-groups]
+          (data-perms/set-database-permission! group database :perms/native-query-editing :no))
+        (do
+          (data-perms/set-database-permission! all-users-group database :perms/native-query-editing :yes)
+          (doseq [group non-magic-groups]
+            (data-perms/set-database-permission! group database :perms/native-query-editing :no))))
       (doseq [group non-admin-groups]
         (data-perms/set-database-permission! group database :perms/manage-database :no)))))
 

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -70,9 +70,14 @@
           non-magic-groups (perms-group/non-magic-groups)
           non-admin-groups (conj non-magic-groups all-users-group)]
       ;; Data access permissions
-      (data-perms/set-table-permission! all-users-group table :perms/data-access :unrestricted)
-      (doseq [group non-magic-groups]
-        (data-perms/set-table-permission! group table :perms/data-access :no-self-service))
+      (if (= (:db_id table) perms/audit-db-id)
+        ;; Tables in audit DB should start out with no-self-service in all groups
+        (doseq [group non-admin-groups]
+         (data-perms/set-table-permission! group table :perms/data-access :no-self-service))
+        (do
+          (data-perms/set-table-permission! all-users-group table :perms/data-access :unrestricted)
+          (doseq [group non-magic-groups]
+            (data-perms/set-table-permission! group table :perms/data-access :no-self-service))))
       ;; Download permissions
       (data-perms/set-table-permission! all-users-group table :perms/download-results :one-million-rows)
       (doseq [group non-magic-groups]


### PR DESCRIPTION
Sets default audit DB perms in `data_permissions` table, so that all users start out with `no-self-service` data access perms, and no other perms.