### PR TITLE
Parse template optionality

### DIFF
--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -143,7 +143,16 @@ export interface TemplateTag {
   type: TemplateTagType;
   dimension?: LocalFieldReference;
   "widget-type"?: string;
+
   required?: boolean;
+
+  /**
+   * optional will be true if the template tag in the query is nested in
+   * an optional block. It is a property of the query text and is therefore not
+   * not user-editable (other than editing the query directly).
+   *
+   * This is different from the `required` property, which _is_ user-editable.
+   */
   optional: boolean;
   default?: string | null;
   options?: ParameterOptions;

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -153,7 +153,7 @@ export interface TemplateTag {
    *
    * This is different from the `required` property, which _is_ user-editable.
    */
-  optional: boolean;
+  readonly optional: boolean;
   default?: string | null;
   options?: ParameterOptions;
 

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -144,6 +144,7 @@ export interface TemplateTag {
   dimension?: LocalFieldReference;
   "widget-type"?: string;
   required?: boolean;
+  optional: boolean;
   default?: string | null;
   options?: ParameterOptions;
 

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -15,12 +15,12 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
 
-(def tokens
+(def separators
   "The tokens used for template tags."
   #{"{{" "}}" "[[" "]]"})
 
-(defn- next-token [text start]
-  (let [indexes (map #(or (str/index-of text % start) ##Inf) tokens)
+(defn- next-separator [text start]
+  (let [indexes (map #(or (str/index-of text % start) ##Inf) separators)
         index   (apply min indexes)]
     (if (infinite? index)
       [nil nil]
@@ -28,15 +28,15 @@
 
 (mu/defn ^:private tokenize-query :- [:sequential :string]
   "Tokenize the query for easier parsing.
-   This splits the string at the following tokens: {{ }} [[ ]],
-   and keeps the tokens in the result."
+   This splits the string at the separators defined in `separators`
+   but keeps them in the resulting sequence."
   [query-text :- ::common/non-blank-string]
   (let [cnt (count query-text)]
     (loop [idx 0
           res []]
       (if (>= idx cnt)
         res
-        (let [[jdx tok] (next-token query-text idx)]
+        (let [[jdx tok] (next-separator query-text idx)]
           (if (nil? jdx)
             (recur cnt (conj res (subs query-text idx cnt)))
             (recur (+ 2 jdx) (conj res (subs query-text idx jdx) tok))))))))

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -69,13 +69,13 @@
           (recur tags tail in-optional-block in-template-tag current-template-text))))))
 
 (def ^:private variable-tag-regex
-  #"^([A-Za-z0-9_\.]+)$")
+  #"^[A-Za-z0-9_\.]+$")
 
 (def ^:private snippet-tag-regex
-  #"^(snippet:\s*[^}]+)$")
+  #"^snippet:\s*[^}]+$")
 
 (def ^:private card-tag-regex
-  #"^#[0-9]+(-[a-z0-9-]*)?$")
+  #"^#[0-9]+(?:-[a-z0-9-]*)?$")
 
 (def ^:private tag-regexes
   [snippet-tag-regex card-tag-regex variable-tag-regex])
@@ -83,8 +83,8 @@
 (mu/defn ^:private format-template-tag-name :- [:maybe :string]
   "Parse and validate a template tag's content."
   [content :- :string]
-  (first (first
-    (mapcat #(re-seq % (str/trim content)) tag-regexes))))
+  (first
+    (mapcat #(re-seq % (str/trim content)) tag-regexes)))
 
 (mu/defn ^:private format-template-tag :- ::template-tag-with-context
   "Format a template tags name."

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -83,8 +83,7 @@
 (mu/defn ^:private format-template-tag-name :- [:maybe :string]
   "Parse and validate a template tag's content."
   [content :- :string]
-  (first
-    (mapcat #(re-seq % (str/trim content)) tag-regexes)))
+  (some #(re-find % (str/trim content)) tag-regexes))
 
 (mu/defn ^:private format-template-tag :- ::template-tag-with-context
   "Format a template tags name."

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -80,7 +80,7 @@
 (def ^:private tag-regexes
   [snippet-tag-regex card-tag-regex variable-tag-regex])
 
-(mu/defn ^:private parse-template-tag :- [:maybe :string]
+(mu/defn ^:private format-template-tag-name :- [:maybe :string]
   "Parse and validate a template tag's content."
   [content :- :string]
   (first (first
@@ -89,7 +89,7 @@
 (mu/defn ^:private format-template-tag :- ::template-tag-with-context
   "Format a template tags name."
   [tag :- ::template-tag-with-context]
-  (update tag :name parse-template-tag))
+  (update tag :name format-template-tag-name))
 
 (mu/defn ^:private format-template-tags :- [:sequential ::template-tag-with-context]
   "Format all template tags and filter out invalid ones."

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -81,7 +81,7 @@
   [snippet-tag-regex card-tag-regex variable-tag-regex])
 
 (mu/defn ^:private format-template-tag-name :- [:maybe :string]
-  "Parse and validate a template tag's content."
+  "Format and validate a template tag's content."
   [content :- :string]
   (second (some #(re-find % (str/triml content)) tag-regexes)))
 

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -17,7 +17,7 @@
 
 (def tokens
   "The tokens used for template tags."
-  ["{{" "}}" "[[" "]]"])
+  #{"{{" "}}" "[[" "]]"})
 
 (defn- next-token [text start]
   (let [indexes (map #(or (str/index-of text % start) ##Inf) tokens)

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -69,13 +69,13 @@
           (recur tags tail in-optional-block in-template-tag current-template-text))))))
 
 (def ^:private variable-tag-regex
-  #"^[A-Za-z0-9_\.]+$")
+  #"^([A-Za-z0-9_\.]+)\s*$")
 
 (def ^:private snippet-tag-regex
-  #"^snippet:\s*[^}]+$")
+  #"^(snippet:.+)$")
 
 (def ^:private card-tag-regex
-  #"^#[0-9]+(?:-[a-z0-9-]*)?$")
+  #"^(#[0-9]+(?:-[a-z0-9-]*)?)\s*$")
 
 (def ^:private tag-regexes
   [snippet-tag-regex card-tag-regex variable-tag-regex])
@@ -83,7 +83,7 @@
 (mu/defn ^:private format-template-tag-name :- [:maybe :string]
   "Parse and validate a template tag's content."
   [content :- :string]
-  (some #(re-find % (str/trim content)) tag-regexes))
+  (second (some #(re-find % (str/triml content)) tag-regexes)))
 
 (mu/defn ^:private format-template-tag :- ::template-tag-with-context
   "Format a template tags name."

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -30,8 +30,7 @@
 (mu/defn ^:private tokenize-query :- [:sequential :string]
   "Tokenize the query for easier parsing.
    This splits the string at the separators defined in `separators`
-   but keeps them in the resulting sequence.
-   Assumes all separators have a len of 2 characters."
+   but keeps them in the resulting sequence."
   [query-text :- ::common/non-blank-string]
   (let [cnt (count query-text)]
     (loop [idx 0
@@ -41,7 +40,7 @@
         (let [[jdx tok] (next-separator query-text idx)]
           (if (nil? jdx)
             (conj res (subs query-text idx cnt))
-            (recur (+ 2 jdx) (conj res (subs query-text idx jdx) tok))))))))
+            (recur (+ (count tok) jdx) (conj res (subs query-text idx jdx) tok))))))))
 
 (mr/def ::template-tag-with-context
    [:map

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -19,17 +19,19 @@
   "The tokens used for template tags."
   #{"{{" "}}" "[[" "]]"})
 
-(defn- next-separator [text start]
-  (let [indexes (map #(or (str/index-of text % start) ##Inf) separators)
-        index   (apply min indexes)]
-    (if (infinite? index)
-      [nil nil]
+(defn- next-separator
+  "Finds the next separator in the query.
+   Assumes all separators have a len of 2 characters."
+  [text start]
+  (when-let [indexes (seq (keep #(str/index-of text % start) separators))]
+    (let [index (apply min indexes)]
       [index (subs text index (+ 2 index))])))
 
 (mu/defn ^:private tokenize-query :- [:sequential :string]
   "Tokenize the query for easier parsing.
    This splits the string at the separators defined in `separators`
-   but keeps them in the resulting sequence."
+   but keeps them in the resulting sequence.
+   Assumes all separators have a len of 2 characters."
   [query-text :- ::common/non-blank-string]
   (let [cnt (count query-text)]
     (loop [idx 0

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -83,7 +83,7 @@
 (mu/defn ^:private format-template-tag-name :- [:maybe :string]
   "Format and validate a template tag's content."
   [content :- :string]
-  (second (some #(re-find % (str/triml content)) tag-regexes)))
+  (second (some #(re-matches % (str/triml content)) tag-regexes)))
 
 (mu/defn ^:private format-template-tag :- ::template-tag-with-context
   "Format a template tags name."

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -94,9 +94,7 @@
 (mu/defn ^:private format-template-tags :- [:sequential ::template-tag-with-context]
   "Format all template tags and filter out invalid ones."
   [tags :- [:sequential ::template-tag-with-context]]
-  (remove (comp nil? :name)
-  (map format-template-tag tags)))
-
+  (filter :name (map format-template-tag tags)))
 
 (mu/defn ^:private recognize-template-tags :- [:sequential ::template-tag-with-context]
   "Find all template tags and test if they are optional."

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -38,7 +38,7 @@
         res
         (let [[jdx tok] (next-separator query-text idx)]
           (if (nil? jdx)
-            (recur cnt (conj res (subs query-text idx cnt)))
+            (conj res (subs query-text idx cnt))
             (recur (+ 2 jdx) (conj res (subs query-text idx jdx) tok))))))))
 
 (mr/def ::template-tag-with-context

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -78,10 +78,14 @@
   (remove (comp nil? :name)
   (map format-template-tag tags)))
 
+
 (mu/defn ^:private recognize-template-tags :- [:sequential ::template-tag-with-context]
   "Find all template tags and test if they are optional."
   [query-text :- ::common/non-blank-string]
-  (format-template-tags (parse-template-tags (tokenize-query query-text))))
+  (let [tokens        (tokenize-query query-text)
+        tags          (parse-template-tags tokens)
+        template-tags (format-template-tags tags)]
+    template-tags))
 
 (defn- tag-name->card-id [tag-name]
   (when-let [[_ id-str] (re-matches #"^#(\d+)(-[a-z0-9-]*)?$" tag-name)]

--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -113,7 +113,8 @@
 (mr/def ::template-tag
   [:and
    [:map
-    [:type [:ref ::type]]]
+    [:type [:ref ::type]]
+    [:optional :boolean]]
    [:multi {:dispatch :type}
     [:dimension   [:ref ::field-filter]]
     [:snippet     [:ref ::snippet]]

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -104,6 +104,7 @@
                        :type :dimension
                        :dimension [:field 866 nil]
                        :widget-type :string/=
+                       :optional true
                        :default nil}}}
                     :database 76}
           converted (lib.convert/->pMBQL original)]

--- a/test/metabase/lib/js_test.cljs
+++ b/test/metabase/lib/js_test.cljs
@@ -138,6 +138,7 @@
                     {:type :snippet
                      :name "snippet: my snippet"
                      :id "fd5e96f7-08f8-486b-9919-b2ab72857db4"
+                     :optional true
                      :display-name "Snippet: My Snippet"
                      :snippet-name "my snippet"
                      :snippet-id 1}}
@@ -155,10 +156,12 @@
           tags {tag-name {:type         :text
                           :name         tag-name
                           :display-name "Foo"
+                          :optional      false
                           :id           (str (random-uuid))}}]
       (is (= {"bar" {"type"         "text"
                      "name"         "bar"
                      "display-name" "Bar"
+                     "optional"     false
                      "id"           (get-in tags [tag-name :id])}}
              (-> (lib.js/extract-template-tags "SELECT * FROM table WHERE {{bar}}"
                                                (add-undefined-params (clj->js tags) tag-name))

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -62,7 +62,6 @@
         {"foo" foo} (lib.native/extract-template-tags "SELECT * FROM table WHERE [[ {{ bar ]] }} AND ]] {{ foo }}")
         {"foo" foo} (lib.native/extract-template-tags "SELECT * FROM table WHERE [[ {{ bar [[ }} AND ]] {{ foo }}")
         {"foo" foo} (lib.native/extract-template-tags "SELECT * FROM table WHERE [[ {{ bar {{ }} AND ]] {{ foo }}")
-        {"foo" foo} (lib.native/extract-template-tags "SELECT * FROM table WHERE [[ {{ bar {{ }} AND ]] {{ foo }}")
         {} (lib.native/extract-template-tags "SELECT * FROM table WHERE {{ foo [[ }}")
         {} (lib.native/extract-template-tags "SELECT * FROM table WHERE {{ foo ]] }}")
         {} (lib.native/extract-template-tags "SELECT * FROM table WHERE {{ foo {{ }}")

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -27,7 +27,8 @@
 
 (deftest ^:parallel snippet-tag-test
   (are [exp input] (= exp (set (keys (lib.native/extract-template-tags input))))
-    #{"snippet:   foo"} "SELECT * FROM table WHERE {{snippet:   foo  }} AND some_field IS NOT NULL"
+    #{"snippet:   foo  "} "SELECT * FROM table WHERE {{snippet:   foo  }} AND some_field IS NOT NULL"
+    #{"snippet:   foo  "} "SELECT * FROM table WHERE {{  snippet:   foo  }} AND some_field IS NOT NULL"
     #{"snippet:   foo  *#&@"} "SELECT * FROM table WHERE {{snippet:   foo  *#&@}}"
     ;; TODO: This logic should trim the whitespace and unify these two snippet names.
     ;; I think this is a bug in the original code but am aiming to reproduce it exactly for now.


### PR DESCRIPTION
Related to #37127

### Description

Currently the template tag parser does not return any information on whether or not a template tag is nested in an optional block.
Therefore, in the native query editor, the parameters that get created for the template tags in the query text do not get their `required` flag set correctly.

For instance, creating the following query in `New` → `SQL Query` → `Sample Dataset`,
```sql
SELECT * FROM USER_ID WHERE id = {{ id }}
```
creates a parameter `id` but even though the `id` template tag is not optional, the parameter is not set to be required, even though running this query without a value for `id` will result in an error.

This results in issues like #37127, where certain assumptions about template tags and parameters are incorrect because there is not enough information.

This PR is part of the solution for fixing that. It adds a property `:optional` to the template tags that are parsed from the query, which denotes whether or not the template tag is nested in an optional tag. For example:
```clojure
(extract-template-tags "SELECT * FROM USER_ID WHERE x = {{ x }} [[ AND y = {{ y }} ]]")
;; {"x" {:name "x" :optional false} "y" {:name "y" :optional true}}
```

In a follow up PR, we can use this information to correctly set the optionality of a parameter.

Additionally, I think it would be helpful if we disambiguated further template tags and query parameters.

Here's a video explaining some of the issues that might be resolved by this:
<div>
    <a href="https://www.loom.com/share/d04180cea7884ccf82b91ddeffb8cd54">
      <p>Explaining SQL Query Issues - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/d04180cea7884ccf82b91ddeffb8cd54">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/d04180cea7884ccf82b91ddeffb8cd54-with-play.gif">
    </a>
  </div>

### How to verify

This PR does not add any UI functionality and all functionality has been tested.
You can make sure the template tags still get parsed normally by:

1. `New` → `SQL Query` → `Sample Dataset`
2. Type:
   ```sql
   SELECT * FROM USER_ID WHERE id = {{ id }}
   ```
3. a variable with the name `id` should have been created

### Notes

- This is my first time touching Clojure in a long time, so forgive my naive code style. Feel free to be strict in reviewing this PR!
- I switched to manually tokenizing the query instead of using a regex because there are subtle differences in how Clojure/Java handles it versus JavaScript.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
