### PR TITLE
Migrate `isStructured` method references to MLv2

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -204,14 +204,6 @@ class Question {
   }
 
   /**
-   * @deprecated use MLv2
-   */
-  isStructured(): boolean {
-    const { isNative } = Lib.queryDisplayInfo(this.query());
-    return !isNative;
-  }
-
-  /**
    * Returns a new Question object with an updated query.
    * The query is saved to the `dataset_query` field of the Card object.
    */
@@ -494,8 +486,9 @@ class Question {
 
     const hasSinglePk =
       table?.fields?.filter(field => field.isPK())?.length === 1;
+    const isStructured = !Lib.queryDisplayInfo(this.query()).isNative;
 
-    return this.isStructured() && !Lib.hasClauses(query, -1) && hasSinglePk;
+    return isStructured && !Lib.hasClauses(query, -1) && hasSinglePk;
   }
 
   canAutoRun(): boolean {
@@ -549,8 +542,9 @@ class Question {
    * of Question interface instead of Query interface makes it more convenient to also change the current visualization
    */
   usesMetric(metricId): boolean {
+    const isStructured = !Lib.queryDisplayInfo(this.query()).isNative;
     return (
-      this.isStructured() &&
+      isStructured &&
       _.any(
         QUERY.getAggregations(
           this.legacyQuery({ useStructuredQuery: true }).legacyQuery({
@@ -563,8 +557,9 @@ class Question {
   }
 
   usesSegment(segmentId): boolean {
+    const isStructured = !Lib.queryDisplayInfo(this.query()).isNative;
     return (
-      this.isStructured() &&
+      isStructured &&
       QUERY.getFilters(
         this.legacyQuery({ useStructuredQuery: true }).legacyQuery({
           useStructuredQuery: true,
@@ -1021,11 +1016,13 @@ class Question {
   }
 
   _convertParametersToMbql(): Question {
-    if (!this.isStructured()) {
+    const query = this.query();
+    const { isNative } = Lib.queryDisplayInfo(query);
+
+    if (isNative) {
       return this;
     }
 
-    const query = this.query();
     const stageIndex = -1;
     const filters = this.parameters()
       .map(parameter =>

--- a/frontend/src/metabase-lib/queries/drills/dashboard-click-drill.js
+++ b/frontend/src/metabase-lib/queries/drills/dashboard-click-drill.js
@@ -1,6 +1,7 @@
 import _ from "underscore";
 import { getIn } from "icepick";
 import querystring from "querystring";
+import * as Lib from "metabase-lib";
 import * as Urls from "metabase/lib/urls";
 import { renderLinkURLForClick } from "metabase/lib/formatting/link";
 import {
@@ -116,7 +117,11 @@ export function getDashboardDrillQuestionUrl(question, clicked) {
     clickBehavior,
   });
 
-  return targetQuestion.isStructured()
+  const isTargetQuestionStructured = !Lib.queryDisplayInfo(
+    targetQuestion.query(),
+  ).isNative;
+
+  return isTargetQuestionStructured
     ? ML_Urls.getUrlWithParameters(targetQuestion, parameters, queryParams)
     : `${ML_Urls.getUrl(targetQuestion)}?${querystring.stringify(queryParams)}`;
 }

--- a/frontend/src/metabase-lib/queries/utils/card.js
+++ b/frontend/src/metabase-lib/queries/utils/card.js
@@ -8,7 +8,7 @@ import { deriveFieldOperatorFromParameter } from "metabase-lib/parameters/utils/
 import * as Q_DEPRECATED from "metabase-lib/queries/utils"; // legacy
 
 export function isStructured(card) {
-  return card.dataset_query.type === "query";
+  return card.dataset_query?.type === "query";
 }
 
 function cardVisualizationIsEquivalent(cardA, cardB) {

--- a/frontend/src/metabase-lib/queries/utils/pivot.js
+++ b/frontend/src/metabase-lib/queries/utils/pivot.js
@@ -1,10 +1,12 @@
 import _ from "underscore";
+import * as Lib from "metabase-lib";
 import { FieldDimension } from "metabase-lib/Dimension";
 
 export function getPivotColumnSplit(question) {
   const setting = question.setting("pivot_table.column_split");
+  const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
   const breakout =
-    (question.isStructured() &&
+    (isStructured &&
       question.legacyQuery({ useStructuredQuery: true }).breakouts()) ||
     [];
   const { rows: pivot_rows, columns: pivot_cols } = _.mapObject(

--- a/frontend/src/metabase-lib/urls.ts
+++ b/frontend/src/metabase-lib/urls.ts
@@ -55,7 +55,9 @@ export function getUrlWithParameters(
   const includeDisplayIsLocked = true;
   const { isEditable } = Lib.queryDisplayInfo(question.query());
 
-  if (question.isStructured()) {
+  const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
+
+  if (isStructured) {
     let questionWithParameters = question.setParameters(parameters);
 
     if (isEditable) {

--- a/frontend/src/metabase/parameters/utils/mapping-options.js
+++ b/frontend/src/metabase/parameters/utils/mapping-options.js
@@ -97,8 +97,9 @@ export function getParameterMappingOptions(
   }
 
   const question = new Question(card, metadata);
+  const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
   const options = [];
-  if (question.isStructured() || question.isDataset()) {
+  if (isStructured || question.isDataset()) {
     // treat the dataset/model question like it is already composed so that we can apply
     // dataset/model-specific metadata to the underlying dimension options
     const query = question.isDataset()

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -248,7 +248,9 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
       );
     }
 
-    if (question.isStructured()) {
+    const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
+
+    if (isStructured) {
       rerunQuery = rerunQuery ?? isResultDirty;
     }
 

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -377,7 +377,8 @@ async function handleQBInit(
   });
 
   if (uiControls.queryBuilderMode !== "notebook") {
-    if (question.canRun() && (question.isSaved() || question.isStructured())) {
+    const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
+    if (question.canRun() && (question.isSaved() || isStructured)) {
       // Timeout to allow Parameters widget to set parameterValues
       setTimeout(
         () => dispatch(runQuestionQuery({ shouldUpdateUrl: false })),

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -7,6 +7,7 @@ import { equals } from "metabase/lib/utils";
 
 import { isEqualCard } from "metabase/lib/card";
 
+import * as Lib from "metabase-lib";
 import { isAdHocModelQuestion } from "metabase-lib/metadata/utils/models";
 import {
   getCard,
@@ -137,9 +138,10 @@ export const updateUrl = createThunkAction(
           (!isAdHocModel && question.isDirtyComparedTo(originalQuestion));
       }
 
+      const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
       // prevent clobbering of hash when there are fake parameters on the question
       // consider handling this in a more general way, somehow
-      if (question.isStructured() && question.parameters().length > 0) {
+      if (isStructured && question.parameters().length > 0) {
         dirty = true;
       }
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -221,7 +221,9 @@ function DatasetEditor(props) {
   const isEditingMetadata = datasetEditorTab === "metadata";
 
   const initialEditorHeight = useMemo(() => {
-    if (dataset.isStructured()) {
+    const isStructured = !Lib.queryDisplayInfo(dataset.query()).isNative;
+
+    if (isStructured) {
       return INITIAL_NOTEBOOK_EDITOR_HEIGHT;
     }
     return calcInitialEditorHeight({
@@ -414,7 +416,8 @@ function DatasetEditor(props) {
   );
 
   const canSaveChanges = useMemo(() => {
-    const isEmpty = dataset.isStructured()
+    const isStructured = !Lib.queryDisplayInfo(dataset.query()).isNative;
+    const isEmpty = isStructured
       ? Lib.databaseID(dataset.query()) == null
       : dataset.legacyQuery().isEmpty();
 

--- a/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/Notebook.tsx
@@ -93,8 +93,9 @@ const Notebook = ({ className, updateQuestion, ...props }: NotebookProps) => {
 
 function getSourceQuestionId(question: Question) {
   const query = question.query();
+  const isStructured = !Lib.queryDisplayInfo(query).isNative;
 
-  if (question.isStructured()) {
+  if (isStructured) {
     const sourceTableId = Lib.sourceTableOrCardId(query);
 
     if (isVirtualCardId(sourceTableId)) {

--- a/frontend/src/metabase/query_builder/components/view/ConvertQueryButton/ConvertQueryButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ConvertQueryButton/ConvertQueryButton.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { t } from "ttag";
+import * as Lib from "metabase-lib";
 import { getEngineNativeType } from "metabase/lib/engine";
 import Tooltip from "metabase/core/components/Tooltip";
 import { MODAL_TYPES } from "metabase/query_builder/constants";
@@ -45,8 +46,9 @@ ConvertQueryButton.shouldRender = ({
   question,
   queryBuilderMode,
 }: ConvertQueryButtonOpts) => {
+  const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
   return (
-    question.isStructured() &&
+    isStructured &&
     question.database()?.native_permissions === "write" &&
     queryBuilderMode === "notebook"
   );

--- a/frontend/src/metabase/query_builder/components/view/FilterHeaderButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/FilterHeaderButton.tsx
@@ -43,10 +43,10 @@ FilterHeaderButton.shouldRender = ({
   isObjectDetail,
   isActionListVisible,
 }: RenderCheckOpts) => {
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
   return (
     queryBuilderMode === "view" &&
-    question.isStructured() &&
+    !isNative &&
     isEditable &&
     !isObjectDetail &&
     isActionListVisible

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSource.jsx
@@ -41,7 +41,9 @@ function QuestionDataSource({ question, originalQuestion, subHead, ...props }) {
 
   const variant = subHead ? "subhead" : "head";
 
-  if (!question.isStructured() || !isMaybeBasedOnDataset(question)) {
+  const { isNative } = Lib.queryDisplayInfo(question.query());
+
+  if (isNative || !isMaybeBasedOnDataset(question)) {
     return (
       <DataSourceCrumbs question={question} variant={variant} {...props} />
     );
@@ -173,7 +175,7 @@ function getDataSourceParts({ question, subHead, isObjectDetail }) {
   const parts = [];
   const query = question.query();
   const metadata = question.metadata();
-  const isStructured = question.isStructured();
+  const isStructured = !Lib.queryDisplayInfo(query).isNative;
 
   const database = metadata.database(Lib.databaseID(query));
   if (database) {

--- a/frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDescription.jsx
@@ -12,8 +12,10 @@ const QuestionDescription = ({
   isObjectDetail,
   onClick,
 }) => {
-  if (question.isStructured()) {
-    const query = question.query();
+  const query = question.query();
+  const isStructured = !Lib.queryDisplayInfo(query).isNative;
+
+  if (isStructured) {
     const stageIndex = -1;
     const aggregations = Lib.aggregations(query, stageIndex);
     const breakouts = Lib.breakouts(query, stageIndex);

--- a/frontend/src/metabase/query_builder/components/view/QuestionFilters/QuestionFilters.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionFilters/QuestionFilters.tsx
@@ -67,12 +67,9 @@ const shouldRender = ({
   queryBuilderMode,
   isObjectDetail,
 }: RenderCheckOpts) => {
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
   return (
-    queryBuilderMode === "view" &&
-    question.isStructured() &&
-    isEditable &&
-    !isObjectDetail
+    queryBuilderMode === "view" && !isNative && isEditable && !isObjectDetail
   );
 };
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton/QuestionNotebookButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionNotebookButton/QuestionNotebookButton.jsx
@@ -34,6 +34,6 @@ export function QuestionNotebookButton({
 }
 
 QuestionNotebookButton.shouldRender = ({ question, isActionListVisible }) => {
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
-  return question.isStructured() && isEditable && isActionListVisible;
+  const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
+  return !isNative && isEditable && isActionListVisible;
 };

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.tsx
@@ -74,22 +74,21 @@ function QuestionRowCount({
   className,
   onChangeLimit,
 }: QuestionRowCountProps) {
+  const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
   const message = useMemo(() => {
-    if (!question.isStructured()) {
+    if (isNative) {
       return isResultDirty ? "" : getRowCountMessage(result);
     }
     return isResultDirty
       ? getLimitMessage(question, result)
       : getRowCountMessage(result);
-  }, [question, result, isResultDirty]);
+  }, [question, result, isResultDirty, isNative]);
 
   const handleLimitChange = (limit: number) => {
     onChangeLimit(limit > 0 ? limit : null);
   };
 
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
-
-  const canChangeLimit = question.isStructured() && isEditable;
+  const canChangeLimit = !isNative && isEditable;
 
   const limit = canChangeLimit ? Lib.currentLimit(question.query(), -1) : null;
 

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
@@ -45,8 +45,9 @@ type SetupOpts = {
 };
 
 function patchQuestion(question: Question) {
-  if (question.isStructured()) {
-    const query = question.query();
+  const query = question.query();
+  const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
+  if (isStructured) {
     const [sampleColumn] = Lib.orderableColumns(query, 0);
     const nextQuery = Lib.orderBy(query, 0, sampleColumn);
     return question.setDatasetQuery(Lib.toLegacyQuery(nextQuery));

--- a/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionSummaries.jsx
@@ -67,11 +67,11 @@ QuestionSummarizeWidget.shouldRender = ({
   isObjectDetail,
   isActionListVisible,
 }) => {
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
   return (
     queryBuilderMode === "view" &&
     question &&
-    question.isStructured() &&
+    !isNative &&
     isEditable &&
     !isObjectDetail &&
     isActionListVisible

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -192,7 +192,8 @@ class View extends Component {
 
   getRightSidebar = () => {
     const { question } = this.props;
-    const isStructured = question.isStructured();
+    const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
+
     return isStructured
       ? this.getRightSidebarForStructuredQuery()
       : this.getRightSidebarForNativeQuery();
@@ -202,9 +203,10 @@ class View extends Component {
     const { question } = this.props;
     const query = question.query();
     const legacyQuery = question.legacyQuery({ useStructuredQuery: true });
+    const isStructured = !Lib.queryDisplayInfo(query).isNative;
 
     const isNewQuestion =
-      question.isStructured() &&
+      isStructured &&
       Lib.sourceTableOrCardId(query) === null &&
       !legacyQuery.sourceQuery();
 
@@ -331,9 +333,10 @@ class View extends Component {
 
     const query = question.query();
     const legacyQuery = question.legacyQuery({ useStructuredQuery: true });
+    const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
 
     const isNewQuestion =
-      question.isStructured() &&
+      isStructured &&
       Lib.sourceTableOrCardId(query) === null &&
       !legacyQuery.sourceQuery();
 
@@ -370,7 +373,7 @@ class View extends Component {
         <QueryBuilderViewRoot className="QueryBuilder">
           {isHeaderVisible && this.renderHeader()}
           <QueryBuilderContentContainer>
-            {question.isStructured() && (
+            {isStructured && (
               <QueryViewNotebook
                 isNotebookContainerOpen={isNotebookContainerOpen}
                 {...this.props}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -93,12 +93,17 @@ export function ViewTitleHeader(props) {
   const previousQuery = usePrevious(query);
 
   useEffect(() => {
-    if (!question.isStructured() || !previousQuestion?.isStructured()) {
+    const { isNative } = Lib.queryDisplayInfo(query);
+    const isPreviousQuestionNative =
+      previousQuery && Lib.queryDisplayInfo(previousQuery).isNative;
+
+    if (isNative || isPreviousQuestionNative) {
       return;
     }
 
     const filtersCount = Lib.filters(query, -1).length;
-    const previousFiltersCount = Lib.filters(previousQuery, -1).length;
+    const previousFiltersCount =
+      previousQuery && Lib.filters(previousQuery, -1).length;
 
     if (filtersCount > previousFiltersCount) {
       expandFilters();

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -639,7 +639,11 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
       return isSavedQuestionChanged;
     }
 
-    if (originalQuestion?.isStructured()) {
+    const isOriginalQuestionStructured =
+      originalQuestion &&
+      !Lib.queryDisplayInfo(originalQuestion.query()).isNative;
+
+    if (isOriginalQuestionStructured) {
       return uiControls.isModifiedFromNotebook;
     }
 

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -81,7 +81,10 @@ export const isNavigationAllowed = ({
 
   const { hash, pathname } = destination;
 
-  const runModelPathnames = question.isStructured()
+  const { isNative } = Lib.queryDisplayInfo(question.query());
+  const isStructured = !isNative;
+
+  const runModelPathnames = isStructured
     ? ["/model", "/model/notebook"]
     : ["/model"];
   const isRunningModel =
@@ -105,8 +108,6 @@ export const isNavigationAllowed = ({
     return isRunningModel || allowedPathnames.includes(pathname);
   }
 
-  const { isNative } = Lib.queryDisplayInfo(question.query());
-
   if (isNative) {
     const isRunningQuestion = pathname === "/question" && hash.length > 0;
     return isRunningQuestion;
@@ -115,8 +116,9 @@ export const isNavigationAllowed = ({
   /**
    * New structured questions will be handled in
    * https://github.com/metabase/metabase/issues/34686
+   *
    */
-  if (!isNewQuestion && question.isStructured()) {
+  if (!isNewQuestion && isStructured) {
     const isRunningQuestion =
       ["/question", "/question/notebook"].includes(pathname) && hash.length > 0;
     const allowedPathnames = validSlugs.flatMap(slug => [

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -2,6 +2,7 @@ import _ from "underscore";
 import api, { GET, PUT, POST, DELETE } from "metabase/lib/api";
 import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 
+import * as Lib from "metabase-lib";
 import Question from "metabase-lib/Question";
 import { normalizeParameters } from "metabase-lib/parameters/utils/parameter-values";
 import { getPivotColumnSplit } from "metabase-lib/queries/utils/pivot";
@@ -50,6 +51,7 @@ export const StoreApi = {
 // If we add breakout/grouping sets to MBQL in the future we can remove this API switching.
 export function maybeUsePivotEndpoint(api, card, metadata) {
   const question = new Question(card, metadata);
+  const { isNative } = Lib.queryDisplayInfo(question.query());
 
   function wrap(api) {
     return (params, ...rest) => {
@@ -59,7 +61,7 @@ export function maybeUsePivotEndpoint(api, card, metadata) {
   }
   if (
     question.display() !== "pivot" ||
-    !question.isStructured() ||
+    isNative ||
     // if we have metadata for the db, check if it supports pivots
     (question.database() && !question.database().supportsPivots())
   ) {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -2,9 +2,9 @@ import _ from "underscore";
 import api, { GET, PUT, POST, DELETE } from "metabase/lib/api";
 import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 
-import * as Lib from "metabase-lib";
 import Question from "metabase-lib/Question";
 import { normalizeParameters } from "metabase-lib/parameters/utils/parameter-values";
+import { isStructured } from "metabase-lib/queries/utils/card";
 import { getPivotColumnSplit } from "metabase-lib/queries/utils/pivot";
 import { injectTableMetadata } from "metabase-lib/metadata/utils/tables";
 
@@ -51,7 +51,6 @@ export const StoreApi = {
 // If we add breakout/grouping sets to MBQL in the future we can remove this API switching.
 export function maybeUsePivotEndpoint(api, card, metadata) {
   const question = new Question(card, metadata);
-  const { isNative } = Lib.queryDisplayInfo(question.query());
 
   function wrap(api) {
     return (params, ...rest) => {
@@ -61,7 +60,7 @@ export function maybeUsePivotEndpoint(api, card, metadata) {
   }
   if (
     question.display() !== "pivot" ||
-    isNative ||
+    !isStructured(card) ||
     // if we have metadata for the db, check if it supports pivots
     (question.database() && !question.database().supportsPivots())
   ) {

--- a/frontend/src/metabase/visualizations/components/LeafletMap.jsx
+++ b/frontend/src/metabase/visualizations/components/LeafletMap.jsx
@@ -158,7 +158,9 @@ export default class LeafletMap extends Component {
     });
 
     const question = new Question(card, metadata);
-    if (question.isStructured()) {
+    const isStructured = !Lib.queryDisplayInfo(question.query()).isNative;
+
+    if (isStructured) {
       const query = question.query();
       const stageIndex = -1;
       const filterBounds = {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/ChartSettingTableColumns.tsx
@@ -3,7 +3,7 @@ import type {
   DatasetColumn,
   TableColumnOrderSetting,
 } from "metabase-types/api";
-import type * as Lib from "metabase-lib";
+import * as Lib from "metabase-lib";
 import type { EditWidgetConfig } from "metabase/visualizations/components/settings/ChartSettingTableColumns/types";
 import type Question from "metabase-lib/Question";
 import { DatasetColumnSelector } from "./DatasetColumnSelector";
@@ -39,7 +39,10 @@ export const ChartSettingTableColumns = ({
     [question, onChange],
   );
 
-  if (question?.isStructured()) {
+  const isStructured =
+    question && !Lib.queryDisplayInfo(question.query()).isNative;
+
+  if (isStructured) {
     const query = question.query();
 
     return (


### PR DESCRIPTION
This PR migrates `isStructured()` references to MLv2.
It also removes the method altogether from the `Question` prototype.

Resolves  #37389