### PR TITLE
Dashboard required params

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -19,6 +19,10 @@ export function getDashboardCard(index = 0) {
   return getDashboardCards().eq(index);
 }
 
+export function ensureDashboardCardHasText(text, index = 0) {
+  cy.get(".Card").eq(index).findByText(text);
+}
+
 function getDashboardApiUrl(dashId) {
   return `/api/dashboard/${dashId}`;
 }
@@ -134,6 +138,10 @@ export function setFilter(type, subType) {
   });
 }
 
+export function toggleRequiredParameter() {
+  cy.findByLabelText("Always require a value").click();
+}
+
 export function createEmptyTextBox() {
   cy.findByLabelText("Edit dashboard").click();
   cy.findByLabelText("Add a heading or text box").click();
@@ -238,6 +246,10 @@ export const dashboardHeader = () => {
 export const dashboardGrid = () => {
   return cy.findByTestId("dashboard-grid");
 };
+
+export function dashboardSaveButton() {
+  return cy.findByRole("button", { name: "Save" });
+}
 
 /**
  * @param {Object=} option

--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -20,7 +20,7 @@ export function getDashboardCard(index = 0) {
 }
 
 export function ensureDashboardCardHasText(text, index = 0) {
-  cy.get(".Card").eq(index).findByText(text);
+  cy.get(".Card").eq(index).should("contain", text);
 }
 
 function getDashboardApiUrl(dashId) {
@@ -248,7 +248,7 @@ export const dashboardGrid = () => {
 };
 
 export function dashboardSaveButton() {
-  return cy.findByRole("button", { name: "Save" });
+  return cy.findByTestId("edit-bar").findByRole("button", { name: "Save" });
 }
 
 /**

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -101,7 +101,7 @@ export function toggleFilterWidgetValues(values = [], index = 0) {
 
   popover().within(() => {
     values.forEach(value => cy.findByText(value).click());
-    cy.findByText("Update filter").click();
+    cy.button("Update filter").click();
   });
 }
 

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -81,6 +81,30 @@ export function clearFilterWidget(index = 0) {
   return filterWidget().eq(index).icon("close").click();
 }
 
+export function resetFilterWidgetToDefault(index = 0) {
+  return filterWidget().eq(index).icon("refresh").click();
+}
+
+export function setFilterWidgetValue(value, targetPlaceholder, index = 0) {
+  filterWidget().eq(index).click();
+  popover().within(() => {
+    cy.icon("close").click();
+    if (value) {
+      cy.findByPlaceholderText(targetPlaceholder).type(value).blur();
+    }
+    cy.button("Update filter").click();
+  });
+}
+
+export function toggleFilterWidgetValues(values = [], index = 0) {
+  filterWidget().eq(index).click();
+
+  popover().within(() => {
+    values.forEach(value => cy.findByText(value).click());
+    cy.findByText("Update filter").click();
+  });
+}
+
 export const openQuestionActions = () => {
   cy.findByTestId("qb-header-action-panel").icon("ellipsis").click();
 };

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -105,7 +105,9 @@ describe("scenarios > dashboard > filters > date", () => {
     toggleRequiredParameter();
     dashboardSaveButton().should("be.disabled");
     dashboardSaveButton().realHover();
-    cy.get("body").findByText(
+
+    cy.findByRole("tooltip").should(
+      "contain.text",
       'The "Month and Year" parameter requires a default value but none was provided.',
     );
 
@@ -116,7 +118,6 @@ describe("scenarios > dashboard > filters > date", () => {
     });
 
     selectDashboardFilter(cy.findByTestId("dashcard"), "Created At");
-    dashboardSaveButton().should("not.be.disabled");
     saveDashboard();
 
     // Updates the filter value

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -7,6 +7,12 @@ import {
   saveDashboard,
   setFilter,
   visitDashboard,
+  toggleRequiredParameter,
+  dashboardSaveButton,
+  selectDashboardFilter,
+  ensureDashboardCardHasText,
+  resetFilterWidgetToDefault,
+  sidebar,
 } from "e2e/support/helpers";
 import {
   ORDERS_DASHBOARD_ID,
@@ -90,6 +96,39 @@ describe("scenarios > dashboard > filters > date", () => {
     popover().contains("June").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("33.9");
+  });
+
+  it("should support being required", () => {
+    setFilter("Time", "Month and Year");
+
+    // Can't save without a default value
+    toggleRequiredParameter();
+    dashboardSaveButton().should("be.disabled");
+    dashboardSaveButton().realHover();
+    cy.get("body").findByText(
+      'The "Month and Year" parameter requires a default value but none was provided.',
+    );
+
+    sidebar().findByText("Default value").next().click();
+    DateFilter.setMonthAndYear({
+      month: "November",
+      year: "2023",
+    });
+
+    selectDashboardFilter(cy.findByTestId("dashcard"), "Created At");
+    dashboardSaveButton().should("not.be.disabled");
+    saveDashboard();
+
+    // Updates the filter value
+    filterWidget().click();
+    popover().findByText("December").click();
+    filterWidget().findByText("December 2023");
+    ensureDashboardCardHasText("Rows 1-8 of 418");
+
+    // Resets the value back by clicking widget icon
+    resetFilterWidgetToDefault();
+    filterWidget().findByText("November 2023");
+    ensureDashboardCardHasText("Rows 1-8 of 394");
   });
 
   it("should show sub-day resolutions in relative date filter (metabase#6660)", () => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -123,12 +123,12 @@ describe("scenarios > dashboard > filters > date", () => {
     filterWidget().click();
     popover().findByText("December").click();
     filterWidget().findByText("December 2023");
-    ensureDashboardCardHasText("Rows 1-8 of 418");
+    ensureDashboardCardHasText("76.83");
 
     // Resets the value back by clicking widget icon
     resetFilterWidgetToDefault();
     filterWidget().findByText("November 2023");
-    ensureDashboardCardHasText("Rows 1-8 of 394");
+    ensureDashboardCardHasText("27.74");
   });
 
   it("should show sub-day resolutions in relative date filter (metabase#6660)", () => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -8,6 +8,12 @@ import {
   setFilter,
   visitDashboard,
   selectDashboardFilter,
+  toggleRequiredParameter,
+  setFilterWidgetValue,
+  resetFilterWidgetToDefault,
+  dashboardSaveButton,
+  ensureDashboardCardHasText,
+  sidebar,
 } from "e2e/support/helpers";
 import {
   ORDERS_DASHBOARD_ID,
@@ -79,5 +85,39 @@ describe("scenarios > dashboard > filters > number", () => {
     cy.get(".Card").within(() => {
       cy.findByText("101.04");
     });
+  });
+
+  it("should support being required", () => {
+    setFilter("Number", "Equal to");
+    selectDashboardFilter(cy.findByTestId("dashcard"), "Tax");
+
+    // Can't save without a default value
+    toggleRequiredParameter();
+    dashboardSaveButton().should("be.disabled");
+    dashboardSaveButton().realHover();
+    cy.get("body").findByText(
+      'The "Equal to" parameter requires a default value but none was provided.',
+    );
+
+    sidebar().findByText("Default value").next().click();
+    addWidgetNumberFilter("2.07");
+    dashboardSaveButton().should("not.be.disabled");
+
+    saveDashboard();
+    ensureDashboardCardHasText("37.65");
+
+    // Updates the filter value
+    setFilterWidgetValue("5.27", "Enter a number");
+    ensureDashboardCardHasText("95.77");
+
+    // Resets the value back by clicking widget icon
+    resetFilterWidgetToDefault();
+    filterWidget().findByText("2.07");
+    ensureDashboardCardHasText("37.65");
+
+    // Removing value resets back to default
+    setFilterWidgetValue(null, "Enter a number");
+    filterWidget().findByText("2.07");
+    ensureDashboardCardHasText("37.65");
   });
 });

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -95,13 +95,14 @@ describe("scenarios > dashboard > filters > number", () => {
     toggleRequiredParameter();
     dashboardSaveButton().should("be.disabled");
     dashboardSaveButton().realHover();
-    cy.get("body").findByText(
+
+    cy.findByRole("tooltip").should(
+      "contain.text",
       'The "Equal to" parameter requires a default value but none was provided.',
     );
 
     sidebar().findByText("Default value").next().click();
     addWidgetNumberFilter("2.07");
-    dashboardSaveButton().should("not.be.disabled");
 
     saveDashboard();
     ensureDashboardCardHasText("37.65");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -146,7 +146,8 @@ describe("scenarios > dashboard > filters > text/category", () => {
     toggleRequiredParameter();
     dashboardSaveButton().should("be.disabled");
     dashboardSaveButton().realHover();
-    cy.get("body").findByText(
+    cy.findByRole("tooltip").should(
+      "contain.text",
       'The "Text" parameter requires a default value but none was provided.',
     );
 

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -7,13 +7,22 @@ import {
   saveDashboard,
   setFilter,
   visitDashboard,
+  selectDashboardFilter,
+  toggleRequiredParameter,
+  dashboardSaveButton,
+  ensureDashboardCardHasText,
+  toggleFilterWidgetValues,
+  resetFilterWidgetToDefault,
 } from "e2e/support/helpers";
 import {
   ORDERS_DASHBOARD_ID,
   ORDERS_DASHBOARD_DASHCARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
-import { applyFilterByType } from "../native-filters/helpers/e2e-field-filter-helpers";
+import {
+  applyFilterByType,
+  selectDefaultValueFromPopover,
+} from "../native-filters/helpers/e2e-field-filter-helpers";
 import { DASHBOARD_TEXT_FILTERS } from "./shared/dashboard-filters-text-category";
 
 describe("scenarios > dashboard > filters > text/category", () => {
@@ -127,5 +136,32 @@ describe("scenarios > dashboard > filters > text/category", () => {
     cy.location("search").should("eq", "?text=&id=4");
     filterWidget().contains("Text");
     filterWidget().contains("Arnold Adams");
+  });
+
+  it("should support being required", () => {
+    setFilter("Text or Category", "Is");
+    selectDashboardFilter(cy.findByTestId("dashcard"), "Source");
+
+    // Can't save without a default value
+    toggleRequiredParameter();
+    dashboardSaveButton().should("be.disabled");
+    dashboardSaveButton().realHover();
+    cy.get("body").findByText(
+      'The "Text" parameter requires a default value but none was provided.',
+    );
+
+    // Updates the filter value
+    selectDefaultValueFromPopover("Twitter");
+    saveDashboard();
+    ensureDashboardCardHasText("37.65");
+
+    // Resets the value back by clicking widget icon
+    toggleFilterWidgetValues(["Google", "Organic"]);
+    resetFilterWidgetToDefault();
+    filterWidget().findByText("Twitter");
+
+    // Removing value resets back to default
+    toggleFilterWidgetValues(["Twitter"]);
+    filterWidget().findByText("Twitter");
   });
 });

--- a/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-field-filter-helpers.js
@@ -207,3 +207,8 @@ export function clearDefaultFilterValue() {
     .find(".Icon-close")
     .click();
 }
+
+export function selectDefaultValueFromPopover(value) {
+  cy.findByText("Default value").next().click();
+  selectFilterValueFromList(value);
+}

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -30,7 +30,7 @@ export function getDefaultValuePopulatedParameters(
 
 // Needed because parameter values might be arrays
 // in which case order of elements isn't guaranteed
-export function isParameterValuesIdentical(a, b) {
+export function areParameterValuesIdentical(a, b) {
   return _.isEqual(
     Array.isArray(a) ? a.slice().sort() : a,
     Array.isArray(b) ? b.slice().sort() : b,

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -28,6 +28,15 @@ export function getDefaultValuePopulatedParameters(
   });
 }
 
+// Needed because parameter values might be arrays
+// in which case order of elements isn't guaranteed
+export function isParameterValuesIdentical(a, b) {
+  return _.isEqual(
+    Array.isArray(a) ? a.slice().sort() : a,
+    Array.isArray(b) ? b.slice().sort() : b,
+  );
+}
+
 export function normalizeParameter(parameter) {
   return {
     id: parameter.id,

--- a/frontend/src/metabase/dashboard/actions/parameters.js
+++ b/frontend/src/metabase/dashboard/actions/parameters.js
@@ -228,6 +228,39 @@ export const setParameterDefaultValue = createThunkAction(
   },
 );
 
+export const SET_PARAMETER_VALUE_TO_DEFAULT =
+  "metabase/dashboard/SET_PARAMETER_VALUE_TO_DEFAULT";
+export const setParameterValueToDefault = createThunkAction(
+  SET_PARAMETER_VALUE_TO_DEFAULT,
+  parameterId => (dispatch, getState) => {
+    const parameter = getParameters(getState()).find(
+      ({ id }) => id === parameterId,
+    );
+    const defaultValue = parameter?.default;
+    if (defaultValue) {
+      dispatch(setParameterValue(parameterId, defaultValue));
+    }
+  },
+);
+
+export const SET_PARAMETER_REQUIRED =
+  "metabase/dashboard/SET_PARAMETER_REQUIRED";
+export const setParameterRequired = createThunkAction(
+  SET_PARAMETER_REQUIRED,
+  (parameterId, value) => (dispatch, getState) => {
+    const parameter = getParameters(getState()).find(
+      ({ id }) => id === parameterId,
+    );
+
+    if (parameter.required !== value) {
+      updateParameter(dispatch, getState, parameterId, parameter => ({
+        ...parameter,
+        required: value,
+      }));
+    }
+  },
+);
+
 export const SET_PARAMETER_IS_MULTI_SELECT =
   "metabase/dashboard/SET_PARAMETER_DEFAULT_VALUE";
 export const setParameterIsMultiSelect = createThunkAction(

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -466,6 +466,7 @@ function DashboardInner(props: DashboardProps) {
       setParameterIndex={setParameterIndex}
       setEditingParameter={setEditingParameter}
       setParameterValueToDefault={setParameterValueToDefault}
+      enableParameterRequiredBehavior
     />
   );
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -151,6 +151,7 @@ interface DashboardProps {
   setParameterIndex: (id: ParameterId, index: number) => void;
   setParameterValue: (id: ParameterId, value: RowValue) => void;
   setParameterDefaultValue: (id: ParameterId, value: RowValue) => void;
+  setParameterValueToDefault: (id: ParameterId) => void;
   setEditingParameter: (id: ParameterId) => void;
   setParameterIsMultiSelect: (id: ParameterId, isMultiSelect: boolean) => void;
   setParameterQueryType: (id: ParameterId, queryType: ValuesQueryType) => void;
@@ -216,6 +217,7 @@ function DashboardInner(props: DashboardProps) {
     setErrorPage,
     setParameterIndex,
     setParameterValue,
+    setParameterValueToDefault,
     setSharing,
     toggleSidebar,
   } = props;
@@ -463,6 +465,7 @@ function DashboardInner(props: DashboardProps) {
       setParameterValue={setParameterValue}
       setParameterIndex={setParameterIndex}
       setEditingParameter={setEditingParameter}
+      setParameterValueToDefault={setParameterValueToDefault}
     />
   );
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -152,6 +152,7 @@ interface DashboardProps {
   setParameterValue: (id: ParameterId, value: RowValue) => void;
   setParameterDefaultValue: (id: ParameterId, value: RowValue) => void;
   setParameterValueToDefault: (id: ParameterId) => void;
+  setParameterRequired: (id: ParameterId, value: boolean) => void;
   setEditingParameter: (id: ParameterId) => void;
   setParameterIsMultiSelect: (id: ParameterId, isMultiSelect: boolean) => void;
   setParameterQueryType: (id: ParameterId, queryType: ValuesQueryType) => void;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -30,6 +30,7 @@ import TippyPopover from "metabase/components/Popover/TippyPopover";
 import { getPulseFormInput } from "metabase/pulse/selectors";
 import { fetchPulseFormInput } from "metabase/pulse/actions";
 import {
+  getCanSaveDashboard,
   getIsBookmarked,
   getIsShowDashboardInfoSidebar,
 } from "metabase/dashboard/selectors";
@@ -147,6 +148,7 @@ interface StateProps {
   isNavBarOpen: boolean;
   isShowingDashboardInfoSidebar: boolean;
   isHomepageDashboard: boolean;
+  canSaveDashboard: boolean;
 }
 
 interface DispatchProps {
@@ -176,6 +178,7 @@ const mapStateToProps = (state: State, props: OwnProps): StateProps => {
     isHomepageDashboard:
       getSetting(state, "custom-homepage") &&
       getSetting(state, "custom-homepage-dashboard") === props.dashboard?.id,
+    canSaveDashboard: getCanSaveDashboard(state),
   };
 };
 
@@ -307,6 +310,8 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
         activeText={t`Saving…`}
         failedText={t`Save failed`}
         successText={t`Saved`}
+        // TODO add an explanatory message as to why it is not available?
+        disabled={!this.props.canSaveDashboard}
       />,
     ];
   }

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -32,6 +32,7 @@ DashboardSidebars.propTypes = {
   setParameterSourceType: PropTypes.func.isRequired,
   setParameterSourceConfig: PropTypes.func.isRequired,
   setParameterFilteringParameters: PropTypes.func.isRequired,
+  setParameterRequired: PropTypes.func.isRequired,
   dashcardData: PropTypes.object,
   isSharing: PropTypes.bool.isRequired,
   isEditing: PropTypes.bool.isRequired,
@@ -65,6 +66,7 @@ export function DashboardSidebars({
   setParameterSourceType,
   setParameterSourceConfig,
   setParameterFilteringParameters,
+  setParameterRequired,
   dashcardData,
   isFullscreen,
   onCancel,
@@ -146,6 +148,7 @@ export function DashboardSidebars({
           onRemoveParameter={removeParameter}
           onShowAddParameterPopover={showAddParameterPopover}
           onClose={closeSidebar}
+          onChangeRequired={setParameterRequired}
         />
       );
     }

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -320,16 +320,13 @@ export const getParameters = createSelector(
   },
 );
 
-export const getRequiredParameters = createSelector(
-  [getParameters],
-  parameters => parameters.filter(param => param.required),
-);
-
 export const getMissingRequiredParameters = createSelector(
-  [getRequiredParameters],
-  requiredParameters =>
-    requiredParameters.filter(
-      p => !p.default || (Array.isArray(p.default) && p.default.length === 0),
+  [getParameters],
+  parameters =>
+    parameters.filter(
+      p =>
+        p.required &&
+        (!p.default || (Array.isArray(p.default) && p.default.length === 0)),
     ),
 );
 

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -25,7 +25,6 @@ import type {
   EditParameterSidebarState,
   State,
 } from "metabase-types/store";
-import { isParameterValueEmpty } from "metabase-lib/parameters/utils/parameter-values";
 
 type SidebarState = State["dashboard"]["sidebar"];
 
@@ -321,6 +320,19 @@ export const getParameters = createSelector(
   },
 );
 
+export const getRequiredParameters = createSelector(
+  [getParameters],
+  parameters => parameters.filter(param => param.required),
+);
+
+export const getMissingRequiredParameters = createSelector(
+  [getRequiredParameters],
+  requiredParameters =>
+    requiredParameters.filter(
+      param => !param.default || param?.default.length === 0,
+    ),
+);
+
 export const getParameterMappingOptions = createSelector(
   [getMetadata, getEditingParameter, getCard, getDashCard],
   (metadata, parameter, card, dashcard) => {
@@ -348,19 +360,3 @@ export const getTabs = createSelector([getDashboard], dashboard => {
 export function getSelectedTabId(state: State) {
   return state.dashboard.selectedTabId;
 }
-
-// Currently used only with regards to required parameters having default values,
-// but could be extended should we want any additional pre-save logic.
-// TODO add an explanatory message as to why it is disabled?
-export const getCanSaveDashboard = createSelector(
-  [getIsEditing, getParameters],
-  (isEditing, parameters) => {
-    if (!isEditing) {
-      return false;
-    }
-
-    return parameters
-      .filter(param => param.required)
-      .every(param => !isParameterValueEmpty(param.default));
-  },
-);

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -25,6 +25,7 @@ import type {
   EditParameterSidebarState,
   State,
 } from "metabase-types/store";
+import { isParameterValueEmpty } from "metabase-lib/parameters/utils/parameter-values";
 
 type SidebarState = State["dashboard"]["sidebar"];
 
@@ -347,3 +348,19 @@ export const getTabs = createSelector([getDashboard], dashboard => {
 export function getSelectedTabId(state: State) {
   return state.dashboard.selectedTabId;
 }
+
+// Currently used only with regards to required parameters having default values,
+// but could be extended should we want any additional pre-save logic.
+// TODO add an explanatory message as to why it is disabled?
+export const getCanSaveDashboard = createSelector(
+  [getIsEditing, getParameters],
+  (isEditing, parameters) => {
+    if (!isEditing) {
+      return false;
+    }
+
+    return parameters
+      .filter(param => param.required)
+      .every(param => !isParameterValueEmpty(param.default));
+  },
+);

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -329,7 +329,7 @@ export const getMissingRequiredParameters = createSelector(
   [getRequiredParameters],
   requiredParameters =>
     requiredParameters.filter(
-      param => !param.default || param?.default.length === 0,
+      p => !p.default || (Array.isArray(p.default) && p.default.length === 0),
     ),
 );
 

--- a/frontend/src/metabase/dashboard/selectors.unit.spec.js
+++ b/frontend/src/metabase/dashboard/selectors.unit.spec.js
@@ -8,6 +8,7 @@ import {
   getIsEditingParameter,
   getClickBehaviorSidebarDashcard,
   getDashboardComplete,
+  getCanSaveDashboard,
 } from "metabase/dashboard/selectors";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 import Field from "metabase-lib/metadata/Field";
@@ -402,4 +403,6 @@ describe("dashboard/selectors", () => {
       expect(cards[0].card.id).toBe(2);
     });
   });
+
+  describe("getCanSaveDashboard", () => {});
 });

--- a/frontend/src/metabase/dashboard/selectors.unit.spec.js
+++ b/frontend/src/metabase/dashboard/selectors.unit.spec.js
@@ -8,7 +8,6 @@ import {
   getIsEditingParameter,
   getClickBehaviorSidebarDashcard,
   getDashboardComplete,
-  getCanSaveDashboard,
 } from "metabase/dashboard/selectors";
 import { createMockSettingsState } from "metabase-types/store/mocks";
 import Field from "metabase-lib/metadata/Field";
@@ -403,6 +402,4 @@ describe("dashboard/selectors", () => {
       expect(cards[0].card.id).toBe(2);
     });
   });
-
-  describe("getCanSaveDashboard", () => {});
 });

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
@@ -17,6 +17,11 @@ export const SettingLabel = styled.label`
   font-weight: bold;
 `;
 
+export const SettingLabelError = styled.span`
+  margin: 0 0.5rem;
+  color: ${color("error")};
+`;
+
 export const SettingValueWidget = styled(ParameterValueWidget)`
   color: ${color("text-dark")};
   padding: 0.75rem 0.75rem;

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
@@ -24,3 +24,17 @@ export const SettingValueWidget = styled(ParameterValueWidget)`
   border-radius: 0.5rem;
   background-color: ${color("white")};
 `;
+
+export const SettingRequiredContainer = styled.div`
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+`;
+
+export const SettingRequiredLabel = styled.label`
+  display: block;
+  margin-top: 0.35rem;
+  font-weight: 700;
+  color: ${color("text-medium")};
+  cursor: pointer;
+`;

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -15,6 +15,7 @@ import { isSingleOrMultiSelectable } from "../../utils/parameter-type";
 import ValuesSourceSettings from "../ValuesSourceSettings";
 import {
   SettingLabel,
+  SettingLabelError,
   SettingRequiredContainer,
   SettingRequiredLabel,
   SettingSection,
@@ -116,7 +117,13 @@ const ParameterSettings = ({
       )}
 
       <SettingSection>
-        <SettingLabel>{t`Default value`}</SettingLabel>
+        <SettingLabel>
+          {t`Default value`}
+          {parameter.required && !parameter.default && (
+            <SettingLabelError>({t`required`})</SettingLabelError>
+          )}
+        </SettingLabel>
+
         <SettingValueWidget
           parameter={parameter}
           name={parameter.name}

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -15,15 +15,12 @@ import { isSingleOrMultiSelectable } from "../../utils/parameter-type";
 import ValuesSourceSettings from "../ValuesSourceSettings";
 import {
   SettingLabel,
+  SettingRequiredContainer,
+  SettingRequiredLabel,
   SettingSection,
   SettingsRoot,
   SettingValueWidget,
 } from "./ParameterSettings.styled";
-
-const MULTI_SELECT_OPTIONS = [
-  { name: t`Multiple values`, value: true },
-  { name: t`A single value`, value: false },
-];
 
 export interface ParameterSettingsProps {
   parameter: Parameter;
@@ -108,12 +105,16 @@ const ParameterSettings = ({
           <SettingLabel>{t`People can pick`}</SettingLabel>
           <Radio
             value={getIsMultiSelect(parameter)}
-            options={MULTI_SELECT_OPTIONS}
+            options={[
+              { name: t`Multiple values`, value: true },
+              { name: t`A single value`, value: false },
+            ]}
             vertical
             onChange={onChangeIsMultiSelect}
           />
         </SettingSection>
       )}
+
       <SettingSection>
         <SettingLabel>{t`Default value`}</SettingLabel>
         <SettingValueWidget
@@ -124,21 +125,21 @@ const ParameterSettings = ({
           setValue={onChangeDefaultValue}
         />
 
-        <Toggle
-          // id={`tag-editor-required_${tag.id}`}
-          value={parameter.required}
-          onChange={onChangeRequired}
-        />
-
-        {t`Always require a value`}
-        <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
-
-        {/* <div>
-          <ToggleLabel htmlFor={`tag-editor-required_${tag.id}`}>
-            {t`Always require a value`}
-          </ToggleLabel>
-          <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
-        </div> */}
+        <SettingRequiredContainer>
+          <Toggle
+            id={`parameter-setting-required_${parameter.id}`}
+            value={parameter.required}
+            onChange={onChangeRequired}
+          />
+          <div>
+            <SettingRequiredLabel
+              htmlFor={`parameter-setting-required_${parameter.id}`}
+            >
+              {t`Always require a value`}
+            </SettingRequiredLabel>
+            <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
+          </div>
+        </SettingRequiredContainer>
       </SettingSection>
     </SettingsRoot>
   );

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -8,6 +8,7 @@ import type {
   ValuesSourceType,
 } from "metabase-types/api";
 import { TextInput } from "metabase/ui";
