### PR TITLE
Namespace permission types

### DIFF
--- a/resources/migrations/permissions/data_access.sql
+++ b/resources/migrations/permissions/data_access.sql
@@ -2,7 +2,7 @@
 
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'data-access' AS perm_type,
+       'perms/data-access' AS perm_type,
        md.id AS db_id,
        NULL AS schema_name,
        NULL AS table_id,
@@ -32,7 +32,7 @@ WHERE pg.name != 'Administrators'
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = md.id
-       AND dp.perm_type = 'data-access' )
+       AND dp.perm_type = 'perms/data-access' )
   AND CASE
           WHEN EXISTS
                  (SELECT 1
@@ -65,7 +65,7 @@ WITH escaped_schema_table AS (
 )
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'data-access' AS perm_type,
+       'perms/data-access' AS perm_type,
        mt.db_id,
        mt.schema AS schema_name,
        mt.id AS table_id,
@@ -89,11 +89,11 @@ WHERE pg.name != 'Administrators'
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id = mt.id
-       AND dp.perm_type = 'data-access' )
+       AND dp.perm_type = 'perms/data-access' )
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id IS NULL
-       AND dp.perm_type = 'data-access' );
+       AND dp.perm_type = 'perms/data-access' );

--- a/resources/migrations/permissions/download_results.sql
+++ b/resources/migrations/permissions/download_results.sql
@@ -2,7 +2,7 @@
 
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'download-results' AS perm_type,
+       'perms/download-results' AS perm_type,
        md.id AS db_id,
        NULL AS schema_name,
        NULL AS table_id,
@@ -34,7 +34,7 @@ WHERE pg.name != 'Administrators'
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = md.id
-       AND dp.perm_type = 'download-results')
+       AND dp.perm_type = 'perms/download-results')
   AND CASE
           WHEN EXISTS
                  (SELECT 1
@@ -65,7 +65,7 @@ WITH escaped_schema_table AS (
 )
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'download-results' AS perm_type,
+       'perms/download-results' AS perm_type,
        mt.db_id,
        mt.schema AS schema_name,
        mt.id AS table_id,
@@ -93,11 +93,11 @@ WHERE pg.name != 'Administrators'
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id = mt.id
-       AND dp.perm_type = 'download-results')
+       AND dp.perm_type = 'perms/download-results')
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id IS NULL
-       AND dp.perm_type = 'download-results');
+       AND dp.perm_type = 'perms/download-results');

--- a/resources/migrations/permissions/manage_database.sql
+++ b/resources/migrations/permissions/manage_database.sql
@@ -1,6 +1,6 @@
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'manage-database' AS perm_type,
+       'perms/manage-database' AS perm_type,
        md.id AS db_id,
        NULL AS schema_name,
        NULL AS table_id,
@@ -20,4 +20,4 @@ WHERE pg.name != 'Administrators'
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = md.id
-       AND dp.perm_type = 'manage-database');
+       AND dp.perm_type = 'perms/manage-database');

--- a/resources/migrations/permissions/manage_table_metadata.sql
+++ b/resources/migrations/permissions/manage_table_metadata.sql
@@ -2,7 +2,7 @@
 
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'manage-table-metadata' AS perm_type,
+       'perms/manage-table-metadata' AS perm_type,
        md.id AS db_id,
        NULL AS schema_name,
        NULL AS table_id,
@@ -23,7 +23,7 @@ WHERE pg.name != 'Administrators'
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = md.id
-       AND dp.perm_type = 'manage-table-metadata')
+       AND dp.perm_type = 'perms/manage-table-metadata')
   AND CASE
           WHEN EXISTS
                  (SELECT 1
@@ -49,7 +49,7 @@ SELECT mt.id,
 )
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'manage-table-metadata' AS perm_type,
+       'perms/manage-table-metadata' AS perm_type,
        mt.db_id,
        mt.schema AS schema_name,
        mt.id AS table_id,
@@ -70,11 +70,11 @@ WHERE pg.name != 'Administrators'
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id = mt.id
-       AND dp.perm_type = 'manage-table-metadata')
+       AND dp.perm_type = 'perms/manage-table-metadata')
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id IS NULL
-       AND dp.perm_type = 'manage-table-metadata');
+       AND dp.perm_type = 'perms/manage-table-metadata');

--- a/resources/migrations/permissions/mysql_data_access.sql
+++ b/resources/migrations/permissions/mysql_data_access.sql
@@ -2,7 +2,7 @@
 
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'data-access' AS perm_type,
+       'perms/data-access' AS perm_type,
        md.id AS db_id,
        NULL AS schema_name,
        NULL AS table_id,
