### PR TITLE
Formatting for time types

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -373,6 +373,57 @@ describe("scenarios > visualizations > table > conditional formatting", () => {
   });
 });
 
+describe("scenarios > visualizations > table > time formatting (#11398)", () => {
+  const singleTimeQuery = `
+      WITH t1 AS (SELECT TIMESTAMP '2023-01-01 18:34:00' AS time_value),
+           t2 AS (SELECT CAST(time_value AS TIME) AS creation_time
+                  FROM t1)
+      SELECT *
+      FROM t2;
+  `;
+
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should work with boolean columns", { tags: ["@external"] }, () => {
+    cy.createNativeQuestion(
+      {
+        name: "11398",
+        native: {
+          query: singleTimeQuery,
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    // Open the formatting menu
+    cy.icon("chevrondown").click();
+    cy.findByTestId("drill-through-section").within(() => {
+      cy.icon("gear").click();
+    });
+
+    cy.findByTestId("column-formatting-settings").within(() => {
+      // Set to hours, minutes, seconds, 24-hour clock
+      cy.findByText("HH:MM:SS").click();
+      cy.findByText("17:24 (24-hour clock)").click();
+    });
+
+    // And you should find the result
+    cy.findByRole("gridcell").findByText("18:34:00");
+
+    cy.findByTestId("column-formatting-settings").within(() => {
+      // Add millisecond display and change back to 12 hours
+      cy.findByText("HH:MM:SS.MS").click();
+      cy.findByText("5:24 PM (12-hour clock)").click();
+    });
+
+    // And you should find the result
+    cy.findByRole("gridcell").findByText("6:34:00.000 PM");
+  });
+});
+
 function headerCells() {
   return cy.findAllByTestId("header-cell");
 }

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -387,7 +387,7 @@ describe("scenarios > visualizations > table > time formatting (#11398)", () => 
     cy.signInAsNormalUser();
   });
 
