### PR TITLE
[Metrics v2] Add "Metric" to the new entity menu

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -65,6 +65,7 @@ import type { Query } from "./types";
 export type QuestionCreatorOpts = {
   databaseId?: DatabaseId;
   dataset?: boolean;
+  cardType?: CardType;
   tableId?: TableId;
   collectionId?: CollectionId;
   metadata?: Metadata;
@@ -1132,6 +1133,7 @@ class Question {
     display = "table",
     visualization_settings = {},
     dataset,
+    cardType,
     dataset_query = type === "native"
       ? NATIVE_QUERY_TEMPLATE
       : STRUCTURED_QUERY_TEMPLATE,
@@ -1143,6 +1145,7 @@ class Question {
       visualization_settings,
       dataset,
       dataset_query,
+      type: cardType,
     };
 
     if (type === "native") {

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -109,6 +109,7 @@ const NewItemMenu = ({
         action: () => setModal("new-collection"),
       },
     );
+
     if (hasNativeWrite) {
       const collectionQuery = collectionId
         ? `?collectionId=${collectionId}`
@@ -127,6 +128,15 @@ const NewItemMenu = ({
         title: t`Action`,
         icon: "bolt",
         action: () => setModal("new-action"),
+      });
+    }
+
+    if (hasDataAccess) {
+      items.push({
+        title: t`Metric`,
+        icon: "metric",
+        link: "/metric/query",
+        onClose: onCloseNavbar,
       });
     }
 

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -135,7 +135,11 @@ const NewItemMenu = ({
       items.push({
         title: t`Metric`,
         icon: "metric",
-        link: "/metric/notebook",
+        link: Urls.newQuestion({
+          mode: "notebook",
+          collectionId,
+          cardType: "metric",
+        }),
         onClose: onCloseNavbar,
       });
     }

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -135,7 +135,7 @@ const NewItemMenu = ({
       items.push({
         title: t`Metric`,
         icon: "metric",
-        link: "/metric/query",
+        link: "/metric/notebook",
         onClose: onCloseNavbar,
       });
     }

--- a/frontend/src/metabase/lib/urls/questions.ts
+++ b/frontend/src/metabase/lib/urls/questions.ts
@@ -107,9 +107,10 @@ export function newQuestion({
   });
 
   const entity = question.isDataset() ? "model" : "question";
+  const type = question.type() ?? entity;
 
   if (mode) {
-    return url.replace(/^\/(question|model)/, `/${entity}\/${mode}`);
+    return url.replace(/^\/(question|model)/, `/${type}\/${mode}`);
   } else {
     return url;
   }

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -222,7 +222,7 @@ export const getRoutes = store => {
 
           <Route path="/metric">
             <IndexRoute component={QueryBuilder} />
-            <Route path="query" component={QueryBuilder} />
+            <Route path="notebook" component={QueryBuilder} />
           </Route>
 
           <Route path="browse">

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -218,6 +218,13 @@ export const getRoutes = store => {
             <Route path="metabot" component={QueryBuilder} />
           </Route>
 
+          {/* METRICS V2 */}
+
+          <Route path="/metric">
+            <IndexRoute component={QueryBuilder} />
+            <Route path="query" component={QueryBuilder} />
+          </Route>
+
           <Route path="browse">
             <IndexRedirect to="/browse/models" />
             <Route path="models" component={() => <BrowseApp tab="models" />} />


### PR DESCRIPTION
This PR adds a new option/entry to the "New" entity menu. This time for a metric.
It also adds a route for `/metric/query` that currently defaults to the `QueryBuilder` component.

![image](https://github.com/metabase/metabase/assets/31325167/3e19d321-edcc-419e-b4d8-05e5233326bc)

`/metric/query` starts at the data selection point
![image](https://github.com/metabase/metabase/assets/31325167/fc918cf8-8874-41c0-b4c5-3ca23f88cb91)

New Metric flow from the home page
https://www.loom.com/share/5e5a2d7f0eb44a089ec6c9f35326d645?sid=2502275b-f81d-45d2-a069-796593f3fba4

New Metric flow from the collection
https://www.loom.com/share/4884a373224a472194fdfc834ce91d90?sid=7802db85-9c6e-4ce7-bff8-c9e193da74a7

Resolves #37352