### PR TITLE
Evaluate all defsetting arguments at runtime

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1071,13 +1071,13 @@
               {:description-form ~description-form})))
 
 ;; This exists as its own method so that we can stub it in tests
-(defn- in-test? [ns] (str/ends-with? ns "-test"))
+(defn- ns-in-test? [ns-name] (str/ends-with? ns-name "-test"))
 
 (defn- requires-i18n?
   [setting-definition]
   (and (not= (:visibility setting-definition) :internal)
        (not= (:setter setting-definition) :none)
-       (not (in-test? (:namespace setting-definition)))))
+       (not (ns-in-test? (:namespace setting-definition)))))
 
 (defmacro defsetting
   "Defines a new Setting that will be added to the DB at some point in the future.

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1055,24 +1055,29 @@
 (defn- valid-trs-or-tru? [desc]
   (is-form? allowed-deferred-i18n-forms desc))
 
-(defn- validate-description-form
-  "Check that `description-form` is a i18n form (e.g. [[metabase.util.i18n/deferred-tru]]). Returns `description-form`
-  as-is."
+(defn- validate-description-form*
+  "Check that `description-form` is a i18n form (e.g. [[metabase.util.i18n/deferred-tru]]).
+   If not, return a form for an exception to throw at a later stage.
+   The reason for this strange behaviour is that we need to build the exception at compile time, but will only know
+   whether we should throw it once all the macro arguments have been evaluated at runtime."
   [description-form]
   (when-not (valid-trs-or-tru? description-form)
     ;; this doesn't need to be i18n'ed because it's a compile-time error.
-    (throw (ex-info (str "defsetting docstrings must be a *deferred* i18n form unless the Setting has"
-                         " `:visibilty` `:internal`, `:setter` `:none`, or is defined in a test namespace."
-                         (format " Got: ^%s %s"
-                                 (some-> description-form class (.getCanonicalName))
-                                 (pr-str description-form)))
-                    {:description-form description-form})))
-  description-form)
+    `(ex-info (str "defsetting docstrings must be a *deferred* i18n form unless the Setting has"
+                   " `:visibility` `:internal`, `:setter` `:none`, or is defined in a test namespace."
+                   (format " Got: ^%s %s"
+                           (some-> ~description-form class (.getCanonicalName))
+                           (pr-str ~description-form)))
+              {:description-form ~description-form})))
 
-(defn- in-test?
-  "Is `defsetting` currently being used in a test namespace?"
-  []
-  (str/ends-with? (ns-name *ns*) "-test"))
+;; This exists as its own method so that we can stub it in tests
+(defn- in-test? [ns] (str/ends-with? ns "-test"))
+
+(defn- requires-i18n?
+  [setting-definition]
+  (and (not= (:visibility setting-definition) :internal)
+       (not= (:setter setting-definition) :none)
+       (not (in-test? (:namespace setting-definition)))))
 
 (defmacro defsetting
   "Defines a new Setting that will be added to the DB at some point in the future.
@@ -1190,31 +1195,31 @@
          ;; don't put exclamation points in your Setting names. We don't want functions like `exciting!` for the getter
          ;; and `exciting!!` for the setter.
          (not (str/includes? (name setting-symbol) "!"))]}
-  (let [description               (if (or (= (:visibility options) :internal)
-                                          (= (:setter options) :none)
-                                          (in-test?))
-                                    description
-                                    (validate-description-form description))
-        ;; wrap the description form in a thunk, so its result updates with its dependencies
-        description               `(fn [] ~description)
-        definition-form           (assoc options
-                                         :name (keyword setting-symbol)
-                                         :description description
-                                         :namespace (list 'quote (ns-name *ns*)))
+  (let [;; we need the compile-time description form to check whether it supports i18n
+        ;; we only build the ex for now - we must check the runtime expanded setting-definition for whether i18n is required
+        maybe-i18n-exception     (validate-description-form* description)
+        setting-metadata         {:name        (keyword setting-symbol)
+                                  ;; wrap the description form in a thunk, so its result updates with its dependencies
+                                  :description `(fn [] ~description)
+                                  :namespace   (list 'quote (ns-name *ns*))}
         ;; create symbols for the getter and setter functions e.g. `my-setting` and `my-setting!` respectively.
         ;; preserve metadata from the `setting-symbol` passed to `defsetting`.
-        setting-getter-fn-symbol  setting-symbol
-        setting-setter-fn-symbol  (-> (symbol (str (name setting-symbol) \!))
-                                      (with-meta (meta setting-symbol)))
-        ;; create a symbol for the Setting definition from [[register-setting!]]
-        setting-definition-symbol (gensym "setting-")]
-    `(let [~setting-definition-symbol (register-setting! ~definition-form)]
-       (-> (def ~setting-getter-fn-symbol (setting-fn :getter ~setting-definition-symbol))
-           (alter-meta! merge (setting-fn-metadata :getter ~setting-definition-symbol)))
-       ~(when-not (= (:setter options) :none)
-          `(-> (def ~setting-setter-fn-symbol (setting-fn :setter ~setting-definition-symbol))
-               (alter-meta! merge (setting-fn-metadata :setter ~setting-definition-symbol)))))))
-
+        setting-getter-fn-symbol setting-symbol
+        setting-setter-fn-symbol (-> (symbol (str (name setting-symbol) \!))
+                                     (with-meta (meta setting-symbol)))]
+    `(let [setting-options#   (merge ~options ~setting-metadata)
+           setting-definition# (register-setting! setting-options#)]
+       (when (and ~maybe-i18n-exception (#'requires-i18n? setting-definition#))
+         (throw ~maybe-i18n-exception))
+       (-> (def ~setting-getter-fn-symbol (setting-fn :getter setting-definition#))
+           (alter-meta! merge (setting-fn-metadata :getter setting-definition#)))
+       ;; unfortunately we can't evaluate this condition at compile time, as the options might contain runtime forms.
+       (when (not= (:setter setting-definition#) :none)
+         ;; therefore we need to do some runtime skullduggery to ensure the var is only created conditionally
+         (-> (intern (:namespace setting-definition#)
+                     '~setting-setter-fn-symbol
+                     (setting-fn :setter setting-definition#))
+             (alter-meta! merge (setting-fn-metadata :setter setting-definition#)))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                 EXTRA UTIL FNS                                                 |

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -622,6 +622,23 @@
              (settings-last-updated-value-in-db))))))
 
 
+;;; ---------------------------------------------- Runtime Setting Options ----------------------------------------------
+
+(def my-default 3)
+
+(defsetting test-dynamic-setting
+  (deferred-tru "This is a sample sensitive Setting.")
+  :default    my-default
+  :type       :integer
+  :visibility (if (odd? my-default) :internal :public))
+
+(deftest var-value-test
+  (testing "The defsetting macro allows references to vars for inputs"
+    (is (= 3 (test-dynamic-setting))))
+  (testing "The defsetting macro allows arbitrary code forms for values"
+    (is (= :internal (:visibility (setting/resolve-setting :test-dynamic-setting))))))
+
+
 ;;; ----------------------------------------------- Sensitive Settings -----------------------------------------------
 
 (defsetting test-sensitive-setting


### PR DESCRIPTION
### Description

This refactor changes `defsetting` so that we only process its arguments at runtime, allowing us to use references and expressions to define things dynamically.

~~Note that this PR does *not* add support for a trailing kwargs map, that's left in https://github.com/metabase/metabase/pull/38090, which I plan to rebase on this branch.~~ Scrapped that feature anyway.