### PR TITLE
Upgrade `jsrsasign` to `v11.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "inflection": "^1.7.1",
     "js-cookie": "^2.1.2",
     "jspdf": "^2.5.1",
-    "jsrsasign": "^10.5.25",
+    "jsrsasign": "^11.0.0",
     "leaflet": "^1.2.0",
     "leaflet-draw": "^0.4.9",
     "leaflet.heat": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14306,10 +14306,10 @@ jsprim@^2.0.2:
     json-schema "0.4.0"
     verror "1.10.0"
 
-jsrsasign@^10.5.25:
-  version "10.5.25"
-  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-10.5.25.tgz#8eb3f943718d73f2dd3d85f587f241a5316b835a"
-  integrity sha512-N7zxHaCwYvFlXsybq4p4RxRwn4AbEq3cEiyjbCrWmwA7g8aS4LTKDJ9AJmsXxwtYesYx0imJ+ITtkyyxLCgeIg==
+jsrsasign@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/jsrsasign/-/jsrsasign-11.0.0.tgz#766570c21f87d68075a142f5188f7e583cee9d70"
+  integrity sha512-BtRwVKS+5dsgPpAtzJcpo5OoWjSs1/zllSBG0+8o8/aV0Ki76m6iZwHnwnsqoTdhfFZDN1XIdcaZr5ZkP+H2gg==
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0":
   version "3.2.0"


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase/security/dependabot/130
