### PR TITLE
remove border from SearchContainer until activated

### DIFF
--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.styled.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.styled.tsx
@@ -65,13 +65,14 @@ export const SearchInputContainer = styled.div<{
     width: 2rem;
     height: 2rem;
     border-radius: 99px;
-
+    border-color: transparent;
     ${props =>
       props.isActive &&
       css`
         width: 100%;
+        border-color: ${color("border")};
         ${activeInputCSS};
-      `}
+      `};
   }
 
   ${breakpointMinSmall} {


### PR DESCRIPTION
Was frustrated by this during the e-charts bug bash with two "mobile" breakpoint screens side by side on my laptop. Our search icon has a border unlike all the other nav items when in "mobile" presentation. This removes the border until the search bar is activated to standardize the appearance.

Before:
![Screenshot 2024-01-25 at 11 21 55 AM](https://github.com/metabase/metabase/assets/5248953/f0e75b20-bce0-4d84-852d-e65c4b56709b)

After:
![Screenshot 2024-01-25 at 11 21 28 AM](https://github.com/metabase/metabase/assets/5248953/67e75f61-1591-4778-8892-131cebfa274b)

And for posterity, here's a screenshot showing that everything's fine when outside of the breakpoint, so no knock on changes.
![Screenshot 2024-01-25 at 11 25 25 AM](https://github.com/metabase/metabase/assets/5248953/12f4362f-7619-4f27-8b02-3d3bcf0791e6)


