### PR TITLE
Exclude metabase.sync* and metabase.upload* from malli instrumentation

### DIFF
--- a/src/metabase/util/malli/fn.clj
+++ b/src/metabase/util/malli/fn.clj
@@ -301,7 +301,9 @@
   "Used to track namespaces to not enforce malli schemas on with `mu.fn/fn`."
   [namespace]
   (let [lib-and-middleware [#"^metabase\.lib\..*"
-                            #"^metabase\.query-processor\.middleware\..*"]
+                            #"^metabase\.query-processor\.middleware\..*"
+                            #"^metabase\.sync.*"
+                            #"^metabase\.upload.*"]
         matches?           (core/fn [namespace regexes]
                              (let [n (-> namespace ns-name str)]
                                (some #(re-matches % n) regexes)))


### PR DESCRIPTION
Hopefully fixes https://github.com/metabase/metabase/issues/38072.

This PR excludes `metabase.sync*` and `metabase.upload*` from `mu/defn` malli instrumentation in production.

I couldn't reproduce [the issue](https://github.com/metabase/metabase/issues/38072), but I noticed the issue is similar to https://github.com/metabase/metabase/pull/33682, where we found a performance regression was mostly fixed in another part of the codebase by disabling malli instrumentation in production.

We migrated `metabase.sync*` namespaces were migrated to use malli in 48: https://github.com/metabase/metabase/pull/33682

`metabase.upload*` is unrelated. I'm just familiar enough with this part of the code to also exclude it with this PR with confidence.