### PR TITLE
 Replace anaphoric `with-source-and-dest-dbs` with hygienic alternative

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -419,6 +419,7 @@
   honeysql.helpers/defhelper                                                           clj-kondo.lint-as/def-catch-all
   honeysql.util/defalias                                                               clojure.core/def
   metabase-enterprise.serialization.test-util/with-random-dump-dir                     clojure.core/let
+  metabase-enterprise.serialization.test-util/with-dbs                                 clojure.core/fn
   metabase.actions.test-util/with-actions                                              clojure.core/let
   metabase.api.common/let-404                                                          clojure.core/let
   metabase.api.search-test/do-test-users                                               clojure.core/let

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -80,9 +80,9 @@
     (mt/with-premium-features #{:serialization}
       (ts/with-random-dump-dir [dump-dir "serialization"]
         (let [dashboard-yaml-filename (str dump-dir "/collections/root/dashboards/Dashboard.yaml")]
-          (ts/with-source-and-dest-dbs
+          (ts/with-dbs [source-db dest-db]
             (testing "create 2 questions in the source and add them to a dashboard"
-              (ts/with-source-db
+              (ts/with-db source-db
                 (let [{db-id :id, :as db} (ts/create! Database :name "My_Database")]
                   (mt/with-db db
                     (let [{user-id :id}      (ts/create! User, :is_superuser true)
@@ -108,7 +108,7 @@
                                                  {:card_id "/collections/root/cards/Card_2"}]}
                               yaml))))
             (testing "load into destination"
-              (ts/with-dest-db
+              (ts/with-db dest-db
                 (testing "Create admin user"
                   (is (some? (ts/create! User, :is_superuser true)))
                   (is (t2/exists? User :is_superuser true)))
@@ -118,12 +118,12 @@
                   (is (= 2 (t2/count Card)) "# Cards")
                   (is (= 2 (t2/count DashboardCard)) "# DashboardCards") >)))
             (testing "remove one of the questions in the source's dashboard"
-              (ts/with-source-db
+              (ts/with-db source-db
                 (t2/delete! Card :name "Card_2")
                 (is (= 1 (t2/count Card)) "# Cards")
                 (is (= 1 (t2/count DashboardCard)) "# DashboardCards")))
             (testing "dump again"
-              (ts/with-source-db
+              (ts/with-db source-db
                 (cmd/dump dump-dir))
               (testing "Verify dump only contains one Card"
                 (is (.exists (io/file dashboard-yaml-filename)))
@@ -131,7 +131,7 @@
                   (is (partial= {:dashboard_cards [{:card_id "/collections/root/cards/Card_1"}]}
                                 yaml)))))
             (testing "load again, with --mode update, destination Dashboard should now only have one question."
-              (ts/with-dest-db
+              (ts/with-db dest-db
                 (is (nil? (cmd/load dump-dir "--mode" "update", "--on-error" "abort")))
                 (is (= 1 (t2/count Dashboard)) "# Dashboards")
                 (testing "Don't delete the Card even tho it was deleted. Just delete the DashboardCard"

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -93,29 +93,6 @@
      (fn ~db-bindings
        ~@body)))
 
-(defmacro with-source-and-dest-dbs
-  "Creates and sets up two in-memory H2 application databases, a source database and an application database. For
-  testing load/dump/serialization stuff. To use the source DB, use [[with-source-db]], which makes binds it as the
-  current application database; [[with-dest-db]] binds the destination DB as the current application database."
-  {:style/indent 0 :deprecated "0.48.0"}
-  [& body]
-  ;; this is implemented by introducing the anaphors `&source-db` and `&dest-db` which are used by
-  ;; [[with-source-db]] and [[with-dest-db]]
-  `(with-dbs [~'&source-db ~'&dest-db]
-       ~@body))
-
-(defmacro with-source-db
-  "For use with [[with-source-and-dest-dbs]]. Makes the source DB the current application database."
-  {:style/indent 0 :deprecated "0.48.0"}
-  [& body]
-  `(fn [~'source-db] ~@body))
-
-(defmacro with-dest-db
-  "For use with [[with-source-and-dest-dbs]]. Makes the destination DB the current application database."
-  {:style/indent 0 :deprecated "0.48.0"}
-  [& body]
-  `(fn [~'&dest-db] ~@body))
-
 (defn random-dump-dir [prefix]
   (str (u.files/get-path (System/getProperty "java.io.tmpdir") prefix (mt/random-name))))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -85,13 +85,15 @@
                  (apply f data-source args)))))))
 
 (defmacro with-dbs
-  ;; TODO: create a db for each binding
+  "Create and set up in-memory H2 application databases for each symbol in the bindings vector, each of which is then
+   bound to the corresponding data-source when executing the body. You can then use [[with-db]] to make any of these
+   data-sources the current application database.
+
+   This is particularly useful for load/dump/serialization tests, where you need both a source and application db."
   {:style/indent 0}
-  [db-bindings & body]
-  `(do-with-dbs
-     ~(count db-bindings)
-     (fn ~db-bindings
-       ~@body)))
+  [bindings & body]
+  (let [arity (count bindings)]
+    `(do-with-dbs ~arity (fn ~bindings ~@body))))
 
 (defn random-dump-dir [prefix]
   (str (u.files/get-path (System/getProperty "java.io.tmpdir") prefix (mt/random-name))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -99,26 +99,23 @@
   "Creates and sets up two in-memory H2 application databases, a source database and an application database. For
   testing load/dump/serialization stuff. To use the source DB, use [[with-source-db]], which makes binds it as the
   current application database; [[with-dest-db]] binds the destination DB as the current application database."
-
   [& body]
-  ;; this is implemented by introducing the anaphors `&do-with-source-db` and `&do-with-dest-db` which are used by
+  ;; this is implemented by introducing the anaphors `&source-db` and `&dest-db` which are used by
   ;; [[with-source-db]] and [[with-dest-db]]
-  `(with-dbs [source-db dest-db]
-     (let [~'&do-with-source-db #(with-db source-db @%)
-           ~'&do-with-dest-db #(with-db dest-db @%)]
-       ~@body)))
+  `(with-dbs [~'&source-db ~'&dest-db]
+       ~@body))
 
 (defmacro with-source-db
   "For use with [[with-source-and-dest-dbs]]. Makes the source DB the current application database."
   {}
   [& body]
-  `(~'&do-with-source-db (fn [] ~@body)))
+  `(fn [~'source-db] ~@body))
 
 (defmacro with-dest-db
   "For use with [[with-source-and-dest-dbs]]. Makes the destination DB the current application database."
   {:style/indent 0 :deprecated "0.48.0"}
   [& body]
-  `(~'&do-with-dest-db (fn [] ~@body)))
+  `(fn [~'&dest-db] ~@body))
 
 (defn random-dump-dir [prefix]
   (str (u.files/get-path (System/getProperty "java.io.tmpdir") prefix (mt/random-name))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -60,9 +60,7 @@
   `(binding [mdb.connection/*application-db* (mdb.connection/application-db :h2 ~data-source)]
      ;; TODO mt/with-empty-h2-app-db also rebinds some perms-group/* - do we want to do that too?
      ;;   redefs not great for parallelism
-
-     ;; TODO Check whether we need type hint
-    (testing (format "\nApp DB = %s" (pr-str (.url #_metabase.db.data_source.DataSource ~data-source)))
+    (testing (format "\nApp DB = %s" (pr-str (.url ~data-source)))
       ~@body)) )
 
 (defn- do-with-in-memory-h2-db [db-name-prefix f]

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -99,6 +99,7 @@
   "Creates and sets up two in-memory H2 application databases, a source database and an application database. For
   testing load/dump/serialization stuff. To use the source DB, use [[with-source-db]], which makes binds it as the
   current application database; [[with-dest-db]] binds the destination DB as the current application database."
+  {:style/indent 0 :deprecated "0.48.0"}
   [& body]
   ;; this is implemented by introducing the anaphors `&source-db` and `&dest-db` which are used by
   ;; [[with-source-db]] and [[with-dest-db]]
@@ -107,7 +108,7 @@
 
 (defmacro with-source-db
   "For use with [[with-source-and-dest-dbs]]. Makes the source DB the current application database."
-  {}
+  {:style/indent 0 :deprecated "0.48.0"}
   [& body]
   `(fn [~'source-db] ~@body))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/test_util.clj
@@ -56,25 +56,32 @@
 (defn create! [model & {:as properties}]
  (first (t2/insert-returning-instances! model (merge (t2.with-temp/with-temp-defaults model) properties))))
 
+(defmacro with-db [data-source & body]
+  `(binding [mdb.connection/*application-db* (mdb.connection/application-db :h2 ~data-source)]
+     ;; TODO mt/with-empty-h2-app-db also rebinds some perms-group/* - do we want to do that too?
+     ;;   redefs not great for parallelism
+
+     ;; TODO Check whether we need type hint
+    (testing (format "\nApp DB = %s" (pr-str (.url #_metabase.db.data_source.DataSource ~data-source)))
+      ~@body)) )
+
 (defn- do-with-in-memory-h2-db [db-name-prefix f]
-  (let [db-name           (str db-name-prefix (mt/random-name))
+  (let [db-name           (str db-name-prefix "-" (mt/random-name))
         connection-string (format "jdbc:h2:mem:%s" db-name)
         data-source       (mdb.data-source/raw-connection-string->DataSource connection-string)]
     ;; DB should stay open as long as `conn` is held open.
     (with-open [_conn (.getConnection data-source)]
       (letfn [(do-with-app-db [thunk]
-                (binding [mdb.connection/*application-db* (mdb.connection/application-db :h2 data-source)]
-                  (testing (format "\nApp DB = %s" (pr-str connection-string))
-                    (thunk))))]
+                (with-db data-source (thunk)))]
         (do-with-app-db mdb/setup-db!)
         (f do-with-app-db)))))
 
 (defn do-with-source-and-dest-dbs [f]
   (do-with-in-memory-h2-db
-   "source-"
+   "source"
    (fn [do-with-source-db]
      (do-with-in-memory-h2-db
-      "dest-"
+      "dest"
       (fn [do-with-dest-db]
         (f do-with-source-db do-with-dest-db))))))
 
@@ -82,7 +89,7 @@
   "Creates and sets up two in-memory H2 application databases, a source database and an application database. For
   testing load/dump/serialization stuff. To use the source DB, use [[with-source-db]], which makes binds it as the
   current application database; [[with-dest-db]] binds the destination DB as the current application database."
-  {:style/indent 0}
+  {:style/indent 0 :deprecated "0.48.0"}
   [& body]
   ;; this is implemented by introducing the anaphors `&do-with-source-db` and `&do-with-dest-db` which are used by
   ;; [[with-source-db]] and [[with-dest-db]]
@@ -92,13 +99,13 @@
 
 (defmacro with-source-db
   "For use with [[with-source-and-dest-dbs]]. Makes the source DB the current application database."
-  {:style/indent 0}
+  {:style/indent 0 :deprecated "0.48.0"}
   [& body]
   `(~'&do-with-source-db (fn [] ~@body)))
 
 (defmacro with-dest-db
   "For use with [[with-source-and-dest-dbs]]. Makes the destination DB the current application database."
-  {:style/indent 0}
+  {:style/indent 0 :deprecated "0.48.0"}
   [& body]
   `(~'&do-with-dest-db (fn [] ~@body)))
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -107,10 +107,10 @@
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
     (let [extraction (atom nil)
           entities   (atom nil)]
-      (ts/with-source-and-dest-dbs
+      (ts/with-dbs [source-db dest-db]
         ;; TODO Generating some nested collections would make these tests more robust, but that's difficult.
         ;; There are handwritten tests for storage and ingestion that check out the nesting, at least.
-        (ts/with-source-db
+        (ts/with-db source-db
           (testing "insert"
             (test-gen/insert!
               {;; Actions are special case where there is a 1:1 relationship between an action and an action subtype (query, implicit, or http)
@@ -308,7 +308,7 @@
               (is (.exists (io/file dump-dir "settings.yaml")))))
 
           (testing "ingest and load"
-            (ts/with-dest-db
+            (ts/with-db dest-db
               (testing "ingested set matches extracted set"
                 (let [extracted-set (set (map (comp #'ingest/strip-labels serdes/path) @extraction))]
                   (is (= (count extracted-set)
@@ -429,8 +429,8 @@
 (deftest card-and-dashboard-has-parameter-with-source-is-card-test
   (testing "Dashboard and Card that has parameter with source is a card must be deserialized correctly"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-      (ts/with-source-and-dest-dbs
-        (ts/with-source-db
+      (ts/with-dbs [source-db dest-db]
+        (ts/with-db source-db
           ;; preparation
           (mt/test-helpers-set-global-values!
             (mt/with-temp
@@ -491,7 +491,7 @@
                   (storage/store! (seq extraction) dump-dir)))
 
              (testing "ingest and load"
-               (ts/with-dest-db
+               (ts/with-db dest-db
                  ;; ingest
                  (testing "doing ingestion"
                    (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
@@ -521,8 +521,8 @@
 
 (deftest dashcards-with-link-cards-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-    (ts/with-source-and-dest-dbs
-      (ts/with-source-db
+    (ts/with-dbs [source-db dest-db]
+      (ts/with-db source-db
         (let [link-card-viz-setting (fn [model id]
                                       {:virtual_card {:display "link"}
                                        :link         {:entity {:id    id
@@ -600,7 +600,7 @@
 
             (testing "ingest and load"
               ;; ingest
-              (ts/with-dest-db
+              (ts/with-db dest-db
                 (testing "doing ingestion"
                   (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
                       "successful"))
@@ -633,8 +633,8 @@
 
 (deftest dashcards-with-series-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-    (ts/with-source-and-dest-dbs
-      (ts/with-source-db
+    (ts/with-dbs [source-db dest-db]
+      (ts/with-db source-db
         (mt/with-temp
           [:model/Collection {coll-id :id} {:name "Some Collection"}
            :model/Card {c1-id :id :as c1} {:name "Some Question", :collection_id coll-id}
@@ -658,7 +658,7 @@
             (let [extraction (serdes/with-cache (into [] (extract/extract {})))]
               (storage/store! (seq extraction) dump-dir)))
           (testing "ingest and load"
-            (ts/with-dest-db
+            (ts/with-db dest-db
               (testing "doing ingestion"
                 (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
                     "successful"))
@@ -686,8 +686,8 @@
 (deftest dashboard-with-tabs-test
   (testing "Dashboard with tabs must be deserialized correctly"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-     (ts/with-source-and-dest-dbs
-       (ts/with-source-db
+     (ts/with-dbs [source-db dest-db]
+       (ts/with-db source-db
          ;; preparation
          (t2.with-temp/with-temp
            [Dashboard           {dashboard-id :id
@@ -716,7 +716,7 @@
              (storage/store! (seq extraction) dump-dir))
 
            (testing "ingest and load"
-             (ts/with-dest-db
+             (ts/with-db dest-db
                ;; ingest
                (testing "doing ingestion"
                  (is (serdes/with-cache (serdes.load/load-metabase! (ingest/ingest-yaml dump-dir)))
@@ -755,8 +755,8 @@
   (testing "with :serialization enabled on the token"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
       (mt/with-premium-features #{:serialization}
-        (ts/with-source-and-dest-dbs
-          (ts/with-source-db
+        (ts/with-dbs [source-db dest-db]
+          (ts/with-db source-db
             ;; preparation
             (t2.with-temp/with-temp [Dashboard _ {:name "some dashboard"}]
               (testing "export (v2-dump) command"
@@ -764,7 +764,7 @@
                     "works"))
 
               (testing "import (v2-load) command"
-                (ts/with-dest-db
+                (ts/with-db dest-db
                   (testing "doing ingestion"
                     (is (cmd/v2-load! dump-dir {})
                         "works"))))))))))
@@ -772,8 +772,8 @@
   (testing "without :serialization feature enabled"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
       (mt/with-premium-features #{}
-        (ts/with-source-and-dest-dbs
-          (ts/with-source-db
+        (ts/with-dbs [source-db dest-db]
+          (ts/with-db source-db
             ;; preparation
             (t2.with-temp/with-temp [Dashboard _ {:name "some dashboard"}]
               (testing "export (v2-dump) command"
@@ -782,7 +782,7 @@
                     "throws"))
 
               (testing "import (v2-load) command"
-                (ts/with-dest-db
+                (ts/with-db dest-db
                   (testing "doing ingestion"
                     (is (thrown-with-msg? Exception #"Please upgrade"
                                           (cmd/v2-load! dump-dir {}))
@@ -793,8 +793,8 @@
     (let [old-ids (atom nil)
           card1s  (atom nil)]
       (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-        (ts/with-source-and-dest-dbs
-          (ts/with-source-db
+        (ts/with-dbs [source-db dest-db]
+          (ts/with-db source-db
             (mt/dataset test-data
               ;; ensuring field ids are stable by loading dataset in db first
               (mt/db)
@@ -825,7 +825,7 @@
                   (reset! card1s card)
                   (storage/store! (extract/extract {}) dump-dir)))))
 
-          (ts/with-dest-db
+          (ts/with-db dest-db
             ;; ensure there is something in db so that test-data gets different field ids for sure
             (mt/dataset office-checkins
               (mt/db))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -107,6 +107,7 @@
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
     (let [extraction (atom nil)
           entities   (atom nil)]
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         ;; TODO Generating some nested collections would make these tests more robust, but that's difficult.
         ;; There are handwritten tests for storage and ingestion that check out the nesting, at least.
@@ -429,6 +430,7 @@
 (deftest card-and-dashboard-has-parameter-with-source-is-card-test
   (testing "Dashboard and Card that has parameter with source is a card must be deserialized correctly"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (ts/with-source-db
           ;; preparation
@@ -521,6 +523,7 @@
 
 (deftest dashcards-with-link-cards-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+    #_{:clj-kondo/ignore [:deprecated-var]}
     (ts/with-source-and-dest-dbs
       (ts/with-source-db
         (let [link-card-viz-setting (fn [model id]
@@ -633,6 +636,7 @@
 
 (deftest dashcards-with-series-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+    #_{:clj-kondo/ignore [:deprecated-var]}
     (ts/with-source-and-dest-dbs
       (ts/with-source-db
         (mt/with-temp
@@ -686,6 +690,7 @@
 (deftest dashboard-with-tabs-test
   (testing "Dashboard with tabs must be deserialized correctly"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+      #_{:clj-kondo/ignore [:deprecated-var]}
      (ts/with-source-and-dest-dbs
        (ts/with-source-db
          ;; preparation
@@ -755,6 +760,7 @@
   (testing "with :serialization enabled on the token"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
       (mt/with-premium-features #{:serialization}
+        #_{:clj-kondo/ignore [:deprecated-var]}
         (ts/with-source-and-dest-dbs
           (ts/with-source-db
             ;; preparation
@@ -772,6 +778,7 @@
   (testing "without :serialization feature enabled"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
       (mt/with-premium-features #{}
+        #_{:clj-kondo/ignore [:deprecated-var]}
         (ts/with-source-and-dest-dbs
           (ts/with-source-db
             ;; preparation
@@ -793,6 +800,7 @@
     (let [old-ids (atom nil)
           card1s  (atom nil)]
       (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+        #_{:clj-kondo/ignore [:deprecated-var]}
         (ts/with-source-and-dest-dbs
           (ts/with-source-db
             (mt/dataset test-data

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -107,7 +107,6 @@
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
     (let [extraction (atom nil)
           entities   (atom nil)]
-      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         ;; TODO Generating some nested collections would make these tests more robust, but that's difficult.
         ;; There are handwritten tests for storage and ingestion that check out the nesting, at least.
@@ -430,7 +429,6 @@
 (deftest card-and-dashboard-has-parameter-with-source-is-card-test
   (testing "Dashboard and Card that has parameter with source is a card must be deserialized correctly"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (ts/with-source-db
           ;; preparation
@@ -523,7 +521,6 @@
 
 (deftest dashcards-with-link-cards-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-    #_{:clj-kondo/ignore [:deprecated-var]}
     (ts/with-source-and-dest-dbs
       (ts/with-source-db
         (let [link-card-viz-setting (fn [model id]
@@ -636,7 +633,6 @@
 
 (deftest dashcards-with-series-test
   (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-    #_{:clj-kondo/ignore [:deprecated-var]}
     (ts/with-source-and-dest-dbs
       (ts/with-source-db
         (mt/with-temp
@@ -690,7 +686,6 @@
 (deftest dashboard-with-tabs-test
   (testing "Dashboard with tabs must be deserialized correctly"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-      #_{:clj-kondo/ignore [:deprecated-var]}
      (ts/with-source-and-dest-dbs
        (ts/with-source-db
          ;; preparation
@@ -760,7 +755,6 @@
   (testing "with :serialization enabled on the token"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
       (mt/with-premium-features #{:serialization}
-        #_{:clj-kondo/ignore [:deprecated-var]}
         (ts/with-source-and-dest-dbs
           (ts/with-source-db
             ;; preparation
@@ -778,7 +772,6 @@
   (testing "without :serialization feature enabled"
     (ts/with-random-dump-dir [dump-dir "serdesv2-"]
       (mt/with-premium-features #{}
-        #_{:clj-kondo/ignore [:deprecated-var]}
         (ts/with-source-and-dest-dbs
           (ts/with-source-db
             ;; preparation
@@ -800,7 +793,6 @@
     (let [old-ids (atom nil)
           card1s  (atom nil)]
       (ts/with-random-dump-dir [dump-dir "serdesv2-"]
-        #_{:clj-kondo/ignore [:deprecated-var]}
         (ts/with-source-and-dest-dbs
           (ts/with-source-db
             (mt/dataset test-data

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -52,9 +52,9 @@
   (testing "a simple, fresh collection is imported"
     (let [serialized (atom nil)
           eid1       "0123456789abcdef_0123"]
-      (ts/with-source-and-dest-dbs
+      (ts/with-dbs [source-db dest-db]
         (testing "extraction succeeds"
-          (ts/with-source-db
+          (ts/with-db source-db
             (ts/create! Collection :name "Basic Collection" :entity_id eid1)
             (reset! serialized (into [] (serdes.extract/extract {})))
             (is (some (fn [{[{:keys [model id]}] :serdes/meta}]
@@ -62,7 +62,7 @@
                       @serialized))))
 
         (testing "loading into an empty database succeeds"
-          (ts/with-dest-db
+          (ts/with-db dest-db
             (serdes.load/load-metabase! (ingestion-in-memory @serialized))
             (let [colls (t2/select Collection)]
               (is (= 1 (count colls)))
@@ -70,7 +70,7 @@
               (is (= eid1               (:entity_id (first colls)))))))
 
         (testing "loading again into the same database does not duplicate"
-          (ts/with-dest-db
+          (ts/with-db dest-db
             (serdes.load/load-metabase! (ingestion-in-memory @serialized))
             (let [colls (t2/select Collection)]
               (is (= 1 (count colls)))
@@ -83,9 +83,9 @@
           parent     (atom nil)
           child      (atom nil)
           grandchild (atom nil)]
-      (ts/with-source-and-dest-dbs
+      (ts/with-dbs [source-db dest-db]
         (testing "serialization of the three collections"
-          (ts/with-source-db
+          (ts/with-db source-db
             (reset! parent     (ts/create! Collection :name "Parent Collection" :location "/"))
             (reset! child      (ts/create! Collection
                                            :name "Child Collection"
@@ -96,7 +96,7 @@
             (reset! serialized (into [] (serdes.extract/extract {})))))
 
         (testing "deserialization into a database that already has the parent, but with a different ID"
-          (ts/with-dest-db
+          (ts/with-db dest-db
             (ts/create! Collection :name "Unrelated Collection")
             (ts/create! Collection :name "Parent Collection" :location "/" :entity_id (:entity_id @parent))
             (serdes.load/load-metabase! (ingestion-in-memory @serialized))
@@ -126,9 +126,9 @@
           t2s        (atom nil)
           f1s        (atom nil)
           f2s        (atom nil)]
-      (ts/with-source-and-dest-dbs
+      (ts/with-dbs [source-db dest-db]
         (testing "serializing the two databases"
-          (ts/with-source-db
+          (ts/with-db source-db
             (reset! db1s (ts/create! Database :name "db1"))
             (reset! t1s  (ts/create! Table    :name "posts" :db_id (:id @db1s)))
             (reset! db2s (ts/create! Database :name "db2"))
@@ -157,7 +157,7 @@
                       first))))
 
         (testing "deserialization works properly, keeping the same-named tables apart"
-          (ts/with-dest-db
+          (ts/with-db dest-db
             (serdes.load/load-metabase! (ingestion-in-memory @serialized))
             (reset! db1d (t2/select-one Database :name (:name @db1s)))
             (reset! db2d (t2/select-one Database :name (:name @db2s)))
@@ -193,9 +193,9 @@
           table2d    (atom nil)
           field2d    (atom nil)]
 
-      (ts/with-source-and-dest-dbs
+      (ts/with-dbs [source-db dest-db]
         (testing "serializing the original database, table, field and card"
-          (ts/with-source-db
+          (ts/with-db source-db
             (reset! coll1s  (ts/create! Collection :name "pop! minis"))
             (reset! db1s    (ts/create! Database :name "my-db"))
             (reset! table1s (ts/create! Table :name "customers" :db_id (:id @db1s)))
@@ -227,7 +227,7 @@
                       :dataset_query))))
 
         (testing "deserializing adjusts the IDs properly"
-          (ts/with-dest-db
+          (ts/with-db dest-db
             ;; A different database and tables, so the IDs don't match.
             (reset! db2d    (ts/create! Database :name "other-db"))
             (reset! table2d (ts/create! Table    :name "orders" :db_id (:id @db2d)))
@@ -281,9 +281,9 @@
           field2d    (atom nil)]
 
 
-      (ts/with-source-and-dest-dbs
+      (ts/with-dbs [source-db dest-db]
         (testing "serializing the original database, table, field and card"
-          (ts/with-source-db
+          (ts/with-db source-db
             (reset! coll1s  (ts/create! Collection :name "pop! minis"))
             (reset! db1s    (ts/create! Database :name "my-db"))
             (reset! table1s (ts/create! Table :name "customers" :db_id (:id @db1s)))
@@ -306,7 +306,7 @@
                      :definition))))
 
         (testing "deserializing adjusts the IDs properly"
-          (ts/with-dest-db
+          (ts/with-db dest-db
             ;; A different database and tables, so the IDs don't match.
             (reset! db2d    (ts/create! Database :name "other-db"))
             (reset! table2d (ts/create! Table    :name "orders" :db_id (:id @db2d)))
@@ -358,9 +358,9 @@
           field2d    (atom nil)]
 
 
-      (ts/with-source-and-dest-dbs
+      (ts/with-dbs [source-db dest-db]
         (testing "serializing the original database, table, field and card"
-          (ts/with-source-db
+          (ts/with-db source-db
             (reset! coll1s   (ts/create! Collection :name "pop! minis"))
             (reset! db1s     (ts/create! Database :name "my-db"))
             (reset! table1s  (ts/create! Table :name "orders" :db_id (:id @db1s)))
@@ -381,7 +381,7 @@
                      :definition))))
 
         (testing "deserializing adjusts the IDs properly"
-          (ts/with-dest-db
+          (ts/with-db dest-db
             ;; A different database and tables, so the IDs don't match.
             (reset! db2d    (ts/create! Database :name "other-db"))
             (reset! table2d (ts/create! Table    :name "customers" :db_id (:id @db2d)))
@@ -442,9 +442,9 @@
           field3d    (atom nil)]
 
 
-      (ts/with-source-and-dest-dbs
+      (ts/with-dbs [source-db dest-db]
         (testing "serializing the original database, table, field and card"
-          (ts/with-source-db
+          (ts/with-db source-db
             (reset! coll1s   (ts/create! Collection :name "pop! minis"))
             (reset! db1s     (ts/create! Database :name "my-db"))
             (reset! table1s  (ts/create! Table :name "orders" :db_id (:id @db1s)))
@@ -586,7 +586,7 @@
 
 
         (testing "deserializing adjusts the IDs properly"
-          (ts/with-dest-db
+          (ts/with-db dest-db
             ;; A different database and tables, so the IDs don't match.
             (reset! db2d    (ts/create! Database :name "other-db"))
             (reset! table2d (ts/create! Table    :name "customers" :db_id (:id @db2d)))
@@ -645,9 +645,9 @@
           eventsT1   (atom nil)
           eventsT2   (atom nil)]
 
-      (ts/with-source-and-dest-dbs
+      (ts/with-dbs [source-db dest-db]
         (testing "serialize correctly"
-          (ts/with-source-db
+          (ts/with-db source-db
             (reset! coll1s     (ts/create! Collection :name "col1"))
             (reset! user1s     (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
             (reset! timeline1s (ts/create! Timeline :name "Some events" :creator_id (:id @user1s)
@@ -704,7 +704,7 @@
                 (is (= 1 (-> timeline2 :events count)))))))
 
         (testing "deserializing merges events properly"
-          (ts/with-dest-db
+          (ts/with-db dest-db
             ;; The collection, timeline 1 and event 2 already exist. Event 1, plus timeline 2 and its event 3, are new.
             (reset! user1d     (ts/create! User  :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
             (reset! coll1d     (ts/create! Collection :name "col1" :entity_id (:entity_id @coll1s)))
@@ -753,9 +753,9 @@
           metric1d   (atom nil)
           metric2d   (atom nil)]
 
-      (ts/with-source-and-dest-dbs
+      (ts/with-dbs [source-db dest-db]
         (testing "serializing the original entities"
-          (ts/with-source-db
+          (ts/with-db source-db
             (reset! user1s    (ts/create! User :first_name "Tom" :last_name "Scholz" :email "tom@bost.on"))
             (reset! user2s    (ts/create! User :first_name "Neil"  :last_name "Peart"   :email "neil@rush.yyz"))
             (reset! metric1s  (ts/create! Metric
@@ -778,7 +778,7 @@
                      :creator_id))))
 
         (testing "deserializing finds the matching user and synthesizes the missing one"
-          (ts/with-dest-db
+          (ts/with-db dest-db
             ;; Create another random user to change the user IDs.
             (ts/create! User   :first_name "Gideon" :last_name "Nav" :email "griddle@ninth.tomb")
             ;; Likewise, create some other metrics.
@@ -1033,9 +1033,9 @@
 (deftest load-action-test
   (let [serialized (atom nil)
         eid (u/generate-nano-id)]
-    (ts/with-source-and-dest-dbs
+    (ts/with-dbs [source-db dest-db]
       (testing "extraction succeeds"
-        (ts/with-source-db
+        (ts/with-db source-db
           (let [db       (ts/create! Database :name "my-db")
                 card     (ts/create! Card
                                      :name "the query"
@@ -1059,7 +1059,7 @@
               (testing ":type should be a string"
                 (is (string? (:type action-serialized))))))))
       (testing "loading succeeds"
-        (ts/with-dest-db
+        (ts/with-db dest-db
           (serdes.load/load-metabase! (ingestion-in-memory @serialized))
           (let [action (t2/select-one Action :entity_id eid)]
             (is (some? action))
@@ -1074,9 +1074,9 @@
         dashcard2d (atom nil)
         tab1s      (atom nil)
         tab2d      (atom nil)]
-    (ts/with-source-and-dest-dbs
+    (ts/with-dbs [source-db dest-db]
       (testing "Serializing the original database"
-        (ts/with-source-db
+        (ts/with-db source-db
           (reset! dash1s (ts/create! Dashboard :name "My Dashboard"))
           (reset! tab1s (ts/create! :model/DashboardTab :name "Tab 1" :dashboard_id (:id @dash1s)))
           (reset! dashcard1s (ts/create! DashboardCard :dashboard_id (:id @dash1s) :dashboard_tab_id (:id tab1s)))
@@ -1084,7 +1084,7 @@
           (reset! serialized (into [] (serdes.extract/extract {})))))
 
       (testing "New dashcard will be removed on load"
-        (ts/with-dest-db
+        (ts/with-db dest-db
           (reset! dash1d (ts/create! Dashboard :name "Weird Name" :entity_id (:entity_id @dash1s)))
           ;; A dashcard to be removed since it does not exist in serialized data
           (reset! dashcard2d (ts/create! DashboardCard :dashboard_id (:id @dash1d)))
@@ -1114,9 +1114,9 @@
                       (:entity_id @tab2d)))))))))
 
 (deftest dashcard-series-test
-  (ts/with-source-and-dest-dbs
+  (ts/with-dbs [source-db dest-db]
     (testing "Dashcard series are updated and deleted correctly"
-     (ts/with-source-db
+     (ts/with-db source-db
        (let [dash1s        (ts/create! :model/Dashboard :name "My Dashboard")
              tab1s         (ts/create! :model/DashboardTab :name "Tab 1" :dashboard_id (:id dash1s))
              card1s        (ts/create! Card :name "The Card")
@@ -1128,15 +1128,15 @@
              series2s      (ts/create! :model/DashboardCardSeries :dashboardcard_id (:id dashcard1s) :card_id (:id series-card2s) :position 1)
              series3s      (ts/create! :model/DashboardCardSeries :dashboardcard_id (:id dashcard1s) :card_id (:id series-card3s) :position 2)
              extract1      (into [] (serdes.extract/extract {}))]
-         (ts/with-dest-db
+         (ts/with-db dest-db
            (serdes.load/load-metabase! (ingestion-in-memory extract1))
-           (ts/with-source-db
+           (ts/with-db source-db
              ;; delete the 1st series and update the 3rd series to have position 0, and the 2nd series to have position 1
              (t2/delete! :model/DashboardCardSeries (:id series1s))
              (t2/update! :model/DashboardCardSeries (:id series3s) {:position 0})
              (t2/update! :model/DashboardCardSeries (:id series2s) {:position 1})
              (let [extract2 (into [] (serdes.extract/extract {}))]
-               (ts/with-dest-db
+               (ts/with-db dest-db
                  (let [series-card2d        (t2/select-one :model/Card :entity_id (:entity_id series-card2s))
                        series-card3d        (t2/select-one :model/Card :entity_id (:entity_id series-card3s))
                        ;; we deleted the card that corresponds to `series1s`, so a shortcut is to get the one with position=0
@@ -1165,9 +1165,9 @@
 (deftest extraneous-keys-test
   (let [serialized (atom nil)
         eid (u/generate-nano-id)]
-    (ts/with-source-and-dest-dbs
+    (ts/with-dbs [source-db dest-db]
       (testing "Sprinkle the source database with a variety of different models"
-        (ts/with-source-db
+        (ts/with-db source-db
           (let [db         (ts/create! Database :name "my-db")
                 card       (ts/create! Card
                                  :name "the query"
@@ -1193,5 +1193,5 @@
                          (map #(assoc % :my-extraneous-keeeeeey "foobar!!!!"))
                          (into []))))))
       (testing "The extraneous keys do not interfere with loading"
-        (ts/with-dest-db
+        (ts/with-db dest-db
           (is (serdes.load/load-metabase! (ingestion-in-memory @serialized))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -52,7 +52,6 @@
   (testing "a simple, fresh collection is imported"
     (let [serialized (atom nil)
           eid1       "0123456789abcdef_0123"]
-      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "extraction succeeds"
           (ts/with-source-db
@@ -84,7 +83,6 @@
           parent     (atom nil)
           child      (atom nil)
           grandchild (atom nil)]
-      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serialization of the three collections"
           (ts/with-source-db
@@ -128,7 +126,6 @@
           t2s        (atom nil)
           f1s        (atom nil)
           f2s        (atom nil)]
-      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serializing the two databases"
           (ts/with-source-db
@@ -195,7 +192,7 @@
           db2d       (atom nil)
           table2d    (atom nil)
           field2d    (atom nil)]
-      #_{:clj-kondo/ignore [:deprecated-var]}
+
       (ts/with-source-and-dest-dbs
         (testing "serializing the original database, table, field and card"
           (ts/with-source-db
@@ -283,7 +280,7 @@
           table2d    (atom nil)
           field2d    (atom nil)]
 
-      #_{:clj-kondo/ignore [:deprecated-var]}
+
       (ts/with-source-and-dest-dbs
         (testing "serializing the original database, table, field and card"
           (ts/with-source-db
@@ -360,7 +357,7 @@
           table2d    (atom nil)
           field2d    (atom nil)]
 
-      #_{:clj-kondo/ignore [:deprecated-var]}
+
       (ts/with-source-and-dest-dbs
         (testing "serializing the original database, table, field and card"
           (ts/with-source-db
@@ -444,7 +441,7 @@
           table2d    (atom nil)
           field3d    (atom nil)]
 
-      #_{:clj-kondo/ignore [:deprecated-var]}
+
       (ts/with-source-and-dest-dbs
         (testing "serializing the original database, table, field and card"
           (ts/with-source-db
@@ -648,7 +645,6 @@
           eventsT1   (atom nil)
           eventsT2   (atom nil)]
 
-      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serialize correctly"
           (ts/with-source-db
@@ -757,7 +753,6 @@
           metric1d   (atom nil)
           metric2d   (atom nil)]
 
-      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serializing the original entities"
           (ts/with-source-db
@@ -1038,7 +1033,6 @@
 (deftest load-action-test
   (let [serialized (atom nil)
         eid (u/generate-nano-id)]
-    #_{:clj-kondo/ignore [:deprecated-var]}
     (ts/with-source-and-dest-dbs
       (testing "extraction succeeds"
         (ts/with-source-db
@@ -1080,7 +1074,6 @@
         dashcard2d (atom nil)
         tab1s      (atom nil)
         tab2d      (atom nil)]
-    #_{:clj-kondo/ignore [:deprecated-var]}
     (ts/with-source-and-dest-dbs
       (testing "Serializing the original database"
         (ts/with-source-db
@@ -1121,7 +1114,6 @@
                       (:entity_id @tab2d)))))))))
 
 (deftest dashcard-series-test
-  #_{:clj-kondo/ignore [:deprecated-var]}
   (ts/with-source-and-dest-dbs
     (testing "Dashcard series are updated and deleted correctly"
      (ts/with-source-db
@@ -1173,7 +1165,6 @@
 (deftest extraneous-keys-test
   (let [serialized (atom nil)
         eid (u/generate-nano-id)]
-    #_{:clj-kondo/ignore [:deprecated-var]}
     (ts/with-source-and-dest-dbs
       (testing "Sprinkle the source database with a variety of different models"
         (ts/with-source-db

--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/load_test.clj
@@ -52,6 +52,7 @@
   (testing "a simple, fresh collection is imported"
     (let [serialized (atom nil)
           eid1       "0123456789abcdef_0123"]
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "extraction succeeds"
           (ts/with-source-db
@@ -83,6 +84,7 @@
           parent     (atom nil)
           child      (atom nil)
           grandchild (atom nil)]
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serialization of the three collections"
           (ts/with-source-db
@@ -126,6 +128,7 @@
           t2s        (atom nil)
           f1s        (atom nil)
           f2s        (atom nil)]
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serializing the two databases"
           (ts/with-source-db
@@ -192,7 +195,7 @@
           db2d       (atom nil)
           table2d    (atom nil)
           field2d    (atom nil)]
-
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serializing the original database, table, field and card"
           (ts/with-source-db
@@ -280,7 +283,7 @@
           table2d    (atom nil)
           field2d    (atom nil)]
 
-
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serializing the original database, table, field and card"
           (ts/with-source-db
@@ -357,7 +360,7 @@
           table2d    (atom nil)
           field2d    (atom nil)]
 
-
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serializing the original database, table, field and card"
           (ts/with-source-db
@@ -441,7 +444,7 @@
           table2d    (atom nil)
           field3d    (atom nil)]
 
-
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serializing the original database, table, field and card"
           (ts/with-source-db
@@ -645,6 +648,7 @@
           eventsT1   (atom nil)
           eventsT2   (atom nil)]
 
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serialize correctly"
           (ts/with-source-db
@@ -753,6 +757,7 @@
           metric1d   (atom nil)
           metric2d   (atom nil)]
 
+      #_{:clj-kondo/ignore [:deprecated-var]}
       (ts/with-source-and-dest-dbs
         (testing "serializing the original entities"
           (ts/with-source-db
@@ -1033,6 +1038,7 @@
 (deftest load-action-test
   (let [serialized (atom nil)
         eid (u/generate-nano-id)]
+    #_{:clj-kondo/ignore [:deprecated-var]}
     (ts/with-source-and-dest-dbs
       (testing "extraction succeeds"
         (ts/with-source-db
@@ -1074,6 +1080,7 @@
         dashcard2d (atom nil)
         tab1s      (atom nil)
         tab2d      (atom nil)]
+    #_{:clj-kondo/ignore [:deprecated-var]}
     (ts/with-source-and-dest-dbs
       (testing "Serializing the original database"
         (ts/with-source-db
@@ -1114,6 +1121,7 @@
                       (:entity_id @tab2d)))))))))
 
 (deftest dashcard-series-test
+  #_{:clj-kondo/ignore [:deprecated-var]}
   (ts/with-source-and-dest-dbs
     (testing "Dashcard series are updated and deleted correctly"
      (ts/with-source-db
@@ -1165,6 +1173,7 @@
 (deftest extraneous-keys-test
   (let [serialized (atom nil)
         eid (u/generate-nano-id)]
+    #_{:clj-kondo/ignore [:deprecated-var]}
     (ts/with-source-and-dest-dbs
       (testing "Sprinkle the source database with a variety of different models"
         (ts/with-source-db


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36103

### Description

This change introduces a new `with-dbs` macro which is hygienic and supports an arbitrary number of databases.

For now I am leaving the old `with-source-and-dest-dbs` macro, so we can deal with the noise of upgrading the tests in a later PR. I upgrade a single test so that the usage is clear.

### Checklist

- [x] Finalize caller form of the macro
	 - ~~Can we make it work with Cursive?~~ Aha, resolve as `fn` works
- [x] Configure linting for this macro
- [x] Replace all usages and remove the old macro