-  it("should work with boolean columns", { tags: ["@external"] }, () => {
+  it("should work with time columns", { tags: ["@external"] }, () => {
     cy.createNativeQuestion(
       {
         name: "11398",
@@ -399,7 +399,8 @@ describe("scenarios > visualizations > table > time formatting (#11398)", () => 
     );
 
     // Open the formatting menu
-    cy.icon("chevrondown").click();
+    cy.findByTestId("field-info-popover").click();
+
     cy.findByTestId("drill-through-section").within(() => {
       cy.icon("gear").click();
     });

--- a/frontend/src/metabase/lib/formatting/time.ts
+++ b/frontend/src/metabase/lib/formatting/time.ts
@@ -28,12 +28,6 @@ export function duration(milliseconds: number) {
   return ngettext(msgid`${seconds} second`, `${seconds} seconds`, seconds);
 }
 
-export function formatTime(time: Moment) {
-  const parsedTime = parseTime(time);
-
-  return parsedTime.isValid() ? parsedTime.format("LT") : String(time);
-}
-
 interface TimeWithUnitType {
   local?: boolean;
   time_enabled?: "minutes" | "milliseconds" | "seconds" | boolean;
@@ -77,24 +71,25 @@ interface TimeOnlyOptions {
 
 export function formatTimeWithOptions(
   time: Moment,
-  unit: DatetimeUnit,
+  unit: DatetimeUnit = "default",
   options: TimeOnlyOptions = {},
 ) {
   const parsedTime = parseTime(time);
 
-  const timeStyle = options.time_style
-    ? options.time_style
-    : DEFAULT_TIME_STYLE;
+  const timeStyle = options.time_style ?? DEFAULT_TIME_STYLE;
 
-  const timeEnabled = options.time_enabled
-    ? options.time_enabled
-    : hasHour(unit)
-    ? "minutes"
-    : null;
+  let timeEnabled;
+  if (options.time_enabled) {
+    timeEnabled = options.time_enabled;
+  } else if (hasHour(unit)) {
+    timeEnabled = "minute";
+  } else {
+    timeEnabled = null;
+  }
 
-  const timeFormat = options.time_format
-    ? options.time_format
-    : getTimeFormatFromStyle(timeStyle, unit, timeEnabled as any);
+  const timeFormat =
+    options.time_format ??
+    getTimeFormatFromStyle(timeStyle, unit, timeEnabled as any);
 
-return parsedTime.isValid() ? parsedTime.format("LT") : String(time);
+  return parsedTime.isValid() ? parsedTime.format(timeFormat) : String(time);
 }

--- a/frontend/src/metabase/lib/formatting/time.ts
+++ b/frontend/src/metabase/lib/formatting/time.ts
@@ -96,5 +96,5 @@ export function formatTimeWithOptions(
     ? options.time_format
     : getTimeFormatFromStyle(timeStyle, unit, timeEnabled as any);
 
-  return parsedTime.format(timeFormat);
+return parsedTime.isValid() ? parsedTime.format("LT") : String(time);
 }

--- a/frontend/src/metabase/lib/formatting/time.ts
+++ b/frontend/src/metabase/lib/formatting/time.ts
@@ -69,7 +69,7 @@ interface TimeOnlyOptions {
   time_style?: string;
 }
 
-export function formatTimeWithOptions(
+export function formatTime(
   time: Moment,
   unit: DatetimeUnit = "default",
   options: TimeOnlyOptions = {},

--- a/frontend/src/metabase/lib/formatting/time.ts
+++ b/frontend/src/metabase/lib/formatting/time.ts
@@ -67,3 +67,34 @@ export function formatTimeWithUnit(
 
   return m.format(timeFormat);
 }
+
+interface TimeOnlyOptions {
+  local?: boolean;
+  time_enabled?: "minutes" | "milliseconds" | "seconds" | null;
+  time_format?: string;
+  time_style?: string;
+}
+
+export function formatTimeWithOptions(
+  time: Moment,
+  unit: DatetimeUnit,
+  options: TimeOnlyOptions = {},
+) {
+  const parsedTime = parseTime(time);
+
+  const timeStyle = options.time_style
+    ? options.time_style
+    : DEFAULT_TIME_STYLE;
+
+  const timeEnabled = options.time_enabled
+    ? options.time_enabled
+    : hasHour(unit)
+    ? "minutes"
+    : null;
+
+  const timeFormat = options.time_format
+    ? options.time_format
+    : getTimeFormatFromStyle(timeStyle, unit, timeEnabled as any);
+
+  return parsedTime.format(timeFormat);
+}

--- a/frontend/src/metabase/lib/formatting/time.ts
+++ b/frontend/src/metabase/lib/formatting/time.ts
@@ -4,6 +4,7 @@ import type { Moment } from "moment-timezone";
 import { parseTime, parseTimestamp } from "metabase/lib/time";
 
 import type { DatetimeUnit } from "metabase-types/api/query";
+import type { TimeOnlyOptions } from "metabase/lib/formatting/types";
 import {
   DEFAULT_TIME_STYLE,
   getTimeFormatFromStyle,
@@ -60,13 +61,6 @@ export function formatTimeWithUnit(
     : getTimeFormatFromStyle(timeStyle, unit, timeEnabled as any);
 
   return m.format(timeFormat);
-}
-
-interface TimeOnlyOptions {
-  local?: boolean;
-  time_enabled?: "minutes" | "milliseconds" | "seconds" | null;
-  time_format?: string;
-  time_style?: string;
 }
 
 export function formatTime(

--- a/frontend/src/metabase/lib/formatting/types.ts
+++ b/frontend/src/metabase/lib/formatting/types.ts
@@ -1,4 +1,11 @@
-export interface OptionsType {
+export interface TimeOnlyOptions {
+  local?: boolean;
+  time_enabled?: "minutes" | "milliseconds" | "seconds" | null;
+  time_format?: string;
+  time_style?: string;
+}
+
+export interface OptionsType extends TimeOnlyOptions {
   click_behavior?: any;
   clicked?: any;
   column?: any;
@@ -12,7 +19,6 @@ export interface OptionsType {
   jsx?: boolean;
   link_text?: string;
   link_url?: string;
-  local?: boolean;
   majorWidth?: number;
   markdown_template?: any;
   maximumFractionDigits?: number;
@@ -25,9 +31,6 @@ export interface OptionsType {
   removeYear?: boolean;
   rich?: boolean;
   suffix?: string;
-  time_enabled?: "minutes" | "milliseconds" | "seconds" | null;
-  time_format?: string;
-  time_style?: string;
   type?: string;
   view_as?: string | null;
   weekday_enabled?: boolean;

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -24,7 +24,7 @@ import {
   isURL,
 } from "metabase-lib/types/utils/isa";
 import { formatEmail } from "./email";
-import { formatTimeWithOptions } from "./time";
+import { formatTime } from "./time";
 import { formatUrl } from "./url";
 import { formatDateTimeWithUnit, formatRange } from "./date";
 import { formatNumber } from "./numbers";
@@ -177,7 +177,7 @@ export function formatValueRaw(
   } else if (isEmail(column)) {
     return formatEmail(value as string, options);
   } else if (isTime(column)) {
-    return formatTimeWithOptions(value as Moment, column.unit, options);
+    return formatTime(value as Moment, column.unit, options);
   } else if (column && column.unit != null) {
     return formatDateTimeWithUnit(
       value as string | number,

--- a/frontend/src/metabase/lib/formatting/value.tsx
+++ b/frontend/src/metabase/lib/formatting/value.tsx
@@ -24,7 +24,7 @@ import {
   isURL,
 } from "metabase-lib/types/utils/isa";
 import { formatEmail } from "./email";
-import { formatTime } from "./time";
+import { formatTimeWithOptions } from "./time";
 import { formatUrl } from "./url";
 import { formatDateTimeWithUnit, formatRange } from "./date";
 import { formatNumber } from "./numbers";
@@ -177,7 +177,7 @@ export function formatValueRaw(
   } else if (isEmail(column)) {
     return formatEmail(value as string, options);
   } else if (isTime(column)) {
-    return formatTime(value as Moment);
+    return formatTimeWithOptions(value as Moment, column.unit, options);
   } else if (column && column.unit != null) {
     return formatDateTimeWithUnit(
       value as string | number,

--- a/frontend/src/metabase/static-viz/lib/format.ts
+++ b/frontend/src/metabase/static-viz/lib/format.ts
@@ -8,7 +8,7 @@ import type {
   RowValue,
   VisualizationSettings,
 } from "metabase-types/api";
-import { formatTime } from "metabase/lib/formatting/time";
+import { formatTimeWithOptions } from "metabase/lib/formatting/time";
 import {
   formatDateTimeWithUnit,
   formatRange,
@@ -57,7 +57,11 @@ export const formatStaticValue = (value: unknown, options: OptionsType) => {
   if (value == null) {
     formattedValue = JSON.stringify(null);
   } else if (isTime(column)) {
-    formattedValue = formatTime(value as Moment);
+    formattedValue = formatTimeWithOptions(
+      value as Moment,
+      column.unit,
+      options,
+    );
   } else if (column?.unit != null) {
     formattedValue = formatDateTimeWithUnit(
       value as string | number,

--- a/frontend/src/metabase/static-viz/lib/format.ts
+++ b/frontend/src/metabase/static-viz/lib/format.ts
@@ -8,7 +8,7 @@ import type {
   RowValue,
   VisualizationSettings,
 } from "metabase-types/api";
-import { formatTimeWithOptions } from "metabase/lib/formatting/time";
+import { formatTime } from "metabase/lib/formatting/time";
 import {
   formatDateTimeWithUnit,
   formatRange,
@@ -57,11 +57,7 @@ export const formatStaticValue = (value: unknown, options: OptionsType) => {
   if (value == null) {
     formattedValue = JSON.stringify(null);
   } else if (isTime(column)) {
-    formattedValue = formatTimeWithOptions(
-      value as Moment,
-      column.unit,
-      options,
-    );
+    formattedValue = formatTime(value as Moment, column.unit, options);
   } else if (column?.unit != null) {
     formattedValue = formatDateTimeWithUnit(
       value as string | number,

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -698,6 +698,8 @@ class TableInteractive extends Component {
     const isSorted = sortDirection != null;
     const isAscending = sortDirection === "asc";
 
+    const fieldInfoPopoverTestId = "field-info-popover";
+
     return (
       <TableDraggable
         /* needs to be index+name+counter so Draggable resets after each drag */
@@ -793,6 +795,7 @@ class TableInteractive extends Component {
                     className="Icon mr1"
                     name={isAscending ? "chevronup" : "chevrondown"}
                     size={10}
+                    data-testid={fieldInfoPopoverTestId}
                   />
                 )}
                 {columnTitle}
@@ -801,6 +804,7 @@ class TableInteractive extends Component {
                     className="Icon ml1"
                     name={isAscending ? "chevronup" : "chevrondown"}
                     size={10}
+                    data-testid={fieldInfoPopoverTestId}
                   />
                 )}
               </Ellipsified>,

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -8,7 +8,7 @@ import {
   formatValue,
   formatUrl,
   formatDateTimeWithUnit,
-  formatTime,
+  formatTimeWithOptions,
   formatTimeWithUnit,
   slugify,
   getCurrencySymbol,
@@ -598,8 +598,8 @@ describe("formatting", () => {
     );
   });
 
-  describe("formatTime", () => {
-    const FORMAT_TIME_TESTS = [
+  describe("formatTimeWithOptions", () => {
+    const FORMAT_TIME_WITH_OPTIONS_TESTS = [
       ["01:02:03.456+07:00", "1:02 AM"],
       ["01:02", "1:02 AM"],
       ["22:29:59.26816+01:00", "10:29 PM"],
@@ -611,10 +611,10 @@ describe("formatting", () => {
       ["17:01:23+01:00", "5:01 PM"],
     ];
 
-    test.each(FORMAT_TIME_TESTS)(
-      `parseTime(%p) to be %p`,
+    test.each(FORMAT_TIME_WITH_OPTIONS_TESTS)(
+      `formatTimeWithOptions(%p) to be %p`,
       (value, resultStr) => {
-        const result = formatTime(value);
+        const result = formatTimeWithOptions(value);
         expect(result).toBe(resultStr);
       },
     );

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -618,6 +618,17 @@ describe("formatting", () => {
         expect(result).toBe(resultStr);
       },
     );
+
+    it("should use options when formatting times", () => {
+      const value = "20:34:56";
+      const t12 = formatTimeWithOptions(value, "default", {});
+      expect(t12).toBe("8:34 PM");
+      const t24 = formatTimeWithOptions(value, "default", {
+        time_enabled: "minutes",
+        time_style: "HH:mm",
+      });
+      expect(t24).toBe("20:34");
+    });
   });
 
   describe("formatTimeWithUnit", () => {

--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -8,7 +8,7 @@ import {
   formatValue,
   formatUrl,
   formatDateTimeWithUnit,
-  formatTimeWithOptions,
+  formatTime,
   formatTimeWithUnit,
   slugify,
   getCurrencySymbol,
@@ -598,8 +598,8 @@ describe("formatting", () => {
     );
   });
 
-  describe("formatTimeWithOptions", () => {
-    const FORMAT_TIME_WITH_OPTIONS_TESTS = [
+  describe("formatTime", () => {
+    const FORMAT_TIME_TESTS = [
       ["01:02:03.456+07:00", "1:02 AM"],
       ["01:02", "1:02 AM"],
       ["22:29:59.26816+01:00", "10:29 PM"],
@@ -611,19 +611,19 @@ describe("formatting", () => {
       ["17:01:23+01:00", "5:01 PM"],
     ];
 
-    test.each(FORMAT_TIME_WITH_OPTIONS_TESTS)(
-      `formatTimeWithOptions(%p) to be %p`,
+    test.each(FORMAT_TIME_TESTS)(
+      `formatTime(%p) to be %p`,
       (value, resultStr) => {
-        const result = formatTimeWithOptions(value);
+        const result = formatTime(value);
         expect(result).toBe(resultStr);
       },
     );
 
     it("should use options when formatting times", () => {
       const value = "20:34:56";
-      const t12 = formatTimeWithOptions(value, "default", {});
+      const t12 = formatTime(value, "default", {});
       expect(t12).toBe("8:34 PM");
-      const t24 = formatTimeWithOptions(value, "default", {
+      const t24 = formatTime(value, "default", {
         time_enabled: "minutes",
         time_style: "HH:mm",
       });


### PR DESCRIPTION
Currently, the frontend does not do any special formatting for time of day types. These are always formatted as 12 hour AM/PM times. This PR adds a new function to `frontend/src/metabase/lib/formatting/time.ts`, `formatTimeWithOptions`, that applies user-defined formatting to the time. Previously, `formatTime` was called, which takes no formatting options, so none can be applied.

Fixes #11398