+import Toggle from "metabase/core/components/Toggle";
 import { canUseCustomSource } from "metabase-lib/parameters/utils/parameter-source";
 import { getIsMultiSelect } from "../../utils/dashboards";
 import { isSingleOrMultiSelectable } from "../../utils/parameter-type";
@@ -33,6 +34,7 @@ export interface ParameterSettingsProps {
   onChangeQueryType: (queryType: ValuesQueryType) => void;
   onChangeSourceType: (sourceType: ValuesSourceType) => void;
   onChangeSourceConfig: (sourceConfig: ValuesSourceConfig) => void;
+  onChangeRequired: (value: boolean) => void;
 }
 
 const ParameterSettings = ({
@@ -44,6 +46,7 @@ const ParameterSettings = ({
   onChangeQueryType,
   onChangeSourceType,
   onChangeSourceConfig,
+  onChangeRequired,
 }: ParameterSettingsProps): JSX.Element => {
   const [tempLabelValue, setTempLabelValue] = useState(parameter.name);
 
@@ -99,16 +102,7 @@ const ParameterSettings = ({
           />
         </SettingSection>
       )}
-      <SettingSection>
-        <SettingLabel>{t`Default value`}</SettingLabel>
-        <SettingValueWidget
-          parameter={parameter}
-          name={parameter.name}
-          value={parameter.default}
-          placeholder={t`No default`}
-          setValue={onChangeDefaultValue}
-        />
-      </SettingSection>
+
       {isSingleOrMultiSelectable(parameter) && (
         <SettingSection>
           <SettingLabel>{t`People can pick`}</SettingLabel>
@@ -120,6 +114,32 @@ const ParameterSettings = ({
           />
         </SettingSection>
       )}
+      <SettingSection>
+        <SettingLabel>{t`Default value`}</SettingLabel>
+        <SettingValueWidget
+          parameter={parameter}
+          name={parameter.name}
+          value={parameter.default}
+          placeholder={t`No default`}
+          setValue={onChangeDefaultValue}
+        />
+
+        <Toggle
+          // id={`tag-editor-required_${tag.id}`}
+          value={parameter.required}
+          onChange={onChangeRequired}
+        />
+
+        {t`Always require a value`}
+        <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
+
+        {/* <div>
+          <ToggleLabel htmlFor={`tag-editor-required_${tag.id}`}>
+            {t`Always require a value`}
+          </ToggleLabel>
+          <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
+        </div> */}
+      </SettingSection>
     </SettingsRoot>
   );
 };

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -111,6 +111,7 @@ const setup = ({ parameter = createMockUiParameter() }: SetupOpts = {}) => {
       onChangeQueryType={onChangeQueryType}
       onChangeSourceType={jest.fn()}
       onChangeSourceConfig={jest.fn()}
+      onChangeRequired={jest.fn()}
     />,
   );
 

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -40,6 +40,7 @@ export interface ParameterSidebarProps {
     parameterId: ParameterId,
     filteringParameters: string[],
   ) => void;
+  onChangeRequired: (parameterId: ParameterId, value: boolean) => void;
   onRemoveParameter: (parameterId: ParameterId) => void;
   onShowAddParameterPopover: () => void;
   onClose: () => void;
@@ -55,6 +56,7 @@ export const ParameterSidebar = ({
   onChangeSourceType,
   onChangeSourceConfig,
   onChangeFilteringParameters,
+  onChangeRequired,
   onRemoveParameter,
   onShowAddParameterPopover,
   onClose,
@@ -123,6 +125,13 @@ export const ParameterSidebar = ({
     [otherParameters],
   );
 
+  const handleChangeRequired = useCallback(
+    (value: boolean) => {
+      onChangeRequired(parameterId, value);
+    },
+    [parameterId, onChangeRequired],
+  );
+
   return (
     <Sidebar onClose={onClose} onRemove={handleRemove}>
       <SidebarHeader>
@@ -144,6 +153,7 @@ export const ParameterSidebar = ({
             onChangeQueryType={handleQueryTypeChange}
             onChangeSourceType={handleSourceTypeChange}
             onChangeSourceConfig={handleSourceConfigChange}
+            onChangeRequired={handleChangeRequired}
           />
         ) : (
           <ParameterLinkedFilters

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -125,12 +125,8 @@ export const ParameterSidebar = ({
     [otherParameters],
   );
 
-  const handleChangeRequired = useCallback(
-    (value: boolean) => {
-      onChangeRequired(parameterId, value);
-    },
-    [parameterId, onChangeRequired],
-  );
+  const handleChangeRequired = (value: boolean) =>
+    onChangeRequired(parameterId, value);
 
   return (
     <Sidebar onClose={onClose} onRemove={handleRemove}>

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -52,6 +52,7 @@ const setup = ({
           onRemoveParameter={jest.fn()}
           onShowAddParameterPopover={jest.fn()}
           onClose={jest.fn()}
+          onChangeRequired={jest.fn()}
         />
       </div>
     );

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -32,6 +32,7 @@ import {
 } from "metabase-lib/parameters/utils/parameter-type";
 import { hasFields } from "metabase-lib/parameters/utils/parameter-fields";
 
+import { isParameterValuesIdentical } from "metabase-lib/parameters/utils/parameter-values";
 import ParameterFieldWidget from "./widgets/ParameterFieldWidget/ParameterFieldWidget";
 import S from "./ParameterValueWidget.css";
 
@@ -142,9 +143,13 @@ class ParameterValueWidget extends Component {
 
   getRequiredActionIcon() {
     const { required, default: defaultValue } = this.props.parameter;
-    const { value, setParameterValueToDefault } = this.props;
+    const { value, setParameterValueToDefault = () => {} } = this.props;
 
-    if (required && defaultValue && value !== defaultValue) {
+    if (
+      required &&
+      defaultValue &&
+      !isParameterValuesIdentical(value, defaultValue)
+    ) {
       return (
         <WidgetStatusIcon
           name="refresh"

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -31,8 +31,7 @@ import {
   isNumberParameter,
 } from "metabase-lib/parameters/utils/parameter-type";
 import { hasFields } from "metabase-lib/parameters/utils/parameter-fields";
-
-import { isParameterValuesIdentical } from "metabase-lib/parameters/utils/parameter-values";
+import { areParameterValuesIdentical } from "metabase-lib/parameters/utils/parameter-values";
 import ParameterFieldWidget from "./widgets/ParameterFieldWidget/ParameterFieldWidget";
 import S from "./ParameterValueWidget.css";
 
@@ -148,7 +147,7 @@ class ParameterValueWidget extends Component {
     if (
       required &&
       defaultValue &&
-      !isParameterValuesIdentical(value, defaultValue)
+      !areParameterValuesIdentical(value, defaultValue)
     ) {
       return (
         <WidgetStatusIcon

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -261,6 +261,16 @@ function Widget({
     ? value
     : [value].filter(v => v != null);
 
+  // TODO this is due to some widgets not supporting focusChanged callback.
+  const setValueOrDefault = value => {
+    const { required, default: defaultValue } = parameter;
+    const shouldUseDefault =
+      enableRequiredBehavior && required && defaultValue && !value?.length;
+
+    setValue(shouldUseDefault ? defaultValue : value);
+    onPopoverClose();
+  };
+
   if (isDateParameter(parameter)) {
     const DateWidget = DATE_WIDGETS[parameter.type];
     return (
@@ -283,10 +293,7 @@ function Widget({
     return (
       <NumberInputWidget
         value={normalizedValue}
-        setValue={value => {
-          setValue(value);
-          onPopoverClose();
-        }}
+        setValue={setValueOrDefault}
         arity={arity}
         infixText={typeof arity === "number" && arity > 1 ? t`and` : undefined}
         autoFocus
@@ -295,16 +302,6 @@ function Widget({
       />
     );
   } else if (isFieldWidget(parameter)) {
-    // TODO this is due to ParameterFieldWidget not supporting focusChanged callback.
-    const setValueOrDefault = value => {
-      const { required, default: defaultValue } = parameter;
-      const shouldUseDefault =
-        enableRequiredBehavior && required && defaultValue && !value?.length;
-
-      setValue(shouldUseDefault ? defaultValue : value);
-      onPopoverClose();
-    };
-
     return (
       <ParameterFieldWidget
         target={target}
@@ -319,22 +316,18 @@ function Widget({
         isEditing={isEditing}
       />
     );
-  } else {
-    return (
-      <StringInputWidget
-        value={normalizedValue}
-        setValue={value => {
-          setValue(value);
-          onPopoverClose();
-        }}
-        className={className}
-        autoFocus
-        placeholder={isEditing ? t`Enter a default value…` : undefined}
-        arity={getStringParameterArity(parameter)}
-        label={getParameterWidgetTitle(parameter)}
-      />
-    );
   }
+  return (
+    <StringInputWidget
+      value={normalizedValue}
+      setValue={setValueOrDefault}
+      className={className}
+      autoFocus
+      placeholder={isEditing ? t`Enter a default value…` : undefined}
+      arity={getStringParameterArity(parameter)}
+      label={getParameterWidgetTitle(parameter)}
+    />
+  );
 }
 
 Widget.propTypes = {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -358,7 +358,7 @@ class TagEditorParamInner extends Component<Props> {
           <ContainerLabel>
             {t`Default filter widget value`}
             {hasNoDefaultValue && tag.required && (
-              <ErrorSpan>{t`(required)`}</ErrorSpan>
+              <ErrorSpan>({t`required`})</ErrorSpan>
             )}
           </ContainerLabel>
           <DefaultParameterValueWidget


### PR DESCRIPTION
Parent epic: https://github.com/metabase/metabase/issues/36524

## Description
We allow making parameters required on the dashboards, where a required parameter from now on needs a default value. Otherwise, we prevent the dashboard from being saved and show an explanatory tooltip near the save button.

The parameter widget behavior is the same as in the https://github.com/metabase/metabase/pull/37709

## How to check

https://github.com/metabase/metabase/assets/2196347/97680e59-5986-4066-a828-e32de726db59

Basically follow the steps shown in the screencast:

1. Open or create a dashboard with some cards and create connected parameters
2. Try making a parameter required and observe that the dashboard cannot be saved without a default value
3. Set a value and save it
4. Repeat for other parameters of different types
5. Once your dashboard is saved, check that parameter widgets work as intended
    - there's never an `x` to clear a required parameter
    - when the value is different from the default, we show the "reset" icon and allow reverting back to default
    - when you try to unset the value of a required filter, we revert it back to default

## How it works
- the `required` field for the parameters was partially supported and finally added here: https://github.com/metabase/metabase/pull/37800
- there are 2 new actions: `metabase/dashboard/SET_PARAMETER_VALUE_TO_DEFAULT` and `metabase/dashboard/SET_PARAMETER_REQUIRED` which are self-explanatory
- `DashboardHeader` is updated to use `getMissingRequiredParameters` selector, which returns parameters with `required` but without a `default` value — and then disables the Save button and shows a tooltip near it so it's clear why we cannot save
- `ParameterSettings` is updated to include the "Required" switch, identical to https://github.com/metabase/metabase/pull/37709
- `ParameterValueWidget` was also update in the PR mentioned above so the only required change was to add the `enableParameterRequiredBehavior` prop in the `Dashboard`, which is propagated down the component tree



## Tests
Testing e2e three parameter types: strings, numbers and dates. The rest behave pretty much in the same way.