### PR TITLE
Adding geographic coordinate formatting to exports

### DIFF
--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [dk.ative.docjure.spreadsheet :as spreadsheet]
    [java-time.api :as t]
+   [metabase.formatter :as formatter]
    [metabase.lib.schema.temporal-bucketing
     :as lib.schema.temporal-bucketing]
    [metabase.query-processor.streaming.common :as common]
@@ -219,6 +220,9 @@
         (isa? col-type :Relation/*)
         "0"
 
+        (isa? semantic-type :type/Coordinate)
+        nil
+
         ;; This logic is a guard against someone setting the semantic type of a non-temporal value like 1.0 to temporal.
         ;; It will not apply formatting to the value in this case.
         (and (or (some #(contains? datetime-setting-keys %) (keys format-settings))
@@ -369,6 +373,13 @@
   formatting can be applied. This should be enabled for generation of pulse/dashboard subscription attachments."
   false)
 
+(defn- maybe-parse-coordinate-value [value {:keys [semantic_type]}]
+  (when (isa? semantic_type :type/Coordinate)
+    (try (formatter/format-geographic-coordinates semantic_type value)
+         ;; Fallback to plain string value if it couldn't be parsed
+         (catch Exception _ value
+                            value))))
+
 (defn- maybe-parse-temporal-value
   [value col]
   (when (and *parse-temporal-string-values*
@@ -378,6 +389,7 @@
          ;; Fallback to plain string value if it couldn't be parsed
          (catch Exception _ value
                 value))))
+
 (defn- add-row!
   "Adds a row of values to the spreadsheet. Values with the `scaled` viz setting are scaled prior to being added.
 
@@ -398,6 +410,7 @@
             ;; dashboard subscription/pulse generation. If so, we should parse them here so that formatting is applied.
             parsed-value (or
                            (maybe-parse-temporal-value value col)
+                           (maybe-parse-coordinate-value value col)
                            scaled-val)]
         (set-cell! (.createCell ^SXSSFRow row ^Integer index) parsed-value styles typed-cell-styles)))
     row))

--- a/test/metabase/formatter_test.clj
+++ b/test/metabase/formatter_test.clj
@@ -141,3 +141,22 @@
                                            {{::mb.viz/column-id 1}
                                             {::mb.viz/number-style "percent"}}})
               "bob"))))))
+
+(deftest coords-formatting-test
+  (testing "Test the correctness of formatting longitude and latitude values"
+    (is (= "12.34560000° E"
+           (formatter/format-geographic-coordinates :type/Longitude 12.3456)))
+    (is (= "12.34560000° W"
+           (formatter/format-geographic-coordinates :type/Longitude -12.3456)))
+    (is (= "12.34560000° N"
+           (formatter/format-geographic-coordinates :type/Latitude 12.3456)))
+    (is (= "12.34560000° S"
+           (formatter/format-geographic-coordinates :type/Latitude -12.3456)))
+    (testing "0 corresponds to the non-negative direction"
+      (is (= "0.00000000° E"
+             (formatter/format-geographic-coordinates :type/Longitude 0)))
+      (is (= "0.00000000° N"
+             (formatter/format-geographic-coordinates :type/Latitude 0))))
+    (testing "A non-coordinate type just stringifies the value"
+      (is (= "0.0"
+             (formatter/format-geographic-coordinates :type/Froobitude 0))))))

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -759,14 +759,21 @@
 (deftest geographic-coordinates-formatting-test
   (testing "Longitude and latitude columns should format correctly on export (#38419)"
     (mt/dataset airports
-      (let [card {:dataset_query {:database (mt/id)
-                                  :type     :query
-                                  :query    {:source-table (mt/id :airport)
-                                             :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
-                                                            [:field (mt/id :airport :longitude) {:base-type :type/Float}]
-                                                            [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
-                                             :order-by     [[:asc (mt/id :airport :id)]]
-                                             :limit        5}}}]
+      (let [card {:dataset_query   {:database (mt/id)
+                                    :type     :query
+                                    :query    {:source-table (mt/id :airport)
+                                               :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
+                                                              [:field (mt/id :airport :longitude) {:base-type :type/Float}]
+                                                              [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
+                                               :order-by     [[:asc (mt/id :airport :id)]]
+                                               :limit        5}}
+                  :dataset         true
+                  :result_metadata [{:name               "ID"
+                                     :id                 (mt/id :airport :id)}
+                                    {:semantic_type      :type/Longitude
+                                     :field_ref          [:field (mt/id :airport :longitude) {:base-type :type/Float}]}
+                                    {:semantic_type      :type/Latitude
+                                     :field_ref          [:field (mt/id :airport :latitude) {:base-type :type/Float}]}]}]
         (mt/with-temp [Card {card-id :id} card
                        Dashboard {dash-id :id} {:name "just dash"}
                        DashboardCard {dash-card-id :id} {:dashboard_id dash-id

--- a/test/metabase/pulse/pulse_integration_test.clj
+++ b/test/metabase/pulse/pulse_integration_test.clj
@@ -4,16 +4,16 @@
   These tests should build content then mock out distrubution by usual channels (e.g. email) and check the results of
   the distributed content for correctness."
   (:require
-    [clojure.data.csv :as csv]
-    [clojure.string :as str]
-    [clojure.test :refer :all]
-    [hickory.core :as hik]
-    [hickory.select :as hik.s]
-    [metabase.email :as email]
-    [metabase.models :refer [Card Collection Dashboard DashboardCard Pulse PulseCard PulseChannel PulseChannelRecipient]]
-    [metabase.pulse]
-    [metabase.test :as mt]
-    [metabase.util :as u]))
+   [clojure.data.csv :as csv]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [hickory.core :as hik]
+   [hickory.select :as hik.s]
+   [metabase.email :as email]
+   [metabase.models :refer [Card Collection Dashboard DashboardCard Pulse PulseCard PulseChannel PulseChannelRecipient]]
+   [metabase.pulse]
+   [metabase.test :as mt]
+   [metabase.util :as u]))
 
 (defmacro with-metadata-data-cards
   "Provide a fixture that includes:
@@ -759,37 +759,56 @@
 (deftest geographic-coordinates-formatting-test
   (testing "Longitude and latitude columns should format correctly on export (#38419)"
     (mt/dataset airports
-      (let [card {:dataset_query   {:database (mt/id)
-                                    :type     :query
-                                    :query    {:source-table (mt/id :airport)
-                                               :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
-                                                              [:field (mt/id :airport :longitude) {:base-type :type/Float}]
-                                                              [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
-                                               :order-by     [[:asc (mt/id :airport :id)]]
-                                               :limit        5}}
-                  :dataset         true
-                  :result_metadata [{:name               "ID"
-                                     :id                 (mt/id :airport :id)}
-                                    {:semantic_type      :type/Longitude
-                                     :field_ref          [:field (mt/id :airport :longitude) {:base-type :type/Float}]}
-                                    {:semantic_type      :type/Latitude
-                                     :field_ref          [:field (mt/id :airport :latitude) {:base-type :type/Float}]}]}]
-        (mt/with-temp [Card {card-id :id} card
-                       Dashboard {dash-id :id} {:name "just dash"}
+      (let [base-card {:dataset_query {:database (mt/id)
+                                       :type     :query
+                                       :query    {:source-table (mt/id :airport)
+                                                  :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
+                                                                 [:field (mt/id :airport :longitude) {:base-type :type/Float}]
+                                                                 [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
+                                                  :order-by     [[:asc (mt/id :airport :id)]]
+                                                  :limit        5}}}
+            model     {:dataset_query   {:database (mt/id)
+                                         :type     :query
+                                         :query    {:source-table (mt/id :airport)
+                                                    :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
+                                                                   [:field (mt/id :airport :longitude) {:base-type :type/Float}]
+                                                                   [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
+                                                    :order-by     [[:asc (mt/id :airport :id)]]
+                                                    :limit        5}}
+                       :dataset         true
+                       :result_metadata [{:name "ID"
+                                          :id   (mt/id :airport :id)}
+                                         {:semantic_type :type/Longitude
+                                          :field_ref     [:field (mt/id :airport :longitude) {:base-type :type/Float}]}
+                                         {:semantic_type :type/Latitude
+                                          :field_ref     [:field (mt/id :airport :latitude) {:base-type :type/Float}]}]}]
+        (mt/with-temp [Card {card-id :id} base-card
+                       Card {model-id :id} model
+                       Dashboard {dash-id :id} {}
                        DashboardCard {dash-card-id :id} {:dashboard_id dash-id
                                                          :card_id      card-id}
+                       DashboardCard {model-card-id :id} {:dashboard_id dash-id
+                                                          :card_id      model-id}
                        Pulse {pulse-id :id :as pulse} {:name         "Test Pulse"
                                                        :dashboard_id dash-id}
                        PulseCard _ {:pulse_id          pulse-id
                                     :card_id           card-id
                                     :dashboard_card_id dash-card-id}
+                       PulseCard _ {:pulse_id          pulse-id
+                                    :card_id           model-id
+                                    :dashboard_card_id model-card-id}
                        PulseChannel {pulse-channel-id :id} {:channel_type :email
                                                             :pulse_id     pulse-id
                                                             :enabled      true}
                        PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
                                                 :user_id          (mt/user->id :rasta)}]
           (testing "The html output renders the table cells as geographic coordinates"
-            (is (= [[["1" "9.84924316° E" "57.09275891° N"]
+            (is (= [[["1" "9.85" "57.09"]
+                     ["2" "39.22" "-6.2"]
+                     ["3" "-2.2" "57.2"]
+                     ["4" "-89.68" "39.84"]
+                     ["5" "54.65" "24.43"]]
+                    [["1" "9.84924316° E" "57.09275891° N"]
                      ["2" "39.22489900° E" "6.22202000° S"]
                      ["3" "2.19777989° W" "57.20190048° N"]
                      ["4" "89.67790222° W" "39.84410095° N"]

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -164,16 +164,16 @@
 
 ;; Basic test that result rows are formatted correctly (dates, floating point numbers etc)
 (deftest format-result-rows
-  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
-          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014, 3:15 PM" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014, 12:45 PM" "The Gorbals"]}]
+  (is (= [{:bar-width nil, :row [(number "1" 1) "34.09960000° N" "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
+          {:bar-width nil, :row [(number "2" 2) "34.04060000° N" "December 5, 2014, 3:15 PM" "The Apple Pan"]}
+          {:bar-width nil, :row [(number "3" 3) "34.04740000° N" "August 1, 2014, 12:45 PM" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows example-test-data})))))
 
 ;; Testing the bar-column, which is the % of this row relative to the max of that column
 (deftest bar-column
-  (is (= [{:bar-width (float 85.249), :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
-          {:bar-width (float 85.1015), :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014, 3:15 PM" "The Apple Pan"]}
-          {:bar-width (float 85.1185), :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014, 12:45 PM" "The Gorbals"]}]
+  (is (= [{:bar-width (float 85.249), :row [(number "1" 1) "34.09960000° N" "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
+          {:bar-width (float 85.1015), :row [(number "2" 2) "34.04060000° N" "December 5, 2014, 3:15 PM" "The Apple Pan"]}
+          {:bar-width (float 85.1185), :row [(number "3" 3) "34.04740000° N" "August 1, 2014, 12:45 PM" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows example-test-data}
                  {:bar-column second, :min-value 0, :max-value 40})))))
 
@@ -214,9 +214,9 @@
 
 ;; Result rows should include only the remapped column value, not the original
 (deftest include-only-remapped-column-name
-  (is (= [[(number "1" 1) (number "34.1" 34.0996) "Bad" "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]
-          [(number "2" 2) (number "34.04" 34.0406) "Ok" "December 5, 2014, 3:15 PM" "The Apple Pan"]
-          [(number "3" 3) (number "34.05" 34.0474) "Good" "August 1, 2014, 12:45 PM" "The Gorbals"]]
+  (is (= [[(number "1" 1) "34.09960000° N" "Bad" "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]
+          [(number "2" 2) "34.04060000° N" "Ok" "December 5, 2014, 3:15 PM" "The Apple Pan"]
+          [(number "3" 3) "34.04740000° N" "Good" "August 1, 2014, 12:45 PM" "The Gorbals"]]
          (map :row (rest (#'body/prep-for-html-rendering pacific-tz
                            {}
                            {:cols test-columns-with-remapping :rows test-data-with-remapping}))))))
@@ -238,9 +238,9 @@
                                 :coercion_strategy :Coercion/ISO8601->DateTime}))
 
 (deftest cols-with-semantic-types
-  (is (= [{:bar-width nil, :row [(number "1" 1) (number "34.1" 34.0996) "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
-          {:bar-width nil, :row [(number "2" 2) (number "34.04" 34.0406) "December 5, 2014, 3:15 PM" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3" 3) (number "34.05" 34.0474) "August 1, 2014, 12:45 PM" "The Gorbals"]}]
+  (is (= [{:bar-width nil, :row [(number "1" 1) "34.09960000° N" "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
+          {:bar-width nil, :row [(number "2" 2) "34.04060000° N" "December 5, 2014, 3:15 PM" "The Apple Pan"]}
+          {:bar-width nil, :row [(number "3" 3) "34.04740000° N" "August 1, 2014, 12:45 PM" "The Gorbals"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz
                  {}
                  {:cols test-columns-with-date-semantic-type :rows example-test-data})))))

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -64,6 +64,27 @@
             ["5" "Quentin Sören" "October 3, 2014, 5:30 PM"]]
            (parse-and-sort-csv result)))))
 
+(deftest geographic-coordinates-test
+  (testing "Ensure CSV longtitude and latitude values are correctly exported"
+    (mt/dataset airports
+      (let [result (mt/user-http-request
+                     :rasta :post 200 "dataset/csv" :query
+                     (json/generate-string
+                       {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (mt/id :airport)
+                                   :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
+                                                  [:field (mt/id :airport :longitude) {:base-type :type/Float}]
+                                                  [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
+                                   :order-by     [[:asc (mt/id :airport :id)]]
+                                   :limit        5}}))]
+        (is (= [["1" "9.84924316° E" "57.09275891° N"]
+                ["2" "39.22489900° E" "6.22202000° S"]
+                ["3" "2.19777989° W" "57.20190048° N"]
+                ["4" "89.67790222° W" "39.84410095° N"]
+                ["5" "54.65110016° E" "24.43300056° N"]]
+               (parse-and-sort-csv result)))))))
+
 (defn- csv-export
   "Given a seq of result rows, write it as a CSV, then read the CSV and return the resulting data."
   [rows]

--- a/test/metabase/query_processor/streaming/csv_test.clj
+++ b/test/metabase/query_processor/streaming/csv_test.clj
@@ -65,25 +65,24 @@
            (parse-and-sort-csv result)))))
 
 (deftest geographic-coordinates-test
-  (testing "Ensure CSV longtitude and latitude values are correctly exported"
-    (mt/dataset airports
-      (let [result (mt/user-http-request
-                     :rasta :post 200 "dataset/csv" :query
-                     (json/generate-string
-                       {:database (mt/id)
-                        :type     :query
-                        :query    {:source-table (mt/id :airport)
-                                   :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
-                                                  [:field (mt/id :airport :longitude) {:base-type :type/Float}]
-                                                  [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
-                                   :order-by     [[:asc (mt/id :airport :id)]]
-                                   :limit        5}}))]
-        (is (= [["1" "9.84924316° E" "57.09275891° N"]
-                ["2" "39.22489900° E" "6.22202000° S"]
-                ["3" "2.19777989° W" "57.20190048° N"]
-                ["4" "89.67790222° W" "39.84410095° N"]
-                ["5" "54.65110016° E" "24.43300056° N"]]
-               (parse-and-sort-csv result)))))))
+  (testing "Ensure CSV longitude and latitude values are correctly exported"
+    (let [result (mt/user-http-request
+                   :rasta :post 200 "dataset/csv" :query
+                   (json/generate-string
+                     {:database (mt/id)
+                      :type     :query
+                      :query    {:source-table (mt/id :venues)
+                                 :fields       [[:field (mt/id :venues :id) {:base-type :type/Integer}]
+                                                [:field (mt/id :venues :longitude) {:base-type :type/Float}]
+                                                [:field (mt/id :venues :latitude) {:base-type :type/Float}]]
+                                 :order-by     [[:asc (mt/id :venues :id)]]
+                                 :limit        5}}))]
+      (is (= [["1" "165.37400000° W" "10.06460000° N"]
+              ["2" "118.32900000° W" "34.09960000° N"]
+              ["3" "118.42800000° W" "34.04060000° N"]
+              ["4" "118.46500000° W" "33.99970000° N"]
+              ["5" "118.26100000° W" "34.07780000° N"]]
+             (parse-and-sort-csv result))))))
 
 (defn- csv-export
   "Given a seq of result rows, write it as a CSV, then read the CSV and return the resulting data."

--- a/test/metabase/query_processor/streaming/json_test.clj
+++ b/test/metabase/query_processor/streaming/json_test.clj
@@ -1,8 +1,31 @@
 (ns metabase.query-processor.streaming.json-test
   (:require
+   [cheshire.core :as json]
    [clojure.test :refer :all]
-   [metabase.query-processor.streaming.json :as streaming.json]))
+   [metabase.query-processor.streaming.json :as streaming.json]
+   [metabase.test :as mt]))
 
 (deftest map->serialized-json-kvs-test
   (is (= "\"a\":100,\"b\":200"
          (#'streaming.json/map->serialized-json-kvs {:a 100, :b 200}))))
+
+(deftest geographic-coordinates-json-test
+  (testing "Ensure CSV longtitude and latitude values are correctly exported"
+    (mt/dataset airports
+      (let [result (mt/user-http-request
+                     :rasta :post 200 "dataset/json" :query
+                     (json/generate-string
+                       {:database (mt/id)
+                        :type     :query
+                        :query    {:source-table (mt/id :airport)
+                                   :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
+                                                  [:field (mt/id :airport :longitude) {:base-type :type/Float}]
+                                                  [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
+                                   :order-by     [[:asc (mt/id :airport :id)]]
+                                   :limit        5}}))]
+        (is (= [{:ID "1", :Longitude "9.84924316° E", :Latitude "57.09275891° N"}
+                {:ID "2", :Longitude "39.22489900° E", :Latitude "6.22202000° S"}
+                {:ID "3", :Longitude "2.19777989° W", :Latitude "57.20190048° N"}
+                {:ID "4", :Longitude "89.67790222° W", :Latitude "39.84410095° N"}
+                {:ID "5", :Longitude "54.65110016° E", :Latitude "24.43300056° N"}]
+               result))))))

--- a/test/metabase/query_processor/streaming/json_test.clj
+++ b/test/metabase/query_processor/streaming/json_test.clj
@@ -10,22 +10,21 @@
          (#'streaming.json/map->serialized-json-kvs {:a 100, :b 200}))))
 
 (deftest geographic-coordinates-json-test
-  (testing "Ensure CSV longtitude and latitude values are correctly exported"
-    (mt/dataset airports
-      (let [result (mt/user-http-request
-                     :rasta :post 200 "dataset/json" :query
-                     (json/generate-string
-                       {:database (mt/id)
-                        :type     :query
-                        :query    {:source-table (mt/id :airport)
-                                   :fields       [[:field (mt/id :airport :id) {:base-type :type/Integer}]
-                                                  [:field (mt/id :airport :longitude) {:base-type :type/Float}]
-                                                  [:field (mt/id :airport :latitude) {:base-type :type/Float}]]
-                                   :order-by     [[:asc (mt/id :airport :id)]]
-                                   :limit        5}}))]
-        (is (= [{:ID "1", :Longitude "9.84924316° E", :Latitude "57.09275891° N"}
-                {:ID "2", :Longitude "39.22489900° E", :Latitude "6.22202000° S"}
-                {:ID "3", :Longitude "2.19777989° W", :Latitude "57.20190048° N"}
-                {:ID "4", :Longitude "89.67790222° W", :Latitude "39.84410095° N"}
-                {:ID "5", :Longitude "54.65110016° E", :Latitude "24.43300056° N"}]
-               result))))))
+  (testing "Ensure JSON longitude and latitude values are correctly exported"
+    (let [result (mt/user-http-request
+                   :rasta :post 200 "dataset/json" :query
+                   (json/generate-string
+                     {:database (mt/id)
+                      :type     :query
+                      :query    {:source-table (mt/id :venues)
+                                 :fields       [[:field (mt/id :venues :id) {:base-type :type/Integer}]
+                                                [:field (mt/id :venues :longitude) {:base-type :type/Float}]
+                                                [:field (mt/id :venues :latitude) {:base-type :type/Float}]]
+                                 :order-by     [[:asc (mt/id :venues :id)]]
+                                 :limit        5}}))]
+      (is (= [{:ID "1", :Longitude "165.37400000° W", :Latitude "10.06460000° N"}
+              {:ID "2", :Longitude "118.32900000° W", :Latitude "34.09960000° N"}
+              {:ID "3", :Longitude "118.42800000° W", :Latitude "34.04060000° N"}
+              {:ID "4", :Longitude "118.46500000° W", :Latitude "33.99970000° N"}
+              {:ID "5", :Longitude "118.26100000° W", :Latitude "34.07780000° N"}]
+             result)))))

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -616,6 +616,23 @@
     (is (= [:DIV0]
            (second (xlsx-export [{:id 0, :name "Col"}] {} [[##-Inf]]))))))
 
+(deftest geographic-coordinates-test
+  (testing "Geograpic coordinates are correctly transformed"
+    (is (= ["12.34560000° E"
+            "12.34560000° W"
+            "12.34560000° N"
+            "12.34560000° S"
+            "0.00000000° E"
+            "0.00000000° N"]
+           (second (xlsx-export [{:name "Lon+" :semantic_type :type/Longitude}
+                                 {:name "Lon-" :semantic_type :type/Longitude}
+                                 {:name "Lat+" :semantic_type :type/Latitude}
+                                 {:name "Lat-" :semantic_type :type/Latitude}
+                                 {:name "Lon0" :semantic_type :type/Longitude}
+                                 {:name "Lat0" :semantic_type :type/Latitude}]
+                                {}
+                                [[12.3456 -12.3456 12.3456 -12.3456 0 0]]))))))
+
 (defrecord ^:private SampleNastyClass [^String v])
 
 (json.generate/add-encoder

--- a/test/metabase/query_processor/streaming_test.clj
+++ b/test/metabase/query_processor/streaming_test.clj
@@ -44,21 +44,76 @@
       (doseq [export-format (qp.streaming/export-formats)]
         (testing (u/colorize :yellow export-format)
           (case export-format
-            ;; CSVs round decimals to 2 digits without viz-settings so are not identical to results from expected-results*
             :csv (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
-                         ["1" "Red Medicine" "4" "10.06" "-165.37" "3"]
-                         ["2" "Stout Burgers & Beers" "11" "34.1" "-118.33" "2"]
-                         ["3" "The Apple Pan" "11" "34.04" "-118.43" "2"]
-                         ["4" "Wurstküche" "29" "34" "-118.47" "2"]
-                         ["5" "Brite Spot Family Restaurant" "20" "34.08" "-118.26" "2"]]
+                         ["1" "Red Medicine" "4" "10.06460000° N" "165.37400000° W" "3"]
+                         ["2" "Stout Burgers & Beers" "11" "34.09960000° N" "118.32900000° W" "2"]
+                         ["3" "The Apple Pan" "11" "34.04060000° N" "118.42800000° W" "2"]
+                         ["4" "Wurstküche" "29" "33.99970000° N" "118.46500000° W" "2"]
+                         ["5" "Brite Spot Family Restaurant" "20" "34.07780000° N" "118.26100000° W" "2"]]
                         (basic-actual-results* export-format query)))
             ;; Consistent formatting with CSVs and the UI
-            :json (is (= [{"ID" "1" "Name" "Red Medicine" "Category ID" "4" "Latitude" "10.06" "Longitude" "-165.37" "Price" "3"}
-                          {"ID" "2" "Name" "Stout Burgers & Beers" "Category ID" "11" "Latitude" "34.1" "Longitude" "-118.33" "Price" "2"}
-                          {"ID" "3" "Name" "The Apple Pan" "Category ID" "11" "Latitude" "34.04" "Longitude" "-118.43" "Price" "2"}
-                          {"ID" "4" "Name" "Wurstküche" "Category ID" "29" "Latitude" "34" "Longitude" "-118.47" "Price" "2"}
-                          {"ID" "5" "Name" "Brite Spot Family Restaurant" "Category ID" "20" "Latitude" "34.08" "Longitude" "-118.26" "Price" "2"}]
+            :json (is (= [{"ID" "1",
+                           "Name" "Red Medicine",
+                           "Category ID" "4",
+                           "Latitude" "10.06460000° N",
+                           "Longitude" "165.37400000° W",
+                           "Price" "3"}
+                          {"ID" "2",
+                           "Name" "Stout Burgers & Beers",
+                           "Category ID" "11",
+                           "Latitude" "34.09960000° N",
+                           "Longitude" "118.32900000° W",
+                           "Price" "2"}
+                          {"ID" "3",
+                           "Name" "The Apple Pan",
+                           "Category ID" "11",
+                           "Latitude" "34.04060000° N",
+                           "Longitude" "118.42800000° W",
+                           "Price" "2"}
+                          {"ID" "4",
+                           "Name" "Wurstküche",
+                           "Category ID" "29",
+                           "Latitude" "33.99970000° N",
+                           "Longitude" "118.46500000° W",
+                           "Price" "2"}
+                          {"ID" "5",
+                           "Name" "Brite Spot Family Restaurant",
+                           "Category ID" "20",
+                           "Latitude" "34.07780000° N",
+                           "Longitude" "118.26100000° W",
+                           "Price" "2"}]
                          (map #(update-keys % name) (basic-actual-results* export-format query))))
+            :xlsx (is (= [{"ID" 1.0,
+                           "Name" "Red Medicine",
+                           "Category ID" 4.0,
+                           "Latitude" "10.06460000° N",
+                           "Longitude" "165.37400000° W",
+                           "Price" 3.0}
+                          {"ID" 2.0,
+                           "Name" "Stout Burgers & Beers",
+                           "Category ID" 11.0,
+                           "Latitude" "34.09960000° N",
+                           "Longitude" "118.32900000° W",
+                           "Price" 2.0}
+                          {"ID" 3.0,
+                           "Name" "The Apple Pan",
+                           "Category ID" 11.0,
+                           "Latitude" "34.04060000° N",
+                           "Longitude" "118.42800000° W",
+                           "Price" 2.0}
+                          {"ID" 4.0,
+                           "Name" "Wurstküche",
+                           "Category ID" 29.0,
+                           "Latitude" "33.99970000° N",
+                           "Longitude" "118.46500000° W",
+                           "Price" 2.0}
+                          {"ID" 5.0,
+                           "Name" "Brite Spot Family Restaurant",
+                           "Category ID" 20.0,
+                           "Latitude" "34.07780000° N",
+                           "Longitude" "118.26100000° W",
+                           "Price" 2.0}]
+                         (basic-actual-results* export-format query)))
             (is (= (expected-results* export-format query)
                    (basic-actual-results* export-format query)))))))))
 
@@ -68,15 +123,12 @@
 (defn- compare-results [export-format query]
   (is (= (expected-results* export-format query)
          (cond-> (actual-results* export-format query)
-           (= export-format :api) (dissoc :cached)))))
+           (= export-format :api)
+           (dissoc :cached)))))
 
 (deftest streaming-response-test
   (testing "Test that the actual results going thru the same steps as an API response are correct."
-    ;; CSV and JSON exports round decimals to 2 digits to conform to the Metabase UI
-    ;; so are not identical to results from expected-results*
-    (doseq [export-format (disj (qp.streaming/export-formats) :csv :json)]
-      (testing (u/colorize :yellow export-format)
-        (compare-results export-format (mt/mbql-query venues {:limit 5}))))))
+    (compare-results :api (mt/mbql-query venues {:limit 5}))))
 
 (deftest utf8-test
   ;; UTF-8 isn't currently working for XLSX -- fix me
@@ -321,30 +373,30 @@
 
 (deftest basic-export-test
   (do-test
-   "A simple export of a table succeeds"
-   {:query      {:database (mt/id)
-                 :type     :query
-                 :query    {:source-table (mt/id :venues)
-                            :limit 2}}
+    "A simple export of a table succeeds"
+    {:query      {:database (mt/id)
+                  :type     :query
+                  :query    {:source-table (mt/id :venues)
+                             :limit        2}}
 
-    :assertions {:csv (fn [results]
-                        ;; CSVs round decimals to 2 digits without viz-settings
-                        (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
-                                ["1" "Red Medicine" "4" "10.06" "-165.37" "3"]
-                                ["2" "Stout Burgers & Beers" "11" "34.1" "-118.33" "2"]]
-                               (csv/read-csv results))))
+     :assertions {:csv  (fn [results]
+                          ;; CSVs round decimals to 2 digits without viz-settings
+                          (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
+                                  ["1" "Red Medicine" "4" "10.06460000° N" "165.37400000° W" "3"]
+                                  ["2" "Stout Burgers & Beers" "11" "34.09960000° N" "118.32900000° W" "2"]]
+                                 (csv/read-csv results))))
 
-                 :json (fn [results]
-                         (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
-                                 ["1" "Red Medicine" "4" "10.06" "-165.37" "3"]
-                                 ["2" "Stout Burgers & Beers" "11" "34.1" "-118.33" "2"]]
-                                (parse-json-results results))))
+                  :json (fn [results]
+                          (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
+                                  ["1" "Red Medicine" "4" "10.06460000° N" "165.37400000° W" "3"]
+                                  ["2" "Stout Burgers & Beers" "11" "34.09960000° N" "118.32900000° W" "2"]]
+                                 (parse-json-results results))))
 
-                 :xlsx (fn [results]
-                        (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
-                                [1.0 "Red Medicine" 4.0 10.0646 -165.374 3.0]
-                                [2.0 "Stout Burgers & Beers" 11.0 34.0996 -118.329 2.0]]
-                               (xlsx-test/parse-xlsx-results results))))}}))
+                  :xlsx (fn [results]
+                          (is (= [["ID" "Name" "Category ID" "Latitude" "Longitude" "Price"]
+                                  [1.0 "Red Medicine" 4.0 "10.06460000° N" "165.37400000° W" 3.0]
+                                  [2.0 "Stout Burgers & Beers" 11.0 "34.09960000° N" "118.32900000° W" 2.0]]
+                                 (xlsx-test/parse-xlsx-results results))))}}))
 
 (deftest reordered-columns-test
   (do-test
@@ -384,43 +436,42 @@
                              :internal "Category ID [internal remap]"
                              :external "Category ID [external remap]")]
               (do-test
-               "Remapped values are used in exports"
-               {:query {:database (mt/id)
-                        :type     :query
-                        :query    {:source-table (mt/id :venues)
-                                   :limit        1}}
+                "Remapped values are used in exports"
+                {:query      {:database (mt/id)
+                              :type     :query
+                              :query    {:source-table (mt/id :venues)
+                                         :limit        1}}
 
-                :assertions {:csv (fn [results]
-                                    ;; CSVs round decimals to 2 digits without viz-settings
-                                    (is (= [["ID" "Name" col-name "Latitude" "Longitude" "Price"]
-                                            ["1" "Red Medicine" "Asian" "10.06" "-165.37" "3"]]
-                                           (csv/read-csv results))))
+                 :assertions {:csv  (fn [results]
+                                      (is (= [["ID" "Name" col-name "Latitude" "Longitude" "Price"]
+                                              ["1" "Red Medicine" "Asian" "10.06460000° N" "165.37400000° W" "3"]]
+                                             (csv/read-csv results))))
 
-                             :json (fn [results]
-                                     (is (= [["ID" "Name" col-name "Latitude" "Longitude" "Price"]
-                                             ["1" "Red Medicine" "Asian" "10.06" "-165.37" "3"]]
-                                            (parse-json-results results))))
+                              :json (fn [results]
+                                      (is (= [["ID" "Name" col-name "Latitude" "Longitude" "Price"]
+                                              ["1" "Red Medicine" "Asian" "10.06460000° N" "165.37400000° W" "3"]]
+                                             (parse-json-results results))))
 
-                             :xlsx (fn [results]
-                                     (is (= [["ID" "Name" col-name "Latitude" "Longitude" "Price"]
-                                             [1.0 "Red Medicine" "Asian" 10.0646 -165.374 3.0]]
-                                            (xlsx-test/parse-xlsx-results results))))}})))]
+                              :xlsx (fn [results]
+                                      (is (= [["ID" "Name" col-name "Latitude" "Longitude" "Price"]
+                                              [1.0 "Red Medicine" "Asian" "10.06460000° N" "165.37400000° W" 3.0]]
+                                             (xlsx-test/parse-xlsx-results results))))}})))]
     (mt/with-column-remappings [venues.category_id categories.name]
-      (testfn :external))
+                               (testfn :external))
     (mt/with-column-remappings [venues.category_id (values-of categories.name)]
-      (testfn :internal))))
+                               (testfn :internal))))
 
 (deftest join-export-test
   (do-test
-   "A query with a join can be exported succesfully"
-   {:query {:database (mt/id)
-            :query
-            {:source-table (mt/id :venues)
-             :joins
-             [{:fields "all",
-               :source-table (mt/id :categories)
-               :condition ["="
-                           ["field" (mt/id :venues :category_id) nil]
+    "A query with a join can be exported succesfully"
+    {:query       {:database (mt/id)
+                   :query
+                   {:source-table (mt/id :venues)
+                    :joins
+                    [{:fields       "all",
+                      :source-table (mt/id :categories)
+                      :condition    ["="
+                                     ["field" (mt/id :venues :category_id) nil]
                            ["field" (mt/id :categories :id) {:join-alias "Categories"}]],
                :alias "Categories"}]
              :limit 1}


### PR DESCRIPTION
Prior to this PR, exports as csv, excel, and json files as well as html in emails all treated longitude and latitude values as plain floats while the UI rendered the coordinates as degrees NSEW. This PR adds a new function, `format-geographic-coordinates`, in `metabase.formatter` and applies it to these tabular exports.

The function is applied as follows:

- For everything but excel exports, a new case  in `metabase.formatter/create-formatter` was added that renders all `:type/Coordinate`s
- For excel exports, `metabase.query-processor.streaming.xlsx/maybe-parse-coordinate-value` was added in the `add-row!` function and follows the same pattern as `maybe-parse-temporal-value`

Unit tests were added to cover all three export formats as well as html rendering in pulses (emails).

Fixes #38419