### PR TITLE
allow users to duplicate dashboard tabs

### DIFF
--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -210,7 +210,7 @@ export const RenameableTabButtonStyled = styled(_TabButton)<{
 
 export function RenameableTabButton<T>({
   label: labelProp,
-  menuItems: originalMenuItems = [],
+  menuItems = [],
   onRename,
   renameMenuLabel = t`Rename`,
   renameMenuIndex = 0,
@@ -246,17 +246,19 @@ export function RenameableTabButton<T>({
     setIsRenaming(false);
   };
 
-  const renameItem = {
-    label: renameMenuLabel,
-    action: () => {
-      setIsRenaming(true);
-    },
-  };
-  const menuItems = [
-    ...originalMenuItems.slice(0, renameMenuIndex),
-    renameItem,
-    ...originalMenuItems.slice(renameMenuIndex),
-  ];
+  if (canRename) {
+    const renameItem = {
+      label: renameMenuLabel,
+      action: () => {
+        setIsRenaming(true);
+      },
+    };
+    menuItems = [
+      ...menuItems.slice(0, renameMenuIndex),
+      renameItem,
+      ...menuItems.slice(renameMenuIndex),
+    ];
+  }
 
   const dragLabel = (s: string) => {
     if (s.length < 20) {

--- a/frontend/src/metabase/core/components/TabButton/TabButton.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.tsx
@@ -210,7 +210,7 @@ export const RenameableTabButtonStyled = styled(_TabButton)<{
 
 export function RenameableTabButton<T>({
   label: labelProp,
-  menuItems = [],
+  menuItems: originalMenuItems = [],
   onRename,
   renameMenuLabel = t`Rename`,
   renameMenuIndex = 0,
@@ -246,6 +246,7 @@ export function RenameableTabButton<T>({
     setIsRenaming(false);
   };
 
+  let menuItems = [...originalMenuItems];
   if (canRename) {
     const renameItem = {
       label: renameMenuLabel,

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -5,7 +5,6 @@ import { arrayMove } from "@dnd-kit/sortable";
 
 import type {
   DashCardId,
-  DashboardCard,
   DashboardId,
   DashboardTabId,
 } from "metabase-types/api";
@@ -322,10 +321,9 @@ export const tabsReducer = createReducer<DashboardState>(
         }
 
         // 2. Duplicate dashcards
-        const sourceTabDashCards: DashboardCard[] | Draft<DashboardCard>[] = // type def needed to fix `possibly infinite` type error
-          prevDash.dashcards
-            .map(id => state.dashcards[id])
-            .filter(dashCard => dashCard.dashboard_tab_id === sourceTabId);
+        const sourceTabDashCards = prevDash.dashcards
+          .map(id => state.dashcards[id])
+          .filter(dashCard => dashCard.dashboard_tab_id === sourceTabId);
 
         sourceTabDashCards.forEach(sourceDashCard => {
           const newDashCardId = generateTemporaryDashcardId();
@@ -340,6 +338,7 @@ export const tabsReducer = createReducer<DashboardState>(
           };
 
           // We don't have card (question) data for virtual dashcards (text, heading, link, action)
+          // @ts-expect-error - possibly infinite type error https://metaboat.slack.com/archives/C505ZNNH4/p1699541570878059?thread_ts=1699520485.702539&cid=C505ZNNH4
           if (isVirtualDashCard(sourceDashCard)) {
             return;
           }

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -126,6 +126,7 @@ export function createNewTab() {
 const duplicateTabAction = createAction<DuplicateTabPayload>(DUPLICATE_TAB);
 
 export function duplicateTab(sourceTabId: DashboardTabId | null) {
+  // Decrement by 2 to leave space for two new tabs if dash doesn't have tabs already
   const newTabId = tempTabId;
   tempTabId -= 2;
 

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.styled.tsx
@@ -1,6 +1,5 @@
 import styled from "@emotion/styled";
 
-import { TabButton as BaseTabButton } from "metabase/core/components/TabButton";
 import BaseButton from "metabase/core/components/Button";
 
 export const Container = styled.div`
@@ -9,10 +8,6 @@ export const Container = styled.div`
   gap: 1.5rem;
   width: 100%;
 `;
-
-export const PlaceholderTab = ({ label }: { label: string }) => (
-  <BaseTabButton label={label} value={null} disabled />
-);
 
 export const CreateTabButton = styled(BaseButton)`
   border: none;

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
@@ -25,6 +25,7 @@ export function DashboardTabs({
   const {
     tabs,
     createNewTab,
+    duplicateTab,
     deleteTab,
     renameTab,
     selectTab,
@@ -58,6 +59,10 @@ export function DashboardTabs({
                 canRename={isEditing}
                 showMenu={isEditing}
                 menuItems={[
+                  {
+                    label: t`Duplicate`,
+                    action: (_, value) => duplicateTab(value),
+                  },
                   {
                     label: t`Delete`,
                     action: (_, value) => deleteTab(value),

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
@@ -2,15 +2,12 @@ import { t } from "ttag";
 
 import type { Location } from "history";
 import { TabRow } from "metabase/core/components/TabRow";
+import type { TabButtonMenuItem } from "metabase/core/components/TabButton";
 import { TabButton } from "metabase/core/components/TabButton";
 import type { SelectedTabId } from "metabase-types/store";
 import { Sortable } from "metabase/core/components/Sortable";
 
-import {
-  Container,
-  CreateTabButton,
-  PlaceholderTab,
-} from "./DashboardTabs.styled";
+import { Container, CreateTabButton } from "./DashboardTabs.styled";
 import { useDashboardTabs } from "./use-dashboard-tabs";
 
 interface DashboardTabsProps {
@@ -32,11 +29,25 @@ export function DashboardTabs({
     selectedTabId,
     moveTab,
   } = useDashboardTabs({ location });
-  const showTabs = tabs.length > 1 || isEditing;
-  const showPlaceholder = tabs.length <= 1 && isEditing;
+  const hasMultipleTabs = tabs.length > 1;
+  const showTabs = hasMultipleTabs || isEditing;
+  const showPlaceholder = tabs.length === 0 && isEditing;
 
   if (!showTabs) {
     return null;
+  }
+
+  const menuItems: TabButtonMenuItem<SelectedTabId>[] = [
+    {
+      label: t`Duplicate`,
+      action: (_, value) => duplicateTab(value),
+    },
+  ];
+  if (hasMultipleTabs) {
+    menuItems.push({
+      label: t`Delete`,
+      action: (_, value) => deleteTab(value),
+    });
   }
 
   return (
@@ -48,7 +59,12 @@ export function DashboardTabs({
         handleDragEnd={moveTab}
       >
         {showPlaceholder ? (
-          <PlaceholderTab label={tabs.length === 1 ? tabs[0].name : t`Tab 1`} />
+          <TabButton
+            label={t`Tab 1`}
+            value={null}
+            showMenu
+            menuItems={menuItems}
+          />
         ) : (
           tabs.map(tab => (
             <Sortable key={tab.id} id={tab.id} disabled={!isEditing}>
@@ -56,18 +72,9 @@ export function DashboardTabs({
                 value={tab.id}
                 label={tab.name}
                 onRename={name => renameTab(tab.id, name)}
-                canRename={isEditing}
+                canRename={isEditing && hasMultipleTabs}
                 showMenu={isEditing}
-                menuItems={[
-                  {
-                    label: t`Duplicate`,
-                    action: (_, value) => duplicateTab(value),
-                  },
-                  {
-                    label: t`Delete`,
-                    action: (_, value) => deleteTab(value),
-                  },
-                ]}
+                menuItems={menuItems}
               />
             </Sortable>
           ))

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -92,7 +92,19 @@ function createNewTab() {
   userEvent.click(screen.getByLabelText("Create new tab"));
 }
 
-async function selectTabMenuItem(num: number, name: "Delete" | "Rename") {
+async function openTabMenu(num: number) {
+  const dropdownIcons = screen.getAllByRole("img", {
+    name: "chevrondown icon",
+    hidden: true,
+  });
+  userEvent.click(dropdownIcons[num - 1]);
+  await screen.findByRole("option");
+}
+
+async function selectTabMenuItem(
+  num: number,
+  name: "Delete" | "Rename" | "Duplicate",
+) {
   const dropdownIcons = screen.getAllByRole("img", {
     name: "chevrondown icon",
     hidden: true,
@@ -113,6 +125,10 @@ async function renameTab(num: number, name: string) {
     hidden: true,
   });
   userEvent.type(inputEl, `${name}{enter}`);
+}
+
+async function duplicateTab(num: number) {
+  return selectTabMenuItem(num, "Duplicate");
 }
 
 async function findSlug({ tabId, name }: { tabId: number; name: string }) {
@@ -202,21 +218,27 @@ describe("DashboardTabs", () => {
   });
 
   describe("when editing", () => {
-    it("should display a placeholder tab when there are none", () => {
+    it("should display a placeholder tab when there are none", async () => {
       setup({ tabs: [] });
 
-      const placeholderTab = queryTab("Tab 1");
-      expect(placeholderTab).toHaveAttribute("aria-disabled", "true");
+      expect(queryTab("Tab 1")).toBeInTheDocument();
+
+      await openTabMenu(1);
+      expect(screen.getByText("Duplicate")).toBeInTheDocument();
+
       expect(screen.getByText("Path is /dashboard/1")).toBeInTheDocument();
     });
 
-    it("should display a placeholder tab when there is only one", () => {
+    it("should display a placeholder tab when there is only one", async () => {
       setup({
         tabs: [getDefaultTab({ tabId: 1, dashId: 1, name: "Lonely tab" })],
       });
 
-      const placeholderTab = queryTab("Lonely tab");
-      expect(placeholderTab).toHaveAttribute("aria-disabled", "true");
+      expect(queryTab("Lonely tab")).toBeInTheDocument();
+
+      await openTabMenu(1);
+      expect(screen.getByText("Duplicate")).toBeInTheDocument();
+
       expect(screen.getByText("Path is /dashboard/1")).toBeInTheDocument();
     });
 
@@ -296,7 +318,7 @@ describe("DashboardTabs", () => {
         expect(await findSlug({ tabId: 2, name: "Tab 2" })).toBeInTheDocument();
       });
 
-      it("should disable the last tab and remove slug if the penultimate tab was deleted", async () => {
+      it("should keep the last tab and remove slug if the penultimate tab was deleted", async () => {
         setup();
         await deleteTab(3);
 
@@ -304,7 +326,10 @@ describe("DashboardTabs", () => {
 
         await deleteTab(2);
 
-        expect(queryTab(1)).toHaveAttribute("aria-disabled", "true");
+        expect(queryTab(1)).toBeInTheDocument();
+        await openTabMenu(1);
+        expect(screen.getByText("Duplicate")).toBeInTheDocument();
+
         expect(screen.getByText("Path is /dashboard/1")).toBeInTheDocument();
       });
 
@@ -345,6 +370,31 @@ describe("DashboardTabs", () => {
         expect(queryTab(name)).toBeInTheDocument();
         expect(await findSlug({ tabId: 1, name })).toBeInTheDocument();
       });
+    });
+  });
+
+  describe("when duplicating tabs", () => {
+    it("should allow the user to duplicate the placeholder tab if there are none", async () => {
+      setup({ tabs: [] });
+
+      await duplicateTab(1);
+
+      expect(queryTab("Tab 1")).toBeInTheDocument();
+      expect(queryTab("Copy of Tab 1")).toBeInTheDocument();
+
+      expect(screen.getByText("Selected tab id is -2")).toBeInTheDocument();
+      expect(screen.getByText("Path is /dashboard/1")).toBeInTheDocument();
+    });
+
+    it("should allow the user to duplicate a tab", async () => {
+      setup();
+
+      await duplicateTab(1);
+
+      expect(queryTab("Copy of Tab 1")).toBeInTheDocument();
+
+      expect(screen.getByText("Selected tab id is -2")).toBeInTheDocument();
+      expect(screen.getByText("Path is /dashboard/1")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
@@ -72,4 +72,8 @@ export const TEST_DASHBOARD_STATE: DashboardState = {
     1: createMockDashCard({ dashCardId: 1, tabId: 1 }),
     2: createMockDashCard({ dashCardId: 2, tabId: 2 }),
   },
+  dashcardData: {
+    1: { 1: null },
+    2: { 1: null },
+  },
 };

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
@@ -61,7 +61,7 @@ export function useDashboardTabs({ location }: { location: Location }) {
     tabs,
     selectedTabId,
     createNewTab: () => dispatch(createNewTab()),
-    duplicateTab: (tabId: SelectedTabId) => dispatch(duplicateTab(tabId!)), // TODO remove non-null assertion
+    duplicateTab: (tabId: SelectedTabId) => dispatch(duplicateTab(tabId)),
     deleteTab,
     renameTab: (tabId: SelectedTabId, name: string) =>
       dispatch(renameTab({ tabId, name })),

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
@@ -12,6 +12,7 @@ import {
   selectTab,
   undoDeleteTab,
   moveTab as moveTabAction,
+  duplicateTab,
 } from "metabase/dashboard/actions";
 import type { SelectedTabId } from "metabase-types/store";
 import { getSelectedTabId, getTabs } from "metabase/dashboard/selectors";
@@ -60,6 +61,7 @@ export function useDashboardTabs({ location }: { location: Location }) {
     tabs,
     selectedTabId,
     createNewTab: () => dispatch(createNewTab()),
+    duplicateTab: (tabId: SelectedTabId) => dispatch(duplicateTab(tabId!)), // TODO remove non-null assertion
     deleteTab,
     renameTab: (tabId: SelectedTabId, name: string) =>
       dispatch(renameTab({ tabId, name })),


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38208

### Description

Adds a item to the dashboard tab menu to duplicate the tab.

### How to verify

1. Open a dashboard you can edit
2. Go to edit more, click the tab menu for a tab
3. Click duplicate, tab should be duplicated

### Demo

https://www.loom.com/share/d73aad469074440992618ee179518d39

### Checklist

~~- [ ] Tests have been added/updated to cover changes in this PR~~

e2e tests are added in the next PR in the stack
