### PR TITLE
Upload random replays from master only

### DIFF
--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -51,6 +51,7 @@ const defaultConfig = {
             r.metadata.test?.result === "passed" &&
             r.metadata.test.tests.some(r => r.result === "failed");
           const randomlyUploadAll =
+            r.metadata.source.branch === "master" &&
             convertStringToInt(r.metadata.test.run.id) % 10 === 1;
 
           console.log("upload replay ::", {
@@ -58,6 +59,10 @@ const defaultConfig = {
             hasFailed,
             isFlaky,
             randomlyUploadAll,
+            branch: r.metadata.source.branch,
+            result: r.metadata.test?.result,
+            status: r.status,
+            runId: r.metadata.test.run.id,
           });
           return hasCrashed || hasFailed || isFlaky || randomlyUploadAll;
         },


### PR DESCRIPTION
Adding `r.metadata.source.branch === "master" &&` to `randomlyUploadAll` for master-only uploads.

Also adding more info to log message.