### PR TITLE
Revert Trunk upload

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -46,7 +46,8 @@ runs:
       if: ${{ always() }}
       uses: trunk-io/analytics-uploader@main
       with:
-        junit-paths: ${{ inputs.input-path }}
-        org-slug: metabase
+        junit-paths: ${{ inputs.input-path }} 
+        org-slug: metabase 
         token: ${{ secrets.TRUNK_API_TOKEN }}
       continue-on-error: true
+

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -41,13 +41,3 @@ runs:
       run: | # sh
         DATE=$(date '+%Y-%m-%d')
         aws s3 cp ${OUTPUT_FILE}.zip s3://$BUCKET/$DATE/$GITHUB_RUN_ID/$GITHUB_RUN_ATTEMPT/
-
-    - name: Upload results to Trunk
-      if: ${{ always() }}
-      uses: trunk-io/analytics-uploader@main
-      with:
-        junit-paths: ${{ inputs.input-path }} 
-        org-slug: metabase 
-        token: ${{ secrets.TRUNK_API_TOKEN }}
-      continue-on-error: true
-


### PR DESCRIPTION
This PR reverts both #38057 and #37490 due to this error: https://github.com/metabase/metabase/actions/runs/7631877472/job/20790845134#step:7:1

```
Error: /home/runner/work/metabase/metabase/./.github/actions/upload-test-results/action.yml (Line: 51, Col: 16): 
Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.TRUNK_API_TOKEN
```