### PR TITLE
Add data-permissions-graph-for-user function

### DIFF
--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -145,62 +145,79 @@
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
-(mu/defn data-permissions-graph-for-user
-  "Returns a permissions graph for a single user."
+
+(defn- admin-permission-graph
+  "Returns the graph representing admin permissions for all groups"
+  [& {:keys [db-id perm-type]}]
+  (let [db-ids     (if db-id [db-id] (t2/select-pks-vec :model/Database))
+        perm-types (if perm-type [perm-type] (keys Permissions))]
+    (into {} (map (fn [db-id]
+                    [db-id (into {} (map (fn [perm] [perm (most-permissive-value perm)])
+                                         perm-types))])
+                  db-ids))))
+
+(mu/defn permissions-for-user
+  "Returns a graph representing the permissions for a single user. Can be optionally filtered by database ID and/or permission type.
+  Combines permissions from multiple groups into a single value for each DB/table and permission type.
+
+  This is intended to be used for logging and debugging purposes, to see what a user's real permissions are at a glance. Enforcement
+  should happen via `database-permission-for-user` and `table-permission-for-user`."
   [user-id & {:keys [db-id perm-type]}]
-  (let [data-perms    (t2/select :model/DataPermissions
-                                 {:select [[:p.perm_type :perm-type]
-                                           [:p.group_id :group-id]
-                                           [:p.perm_value :value]
-                                           [:p.db_id :db-id]
-                                           [:p.table_id :table-id]]
-                                  :from [[:permissions_group_membership :pgm]]
-                                  :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
-                                         [:data_permissions :p]   [:= :p.group_id :pg.id]]
-                                  :where [:and
-                                          [:= :pgm.user_id user-id]
-                                          (when db-id [:= :db_id db-id])
-                                          (when perm-type [:= :perm_type (u/qualified-name perm-type)])]})
-        grouped-perms (group-by (fn [{:keys [db-id perm-type table-id]}]
-                                  (if table-id
-                                    [db-id perm-type table-id]
-                                    [db-id perm-type]))
-                                data-perms)
-        coalesced-perms (reduce-kv
-                         (fn [result path perms]
-                           ;; Coalesce the values for permissions set in multiple groups for the same user
-                           (let [[db-id perm-type] path
-                                 coalesced-perms (coalesce perm-type
-                                                           (concat
-                                                            (map :value perms)
-                                                            (map :value (get grouped-perms [db-id perm-type]))))]
-                             (assoc result path coalesced-perms)))
-                         {}
-                         grouped-perms)
-        granular-graph  (reduce
-                         (fn [graph [[db-id perm-type table-id] value]]
-                           (let [current-perms (get-in graph [db-id perm-type])
-                                 updated-perms (if table-id
-                                                 (if (keyword? current-perms)
-                                                   {table-id value}
-                                                   (assoc current-perms table-id value))
-                                                 (if (map? current-perms)
-                                                   current-perms
-                                                   value))]
-                             (assoc-in graph [db-id perm-type] updated-perms)))
-                         {}
-                         coalesced-perms)]
-    (reduce (fn [new-graph [db-id perms]]
-              (assoc new-graph db-id
-                     (reduce (fn [new-perms [perm-type value]]
-                               (if (and (map? value)
-                                        (apply = (vals value)))
-                                 (assoc new-perms perm-type (first (vals value)))
-                                 (assoc new-perms perm-type value)))
-                             {}
-                             perms)))
-            {}
-            granular-graph)))
+  (if (t2/select-one-fn :is_superuser :model/User :id user-id)
+    (admin-permission-graph :db-id db-id :perm-type perm-type)
+    (let [data-perms    (t2/select :model/DataPermissions
+                                   {:select [[:p.perm_type :perm-type]
+                                             [:p.group_id :group-id]
+                                             [:p.perm_value :value]
+                                             [:p.db_id :db-id]
+                                             [:p.table_id :table-id]]
+                                    :from [[:permissions_group_membership :pgm]]
+                                    :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                                           [:data_permissions :p]   [:= :p.group_id :pg.id]]
+                                    :where [:and
+                                            [:= :pgm.user_id user-id]
+                                            (when db-id [:= :db_id db-id])
+                                            (when perm-type [:= :perm_type (u/qualified-name perm-type)])]})
+          path->perms     (group-by (fn [{:keys [db-id perm-type table-id]}]
+                                      (if table-id
+                                        [db-id perm-type table-id]
+                                        [db-id perm-type]))
+                                    data-perms)
+          coalesced-perms (reduce-kv
+                           (fn [result path perms]
+                             ;; Combine permissions from multiple groups into a single value
+                             (let [[db-id perm-type] path
+                                   coalesced-perms (coalesce perm-type
+                                                             (concat
+                                                              (map :value perms)
+                                                              (map :value (get path->perms [db-id perm-type]))))]
+                               (assoc result path coalesced-perms)))
+                           {}
+                           path->perms)
+          granular-graph  (reduce
+                           (fn [graph [[db-id perm-type table-id] value]]
+                             (let [current-perms (get-in graph [db-id perm-type])
+                                   updated-perms (if table-id
+                                                   (if (keyword? current-perms)
+                                                     {table-id value}
+                                                     (assoc current-perms table-id value))
+                                                   (if (map? current-perms)
+                                                     current-perms
+                                                     value))]
+                               (assoc-in graph [db-id perm-type] updated-perms)))
+                           {}
+                           coalesced-perms)]
+      (reduce (fn [new-graph [db-id perms]]
+                (assoc new-graph db-id
+                       (reduce (fn [new-perms [perm-type value]]
+                                 (if (and (map? value)
+                                          (apply = (vals value)))
+                                   (assoc new-perms perm-type (first (vals value)))
+                                   (assoc new-perms perm-type value)))
+                               {}
+                               perms)))
+              {}
+              granular-graph))))
 
 
 ;;; ---------------------------------------- Fetching the data permissions graph --------------------------------------

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -142,7 +142,7 @@
 (deftest table-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}  {}
                  :model/PermissionsGroup           {group-id-2 :id}  {}