@@ -32,7 +32,7 @@ WHERE pg.name != 'Administrators'
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = md.id
-       AND dp.perm_type = 'data-access' )
+       AND dp.perm_type = 'perms/data-access' )
   AND CASE
           WHEN EXISTS
                  (SELECT 1
@@ -65,7 +65,7 @@ WITH escaped_schema_table AS (
     FROM metabase_table mt
 )
 SELECT pg.id AS group_id,
-       'data-access' AS perm_type,
+       'perms/data-access' AS perm_type,
        mt.db_id,
        mt.schema AS schema_name,
        mt.id AS table_id,
@@ -89,11 +89,11 @@ WHERE pg.name != 'Administrators'
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id = mt.id
-       AND dp.perm_type = 'data-access' )
+       AND dp.perm_type = 'perms/data-access' )
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id IS NULL
-       AND dp.perm_type = 'data-access' );
+       AND dp.perm_type = 'perms/data-access' );

--- a/resources/migrations/permissions/mysql_download_results.sql
+++ b/resources/migrations/permissions/mysql_download_results.sql
@@ -2,7 +2,7 @@
 
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'download-results' AS perm_type,
+       'perms/download-results' AS perm_type,
        md.id AS db_id,
        NULL AS schema_name,
        NULL AS table_id,
@@ -34,7 +34,7 @@ WHERE pg.name != 'Administrators'
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = md.id
-       AND dp.perm_type = 'download-results')
+       AND dp.perm_type = 'perms/download-results')
   AND CASE
           WHEN EXISTS
                  (SELECT 1
@@ -65,7 +65,7 @@ WITH escaped_schema_table AS (
     FROM metabase_table mt
 )
 SELECT pg.id AS group_id,
-       'download-results' AS perm_type,
+       'perms/download-results' AS perm_type,
        mt.db_id,
        mt.schema AS schema_name,
        mt.id AS table_id,
@@ -93,11 +93,11 @@ WHERE pg.name != 'Administrators'
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id = mt.id
-       AND dp.perm_type = 'download-results')
+       AND dp.perm_type = 'perms/download-results')
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id IS NULL
-       AND dp.perm_type = 'download-results');
+       AND dp.perm_type = 'perms/download-results');

--- a/resources/migrations/permissions/mysql_manage_table_metadata.sql
+++ b/resources/migrations/permissions/mysql_manage_table_metadata.sql
@@ -2,7 +2,7 @@
 
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'manage-table-metadata' AS perm_type,
+       'perms/manage-table-metadata' AS perm_type,
        md.id AS db_id,
        NULL AS schema_name,
        NULL AS table_id,
@@ -23,7 +23,7 @@ WHERE pg.name != 'Administrators'
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = md.id
-       AND dp.perm_type = 'manage-table-metadata')
+       AND dp.perm_type = 'perms/manage-table-metadata')
   AND CASE
           WHEN EXISTS
                  (SELECT 1
@@ -49,7 +49,7 @@ SELECT mt.id,
     FROM metabase_table mt
 )
 SELECT pg.id AS group_id,
-       'manage-table-metadata' AS perm_type,
+       'perms/manage-table-metadata' AS perm_type,
        mt.db_id,
        mt.schema AS schema_name,
        mt.id AS table_id,
@@ -70,11 +70,11 @@ WHERE pg.name != 'Administrators'
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id = mt.id
-       AND dp.perm_type = 'manage-table-metadata')
+       AND dp.perm_type = 'perms/manage-table-metadata')
   AND NOT EXISTS
     (SELECT 1
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = mt.db_id
        AND dp.table_id IS NULL
-       AND dp.perm_type = 'manage-table-metadata');
+       AND dp.perm_type = 'perms/manage-table-metadata');

--- a/resources/migrations/permissions/native_query_editing.sql
+++ b/resources/migrations/permissions/native_query_editing.sql
@@ -1,6 +1,6 @@
 INSERT INTO data_permissions (group_id, perm_type, db_id, schema_name, table_id, perm_value)
 SELECT pg.id AS group_id,
-       'native-query-editing' AS perm_type,
+       'perms/native-query-editing' AS perm_type,
        md.id AS db_id,
        NULL AS schema_name,
        NULL AS table_id,
@@ -21,4 +21,4 @@ WHERE pg.name != 'Administrators'
      FROM data_permissions dp
      WHERE dp.group_id = pg.id
        AND dp.db_id = md.id
-       AND dp.perm_type = 'native-query-editing' );
+       AND dp.perm_type = 'perms/native-query-editing' );

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -55,7 +55,7 @@
                              :all  :yes
                              :none :no)))
             (update-keys (fn [table-id] {:id table-id :db_id db-id :schema schema})))]
