### PR TITLE
Make Bookmarks Normal

### DIFF
--- a/frontend/src/metabase-types/api/bookmark.ts
+++ b/frontend/src/metabase-types/api/bookmark.ts
@@ -1,14 +1,5 @@
-export type BookmarkType = "card" | "collection" | "dashboard";
+import type { SearchResult } from "./search";
 
-export interface Bookmark {
-  authority_level?: string;
-  card_id: string;
-  display?: string;
-  id: string;
-  item_id: number;
-  name: string;
-  type: BookmarkType;
-
-  // For questions and models
-  dataset?: boolean;
+export interface Bookmark extends SearchResult {
+  bookmark_id: string; // format is {model}-{id}
 }

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.tsx
@@ -40,7 +40,7 @@ function getIsBookmarked(item: CollectionItem, bookmarks: Bookmark[]) {
 
   return bookmarks.some(
     bookmark =>
-      bookmark.type === normalizedItemModel && bookmark.item_id === item.id,
+      bookmark.model === normalizedItemModel && bookmark.id === item.id,
   );
 }
 

--- a/frontend/src/metabase/collections/selectors.ts
+++ b/frontend/src/metabase/collections/selectors.ts
@@ -9,5 +9,5 @@ type GetIsBookmarkedProps = {
 export const getIsBookmarked = (_state: State, props: GetIsBookmarkedProps) =>
   props.bookmarks.some(
     bookmark =>
-      bookmark.type === "collection" && bookmark.item_id === props.collectionId,
+      bookmark.model === "collection" && bookmark.id === props.collectionId,
   );

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -240,8 +240,7 @@ export const getIsBookmarked = (
   { bookmarks, dashboardId }: IsBookmarkedSelectorProps,
 ) =>
   bookmarks.some(
-    bookmark =>
-      bookmark.type === "dashboard" && bookmark.item_id === dashboardId,
+    bookmark => bookmark.model === "dashboard" && bookmark.id === dashboardId,
   );
 
 export const getIsDirty = createSelector(

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -30,9 +30,9 @@ const Bookmarks = createEntity({
   },
   actions: {
     reorder: bookmarks => {
-      const orderings = bookmarks.map(({ type, item_id }) => ({
-        type,
-        item_id,
+      const orderings = bookmarks.map(({ model, id }) => ({
+        type: model,
+        item_id: id,
       }));
       BookmarkApi.reorder(
         { orderings: { orderings } },
@@ -96,23 +96,23 @@ const Bookmarks = createEntity({
   },
 });
 
-function getEntityFor(type) {
+function getEntityFor(model) {
   const entities = {
     card: Questions,
     collection: Collections,
     dashboard: Dashboards,
   };
 
-  return entities[type];
+  return entities[model];
 }
 
 function getIcon(bookmark) {
-  const bookmarkEntity = getEntityFor(bookmark.type);
+  const bookmarkEntity = getEntityFor(bookmark.model);
   return bookmarkEntity.objectSelectors.getIcon(bookmark);
 }
 
 export function isModelBookmark(bookmark) {
-  return bookmark.type === "card" && bookmark.dataset;
+  return bookmark.model === "card" && bookmark.dataset;
 }
 
 export const getOrderedBookmarks = createSelector(

--- a/frontend/src/metabase/lib/urls/bookmarks.ts
+++ b/frontend/src/metabase/lib/urls/bookmarks.ts
@@ -5,14 +5,14 @@ import type { Bookmark } from "metabase-types/api";
 import { appendSlug } from "./utils";
 
 function getBookmarkBasePath(bookmark: Bookmark) {
-  if (bookmark.type === "card") {
+  if (bookmark.model === "card") {
     return bookmark.dataset ? "model" : "question";
   }
-  return bookmark.type;
+  return bookmark.model;
 }
 
 export function bookmark(bookmark: Bookmark) {
-  const [, itemId] = bookmark.id.split("-");
+  const itemId = bookmark.id;
   const basePath = getBookmarkBasePath(bookmark);
   const itemPath = appendSlug(itemId, slugg(bookmark.name));
   return `/${basePath}/${itemPath}`;

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -29,8 +29,8 @@ import { SidebarHeading } from "../../MainNavbar.styled";
 import { SidebarBookmarkItem } from "./BookmarkList.styled";
 
 const mapDispatchToProps = {
-  onDeleteBookmark: ({ item_id, type }: Bookmark) =>
-    Bookmarks.actions.delete({ id: item_id, type }),
+  onDeleteBookmark: ({ id, model }: Bookmark) =>
+    Bookmarks.actions.delete({ id, type: model }),
 };
 
 interface CollectionSidebarBookmarksProps {
@@ -64,7 +64,7 @@ function isBookmarkSelected(bookmark: Bookmark, selectedItem?: SelectedItem) {
     return false;
   }
   return (
-    bookmark.type === selectedItem.type && bookmark.item_id === selectedItem.id
+    bookmark.model === selectedItem.type && bookmark.id === selectedItem.id
   );
 }
 
@@ -81,13 +81,13 @@ const BookmarkItem = ({
   const onRemove = () => onDeleteBookmark(bookmark);
 
   const isIrregularCollection =
-    bookmark.type === "collection" &&
+    bookmark.model === "collection" &&
     !PLUGIN_COLLECTIONS.isRegularCollection(bookmark);
 
   return (
-    <Sortable id={bookmark.id} key={bookmark.id}>
+    <Sortable id={bookmark.bookmark_id} key={bookmark.bookmark_id}>
       <SidebarBookmarkItem
-        key={`bookmark-${bookmark.id}`}
+        key={`bookmark-${bookmark.bookmark_id}`}
         url={url}
         icon={icon}
         isSelected={isSelected}
@@ -139,14 +139,18 @@ const BookmarkList = ({
     input => {
       document.body.classList.remove("grabbing");
       setIsSorting(false);
-      const newIndex = bookmarks.findIndex(b => b.id === input.over.id);
-      const oldIndex = bookmarks.findIndex(b => b.id === input.active.id);
+      const newIndex = bookmarks.findIndex(
+        b => b.bookmark_id === input.over.id,
+      );
+      const oldIndex = bookmarks.findIndex(
+        b => b.bookmark_id === input.active.id,
+      );
       reorderBookmarks({ newIndex, oldIndex });
     },
     [reorderBookmarks, bookmarks],
   );
 
-  const bookmarkIds = bookmarks.map(b => b.id);
+  const bookmarkIds = bookmarks.map(b => b.bookmark_id);
 
   return (
     <CollapseSection

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -98,8 +98,7 @@ const getRawQueryResults = state => state.qb.queryResults;
 
 export const getIsBookmarked = (state, props) =>
   props.bookmarks.some(
-    bookmark =>
-      bookmark.type === "card" && bookmark.item_id === state.qb.card?.id,
+    bookmark => bookmark.model === "card" && bookmark.id === state.qb.card?.id,
   );
 
 export const getQueryResults = createSelector(

--- a/src/metabase/api/bookmark.clj
+++ b/src/metabase/api/bookmark.clj
@@ -49,7 +49,7 @@
     (api/check (not (t2/exists? bookmark-model item-key id
                                 :user_id api/*current-user-id*))
       [400 "Bookmark already exists"])
-    (first (t2/insert-returning-instances! bookmark-model {item-key id :user_id api/*current-user-id*}))))
+    (bookmark/present-bookmark (first (t2/insert-returning-instances! bookmark-model {item-key id :user_id api/*current-user-id*})))))
 
 (api/defendpoint DELETE "/:model/:id"
   "Delete a bookmark. Will delete a bookmark assigned to the user making the request by model and id."

--- a/src/metabase/models/bookmark.clj
+++ b/src/metabase/models/bookmark.clj
@@ -120,6 +120,15 @@
           (assoc bookmark :dashboard (dashboard-id->dashboard (:item_id bookmark)))
           bookmark)))))
 
+(defn present-bookmarks [bookmarks]
+  (->> bookmarks
+       add-cards-to-bookmarks
+       add-collections-to-bookmarks
+       add-dashboards-to-bookmarks
+       (map normalize-bookmark-result)))
+
+(defn present-bookmark [bookmark]
+  (first (present-bookmarks [bookmark])))
 
 (mu/defn bookmarks-for-user
   "Get all bookmarks for a user. Each bookmark will have a string id made of the model and model-id, a type, and
@@ -149,10 +158,7 @@
                                                     (:postgres :h2) :asc-nulls-last
                                                     :mysql          :asc)]
                      [:created_at :desc]]})
-       (add-cards-to-bookmarks)
-       (add-collections-to-bookmarks)
-       (add-dashboards-to-bookmarks)
-       (map normalize-bookmark-result)))
+       present-bookmarks))
 
 ;; type to model
 ;; id = underlying item id

--- a/src/metabase/models/bookmark.clj
+++ b/src/metabase/models/bookmark.clj
@@ -38,9 +38,9 @@
   "Shape of a bookmark returned for user. Id is a string because it is a concatenation of the model and the model's
   id. This is required for the frontend entity loading system and does not refer to any particular bookmark id,
   although the compound key can be inferred from it."
-  [:map {:closed true}
-   [:id                               :string]
-   [:type                             [:enum "card" "collection" "dashboard"]]
+  [:map {:closed false}
+   [:id                               ms/PositiveInt]
+   [:model                            [:enum "card" "collection" "dashboard"]]
    [:item_id                          ms/PositiveInt]
    [:name                             ms/NonBlankString]
    [:authority_level {:optional true} [:maybe :string]]
@@ -48,21 +48,16 @@
    [:description     {:optional true} [:maybe :string]]
    [:display         {:optional true} [:maybe :string]]])
 
-(mu/defn ^:private normalize-bookmark-result :- BookmarkResult
+(mu/defn ^:private normalize-bookmark-result
   "Normalizes bookmark results. Bookmarks are left joined against the card, collection, and dashboard tables, but only
   points to one of them. Normalizes it so it has just the desired fields."
   [result]
-  (let [result            (cond-> (into {} (remove (comp nil? second) result))
-                            ;; If not a collection then remove collection properties
-                            ;; to avoid shadowing the "real" properties.
-                            (not= (:type result) "collection")
-                            (dissoc :collection.description :collection.name))
-        normalized-result (zipmap (map unqualify-key (keys result)) (vals result))
-        id-str            (str (:type normalized-result) "-" (:item_id normalized-result))]
-    (-> normalized-result
-        (select-keys [:item_id :type :name :dataset :description :display
-                      :authority_level])
-        (assoc :id id-str))))
+
+  (let [item (into {} (or (:card result) (:dashboard result) (:collection result)))
+        id-str            (str (:type result) "-" (:id item))]
+    (assoc item
+           :model (:type result)
+           :bookmark_id id-str)))
 
 (defn- bookmarks-union-query
   [user-id]
@@ -92,26 +87,48 @@
                   :from   [:collection_bookmark]
                   :where  [:= :user_id user-id]}]}))
 
-(mu/defn bookmarks-for-user :- [:sequential BookmarkResult]
+(defn- add-cards-to-bookmarks [bookmarks]
+  (when (seq bookmarks)
+    (let [card-ids (map :item_id (filter #(= (:type %) "card") bookmarks))
+          cards (when (seq card-ids)
+                  (t2/select :model/Card {:where [:in :id card-ids]}))
+          card-id->card (into {} (map (fn [card] [(:id card) card]) cards))]
+      (for [bookmark bookmarks]
+        (if (= (:type bookmark) "card")
+          (assoc bookmark :card (card-id->card (:item_id bookmark)))
+          bookmark)))))
+
+(defn- add-collections-to-bookmarks [bookmarks]
+  (when (seq bookmarks)
+    (let [collection-ids (map :item_id (filter #(= (:type %) "collection") bookmarks))
+          collections (when (seq collection-ids)
+                        (t2/select :model/Collection {:where [:in :id collection-ids]}))
+          collection-id->collection (into {} (map (fn [collection] [(:id collection) collection]) collections))]
+      (for [bookmark bookmarks]
+        (if (= (:type bookmark) "collection")
+          (assoc bookmark :collection (collection-id->collection (:item_id bookmark)))
+          bookmark)))))
+
+(defn- add-dashboards-to-bookmarks [bookmarks]
+  (when (seq bookmarks)
+    (let [dashboard-ids (map :item_id (filter #(= (:type %) "dashboard") bookmarks))
+          dashboards (when (seq dashboard-ids)
+                        (t2/select :model/Dashboard {:where [:in :id dashboard-ids]}))
+          dashboard-id->dashboard (into {} (map (fn [dashboard] [(:id dashboard) dashboard]) dashboards))]
+      (for [bookmark bookmarks]
+        (if (= (:type bookmark) "dashboard")
+          (assoc bookmark :dashboard (dashboard-id->dashboard (:item_id bookmark)))
+          bookmark)))))
+
+
+(mu/defn bookmarks-for-user
   "Get all bookmarks for a user. Each bookmark will have a string id made of the model and model-id, a type, and
   item_id, name, and description from the underlying bookmarked item."
   [user-id]
   (->> (mdb.query/query
         {:select    [[:bookmark.created_at        :created_at]
                      [:bookmark.type              :type]
-                     [:bookmark.item_id           :item_id]
-                     [:card.name                  (mdb.u/qualify Card :name)]
-                     [:card.dataset               (mdb.u/qualify Card :dataset)]
-                     [:card.display               (mdb.u/qualify Card :display)]
-                     [:card.description           (mdb.u/qualify Card :description)]
-                     [:card.archived              (mdb.u/qualify Card :archived)]
-                     [:dashboard.name             (mdb.u/qualify Dashboard :name)]
-                     [:dashboard.description      (mdb.u/qualify Dashboard :description)]
-                     [:dashboard.archived         (mdb.u/qualify Dashboard :archived)]
-                     [:collection.name            (mdb.u/qualify Collection  :name)]
-                     [:collection.authority_level (mdb.u/qualify Collection :authority_level)]
-                     [:collection.description     (mdb.u/qualify Collection :description)]
-                     [:collection.archived        (mdb.u/qualify Collection :archived)]]
+                     [:bookmark.item_id           :item_id]]
          :from      [[(bookmarks-union-query user-id) :bookmark]]
          :left-join [[:report_card :card]                    [:= :bookmark.card_id :card.id]
                      [:report_dashboard :dashboard]          [:= :bookmark.dashboard_id :dashboard.id]
@@ -132,7 +149,16 @@
                                                     (:postgres :h2) :asc-nulls-last
                                                     :mysql          :asc)]
                      [:created_at :desc]]})
+       (add-cards-to-bookmarks)
+       (add-collections-to-bookmarks)
+       (add-dashboards-to-bookmarks)
        (map normalize-bookmark-result)))
+
+;; type to model
+;; id = underlying item id
+;; bookmark_id = ... bookmark id
+;; bookmark order
+;; display
 
 (defn save-ordering!
   "Saves a bookmark ordering of shape `[{:type, :item_id}]`


### PR DESCRIPTION
### Description

Instead of having a special, confusing, data format for bookmarks, make them follow something similar to the search payload that will play nicer with other data in the app.

Fixes https://github.com/metabase/metabase/issues/36273
Also fixes bookmarked verified collections icon (no issue for that one)

![Screen Shot 2024-02-05 at 9 56 34 AM](https://github.com/metabase/metabase/assets/30528226/5f3f76f3-2ef8-4c39-99c8-28e69e94009e)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
