### PR TITLE
update graalvm

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -153,7 +153,7 @@
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
   org.eclipse.jetty/jetty-server            {:mvn/version "11.0.17"}            ; web server
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
-  org.graalvm.js/js                         {:mvn/version "22.3.4"}             ; JavaScript engine
+  org.graalvm.js/js                         {:mvn/version "22.3.5"}             ; JavaScript engine
   org.jsoup/jsoup                           {:mvn/version "1.17.2"}             ; required by hickory
   org.liquibase/liquibase-core              {:mvn/version "4.25.1"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}


### PR DESCRIPTION
That should drop 9 of 12 Snyk warnings.