### PR TITLE
Migrate `canRun()` method for the structured query to MLv2 

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -459,7 +459,11 @@ class Question {
    * Question is valid (as far as we know) and can be executed
    */
   canRun(): boolean {
-    return Lib.canRun(this.query());
+    const { isNative } = Lib.queryDisplayInfo(this.query());
+
+    return isNative
+      ? this.legacyQuery({ useStructuredQuery: true }).canRun()
+      : Lib.canRun(this.query());
   }
 
   canWrite(): boolean {

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -459,7 +459,7 @@ class Question {
    * Question is valid (as far as we know) and can be executed
    */
   canRun(): boolean {
-    return this.legacyQuery({ useStructuredQuery: true }).canRun();
+    return Lib.canRun(this.query());
   }
 
   canWrite(): boolean {

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -127,13 +127,6 @@ class StructuredQuery extends AtomicQuery {
   /* Query superclass methods */
 
   /**
-   * @returns true if this query is in a state where it can be run.
-   */
-  canRun() {
-    return !!(this._sourceTableId() || this.sourceQuery());
-  }
-
-  /**
    * @returns true if we have metadata for the root source table loaded
    */
   hasMetadata(): boolean {

--- a/frontend/src/metabase-lib/query.ts
+++ b/frontend/src/metabase-lib/query.ts
@@ -94,3 +94,7 @@ export function replaceClause(
 export function sourceTableOrCardId(query: Query): TableId | null {
   return ML.source_table_or_card_id(query);
 }
+
+export function canRun(query: Query): boolean {
+  return ML.can_run(query);
+}

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -294,9 +294,6 @@ describe("StructuredQuery", () => {
       it("Expect a reset query to not have a selected database", () => {
         expect(query.reset()._database()).toBe(null);
       });
-      it("Expect a reset query to not be runnable", () => {
-        expect(query.reset().canRun()).toBe(false);
-      });
     });
     describe("query", () => {
       it("returns the wrapper for the query dictionary", () => {
@@ -314,14 +311,6 @@ describe("StructuredQuery", () => {
     describe("_sourceTableId", () => {
       it("Return the right table id", () => {
         expect(query._sourceTableId()).toBe(ORDERS_ID);
-      });
-    });
-  });
-
-  describe("QUERY STATUS METHODS", () => {
-    describe("canRun", () => {
-      it("runs a valid query", () => {
-        expect(query.canRun()).toBe(true);
       });
     });
   });

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1254,3 +1254,8 @@
   for the FE to function properly."
   [a-query]
   (to-array (map clj->js (lib.core/dependent-metadata a-query))))
+
+(defn ^:export can-run
+  "Returns true if the query is runnable."
+  [a-query]
+  (lib.core/can-run a-query))


### PR DESCRIPTION
This PR migrates `canRun()` method on the Question prototype only for the structured query type. It still uses a fallback for native queries until https://github.com/metabase/metabase/issues/38268 gets resolved.

It exposes `lib.core/can-run` query to the FE, and it adds a TS wrapper for that new function.