### PR TITLE
Remove useless warnings from defendpoint missing a malli schema

### DIFF
--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -78,7 +78,10 @@
 (defn- dox-for-schema
   "Generate the docstring for `schema` for use in auto-generated API documentation."
   [schema route-str]
-  (try (with-out-str (umd/describe schema))
+  (try
+    ;; we can ignore the warning printed by umd/describe when schema is `nil`.
+    (binding [*out* (new java.io.StringWriter)]
+      (umd/describe schema))
        (catch Exception _
          (ex-data
           (when (and schema config/is-dev?) ;; schema is nil for any var without a schema. That's ok!

--- a/src/metabase/api/common/internal.clj
+++ b/src/metabase/api/common/internal.clj
@@ -78,7 +78,7 @@
 (defn- dox-for-schema
   "Generate the docstring for `schema` for use in auto-generated API documentation."
   [schema route-str]
-  (try (umd/describe schema)
+  (try (with-out-str (umd/describe schema))
        (catch Exception _
          (ex-data
           (when (and schema config/is-dev?) ;; schema is nil for any var without a schema. That's ok!


### PR DESCRIPTION
in defendpoint, we knowingly call umd/describe on a possibly-nil value (`nil` is not a malli schema). When unable to create a schema, malli will print a warning about that, however that's ok in this instance, so don't warn about it.

This might be a good place to log a warning about having a missing schema for a var, but didn't want to make that choice here. for now let's just get rid of the unhelpful warning.