### PR TITLE
Restore border in a default state for a bulk filter input

### DIFF
--- a/frontend/src/metabase/querying/components/FilterModal/FilterSearchInput/FilterSearchInput.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/FilterSearchInput/FilterSearchInput.tsx
@@ -3,8 +3,6 @@ import { useDebounce } from "react-use";
 import { t } from "ttag";
 import { Flex, TextInput, Icon } from "metabase/ui";
 
-import { isSearchActive } from "../utils";
-
 const SEARCH_TIMEOUT = 200;
 
 interface FilterSearchInputProps {
@@ -17,8 +15,6 @@ export function FilterSearchInput({
   onChange,
 }: FilterSearchInputProps) {
   const [inputText, setInputText] = useState("");
-  const [isFocused, setIsFocused] = useState(false);
-  const isActive = isFocused || isSearchActive(inputText);
 
   useDebounce(
     () => inputText !== searchText && onChange(inputText),
@@ -32,12 +28,9 @@ export function FilterSearchInput({
         type="search"
         value={inputText}
         icon={<Icon name="search" />}
-        variant={isActive ? "default" : "unstyled"}
         placeholder={t`Search for a column…`}
         aria-hidden
         onChange={event => setInputText(event.currentTarget.value)}
-        onFocus={() => setIsFocused(true)}
-        onBlur={() => setIsFocused(false)}
       />
     </Flex>
   );


### PR DESCRIPTION
This PR restores a border around a bulk filter search input field. This visual regression was caused by a recent MLv2 migration.

### Before
![Kapture 2024-01-25 at 18 51 01](https://github.com/metabase/metabase/assets/31325167/bdaf1335-1377-4a73-8f68-9a39191163b7)

### After
![Kapture 2024-01-25 at 18 49 48](https://github.com/metabase/metabase/assets/31325167/cc7ae818-143f-476b-8af6-f9f6a3bbf4ca)

Fixes #38149