### PR TITLE
 refactor: prepare SettingsPage to have conditionally rendered steps

### DIFF
--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -26,9 +26,10 @@ import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InvactiveStep";
 import { InviteUserForm } from "../InviteUserForm";
 import { SetupSection } from "../SetupSection";
+import type { NumberedStepProps } from "../types";
 import { StepDescription } from "./DatabaseStep.styled";
 
-export const DatabaseStep = (): JSX.Element => {
+export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const user = useSelector(getUser);
   const database = useSelector(getDatabase);
   const engine = useSelector(getDatabaseEngine);
@@ -71,7 +72,7 @@ export const DatabaseStep = (): JSX.Element => {
     return (
       <InactiveStep
         title={getStepTitle(database, invite, isStepCompleted)}
-        label={3}
+        label={stepLabel}
         isStepCompleted={isStepCompleted}
         isSetupCompleted={isSetupCompleted}
         onStepSelect={handleStepSelect}
@@ -82,7 +83,7 @@ export const DatabaseStep = (): JSX.Element => {
   return (
     <ActiveStep
       title={getStepTitle(database, invite, isStepCompleted)}
-      label={3}
+      label={stepLabel}
     >
       <StepDescription>
         <div>{t`Are you ready to start exploring your data? Add it below.`}</div>

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.unit.spec.tsx
@@ -30,7 +30,9 @@ const setup = ({
     }),
   });
 
-  renderWithProviders(<DatabaseStep />, { storeInitialState: state });
+  renderWithProviders(<DatabaseStep stepLabel={0} />, {
+    storeInitialState: state,
+  });
 };
 
 describe("DatabaseStep", () => {

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
@@ -16,6 +16,7 @@ import {
 import { getLocales } from "../../utils";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InvactiveStep";
+import type { NumberedStepProps } from "../types";
 import {
   LocaleGroup,
   LocaleInput,
@@ -24,7 +25,7 @@ import {
   StepDescription,
 } from "./LanguageStep.styled";
 
-export const LanguageStep = (): JSX.Element => {
+export const LanguageStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const locale = useSelector(getLocale);
   const localeData = useSelector(getAvailableLocales);
   const isStepActive = useSelector(state =>
@@ -54,7 +55,7 @@ export const LanguageStep = (): JSX.Element => {
     return (
       <InactiveStep
         title={t`Your language is set to ${locale?.name}`}
-        label={1}
+        label={stepLabel}
         isStepCompleted={isStepCompleted}
         isSetupCompleted={isSetupCompleted}
         onStepSelect={handleStepSelect}
@@ -63,7 +64,7 @@ export const LanguageStep = (): JSX.Element => {
   }
 
   return (
-    <ActiveStep title={t`What's your preferred language?`} label={1}>
+    <ActiveStep title={t`What's your preferred language?`} label={stepLabel}>
       <StepDescription>
         {t`This language will be used throughout Metabase and will be the default for new users.`}
       </StepDescription>

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.unit.spec.tsx
@@ -26,7 +26,9 @@ const setup = ({ step = LANGUAGE_STEP, locale }: SetupOpts = {}) => {
     }),
   });
 
-  renderWithProviders(<LanguageStep />, { storeInitialState: state });
+  renderWithProviders(<LanguageStep stepLabel={0} />, {
+    storeInitialState: state,
+  });
 };
 
 describe("LanguageStep", () => {

--- a/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.tsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../selectors";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InvactiveStep";
+import type { NumberedStepProps } from "../types";
 import {
   StepDescription,
   StepToggleContainer,
@@ -24,7 +25,9 @@ import {
   StepToggle,
 } from "./PreferencesStep.styled";
 
-export const PreferencesStep = (): JSX.Element => {
+export const PreferencesStep = ({
+  stepLabel,
+}: NumberedStepProps): JSX.Element => {
   const [errorMessage, setErrorMessage] = useState<string>();
   const isTrackingAllowed = useSelector(getIsTrackingAllowed);
   const isStepActive = useSelector(state =>
@@ -57,7 +60,7 @@ export const PreferencesStep = (): JSX.Element => {
     return (
       <InactiveStep
         title={getStepTitle(isTrackingAllowed, isStepCompleted)}
-        label={4}
+        label={stepLabel}
         isStepCompleted={isStepCompleted}
         isSetupCompleted={isSetupCompleted}
         onStepSelect={handleStepSelect}
@@ -68,7 +71,7 @@ export const PreferencesStep = (): JSX.Element => {
   return (
     <ActiveStep
       title={getStepTitle(isTrackingAllowed, isStepCompleted)}
-      label={4}
+      label={stepLabel}
     >
       <StepDescription>
         {t`In order to help us improve Metabase, we'd like to collect certain data about product usage.`}{" "}

--- a/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.unit.spec.tsx
@@ -20,7 +20,9 @@ const setup = ({ step = PREFERENCES_STEP }: SetupOpts = {}) => {
   });
 
   setupErrorSetupEndpoints();
-  renderWithProviders(<PreferencesStep />, { storeInitialState: state });
+  renderWithProviders(<PreferencesStep stepLabel={0} />, {
+    storeInitialState: state,
+  });
 };
 
 describe("PreferencesStep", () => {

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -1,29 +1,39 @@
 import LogoIcon from "metabase/components/LogoIcon";
+import { isNotFalsy } from "metabase/lib/types";
 import { CloudMigrationHelp } from "../CloudMigrationHelp";
-import { DatabaseHelp } from "../DatabaseHelp";
 import { DatabaseStep } from "../DatabaseStep";
 import { CompletedStep } from "../CompletedStep";
 import { LanguageStep } from "../LanguageStep";
 import { PreferencesStep } from "../PreferencesStep";
 import { UserStep } from "../UserStep";
 import { SetupHelp } from "../SetupHelp";
+import { DatabaseHelp } from "../DatabaseHelp";
 import { PageBody, PageHeader } from "./SettingsPage.styled";
 
 export const SettingsPage = (): JSX.Element => {
+  const numberedSteps = [
+    { component: LanguageStep, key: "language-step" },
+    { component: UserStep, key: "user-step" },
+    {
+      component: DatabaseStep,
+      key: "database-step",
+    },
+    { component: PreferencesStep, key: "preferences-step" },
+  ].filter(isNotFalsy);
+
   return (
     <div data-testid="setup-forms">
       <PageHeader>
         <LogoIcon height={51} />
       </PageHeader>
       <PageBody>
-        <LanguageStep />
-        <UserStep />
-        <DatabaseStep />
-        <DatabaseHelp />
-        <PreferencesStep />
+        {numberedSteps.map(({ component: Component, key }, index) => (
+          <Component key={key} stepLabel={index + 1} />
+        ))}
         <CompletedStep />
         <CloudMigrationHelp />
         <SetupHelp />
+        <DatabaseHelp />
       </PageBody>
     </div>
   );

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
@@ -14,9 +14,10 @@ import {
   getUser,
 } from "../../selectors";
 import { validatePassword } from "../../utils";
+import type { NumberedStepProps } from "../types";
 import { StepDescription } from "./UserStep.styled";
 
-export const UserStep = (): JSX.Element => {
+export const UserStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const user = useSelector(getUser);
   const isHosted = useSelector(getIsHosted);
   const isStepActive = useSelector(state => getIsStepActive(state, USER_STEP));
@@ -38,7 +39,7 @@ export const UserStep = (): JSX.Element => {
     return (
       <InactiveStep
         title={getStepTitle(user, isStepCompleted)}
-        label={2}
+        label={stepLabel}
         isStepCompleted={isStepCompleted}
         isSetupCompleted={isSetupCompleted}
         onStepSelect={handleStepSelect}
@@ -47,7 +48,7 @@ export const UserStep = (): JSX.Element => {
   }
 
   return (
-    <ActiveStep title={getStepTitle(user, isStepCompleted)} label={2}>
+    <ActiveStep title={getStepTitle(user, isStepCompleted)} label={stepLabel}>
       {isHosted && (
         <StepDescription>
           {t`We know you’ve already created one of these.`}{" "}

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.unit.spec.tsx
@@ -21,7 +21,7 @@ const setup = ({ step = USER_STEP, user }: SetupOpts = {}) => {
     }),
   });
 
-  renderWithProviders(<UserStep />, { storeInitialState: state });
+  renderWithProviders(<UserStep stepLabel={0} />, { storeInitialState: state });
 };
 
 describe("UserStep", () => {

--- a/frontend/src/metabase/setup/components/types.ts
+++ b/frontend/src/metabase/setup/components/types.ts
@@ -1,0 +1,1 @@
+export type NumberedStepProps = { stepLabel: number };


### PR DESCRIPTION
### Description

The upcoming project [Meet embedders at the door during setup](https://www.notion.so/metabase/Meet-embedders-at-the-door-during-setup-d291f12e5ba244ba8cf803af18f63e86) will need to render conditionally some steps, this PR makes it easy to do so while retaining the numeric labels correct.

Changes:
- The steps that had the numeric label are now rendered by a mapping from an array that passes the step number to them
- <DatabaseHelp/> is a fixed position card, so it doesn't matter where it's rendered by react
<img width="1324" alt="image" src="https://github.com/metabase/metabase/assets/1914270/3d00ef8c-10df-4498-baf5-8f50fe9acaa4">


### How to verify

Nothing should fail in CI.
I added a fake toggle to remove one step to test it locally, see the demo

### Demo

https://github.com/metabase/metabase/assets/1914270/4056a433-d5af-4ef1-9b1c-b29b76870071



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
-> no behaviour change
