### PR TITLE
format native queries

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -27,12 +27,13 @@ export function openNativeEditor({
   databaseName,
   alias = "editor",
   fromCurrentPage,
+  newMenuItemTitle = "SQL query",
 } = {}) {
   if (!fromCurrentPage) {
     cy.visit("/");
   }
   cy.findByText("New").click();
-  cy.findByText("SQL query").click();
+  cy.findByText(newMenuItemTitle).click();
 
   databaseName && cy.findByText(databaseName).click();
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -56,6 +56,7 @@ import { ResponsiveParametersList } from "../ResponsiveParametersList";
 import { ACE_ELEMENT_ID, SCROLL_MARGIN, MIN_HEIGHT_LINES } from "./constants";
 import {
   calcInitialEditorHeight,
+  formatQuery,
   getEditorLineHeight,
   getMaxAutoSizeLines,
 } from "./utils";
@@ -723,6 +724,17 @@ export class NativeQueryEditor extends Component<
     );
   };
 
+  formatQuery = async () => {
+    const engine = this.props.question?.database?.()?.engine;
+    const queryText = this._editor?.getValue();
+    if (!queryText || !engine) {
+      return;
+    }
+
+    this.handleQueryUpdate(await formatQuery(queryText, engine));
+    this._editor?.focus();
+  };
+
   render() {
     const {
       question,
@@ -854,6 +866,7 @@ export class NativeQueryEditor extends Component<
                 features={sidebarFeatures}
                 onShowPromptInput={this.togglePromptVisibility}
                 isPromptInputVisible={isPromptInputVisible}
+                onFormatQuery={this.formatQuery}
                 {...this.props}
               />
             )}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -20,6 +20,7 @@ import "ace/snippets/json";
 import { Flex } from "metabase/ui";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Modal from "metabase/components/Modal";
+import * as Lib from "metabase-lib";
 
 import { canGenerateQueriesForDatabase } from "metabase/metabot/utils";
 import SnippetFormModal from "metabase/query_builder/components/template_tags/SnippetFormModal";
