### PR TITLE
Upload flakes to replay

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -47,15 +47,19 @@ const defaultConfig = {
         filter: r => {
           const hasCrashed = r.status === "crashed";
           const hasFailed = r.metadata.test?.result === "failed";
+          const isFlaky =
+            r.metadata.test?.result === "passed" &&
+            r.metadata.test.tests.some(r => r.result === "failed");
           const randomlyUploadAll =
             convertStringToInt(r.metadata.test.run.id) % 10 === 1;
 
           console.log("upload replay ::", {
             hasCrashed,
             hasFailed,
+            isFlaky,
             randomlyUploadAll,
           });
-          return hasCrashed || hasFailed || randomlyUploadAll;
+          return hasCrashed || hasFailed || isFlaky || randomlyUploadAll;
         },
       });
     }


### PR DESCRIPTION
Adds additional logic per [this Slack thread](https://metaboat.slack.com/archives/C052LBPDAF3/p1706613621488479) to upload flake replays.