### PR TITLE
Switch to using enableRequiredBehavior instead of isInsideNativeQuery

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
@@ -34,6 +34,7 @@ export class ParameterWidget extends Component {
       commitImmediately,
       parameters,
       setParameterValueToDefault,
+      enableParameterRequiredBehavior,
     } = this.props;
 
     const isEditingParameter = editingParameter?.id === parameter.id;
@@ -53,6 +54,7 @@ export class ParameterWidget extends Component {
         isFullscreen={isFullscreen}
         commitImmediately={commitImmediately}
         setParameterValueToDefault={setParameterValueToDefault}
+        enableRequiredBehavior={enableParameterRequiredBehavior}
       />
     );
   }

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
@@ -74,6 +74,7 @@ export class ParameterWidget extends Component {
       setValue,
       children,
       dragHandle,
+      enableParameterRequiredBehavior,
     } = this.props;
 
     const isEditingParameter =
@@ -87,7 +88,7 @@ export class ParameterWidget extends Component {
       return (
         <ParameterFieldSet
           legend={legend}
-          required={Boolean(parameter.required)}
+          required={enableParameterRequiredBehavior && parameter.required}
           noPadding={true}
           fieldHasValueOrFocus={fieldHasValueOrFocus}
           className={className}

--- a/frontend/src/metabase/parameters/components/ParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/ParametersList.jsx
@@ -49,6 +49,7 @@ function ParametersList({
   setParameterValue,
   setParameterIndex,
   setEditingParameter,
+  enableParameterRequiredBehavior,
 }) {
   const handleSortStart = () => {
     document.body.classList.add("grabbing");
@@ -107,6 +108,7 @@ function ParametersList({
             (value => setParameterValue(valuePopulatedParameter.id, value))
           }
           setParameterValueToDefault={setParameterValueToDefault}
+          enableParameterRequiredBehavior
           commitImmediately={commitImmediately}
           dragHandle={
             isEditing && setParameterIndex ? <SortableParameterHandle /> : null

--- a/frontend/src/metabase/parameters/components/ParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/ParametersList.jsx
@@ -108,7 +108,7 @@ function ParametersList({
             (value => setParameterValue(valuePopulatedParameter.id, value))
           }
           setParameterValueToDefault={setParameterValueToDefault}
-          enableParameterRequiredBehavior
+          enableParameterRequiredBehavior={enableParameterRequiredBehavior}
           commitImmediately={commitImmediately}
           dragHandle={
             isEditing && setParameterIndex ? <SortableParameterHandle /> : null

--- a/frontend/src/metabase/parameters/components/SyncedParametersList/SyncedParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/SyncedParametersList/SyncedParametersList.jsx
@@ -22,6 +22,7 @@ const propTypes = {
   setParameterIndex: PropTypes.func,
   setEditingParameter: PropTypes.func,
   setParameterValueToDefault: PropTypes.func,
+  enableParameterRequiredBehavior: PropTypes.bool,
 };
 
 export function SyncedParametersList({
@@ -42,6 +43,7 @@ export function SyncedParametersList({
   setParameterIndex,
   setEditingParameter,
   setParameterValueToDefault,
+  enableParameterRequiredBehavior,
 }) {
   useSyncedQueryString(
     () => getParameterValuesBySlug(parameters),
@@ -64,6 +66,7 @@ export function SyncedParametersList({
       setParameterIndex={setParameterIndex}
       setEditingParameter={setEditingParameter}
       setParameterValueToDefault={setParameterValueToDefault}
+      enableParameterRequiredBehavior={enableParameterRequiredBehavior}
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -805,6 +805,7 @@ export class NativeQueryEditor extends Component<
                 setParameterValue={setParameterValue}
                 setParameterIndex={this.setParameterIndex}
                 setParameterValueToDefault={setParameterValueToDefault}
+                enableParameterRequiredBehavior
               />
             )}
             {query.hasWritePermission() && this.props.setIsNativeEditorOpen && (

--- a/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
+++ b/frontend/src/metabase/query_builder/components/ResponsiveParametersList.tsx
@@ -19,6 +19,7 @@ interface ResponsiveParametersListProps {
   setParameterValue: (parameterId: string, value: string) => void;
   setParameterValueToDefault: (parameterId: ParameterId) => void;
   setParameterIndex: (parameterId: string, parameterIndex: number) => void;
+  enableParameterRequiredBehavior: boolean;
 }
 
 export const ResponsiveParametersList = ({
@@ -27,6 +28,7 @@ export const ResponsiveParametersList = ({
   setParameterValue,
   setParameterIndex,
   setParameterValueToDefault,
+  enableParameterRequiredBehavior,
 }: ResponsiveParametersListProps) => {
   const [mobileShowParameterList, setShowMobileParameterList] = useState(false);
   const isSmallScreen = useIsSmallScreen();
@@ -81,6 +83,7 @@ export const ResponsiveParametersList = ({
           setParameterValue={setParameterValue}
           setParameterIndex={setParameterIndex}
           setParameterValueToDefault={setParameterValueToDefault}
+          enableParameterRequiredBehavior={enableParameterRequiredBehavior}
           isEditing
           commitImmediately
         />


### PR DESCRIPTION
Part of milestone 2 for the [required parameters epic](https://github.com/metabase/metabase/issues/36524) 

## Description 
When adding "required" to the template tags, I used [`isInsideNativeQuery`](https://github.com/metabase/metabase/pull/37709/files#diff-fb656618096d3e68aee4f568170da19f7a853e0480ae22f8b40c28d04e1c692fR153-R160) to determine wether we need the "reset to default" and other related behaviors inside the `ParameterValueWidget`. This was convenient but incorrect. Now I introduce the explicit prop to define this behavior.

## How to test
Nothing should break or change from the previous state.
You could rely on the e2e for that, since I've added quite a few of them ([commit #1](https://github.com/metabase/metabase/pull/37709/commits/1d7448383fccfe809b5346101e3eeb7921f723a6), [commit #2](https://github.com/metabase/metabase/pull/37709/commits/ede5a046c0ceda22a2ad78c44f838036352113d6))