### PR TITLE
Move the "remove" button to the sidebar footer

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -4,7 +4,7 @@ import _ from "underscore";
 
 import { SIDEBAR_NAME } from "metabase/dashboard/constants";
 
-import ParameterSidebar from "metabase/parameters/components/ParameterSidebar";
+import { ParameterSidebar } from "metabase/parameters/components/ParameterSidebar";
 import SharingSidebar from "metabase/sharing/components/SharingSidebar";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { ClickBehaviorSidebar } from "./ClickBehaviorSidebar/ClickBehaviorSidebar";

--- a/frontend/src/metabase/dashboard/components/Sidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.styled.tsx
@@ -2,6 +2,30 @@ import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 
+export const SidebarAside = styled.aside<{ $width: number }>`
+  display: flex;
+  flex-direction: column;
+  width: ${props => props.$width}px;
+  min-width: ${props => props.$width}px;
+  border-left: 1px solid ${color("border")};
+  background: ${color("bg-white")};
+`;
+
+export const ChildrenContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: auto;
+  overflow-y: auto;
+`;
+
+export const ButtonContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 12px 32px;
+  border-top: 1px solid ${color("border")};
+`;
+
 export const RemoveButton = styled(IconButtonWrapper)`
   color: ${color("text-medium")};
   font-weight: bold;

--- a/frontend/src/metabase/dashboard/components/Sidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.styled.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+import IconButtonWrapper from "metabase/components/IconButtonWrapper";
+
+export const RemoveButton = styled(IconButtonWrapper)`
+  color: ${color("text-medium")};
+  font-weight: bold;
+
+  &:hover {
+    color: ${color("error")};
+  }
+`;

--- a/frontend/src/metabase/dashboard/components/Sidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 
 export const SidebarAside = styled.aside<{ $width: number }>`
   display: flex;
@@ -24,13 +23,4 @@ export const ButtonContainer = styled.div`
   gap: 20px;
   padding: 12px 32px;
   border-top: 1px solid ${color("border")};
-`;
-
-export const RemoveButton = styled(IconButtonWrapper)`
-  color: ${color("text-medium")};
-  font-weight: bold;
-
-  &:hover {
-    color: ${color("error")};
-  }
 `;

