### PR TITLE
Add :impersonated to the cond in a debug log to fix impersonation on stats

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
@@ -97,7 +97,8 @@
                   (case changes
                     :none  "no longer has any perms"
                     :all   "now has full data perms"
-                    :block "is now BLOCKED from all non-data-perms access")
+                    :block "is now BLOCKED from all non-data-perms access"
+                    :impersonated "is now using connection impersonation")
                   database-id)
       (delete-gtaps-with-condition! group-id [:= :table.db_id database-id]))
     (doseq [schema-name (set (keys changes))]


### PR DESCRIPTION
Connection impersonation can't be set on stats because they have log level set to `debug`, which is hitting this `cond`, which doesn't have a case for `:impersonated` so it's throwing an error.