### PR TITLE
Fix hover cursor is always crosshair instead of pointer on brushable charts

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -227,22 +227,27 @@ export function CartesianChart(props: VisualizationProps) {
   // In order to keep brushing always enabled we have to re-enable it on every model change
   useEffect(
     function enableBrushing() {
-      if (!canBrush(rawSeries, settings, onChangeCardAndRun)) {
-        return;
-      }
+      const shouldEnableBrushing =
+        canBrush(rawSeries, settings, onChangeCardAndRun) && !hovered;
 
       setTimeout(() => {
-        chartRef.current?.dispatchAction({
-          type: "takeGlobalCursor",
-          key: "brush",
-          brushOption: {
-            brushType: "lineX",
-            brushMode: "single",
-          },
-        });
+        if (shouldEnableBrushing) {
+          chartRef.current?.dispatchAction({
+            type: "takeGlobalCursor",
+            key: "brush",
+            brushOption: {
+              brushType: "lineX",
+              brushMode: "single",
+            },
+          });
+        } else {
+          chartRef.current?.dispatchAction({
+            type: "takeGlobalCursor",
+          });
+        }
       }, 0);
     },
-    [onChangeCardAndRun, option, rawSeries, settings],
+    [onChangeCardAndRun, option, rawSeries, settings, hovered],
   );
 
   const handleSelectSeries = useCallback(


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38439

### Description

On timeseries and numeric x-axis charts brushing is enabled by default. This leads to always showing `crosshair` cursor (cross) instead of `pointer` even when hovering chart elements like bars.

### How to verify

- create any echarts cartesian chart with timeseries or numeric x-axis
- ensure it shows cursor pointer when you hover bars/dots

### Demo

https://github.com/metabase/metabase/assets/14301985/b806c762-3616-4e8f-b5ce-74e60e261fa4

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