-    (data-perms/set-table-permissions! group-id :manage-table-metadata new-table-perms)))
+    (data-perms/set-table-permissions! group-id :perms/manage-table-metadata new-table-perms)))
 
 (defn- update-schema-level-metadata-permissions!
   [group-id db-id schema new-schema-perms]
@@ -64,10 +64,10 @@
     (let [tables (db/select :model/Table :db_id db-id :schema (not-empty schema))]
      (case new-schema-perms
        :all
-       (data-perms/set-table-permissions! group-id :manage-table-metadata (zipmap tables (repeat :yes)))
+       (data-perms/set-table-permissions! group-id :perms/manage-table-metadata (zipmap tables (repeat :yes)))
 
        :none
-       (data-perms/set-table-permissions! group-id :manage-table-metadata (zipmap tables (repeat :no)))))))
+       (data-perms/set-table-permissions! group-id :perms/manage-table-metadata (zipmap tables (repeat :no)))))))
 
 (defn- update-db-level-metadata-permissions!
   [group-id db-id new-db-perms]
@@ -77,10 +77,10 @@
         (update-schema-level-metadata-permissions! group-id db-id schema schema-changes))
       (case schemas
         :all
-        (data-perms/set-database-permission! group-id db-id :manage-table-metadata :yes)
+        (data-perms/set-database-permission! group-id db-id :perms/manage-table-metadata :yes)
 
         :none
-        (data-perms/set-database-permission! group-id db-id :manage-table-metadata :no)))))
+        (data-perms/set-database-permission! group-id db-id :perms/manage-table-metadata :no)))))
 
 (defn- update-table-level-download-permissions!
   [group-id db-id schema new-table-perms]
@@ -92,7 +92,7 @@
                              :limited :ten-thousand-rows
                              :none    :no)))
             (update-keys (fn [table-id] {:id table-id :db_id db-id :schema schema})))]
-    (data-perms/set-table-permissions! group-id :download-results new-table-perms)))
+    (data-perms/set-table-permissions! group-id :perms/download-results new-table-perms)))
 
 (defn- update-schema-level-download-permissions!
   [group-id db-id schema new-schema-perms]
@@ -101,13 +101,13 @@
     (let [tables (db/select :model/Table :db_id db-id :schema (not-empty schema))]
       (case new-schema-perms
         :full
-        (data-perms/set-table-permissions! group-id :download-results (zipmap tables (repeat :one-million-rows)))
+        (data-perms/set-table-permissions! group-id :perms/download-results (zipmap tables (repeat :one-million-rows)))
 
         :limited
-        (data-perms/set-table-permissions! group-id :download-results (zipmap tables (repeat :ten-thousand-rows)))
+        (data-perms/set-table-permissions! group-id :perms/download-results (zipmap tables (repeat :ten-thousand-rows)))
 
         :none
-        (data-perms/set-table-permissions! group-id :download-results (zipmap tables (repeat :no)))))))
+        (data-perms/set-table-permissions! group-id :perms/download-results (zipmap tables (repeat :no)))))))
 
 ; ;; TODO: Make sure we update download perm enforcement to infer native download permissions, since
 ; ;; we'll no longer be setting them explicitly in the database.
@@ -121,19 +121,19 @@
         (update-schema-level-download-permissions! group-id db-id schema schema-changes))
       (case schemas
         :full
-        (data-perms/set-database-permission! group-id db-id :download-results :one-million-rows)
+        (data-perms/set-database-permission! group-id db-id :perms/download-results :one-million-rows)
 
         :limited
-        (data-perms/set-database-permission! group-id db-id :download-results :ten-thousand-rows)
+        (data-perms/set-database-permission! group-id db-id :perms/download-results :ten-thousand-rows)
 
         :none
-        (data-perms/set-database-permission! group-id db-id :download-results :no)))))
+        (data-perms/set-database-permission! group-id db-id :perms/download-results :no)))))
 
 (defn- update-native-data-access-permissions!
   [group-id db-id new-native-perms]
-  (data-perms/set-database-permission! group-id db-id :native-query-editing (case new-native-perms
-                                                                              :write :yes
-                                                                              :none  :no)))
+  (data-perms/set-database-permission! group-id db-id :perms/native-query-editing (case new-native-perms
+                                                                                    :write :yes
+                                                                                    :none  :no)))
 
 (defn- update-table-level-data-access-permissions!
   [group-id db-id schema new-table-perms]
@@ -142,7 +142,7 @@
             (update-vals (fn [table-perm]
                            (if (map? table-perm)
                              (if (#{:all :segmented} (table-perm :query))
-                               ;; `:segmented` indicates that the table is sandboxed, but we should set :data-access
+                               ;; `:segmented` indicates that the table is sandboxed, but we should set :perms/data-access
                                ;; permissions to :unrestricted and rely on the `sandboxes` table as the source of truth
                                ;; for sandboxing.
                                :unrestricted
@@ -151,7 +151,7 @@
                                :all  :unrestricted
                                :none :no-self-service))))
             (update-keys (fn [table-id] {:id table-id :db_id db-id :schema schema})))]
