### PR TITLE
Fixes settings that should default to `false` returning null

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -569,7 +569,7 @@
                      env-var-value
                      db-or-cache-value
                      (cond
-                       (:default setting) default-value
+                       (some?(:default setting)) default-value
                        (:init setting)    (when-not *disable-init*
                                             init!))]]
      (loop [[f & more] source-fns]
@@ -976,7 +976,7 @@
         (throw (ex-info (tru "Setting {0} allows both user-local and database-local values; this is not supported"
                              setting-name)
                         {:setting setting})))
-      (when (and (:default setting) (:init setting))
+      (when (and (some? (:default setting)) (:init setting))
         (throw (ex-info (tru "Setting {0} uses both :default and :init options, which are mutually exclusive"
                              setting-name)
                         {:setting setting})))


### PR DESCRIPTION
Closes #38138

I believe the issue was that `(:default setting)` returned the default value, and in the case of `:default false` it returned false -> it didn't return the default value

# How to reproduce

- Nuke the db
- Start metabase
- complete setup
- see that the settings are correct, one example is `enable-public-sharing` that should return `false` instead of `null`