### PR TITLE
[CI] Upgrade `actions/checkout` action to v4

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -16,7 +16,7 @@ jobs:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}
           private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Assign author and their team. Returns true if team exists.
         id: auto-assign

--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'backport') && github.event.action == 'closed' || github.event.label.name == 'backport')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: tibdex/github-app-token@v2.1.0

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -24,7 +24,7 @@ jobs:
       backend_all: ${{ steps.changes.outputs.backend_all }}
       frontend_sources: ${{ steps.changes.outputs.frontend_sources }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -41,7 +41,7 @@ jobs:
     outputs:
       static_viz: ${{ steps.static_viz.outputs.static_viz }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
@@ -94,7 +94,7 @@ jobs:
     env:
       DOWNLOAD_URL: https://github.com/clj-kondo/clj-kondo/releases/download
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:
@@ -141,7 +141,7 @@ jobs:
     name: be-tests-java-11-ee-pre-check
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
@@ -182,7 +182,7 @@ jobs:
         edition: [oss, ee]
         java-version: [11, 17, 21]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
@@ -266,7 +266,7 @@ jobs:
       matrix:
         java-version: [11, 17, 21]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare backend
         uses: ./.github/actions/prepare-backend
         with:

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}
           private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Cherry-pick commits and create PR
         with:
           fetch-depth: 0
@@ -155,7 +155,7 @@ jobs:
     needs: create_pull_request
     if: ${{ failure() }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/notify-pull-request
         with:
           include-log: true

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -27,7 +27,7 @@ jobs:
         echo "It must start with either 'v0.' or 'v1.'."
         echo "Please, try again."
         exit 1
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: release
     - name: Prepare build scripts
@@ -75,7 +75,7 @@ jobs:
     timeout-minutes: 10
     steps:
     - name: Check out the code to verify the release branch
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0  # IMPORTANT! to get all the branches
         sparse-checkout: release
@@ -107,7 +107,7 @@ jobs:
       node_version: ${{ fromJson(steps.dependencies.outputs.result).node_version }}
       build_process: ${{ fromJson(steps.dependencies.outputs.result).build_process }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: release
     - name: Prepare build scripts
@@ -160,7 +160,7 @@ jobs:
       with:
         node-version: ${{ needs.get-build-requirements.outputs.node_version }}.x
     - name: Check out the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.commit }}
     - name: Prepare front-end environment

--- a/.github/workflows/build-scripts.yml
+++ b/.github/workflows/build-scripts.yml
@@ -12,7 +12,7 @@ jobs:
   test-build-scripts:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Prepare back-end environment
       timeout-minutes: 5
       uses: ./.github/actions/prepare-backend

--- a/.github/workflows/check-backport-script.yml
+++ b/.github/workflows/check-backport-script.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check for backport.sh file
         run: |
           if [ -f "./backport.sh" ]; then

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,7 +20,7 @@ jobs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
       e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Prepare front-end environment

--- a/.github/workflows/clean-cache.yml
+++ b/.github/workflows/clean-cache.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cleanup
         run: |

--- a/.github/workflows/cljs.yml
+++ b/.github/workflows/cljs.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       cljs: ${{ steps.changes.outputs.cljs }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - name: Prepare back-end environment

--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Codenotify
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: sourcegraph/codenotify@v0.6.4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       codeql: ${{ steps.changes.outputs.codeql }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:

--- a/.github/workflows/doc-md-links.yml
+++ b/.github/workflows/doc-md-links.yml
@@ -11,7 +11,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Lint doc links

--- a/.github/workflows/drivers-stress-test.yml
+++ b/.github/workflows/drivers-stress-test.yml
@@ -59,7 +59,7 @@ jobs:
       MB_ATHENA_TEST_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_SECRET_KEY }}
       MB_ATHENA_TEST_S3_STAGING_DIR: ${{ secrets.MB_ATHENA_TEST_S3_STAGING_DIR }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Athena driver
       uses: ./.github/actions/test-driver
       with:
@@ -80,7 +80,7 @@ jobs:
       MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test BigQuery Cloud SDK driver
       uses: ./.github/actions/test-driver
       with:
@@ -102,7 +102,7 @@ jobs:
         env:
           CLUSTER_SIZE: nano-quickstart
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Druid driver
       uses: ./.github/actions/test-driver
       with:
@@ -117,7 +117,7 @@ jobs:
       CI: 'true'
       DRIVERS: googleanalytics
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Google Analytics driver
       uses: ./.github/actions/test-driver
       with:
@@ -138,7 +138,7 @@ jobs:
       MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Google Related Drivers Classpath
       uses: ./.github/actions/test-driver
       with:
@@ -164,7 +164,7 @@ jobs:
         ports:
           - "3306:3306"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MariaDB driver (10.2)
       uses: ./.github/actions/test-driver
       with:
@@ -190,7 +190,7 @@ jobs:
         ports:
           - "3306:3306"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MariaDB driver (latest)
       uses: ./.github/actions/test-driver
       with:
@@ -212,7 +212,7 @@ jobs:
         ports:
           - "27017:27017"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MongoDB driver (4.4)
       uses: ./.github/actions/test-driver
       with:
@@ -230,7 +230,7 @@ jobs:
       MB_MONGO_TEST_PASSWORD: metasample123
       MB_TEST_MONGO_REQUIRES_SSL: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Spin up Mongo docker container
         run: docker run -d -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-4.4 mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
       - name: Wait until the port 27017 is ready
@@ -268,7 +268,7 @@ jobs:
         ports:
           - "27017:27017"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MongoDB driver (5.0)
       uses: ./.github/actions/test-driver
       with:
@@ -286,7 +286,7 @@ jobs:
       MB_MONGO_TEST_PASSWORD: metasample123
       MB_TEST_MONGO_REQUIRES_SSL: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Spin up Mongo docker container
       run: docker run -d -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-5.0 mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
     - name: Wait until the port 27017 is ready
@@ -327,7 +327,7 @@ jobs:
           MONGO_INITDB_ROOT_USERNAME: metabase
           MONGO_INITDB_ROOT_PASSWORD: metasample123
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MongoDB driver (latest)
       uses: ./.github/actions/test-driver
       with:
@@ -353,7 +353,7 @@ jobs:
         ports:
           - "3306:3306"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MySQL driver (8.0)
       uses: ./.github/actions/test-driver
       with:
@@ -391,7 +391,7 @@ jobs:
         ports:
         - "3306:3306"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MySQL driver (latest)
       uses: ./.github/actions/test-driver
       with:
@@ -417,7 +417,7 @@ jobs:
         ports:
           - "1521:1521"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Oracle driver (18.4)
       uses: ./.github/actions/test-driver
       with:
@@ -452,7 +452,7 @@ jobs:
         ports:
           - "2484:2484"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Oracle driver (21.3)
       uses: ./.github/actions/test-driver
       with:
@@ -482,7 +482,7 @@ jobs:
           POSTGRES_DB: mb_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Postgres driver (12)
       uses: ./.github/actions/test-driver
       with:
@@ -515,7 +515,7 @@ jobs:
           POSTGRES_DB: circle_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Postgres driver (latest)
       uses: ./.github/actions/test-driver
       with:
@@ -545,7 +545,7 @@ jobs:
         env:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Wait for port ${{ env.MB_PRESTO_JDBC_TEST_PORT }} to be ready
       run: while ! nc -z localhost ${{ env.MB_PRESTO_JDBC_TEST_PORT }}; do sleep 0.1; done
       timeout-minutes: 15
@@ -583,7 +583,7 @@ jobs:
       MB_REDSHIFT_TEST_HOST: ${{ secrets.MB_REDSHIFT_TEST_HOST }}
       MB_REDSHIFT_TEST_PASSWORD: ${{ secrets.MB_REDSHIFT_TEST_PASSWORD }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Redshift driver
       uses: ./.github/actions/test-driver
       with:
@@ -604,7 +604,7 @@ jobs:
       MB_SNOWFLAKE_TEST_PK_USER: METABASE PK
       MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY: ${{ secrets.MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Snowflake driver
       uses: ./.github/actions/test-driver
       with:
@@ -624,7 +624,7 @@ jobs:
         ports:
           - "10000:10000"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Spark driver
       uses: ./.github/actions/test-driver
       with:
@@ -639,7 +639,7 @@ jobs:
       CI: 'true'
       DRIVERS: sqlite
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test SQLite driver
       uses: ./.github/actions/test-driver
       with:
@@ -666,7 +666,7 @@ jobs:
           SA_PASSWORD: 'P@ssw0rd'
           MSSQL_MEMORY_LIMIT_MB: 1024
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MS SQL Server 2017 driver
       uses: ./.github/actions/test-driver
       with:
@@ -693,7 +693,7 @@ jobs:
           SA_PASSWORD: 'P@ssw0rd'
           MSSQL_MEMORY_LIMIT_MB: 1024
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MS SQL Server 2022 driver
       uses: ./.github/actions/test-driver
       with:
@@ -713,7 +713,7 @@ jobs:
         ports:
           - "5433:5433"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Make plugins directory
       run: mkdir plugins
     - name: Test Vertica driver

--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       backend_all: ${{ steps.changes.outputs.backend_all }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -41,7 +41,7 @@ jobs:
       MB_ATHENA_TEST_SECRET_KEY: ${{ secrets.MB_ATHENA_TEST_SECRET_KEY }}
       MB_ATHENA_TEST_S3_STAGING_DIR: ${{ secrets.MB_ATHENA_TEST_S3_STAGING_DIR }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Athena driver
       uses: ./.github/actions/test-driver
       with:
@@ -74,7 +74,7 @@ jobs:
       MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test BigQuery Cloud SDK driver
       uses: ./.github/actions/test-driver
       with:
@@ -108,7 +108,7 @@ jobs:
         env:
           CLUSTER_SIZE: nano-quickstart
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Druid driver
       uses: ./.github/actions/test-driver
       with:
@@ -135,7 +135,7 @@ jobs:
       CI: 'true'
       DRIVERS: googleanalytics
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Google Analytics driver
       uses: ./.github/actions/test-driver
       with:
@@ -168,7 +168,7 @@ jobs:
       MB_BIGQUERY_TEST_REFRESH_TOKEN: ${{ secrets.MB_BIGQUERY_TEST_REFRESH_TOKEN }}
       MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON: ${{ secrets.MB_BIGQUERY_CLOUD_SDK_TEST_SERVICE_ACCOUNT_JSON }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Google Related Drivers Classpath
       uses: ./.github/actions/test-driver
       with:
@@ -206,7 +206,7 @@ jobs:
         ports:
           - "3306:3306"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MariaDB driver (10.2)
       uses: ./.github/actions/test-driver
       with:
@@ -243,7 +243,7 @@ jobs:
         ports:
           - "3306:3306"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MariaDB driver (latest)
       uses: ./.github/actions/test-driver
       with:
@@ -276,7 +276,7 @@ jobs:
         ports:
           - "27017:27017"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MongoDB driver (4.4)
       uses: ./.github/actions/test-driver
       with:
@@ -306,7 +306,7 @@ jobs:
       MB_MONGO_TEST_PASSWORD: metasample123
       MB_TEST_MONGO_REQUIRES_SSL: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Spin up Mongo docker container
         run: docker run -d -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-4.4 mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
       - name: Wait until the port 27017 is ready
@@ -356,7 +356,7 @@ jobs:
         ports:
           - "27017:27017"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MongoDB driver (5.0)
       uses: ./.github/actions/test-driver
       with:
@@ -386,7 +386,7 @@ jobs:
       MB_MONGO_TEST_PASSWORD: metasample123
       MB_TEST_MONGO_REQUIRES_SSL: true
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Spin up Mongo docker container
       run: docker run -d -p 27017:27017 --name metamongo metabase/qa-databases:mongo-sample-5.0 mongod --dbpath /data/db2/ --tlsMode requireTLS --tlsCertificateKeyFile /etc/mongo/metamongo.pem --tlsCAFile /etc/mongo/metaca.crt
     - name: Wait until the port 27017 is ready
@@ -439,7 +439,7 @@ jobs:
           MONGO_INITDB_ROOT_USERNAME: metabase
           MONGO_INITDB_ROOT_PASSWORD: metasample123
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MongoDB driver (latest)
       uses: ./.github/actions/test-driver
       with:
@@ -477,7 +477,7 @@ jobs:
         ports:
           - "3306:3306"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MySQL driver (8.0)
       uses: ./.github/actions/test-driver
       with:
@@ -518,7 +518,7 @@ jobs:
         ports:
         - "3306:3306"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MySQL driver (latest)
       uses: ./.github/actions/test-driver
       with:
@@ -555,7 +555,7 @@ jobs:
         ports:
           - "1521:1521"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Oracle driver (18.4)
       uses: ./.github/actions/test-driver
       with:
@@ -602,7 +602,7 @@ jobs:
         ports:
           - "2484:2484"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Oracle driver (21.3)
       uses: ./.github/actions/test-driver
       with:
@@ -644,7 +644,7 @@ jobs:
           POSTGRES_DB: mb_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Postgres driver (12)
       uses: ./.github/actions/test-driver
       with:
@@ -677,7 +677,7 @@ jobs:
           POSTGRES_DB: circle_test
           POSTGRES_HOST_AUTH_METHOD: trust
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Postgres driver (latest)
       uses: ./.github/actions/test-driver
       with:
@@ -718,7 +718,7 @@ jobs:
         env:
           JAVA_TOOL_OPTIONS: "-Xmx2g"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Wait for port ${{ env.MB_PRESTO_JDBC_TEST_PORT }} to be ready
       run: while ! nc -z localhost ${{ env.MB_PRESTO_JDBC_TEST_PORT }}; do sleep 0.1; done
       timeout-minutes: 15
@@ -768,7 +768,7 @@ jobs:
       MB_REDSHIFT_TEST_HOST: ${{ secrets.MB_REDSHIFT_TEST_HOST }}
       MB_REDSHIFT_TEST_PASSWORD: ${{ secrets.MB_REDSHIFT_TEST_PASSWORD }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Redshift driver
       uses: ./.github/actions/test-driver
       with:
@@ -801,7 +801,7 @@ jobs:
       MB_SNOWFLAKE_TEST_PK_USER: METABASE PK
       MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY: ${{ secrets.MB_SNOWFLAKE_TEST_PK_PRIVATE_KEY }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Snowflake driver
       uses: ./.github/actions/test-driver
       with:
@@ -833,7 +833,7 @@ jobs:
         ports:
           - "10000:10000"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test Spark driver
       uses: ./.github/actions/test-driver
       with:
@@ -860,7 +860,7 @@ jobs:
       CI: 'true'
       DRIVERS: sqlite
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test SQLite driver
       uses: ./.github/actions/test-driver
       with:
@@ -899,7 +899,7 @@ jobs:
           SA_PASSWORD: 'P@ssw0rd'
           MSSQL_MEMORY_LIMIT_MB: 1024
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MS SQL Server 2017 driver
       uses: ./.github/actions/test-driver
       with:
@@ -938,7 +938,7 @@ jobs:
           SA_PASSWORD: 'P@ssw0rd'
           MSSQL_MEMORY_LIMIT_MB: 1024
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Test MS SQL Server 2022 driver
       uses: ./.github/actions/test-driver
       with:
@@ -970,7 +970,7 @@ jobs:
         ports:
           - "5433:5433"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Make plugins directory
       run: mkdir plugins
     - name: Test Vertica driver

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set source Docker image to OSS
       run: |
         echo "DOCKER_SOURCE_IMAGE=metabase/metabase:${{ matrix.version.source }}" >> $GITHUB_ENV

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -54,7 +54,7 @@ jobs:
       TERM: xterm
       TZ: US/Pacific # to make node match the instance tz
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # Important because we need previous commits hashes to find and download the uberjar!
           fetch-depth: 20

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       e2e_all: ${{ steps.changes.outputs.e2e_all }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -34,7 +34,7 @@ jobs:
     outputs:
       matrix: ${{ steps.e2e-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Generate matrix for E2E tests
         id: e2e-matrix
         uses: ./.github/actions/build-e2e-matrix
@@ -55,7 +55,7 @@ jobs:
       MB_EDITION: ${{ matrix.edition }}
       INTERACTIVE: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
@@ -100,7 +100,7 @@ jobs:
       matrix: ${{ fromJSON(needs.e2e-matrix-builder.outputs.matrix) }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare Docker containers
         uses: ./.github/actions/e2e-prepare-containers
@@ -225,7 +225,7 @@ jobs:
       !cancelled() && needs.build.result == 'success'
     name: percy-visual-regression-tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare Docker containers
         uses: ./.github/actions/e2e-prepare-containers

--- a/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
+++ b/.github/workflows/frontend-unit-test-stress-test-flake-fix.yml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: 60
     name: Stress test frontend unit test flake fix
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -21,7 +21,7 @@ jobs:
       frontend_all: ${{ steps.changes.outputs.frontend_all }}
       e2e_specs: ${{ steps.changes.outputs.e2e_specs }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
@@ -76,7 +76,7 @@ jobs:
       JEST_JUNIT_OUTPUT_DIR: ./target/junit
       JEST_JUNIT_OUTPUT_NAME: test-report-frontend-unit.xml
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - name: Prepare back-end environment
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - name: Prepare back-end environment

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       i18n: ${{ steps.changes.outputs.i18n }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - name: Prepare back-end environment

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
       with:

--- a/.github/workflows/percy-issue-comment.yml
+++ b/.github/workflows/percy-issue-comment.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           app_id: ${{ secrets.METABASE_BOT_APP_ID }}
           private_key: ${{ secrets.METABASE_BOT_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr_info.outputs.branch_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,7 +62,7 @@ jobs:
       CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
       CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.pr_info.outputs.branch_name }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/percy-visual-label.yml
+++ b/.github/workflows/percy-visual-label.yml
@@ -17,7 +17,7 @@ jobs:
       CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
       CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare front-end environment
         uses: ./.github/actions/prepare-frontend
       - name: Prepare back-end environment

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -133,7 +133,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
     - name: Check out the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ needs.release-artifact.outputs.commit }}
     - name: Prepare front-end environment
@@ -193,7 +193,7 @@ jobs:
           echo "VERSION=${{ needs.release-artifact.outputs.oss_version }}" >> $GITHUB_ENV
         fi
     - name: Check out the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ needs.release-artifact.outputs.commit }}
     - uses: actions/download-artifact@v3

--- a/.github/workflows/presto-kerberos-integration-test.yml
+++ b/.github/workflows/presto-kerberos-integration-test.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       backend_presto_kerberos: ${{ steps.changes.outputs.backend_presto_kerberos }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -41,11 +41,11 @@ jobs:
             && sudo ./install \
             && cd -
       - name: Checkout Metabase repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check out Presto Kerberos Docker Compose
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: metabase/presto-kerberos-docker
           ref: master
@@ -64,7 +64,7 @@ jobs:
       - name: Copy client.keytab file to resources
         run: docker cp presto-kerberos:/home/presto/client.keytab resources
       - name: Checkout mba
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: metabase/mba
           ref: master

--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: release
     - name: Prepare build scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         echo "It must start with either 'v0.' or 'v1.'."
         echo "Please, try again."
         exit 1
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: release
     - name: Prepare build scripts
@@ -174,7 +174,7 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: release
     - name: prepare release scripts
@@ -285,7 +285,7 @@ jobs:
         ports:
           - 5000:5000
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0  # IMPORTANT! to get all the tags
     - name: prepare release scripts
@@ -437,7 +437,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: release
     - name: prepare release scripts
@@ -514,7 +514,7 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: release
       - name: prepare release scripts
@@ -570,7 +570,7 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY }}
         aws-region: ${{ vars.AWS_REGION }}
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: release
     - name: Prepare build scripts
@@ -617,7 +617,7 @@ jobs:
     needs: [draft-release-notes, publish-version-info] # this will ensure that the milestone stays open until the release notes are published
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: release
     - name: Prepare build scripts

--- a/.github/workflows/require-percy-tests.yml
+++ b/.github/workflows/require-percy-tests.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       visualizations: ${{ steps.changes.outputs.visualizations }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes

--- a/.github/workflows/snowplow.yml
+++ b/.github/workflows/snowplow.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       snowplow: ${{ steps.changes.outputs.snowplow }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -27,6 +27,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Lint
         run: docker run -v $(pwd):/snowplow snowplow/igluctl:0.6.0 lint snowplow

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -19,7 +19,7 @@ jobs:
     name: Generate Snyk report
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Prepare back-end environment
         uses: ./.github/actions/prepare-backend
         with:

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -32,7 +32,7 @@ jobs:
       INTERACTIVE: false
     steps:
     - name: Check out the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.commit }}
     - name: Prepare front-end environment
@@ -94,7 +94,7 @@ jobs:
     - name: Verify the intended tag of the container image
       run: echo "Container image will be tagged as ${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}"
     - name: Check out the code (Dockerfile needed)
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.commit }}
     - name: Download uploaded artifacts to insert into container
@@ -211,7 +211,7 @@ jobs:
       - name: Verify the intended tag of the container image
         run: echo "Container image will be tagged as ${{ steps.extract_branch.outputs.branch }}-${{ matrix.edition }}"
       - name: Check out the code (Dockerfile needed)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.commit }}
       - name: Download uploaded artifacts to insert into container

--- a/.github/workflows/whitespace.yml
+++ b/.github/workflows/whitespace.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Prepare back-end environment
       uses: ./.github/actions/prepare-backend
       with:

--- a/.github/workflows/yaml.yml
+++ b/.github/workflows/yaml.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       yaml: ${{ steps.changes.outputs.yaml }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Test which files changed
         uses: dorny/paths-filter@v2.11.1
         id: changes
@@ -28,7 +28,7 @@ jobs:
     if: needs.files-changed.outputs.yaml == 'true'
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Prepare front-end environment
       uses: ./.github/actions/prepare-frontend
     - run: yarn run lint-yaml

--- a/docs/developers-guide/drivers/driver-tests.md
+++ b/docs/developers-guide/drivers/driver-tests.md
@@ -6,10 +6,10 @@ title: Submitting a PR for a new driver
 
 If you want to submit a PR to add a driver plugin to the [Metabase repo](https://github.com/metabase/metabase) (as opposed to keeping it in a separate repo), you'll need to:
 
-- Be able to run your database locally with Docker. 
+- Be able to run your database locally with Docker.
 - Make sure your driver passes Metabase's core test suite.
 
-## Testing your driver 
+## Testing your driver
 
 To test your driver, you'll need to:
 
@@ -157,10 +157,10 @@ Let's take a look at what's going on here.
 
 ### Connection context
 
-`tx/dbdef->connection-details` is called in two different contexts: 
+`tx/dbdef->connection-details` is called in two different contexts:
 
 - When creating a database,
-- And when loading data into one and syncing. 
+- And when loading data into one and syncing.
 
 Most databases won't let you connect to a database that hasn't been created yet, meaning something like a `CREATE DATABASE "test-data";` statement would have to be ran _without_ specifying `test-data` as part of the connection. Thus, the `context` parameter. `context` is either `:server`, meaning "give me details for connecting to the DBMS server, but not to a specific database", or `:db`, meaning "give me details for connecting to a specific database". In MySQL's case, it adds the `:db` connection property whenever context is `:db`.
 
@@ -228,7 +228,7 @@ be-tests-postgres-latest-ee:
         POSTGRES_DB: circle_test
         POSTGRES_HOST_AUTH_METHOD: trust
   steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - name: Test Postgres driver (latest)
     uses: ./.github/actions/test-driver
     with:


### PR DESCRIPTION
Completes one of the tasks in #38301

### How to make sure things are working
- All tests must pass CI
- When observing any job summary, warnings related to `actions/checkout` should not be present