-    (data-perms/set-table-permissions! group-id :data-access new-table-perms)))
+    (data-perms/set-table-permissions! group-id :perms/data-access new-table-perms)))
 
 (defn- update-schema-level-data-access-permissions!
   [group-id db-id schema new-schema-perms]
@@ -160,10 +160,10 @@
     (let [tables (db/select :model/Table :db_id db-id :schema (not-empty schema))]
       (case new-schema-perms
         :all
-        (data-perms/set-table-permissions! group-id :data-access (zipmap tables (repeat :unrestricted)))
+        (data-perms/set-table-permissions! group-id :perms/data-access (zipmap tables (repeat :unrestricted)))
 
         :none
-        (data-perms/set-table-permissions! group-id :data-access (zipmap tables (repeat :no-self-service)))))))
+        (data-perms/set-table-permissions! group-id :perms/data-access (zipmap tables (repeat :no-self-service)))))))
 
 (defn- update-db-level-data-access-permissions!
   [group-id db-id new-db-perms]
@@ -175,17 +175,17 @@
         (update-schema-level-data-access-permissions! group-id db-id schema schema-changes))
       (case schemas
         (:all :impersonated)
-        (data-perms/set-database-permission! group-id db-id :data-access :unrestricted)
+        (data-perms/set-database-permission! group-id db-id :perms/data-access :unrestricted)
 
         :none
-        (data-perms/set-database-permission! group-id db-id :data-access :no-self-service)
+        (data-perms/set-database-permission! group-id db-id :perms/data-access :no-self-service)
 
         :block
-        (data-perms/set-database-permission! group-id db-id :data-access :block)))))
+        (data-perms/set-database-permission! group-id db-id :perms/data-access :block)))))
 
 (defn- update-details-perms!
   [group-id db-id value]
-  (data-perms/set-database-permission! group-id db-id :manage-database value))
+  (data-perms/set-database-permission! group-id db-id :perms/manage-database value))
 
 (defn update-data-perms-graph!
   "Takes an API-style perms graph and sets the permissions in the database accordingly."

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -102,11 +102,11 @@
           non-magic-groups (perms-group/non-magic-groups)
           non-admin-groups (conj non-magic-groups all-users-group)]
       ;; All other permissions are set at the table-level, so they are added when individual tables are synced
-      (data-perms/set-database-permission! all-users-group database :native-query-editing :yes)
+      (data-perms/set-database-permission! all-users-group database :perms/native-query-editing :yes)
       (doseq [group non-magic-groups]
-        (data-perms/set-database-permission! group database :native-query-editing :no))
+        (data-perms/set-database-permission! group database :perms/native-query-editing :no))
       (doseq [group non-admin-groups]
-        (data-perms/set-database-permission! group database :manage-database :no)))))
+        (data-perms/set-database-permission! group database :perms/manage-database :no)))))
 
 (t2/define-after-insert :model/Database
   [database]

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -97,11 +97,11 @@
   ;; New groups get *no* permissions by default
   (t2/with-transaction [_conn]
     (doseq [db-id (t2/select-pks-vec :model/Database)]
-      (data-perms/set-database-permission! group db-id :data-access :no-self-service)
-      (data-perms/set-database-permission! group db-id :download-results :no)
-      (data-perms/set-database-permission! group db-id :manage-table-metadata :no)
-      (data-perms/set-database-permission! group db-id :native-query-editing :no)
-      (data-perms/set-database-permission! group db-id :manage-database :no))))
+      (data-perms/set-database-permission! group db-id :perms/data-access           :no-self-service)
+      (data-perms/set-database-permission! group db-id :perms/download-results      :no)
+      (data-perms/set-database-permission! group db-id :perms/manage-table-metadata :no)
+      (data-perms/set-database-permission! group db-id :perms/native-query-editing  :no)
+      (data-perms/set-database-permission! group db-id :perms/manage-database       :no))))
 
 (t2/define-after-insert :model/PermissionsGroup
   [group]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -70,16 +70,16 @@
           non-magic-groups (perms-group/non-magic-groups)
           non-admin-groups (conj non-magic-groups all-users-group)]
       ;; Data access permissions
-      (data-perms/set-table-permission! all-users-group table :data-access :unrestricted)
+      (data-perms/set-table-permission! all-users-group table :perms/data-access :unrestricted)
       (doseq [group non-magic-groups]
-        (data-perms/set-table-permission! group table :data-access :no-self-service))
+        (data-perms/set-table-permission! group table :perms/data-access :no-self-service))
       ;; Download permissions
-      (data-perms/set-table-permission! all-users-group table :download-results :one-million-rows)
+      (data-perms/set-table-permission! all-users-group table :perms/download-results :one-million-rows)
       (doseq [group non-magic-groups]
-        (data-perms/set-table-permission! group table :download-results :no))
+        (data-perms/set-table-permission! group table :perms/download-results :no))
       ;; Table metadata management
       (doseq [group non-admin-groups]
-        (data-perms/set-table-permission! group table :manage-table-metadata :no)))))
+        (data-perms/set-table-permission! group table :perms/manage-table-metadata :no)))))
 
 (t2/define-after-insert :model/Table
   [table]

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -834,7 +834,7 @@
                                                   :db_id db-id :table_id nil :group_id group-id)))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id-1 :group_id group-id))))
