### PR TITLE
[MLv2] Cache JS -> CLJS metadata conversion

### DIFF
--- a/src/metabase/lib/cache.cljc
+++ b/src/metabase/lib/cache.cljc
@@ -10,19 +10,20 @@
 
   If there is not already a key `subkey` in the map, calls `(f x)` and caches the value at `subkey`.
   If there is a value at `subkey`, it is returned directly."
-  [subkey x f]
-  (comment subkey) ; Avoids lint warning for half-unused `subkey`.
-  #?(:clj  (f x)
-     :cljs (if (or (object? x) (map? x))
-             (do
-               (when-not (.-__mbcache ^js x)
-                 (set! (.-__mbcache ^js x) (atom {})))
-               (if-let [cache (.-__mbcache ^js x)]
-                 (if-let [cached (get @cache subkey)]
-                   cached
-                   ;; Cache miss - generate the value and cache it.
-                   (let [value (f x)]
-                     (swap! cache assoc subkey value)
-                     value))
-                 (f x)))
-             (f x))))
+  ([subkey x f] (side-channel-cache subkey x f false))
+  ([subkey x f force?]
+   (comment subkey, force?) ; Avoids lint warning for half-unused inputs.
+   #?(:clj  (f x)
+      :cljs (if (or force? (object? x) (map? x))
+              (do
+                (when-not (.-__mbcache ^js x)
+                  (set! (.-__mbcache ^js x) (atom {})))
+                (if-let [cache (.-__mbcache ^js x)]
+                  (if-let [cached (get @cache subkey)]
+                    cached
+                    ;; Cache miss - generate the value and cache it.
+                    (let [value (f x)]
+                      (swap! cache assoc subkey value)
+                      value))
+                  (f x)))
+              (f x)))))


### PR DESCRIPTION
This previous got rebuilt from scratch over and over, since different
queries being handed the same JS `Metadata` instance were returning
completely separate `MetadataProvider`s.

The FE replaces the `Metadata` instance as new metadata arrives from the
BE, so the `metabase.lib.cache/side-channel-cache` which is attached to
the input object is implicitly invalidated when the old `Metadata` is
thrown away.

