### PR TITLE
Handle multiple date filters for the same template tag

### DIFF
--- a/src/metabase/driver/common/parameters/values.clj
+++ b/src/metabase/driver/common/parameters/values.clj
@@ -133,9 +133,9 @@
                                          (nil? (:value param)))
                                        matching-params))]
     (cond
-      ;; if we have matching parameter(s) that all have actual values, return those.
-      (and (seq matching-params) (every? :value matching-params))
-      (normalize-params matching-params)
+      ;; if we have matching parameter(s) with at least one actual value, return them.
+      (and (seq matching-params) (some :value matching-params))
+      (normalize-params (filter :value matching-params))
       ;; If a FieldFilter has value=nil, return a [[params/no-value]]
       ;; so that this filter can be substituted with "1 = 1" regardless of whether or not this tag has default value
       (and (not (:required tag)) nil-value?)

--- a/src/metabase/lib/schema/template_tag.cljc
+++ b/src/metabase/lib/schema/template_tag.cljc
@@ -56,7 +56,7 @@
     ;; are allowed to be specified for it.
     [:widget-type [:ref ::widget-type]]
     ;; optional map to be appended to filter clause
-    [:options {:optional true} :map]]])
+    [:options {:optional true} [:maybe :map]]]])
 
 ;; Example:
 ;;

--- a/src/metabase/mbql/schema.cljc
+++ b/src/metabase/mbql/schema.cljc
@@ -1174,7 +1174,7 @@
     ;; are allowed to be specified for it.
     [:widget-type WidgetType]
     ;; optional map to be appended to filter clause
-    [:options {:optional true} [:map-of :keyword :any]]]])
+    [:options {:optional true} [:maybe [:map-of :keyword :any]]]]])
 
 (def raw-value-template-tag-types
   "Set of valid values of `:type` for raw value template tags."

--- a/test/metabase/driver/common/parameters/values_test.clj
+++ b/test/metabase/driver/common/parameters/values_test.clj
@@ -8,6 +8,7 @@
    [metabase.driver.common.parameters.values :as params.values]
    [metabase.driver.ddl.interface :as ddl.i]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
+   [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -760,3 +761,77 @@
               (is (=? {param-name ReferencedCardQuery}
                       (query->params-map {:template-tags template-tags
                                           :parameters    parameters}))))))))))
+
+(deftest ^:parallel handle-dashboard-parameters-without-values-test
+  (testing "dash params for a template tag may have no :value or :default (#38012)"
+    (mt/dataset test-data
+      (qp.store/with-metadata-provider (lib.tu/metadata-provider-with-cards-for-queries
+                                        meta/metadata-provider
+                                        [(lib.tu.macros/mbql-query orders)
+                                         (lib/with-template-tags
+                                           (lib/native-query meta/metadata-provider
+                                                             "SELECT * FROM Orders WHERE {{createdAt}}")
+                                           {"createdAt"
+                                            {:type         :dimension
+                                             :dimension    #_[:field (meta/id :orders :created-at)]
+                                             (lib/ref (meta/field-metadata :orders :created-at))
+                                             :name         "createdAt"
+                                             :id           "4636d745-1467-4a70-ba20-2a08069d77ff"
+                                             :display-name "CreatedAt"
+                                             :widget-type  :date/all-options}})])
+        (let [template-tags {"createdAt" {:type         :dimension
+                                          :dimension    [:field (meta/id :orders :created-at) {}]
+                                          :name         "createdAt"
+                                          :id           "4636d745-1467-4a70-ba20-2a08069d77ff"
+                                          :display-name "CreatedAt"
+                                          :widget-type  :date/all-options}}]
+
+          (testing "with no parameters given, no value"
+            (is (=? {"createdAt" {:field {:lib/type :metadata/column}
+                                  :value params/no-value}}
+                    (query->params-map {:template-tags template-tags}))))
+          (testing "with parameters given but blank, no value"
+            (is (=? {"createdAt" {:field {:lib/type :metadata/column}
+                                  :value params/no-value}}
+                    (query->params-map {:template-tags template-tags
+                                        :parameters    [{:type   :date/relative
+                                                         :value  nil
+                                                         :target [:dimension [:template-tag "createdAt"]]}
+                                                        {:type   :date/month-year
+                                                         :value  nil
+                                                         :target [:dimension [:template-tag "createdAt"]]}]}))))
+          (testing "with only the relative date parameter set, use it"
+            (is (=? {"createdAt" {:field {:lib/type :metadata/column}
+                                  :value {:type  :date/relative
+                                          :value "past30days"}}}
+                    (query->params-map {:template-tags template-tags
+                                        :parameters    [{:type   :date/relative
+                                                         :value  "past30days"
+                                                         :target [:dimension [:template-tag "createdAt"]]}
+                                                        {:type   :date/month-year
+                                                         :value  nil
+                                                         :target [:dimension [:template-tag "createdAt"]]}]}))))
+          (testing "with only the month-year parameter set, use it"
+            (is (=? {"createdAt" {:field {:lib/type :metadata/column}
+                                  :value {:type  :date/month-year
+                                          :value "2023-01"}}}
+                    (query->params-map {:template-tags template-tags
+                                        :parameters    [{:type   :date/relative
+                                                         :value  nil
+                                                         :target [:dimension [:template-tag "createdAt"]]}
+                                                        {:type   :date/month-year
+                                                         :value  "2023-01"
+                                                         :target [:dimension [:template-tag "createdAt"]]}]}))))
+          (testing "with both parameters set, use both"
+            (is (=? {"createdAt" {:field {:lib/type :metadata/column}
+                                  :value [{:type  :date/relative
+                                           :value "past30days"}
+                                          {:type  :date/month-year
+                                           :value "2023-01"}]}}
+                    (query->params-map {:template-tags template-tags
+                                        :parameters    [{:type   :date/relative
+                                                         :value  "past30days"
+                                                         :target [:dimension [:template-tag "createdAt"]]}
+                                                        {:type   :date/month-year
+                                                         :value  "2023-01"
+                                                         :target [:dimension [:template-tag "createdAt"]]}]})))))))))


### PR DESCRIPTION
This regressed in 48 - it only works when either none of the
several filters has a value, or when all of them do.

This PR restores the 47 behavior: whatever subset of the filters have
values (including defaults) will be used, and the others are ignored.

The fix is on the BE but the change actually occurred in the FE -
previously only those parameters with values were sent in the request.
We might want that FE behavior back, but the new BE logic should work
either way.

Fixes #38012.