-                 :model/User                       {user-id :id}     {}
+                 :model/User                       {user-id   :id}   {}
                  :model/PermissionsGroupMembership {}                {:user_id  user-id
                                                                       :group_id group-id-1}
                  :model/PermissionsGroupMembership {}                {:user_id  user-id
@@ -162,6 +162,84 @@
 
       (testing "Admins always have the most permissive value, regardless of group membership"
         (is (= :unrestricted (data-perms/table-permission-for-user (mt/user->id :crowberto) :perms/data-access database-id table-id-2)))))))
+
+(deftest permissions-for-user-test
+  (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}
+                 :model/PermissionsGroup           {group-id-2 :id}    {}
+                 :model/User                       {user-id-1 :id}     {}
+                 :model/User                       {user-id-2 :id}     {:is_superuser true}
+                 :model/PermissionsGroupMembership {}                  {:user_id  user-id-1
+                                                                        :group_id group-id-1}
+                 :model/PermissionsGroupMembership {}                  {:user_id  user-id-1
+                                                                        :group_id group-id-2}
+                 :model/PermissionsGroupMembership {}                  {:user_id  user-id-2
+                                                                        :group_id group-id-1}
+                 :model/PermissionsGroupMembership {}                  {:user_id  user-id-2
+                                                                        :group_id group-id-2}
+                 :model/Database                   {database-id-1 :id} {}
+                 :model/Database                   {database-id-2 :id} {}
+                 :model/Table                      {table-id-1 :id}    {:db_id database-id-1}
+                 :model/Table                      {table-id-2 :id}    {:db_id database-id-1}]
+    (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
+      (mt/with-no-data-perms-for-all-users!
+        ;; Clear the default permissions for the groups
+        (t2/delete! :model/DataPermissions :group_id group-id-1)
+        (t2/delete! :model/DataPermissions :group_id group-id-2)
+        (testing "A single user's data permissions can be fetched as a graph"
+          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/data-access :unrestricted)
+          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
+          (data-perms/set-database-permission! group-id-1 database-id-2 :perms/data-access :no-self-service)
+          (data-perms/set-database-permission! group-id-1 database-id-2 :perms/native-query-editing :no)
+          (is (partial=
+               {database-id-1
+                {:perms/data-access :unrestricted
+                 :perms/native-query-editing :yes}
+                database-id-2
+                {:perms/data-access :no-self-service
+                 :perms/native-query-editing :no}}
+               (data-perms/permissions-for-user user-id-1))))
+
+        (testing "Perms from multiple groups are coalesced"
+          (data-perms/set-database-permission! group-id-2 database-id-1 :perms/data-access :no-self-service)
+          (data-perms/set-database-permission! group-id-2 database-id-1 :perms/native-query-editing :no)
+          (data-perms/set-database-permission! group-id-2 database-id-2 :perms/data-access :unrestricted)
+          (data-perms/set-database-permission! group-id-2 database-id-2 :perms/native-query-editing :yes)
+          (is (partial=
+               {database-id-1
+                {:perms/data-access :unrestricted
+                 :perms/native-query-editing :yes}
+                database-id-2
+                {:perms/data-access :unrestricted
+                 :perms/native-query-editing :yes}}
+               (data-perms/permissions-for-user user-id-1))))
+
+        (testing "Table-level perms are included if they're more permissive than any database-level perms"
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
+          (is (partial=
+               {database-id-1
+                {:perms/data-access {table-id-1 :no-self-service
+                                     table-id-2 :unrestricted}}}
+               (data-perms/permissions-for-user user-id-1))))
+
+        (testing "Table-level perms are not included if a database-level perm is more permissive"
+          (data-perms/set-database-permission! group-id-2 database-id-1 :perms/data-access :unrestricted)
+          (is (partial=
+               {database-id-1
+                {:perms/data-access :unrestricted}}
+               (data-perms/permissions-for-user user-id-1))))
+
+        (testing "Admins always have full permissions"
+          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/data-access :no-self-service)
+          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :no)
+          (is (partial=
+               {database-id-1
+                {:perms/data-access :unrestricted
+                 :perms/native-query-editing :yes
+                 :perms/manage-database :yes
+                 :perms/manage-table-metadata :yes
+                 :perms/download-results :one-million-rows}}
+               (data-perms/permissions-for-user user-id-2))))))))
 
 (deftest data-permissions-graph-test
   (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -180,66 +180,65 @@
                  :model/Database                   {database-id-2 :id} {}
                  :model/Table                      {table-id-1 :id}    {:db_id database-id-1}
                  :model/Table                      {table-id-2 :id}    {:db_id database-id-1}]
-    (mt/with-restored-data-perms-for-groups! [()]
-      (mt/with-no-data-perms-for-all-users!
-        ;; Clear the default permissions for the groups
-        (t2/delete! :model/DataPermissions :group_id group-id-1)
-        (t2/delete! :model/DataPermissions :group_id group-id-2)
-        (testing "A single user's data permissions can be fetched as a graph"
-          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
-          (data-perms/set-database-permission! group-id-1 database-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-database-permission! group-id-1 database-id-2 :perms/native-query-editing :no)
-          (is (partial=
-               {database-id-1
-                {:perms/data-access :unrestricted
-                 :perms/native-query-editing :yes}
-                database-id-2
-                {:perms/data-access :no-self-service
-                 :perms/native-query-editing :no}}
-               (data-perms/permissions-for-user user-id-1))))
+    (mt/with-no-data-perms-for-all-users!
+      ;; Clear the default permissions for the groups
+      (t2/delete! :model/DataPermissions :group_id group-id-1)
+      (t2/delete! :model/DataPermissions :group_id group-id-2)
+      (testing "A single user's data permissions can be fetched as a graph"
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/data-access :unrestricted)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
+        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/data-access :no-self-service)
+        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/native-query-editing :no)
+        (is (partial=
+             {database-id-1
+              {:perms/data-access :unrestricted
+               :perms/native-query-editing :yes}
+              database-id-2
+              {:perms/data-access :no-self-service
+               :perms/native-query-editing :no}}
+             (data-perms/permissions-for-user user-id-1))))
 
-        (testing "Perms from multiple groups are coalesced"
-          (data-perms/set-database-permission! group-id-2 database-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-database-permission! group-id-2 database-id-1 :perms/native-query-editing :no)
-          (data-perms/set-database-permission! group-id-2 database-id-2 :perms/data-access :unrestricted)
-          (data-perms/set-database-permission! group-id-2 database-id-2 :perms/native-query-editing :yes)
-          (is (partial=
-               {database-id-1
-                {:perms/data-access :unrestricted
-                 :perms/native-query-editing :yes}
-                database-id-2
-                {:perms/data-access :unrestricted
-                 :perms/native-query-editing :yes}}
-               (data-perms/permissions-for-user user-id-1))))
+      (testing "Perms from multiple groups are coalesced"
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/data-access :no-self-service)
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/native-query-editing :no)
+        (data-perms/set-database-permission! group-id-2 database-id-2 :perms/data-access :unrestricted)
+        (data-perms/set-database-permission! group-id-2 database-id-2 :perms/native-query-editing :yes)
+        (is (partial=
+             {database-id-1
+              {:perms/data-access :unrestricted
+               :perms/native-query-editing :yes}
+              database-id-2
+              {:perms/data-access :unrestricted
+               :perms/native-query-editing :yes}}
+             (data-perms/permissions-for-user user-id-1))))
 
