### PR TITLE
Showing `currency_in_header` options in admin for fields

### DIFF
--- a/e2e/support/helpers/e2e-viz-settings-helpers.js
+++ b/e2e/support/helpers/e2e-viz-settings-helpers.js
@@ -14,7 +14,7 @@ export function openSeriesSettings(field, isBreakout = false) {
       .find(".Icon-ellipsis")
       .click();
     popover().within(() => {
-      cy.findByRole("radiogroup").findByText("Style").click();
+      cy.findAllByRole("radiogroup").findByText("Style").click();
     });
   }
 }

--- a/e2e/test/scenarios/admin/settings/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/settings.cy.spec.js
@@ -8,9 +8,11 @@ import {
   isEE,
   setTokenFeatures,
 } from "e2e/support/helpers";
+
+import { SAMPLE_DB_ID, SAMPLE_DB_SCHEMA_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 
-const { ORDERS } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe("scenarios > admin > settings", () => {
   beforeEach(() => {
@@ -187,6 +189,32 @@ describe("scenarios > admin > settings", () => {
 
     cy.findByTextEnsureVisible("Created At");
     cy.get(".cellData").and("contain", "2025/2/11, 9:40 PM");
+  });
+
+  it("should show where to display the unit of currency (metabase#table-metadata-missing-38021 and update the formatting", () => {
+    // Set the semantic type of total to currency
+    cy.request("PUT", `/api/field/${ORDERS.TOTAL}`, {
+      semantic_type: "type/Currency",
+    });
+
+    cy.visit(
+      `/admin/datamodel/database/${SAMPLE_DB_ID}/schema/${SAMPLE_DB_SCHEMA_ID}/table/${ORDERS_ID}/field/${ORDERS.TOTAL}/formatting`,
+    );
+
+    cy.findByTestId("admin-layout-content").within(() => {
+      // Assert that this option now exists
+      cy.findByText("Where to display the unit of currency");
+      cy.findByText("In every table cell").click();
+    });
+
+    // Open the orders table
+    openOrdersTable({ limit: 2 });
+
+    cy.get("#main-data-grid").within(() => {
+      // Items in the total column should have a leading dollar sign
+      cy.findByText("$39.72");
+      cy.findByText("$117.03");
+    });
   });
 
   it("should search for and select a new timezone", () => {

--- a/frontend/src/metabase/admin/datamodel/metadata/components/FieldFormattingSettings/FieldFormattingSettings.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/FieldFormattingSettings/FieldFormattingSettings.tsx
@@ -50,6 +50,7 @@ const FieldFormattingSettings = ({
         denylist={denyList}
         inheritedSettings={inheritedSettings}
         onChange={handleChangeSettings}
+        extraData={{ forAdminSettings: true }}
       />
     </MetadataSection>
   );

--- a/frontend/src/metabase/visualizations/components/ColumnSettings.jsx
+++ b/frontend/src/metabase/visualizations/components/ColumnSettings.jsx
@@ -20,6 +20,7 @@ function getWidgets({
   onChangeSetting,
   allowlist,
   denylist,
+  extraData,
 }) {
   // fake series
   const series = [{ card: {}, data: { rows: [], cols: [] } }];
@@ -35,7 +36,7 @@ function getWidgets({
     settingsDefs,
     column,
     { ...inheritedSettings, ...storedSettings },
-    { series },
+    { series, ...extraData },
   );
 
   const widgets = getSettingsWidgets(
@@ -51,7 +52,7 @@ function getWidgets({
         onChangeSetting(changedSettings);
       }
     },
-    { series },
+    { series, ...extraData },
   );
 
   return widgets.filter(

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -345,9 +345,16 @@ export const NUMBER_COLUMN_SETTINGS = {
       ],
     },
     default: true,
-    getHidden: (column, settings, { series }) =>
-      settings["number_style"] !== "currency" &&
-      (!series[0].card.display || series[0].card.display === "table"),
+    getHidden: (_column, settings, { series, forAdminSettings }) => {
+      if (forAdminSettings === true) {
+        return false;
+      } else {
+        return (
+          settings["number_style"] !== "currency" ||
+          series[0].card.display !== "table"
+        );
+      }
+    },
     readDependencies: ["number_style"],
   },
   number_separators: {

--- a/frontend/src/metabase/visualizations/lib/settings/column.js
+++ b/frontend/src/metabase/visualizations/lib/settings/column.js
@@ -346,8 +346,8 @@ export const NUMBER_COLUMN_SETTINGS = {
     },
     default: true,
     getHidden: (column, settings, { series }) =>
-      settings["number_style"] !== "currency" ||
-      series[0].card.display !== "table",
+      settings["number_style"] !== "currency" &&
+      (!series[0].card.display || series[0].card.display === "table"),
     readDependencies: ["number_style"],
   },
   number_separators: {


### PR DESCRIPTION
The Table Metadata > Database Name > Table Name > Field Name > Formatting view did not show `Where to display the unit of currency` due to the following previous logic:

```
getHidden: (column, settings, { series }) =>
  settings["number_style"] !== "currency" ||
  series[0].card.display !== "table"
```

The second clause, `series[0].card.display !== "table"`, always returned true since `series[0].card.display` is `undefined`.

This has been updated to:

```
getHidden: (column, settings, { series }) =>
  settings["number_style"] !== "currency" &&
  (!series[0].card.display || series[0].card.display === "table")
```

The requirement is now that the series card display must be defined or be of type table.

Fixes #38021
