### PR TITLE
Return card__<id> for non-model cards and FK targets for tables

### DIFF
--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -152,7 +152,8 @@
   (testing "simple query"
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
-                      {:type :table,    :id (meta/id :venues)}]
+                      {:type :table,    :id (meta/id :venues)}
+                      {:type :field,    :id (meta/id :categories :id)}]
                      (lib/dependent-metadata query))
       lib.tu/venues-query
       (lib/append-stage lib.tu/venues-query)))
@@ -160,19 +161,22 @@
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
                       {:type :table,    :id (meta/id :venues)}
+                      {:type :field,    :id (meta/id :categories :id)}
                       {:type :table,    :id (meta/id :categories)}]
                      (lib/dependent-metadata query))
       lib.tu/query-with-join
       (lib/append-stage lib.tu/query-with-join)))
   (testing "source card based query"
     (are [query] (=? [{:type :database, :id (meta/id)}
-                      {:type :schema,   :id (meta/id)}]
+                      {:type :schema,   :id (meta/id)}
+                      {:type :table,    :id "card__1"}]
                      (lib/dependent-metadata query))
       lib.tu/query-with-source-card
       (lib/append-stage lib.tu/query-with-source-card)))
   (testing "source card based query with result metadata"
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
+                      {:type :table,    :id "card__1"}
                       {:type :field,    :id (meta/id :users :id)}]
                      (lib/dependent-metadata query))
       lib.tu/query-with-source-card-with-result-metadata


### PR DESCRIPTION
Fixes #38312.

Returning `card__<id>` table items was restricted to models and foreign key targets were restricted to cards. Both of these restrictions are lifted in this PR.