### PR TITLE
Add path filtering for cljs workflow

### DIFF
--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -135,3 +135,4 @@ cljs:
   - *shared_sources
   - *shared_specs
   - ".github/workflows/cljs.yml"
+  - "shadow-cljs.edn"

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -130,3 +130,8 @@ visualizations:
   - "frontend/src/metabase/visualizations/**"
   - "frontend/src/metabase/static-viz/**"
   - "src/metabase/pulse/**"
+
+cljs:
+  - *shared_sources
+  - *shared_specs
+  - ".github/workflows/cljs.yml"

--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -12,8 +12,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  files-changed:
+    name: Check which files changed
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    outputs:
+      cljs: ${{ steps.changes.outputs.cljs }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Test which files changed
+        uses: dorny/paths-filter@v2.11.1
+        id: changes
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-paths.yaml
 
   shared-tests-cljs:
+    needs: files-changed
+    if: needs.files-changed.outputs.cljs == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Closes  #36221

This PR makes CI use path filtering for `.cljs` and `.cljc` tests. Existing entries in `.github/file-paths.yaml` are reused and merged into `cljs` path.