### PR TITLE
Field values cache needs to check permissions

### DIFF
--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -74,6 +74,7 @@
    [metabase.models :refer [Field FieldValues Table]]
    [metabase.models.field :as field]
    [metabase.models.field-values :as field-values]
+   [metabase.models.interface :as mi]
    [metabase.models.params :as params]
    [metabase.models.params.chain-filter.dedupe-joins :as dedupe]
    [metabase.models.params.field-values :as params.field-values]
@@ -515,6 +516,7 @@
   [field-id]
   (and
     field-id
+    (mi/can-read? Field field-id)
     (field-values/field-should-have-field-values? field-id)))
 
 (defn- cached-field-values [field-id constraints {:keys [limit]}]

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -518,13 +518,12 @@
     field-id
     (field-values/field-should-have-field-values? field-id)))
 
-(defn- check-field-value-query-permissions!
+(defn- check-field-value-query-permissions
   "Check query permissions against the chain-filter-mbql-query (private #196)"
   [field-id constraints options]
   (->> (chain-filter-mbql-query field-id constraints options)
-         qp/preprocess
-         qp.perms/check-query-permissions*)
-  true)
+       qp/preprocess
+       qp.perms/check-query-permissions*))
 
 (defn- cached-field-values [field-id constraints {:keys [limit]}]
   ;; TODO: why don't we remap the human readable values here?
@@ -569,10 +568,10 @@
      (-> (unremapped-chain-filter field-id constraints options)
          (update :values add-human-readable-values v->human-readable))
 
-     (and (use-cached-field-values? field-id)
-          (nil? @the-remapped-field-id)
-          (check-field-value-query-permissions! field-id constraints options))
-     (cached-field-values field-id constraints options)
+     (and (use-cached-field-values? field-id) (nil? @the-remapped-field-id))
+     (do
+       (check-field-value-query-permissions field-id constraints options)
+       (cached-field-values field-id constraints options))
 
      ;; This is Field->Field remapping e.g. `venue.category_id `-> `category.name `;
      ;; search by `category.name` but return tuples of `[venue.category_id category.name]`.

--- a/src/metabase/models/params/chain_filter.clj
+++ b/src/metabase/models/params/chain_filter.clj
@@ -522,8 +522,9 @@
   "Check query permissions against the chain-filter-mbql-query (private #196)"
   [field-id constraints options]
   (->> (chain-filter-mbql-query field-id constraints options)
-       qp/preprocess
-       qp.perms/check-query-permissions*))
+         qp/preprocess
+         qp.perms/check-query-permissions*)
+  true)
 
 (defn- cached-field-values [field-id constraints {:keys [limit]}]
   ;; TODO: why don't we remap the human readable values here?

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -11,22 +11,23 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
+(defn current-user-can-fetch-field-values?
+  "Whether the current User has permissions to fetch FieldValues for a `field`."
+  [field]
+  ;; read permissions for a Field = partial permissions for its parent Table (including EE segmented permissions)
+  (mi/can-read? field))
+
 (defn default-get-or-create-field-values-for-current-user!
   "OSS implementation; used as a fallback for the EE implementation if the field isn't sandboxed."
   [field]
-  (field-values/get-or-create-full-field-values! field))
+  (when (mi/can-read? field)
+    (field-values/get-or-create-full-field-values! field)))
 
 (defenterprise get-or-create-field-values-for-current-user!*
   "Fetch cached FieldValues for a `field`, creating them if needed if the Field should have FieldValues."
   metabase-enterprise.sandbox.models.params.field-values
   [field]
   (default-get-or-create-field-values-for-current-user! field))
-
-(defn current-user-can-fetch-field-values?
-  "Whether the current User has permissions to fetch FieldValues for a `field`."
-  [field]
-  ;; read permissions for a Field = partial permissions for its parent Table (including EE segmented permissions)
-  (mi/can-read? field))
 
 (defn- postprocess-field-values
   "Format a FieldValues to use by params functions.

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -11,23 +11,22 @@
    [metabase.util :as u]
    [toucan2.core :as t2]))
 
-(defn current-user-can-fetch-field-values?
-  "Whether the current User has permissions to fetch FieldValues for a `field`."
-  [field]
-  ;; read permissions for a Field = partial permissions for its parent Table (including EE segmented permissions)
-  (mi/can-read? field))
-
 (defn default-get-or-create-field-values-for-current-user!
   "OSS implementation; used as a fallback for the EE implementation if the field isn't sandboxed."
   [field]
-  (when (mi/can-read? field)
-    (field-values/get-or-create-full-field-values! field)))
+  (field-values/get-or-create-full-field-values! field))
 
 (defenterprise get-or-create-field-values-for-current-user!*
   "Fetch cached FieldValues for a `field`, creating them if needed if the Field should have FieldValues."
   metabase-enterprise.sandbox.models.params.field-values
   [field]
   (default-get-or-create-field-values-for-current-user! field))
+
+(defn current-user-can-fetch-field-values?
+  "Whether the current User has permissions to fetch FieldValues for a `field`."
+  [field]
+  ;; read permissions for a Field = partial permissions for its parent Table (including EE segmented permissions)
+  (mi/can-read? field))
 
 (defn- postprocess-field-values
   "Format a FieldValues to use by params functions.

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -106,7 +106,7 @@
   (throw (ex-info (tru "Querying this database requires the audit-app feature flag")
                   query)))
 
