### PR TITLE
Migrate download perm enforcement to data_permissions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
@@ -86,5 +86,10 @@
                         {:type qp.error-type/missing-required-permissions
                          :permissions-error? true})))
       (qp query
-          (fn [metadata] (rff (some-> metadata (assoc :download_perms download-perms-level))))
+          (fn [metadata] (rff (some-> metadata
+                                      ;; Convert to API-style value names for the FE, for now
+                                      (assoc :download_perms (case download-perms-level
+                                                               :no :none
+                                                               :ten-thousand-rows :limited
+                                                               :one-million-rows :full)))))
           context))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
@@ -34,7 +34,9 @@
   (let [table-ids   (query-perms/query->source-table-ids (dissoc query :native))
         table-perms (into #{}
                           (map (fn [table-id]
-                                 (data-perms/table-permission-for-user api/*current-user-id* :perms/download-results db-id table-id))
+                                 (if (= table-id ::query-perms/native)
+                                   (data-perms/native-download-permission-for-user api/*current-user-id* db-id)
+                                   (data-perms/table-permission-for-user api/*current-user-id* :perms/download-results db-id table-id)))
                                table-ids))]
     ;; The download perm level for a query should be equal to the lowest perm level of any table referenced by the query.
     (or (table-perms :no)

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/query_processor/middleware/permissions.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.string :as str]
    [metabase.api.common :as api]
-   [metabase.models.permissions :as perms]
+   [metabase.models.data-permissions :as data-perms]
    [metabase.models.query.permissions :as query-perms]
    [metabase.public-settings.premium-features
     :as premium-features
@@ -17,78 +17,39 @@
   [query]
   (some-> query :info :context name (str/includes? "download")))
 
-(defn- table->download-perms-path
-  "Given a table-id referenced by a query, returns the permissions path required to download the results of the query
-  at the level specified by `download-level` (either :full or :limited)."
-  [db-id table-id download-level]
-  (first
-   (query-perms/tables->permissions-path-set
-    db-id
-    #{table-id}
-    {:table-perms-fn (fn [& path-components] (apply perms/feature-perms-path :download download-level path-components))
-     :native-perms-fn (fn [db-id] (perms/native-feature-perms-path :download download-level db-id))})))
-
-(defn- table-id->download-perms-level
-  "Given a table-id referenced by a query, returns the level at which the current user can download the data in the
-  table (:full, :limited or :none)."
-  [db-id table-id]
-  (cond (perms/set-has-full-permissions? @api/*current-user-permissions-set* (table->download-perms-path db-id table-id :full))
-        :full
-
-        (perms/set-has-full-permissions? @api/*current-user-permissions-set* (table->download-perms-path db-id table-id :limited))
-        :limited
-
-        :else
-        :none))
-
 (defmulti ^:private current-user-download-perms-level :type)
 
 (defmethod current-user-download-perms-level :default
   [_]
-  :full)
+  :one-million-rows)
 
 (defmethod current-user-download-perms-level :native
   [{database :database}]
-  (cond
-    (perms/set-has-full-permissions? @api/*current-user-permissions-set* (perms/native-feature-perms-path :download :full database))
-    :full
-
-    (perms/set-has-full-permissions? @api/*current-user-permissions-set* (perms/native-feature-perms-path :download :limited database))
-    :limited
-
-    :else
-    :none))
+  (data-perms/native-download-permission-for-user api/*current-user-id* database))
 
 (defmethod current-user-download-perms-level :query
   [{db-id :database, :as query}]
   ;; Remove the :native key (containing the transpiled MBQL) so that this helper function doesn't think the query is
   ;; a native query. Actual native queries are dispatched to a different method by the :type key.
-  (let [table-ids (query-perms/query->source-table-ids (dissoc query :native))]
+  (let [table-ids   (query-perms/query->source-table-ids (dissoc query :native))
+        table-perms (into #{}
+                          (map (fn [table-id]
+                                 (data-perms/table-permission-for-user api/*current-user-id* :perms/download-results db-id table-id))
+                               table-ids))]
     ;; The download perm level for a query should be equal to the lowest perm level of any table referenced by the query.
-    (reduce (fn [lowest-seen-perm-level table-id]
-              (let [table-perm-level (table-id->download-perms-level db-id table-id)]
-                (cond
-                  (= table-perm-level :none)
-                  (reduced :none)
-
-                  (or (= lowest-seen-perm-level :limited)
-                      (= table-perm-level :limited))
-                  :limited
-
-                  :else
-                  :full)))
-            :full
-            table-ids)))
+    (or (table-perms :no)
+        (table-perms :ten-thousand-rows)
+        :one-million-rows)))
 
 (defenterprise apply-download-limit
-  "Pre-processing middleware to apply row limits to MBQL export queries if the user has `limited` download perms. This
-  does not apply to native queries, which are instead limited by the [[limit-download-result-rows]] post-processing
-  middleware."
+  "Pre-processing middleware to apply row limits to MBQL export queries if the user has `ten-thousand-rows` download
+  perms. This does not apply to native queries, which are instead limited by the [[limit-download-result-rows]]
+  post-processing middleware."
   :feature :advanced-permissions
   [{query-type :type, {original-limit :limit} :query, :as query}]
   (if (and (is-download? query)
            (= query-type :query)
-           (= (current-user-download-perms-level query) :limited))
+           (= (current-user-download-perms-level query) :ten-thousand-rows))
     (assoc-in query
               [:query :limit]
               (apply min (filter some? [original-limit max-rows-in-limited-downloads])))
@@ -101,7 +62,7 @@
   :feature :advanced-permissions
   [query rff]
   (if (and (is-download? query)
-           (= (current-user-download-perms-level query) :limited))
+           (= (current-user-download-perms-level query) :ten-thousand-rows))
     (fn limit-download-result-rows* [metadata]
       ((take max-rows-in-limited-downloads) (rff metadata)))
     rff))
@@ -115,12 +76,12 @@
   :feature :advanced-permissions
   [qp]
   (fn [query rff context]
-    (let [download-perms-level (if api/*current-user-permissions-set*
+    (let [download-perms-level (if api/*current-user-id*
                                  (current-user-download-perms-level query)
                                  ;; If no user is bound, assume full download permissions (e.g. for public questions)
-                                 :full)]
+                                 :one-million-rows)]
       (when (and (is-download? query)
-                 (= download-perms-level :none))
+                 (= download-perms-level :no))
         (throw (ex-info (tru "You do not have permissions to download the results of this query.")
                         {:type qp.error-type/missing-required-permissions
                          :permissions-error? true})))

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/query-downloads.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/query-downloads.ts
@@ -2,10 +2,10 @@ import { t } from "ttag";
 import type { Dataset } from "metabase-types/api/dataset";
 
 export const canDownloadResults = (result: Dataset) =>
-  result.data?.download_perms !== "none";
+  result.data?.download_perms !== "no";
 
 export const getDownloadWidgetMessageOverride = (result: Dataset) => {
-  if (result.data?.download_perms === "limited") {
+  if (result.data?.download_perms === "ten-thousand-rows") {
     return t`You're allowed to download up to 10,000 rows.`;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/query-downloads.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/query-downloads.ts
@@ -2,10 +2,10 @@ import { t } from "ttag";
 import type { Dataset } from "metabase-types/api/dataset";
 
 export const canDownloadResults = (result: Dataset) =>
-  result.data?.download_perms !== "no";
+  result.data?.download_perms !== "none";
 
 export const getDownloadWidgetMessageOverride = (result: Dataset) => {
-  if (result.data?.download_perms === "ten-thousand-rows") {
+  if (result.data?.download_perms === "limited") {
     return t`You're allowed to download up to 10,000 rows.`;
   }
 

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -438,7 +438,8 @@
                                           :perm_value value
                                           :db_id      db-id})
       (when (= [:perms/data-access :block] [perm-type value])
-        (set-database-permission! group-or-id db-or-id :perms/native-query-editing :no)))))
+        (set-database-permission! group-or-id db-or-id :perms/native-query-editing :no)
+        (set-database-permission! group-or-id db-or-id :perms/download-results :no)))))
 
 (mu/defn set-table-permissions!
   "Sets table permissions to specified values for a given group. If a permission value already exists for a specified

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -263,9 +263,7 @@
           (-> (group-by :group_id perm-values)
               (update-vals (fn [perms]
                              (let [values (set (map :value perms))]
-                               (or (values :no)
-                                   (values :ten-thousand-rows)
-                                   (values :one-million-rows))))))]
+                               (coalesce-most-restrictive :perms/download-results values)))))]
       (or (coalesce :perms/download-results (vals value-by-group))
           (least-permissive-value :perms/download-results)))))
 

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -241,6 +241,26 @@
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
+(mu/defn native-download-permission-for-user :- PermissionValue
+  "Returns the effective download permission value for a given user and database ID, for native queries on the database.
+  This should be the lowest permission level of any table in the database."
+  [user-id database-id]
+  (if (is-superuser? user-id)
+    (most-permissive-value :perms/download-results)
+    (let [perm-values (t2/select-fn-set :value
+                                        :model/DataPermissions
+                                        {:select [[:p.perm_value :value]]
+                                         :from [[:permissions_group_membership :pgm]]
+                                         :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                                                [:data_permissions :p]   [:= :p.group_id :pg.id]]
+                                         :where [:and
+                                                 [:= :pgm.user_id user-id]
+                                                 [:= :p.perm_type (u/qualified-name :perms/download-results)]
+                                                 [:= :p.db_id database-id]]})]
+      (or (perm-values :no)
+          (perm-values :ten-thousand-rows)
+          (perm-values :one-million-rows)))))
+
 (mu/defn user-has-block-perms-for-database? :- :boolean
   "Returns a Boolean indicating whether the given user should have block permissions enforced for the given database.
   This is a standalone function because block perms are only set at the database-level, but :perms/data-access is

--- a/test/metabase/models/data_permissions/graph_test.clj
+++ b/test/metabase/models/data_permissions/graph_test.clj
@@ -68,7 +68,7 @@
                                ""
                                {table-id-3 :no-self-service}}}}}
 
-        ;; Setting block permissions for the database
+        ;; Setting block permissions for the database also sets :native-query-editing and :downlaod-results to :no
         {group-id-1
          {database-id-1
           {:data
@@ -77,7 +77,8 @@
         {group-id-1
           {database-id-1
            {:perms/native-query-editing :no
-            :perms/data-access :block}}}))))
+            :perms/data-access :block
+            :perms/download-results :no}}}))))
 
 (deftest update-db-level-download-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id-1 :id}      {}

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -310,59 +310,58 @@
   "Test helper to enable writing API-level export tests across multiple export endpoints and formats."
   [message {:keys [query viz-settings assertions endpoints user]}]
   (testing message
-    (mt/with-full-data-perms-for-all-users!
-      (let [query-json        (json/generate-string query)
-            viz-settings-json (json/generate-string viz-settings)
-            public-uuid       (str (random-uuid))
-            card-defaults     {:dataset_query query, :public_uuid public-uuid, :enable_embedding true}
-            user              (or user :rasta)]
-        (mt/with-temporary-setting-values [enable-public-sharing true
-                                           enable-embedding      true]
-          (embed-test/with-new-secret-key
-            (t2.with-temp/with-temp [Card          card      (if viz-settings
-                                                               (assoc card-defaults :visualization_settings viz-settings)
-                                                               card-defaults)
-                                     Dashboard     dashboard {:name "Test Dashboard"}
-                                     DashboardCard dashcard  {:card_id (u/the-id card) :dashboard_id (u/the-id dashboard)}]
-              (doseq [export-format (keys assertions)
-                      endpoint      (or endpoints [:dataset :card :dashboard :public :embed])]
-                (testing endpoint
-                  (case endpoint
-                    :dataset
-                    (let [results (mt/user-http-request user :post 200
-                                                        (format "dataset/%s" (name export-format))
-                                                        {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}}
-                                                        :query query-json
-                                                        :visualization_settings viz-settings-json)]
-                      ((-> assertions export-format) results))
+    (let [query-json        (json/generate-string query)
+          viz-settings-json (json/generate-string viz-settings)
+          public-uuid       (str (random-uuid))
+          card-defaults     {:dataset_query query, :public_uuid public-uuid, :enable_embedding true}
+          user              (or user :rasta)]
+      (mt/with-temporary-setting-values [enable-public-sharing true
+                                         enable-embedding      true]
+        (embed-test/with-new-secret-key
+          (t2.with-temp/with-temp [Card          card      (if viz-settings
+                                                             (assoc card-defaults :visualization_settings viz-settings)
+                                                             card-defaults)
+                                   Dashboard     dashboard {:name "Test Dashboard"}
+                                   DashboardCard dashcard  {:card_id (u/the-id card) :dashboard_id (u/the-id dashboard)}]
+            (doseq [export-format (keys assertions)
+                    endpoint      (or endpoints [:dataset :card :dashboard :public :embed])]
+              (testing endpoint
+                (case endpoint
+                  :dataset
+                  (let [results (mt/user-http-request user :post 200
+                                                      (format "dataset/%s" (name export-format))
+                                                      {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}}
+                                                      :query query-json
+                                                      :visualization_settings viz-settings-json)]
+                    ((-> assertions export-format) results))
 
-                    :card
-                    (let [results (mt/user-http-request user :post 200
-                                                        (format "card/%d/query/%s" (u/the-id card) (name export-format))
-                                                        {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
-                      ((-> assertions export-format) results))
+                  :card
+                  (let [results (mt/user-http-request user :post 200
+                                                      (format "card/%d/query/%s" (u/the-id card) (name export-format))
+                                                      {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
+                    ((-> assertions export-format) results))
 
-                    :dashboard
-                    (let [results (mt/user-http-request user :post 200
-                                                        (format "dashboard/%d/dashcard/%d/card/%d/query/%s"
-                                                                (u/the-id dashboard)
-                                                                (u/the-id dashcard)
-                                                                (u/the-id card)
-                                                                (name export-format))
-                                                        {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
-                      ((-> assertions export-format) results))
+                  :dashboard
+                  (let [results (mt/user-http-request user :post 200
+                                                      (format "dashboard/%d/dashcard/%d/card/%d/query/%s"
+                                                              (u/the-id dashboard)
+                                                              (u/the-id dashcard)
+                                                              (u/the-id card)
+                                                              (name export-format))
+                                                      {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
+                    ((-> assertions export-format) results))
 
-                    :public
-                    (let [results (mt/user-http-request user :get 200
-                                                        (format "public/card/%s/query/%s" public-uuid (name export-format))
-                                                        {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
-                      ((-> assertions export-format) results))
+                  :public
+                  (let [results (mt/user-http-request user :get 200
+                                                      (format "public/card/%s/query/%s" public-uuid (name export-format))
+                                                      {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
+                    ((-> assertions export-format) results))
 
-                    :embed
-                    (let [results (mt/user-http-request user :get 200
-                                                        (embed-test/card-query-url card (str "/" (name export-format)))
-                                                        {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
-                      ((-> assertions export-format) results))))))))))))
+                  :embed
+                  (let [results (mt/user-http-request user :get 200
+                                                      (embed-test/card-query-url card (str "/" (name export-format)))
+                                                      {:request-options {:as (if (= export-format :xlsx) :byte-array :string)}})]
+                    ((-> assertions export-format) results)))))))))))
 
 (defn- parse-json-results
   "Convert JSON results into a convenient format for test assertions. Results are transformed into a nested list,


### PR DESCRIPTION
Updates download permission enforcement to read from the `data_permissions` table.