### PR TITLE
🚧 Expose find-column with two params

### DIFF
--- a/frontend/src/metabase-lib/comparison.ts
+++ b/frontend/src/metabase-lib/comparison.ts
@@ -14,14 +14,22 @@ export function areLegacyQueriesEqual(
   return ML.query_EQ_(query1, query2, fieldIds);
 }
 
-export function findMatchingColumn(
+declare function FindMatchingColumnFn(
   query: Query,
   stageIndex: number,
   column: ColumnMetadata,
   columns: ColumnMetadata[],
-): ColumnMetadata | null {
-  return ML.find_matching_column(query, stageIndex, column, columns);
-}
+): ColumnMetadata | null;
+
+declare function FindMatchingColumnFn(
+  fieldRef: FieldReference,
+  columns: ColumnMetadata[],
+): ColumnMetadata | null;
+
+// TODO: I tried passing both fieldRef and column into a variant with 2 params
+// and got an error
+export const findMatchingColumn: typeof FindMatchingColumnFn =
+  ML.find_matching_column;
 
 export function findColumnIndexesFromLegacyRefs(
   query: Query,

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1175,8 +1175,11 @@
    - The same disambiguation (by `:join-alias` etc.) is applied if there are multiple plausible matches.
 
    Returns the matching column, or nil if no match is found."
-  [a-query stage-number a-ref columns]
+  ([a-query stage-number a-ref columns]
   (lib.core/find-matching-column a-query stage-number a-ref columns))
+
+  ([a-ref columns]
+  (lib.core/find-matching-column a-ref columns)))
 
 (defn ^:export has-clauses
   "Does given query stage have any clauses?"


### PR DESCRIPTION
Expose find-matching-column to compare two columns