### PR TITLE
add snowplow event tracking for card and tab duplication

### DIFF
--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -56,3 +56,17 @@ export const trackQuestionReplaced = (dashboardId: DashboardId) => {
     dashboard_id: dashboardId,
   });
 };
+
+export const trackDashcardDuplicated = (dashboardId: DashboardId) => {
+  trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
+    event: "dashboard_card_duplicated",
+    dashboard_id: dashboardId,
+  });
+};
+
+export const trackTabDuplicated = (dashboardId: DashboardId) => {
+  trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
+    event: "dashboard_tab_duplicated",
+    dashboard_id: dashboardId,
+  });
+};

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/use-duplicate-dashcard.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/use-duplicate-dashcard.ts
@@ -16,6 +16,7 @@ import {
 import { getExistingDashCards } from "metabase/dashboard/actions/utils";
 import { isVirtualDashCard } from "metabase/dashboard/utils";
 import type { Dashboard, DashboardCard } from "metabase-types/api";
+import { trackDashcardDuplicated } from "metabase/dashboard/analytics";
 
 export function useDuplicateDashCard({
   dashboard,
@@ -68,6 +69,8 @@ export function useDuplicateDashCard({
         }),
       );
     }
+
+    trackDashcardDuplicated(dashboard.id);
   }, [
     dispatch,
     dashboard.id,

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -153,7 +153,11 @@ export function DashboardHeaderComponent({
           </HeaderButtonsContainer>
         </HeaderRow>
         <HeaderRow isNavBarOpen={isNavBarOpen}>
-          <DashboardTabs location={location} isEditing={isEditing} />
+          <DashboardTabs
+            dashboardId={dashboard.id}
+            location={location}
+            isEditing={isEditing}
+          />
         </HeaderRow>
       </div>
     </div>

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.tsx
@@ -1,6 +1,7 @@
 import { t } from "ttag";
-
 import type { Location } from "history";
+
+import type { DashboardId } from "metabase-types/api";
 import { TabRow } from "metabase/core/components/TabRow";
 import type { TabButtonMenuItem } from "metabase/core/components/TabButton";
 import { TabButton } from "metabase/core/components/TabButton";
@@ -11,11 +12,13 @@ import { Container, CreateTabButton } from "./DashboardTabs.styled";
 import { useDashboardTabs } from "./use-dashboard-tabs";
 
 interface DashboardTabsProps {
+  dashboardId: DashboardId;
   location: Location;
   isEditing?: boolean;
 }
 
 export function DashboardTabs({
+  dashboardId,
   location,
   isEditing = false,
 }: DashboardTabsProps) {
@@ -28,7 +31,7 @@ export function DashboardTabs({
     selectTab,
     selectedTabId,
     moveTab,
-  } = useDashboardTabs({ location });
+  } = useDashboardTabs({ location, dashboardId });
   const hasMultipleTabs = tabs.length > 1;
   const showTabs = hasMultipleTabs || isEditing;
   const showPlaceholder = tabs.length === 0 && isEditing;

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -35,11 +35,15 @@ function setup({
   };
 
   const DashboardComponent = ({ location }: { location: Location }) => {
-    const { selectedTabId } = useDashboardTabs({ location });
+    const { selectedTabId } = useDashboardTabs({ location, dashboardId: 1 });
 
     return (
       <>
-        <DashboardTabs location={location} isEditing={isEditing} />
+        <DashboardTabs
+          dashboardId={1}
+          location={location}
+          isEditing={isEditing}
+        />
         <span>Selected tab id is {selectedTabId}</span>
         <br />
         <span>Path is {location.pathname + location.search}</span>

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/use-dashboard-tabs.ts
@@ -12,23 +12,36 @@ import {
   selectTab,
   undoDeleteTab,
   moveTab as moveTabAction,
-  duplicateTab,
+  duplicateTab as duplicateTabAction,
 } from "metabase/dashboard/actions";
 import type { SelectedTabId } from "metabase-types/store";
 import { getSelectedTabId, getTabs } from "metabase/dashboard/selectors";
 import { addUndo } from "metabase/redux/undo";
 
+import { trackTabDuplicated } from "metabase/dashboard/analytics";
+import type { DashboardId } from "metabase-types/api";
 import { parseSlug, useSyncURLSlug } from "./use-sync-url-slug";
 
 let tabDeletionId = 1;
 
-export function useDashboardTabs({ location }: { location: Location }) {
+export function useDashboardTabs({
+  location,
+  dashboardId,
+}: {
+  location: Location;
+  dashboardId: DashboardId;
+}) {
   const dispatch = useDispatch();
   const tabs = useSelector(getTabs);
   const selectedTabId = useSelector(getSelectedTabId);
 
   useSyncURLSlug({ location });
   useMount(() => dispatch(initTabs({ slug: parseSlug({ location }) })));
+
+  const duplicateTab = (tabId: SelectedTabId) => {
+    dispatch(duplicateTabAction(tabId));
+    trackTabDuplicated(dashboardId);
+  };
 
   const deleteTab = (tabId: SelectedTabId) => {
     const tabName = tabs.find(({ id }) => id === tabId)?.name;
@@ -61,7 +74,7 @@ export function useDashboardTabs({ location }: { location: Location }) {
     tabs,
     selectedTabId,
     createNewTab: () => dispatch(createNewTab()),
-    duplicateTab: (tabId: SelectedTabId) => dispatch(duplicateTab(tabId)),
+    duplicateTab,
     deleteTab,
     renameTab: (tabId: SelectedTabId, name: string) =>
       dispatch(renameTab({ tabId, name })),

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-3
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-3
@@ -19,13 +19,15 @@
         "auto_apply_filters_disabled",
         "dashboard_tab_created",
         "dashboard_tab_deleted",
+        "dashboard_tab_duplicated",
         "new_text_card_created",
         "new_heading_card_created",
         "new_link_card_created",
         "new_action_card_created",
         "card_set_to_hide_when_no_results",
         "dashboard_pdf_exported",
-        "card_moved_to_tab"
+        "card_moved_to_tab",
+        "dashboard_card_duplicated"
       ],
       "maxLength": 1024
     },


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/38208

### Description

Adds snowplow event tracking for dashboard card and tab duplication. No snowplow schema changes were made, we just added a couple of new event names.

### How to verify

Follow this [guide](https://www.notion.so/metabase/Snowplow-integration-5da1f874beda4153b4fccfa6c1e77caa) on running snowplow locally, then go to a dashboard and duplicate some cards and tabs, confirm the logs appear.

### Demo

https://github.com/metabase/metabase/assets/37751258/db59337d-a3aa-4d5d-afd0-fdd9998b13ed


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
