### PR TITLE
CVE updates: lambdaisland/uri, aws sdk (for ions), specify guava for googleanalytics

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -106,7 +106,8 @@
                                                            org.slf4j/slf4j-api]}
   net.sf.cssbox/cssbox                      {:mvn/version "5.0.1"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api
-                                                           junit/junit]}
+                                                           junit/junit
+                                                           org.codelibs/nekohtml]}
   net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20230409"} ; Java implementation of the JQ json query language
   org.apache.commons/commons-compress       {:mvn/version "1.25.0"}             ; compression utils
   org.apache.commons/commons-lang3          {:mvn/version "3.14.0"}             ; helper methods for working with java.lang stuff
@@ -127,11 +128,11 @@
                                              :exclusions  [org.slf4j/slf4j-api
                                                            org.slf4j/jcl-over-slf4j]}
   org.apache.xmlgraphics/batik-all          {:mvn/version "1.17"}               ; SVG -> image
-  org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client
   org.bouncycastle/bcpkix-jdk18on           {:mvn/version "1.77"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
   org.bouncycastle/bcprov-jdk18on           {:mvn/version "1.77"}
   org.clj-commons/hickory                   {:mvn/version "0.7.3"               ; Parse HTML into Clojure data structures
                                              :exclusions [org.jsoup/jsoup]}
+  org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client
   org.clojure/clojure                       {:mvn/version "1.11.1"}
   org.clojure/core.async                    {:mvn/version "1.6.681"
                                              :exclusions  [org.clojure/tools.reader]}
@@ -151,6 +152,7 @@
   org.clojure/tools.namespace               {:mvn/version "1.4.4"}
   org.clojure/tools.reader                  {:mvn/version "1.3.7"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
+  org.codelibs/nekohtml                     {:mvn/version "2.1.2"}              ; used in cssbox
   org.eclipse.jetty/jetty-server            {:mvn/version "11.0.17"}            ; web server
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.4"}             ; JavaScript engine

--- a/deps.edn
+++ b/deps.edn
@@ -106,8 +106,7 @@
                                                            org.slf4j/slf4j-api]}
   net.sf.cssbox/cssbox                      {:mvn/version "5.0.1"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api
-                                                           junit/junit
-                                                           org.codelibs/nekohtml]}
+                                                           junit/junit]}
   net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20230409"} ; Java implementation of the JQ json query language
   org.apache.commons/commons-compress       {:mvn/version "1.25.0"}             ; compression utils
   org.apache.commons/commons-lang3          {:mvn/version "3.14.0"}             ; helper methods for working with java.lang stuff
@@ -152,7 +151,6 @@
   org.clojure/tools.namespace               {:mvn/version "1.4.4"}
   org.clojure/tools.reader                  {:mvn/version "1.3.7"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
-  org.codelibs/nekohtml                     {:mvn/version "2.1.2"}              ; used in cssbox
   org.eclipse.jetty/jetty-server            {:mvn/version "11.0.17"}            ; web server
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.4"}             ; JavaScript engine

--- a/deps.edn
+++ b/deps.edn
@@ -86,7 +86,7 @@
   joda-time/joda-time                       {:mvn/version "2.12.5"}
   kixi/stats                                {:mvn/version "0.5.5"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
-  lambdaisland/uri                          {:mvn/version "1.16.134"}           ; Used by opanai-clojure. security bump
+  lambdaisland/uri                          {:mvn/version "1.19.155"}           ; Used by openai-clojure
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
   metabase/saml20-clj                       {:mvn/version "2.2.4"               ; EE SAML integration.

--- a/modules/drivers/athena/deps.edn
+++ b/modules/drivers/athena/deps.edn
@@ -5,5 +5,5 @@
  {"athena" {:url "https://s3.amazonaws.com/maven-athena"}}
 
  :deps
- {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.619"}
+ {com.amazonaws/aws-java-sdk-core {:mvn/version "1.12.643"}
   com.metabase/athena-jdbc {:mvn/version "2.0.35"}}}

--- a/modules/drivers/googleanalytics/deps.edn
+++ b/modules/drivers/googleanalytics/deps.edn
@@ -4,6 +4,7 @@
  {com.google.apis/google-api-services-analytics      {:mvn/version "v3-rev20190807-2.0.0"}
   ;; CVE on 2.8.7 from google api services (NB: also in bigquery-cloud-sdk)
   com.google.code.gson/gson                          {:mvn/version "2.10.1"}
+  com.google.guava/guava                             {:mvn/version "32.1.3-jre"} ; specified separately so that Snyk is happy
   com.google.oauth-client/google-oauth-client        {:mvn/version "1.34.1"}
   ;; for some reason, Google stopped depending on google-http-client-jackson2 from google-api-client somewhere between
   ;; 1.30.7 and 1.32.1, so we must explicitly bring it in because the google driver uses it directly


### PR DESCRIPTION
Should close [a few issues](https://github.com/metabase/metabase/security/code-scanning)