### PR TITLE
specify one more guava explicitly

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -4,5 +4,6 @@
  :deps
  ;; TODO: figure out how to be able to leave off this version string and use the version from the BOM
  {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.35.0"}
+  com.google.guava/guava                      {:mvn/version "32.1.3-jre"} ; specified separately so that Snyk is happy
   com.google.code.gson/gson                   {:mvn/version "2.10.1"}
   com.google.oauth-client/google-oauth-client {:mvn/version "1.34.1"}}}


### PR DESCRIPTION
It's hard for Snyk to understand which version will be used in the end, so it complains.
