### PR TITLE
Update manage-table-metadata migration to handle schema-level perms

### DIFF
--- a/resources/migrations/permissions/manage_table_metadata.sql
+++ b/resources/migrations/permissions/manage_table_metadata.sql
@@ -58,7 +58,8 @@ SELECT pg.id AS group_id,
                   (SELECT 1
                    FROM permissions p
                    WHERE p.group_id = pg.id
-                     AND p.object = concat('/data-model/db/', mt.db_id, '/schema/', mt.escaped_schema, '/table/', mt.id, '/')) THEN 'yes'
+                     AND (p.object = concat('/data-model/db/', mt.db_id, '/schema/', mt.escaped_schema, '/')
+                          OR p.object = concat('/data-model/db/', mt.db_id, '/schema/', mt.escaped_schema, '/table/', mt.id, '/'))) THEN 'yes'
            ELSE 'no'
        END AS perm_value
 FROM permissions_group pg

--- a/resources/migrations/permissions/mysql_manage_table_metadata.sql
+++ b/resources/migrations/permissions/mysql_manage_table_metadata.sql
@@ -58,7 +58,8 @@ SELECT pg.id AS group_id,
                   (SELECT 1
                    FROM permissions p
                    WHERE p.group_id = pg.id
-                     AND p.object = concat('/data-model/db/', mt.db_id, '/schema/', mt.escaped_schema, '/table/', mt.id, '/')) THEN 'yes'
+                     AND (p.object = concat('/data-model/db/', mt.db_id, '/schema/', mt.escaped_schema, '/')
+                          OR p.object = concat('/data-model/db/', mt.db_id, '/schema/', mt.escaped_schema, '/table/', mt.id, '/'))) THEN 'yes'
            ELSE 'no'
        END AS perm_value
 FROM permissions_group pg

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1161,6 +1161,19 @@
                                       (t2/table-name :model/DataPermissions)
                                       :db_id db-id :table_id table-id :group_id group-id :perm_type "perms/manage-table-metadata"))))
 
+        (testing "Manage table metadata access for a schema"
+          (clear-permissions!)
+          (t2/insert! (t2/table-name Permissions) {:group_id group-id
+                                                   :object   (format "/data-model/db/%d/schema/PUBLIC/" db-id)})
+          (migrate!)
+          (is (nil? (t2/select-one-fn :perm_value
+                                      (t2/table-name :model/DataPermissions)
+                                      :db_id db-id :table_id nil :group_id group-id :perm_type "perms/manage-table-metadata")))
+          (is (= "yes"
+                 (t2/select-one-fn :perm_value
+                                   (t2/table-name :model/DataPermissions)
+                                   :db_id db-id :table_id table-id :group_id group-id :perm_type "perms/manage-table-metadata"))))
+
         (testing "Manage table metadata access for a table"
           (clear-permissions!)
           (t2/insert! (t2/table-name Permissions) {:group_id group-id


### PR DESCRIPTION
Update `manage-table-metadata` SQL migrations to handle schema-level permission paths as well. Small omission from the original PR.