### PR TITLE
remove extra border from recipient picker in dash subs

### DIFF
--- a/frontend/src/metabase/pulse/components/RecipientPicker.jsx
+++ b/frontend/src/metabase/pulse/components/RecipientPicker.jsx
@@ -58,7 +58,7 @@ export default class RecipientPicker extends Component {
 
     return (
       <div>
-        <div className="bordered rounded" style={{ padding: "2px" }}>
+        <div style={{ padding: "2px" }}>
           <TokenField
             value={recipients}
             options={users ? users.map(user => ({ value: user })) : []}


### PR DESCRIPTION
Removes an extraneous border from the To: Input in dashboard subscriptions. While normally I'm all for two for the price of one, this seems a little excessive.

Before:
![Screenshot 2024-01-25 at 8 29 30 AM](https://github.com/metabase/metabase/assets/5248953/ec7b4d99-c14d-419e-90a1-729ce719e600)

After:
![Screenshot 2024-01-25 at 9 12 35 AM](https://github.com/metabase/metabase/assets/5248953/e0fed0fb-38d4-4047-b96d-a63431de9bb1)
