### PR TITLE
add dashcard replace event to snowplow schema and e2e test

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashcard-replace-question.cy.spec.js
@@ -5,6 +5,11 @@ import {
   restore,
   visitDashboard,
   findDashCardAction,
+  resetSnowplow,
+  enableTracking,
+  describeWithSnowplow,
+  expectGoodSnowplowEvent,
+  expectNoBadSnowplowEvents,
 } from "e2e/support/helpers";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { USER_GROUPS } from "e2e/support/cypress_data";
@@ -104,10 +109,12 @@ function getDashboardCards(mappedQuestionId) {
   ];
 }
 
-describe("scenarios > dashboard cards > replace question", () => {
+describeWithSnowplow("scenarios > dashboard cards > replace question", () => {
   beforeEach(() => {
+    resetSnowplow();
     restore();
-    cy.signInAsNormalUser();
+    cy.signInAsAdmin();
+    enableTracking();
 
     cy.intercept("POST", `/api/card/*/query`).as("cardQuery");
 
@@ -128,6 +135,10 @@ describe("scenarios > dashboard cards > replace question", () => {
     );
   });
 
+  afterEach(() => {
+    expectNoBadSnowplowEvents();
+  });
+
   it("should replace a dashboard card question (metabase#36984)", () => {
     visitDashboardAndEdit();
 
@@ -138,6 +149,7 @@ describe("scenarios > dashboard cards > replace question", () => {
       nextQuestionName: "Next question",
       collectionName: "First collection",
     });
+    expectGoodSnowplowEvent({ event: "dashboard_card_replaced" });
     findTargetDashcard().within(() => {
       assertDashCardTitle("Next question");
       cy.findByText("Ean").should("exist");

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-3
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-3
@@ -27,7 +27,8 @@
         "card_set_to_hide_when_no_results",
         "dashboard_pdf_exported",
         "card_moved_to_tab",
-        "dashboard_card_duplicated"
+        "dashboard_card_duplicated",
+        "dashboard_card_replaced"
       ],
       "maxLength": 1024
     },


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/36497

### Description

In https://github.com/metabase/metabase/pull/36744 we tracked dashcard replacement with a new event name, but did not add this event name to the dashboard snowplow schema.

In this PR we add the name to the schema, and update an e2e test to ensure the event is being tracked.

### How to verify

Follow this [guide](https://www.notion.so/metabase/Snowplow-integration-5da1f874beda4153b4fccfa6c1e77caa) to run snowplow, then try replacing a dashcard locally, you should see the log in the console.

### Demo

https://github.com/metabase/metabase/assets/37751258/e8566f09-b9b8-47de-b215-fe0e25c7d920

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
