### PR TITLE
Forbid using InternalQuery with MLv2

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/AuditTable.jsx
@@ -51,7 +51,7 @@ function AuditTable({
 
   const handleOnLoad = results => {
     setLoadedCount(results[0].row_count);
-    onLoad(results);
+    onLoad?.(results);
   };
 
   const card = chain(table.card)

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1045,6 +1045,10 @@ class Question {
   }
 
   query(metadata = this._metadata): Query {
+    if (this._legacyQuery() instanceof InternalQuery) {
+      throw new Error("Internal query is not supported by MLv2");
+    }
+
     const databaseId = this.datasetQuery()?.database;
 
     // cache the metadata provider we create for our metadata.


### PR DESCRIPTION
### Description

Using `InternalQuery` with `question.query()` led to problems, as `InternalQuery` is not supported by MLv2. 
From now `question.query()` will throw for `InternalQuery`

### How to verify

Tests should pass

