### PR TITLE
shortcut POC using react-hotkeys-hook

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -7,6 +7,8 @@ import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import _ from "underscore";
 import { t } from "ttag";
+import { useHotkeys } from "react-hotkeys-hook";
+import { SHORTCUTS } from "metabase/shortcuts";
 
 import { LeaveConfirmationModal } from "metabase/components/LeaveConfirmationModal";
 
@@ -179,6 +181,13 @@ const DashboardApp = (props: DashboardAppProps) => {
   const options = parseHashOptions(window.location.hash);
   const editingOnLoad = options.edit;
   const addCardOnLoad = options.add != null ? Number(options.add) : undefined;
+
+  useHotkeys(SHORTCUTS.global.edit, () => {
+    alert("edit");
+  });
+  useHotkeys(SHORTCUTS.dashboard.save, () => {
+    alert("saved");
+  });
 
   const dispatch = useDispatch();
 

--- a/frontend/src/metabase/shortcuts/index.ts
+++ b/frontend/src/metabase/shortcuts/index.ts
@@ -1,0 +1,9 @@
+export const SHORTCUTS = {
+  global: {
+    edit: "e",
+    bookmark: "b",
+  },
+  dashboard: {
+    save: "ctrl+s",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react-draggable": "^3.3.2",
     "react-dropzone": "^14.2.3",
     "react-grid-layout": "^1.2.5",
+    "react-hotkeys-hook": "^4.4.4",
     "react-innertext": "^1.1.5",
     "react-is": "^17.0.2",
     "react-markdown": "^8.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18378,6 +18378,11 @@ react-grid-layout@^1.2.5:
     react-draggable "^4.0.0"
     react-resizable "^3.0.1"
 
+react-hotkeys-hook@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-4.4.4.tgz#5f055f39113218fe5e23f8723db68ccf99d155ab"
+  integrity sha512-wzZmqb/Obr0ds9Myc1sIFPJ52GA/Eeg/vXBWV0HA1LvHlVAW5Va3KB0q6EZNlNSHQWscWZ2K8+6w0GYSie2o7A==
+
 react-innertext@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/react-innertext/-/react-innertext-1.1.5.tgz#8147ac54db3f7067d95f49e2d2c05a720d27d8d0"


### PR DESCRIPTION
Quick proof of concept of using `react-hokeys-hook` along with a global shortcuts file to help standardize shortcuts.