### PR TITLE
Improve performance of adding new table perms

### DIFF
--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -1,5 +1,6 @@
 (ns metabase.models.data-permissions
   (:require
+   [clojure.set :as set]
    [clojure.string :as str]
    [malli.core :as mc]
    [metabase.api.common :as api]
@@ -433,10 +434,9 @@
    value       :- :keyword]
   (set-table-permissions! group-or-id perm-type {table-or-id value}))
 
-(mu/defn set-simple-table-permission-in-groups!
-  "Sets permissions for a single table to the specified value in all of the provided groups. Does not do any coalescing
-  of table-level rows into a DB-level row. This should be used in cases where a number of tables are being updated, but
-  a bulk update is not possible, such as during sync."
+(mu/defn set-new-table-permissions!
+  "Sets permissions for a single table to the specified value in all the provided groups.
+  Does not update any groups where the permission is already set at the database level."
   [groups-or-ids :- [:sequential TheIdable]
    table-or-id   :- TheIdable
    perm-type     :- :keyword
@@ -447,21 +447,28 @@
   (when (= value :block)
     (throw (ex-info (tru "Block permissions must be set at the database-level only.")
                     {})))
-  (t2/with-transaction [_conn]
-    (let [group-ids (map u/the-id groups-or-ids)
-          table     (if (map? table-or-id)
-                       table-or-id
-                       (t2/select-one [:model/Table :id :db_id :schema] :id table-or-id))
-          table-id  (u/the-id table)
-          new-perms (map
-                     (fn [group-id]
-                       (let [{:keys [id db_id schema]} table]
-                         {:perm_type   perm-type
-                          :group_id    group-id
-                          :perm_value  value
-                          :db_id       db_id
-                          :table_id    id
-                          :schema_name schema}))
-                     group-ids)]
-      (t2/delete! :model/DataPermissions :perm_type perm-type :table_id table-id {:where [:in :group_id group-ids]})
-      (t2/insert! :model/DataPermissions new-perms))))
+  (when (seq groups-or-ids)
+    (t2/with-transaction [_conn]
+      (let [group-ids         (map u/the-id groups-or-ids)
+            table             (if (map? table-or-id)
+                                table-or-id
+                                (t2/select-one [:model/Table :id :db_id :schema] :id table-or-id))
+            db-id             (:db_id table)
+            db-level-perms    (t2/select :model/DataPermissions
+                                         :perm_type (u/qualified-name perm-type)
+                                         :db_id     db-id
+                                         :table_id  nil
+                                         {:where [:in :group_id group-ids]})
+            db-level-group-ids (set (map :group_id db-level-perms))
+            granular-group-ids (set/difference (set group-ids) db-level-group-ids)
+            new-perms (map
+                       (fn [group-id]
+                         (let [{:keys [id db_id schema]} table]
+                           {:perm_type   perm-type
+                            :group_id    group-id
+                            :perm_value  value
+                            :db_id       db_id
+                            :table_id    id
+                            :schema_name schema}))
+                       granular-group-ids)]
+        (t2/insert! :model/DataPermissions new-perms)))))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -107,12 +107,19 @@
       ;; tables.
       (if (:is_audit database)
         (doseq [group non-admin-groups]
+          (data-perms/set-database-permission! group database :perms/data-access :no-self-service)
           (data-perms/set-database-permission! group database :perms/native-query-editing :no))
         (do
+          (data-perms/set-database-permission! all-users-group database :perms/download-results :one-million-rows)
+          (data-perms/set-database-permission! all-users-group database :perms/data-access :unrestricted)
           (data-perms/set-database-permission! all-users-group database :perms/native-query-editing :yes)
           (doseq [group non-magic-groups]
+            (data-perms/set-database-permission! group database :perms/download-results :no)
+            (data-perms/set-database-permission! group database :perms/data-access :no-self-service)
             (data-perms/set-database-permission! group database :perms/native-query-editing :no))))
+
       (doseq [group non-admin-groups]
+        (data-perms/set-database-permission! group database :perms/manage-table-metadata :no)
         (data-perms/set-database-permission! group database :perms/manage-database :no)))))
 
 (t2/define-after-insert :model/Database

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -108,11 +108,12 @@
       (if (:is_audit database)
         (doseq [group non-admin-groups]
           (data-perms/set-database-permission! group database :perms/data-access :no-self-service)
-          (data-perms/set-database-permission! group database :perms/native-query-editing :no))
+          (data-perms/set-database-permission! group database :perms/native-query-editing :no)
+          (data-perms/set-database-permission! group database :perms/download-results :one-million-rows))
         (do
-          (data-perms/set-database-permission! all-users-group database :perms/download-results :one-million-rows)
           (data-perms/set-database-permission! all-users-group database :perms/data-access :unrestricted)
           (data-perms/set-database-permission! all-users-group database :perms/native-query-editing :yes)
+          (data-perms/set-database-permission! all-users-group database :perms/download-results :one-million-rows)
           (doseq [group non-magic-groups]
             (data-perms/set-database-permission! group database :perms/download-results :no)
             (data-perms/set-database-permission! group database :perms/data-access :no-self-service)

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -71,15 +71,15 @@
       ;; Data access permissions
       (if (= (:db_id table) perms/audit-db-id)
         ;; Tables in audit DB should start out with no-self-service in all groups
-        (data-perms/set-simple-table-permission-in-groups! non-admin-groups table :perms/data-access :no-self-service)
+        (data-perms/set-new-table-permissions! non-admin-groups table :perms/data-access :no-self-service)
         (do
-          (data-perms/set-simple-table-permission-in-groups! [all-users-group] table :perms/data-access :unrestricted)
-          (data-perms/set-simple-table-permission-in-groups! non-magic-groups table :perms/data-access :no-self-service)))
+          (data-perms/set-new-table-permissions! [all-users-group] table :perms/data-access :unrestricted)
+          (data-perms/set-new-table-permissions! non-magic-groups table :perms/data-access :no-self-service)))
       ;; Download permissions
-      (data-perms/set-simple-table-permission-in-groups! [all-users-group] table :perms/download-results :one-million-rows)
-      (data-perms/set-simple-table-permission-in-groups! non-magic-groups table :perms/download-results :no)
+      (data-perms/set-new-table-permissions! [all-users-group] table :perms/download-results :one-million-rows)
+      (data-perms/set-new-table-permissions! non-magic-groups table :perms/download-results :no)
       ;; Table metadata management
-      (data-perms/set-simple-table-permission-in-groups! non-admin-groups table :perms/manage-table-metadata :no))))
+      (data-perms/set-new-table-permissions! non-admin-groups table :perms/manage-table-metadata :no))))
 
 (t2/define-after-insert :model/Table
   [table]

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -71,19 +71,15 @@
       ;; Data access permissions
       (if (= (:db_id table) perms/audit-db-id)
         ;; Tables in audit DB should start out with no-self-service in all groups
-        (doseq [group non-admin-groups]
-         (data-perms/set-table-permission! group table :perms/data-access :no-self-service))
+        (data-perms/set-simple-table-permission-in-groups! non-admin-groups table :perms/data-access :no-self-service)
         (do
-          (data-perms/set-table-permission! all-users-group table :perms/data-access :unrestricted)
-          (doseq [group non-magic-groups]
-            (data-perms/set-table-permission! group table :perms/data-access :no-self-service))))
+          (data-perms/set-simple-table-permission-in-groups! [all-users-group] table :perms/data-access :unrestricted)
+          (data-perms/set-simple-table-permission-in-groups! non-magic-groups table :perms/data-access :no-self-service)))
       ;; Download permissions
