### PR TITLE
Replace deprecated `unescape` function in a Cypress helper

### DIFF
--- a/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
+++ b/e2e/support/helpers/e2e-ad-hoc-question-helpers.js
@@ -13,7 +13,7 @@ export function adhocQuestionHash(question) {
     // without "locking" the display, the QB will run its picking logic and override the setting
     question = Object.assign({}, question, { displayIsLocked: true });
   }
-  return btoa(unescape(encodeURIComponent(JSON.stringify(question))));
+  return btoa(decodeURIComponent(encodeURIComponent(JSON.stringify(question))));
 }
 
 /**


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/unescape