### PR TITLE
Optimize MLv2 usage in parameters auto-wiring code

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/cards.ts
+++ b/frontend/src/metabase-lib/parameters/utils/cards.ts
@@ -28,7 +28,7 @@ export function getCardUiParameters(
     const target: ParameterTarget | undefined = (
       parameter as ParameterWithTarget
     ).target;
-    const field = getParameterTargetField(target, metadata, question);
+    const field = getParameterTargetField(target, question);
     if (field) {
       return {
         ...parameter,

--- a/frontend/src/metabase-lib/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/parameters/utils/targets.ts
@@ -23,13 +23,13 @@ export function getTemplateTagFromTarget(target: ParameterTarget) {
 
 export function getParameterTargetField(
   target: ParameterTarget,
-  metadata: Metadata,
   question: Question,
 ) {
   if (isDimensionTarget(target)) {
     const query = question.legacyQuery({ useStructuredQuery: true }) as
       | NativeQuery
       | StructuredQuery;
+    const metadata = question.metadata();
     const dimension = Dimension.parseMBQL(target[1], metadata, query);
 
     return dimension?.field();
@@ -60,23 +60,22 @@ export function getTargetFieldFromCard(
   metadata: Metadata,
 ) {
   const question = new Question(card, metadata);
-  const field = getParameterTargetField(target, metadata, question);
+  const field = getParameterTargetField(target, question);
   return field ?? null;
 }
 
 export function compareMappingOptionTargets(
   target1: ParameterTarget,
   target2: ParameterTarget,
-  card1: Card,
-  card2: Card,
-  metadata: Metadata,
+  question1: Question,
+  question2: Question,
 ) {
   if (!isDimensionTarget(target1) || !isDimensionTarget(target2)) {
     return false;
   }
 
-  const fieldReference1 = getTargetFieldFromCard(target1, card1, metadata);
-  const fieldReference2 = getTargetFieldFromCard(target2, card2, metadata);
+  const fieldReference1 = getParameterTargetField(target1, question1);
+  const fieldReference2 = getParameterTargetField(target2, question2);
 
   return fieldReference1?.id === fieldReference2?.id;
 }

--- a/frontend/src/metabase-lib/parameters/utils/targets.unit.spec.ts
+++ b/frontend/src/metabase-lib/parameters/utils/targets.unit.spec.ts
@@ -93,7 +93,6 @@ describe("parameters/utils/targets", () => {
       expect(
         getParameterTargetField(
           ["variable", ["template-tag", "foo"]],
-          metadata,
           question,
         ),
       ).toBe(null);
@@ -114,7 +113,7 @@ describe("parameters/utils/targets", () => {
         },
       });
 
-      expect(getParameterTargetField(target, metadata, question)).toEqual(
+      expect(getParameterTargetField(target, question)).toEqual(
         expect.objectContaining({
           id: PRODUCTS.CATEGORY,
         }),
@@ -129,7 +128,7 @@ describe("parameters/utils/targets", () => {
       const question = db.question({
         "source-table": PRODUCTS_ID,
       });
-      expect(getParameterTargetField(target, metadata, question)).toEqual(
+      expect(getParameterTargetField(target, question)).toEqual(
         expect.objectContaining({
           id: PRODUCTS.CATEGORY,
         }),

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts
@@ -1,5 +1,4 @@
 import type {
-  Card,
   DashboardCard,
   DashCardId,
   ParameterId,
@@ -26,6 +25,7 @@ import { getDashCardById } from "metabase/dashboard/selectors";
 import { getParameterMappingOptions } from "metabase/parameters/utils/mapping-options";
 import { getMetadata } from "metabase/selectors/metadata";
 import { compareMappingOptionTargets } from "metabase-lib/parameters/utils/targets";
+import Question from "metabase-lib/Question";
 
 export function autoWireDashcardsWithMatchingParameters(
   parameter_id: ParameterId,
@@ -102,6 +102,12 @@ export function autoWireParametersToNewCard({
       dashboardId,
     );
 
+    const dashcardWithQuestions: Array<[StoreDashcard, Question]> =
+      dashcards.map(dashcard => [
+        dashcard,
+        new Question(dashcard.card, metadata),
+      ]);
+
     const targetDashcard: StoreDashcard = getDashCardById(
       getState(),
       dashcard_id,
@@ -118,18 +124,19 @@ export function autoWireParametersToNewCard({
       targetDashcard,
     );
 
+    const targetQuestion = new Question(targetDashcard.card, metadata);
+
     const parametersToAutoApply = [];
     const processedParameterIds = new Set();
 
     for (const opt of dashcardMappingOptions) {
-      for (const dashcard of dashcards) {
+      for (const [dashcard, question] of dashcardWithQuestions) {
         const param = dashcard.parameter_mappings?.find(mapping =>
           compareMappingOptionTargets(
             mapping.target,
             opt.target,
-            dashcard.card as Card,
-            targetDashcard.card as Card,
-            metadata,
+            question,
+            targetQuestion,
           ),
         );
 

--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
@@ -15,6 +15,7 @@ import { isVirtualDashCard } from "metabase/dashboard/utils";
 import { getParameterMappingOptions } from "metabase/parameters/utils/mapping-options";
 import { compareMappingOptionTargets } from "metabase-lib/parameters/utils/targets";
 import type Metadata from "metabase-lib/metadata/Metadata";
+import Question from "metabase-lib/Question";
 
 export function getAllDashboardCardsWithUnmappedParameters({
   dashboardState,
@@ -54,6 +55,8 @@ export function getMatchingParameterOption(
     return null;
   }
 
+  const targetQuestion = new Question(targetDashcard.card, metadata);
+
   return (
     getParameterMappingOptions(
       metadata,
@@ -64,9 +67,8 @@ export function getMatchingParameterOption(
       compareMappingOptionTargets(
         targetDimension,
         param.target,
-        targetDashcard.card,
-        dashcardToCheck.card,
-        metadata,
+        targetQuestion,
+        new Question(dashcardToCheck.card, metadata),
       ),
     ) ?? null
   );


### PR DESCRIPTION
Closes #37875 

Fixes that adding a new question on a busy dashboard was taking seconds (~8s for an x-rayed sample orders table)

The performance drop appeared in #37436 when we added a [MLv1-MLv2 query conversion](https://github.com/metabase/metabase/blob/fa22eb83440162cfa5c62b03fcdfe46b081412a9/frontend/src/metabase-lib/queries/utils/structured-query-table.ts#L23) to `StructuredQuery.prototype.table()`. Here's how we get to it:

1. We're adding a new question to a dashboard with [`addCardToDashboard` redux action](https://github.com/metabase/metabase/blob/0cfa393d0bd0c26761e99e3dd7b7993c1eba2ccb/frontend/src/metabase/dashboard/actions/cards.js#L37)
2. At the end of `addCardToDashboard`, [we dispatch `autoWireParametersToNewCard`](https://github.com/metabase/metabase/blob/0cfa393d0bd0c26761e99e3dd7b7993c1eba2ccb/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts#L83C17-L83C44)
3. `autoWireParametersToNewCard` [is calling `compareMappingOptionTargets` in a nested loop](https://github.com/metabase/metabase/blob/0cfa393d0bd0c26761e99e3dd7b7993c1eba2ccb/frontend/src/metabase/dashboard/actions/auto-wire-parameters/actions.ts#L127C11-L127C38) (a number of columns suitable for a given dashboard filter * number of dashcards)
4. `compareMappingOptionTargets` [instantiates a `Question`](https://github.com/metabase/metabase/blob/0cfa393d0bd0c26761e99e3dd7b7993c1eba2ccb/frontend/src/metabase-lib/parameters/utils/targets.ts#L62) internally. It actually happens two times (for the "target dashcard question" and the compared dashcard question)

So if we had 30 mappable columns and 15 dashcards, we'd instantiate a `Question` around 30 * 15 * 2 = 900 times. Because all of them are different instances, we can't benefit from the MLv2 query cache on the question instance.

Fixed by:
- switching `compareMappingOptionTargets` to `getParameterTargetField` that accepts a question instead of a card + metadata
- updating `autoWireParametersToNewCard` so we instantiate the target question once vs. every iteration
- updating `autoWireParametersToNewCard` so we instantiate dashcard questions upfront vs. every iteration

### Demo

**Before**
![perf-before](https://github.com/metabase/metabase/assets/17258145/16f53305-4c67-46bc-ac77-ead55bbb0e16)

**After**
(varies between ~500ms — ~1.2s for me)
![perf-after](https://github.com/metabase/metabase/assets/17258145/fc810fa5-1365-43b4-8dc4-d4f47eae278f)
