### PR TITLE
[E2E] Overload the existing E2E `visitDashboard` helper to make it work with the alias

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -160,15 +160,15 @@ export function visitModel(id, { hasDataAccess = true } = {}) {
  */
 export function visitDashboard(dashboardIdOrAlias, { params = {} } = {}) {
   if (typeof dashboardIdOrAlias === "number") {
-    _visitDashboard(dashboardIdOrAlias, { params });
+    visitDashboardById(dashboardIdOrAlias, { params });
   }
 
   if (typeof dashboardIdOrAlias === "string") {
-    _visitDashboardAlias(dashboardIdOrAlias, { params });
+    visitDashboardByAlias(dashboardIdOrAlias, { params });
   }
 }
 
-function _visitDashboard(dashboard_id, config) {
+function visitDashboardById(dashboard_id, config) {
   // Some users will not have permissions for this request
   cy.request({
     method: "GET",
@@ -234,7 +234,7 @@ function _visitDashboard(dashboard_id, config) {
  * Visit a dashboard by using its previously saved dashboard id alias.
  * @param {string} alias
  */
-function _visitDashboardAlias(alias, config) {
+function visitDashboardByAlias(alias, config) {
   cy.get(alias).then(id => visitDashboard(id, config));
 }
 

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -219,6 +219,14 @@ export function visitDashboard(dashboard_id, { params = {} } = {}) {
   });
 }
 
+/**
+ * Visit a dashboard by using its previously saved dashboard id alias.
+ * @param {string} alias
+ */
+export function visitDashboardAlias(alias) {
+  cy.get(alias).then(id => visitDashboard(id));
+}
+
 function hasAccess(statusCode) {
   return statusCode !== 403;
 }

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -155,9 +155,20 @@ export function visitModel(id, { hasDataAccess = true } = {}) {
 /**
  * Visit a dashboard and wait for the related queries to load.
  *
- * @param {number} dashboard_id
+ * @param {number|string} dashboardIdOrAlias
+ * @param {Object} config
  */
-export function visitDashboard(dashboard_id, { params = {} } = {}) {
+export function visitDashboard(dashboardIdOrAlias, { params = {} } = {}) {
+  if (typeof dashboardIdOrAlias === "number") {
+    _visitDashboard(dashboardIdOrAlias, { params });
+  }
+
+  if (typeof dashboardIdOrAlias === "string") {
+    _visitDashboardAlias(dashboardIdOrAlias, { params });
+  }
+}
+
+function _visitDashboard(dashboard_id, config) {
   // Some users will not have permissions for this request
   cy.request({
     method: "GET",
@@ -203,7 +214,7 @@ export function visitDashboard(dashboard_id, { params = {} } = {}) {
 
       cy.visit({
         url: `/dashboard/${dashboard_id}`,
-        qs: params,
+        qs: config.params,
       });
 
       cy.wait(aliases);
@@ -223,8 +234,8 @@ export function visitDashboard(dashboard_id, { params = {} } = {}) {
  * Visit a dashboard by using its previously saved dashboard id alias.
  * @param {string} alias
  */
-export function visitDashboardAlias(alias) {
-  cy.get(alias).then(id => visitDashboard(id));
+function _visitDashboardAlias(alias, config) {
+  cy.get(alias).then(id => visitDashboard(id, config));
 }
 
 function hasAccess(statusCode) {

--- a/e2e/support/integration/visit-dashboard.cy.spec.js
+++ b/e2e/support/integration/visit-dashboard.cy.spec.js
@@ -18,39 +18,27 @@ describe(`visitDashboard e2e helper`, () => {
       });
 
       it("should work on an empty dashboard", () => {
-        cy.get("@emptyDashboard").then(id => {
-          visitDashboard(id);
-        });
+        visitDashboard("@emptyDashboard");
       });
 
       it("should work on a dashboard with markdown card", () => {
-        cy.get("@markdownOnly").then(id => {
-          visitDashboard(id);
-        });
+        visitDashboard("@markdownOnly");
       });
 
       it("should work on a dashboard with a model", () => {
-        cy.get("@modelDashboard").then(id => {
-          visitDashboard(id);
-        });
+        visitDashboard("@modelDashboard");
       });
 
       it("should work on a dashboard with a GUI question", () => {
-        cy.get("@guiDashboard").then(id => {
-          visitDashboard(id);
-        });
+        visitDashboard("@guiDashboard");
       });
 
       it("should work on a dashboard with a native question", () => {
-        cy.get("@nativeDashboard").then(id => {
-          visitDashboard(id);
-        });
+        visitDashboard("@nativeDashboard");
       });
 
       it("should work on a dashboard with multiple cards (including markdown, models, pivot tables, GUI and native)", () => {
-        cy.get("@multiDashboard").then(id => {
-          visitDashboard(id);
-        });
+        visitDashboard("@multiDashboard");
       });
     });
   });

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -76,9 +76,7 @@ describe(
 
       it("does not show model actions in model visualization on a dashboard", () => {
         asAdmin(() => {
-          cy.get("@dashboardId").then(dashboardId => {
-            visitDashboard(dashboardId);
-          });
+          visitDashboard("@dashboardId");
 
           cy.findByTestId("dashcard").within(() => {
             assertActionsDropdownNotExists();

--- a/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-on-dashboards.cy.spec.js
@@ -434,9 +434,7 @@ const MODEL_NAME = "Test Action Model";
               cy.findByText("Update").click();
             });
 
-            cy.get("@dashboardId").then(dashboardId => {
-              visitDashboard(dashboardId);
-            });
+            visitDashboard("@dashboardId");
 
             cy.findByRole("button", { name: "Update Score" }).click();
 

--- a/e2e/test/scenarios/actions/reproductions/32974-linked-parameter-via-url-does-not-work.cy.spec.js
+++ b/e2e/test/scenarios/actions/reproductions/32974-linked-parameter-via-url-does-not-work.cy.spec.js
@@ -8,6 +8,7 @@ import {
   setActionsEnabledForDB,
   undoToast,
   getDashboardCard,
+  visitDashboard,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
@@ -104,9 +105,7 @@ describe("Issue 32974", { tags: ["@external", "@actions"] }, () => {
 
     setupDashboard();
 
-    cy.get("@dashboardId").then(dashboardId => {
-      cy.visit({ url: `/dashboard/${dashboardId}`, qs: { id: 1 } });
-    });
+    visitDashboard("@dashboardId", { params: { id: 1 } });
 
     cy.log("Execute action");
     cy.button(QUERY_ACTION.name).click();

--- a/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
@@ -231,10 +231,8 @@ describe("scenarios > dashboard cards > replace question", () => {
 });
 
 function visitDashboardAndEdit() {
-  cy.get("@dashboardId").then(dashboardId => {
-    visitDashboard(dashboardId);
-    cy.findByLabelText("Edit dashboard").click();
-  });
+  visitDashboard("@dashboardId");
+  cy.findByLabelText("Edit dashboard").click();
 }
 
 function findHeadingDashcard() {

--- a/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
@@ -74,10 +74,8 @@ describe("scenarios > dashboard cards > duplicate", () => {
 
   it("should allow the user to duplicate a dashcard", () => {
     // 1. Confirm duplication works
-    cy.get("@dashboardId").then(dashboardId => {
-      visitDashboard(dashboardId);
-      cy.findByLabelText("Edit dashboard").click();
-    });
+    visitDashboard("@dashboardId");
+    cy.findByLabelText("Edit dashboard").click();
 
     findDashCardAction(getDashboardCard(0), "Duplicate").click();
     saveDashboard();
@@ -96,10 +94,8 @@ describe("scenarios > dashboard cards > duplicate", () => {
 
   it("should allow the user to duplicate a tab", () => {
     // 1. Confirm duplication works
-    cy.get("@dashboardId").then(dashboardId => {
-      visitDashboard(dashboardId);
-      cy.findByLabelText("Edit dashboard").click();
-    });
+    visitDashboard("@dashboardId");
+    cy.findByLabelText("Edit dashboard").click();
 
     duplicateTab("Tab 1");
     saveDashboard();

--- a/e2e/test/scenarios/dashboard-cards/reproductions/22265-broken-added-series-prevents-editing-card.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/reproductions/22265-broken-added-series-prevents-editing-card.cy.spec.js
@@ -77,10 +77,7 @@ describe("issue 22265", () => {
       cy.request("PUT", `/api/card/${invalidQuestionId}`, questionDetailUpdate);
     });
 
-    cy.get("@dashboardId").then(dashboardId => {
-      visitDashboard(dashboardId);
-    });
-
+    visitDashboard("@dashboardId");
     editDashboard();
     cy.findByTestId("add-series-button").click({ force: true });
     cy.wait("@seriesQuery");

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -667,9 +667,7 @@ const openDashboard = (params = {}) => {
     "cardQuery",
   );
 
-  cy.get("@dashboardId").then(dashboardId => {
-    visitDashboard(dashboardId, { params });
-  });
+  visitDashboard("@dashboardId", { params });
 };
 
 const openSlowDashboard = (params = {}) => {

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -675,12 +675,7 @@ const openSlowDashboard = (params = {}) => {
     "cardQuery",
   );
 
-  cy.get("@dashboardId").then(dashboardId => {
-    return cy.visit({
-      url: `/dashboard/${dashboardId}`,
-      qs: params,
-    });
-  });
+  visitDashboard("@dashboardId", { params });
 
   getDashboardCard().should("be.visible");
 };

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-auto-apply.cy.spec.js
@@ -675,7 +675,12 @@ const openSlowDashboard = (params = {}) => {
     "cardQuery",
   );
 
-  visitDashboard("@dashboardId", { params });
+  cy.get("@dashboardId").then(dashboardId => {
+    return cy.visit({
+      url: `/dashboard/${dashboardId}`,
+      qs: params,
+    });
+  });
 
   getDashboardCard().should("be.visible");
 };

--- a/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/parameters.cy.spec.js
@@ -1038,9 +1038,7 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should autowire and filter cards with foreign keys when added to the dashboard via the sidebar", () => {
-        cy.get("@dashboardId").then(dashboardId => {
-          visitDashboard(dashboardId);
-        });
+        visitDashboard("@dashboardId");
         editDashboard();
         setFilter("ID");
         selectDashboardFilter(getDashboardCard(0), "ID");
@@ -1080,10 +1078,7 @@ describe("scenarios > dashboard > parameters", () => {
       });
 
       it("should autowire and filter cards with foreign keys when added to the dashboard via the query builder", () => {
-        cy.get("@dashboardId").then(dashboardId => {
-          visitDashboard(dashboardId);
-        });
-
+        visitDashboard("@dashboardId");
         editDashboard();
         setFilter("ID");
         selectDashboardFilter(getDashboardCard(0), "ID");

--- a/e2e/test/scenarios/dashboard-filters/reproductions/29347-remapped-field-values.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/29347-remapped-field-values.cy.spec.js
@@ -58,7 +58,7 @@ describe("issues 29347, 29346", () => {
 
     it("should be able to filter on remapped values (metabase#29347, metabase#29346)", () => {
       createDashboard();
-      cy.get("@dashboardId").then(dashboardId => visitDashboard(dashboardId));
+      visitDashboard("@dashboardId");
       cy.wait("@dashboard");
       cy.wait("@cardQuery");
 
@@ -70,11 +70,10 @@ describe("issues 29347, 29346", () => {
 
     it("should be able to filter on remapped values in the url (metabase#29347, metabase#29346)", () => {
       createDashboard();
-      cy.get("@dashboardId").then(dashboardId => {
-        visitDashboard(dashboardId, {
-          params: { [filterDetails.slug]: filterValue },
-        });
+      visitDashboard("@dashboardId", {
+        params: { [filterDetails.slug]: filterValue },
       });
+
       cy.wait("@dashboard");
       cy.wait("@cardQuery");
 

--- a/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-back-navigation.cy.spec.js
@@ -87,7 +87,7 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
 
   it("should expand the native editor when editing a question from a dashboard", () => {
     createDashboardWithNativeCard();
-    cy.get("@dashboardId").then(visitDashboard);
+    visitDashboard("@dashboardId");
     getDashboardCard().realHover();
     getDashboardCardMenu().click();
     popover().findByText("Edit question").click();
@@ -150,7 +150,7 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
 
   it("should preserve query results when navigating between the dashboard and the query builder", () => {
     createDashboardWithCards();
-    cy.get("@dashboardId").then(visitDashboard);
+    visitDashboard("@dashboardId");
     cy.wait("@dashboard");
     cy.wait("@dashcardQuery");
 
@@ -225,7 +225,7 @@ describe("scenarios > dashboard > dashboard back navigation", () => {
   it("should navigate back to a dashboard with permission errors", () => {
     createDashboardWithPermissionError();
     cy.signInAsNormalUser();
-    cy.get("@dashboardId").then(visitDashboard);
+    visitDashboard("@dashboardId");
     cy.wait("@dashboard");
     cy.wait("@dashcardQuery");
 

--- a/e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js
@@ -26,7 +26,7 @@ describe("issue 34382", () => {
     { tags: "@flaky" },
     () => {
       createDashboardWithCards();
-      cy.get("@dashboardId").then(visitDashboard);
+      visitDashboard("@dashboardId");
 
       addFilterValue("Gizmo");
       applyFilter();

--- a/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/title-drill.cy.spec.js
@@ -400,21 +400,19 @@ describe("scenarios > dashboard > title drill", () => {
     });
 
     it("should lead you to a table question with filtered ID (metabase#17213)", () => {
-      cy.get("@dashboardId").then(dashboardId => {
-        const productRecordId = 3;
-        visitDashboard(dashboardId, { params: { id: productRecordId } });
+      const productRecordId = 3;
+      visitDashboard("@dashboardId", { params: { id: productRecordId } });
 
-        getDashboardCard().findByText(baseNestedQuestionDetails.name).click();
+      getDashboardCard().findByText(baseNestedQuestionDetails.name).click();
 
-        appBar()
-          .contains(`Started from ${baseNestedQuestionDetails.name}`)
-          .should("be.visible");
-        cy.findByTestId("question-row-count")
-          .findByText("Showing 1 row")
-          .should("be.visible");
+      appBar()
+        .contains(`Started from ${baseNestedQuestionDetails.name}`)
+        .should("be.visible");
+      cy.findByTestId("question-row-count")
+        .findByText("Showing 1 row")
+        .should("be.visible");
 
-        cy.findByTestId("object-detail").should("not.exist");
-      });
+      cy.findByTestId("object-detail").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -50,9 +50,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
 
   context("UI", () => {
     it("should be disabled by default but able to be set to editable and/or locked (metabase#20357)", () => {
-      cy.get("@dashboardId").then(dashboardId => {
-        visitDashboard(dashboardId);
-      });
+      visitDashboard("@dashboardId");
 
       openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: true });
 
@@ -133,9 +131,7 @@ describe("scenarios > embedding > dashboard parameters", () => {
       );
       cy.signInAsAdmin();
 
-      cy.get("@dashboardId").then(dashboardId => {
-        visitDashboard(dashboardId);
-      });
+      visitDashboard("@dashboardId");
 
       openStaticEmbeddingModal({ activeTab: "parameters", acceptTerms: false });
 
@@ -396,9 +392,7 @@ describe("scenarios > embedding > dashboard parameters with defaults", () => {
       mapParameters({ id, card_id, dashboard_id });
     });
 
-    cy.get("@dashboardId").then(dashboardId => {
-      visitDashboard(dashboardId);
-    });
+    visitDashboard("@dashboardId");
   });
 
   it("card parameter defaults should apply for disabled parameters, but not for editable or locked parameters", () => {

--- a/e2e/test/scenarios/filters/view.cy.spec.js
+++ b/e2e/test/scenarios/filters/view.cy.spec.js
@@ -109,9 +109,8 @@ describe("scenarios > question > view", () => {
     it("should be able to filter Q by Vendor as user (from Dashboard) (metabase#12654)", () => {
       // Navigate to Q from Dashboard
       cy.signIn("nodata");
-      cy.get("@dashboardId").then(dashboardId => {
-        visitDashboard(dashboardId);
-      });
+      visitDashboard("@dashboardId");
+
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Question").click();
 

--- a/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
@@ -96,9 +96,7 @@ describe("issue 29517 - nested question based on native model with remapped valu
   });
 
   it("click behavior to custom destination should work (metabase#29517-2)", () => {
-    cy.get("@dashboardId").then(id => {
-      visitDashboard(id);
-    });
+    visitDashboard("@dashboardId");
 
     cy
       .intercept("GET", `/api/dashboard/${ORDERS_DASHBOARD_ID}`)

--- a/e2e/test/scenarios/permissions/reproductions/24966-saved-native-q-field-values.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/24966-saved-native-q-field-values.cy.spec.js
@@ -106,20 +106,18 @@ describeEE("issue 24966", () => {
   });
 
   it("should correctly fetch field values for a filter when native question is used for sandboxing (metabase#24966)", () => {
-    cy.get("@dashboardId").then(id => {
-      cy.signIn("nodata");
-      visitDashboard(id);
-      filterWidget().click();
-      cy.findByTestId("Gizmo-filter-value").click();
-      cy.button("Add filter").click();
-      cy.location("search").should("eq", "?text=Gizmo");
+    cy.signIn("nodata");
+    visitDashboard("@dashboardId");
+    filterWidget().click();
+    cy.findByTestId("Gizmo-filter-value").click();
+    cy.button("Add filter").click();
+    cy.location("search").should("eq", "?text=Gizmo");
 
-      cy.signInAsSandboxedUser();
-      visitDashboard(id);
-      filterWidget().click();
-      cy.findByTestId("Widget-filter-value").click();
-      cy.button("Add filter").click();
-      cy.location("search").should("eq", "?text=Widget");
-    });
+    cy.signInAsSandboxedUser();
+    visitDashboard("@dashboardId");
+    filterWidget().click();
+    cy.findByTestId("Widget-filter-value").click();
+    cy.button("Add filter").click();
+    cy.location("search").should("eq", "?text=Widget");
   });
 });

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -93,9 +93,7 @@ describe("scenarios > public > dashboard", () => {
   });
 
   it("should allow users to create public dashboards", () => {
-    cy.get("@dashboardId").then(id => {
-      visitDashboard(id);
-    });
+    visitDashboard("@dashboardId");
 
     openNewPublicLinkDropdown("dashboard");
 
@@ -116,9 +114,7 @@ describe("scenarios > public > dashboard", () => {
     });
 
     cy.signInAsNormalUser().then(() => {
-      cy.get("@dashboardId").then(id => {
-        visitDashboard(id);
-      });
+      visitDashboard("@dashboardId");
 
       cy.icon("share").click();
 

--- a/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-sharing-embed-button-behavior.cy.spec.js
@@ -199,9 +199,7 @@ describe("embed modal display", () => {
   describeEE("when the user has a paid instance", () => {
     it("should display a link to the interactive embedding settings", () => {
       setTokenFeatures("all");
-      cy.get("@dashboardId").then(id => {
-        visitResource("dashboard", id);
-      });
+      visitDashboard("@dashboardId");
 
       openEmbedModalFromMenu();
 
@@ -229,9 +227,7 @@ describe("embed modal display", () => {
   describe("when the user has an OSS instance", () => {
     it("should display a link to the product page for embedded analytics", () => {
       cy.signInAsAdmin();
-      cy.get("@dashboardId").then(id => {
-        visitResource("dashboard", id);
-      });
+      visitDashboard("@dashboardId");
       openEmbedModalFromMenu();
 
       getEmbedModalSharingPane().within(() => {

--- a/e2e/test/scenarios/visualizations-charts/reproductions/21665-multi-series-frontend-reload.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/21665-multi-series-frontend-reload.cy.spec.js
@@ -60,9 +60,7 @@ describe("issue 21665", () => {
       editQ2NativeQuery("select order by --", questionId);
     });
 
-    cy.get("@dashboardId").then(id => {
-      visitDashboard(id);
-    });
+    visitDashboard("@dashboardId");
 
     cy.get("@dashboardLoaded").should("have.been.calledThrice");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage


### PR DESCRIPTION
This PR overloads the existing `visitDashboard` E2E helper to make it accept either:
1. a direct dashboard id (number) or
2. a dashboard id alias (string)

It then replaces and updates related specs that were grabbing the dashboard id alias and then calling the `visitDashboard` function. The code can be simplified like this:

```diff
- cy.get("@emptyDashboard").then(id => {
-   visitDashboard(id);
- });
+ visitDashboard("@emptyDashboard");
```