### PR TITLE
Speculative fix for migration on multi instances

### DIFF
--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -130,6 +130,7 @@
   ;; Custom migrations use toucan2, so we need to make sure it uses the same connection with liquibase
   (let [f* (fn [liquibase]
              ;; trigger liquibase to create databasechangelog tables if needed
+             ;; we need to do this until https://github.com/liquibase/liquibase/issues/5537 is fixed
              (.checkLiquibaseTables liquibase false (.getDatabaseChangeLog liquibase) nil nil)
              (f liquibase))]
     (binding [t2.conn/*current-connectable* conn-or-data-source]

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -129,7 +129,7 @@
    f                   :- fn?]
   ;; Custom migrations use toucan2, so we need to make sure it uses the same connection with liquibase
   (let [f* (fn [^Liquibase liquibase]
-             ;; trigger liquibase to create databasechangelog tables if needed
+             ;; trigger creation of liquibase's databasechangelog tables if needed, without updating any checksums
              ;; we need to do this until https://github.com/liquibase/liquibase/issues/5537 is fixed
              (.checkLiquibaseTables liquibase false (.getDatabaseChangeLog liquibase) nil nil)
              (f liquibase))]

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -128,7 +128,7 @@
   [conn-or-data-source :- [:or (ms/InstanceOfClass java.sql.Connection) (ms/InstanceOfClass javax.sql.DataSource)]
    f                   :- fn?]
   ;; Custom migrations use toucan2, so we need to make sure it uses the same connection with liquibase
-  (let [f* (fn [liquibase]
+  (let [f* (fn [^Liquibase liquibase]
              ;; trigger liquibase to create databasechangelog tables if needed
              ;; we need to do this until https://github.com/liquibase/liquibase/issues/5537 is fixed
              (.checkLiquibaseTables liquibase false (.getDatabaseChangeLog liquibase) nil nil)
@@ -235,7 +235,7 @@
          (let [^Contexts contexts nil
                start-time         (System/currentTimeMillis)]
            (log/info (trs "Running {0} migrations ..." unrun-migrations-count))
-           (doseq [change to-run-migrations]
+           (doseq [^ChangeSet change to-run-migrations]
              (log/tracef "To run migration %s" (.getId change)))
            (.update liquibase contexts)
            (log/info (trs "Migration complete in {0}" (u/format-milliseconds (- (System/currentTimeMillis) start-time)))))

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -17,6 +17,7 @@
   (:import
    (java.io StringWriter)
    (java.util List Map)
+   (javax.sql DataSource)
    (liquibase Contexts LabelExpression Liquibase RuntimeEnvironment Scope Scope$Attr Scope$ScopedRunner)
    (liquibase.change.custom CustomChangeWrapper)
    (liquibase.changelog ChangeLogIterator ChangeSet ChangeSet$ExecType)
@@ -170,8 +171,9 @@
   using them.
 
   (I'm not 100% sure whether `Liquibase.update()` still acquires locks if the database is already up-to-date)"
-  [^Liquibase liquibase]
-  (.listUnrunChangeSets liquibase nil (LabelExpression.)))
+  [^DataSource data-source]
+  (with-liquibase [liquibase (.getConnection data-source)]
+     (.listUnrunChangeSets liquibase nil (LabelExpression.))))
 
 (defn- migration-lock-exists?
   "Is a migration lock in place for `liquibase`?"
@@ -197,31 +199,39 @@
   "Check and make sure the database isn't locked. If it is, sleep for 2 seconds and then retry several times. There's a
   chance the lock will end up clearing up so we can run migrations normally."
   [^Liquibase liquibase]
-  (u/auto-retry 5
-    (when (migration-lock-exists? liquibase)
-      (Thread/sleep 2000)
-      (throw
-       (LockException.
-        (str
-         (trs "Database has migration lock; cannot run migrations.")
-         " "
-         (trs "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`.")))))))
+  (if (migration-lock-exists? liquibase)
+    (do
+     (log/info "Database has migration lock. Waiting for lock to be cleared...")
+     (Thread/sleep 2000)
+     (u/auto-retry 4
+       (when (migration-lock-exists? liquibase)
+         (Thread/sleep 2000)
+         (throw
+          (LockException.
+           (str
+            (trs "Database has migration lock; cannot run migrations.")
+            " "
+            (trs "You can force-release these locks by running `java -jar metabase.jar migrate release-locks`.")))))))
+    (log/info "No migration lock found.")))
 
 (defn migrate-up-if-needed!
   "Run any unrun `liquibase` migrations, if needed."
-  [^Liquibase liquibase]
+  [^Liquibase liquibase ^DataSource data-source]
   (log/info (trs "Checking if Database has unrun migrations..."))
-  (if (seq (unrun-migrations liquibase))
+  (if (seq (unrun-migrations data-source))
     (do
-     (log/info (trs "Database has unrun migrations. Waiting for migration lock to be cleared..."))
+     (log/info (trs "Database has unrun migrations. Checking if migraton lock is cleared..."))
      (wait-for-migration-lock-to-be-cleared liquibase)
     ;; while we were waiting for the lock, it was possible that another instance finished the migration(s), so make
     ;; sure something still needs to be done...
-     (let [unrun-migrations-count (count (unrun-migrations liquibase))]
+     (let [to-run-migrations      (unrun-migrations data-source)
+           unrun-migrations-count (count to-run-migrations)]
        (if (pos? unrun-migrations-count)
          (let [^Contexts contexts nil
                start-time         (System/currentTimeMillis)]
-           (log/info (trs "Migration lock is cleared. Running {0} migrations ..." unrun-migrations-count))
+           (log/info (trs "Running {0} migrations ..." unrun-migrations-count))
+           (doseq [change to-run-migrations]
+             (log/infof "Unrun migration %s" (.getId change)))
            (.update liquibase contexts)
            (log/info (trs "Migration complete in {0}" (u/format-milliseconds (- (System/currentTimeMillis) start-time)))))
          (log/info
@@ -270,11 +280,12 @@
 
   It can be used to fix situations where the database got into a weird state, as was common before the fixes made in
   #3295."
-  [^Liquibase liquibase :- (ms/InstanceOfClass Liquibase)]
+  [^Liquibase liquibase :- (ms/InstanceOfClass Liquibase)
+   ^DataSource data-source :- (ms/InstanceOfClass DataSource)]
   ;; have to do this before clear the checksums else it will wait for locks to be released
   (release-lock-if-needed! liquibase)
   (.clearCheckSums liquibase)
-  (when (seq (unrun-migrations liquibase))
+  (when (seq (unrun-migrations data-source))
     (let [change-log     (.getDatabaseChangeLog liquibase)
           fail-on-errors (mapv (fn [^ChangeSet change-set] [change-set (.getFailOnError change-set)])
                                (.getChangeSets change-log))

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -170,10 +170,10 @@
   skip creating and releasing migration locks, which is both slightly dangerous and a waste of time when we won't be
   using them.
 
-  (I'm not 100% sure whether `Liquibase.update()` still acquires locks if the database is already up-to-date)"
+  IMPORTANT: this function takes `data-source` but not `liquibase` because `.listUnrunChangeSets` is buggy. See #38257."
   [^DataSource data-source]
   (with-liquibase [liquibase (.getConnection data-source)]
-     (.listUnrunChangeSets liquibase nil (LabelExpression.))))
+    (.listUnrunChangeSets liquibase nil (LabelExpression.))))
 
 (defn- migration-lock-exists?
   "Is a migration lock in place for `liquibase`?"

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -236,7 +236,7 @@
                start-time         (System/currentTimeMillis)]
            (log/info (trs "Running {0} migrations ..." unrun-migrations-count))
            (doseq [change to-run-migrations]
-             (log/infof "Unrun migration %s" (.getId change)))
+             (log/tracef "To run migration %s" (.getId change)))
            (.update liquibase contexts)
            (log/info (trs "Migration complete in {0}" (u/format-milliseconds (- (System/currentTimeMillis) start-time)))))
          (log/info

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -39,8 +39,8 @@
 (defn- print-migrations-and-quit-if-needed!
   "If we are not doing auto migrations then print out migration SQL for user to run manually. Then throw an exception to
   short circuit the setup process and make it clear we can't proceed."
-  [liquibase]
-  (when (seq (liquibase/unrun-migrations liquibase))
+  [liquibase data-source]
+  (when (seq (liquibase/unrun-migrations data-source))
     (log/info (str (trs "Database Upgrade Required")
                    "\n\n"
                    (trs "NOTICE: Your database requires updates to work with this version of Metabase.")
@@ -77,10 +77,10 @@
        (liquibase/consolidate-liquibase-changesets! conn)
        (log/info (trs "Liquibase is ready."))
        (case direction
-         :up            (liquibase/migrate-up-if-needed! liquibase)
-         :force         (liquibase/force-migrate-up-if-needed! liquibase)
+         :up            (liquibase/migrate-up-if-needed! liquibase data-source)
+         :force         (liquibase/force-migrate-up-if-needed! liquibase data-source)
          :down          (apply liquibase/rollback-major-version db-type conn liquibase args)
-         :print         (print-migrations-and-quit-if-needed! liquibase)
+         :print         (print-migrations-and-quit-if-needed! liquibase data-source)
          :release-locks (liquibase/force-release-locks! liquibase))
        ;; Migrations were successful; commit everything and re-enable auto-commit
        (.commit conn)


### PR DESCRIPTION
Speculative fixes for #37599 #37344
I could not reproduce both of those issues, but it seems to me that they have the same problem: liquibase tries to run a migration twice.

While debugging this, I noticed that if you have 2 metabase instances trying to run migration simultaneously, one will acquire the lock and do the migration, while the other will wait for a while to see if it can acquire the lock.

The strange thing is when the 1st instance finished migrating, for some reason, the second instance will still attempt to update`(.update liquibase)`. Even though liquibase will skip all the migrations on the 2nd instance, we still shouldn't trigger this.

It's clearer if you look at the log of the 2 instances I've included below.
log for the 1st instance that will do the migration
[1.txt](https://github.com/metabase/metabase/files/14097318/1.txt)
second instance that wait til the lock is released.
[2.txt](https://github.com/metabase/metabase/files/14097319/2.txt)

Notice the log of the 2nd instance.

```
2024-01-30 17:53:12,179 INFO db.liquibase :: Checking if Database has unrun migrations...
2024-01-30 17:53:12,418 INFO db.liquibase :: Database has unrun migrations. Checking if the migration lock is cleared...
2024-01-30 17:53:12,422 INFO db.liquibase :: Database has migration lock. Waiting for lock to be cleared...
2024-01-30 17:53:14,452 INFO db.liquibase :: Running 248 migrations ...
2024-01-30 17:53:14,452 INFO db.liquibase :: Unrun migration v00.00-000
2024-01-30 17:53:14,453 INFO db.liquibase :: Unrun migration v45.00-001
....
2024-01-30 17:53:14,467 INFO db.liquibase :: Unrun migration v49.00-059

UPDATE SUMMARY
Run:                          0
Previously run:             248
Filtered out:                17
-------------------------------
Total change sets:          265


FILTERED CHANGE SETS SUMMARY
DBMS mismatch:               17

```
It waited for the 1st instance to finish, but after that, it still thought that there were un-run migrations and tried to do the update again. Even though liquibase does not re-run any migration (indicated by run :0 in update summary), but we shouldn't be triggering that on the 2nd instance.

This PR will ensure we don't attempt migrating if the other instance finished it.

Comment on liquibase: I have 2 theories:
- Liquibase has a bug in how it checks unrun migrations internally; if that's true, then it might be the root cause of the 2 bugs in that some of the migrations do get re-run.  might relate: 
  - https://github.com/liquibase/liquibase/issues/5516
  - https://github.com/liquibase/liquibase/issues/5395
  - https://github.com/liquibase/liquibase/issues/5254
  - I also noticed that checksum has changed for different liquibase versions, for example the checksum for migration id '1' is `8:7182ca8e82947c24fa827d31f78b19aa` on 42, but it's `8:70d9a1021171b879cc55058f4d094a9c` on 47
- Migration operation is not atomic: a migration could be run but it does not get recorded into databasechangelog

again, I really can't reproduce those bugs, so this is just a speculation.

### How to reproduce
1. create an empty db
2. start 2 Metabase instances at the same time