+                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/data-access"))))
 
         (testing "Unrestricted not-native data access for a DB"
           (clear-permissions!)
@@ -843,10 +843,10 @@
           (migrate!)
           (is (= "unrestricted" (t2/select-one-fn :perm_value
                                                   (t2/table-name :model/DataPermissions)
-                                                  :db_id db-id :table_id nil :group_id group-id)))
+                                                  :db_id db-id :table_id nil :group_id group-id :perm_type "perms/data-access")))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id-1 :group_id group-id))))
+                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/data-access"))))
 
         (testing "Unrestricted data access for a schema"
           (clear-permissions!)
@@ -855,11 +855,11 @@
           (migrate!)
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id nil :group_id group-id)))
+                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/data-access")))
           (is (= "unrestricted"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id table-id-1 :group_id group-id))))
+                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/data-access"))))
 
         (testing "Unrestricted data access for a table"
           (clear-permissions!)
@@ -868,11 +868,11 @@
           (migrate!)
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id nil :group_id group-id)))
+                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/data-access")))
           (is (= "unrestricted"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id table-id-1 :group_id group-id))))
+                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/data-access"))))
 
         (testing "Query access to a table"
           (clear-permissions!)
@@ -881,11 +881,11 @@
           (migrate!)
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id nil :group_id group-id)))
+                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/data-access")))
           (is (= "unrestricted"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id table-id-1 :group_id group-id))))
+                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/data-access"))))
 
         (testing "Segmented query access to a table - maps to unrestricted data access; sandboxing is determined by the
                                      `sandboxes` table"
@@ -895,11 +895,11 @@
           (migrate!)
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id nil :group_id group-id)))
+                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/data-access")))
           (is (= "unrestricted"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id table-id-1 :group_id group-id))))
+                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/data-access"))))
 
         (testing "No self service database access"
           (clear-permissions!)
@@ -907,10 +907,10 @@
           (is (= "no-self-service"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id nil :group_id group-id)))
+                                   :db_id db-id :table_id nil :group_id group-id :perm_type "perms/data-access")))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id-1 :group_id group-id))))
+                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/data-access"))))
 
         (testing "Granular table permissions"
           (clear-permissions!)
@@ -920,15 +920,15 @@
           (is (nil?
                (t2/select-one-fn :perm_value
                                  (t2/table-name :model/DataPermissions)
-                                 :db_id db-id :table_id nil :group_id group-id)))
+                                 :db_id db-id :table_id nil :group_id group-id :perm_type "perms/data-access")))
           (is (= "no-self-service"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id table-id-1 :group_id group-id)))
+                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/data-access")))
           (is (= "unrestricted"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id table-id-2 :group_id group-id))))
+                                   :db_id db-id :table_id table-id-2 :group_id group-id :perm_type "perms/data-access"))))
 
         (testing "Block permissions for a database"
           (clear-permissions!)
@@ -937,10 +937,10 @@
           (migrate!)
           (is (= "block" (t2/select-one-fn :perm_value
                                            (t2/table-name :model/DataPermissions)
-                                           :db_id db-id :table_id nil :group_id group-id)))
+                                           :db_id db-id :table_id nil :group_id group-id :perm_type "perms/data-access")))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id-1 :group_id group-id))))))))
+                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/data-access"))))))))
 
 (deftest native-query-editing-permissions-schema-migration-test
   (testing "Native query editing permissions are correctly migrated from `permissions` to `permissions_v2`"
@@ -958,7 +958,7 @@
           (migrate!)
           (is (= "yes" (t2/select-one-fn :perm_value
                                          (t2/table-name :model/DataPermissions)
-                                         :db_id db-id :table_id nil :group_id group-id :perm_type "native-query-editing"))))
+                                         :db_id db-id :table_id nil :group_id group-id :perm_type "perms/native-query-editing"))))
 
         (testing "Native query editing explicitly allowed"
           (clear-permissions!)
@@ -967,14 +967,14 @@
           (migrate!)
           (is (= "yes" (t2/select-one-fn :perm_value
                                          (t2/table-name :model/DataPermissions)
-                                         :db_id db-id :table_id nil :group_id group-id :perm_type "native-query-editing"))))
+                                         :db_id db-id :table_id nil :group_id group-id :perm_type "perms/native-query-editing"))))
 
         (testing "Native query editing not allowed"
           (clear-permissions!)
           (migrate!)
           (is (= "no" (t2/select-one-fn :perm_value
                                         (t2/table-name :model/DataPermissions)
-                                        :db_id db-id :table_id nil :group_id group-id :perm_type "native-query-editing"))))))))
+                                        :db_id db-id :table_id nil :group_id group-id :perm_type "perms/native-query-editing"))))))))
 
 (deftest download-results-permissions-schema-migration-test
   (testing "Download results permissions are correctly migrated from `permissions` to `permissions_v2`"
@@ -1010,10 +1010,10 @@
           (migrate!)
           (is (= "one-million-rows" (t2/select-one-fn :perm_value
                                                       (t2/table-name :model/DataPermissions)
-                                                      :db_id db-id :table_id nil :group_id group-id :perm_type "download-results")))
+                                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/download-results")))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "download-results")))
+                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/download-results")))
 
           (clear-permissions!)
           (t2/insert! (t2/table-name Permissions) {:group_id group-id
@@ -1021,10 +1021,10 @@
           (migrate!)
           (is (= "one-million-rows" (t2/select-one-fn :perm_value
                                                       (t2/table-name :model/DataPermissions)
-                                                      :db_id db-id :table_id nil :group_id group-id :perm_type "download-results")))
+                                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/download-results")))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "download-results"))))
+                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/download-results"))))
 
         (testing "Ten-thousand-rows download access for a DB"
           (clear-permissions!)
@@ -1033,10 +1033,10 @@
           (migrate!)
           (is (= "ten-thousand-rows" (t2/select-one-fn :perm_value
                                                        (t2/table-name :model/DataPermissions)
-                                                       :db_id db-id :table_id nil :group_id group-id :perm_type "download-results")))
+                                                       :db_id db-id :table_id nil :group_id group-id :perm_type "perms/download-results")))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "download-results")))
+                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/download-results")))
 
           (clear-permissions!)
           (t2/insert! (t2/table-name Permissions) {:group_id group-id
@@ -1044,20 +1044,20 @@
           (migrate!)
           (is (= "ten-thousand-rows" (t2/select-one-fn :perm_value
                                                        (t2/table-name :model/DataPermissions)
-                                                       :db_id db-id :table_id nil :group_id group-id :perm_type "download-results")))
+                                                       :db_id db-id :table_id nil :group_id group-id :perm_type "perms/download-results")))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "download-results"))))
+                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/download-results"))))
 
         (testing "No download access for a DB"
           (clear-permissions!)
           (migrate!)
           (is (= "no" (t2/select-one-fn :perm_value
                                         (t2/table-name :model/DataPermissions)
-                                        :db_id db-id :table_id nil :group_id group-id :perm_type "download-results")))
+                                        :db_id db-id :table_id nil :group_id group-id :perm_type "perms/download-results")))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "download-results"))))
+                                      :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/download-results"))))
 
 
         (testing "One-million-rows download access for a table"
@@ -1067,11 +1067,11 @@
           (migrate!)
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id nil :group_id group-id :perm_type "download-results")))
+                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/download-results")))
           (is (= "one-million-rows"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "download-results"))))
