### PR TITLE
Run selected text loses parameters

### DIFF
--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -7,7 +7,7 @@ describe("issue 16584", () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
-  it("should pass parameters when running with 'Run select text' (metabase#16584)", async () => {
+  it("should pass parameters when running with 'Run select text' (metabase#16584)", () => {
     const editor = openNativeEditor();
 
     editor.type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country ");

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -1,0 +1,24 @@
+import { restore, openNativeEditor } from "e2e/support/helpers";
+
+describe("issue 16584", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("POST", "/api/dataset").as("run");
+  });
+
+  it("should pass parameters when running with 'Run select text' (metabase#16584)", async () => {
+    const editor = openNativeEditor();
+
+    editor.type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country ");
+    editor.type("{selectAll}");
+
+    cy.get("input[placeholder='Country']").type("NL");
+
+    cy.get("button[aria-label='Get Answer']").first().click();
+    cy.wait("@run").then(({ request }) => {
+      const { body } = request;
+      expect(body.parameters[0].value).to.equal("NL");
+    });
+  });
+});

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -4,7 +4,7 @@ describe("issue 16584", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.intercept("POST", "/api/dataset").as("run");
+    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should pass parameters when running with 'Run select text' (metabase#16584)", async () => {
@@ -16,7 +16,7 @@ describe("issue 16584", () => {
     cy.get("input[placeholder='Country']").type("NL");
 
     cy.get("button[aria-label='Get Answer']").first().click();
-    cy.wait("@run").then(({ request }) => {
+    cy.wait("@dataset").then(({ request }) => {
       const { body } = request;
       expect(body.parameters[0].value).to.equal("NL");
     });

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -8,8 +8,12 @@ describe("issue 16584", () => {
   });
 
   it("should pass parameters when running with 'Run select text' (metabase#16584)", () => {
+    // The bug described in is #16584 can be further simplified:
+    // - the issue persists even when selecting the *entire* query
+    // - the issue is unrelated to using a date filter, using a text filter works too
+    // - the issue is unrelated to whether or not the parameter is required or if default value is set
     openNativeEditor()
-      .type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country }}", {
+      .type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country }} ", {
         parseSpecialCharSequences: false,
         delay: 0,
       })

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -13,7 +13,7 @@ describe("issue 16584", () => {
     // - the issue is unrelated to using a date filter, using a text filter works too
     // - the issue is unrelated to whether or not the parameter is required or if default value is set
     openNativeEditor()
-      .type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country }} ", {
+      .type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country }} LIMIT 10", {
         parseSpecialCharSequences: false,
         delay: 0,
       })

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -26,8 +26,6 @@ describe("issue 16584", () => {
 
     runNativeQuery();
 
-    cy.get(".Visualization").within(() => {
-      cy.findByText("NL").should("exist");
-    });
+    cy.get(".Visualization").findByText("NL").should("exist");
   });
 });

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -11,6 +11,7 @@ describe("issue 16584", () => {
     // - the issue persists even when selecting the *entire* query
     // - the issue is unrelated to using a date filter, using a text filter works too
     // - the issue is unrelated to whether or not the parameter is required or if default value is set
+    // - the space at the end of the query is not needed to reproduce this issue
     openNativeEditor()
       .type(
         "SELECT COUNTRY FROM ACCOUNTS WHERE COUNTRY = {{ country }} LIMIT 1",

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -9,7 +9,9 @@ describe("issue 16584", () => {
 
   it("should pass parameters when running with 'Run select text' (metabase#16584)", () => {
     openNativeEditor()
-      .type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country ")
+      .type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country }}", {
+        parseSpecialCharSequences: false,
+      })
       .type("{selectAll}");
 
     cy.findByPlaceholderText("Country").type("NL");

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -4,7 +4,6 @@ describe("issue 16584", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();
-    cy.intercept("POST", "/api/dataset").as("dataset");
   });
 
   it("should pass parameters when running with 'Run select text' (metabase#16584)", () => {
@@ -13,19 +12,21 @@ describe("issue 16584", () => {
     // - the issue is unrelated to using a date filter, using a text filter works too
     // - the issue is unrelated to whether or not the parameter is required or if default value is set
     openNativeEditor()
-      .type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country }} LIMIT 10", {
-        parseSpecialCharSequences: false,
-        delay: 0,
-      })
+      .type(
+        "SELECT COUNTRY FROM ACCOUNTS WHERE COUNTRY = {{ country }} LIMIT 1",
+        {
+          parseSpecialCharSequences: false,
+          delay: 0,
+        },
+      )
       .type("{selectAll}");
 
     cy.findByPlaceholderText("Country").type("NL", { delay: 0 });
 
     runNativeQuery();
 
-    cy.wait("@dataset").then(({ request }) => {
-      const { body } = request;
-      expect(body.parameters[0].value).to.equal("NL");
+    cy.get(".Visualization").within(() => {
+      cy.findByText("NL").should("exist");
     });
   });
 });

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -8,10 +8,9 @@ describe("issue 16584", () => {
   });
 
   it("should pass parameters when running with 'Run select text' (metabase#16584)", () => {
-    const editor = openNativeEditor();
-
-    editor.type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country ");
-    editor.type("{selectAll}");
+    openNativeEditor()
+      .type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country ")
+      .type("{selectAll}");
 
     cy.findByPlaceholderText("Country").type("NL");
 

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -11,10 +11,11 @@ describe("issue 16584", () => {
     openNativeEditor()
       .type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country }}", {
         parseSpecialCharSequences: false,
+        delay: 0,
       })
       .type("{selectAll}");
 
-    cy.findByPlaceholderText("Country").type("NL");
+    cy.findByPlaceholderText("Country").type("NL", { delay: 0 });
 
     runNativeQuery();
 

