### PR TITLE
Implicitly delete obsolete FieldValues when fetching the current ones

### DIFF
--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -318,7 +318,7 @@
                        :human_readable_values (when human-readable-values?
                                                 (map second value-pairs))}]
       (t2/with-transaction [_conn]
-        (if-let [field-value-id (field-values/get-latest-full-field-values id)]
+        (if-let [field-value-id (:id (field-values/get-latest-full-field-values id))]
           (update-field-values! field-value-id update-map)
           (create-field-values! field update-map)))))
   {:status :success})

--- a/src/metabase/api/field.clj
+++ b/src/metabase/api/field.clj
@@ -318,7 +318,7 @@
                        :human_readable_values (when human-readable-values?
                                                 (map second value-pairs))}]
       (t2/with-transaction [_conn]
-        (if-let [field-value-id (t2/select-one-pk FieldValues, :field_id id :type :full)]
+        (if-let [field-value-id (field-values/get-latest-full-field-values id)]
           (update-field-values! field-value-id update-map)
           (create-field-values! field update-map)))))
   {:status :success})

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -232,8 +232,8 @@
   [fields]
   ;; In 44 we added a new concept of Advanced FieldValues, so FieldValues are no longer have an one-to-one relationship
   ;; with Field. See the doc in [[metabase.models.field-values]] for more.
-  ;; Adding an explicity filter by :type =:full for FieldValues here bc I believe this hydration does not concern
-  ;; the new Advanced FieldValues.
+  ;; We filter down to only :type =:full values, as they contain configured labels which must be preserved. The Advanced
+  ;; FieldValues can then be regenerated without loss given these Full entities.
   (let [id->field-values (select-field-id->instance fields FieldValues :type :full)]
     (for [field fields]
       (assoc field :values (get id->field-values (:id field) [])))))

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -493,7 +493,7 @@
 (defmethod serdes/load-find-local "FieldValues" [path]
   ;; Delegate to finding the parent Field, then look up its corresponding FieldValues.
   (let [field (serdes/load-find-local (pop path))]
-    (t2/select-one FieldValues :field_id (:id field))))
+    (t2/select-one FieldValues :field_id (:id field) :type :full)))
 
 (defmethod serdes/load-update! "FieldValues" [_ ingested local]
   ;; It's illegal to change the :type and :hash_key fields, and there's a pre-update check for this.

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -334,6 +334,25 @@
       (log/error e (trs "Error fetching field values"))
       nil)))
 
