### PR TITLE
Use "filled" bookmark icon when the item is bookmarked

### DIFF
--- a/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-collection.cy.spec.js
@@ -54,18 +54,21 @@ describe("scenarios > organization > bookmarks > collection", () => {
     // Rename bookmarked collection
     cy.findByTestId("collection-name-heading").click().type(" 2").blur();
 
-    navigationSidebar().within(() => {
-      cy.findAllByText("First collection 2").should("have.length", 2);
-    });
+    navigationSidebar()
+      .findAllByText("First collection 2")
+      .should("have.length", 2);
 
     // Remove bookmark
-    cy.findByTestId("collection-menu").within(() => {
-      cy.icon("bookmark").click();
-    });
+    cy.findByTestId("collection-menu").icon("bookmark_filled").click();
 
-    navigationSidebar().within(() => {
-      cy.findAllByText("First collection 2").should("have.length", 1);
-    });
+    navigationSidebar()
+      .findAllByText("First collection 2")
+      .should("have.length", 1);
+
+    cy.findByTestId("collection-menu")
+      .icon("bookmark_filled")
+      .should("not.exist");
+    cy.findByTestId("collection-menu").icon("bookmark").should("exist");
   });
 
   it("can add/remove bookmark from unpinned Question in collection", () => {
@@ -118,10 +121,10 @@ describe("scenarios > organization > bookmarks > collection", () => {
     cy.visit(`/collection/${ADMIN_PERSONAL_COLLECTION_ID}`);
 
     // Add bookmark
-    cy.icon("bookmark").click();
+    cy.findByTestId("collection-menu").icon("bookmark").click();
 
     navigationSidebar().within(() => {
-      cy.icon("bookmark").click({ force: true });
+      cy.icon("bookmark_filled").click({ force: true });
     });
 
     getSectionTitle(/Bookmarks/).should("not.exist");

--- a/e2e/test/scenarios/organization/bookmarks-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-dashboard.cy.spec.js
@@ -17,9 +17,7 @@ describe("scenarios > dashboard > bookmarks", () => {
     openNavigationSidebar();
 
     // Add bookmark
-    cy.get("main header").within(() => {
-      cy.icon("bookmark").click();
-    });
+    cy.get("main header").icon("bookmark").click();
 
     navigationSidebar().within(() => {
       cy.findByText("Orders in a dashboard");
@@ -33,9 +31,7 @@ describe("scenarios > dashboard > bookmarks", () => {
     });
 
     // Remove bookmark
-    cy.get("main header").within(() => {
-      cy.icon("bookmark").click();
-    });
+    cy.get("main header").icon("bookmark_filled").click();
 
     navigationSidebar().within(() => {
       cy.findByText("Orders in a dashboard 2").should("not.exist");

--- a/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
+++ b/e2e/test/scenarios/organization/bookmarks-question.cy.spec.js
@@ -54,7 +54,7 @@ describe("scenarios > question > bookmarks", () => {
     });
 
     // Remove bookmark
-    toggleBookmark();
+    toggleBookmark({ wasSelected: true });
 
     navigationSidebar().within(() => {
       getSectionTitle(/Bookmarks/).should("not.exist");
@@ -63,9 +63,10 @@ describe("scenarios > question > bookmarks", () => {
   });
 });
 
-function toggleBookmark() {
+function toggleBookmark({ wasSelected = false } = {}) {
+  const iconName = wasSelected ? "bookmark_filled" : "bookmark";
   cy.findByTestId("qb-header-action-panel").within(() => {
-    cy.icon("bookmark").click();
+    cy.icon(iconName).click();
   });
   cy.wait("@toggleBookmark");
 }

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/common.unit.spec.tsx
@@ -170,7 +170,7 @@ describe("CollectionHeader", () => {
         collection,
         isBookmarked: true,
       });
-      userEvent.click(screen.getByLabelText("bookmark icon"));
+      userEvent.click(screen.getByLabelText("bookmark_filled icon"));
 
       expect(onDeleteBookmark).toHaveBeenCalledWith(myCollection);
     });

--- a/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.styled.tsx
+++ b/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.styled.tsx
@@ -42,7 +42,7 @@ export const BookmarkButton = styled(Button)<BookmarkButtonProps>`
 
   &:hover {
     color: ${color("brand")};
-    background-color: ${color("bg-light")};
+    background-color: ${color("bg-medium")};
   }
 
   svg {

--- a/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.styled.tsx
+++ b/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.styled.tsx
@@ -41,9 +41,8 @@ export const BookmarkButton = styled(Button)<BookmarkButtonProps>`
   width: 2rem;
 
   &:hover {
-    color: ${({ isBookmarked }) =>
-      isBookmarked ? color("brand") : color("text-dark")};
-    background-color: ${color("bg-medium")};
+    color: ${color("brand")};
+    background-color: ${color("bg-light")};
   }
 
   svg {
@@ -53,5 +52,5 @@ export const BookmarkButton = styled(Button)<BookmarkButtonProps>`
 
 BookmarkButton.defaultProps = {
   onlyIcon: true,
-  iconSize: 20,
+  iconSize: 16,
 };

--- a/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.tsx
+++ b/frontend/src/metabase/core/components/BookmarkToggle/BookmarkToggle.tsx
@@ -37,6 +37,8 @@ const BookmarkToggle = forwardRef(function BookmarkToggle(
     setIsAnimating(false);
   }, []);
 
+  const iconName = isBookmarked ? "bookmark_filled" : "bookmark";
+
   return (
     <Tooltip
       tooltip={isBookmarked ? t`Remove from bookmarks` : t`Bookmark`}
@@ -49,7 +51,7 @@ const BookmarkToggle = forwardRef(function BookmarkToggle(
         onClick={handleClick}
       >
         <BookmarkIcon
-          name="bookmark"
+          name={iconName}
           isBookmarked={isBookmarked}
           isAnimating={isAnimating}
           onAnimationEnd={handleAnimationEnd}

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.styled.tsx
@@ -29,7 +29,7 @@ export const DashboardHeaderButton = styled(Button)<{
           padding: 0;
         `}
 
-  color: ${props => (props.isActive ? color("brand") : color("text-medium"))};
+  color: ${props => (props.isActive ? color("brand") : color("text-dark"))};
   font-size: 1rem;
 
   &:hover {
@@ -53,7 +53,7 @@ export const DashboardHeaderButton = styled(Button)<{
 
 DashboardHeaderButton.defaultProps = {
   onlyIcon: true,
-  iconSize: 20,
+  iconSize: 16,
   visibleOnSmallScreen: true,
   hasBackground: true,
 };

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.styled.tsx
@@ -35,7 +35,7 @@ export const DashboardHeaderButton = styled(Button)<{
   &:hover {
     color: ${color("brand")};
     background: ${({ hasBackground }) =>
-      hasBackground ? color("bg-light") : "transparent"};
+      hasBackground ? color("bg-medium") : "transparent"};
   }
 
   svg {

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -84,6 +84,8 @@ const BookmarkItem = ({
     bookmark.type === "collection" &&
     !PLUGIN_COLLECTIONS.isRegularCollection(bookmark);
 
+  const iconName = isSelected ? "bookmark_filled" : "bookmark";
+
   return (
     <Sortable id={bookmark.id} key={bookmark.id}>
       <SidebarBookmarkItem
@@ -97,7 +99,7 @@ const BookmarkItem = ({
         right={
           <button onClick={onRemove}>
             <Tooltip tooltip={t`Remove bookmark`} placement="bottom">
-              <Icon name="bookmark" />
+              <Icon name={iconName} />
             </Tooltip>
           </button>
         }


### PR DESCRIPTION
This PR resolves #34327 by increasing the icon size, and by changing the icon type to filled once it is selected.

Take a look at the original issue > Additional context to get a sense for how this should look.

These are the screenshots from this branch:
![image](https://github.com/metabase/metabase/assets/31325167/4151b1b3-39c1-4cd5-be0b-e4e40c61ca17)
![image](https://github.com/metabase/metabase/assets/31325167/06bd9120-fed7-4890-aef0-ef50ebbbbc1d)

![image](https://github.com/metabase/metabase/assets/31325167/44de6662-4f6e-4e5f-99f9-bbea812f8856)
![image](https://github.com/metabase/metabase/assets/31325167/d59bb092-0009-488d-ad70-fde7b4053fab)
