### PR TITLE
[MLv2] Drill-thru coverage: Add a structured column and fix that case

### DIFF
--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -106,6 +106,7 @@
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              column
              (some? value) ; Deliberately allows value :null, only a missing value should fail this test.
+             (not (lib.types.isa/structured?  column))
              (not (lib.types.isa/primary-key? column))
              (not (lib.types.isa/foreign-key? column)))
     ;; For aggregate columns, we want to introduce a new stage when applying the drill-thru.

--- a/test/metabase/lib/drill_thru/column_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/column_filter_test.cljc
@@ -8,16 +8,18 @@
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
+   [metabase.lib.types.isa :as lib.types.isa]
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
 (deftest ^:parallel column-filter-availability-test
   (testing "column-filter is available for any header click, and nothing else"
-    (doseq [[test-case context {:keys [click]}] (canned/canned-clicks)]
-      (if (= click :header)
-        (is (canned/returned test-case context :drill-thru/column-filter))
-        (is (not (canned/returned test-case context :drill-thru/column-filter)))))))
+    (canned/canned-test
+      :drill-thru/column-filter
+      (fn [_test-case context {:keys [click]}]
+        (and (= click :header)
+             (not (lib.types.isa/structured? (:column context))))))))
 
 (deftest ^:parallel returns-column-filter-test-1
   (lib.drill-thru.tu/test-returns-drill

--- a/test/metabase/lib/drill_thru/fk_details_test.cljc
+++ b/test/metabase/lib/drill_thru/fk_details_test.cljc
@@ -12,12 +12,12 @@
 
 (deftest ^:parallel fk-details-availability-test
   (testing "FK details is available for cell clicks on non-NULL FKs"
-    (doseq [[test-case context {:keys [click column-type]}] (canned/canned-clicks)]
-      (if (and (= click :cell)
-               (= column-type :fk)
-               (not= (:value context) :null))
-        (is (canned/returned test-case context :drill-thru/fk-details))
-        (is (not (canned/returned test-case context :drill-thru/fk-details)))))))
+    (canned/canned-test
+      :drill-thru/fk-details
+      (fn [_test-case context {:keys [click column-type]}]
+        (and (= click :cell)
+             (= column-type :fk)
+             (not= (:value context) :null))))))
 
 (deftest ^:parallel returns-fk-details-test-1
   (lib.drill-thru.tu/test-returns-drill

--- a/test/metabase/lib/drill_thru/pivot_test.cljc
+++ b/test/metabase/lib/drill_thru/pivot_test.cljc
@@ -19,10 +19,15 @@
 
 (deftest ^:parallel pivot-availability-test
   (testing "pivot drill is available only for cell clicks"
-    ;; Other conditions are too complex to capture here; other tests check them.
-    (doseq [[test-case context {:keys [click]}] (canned/canned-clicks)
-            :when (not= click :cell)]
-      (is (not (canned/returned test-case context :drill-thru/pivot))))))
+    (canned/canned-test
+      :drill-thru/pivot
+      (fn [_test-case _context {:keys [click]}]
+        (if (= click :cell)
+          ;; The pivot conditions are too complex to capture here; other tests check them.
+          ;; Just skip the canned cases for cell clicks.
+          ::canned/skip
+          ;; Non-cell clicks are false though.
+          false)))))
 
 (def ^:private orders-date-only-test-case
   {:drill-type   :drill-thru/pivot

--- a/test/metabase/lib/drill_thru/pk_test.cljc
+++ b/test/metabase/lib/drill_thru/pk_test.cljc
@@ -22,9 +22,14 @@
                 (lib/available-drill-thrus query -1 context)))
 
 (deftest ^:parallel pk-unavailable-for-non-cell-test
-  (doseq [[test-case context {:keys [click]}] (canned/canned-clicks)
-          :when (not= click :cell)]
-    (is (not (canned/returned test-case context :drill-thru/pk)))))
+  (canned/canned-test
+    :drill-thru/pk
+    (fn [_test-case _context {:keys [click]}]
+      ;; Tricky logic, so other tests check the cell clicks.
+      ;; Non-cell clicks are not available.
+      (if (= click :cell)
+        ::canned/skip
+        false))))
 
 (deftest ^:parallel do-not-return-pk-for-nil-test
   (testing "do not return pk drills for nil PK values (#36126)"

--- a/test/metabase/lib/drill_thru/sort_test.cljc
+++ b/test/metabase/lib/drill_thru/sort_test.cljc
@@ -8,6 +8,7 @@
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.drill-thru.test-util.canned :as canned]
    [metabase.lib.test-metadata :as meta]
+   [metabase.lib.types.isa :as lib.types.isa]
    [metabase.util.malli :as mu]
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
@@ -15,10 +16,11 @@
 
 (deftest ^:parallel sort-drill-availability-test
   (testing "sort is available on column headers only"
-    (doseq [[test-case context {:keys [click]}] (canned/canned-clicks)]
-      (if (= click :header)
-        (is (canned/returned test-case context :drill-thru/sort))
-        (is (not (canned/returned test-case context :drill-thru/sort)))))))
+    (canned/canned-test
+      :drill-thru/sort
+      (fn [_test-case context {:keys [click]}]
+        (and (= click :header)
+             (not (lib.types.isa/structured? (:column context))))))))
 
 (deftest ^:parallel sort-e2e-test
   (let [query (lib/query meta/metadata-provider (meta/table-metadata :orders))

--- a/test/metabase/lib/drill_thru/summarize_column_by_time_test.cljc
+++ b/test/metabase/lib/drill_thru/summarize_column_by_time_test.cljc
@@ -15,16 +15,16 @@
 (deftest ^:parallel summarize-column-by-time-availability-test
   (testing (str "summarize-column-by-time is available for header click with no aggregations or breakouts, "
                 "for a summable column and at least one date-flavoured breakout available")
-    (doseq [[test-case context {:keys [click column-type]}] (canned/canned-clicks)]
-      (if (and (= click :header)
-               (= column-type :number)
-               (zero? (:aggregations test-case))
-               (zero? (:breakouts test-case))
-               (some #(or (isa? (:effective-type %) :type/Date)
-                          (isa? (:effective-type %) :type/DateTime))
-                     (lib/breakoutable-columns (:query test-case))))
-        (is (canned/returned test-case context :drill-thru/summarize-column-by-time))
-        (is (not (canned/returned test-case context :drill-thru/summarize-column-by-time)))))))
+    (canned/canned-test
+      :drill-thru/summarize-column-by-time
+      (fn [test-case _context {:keys [click column-type]}]
+        (and (= click :header)
+             (= column-type :number)
+             (zero? (:aggregations test-case))
+             (zero? (:breakouts test-case))
+             (some #(or (isa? (:effective-type %) :type/Date)
+                        (isa? (:effective-type %) :type/DateTime))
+                   (lib/breakoutable-columns (:query test-case))))))))
 
 (deftest ^:parallel aggregate-column-test
   (testing "Don't suggest summarize-column-by-time drill thrus for aggregate columns like `count(*)`"

--- a/test/metabase/lib/drill_thru/summarize_column_test.cljc
+++ b/test/metabase/lib/drill_thru/summarize_column_test.cljc
@@ -1,19 +1,21 @@
 (ns metabase.lib.drill-thru.summarize-column-test
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest testing]]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.drill-thru.test-util.canned :as canned]
-   [metabase.lib.test-metadata :as meta]))
+   [metabase.lib.test-metadata :as meta]
+   [metabase.lib.types.isa :as lib.types.isa]))
 
 (deftest ^:parallel summarize-column-availability-test
   (testing "summarize-column is available for column headers with no aggregations or breakouts"
-    (doseq [[test-case context {:keys [click]}] (canned/canned-clicks)]
-      (if (and (= click :header)
-               (zero? (:aggregations test-case))
-               (zero? (:breakouts test-case)))
-        (is (canned/returned test-case context :drill-thru/summarize-column))
-        (is (not (canned/returned test-case context :drill-thru/summarize-column)))))))
+    (canned/canned-test
+      :drill-thru/summarize-column
+      (fn [test-case context {:keys [click]}]
+        (and (= click :header)
+             (zero? (:aggregations test-case))
+             (zero? (:breakouts test-case))
+             (not (lib.types.isa/structured? (:column context))))))))
 
 (deftest ^:parallel returns-summarize-column-test-1
   (lib.drill-thru.tu/test-returns-drill

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -5,6 +5,7 @@
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru :as lib.drill-thru]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
+   [metabase.lib.drill-thru.test-util.canned :as canned]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.options :as lib.options]
    [metabase.lib.test-metadata :as meta]