+                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/download-results"))))
 
         (testing "One-million-rows download access for a table"
           (clear-permissions!)
@@ -1080,11 +1080,11 @@
           (migrate!)
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id nil :group_id group-id :perm_type "download-results")))
+                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/download-results")))
           (is (= "one-million-rows"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "download-results"))))
+                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/download-results"))))
 
         (testing "Ten-thousand-rows download access for a table"
           (clear-permissions!)
@@ -1093,11 +1093,11 @@
           (migrate!)
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id nil :group_id group-id :perm_type "download-results")))
+                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/download-results")))
           (is (= "ten-thousand-rows"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "download-results"))))
+                                   :db_id db-id :table_id table-id-1 :group_id group-id :perm_type "perms/download-results"))))
 
         (testing "Granular table permissions"
           (clear-permissions!)
@@ -1146,20 +1146,20 @@
           (migrate!)
           (is (= "yes" (t2/select-one-fn :perm_value
                                          (t2/table-name :model/DataPermissions)
-                                         :db_id db-id :table_id nil :group_id group-id :perm_type "manage-table-metadata")))
+                                         :db_id db-id :table_id nil :group_id group-id :perm_type "perms/manage-table-metadata")))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id :group_id group-id :perm_type "manage-table-metadata"))))
+                                      :db_id db-id :table_id table-id :group_id group-id :perm_type "perms/manage-table-metadata"))))
 
         (testing "No manage table metadata access for a DB"
           (clear-permissions!)
           (migrate!)
           (is (= "no" (t2/select-one-fn :perm_value
                                         (t2/table-name :model/DataPermissions)
-                                        :db_id db-id :table_id nil :group_id group-id :perm_type "manage-table-metadata")))
+                                        :db_id db-id :table_id nil :group_id group-id :perm_type "perms/manage-table-metadata")))
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id table-id :group_id group-id :perm_type "manage-table-metadata"))))
+                                      :db_id db-id :table_id table-id :group_id group-id :perm_type "perms/manage-table-metadata"))))
 
         (testing "Manage table metadata access for a table"
           (clear-permissions!)
@@ -1168,11 +1168,11 @@
           (migrate!)
           (is (nil? (t2/select-one-fn :perm_value
                                       (t2/table-name :model/DataPermissions)
-                                      :db_id db-id :table_id nil :group_id group-id :perm_type "manage-table-metadata")))
+                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/manage-table-metadata")))
           (is (= "yes"
                  (t2/select-one-fn :perm_value
                                    (t2/table-name :model/DataPermissions)
-                                   :db_id db-id :table_id table-id :group_id group-id :perm_type "manage-table-metadata"))))))))
+                                   :db_id db-id :table_id table-id :group_id group-id :perm_type "perms/manage-table-metadata"))))))))
 
 (deftest manage-database-permissions-schema-migration-test
   (testing "Manage database permissions are correctly migrated from `permissions` to `permissions_v2`"
@@ -1190,11 +1190,11 @@
           (migrate!)
           (is (= "yes" (t2/select-one-fn :perm_value
                                          (t2/table-name :model/DataPermissions)
-                                         :db_id db-id :group_id group-id :perm_type "manage-database"))))
+                                         :db_id db-id :group_id group-id :perm_type "perms/manage-database"))))
 
         (testing "No manage database permission"
           (clear-permissions!)
           (migrate!)
           (is (= "no" (t2/select-one-fn :perm_value
                                         (t2/table-name :model/DataPermissions)
-                                        :db_id db-id :group_id group-id :perm_type "manage-database"))))))))
+                                        :db_id db-id :group_id group-id :perm_type "perms/manage-database"))))))))

