### PR TITLE
[Dashboard] Do not update dashboard settings on every keypress in Heading

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { t } from "ttag";
 
@@ -47,6 +47,11 @@ export function Heading({
   const [textValue, setTextValue] = useState(settings.text);
   const preventDragging = (e: MouseEvent<HTMLInputElement>) =>
     e.stopPropagation();
+
+  // handles a case when settings are updated externally
+  useEffect(() => {
+    setTextValue(settings.text);
+  }, [settings.text]);
 
   const content = useMemo(
     () =>

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.tsx
@@ -1,5 +1,5 @@
 import type { MouseEvent } from "react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { t } from "ttag";
 
@@ -44,8 +44,7 @@ export function Heading({
     useToggle(justAdded);
   const isPreviewing = !isFocused;
 
-  const handleTextChange = (text: string) =>
-    onUpdateVisualizationSettings({ text });
+  const [textValue, setTextValue] = useState(settings.text);
   const preventDragging = (e: MouseEvent<HTMLInputElement>) =>
     e.stopPropagation();
 
@@ -84,11 +83,17 @@ export function Heading({
             name="heading"
             data-testid="editing-dashboard-heading-input"
             placeholder={placeholder}
-            value={settings.text}
+            value={textValue}
             autoFocus={justAdded || isFocused}
-            onChange={e => handleTextChange(e.target.value)}
+            onChange={e => setTextValue(e.target.value)}
             onMouseDown={preventDragging}
-            onBlur={toggleFocusOff}
+            onBlur={() => {
+              toggleFocusOff();
+
+              if (settings.text !== textValue) {
+                onUpdateVisualizationSettings({ text: textValue });
+              }
+            }}
           />
         )}
       </InputContainer>

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
@@ -206,6 +206,26 @@ describe("Text", () => {
           screen.getByDisplayValue("Variable: {{variable}}"),
         ).toBeInTheDocument();
       });
+
+      it("should call onUpdateVisualizationSettings on blur", () => {
+        const mockOnUpdateVisualizationSettings = jest.fn();
+        const options = {
+          settings: getSettingsWithText("text"),
+          isEditing: true,
+          onUpdateVisualizationSettings: mockOnUpdateVisualizationSettings,
+        };
+        setup(options);
+
+        userEvent.click(
+          screen.getByTestId("editing-dashboard-heading-preview"),
+        );
+        userEvent.type(screen.getByRole("textbox"), "foo");
+        userEvent.tab();
+
+        expect(mockOnUpdateVisualizationSettings).toHaveBeenCalledWith({
+          text: "textfoo",
+        });
+      });
     });
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
@@ -222,6 +222,7 @@ describe("Text", () => {
         userEvent.type(screen.getByRole("textbox"), "foo");
         userEvent.tab();
 
+        expect(mockOnUpdateVisualizationSettings).toHaveBeenCalledTimes(1);
         expect(mockOnUpdateVisualizationSettings).toHaveBeenCalledWith({
           text: "textfoo",
         });

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.unit.spec.tsx
@@ -167,6 +167,7 @@ describe("Text", () => {
         userEvent.type(screen.getByRole("textbox"), "foo");
         userEvent.tab();
 
+        expect(mockOnUpdateVisualizationSettings).toHaveBeenCalledTimes(1);
         expect(mockOnUpdateVisualizationSettings).toHaveBeenCalledWith({
           text: "textfoo",
         });


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/38225

### Description

We used to update dashboard viz settings on every keystroke, but keeping in mind slowness of re-rendering, we can avoid unnecessary re-renderings and update a dashboard only when you stop typing and focus out of the input.

### How to verify

1. Open a dashboard with many cards
2. go to edit mode, add Heading
3. start typing something -> you'll be able to type as usual without any delay

### Demo

https://www.loom.com/share/ebe74cebe016440d837c1cc5f789b821

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