@@ -16,6 +17,22 @@
               [metabase.util.malli.fn :as mu.fn]))))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
+
+(deftest ^:parallel underlying-records-availability-test
+  (testing "underlying-records is available for non-header clicks with at least one breakout"
+    (canned/canned-test
+      :drill-thru/underlying-records
+      (fn [_test-case context {:keys [click]}]
+        ;; TODO: The docs claim that underlying-records works on pivot cells, and so it does, but the so-called pivot case
+        ;; never occurs in actual pivot tables!
+        ;; - Clicks on row/column "headers", (that is, breakout values like a month or product category) look like regular
+        ;;   cell clicks (column and value set per the breakout, no :dimensions).
+        ;; - Clicks on cells (that is, aggregation values) have column, column-ref and value all nil, and :dimensions
+        ;;   contains all the breakouts (not exactly 2 as claimed in the spec).
+        ;; That all makes sense to me (Braden) and I think this is a bug in the docs, but it also might be a bug in the FE
+        ;; code that should be setting the aggregation :value for cell clicks?
+        (and (#{:cell #_:pivot :legend} click)
+             (seq (:dimensions context)))))))
 
 (deftest ^:parallel returns-underlying-records-test-1
   (lib.drill-thru.tu/test-returns-drill

--- a/test/metabase/lib/drill_thru/zoom_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_test.cljc
@@ -9,20 +9,20 @@
 
 (deftest ^:parallel zoom-availability-test
   (testing "zoom drill is available for cell clicks on non-FKs in tables with only 1 PK, and the PK in the result set"
-    (doseq [[test-case {:keys [value] :as context} {:keys [click column-type]}] (canned/canned-clicks)]
-      (if (and (= click :cell)
-               ;; With an FK column and a non-NULL value, this will be an fk-filter drill instead.
-               ;; So we don't expect a zoom drill in that case.
-               (not (and (= column-type :fk)
-                         (some? value)
-                         (not= value :null)))
-               ;; PK must be in the result set; if not, no zoom drill. This happens for eg. aggregations.
-               ((set (keys (:row test-case))) "ID")
-               ;; Special case: clicking a NULL PK does not return the zoom drill.
-               (not (and (= value :null)
-                         (= column-type :pk))))
-        (is (canned/returned test-case context :drill-thru/zoom))
-        (is (not (canned/returned test-case context :drill-thru/zoom)))))))
+    (canned/canned-test
+      :drill-thru/zoom
+      (fn [test-case {:keys [value]} {:keys [click column-type]}]
+        (and (= click :cell)
+             ;; With an FK column and a non-NULL value, this will be an fk-filter drill instead.
+             ;; So we don't expect a zoom drill in that case.
+             (not (and (= column-type :fk)
+                       (some? value)
+                       (not= value :null)))
+             ;; PK must be in the result set; if not, no zoom drill. This happens for eg. aggregations.
+             ((set (keys (:row test-case))) "ID")
+             ;; Special case: clicking a NULL PK does not return the zoom drill.
+             (not (and (= value :null)
+                       (= column-type :pk))))))))
 
 (deftest ^:parallel returns-zoom-test-1
   (lib.drill-thru.tu/test-returns-drill


### PR DESCRIPTION
Most drills don't appear for structured (eg. JSON, XML) columns.

This adds a new canned query and canned clicks for such a column
(by lying in the metadata), then fixes a few test expectations
plus one broken drill.

Progress towards #36253.
