### PR TITLE
Native query editor: Add an explanatory tooltip for the save button when required template tags miss defaults

### DIFF
--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -53,6 +53,12 @@ describe("scenarios > filters > sql filters > field filter", () => {
       SQLFilter.getRunQueryButton().should("be.disabled");
       SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
 
+      SQLFilter.getSaveQueryButton().realHover();
+      // eslint-disable-next-line no-unscoped-text-selectors -- tooltips are rendered in the body
+      cy.findByText(
+        'The "Filter" variable requires a default value but none was provided.',
+      );
+
       setDefaultFieldValue(4);
 
       SQLFilter.getRunQueryButton().should("not.be.disabled");

--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -54,11 +54,9 @@ describe("scenarios > filters > sql filters > field filter", () => {
       SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
 
       SQLFilter.getSaveQueryButton().realHover();
-      cy.get("body").within(() => {
-        cy.findByText(
-          'The "Filter" variable requires a default value but none was provided.',
-        );
-      });
+      cy.get("body").findByText(
+        'The "Filter" variable requires a default value but none was provided.',
+      );
 
       setDefaultFieldValue(4);
 

--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -54,10 +54,11 @@ describe("scenarios > filters > sql filters > field filter", () => {
       SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
 
       SQLFilter.getSaveQueryButton().realHover();
-      // eslint-disable-next-line no-unscoped-text-selectors -- tooltips are rendered in the body
-      cy.findByText(
-        'The "Filter" variable requires a default value but none was provided.',
-      );
+      cy.get("body").within(() => {
+        cy.findByText(
+          'The "Filter" variable requires a default value but none was provided.',
+        );
+      });
 
       setDefaultFieldValue(4);
 

--- a/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
@@ -55,10 +55,11 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
         SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
 
         SQLFilter.getSaveQueryButton().realHover();
-        // eslint-disable-next-line no-unscoped-text-selectors -- tooltips are rendered in the body
-        cy.findByText(
-          'The "TextFilter" variable requires a default value but none was provided.',
-        );
+        cy.get("body").within(() => {
+          cy.findByText(
+            'The "TextFilter" variable requires a default value but none was provided.',
+          );
+        });
 
         SQLFilter.setDefaultValue("Some text");
         SQLFilter.getRunQueryButton().should("not.be.disabled");
@@ -135,10 +136,11 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
         SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
 
         SQLFilter.getSaveQueryButton().realHover();
-        // eslint-disable-next-line no-unscoped-text-selectors -- tooltips are rendered in the body
-        cy.findByText(
-          'The "NumberFilter" variable requires a default value but none was provided.',
-        );
+        cy.get("body").within(() => {
+          cy.findByText(
+            'The "NumberFilter" variable requires a default value but none was provided.',
+          );
+        });
 
         SQLFilter.setDefaultValue("33");
         SQLFilter.getRunQueryButton().should("not.be.disabled");
@@ -235,10 +237,11 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
         SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
 
         SQLFilter.getSaveQueryButton().realHover();
-        // eslint-disable-next-line no-unscoped-text-selectors -- tooltips are rendered in the body
-        cy.findByText(
-          'The "DateFilter" variable requires a default value but none was provided.',
-        );
+        cy.get("body").within(() => {
+          cy.findByText(
+            'The "DateFilter" variable requires a default value but none was provided.',
+          );
+        });
 
         setDefaultDate();
 

--- a/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
@@ -54,6 +54,12 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
         SQLFilter.getRunQueryButton().should("be.disabled");
         SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
 
+        SQLFilter.getSaveQueryButton().realHover();
+        // eslint-disable-next-line no-unscoped-text-selectors -- tooltips are rendered in the body
+        cy.findByText(
+          'The "TextFilter" variable requires a default value but none was provided.',
+        );
+
         SQLFilter.setDefaultValue("Some text");
         SQLFilter.getRunQueryButton().should("not.be.disabled");
         SQLFilter.getSaveQueryButton().should("not.have.attr", "disabled");
@@ -127,6 +133,12 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
         SQLFilter.toggleRequired();
         SQLFilter.getRunQueryButton().should("be.disabled");
         SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
+
+        SQLFilter.getSaveQueryButton().realHover();
+        // eslint-disable-next-line no-unscoped-text-selectors -- tooltips are rendered in the body
+        cy.findByText(
+          'The "NumberFilter" variable requires a default value but none was provided.',
+        );
 
         SQLFilter.setDefaultValue("33");
         SQLFilter.getRunQueryButton().should("not.be.disabled");
@@ -221,6 +233,12 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
         SQLFilter.toggleRequired();
         SQLFilter.getRunQueryButton().should("be.disabled");
         SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
+
+        SQLFilter.getSaveQueryButton().realHover();
+        // eslint-disable-next-line no-unscoped-text-selectors -- tooltips are rendered in the body
+        cy.findByText(
+          'The "DateFilter" variable requires a default value but none was provided.',
+        );
 
         setDefaultDate();
 

--- a/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
@@ -55,11 +55,9 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
         SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
 
         SQLFilter.getSaveQueryButton().realHover();
-        cy.get("body").within(() => {
-          cy.findByText(
-            'The "TextFilter" variable requires a default value but none was provided.',
-          );
-        });
+        cy.get("body").findByText(
+          'The "TextFilter" variable requires a default value but none was provided.',
+        );
 
         SQLFilter.setDefaultValue("Some text");
         SQLFilter.getRunQueryButton().should("not.be.disabled");
@@ -136,11 +134,10 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
         SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
 
         SQLFilter.getSaveQueryButton().realHover();
-        cy.get("body").within(() => {
-          cy.findByText(
-            'The "NumberFilter" variable requires a default value but none was provided.',
-          );
-        });
+
+        cy.get("body").findByText(
+          'The "NumberFilter" variable requires a default value but none was provided.',
+        );
 
         SQLFilter.setDefaultValue("33");
         SQLFilter.getRunQueryButton().should("not.be.disabled");
@@ -237,11 +234,10 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
         SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
 
         SQLFilter.getSaveQueryButton().realHover();
-        cy.get("body").within(() => {
-          cy.findByText(
-            'The "DateFilter" variable requires a default value but none was provided.',
-          );
-        });
+
+        cy.get("body").findByText(
+          'The "DateFilter" variable requires a default value but none was provided.',
+        );
 
         setDefaultDate();
 

--- a/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
@@ -40,7 +40,7 @@ describe("UI elements that make no sense for users without data permissions (met
 
     cy.get("@saveButton").realHover();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("You don't have permissions to save this question.");
+    cy.findByText("You don't have permission to save this question.");
 
     cy.findByTestId("qb-header-action-panel").within(() => {
       cy.icon("refresh").should("not.exist");

--- a/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
@@ -40,7 +40,7 @@ describe("UI elements that make no sense for users without data permissions (met
 
     cy.get("@saveButton").realHover();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("You don't have permission to save this question.");
+    cy.findByText("You don't have permissions to save this question.");
 
     cy.findByTestId("qb-header-action-panel").within(() => {
       cy.icon("refresh").should("not.exist");

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -550,7 +550,7 @@ function getDisabledSaveTooltip(
   requiredTemplateTags = [],
 ) {
   if (!isEditable) {
-    return t`You don't have permissions to save this question.`;
+    return t`You don't have permission to save this question.`;
   }
 
   const missingValueRequiredTTags = requiredTemplateTags.filter(

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -419,7 +419,7 @@ function ViewTitleHeaderRightSide(props) {
     onCloseQuestionInfo,
     onOpenQuestionInfo,
     onModelPersistenceChange,
-    requiredTemplateTags = [],
+    requiredTemplateTags,
   } = props;
   const isShowingNotebook = queryBuilderMode === "notebook";
   const { isEditable } = Lib.queryDisplayInfo(question.query());
@@ -544,13 +544,17 @@ function ViewTitleHeaderRightSide(props) {
 
 ViewTitleHeader.propTypes = viewTitleHeaderPropTypes;
 
-function getDisabledSaveTooltip(question, isEditable, requiredTemplateTags) {
+function getDisabledSaveTooltip(
+  question,
+  isEditable,
+  requiredTemplateTags = [],
+) {
   if (!isEditable) {
     return t`You don't have permissions to save this question.`;
   }
 
   const missingValueRequiredTTags = requiredTemplateTags.filter(
-    t => t.required && !t.default,
+    tag => tag.required && !tag.default,
   );
 
   if (!question.canRun()) {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -449,9 +449,13 @@ function ViewTitleHeaderRightSide(props) {
     [isRunning],
   );
 
+  const missingValueRequiredTTags = requiredTemplateTags.filter(
+    t => t.required && !t.default,
+  );
+
   const isSaveDisabled = !question.canRun() || !isEditable;
   const disabledSaveTooltip = !question.canRun()
-    ? getMissingRequiredTemplateTagsTooltip(requiredTemplateTags)
+    ? getMissingRequiredTemplateTagsTooltip(missingValueRequiredTTags)
     : !isEditable
     ? t`You don't have permissions to save this question.`
     : "";

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader.jsx
@@ -577,6 +577,6 @@ function getMissingRequiredTemplateTagsTooltip(requiredTemplateTags = []) {
   return ngettext(
     msgid`The ${names} variable requires a default value but none was provided.`,
     `The ${names} variables require default values but none were provided.`,
-    names.length,
+    requiredTemplateTags.length,
   );
 }

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -88,6 +88,7 @@ import {
   getCardAutocompleteResultsFn,
   isResultsMetadataDirty,
   getShouldShowUnsavedChangesWarning,
+  getRequiredTemplateTags,
 } from "../selectors";
 import * as actions from "../actions";
 import { VISUALIZATION_SLOW_TIMEOUT } from "../constants";
@@ -179,6 +180,8 @@ const mapStateToProps = (state, props) => {
     loadingMessage: getWhiteLabeledLoadingMessage(state),
 
     reportTimezone: getSetting(state, "report-timezone-long"),
+
+    requiredTemplateTags: getRequiredTemplateTags(state),
   };
 };
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1001,11 +1001,10 @@ export const getTemplateTags = createSelector([getCard], card =>
 
 export const getRequiredTemplateTags = createSelector(
   [getTemplateTags],
-  templateTags => {
-    return templateTags
+  templateTags =>
+    templateTags
       ? Object.keys(templateTags)
           .filter(key => templateTags[key].required)
           .map(key => templateTags[key])
-      : [];
-  },
+      : [],
 );

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -995,9 +995,9 @@ export const getDashboard = state => {
   return getDashboardById(state, getDashboardId(state));
 };
 
-export const getTemplateTags = createSelector([getCard], card => {
-  return getIn(card, ["dataset_query", "native", "template-tags"]);
-});
+export const getTemplateTags = createSelector([getCard], card =>
+  getIn(card, ["dataset_query", "native", "template-tags"]),
+);
 
 export const getRequiredTemplateTags = createSelector(
   [getTemplateTags],

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -994,3 +994,18 @@ export const getIsEditingInDashboard = state => {
 export const getDashboard = state => {
   return getDashboardById(state, getDashboardId(state));
 };
+
+export const getTemplateTags = createSelector([getCard], card => {
+  return getIn(card, ["dataset_query", "native", "template-tags"]);
+});
+
+export const getRequiredTemplateTags = createSelector(
+  [getTemplateTags],
+  templateTags => {
+    return templateTags
+      ? Object.keys(templateTags)
+          .filter(key => templateTags[key].required)
+          .map(key => templateTags[key])
+      : [];
+  },
+);


### PR DESCRIPTION
Part of the epic https://github.com/metabase/metabase/issues/36524

## Description 
Following the discussion and conclusion [on Slack](https://metaboat.slack.com/archives/C064QMXEV9N/p1706542715006239?thread_ts=1706276000.737189&cid=C064QMXEV9N), I am adding an explanatory tooltip for the disabled Save button.

https://github.com/metabase/metabase/assets/2196347/8de89193-3ea0-4ba2-ada0-a9a5f7c4e1ac



## How to test

1. Create a native query
2. Add 1 or 2 variables
3. Make either of them or both required but omit the default value
4. Observe the disabled save button (was there before) and the tooltip (added)

## Test
Updated existing e2e tests related to the save button being disabled when there are required parameters missing default values.
