### PR TITLE
Vim & Emacs keybindings

### DIFF
--- a/frontend/src/metabase-types/api/mocks/user.ts
+++ b/frontend/src/metabase-types/api/mocks/user.ts
@@ -17,6 +17,7 @@ export const createMockUser = (opts?: Partial<User>): User => ({
   has_invited_second_user: false,
   has_question_and_dashboard: false,
   personal_collection_id: 1,
+  keybindings: null,
   date_joined: new Date().toISOString(),
   first_login: new Date().toISOString(),
   last_login: new Date().toISOString(),

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -231,7 +231,7 @@ export interface Settings {
   "is-metabot-enabled": boolean;
   "jwt-enabled"?: boolean;
   "jwt-configured"?: boolean;
-  "keybindings"?: string;
+  keybindings?: string;
   "ldap-configured?": boolean;
   "ldap-enabled": boolean;
   "loading-message": LoadingMessage;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -231,6 +231,7 @@ export interface Settings {
   "is-metabot-enabled": boolean;
   "jwt-enabled"?: boolean;
   "jwt-configured"?: boolean;
+  "keybindings"?: string;
   "ldap-configured?": boolean;
   "ldap-enabled": boolean;
   "loading-message": LoadingMessage;

--- a/frontend/src/metabase-types/api/user.ts
+++ b/frontend/src/metabase-types/api/user.ts
@@ -12,6 +12,7 @@ export interface BaseUser {
   common_name: string;
   email: string;
   locale: string | null;
+  keybindings: string | null;
   google_auth: boolean;
   is_active: boolean;
   is_qbnewb: boolean;

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.tsx
@@ -19,6 +19,7 @@ const LOCAL_PROFILE_SCHEMA = SSO_PROFILE_SCHEMA.shape({
   first_name: Yup.string().nullable().default(null).max(100, Errors.maxLength),
   last_name: Yup.string().nullable().default(null).max(100, Errors.maxLength),
   email: Yup.string().ensure().required(Errors.required).email(Errors.email),
+  keybindings: Yup.string().nullable().default(null),
 });
 
 export interface UserProfileFormProps {
@@ -84,6 +85,15 @@ const UserProfileForm = ({
             name="locale"
             title={t`Language`}
             options={localeOptions}
+          />
+          <FormSelect
+            name="keybindings"
+            title={t`SQL Editor Keybindings`}
+            options={[
+              { name: t`Default`, value: null },
+              { name: t`Vim`, value: "vim" },
+              { name: t`Emacs`, value: "emacs" },
+            ]}
           />
           <FormSubmitButton title={t`Update`} disabled={!dirty} primary />
           <FormErrorMessage />

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -8,6 +8,9 @@ import slugg from "slugg";
 import * as ace from "ace-builds/src-noconflict/ace";
 import type { Ace } from "ace-builds";
 
+import "ace-builds/src-noconflict/keybinding-vim";
+import "ace-builds/src-noconflict/keybinding-emacs";
+
 import "ace/ace";
 import "ace/ext-language_tools";
 import "ace/ext-searchbox";
@@ -22,6 +25,8 @@ import ExplicitSize from "metabase/components/ExplicitSize";
 import Modal from "metabase/components/Modal";
 import * as Lib from "metabase-lib";
 
+import { getSetting } from "metabase/selectors/settings";
+
 import { canGenerateQueriesForDatabase } from "metabase/metabot/utils";
 import SnippetFormModal from "metabase/query_builder/components/template_tags/SnippetFormModal";
 
@@ -29,8 +34,6 @@ import Databases from "metabase/entities/databases";
 import Snippets from "metabase/entities/snippets";
 import SnippetCollections from "metabase/entities/snippet-collections";
 import Questions from "metabase/entities/questions";
-
-import { getSetting } from "metabase/selectors/settings";
 
 import { checkNotNull } from "metabase/lib/types";
 import { isEventOverElement } from "metabase/lib/dom";
@@ -146,6 +149,7 @@ type OwnProps = typeof NativeQueryEditor.defaultProps & {
   toggleSnippetSidebar: () => void;
   cancelQuery?: () => void;
   closeSnippetModal: () => void;
+  keybindings: string | null;
 };
 
 interface StateProps {
@@ -398,7 +402,7 @@ export class NativeQueryEditor extends Component<
   };
 
   loadAceEditor() {
-    const { query } = this.props;
+    const { query, keybindings } = this.props;
 
     const editorElement = this.editor.current;
 
@@ -443,6 +447,15 @@ export class NativeQueryEditor extends Component<
       highlightGutterLine: false,
       showLineNumbers: true,
     });
+
+    switch (keybindings) {
+      case "vim":
+        editor.setKeyboardHandler("ace/keyboard/vim");
+        break;
+      case "emacs":
+        editor.setKeyboardHandler("ace/keyboard/emacs");
+        break;
+    }
 
     let lastAutoComplete: LastAutoComplete = {
       timestamp: 0,
@@ -907,6 +920,7 @@ export class NativeQueryEditor extends Component<
 
 const mapStateToProps = (state: State) => ({
   canUsePromptInput: getSetting(state, "is-metabot-enabled"),
+  keybindings: state.currentUser?.keybindings,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -25,8 +25,6 @@ import ExplicitSize from "metabase/components/ExplicitSize";
 import Modal from "metabase/components/Modal";
 import * as Lib from "metabase-lib";
 
-import { getSetting } from "metabase/selectors/settings";
-
 import { canGenerateQueriesForDatabase } from "metabase/metabot/utils";
 import SnippetFormModal from "metabase/query_builder/components/template_tags/SnippetFormModal";
 
@@ -34,6 +32,9 @@ import Databases from "metabase/entities/databases";
 import Snippets from "metabase/entities/snippets";
 import SnippetCollections from "metabase/entities/snippet-collections";
 import Questions from "metabase/entities/questions";
+
+import { getSetting } from "metabase/selectors/settings";
+import { getUser } from "metabase/selectors/user";
 
 import { checkNotNull } from "metabase/lib/types";
 import { isEventOverElement } from "metabase/lib/dom";
@@ -920,7 +921,7 @@ export class NativeQueryEditor extends Component<
 
 const mapStateToProps = (state: State) => ({
   canUsePromptInput: getSetting(state, "is-metabot-enabled"),
-  keybindings: state.currentUser?.keybindings,
+  keybindings: getUser(state)?.keybindings,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -809,3 +809,10 @@
                   (if-not (pos-int? value)
                     20
                     value))))
+
+(defsetting keybindings
+  (deferred-tru "Keybindings to use for the SQL editor for each user")
+  :user-local :only
+  :type       :keyword
+  :default    nil
+  :export?    false)

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -406,16 +406,17 @@
                      Card _ {:name "card1" :display "table" :creator_id (mt/user->id :rasta)}]
         (is (= (-> (merge
                     @user-defaults
-                    {:email                      "rasta@metabase.com"
-                     :first_name                 "Rasta"
-                     :last_name                  "Toucan"
-                     :common_name                "Rasta Toucan"
-                     :first_login                "2021-03-18T19:52:41.808482Z"
-                     :group_ids                  [(u/the-id (perms-group/all-users))]
-                     :personal_collection_id     true
-                     :custom_homepage            nil
-                     :is_installer               (= 1 (mt/user->id :rasta))
-                     :has_invited_second_user    (= 1 (mt/user->id :rasta))})
+                    {:email                   "rasta@metabase.com"
+                     :first_name              "Rasta"
+                     :last_name               "Toucan"
+                     :common_name             "Rasta Toucan"
+                     :first_login             "2021-03-18T19:52:41.808482Z"
+                     :group_ids               [(u/the-id (perms-group/all-users))]
+                     :personal_collection_id  true
+                     :custom_homepage         nil
+                     :is_installer            (= 1 (mt/user->id :rasta))
+                     :has_invited_second_user (= 1 (mt/user->id :rasta))
+                     :keybindings             nil})
                    (dissoc :is_qbnewb :last_login))
                (-> (mt/user-http-request :rasta :get 200 "user/current")
                    mt/boolean-ids-and-timestamps
@@ -434,7 +435,8 @@
                      :has_question_and_dashboard true
                      :custom_homepage            nil
                      :is_installer               (= 1 (mt/user->id :rasta))
-                     :has_invited_second_user    (= 1 (mt/user->id :rasta))})
+                     :has_invited_second_user    (= 1 (mt/user->id :rasta))
+                     :keybindings                nil})
                    (dissoc :is_qbnewb :last_login))
                (-> (mt/user-http-request :rasta :get 200 "user/current")
                    mt/boolean-ids-and-timestamps


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/16419

Adds a new `keybindings` user-local setting which controls the keybindings each user uses in the SQL editor (options are `vim`, `emacs` and `nil` (default))

Adds a new `SQL Editor Keybindings` section to account settings.