### PR TITLE
[Dashboard] Do not update dashboard settings on every keypress in Text

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeExternalLinks from "rehype-external-links";
@@ -51,6 +51,10 @@ export function Text({
   const preventDragging = e => e.stopPropagation();
 
   const isSingleRow = gridSize?.height === 1;
+
+  useEffect(() => {
+    setTextValue(settings.text);
+  }, [settings.text]);
 
   const content = useMemo(
     () =>

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -52,6 +52,7 @@ export function Text({
 
   const isSingleRow = gridSize?.height === 1;
 
+  // handles a case when settings are updated externally
   useEffect(() => {
     setTextValue(settings.text);
   }, [settings.text]);

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeExternalLinks from "rehype-external-links";
@@ -42,12 +42,12 @@ export function Text({
   isMobile,
 }) {
   const justAdded = useMemo(() => dashcard?.justAdded || false, [dashcard]);
+  const [textValue, setTextValue] = useState(settings.text);
 
   const [isFocused, { turnOn: toggleFocusOn, turnOff: toggleFocusOff }] =
     useToggle(justAdded);
   const isPreviewing = !isFocused;
 
-  const handleTextChange = text => onUpdateVisualizationSettings({ text });
   const preventDragging = e => e.stopPropagation();
 
   const isSingleRow = gridSize?.height === 1;
@@ -100,11 +100,17 @@ export function Text({
             data-testid="editing-dashboard-text-input"
             name="text"
             placeholder={placeholder}
-            value={settings.text}
+            value={textValue}
             autoFocus={justAdded || isFocused}
-            onChange={e => handleTextChange(e.target.value)}
+            onChange={e => setTextValue(e.target.value)}
             onMouseDown={preventDragging}
-            onBlur={toggleFocusOff}
+            onBlur={() => {
+              toggleFocusOff();
+
+              if (settings.text !== textValue) {
+                onUpdateVisualizationSettings({ text: textValue });
+              }
+            }}
             isMobile={isMobile}
             isSingleRow={isSingleRow}
           />

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.unit.spec.tsx
@@ -153,6 +153,24 @@ describe("Text", () => {
         userEvent.click(screen.getByTestId("editing-dashboard-text-preview"));
         expect(screen.getByDisplayValue("text text text")).toBeInTheDocument();
       });
+
+      it("should call onUpdateVisualizationSettings on blur", () => {
+        const mockOnUpdateVisualizationSettings = jest.fn();
+        const options = {
+          settings: getSettingsWithText("text"),
+          isEditing: true,
+          onUpdateVisualizationSettings: mockOnUpdateVisualizationSettings,
+        };
+        setup(options);
+
+        userEvent.click(screen.getByTestId("editing-dashboard-text-preview"));
+        userEvent.type(screen.getByRole("textbox"), "foo");
+        userEvent.tab();
+
+        expect(mockOnUpdateVisualizationSettings).toHaveBeenCalledWith({
+          text: "textfoo",
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/38225

### Description

We used to update dashboard viz settings on every keystroke, but keeping in mind slowness of re-rendering, we can avoid unnecessary re-renderings and update a dashboard only when you stop typing and focus out of the input.

### How to verify

1. Open a dashboard with many cards
2. go to edit mode, add Text
3. start typing something -> you'll be able to type as usual without any delay

### Demo

Same fix as for Heading
https://www.loom.com/share/ebe74cebe016440d837c1cc5f789b821

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