-(mu/defn ^:private check-query-permissions*
+(mu/defn check-query-permissions*
   "Check that User with `user-id` has permissions to run `query`, or throw an exception."
   [{database-id :database, :as outer-query} :- [:map [:database ::lib.schema.id/database]]]
   (when *current-user-id*

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4051,18 +4051,19 @@
 
 (deftest param-values-permissions-test
   (testing "Users without permissions should not see all options in a dashboard filter (#196)"
-    (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
-      (testing "Return values if permitted"
-        (is (=? {:values (comp #(contains? % ["African"]) set)}
-                (mt/user-http-request :rasta :get 200
-                                      (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))
-      (testing "Don't return `param_values` for Fields for which the current User has no data perms."
-        (perms/update-data-perms-graph! [(:id (perms-group/all-users)) (mt/id) :data]
-                                        {:schemas :block})
-        (is (= "You don't have permissions to do that."
-               (mt/user-http-request :rasta :get 403
-                                     (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))
-      (testing "Return values for admin"
-        (is (=? {:values (comp #(contains? % ["African"]) set)}
-                (mt/user-http-request :crowberto :get 200
-                                      (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values"))))))))
+    (mt/with-temp-copy-of-db
+      (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
+        (testing "Return values if permitted"
+          (is (=? {:values (comp #(contains? % ["African"]) set)}
+                  (mt/user-http-request :rasta :get 200
+                                        (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))
+        (testing "Don't return `param_values` for Fields for which the current User has no data perms."
+          (perms/update-data-perms-graph! [(:id (perms-group/all-users)) (mt/id) :data]
+                                          {:schemas :block})
+          (is (= "You don't have permissions to do that."
+                 (mt/user-http-request :rasta :get 403
+                                       (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))
+        (testing "Return values for admin"
+          (is (=? {:values (comp #(contains? % ["African"]) set)}
+                  (mt/user-http-request :crowberto :get 200
+                                        (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -2832,15 +2832,16 @@
                       (chain-filter-test/take-n-values 3)))))))
 
     (testing "block data perms should not allow access to field values"
-      (mt/with-premium-features #{:advanced-permissions}
-        (mt/with-temp-copy-of-db
-          (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
-            (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
-            (perms/update-data-perms-graph! [(:id (perms-group/all-users)) (mt/id) :data]
-                                            {:schemas :block})
-            (is (= "You don't have permissions to do that."
-                   (->> (chain-filter-values-url (:id dashboard) (:category-name param-keys))
-                        (mt/user-http-request :rasta :get 403))))))))))
+      (when config/ee-available?
+        (mt/with-premium-features #{:advanced-permissions}
+          (mt/with-temp-copy-of-db
+            (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
+              (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
+              (perms/update-data-perms-graph! [(:id (perms-group/all-users)) (mt/id) :data]
+                                              {:schemas :block})
+              (is (= "You don't have permissions to do that."
+                     (->> (chain-filter-values-url (:id dashboard) (:category-name param-keys))
+                          (mt/user-http-request :rasta :get 403)))))))))))
 
 (deftest dashboard-with-static-list-parameters-test
   (testing "A dashboard that has parameters that has static values"
@@ -4062,27 +4063,28 @@
 
 (deftest param-values-permissions-test
   (testing "Users without permissions should not see all options in a dashboard filter (#196)"
-    (mt/with-premium-features #{:advanced-permissions}
-      (mt/with-temp-copy-of-db
-        (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
-          (testing "Return values with access"
-            (is (=? {:values (comp #(contains? % ["African"]) set)}
-                    (mt/user-http-request :rasta :get 200
-                                          (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))
-          (testing "Return values with self-service (#26874)"
-            (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
-            (is (=? {:values (comp #(contains? % ["African"]) set)}
-                    (mt/user-http-request :rasta :get 200
-                                          (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))
-          (testing "Return values for admin"
-            (perms/update-data-perms-graph! [(:id (perms-group/all-users)) (mt/id) :data]
-                                            {:schemas :block})
-            (is (=? {:values (comp #(contains? % ["African"]) set)}
-                    (mt/user-http-request :crowberto :get 200
-                                          (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))
-          (testing "Don't return with block perms."
-            (perms/update-data-perms-graph! [(:id (perms-group/all-users)) (mt/id) :data]
-                                            {:schemas :block})
-            (is (= "You don't have permissions to do that."
-                   (mt/user-http-request :rasta :get 403
-                                         (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values"))))))))))
+    (when config/ee-available?
+      (mt/with-premium-features #{:advanced-permissions}
+        (mt/with-temp-copy-of-db
+          (with-chain-filter-fixtures [{:keys [dashboard param-keys]}]
+            (testing "Return values with access"
+              (is (=? {:values (comp #(contains? % ["African"]) set)}
+                      (mt/user-http-request :rasta :get 200
+                                            (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))
+            (testing "Return values with self-service (#26874)"
+              (perms/revoke-data-perms! (perms-group/all-users) (mt/id))
+              (is (=? {:values (comp #(contains? % ["African"]) set)}
+                      (mt/user-http-request :rasta :get 200
+                                            (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))
+            (testing "Return values for admin"
+              (perms/update-data-perms-graph! [(:id (perms-group/all-users)) (mt/id) :data]
+                                              {:schemas :block})
+              (is (=? {:values (comp #(contains? % ["African"]) set)}
+                      (mt/user-http-request :crowberto :get 200
+                                            (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))
+            (testing "Don't return with block perms."
+              (perms/update-data-perms-graph! [(:id (perms-group/all-users)) (mt/id) :data]
+                                              {:schemas :block})
+              (is (= "You don't have permissions to do that."
+                     (mt/user-http-request :rasta :get 403
+                                           (str "dashboard/" (:id dashboard) "/params/" (:category-name param-keys) "/values")))))))))))


### PR DESCRIPTION
If a user does not have permissions to field values, we should not return the cached field values.

Rely on the query processor permissions code, to check the query that would be run if the cache was not available. This considers gtap and block perms.