### PR TITLE
Update fieldvalues in a transaction

### DIFF
--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -297,22 +297,11 @@
       [400 "If remapped values are specified, they must be specified for all field values"])
     has-human-readable-values?))
 
-(defn- update-field-values! [field-value-id value-pairs]
-  (let [human-readable-values? (validate-human-readable-pairs value-pairs)]
-    (api/check-500 (pos? (t2/update! FieldValues field-value-id
-                                     {:values (map first value-pairs)
-                                      :human_readable_values (when human-readable-values?
-                                                               (map second value-pairs))})))))
+(defn- update-field-values! [field-value-id update-map]
+  (api/check-500 (pos? (t2/update! FieldValues field-value-id update-map))))
 
-(defn- create-field-values!
-  [field-or-id value-pairs]
-  (let [human-readable-values? (validate-human-readable-pairs value-pairs)]
-    (t2/insert! FieldValues
-                :type :full
-                :field_id (u/the-id field-or-id)
-                :values (map first value-pairs)
-                :human_readable_values (when human-readable-values?
-                                         (map second value-pairs)))))
+(defn- create-field-values! [field-or-id update-map]
+  (t2/insert! FieldValues (assoc update-map :type :full :field_id (u/the-id field-or-id))))
 
 (api/defendpoint POST "/:id/values"
   "Update the fields values and human-readable values for a `Field` whose semantic type is
@@ -324,9 +313,14 @@
     (api/check (field-values/field-should-have-field-values? field)
       [400 (str "You can only update the human readable values of a mapped values of a Field whose value of "
                 "`has_field_values` is `list` or whose 'base_type' is 'type/Boolean'.")])
-    (if-let [field-value-id (t2/select-one-pk FieldValues, :field_id id :type :full)]
-      (update-field-values! field-value-id value-pairs)
-      (create-field-values! field value-pairs)))
+    (let [human-readable-values? (validate-human-readable-pairs value-pairs)
+          update-map  {:values                (map first value-pairs)
+                       :human_readable_values (when human-readable-values?
+                                                (map second value-pairs))}]
+      (t2/with-transaction [_conn]
+        (if-let [field-value-id (t2/select-one-pk FieldValues, :field_id id :type :full)]
+          (update-field-values! field-value-id update-map)
+          (create-field-values! field update-map)))))
   {:status :success})
 
 (api/defendpoint POST "/:id/rescan_values"


### PR DESCRIPTION
Refs https://github.com/metabase/metabase/issues/668 (potentially the only root cause)

### Description

There was a potential race condition here where we could insert multiple field value rows, or fail to update them. Adding a database transaction should fix this.

While making this change we also removed some duplication between the insert and update branches.
