### PR TITLE
Upgrade `actions/upload-artifact` and `actions/download-artifact` action to v4

### DIFF
--- a/.github/actions/prepare-uberjar-artifact/action.yml
+++ b/.github/actions/prepare-uberjar-artifact/action.yml
@@ -16,7 +16,7 @@ runs:
       run: sha256sum ./target/uberjar/metabase.jar > SHA256.sum
       shell: bash
     - name: Upload JARs as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.name }}
         path: |

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Build static-viz frontend
         run: yarn build-static-viz
       - name: Upload Static Viz Bundle Artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: static-viz-bundle-${{ github.sha }}
           path: resources/frontend_client/app/dist

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -196,7 +196,7 @@ jobs:
         run: yarn build-static-viz
       - name: Download Static Viz Bundle Artifact
         if: needs.static-viz-files-changed.outputs.static_viz == 'true'
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: static-viz-bundle-${{ github.sha }}
           path: resources/frontend_client/app/dist

--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -185,7 +185,7 @@ jobs:
       run: sha256sum ./metabase.jar > SHA256.sum
       shell: bash
     - name: Upload JARs as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: metabase-release-${{ matrix.edition }}-${{ inputs.commit }}-uberjar
         path: |

--- a/.github/workflows/e2e-cross-version.yml
+++ b/.github/workflows/e2e-cross-version.yml
@@ -86,7 +86,7 @@ jobs:
           --config-file e2e/test/scenarios/cross-version/target/shared/cross-version-target.config.js \
           --spec e2e/test/scenarios/cross-version/target/**/*.cy.spec.js
     - name: Upload Cypress Artifacts upon failure
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: cypress-artifacts-${{ matrix.version.source}}-to-${{ matrix.version.target }}

--- a/.github/workflows/e2e-stress-test-flake-fix.yml
+++ b/.github/workflows/e2e-stress-test-flake-fix.yml
@@ -98,7 +98,7 @@ jobs:
           --browser 'replay-chromium'
 
       - name: Upload Cypress Artifacts upon failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-failed-tests-recording

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -193,7 +193,7 @@ jobs:
           trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
 
       - name: Upload Cypress Artifacts upon failure
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-recording-${{ matrix.name }}-${{ matrix.edition }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -114,7 +114,7 @@ jobs:
           mongo: ${{ matrix.name == 'mongo'}}
 
       - name: Retrieve uberjar artifact for ${{ matrix.edition }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: metabase-${{ matrix.edition }}-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
 
@@ -235,7 +235,7 @@ jobs:
           maildev: true
 
       - name: Retrieve uberjar artifact for ${{ matrix.edition }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: metabase-ee-${{ github.event.pull_request.head.sha || github.sha }}-uberjar
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -73,7 +73,7 @@ jobs:
           fi
         shell: bash
       - name: Upload Metabase ${{ matrix.edition }} JAR as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: metabase-${{ matrix.edition }}-uberjar
           path: |
@@ -161,7 +161,7 @@ jobs:
         yarn test-cypress-run --folder onboarding
 
     - name: Upload Cypress Artifacts upon failure
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: cypress-failed-tests-recording

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -98,7 +98,7 @@ jobs:
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
     - run: java -version
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       name: Retrieve uberjar artifact
       with:
         name: metabase-${{ matrix.edition }}-uberjar
@@ -147,7 +147,7 @@ jobs:
       uses: ./.github/actions/prepare-cypress
     - name: Run Snowplow micro
       uses: ./.github/actions/run-snowplow-micro
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       name: Retrieve uberjar artifact for ${{ matrix.edition }}
       with:
         name: metabase-${{ matrix.edition }}-uberjar
@@ -196,7 +196,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: ${{ needs.release-artifact.outputs.commit }}
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       name: Retrieve uberjar artifact
       with:
         name: metabase-${{ matrix.edition }}-uberjar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
         sparse-checkout: release
     - name: prepare release scripts
       run: cd release && yarn && yarn build
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       name: Retrieve uberjar artifact
       with:
         name: metabase-${{ matrix.edition }}-uberjar
@@ -246,7 +246,7 @@ jobs:
       matrix:
         edition: [oss, ee]
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       name: Retrieve uberjar artifact
       with:
         name: metabase-${{ matrix.edition }}-uberjar
@@ -323,7 +323,7 @@ jobs:
           console.log("Latest version?", isLatest);
 
           return isLatest ? "latest" : "not-latest";
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       name: Retrieve previously downloaded Uberjar
       with:
         name: metabase-${{ matrix.edition }}-uberjar
@@ -519,7 +519,7 @@ jobs:
           sparse-checkout: release
       - name: prepare release scripts
         run: cd release && yarn && yarn build
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Retrieve uberjar artifact
         with:
           name: metabase-${{ matrix.edition }}-uberjar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
         # ensure the build is not a snapshot build
         grep -q "SNAPSHOT" version.properties && (echo "jar is a snapshot" && exit 1) || echo "jar is not a snapshot build"
     - name: Upload Uberjar as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: metabase-${{ matrix.edition }}-uberjar
         path: |

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -65,7 +65,7 @@ jobs:
         java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
     - run: java -version
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       name: Retrieve uberjar artifact
       with:
         name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
@@ -98,7 +98,7 @@ jobs:
       with:
         ref: ${{ github.event.inputs.commit }}
     - name: Download uploaded artifacts to insert into container
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
         path: bin/docker/
@@ -215,7 +215,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit }}
       - name: Download uploaded artifacts to insert into container
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: metabase-${{ matrix.edition }}-${{ github.sha }}-uberjar
           path: bin/docker/


### PR DESCRIPTION
This PR upgrades upload and download artifact actions to their latest version `v4`.
Since these actions are used in the release process, I'd feel better if @iethree gave an explicit approval.

Here's the related documentation re: the migration from v3 to v4.
- https://github.com/actions/download-artifact?tab=readme-ov-file#v4---whats-new
- https://github.com/actions/download-artifact/blob/main/docs/MIGRATION.md