### PR TITLE
Embedding + required params

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -138,8 +138,12 @@ export function setFilter(type, subType) {
   });
 }
 
+export function getRequiredToggle() {
+  return cy.findByLabelText("Always require a value");
+}
+
 export function toggleRequiredParameter() {
-  cy.findByLabelText("Always require a value").click();
+  getRequiredToggle().click();
 }
 
 export function createEmptyTextBox() {

--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -1,5 +1,5 @@
 import { METABASE_SECRET_KEY } from "e2e/support/cypress_data";
-import { modal } from "e2e/support/helpers/e2e-ui-elements-helpers";
+import { modal, popover } from "e2e/support/helpers/e2e-ui-elements-helpers";
 
 /**
  * @typedef {object} QuestionResource
@@ -195,6 +195,47 @@ export function openStaticEmbeddingModal({
       cy.findByText(previewModeToKeyMap[previewMode]).click();
     }
   });
+}
+
+export function closeStaticEmbeddingModal() {
+  modal().icon("close").click();
+}
+
+/**
+ * Open Static Embedding setup modal
+ * @param apiPath - "card" or "dashboard"
+ * @param callback
+ */
+export function publishChanges(apiPath, callback) {
+  cy.intercept("PUT", `/api/${apiPath}/*`).as("publishChanges");
+
+  cy.button(/^(Publish|Publish changes)$/).click();
+
+  // TODO this could be simplified when we send one publish request instead of two
+  cy.wait(["@publishChanges", "@publishChanges"]).then(xhrs => {
+    // Unfortunately, the order of requests is not always the same.
+    // Therefore, we must first get the one that has the `embedding_params` and then assert on it.
+    const targetXhr = xhrs.find(({ request }) =>
+      Object.keys(request.body).includes("embedding_params"),
+    );
+    callback?.(targetXhr);
+  });
+}
+
+export function getParametersContainer() {
+  return cy.findByLabelText("Configuring parameters");
+}
+
+export function setEmbeddingParameter(name, value) {
+  getParametersContainer().findByText(name).siblings("a").click();
+  popover().contains(value).click();
+}
+
+export function assertEmbeddingParameter(name, value) {
+  getParametersContainer()
+    .findByText(name)
+    .siblings("a")
+    .should("have.text", value);
 }
 
 // @param {("card"|"dashboard")} resourceType - The type of resource we are sharing

--- a/e2e/support/helpers/e2e-embedding-helpers.js
+++ b/e2e/support/helpers/e2e-embedding-helpers.js
@@ -203,7 +203,7 @@ export function closeStaticEmbeddingModal() {
 
 /**
  * Open Static Embedding setup modal
- * @param apiPath - "card" or "dashboard"
+ * @param {"card" | "dashboard"} apiPath
  * @param callback
  */
 export function publishChanges(apiPath, callback) {
@@ -227,15 +227,12 @@ export function getParametersContainer() {
 }
 
 export function setEmbeddingParameter(name, value) {
-  getParametersContainer().findByText(name).siblings("a").click();
+  getParametersContainer().findByLabelText(name).click();
   popover().contains(value).click();
 }
 
 export function assertEmbeddingParameter(name, value) {
-  getParametersContainer()
-    .findByText(name)
-    .siblings("a")
-    .should("have.text", value);
+  getParametersContainer().findByLabelText(name).should("have.text", value);
 }
 
 // @param {("card"|"dashboard")} resourceType - The type of resource we are sharing

--- a/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-native.cy.spec.js
@@ -50,18 +50,6 @@ describe("scenarios > embedding > native questions", () => {
       setParameter("State", "Editable");
       setParameter("Product ID", "Editable");
 
-      // We must enter a value for a locked parameter
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Previewing locked parameters")
-        .parent()
-        .within(() => {
-          cy.findByText("Total").click();
-        });
-
-      // Total is greater than or equal to 0
-      cy.findByPlaceholderText("Enter a number").type("0").blur();
-      cy.button("Add filter").click();
-
       publishChanges(({ request }) => {
         const actual = request.body.embedding_params;
 

--- a/e2e/test/scenarios/embedding/shared/embedding-native.js
+++ b/e2e/test/scenarios/embedding/shared/embedding-native.js
@@ -46,7 +46,6 @@ export const questionDetails = {
         dimension: ["field", ORDERS.TOTAL, null],
         "widget-type": "number/>=",
         default: [0],
-        required: true,
       },
       source: {
         id: "44038e73-f909-1bed-0974-2a42ce8979e8",

--- a/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -62,6 +62,10 @@ export function getRequiredToggle() {
   return cy.findByText("Always require a value");
 }
 
+export function getRequiredInput() {
+  return cy.findByLabelText("Always require a value");
+}
+
 /**
  * Toggle the required SQL filter on or off. It is off by default.
  */

--- a/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -58,11 +58,15 @@ export function setDefaultValue(value) {
 
 // UI PATTERNS
 
+export function getRequiredToggle() {
+  return cy.findByText("Always require a value");
+}
+
 /**
  * Toggle the required SQL filter on or off. It is off by default.
  */
 export function toggleRequired() {
-  cy.findByText("Always require a value").click();
+  getRequiredToggle().click();
 }
 
 // FILTER QUERY

--- a/frontend/src/metabase-lib/parameters/utils/cards.ts
+++ b/frontend/src/metabase-lib/parameters/utils/cards.ts
@@ -21,7 +21,7 @@ export function getCardUiParameters(
 
   const valuePopulatedParameters: (Parameter[] | ParameterWithTarget[]) & {
     value?: any;
-  } = getValuePopulatedParameters(parameters, parameterValues);
+  } = getValuePopulatedParameters({ parameters, values: parameterValues });
   const question = new Question(card, metadata);
 
   return valuePopulatedParameters.map(parameter => {

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -18,7 +18,7 @@ export function getParameterValue({
   values = {},
   defaultRequired = false,
 }) {
-  const value = values[parameter.id];
+  const value = values?.[parameter.id];
   const useDefault = defaultRequired && parameter.required;
   return value ?? (useDefault ? parameter.default : null);
 }

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -18,7 +18,7 @@ export function getParameterValue({
   values = {},
   defaultRequired = false,
 }) {
-  const value = values?.[parameter.id];
+  const value = values[parameter.id];
   const useDefault = defaultRequired && parameter.required;
   return value ?? (useDefault ? parameter.default : null);
 }

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -9,12 +9,39 @@ import {
 export const PULSE_PARAM_EMPTY = null;
 export const PULSE_PARAM_USE_DEFAULT = undefined;
 
-export function getValuePopulatedParameters(parameters, parameterValues) {
+/**
+ * In some cases, we need to use default parameter value in place of an absent one.
+ * Please use this function when dealing with the required parameters.
+ */
+export function getParameterValue({
+  parameter,
+  values = {},
+  defaultRequired = false,
+}) {
+  const value = values?.[parameter.id];
+  const useDefault = defaultRequired && parameter.required;
+  return value ?? (useDefault ? parameter.default : null);
+}
+
+/**
+ * In some cases, we need to use default parameter value in place of an absent one.
+ * Please use this function when dealing with the required parameters.
+ */
+export function getValuePopulatedParameters({
+  parameters,
+  values = {},
+  defaultRequired = false,
+}) {
   return parameters.map(parameter => ({
     ...parameter,
-    value: parameterValues?.[parameter.id] ?? null,
+    value: getParameterValue({
+      parameter,
+      values,
+      defaultRequired,
+    }),
   }));
 }
+
 export function getDefaultValuePopulatedParameters(
   parameters,
   parameterValues,

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.unit.spec.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.unit.spec.js
@@ -73,9 +73,12 @@ describe("parameters/utils/parameter-values", () => {
   describe("getValuePopulatedParameters", () => {
     it("should return an array of parameter objects with the `value` property set if it exists in the given `parameterValues` id, value map, and null if it doesn't exist", () => {
       expect(
-        getValuePopulatedParameters([parameter1, parameter2], {
-          [parameter1.id]: "parameter1 value",
-          [parameter2.id]: "parameter2 value",
+        getValuePopulatedParameters({
+          parameters: [parameter1, parameter2],
+          values: {
+            [parameter1.id]: "parameter1 value",
+            [parameter2.id]: "parameter2 value",
+          },
         }),
       ).toEqual([
         {
@@ -90,9 +93,9 @@ describe("parameters/utils/parameter-values", () => {
     });
 
     it("should return null value if the parameter doesn't exist in the parameterValues arg", () => {
-      expect(getValuePopulatedParameters([parameter1], {})).toEqual([
-        { ...parameter1, value: null },
-      ]);
+      expect(
+        getValuePopulatedParameters({ parameters: [parameter1], values: {} }),
+      ).toEqual([{ ...parameter1, value: null }]);
     });
 
     it("should handle there being an undefined or null parameterValues object", () => {
@@ -106,11 +109,14 @@ describe("parameters/utils/parameter-values", () => {
           value: null,
         },
       ];
-      expect(getValuePopulatedParameters([parameter1, parameter2])).toEqual(
-        parametersWithNulls,
-      );
       expect(
-        getValuePopulatedParameters([parameter1, parameter2], null),
+        getValuePopulatedParameters({ parameters: [parameter1, parameter2] }),
+      ).toEqual(parametersWithNulls);
+      expect(
+        getValuePopulatedParameters({
+          parameters: [parameter1, parameter2],
+          values: null,
+        }),
       ).toEqual(parametersWithNulls);
     });
   });

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -7,6 +7,7 @@ import type {
   ParameterTarget,
 } from "metabase-types/api";
 
+import type { EmbeddingParameters } from "metabase/public/lib/types";
 import type { ActionDisplayType, WritebackAction } from "./actions";
 import type { SearchModelType } from "./search";
 import type { Card, CardId, CardDisplayType } from "./card";
@@ -43,8 +44,8 @@ export interface Dashboard {
   auto_apply_filters: boolean;
   archived: boolean;
   public_uuid: string | null;
-  embedding_params?: Record<string, string> | null;
   width: "full" | "fixed";
+  embedding_params?: EmbeddingParameters | null;
 
   /* Indicates whether static embedding for this dashboard has been published */
   enable_embedding: boolean;

--- a/frontend/src/metabase/core/components/Toggle/Toggle.styled.tsx
+++ b/frontend/src/metabase/core/components/Toggle/Toggle.styled.tsx
@@ -44,6 +44,12 @@ export const ToggleRoot = styled.input<ToggleRootProps>`
   transition: background-color 0.3s;
   flex-shrink: 0;
 
+  &[disabled] {
+    cursor: not-allowed;
+    opacity: 0.5;
+    background-color: ${color("bg-medium")};
+  }
+
   &:after {
     content: "";
     width: ${props => (props.small ? "13px" : "20px")};

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -38,6 +38,7 @@ import type {
   StoreDashcard,
 } from "metabase-types/store";
 
+import type { EmbeddingParameters } from "metabase/public/lib/types";
 import type Database from "metabase-lib/metadata/Database";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import type Metadata from "metabase-lib/metadata/Metadata";
@@ -88,6 +89,7 @@ interface DashboardProps {
   editingParameter?: Parameter | null;
   parameters: UiParameter[];
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
+  embeddingParameters: EmbeddingParameters;
   draftParameterValues: Record<ParameterId, ParameterValueOrArray | null>;
   metadata: Metadata;
   loadingStartTime: number | null;
@@ -453,10 +455,10 @@ function DashboardInner(props: DashboardProps) {
 
   const parametersWidget = (
     <SyncedParametersList
-      parameters={getValuePopulatedParameters(
+      parameters={getValuePopulatedParameters({
         parameters,
-        isAutoApplyFilters ? parameterValues : draftParameterValues,
-      )}
+        values: isAutoApplyFilters ? parameterValues : draftParameterValues,
+      })}
       editingParameter={editingParameter}
       hideParameters={hiddenParameterSlugs}
       dashboard={dashboard}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -38,7 +38,7 @@ import type {
   StoreDashcard,
 } from "metabase-types/store";
 
-import type { EmbeddingParameters } from "metabase/public/lib/types";
+import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import type Database from "metabase-lib/metadata/Database";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import type Metadata from "metabase-lib/metadata/Metadata";
@@ -89,7 +89,6 @@ interface DashboardProps {
   editingParameter?: Parameter | null;
   parameters: UiParameter[];
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
-  embeddingParameters: EmbeddingParameters;
   draftParameterValues: Record<ParameterId, ParameterValueOrArray | null>;
   metadata: Metadata;
   loadingStartTime: number | null;
@@ -183,6 +182,9 @@ interface DashboardProps {
     columnKey: string,
     settings?: Record<string, unknown> | null,
   ) => void;
+  getEmbeddedParameterVisibility: (
+    slug: string,
+  ) => EmbeddingParameterVisibility | null;
 }
 
 function DashboardInner(props: DashboardProps) {

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -39,6 +39,7 @@ DashboardSidebars.propTypes = {
   isFullscreen: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   params: PropTypes.object,
+  embeddingParameters: PropTypes.object,
   sidebar: PropTypes.shape({
     name: PropTypes.string,
     props: PropTypes.object,
@@ -75,6 +76,7 @@ export function DashboardSidebars({
   closeSidebar,
   setDashboardAttribute,
   selectedTabId,
+  embeddingParameters,
 }) {
   const handleAddCard = useCallback(
     cardId => {
@@ -138,6 +140,7 @@ export function DashboardSidebars({
         <ParameterSidebar
           parameter={parameter}
           otherParameters={otherParameters}
+          embeddingParameters={embeddingParameters}
           onChangeName={setParameterName}
           onChangeDefaultValue={setParameterDefaultValue}
           onChangeIsMultiSelect={setParameterIsMultiSelect}

--- a/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardSidebars.jsx
@@ -39,7 +39,6 @@ DashboardSidebars.propTypes = {
   isFullscreen: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   params: PropTypes.object,
-  embeddingParameters: PropTypes.object,
   sidebar: PropTypes.shape({
     name: PropTypes.string,
     props: PropTypes.object,
@@ -47,6 +46,7 @@ DashboardSidebars.propTypes = {
   closeSidebar: PropTypes.func.isRequired,
   setDashboardAttribute: PropTypes.func,
   selectedTabId: PropTypes.number,
+  getEmbeddedParameterVisibility: PropTypes.func.isRequired,
 };
 
 export function DashboardSidebars({
@@ -76,7 +76,7 @@ export function DashboardSidebars({
   closeSidebar,
   setDashboardAttribute,
   selectedTabId,
-  embeddingParameters,
+  getEmbeddedParameterVisibility,
 }) {
   const handleAddCard = useCallback(
     cardId => {
@@ -138,9 +138,9 @@ export function DashboardSidebars({
       );
       return (
         <ParameterSidebar
+          getEmbeddedParameterVisibility={getEmbeddedParameterVisibility}
           parameter={parameter}
           otherParameters={otherParameters}
-          embeddingParameters={embeddingParameters}
           onChangeName={setParameterName}
           onChangeDefaultValue={setParameterDefaultValue}
           onChangeIsMultiSelect={setParameterIsMultiSelect}

--- a/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
+++ b/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx
@@ -157,10 +157,10 @@ class AutomaticDashboardAppInner extends Component {
               <div className="px1 pt1">
                 <SyncedParametersList
                   className="mt1"
-                  parameters={getValuePopulatedParameters(
+                  parameters={getValuePopulatedParameters({
                     parameters,
-                    parameterValues,
-                  )}
+                    values: parameterValues,
+                  })}
                   setParameterValue={setParameterValue}
                 />
               </div>

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -44,6 +44,7 @@ import type {
   ParameterValueOrArray,
 } from "metabase-types/api";
 import type { SelectedTabId, State, StoreDashcard } from "metabase-types/store";
+import type { EmbeddingParameters } from "metabase/public/lib/types";
 import type Database from "metabase-lib/metadata/Database";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import type Metadata from "metabase-lib/metadata/Metadata";
@@ -55,6 +56,7 @@ import {
   getClickBehaviorSidebarDashcard,
   getDashboardBeforeEditing,
   getDashboardComplete,
+  getDashboardEmbeddingParams,
   getDocumentTitle,
   getDraftParameterValues,
   getEditingParameter,
@@ -101,6 +103,7 @@ type StateProps = {
   editingParameter?: Parameter | null;
   parameters: UiParameter[];
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
+  embeddingParameters: EmbeddingParameters;
   draftParameterValues: Record<ParameterId, ParameterValueOrArray | null>;
   metadata: Metadata;
   loadingStartTime: number | null;
@@ -146,6 +149,7 @@ const mapStateToProps = (state: State): StateProps => {
     parameters: getParameters(state),
     parameterValues: getParameterValues(state),
     draftParameterValues: getDraftParameterValues(state),
+    embeddingParameters: getDashboardEmbeddingParams(state),
     metadata,
     loadingStartTime: getLoadingStartTime(state),
     clickBehaviorSidebarDashcard: getClickBehaviorSidebarDashcard(state),

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.tsx
@@ -44,7 +44,7 @@ import type {
   ParameterValueOrArray,
 } from "metabase-types/api";
 import type { SelectedTabId, State, StoreDashcard } from "metabase-types/store";
-import type { EmbeddingParameters } from "metabase/public/lib/types";
+import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import type Database from "metabase-lib/metadata/Database";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import type Metadata from "metabase-lib/metadata/Metadata";
@@ -56,7 +56,6 @@ import {
   getClickBehaviorSidebarDashcard,
   getDashboardBeforeEditing,
   getDashboardComplete,
-  getDashboardEmbeddingParams,
   getDocumentTitle,
   getDraftParameterValues,
   getEditingParameter,
@@ -78,6 +77,7 @@ import {
   getSelectedTabId,
   getSidebar,
   getSlowCards,
+  getEmbeddedParameterVisibility,
 } from "../../selectors";
 
 type OwnProps = {
@@ -103,7 +103,6 @@ type StateProps = {
   editingParameter?: Parameter | null;
   parameters: UiParameter[];
   parameterValues: Record<ParameterId, ParameterValueOrArray>;
-  embeddingParameters: EmbeddingParameters;
   draftParameterValues: Record<ParameterId, ParameterValueOrArray | null>;
   metadata: Metadata;
   loadingStartTime: number | null;
@@ -119,6 +118,9 @@ type StateProps = {
   selectedTabId: SelectedTabId;
   isAutoApplyFilters: boolean;
   isNavigatingBackToDashboard: boolean;
+  getEmbeddedParameterVisibility: (
+    slug: string,
+  ) => EmbeddingParameterVisibility | null;
 };
 
 type DispatchProps = {
@@ -149,7 +151,7 @@ const mapStateToProps = (state: State): StateProps => {
     parameters: getParameters(state),
     parameterValues: getParameterValues(state),
     draftParameterValues: getDraftParameterValues(state),
-    embeddingParameters: getDashboardEmbeddingParams(state),
+
     metadata,
     loadingStartTime: getLoadingStartTime(state),
     clickBehaviorSidebarDashcard: getClickBehaviorSidebarDashcard(state),
@@ -164,6 +166,8 @@ const mapStateToProps = (state: State): StateProps => {
     selectedTabId: getSelectedTabId(state),
     isAutoApplyFilters: getIsAutoApplyFilters(state),
     isNavigatingBackToDashboard: getIsNavigatingBackToDashboard(state),
+    getEmbeddedParameterVisibility: (slug: string) =>
+      getEmbeddedParameterVisibility(state, slug),
   };
 };
 

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -26,7 +26,9 @@ import type {
   ClickBehaviorSidebarState,
   EditParameterSidebarState,
   State,
+  StoreDashboard,
 } from "metabase-types/store";
+import type { EmbeddingParameters } from "metabase/public/lib/types";
 import Question from "metabase-lib/Question";
 import { isQuestionDashCard } from "./utils";
 
@@ -382,6 +384,26 @@ export const getDashcardParameterMappingOptions = createCachedSelector(
 )((state, props) => {
   return props.card.id ?? props.dashcard.id;
 });
+
+export const getDashboardEmbeddingParams = createSelector(
+  [getDashboard],
+  (dashboard: StoreDashboard | undefined): EmbeddingParameters => {
+    if (!dashboard?.enable_embedding) {
+      return {};
+    }
+
+    return dashboard.embedding_params ?? {};
+  },
+);
+
+export const getEmbeddingDisabledRequiredParameters = createSelector(
+  [getParameters, getDashboardEmbeddingParams],
+  (parameters, embeddingParameters) => {
+    return parameters.filter(
+      param => param.required && embeddingParameters[param.slug] === "disabled",
+    );
+  },
+);
 
 export const getIsHeaderVisible = createSelector(
   [getIsEmbedded, getEmbedOptions],

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
@@ -29,19 +29,3 @@ export const SettingValueWidget = styled(ParameterValueWidget)`
   border-radius: 0.5rem;
   background-color: ${color("white")};
 `;
-
-export const SettingRequiredContainer = styled.div`
-  display: flex;
-  gap: 0.5rem;
-  margin: 0.5rem 0;
-`;
-
-export const SettingRequiredLabel = styled.label`
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-top: 0.35rem;
-  font-weight: 700;
-  color: ${color("text-medium")};
-  cursor: pointer;
-`;

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
@@ -38,6 +38,7 @@ export const SettingRequiredContainer = styled.div`
 
 export const SettingRequiredLabel = styled.label`
   display: flex;
+  align-items: center;
   gap: 0.5rem;
   margin-top: 0.35rem;
   font-weight: 700;

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.styled.tsx
@@ -37,7 +37,8 @@ export const SettingRequiredContainer = styled.div`
 `;
 
 export const SettingRequiredLabel = styled.label`
-  display: block;
+  display: flex;
+  gap: 0.5rem;
   margin-top: 0.35rem;
   font-weight: 700;
   color: ${color("text-medium")};

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -138,7 +138,7 @@ export const ParameterSettings = ({
         />
 
         <SettingRequiredContainer
-          // This forces re-rendering when switching between parameters,
+          // This forces the toggle to be a new instance when the parameter changes,
           // so that toggles don't slide, which is confusing.
           key={`parameter-setting-required_${parameter.id}`}
         >

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -7,18 +7,16 @@ import type {
   ValuesSourceConfig,
   ValuesSourceType,
 } from "metabase-types/api";
-import { Icon, TextInput, Text, HoverCard, Stack } from "metabase/ui";
-import Toggle from "metabase/core/components/Toggle";
+import { Text, TextInput } from "metabase/ui";
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import { canUseCustomSource } from "metabase-lib/parameters/utils/parameter-source";
 import { getIsMultiSelect } from "../../utils/dashboards";
 import { isSingleOrMultiSelectable } from "../../utils/parameter-type";
 import ValuesSourceSettings from "../ValuesSourceSettings";
+import { RequiredParamToggle } from "../RequiredParamToggle/RequiredParamToggle";
 import {
   SettingLabel,
   SettingLabelError,
-  SettingRequiredContainer,
-  SettingRequiredLabel,
   SettingSection,
   SettingsRoot,
   SettingValueWidget,
@@ -137,52 +135,34 @@ export const ParameterSettings = ({
           setValue={onChangeDefaultValue}
         />
 
-        <SettingRequiredContainer
+        <RequiredParamToggle
           // This forces the toggle to be a new instance when the parameter changes,
           // so that toggles don't slide, which is confusing.
-          key={`parameter-setting-required_${parameter.id}`}
-        >
-          <Toggle
-            disabled={isEmbeddedDisabled}
-            id={`parameter-setting-required_${parameter.id}`}
-            value={parameter.required}
-            onChange={onChangeRequired}
-          />
-          <div>
-            <SettingRequiredLabel
-              htmlFor={`parameter-setting-required_${parameter.id}`}
-            >
-              {t`Always require a value`}
-              {isEmbeddedDisabled && (
-                <HoverCard position="top-end" shadow="xs">
-                  <HoverCard.Target>
-                    <Icon name="info_filled" />
-                  </HoverCard.Target>
-                  <HoverCard.Dropdown w={"300px"}>
-                    <Stack p="md" spacing="sm">
-                      <Text lh={1.4}>
-                        {t`This filter is set to disabled in an embedded dashboard.`}
-                      </Text>
-                      <Text lh={1.4}>
-                        {t`To always require a value, first visit embedding settings,
-                      make this filter editable or locked, re-publish the
-                      dashboard, then return to this page.`}
-                      </Text>
-                      <Text size="sm">
-                        {t`Note`}:{" "}
-                        {t`making it locked, will require updating the
-                      embedding code before proceeding, otherwise the embed will
-                      break.`}
-                      </Text>
-                    </Stack>
-                  </HoverCard.Dropdown>
-                </HoverCard>
-              )}
-            </SettingRequiredLabel>
-
-            <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
-          </div>
-        </SettingRequiredContainer>
+          key={`required_param_toggle_${parameter.id}`}
+          uniqueId={parameter.id}
+          disabled={isEmbeddedDisabled}
+          value={parameter.required ?? false}
+          onChange={onChangeRequired}
+          disabledTooltip={
+            <>
+              <Text lh={1.4}>
+                {t`This filter is set to disabled in an embedded dashboard.`}
+              </Text>
+              <Text lh={1.4}>
+                {t`To always require a value, first visit embedding settings,
+                    make this filter editable or locked, re-publish the
+                    dashboard, then return to this page.`}
+              </Text>
+              <Text size="sm">
+                {t`Note`}:{" "}
+                {t`making it locked, will require updating the
+                    embedding code before proceeding, otherwise the embed will
+                    break.`}
+              </Text>
+            </>
+          }
+          description={t`When enabled, people can change the value or reset it, but can't clear it entirely.`}
+        ></RequiredParamToggle>
       </SettingSection>
     </SettingsRoot>
   );

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -161,7 +161,6 @@ export const ParameterSettings = ({
               </Text>
             </>
           }
-          description={t`When enabled, people can change the value or reset it, but can't clear it entirely.`}
         ></RequiredParamToggle>
       </SettingSection>
     </SettingsRoot>

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -7,7 +7,7 @@ import type {
   ValuesSourceConfig,
   ValuesSourceType,
 } from "metabase-types/api";
-import { Icon, TextInput, Tooltip } from "metabase/ui";
+import { Icon, TextInput, Text, HoverCard, Stack } from "metabase/ui";
 import Toggle from "metabase/core/components/Toggle";
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import { canUseCustomSource } from "metabase-lib/parameters/utils/parameter-source";
@@ -154,16 +154,29 @@ export const ParameterSettings = ({
             >
               {t`Always require a value`}
               {isEmbeddedDisabled && (
-                <Tooltip
-                  width={200}
-                  multiline
-                  withArrow
-                  label={
-                    'This filter visiblity is set to "disabled" in the embedded dashboard, so you can\'t make it required'
-                  }
-                >
-                  <Icon name="warning" />
-                </Tooltip>
+                <HoverCard position="top-end" shadow="xs">
+                  <HoverCard.Target>
+                    <Icon name="info_filled" />
+                  </HoverCard.Target>
+                  <HoverCard.Dropdown w={"300px"}>
+                    <Stack p="md" spacing="sm">
+                      <Text lh={1.4}>
+                        {t`This filter is set to disabled in an embedded dashboard.`}
+                      </Text>
+                      <Text lh={1.4}>
+                        {t`To always require a value, first visit embedding settings,
+                      make this filter editable or locked, re-publish the
+                      dashboard, then return to this page.`}
+                      </Text>
+                      <Text size="sm">
+                        {t`Note`}:{" "}
+                        {t`making it locked, will require updating the
+                      embedding code before proceeding, otherwise the embed will
+                      break.`}
+                      </Text>
+                    </Stack>
+                  </HoverCard.Dropdown>
+                </HoverCard>
               )}
             </SettingRequiredLabel>
 

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -7,8 +7,9 @@ import type {
   ValuesSourceConfig,
   ValuesSourceType,
 } from "metabase-types/api";
-import { TextInput } from "metabase/ui";
+import { Icon, TextInput, Tooltip } from "metabase/ui";
 import Toggle from "metabase/core/components/Toggle";
+import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import { canUseCustomSource } from "metabase-lib/parameters/utils/parameter-source";
 import { getIsMultiSelect } from "../../utils/dashboards";
 import { isSingleOrMultiSelectable } from "../../utils/parameter-type";
@@ -33,9 +34,10 @@ export interface ParameterSettingsProps {
   onChangeSourceType: (sourceType: ValuesSourceType) => void;
   onChangeSourceConfig: (sourceConfig: ValuesSourceConfig) => void;
   onChangeRequired: (value: boolean) => void;
+  embeddedParameterVisibility?: EmbeddingParameterVisibility;
 }
 
-const ParameterSettings = ({
+export const ParameterSettings = ({
   parameter,
   isParameterSlugUsed,
   onChangeName,
@@ -45,6 +47,7 @@ const ParameterSettings = ({
   onChangeSourceType,
   onChangeSourceConfig,
   onChangeRequired,
+  embeddedParameterVisibility,
 }: ParameterSettingsProps): JSX.Element => {
   const [tempLabelValue, setTempLabelValue] = useState(parameter.name);
 
@@ -77,6 +80,8 @@ const ParameterSettings = ({
     },
     [onChangeSourceType, onChangeSourceConfig],
   );
+
+  const isEmbeddedDisabled = embeddedParameterVisibility === "disabled";
 
   return (
     <SettingsRoot>
@@ -132,8 +137,13 @@ const ParameterSettings = ({
           setValue={onChangeDefaultValue}
         />
 
-        <SettingRequiredContainer>
+        <SettingRequiredContainer
+          // This forces re-rendering when switching between parameters,
+          // so that toggles don't slide, which is confusing.
+          key={`parameter-setting-required_${parameter.id}`}
+        >
           <Toggle
+            disabled={isEmbeddedDisabled}
             id={`parameter-setting-required_${parameter.id}`}
             value={parameter.required}
             onChange={onChangeRequired}
@@ -143,7 +153,20 @@ const ParameterSettings = ({
               htmlFor={`parameter-setting-required_${parameter.id}`}
             >
               {t`Always require a value`}
+              {isEmbeddedDisabled && (
+                <Tooltip
+                  width={200}
+                  multiline
+                  withArrow
+                  label={
+                    'This filter visiblity is set to "disabled" in the embedded dashboard, so you can\'t make it required'
+                  }
+                >
+                  <Icon name="warning" />
+                </Tooltip>
+              )}
             </SettingRequiredLabel>
+
             <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
           </div>
         </SettingRequiredContainer>
@@ -170,5 +193,3 @@ function getLabelError({
   }
   return null;
 }
-
-export { ParameterSettings };

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -13,7 +13,7 @@ import { canUseCustomSource } from "metabase-lib/parameters/utils/parameter-sour
 import { getIsMultiSelect } from "../../utils/dashboards";
 import { isSingleOrMultiSelectable } from "../../utils/parameter-type";
 import ValuesSourceSettings from "../ValuesSourceSettings";
-import { RequiredParamToggle } from "../RequiredParamToggle/RequiredParamToggle";
+import { RequiredParamToggle } from "../RequiredParamToggle";
 import {
   SettingLabel,
   SettingLabelError,

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -34,7 +34,7 @@ export interface ParameterSettingsProps {
   onChangeSourceType: (sourceType: ValuesSourceType) => void;
   onChangeSourceConfig: (sourceConfig: ValuesSourceConfig) => void;
   onChangeRequired: (value: boolean) => void;
-  embeddedParameterVisibility?: EmbeddingParameterVisibility;
+  embeddedParameterVisibility: EmbeddingParameterVisibility | null;
 }
 
 export const ParameterSettings = ({

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -103,6 +103,7 @@ const setup = ({ parameter = createMockUiParameter() }: SetupOpts = {}) => {
 
   renderWithProviders(
     <ParameterSettings
+      embeddedParameterVisibility={null}
       parameter={parameter}
       isParameterSlugUsed={jest.fn()}
       onChangeName={onChangeName}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -51,7 +51,7 @@ export interface ParameterSidebarProps {
 export const ParameterSidebar = ({
   parameter,
   otherParameters,
-  embeddingParameters: embedParams,
+  embeddingParameters,
   onChangeName,
   onChangeDefaultValue,
   onChangeIsMultiSelect,
@@ -145,7 +145,7 @@ export const ParameterSidebar = ({
         {tab === "settings" ? (
           <ParameterSettings
             parameter={parameter}
-            embeddedParameterVisibility={embedParams[parameter.slug]}
+            embeddedParameterVisibility={embeddingParameters[parameter.slug]}
             isParameterSlugUsed={isParameterSlugUsed}
             onChangeName={handleNameChange}
             onChangeDefaultValue={handleDefaultValueChange}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -10,6 +10,7 @@ import type {
   ValuesSourceType,
 } from "metabase-types/api";
 import { slugify } from "metabase/lib/formatting";
+import type { EmbeddingParameters } from "metabase/public/lib/types";
 import { canUseLinkedFilters } from "../../utils/linked-filters";
 import { ParameterSettings } from "../ParameterSettings";
 import ParameterLinkedFilters from "../ParameterLinkedFilters";
@@ -18,6 +19,7 @@ import { SidebarBody, SidebarHeader } from "./ParameterSidebar.styled";
 export interface ParameterSidebarProps {
   parameter: Parameter;
   otherParameters: Parameter[];
+  embeddingParameters: EmbeddingParameters;
   onChangeName: (parameterId: ParameterId, name: string) => void;
   onChangeDefaultValue: (parameterId: ParameterId, value: unknown) => void;
   onChangeIsMultiSelect: (
@@ -49,6 +51,7 @@ export interface ParameterSidebarProps {
 export const ParameterSidebar = ({
   parameter,
   otherParameters,
+  embeddingParameters: embedParams,
   onChangeName,
   onChangeDefaultValue,
   onChangeIsMultiSelect,
@@ -142,6 +145,7 @@ export const ParameterSidebar = ({
         {tab === "settings" ? (
           <ParameterSettings
             parameter={parameter}
+            embeddedParameterVisibility={embedParams[parameter.slug]}
             isParameterSlugUsed={isParameterSlugUsed}
             onChangeName={handleNameChange}
             onChangeDefaultValue={handleDefaultValueChange}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -10,7 +10,7 @@ import type {
   ValuesSourceType,
 } from "metabase-types/api";
 import { slugify } from "metabase/lib/formatting";
-import type { EmbeddingParameters } from "metabase/public/lib/types";
+import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import { canUseLinkedFilters } from "../../utils/linked-filters";
 import { ParameterSettings } from "../ParameterSettings";
 import ParameterLinkedFilters from "../ParameterLinkedFilters";
@@ -19,7 +19,6 @@ import { SidebarBody, SidebarHeader } from "./ParameterSidebar.styled";
 export interface ParameterSidebarProps {
   parameter: Parameter;
   otherParameters: Parameter[];
-  embeddingParameters: EmbeddingParameters;
   onChangeName: (parameterId: ParameterId, name: string) => void;
   onChangeDefaultValue: (parameterId: ParameterId, value: unknown) => void;
   onChangeIsMultiSelect: (
@@ -46,12 +45,14 @@ export interface ParameterSidebarProps {
   onRemoveParameter: (parameterId: ParameterId) => void;
   onShowAddParameterPopover: () => void;
   onClose: () => void;
+  getEmbeddedParameterVisibility: (
+    slug: string,
+  ) => EmbeddingParameterVisibility | null;
 }
 
 export const ParameterSidebar = ({
   parameter,
   otherParameters,
-  embeddingParameters,
   onChangeName,
   onChangeDefaultValue,
   onChangeIsMultiSelect,
@@ -63,6 +64,7 @@ export const ParameterSidebar = ({
   onRemoveParameter,
   onShowAddParameterPopover,
   onClose,
+  getEmbeddedParameterVisibility,
 }: ParameterSidebarProps): JSX.Element => {
   const parameterId = parameter.id;
   const tabs = useMemo(() => getTabs(parameter), [parameter]);
@@ -145,7 +147,9 @@ export const ParameterSidebar = ({
         {tab === "settings" ? (
           <ParameterSettings
             parameter={parameter}
-            embeddedParameterVisibility={embeddingParameters[parameter.slug]}
+            embeddedParameterVisibility={getEmbeddedParameterVisibility(
+              parameter.slug,
+            )}
             isParameterSlugUsed={isParameterSlugUsed}
             onChangeName={handleNameChange}
             onChangeDefaultValue={handleDefaultValueChange}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -41,6 +41,7 @@ const setup = ({
         </button>
         <ParameterSidebar
           parameter={parameter}
+          embeddingParameters={{}}
           otherParameters={otherParameters}
           onChangeName={onChangeName}
           onChangeDefaultValue={jest.fn()}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -41,7 +41,6 @@ const setup = ({
         </button>
         <ParameterSidebar
           parameter={parameter}
-          embeddingParameters={{}}
           otherParameters={otherParameters}
           onChangeName={onChangeName}
           onChangeDefaultValue={jest.fn()}
@@ -54,6 +53,7 @@ const setup = ({
           onShowAddParameterPopover={jest.fn()}
           onClose={jest.fn()}
           onChangeRequired={jest.fn()}
+          getEmbeddedParameterVisibility={() => null}
         />
       </div>
     );

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -284,7 +284,7 @@ function Widget({
     return (
       <TextWidget
         value={value}
-        setValue={setValue}
+        setValue={setValueOrDefault}
         className={className}
         isEditing={isEditing}
         commitImmediately={commitImmediately}

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -284,7 +284,7 @@ function Widget({
     return (
       <TextWidget
         value={value}
-        setValue={setValueOrDefault}
+        setValue={setValue}
         className={className}
         isEditing={isEditing}
         commitImmediately={commitImmediately}

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
@@ -18,6 +18,8 @@ export class ParameterWidget extends Component {
   static propTypes = {
     parameter: PropTypes.object,
     commitImmediately: PropTypes.bool,
+    setParameterValueToDefault: PropTypes.func,
+    enableParameterRequiredBehavior: PropTypes.bool,
   };
 
   static defaultProps = {

--- a/frontend/src/metabase/parameters/components/RequiredParamToggle/RequierParamToggle.styled.tsx
+++ b/frontend/src/metabase/parameters/components/RequiredParamToggle/RequierParamToggle.styled.tsx
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+import { color } from "metabase/lib/colors";
+
+export const SettingRequiredLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.35rem;
+  font-weight: 700;
+  color: ${color("text-medium")};
+  cursor: pointer;
+`;

--- a/frontend/src/metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.tsx
+++ b/frontend/src/metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.tsx
@@ -10,12 +10,10 @@ interface RequiredParamToggleProps {
   value: boolean;
   onChange: (value: boolean) => void;
   disabledTooltip: ReactNode;
-  description: string;
 }
 
 export function RequiredParamToggle(props: RequiredParamToggleProps) {
-  const { disabled, value, onChange, uniqueId, disabledTooltip, description } =
-    props;
+  const { disabled, value, onChange, uniqueId, disabledTooltip } = props;
   const id = `required_param_toggle_${uniqueId}`;
 
   return (
@@ -38,7 +36,7 @@ export function RequiredParamToggle(props: RequiredParamToggleProps) {
           )}
         </SettingRequiredLabel>
 
-        <p>{description}</p>
+        <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
       </div>
     </Flex>
   );

--- a/frontend/src/metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.tsx
+++ b/frontend/src/metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 import type { ReactNode } from "react";
-import { Icon, HoverCard, Stack, Flex } from "metabase/ui";
+import { Icon, HoverCard, Stack, Flex, Text } from "metabase/ui";
 import Toggle from "metabase/core/components/Toggle";
 import { SettingRequiredLabel } from "./RequierParamToggle.styled";
 
@@ -36,7 +36,10 @@ export function RequiredParamToggle(props: RequiredParamToggleProps) {
           )}
         </SettingRequiredLabel>
 
-        <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
+        <Text
+          mt="sm"
+          lh={1.2}
+        >{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</Text>
       </div>
     </Flex>
   );

--- a/frontend/src/metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.tsx
+++ b/frontend/src/metabase/parameters/components/RequiredParamToggle/RequiredParamToggle.tsx
@@ -1,0 +1,45 @@
+import { t } from "ttag";
+import type { ReactNode } from "react";
+import { Icon, HoverCard, Stack, Flex } from "metabase/ui";
+import Toggle from "metabase/core/components/Toggle";
+import { SettingRequiredLabel } from "./RequierParamToggle.styled";
+
+interface RequiredParamToggleProps {
+  disabled?: boolean;
+  uniqueId: string;
+  value: boolean;
+  onChange: (value: boolean) => void;
+  disabledTooltip: ReactNode;
+  description: string;
+}
+
+export function RequiredParamToggle(props: RequiredParamToggleProps) {
+  const { disabled, value, onChange, uniqueId, disabledTooltip, description } =
+    props;
+  const id = `required_param_toggle_${uniqueId}`;
+
+  return (
+    <Flex gap="sm" mt="md">
+      <Toggle disabled={disabled} id={id} value={value} onChange={onChange} />
+      <div>
+        <SettingRequiredLabel htmlFor={id}>
+          {t`Always require a value`}
+          {disabled && (
+            <HoverCard position="top-end" shadow="xs">
+              <HoverCard.Target>
+                <Icon name="info_filled" />
+              </HoverCard.Target>
+              <HoverCard.Dropdown w={320}>
+                <Stack p="md" spacing="sm">
+                  {disabledTooltip}
+                </Stack>
+              </HoverCard.Dropdown>
+            </HoverCard>
+          )}
+        </SettingRequiredLabel>
+
+        <p>{description}</p>
+      </div>
+    </Flex>
+  );
+}

--- a/frontend/src/metabase/parameters/components/RequiredParamToggle/index.ts
+++ b/frontend/src/metabase/parameters/components/RequiredParamToggle/index.ts
@@ -1,0 +1,1 @@
+export { RequiredParamToggle } from "./RequiredParamToggle";

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -59,6 +59,8 @@ interface OwnProps {
   hiddenParameterSlugs?: string;
   setParameterValue?: (parameterId: ParameterId, value: any) => void;
   children: ReactNode;
+  enableParameterRequiredBehavior?: boolean;
+  setParameterValueToDefault: (id: ParameterId) => void;
 }
 
 interface StateProps {
@@ -100,6 +102,8 @@ function EmbedFrame({
   draftParameterValues,
   hiddenParameterSlugs,
   setParameterValue,
+  setParameterValueToDefault,
+  enableParameterRequiredBehavior,
 }: Props) {
   const [hasInnerScroll, setInnerScroll] = useState(true);
 
@@ -158,14 +162,18 @@ function EmbedFrame({
                   className="mt1"
                   question={question}
                   dashboard={dashboard}
-                  parameters={getValuePopulatedParameters(
+                  parameters={getValuePopulatedParameters({
                     parameters,
-                    _.isEmpty(draftParameterValues)
+                    values: _.isEmpty(draftParameterValues)
                       ? parameterValues
                       : draftParameterValues,
-                  )}
+                  })}
                   setParameterValue={setParameterValue}
                   hideParameters={hideParameters}
+                  setParameterValueToDefault={setParameterValueToDefault}
+                  enableParameterRequiredBehavior={
+                    enableParameterRequiredBehavior
+                  }
                 />
                 {dashboard && <FilterApplyButton />}
               </ParametersWidgetContainer>

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
@@ -76,10 +76,7 @@ export const ParametersSettings = ({
                   "aria-label": parameter.name,
                 }}
                 className="ml-auto bg-white"
-                value={
-                  embeddingParams[parameter.slug] ||
-                  getDefaultParameterSelectValue(parameter)
-                }
+                value={embeddingParams[parameter.slug] || "disabled"}
                 onChange={(e: ChangeEvent<HTMLSelectElement>) =>
                   onChangeEmbeddingParameters({
                     ...embeddingParams,
@@ -161,7 +158,3 @@ const getIconForParameter = (parameter: EmbedResourceParameter): IconName => {
 
   return "unknown";
 };
-
-function getDefaultParameterSelectValue(parameter: EmbedResourceParameter) {
-  return parameter.required ? "enabled" : "disabled";
-}

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
@@ -8,6 +8,7 @@ import { ParameterWidget as StaticParameterWidget } from "metabase/parameters/co
 import type {
   EmbeddingParameters,
   EmbeddingParametersValues,
+  EmbeddingParameterVisibility,
   EmbedResourceParameter,
   EmbedResourceType,
 } from "metabase/public/lib/types";
@@ -39,11 +40,16 @@ export const ParametersSettings = ({
 }: ParametersSettingsProps): JSX.Element => {
   const valuePopulatedLockedParameters = useMemo(
     () =>
-      getValuePopulatedParameters(
-        lockedParameters,
-        parameterValues,
-      ) as EmbedResourceParameterWithValue[],
+      getValuePopulatedParameters({
+        parameters: lockedParameters,
+        values: parameterValues,
+        defaultRequired: true,
+      }) as EmbedResourceParameterWithValue[],
     [lockedParameters, parameterValues],
+  );
+
+  const hasRequiredParameters = resourceParameters.some(
+    param => param.required,
   );
 
   return resourceParameters.length > 0 ? (
@@ -57,26 +63,48 @@ export const ParametersSettings = ({
           {resourceParameters.map(parameter => (
             <div key={parameter.id} className="flex align-center">
               <Icon name={getIconForParameter(parameter)} className="mr2" />
-              <h3>{parameter.name}</h3>
+              <h3>
+                {parameter.name}
+                {parameter.required && (
+                  <Text color="error" span>
+                    &nbsp;*
+                  </Text>
+                )}
+              </h3>
               <Select
                 buttonProps={{
                   "aria-label": parameter.name,
                 }}
                 className="ml-auto bg-white"
-                value={embeddingParams[parameter.slug] || "disabled"}
+                value={
+                  embeddingParams[parameter.slug] ||
+                  getDefaultParameterSelectValue(parameter)
+                }
                 onChange={(e: ChangeEvent<HTMLSelectElement>) =>
                   onChangeEmbeddingParameters({
                     ...embeddingParams,
-                    [parameter.slug]: e.target.value,
+                    [parameter.slug]: e.target
+                      .value as EmbeddingParameterVisibility,
                   })
                 }
               >
-                <Option icon="close" value="disabled">{t`Disabled`}</Option>
+                <Option
+                  icon="close"
+                  value="disabled"
+                  disabled={parameter.required}
+                >{t`Disabled`}</Option>
                 <Option icon="pencil" value="enabled">{t`Editable`}</Option>
                 <Option icon="lock" value="locked">{t`Locked`}</Option>
               </Select>
             </div>
           ))}
+
+          {hasRequiredParameters && (
+            <Text size="xm">
+              <strong>{t`Note`}: </strong>
+              {t`Parameters marked with a red asterisk are required and can't be disabled.`}
+            </Text>
+          )}
         </Stack>
       </StaticEmbedSetupPaneSettingsContentSection>
 
@@ -95,9 +123,16 @@ export const ParametersSettings = ({
                   className="m0"
                   parameter={parameter}
                   parameters={valuePopulatedLockedParameters}
-                  setValue={(value: string) => {
-                    onChangeParameterValue(parameter.id, value);
+                  setValue={(value: string) =>
+                    onChangeParameterValue(parameter.id, value)
+                  }
+                  setParameterValueToDefault={() => {
+                    onChangeParameterValue(
+                      parameter.id,
+                      parameter.default as any,
+                    );
                   }}
+                  enableParameterRequiredBehavior
                 />
               ))}
             </Stack>
@@ -126,3 +161,7 @@ const getIconForParameter = (parameter: EmbedResourceParameter): IconName => {
 
   return "unknown";
 };
+
+function getDefaultParameterSelectValue(parameter: EmbedResourceParameter) {
+  return parameter.required ? "enabled" : "disabled";
+}

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -291,19 +291,24 @@ function getDefaultEmbeddingParams(
   resource: EmbedResource,
   resourceParameters: EmbedResourceParameter[],
 ): EmbeddingParameters {
-  return filterValidResourceParameters(
-    resourceParameters,
-    resource.embedding_params || {},
+  const validSlugs = resourceParameters.map(param => param.slug);
+  // We first pick only dashboard parameters with valid slugs
+  const defaultParams = _.pick(resource.embedding_params || {}, validSlugs);
+  // Then pick valid required dashboard parameters
+  const validRequiredParams = resourceParameters.filter(
+    param => param.slug && param.required,
   );
-}
 
-function filterValidResourceParameters(
-  resourceParameters: EmbedResourceParameter[],
-  embeddingParams: EmbeddingParameters,
-) {
-  const validParameters = resourceParameters.map(parameter => parameter.slug);
-
-  return _.pick(embeddingParams, validParameters);
+  // And for each required parameter set its value to "enabled"
+  // (Editable) because this is the default for a required parameter.
+  // This is needed to save embedding_parameters when a user clicks
+  // "Publish" without changing parameter visibility.
+  return validRequiredParams.reduce((acc, param) => {
+    if (!acc[param.slug] || acc[param.slug] === "disabled") {
+      acc[param.slug] = "enabled";
+    }
+    return acc;
+  }, defaultParams);
 }
 
 function getPreviewParamsBySlug({

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -301,7 +301,7 @@ function getDefaultEmbeddingParams(
 
   // And for each required parameter set its value to "enabled"
   // (Editable) because this is the default for a required parameter.
-  // This is needed to save embedding_parameters when a user clicks
+  // This is needed to save embedding_params when a user clicks
   // "Publish" without changing parameter visibility.
   return validRequiredParams.reduce((acc, param) => {
     if (!acc[param.slug] || acc[param.slug] === "disabled") {

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -332,7 +332,7 @@ function getPreviewParamsBySlug({
         parameter,
         values: parameterValues,
         defaultRequired: true,
-      }) ?? null,
+      }),
     ]),
   );
 }

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -19,6 +19,7 @@ import {
 } from "metabase/public/lib/embed";
 import { getEmbedServerCodeExampleOptions } from "metabase/public/lib/code";
 
+import { getParameterValue } from "metabase-lib/parameters/utils/parameter-values";
 import { DEFAULT_DISPLAY_OPTIONS } from "./config";
 import { ServerEmbedCodePane } from "./ServerEmbedCodePane";
 import { EmbedModalContentStatusBar } from "./EmbedModalContentStatusBar";
@@ -322,7 +323,11 @@ function getPreviewParamsBySlug({
   return Object.fromEntries(
     lockedParameters.map(parameter => [
       parameter.slug,
-      parameterValues[parameter.id] ?? null,
+      getParameterValue({
+        parameter,
+        values: parameterValues,
+        defaultRequired: true,
+      }) ?? null,
     ]),
   );
 }

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -159,6 +159,7 @@ class PublicDashboard extends Component {
       draftParameterValues,
       isFullscreen,
       isNightMode,
+      setParameterValueToDefault,
     } = this.props;
 
     const buttons = !isWithinIframe()
@@ -178,6 +179,8 @@ class PublicDashboard extends Component {
         actionButtons={
           buttons.length > 0 && <div className="flex">{buttons}</div>
         }
+        setParameterValueToDefault={setParameterValueToDefault}
+        enableParameterRequiredBehavior
       >
         <LoadingAndErrorWrapper
           className={cx({

--- a/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.jsx
+++ b/frontend/src/metabase/public/containers/PublicQuestion/PublicQuestion.jsx
@@ -119,6 +119,14 @@ class PublicQuestionInner extends Component {
     );
   };
 
+  setParameterValueToDefault = parameterId => {
+    const parameters = this.getParameters();
+    const parameter = parameters.find(({ id }) => id === parameterId);
+    if (parameter) {
+      this.setParameterValue(parameterId, parameter.default);
+    }
+  };
+
   run = async () => {
     const {
       setErrorPage,
@@ -166,6 +174,22 @@ class PublicQuestionInner extends Component {
     }
   };
 
+  getParameters() {
+    const { metadata } = this.props;
+    const { card, initialized } = this.state;
+
+    if (!initialized || !card) {
+      return [];
+    }
+
+    return getCardUiParameters(
+      card,
+      metadata,
+      {},
+      card.parameters || undefined,
+    );
+  }
+
   render() {
     const {
       params: { uuid, token },
@@ -184,19 +208,17 @@ class PublicQuestionInner extends Component {
       />
     );
 
-    const parameters =
-      card &&
-      getCardUiParameters(card, metadata, {}, card.parameters || undefined);
-
     return (
       <EmbedFrame
         name={card && card.name}
         description={card && card.description}
         actionButtons={actionButtons}
         question={question}
-        parameters={initialized ? parameters : []}
+        parameters={this.getParameters()}
         parameterValues={parameterValues}
         setParameterValue={this.setParameterValue}
+        enableParameterRequiredBehavior
+        setParameterValueToDefault={this.setParameterValueToDefault}
       >
         <LoadingAndErrorWrapper
           className="flex-full"

--- a/frontend/src/metabase/public/lib/types.ts
+++ b/frontend/src/metabase/public/lib/types.ts
@@ -13,9 +13,13 @@ export type EmbedResourceParameter = {
   name: string;
   slug: string;
   type: string;
+  required?: boolean;
+  default?: unknown;
 };
 
-export type EmbeddingParameters = Record<string, string>;
+export type EmbeddingParameterVisibility = "disabled" | "enabled" | "locked";
+
+export type EmbeddingParameters = Record<string, EmbeddingParameterVisibility>;
 
 export type EmbeddingParametersValues = Record<string, string>;
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.styled.tsx
@@ -55,7 +55,8 @@ export const ToggleContainer = styled.div`
 `;
 
 export const ToggleLabel = styled.label`
-  display: block;
+  display: flex;
+  gap: 0.5rem;
   margin-top: 0.35rem;
   font-weight: 700;
   color: ${color("text-medium")};

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -55,7 +55,7 @@ import {
 interface Props {
   tag: TemplateTag;
   parameter: Parameter;
-  embeddedParameterVisibility?: EmbeddingParameterVisibility;
+  embeddedParameterVisibility?: EmbeddingParameterVisibility | null;
   database?: Database | null;
   databases: Database[];
   databaseFields?: Field[];

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -5,11 +5,10 @@ import { connect } from "react-redux";
 import { Link } from "react-router";
 
 import Schemas from "metabase/entities/schemas";
-import Toggle from "metabase/core/components/Toggle";
 import InputBlurChange from "metabase/components/InputBlurChange";
 import type { SelectChangeEvent } from "metabase/core/components/Select";
 import Select, { Option } from "metabase/core/components/Select";
-
+import { Text } from "metabase/ui";
 import ValuesSourceSettings from "metabase/parameters/components/ValuesSourceSettings";
 
 import { fetchField } from "metabase/redux/metadata";
@@ -31,7 +30,7 @@ import type {
 } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
-import { Icon, Tooltip } from "metabase/ui";
+import { RequiredParamToggle } from "metabase/parameters/components/RequiredParamToggle/RequiredParamToggle";
 import type Metadata from "metabase-lib/metadata/Metadata";
 import type Database from "metabase-lib/metadata/Database";
 import type Table from "metabase-lib/metadata/Table";
@@ -51,8 +50,6 @@ import {
   InputContainer,
   TagContainer,
   TagName,
-  ToggleContainer,
-  ToggleLabel,
 } from "./TagEditorParam.styled";
 
 interface Props {
@@ -397,32 +394,30 @@ class TagEditorParamInner extends Component<Props> {
             commitImmediately
           />
 
-          <ToggleContainer>
-            <Toggle
-              disabled={isEmbeddedDisabled}
-              id={`tag-editor-required_${tag.id}`}
-              value={tag.required}
-              onChange={this.setRequired}
-            />
-            <div>
-              <ToggleLabel htmlFor={`tag-editor-required_${tag.id}`}>
-                {t`Always require a value`}
-                {isEmbeddedDisabled && (
-                  <Tooltip
-                    width={200}
-                    multiline
-                    withArrow
-                    label={
-                      'This filter visiblity is set to "disabled" in the embedded question, so you can\'t make it required'
-                    }
-                  >
-                    <Icon name="warning" />
-                  </Tooltip>
-                )}
-              </ToggleLabel>
-              <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
-            </div>
-          </ToggleContainer>
+          <RequiredParamToggle
+            uniqueId={tag.id}
+            disabled={isEmbeddedDisabled}
+            value={tag.required ?? false}
+            onChange={this.setRequired}
+            disabledTooltip={
+              <>
+                <Text lh={1.4}>
+                  {t`This filter is set to disabled in an embedded question.`}
+                </Text>
+                <Text lh={1.4}>
+                  {t`To always require a value, first visit embedding settings,
+                    make this filter editable or locked, re-publish the
+                    question, then return to this page.`}
+                </Text>
+                <Text size="sm">
+                  {t`Note`}:{" "}
+                  {t`making it locked, will require updating the
+                    embedding code before proceeding, otherwise the embed will
+                    break.`}
+                </Text>
+              </>
+            }
+          />
         </div>
       </TagContainer>
     );

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -234,7 +234,7 @@ class TagEditorParamInner extends Component<Props> {
     const isEmbeddedDisabled = embeddedParameterVisibility === "disabled";
 
     return (
-      <TagContainer>
+      <TagContainer data-testid={`tag-editor-variable-${tag.name}`}>
         <ContainerLabel paddingTop>{t`Variable name`}</ContainerLabel>
         <TagName>{tag.name}</TagName>
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -30,6 +30,8 @@ import type {
   ValuesSourceType,
 } from "metabase-types/api";
 import type { State } from "metabase-types/store";
+import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
+import { Icon, Tooltip } from "metabase/ui";
 import type Metadata from "metabase-lib/metadata/Metadata";
 import type Database from "metabase-lib/metadata/Database";
 import type Table from "metabase-lib/metadata/Table";
@@ -56,6 +58,7 @@ import {
 interface Props {
   tag: TemplateTag;
   parameter: Parameter;
+  embeddedParameterVisibility?: EmbeddingParameterVisibility;
   database?: Database | null;
   databases: Database[];
   databaseFields?: Field[];
@@ -202,7 +205,14 @@ class TagEditorParamInner extends Component<Props> {
   };
 
   render() {
-    const { tag, database, databases, metadata, parameter } = this.props;
+    const {
+      tag,
+      database,
+      databases,
+      metadata,
+      parameter,
+      embeddedParameterVisibility,
+    } = this.props;
     let widgetOptions: { name?: string; type: string }[] = [];
     let field: Field | null = null;
     let table: Table | null | undefined = null;
@@ -224,6 +234,7 @@ class TagEditorParamInner extends Component<Props> {
       tag["widget-type"] === "none" || !tag["widget-type"];
     const hasNoWidgetLabel = !tag["display-name"];
     const hasNoDefaultValue = !tag.default;
+    const isEmbeddedDisabled = embeddedParameterVisibility === "disabled";
 
     return (
       <TagContainer>
@@ -388,6 +399,7 @@ class TagEditorParamInner extends Component<Props> {
 
           <ToggleContainer>
             <Toggle
+              disabled={isEmbeddedDisabled}
               id={`tag-editor-required_${tag.id}`}
               value={tag.required}
               onChange={this.setRequired}
@@ -395,6 +407,18 @@ class TagEditorParamInner extends Component<Props> {
             <div>
               <ToggleLabel htmlFor={`tag-editor-required_${tag.id}`}>
                 {t`Always require a value`}
+                {isEmbeddedDisabled && (
+                  <Tooltip
+                    width={200}
+                    multiline
+                    withArrow
+                    label={
+                      'This parameter visiblity is set to "disabled" in the embedded question, so you can\'t make it required'
+                    }
+                  >
+                    <Icon name="warning" />
+                  </Tooltip>
+                )}
               </ToggleLabel>
               <p>{t`When enabled, people can change the value or reset it, but can't clear it entirely.`}</p>
             </div>

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -30,7 +30,7 @@ import type {
 } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
-import { RequiredParamToggle } from "metabase/parameters/components/RequiredParamToggle/RequiredParamToggle";
+import { RequiredParamToggle } from "metabase/parameters/components/RequiredParamToggle";
 import type Metadata from "metabase-lib/metadata/Metadata";
 import type Database from "metabase-lib/metadata/Database";
 import type Table from "metabase-lib/metadata/Table";

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -413,7 +413,7 @@ class TagEditorParamInner extends Component<Props> {
                     multiline
                     withArrow
                     label={
-                      'This parameter visiblity is set to "disabled" in the embedded question, so you can\'t make it required'
+                      'This filter visiblity is set to "disabled" in the embedded question, so you can\'t make it required'
                     }
                   >
                     <Icon name="warning" />

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -1,5 +1,4 @@
 import { Component } from "react";
-import PropTypes from "prop-types";
 import { t } from "ttag";
 import cx from "classnames";
 import _ from "underscore";
@@ -17,7 +16,7 @@ import type {
   TemplateTag,
   TemplateTagId,
 } from "metabase-types/api";
-import type { EmbeddingParameters } from "metabase/public/lib/types";
+import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import type Database from "metabase-lib/metadata/Database";
 import type Field from "metabase-lib/metadata/Field";
@@ -25,6 +24,10 @@ import type Question from "metabase-lib/Question";
 
 import { TagEditorParam } from "./TagEditorParam";
 import { TagEditorHelp } from "./TagEditorHelp";
+
+type GetEmbeddedParamVisibility = (
+  slug: string,
+) => EmbeddingParameterVisibility;
 
 interface TagEditorSidebarProps {
   card: Card;
@@ -38,7 +41,7 @@ interface TagEditorSidebarProps {
   setTemplateTagConfig: (tag: TemplateTag, config: Parameter) => void;
   setParameterValue: (tagId: TemplateTagId, value: RowValue) => void;
   onClose: () => void;
-  embeddingParameters: EmbeddingParameters;
+  getEmbeddedParameterVisibility: GetEmbeddedParamVisibility;
 }
 
 interface TagEditorSidebarState {
@@ -48,17 +51,6 @@ interface TagEditorSidebarState {
 export class TagEditorSidebar extends Component<TagEditorSidebarProps> {
   state: TagEditorSidebarState = {
     section: "settings",
-  };
-
-  static propTypes = {
-    card: PropTypes.object.isRequired,
-    onClose: PropTypes.func.isRequired,
-    databaseFields: PropTypes.array,
-    sampleDatabaseId: PropTypes.number,
-    setDatasetQuery: PropTypes.func.isRequired,
-    setTemplateTag: PropTypes.func.isRequired,
-    setTemplateTagConfig: PropTypes.func.isRequired,
-    setParameterValue: PropTypes.func.isRequired,
   };
 
   setSection(section: "settings" | "help") {
@@ -82,7 +74,7 @@ export class TagEditorSidebar extends Component<TagEditorSidebarProps> {
       setTemplateTagConfig,
       setParameterValue,
       onClose,
-      embeddingParameters,
+      getEmbeddedParameterVisibility,
     } = this.props;
     const tags = query.variableTemplateTags();
     const database = question.database();
@@ -124,7 +116,7 @@ export class TagEditorSidebar extends Component<TagEditorSidebarProps> {
               setTemplateTag={setTemplateTag}
               setTemplateTagConfig={setTemplateTagConfig}
               setParameterValue={setParameterValue}
-              embeddingParameters={embeddingParameters}
+              getEmbeddedParameterVisibility={getEmbeddedParameterVisibility}
             />
           ) : (
             <TagEditorHelp
@@ -146,10 +138,10 @@ interface SettingsPaneProps {
   databases: Database[];
   databaseFields: Field[];
   parametersById: Record<ParameterId, Parameter>;
-  embeddingParameters: EmbeddingParameters;
   setTemplateTag: (tag: TemplateTag) => void;
   setTemplateTagConfig: (tag: TemplateTag, config: Parameter) => void;
   setParameterValue: (tagId: TemplateTagId, value: RowValue) => void;
+  getEmbeddedParameterVisibility: GetEmbeddedParamVisibility;
 }
 
 const SettingsPane = ({
@@ -161,18 +153,18 @@ const SettingsPane = ({
   setTemplateTag,
   setTemplateTagConfig,
   setParameterValue,
-  embeddingParameters,
+  getEmbeddedParameterVisibility,
 }: SettingsPaneProps) => (
   <div>
     {tags.map(tag => (
-      <div key={tag.name}>
+      <div key={tag.id}>
         <TagEditorParam
           tag={tag}
           key={tag.name}
           parameter={parametersById[tag.id]}
-          embeddedParameterVisibility={
-            embeddingParameters[parametersById[tag.id].slug]
-          }
+          embeddedParameterVisibility={getEmbeddedParameterVisibility(
+            parametersById[tag.id].slug,
+          )}
           databaseFields={databaseFields}
           database={database}
           databases={databases}

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -162,9 +162,11 @@ const SettingsPane = ({
           tag={tag}
           key={tag.name}
           parameter={parametersById[tag.id]}
-          embeddedParameterVisibility={getEmbeddedParameterVisibility(
-            parametersById[tag.id].slug,
-          )}
+          embeddedParameterVisibility={
+            parametersById[tag.id]
+              ? getEmbeddedParameterVisibility(parametersById[tag.id].slug)
+              : null
+          }
           databaseFields={databaseFields}
           database={database}
           databases={databases}

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorSidebar.tsx
@@ -17,6 +17,7 @@ import type {
   TemplateTag,
   TemplateTagId,
 } from "metabase-types/api";
+import type { EmbeddingParameters } from "metabase/public/lib/types";
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import type Database from "metabase-lib/metadata/Database";
 import type Field from "metabase-lib/metadata/Field";
@@ -37,6 +38,7 @@ interface TagEditorSidebarProps {
   setTemplateTagConfig: (tag: TemplateTag, config: Parameter) => void;
   setParameterValue: (tagId: TemplateTagId, value: RowValue) => void;
   onClose: () => void;
+  embeddingParameters: EmbeddingParameters;
 }
 
 interface TagEditorSidebarState {
@@ -80,6 +82,7 @@ export class TagEditorSidebar extends Component<TagEditorSidebarProps> {
       setTemplateTagConfig,
       setParameterValue,
       onClose,
+      embeddingParameters,
     } = this.props;
     const tags = query.variableTemplateTags();
     const database = question.database();
@@ -121,6 +124,7 @@ export class TagEditorSidebar extends Component<TagEditorSidebarProps> {
               setTemplateTag={setTemplateTag}
               setTemplateTagConfig={setTemplateTagConfig}
               setParameterValue={setParameterValue}
+              embeddingParameters={embeddingParameters}
             />
           ) : (
             <TagEditorHelp
@@ -142,6 +146,7 @@ interface SettingsPaneProps {
   databases: Database[];
   databaseFields: Field[];
   parametersById: Record<ParameterId, Parameter>;
+  embeddingParameters: EmbeddingParameters;
   setTemplateTag: (tag: TemplateTag) => void;
   setTemplateTagConfig: (tag: TemplateTag, config: Parameter) => void;
   setParameterValue: (tagId: TemplateTagId, value: RowValue) => void;
@@ -156,6 +161,7 @@ const SettingsPane = ({
   setTemplateTag,
   setTemplateTagConfig,
   setParameterValue,
+  embeddingParameters,
 }: SettingsPaneProps) => (
   <div>
     {tags.map(tag => (
@@ -164,6 +170,9 @@ const SettingsPane = ({
           tag={tag}
           key={tag.name}
           parameter={parametersById[tag.id]}
+          embeddedParameterVisibility={
+            embeddingParameters[parametersById[tag.id].slug]
+          }
           databaseFields={databaseFields}
           database={database}
           databases={databases}

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -89,7 +89,7 @@ import {
   isResultsMetadataDirty,
   getShouldShowUnsavedChangesWarning,
   getRequiredTemplateTags,
-  getEmbeddingParameters,
+  getEmbeddedParameterVisibility,
 } from "../selectors";
 import * as actions from "../actions";
 import { VISUALIZATION_SLOW_TIMEOUT } from "../constants";
@@ -183,7 +183,8 @@ const mapStateToProps = (state, props) => {
     reportTimezone: getSetting(state, "report-timezone-long"),
 
     requiredTemplateTags: getRequiredTemplateTags(state),
-    embeddingParameters: getEmbeddingParameters(state),
+    getEmbeddedParameterVisibility: slug =>
+      getEmbeddedParameterVisibility(state, slug),
   };
 };
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -89,6 +89,7 @@ import {
   isResultsMetadataDirty,
   getShouldShowUnsavedChangesWarning,
   getRequiredTemplateTags,
+  getEmbeddingParameters,
 } from "../selectors";
 import * as actions from "../actions";
 import { VISUALIZATION_SLOW_TIMEOUT } from "../constants";
@@ -182,6 +183,7 @@ const mapStateToProps = (state, props) => {
     reportTimezone: getSetting(state, "report-timezone-long"),
 
     requiredTemplateTags: getRequiredTemplateTags(state),
+    embeddingParameters: getEmbeddingParameters(state),
   };
 };
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1042,5 +1042,6 @@ export function getEmbeddedParameterVisibility(state, slug) {
     return null;
   }
 
-  return (card.embedding_params ?? {})[slug] ?? "disabled";
+  const embeddingParams = card.embedding_params ?? {};
+  return embeddingParams[slug] ?? "disabled";
 }

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1032,3 +1032,15 @@ export const getEmbeddingParameters = createSelector([getCard], card => {
 
   return card.embedding_params ?? {};
 });
+
+// Embeddings might be published without passing embedding_params to the server,
+// in which case it's an empty object. We should treat such situations with
+// caution, assuming that an absent parameter is "disabled".
+export function getEmbeddedParameterVisibility(state, slug) {
+  const card = getCard(state);
+  if (!card?.enable_embedding) {
+    return null;
+  }
+
+  return (card.embedding_params ?? {})[slug] ?? "disabled";
+}

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1024,3 +1024,11 @@ export const getRequiredTemplateTags = createSelector(
           .map(key => templateTags[key])
       : [],
 );
+
+export const getEmbeddingParameters = createSelector([getCard], card => {
+  if (!card?.enable_embedding) {
+    return {};
+  }
+
+  return card.embedding_params ?? {};
+});


### PR DESCRIPTION
Parent epic: https://github.com/metabase/metabase/issues/36524

## Description
Part of the feature [Let creators make parameters required](https://github.com/metabase/metabase/issues/36524), I add required parameters to the 1) question and 2) dashboard static embeddings.

### How it works
1. When a parameter is required, it _must have_ a default value
2. Embedding modal (both questions and dashboards):
    - a required parameter cannot be disabled anymore ("disabled" option is disabled)
    - it's value in the embedding code and JWT is no longer `null` by default — instead, it's set to the default value
    - when a parameter is locked, the filter widget works in the special required mode, which won't allow removing the value
    - when a parameter is editable, nothing changes in the modal
    - in preview, filter widgets work in the special required mode too
3. Static embedding
    - when a required parameter is locked, takes its value from the JWT
    - when a required parameter is editable, renders the filter widget in the required mode
    - non-required parameters should work as before
4. Setting up dashboard / parameter values
    - when a dashboard is embedded and the parameter you're changing is disabled, we prevent it from being made required with a warning

## How to check
There are a few flows we want to check. Since the logic is similar for questions and dashboards, I'll describe them together.

### 1. Not embedded yet question & dashboard
1. Create a question or a dashboard
2. Add required parameter(s) with default values
3. Observe that they can be made required as previously
4. Now go to the embedding settings and see that you cannot set this parameter to "disabled"
5. Check that when you choose "locked", you see the default values in the embedding code (JWT source)
6. Publish embedding and check that "editable" filters use widget in the default mode

### 2. Already embedded question or dashboard
1. Create a question or dashboard
2. Add parameters without making them required
3. In the embedding settings, make one of them "disabled" (this is the default anyway)
4. Edit the dashboard and observe that you cannot make this parameter required anymore

## TODO

- [x] disable "Disabled" option for required parameters + indicate a parameter is required
- [x] update texts if needed
- [x] locked preview widget + locked value in the embedding code
- [x] update parameter widget in the preview UI
- [x] update parameter widget in the actual embed
- [ ] ~~validation and errors: disallow publishing an embedding with required parameters set to disabled, with null locked value (BE) + check for errors (FE) + optionally refactor 2 API calls (FE, to be confirmed)~~
- [x] validation: generated embedding code for locker required parameters should include the default value
- [ ] ~~?when we pass empty value for a required parameter through JWT, use default~~
- [x] embedded questions, including disabling "required" toggle when parameter is "disabled" in an embedded question
- [x] update existing tests
- [x] add new e2e tests

