### PR TITLE
deprecate trackStructEvent to avoid confusion

### DIFF
--- a/frontend/src/metabase/lib/analytics.js
+++ b/frontend/src/metabase/lib/analytics.js
@@ -31,6 +31,9 @@ export const trackPageView = url => {
   }
 };
 
+/**
+ * @deprecated This uses GA which is not setup. We should use `trackSchemaEvent`.
+ */
 export const trackStructEvent = (category, action, label, value) => {
   if (!category || !label || !Settings.trackingEnabled()) {
     return;


### PR DESCRIPTION

`trackStructEvent` and `trackSchemaEvent` visually look similar and I always mix them up. When I open a `analytics.ts` file I often get confused on which tracking function is actually doing something and which aren't, risking not adding analytics when needed thinking we already have some.

This marks `trackStructEvent` as deprecated, all editors should be able to visually mark them as such.

<img width="722" alt="image" src="https://github.com/metabase/metabase/assets/1914270/734daf2f-48a8-40b1-aad9-33d9e94646ac">


`trackStructEvent` will eventually be removed in https://github.com/metabase/metabase/pull/37941 but in the meantime this should help us
