### PR TITLE
add sourcemap option to cypress preprocessor

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -62,7 +62,10 @@ const defaultConfig = {
 
     on(
       "file:preprocessor",
-      createBundler({ plugins: [NodeModulesPolyfillPlugin()] }),
+      createBundler({
+        plugins: [NodeModulesPolyfillPlugin()],
+        sourcemap: "inline",
+      }),
     );
 
     /********************************************************************


### PR DESCRIPTION
### Description

Hey team, I added a small improvement to your Replay experience. Currently when you open a replay to debug a flaky Cypress test, you’ll see your spec file as one giant 65k long file. It is kinda hard to navigate through. The reason for this is that you are using a custom bundler (which is great) but haven’t added an option to include sourcemapping. This PR adds that option.

It is a QOL improvement

### How to verify

Simply running tests should be enough to verify everything works as expeced.