### PR TITLE
deserialization should happen inside a transaction

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/v2/load.clj
@@ -7,7 +7,8 @@
    [metabase-enterprise.serialization.v2.ingest :as serdes.ingest]
    [metabase.models.serialization :as serdes]
    [metabase.util.i18n :refer [trs]]
-   [metabase.util.log :as log]))
+   [metabase.util.log :as log]
+   [toucan2.core :as t2]))
 
 (declare load-one!)
 
@@ -85,19 +86,20 @@
   [ingestion & {:keys [abort-on-error backfill?]
                 :or {abort-on-error true
                      backfill? true}}]
-  ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared dependencies guide
-  ;; the import, and make sure all containers are imported before contents, etc.
-  (when backfill?
-    (serdes.backfill/backfill-ids!))
-  (let [contents (serdes.ingest/ingest-list ingestion)
-        ctx      {:expanding #{}
-                  :seen      #{}
-                  :ingestion ingestion
-                  :from-ids  (m/index-by :id contents)
-                  :errors    []}
-        result   (reduce (if abort-on-error load-one! try-load-one!) ctx contents)]
-    (when-let [errors (seq (:errors result))]
-      (log/error (trs "Errors were encountered during import."))
-      (doseq [e errors]
-        (log/error e "Import error details:")))
-    result))
+  (t2/with-transaction [_tx]
+    ;; We proceed in the arbitrary order of ingest-list, deserializing all the files. Their declared dependencies
+    ;; guide the import, and make sure all containers are imported before contents, etc.
+    (when backfill?
+      (serdes.backfill/backfill-ids!))
+    (let [contents (serdes.ingest/ingest-list ingestion)
+          ctx      {:expanding #{}
+                    :seen      #{}
+                    :ingestion ingestion
+                    :from-ids  (m/index-by :id contents)
+                    :errors    []}
+          result   (reduce (if abort-on-error load-one! try-load-one!) ctx contents)]
+      (when-let [errors (seq (:errors result))]
+        (log/error (trs "Errors were encountered during import."))
+        (doseq [e errors]
+          (log/error e "Import error details:")))
+      result)))


### PR DESCRIPTION
Deserialization can leave a target database in a broken state if an error happens. Wrapping it into transaction will prevent this.

Resolves #20632.