### PR TITLE
Fix trailing whitespace

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -46,8 +46,7 @@ runs:
       if: ${{ always() }}
       uses: trunk-io/analytics-uploader@main
       with:
-        junit-paths: ${{ inputs.input-path }} 
-        org-slug: metabase 
+        junit-paths: ${{ inputs.input-path }}
+        org-slug: metabase
         token: ${{ secrets.TRUNK_API_TOKEN }}
       continue-on-error: true
-


### PR DESCRIPTION
We didn't run CI on https://github.com/metabase/metabase/pull/37490 because it's an external PR. Unfortunately, there was a whitespace error.

This PR fixes it and it makes `master` green again™.