### PR TITLE
Fix issue where reverted question does not use parameter values

### DIFF
--- a/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
@@ -28,7 +28,8 @@ describe("issue 38176", () => {
     );
 
     cy.findByPlaceholderText("Country").type("NL");
-    cy.get("button[aria-label='Get Answer']").first().click();
+
+    cy.findByTestId("query-builder-main").button("Get Answer").click();
 
     questionInfoButton().click();
     rightSidebar().within(() => {

--- a/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
@@ -45,8 +45,6 @@ describe("issue 38176", () => {
       cy.findByText(/reverted to an earlier version/i).should("be.visible");
     });
 
-    cy.findByTestId("TableInteractive-root").within(() => {
-      cy.findByText("COUNTRY").should("be.visible");
-    });
+    cy.findAllByRole("gridcell").should("contain", "NL");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
@@ -27,7 +27,7 @@ describe("issue 38176", () => {
       { visitQuestion: true },
     );
 
-    cy.findByPlaceholderText("Country").type("NL", { delay: 0 });
+    cy.findByPlaceholderText("Country").type("NL");
     cy.get("button[aria-label='Get Answer']").first().click();
 
     questionInfoButton().click();

--- a/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
@@ -1,0 +1,52 @@
+import { restore, questionInfoButton, rightSidebar } from "e2e/support/helpers";
+
+describe("issue 38176", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("PUT", "/api/card/**").as("updateQuestion");
+  });
+
+  it("restoring a question to a previous version should preserve the variables", () => {
+    cy.createNativeQuestion(
+      {
+        name: "30165",
+        native: {
+          query:
+            'SELECT "COUNTRY" from "ACCOUNTS" WHERE country = {{ country }} LIMIT 5',
+          "template-tags": {
+            country: {
+              type: "text",
+              id: "dd06cd10-596b-41d0-9d6e-94e98ceaf989",
+              name: "country",
+              "display-name": "Country",
+            },
+          },
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    cy.findByPlaceholderText("Country").type("NL", { delay: 0 });
+    cy.get("button[aria-label='Get Answer']").first().click();
+
+    questionInfoButton().click();
+    rightSidebar().within(() => {
+      cy.findByText("History");
+
+      cy.findByPlaceholderText("Add description")
+        .type("This is a question")
+        .blur();
+
+      cy.wait("@updateQuestion");
+      cy.findByText(/added a description/i);
+      cy.findByTestId("question-revert-button").click();
+
+      cy.findByText(/reverted to an earlier version/i).should("be.visible");
+    });
+
+    cy.findByTestId("TableInteractive-root").within(() => {
+      cy.findByText("COUNTRY").should("be.visible");
+    });
+  });
+});

--- a/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
@@ -10,7 +10,7 @@ describe("issue 38176", () => {
   it("restoring a question to a previous version should preserve the variables (metabase#38176)", () => {
     cy.createNativeQuestion(
       {
-        name: "30165",
+        name: "38176",
         native: {
           query:
             'SELECT "COUNTRY" from "ACCOUNTS" WHERE country = {{ country }} LIMIT 5',

--- a/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/38176-revert-to-previous-does-not-honor-parameters.cy.spec.js
@@ -7,7 +7,7 @@ describe("issue 38176", () => {
     cy.intercept("PUT", "/api/card/**").as("updateQuestion");
   });
 
-  it("restoring a question to a previous version should preserve the variables", () => {
+  it("restoring a question to a previous version should preserve the variables (metabase#38176)", () => {
     cy.createNativeQuestion(
       {
         name: "30165",

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -77,6 +77,9 @@ export const reloadCard = createThunkAction(RELOAD_CARD, () => {
     );
     const card = Questions.HACK_getObjectFromAction(action);
 
+    // We need to manually massage the paramters into the parameterValues shape,
+    // to be able to pass them to new Question.
+    // We could use _parameterValues here but prefer not to use internal fields.
     const parameterValues = outdatedQuestion.parameters().reduce(
       (acc, next) => ({
         ...acc,

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -76,10 +76,19 @@ export const reloadCard = createThunkAction(RELOAD_CARD, () => {
       Questions.actions.fetch({ id: outdatedQuestion.id() }, { reload: true }),
     );
     const card = Questions.HACK_getObjectFromAction(action);
+
+    const parameterValues = outdatedQuestion.parameters().reduce(
+      (acc, next) => ({
+        ...acc,
+        [next.id]: next.value,
+      }),
+      {},
+    );
+
     const question = new Question(
       card,
       getMetadata(getState()),
-      outdatedQuestion._parameterValues,
+      parameterValues,
     );
 
     dispatch(loadMetadataForCard(card));

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -79,7 +79,7 @@ export const reloadCard = createThunkAction(RELOAD_CARD, () => {
     const question = new Question(
       card,
       getMetadata(getState()),
-      outdatedQuestion.parameters(),
+      outdatedQuestion._parameterValues,
     );
 
     dispatch(loadMetadataForCard(card));


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38176

### Description

Fixes #38176. The shape of the parameter values passed to `Question` was wrong.

My fix uses `question._parameterValues`. I'm not sure how to pull the current parameter values from a question in the correct shape, so I'm open to suggestions.

### How to verify

Describe the steps to verify that the changes are working as expected.
1. `New` → `SQL Query` → `Example Dataset`
2. Write a query:
   ```sql
   SELECT * FROM "ACCOUNTS" WHERE "COUNTRY" = {{ country }}
   ```
3. `Save` the question (ie, as `Foo`)
4. Edit the SQL to:
   ```sql
   SELECT * FROM "ACCOUNTS" WHERE "COUNTRY" = {{ country }} AND true
   ```
5. `Save` the question again and `Replace the original question 'Foo'`
6. Open saved question
7. Enter a value for the `Country` filter: `NL`
8. Run the question and make sure you're getting data
9. Click the `More info` button on the top right (`i`)
10. In the history sidebar, on the first version click the `Revert this version` button (`⟲`)
11. You should not see and error in the explorer, but instead see the data.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
