### PR TITLE
Prevent categorizing extraction of/truncation to year as temporal-extraction

### DIFF
--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -370,7 +370,7 @@
        (when-let [inner-metadata (cond
                                    (integer? table-id) (lib.metadata/table query table-id)
                                    (string? table-id)  (lib.metadata/card
-                                                         query (lib.util/legacy-string-table-id->card-id table-id)))]
+                                                        query (lib.util/legacy-string-table-id->card-id table-id)))]
          {:table (display-info query stage-number inner-metadata)}))
      (when-let [source (:lib/source x-metadata)]
        {:is-from-previous-stage (= source :source/previous-stage)
@@ -382,7 +382,9 @@
      (when-some [selected (:selected? x-metadata)]
        {:selected selected})
      (when-let [temporal-unit ((some-fn :metabase.lib.field/temporal-unit :temporal-unit) x-metadata)]
-       {:is-temporal-extraction (contains? lib.schema.temporal-bucketing/datetime-extraction-units temporal-unit)})
+       {:is-temporal-extraction
+        (and (contains? lib.schema.temporal-bucketing/datetime-extraction-units temporal-unit)
+             (not (contains? lib.schema.temporal-bucketing/datetime-truncation-units temporal-unit)))})
      (select-keys x-metadata [:breakout-position :order-by-position :filter-positions]))))
 
 (defmethod display-info-method :default

--- a/src/metabase/lib/temporal_bucket.cljc
+++ b/src/metabase/lib/temporal_bucket.cljc
@@ -199,8 +199,11 @@
   [query stage-number option]
   (merge {:display-name (lib.metadata.calculation/display-name query stage-number option)
           :short-name (u/qualified-name (raw-temporal-bucket option))
-          :is-temporal-extraction (contains? lib.schema.temporal-bucketing/datetime-extraction-units
-                                             (raw-temporal-bucket option))}
+          :is-temporal-extraction (let [bucket (raw-temporal-bucket option)]
+                                    (and (contains? lib.schema.temporal-bucketing/datetime-extraction-units
+                                                    bucket)
+                                         (not (contains? lib.schema.temporal-bucketing/datetime-truncation-units
+                                                         bucket))))}
          (select-keys option [:default :selected])))
 
 (defmulti available-temporal-buckets-method

--- a/test/metabase/lib/temporal_bucket_test.cljc
+++ b/test/metabase/lib/temporal_bucket_test.cljc
@@ -182,7 +182,7 @@
             "week"            false
             "month"           false
             "quarter"         false
-            "year"            true
+            "year"            false
             "minute-of-hour"  true
             "hour-of-day"     true
             "day-of-week"     true

--- a/test/metabase/lib/temporal_bucket_test.cljc
+++ b/test/metabase/lib/temporal_bucket_test.cljc
@@ -195,3 +195,12 @@
                  (comp (map #(lib/display-info query -1 %))
                        (map (juxt :short-name :is-temporal-extraction)))
                  (lib.temporal-bucket/available-temporal-buckets query (meta/field-metadata :products :created-at)))))))
+
+(deftest ^:parallel source-card-temporal-extraction-test
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
+                  (lib/breakout (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :year)))]
+    (is (=? {:display-name "Created At: Year"
+             :is-temporal-extraction false}
+            (->> (lib/breakouts query)
+                 first
+                 (lib/display-info query -1))))))


### PR DESCRIPTION
Fixes #38253.

Getting the year is both a truncation and extraction operation, but the FE traditionally doesn't see it as extraction. This PR leaves `:year` as an extraction unit, but when generating the display-info, it returns false in `:is-temporal-extraction`.