### PR TITLE
Remove the newline icon from the parameter value widget

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -101,13 +101,7 @@ class ParameterValueWidget extends Component {
       );
     }
 
-    const noPopover = hasNoPopover(this.props.parameter);
-
-    if (noPopover && this.state.isFocused) {
-      return <WidgetStatusIcon name="enter_or_return" />;
-    }
-
-    if (!noPopover) {
+    if (!hasNoPopover(this.props.parameter)) {
       return <WidgetStatusIcon name="chevrondown" />;
     }
 

--- a/frontend/src/metabase/parameters/components/WidgetStatusIcon.tsx
+++ b/frontend/src/metabase/parameters/components/WidgetStatusIcon.tsx
@@ -2,7 +2,7 @@ import cx from "classnames";
 import { Icon } from "metabase/ui";
 
 type Props = {
-  name: "close" | "enter_or_return" | "empty" | "chevrondown";
+  name: "close" | "empty" | "chevrondown";
   onClick?: () => void;
 };
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/38084
The context and slack discussion link are there.

## What changes

### Before
<img width="1029" alt="Screenshot 2024-01-24 at 11 36 49" src="https://github.com/metabase/metabase/assets/2196347/ce85f920-dae9-4cb1-83ab-1f030e967768">

We did show the "newline" icon, which was meant to show the input is in focus — but it's a weak justification for adding visual noise.

### After
<img width="1017" alt="Screenshot 2024-01-24 at 11 36 03" src="https://github.com/metabase/metabase/assets/2196347/78e6de4d-e926-4b36-a8f6-2a2d49af5941">

We don't show the "newline" icon in an empty parameter value text input anymore