### PR TITLE
Fix Snowflake sync not returning all schemas regression in 48+

### DIFF
--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -10,10 +10,14 @@
    [metabase.driver.sql :as driver.sql]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
+   [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
+   [metabase.driver.sql-jdbc.sync.describe-database :as sql-jdbc.describe-database]
+   [metabase.lib.test-util :as lib.tu]
    [metabase.models :refer [Table]]
    [metabase.models.database :refer [Database]]
    [metabase.public-settings :as public-settings]
    [metabase.query-processor :as qp]
+   [metabase.query-processor.store :as qp.store]
    [metabase.sync :as sync]
    [metabase.sync.util :as sync-util]
    [metabase.test :as mt]
@@ -141,6 +145,27 @@
                (ddl/create-db-tables-ddl-statements :snowflake (-> (mt/get-dataset-definition defs/test-data)
                                                                    (update :database-name #(str "v4_" %))))))))))
 
+(deftest ^:parallel simple-select-probe-query-test
+  (testing "the simple-select-probe-query used by have-select-privilege? should be qualified with the Database name. Ignore blank keys."
+    (mt/test-driver :snowflake
+      (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider
+                                        {:database (assoc (mt/db)
+                                                          :details {:db     " "
+                                                                    :dbname "dbname"})})
+        (is (= ["SELECT TRUE AS \"_\" FROM \"dbname\".\"PUBLIC\".\"table\" WHERE 1 <> 1 LIMIT 0"]
+               (sql-jdbc.describe-database/simple-select-probe-query :snowflake "PUBLIC" "table")))))))
+
+(deftest ^:parallel have-select-privilege?-test
+  (mt/test-driver :snowflake
+    (qp.store/with-metadata-provider (mt/id)
+      (sql-jdbc.execute/do-with-connection-with-options
+       :snowflake
+       (mt/db)
+       nil
+       (fn [^java.sql.Connection conn]
+         (is (sql-jdbc.sync/have-select-privilege? :snowflake conn "PUBLIC" "venues")))))))
+
+
 (deftest describe-database-test
   (mt/test-driver :snowflake
     (testing "describe-database"
@@ -166,22 +191,51 @@
           (is (= expected
                  (driver/describe-database :snowflake (assoc (mt/db) :name "ABC")))))))))
 
+(deftest describe-database-default-schema-test
+  (testing "describe-database should include Tables from all schemas even if the DB has a default schema (#38135)"
+    (mt/test-driver :snowflake
+      (let [details     (assoc (mt/dbdef->connection-details :snowflake :db {:database-name "lowercase_test"})
+                               ;; simulate a DB default schema or session schema by including it in the connection
+                               ;; details... see
+                               ;; https://metaboat.slack.com/archives/C04DN5VRQM6/p1706219065462619?thread_ts=1706156558.940489&cid=C04DN5VRQM6
+                               :schema "PUBLIC"
+                               :schema-filters-type "inclusion"
+                               :schema-filters-patterns "test_schema")
+            db-name     (:db details)
+            schema-name "test_schema"
+            table-name  "test_table"
+            field-name  "test_id"
+            spec        (sql-jdbc.conn/connection-details->spec :snowflake details)
+            identifier  (fn [& args]
+                          (str/join \. (map #(str \" % \") args)))]
+        ;; create the snowflake DB
+        (doseq [stmt [(format "DROP DATABASE IF EXISTS %s;" (identifier db-name))
+                      (format "CREATE DATABASE %s;" (identifier db-name))
+                      (format "CREATE SCHEMA %s;" (identifier db-name schema-name))
+                      (format "CREATE TABLE %s (%s INTEGER AUTOINCREMENT);" (identifier db-name schema-name table-name) (identifier field-name))
+                      (format "GRANT SELECT ON %s TO PUBLIC;" (identifier db-name schema-name table-name))]]
+          (jdbc/execute! spec [stmt] {:transaction? false}))
+        ;; create the DB object
+        (t2.with-temp/with-temp [Database database {:engine :snowflake, :details details}]
+          (is (=? {:tables #{{:name table-name, :schema schema-name, :description nil}}}
+                  (driver/describe-database :snowflake database))))))))
+
 (deftest describe-database-views-test
   (mt/test-driver :snowflake
     (testing "describe-database views"
       (let [details (mt/dbdef->connection-details :snowflake :db {:database-name "views_test"})
+            db-name (:db details)
             spec    (sql-jdbc.conn/connection-details->spec :snowflake details)]
         ;; create the snowflake DB
-        (jdbc/execute! spec ["DROP DATABASE IF EXISTS \"views_test\";"]
-                       {:transaction? false})
-        (jdbc/execute! spec ["CREATE DATABASE \"views_test\";"]
-                       {:transaction? false})
+        (doseq [stmt [(format "DROP DATABASE IF EXISTS \"%s\";" db-name)
+                      (format "CREATE DATABASE \"%s\";" db-name)]]
+          (jdbc/execute! spec [stmt] {:transaction? false}))
         ;; create the DB object
-        (t2.with-temp/with-temp [Database database {:engine :snowflake, :details (assoc details :db "views_test")}]
+        (t2.with-temp/with-temp [Database database {:engine :snowflake, :details details}]
           (let [sync! #(sync/sync-database! database)]
             ;; create a view
-            (doseq [statement ["CREATE VIEW \"views_test\".\"PUBLIC\".\"example_view\" AS SELECT 'hello world' AS \"name\";"
-                               "GRANT SELECT ON \"views_test\".\"PUBLIC\".\"example_view\" TO PUBLIC;"]]
+            (doseq [statement [(format "CREATE VIEW \"%s\".\"PUBLIC\".\"example_view\" AS SELECT 'hello world' AS \"name\";" db-name)
+                               (format "GRANT SELECT ON \"%s\".\"PUBLIC\".\"example_view\" TO PUBLIC;" db-name)]]
               (jdbc/execute! spec [statement]))
             ;; now sync the DB
             (sync!)
@@ -213,7 +267,7 @@
                      (set (t2/select [:model/Field :name :base_type]
                                      :table_id (t2/select-one-pk :model/Table :name "metabase_fan" :db_id db-id))))))))))))
 
-(deftest describe-table-test
+(deftest ^:parallel describe-table-test
   (mt/test-driver :snowflake
     (testing "make sure describe-table uses the NAME FROM DETAILS too"
       (is (= {:name   "categories"
@@ -235,7 +289,7 @@
                          :json-unfolding    false}}}
              (driver/describe-table :snowflake (assoc (mt/db) :name "ABC") (t2/select-one Table :id (mt/id :categories))))))))
 
-(deftest describe-table-fks-test
+(deftest ^:parallel describe-table-fks-test
   (mt/test-driver :snowflake
     (testing "make sure describe-table-fks uses the NAME FROM DETAILS too"
       (is (= #{{:fk-column-name   "category_id"
@@ -370,7 +424,7 @@
                 (is (= [[friday-int 1]]
                        (mt/rows (qp/process-query query))))))))))))
 
-(deftest normalize-test
+(deftest ^:parallel normalize-test
   (mt/test-driver :snowflake
     (testing "details should be normalized coming out of the DB"
       (t2.with-temp/with-temp [Database db {:name    "Legacy Snowflake DB"
@@ -380,7 +434,7 @@
         (is (= {:account "my-instance.us-west-1"}
                (:details db)))))))
 
-(deftest set-role-statement-test
+(deftest ^:parallel set-role-statement-test
   (testing "set-role-statement should return a USE ROLE command, with the role quoted if it contains special characters"
     ;; No special characters
     (is (= "USE ROLE MY_ROLE;"        (driver.sql/set-role-statement :snowflake "MY_ROLE")))
@@ -391,7 +445,7 @@
     (is (= "USE ROLE \"Role.123\";"   (driver.sql/set-role-statement :snowflake "Role.123")))
     (is (= "USE ROLE \"$role\";"      (driver.sql/set-role-statement :snowflake "$role")))))
 
-(deftest remark-test
+(deftest ^:parallel remark-test
   (testing "Queries should have a remark formatted as JSON appended to them with additional metadata"
     (mt/test-driver :snowflake
       (let [expected-map {"pulseId" nil

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -165,7 +165,6 @@
        (fn [^java.sql.Connection conn]
          (is (sql-jdbc.sync/have-select-privilege? :snowflake conn "PUBLIC" "venues")))))))
 
-
 (deftest describe-database-test
   (mt/test-driver :snowflake
     (testing "describe-database"

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -193,17 +193,17 @@
 (deftest describe-database-default-schema-test
   (testing "describe-database should include Tables from all schemas even if the DB has a default schema (#38135)"
     (mt/test-driver :snowflake
-      (let [details     (assoc (mt/dbdef->connection-details :snowflake :db {:database-name "lowercase_test"})
+      (let [details     (assoc (mt/dbdef->connection-details :snowflake :db {:database-name "Default-Schema-Test"})
                                ;; simulate a DB default schema or session schema by including it in the connection
                                ;; details... see
                                ;; https://metaboat.slack.com/archives/C04DN5VRQM6/p1706219065462619?thread_ts=1706156558.940489&cid=C04DN5VRQM6
                                :schema "PUBLIC"
                                :schema-filters-type "inclusion"
-                               :schema-filters-patterns "test_schema")
+                               :schema-filters-patterns "Test-Schema")
             db-name     (:db details)
-            schema-name "test_schema"
-            table-name  "test_table"
-            field-name  "test_id"
+            schema-name "Test-Schema"
+            table-name  "Test-Table"
+            field-name  "Test-ID"
             spec        (sql-jdbc.conn/connection-details->spec :snowflake details)
             identifier  (fn [& args]
                           (str/join \. (map #(str \" % \") args)))]

--- a/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
+++ b/modules/drivers/snowflake/test/metabase/driver/snowflake_test.clj
@@ -447,7 +447,7 @@
     (is (= "USE ROLE \"Role.123\";"   (driver.sql/set-role-statement :snowflake "Role.123")))
     (is (= "USE ROLE \"$role\";"      (driver.sql/set-role-statement :snowflake "$role")))))
 
-(deftest ^:parallel remark-test
+(deftest remark-test
   (testing "Queries should have a remark formatted as JSON appended to them with additional metadata"
     (mt/test-driver :snowflake
       (let [expected-map {"pulseId" nil

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -96,6 +96,11 @@
   "Fetch a JDBC Metadata ResultSet of tables in the DB, optionally limited to ones belonging to a given
   schema. Returns a reducible sequence of results."
   [driver ^DatabaseMetaData metadata ^String schema-or-nil ^String db-name-or-nil]
+  ;; seems like some JDBC drivers like Snowflake are dumb and still narrow the search results by the current session
+  ;; schema if you pass in `nil` for `schema-or-nil`, which means not to narrow results at all... For Snowflake, I fixed
+  ;; this by passing in `"%"` instead -- consider making this the default behavior. See this Slack thread
+  ;; https://metaboat.slack.com/archives/C04DN5VRQM6/p1706220295862639?thread_ts=1706156558.940489&cid=C04DN5VRQM6 for
+  ;; more info.
   (with-open [rset (.getTables metadata db-name-or-nil (some->> schema-or-nil (driver/escape-entity-name-for-metadata driver)) "%"
                                (into-array String ["TABLE" "PARTITIONED TABLE" "VIEW" "FOREIGN TABLE" "MATERIALIZED VIEW"
                                                    "EXTERNAL TABLE" "DYNAMIC_TABLE"]))]


### PR DESCRIPTION
Fixes #38135

The root issue was that if you had a default schema (which I think you can set in the Snowflake admin console somehow) or session schema in play (i.e., `USE SCHEMA x` or `&schema=x` in the additional JDBC options), the new Snowflake sync code in #36121 would not return Tables in any other schema, causing them to get marked inactive. This was not a problem in earlier versions of MB (47 and earlier) since it used different sync code that still worked regardless of default schema.

I think this is actually an upstream bug with the Snowflake JDBC driver... the new sync code called [`DatabaseMetaData.getTables()`](https://docs.oracle.com/en/java/javase/11/docs/api/java.sql/java/sql/DatabaseMetaData.html#getTables(java.lang.String,java.lang.String,java.lang.String,java.lang.String%5B%5D)) with a `null` schema pattern, and the JDBC spec says

> `schemaPattern` - a schema name pattern; must match the schema name as it is stored in the database; `""` retrieves those without a schema; `null` means that the schema name should not be used to narrow the search

And the Snowflake JDBC driver is clearly narrowing the search anyway. Passing in a wildcard pattern like `"%"` seemed to resolve the issue. Maybe I need to open an upstream bug against the Snowflake JDBC driver for our friends at Snowflake now.

Ultimately this had nothing to do with the MLv2 metadata refactor, that was a big ol' red herring. See https://metaboat.slack.com/archives/C04DN5VRQM6/p1706156558940489 if you want to read the play by play of my investigation of this or see more details