### PR TITLE
Use Cypress event listener for `beforeunload` globally

### DIFF
--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -54,3 +54,24 @@ Cypress.on("test:after:run", (test, runnable) => {
     );
   }
 });
+
+/**
+ * Our app registers beforeunload event listener e.g. when editing a native SQL question.
+ * Cypress does not automatically close the browser prompt and does not allow manually
+ * interacting with it (unlike with window.confirm). The test will hang forever with
+ * the prompt displayed and will eventually time out. We need to work around this by
+ * monkey-patching window.addEventListener to ignore beforeunload event handlers.
+ *
+ * @see https://github.com/cypress-io/cypress/issues/2118
+ */
+Cypress.on("window:load", window => {
+  const addEventListener = window.addEventListener;
+
+  window.addEventListener = function (event) {
+    if (event === "beforeunload") {
+      return;
+    }
+
+    return addEventListener.apply(this, arguments);
+  };
+});

--- a/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/pivot_tables.cy.spec.js
@@ -36,27 +36,6 @@ const TEST_CASES = [
   { case: "dashboard", subject: DASHBOARD_NAME, confirmSave: false },
 ];
 
-/**
- * Our app registers beforeunload event listener e.g. when editing a native SQL question.
- * Cypress does not automatically close the browser prompt and does not allow manually
- * interacting with it (unlike with window.confirm). The test will hang forever with
- * the prompt displayed and will eventually time out. We need to work around this by
- * monkey-patching window.addEventListener to ignore beforeunload event handlers.
- *
- * @see https://github.com/cypress-io/cypress/issues/2118
- */
-Cypress.on("window:load", window => {
-  const addEventListener = window.addEventListener;
-
-  window.addEventListener = function (event) {
-    if (event === "beforeunload") {
-      return;
-    }
-
-    return addEventListener.apply(this, arguments);
-  };
-});
-
 describe("scenarios > visualizations > pivot tables", { tags: "@slow" }, () => {
   beforeEach(() => {
     restore();


### PR DESCRIPTION
@kamilmielnik added this workaround a while ago to the `pivot_tables.cy.spec.js` spec. But we saw other specs hanging and eventually timing out. Let's move this patch to the global Cypress file so it gets applied all specs.

Please see this upstream issue:
https://github.com/cypress-io/cypress/issues/2118