### PR TITLE
Fix BE flake: metabase.driver.bigquery-cloud-sdk-test/query-drive-external-tables

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
+++ b/modules/drivers/bigquery-cloud-sdk/test/metabase/driver/bigquery_cloud_sdk_test.clj
@@ -711,7 +711,7 @@
               (is (= ["my-dataset" "my-dataset"]
                      (t2/select-fn-vec :schema Table :id [:in [(u/the-id table1) (u/the-id table2)]]))))))))))
 
-(deftest ^:parallel query-drive-external-tables
+(deftest query-drive-external-tables
   (mt/test-driver :bigquery-cloud-sdk
     (testing "Google Sheets external tables can be queried via BigQuery (#4179)"
       ;; link to the underlying Google sheet, which everyone in the Google domain should have edit permission on


### PR DESCRIPTION
Hopefully fixes https://github.com/metabase/metabase/issues/37951

I couldn't reproduce this, but it's too much of a coincidence that the first flakes started happening on Dec 14 ([stats question](https://stats.metabase.com/question#eyJuYW1lIjoiVGVzdCBGbGFraW5lc3MiLCJkZXNjcmlwdGlvbiI6IkZsYWtleSB0ZXN0cyBmb3IgTWV0YWJhc2UgZnJvbSB3b3JrZmxvdyBqb2JzIHBlciB0ZXN0L2pvYi9ydW4vYnJhbmNoL2NvbW1pdC4gVXBkYXRlZCBkYWlseS4iLCJkYXRhc2V0X3F1ZXJ5Ijp7ImRhdGFiYXNlIjoyNiwidHlwZSI6InF1ZXJ5IiwicXVlcnkiOnsib3JkZXItYnkiOltbImRlc2MiLFsiZmllbGQiLDU3ODkyOSx7ImJhc2UtdHlwZSI6InR5cGUvRGF0ZVRpbWVXaXRoTG9jYWxUWiIsInRlbXBvcmFsLXVuaXQiOiJkZWZhdWx0In1dXV0sInNvdXJjZS10YWJsZSI6ImNhcmRfXzE0ODI4IiwiZmlsdGVyIjpbIj0iLFsiZmllbGQiLCJ0ZXN0X25hbWUiLHsiYmFzZS10eXBlIjoidHlwZS9UZXh0In1dLCJxdWVyeS1kcml2ZS1leHRlcm5hbC10YWJsZXMiXX19LCJkaXNwbGF5IjoidGFibGUiLCJwYXJhbWV0ZXJzIjpbXSwidmlzdWFsaXphdGlvbl9zZXR0aW5ncyI6e30sIm9yaWdpbmFsX2NhcmRfaWQiOjE0ODI4fQ==)), one day after Cam [changed this test](https://github.com/metabase/metabase/issues/36670) to run in parallel. So this PR makes this test run in series.