### PR TITLE
[QC] Clean up `isStructured` (v1) utilities

### DIFF
--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -14,7 +14,7 @@ import type Database from "metabase-lib/metadata/Database";
 import type Question from "metabase-lib/Question";
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import { isSameField } from "metabase-lib/queries/utils/field-ref";
-import { isStructured } from "metabase-lib/queries/utils";
+import { isStructured } from "metabase-lib/queries/utils/card";
 
 type FieldMetadata = {
   id?: FieldId | FieldReference;
@@ -114,7 +114,7 @@ export function checkCanBeModel(question: Question) {
 }
 
 export function isAdHocModelQuestionCard(card: Card, originalCard?: Card) {
-  if (!originalCard || !isStructured(card.dataset_query)) {
+  if (!originalCard || !isStructured(card)) {
     return false;
   }
 

--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -14,7 +14,7 @@ import type Database from "metabase-lib/metadata/Database";
 import type Question from "metabase-lib/Question";
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import { isSameField } from "metabase-lib/queries/utils/field-ref";
-import { isStructured } from "metabase-lib/queries/utils/card";
+import { isNative } from "metabase-lib/queries/utils/card";
 
 type FieldMetadata = {
   id?: FieldId | FieldReference;
@@ -114,7 +114,7 @@ export function checkCanBeModel(question: Question) {
 }
 
 export function isAdHocModelQuestionCard(card: Card, originalCard?: Card) {
-  if (!originalCard || !isStructured(card)) {
+  if (!originalCard || isNative(card)) {
     return false;
   }
 

--- a/frontend/src/metabase-lib/queries/utils/card.js
+++ b/frontend/src/metabase-lib/queries/utils/card.js
@@ -7,8 +7,8 @@ import { normalizeParameterValue } from "metabase-lib/parameters/utils/parameter
 import { deriveFieldOperatorFromParameter } from "metabase-lib/parameters/utils/operators";
 import * as Q_DEPRECATED from "metabase-lib/queries/utils"; // legacy
 
-export function isStructured(card) {
-  return card.dataset_query?.type === "query";
+export function isNative(card) {
+  return card?.dataset_query?.type === "native";
 }
 
 function cardVisualizationIsEquivalent(cardA, cardB) {

--- a/frontend/src/metabase-lib/queries/utils/index.js
+++ b/frontend/src/metabase-lib/queries/utils/index.js
@@ -9,10 +9,6 @@ export * from "./field-ref";
 // need to communicate or use that, use this constant
 export const HARD_ROW_LIMIT = 2000;
 
-export function isStructured(dataset_query) {
-  return dataset_query && dataset_query.type === "query";
-}
-
 export function cleanQuery(query) {
   if (!query) {
     return query;

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -4,7 +4,7 @@ import { IS_EMBED_PREVIEW } from "metabase/lib/embed";
 
 import Question from "metabase-lib/Question";
 import { normalizeParameters } from "metabase-lib/parameters/utils/parameter-values";
-import { isStructured } from "metabase-lib/queries/utils/card";
+import { isNative } from "metabase-lib/queries/utils/card";
 import { getPivotColumnSplit } from "metabase-lib/queries/utils/pivot";
 import { injectTableMetadata } from "metabase-lib/metadata/utils/tables";
 
@@ -60,7 +60,7 @@ export function maybeUsePivotEndpoint(api, card, metadata) {
   }
   if (
     question.display() !== "pivot" ||
-    !isStructured(card) ||
+    isNative(card) ||
     // if we have metadata for the db, check if it supports pivots
     (question.database() && !question.database().supportsPivots())
   ) {

--- a/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
+++ b/frontend/src/metabase/visualizations/lib/LineAreaBarRenderer.js
@@ -8,7 +8,7 @@ import { lighten } from "metabase/lib/colors";
 
 import { keyForSingleSeries } from "metabase/visualizations/lib/settings/series";
 import * as Lib from "metabase-lib";
-import { isStructured } from "metabase-lib/queries/utils/card";
+import { isNative } from "metabase-lib/queries/utils/card";
 import Question from "metabase-lib/Question";
 
 import {
@@ -74,7 +74,7 @@ const enableBrush = (series, onChangeCardAndRun) =>
   !!(
     onChangeCardAndRun &&
     !isMultiCardSeries(series) &&
-    isStructured(series[0].card) &&
+    !isNative(series[0].card) &&
     !isRemappedToString(series) &&
     !hasClickBehavior(series)
   );

--- a/frontend/src/metabase/visualizations/lib/renderer_utils.js
+++ b/frontend/src/metabase/visualizations/lib/renderer_utils.js
@@ -11,7 +11,7 @@ import {
 import { formatNullable } from "metabase/lib/formatting/nullable";
 import { datasetContainsNoResults } from "metabase-lib/queries/utils/dataset";
 
-import { isStructured } from "metabase-lib/queries/utils/card";
+import { isNative } from "metabase-lib/queries/utils/card";
 import { isNumeric } from "metabase-lib/types/utils/isa";
 import {
   computeTimeseriesDataInverval,
@@ -358,7 +358,7 @@ export function xValueForWaterfallTotal({ settings, series }) {
 const uniqueCards = series => _.uniq(series.map(({ card }) => card.id)).length;
 
 const getMetricColumnsCount = series => {
-  const metricColumnPredicate = isStructured(series[0]?.card)
+  const metricColumnPredicate = !isNative(series[0]?.card)
     ? column => column.source === "aggregation"
     : column => isNumeric(column);
 

--- a/frontend/src/metabase/visualizations/visualizations/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.tsx
@@ -43,7 +43,7 @@ import {
   isAvatarURL,
 } from "metabase-lib/types/utils/isa";
 import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
-import { isStructured } from "metabase-lib/queries/utils/card";
+import { isNative } from "metabase-lib/queries/utils/card";
 
 import type { ColumnSettingDefinition, VisualizationProps } from "../types";
 import { TableSimple } from "../components/TableSimple";
@@ -93,7 +93,7 @@ class Table extends Component<TableProps, TableState> {
         if (
           !data ||
           data.cols.length !== 3 ||
-          !isStructured(card) ||
+          isNative(card) ||
           data.cols.filter(isMetric).length !== 1 ||
           data.cols.filter(isDimension).length !== 2
         ) {

--- a/frontend/src/metabase/visualizations/visualizations/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.tsx
@@ -43,7 +43,7 @@ import {
   isAvatarURL,
 } from "metabase-lib/types/utils/isa";
 import { findColumnIndexForColumnSetting } from "metabase-lib/queries/utils/dataset";
-import * as Q_DEPRECATED from "metabase-lib/queries/utils";
+import { isStructured } from "metabase-lib/queries/utils/card";
 
 import type { ColumnSettingDefinition, VisualizationProps } from "../types";
 import { TableSimple } from "../components/TableSimple";
@@ -93,7 +93,7 @@ class Table extends Component<TableProps, TableState> {
         if (
           !data ||
           data.cols.length !== 3 ||
-          !Q_DEPRECATED.isStructured(card.dataset_query) ||
+          !isStructured(card) ||
           data.cols.filter(isMetric).length !== 1 ||
           data.cols.filter(isDimension).length !== 2
         ) {


### PR DESCRIPTION
This is a follow-up after https://github.com/metabase/metabase/pull/37977.
Related to https://github.com/metabase/metabase/issues/37953

We agreed to use the `isNative` nomenclature and to completely get rid of `isStructured` term. This PR follows that logic.