### PR TITLE
update `can-read?` and `can-write?` for Field

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -2,10 +2,25 @@
   (:require
    [metabase.api.common :as api]
    [metabase.models :refer [PermissionsGroupMembership]]
+   [metabase.models.data-permissions :as data-perms]
+   [metabase.models.database :as database]
    [metabase.models.permissions :as perms]
-   [metabase.public-settings.premium-features :as premium-features]
+   [metabase.public-settings.premium-features
+    :as premium-features
+    :refer [defenterprise]]
    [metabase.util :as u]
    [toucan2.core :as t2]))
+
+(defenterprise current-user-can-write-field?
+  "Enterprise version. Returns a boolean whether the current user can write the given field."
+  :feature :advanced-permissions
+  [instance]
+  (= :yes (data-perms/table-permission-for-user
+           api/*current-user-id*
+           :perms/manage-table-metadata
+           (or (get-in instance [:table :db_id])
+               (database/table-id->database-id (:table_id instance)))
+           (:table_id instance))))
 
 (defn with-advanced-permissions
   "Adds to `user` a set of boolean flag indiciate whether or not current user has access to an advanced permissions.

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -8,9 +8,9 @@
    [medley.core :as m]
    [metabase.mbql.normalize :as mbql.normalize]
    [metabase.models.card :refer [Card]]
+   [metabase.models.database :as database]
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms :refer [Permissions]]
-   [metabase.models.table :as table]
    [metabase.plugins.classloader :as classloader]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.query-processor.error-type :as qp.error-type]
@@ -53,7 +53,7 @@
   (classloader/require 'metabase.query-processor)
   (into {} (for [col (mw.session/with-current-user nil
                        ((resolve 'metabase.query-processor/query->expected-cols)
-                        {:database (table/table-id->database-id table-id)
+                        {:database (database/table-id->database-id table-id)
                          :type     :query
                          :query    {:source-table table-id}}))]
              [(:name col) col])))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -33,9 +33,10 @@
     (mt/with-additional-premium-features #{:advanced-permissions}
       (memoize/memo-clear! @#'field/cached-db-id)
       (perms.test-util/with-restored-perms!
-        (u/ignore-exceptions (@#'perms/update-group-permissions! all-users-group-id graph))
-        (data-perms.graph/update-data-perms-graph! {all-users-group-id graph})
-        (f)))))
+        (perms.test-util/with-restored-data-perms!
+          (u/ignore-exceptions (@#'perms/update-group-permissions! all-users-group-id graph))
+          (data-perms.graph/update-data-perms-graph! {all-users-group-id graph})
+          (f))))))
 
 (defmacro ^:private with-all-users-data-perms!
   "Runs `body` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -31,7 +31,7 @@
   [graph f]
   (let [all-users-group-id  (u/the-id (perms-group/all-users))]
     (mt/with-additional-premium-features #{:advanced-permissions}
-      (memoize/memo-clear! @#'field/cached-perms-object-set)
+      (memoize/memo-clear! @#'field/cached-db-id)
       (perms.test-util/with-restored-perms!
         (u/ignore-exceptions (@#'perms/update-group-permissions! all-users-group-id graph))
         (data-perms.graph/update-data-perms-graph! {all-users-group-id graph})

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -1,6 +1,5 @@
 (ns metabase-enterprise.advanced-permissions.common-test
   (:require
-   [clojure.core.memoize :as memoize]
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
    [metabase.api.database :as api.database]
@@ -10,7 +9,6 @@
     :refer [Dashboard DashboardCard Database Field FieldValues Table]]
    [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.database :as database]
-   [metabase.models.field :as field]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.permissions.test-util :as perms.test-util]
@@ -31,7 +29,6 @@
   [graph f]
   (let [all-users-group-id  (u/the-id (perms-group/all-users))]
     (mt/with-additional-premium-features #{:advanced-permissions}
-      (memoize/memo-clear! @#'field/cached-db-id)
       (perms.test-util/with-restored-perms!
         (perms.test-util/with-restored-data-perms!
           (u/ignore-exceptions (@#'perms/update-group-permissions! all-users-group-id graph))

--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -618,7 +618,8 @@
         (throw (ex-info (tru "You can''t specify a value for {0} if it's already set in the JWT." (pr-str searched-param-slug))
                         {:status-code 400})))
       (try
-        (binding [api/*current-user-permissions-set* (atom #{"/"})]
+        (binding [api/*current-user-permissions-set* (atom #{"/"})
+                  api/*is-superuser?* true]
           (api.card/param-values card param-key search-prefix))
         (catch Throwable e
           (throw (ex-info (.getMessage e)

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -361,67 +361,69 @@
     (when (values :block)
       (throw (ex-info (tru "Block permissions must be set at the database-level only.")
                       {})))
-    (t2/with-transaction [_conn]
-      (let [group-id               (u/the-id group-or-id)
-            new-perms              (map (fn [[table value]]
-                                          (let [{:keys [id db_id schema]}
-                                                (if (map? table)
-                                                  table
-                                                  (t2/select-one [:model/Table :id :db_id :schema] :id table))]
-                                            {:perm_type   perm-type
-                                             :group_id    group-id
-                                             :perm_value  value
-                                             :db_id       db_id
-                                             :table_id    id
-                                             :schema_name schema}))
-                                        table-perms)
-            _                      (when (not= (count (set (map :db_id new-perms))) 1)
-                                     (throw (ex-info (tru "All tables must belong to the same database.")
-                                                     {:new-perms new-perms})))
-            table-ids              (map :table_id new-perms)
-            db-id                  (:db_id (first new-perms))
-            existing-db-perm       (t2/select-one :model/DataPermissions
-                                                  {:where
-                                                   [:and
-                                                    [:= :perm_type (u/qualified-name perm-type)]
-                                                    [:= :group_id  group-id]
-                                                    [:= :db_id     db-id]
-                                                    [:= :table_id  nil]]})
-            existing-db-perm-value (:perm_value existing-db-perm)]
-        (if existing-db-perm
-          (when (not= values #{existing-db-perm-value})
-            ;; If we're setting any table permissions to a value that is different from the database-level permission,
-            ;; we need to replace it with individual permission rows for every table in the database instead.
-            (let [other-tables    (t2/select :model/Table {:where [:and
-                                                                   [:= :db_id db-id]
-                                                                   [:not [:in :id table-ids]]]})
-                  other-new-perms (map (fn [table]
-                                         {:perm_type   perm-type
-                                          :group_id    group-id
-                                          :perm_value  existing-db-perm-value
-                                          :db_id       db-id
-                                          :table_id    (:id table)
-                                          :schema_name (:schema table)})
-                                       other-tables)]
-              (t2/delete! :model/DataPermissions :id (:id existing-db-perm))
-              (t2/insert! :model/DataPermissions (concat other-new-perms new-perms))))
-          (let [existing-table-perms (t2/select :model/DataPermissions
-                                                :perm_type (u/qualified-name perm-type)
-                                                :group_id  group-id
-                                                :db_id     db-id
-                                                {:where [:and
-                                                         [:not= :table_id nil]
-                                                         [:not [:in :table_id table-ids]]]})
-                existing-table-values (set (map :perm_value existing-table-perms))]
-            (if (and (= (count existing-table-values) 1)
-                     (= values existing-table-values))
-              ;; If all tables would have the same permissions after we update these ones, we can replace all of the table
-              ;; perms with a DB-level perm instead.
-              (set-database-permission! group-or-id db-id perm-type (first values))
-              ;; Otherwise, just replace the rows for the individual table perm
-              (do
-                (t2/delete! :model/DataPermissions :perm_type perm-type :group_id group-id {:where [:in :table_id table-ids]})
-                (t2/insert! :model/DataPermissions new-perms)))))))))
+    ;; if `table-perms` is empty, there's nothing to do
+    (when (seq table-perms)
+      (t2/with-transaction [_conn]
+        (let [group-id               (u/the-id group-or-id)
+              new-perms              (map (fn [[table value]]
+                                            (let [{:keys [id db_id schema]}
+                                                  (if (map? table)
+                                                    table
+                                                    (t2/select-one [:model/Table :id :db_id :schema] :id table))]
+                                              {:perm_type   perm-type
+                                               :group_id    group-id
+                                               :perm_value  value
+                                               :db_id       db_id
+                                               :table_id    id
+                                               :schema_name schema}))
+                                          table-perms)
+              _                      (when (not= (count (set (map :db_id new-perms))) 1)
+                                       (throw (ex-info (tru "All tables must belong to the same database.")
+                                                       {:new-perms new-perms})))
+              table-ids              (map :table_id new-perms)
+              db-id                  (:db_id (first new-perms))
+              existing-db-perm       (t2/select-one :model/DataPermissions
+                                                    {:where
+                                                     [:and
+                                                      [:= :perm_type (u/qualified-name perm-type)]
+                                                      [:= :group_id  group-id]
+                                                      [:= :db_id     db-id]
+                                                      [:= :table_id  nil]]})
+              existing-db-perm-value (:perm_value existing-db-perm)]
+          (if existing-db-perm
+            (when (not= values #{existing-db-perm-value})
+              ;; If we're setting any table permissions to a value that is different from the database-level permission,
+              ;; we need to replace it with individual permission rows for every table in the database instead.
+              (let [other-tables    (t2/select :model/Table {:where [:and
+                                                                     [:= :db_id db-id]
+                                                                     [:not [:in :id table-ids]]]})
+                    other-new-perms (map (fn [table]
+                                           {:perm_type   perm-type
+                                            :group_id    group-id
+                                            :perm_value  existing-db-perm-value
+                                            :db_id       db-id
+                                            :table_id    (:id table)
+                                            :schema_name (:schema table)})
+                                         other-tables)]
+                (t2/delete! :model/DataPermissions :id (:id existing-db-perm))
+                (t2/insert! :model/DataPermissions (concat other-new-perms new-perms))))
+            (let [existing-table-perms (t2/select :model/DataPermissions
+                                                  :perm_type (u/qualified-name perm-type)
+                                                  :group_id  group-id
+                                                  :db_id     db-id
+                                                  {:where [:and
+                                                           [:not= :table_id nil]
+                                                           [:not [:in :table_id table-ids]]]})
+                  existing-table-values (set (map :perm_value existing-table-perms))]
+              (if (and (= (count existing-table-values) 1)
+                       (= values existing-table-values))
+                ;; If all tables would have the same permissions after we update these ones, we can replace all of the table
+                ;; perms with a DB-level perm instead.
+                (set-database-permission! group-or-id db-id perm-type (first values))
+                ;; Otherwise, just replace the rows for the individual table perm
+                (do
+                  (t2/delete! :model/DataPermissions :perm_type perm-type :group_id group-id {:where [:in :table_id table-ids]})
+                  (t2/insert! :model/DataPermissions new-perms))))))))))
 
 (mu/defn set-table-permission!
   "Sets permissions for a single table to the specified value for a given group."

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.database
   (:require
    [medley.core :as m]
+   [metabase.db.connection :as mdb.connection]
    [metabase.db.util :as mdb.u]
    [metabase.driver :as driver]
    [metabase.driver.impl :as driver.impl]
@@ -416,3 +417,10 @@
 (defmethod audit-log/model-details Database
   [database _event-type]
   (select-keys database [:id :name :engine]))
+
+(def ^{:arglists '([table-id])} table-id->database-id
+  "Retrieve the `Database` ID for the given table-id."
+  (mdb.connection/memoize-for-application-db
+   (fn [table-id]
+     {:pre [(integer? table-id)]}
+     (t2/select-one-fn :db_id :model/Table, :id table-id))))

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -173,12 +173,12 @@
 
 (defmethod mi/can-read? :model/Field
   ([instance]
-   (contains? #{:unrestricted :no-self-service}
-              (data-perms/table-permission-for-user
-               api/*current-user-id*
-               :perms/data-access
-               (field->db-id instance)
-               (:table_id instance))))
+   (= :unrestricted
+      (data-perms/table-permission-for-user
+       api/*current-user-id*
+       :perms/data-access
+       (field->db-id instance)
+       (:table_id instance))))
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -15,7 +15,8 @@
    [metabase.models.interface :as mi]
    [metabase.models.serialization :as serdes]
    [metabase.public-settings.premium-features
-    :as premium-features]
+    :as premium-features
+    :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.log :as log]
@@ -155,15 +156,15 @@
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 
+(defenterprise current-user-can-write-field?
+  "OSS implementation. Returns a boolean whether the current user can write the given field."
+  metabase-enterprise.advanced-permissions.common
+  [_instance]
+  (mi/superuser?))
+
 (defmethod mi/can-write? :model/Field
   ([instance]
-   (if (premium-features/enable-advanced-permissions?)
-     (= :yes (data-perms/table-permission-for-user
-              api/*current-user-id*
-              :perms/manage-table-metadata
-              (field->db-id instance)
-              (:table_id instance)))
-     (mi/superuser?)))
+   (current-user-can-write-field? instance))
   ([model pk]
    (mi/can-write? (t2/select-one model pk))))
 

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -14,10 +14,10 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.mbql.util :as mbql.u]
    [metabase.models.audit-log :as audit-log]
+   [metabase.models.database :as database]
    [metabase.models.interface :as mi]
    [metabase.models.revision :as revision]
    [metabase.models.serialization :as serdes]
-   [metabase.models.table :as table]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -189,7 +189,7 @@
 (defmethod audit-log/model-details :model/Metric
   [metric _event-type]
   (let [table-id (:table_id metric)
-        db-id    (table/table-id->database-id table-id)]
+        db-id    (database/table-id->database-id table-id)]
     (assoc
      (select-keys metric [:name :description :revision_message])
      :table_id    table-id

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -72,12 +72,12 @@
    [metabase.driver.common.parameters.dates :as params.dates]
    [metabase.mbql.util :as mbql.u]
    [metabase.models :refer [Field FieldValues Table]]
+   [metabase.models.database :as database]
    [metabase.models.field :as field]
    [metabase.models.field-values :as field-values]
    [metabase.models.params :as params]
    [metabase.models.params.chain-filter.dedupe-joins :as dedupe]
    [metabase.models.params.field-values :as params.field-values]
-   [metabase.models.table :as table]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.types :as types]
@@ -308,7 +308,7 @@
    ^{::memoize/args-fn (fn [[source-table-id other-table-ids enable-reverse-joins?]]
                          [(mdb.connection/unique-identifier) source-table-id other-table-ids enable-reverse-joins?])}
    (fn [source-table-id other-table-ids enable-reverse-joins?]
-     (let [db-id     (table/table-id->database-id source-table-id)
+     (let [db-id     (database/table-id->database-id source-table-id)
            all-joins (mapcat #(find-joins db-id source-table-id % enable-reverse-joins?)
                              other-table-ids)]
        (when (seq all-joins)

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -13,10 +13,10 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.mbql.util :as mbql.u]
    [metabase.models.audit-log :as audit-log]
+   [metabase.models.database :as database]
    [metabase.models.interface :as mi]
    [metabase.models.revision :as revision]
    [metabase.models.serialization :as serdes]
-   [metabase.models.table :as table]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -177,7 +177,7 @@
 (defmethod audit-log/model-details :model/Segment
   [metric _event-type]
   (let [table-id (:table_id metric)
-        db-id    (table/table-id->database-id table-id)]
+        db-id    (database/table-id->database-id table-id)]
     (assoc
      (select-keys metric [:name :description :revision_message])
      :table_id    table-id

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -1,6 +1,5 @@
 (ns metabase.models.table
   (:require
-   [metabase.db.connection :as mdb.connection]
    [metabase.db.util :as mdb.u]
    [metabase.driver :as driver]
    [metabase.models.audit-log :as audit-log]
@@ -238,13 +237,6 @@
   "Return the `Database` associated with this `Table`."
   [table]
   (t2/select-one Database :id (:db_id table)))
-
-(def ^{:arglists '([table-id])} table-id->database-id
-  "Retrieve the `Database` ID for the given table-id."
-  (mdb.connection/memoize-for-application-db
-   (fn [table-id]
-     {:pre [(integer? table-id)]}
-     (t2/select-one-fn :db_id Table, :id table-id))))
 
 ;;; ------------------------------------------------- Serialization -------------------------------------------------
 (defmethod serdes/dependencies "Table" [table]

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -10,6 +10,7 @@
    [metabase.models.model-index :as model-index]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
+   [metabase.permissions.test-util :as perms.test-util]
    [metabase.query-processor :as qp]
    [metabase.test :as mt]
    [metabase.test.automagic-dashboards :refer [with-dashboard-cleanup]]
@@ -49,24 +50,19 @@
   ([template args revoke-fn validation-fn]
    (mt/with-test-user :rasta
      (with-dashboard-cleanup
-       (mt/with-full-data-perms-for-all-users!
-         (let [api-endpoint (apply format (str "automagic-dashboards/" template) args)
-               resp         (mt/user-http-request :rasta :get 200 api-endpoint)
-               _            (dashcards-schema-check (:dashcards resp))
-               result       (validation-fn resp)]
-           (when (and result
-                      (try
-                        (testing "Endpoint should return 403 if user does not have permissions"
-                          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/data-access :no-self-service)
-                          (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
+       (let [api-endpoint (apply format (str "automagic-dashboards/" template) args)
+             resp         (mt/user-http-request :rasta :get 200 api-endpoint)
+             _            (dashcards-schema-check (:dashcards resp))
+             result       (validation-fn resp)]
+         (when (and result
+                    (testing "Endpoint should return 403 if user does not have permissions"
+                      (perms.test-util/with-no-data-perms-for-all-users!
+                        (perms.test-util/with-no-perms-for-all-users!
                           (revoke-fn)
                           (let [result (mt/user-http-request :rasta :get 403 api-endpoint)]
                             (is (= "You don't have permissions to do that."
-                                   result))))
-                        (finally
-                          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/data-access :unrestricted)
-                          (perms/grant-permissions! (perms-group/all-users) (perms/data-perms-path (mt/id))))))
-             result)))))))
+                                   result)))))))
+           result))))))
 
 ;;; ------------------- X-ray  -------------------
 

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -6,7 +6,6 @@
    [metabase.automagic-dashboards.util :as magic.util]
    [metabase.models
     :refer [Card Collection Dashboard Metric ModelIndex ModelIndexValue Segment]]
-   [metabase.models.data-permissions :as data-perms]
    [metabase.models.model-index :as model-index]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]

--- a/test/metabase/api/automagic_dashboards_test.clj
+++ b/test/metabase/api/automagic_dashboards_test.clj
@@ -49,19 +49,20 @@
   ([template args revoke-fn validation-fn]
    (mt/with-test-user :rasta
      (with-dashboard-cleanup
-       (let [api-endpoint (apply format (str "automagic-dashboards/" template) args)
-             resp         (mt/user-http-request :rasta :get 200 api-endpoint)
-             _            (dashcards-schema-check (:dashcards resp))
-             result       (validation-fn resp)]
-         (when (and result
-                    (testing "Endpoint should return 403 if user does not have permissions"
-                      (perms.test-util/with-no-data-perms-for-all-users!
-                        (perms.test-util/with-no-perms-for-all-users!
-                          (revoke-fn)
-                          (let [result (mt/user-http-request :rasta :get 403 api-endpoint)]
-                            (is (= "You don't have permissions to do that."
-                                   result)))))))
-           result))))))
+       (mt/with-full-data-perms-for-all-users!
+         (let [api-endpoint (apply format (str "automagic-dashboards/" template) args)
+               resp         (mt/user-http-request :rasta :get 200 api-endpoint)
+               _            (dashcards-schema-check (:dashcards resp))
+               result       (validation-fn resp)]
+           (when (and result
+                      (testing "Endpoint should return 403 if user does not have permissions"
+                        (perms.test-util/with-no-data-perms-for-all-users!
+                          (perms.test-util/with-no-perms-for-all-users!
+                            (revoke-fn)
+                            (let [result (mt/user-http-request :rasta :get 403 api-endpoint)]
+                              (is (= "You don't have permissions to do that."
+                                     result)))))))
+             result)))))))
 
 ;;; ------------------- X-ray  -------------------
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -43,6 +43,7 @@
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.revision :as revision]
+   [metabase.permissions.test-util :as perms.test-util]
    [metabase.query-processor :as qp]
    [metabase.query-processor.middleware.permissions :as qp.perms]
    [metabase.query-processor.streaming.test-util :as streaming.test-util]
@@ -580,29 +581,30 @@
 (deftest param-values-test
   (testing "Don't return `param_values` for Fields for which the current User has no data perms."
     (mt/with-temp-copy-of-db
-      (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
-      (perms/grant-permissions! (perms-group/all-users) (perms/table-read-path (mt/id :venues)))
-      (mt/with-temp [Dashboard     {dashboard-id :id} {:name "Test Dashboard"}
-                     Card          {card-id :id}      {:name "Dashboard Test Card"}
-                     DashboardCard {_ :id}            {:dashboard_id       dashboard-id
-                                                       :card_id            card-id
-                                                       :parameter_mappings [{:card_id      card-id
-                                                                             :parameter_id "foo"
-                                                                             :target       [:dimension
-                                                                                            [:field (mt/id :venues :name) nil]]}
-                                                                            {:card_id      card-id
-                                                                             :parameter_id "bar"
-                                                                             :target       [:dimension
-                                                                                            [:field (mt/id :categories :name) nil]]}]}]
+      (perms.test-util/with-no-data-perms-for-all-users!
+        (perms.test-util/with-perm-for-group-and-table!
+            (perms-group/all-users) (mt/id :venues) :perms/data-access :unrestricted
+          (mt/with-temp [Dashboard     {dashboard-id :id} {:name "Test Dashboard"}
+                         Card          {card-id :id}      {:name "Dashboard Test Card"}
+                         DashboardCard {_ :id}            {:dashboard_id       dashboard-id
+                                                           :card_id            card-id
+                                                           :parameter_mappings [{:card_id      card-id
+                                                                                 :parameter_id "foo"
+                                                                                 :target       [:dimension
+                                                                                                [:field (mt/id :venues :name) nil]]}
+                                                                                {:card_id      card-id
+                                                                                 :parameter_id "bar"
+                                                                                 :target       [:dimension
+                                                                                                [:field (mt/id :categories :name) nil]]}]}]
 
-        (is (= {(mt/id :venues :name) {:values                ["20th Century Cafe"
-                                                               "25°"
-                                                               "33 Taps"]
-                                       :field_id              (mt/id :venues :name)
-                                       :human_readable_values []}}
-               (let [response (:param_values (mt/user-http-request :rasta :get 200 (str "dashboard/" dashboard-id)))]
-                 (into {} (for [[field-id m] response]
-                            [field-id (update m :values (partial take 3))])))))))))
+            (is (= {(mt/id :venues :name) {:values                ["20th Century Cafe"
+                                                                   "25°"
+                                                                   "33 Taps"]
+                                           :field_id              (mt/id :venues :name)
+                                           :human_readable_values []}}
+                   (let [response (:param_values (mt/user-http-request :rasta :get 200 (str "dashboard/" dashboard-id)))]
+                     (into {} (for [[field-id m] response]
+                                [field-id (update m :values (partial take 3))])))))))))))
 
 (deftest fetch-a-dashboard-with-param-linked-to-a-field-filter-that-is-not-existed
   (testing "when fetching a dashboard that has a param linked to a field filter that no longer exists, we shouldn't throw an error (#15494)"
@@ -3314,10 +3316,10 @@
                    (mt/user-http-request :rasta :get 400 "dashboard/params/valid-filter-fields" :filtering [%categories.name]))))))
       (testing "should check perms for the Fields in question"
         (mt/with-temp-copy-of-db
-          (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
-          (is (= "You don't have permissions to do that."
+          (perms.test-util/with-no-data-perms-for-all-users!
+            (is (= "You don't have permissions to do that."
                (mt/$ids (mt/user-http-request :rasta :get 403 "dashboard/params/valid-filter-fields"
-                         :filtered [%venues.price] :filtering [%categories.name])))))))))
+                         :filtered [%venues.price] :filtering [%categories.name]))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                             POST /api/dashboard/:dashboard-id/card/:card-id/query                              |

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -12,6 +12,7 @@
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.models.table :as table]
+   [metabase.permissions.test-util :as perms.test-util]
    [metabase.server.middleware.util :as mw.util]
    [metabase.test :as mt]
    [metabase.timeseries-query-processor-test.util :as tqpt]
@@ -298,15 +299,15 @@
                      Field    table-1-id  {:table_id (u/the-id table-1), :name "id", :base_type :type/Integer, :semantic_type :type/PK}
                      Field    _table-2-id {:table_id (u/the-id table-2), :name "id", :base_type :type/Integer, :semantic_type :type/PK}
                      Field    _table-2-fk {:table_id (u/the-id table-2), :name "fk", :base_type :type/Integer, :semantic_type :type/FK, :fk_target_field_id (u/the-id table-1-id)}]
-        ;; grant permissions only to table-2
-        (perms/revoke-data-perms! (perms-group/all-users) (u/the-id db))
-        (perms/grant-permissions! (perms-group/all-users) (u/the-id db) (:schema table-2) (u/the-id table-2))
-        ;; metadata for table-2 should show all fields for table-2, but the FK target info shouldn't be hydrated
-        (is (= #{{:name "id", :target false}
-                 {:name "fk", :target false}}
-               (set (for [field (:fields (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (u/the-id table-2))))]
-                      (-> (select-keys field [:name :target])
-                          (update :target boolean))))))))))
+        (perms.test-util/with-no-data-perms-for-all-users!
+          ;; grant permissions only to table-2
+          (perms.test-util/with-perm-for-group-and-table! (u/the-id (perms-group/all-users)) (u/the-id table-2) :perms/data-access :unrestricted
+            ;; metadata for table-2 should show all fields for table-2, but the FK target info shouldn't be hydrated
+            (is (= #{{:name "id", :target false}
+                     {:name "fk", :target false}}
+                   (set (for [field (:fields (mt/user-http-request :rasta :get 200 (format "table/%d/query_metadata" (u/the-id table-2))))]
+                          (-> (select-keys field [:name :target])
+                              (update :target boolean))))))))))))
 
 (deftest update-table-test
   (testing "PUT /api/table/:id"

--- a/test/metabase/permissions/test_util.clj
+++ b/test/metabase/permissions/test_util.clj
@@ -76,6 +76,19 @@
                                             (data-perms/least-permissive-value perm-type)))
     (thunk)))
 
+(defn do-with-no-perms-for-all-users!
+  "Implementation of `with-no-perms-for-all-users!`."
+  [thunk]
+  (with-restored-perms!
+    (perms/revoke-data-perms! (perms-group/all-users) (data/db))
+    (thunk)))
+
+(defmacro with-no-perms-for-all-users!
+  "Runs `body`, and sets every permission for the test dataset to its least-permissive value for the All Users
+  permission group for the duration of the test."
+  [& body]
+  `(do-with-no-perms-for-all-users! (fn [] ~@body)))
+
 (defmacro with-no-data-perms-for-all-users!
   "Runs `body`, and sets every data permission for all databases to its least permissive value for the All Users
   permission group for the duration of the test. Restores the original permissions afterwards."

--- a/test/metabase/permissions/test_util.clj
+++ b/test/metabase/permissions/test_util.clj
@@ -33,7 +33,9 @@
   "Implementation of `with-restored-perms` and related helper functions. Optionally takes `group-ids` to restore only the
   permissions for a set of groups."
   [group-ids thunk]
-  (let [select-condition [(when group-ids [:in :group_id group-ids])]
+  (let [select-condition (if-not group-ids
+                           true
+                           [:in :group_id group-ids])
         original-perms (t2/select :model/DataPermissions {:where select-condition})]
     (try
       (thunk)

--- a/test/metabase/permissions/test_util.clj
+++ b/test/metabase/permissions/test_util.clj
@@ -102,12 +102,26 @@
   `(do-with-full-data-perms-for-all-users! (fn [] ~@body)))
 
 (defn do-with-perm-for-group!
-  "Implementation of `with-perm-for-group`. Sets the data permission for the the test dataset to the given value
+  "Implementation of `with-perm-for-group`. Sets the data permission for the test dataset to the given value
   for the given permission group for the duration of the test."
   [group-or-id perm-type value thunk]
   (with-restored-data-perms-for-group! (u/the-id (perms-group/all-users))
    (data-perms/set-database-permission! group-or-id (data/db) perm-type value)
    (thunk)))
+
+(defn do-with-perm-for-group-and-table!
+  "Implementation of `with-perm-for-group-and-table`. Sets the data permission for the test dataset/table to the given
+  value for the given permission group for the duration of the test."
+  [group-or-id table-or-id perm-type value thunk]
+  (with-restored-data-perms-for-group! (u/the-id (perms-group/all-users))
+    (data-perms/set-table-permission! group-or-id table-or-id perm-type value)
+    (thunk)))
+
+(defmacro with-perm-for-group-and-table!
+  "Sets the data permission for the test dataset and specified table to the given value for the given permission group
+  and runs `body` in that context."
+  [group-or-id table-or-id perm-type value & body]
+  `(do-with-perm-for-group-and-table! ~group-or-id ~table-or-id ~perm-type ~value (fn [] ~@body)))
 
 (defmacro with-perm-for-group!
   "Runs `body`, and sets the data permission for the the test dataset to the given value for the given permission


### PR DESCRIPTION
The previous behavior was to cache the permissions set for the Field's table. I split this in two: we cache the `db_id` for a given `Field`, but we can tackle caching the specific permissions for that database down the road, when we implement caching on data permissions checks in general.

To fix tests: `set-table-permissions!` previously threw an exception if passed an empty map of `table->permission-value`. I modified it to just skip processing in this case instead.