@@ -725,11 +726,10 @@ export class NativeQueryEditor extends Component<
   };
 
   formatQuery = async () => {
-    const engine = this.props.question?.database?.()?.engine;
-    const queryText = this._editor?.getValue();
-    if (!queryText || !engine) {
-      return;
-    }
+    const { question } = this.props;
+    const query = question.query();
+    const engine = Lib.engine(query);
+    const queryText = Lib.rawNativeQuery(query);
 
     this.handleQueryUpdate(await formatQuery(queryText, engine));
     this._editor?.focus();

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditorSidebar/NativeQueryEditorSidebar.tsx
@@ -9,6 +9,7 @@ import { SnippetSidebarButton } from "metabase/query_builder/components/view/Sni
 import { PreviewQueryButton } from "metabase/query_builder/components/view/PreviewQueryButton";
 
 import type { Collection, NativeQuerySnippet } from "metabase-types/api";
+import { canFormatForEngine } from "metabase/query_builder/components/NativeQueryEditor/utils";
 import type Question from "metabase-lib/Question";
 
 import {
@@ -47,6 +48,7 @@ interface NativeQueryEditorSidebarProps {
   toggleDataReference: () => void;
   toggleTemplateTagsEditor: () => void;
   toggleSnippetSidebar: () => void;
+  onFormatQuery: () => void;
 }
 
 export const NativeQueryEditorSidebar = (
@@ -66,6 +68,7 @@ export const NativeQueryEditorSidebar = (
     features,
     onShowPromptInput,
     canUsePromptInput,
+    onFormatQuery,
   } = props;
 
   // hide the snippet sidebar if there aren't any visible snippets/collections
@@ -88,8 +91,22 @@ export const NativeQueryEditorSidebar = (
 
   const canRunQuery = runQuery && cancelQuery;
 
+  const engine = question.database?.()?.engine;
+  const canFormatQuery = engine != null && canFormatForEngine(engine);
+
   return (
     <Container data-testid="native-query-editor-sidebar">
+      {canFormatQuery && (
+        <Tooltip tooltip={t`Format query`}>
+          <SidebarButton
+            aria-label={t`Format query`}
+            onClick={onFormatQuery}
+            icon="document"
+            iconSize={20}
+            onlyIcon
+          />
+        </Tooltip>
+      )}
       {canUsePromptInput && features.promptInput && !isPromptInputVisible ? (
         <Tooltip tooltip={t`Ask a question`}>
           <SidebarButton

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
@@ -71,21 +71,24 @@ const formatterDialectByEngine: Record<string, SqlLanguage> = {
   redshift: "redshift",
   snowflake: "snowflake",
   sparksql: "spark",
-  sqlite: "sqlite",
-  sqlserver: "tsql",
 };
 
+// Optional clauses cannot be formatted by sql-formatter for these dialects
+const unsupportedFormatterDialects = ["sqlite", "sqlserver"];
+
 function getFormatterDialect(engine: string) {
-  if (getEngineNativeType(engine) === "json") {
+  if (
+    getEngineNativeType(engine) === "json" ||
+    unsupportedFormatterDialects.includes(engine)
+  ) {
     return null;
   }
 
-  // Fall back to ANSI SQL dialect
   return formatterDialectByEngine[engine] ?? "sql";
 }
 
 export function canFormatForEngine(engine: string) {
-  return getEngineNativeType(engine) === "sql";
+  return getFormatterDialect(engine) != null;
 }
 
 export function formatQuery(queryText: string, engine: string) {

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
@@ -102,8 +102,11 @@ export function formatQuery(queryText: string, engine: string) {
     keywordCase: "upper",
     linesBetweenQueries: 2,
     paramTypes: {
-      // Snippets, parameters, nested questions
-      custom: [{ regex: "\\{\\{[^\\{\\}]*\\}\\}" }],
+      // Snippets, parameters, nested questions, and optional clauses
+      custom: [
+        { regex: "\\{\\{[^\\{\\}]*\\}\\}" },
+        { regex: "\\[\\[((.|\\n|\\r)*?)\\]\\]" },
+      ],
     },
   });
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
@@ -58,9 +58,7 @@ export function calcInitialEditorHeight({
 }
 
 const formatSql = async (sql: string, options: FormatOptionsWithLanguage) => {
-  const sqlFormatter = await import(
-    /* webpackChunkName: "sql-formatter" */ "sql-formatter"
-  );
+  const sqlFormatter = await import("sql-formatter");
   return sqlFormatter.format(sql, options);
 };
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.unit.spec.ts
@@ -107,25 +107,6 @@ LIMIT
   10;`,
   },
   {
-    engine: "sqlserver", // No support for optional clauses
-    input:
-      "select CONCAT(first_name, ' ', last_name) AS full_name, DATEDIFF(year, birth_date, GETDATE()) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} ORDER BY full_name OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;\n",
-    output: `SELECT
-  CONCAT(first_name, ' ', last_name) AS full_name,
-  DATEDIFF(YEAR, birth_date, GETDATE()) AS age
-FROM
-  {{#1-users}}
-WHERE
-  status = 'active'
-  AND {{id}}
-ORDER BY
-  full_name
-OFFSET
-  0 ROWS
-FETCH NEXT
-  10 ROWS ONLY;`,
-  },
-  {
     engine: "sparksql",
     input:
       "select CONCAT(first_name, ' ', last_name) AS full_name, YEAR(current_date()) - YEAR(birth_date) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} and [[ user_role = {{role}} ]] ORDER BY full_name LIMIT 10;\n",
@@ -170,23 +151,6 @@ LIMIT
   10;`,
   },
   {
-    engine: "sqlite", // No support for optional clauses
-    input:
-      "select first_name || ' ' || last_name AS full_name, strftime('%Y', 'now') - strftime('%Y', birth_date) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} ORDER BY full_name LIMIT 10;\n",
-    output: `SELECT
-  first_name || ' ' || last_name AS full_name,
-  strftime('%Y', 'now') - strftime('%Y', birth_date) AS age
-FROM
-  {{#1-users}}
-WHERE
-  status = 'active'
-  AND {{id}}
-ORDER BY
-  full_name
-LIMIT
-  10;`,
-  },
-  {
     engine: "h2", // Uses ANSI SQL formatter
     input:
       "SELECT first_name || ' ' || last_name AS full_name, EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM birth_date) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} and [[ user_role = {{role}} ]] ORDER BY full_name FETCH FIRST 10 ROWS ONLY;",
@@ -225,15 +189,15 @@ describe("utils", () => {
       expect(canFormatForEngine("oracle")).toBe(true);
       expect(canFormatForEngine("snowflake")).toBe(true);
       expect(canFormatForEngine("sparksql")).toBe(true);
-      expect(canFormatForEngine("sqlite")).toBe(true);
-      expect(canFormatForEngine("sqlserver")).toBe(true);
       expect(canFormatForEngine("vertica")).toBe(true);
     });
 
-    it("should return false for non-SQL engines", () => {
+    it("should return false for non-SQL engines and unsupported SQL engines", () => {
       expect(canFormatForEngine("mongo")).toBe(false);
       expect(canFormatForEngine("googleanalytics")).toBe(false);
       expect(canFormatForEngine("druid")).toBe(false);
+      expect(canFormatForEngine("sqlite")).toBe(false);
+      expect(canFormatForEngine("sqlserver")).toBe(false);
     });
   });
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.unit.spec.ts
@@ -3,6 +3,217 @@ import {
   formatQuery,
 } from "metabase/query_builder/components/NativeQueryEditor/utils";
 
+const formattingTestCases = [
+  {
+    engine: "mysql",
+    input:
+      "select CONCAT(first_name, ' ', last_name) AS full_name, YEAR(CURDATE()) - YEAR(birth_date) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} and [[ user_role = {{role}} ]] ORDER BY full_name LIMIT 10;",
+    output: `SELECT
+  CONCAT(first_name, ' ', last_name) AS full_name,
+  YEAR(CURDATE()) - YEAR(birth_date) AS age
+FROM
+  {{#1-users}}
+WHERE
+  status = 'active'
+  AND {{id}}
+  AND [[ user_role = {{role}} ]]
+ORDER BY
+  full_name
+LIMIT
+  10;`,
+  },
+  {
+    engine: "postgres",
+    input:
+      "select first_name || ' ' || last_name AS full_name, EXTRACT(YEAR FROM AGE(birth_date)) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} and [[ user_role = {{role}} ]] ORDER BY full_name LIMIT 10;\n",
+    output: `SELECT
+  first_name || ' ' || last_name AS full_name,
+  EXTRACT(
+    YEAR
+    FROM
+      AGE (birth_date)
+  ) AS age
+FROM
+  {{#1-users}}
+WHERE
+  status = 'active'
+  AND {{id}}
+  AND [[ user_role = {{role}} ]]
+ORDER BY
+  full_name
+LIMIT
+  10;`,
+  },
+  {
+    engine: "snowflake",
+    input:
+      "select CONCAT(first_name, ' ', last_name) AS full_name, DATEDIFF(year, birth_date, CURRENT_DATE()) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} and [[ user_role = {{role}} ]] ORDER BY full_name LIMIT 10;\n",
+    output: `SELECT
+  CONCAT(first_name, ' ', last_name) AS full_name,
+  DATEDIFF(YEAR, birth_date, CURRENT_DATE()) AS age
+FROM
+  {{#1-users}}
+WHERE
+  status = 'active'
+  AND {{id}}
+  AND [[ user_role = {{role}} ]]
+ORDER BY
+  full_name
+LIMIT
+  10;`,
+  },
+  {
+    engine: "oracle",
+    input:
+      "select first_name || ' ' || last_name AS full_name, EXTRACT(YEAR FROM SYSDATE) - EXTRACT(YEAR FROM birth_date) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} and [[ user_role = {{role}} ]] ORDER BY full_name FETCH FIRST 10 ROWS ONLY;\n",
+    output: `SELECT
+  first_name || ' ' || last_name AS full_name,
+  EXTRACT(
+    YEAR
+    FROM
+      SYSDATE
+  ) - EXTRACT(
+    YEAR
+    FROM
+      birth_date
+  ) AS age
+FROM
+  {{#1-users}}
+WHERE
+  status = 'active'
+  AND {{id}}
+  AND [[ user_role = {{role}} ]]
+ORDER BY
+  full_name
+FETCH FIRST
+  10 ROWS ONLY;`,
+  },
+  {
+    engine: "redshift",
+    input:
+      "select CONCAT(first_name, ' ', last_name) AS full_name, DATE_PART(year, GETDATE()) - DATE_PART(year, birth_date) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} and [[ user_role = {{role}} ]] ORDER BY full_name LIMIT 10;\n",
+    output: `SELECT
+  CONCAT(first_name, ' ', last_name) AS full_name,
+  DATE_PART(year, GETDATE()) - DATE_PART(year, birth_date) AS age
+FROM
+  {{#1-users}}
+WHERE
+  status = 'active'
+  AND {{id}}
+  AND [[ user_role = {{role}} ]]
+ORDER BY
+  full_name
+LIMIT
+  10;`,
+  },
+  {
+    engine: "sqlserver", // No support for optional clauses
+    input:
+      "select CONCAT(first_name, ' ', last_name) AS full_name, DATEDIFF(year, birth_date, GETDATE()) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} ORDER BY full_name OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;\n",
+    output: `SELECT
+  CONCAT(first_name, ' ', last_name) AS full_name,
+  DATEDIFF(YEAR, birth_date, GETDATE()) AS age
+FROM
+  {{#1-users}}
+WHERE
+  status = 'active'
+  AND {{id}}
+ORDER BY
+  full_name
+OFFSET
+  0 ROWS
+FETCH NEXT
+  10 ROWS ONLY;`,
+  },
+  {
+    engine: "sparksql",
+    input:
+      "select CONCAT(first_name, ' ', last_name) AS full_name, YEAR(current_date()) - YEAR(birth_date) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} and [[ user_role = {{role}} ]] ORDER BY full_name LIMIT 10;\n",
+    output: `SELECT
+  CONCAT(first_name, ' ', last_name) AS full_name,
+  YEAR(current_date()) - YEAR(birth_date) AS age
+FROM
+  {{#1-users}}
+WHERE
+  status = 'active'
+  AND {{id}}
+  AND [[ user_role = {{role}} ]]
+ORDER BY
+  full_name
+LIMIT
+  10;`,
+  },
+  {
+    engine: "presto-jdbc",
+    input:
+      "select CONCAT(first_name, ' ', last_name) AS full_name, EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM birth_date) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} and [[ user_role = {{role}} ]] ORDER BY full_name LIMIT 10;\n",
+    output: `SELECT
+  CONCAT(first_name, ' ', last_name) AS full_name,
+  EXTRACT(
+    YEAR
+    FROM
+      CURRENT_DATE
+  ) - EXTRACT(
+    YEAR
+    FROM
+      birth_date
+  ) AS age
+FROM
+  {{#1-users}}
+WHERE
+  status = 'active'
+  AND {{id}}
+  AND [[ user_role = {{role}} ]]
+ORDER BY
+  full_name
+LIMIT
+  10;`,
+  },
+  {
+    engine: "sqlite", // No support for optional clauses
+    input:
+      "select first_name || ' ' || last_name AS full_name, strftime('%Y', 'now') - strftime('%Y', birth_date) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} ORDER BY full_name LIMIT 10;\n",
+    output: `SELECT
+  first_name || ' ' || last_name AS full_name,
+  strftime('%Y', 'now') - strftime('%Y', birth_date) AS age
+FROM
+  {{#1-users}}
+WHERE
+  status = 'active'
+  AND {{id}}
+ORDER BY
+  full_name
+LIMIT
+  10;`,
+  },
+  {
+    engine: "h2", // Uses ANSI SQL formatter
+    input:
+      "SELECT first_name || ' ' || last_name AS full_name, EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM birth_date) AS age FROM {{#1-users}} WHERE status = 'active' and {{id}} and [[ user_role = {{role}} ]] ORDER BY full_name FETCH FIRST 10 ROWS ONLY;",
+    output: `SELECT
+  first_name || ' ' || last_name AS full_name,
+  EXTRACT(
+    YEAR
+    FROM
+      CURRENT_DATE
+  ) - EXTRACT(
+    YEAR
+    FROM
+      birth_date
+  ) AS age
+FROM
+  {{#1-users}}
+WHERE
+  status = 'active'
+  AND {{id}}
+  AND [[ user_role = {{role}} ]]
+ORDER BY
+  full_name
+FETCH FIRST
+  10 ROWS ONLY;`,
+  },
+];
+
 describe("utils", () => {
   describe("canFormatForEngine", () => {
     it("should return true for SQL engines", () => {
@@ -27,27 +238,12 @@ describe("utils", () => {
   });
 
   describe("formatQuery", () => {
-    it("should format SQL queries", async () => {
-      expect(await formatQuery("SeLeCt \n\n\n\n\n * fRoM foo", "postgres"))
-        .toBe(`SELECT
-  *
-FROM
-  foo`);
-    });
-
-    it("should format queries with parameters and nested queries syntax", async () => {
-      expect(
-        await formatQuery(
-          "select * from {{#1-orders}} where {{idFilter}} and category={{categoryFilter}}",
-          "postgres",
-        ),
-      ).toBe(`SELECT
-  *
-FROM
-  {{#1-orders}}
-WHERE
-  {{idFilter}}
-  AND category = {{categoryFilter}}`);
-    });
+    it.each(formattingTestCases)(
+      "should format %s query",
+      async ({ engine, input, output }) => {
+        const formatted = await formatQuery(input, engine);
+        expect(formatted).toBe(output);
+      },
+    );
   });
 });

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.unit.spec.ts
@@ -1,0 +1,53 @@
+import {
+  canFormatForEngine,
+  formatQuery,
+} from "metabase/query_builder/components/NativeQueryEditor/utils";
+
+describe("utils", () => {
+  describe("canFormatForEngine", () => {
+    it("should return true for SQL engines", () => {
+      expect(canFormatForEngine("postgres")).toBe(true);
+      expect(canFormatForEngine("mysql")).toBe(true);
+      expect(canFormatForEngine("snowflake")).toBe(true);
+      expect(canFormatForEngine("redshift")).toBe(true);
+      expect(canFormatForEngine("bigquery")).toBe(true);
+      expect(canFormatForEngine("oracle")).toBe(true);
+      expect(canFormatForEngine("snowflake")).toBe(true);
+      expect(canFormatForEngine("sparksql")).toBe(true);
+      expect(canFormatForEngine("sqlite")).toBe(true);
+      expect(canFormatForEngine("sqlserver")).toBe(true);
+      expect(canFormatForEngine("vertica")).toBe(true);
+    });
+
+    it("should return false for non-SQL engines", () => {
+      expect(canFormatForEngine("mongo")).toBe(false);
+      expect(canFormatForEngine("googleanalytics")).toBe(false);
+      expect(canFormatForEngine("druid")).toBe(false);
+    });
+  });
+
+  describe("formatQuery", () => {
+    it("should format SQL queries", async () => {
+      expect(await formatQuery("SeLeCt \n\n\n\n\n * fRoM foo", "postgres"))
+        .toBe(`SELECT
+  *
+FROM
+  foo`);
+    });
+
+    it("should format queries with parameters and nested queries syntax", async () => {
+      expect(
+        await formatQuery(
+          "select * from {{#1-orders}} where {{idFilter}} and category={{categoryFilter}}",
+          "postgres",
+        ),
+      ).toBe(`SELECT
+  *
+FROM
+  {{#1-orders}}
+WHERE
+  {{idFilter}}
+  AND category = {{categoryFilter}}`);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "server-text-width": "^1.0.2",
     "simple-statistics": "^3.0.0",
     "slugg": "^1.2.1",
+    "sql-formatter": "^15.1.2",
     "tether": "^1.2.0",
     "tippy.js": "^6.3.5",
     "ttag": "1.7.21",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -192,9 +192,14 @@ const config = (module.exports = {
     splitChunks: {
       cacheGroups: {
         vendors: {
-          test: /[\\/]node_modules[\\/]/,
+          test: /[\\/]node_modules[\\/](?!sql-formatter[\\/])/,
           chunks: "all",
           name: "vendor",
+        },
+        sqlFormatter: {
+          test: /[\\/]node_modules[\\/]sql-formatter[\\/]/,
+          chunks: "all",
+          name: "sql-formatter",
         },
       },
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9494,6 +9494,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==
+
 disposables@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/disposables/-/disposables-1.0.2.tgz#36c6a674475f55a2d6913567a601444e487b4b6e"
@@ -11619,6 +11624,11 @@ get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
+
+get-stdin@=8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
+  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -15900,6 +15910,11 @@ moo-color@^1.0.2:
   dependencies:
     color-name "^1.1.4"
 
+moo@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -16046,6 +16061,16 @@ nconf@^0.12.0:
     ini "^2.0.0"
     secure-keys "^1.0.0"
     yargs "^16.1.1"
+
+nearley@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 needle@^3.0.0, needle@^3.1.0:
   version "3.1.0"
@@ -18130,6 +18155,11 @@ raf@^3.1.0, raf@^3.4.0, raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==
+
 ramda@0.29.0:
   version "0.29.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.29.0.tgz#fbbb67a740a754c8a4cbb41e2a6e0eb8507f55fb"
@@ -18139,6 +18169,14 @@ ramda@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
   integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"
@@ -20217,6 +20255,15 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sql-formatter@^15.1.2:
+  version "15.1.2"
+  resolved "https://registry.yarnpkg.com/sql-formatter/-/sql-formatter-15.1.2.tgz#86df2592eedf6d422244e10e00a74380c22791b7"
+  integrity sha512-zBrLBclCNurCsQaO6yMvkXzHvv7eJPjiF8LIEQ5HdBV/x6UuWIZwqss3mlZ/6HLj+VYhFKeHpQnyLuZWG2agKQ==
+  dependencies:
+    argparse "^2.0.1"
+    get-stdin "=8.0.0"
+    nearley "^2.20.1"
 
 sqlstring@^2.3.2:
   version "2.3.3"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/9142

### Description

It is one of my projects for our internal hackathon. This PR adds format SQL query button.
Since it is a big package which is needed only for a single button, I put it in a separate chunk and import dynamically.
The button is hidden for nosql data sources such as Mongo, Druid, Google Analytics, and some sql databases such as sqlite and mssql for which optional clauses break formatting. For other SQL databases if the formatter library supports the specific dialect of given database it will use the dialcet otherwise it will fall back to ANSI SQL formatter.

### How to verify

Ensure formatting works for SQL databases with the [right dialect](https://github.com/metabase/metabase/pull/38113/files#diff-2432af7b436143db65654d7156e601262c9253931a525630770c53d2dddbec2dR67).
Ensure there is no formatting button for nosql databases.
Ensure the formatter library loads only when user clicks on the Format Query button.

### Demo

https://github.com/metabase/metabase/assets/14301985/d81ff9d6-23de-46c6-a951-7a5d33717a22

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
