### PR TITLE
[QC] Remove `hasData` method from the `StructuredQuery` prototype

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -321,7 +321,7 @@ class StructuredQuery extends AtomicQuery {
   }
 
   isValid() {
-    if (!this.hasData()) {
+    if (!this.table()) {
       return false;
     }
 
@@ -386,13 +386,6 @@ class StructuredQuery extends AtomicQuery {
       console.warn("Error thrown while validating clause", clause, e);
       return false;
     }
-  }
-
-  /**
-   * @deprecated use MLv2
-   */
-  hasData() {
-    return !!this.table();
   }
 
   hasAnyClauses() {


### PR DESCRIPTION
This PR is just a tiny cleanup step. The Boy Scouting rule applied.
Logically the code should behave the same as before, but we're removing a deprecated method from the StructuredQuery prototype.