### PR TITLE
[MLv2] Add caching for the common case of visible-columns w/o options

### DIFF
--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -535,7 +535,12 @@
    (visible-columns query -1 x))
 
   ([query stage-number x]
-   (visible-columns query stage-number x nil))
+   (if (and (map? x)
+            (#{:mbql.stage/mbql :mbql.stage/native} (:lib/type x)))
+     (lib.cache/side-channel-cache
+       (keyword (str stage-number "__visible-columns-no-opts")) query
+       (fn [_] (visible-columns query stage-number x nil)))
+     (visible-columns query stage-number x nil)))
 
   ([query          :- ::lib.schema/query
     stage-number   :- :int


### PR DESCRIPTION
The options make caching
`metabase.lib.metadata.calculation/visible-columns` difficult, but the
common case is to call it without options on things like query stages.

That case is expensive, common, and reusable, so this is a great spot to
cache it.

Note that `metabase.lib.js/visible-columns` is also cached in the same
way, but this does not really overlap. The JS wrapper actually populates
the `selected: true` flags as well, and returns a JS array. This
slightly modified value is what gets cached there, and it's enough extra
work (calling `returned-columns` and `mark-selected`) that it's worth
having both. Structural sharing of the untouched or lightly-edited column
maps means the memory impact is modest.