-      (data-perms/set-table-permission! all-users-group table :perms/download-results :one-million-rows)
-      (doseq [group non-magic-groups]
-        (data-perms/set-table-permission! group table :perms/download-results :no))
+      (data-perms/set-simple-table-permission-in-groups! [all-users-group] table :perms/download-results :one-million-rows)
+      (data-perms/set-simple-table-permission-in-groups! non-magic-groups table :perms/download-results :no)
       ;; Table metadata management
-      (doseq [group non-admin-groups]
-        (data-perms/set-table-permission! group table :perms/manage-table-metadata :no)))))
+      (data-perms/set-simple-table-permission-in-groups! non-admin-groups table :perms/manage-table-metadata :no))))
 
 (t2/define-after-insert :model/Table
   [table]

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -116,6 +116,34 @@
           (is (nil?     (data-access-perm-value table-id-2)))
           (is (nil?     (data-access-perm-value table-id-3))))))))
 
+(deftest set-simple-table-permission-in-groups!-test
+  (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}  {}
+                 :model/PermissionsGroup {group-id-2 :id}  {}
+                 :model/PermissionsGroup {group-id-3 :id}  {}
+                 :model/Database         {database-id :id} {}
+                 :model/Table            {table-id-1 :id}  {:db_id database-id}
+                 :model/Table            {table-id-2 :id}  {:db_id database-id}]
+    (let [data-access-perm-value (fn [table-id group-id]
+                                     (t2/select-one-fn :perm_value :model/DataPermissions
+                                                       :db_id     database-id
+                                                       :group_id  group-id
+                                                       :table_id  table-id
+                                                       :perm_type :perms/data-access))]
+      (testing "A single table can be set to a value in multiple groups"
+        (data-perms/set-simple-table-permission-in-groups!
+         [group-id-1 group-id-2] table-id-1 :perms/data-access :unrestricted)
+        (is (= :unrestricted (data-access-perm-value table-id-1 group-id-1)))
+        (is (= :unrestricted (data-access-perm-value table-id-1 group-id-2)))
+        (is (= :no-self-service (data-access-perm-value table-id-1 group-id-3)))
+        (is (nil? (data-access-perm-value nil group-id-2))))
+
+      (testing "Setting another table to the same value does *not* coalesce the values automatically"
+        (data-perms/set-simple-table-permission-in-groups!
+         [group-id-1] table-id-2 :perms/data-access :unrestricted)
+        (is (= :unrestricted (data-access-perm-value table-id-1 group-id-1)))
+        (is (= :unrestricted (data-access-perm-value table-id-1 group-id-2)))
+        (is (nil? (data-access-perm-value nil group-id-2)))))))
+
 (deftest database-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}
                  :model/PermissionsGroup           {group-id-2 :id}    {}

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -116,33 +116,33 @@
           (is (nil?     (data-access-perm-value table-id-2)))
           (is (nil?     (data-access-perm-value table-id-3))))))))
 
