### PR TITLE
Run cloverage on perms feature branch

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -65,7 +65,8 @@ jobs:
 
   be-linter-cloverage:
     needs: files-changed
-    if: github.ref_name == 'master' && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.ref_name == 'master' || github.ref_name 'perms-refactor-feature-branch')
+      && needs.files-changed.outputs.backend_all == 'true'
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
Temporarily run cloverage on the perms feature branch so that we can preemptively catch any failures there before we merge into master.

It would be nice if we had a label we could add to a PR to run cloverage, but this is a quicker solution.