### PR TITLE
Add intermittent test solver

### DIFF
--- a/test/metabase/test_runner.clj
+++ b/test/metabase/test_runner.clj
@@ -87,6 +87,12 @@
    :exclude-directories excluded-directories
    :test-warn-time      3000})
 
+(defn find-tests
+  "Find all tests, in case you wish to run them yourself."
+  ([] (find-tests {}))
+  ([options]
+   (hawk/find-tests nil (merge (default-options) options))))
+
 (defn find-and-run-tests-repl
   "Find and run tests from the REPL."
   [options]


### PR DESCRIPTION
Sometimes a test passes when run by itself, but fails due to ordering issues. This is typically caused by another test failing to properly clean up after itself, leaving the database in a dirty state. For example, we might change permissions and forget to change them back, so that another test hits an unexpected permissions failure.

Finding the cause of these has been a source of pain for me, so I wrote a small snippet to do it for me.

If you have a test that passes when run by itself, but fails when run along with all the other tests, you can run
`(dev/find-root-test-failure! #'my-ns/my-intermittent-failure-test)`.

It will run *all* tests. After each one, it'll run the test you passed in. Once that test starts failing, it'll alert you about which test caused it to fail.