-(deftest set-simple-table-permission-in-groups!-test
-  (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}  {}
-                 :model/PermissionsGroup {group-id-2 :id}  {}
-                 :model/PermissionsGroup {group-id-3 :id}  {}
-                 :model/Database         {database-id :id} {}
-                 :model/Table            {table-id-1 :id}  {:db_id database-id}
-                 :model/Table            {table-id-2 :id}  {:db_id database-id}]
-    (let [data-access-perm-value (fn [table-id group-id]
-                                     (t2/select-one-fn :perm_value :model/DataPermissions
-                                                       :db_id     database-id
-                                                       :group_id  group-id
-                                                       :table_id  table-id
-                                                       :perm_type :perms/data-access))]
-      (testing "A single table can be set to a value in multiple groups"
-        (data-perms/set-simple-table-permission-in-groups!
-         [group-id-1 group-id-2] table-id-1 :perms/data-access :unrestricted)
-        (is (= :unrestricted (data-access-perm-value table-id-1 group-id-1)))
-        (is (= :unrestricted (data-access-perm-value table-id-1 group-id-2)))
-        (is (= :no-self-service (data-access-perm-value table-id-1 group-id-3)))
-        (is (nil? (data-access-perm-value nil group-id-2))))
+#_(deftest set-simple-table-permission-in-groups!-test
+    (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}  {}
+                   :model/PermissionsGroup {group-id-2 :id}  {}
+                   :model/PermissionsGroup {group-id-3 :id}  {}
+                   :model/Database         {database-id :id} {}
+                   :model/Table            {table-id-1 :id}  {:db_id database-id}
+                   :model/Table            {table-id-2 :id}  {:db_id database-id}]
+      (let [data-access-perm-value (fn [table-id group-id]
+                                       (t2/select-one-fn :perm_value :model/DataPermissions
+                                                         :db_id     database-id
+                                                         :group_id  group-id
+                                                         :table_id  table-id
+                                                         :perm_type :perms/data-access))]
+        (testing "A single table can be set to a value in multiple groups"
+          (data-perms/set-simple-table-permission-in-groups!
+           [group-id-1 group-id-2] table-id-1 :perms/data-access :unrestricted)
+          (is (= :unrestricted (data-access-perm-value table-id-1 group-id-1)))
+          (is (= :unrestricted (data-access-perm-value table-id-1 group-id-2)))
+          (is (= :no-self-service (data-access-perm-value table-id-1 group-id-3)))
+          (is (nil? (data-access-perm-value nil group-id-2))))
 
-      (testing "Setting another table to the same value does *not* coalesce the values automatically"
-        (data-perms/set-simple-table-permission-in-groups!
-         [group-id-1] table-id-2 :perms/data-access :unrestricted)
-        (is (= :unrestricted (data-access-perm-value table-id-1 group-id-1)))
-        (is (= :unrestricted (data-access-perm-value table-id-1 group-id-2)))
-        (is (nil? (data-access-perm-value nil group-id-2)))))))
+        (testing "Setting another table to the same value does *not* coalesce the values automatically"
+          (data-perms/set-simple-table-permission-in-groups!
+           [group-id-1] table-id-2 :perms/data-access :unrestricted)
+          (is (= :unrestricted (data-access-perm-value table-id-1 group-id-1)))
+          (is (= :unrestricted (data-access-perm-value table-id-1 group-id-2)))
+          (is (nil? (data-access-perm-value nil group-id-2)))))))
 
 (deftest database-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -42,22 +42,28 @@
       (let [all-users-group-id (u/the-id (perms-group/all-users))]
         (is (= {all-users-group-id
                 {db-id
-                 {:perms/native-query-editing :yes
-                  :perms/manage-database      :no}}}
+                 {:perms/download-results      :one-million-rows
+                  :perms/data-access           :unrestricted
+                  :perms/native-query-editing  :yes
+                  :perms/manage-table-metadata :no
+                  :perms/manage-database       :no}}}
                (data-perms/data-permissions-graph :group-id all-users-group-id :db-id db-id))))
 
       ;; Other groups should have no DB-level perms
       (is (= {group-id
               {db-id
-               {:perms/native-query-editing :no
-                :perms/manage-database      :no}}}
+               {:perms/download-results      :no
+                :perms/data-access           :no-self-service
+                :perms/native-query-editing  :no
+                :perms/manage-table-metadata :no
+                :perms/manage-database       :no}}}
              (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))
 
 (deftest cleanup-permissions-after-delete-db-test
   (mt/with-temp [:model/Database {db-id :id} {}]
     (is (true? (t2/exists? :model/DataPermissions :db_id db-id)))
     (t2/delete! :model/Database db-id)
-    (testing "Table-level permissions are deleted when we delete the table"
+    (testing "All permissions are deleted when we delete the database"
       (is (false? (t2/exists? :model/DataPermissions :db_id db-id))))))
 
 (deftest tasks-test

--- a/test/metabase/models/table_test.clj
+++ b/test/metabase/models/table_test.clj
@@ -87,32 +87,67 @@
   (testing "New permissions are set appropriately for a new table, for all groups"
     (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
                    :model/Database         {db-id :id}    {}
-                   :model/Table            {table-id :id} {:db_id  db-id
-                                                           :schema "PUBLIC"}]
+                   :model/Table            {table-id-1 :id} {:db_id  db-id
+                                                             :schema "PUBLIC"}
+                   :model/Table            {table-id-2 :id} {:db_id  db-id
+                                                             :schema "PUBLIC"}]
       ;; All Users group should have full data access, full download abilities, and full metadata management
       (let [all-users-group-id (u/the-id (perms-group/all-users))]
         (is (partial=
              {all-users-group-id
               {db-id
-               {:perms/data-access           {"PUBLIC" {table-id :unrestricted}}
-                :perms/download-results      {"PUBLIC" {table-id :one-million-rows}}
-                :perms/manage-table-metadata {"PUBLIC" {table-id :no}}}}}
+               {:perms/data-access           :unrestricted
+                :perms/native-query-editing  :yes
+                :perms/download-results      :one-million-rows
+                :perms/manage-table-metadata :no
+                :perms/manage-database       :no}}}
              (data-perms/data-permissions-graph :group-id all-users-group-id :db-id db-id))))
 
       ;; Other groups should have no-self-service data access and no download abilities or metadata management
       (is (partial=
            {group-id
             {db-id
-             {:perms/data-access           {"PUBLIC" {table-id :no-self-service}}
-              :perms/download-results      {"PUBLIC" {table-id :no}}
-              :perms/manage-table-metadata {"PUBLIC" {table-id :no}}}}}
-           (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))
+               {:perms/data-access           :no-self-service
+                :perms/native-query-editing  :no
+                :perms/download-results      :no
+                :perms/manage-table-metadata :no
+                :perms/manage-database       :no}}}
+           (data-perms/data-permissions-graph :group-id group-id :db-id db-id)))
+
+      (testing "A new table has appropriate defaults, when perms are already set granularly for the DB"
+        (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :unrestricted)
+        (data-perms/set-table-permission! group-id table-id-1 :perms/download-results :one-million-rows)
+        (data-perms/set-table-permission! group-id table-id-1 :perms/manage-table-metadata :yes)
+        (mt/with-temp [:model/Table {table-id-3 :id} {:db_id  db-id
+                                                      :schema "PUBLIC"}]
+          (is (partial=
+               {group-id
+                {db-id
+                   {:perms/data-access           {"PUBLIC"
+                                                  {table-id-1 :unrestricted
+                                                   table-id-2 :no-self-service
+                                                   table-id-3 :no-self-service}}
+                    :perms/native-query-editing  :no
+                    :perms/download-results      {"PUBLIC"
+                                                  {table-id-1 :one-million-rows
+                                                   table-id-2 :no
+                                                   table-id-3 :no}}
+                    :perms/manage-table-metadata {"PUBLIC"
+                                                  {table-id-1 :yes
+                                                   table-id-2 :no
+                                                   table-id-3 :no}}
+                    :perms/manage-database       :no}}}
+               (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))))
 
 (deftest cleanup-permissions-after-delete-table-test
   (mt/with-temp
-    [:model/Database         {db-id :id}    {}
-     :model/Table            {table-id :id} {:db_id  db-id}]
-    (is (true? (t2/exists? :model/DataPermissions :table_id table-id)))
-    (t2/delete! :model/Table table-id)
+    [:model/Database {db-id :id}      {}
+     :model/Table    {table-id-1 :id} {:db_id db-id}
+     :model/Table    {}               {:db_id db-id}]
+    (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/data-access :unrestricted)
+    (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/download-results :one-million-rows)
+    (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/manage-table-metadata :yes)
+    (is (true? (t2/exists? :model/DataPermissions :table_id table-id-1)))
+    (t2/delete! :model/Table table-id-1)
     (testing "Table-level permissions are deleted when we delete the table"
-      (is (false? (t2/exists? :model/DataPermissions :table_id table-id))))))
+      (is (false? (t2/exists? :model/DataPermissions :table_id table-id-1))))))


### PR DESCRIPTION
Adds `set-new-table-permissions!` which doesn't do any coalescing of table-level perms, when new groups are added. This should make sync much more efficient when perms are set at a granular level in an existing DB.