### PR TITLE
Fix wrong `target` prop type on `DashCardParameterMapper`

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.jsx
@@ -74,7 +74,7 @@ DashCardCardParameterMapper.propTypes = {
   card: PropTypes.object.isRequired,
   dashcard: PropTypes.object.isRequired,
   editingParameter: PropTypes.object.isRequired,
-  target: PropTypes.object,
+  target: PropTypes.array,
   mappingOptions: PropTypes.array.isRequired,
   metadata: PropTypes.object.isRequired,
   setParameterMapping: PropTypes.func.isRequired,

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -37,7 +37,7 @@ const setup = options => {
       card={createMockCard()}
       dashcard={createMockDashboardCard()}
       editingParameter={{}}
-      target={null}
+      target={undefined}
       mappingOptions={[]}
       metadata={metadata}
       setParameterMapping={jest.fn()}

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.unit.spec.jsx
@@ -37,7 +37,6 @@ const setup = options => {
       card={createMockCard()}
       dashcard={createMockDashboardCard()}
       editingParameter={{}}
-      target={undefined}
       mappingOptions={[]}
       metadata={metadata}
       setParameterMapping={jest.fn()}


### PR DESCRIPTION
This PR fixes wrong `target` prop type on `DashCardParameterMapper`.

To confirm, follow the repro steps from #37964 and make sure there is no warning in console any more.
You can also open the React dev tools to confirm that the `target` accepts an array, indeed.

When a field is connected
![image](https://github.com/metabase/metabase/assets/31325167/1c2168bc-19f6-4d9e-b70f-d73b3a12734b)

Where a filter isn't connected, or when there's no field to connect it to:
![image](https://github.com/metabase/metabase/assets/31325167/a20d777f-0115-4b22-b779-84a5b210fca9)

Fixes #37964