### PR TITLE
remove generic type from TabButton

### DIFF
--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -40,21 +40,21 @@ import {
 
 export const INPUT_WRAPPER_TEST_ID = "tab-button-input-wrapper";
 
-export type TabButtonMenuAction<T> = (
+export type TabButtonMenuAction = (
   context: TabContextType,
-  value: T,
+  value: UniqueIdentifier | null,
 ) => void;
 
-export interface TabButtonMenuItem<T> {
+export interface TabButtonMenuItem {
   label: string;
-  action: TabButtonMenuAction<T>;
+  action: TabButtonMenuAction;
 }
 
-export interface TabButtonProps<T> extends HTMLAttributes<HTMLDivElement> {
+export interface TabButtonProps extends HTMLAttributes<HTMLDivElement> {
   label: string;
-  value: T;
+  value: UniqueIdentifier | null;
   showMenu?: boolean;
-  menuItems?: TabButtonMenuItem<any>[];
+  menuItems?: TabButtonMenuItem[];
   onRename?: ChangeEventHandler<HTMLInputElement>;
   onFinishRenaming?: () => void;
   isRenaming?: boolean;
@@ -62,7 +62,7 @@ export interface TabButtonProps<T> extends HTMLAttributes<HTMLDivElement> {
   disabled?: boolean;
 }
 
-const _TabButton = forwardRef(function TabButton<T>(
+const _TabButton = forwardRef(function TabButton(
   {
     value,
     menuItems,
@@ -75,7 +75,7 @@ const _TabButton = forwardRef(function TabButton<T>(
     isRenaming = false,
     showMenu: showMenuProp = true,
     ...props
-  }: TabButtonProps<T>,
+  }: TabButtonProps,
   inputRef: Ref<HTMLInputElement>,
 ) {
   const { value: selectedValue, idPrefix, onChange } = useContext(TabContext);
@@ -166,7 +166,7 @@ const _TabButton = forwardRef(function TabButton<T>(
             />
           )}
           popoverContent={({ closePopover }) => (
-            <TabButtonMenu<T>
+            <TabButtonMenu
               menuItems={menuItems}
               value={value}
               closePopover={closePopover}
@@ -178,11 +178,8 @@ const _TabButton = forwardRef(function TabButton<T>(
   );
 });
 
-export interface RenameableTabButtonProps<T>
-  extends Omit<
-    TabButtonProps<T>,
-    "onRename" | "onFinishRenaming" | "isRenaming" | "value"
-  > {
+export interface RenameableTabButtonProps
+  extends Omit<TabButtonProps, "onRename" | "onFinishRenaming" | "isRenaming"> {
   onRename: (newLabel: string) => void;
   renameMenuLabel?: string;
   renameMenuIndex?: number;
@@ -208,18 +205,17 @@ export const RenameableTabButtonStyled = styled(_TabButton)<{
   }
 `;
 
-export function RenameableTabButton<T>({
+export function RenameableTabButton({
   label: labelProp,
   menuItems: originalMenuItems = [],
   onRename,
   renameMenuLabel = t`Rename`,
   renameMenuIndex = 0,
   canRename = true,
-  value,
   ...props
-}: RenameableTabButtonProps<T>) {
+}: RenameableTabButtonProps) {
   const { value: selectedValue } = useContext(TabContext);
-  const isSelected = value === selectedValue;
+  const isSelected = props.value === selectedValue;
 
   const [label, setLabel] = useState(labelProp);
   const [prevLabel, setPrevLabel] = useState(label);
@@ -269,7 +265,7 @@ export function RenameableTabButton<T>({
     }
   };
 
-  const { isDragging } = useSortable({ id: value });
+  const { isDragging } = useSortable({ id: props.value });
 
   return (
     <RenameableTabButtonStyled
@@ -281,10 +277,9 @@ export function RenameableTabButton<T>({
       onFinishRenaming={onFinishEditing}
       onInputDoubleClick={() => setIsRenaming(canRename)}
       menuItems={
-        menuItems as TabButtonMenuItem<unknown>[] /* workaround for styled component swallowing generic type */
+        menuItems as TabButtonMenuItem[] /* workaround for styled component swallowing generic type */
       }
       ref={inputRef}
-      value={value}
       {...props}
     />
   );

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -6,7 +6,7 @@ import { TabRow } from "../TabRow";
 import type { RenameableTabButtonProps } from "./TabButton";
 import { TabButton, INPUT_WRAPPER_TEST_ID } from "./TabButton";
 
-function setup(props?: Partial<RenameableTabButtonProps<string>>) {
+function setup(props?: Partial<RenameableTabButtonProps>) {
   const action = jest.fn();
   const onRename = jest.fn();
   const value = "some_value";

--- a/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButtonMenu.tsx
@@ -1,24 +1,25 @@
 import { useContext } from "react";
+import type { UniqueIdentifier } from "@dnd-kit/core";
 
 import { TabContext } from "../Tab/TabContext";
 import { getTabButtonInputId } from "../Tab/utils";
 import type { TabButtonMenuAction, TabButtonMenuItem } from "./TabButton";
 import { MenuContent, MenuItem } from "./TabButton.styled";
 
-interface TabButtonMenuProps<T> {
-  menuItems: TabButtonMenuItem<T>[];
-  value: T;
+interface TabButtonMenuProps {
+  menuItems: TabButtonMenuItem[];
+  value: UniqueIdentifier | null;
   closePopover: () => void;
 }
 
-export function TabButtonMenu<T>({
+export function TabButtonMenu({
   menuItems,
   value,
   closePopover,
-}: TabButtonMenuProps<T>) {
+}: TabButtonMenuProps) {
   const context = useContext(TabContext);
 
-  const clickHandler = (action: TabButtonMenuAction<T>) => () => {
+  const clickHandler = (action: TabButtonMenuAction) => () => {
     action(context, value);
     closePopover();
   };

--- a/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.stories.tsx
@@ -31,15 +31,12 @@ const Template: ComponentStory<typeof TabRow> = args => {
   const handleChange = (value: unknown) => updateArgs({ value });
   const [message, setMessage] = useState("");
 
-  const action: TabButtonMenuAction<unknown> = (
-    { value: selectedValue },
-    value,
-  ) =>
+  const action: TabButtonMenuAction = ({ value: selectedValue }, value) =>
     setMessage(
       `Clicked ${value}, currently selected value is ${selectedValue}`,
     );
 
-  const menuItems: TabButtonMenuItem<unknown>[] = [
+  const menuItems: TabButtonMenuItem[] = [
     {
       label: "Click me!",
       action,

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
@@ -40,7 +40,7 @@ export function DashboardTabs({
     return null;
   }
 
-  const menuItems: TabButtonMenuItem<SelectedTabId>[] = [
+  const menuItems: TabButtonMenuItem[] = [
     {
       label: t`Duplicate`,
       action: (_, value) => duplicateTab(value),
@@ -71,7 +71,7 @@ export function DashboardTabs({
         ) : (
           tabs.map(tab => (
             <Sortable key={tab.id} id={tab.id} disabled={!isEditing}>
-              <TabButton.Renameable<SelectedTabId>
+              <TabButton.Renameable
                 value={tab.id}
                 label={tab.name}
                 onRename={name => renameTab(tab.id, name)}

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
@@ -24,6 +24,10 @@ import { parseSlug, useSyncURLSlug } from "./use-sync-url-slug";
 
 let tabDeletionId = 1;
 
+function isTabIdType(id: unknown): id is SelectedTabId {
+  return typeof id === "number" || id === null;
+}
+
 export function useDashboardTabs({
   location,
   dashboardId,
@@ -38,12 +42,20 @@ export function useDashboardTabs({
   useSyncURLSlug({ location });
   useMount(() => dispatch(initTabs({ slug: parseSlug({ location }) })));
 
-  const duplicateTab = (tabId: SelectedTabId) => {
+  const duplicateTab = (tabId: UniqueIdentifier | null) => {
+    if (!isTabIdType(tabId)) {
+      throw Error("duplicateTab was called but tab id is invalid");
+    }
+
     dispatch(duplicateTabAction(tabId));
     trackTabDuplicated(dashboardId);
   };
 
-  const deleteTab = (tabId: SelectedTabId) => {
+  const deleteTab = (tabId: UniqueIdentifier | null) => {
+    if (!isTabIdType(tabId)) {
+      throw Error("deleteTab was called but tab id is invalid");
+    }
+
     const tabName = tabs.find(({ id }) => id === tabId)?.name;
     if (!tabName) {
       throw Error(`deleteTab was called but no tab with id ${tabId} was found`);


### PR DESCRIPTION
### Description

In https://github.com/metabase/metabase/pull/37910 we overrided the type of the value prop in `RenameableTabButton` to be `UniqueIdenfitifer`, but it was typed in `TabButton` as a generic, so we had a mix of different types for the same prop in different components.

We resolve this conflict here by removing the generic completely, as it didn't provide any value (we weren't using different types for the generic in code).

### How to verify

Confirm you can still drag tabs, and the bug (dragging tab with a long name) is still fixed.

### Demo

https://github.com/metabase/metabase/assets/37751258/a51bbf0e-fcb8-4ee1-8816-71307b5d713c

### Checklist

- [] Tests have been added/updated to cover changes in this PR

Covered by existing tests.
