### PR TITLE
Add more data_permissions test helper macros

### DIFF
--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -33,7 +33,7 @@
 ;;    fallback.
 
 
-(def ^:private Permissions
+(def Permissions
   "Permissions which apply to individual databases or tables"
   {:perms/data-access           {:model :model/Table :values [:unrestricted :no-self-service :block]}
    :perms/download-results      {:model :model/Table :values [:one-million-rows :ten-thousand-rows :no]}
@@ -55,13 +55,13 @@
 
 ;;; ------------------------------------------- Misc Utils ------------------------------------------------------------
 
-(defn- least-permissive-value
+(defn least-permissive-value
   "The *least* permissive value for a given perm type. This value is used as a fallback when a user does not have a
   value for the permission in the database."
   [perm-type]
   (-> Permissions perm-type :values last))
 
-(defn- most-permissive-value
+(defn most-permissive-value
   "The *most* permissive value for a given perm type. This is the default value for superusers."
   [perm-type]
   (-> Permissions perm-type :values first))

--- a/test/metabase/permissions/test_util.clj
+++ b/test/metabase/permissions/test_util.clj
@@ -87,8 +87,3 @@
   group for the duration of the test."
   [group-or-id perm-type value & body]
   `(do-with-perm-for-group! ~group-or-id ~perm-type ~value (fn [] ~@body)))
-
-(comment
-  (with-no-data-perms-for-all-users!
-    (with-perm-for-group! (perms-group/all-users) :perms/data-access :unrestricted
-     (data-perms/data-permissions-graph :db-id (:id (data/db)) :group-id (u/the-id (perms-group/all-users))))))

--- a/test/metabase/permissions/test_util.clj
+++ b/test/metabase/permissions/test_util.clj
@@ -1,26 +1,94 @@
 (ns metabase.permissions.test-util
   (:require
+   [metabase.models.data-permissions :as data-perms]
    [metabase.models.permissions :as perms]
-   [toucan2.core :as db]))
+   [metabase.models.permissions-group :as perms-group]
+   [metabase.test.data :as data]
+   [metabase.util :as u]
+   [toucan2.core :as t2]))
 
 (defn do-with-restored-perms!
   "Implementation of `with-restored-perms`."
   [thunk]
   ;; Select sandboxes _before_ permissions.
-  (let [original-perms     (db/select :model/Permissions)
-        original-sandboxes (db/select :model/GroupTableAccessPolicy)]
+  (let [original-perms     (t2/select :model/Permissions)
+        original-sandboxes (t2/select :model/GroupTableAccessPolicy)]
     (try
       (thunk)
       (finally
         (binding [perms/*allow-root-entries* true
                   perms/*allow-admin-permissions-changes* true]
-          (db/delete! :model/GroupTableAccessPolicy)
-          (db/delete! :model/Permissions)
+          (t2/delete! :model/GroupTableAccessPolicy)
+          (t2/delete! :model/Permissions)
           ;; Insert perms _before_ sandboxes because of a foreign key constraint on sandboxes.permission_id
-          (db/insert! :model/Permissions original-perms)
-          (db/insert! :model/GroupTableAccessPolicy original-sandboxes))))))
+          (t2/insert! :model/Permissions original-perms)
+          (t2/insert! :model/GroupTableAccessPolicy original-sandboxes))))))
 
 (defmacro with-restored-perms!
   "Runs `body`, and restores permissions and sandboxes to their original state afterwards."
   [& body]
   `(do-with-restored-perms! (fn [] ~@body)))
+
+(defn do-with-restored-data-perms!
+  "Implementation of `with-restored-perms` and related helper functions. Optionally takes `group-ids` to restore only the
+  permissions for a set of groups."
+  [group-ids thunk]
+  (let [select-condition [(when group-ids [:in :group_id group-ids])]
+        original-perms (t2/select :model/DataPermissions {:where select-condition})]
+    (try
+      (thunk)
+      (finally
+        (t2/delete! :model/DataPermissions {:where select-condition})
+        (t2/insert! :model/DataPermissions original-perms)))))
+
+(defmacro with-restored-data-perms!
+  "Runs `body`, and restores all permissions to their original state afterwards."
+  [& body]
+  `(do-with-restored-data-perms! nil (fn [] ~@body)))
+
+(defmacro with-restored-data-perms-for-group!
+  "Runs `body`, and restores all permissions for `group-id` to their original state afterwards."
+  [group-id & body]
+  `(do-with-restored-data-perms! [~group-id] (fn [] ~@body)))
+
+(defmacro with-restored-data-perms-for-groups!
+  "Runs `body`, and restores all permissions for `group-ids` to their original state afterwards."
+  [group-ids & body]
+  `(do-with-restored-data-perms! ~group-ids (fn [] ~@body)))
+
+(defn do-with-no-data-perms-for-all-users!
+  "Implementation of `with-no-data-perms-for-all-users`. Sets every data permission for the test dataset to its
+  least-permissive value for the All Users permission group for the duration of the test."
+  [thunk]
+  (with-restored-data-perms-for-group! (u/the-id (perms-group/all-users))
+    (doseq [[perm-type _] data-perms/Permissions]
+      (data-perms/set-database-permission! (perms-group/all-users)
+                                           (data/db)
+                                           perm-type
+                                           (data-perms/least-permissive-value perm-type)))
+    (thunk)))
+
+(defmacro with-no-data-perms-for-all-users!
+  "Runs `body`, and sets every data permission for the test dataset to its least-permissive value for the All Users
+  permission group for the duration of the test."
+  [& body]
+  `(do-with-no-data-perms-for-all-users! (fn [] ~@body)))
+
+(defn do-with-perm-for-group!
+  "Implementation of `with-perm-for-group`. Sets the data permission for the the test dataset to the given value
+  for the given permission group for the duration of the test."
+  [group-or-id perm-type value thunk]
+  (with-restored-data-perms-for-group! (u/the-id (perms-group/all-users))
+   (data-perms/set-database-permission! group-or-id (data/db) perm-type value)
+   (thunk)))
+
+(defmacro with-perm-for-group!
+  "Runs `body`, and sets the data permission for the the test dataset to the given value for the given permission
+  group for the duration of the test."
+  [group-or-id perm-type value & body]
+  `(do-with-perm-for-group! ~group-or-id ~perm-type ~value (fn [] ~@body)))
+
+(comment
+  (with-no-data-perms-for-all-users!
+    (with-perm-for-group! (perms-group/all-users) :perms/data-access :unrestricted
+     (data-perms/data-permissions-graph :db-id (:id (data/db)) :group-id (u/the-id (perms-group/all-users))))))

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -18,6 +18,7 @@
    [metabase.email-test :as et]
    [metabase.http-client :as client]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
+   [metabase.permissions.test-util :as perms.test-util]
    [metabase.query-processor :as qp]
    [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.test-util :as qp.test-util]
@@ -70,6 +71,7 @@
   mb.hawk.parallel/keep-me
   test.redefs/keep-me
   mw.session/keep-me
+  perms.test-util/keep-me
   qp.store/keep-me
   qp.test-util/keep-me
   qp/keep-me
@@ -88,7 +90,8 @@
   u.random/keep-me
   tu/keep-me
   tx.env/keep-me
-  tx/keep-me)
+  tx/keep-me
+  schema-migrations-test.impl/keep-me)
 
 ;; Add more stuff here as needed
 #_{:clj-kondo/ignore [:discouraged-var :deprecated-var]}
@@ -159,6 +162,13 @@
 
  [mw.session
   with-current-user]
+
+ [perms.test-util
+  with-restored-data-perms!
+  with-restored-data-perms-for-group!
+  with-restored-data-perms-for-groups!
+  with-no-data-perms-for-all-users!
+  with-perm-for-group!]
 
  [qp
   compile
@@ -304,6 +314,7 @@
  [tx.env
   set-test-drivers!
   with-test-drivers]
+
  [schema-migrations-test.impl
   with-temp-empty-app-db])
 


### PR DESCRIPTION
* Moves a number of existing helpers from `metabase.models.data-permissions-test` to `metabase.permissions.test-util`
* Adds `with-no-data-perms-for-all-users!`
* Adds `with-perm-for-group!`