--- a/test/metabase/models/data_permissions/graph_test.clj
+++ b/test/metabase/models/data_permissions/graph_test.clj
@@ -34,12 +34,12 @@
                       {table-id-3 :all}}}}}}
         {group-id-1
          {database-id-1
-          {:native-query-editing :no
-           :data-access {"PUBLIC"
-                         {table-id-1 :unrestricted
-                          table-id-2 :no-self-service}
-                         ""
-                         {table-id-3 :unrestricted}}}}}
+          {:perms/native-query-editing :no
+           :perms/data-access {"PUBLIC"
+                               {table-id-1 :unrestricted
+                                table-id-2 :no-self-service}
+                               ""
+                               {table-id-3 :unrestricted}}}}}
 
         ;; Restoring full data access and native query permissions
         {group-id-1
@@ -49,8 +49,8 @@
             :schemas :all}}}}
         {group-id-1
          {database-id-1
-          {:native-query-editing :yes
-           :data-access :unrestricted}}}
+          {:perms/native-query-editing :yes
+           :perms/data-access :unrestricted}}}
 
         ;; Setting data access permissions at the schema-level
         {group-id-1
@@ -61,12 +61,12 @@
                       ""       :none}}}}}
         {group-id-1
          {database-id-1
-          {:native-query-editing :no
-           :data-access {"PUBLIC"
-                         {table-id-1 :unrestricted
-                          table-id-2 :unrestricted}
-                         ""
-                         {table-id-3 :no-self-service}}}}}
+          {:perms/native-query-editing :no
+           :perms/data-access {"PUBLIC"
+                               {table-id-1 :unrestricted
+                                table-id-2 :unrestricted}
+                               ""
+                               {table-id-3 :no-self-service}}}}}
 
         ;; Setting block permissions for the database
         {group-id-1
@@ -76,8 +76,8 @@
             :schemas :block}}}}
         {group-id-1
           {database-id-1
-           {:native-query-editing :no
-            :data-access :block}}}))))
+           {:perms/native-query-editing :no
+            :perms/data-access :block}}}))))
 
 (deftest update-db-level-download-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
@@ -106,11 +106,11 @@
                       {table-id-3 :limited}}}}}}
         {group-id-1
          {database-id-1
-          {:download-results {"PUBLIC"
-                              {table-id-1 :one-million-rows
-                               table-id-2 :no}
-                              ""
-                              {table-id-3 :ten-thousand-rows}}}}}
+          {:perms/download-results {"PUBLIC"
+                                    {table-id-1 :one-million-rows
+                                     table-id-2 :no}
+                                    ""
+                                    {table-id-3 :ten-thousand-rows}}}}}
 
         ;; Restoring full download permissions
         {group-id-1
@@ -119,7 +119,7 @@
            {:schemas :full}}}}
         {group-id-1
          {database-id-1
-          {:download-results :one-million-rows}}}
+          {:perms/download-results :one-million-rows}}}
 
         ;; Setting download permissions at the schema-level
         {group-id-1
@@ -129,11 +129,11 @@
                       ""       :none}}}}}
         {group-id-1
          {database-id-1
-          {:download-results {"PUBLIC"
-                              {table-id-1 :one-million-rows
-                               table-id-2 :one-million-rows}
-                              ""
-                              {table-id-3 :no}}}}}
+          {:perms/download-results {"PUBLIC"
+                                    {table-id-1 :one-million-rows
+                                     table-id-2 :one-million-rows}
+                                    ""
+                                    {table-id-3 :no}}}}}
 
         ;; Revoking download permissions for the database
         {group-id-1
@@ -142,7 +142,7 @@
            {:schemas :none}}}}
         {group-id-1
          {database-id-1
-          {:download-results :no}}}))))
+          {:perms/download-results :no}}}))))
 
 (deftest update-db-level-metadata-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
@@ -164,20 +164,18 @@
         {group-id-1
          {database-id-1
           {:data-model
-           {:schemas
-            {"PUBLIC"
-             {table-id-1 :all
-              table-id-2 :none}
-             ""
-             {table-id-3 :none}}}}}}
+           {:schemas {"PUBLIC"
+                      {table-id-1 :all
+                       table-id-2 :none}
+                      ""
+                      {table-id-3 :none}}}}}}
         {group-id-1
          {database-id-1
-          {:manage-table-metadata
-           {"PUBLIC"
-            {table-id-1 :yes
-             table-id-2 :no}
-            ""
-            {table-id-3 :no}}}}}
+          {:perms/manage-table-metadata {"PUBLIC"
+                                         {table-id-1 :yes
+                                          table-id-2 :no}
+                                         ""
+                                         {table-id-3 :no}}}}}
 
         ;; Restoring full data model editing permissions
         {group-id-1
@@ -186,7 +184,7 @@
            {:schemas :all}}}}
         {group-id-1
          {database-id-1
-          {:manage-table-metadata :yes}}}
+          {:perms/manage-table-metadata :yes}}}
 
         ;; Setting data model editing permissions at the schema-level
         {group-id-1
@@ -196,11 +194,11 @@
                       ""       :none}}}}}
         {group-id-1
          {database-id-1
-          {:manage-table-metadata {"PUBLIC"
-                                   {table-id-1 :yes
-                                    table-id-2 :yes}
-                                   ""
-                                   {table-id-3 :no}}}}}
+          {:perms/manage-table-metadata {"PUBLIC"
+                                         {table-id-1 :yes
+                                          table-id-2 :yes}
+                                         ""
+                                         {table-id-3 :no}}}}}
 
         ;; Revoking all data model editing permissions for the database
         {group-id-1
@@ -209,7 +207,7 @@
            {:schemas :none}}}}
         {group-id-1
          {database-id-1
-          {:manage-table-metadata :no}}}))))
+          {:perms/manage-table-metadata :no}}}))))
 
 (deftest update-details-perms!-test
   (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}
@@ -227,7 +225,7 @@
           {:details :yes}}}
         {group-id-1
          {database-id-1
-          {:manage-database :yes}}}
+          {:perms/manage-database :yes}}}
 
         ;; Revoking permission to edit database details
         {group-id-1
@@ -235,4 +233,4 @@
           {:details :no}}}
         {group-id-1
          {database-id-1
-          {:manage-database :no}}}))))
+          {:perms/manage-database :no}}}))))

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -42,15 +42,15 @@
       (let [all-users-group-id (u/the-id (perms-group/all-users))]
         (is (= {all-users-group-id
                 {db-id
-                 {:native-query-editing :yes
-                  :manage-database      :no}}}
+                 {:perms/native-query-editing :yes
+                  :perms/manage-database      :no}}}
                (data-perms/data-permissions-graph :group-id all-users-group-id :db-id db-id))))
 
       ;; Other groups should have no DB-level perms
       (is (= {group-id
               {db-id
-               {:native-query-editing :no
-                :manage-database      :no}}}
+               {:perms/native-query-editing :no
+                :perms/manage-database      :no}}}
              (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))
 
 (deftest cleanup-permissions-after-delete-db-test

--- a/test/metabase/models/permissions_group_test.clj
+++ b/test/metabase/models/permissions_group_test.clj
@@ -141,9 +141,9 @@
       (is
        (= {group-id
            {db-id
-            {:data-access :no-self-service,
-             :download-results :no,
-             :manage-table-metadata :no,
-             :native-query-editing :no,
-             :manage-database :no}}}
+            {:perms/data-access :no-self-service,
+             :perms/download-results :no,
+             :perms/manage-table-metadata :no,
+             :perms/native-query-editing :no,
+             :perms/manage-database :no}}}
           (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))

