### PR TITLE
Hide "Add your data" step for people interested in embedding

### DIFF
--- a/frontend/src/metabase/setup/components/ActiveStep/ActiveStep.tsx
+++ b/frontend/src/metabase/setup/components/ActiveStep/ActiveStep.tsx
@@ -18,7 +18,7 @@ export const ActiveStep = ({
   children,
 }: ActiveStepProps): JSX.Element => {
   return (
-    <StepRoot>
+    <StepRoot role="listitem" aria-label={title} aria-current="step">
       <StepTitle>{title}</StepTitle>
       <StepLabel>
         <StepLabelText>{label}</StepLabelText>

--- a/frontend/src/metabase/setup/components/InactiveStep/InactiveStep.tsx
+++ b/frontend/src/metabase/setup/components/InactiveStep/InactiveStep.tsx
@@ -23,8 +23,10 @@ export const InactiveStep = ({
 }: InactiveStepProps): JSX.Element => {
   return (
     <StepRoot
+      role="listitem"
       isCompleted={isStepCompleted}
       onClick={isStepCompleted && !isSetupCompleted ? onStepSelect : undefined}
+      aria-label={title}
     >
       <StepTitle isCompleted={isStepCompleted}>{title}</StepTitle>
       <StepLabel isCompleted={isStepCompleted}>

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import LogoIcon from "metabase/components/LogoIcon";
 import { isNotFalsy } from "metabase/lib/types";
+import { useSelector } from "metabase/lib/redux";
 import { CloudMigrationHelp } from "../CloudMigrationHelp";
 import { DatabaseStep } from "../DatabaseStep";
 import { CompletedStep } from "../CompletedStep";
@@ -12,11 +13,13 @@ import { UsageQuestionStep } from "../UsageQuestionStep";
 import { PageBody, PageHeader } from "./SettingsPage.styled";
 
 export const SettingsPage = (): JSX.Element => {
+  const usageReason = useSelector(s => s.setup.usageReason);
+
   const numberedSteps = [
     { component: LanguageStep, key: "language-step" },
     { component: UserStep, key: "user-step" },
     { component: UsageQuestionStep, key: "usage-question-step" },
-    {
+    usageReason !== "embedding" && {
       component: DatabaseStep,
       key: "database-step",
     },

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import LogoIcon from "metabase/components/LogoIcon";
 import { isNotFalsy } from "metabase/lib/types";
 import { useSelector } from "metabase/lib/redux";
+import { getUsageReason } from "metabase/setup/selectors";
 import { CloudMigrationHelp } from "../CloudMigrationHelp";
 import { DatabaseStep } from "../DatabaseStep";
 import { CompletedStep } from "../CompletedStep";
@@ -13,7 +14,7 @@ import { UsageQuestionStep } from "../UsageQuestionStep";
 import { PageBody, PageHeader } from "./SettingsPage.styled";
 
 export const SettingsPage = (): JSX.Element => {
-  const usageReason = useSelector(s => s.setup.usageReason);
+  const usageReason = useSelector(getUsageReason);
 
   const numberedSteps = [
     { component: LanguageStep, key: "language-step" },

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -54,8 +54,9 @@ export const reducer = createReducer(initialState, builder => {
     state.step = USAGE_STEP;
   });
   builder.addCase(submitUsageReason.pending, (state, { meta }) => {
-    state.usageReason = meta.arg;
-    state.step = DATABASE_STEP;
+    const usageReason = meta.arg;
+    state.usageReason = usageReason;
+    state.step = usageReason === "embedding" ? PREFERENCES_STEP : DATABASE_STEP;
   });
   builder.addCase(updateDatabaseEngine.pending, (state, { meta }) => {
     state.databaseEngine = meta.arg;

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -56,6 +56,7 @@ export const reducer = createReducer(initialState, builder => {
   builder.addCase(submitUsageReason.pending, (state, { meta }) => {
     const usageReason = meta.arg;
     state.usageReason = usageReason;
+    // this logic will be refactored before we introduce more steps, to be less fragile
     state.step = usageReason === "embedding" ? PREFERENCES_STEP : DATABASE_STEP;
   });
   builder.addCase(updateDatabaseEngine.pending, (state, { meta }) => {

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -21,6 +21,10 @@ export const getUserEmail = (state: State): string | undefined => {
   return getUser(state)?.email;
 };
 
+export const getUsageReason = (state: State) => {
+  return state.setup.usageReason;
+};
+
 export const getDatabase = (state: State): DatabaseData | undefined => {
   return state.setup.database;
 };

--- a/frontend/src/metabase/setup/setup.unit.spec.tsx
+++ b/frontend/src/metabase/setup/setup.unit.spec.tsx
@@ -1,0 +1,156 @@
+import { fireEvent, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+import type { UsageReason } from "metabase-types/api";
+import {
+  createMockSettingsState,
+  createMockSetupState,
+  createMockState,
+} from "metabase-types/store/mocks";
+import { renderWithProviders, screen } from "__support__/ui";
+import { Setup } from "./components/Setup";
+
+const setup = async ({ step = 0 } = {}) => {
+  const state = createMockState({
+    setup: createMockSetupState({
+      step,
+    }),
+    settings: createMockSettingsState({
+      "available-locales": [["en", "English"]],
+    }),
+  });
+
+  fetchMock.post("path:/api/util/password_check", { valid: true });
+
+  renderWithProviders(<Setup />, { storeInitialState: state });
+
+  // there is some async stuff going on with the locale loading
+  await screen.findByText("Let's get started");
+
+  return;
+};
+
+describe("setup", () => {
+  describe("default step order", () => {
+    // eslint-disable-next-line jest/expect-expect
+    it.each([
+      ["What's your preferred language?", "1"],
+      ["What should we call you?", "2"],
+      ["What will you use Metabase for?", "3"],
+      ["Add your data", "4"],
+      ["Usage data preferences", "5"],
+    ])(
+      "should have a step for '%s' with label '%s'",
+      async (step: string, label: string) => {
+        await setup();
+        skipWelcomeScreen();
+
+        expectSectionToHaveLabel(step, label);
+      },
+    );
+  });
+
+  describe("Usage question", () => {
+    const setupForUsageQuestion = async () => {
+      await setup();
+      skipWelcomeScreen();
+      skipLanguageStep();
+      await submitUserInfoStep();
+
+      clickNextStep();
+      await screen.findByText("Self-service analytics for my own company");
+    };
+
+    describe("when selecting 'self service'", () => {
+      it("should keep the 'Add your data' step", async () => {
+        await setupForUsageQuestion();
+        fillUsageReason("self-service-analytics");
+        clickNextStep();
+
+        expect(screen.getByText("Add your data")).toBeInTheDocument();
+
+        expect(getSection("Add your data")).toHaveAttribute(
+          "aria-current",
+          "step",
+        );
+
+        expectSectionToHaveLabel("Add your data", "4");
+        expectSectionToHaveLabel("Usage data preferences", "5");
+      });
+    });
+
+    describe("when selecting 'embedding'", () => {
+      it("should hide the 'Add your data' step", async () => {
+        await setupForUsageQuestion();
+        fillUsageReason("embedding");
+        clickNextStep();
+
+        expect(screen.queryByText("Add your data")).not.toBeInTheDocument();
+
+        expect(getSection("Usage data preferences")).toHaveAttribute(
+          "aria-current",
+          "step",
+        );
+
+        expectSectionToHaveLabel("Usage data preferences", "4");
+      });
+    });
+  });
+});
+
+const getSection = (name: string) => screen.getByRole("listitem", { name });
+
+const clickNextStep = () =>
+  userEvent.click(screen.getByRole("button", { name: "Next" }));
+
+const skipWelcomeScreen = () =>
+  userEvent.click(screen.getByText("Let's get started"));
+
+const skipLanguageStep = () => clickNextStep();
+
+const submitUserInfoStep = async ({
+  firstName = "John",
+  lastName = "Smith",
+  email = "john@example.org",
+  companyName = "Acme",
+  password = "Monkeyabc123",
+} = {}) => {
+  fireEvent.change(screen.getByLabelText("First name"), {
+    target: { value: firstName },
+  });
+  fireEvent.change(screen.getByLabelText("Last name"), {
+    target: { value: lastName },
+  });
+  fireEvent.change(screen.getByLabelText("Email"), {
+    target: { value: email },
+  });
+  fireEvent.change(screen.getByLabelText("Company or team name"), {
+    target: { value: companyName },
+  });
+  fireEvent.change(screen.getByLabelText("Create a password"), {
+    target: { value: password },
+  });
+  fireEvent.change(screen.getByLabelText("Confirm your password"), {
+    target: { value: password },
+  });
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled(),
+  );
+};
+
+const fillUsageReason = (usageReason: UsageReason) => {
+  const label = {
+    "self-service-analytics": "Self-service analytics for my own company",
+    embedding: "Embedding analytics into my application",
+    both: "A bit of both",
+    "not-sure": "Bot sure yet",
+  }[usageReason];
+
+  fireEvent.click(screen.getByLabelText(label));
+};
+
+const expectSectionToHaveLabel = (sectionName: string, label: string) => {
+  const section = getSection(sectionName);
+
+  expect(within(section).getByText(label)).toBeInTheDocument();
+};

--- a/frontend/src/metabase/setup/setup.unit.spec.tsx
+++ b/frontend/src/metabase/setup/setup.unit.spec.tsx
@@ -57,11 +57,10 @@ describe("setup", () => {
       skipLanguageStep();
       await submitUserInfoStep();
 
-      clickNextStep();
       await screen.findByText("Self-service analytics for my own company");
     };
 
-    describe("when selecting 'self service'", () => {
+    describe("when selecting 'Self service'", () => {
       it("should keep the 'Add your data' step", async () => {
         await setupForUsageQuestion();
         fillUsageReason("self-service-analytics");
@@ -79,7 +78,7 @@ describe("setup", () => {
       });
     });
 
-    describe("when selecting 'embedding'", () => {
+    describe("when selecting 'Embedding'", () => {
       it("should hide the 'Add your data' step", async () => {
         await setupForUsageQuestion();
         fillUsageReason("embedding");
@@ -93,6 +92,42 @@ describe("setup", () => {
         );
 
         expectSectionToHaveLabel("Usage data preferences", "4");
+      });
+    });
+
+    describe("when selecting 'A bit of both'", () => {
+      it("should keep the 'Add your data' step", async () => {
+        await setupForUsageQuestion();
+        fillUsageReason("both");
+        clickNextStep();
+
+        expect(screen.getByText("Add your data")).toBeInTheDocument();
+
+        expect(getSection("Add your data")).toHaveAttribute(
+          "aria-current",
+          "step",
+        );
+
+        expectSectionToHaveLabel("Add your data", "4");
+        expectSectionToHaveLabel("Usage data preferences", "5");
+      });
+    });
+
+    describe("when selecting 'Not sure yet'", () => {
+      it("should keep the 'Add your data' step", async () => {
+        await setupForUsageQuestion();
+        fillUsageReason("not-sure");
+        clickNextStep();
+
+        expect(screen.getByText("Add your data")).toBeInTheDocument();
+
+        expect(getSection("Add your data")).toHaveAttribute(
+          "aria-current",
+          "step",
+        );
+
+        expectSectionToHaveLabel("Add your data", "4");
+        expectSectionToHaveLabel("Usage data preferences", "5");
       });
     });
   });
@@ -136,6 +171,7 @@ const submitUserInfoStep = async ({
   await waitFor(() =>
     expect(screen.getByRole("button", { name: "Next" })).toBeEnabled(),
   );
+  clickNextStep();
 };
 
 const fillUsageReason = (usageReason: UsageReason) => {
@@ -143,7 +179,7 @@ const fillUsageReason = (usageReason: UsageReason) => {
     "self-service-analytics": "Self-service analytics for my own company",
     embedding: "Embedding analytics into my application",
     both: "A bit of both",
-    "not-sure": "Bot sure yet",
+    "not-sure": "Not sure yet",
   }[usageReason];
 
   fireEvent.click(screen.getByLabelText(label));


### PR DESCRIPTION
[[Epic] Meet embedders at the door - minimal edition](https://github.com/metabase/metabase/issues/38233)

### Description

This only adds the basic logic, I want to have something to show to product and design.
In a later PR I'll refactor the logic and create a selector that will return the enabled steps, so that the logic to show them and to decide which is "next" step will have a single source of truth.
Also more tests will be added later when the logic of this question will be connected to the new custom homepage

### How to verify

If during the setup you select you're interested in embedding, the DB connection step won't be shown.

### Demo

https://github.com/metabase/metabase/assets/1914270/5756ca94-ca84-4da0-b98c-40feaf6b19d4



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
