### PR TITLE
Disable auditing when `site-uuid` nonces are initialized

### DIFF
--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -76,6 +76,7 @@
   :visibility :public
   :type       :string
   :setter     :none
+  :audit      :never
   :init       setting/random-uuid-str
   :doc        false)
 

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -511,13 +511,6 @@
                 (db-value setting)
                 (core/get cache (setting-name setting-definition-or-name))))))))))
 
-(defn- underlying-setter
-  "In the case of a read-only setting, this gives raw access to write a new value. Useful for initialization."
-  [{:keys [setter] setting-type :type :as setting}]
-  (if (= :none setter)
-    (partial set-value-of-type! setting-type setting)
-    setter))
-
 (defonce ^:private ^ReentrantLock init-lock (ReentrantLock.))
 
 (defn- init! [setting-definition-or-name]
@@ -534,11 +527,7 @@
             (read-setting setting)
             (when init
               (when-let [init-value (init)]
-                ;; We use the underlying setter to avoid triggering the audit logs.
-                ;; This is currently needed to avoid a deadlock when the database is first initialized via a config file.
-                (let [setter (underlying-setter setting)]
-                  (setter init-value))
-                #_(metabase.models.setting/set! setting init-value :bypass-read-only? true))))
+                (metabase.models.setting/set! setting init-value :bypass-read-only? true))))
           (finally
             (.unlock init-lock)))))))
 
@@ -886,6 +875,13 @@
   "Returns true if the setting change should be written to the `audit_log`."
   [setting]
   (not= (:audit setting) :never))
+
+(defn- underlying-setter
+  "In the case of a read-only setting, this gives raw access to write a new value. Useful for initialization."
+  [{:keys [setter] setting-type :type :as setting}]
+  (if (= :none setter)
+    (partial set-value-of-type! setting-type setting)
+    setter))
 
 (defn- set-with-audit-logging!
   "Calls the setting's setter with `new-value`, and then writes the change to the `audit_log` table if necessary."

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -128,6 +128,7 @@
   :visibility :authenticated
   :type       :string
   :setter     :none
+  :audit      :never
   :init       setting/random-uuid-str
   :doc        false)
 
@@ -141,6 +142,7 @@
   :visibility :internal
   :type       :string
   :setter     :none
+  :audit      :never
   :init       setting/random-uuid-str
   :doc        false)
 
@@ -150,6 +152,7 @@
   :visibility :internal
   :type       :string
   :setter     :none
+  :audit      :never
   :init       setting/random-uuid-str)
 
 (defsetting site-uuid-for-unsubscribing-url
@@ -158,6 +161,7 @@
   :visibility :internal
   :type       :string
   :setter     :none
+  :audit      :never
   :init       setting/random-uuid-str)
 
 (defn- normalize-site-url [^String s]


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/38009

### Description

With the [ntroduction of the [init mechanism](https://github.com/metabase/metabase/pull/37849/files) for app settings, we introduced a subtle change - the initialization of `site-uuid` settings is now audited.

Unfortunately this change broke the loading of the Enterprise feature flags when first populating the app database, due to a concurrency bug in the auditing code. This resulted in the app silently falling back to a "no feature flags" state. In the case where we are using a config file this issue is then exposure by an immediate crash during startup.

The details of the concurrency bug are quite detailed - see [this comment](https://github.com/metabase/metabase/issues/38009#issuecomment-1906910158) on the parent issue.

This PR simply reverts to the previous behavior - no auditing. 

### How to verify

1. Drop all tables in the app database.
2. Set `MB_CONFIG_FILE_PATH` to point to a config file. A placeholder is fine, it won't be loaded.
3. Set a `MB_PREMIUM_EMBEDDING_TOKEN`. It must have the right format, but won't be used.
4. Start the server.
5.  🌈 

Without this change you should get the following instead:

```
2024-01-23 06:02:29,724 ERROR metabase.core :: Metabase Initialization FAILED
clojure.lang.ExceptionInfo: Metabase config files require a Premium token with the 
  :config-text-file feature. {}
```