### PR TITLE
Fix broken Audit overview page

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -17,6 +17,7 @@ import type {
 } from "metabase-types/api";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/Question";
+import InternalQuery from "metabase-lib/queries/InternalQuery";
 import { CardMenuRoot } from "./DashCardMenu.styled";
 
 interface OwnProps {
@@ -151,10 +152,13 @@ DashCardMenu.shouldRender = ({
   isPublic,
   isEditing,
 }: QueryDownloadWidgetOpts) => {
+  const isInternalQuery =
+    question.legacyQuery({ useStructuredQuery: true }) instanceof InternalQuery;
   if (isEmbed) {
     return isEmbed;
   }
   return (
+    !isInternalQuery &&
     !isPublic &&
     !isEditing &&
     !isXray &&

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.tsx
@@ -152,8 +152,11 @@ DashCardMenu.shouldRender = ({
   isPublic,
   isEditing,
 }: QueryDownloadWidgetOpts) => {
+  // Do not remove this check until we completely remove the old code related to Audit V1!
+  // MLv2 doesn't handle `internal` queries used for Audit V1.
   const isInternalQuery =
     question.legacyQuery({ useStructuredQuery: true }) instanceof InternalQuery;
+
   if (isEmbed) {
     return isEmbed;
   }


### PR DESCRIPTION
This PR fixes the broken audit overview page by reverting the commit that removed the "internal query guard". As explained in the issue, MLv2 doesn't handle the internal query type so we have to be very careful not to invoke MLv2 functions for such queries.

## How to test?
Check out this branch, build and go to `/admin/audit/members/overview`. Make sure that the page loads for you and there are no exceptions related to MLv2 in the console.
![image](https://github.com/metabase/metabase/assets/31325167/bd973460-1edc-4a3a-a824-ddd5b92d79cd)

![image](https://github.com/metabase/metabase/assets/31325167/421fc700-91de-4f55-a5dc-f25a0d30801e)


Fixes #38123