-        (testing "Table-level perms are included if they're more permissive than any database-level perms"
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
-          (is (partial=
-               {database-id-1
-                {:perms/data-access {table-id-1 :no-self-service
-                                     table-id-2 :unrestricted}}}
-               (data-perms/permissions-for-user user-id-1))))
+      (testing "Table-level perms are included if they're more permissive than any database-level perms"
+        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
+        (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
+        (is (partial=
+             {database-id-1
+              {:perms/data-access {table-id-1 :no-self-service
+                                   table-id-2 :unrestricted}}}
+             (data-perms/permissions-for-user user-id-1))))
 
-        (testing "Table-level perms are not included if a database-level perm is more permissive"
-          (data-perms/set-database-permission! group-id-2 database-id-1 :perms/data-access :unrestricted)
-          (is (partial=
-               {database-id-1
-                {:perms/data-access :unrestricted}}
-               (data-perms/permissions-for-user user-id-1))))
+      (testing "Table-level perms are not included if a database-level perm is more permissive"
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/data-access :unrestricted)
+        (is (partial=
+             {database-id-1
+              {:perms/data-access :unrestricted}}
+             (data-perms/permissions-for-user user-id-1))))
 
-        (testing "Admins always have full permissions"
-          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :no)
-          (is (partial=
-               {database-id-1
-                {:perms/data-access :unrestricted
-                 :perms/native-query-editing :yes
-                 :perms/manage-database :yes
-                 :perms/manage-table-metadata :yes
-                 :perms/download-results :one-million-rows}}
-               (data-perms/permissions-for-user user-id-2))))))))
+      (testing "Admins always have full permissions"
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/data-access :no-self-service)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :no)
+        (is (partial=
+             {database-id-1
+              {:perms/data-access :unrestricted
+               :perms/native-query-editing :yes
+               :perms/manage-database :yes
+               :perms/manage-table-metadata :yes
+               :perms/download-results :one-million-rows}}
+             (data-perms/permissions-for-user user-id-2)))))))
 
 (deftest data-permissions-graph-test
   (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -180,7 +180,7 @@
                  :model/Database                   {database-id-2 :id} {}
                  :model/Table                      {table-id-1 :id}    {:db_id database-id-1}
                  :model/Table                      {table-id-2 :id}    {:db_id database-id-1}]
-    (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
+    (mt/with-restored-data-perms-for-groups! [()]
       (mt/with-no-data-perms-for-all-users!
         ;; Clear the default permissions for the groups
         (t2/delete! :model/DataPermissions :group_id group-id-1)

--- a/test/metabase/permissions/test_util.clj
+++ b/test/metabase/permissions/test_util.clj
@@ -57,19 +57,20 @@
   `(do-with-restored-data-perms! ~group-ids (fn [] ~@body)))
 
 (defn do-with-no-data-perms-for-all-users!
-  "Implementation of `with-no-data-perms-for-all-users`. Sets every data permission for the test dataset to its
+  "Implementation of `with-no-data-perms-for-all-users`. Sets every data permission for all databases to the
   least-permissive value for the All Users permission group for the duration of the test."
   [thunk]
   (with-restored-data-perms-for-group! (u/the-id (perms-group/all-users))
-    (doseq [[perm-type _] data-perms/Permissions]
-      (data-perms/set-database-permission! (perms-group/all-users)
-                                           (data/db)
-                                           perm-type
-                                           (data-perms/least-permissive-value perm-type)))
+    (doseq [[perm-type _] data-perms/Permissions
+            db-id         (t2/select-pks-set :model/Database)]
+       (data-perms/set-database-permission! (perms-group/all-users)
+                                            db-id
+                                            perm-type
+                                            (data-perms/least-permissive-value perm-type)))
     (thunk)))
 
 (defmacro with-no-data-perms-for-all-users!
-  "Runs `body`, and sets every data permission for the test dataset to its least-permissive value for the All Users
+  "Runs `body`, and sets every data permission for all databases to its least-permissive value for the All Users
   permission group for the duration of the test."
   [& body]
   `(do-with-no-data-perms-for-all-users! (fn [] ~@body)))


### PR DESCRIPTION
Adds a new function to fetch a graph representing a single user's permissions, combined across all the groups that they are in.