+(defn- report-and-fix-duplicates! [rows]
+  (if (<= (count rows) 1)
+    (first rows)
+    ;; todo - rather use a descending comparator
+    (let [[latest & duplicates] (reverse (sort-by :updated-at rows))]
+      ;; send telemetry to snowplow
+      (t2/delete! FieldValues :id [:in (map :id duplicates)])
+      latest)))
+
+(defn- get-field-values-for-field
+  [field-id type hash]
+  ;; todo - we could rather put this validation in a toucan select hook
+  (assert (= (nil? hash) (= type :full)) ":hash must be nil iff :type is :full")
+  (report-and-fix-duplicates!
+    (t2/select FieldValues :field_id field-id :type type :hash_key hash)))
+
+(defn- get-full-field-values-for-field [field-id]
+  (get-field-values-for-field field-id :full nil))
+
 (defn create-or-update-full-field-values!
   "Create or update the full FieldValues object for `field`. If the FieldValues object already exists, then update values for
    it; otherwise create a new FieldValues object with the newly fetched values. Returns whether the field values were
@@ -341,7 +360,7 @@
 
   Note that if the full FieldValues are create/updated/deleted, it'll delete all the Advanced FieldValues of the same `field`."
   [field & [human-readable-values]]
-  (let [field-values              (t2/select-one FieldValues :field_id (u/the-id field) :type :full)
+  (let [field-values              (get-full-field-values-for-field (u/the-id field))
         {unwrapped-values :values
          :keys [has_more_values]} (distinct-values field)
         ;; unwrapped-values are 1-tuples, so we need to unwrap their values for storage
@@ -411,20 +430,19 @@
   [{field-id :id field-values :values :as field} & [human-readable-values]]
   {:pre [(integer? field-id)]}
   (when (field-should-have-field-values? field)
-    (let [existing (or (not-empty field-values)
-                       (t2/select-one FieldValues :field_id field-id :type :full))]
+    (let [existing (or (not-empty field-values) (get-full-field-values-for-field field-id))]
       (if (or (not existing) (inactive? existing))
         (case (create-or-update-full-field-values! field human-readable-values)
           ::fv-deleted
           nil
 
           ::fv-created
-          (t2/select-one FieldValues :field_id field-id :type :full)
+          (get-full-field-values-for-field field-id)
 
           (do
             (when existing
               (t2/update! FieldValues (:id existing) {:last_used_at :%now}))
-            (t2/select-one FieldValues :field_id field-id :type :full)))
+            (get-full-field-values-for-field field-id)))
         (do
           (t2/update! FieldValues (:id existing) {:last_used_at :%now})
           existing)))))
@@ -493,7 +511,7 @@
 (defmethod serdes/load-find-local "FieldValues" [path]
   ;; Delegate to finding the parent Field, then look up its corresponding FieldValues.
   (let [field (serdes/load-find-local (pop path))]
-    (t2/select-one FieldValues :field_id (:id field) :type :full)))
+    (get-full-field-values-for-field (:id field))))
 
 (defmethod serdes/load-update! "FieldValues" [_ ingested local]
   ;; It's illegal to change the :type and :hash_key fields, and there's a pre-update check for this.

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -346,7 +346,7 @@
 (defn- get-field-values-for-field
   [field-id type hash]
   ;; todo - we could rather put this validation in a toucan select hook
-  (assert (= (nil? hash) (= type :full)) ":hash must be nil iff :type is :full")
+  (assert (= (nil? hash) (= type :full)) ":hash_key must be nil iff :type is :full")
   (report-and-fix-duplicates!
     (t2/select FieldValues :field_id field-id :type type :hash_key hash)))
 

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -522,6 +522,7 @@
 (defmethod serdes/load-find-local "FieldValues" [path]
   ;; Delegate to finding the parent Field, then look up its corresponding FieldValues.
   (let [field (serdes/load-find-local (pop path))]
+    ;; We only serialize the full values, see [metabase.models.field/with-values]]
     (get-latest-full-field-values (:id field))))
 
 (defmethod serdes/load-update! "FieldValues" [_ ingested local]

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -336,7 +336,7 @@
 
 (defn- delete-duplicates-and-return-latest!
   "This is a workaround for the issue of stale FieldValues rows (metabase#668)
-  In order to mitigate the impact of duplicates, we return the most recently updated row, and deleted the older rows."
+  In order to mitigate the impact of duplicates, we return the most recently updated row, and delete the older rows."
   [rows]
   (if (<= (count rows) 1)
     (first rows)

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -340,21 +340,21 @@
   [rows]
   (if (<= (count rows) 1)
     (first rows)
-    (let [[latest & duplicates] (sort-by :updated-at u/reverse-compare rows)]
+    (let [[latest & duplicates] (sort-by :updated_at u/reverse-compare rows)]
       (t2/delete! FieldValues :id [:in (map :id duplicates)])
       latest)))
 
-(defn- get-latest-field-values
+(defn get-latest-field-values
   "This returns the FieldValues with the given :type and :hash_key for the given Field.
-   This may implictly delete shadowed entries in the database, see [[delete-duplicates-and-return-latest!]]"
+   This may implicitly delete shadowed entries in the database, see [[delete-duplicates-and-return-latest!]]"
   [field-id type hash]
   (assert (= (nil? hash) (= type :full)) ":hash_key must be nil iff :type is :full")
   (delete-duplicates-and-return-latest!
     (t2/select FieldValues :field_id field-id :type type :hash_key hash)))
 
-(defn- get-latest-full-field-values
+(defn get-latest-full-field-values
   "This returns the full FieldValues for the given Field.
-   This may implictly delete shadowed entries in the database, see [[delete-duplicates-and-return-latest!]]"
+   This may implicitly delete shadowed entries in the database, see [[delete-duplicates-and-return-latest!]]"
   [field-id]
   (get-latest-field-values field-id :full nil))
 

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -111,9 +111,7 @@
           values                (map first wrapped-values)
           ;; If the full FieldValues of this field has a human-readable-values, fix it with the new values
           human-readable-values (field-values/fixup-human-readable-values
-                                  (t2/select-one FieldValues
-                                                 :field_id (:id field)
-                                                 :type :full)
+                                  (t2/select-one FieldValues :field_id (:id field) :type :full)
                                   values)]
       (first (t2/insert-returning-instances! FieldValues
                                              :field_id (:id field)
@@ -131,9 +129,7 @@
 
   ([fv-type field constraints]
    (let [hash-key (hash-key-for-advanced-field-values fv-type (:id field) constraints)
-         fv       (or (t2/select-one FieldValues :field_id (:id field)
-                                     :type fv-type
-                                     :hash_key hash-key)
+         fv       (or (t2/select-one FieldValues :field_id (:id field) :type fv-type :hash_key hash-key)
                       (create-advanced-field-values! fv-type field hash-key constraints))]
      (cond
        (nil? fv) nil

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -111,7 +111,7 @@
           values                (map first wrapped-values)
           ;; If the full FieldValues of this field has a human-readable-values, fix it with the new values
           human-readable-values (field-values/fixup-human-readable-values
-                                  (t2/select-one FieldValues :field_id (:id field) :type :full)
+                                  (field-values/get-latest-full-field-values (:id field))
                                   values)]
       (first (t2/insert-returning-instances! FieldValues
                                              :field_id (:id field)
@@ -129,7 +129,7 @@
 
   ([fv-type field constraints]
    (let [hash-key (hash-key-for-advanced-field-values fv-type (:id field) constraints)
-         fv       (or (t2/select-one FieldValues :field_id (:id field) :type fv-type :hash_key hash-key)
+         fv       (or (field-values/get-latest-field-values (:id field) fv-type hash-key)
                       (create-advanced-field-values! fv-type field hash-key constraints))]
      (cond
        (nil? fv) nil

--- a/src/metabase/sync/field_values.clj
+++ b/src/metabase/sync/field_values.clj
@@ -25,7 +25,7 @@
 (mu/defn ^:private update-field-values-for-field!
   [field :- i/FieldInstance]
   (log/debug (u/format-color 'green "Looking into updating FieldValues for %s" (sync-util/name-for-logging field)))
-  (let [field-values (t2/select-one FieldValues :field_id (u/the-id field) :type :full)]
+  (let [field-values (field-values/get-latest-full-field-values (u/the-id field))]
     (if (field-values/inactive? field-values)
       (log/debugf "Field %s has not been used since %s. Skipping..."
                   (sync-util/name-for-logging field) (t/format "yyyy-MM-dd" (t/local-date-time (:last_used_at field-values))))

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -874,3 +874,8 @@
       (if (empty? to-traverse)
         traversed
         (recur to-traverse traversed)))))
+
+(defn reverse-compare
+  "A reversed java.util.Comparator, useful for sorting elements in descending in order"
+  [x y]
+  (compare y x))

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -128,6 +128,28 @@
   (sync/sync-database! db)
   (find-values field-values-id))
 
+(deftest implicit-deduplication-test
+  (mt/dataset test-data
+    (testing "We always return the latest FieldValues, and implicitly delete shadowed duplicates"
+      (let [table-id (:id (t2/select-one Table))
+            field-id 12345]
+
+        ;; Create a Field with duplicate FieldValues
+        (t2/insert! Field :id field-id :name "Field" :base_type :type/Text :table_id table-id :database_type "java.lang.String")
+        (t2/insert! FieldValues :field_id field-id :type :full :values ["a" "b"] :human_readable_values ["A" "B"])
+        (t2/insert! FieldValues :field_id field-id :type :full :values ["c" "d"] :human_readable_values ["C" "D"])
+
+        (testing "When we have two FieldValues rows in the database"
+          (is (= 2 (count (t2/select FieldValues :field_id field-id :type :full :hash_key nil))))
+          (testing "We always fetch the most recently inserted row"
+            (is (= ["C" "D"] (:human_readable_values (#'field-values/get-full-field-values-for-field field-id))))
+            (testing "... and the older rows are deleted"
+              (is (= 1 (count (t2/select FieldValues :field_id field-id :type :full)))))))
+
+        ;; Clean up
+        (t2/delete! FieldValues :field_id field-id)
+        (t2/delete! Field :id field-id)))))
+
 (deftest get-or-create-full-field-values!-test
   (mt/dataset test-data
     (testing "create a full Fieldvalues if it does not exist"

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -139,7 +139,7 @@
 
       (testing "When we have two FieldValues rows in the database, "
         (is (= 2 (count (t2/select FieldValues :field_id field-id :type :full :hash_key nil))))
-        (testing "we always return the most recently inserted row"
+        (testing "we always return the most recently updated row"
           (is (= ["C" "D"] (:human_readable_values (field-values/get-latest-full-field-values field-id))))
           (testing "... and older rows are implicitly deleted"
             (is (= 1 (count (t2/select FieldValues :field_id field-id :type :full))))

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -142,7 +142,7 @@
         (testing "When we have two FieldValues rows in the database"
           (is (= 2 (count (t2/select FieldValues :field_id field-id :type :full :hash_key nil))))
           (testing "We always fetch the most recently inserted row"
-            (is (= ["C" "D"] (:human_readable_values (#'field-values/get-full-field-values-for-field field-id))))
+            (is (= ["C" "D"] (:human_readable_values (#'field-values/get-latest-full-field-values field-id))))
             (testing "... and the older rows are deleted"
               (is (= 1 (count (t2/select FieldValues :field_id field-id :type :full)))))))
 

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -137,12 +137,14 @@
                    FieldValues _                 {:field_id field-id :type :full :values ["a" "b"] :human_readable_values ["A" "B"] :updated_at now}
                    FieldValues _                 {:field_id field-id :type :full :values ["c" "d"] :human_readable_values ["C" "D"] :updated_at then}]
 
-      (testing "When we have two FieldValues rows in the database"
+      (testing "When we have two FieldValues rows in the database, "
         (is (= 2 (count (t2/select FieldValues :field_id field-id :type :full :hash_key nil))))
-        (testing "We always fetch the most recently inserted row"
-          (is (= ["C" "D"] (:human_readable_values (#'field-values/get-latest-full-field-values field-id))))
-          (testing "... and the older rows are deleted"
-            (is (= 1 (count (t2/select FieldValues :field_id field-id :type :full))))))))))
+        (testing "we always return the most recently inserted row"
+          (is (= ["C" "D"] (:human_readable_values (field-values/get-latest-full-field-values field-id))))
+          (testing "... and older rows are implicitly deleted"
+            (is (= 1 (count (t2/select FieldValues :field_id field-id :type :full))))
+            ;; double check that we deleted the correct row
+            (is (= ["C" "D"] (:human_readable_values (field-values/get-latest-full-field-values field-id))))))))))
 
 (deftest get-or-create-full-field-values!-test
   (mt/dataset test-data


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/668

### Description

Before this change it was non-deterministic which FieldValues would be used in the presence of stale records. This change ensures that we always use the values that were last inserted, and delete the older rows in the process. 

It also fixes a query that failed to specify the `:type`, and so was totally non-deterministic.

### Checklist

- [x] Improve test quality
- [x] ~~Implement a Snowplow event to track when customer databases encounter duplicates~~ Going to use idempotent operations for all inserts, which will make it safe to insert the constraint. Don't think events will be worth the faff.
