### PR TITLE
use different folders for oss and ee for webpack cache

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ const WebpackNotifierPlugin = require("webpack-notifier");
 const ReactRefreshPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 
 const fs = require("fs");
+const path = require("path");
 
 const ASSETS_PATH = __dirname + "/resources/frontend_client/app/assets";
 const FONTS_PATH = __dirname + "/resources/frontend_client/app/fonts";
@@ -30,6 +31,7 @@ const E2E_PATH = __dirname + "/e2e";
 const WEBPACK_BUNDLE = process.env.WEBPACK_BUNDLE || "development";
 const devMode = WEBPACK_BUNDLE !== "production";
 const useFilesystemCache = process.env.FS_CACHE === "true";
+const edition = process.env.MB_EDITION || "oss";
 const shouldUseEslint =
   process.env.WEBPACK_BUNDLE !== "production" &&
   process.env.USE_ESLINT === "true";
@@ -181,6 +183,11 @@ const config = (module.exports = {
   cache: useFilesystemCache
     ? {
         type: "filesystem",
+        cacheDirectory: path.resolve(
+          __dirname,
+          "node_modules/.cache/",
+          edition === "oss" ? "webpack-oss" : "webpack-ee",
+        ),
         buildDependencies: {
           // invalidates the cache on configuration change
           config: [__filename],


### PR DESCRIPTION

### Description

If we don't wanna run into the annoying memory leak issue with webpack, some of us use `FS_CACHE=true`.

Our doc says:
> When using FS_CACHE=true you may need to remove the node_modules/.cache directory to fix scenarios where the build may be improperly cached, and **you must run rm -rf node_modules/.cache in order for the build to work correctly when alternating between open source and enterprise builds of the codebase**.

This is easy to forget and we may run into weird and hard to debug issues, this PR should fix that by using different cache folders based on the MB_EDITION env var

### How to verify

Not sure if there is a easy to reproduce error that should happen without this when switching between oss and ee, but everything should work fine and we should see the two folders being created when running `MB_EDITION=oss yarn build:hot` and then `MB_EDITION=ee yarn build:hot`

### Demo

<img width="287" alt="image" src="https://github.com/metabase/metabase/assets/1914270/c9ccb066-b50c-49a4-82f0-9bff6ea44494">