--- a/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
+++ b/e2e/test/scenarios/native/reproductions/16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts
@@ -1,4 +1,4 @@
-import { restore, openNativeEditor } from "e2e/support/helpers";
+import { restore, openNativeEditor, runNativeQuery } from "e2e/support/helpers";
 
 describe("issue 16584", () => {
   beforeEach(() => {
@@ -13,9 +13,10 @@ describe("issue 16584", () => {
     editor.type("SELECT * FROM ACCOUNTS WHERE COUNTRY = {{ country ");
     editor.type("{selectAll}");
 
-    cy.get("input[placeholder='Country']").type("NL");
+    cy.findByPlaceholderText("Country").type("NL");
 
-    cy.get("button[aria-label='Get Answer']").first().click();
+    runNativeQuery();
+
     cy.wait("@dataset").then(({ request }) => {
       const { body } = request;
       expect(body.parameters[0].value).to.equal("NL");

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -20,6 +20,7 @@ import { ModelIndexes } from "metabase/entities/model-indexes";
 import { fetchAlertsForQuestion } from "metabase/alert/alert";
 import Revision from "metabase/entities/revisions";
 import * as Lib from "metabase-lib";
+import { getMetadata } from "metabase/selectors/metadata";
 import {
   cardIsEquivalent,
   cardQueryIsEquivalent,
@@ -74,12 +75,17 @@ export const reloadCard = createThunkAction(RELOAD_CARD, () => {
       Questions.actions.fetch({ id: outdatedQuestion.id() }, { reload: true }),
     );
     const card = Questions.HACK_getObjectFromAction(action);
+    const question = new Question(
+      card,
+      getMetadata(getState()),
+      outdatedQuestion.parameters(),
+    );
 
     dispatch(loadMetadataForCard(card));
 
     dispatch(
       runQuestionQuery({
-        overrideWithCard: card,
+        overrideWithQuestion: question,
         shouldUpdateUrl: false,
       }),
     );

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -8,12 +8,9 @@ import { defer } from "metabase/lib/promise";
 import { createThunkAction } from "metabase/lib/redux";
 import { runQuestionQuery as apiRunQuestionQuery } from "metabase/services";
 
-import { getMetadata } from "metabase/selectors/metadata";
 import { getSensibleDisplays } from "metabase/visualizations";
 import { getWhiteLabeledLoadingMessage } from "metabase/selectors/whitelabel";
 import { isSameField } from "metabase-lib/queries/utils/field-ref";
-
-import Question from "metabase-lib/Question";
 
 import { isAdHocModelQuestion } from "metabase-lib/metadata/utils/models";
 import {
@@ -90,22 +87,20 @@ export const runDirtyQuestionQuery = () => async (dispatch, getState) => {
 };
 
 /**
- * Queries the result for the currently active question or alternatively for the card provided in `overrideWithCard`.
+ * Queries the result for the currently active question or alternatively for the card question provided in `overrideWithQuestion`.
  * The API queries triggered by this action creator can be cancelled using the deferred provided in RUN_QUERY action.
  */
 export const RUN_QUERY = "metabase/qb/RUN_QUERY";
 export const runQuestionQuery = ({
   shouldUpdateUrl = true,
   ignoreCache = false,
-  overrideWithCard = null,
+  overrideWithQuestion = null,
 } = {}) => {
   return async (dispatch, getState) => {
     dispatch(loadStartUIControls());
-    const questionFromCard = card =>
-      card && new Question(card, getMetadata(getState()));
 
-    const question = overrideWithCard
-      ? questionFromCard(overrideWithCard)
+    const question = overrideWithQuestion
+      ? overrideWithQuestion
       : getQuestion(getState());
     const originalQuestion = getOriginalQuestion(getState());
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -122,7 +122,7 @@ type OwnProps = typeof NativeQueryEditor.defaultProps & {
   cardAutocompleteResultsFn: (prefix: string) => Promise<CardCompletionItem[]>;
   setDatasetQuery: (query: NativeQuery) => Promise<Question>;
   runQuestionQuery: (opts?: {
-    overrideWithCard?: Card;
+    overrideWithQuestion?: Question;
     shouldUpdateUrl?: boolean;
   }) => void;
   setNativeEditorSelectedRange: (range: Ace.Range) => void;
@@ -382,10 +382,10 @@ export class NativeQueryEditor extends Component<
     const selectedText = this._editor?.getSelectedText();
 
     if (selectedText) {
-      const temporaryCard = query.setQueryText(selectedText).question().card();
+      const temporaryQuestion = query.setQueryText(selectedText).question();
 
       runQuestionQuery({
-        overrideWithCard: temporaryCard,
+        overrideWithQuestion: temporaryQuestion,
         shouldUpdateUrl: false,
       });
     } else if (query.canRun()) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/16584

### Description

The parameter values for a question aren't properly passed through to the card when going though the question → card → question loop. This PR changes the `overrideWithCard` parameter in `runQuestionQuery` with an `overrideWithQuestion` parameter, so we don't have to make that lossy loop. It also changes the one other call location where that parameter is used to make use of questions there.

I would like some feedback on whether or not the approach of moving to questions vs staying in card-land is the right one.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. `+ New` → `SQL Query` → `Sample Database`
2. Type 
   ```sql
   SELECT * FROM "ACCOUNTS" WHERE  COUNTRY = {{country}} AND ID = 71;
   ```
3. Add the value `NL` for the country variable
4. Run the query en validate that you are getting results (one row).
5. Now select the following text in the query editor
   ```sql
   SELECT * FROM "ACCOUNTS" WHERE  COUNTRY = {{country}}
   ```
6. Run the selected text and verify there is no error and you are seeing more than one row.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
