### PR TITLE
Avoid recreating target question in auto-wire parameters handling

### DIFF
--- a/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
+++ b/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts
@@ -44,31 +44,32 @@ export function getAllDashboardCardsWithUnmappedParameters({
 }
 
 export function getMatchingParameterOption(
-  dashcardToCheck: DashboardCard,
-  targetDimension: ParameterTarget,
   targetDashcard: DashboardCard,
+  targetDimension: ParameterTarget,
+  sourceDashcard: DashboardCard,
   metadata: Metadata,
 ): {
   target: ParameterTarget;
 } | null {
-  if (!dashcardToCheck) {
+  if (!targetDashcard) {
     return null;
   }
 
+  const sourceQuestion = new Question(sourceDashcard.card, metadata);
   const targetQuestion = new Question(targetDashcard.card, metadata);
 
   return (
     getParameterMappingOptions(
       metadata,
       null,
-      dashcardToCheck.card,
-      dashcardToCheck,
+      targetDashcard.card,
+      targetDashcard,
     ).find((param: { target: ParameterTarget }) =>
       compareMappingOptionTargets(
         targetDimension,
         param.target,
+        sourceQuestion,
         targetQuestion,
-        new Question(dashcardToCheck.card, metadata),
       ),
     ) ?? null
   );


### PR DESCRIPTION
A part of work on perf #38225, 1/? of splitting https://github.com/metabase/metabase/pull/38425

## Description

Do not re-create question in the loop and fix variable names accordingly with usage

https://github.com/metabase/metabase/blob/8ec3888569e4a4d2125307ea76e28eca7de53845/frontend/src/metabase/dashboard/actions/auto-wire-parameters/utils.ts#L101-L106