### PR TITLE
Migrate info hover card to mantine

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -7,6 +7,13 @@ export function popover() {
   return cy.get(POPOVER_ELEMENT);
 }
 
+const HOVERCARD_ELEMENT = ".emotion-HoverCard-dropdown[role='dialog']";
+
+export function hovercard() {
+  cy.get(HOVERCARD_ELEMENT).should("be.visible");
+  return cy.get(HOVERCARD_ELEMENT);
+}
+
 export function main() {
   return cy.get("main");
 }

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -5,6 +5,7 @@ import {
   openOrdersTable,
   openPeopleTable,
   popover,
+  hovercard,
   restore,
   summarize,
   visualize,
@@ -119,7 +120,7 @@ describe("scenarios > visualizations > table", () => {
     );
   });
 
-  it("should show field metadata in a popover when hovering over a table column header", () => {
+  it("should show field metadata in a hovercard when hovering over a table column header", () => {
     const ccName = "Foo";
 
     openPeopleTable({ mode: "notebook", limit: 2 });
@@ -212,7 +213,7 @@ describe("scenarios > visualizations > table", () => {
         },
       ],
     ].forEach(([column, test]) => {
-      cy.get(".cellData").contains(column).trigger("mouseenter");
+      cy.get(".cellData").contains(column).realHover();
 
       popover().within(() => {
         test();
@@ -227,19 +228,14 @@ describe("scenarios > visualizations > table", () => {
 
     cy.wait("@dataset");
 
-    cy.get(".Visualization").within(() => {
-      cy.contains("Count").trigger("mouseenter");
-    });
-
-    popover().within(() => {
+    cy.get(".cellData").contains("Count").realHover();
+    hovercard().within(() => {
       cy.contains("Quantity");
       cy.findByText("No description");
     });
 
-    cy.get(".Visualization").within(() => {
-      // Make sure new table results loaded with Custom column and Count columns
-      cy.contains(ccName).trigger("mouseenter");
-    });
+    // Make sure new table results loaded with Custom column and Count columns
+    cy.get(".cellData").contains(ccName).realHover();
 
     popover().within(() => {
       cy.contains("No special type");
@@ -250,21 +246,21 @@ describe("scenarios > visualizations > table", () => {
   it("should show the field metadata popover for a foreign key field (metabase#19577)", () => {
     openOrdersTable({ limit: 2 });
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Product ID").trigger("mouseenter");
+    cy.get(".cellData").contains("Product ID").realHover();
 
-    popover().within(() => {
+    hovercard().within(() => {
       cy.contains("Foreign Key");
       cy.contains("The product ID.");
     });
   });
 
-  it("should show field metadata popovers for native query tables", () => {
+  it("should show field metadata hovercards for native query tables", () => {
     openNativeEditor().type("select * from products");
     cy.findByTestId("native-query-editor-container").icon("play").click();
 
-    cy.get(".cellData").contains("CATEGORY").trigger("mouseenter");
-    popover().within(() => {
+    cy.get(".cellData").contains("CATEGORY").realHover();
+
+    hovercard().within(() => {
       cy.contains("No special type");
       cy.findByText("No description");
     });

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -215,6 +215,9 @@ describe("scenarios > visualizations > table", () => {
     ].forEach(([column, test]) => {
       cy.get(".cellData").contains(column).realHover();
 
+      // Add a delay here because there can be two popovers active for a very short time.
+      cy.wait(100);
+
       popover().within(() => {
         test();
       });
@@ -236,6 +239,7 @@ describe("scenarios > visualizations > table", () => {
 
     // Make sure new table results loaded with Custom column and Count columns
     cy.get(".cellData").contains(ccName).realHover();
+    cy.wait(100);
 
     popover().within(() => {
       cy.contains("No special type");

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfo/FieldInfo.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfo/FieldInfo.tsx
@@ -21,7 +21,7 @@ export function FieldInfo({
   field,
   timezone,
   showAllFieldValues,
-  showFingerprintInfo = true,
+  showFingerprintInfo,
 }: FieldInfoProps) {
   return (
     <InfoContainer className={className}>

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfo/FieldInfo.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfo/FieldInfo.tsx
@@ -13,6 +13,7 @@ interface FieldInfoProps {
   field: Field | DatasetColumn;
   timezone?: string;
   showAllFieldValues?: boolean;
+  showFingerprintInfo?: boolean;
 }
 
 export function FieldInfo({
@@ -20,6 +21,7 @@ export function FieldInfo({
   field,
   timezone,
   showAllFieldValues,
+  showFingerprintInfo = true,
 }: FieldInfoProps) {
   return (
     <InfoContainer className={className}>
@@ -29,11 +31,13 @@ export function FieldInfo({
         <EmptyDescription>{t`No description`}</EmptyDescription>
       )}
       <FieldSemanticTypeLabel field={field} />
-      <FieldFingerprintInfo
-        field={field}
-        timezone={timezone}
-        showAllFieldValues={showAllFieldValues}
-      />
+      {showFingerprintInfo && (
+        <FieldFingerprintInfo
+          field={field}
+          timezone={timezone}
+          showAllFieldValues={showAllFieldValues}
+        />
+      )}
     </InfoContainer>
   );
 }

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.styled.tsx
@@ -1,7 +1,22 @@
 import styled from "@emotion/styled";
 import FieldInfo from "metabase/components/MetadataInfo/FieldInfo";
+import { HoverCard } from "metabase/ui";
 
 export const WidthBoundFieldInfo = styled(FieldInfo)`
   width: 300px;
   font-size: 14px;
+`;
+
+export const Dropdown = styled(HoverCard.Dropdown)`
+  overflow: visible;
+`;
+
+export const Target = styled.div`
+  position: absolute;
+  width: 100%;
+  left: -10px;
+  right: -10px;
+  top: -10px;
+  bottom: -10px;
+  min-height: 5px;
 `;

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
@@ -10,6 +10,7 @@ import {
 } from "./FieldInfoPopover.styled";
 
 export const POPOVER_DELAY: [number, number] = [1000, 300];
+export const POPOVER_TRANSITION_DURATION = 150;
 
 type Props = {
   field: Field | DatasetColumn;
@@ -38,7 +39,7 @@ function FieldInfoPopover({
       onOpen={group.onOpen}
       onClose={group.onClose}
       transitionProps={{
-        duration: group.shouldDelay ? 150 : 0,
+        duration: group.shouldDelay ? POPOVER_TRANSITION_DURATION : 0,
         keepMounted: true,
       }}
     >

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
@@ -33,6 +33,7 @@ function FieldInfoPopover({
       closeDelay={group.shouldDelay ? delay[1] : 0}
       onOpen={group.onOpen}
       onClose={group.onClose}
+      transitionProps={{ duration: group.shouldDelay ? 150 : 0 }}
     >
       <HoverCard.Target>{children}</HoverCard.Target>
       <HoverCard.Dropdown>

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
@@ -1,7 +1,5 @@
-import { hideAll } from "tippy.js";
-
-import type { ITippyPopoverProps } from "metabase/components/Popover/TippyPopover";
-import TippyPopover from "metabase/components/Popover/TippyPopover";
+import type { HoverCardProps } from "metabase/ui";
+import { HoverCard, useDelayGroup } from "metabase/ui";
 import type { DatasetColumn } from "metabase-types/api";
 import type Field from "metabase-lib/metadata/Field";
 
@@ -9,44 +7,38 @@ import { WidthBoundFieldInfo } from "./FieldInfoPopover.styled";
 
 export const POPOVER_DELAY: [number, number] = [1000, 300];
 
-type Props = { field: Field | DatasetColumn; timezone?: string } & Pick<
-  ITippyPopoverProps,
-  "children" | "placement" | "disabled" | "delay"
->;
-
-const className = "dimension-info-popover";
+type Props = {
+  field: Field | DatasetColumn;
+  timezone?: string;
+  delay: [number, number];
+} & Pick<HoverCardProps, "children" | "position" | "disabled">;
 
 function FieldInfoPopover({
   field,
   timezone,
-  children,
-  placement,
+  position = "bottom-start",
   disabled,
   delay = POPOVER_DELAY,
+  children,
+  ...rest
 }: Props) {
-  return (
-    <TippyPopover
-      className={className}
-      delay={delay}
-      placement={placement || "left-start"}
-      disabled={disabled}
-      content={<WidthBoundFieldInfo field={field} timezone={timezone} />}
-      onTrigger={instance => {
-        const fieldInfoPopovers = document.querySelectorAll(
-          `.${className}[data-state~='visible']`,
-        );
+  const grp = useDelayGroup();
 
-        // if a dimension info popovers are already visible, hide them and show this popover immediately
-        if (fieldInfoPopovers.length > 0) {
-          hideAll({
-            exclude: instance,
-          });
-          instance.show();
-        }
-      }}
+  return (
+    <HoverCard
+      {...rest}
+      position={position}
+      disabled={disabled}
+      openDelay={grp.shouldDelay ? delay[0] : 0}
+      closeDelay={grp.shouldDelay ? delay[1] : 0}
+      onOpen={grp.onOpen}
+      onClose={grp.onClose}
     >
-      {children}
-    </TippyPopover>
+      <HoverCard.Target>{children}</HoverCard.Target>
+      <HoverCard.Dropdown>
+        <WidthBoundFieldInfo field={field} timezone={timezone} />
+      </HoverCard.Dropdown>
+    </HoverCard>
   );
 }
 

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
@@ -12,6 +12,10 @@ import {
 export const POPOVER_DELAY: [number, number] = [1000, 300];
 export const POPOVER_TRANSITION_DURATION = 150;
 
+// When switching to another hover target in the same delay group,
+// we don't closing immediatly but delay by a short amount to avoid flicker.
+export const POPOVER_CLOSE_DELAY = 25;
+
 type Props = {
   field: Field | DatasetColumn;
   timezone?: string;
@@ -35,12 +39,11 @@ function FieldInfoPopover({
       position={position}
       disabled={disabled}
       openDelay={group.shouldDelay ? delay[0] : 0}
-      closeDelay={group.shouldDelay ? delay[1] : 50}
+      closeDelay={group.shouldDelay ? delay[1] : POPOVER_CLOSE_DELAY}
       onOpen={group.onOpen}
       onClose={group.onClose}
       transitionProps={{
         duration: group.shouldDelay ? POPOVER_TRANSITION_DURATION : 0,
-        keepMounted: true,
       }}
     >
       <HoverCard.Target>{children}</HoverCard.Target>

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
@@ -11,6 +11,7 @@ type Props = {
   field: Field | DatasetColumn;
   timezone?: string;
   delay: [number, number];
+  showFingerprintInfo?: boolean;
 } & Pick<HoverCardProps, "children" | "position" | "disabled">;
 
 function FieldInfoPopover({
@@ -19,6 +20,7 @@ function FieldInfoPopover({
   position = "bottom-start",
   disabled,
   delay = POPOVER_DELAY,
+  showFingerprintInfo,
   children,
   ...rest
 }: Props) {
@@ -36,7 +38,11 @@ function FieldInfoPopover({
     >
       <HoverCard.Target>{children}</HoverCard.Target>
       <HoverCard.Dropdown>
-        <WidthBoundFieldInfo field={field} timezone={timezone} />
+        <WidthBoundFieldInfo
+          field={field}
+          timezone={timezone}
+          showFingerprintInfo={showFingerprintInfo}
+        />
       </HoverCard.Dropdown>
     </HoverCard>
   );

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
@@ -22,13 +22,11 @@ function FieldInfoPopover({
   delay = POPOVER_DELAY,
   showFingerprintInfo,
   children,
-  ...rest
 }: Props) {
   const group = useDelayGroup();
 
   return (
     <HoverCard
-      {...rest}
       position={position}
       disabled={disabled}
       openDelay={group.shouldDelay ? delay[0] : 0}

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
@@ -3,7 +3,11 @@ import { HoverCard, useDelayGroup } from "metabase/ui";
 import type { DatasetColumn } from "metabase-types/api";
 import type Field from "metabase-lib/metadata/Field";
 
-import { WidthBoundFieldInfo } from "./FieldInfoPopover.styled";
+import {
+  WidthBoundFieldInfo,
+  Dropdown,
+  Target,
+} from "./FieldInfoPopover.styled";
 
 export const POPOVER_DELAY: [number, number] = [1000, 300];
 
@@ -30,19 +34,25 @@ function FieldInfoPopover({
       position={position}
       disabled={disabled}
       openDelay={group.shouldDelay ? delay[0] : 0}
-      closeDelay={group.shouldDelay ? delay[1] : 0}
+      closeDelay={group.shouldDelay ? delay[1] : 50}
       onOpen={group.onOpen}
       onClose={group.onClose}
-      transitionProps={{ duration: group.shouldDelay ? 150 : 0 }}
+      transitionProps={{
+        duration: group.shouldDelay ? 150 : 0,
+        keepMounted: true,
+      }}
     >
       <HoverCard.Target>{children}</HoverCard.Target>
-      <HoverCard.Dropdown>
+      <Dropdown>
+        {/* HACK: adds an element between the target and the card */}
+        {/* to avoid the card from disappearing */}
+        <Target />
         <WidthBoundFieldInfo
           field={field}
           timezone={timezone}
           showFingerprintInfo={showFingerprintInfo}
         />
-      </HoverCard.Dropdown>
+      </Dropdown>
     </HoverCard>
   );
 }

--- a/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/FieldInfoPopover/FieldInfoPopover.tsx
@@ -24,17 +24,17 @@ function FieldInfoPopover({
   children,
   ...rest
 }: Props) {
-  const grp = useDelayGroup();
+  const group = useDelayGroup();
 
   return (
     <HoverCard
       {...rest}
       position={position}
       disabled={disabled}
-      openDelay={grp.shouldDelay ? delay[0] : 0}
-      closeDelay={grp.shouldDelay ? delay[1] : 0}
-      onOpen={grp.onOpen}
-      onClose={grp.onClose}
+      openDelay={group.shouldDelay ? delay[0] : 0}
+      closeDelay={group.shouldDelay ? delay[1] : 0}
+      onOpen={group.onOpen}
+      onClose={group.onClose}
     >
       <HoverCard.Target>{children}</HoverCard.Target>
       <HoverCard.Dropdown>

--- a/frontend/src/metabase/query_builder/components/dataref/FieldPane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldPane.tsx
@@ -22,6 +22,7 @@ const FieldPane = ({ onBack, onClose, field }: FieldPaneProps) => {
           field={field}
           timezone={field.table?.database?.timezone}
           showAllFieldValues
+          showFingerprintInfo
         />
       </PaneContent>
     </SidebarContent>

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.stories.mdx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.stories.mdx
@@ -1,0 +1,92 @@
+import { Fragment } from "react";
+import { Canvas, Story, Meta } from "@storybook/addon-docs";
+import {
+  Box,
+  Button,
+  Flex,
+  HoverCard,
+  Text,
+  TextInput,
+  Stack,
+} from "metabase/ui";
+
+export const args = {
+  label: "HoverCard",
+  position: "bottom",
+};
+
+export const argTypes = {
+  position: {
+    options: [
+      "bottom",
+      "left",
+      "right",
+      "top",
+      "bottom-end",
+      "bottom-start",
+      "left-end",
+      "left-start",
+      "right-end",
+      "right-start",
+      "top-end",
+      "top-start",
+    ],
+    control: { type: "select" },
+  },
+};
+
+export const sampleArgs = {
+  simple: <Text>Hover!</Text>,
+  interactive: (
+    <Stack spacing="sm">
+      <TextInput autoFocus placeholder="First name" />
+      <TextInput placeholder="Last name" />
+      <Button>Update</Button>
+    </Stack>
+  ),
+};
+
+<Meta
+  title="Overlays/HoverCard"
+  component={HoverCard}
+  args={args}
+  argTypes={argTypes}
+/>
+
+# HoverCard
+
+Our themed wrapper around [Mantine HoverCard](https://v6.mantine.dev/core/hover-card/).
+
+## Docs
+
+- [Mantine HoverCard Docs](https://v6.mantine.dev/core/hover-card/)
+
+## Examples
+
+export const DefaultTemplate = ({ children, ...args }) => (
+  <Flex justify="center">
+    <HoverCard {...args}>
+      <HoverCard.Target>
+        <Button variant="filled">Hover to open</Button>
+      </HoverCard.Target>
+      <HoverCard.Dropdown>
+        <Box p="md">{children}</Box>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  </Flex>
+);
+
+export const Default = DefaultTemplate.bind({});
+Default.args = {
+  children: sampleArgs.simple,
+};
+
+export const Interactive = DefaultTemplate.bind({});
+Interactive.args = {
+  children: sampleArgs.interactive,
+};
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+  <Story name="Interactive content">{Interactive}</Story>
+</Canvas>

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/HoverCard.styled.tsx
@@ -1,0 +1,19 @@
+import type { MantineThemeOverride } from "@mantine/core";
+
+export const getHoverCardOverrides =
+  (): MantineThemeOverride["components"] => ({
+    HoverCard: {
+      defaultProps: {
+        radius: "sm",
+        shadow: "md",
+        withinPortal: true,
+        middlewares: { shift: true, flip: true, size: true },
+      },
+      styles: () => ({
+        dropdown: {
+          padding: 0,
+          overflow: "auto",
+        },
+      }),
+    },
+  });

--- a/frontend/src/metabase/ui/components/overlays/HoverCard/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/HoverCard/index.tsx
@@ -1,0 +1,3 @@
+export { HoverCard } from "@mantine/core";
+export type { HoverCardProps } from "@mantine/core";
+export { getHoverCardOverrides } from "./HoverCard.styled";

--- a/frontend/src/metabase/ui/components/overlays/index.ts
+++ b/frontend/src/metabase/ui/components/overlays/index.ts
@@ -1,5 +1,5 @@
+export * from "./HoverCard";
 export * from "./Menu";
 export * from "./Modal";
 export * from "./Popover";
 export * from "./Tooltip";
-export * from "./HoverCard";

--- a/frontend/src/metabase/ui/components/overlays/index.ts
+++ b/frontend/src/metabase/ui/components/overlays/index.ts
@@ -2,3 +2,4 @@ export * from "./Menu";
 export * from "./Modal";
 export * from "./Popover";
 export * from "./Tooltip";
+export * from "./HoverCard";

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.tsx
@@ -19,8 +19,10 @@ type DelayGroupProps = {
 
 const DEFAULT_TIMEOUT = 500;
 
-export function DelayGroup(props: DelayGroupProps) {
-  const { children, timeout = DEFAULT_TIMEOUT } = props;
+export function DelayGroup({
+  children,
+  timeout = DEFAULT_TIMEOUT,
+}: DelayGroupProps) {
   const [shouldDelay, setShouldDelay] = React.useState(true);
 
   const t = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+type DelayGroupContext = {
+  shouldDelay: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+};
+
+const context = React.createContext<DelayGroupContext>({
+  shouldDelay: true,
+  onOpen: () => undefined,
+  onClose: () => undefined,
+});
+
+type DelayGroupProps = {
+  timeout?: number;
+  children: React.ReactNode;
+};
+
+const DEFAULT_TIMEOUT = 500;
+
+export function DelayGroup(props: DelayGroupProps) {
+  const { children, timeout = DEFAULT_TIMEOUT } = props;
+  const [shouldDelay, setShouldDelay] = React.useState(true);
+
+  const t = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const value = React.useMemo(
+    () => ({
+      shouldDelay,
+      onOpen() {
+        clearTimeout(t.current);
+        setShouldDelay(false);
+      },
+      onClose() {
+        clearTimeout(t.current);
+        t.current = setTimeout(() => setShouldDelay(true), timeout);
+      },
+    }),
+    [timeout, shouldDelay, setShouldDelay],
+  );
+
+  React.useEffect(function () {
+    return () => clearTimeout(t.current);
+  }, []);
+
+  return <context.Provider value={value}>{children}</context.Provider>;
+}
+
+export function useDelayGroup(): DelayGroupContext {
+  return React.useContext(context);
+}

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.tsx
@@ -39,7 +39,7 @@ export function DelayGroup({
         t.current = setTimeout(() => setShouldDelay(true), timeout);
       },
     }),
-    [timeout, shouldDelay, setShouldDelay],
+    [timeout, shouldDelay],
   );
 
   React.useEffect(function () {

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.tsx
@@ -1,4 +1,11 @@
-import React from "react";
+import {
+  createContext,
+  useMemo,
+  useState,
+  useRef,
+  useEffect,
+  useContext,
+} from "react";
 
 type DelayGroupContext = {
   shouldDelay: boolean;
@@ -6,7 +13,7 @@ type DelayGroupContext = {
   onClose: () => void;
 };
 
-const context = React.createContext<DelayGroupContext>({
+const context = createContext<DelayGroupContext>({
   shouldDelay: true,
   onOpen: () => undefined,
   onClose: () => undefined,
@@ -23,11 +30,11 @@ export function DelayGroup({
   children,
   timeout = DEFAULT_TIMEOUT,
 }: DelayGroupProps) {
-  const [shouldDelay, setShouldDelay] = React.useState(true);
+  const [shouldDelay, setShouldDelay] = useState(true);
 
-  const t = React.useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const t = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
-  const value = React.useMemo(
+  const value = useMemo(
     () => ({
       shouldDelay,
       onOpen() {
@@ -42,7 +49,7 @@ export function DelayGroup({
     [timeout, shouldDelay],
   );
 
-  React.useEffect(function () {
+  useEffect(function () {
     return () => clearTimeout(t.current);
   }, []);
 
@@ -50,5 +57,5 @@ export function DelayGroup({
 }
 
 export function useDelayGroup(): DelayGroupContext {
-  return React.useContext(context);
+  return useContext(context);
 }

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.tsx
@@ -32,25 +32,27 @@ export function DelayGroup({
 }: DelayGroupProps) {
   const [shouldDelay, setShouldDelay] = useState(true);
 
-  const t = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
 
   const value = useMemo(
     () => ({
       shouldDelay,
       onOpen() {
-        clearTimeout(t.current);
+        clearTimeout(timeoutRef.current);
         setShouldDelay(false);
       },
       onClose() {
-        clearTimeout(t.current);
-        t.current = setTimeout(() => setShouldDelay(true), timeout);
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(() => setShouldDelay(true), timeout);
       },
     }),
     [timeout, shouldDelay],
   );
 
   useEffect(function () {
-    return () => clearTimeout(t.current);
+    return () => clearTimeout(timeoutRef.current);
   }, []);
 
   return <context.Provider value={value}>{children}</context.Provider>;

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
@@ -1,0 +1,52 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "__support__/ui";
+import { DelayGroup, useDelayGroup } from "./DelayGroup";
+
+interface SetupOpts {
+  timeout?: number;
+}
+
+function setup(opts: SetupOpts) {
+  const onChange = jest.fn();
+
+  render(
+    <DelayGroup timeout={opts.timeout ?? 100}>
+      <Child />
+    </DelayGroup>,
+  );
+
+  return { onChange };
+}
+
+function Child() {
+  const ctx = useDelayGroup();
+  return (
+    <button onMouseEnter={ctx.onOpen} onMouseLeave={ctx.onClose}>
+      delay: {JSON.stringify(ctx.shouldDelay)}
+    </button>
+  );
+}
+
+describe("DelayGroup", () => {
+  it("should be delayed by default and only remove delay after a timeout", async () => {
+    const timeout = 50;
+    setup({ timeout });
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveTextContent("delay: true");
+
+    userEvent.hover(button);
+    expect(button).toHaveTextContent("delay: false");
+
+    userEvent.unhover(button);
+    expect(button).toHaveTextContent("delay: false");
+    const start = Date.now();
+
+    await waitFor(function () {
+      expect(button).toHaveTextContent("delay: true");
+    });
+
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeCloseTo(timeout, -1);
+  });
+});

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
@@ -3,19 +3,15 @@ import { render, screen, waitFor } from "__support__/ui";
 import { DelayGroup, useDelayGroup } from "./DelayGroup";
 
 interface SetupOpts {
-  timeout?: number;
+  timeout: number;
 }
 
 function setup(opts: SetupOpts) {
-  const onChange = jest.fn();
-
   render(
-    <DelayGroup timeout={opts.timeout ?? 100}>
+    <DelayGroup timeout={opts.timeout}>
       <Child />
     </DelayGroup>,
   );
-
-  return { onChange };
 }
 
 function Child() {

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
@@ -15,10 +15,10 @@ function setup(opts: SetupOpts) {
 }
 
 function Child() {
-  const ctx = useDelayGroup();
+  const { shouldDelay, onOpen, onClose } = useDelayGroup();
   return (
-    <button onMouseEnter={ctx.onOpen} onMouseLeave={ctx.onClose}>
-      delay: {JSON.stringify(ctx.shouldDelay)}
+    <button onMouseEnter={onOpen} onMouseLeave={onClose}>
+      delay: {JSON.stringify(shouldDelay)}
     </button>
   );
 }

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/index.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/index.tsx
@@ -1,0 +1,1 @@
+export * from "./DelayGroup";

--- a/frontend/src/metabase/ui/components/utils/index.ts
+++ b/frontend/src/metabase/ui/components/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./Box";
 export * from "./Divider";
 export * from "./FocusTrap";
 export * from "./Paper";
+export * from "./DelayGroup";

--- a/frontend/src/metabase/ui/components/utils/index.ts
+++ b/frontend/src/metabase/ui/components/utils/index.ts
@@ -1,5 +1,5 @@
 export * from "./Box";
+export * from "./DelayGroup";
 export * from "./Divider";
 export * from "./FocusTrap";
 export * from "./Paper";
-export * from "./DelayGroup";

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -30,6 +30,7 @@ import {
   getTimeInputOverrides,
   getTitleOverrides,
   getTooltipOverrides,
+  getHoverCardOverrides,
 } from "./components";
 import { getThemeColors } from "./utils/colors";
 
@@ -120,5 +121,6 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
     ...getTimeInputOverrides(),
     ...getTitleOverrides(),
     ...getTooltipOverrides(),
+    ...getHoverCardOverrides(),
   },
 });

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -13,6 +13,7 @@ import {
   getDatePickerOverrides,
   getDividerOverrides,
   getFileInputOverrides,
+  getHoverCardOverrides,
   getInputOverrides,
   getMenuOverrides,
   getModalOverrides,
@@ -30,7 +31,6 @@ import {
   getTimeInputOverrides,
   getTitleOverrides,
   getTooltipOverrides,
-  getHoverCardOverrides,
 } from "./components";
 import { getThemeColors } from "./utils/colors";
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -10,7 +10,7 @@ import { Grid, ScrollSync } from "react-virtualized";
 
 import "./TableInteractive.css";
 
-import { Icon } from "metabase/ui";
+import { Icon, DelayGroup } from "metabase/ui";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import Button from "metabase/core/components/Button";
 import Tooltip from "metabase/core/components/Tooltip";
@@ -966,134 +966,136 @@ class TableInteractive extends Component {
     const gutterColumn = this.state.showDetailShortcut ? 1 : 0;
 
     return (
-      <ScrollSync>
-        {({ onScroll, scrollLeft, scrollTop }) => {
-          // Grid's doc says scrollToColumn takes precedence over scrollLeft
-          // (https://github.com/bvaughn/react-virtualized/blob/master/docs/Grid.md#prop-types)
-          // For some reason, for TableInteractive's main grid scrollLeft appears to be more prior
-          const mainGridProps = {};
-          if (scrollToColumn >= 0) {
-            mainGridProps.scrollToColumn = scrollToColumn;
-          } else {
-            mainGridProps.scrollLeft = scrollLeft;
-          }
-          return (
-            <TableInteractiveRoot
-              className={cx(className, "TableInteractive relative", {
-                "TableInteractive--pivot": this.props.isPivoted,
-                "TableInteractive--ready": this.state.contentWidths,
-                // no hover if we're dragging a column
-                "TableInteractive--noHover": this.state.dragColIndex != null,
-              })}
-              onMouseEnter={this.handleOnMouseEnter}
-              onMouseLeave={this.handleOnMouseLeave}
-              data-testid="TableInteractive-root"
-            >
-              <canvas
-                className="spread"
-                style={{ pointerEvents: "none", zIndex: 999 }}
-                width={width}
-                height={height}
-              />
-              {!!gutterColumn && (
-                <>
-                  <div
-                    className="TableInteractive-header TableInteractive--noHover"
-                    style={{
-                      position: "absolute",
-                      top: 0,
-                      left: 0,
-                      width: SIDEBAR_WIDTH,
-                      height: headerHeight,
-                      zIndex: 4,
-                    }}
-                  />
-                  <div
-                    id="gutter-column"
-                    className="TableInteractive-gutter"
-                    style={{
-                      position: "absolute",
-                      top: headerHeight,
-                      left: 0,
-                      height: height - headerHeight - getScrollBarSize(),
-                      width: SIDEBAR_WIDTH,
-                      zIndex: 3,
-                    }}
-                    onMouseMove={this.handleHoverRow}
-                    onMouseLeave={this.handleLeaveRow}
-                  >
-                    <DetailShortcut ref={this.detailShortcutRef} />
-                  </div>
-                </>
-              )}
-              <Grid
-                ref={ref => (this.header = ref)}
-                style={{
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                  height: headerHeight,
-                  position: "absolute",
-                  overflow: "hidden",
-                  paddingRight: getScrollBarSize(),
-                }}
-                className="TableInteractive-header scroll-hide-all"
-                width={width || 0}
-                height={headerHeight}
-                rowCount={1}
-                rowHeight={headerHeight}
-                columnCount={cols.length + gutterColumn}
-                columnWidth={this.getDisplayColumnWidth}
-                cellRenderer={props =>
-                  gutterColumn && props.columnIndex === 0
-                    ? () => null // we need a phantom cell to properly offset columns
-                    : this.tableHeaderRenderer({
-                        ...props,
-                        columnIndex: props.columnIndex - gutterColumn,
-                      })
-                }
-                onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
-                scrollLeft={scrollLeft}
-                tabIndex={null}
-                scrollToColumn={scrollToColumn}
-              />
-              <Grid
-                id="main-data-grid"
-                ref={ref => (this.grid = ref)}
-                style={{
-                  top: headerHeight,
-                  left: 0,
-                  right: 0,
-                  bottom: 0,
-                  position: "absolute",
-                }}
-                width={width}
-                height={height - headerHeight}
-                columnCount={cols.length + gutterColumn}
-                columnWidth={this.getDisplayColumnWidth}
-                rowCount={rows.length}
-                rowHeight={ROW_HEIGHT}
-                cellRenderer={props =>
-                  gutterColumn && props.columnIndex === 0
-                    ? () => null // we need a phantom cell to properly offset columns
-                    : this.cellRenderer({
-                        ...props,
-                        columnIndex: props.columnIndex - gutterColumn,
-                      })
-                }
-                scrollTop={scrollTop}
-                onScroll={({ scrollLeft, scrollTop }) => {
-                  this.props.onActionDismissal();
-                  return onScroll({ scrollLeft, scrollTop });
-                }}
-                {...mainGridProps}
-                tabIndex={null}
-                overscanRowCount={20}
-              />
-            </TableInteractiveRoot>
-          );
-        }}
-      </ScrollSync>
+      <DelayGroup>
+        <ScrollSync>
+          {({ onScroll, scrollLeft, scrollTop }) => {
+            // Grid's doc says scrollToColumn takes precedence over scrollLeft
+            // (https://github.com/bvaughn/react-virtualized/blob/master/docs/Grid.md#prop-types)
+            // For some reason, for TableInteractive's main grid scrollLeft appears to be more prior
+            const mainGridProps = {};
+            if (scrollToColumn >= 0) {
+              mainGridProps.scrollToColumn = scrollToColumn;
+            } else {
+              mainGridProps.scrollLeft = scrollLeft;
+            }
+            return (
+              <TableInteractiveRoot
+                className={cx(className, "TableInteractive relative", {
+                  "TableInteractive--pivot": this.props.isPivoted,
+                  "TableInteractive--ready": this.state.contentWidths,
+                  // no hover if we're dragging a column
+                  "TableInteractive--noHover": this.state.dragColIndex != null,
+                })}
+                onMouseEnter={this.handleOnMouseEnter}
+                onMouseLeave={this.handleOnMouseLeave}
+                data-testid="TableInteractive-root"
+              >
+                <canvas
+                  className="spread"
+                  style={{ pointerEvents: "none", zIndex: 999 }}
+                  width={width}
+                  height={height}
+                />
+                {!!gutterColumn && (
+                  <>
+                    <div
+                      className="TableInteractive-header TableInteractive--noHover"
+                      style={{
+                        position: "absolute",
+                        top: 0,
+                        left: 0,
+                        width: SIDEBAR_WIDTH,
+                        height: headerHeight,
+                        zIndex: 4,
+                      }}
+                    />
+                    <div
+                      id="gutter-column"
+                      className="TableInteractive-gutter"
+                      style={{
+                        position: "absolute",
+                        top: headerHeight,
+                        left: 0,
+                        height: height - headerHeight - getScrollBarSize(),
+                        width: SIDEBAR_WIDTH,
+                        zIndex: 3,
+                      }}
+                      onMouseMove={this.handleHoverRow}
+                      onMouseLeave={this.handleLeaveRow}
+                    >
+                      <DetailShortcut ref={this.detailShortcutRef} />
+                    </div>
+                  </>
+                )}
+                <Grid
+                  ref={ref => (this.header = ref)}
+                  style={{
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    height: headerHeight,
+                    position: "absolute",
+                    overflow: "hidden",
+                    paddingRight: getScrollBarSize(),
+                  }}
+                  className="TableInteractive-header scroll-hide-all"
+                  width={width || 0}
+                  height={headerHeight}
+                  rowCount={1}
+                  rowHeight={headerHeight}
+                  columnCount={cols.length + gutterColumn}
+                  columnWidth={this.getDisplayColumnWidth}
+                  cellRenderer={props =>
+                    gutterColumn && props.columnIndex === 0
+                      ? () => null // we need a phantom cell to properly offset columns
+                      : this.tableHeaderRenderer({
+                          ...props,
+                          columnIndex: props.columnIndex - gutterColumn,
+                        })
+                  }
+                  onScroll={({ scrollLeft }) => onScroll({ scrollLeft })}
+                  scrollLeft={scrollLeft}
+                  tabIndex={null}
+                  scrollToColumn={scrollToColumn}
+                />
+                <Grid
+                  id="main-data-grid"
+                  ref={ref => (this.grid = ref)}
+                  style={{
+                    top: headerHeight,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    position: "absolute",
+                  }}
+                  width={width}
+                  height={height - headerHeight}
+                  columnCount={cols.length + gutterColumn}
+                  columnWidth={this.getDisplayColumnWidth}
+                  rowCount={rows.length}
+                  rowHeight={ROW_HEIGHT}
+                  cellRenderer={props =>
+                    gutterColumn && props.columnIndex === 0
+                      ? () => null // we need a phantom cell to properly offset columns
+                      : this.cellRenderer({
+                          ...props,
+                          columnIndex: props.columnIndex - gutterColumn,
+                        })
+                  }
+                  scrollTop={scrollTop}
+                  onScroll={({ scrollLeft, scrollTop }) => {
+                    this.props.onActionDismissal();
+                    return onScroll({ scrollLeft, scrollTop });
+                  }}
+                  {...mainGridProps}
+                  tabIndex={null}
+                  overscanRowCount={20}
+                />
+              </TableInteractiveRoot>
+            );
+          }}
+        </ScrollSync>
+      </DelayGroup>
     );
   }
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -787,6 +787,7 @@ class TableInteractive extends Component {
             field={column}
             timezone={data.results_timezone}
             disabled={this.props.clicked != null || !hasMetadataPopovers}
+            showFingerprintInfo
           >
             {renderTableHeaderWrapper(
               <Ellipsified tooltip={columnTitle}>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38432

### Description

Migrate the FieldInfo hovercard to Mantine so that it no longer makes use of deprecated components.

This PR does a couple of things:
- Brings in `HoverCard` from Mantine to complement the existing `Popover` and `Tooltip` overlays
- Implements a utility class `DelayGroup` (and matcing `useDelayGroup` hook) that implements the hover delay functionality that Mantine does not implement but tippy.js does. When hovering an element in de `DelayGroup` the timeout only applies the for the first element, and switching between elements does not incur the same delay.
- Convert `InfoFieldPopover` to use these new components.
- Makes showing the fingerprint info for a column optional in the `FieldInfoPopover`, since we don't want to display it everywhere.

Notes:
- `DelayGroup` should technically not be necessary, had Mantine exposed more of the hover internals from `@floating-ui/react`, since then we could use [`FloatingDelayGroup`](https://floating-ui.com/docs/floatingdelaygroup) instead of building our own. Luckily the implementation is fairly simple.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Browse Data → Sample Database → Orders
2. Hover one of the column headers, after 700ms an info card should appear
3. Hover another column header, it should appear immediately


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