--- a/test/metabase/models/table_test.clj
+++ b/test/metabase/models/table_test.clj
@@ -94,18 +94,18 @@
         (is (partial=
              {all-users-group-id
               {db-id
-               {:data-access           {"PUBLIC" {table-id :unrestricted}}
-                :download-results      {"PUBLIC" {table-id :one-million-rows}}
-                :manage-table-metadata {"PUBLIC" {table-id :no}}}}}
+               {:perms/data-access           {"PUBLIC" {table-id :unrestricted}}
+                :perms/download-results      {"PUBLIC" {table-id :one-million-rows}}
+                :perms/manage-table-metadata {"PUBLIC" {table-id :no}}}}}
              (data-perms/data-permissions-graph :group-id all-users-group-id :db-id db-id))))
 
       ;; Other groups should have no-self-service data access and no download abilities or metadata management
       (is (partial=
            {group-id
             {db-id
-             {:data-access           {"PUBLIC" {table-id :no-self-service}}
-              :download-results      {"PUBLIC" {table-id :no}}
-              :manage-table-metadata {"PUBLIC" {table-id :no}}}}}
+             {:perms/data-access           {"PUBLIC" {table-id :no-self-service}}
+              :perms/download-results      {"PUBLIC" {table-id :no}}
+              :perms/manage-table-metadata {"PUBLIC" {table-id :no}}}}}
            (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))
 
 (deftest cleanup-permissions-after-delete-table-test


### PR DESCRIPTION
Namespaces permission types with `:perms/` per Dan's suggestion https://metaboat.slack.com/archives/C064EB1UE5P/p1705683913811889

I've changed everything in-place, such that we're also storing the namespaced keywords in the database. This works well because the `mi/transform-keyword` transformation is already built to handle namespaced keywords automatically.