--- a/frontend/src/metabase/dashboard/components/Sidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.tsx
@@ -12,7 +12,6 @@ interface SidebarProps {
   closeIsDisabled?: boolean;
   children: ReactNode;
   onClose?: () => void;
-  // TODO remove this option once Pulses are deprecated and NewPulseSidebar component is no longer needed
   onCancel?: () => void;
   onRemove?: () => void;
   "data-testid"?: string;

--- a/frontend/src/metabase/dashboard/components/Sidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.tsx
@@ -1,12 +1,18 @@
 import { t } from "ttag";
 import type { ReactNode } from "react";
 import Button from "metabase/core/components/Button";
-import { RemoveButton } from "./Sidebar.styled";
+import {
+  ButtonContainer,
+  ChildrenContainer,
+  RemoveButton,
+  SidebarAside,
+} from "./Sidebar.styled";
 
 interface SidebarProps {
   closeIsDisabled?: boolean;
   children: ReactNode;
   onClose?: () => void;
+  // TODO remove this option once Pulses are deprecated and NewPulseSidebar component is no longer needed
   onCancel?: () => void;
   onRemove?: () => void;
   "data-testid"?: string;
@@ -20,27 +26,11 @@ export function Sidebar({
   onRemove,
   "data-testid": dataTestId,
 }: SidebarProps) {
-  const WIDTH = 384;
   return (
-    <aside
-      data-testid={dataTestId}
-      style={{ width: WIDTH, minWidth: WIDTH }}
-      className="flex flex-column border-left bg-white"
-    >
-      <div className="flex flex-column flex-auto overflow-y-auto">
-        {children}
-      </div>
+    <SidebarAside data-testid={dataTestId} $width={384}>
+      <ChildrenContainer>{children}</ChildrenContainer>
       {(onClose || onCancel || onRemove) && (
-        <div
-          className="flex align-center border-top"
-          style={{
-            paddingTop: 12,
-            paddingBottom: 12,
-            paddingRight: 32,
-            paddingLeft: 32,
-            gap: 20,
-          }}
-        >
+        <ButtonContainer>
           {onRemove && (
             <RemoveButton onClick={onRemove}>{t`Remove`}</RemoveButton>
           )}
@@ -56,8 +46,8 @@ export function Sidebar({
               disabled={closeIsDisabled}
             >{t`Done`}</Button>
           )}
-        </div>
+        </ButtonContainer>
       )}
-    </aside>
+    </SidebarAside>
   );
 }

--- a/frontend/src/metabase/dashboard/components/Sidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.tsx
@@ -1,16 +1,14 @@
-import PropTypes from "prop-types";
 import { t } from "ttag";
+import type { ReactNode } from "react";
 import Button from "metabase/core/components/Button";
 
-const WIDTH = 384;
-
-const propTypes = {
-  closeIsDisabled: PropTypes.bool,
-  children: PropTypes.node,
-  onClose: PropTypes.func,
-  onCancel: PropTypes.func,
-  "data-testid": PropTypes.string,
-};
+interface SidebarProps {
+  closeIsDisabled?: boolean;
+  children: ReactNode;
+  onClose?: () => void;
+  onCancel?: () => void;
+  "data-testid"?: string;
+}
 
 export function Sidebar({
   closeIsDisabled,
@@ -18,7 +16,8 @@ export function Sidebar({
   onClose,
   onCancel,
   "data-testid": dataTestId,
-}) {
+}: SidebarProps) {
+  const WIDTH = 384;
   return (
     <aside
       data-testid={dataTestId}
@@ -55,5 +54,3 @@ export function Sidebar({
     </aside>
   );
 }
-
-Sidebar.propTypes = propTypes;

--- a/frontend/src/metabase/dashboard/components/Sidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.tsx
@@ -1,12 +1,14 @@
 import { t } from "ttag";
 import type { ReactNode } from "react";
 import Button from "metabase/core/components/Button";
+import { RemoveButton } from "./Sidebar.styled";
 
 interface SidebarProps {
   closeIsDisabled?: boolean;
   children: ReactNode;
   onClose?: () => void;
   onCancel?: () => void;
+  onRemove?: () => void;
   "data-testid"?: string;
 }
 
@@ -15,6 +17,7 @@ export function Sidebar({
   children,
   onClose,
   onCancel,
+  onRemove,
   "data-testid": dataTestId,
 }: SidebarProps) {
   const WIDTH = 384;
@@ -27,7 +30,7 @@ export function Sidebar({
       <div className="flex flex-column flex-auto overflow-y-auto">
         {children}
       </div>
-      {(onClose || onCancel) && (
+      {(onClose || onCancel || onRemove) && (
         <div
           className="flex align-center border-top"
           style={{
@@ -35,8 +38,12 @@ export function Sidebar({
             paddingBottom: 12,
             paddingRight: 32,
             paddingLeft: 32,
+            gap: 20,
           }}
         >
+          {onRemove && (
+            <RemoveButton onClick={onRemove}>{t`Remove`}</RemoveButton>
+          )}
           {onCancel && (
             <Button small borderless onClick={onCancel}>{t`Cancel`}</Button>
           )}

--- a/frontend/src/metabase/dashboard/components/Sidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.tsx
@@ -1,10 +1,10 @@
 import { t } from "ttag";
 import type { ReactNode } from "react";
-import Button from "metabase/core/components/Button";
+import ButtonDeprecated from "metabase/core/components/Button";
+import { Button, Icon } from "metabase/ui";
 import {
   ButtonContainer,
   ChildrenContainer,
-  RemoveButton,
   SidebarAside,
 } from "./Sidebar.styled";
 
@@ -31,19 +31,30 @@ export function Sidebar({
       {(onClose || onCancel || onRemove) && (
         <ButtonContainer>
           {onRemove && (
-            <RemoveButton onClick={onRemove}>{t`Remove`}</RemoveButton>
+            <Button
+              leftIcon={<Icon name="trash" />}
+              variant="subtle"
+              color="error"
+              onClick={onRemove}
+              style={{ paddingLeft: 0, paddingRight: 0 }}
+              compact
+            >{t`Remove`}</Button>
           )}
           {onCancel && (
-            <Button small borderless onClick={onCancel}>{t`Cancel`}</Button>
+            <ButtonDeprecated
+              small
+              borderless
+              onClick={onCancel}
+            >{t`Cancel`}</ButtonDeprecated>
           )}
           {onClose && (
-            <Button
+            <ButtonDeprecated
               primary
               small
               className="ml-auto"
               onClick={onClose}
               disabled={closeIsDisabled}
-            >{t`Done`}</Button>
+            >{t`Done`}</ButtonDeprecated>
           )}
         </ButtonContainer>
       )}

--- a/frontend/src/metabase/dashboard/components/Sidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.tsx
@@ -38,6 +38,8 @@ export function Sidebar({
               onClick={onRemove}
               style={{ paddingLeft: 0, paddingRight: 0 }}
               compact
+              role="button"
+              aria-label={t`Remove`}
             >{t`Remove`}</Button>
           )}
           {onCancel && (

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import ParameterValueWidget from "../ParameterValueWidget";
 
 export const SettingsRoot = styled.div`
@@ -24,13 +23,4 @@ export const SettingValueWidget = styled(ParameterValueWidget)`
   border: 1px solid ${color("border")};
   border-radius: 0.5rem;
   background-color: ${color("white")};
-`;
-
-export const SettingRemoveButton = styled(IconButtonWrapper)`
-  color: ${color("text-medium")};
-  font-weight: bold;
-
-  &:hover {
-    color: ${color("error")};
-  }
 `;

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -149,5 +149,4 @@ function getLabelError({
   return null;
 }
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ParameterSettings;
+export { ParameterSettings };

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -14,7 +14,6 @@ import { isSingleOrMultiSelectable } from "../../utils/parameter-type";
 import ValuesSourceSettings from "../ValuesSourceSettings";
 import {
   SettingLabel,
-  SettingRemoveButton,
   SettingSection,
   SettingsRoot,
   SettingValueWidget,
@@ -34,7 +33,6 @@ export interface ParameterSettingsProps {
   onChangeQueryType: (queryType: ValuesQueryType) => void;
   onChangeSourceType: (sourceType: ValuesSourceType) => void;
   onChangeSourceConfig: (sourceConfig: ValuesSourceConfig) => void;
-  onRemoveParameter: () => void;
 }
 
 const ParameterSettings = ({
@@ -46,7 +44,6 @@ const ParameterSettings = ({
   onChangeQueryType,
   onChangeSourceType,
   onChangeSourceConfig,
-  onRemoveParameter,
 }: ParameterSettingsProps): JSX.Element => {
   const [tempLabelValue, setTempLabelValue] = useState(parameter.name);
 
@@ -123,9 +120,6 @@ const ParameterSettings = ({
           />
         </SettingSection>
       )}
-      <SettingRemoveButton onClick={onRemoveParameter}>
-        {t`Remove`}
-      </SettingRemoveButton>
     </SettingsRoot>
   );
 };

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -2,7 +2,7 @@ import userEvent from "@testing-library/user-event";
 import { renderWithProviders, screen } from "__support__/ui";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import { createMockUiParameter } from "metabase-lib/parameters/mock";
-import ParameterSettings from "../ParameterSettings";
+import { ParameterSettings } from "../ParameterSettings";
 
 interface SetupOpts {
   parameter?: UiParameter;

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -111,7 +111,6 @@ const setup = ({ parameter = createMockUiParameter() }: SetupOpts = {}) => {
       onChangeQueryType={onChangeQueryType}
       onChangeSourceType={jest.fn()}
       onChangeSourceConfig={jest.fn()}
-      onRemoveParameter={jest.fn()}
     />,
   );
 

--- a/frontend/src/metabase/parameters/components/ParameterSettings/index.ts
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./ParameterSettings";
+export { ParameterSettings } from "./ParameterSettings";

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -124,7 +124,7 @@ const ParameterSidebar = ({
   );
 
   return (
-    <Sidebar onClose={onClose}>
+    <Sidebar onClose={onClose} onRemove={handleRemove}>
       <SidebarHeader>
         <Radio
           value={tab}
@@ -144,7 +144,6 @@ const ParameterSidebar = ({
             onChangeQueryType={handleQueryTypeChange}
             onChangeSourceType={handleSourceTypeChange}
             onChangeSourceConfig={handleSourceConfigChange}
-            onRemoveParameter={handleRemove}
           />
         ) : (
           <ParameterLinkedFilters

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -11,7 +11,7 @@ import type {
 } from "metabase-types/api";
 import { slugify } from "metabase/lib/formatting";
 import { canUseLinkedFilters } from "../../utils/linked-filters";
-import ParameterSettings from "../ParameterSettings";
+import { ParameterSettings } from "../ParameterSettings";
 import ParameterLinkedFilters from "../ParameterLinkedFilters";
 import { SidebarBody, SidebarHeader } from "./ParameterSidebar.styled";
 
@@ -169,5 +169,4 @@ const getTabs = (parameter: Parameter) => {
   return tabs;
 };
 
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default ParameterSidebar;
+export { ParameterSidebar };

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -45,7 +45,7 @@ export interface ParameterSidebarProps {
   onClose: () => void;
 }
 
-const ParameterSidebar = ({
+export const ParameterSidebar = ({
   parameter,
   otherParameters,
   onChangeName,
@@ -167,5 +167,3 @@ const getTabs = (parameter: Parameter) => {
 
   return tabs;
 };
-
-export { ParameterSidebar };

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { renderWithProviders, screen } from "__support__/ui";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import { createMockUiParameter } from "metabase-lib/parameters/mock";
-import ParameterSidebar from "./ParameterSidebar";
+import { ParameterSidebar } from "./ParameterSidebar";
 
 interface SetupOpts {
   initialParameter: UiParameter;

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/index.ts
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./ParameterSidebar";
+export { ParameterSidebar } from "./ParameterSidebar";


### PR DESCRIPTION
Epic: https://github.com/metabase/metabase/issues/36524

## Description
This is one of the obvious steps in the 2nd milestone of the epic.
The remove button obviously doesn't belong to where it was so we're moving it to the bottom of the sidebar.

Since I've touched the Sidebar, I am also converting it to Typescript and updating styles.

### Before
<img width="1040" alt="Screenshot 2024-01-24 at 15 11 57" src="https://github.com/metabase/metabase/assets/2196347/ffadd609-d11d-4157-8ae8-49c58cad1ac0">


### After
<img width="1211" alt="Screenshot 2024-01-25 at 11 39 31" src="https://github.com/metabase/metabase/assets/2196347/e5d5adfe-89c0-4a97-9f5d-fe9036cb2a7d">
