### PR TITLE
Convert `cards` dashboard actions to TypeScript

### DIFF
--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -54,7 +54,7 @@ export type DashCardId = number;
 export type BaseDashboardCard = {
   id: DashCardId;
   dashboard_id: DashboardId;
-  dashboard_tab_id?: DashboardTabId;
+  dashboard_tab_id?: DashboardTabId | null;
   card_id: CardId | null;
   card: Card | VirtualCard;
   collection_authority_level?: CollectionAuthorityLevel;

--- a/frontend/src/metabase-types/api/dashboard.ts
+++ b/frontend/src/metabase-types/api/dashboard.ts
@@ -54,7 +54,7 @@ export type DashCardId = number;
 export type BaseDashboardCard = {
   id: DashCardId;
   dashboard_id: DashboardId;
-  dashboard_tab_id?: DashboardTabId | null;
+  dashboard_tab_id: DashboardTabId | null;
   card_id: CardId | null;
   card: Card | VirtualCard;
   collection_authority_level?: CollectionAuthorityLevel;

--- a/frontend/src/metabase-types/api/mocks/dashboard.ts
+++ b/frontend/src/metabase-types/api/mocks/dashboard.ts
@@ -35,6 +35,7 @@ export const createMockDashboardCard = (
 ): QuestionDashboardCard => ({
   id: 1,
   dashboard_id: 1,
+  dashboard_tab_id: null,
   col: 0,
   row: 0,
   card_id: 1,
@@ -93,6 +94,7 @@ export const createMockVirtualDashCard = (
   return {
     id: 1,
     dashboard_id: 1,
+    dashboard_tab_id: null,
     col: 0,
     row: 0,
     size_x: 1,

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -3,7 +3,6 @@ import Questions from "metabase/entities/questions";
 import { getDefaultSize } from "metabase/visualizations";
 
 import type {
-  ActionDashboardCard,
   BaseDashboardCard,
   CardId,
   DashCardId,
@@ -39,10 +38,7 @@ type NewDashCardOpts = {
 };
 
 type AddDashCardOpts = NewDashCardOpts & {
-  dashcardOverrides:
-    | Partial<ActionDashboardCard>
-    | Partial<DashboardCard>
-    | Partial<VirtualDashboardCard>;
+  dashcardOverrides: Partial<DashboardCard>;
 };
 
 let tempId = -1;

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -103,6 +103,17 @@ export const addCardToDashboard =
     dispatch(autoWireParametersToNewCard({ dashcard_id: dashcardId }));
   };
 
+export const addHeadingDashCardToDashboard =
+  ({ dashId, tabId }: NewDashCardOpts) =>
+  (dispatch: Dispatch) => {
+    trackCardCreated("heading", dashId);
+    const dc = createVirtualDashCard({
+      display: "heading",
+      visualization_settings: { "dashcard.background": false },
+    });
+    dispatch(addDashCardToDashboard({ dashId, tabId, dashcardOverrides: dc }));
+  };
+
 export const addMarkdownDashCardToDashboard =
   ({ dashId, tabId }: NewDashCardOpts) =>
   (dispatch: Dispatch) => {
@@ -125,8 +136,13 @@ function createDashCard<T extends BaseDashboardCard>(attrs: Partial<T>) {
 
 function createVirtualDashCard({
   display,
+  visualization_settings,
 }: {
   display: VirtualCardDisplay;
+  visualization_settings?: Omit<
+    VirtualDashboardCard["visualization_settings"],
+    "virtual_card"
+  >;
 }): VirtualDashboardCard {
   const virtualCard = {
     name: null,
@@ -139,6 +155,7 @@ function createVirtualDashCard({
   return createDashCard<VirtualDashboardCard>({
     card: virtualCard,
     visualization_settings: {
+      ...visualization_settings,
       virtual_card: virtualCard,
     },
   });

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -122,6 +122,14 @@ export const addMarkdownDashCardToDashboard =
     dispatch(addDashCardToDashboard({ dashId, tabId, dashcardOverrides: dc }));
   };
 
+export const addLinkDashCardToDashboard =
+  ({ dashId, tabId }: NewDashCardOpts) =>
+  (dispatch: Dispatch) => {
+    trackCardCreated("link", dashId);
+    const dc = createVirtualDashCard({ display: "link" });
+    dispatch(addDashCardToDashboard({ dashId, tabId, dashcardOverrides: dc }));
+  };
+
 function createDashCard<T extends BaseDashboardCard>(attrs: Partial<T>) {
   return {
     id: generateTemporaryDashcardId(),

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -1,0 +1,72 @@
+import { createAction } from "metabase/lib/redux";
+import { getDefaultSize } from "metabase/visualizations";
+
+import type {
+  DashboardCard,
+  DashboardId,
+  DashboardTabId,
+} from "metabase-types/api";
+import type { Dispatch, GetState } from "metabase-types/store";
+import {
+  DEFAULT_CARD_SIZE,
+  getPositionForNewDashCard,
+} from "metabase/lib/dashboard_grid";
+
+import { ADD_CARD_TO_DASH } from "./core";
+import { getExistingDashCards } from "./utils";
+
+type NewDashCardOpts = {
+  dashId: DashboardId;
+  tabId: DashboardTabId | null;
+};
+
+type AddDashCardOpts = NewDashCardOpts & {
+  dashcardOverrides: Partial<DashboardCard>;
+};
+
+export const addDashCardToDashboard =
+  ({ dashId, tabId, dashcardOverrides }: AddDashCardOpts) =>
+  (dispatch: Dispatch, getState: GetState) => {
+    const display = dashcardOverrides?.card?.display;
+    const dashCardSize = display
+      ? getDefaultSize(display) || DEFAULT_CARD_SIZE
+      : DEFAULT_CARD_SIZE;
+
+    const dashboardState = getState().dashboard;
+    const dashcards = getExistingDashCards(
+      dashboardState.dashboards,
+      dashboardState.dashcards,
+      dashId,
+      tabId,
+    );
+    const position = getPositionForNewDashCard(
+      dashcards,
+      dashCardSize.width,
+      dashCardSize.height,
+    );
+
+    const dashcard = {
+      id: generateTemporaryDashcardId(),
+
+      dashboard_id: dashId,
+      dashboard_tab_id: tabId ?? null,
+
+      card_id: null,
+      card: null,
+
+      series: [],
+      parameter_mappings: [],
+      visualization_settings: {},
+
+      ...position,
+      ...dashcardOverrides,
+    };
+
+    dispatch(createAction(ADD_CARD_TO_DASH)(dashcard));
+  };
+
+let tempId = -1;
+
+function generateTemporaryDashcardId() {
+  return tempId--;
+}

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -9,8 +9,6 @@ import type {
   DashboardCard,
   DashboardId,
   DashboardTabId,
-  VirtualCardDisplay,
-  VirtualDashboardCard,
 } from "metabase-types/api";
 import type { Dispatch, GetState } from "metabase-types/store";
 import {
@@ -20,7 +18,12 @@ import {
 
 import { trackCardCreated, trackQuestionReplaced } from "../analytics";
 import { getDashCardById, getDashboardId } from "../selectors";
-import { isVirtualDashCard } from "../utils";
+import {
+  createDashCard,
+  createVirtualDashCard,
+  generateTemporaryDashcardId,
+  isVirtualDashCard,
+} from "../utils";
 import { autoWireParametersToNewCard } from "./auto-wire-parameters/actions";
 import {
   ADD_CARD_TO_DASH,
@@ -40,12 +43,6 @@ type NewDashCardOpts = {
 type AddDashCardOpts = NewDashCardOpts & {
   dashcardOverrides: Partial<DashboardCard>;
 };
-
-let tempId = -1;
-
-export function generateTemporaryDashcardId() {
-  return tempId--;
-}
 
 export const MARK_NEW_CARD_SEEN = "metabase/dashboard/MARK_NEW_CARD_SEEN";
 export const markNewCardSeen = createAction(MARK_NEW_CARD_SEEN);
@@ -200,42 +197,3 @@ export const undoRemoveCardFromDashboard = createThunkAction<
 
   return { dashcardId };
 });
-
-function createDashCard<T extends BaseDashboardCard>(attrs: Partial<T>) {
-  return {
-    id: generateTemporaryDashcardId(),
-    card_id: null,
-    card: null,
-    series: [],
-    parameter_mappings: [],
-    visualization_settings: {},
-    ...attrs,
-  };
-}
-
-function createVirtualDashCard({
-  display,
-  visualization_settings,
-}: {
-  display: VirtualCardDisplay;
-  visualization_settings?: Omit<
-    VirtualDashboardCard["visualization_settings"],
-    "virtual_card"
-  >;
-}): VirtualDashboardCard {
-  const virtualCard = {
-    name: null,
-    dataset_query: {},
-    display,
-    visualization_settings: {},
-    archived: false,
-  };
-
-  return createDashCard<VirtualDashboardCard>({
-    card: virtualCard,
-    visualization_settings: {
-      ...visualization_settings,
-      virtual_card: virtualCard,
-    },
-  });
-}

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -1,87 +1,9 @@
-import _ from "underscore";
 import { t } from "ttag";
-import { createAction, createThunkAction } from "metabase/lib/redux";
-
-import Questions from "metabase/entities/questions";
 
 import { createCard } from "metabase/lib/card";
 
-import { autoWireParametersToNewCard } from "metabase/dashboard/actions/auto-wire-parameters/actions";
-import { trackCardCreated, trackQuestionReplaced } from "../analytics";
-import { getDashCardById, getDashboardId } from "../selectors";
-import { isVirtualDashCard } from "../utils";
-import {
-  REMOVE_CARD_FROM_DASH,
-  UNDO_REMOVE_CARD_FROM_DASH,
-  setDashCardAttributes,
-} from "./core";
-import { cancelFetchCardData, fetchCardData } from "./data-fetching";
-import { loadMetadataForDashboard } from "./metadata";
+import { trackCardCreated } from "../analytics";
 import { addDashCardToDashboard } from "./cards-typed";
-
-export const MARK_NEW_CARD_SEEN = "metabase/dashboard/MARK_NEW_CARD_SEEN";
-export const markNewCardSeen = createAction(MARK_NEW_CARD_SEEN);
-
-export const replaceCard =
-  ({ dashcardId, nextCardId }) =>
-  async (dispatch, getState) => {
-    const dashboardId = getDashboardId(getState());
-
-    let dashcard = getDashCardById(getState(), dashcardId);
-    if (isVirtualDashCard(dashcard)) {
-      return;
-    }
-
-    await dispatch(Questions.actions.fetch({ id: nextCardId }));
-    const card = Questions.selectors
-      .getObject(getState(), { entityId: nextCardId })
-      .card();
-
-    await dispatch(
-      setDashCardAttributes({
-        id: dashcardId,
-        attributes: {
-          card,
-          card_id: card.id,
-          series: [],
-          parameter_mappings: [],
-          visualization_settings: {},
-        },
-      }),
-    );
-
-    dashcard = getDashCardById(getState(), dashcardId);
-
-    dispatch(fetchCardData(card, dashcard, { reload: true, clearCache: true }));
-    await dispatch(loadMetadataForDashboard([dashcard]));
-    dispatch(autoWireParametersToNewCard({ dashcard_id: dashcardId }));
-
-    trackQuestionReplaced(dashboardId);
-  };
-
-export const removeCardFromDashboard = createThunkAction(
-  REMOVE_CARD_FROM_DASH,
-  ({ dashcardId, cardId }) =>
-    (dispatch, _getState) => {
-      dispatch(cancelFetchCardData(cardId, dashcardId));
-      return { dashcardId };
-    },
-);
-
-export const undoRemoveCardFromDashboard = createThunkAction(
-  UNDO_REMOVE_CARD_FROM_DASH,
-  ({ dashcardId }) =>
-    (dispatch, getState) => {
-      const dashcard = getDashCardById(getState(), dashcardId);
-      const card = dashcard.card;
-
-      if (!isVirtualDashCard(dashcard)) {
-        dispatch(fetchCardData(card, dashcard));
-      }
-
-      return { dashcardId };
-    },
-);
 
 export const addActionToDashboard =
   async ({ dashId, tabId, action, displayType }) =>

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -83,28 +83,6 @@ export const undoRemoveCardFromDashboard = createThunkAction(
     },
 );
 
-export const addLinkDashCardToDashboard = function ({ dashId, tabId }) {
-  trackCardCreated("link", dashId);
-
-  const virtualLinkCard = {
-    ...createCard(),
-    display: "link",
-    archived: false,
-  };
-
-  const dashcardOverrides = {
-    card: virtualLinkCard,
-    visualization_settings: {
-      virtual_card: virtualLinkCard,
-    },
-  };
-  return addDashCardToDashboard({
-    dashId: dashId,
-    dashcardOverrides: dashcardOverrides,
-    tabId,
-  });
-};
-
 export const addActionToDashboard =
   async ({ dashId, tabId, action, displayType }) =>
   dispatch => {

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -83,29 +83,6 @@ export const undoRemoveCardFromDashboard = createThunkAction(
     },
 );
 
-export const addHeadingDashCardToDashboard = function ({ dashId, tabId }) {
-  trackCardCreated("heading", dashId);
-
-  const virtualTextCard = {
-    ...createCard(),
-    display: "heading",
-    archived: false,
-  };
-
-  const dashcardOverrides = {
-    card: virtualTextCard,
-    visualization_settings: {
-      virtual_card: virtualTextCard,
-      "dashcard.background": false,
-    },
-  };
-  return addDashCardToDashboard({
-    dashId: dashId,
-    dashcardOverrides: dashcardOverrides,
-    tabId,
-  });
-};
-
 export const addLinkDashCardToDashboard = function ({ dashId, tabId }) {
   trackCardCreated("link", dashId);
 

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -83,28 +83,6 @@ export const undoRemoveCardFromDashboard = createThunkAction(
     },
 );
 
-export const addMarkdownDashCardToDashboard = function ({ dashId, tabId }) {
-  trackCardCreated("text", dashId);
-
-  const virtualTextCard = {
-    ...createCard(),
-    display: "text",
-    archived: false,
-  };
-
-  const dashcardOverrides = {
-    card: virtualTextCard,
-    visualization_settings: {
-      virtual_card: virtualTextCard,
-    },
-  };
-  return addDashCardToDashboard({
-    dashId: dashId,
-    dashcardOverrides: dashcardOverrides,
-    tabId,
-  });
-};
-
 export const addHeadingDashCardToDashboard = function ({ dashId, tabId }) {
   trackCardCreated("heading", dashId);
 

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -24,6 +24,7 @@ import {
 import { cancelFetchCardData, fetchCardData } from "./data-fetching";
 import { loadMetadataForDashboard } from "./metadata";
 import { getExistingDashCards } from "./utils";
+import { addDashCardToDashboard } from "./cards-typed";
 
 export const MARK_NEW_CARD_SEEN = "metabase/dashboard/MARK_NEW_CARD_SEEN";
 export const markNewCardSeen = createAction(MARK_NEW_CARD_SEEN);
@@ -140,42 +141,6 @@ export const undoRemoveCardFromDashboard = createThunkAction(
       return { dashcardId };
     },
 );
-
-export const addDashCardToDashboard = function ({
-  dashId,
-  dashcardOverrides,
-  tabId,
-}) {
-  return function (dispatch, getState) {
-    const visualization = getVisualizationRaw([dashcardOverrides]);
-    const createdCardSize = visualization.defaultSize || DEFAULT_CARD_SIZE;
-
-    const dashboardState = getState().dashboard;
-
-    const dashcard = {
-      id: generateTemporaryDashcardId(),
-      card_id: null,
-      card: null,
-      dashboard_id: dashId,
-      dashboard_tab_id: tabId ?? null,
-      series: [],
-      ...getPositionForNewDashCard(
-        getExistingDashCards(
-          dashboardState.dashboards,
-          dashboardState.dashcards,
-          dashId,
-          tabId,
-        ),
-        createdCardSize.width,
-        createdCardSize.height,
-      ),
-      parameter_mappings: [],
-      visualization_settings: {},
-    };
-    _.extend(dashcard, dashcardOverrides);
-    dispatch(createAction(ADD_CARD_TO_DASH)(dashcard));
-  };
-};
 
 export const addMarkdownDashCardToDashboard = function ({ dashId, tabId }) {
   trackCardCreated("text", dashId);

--- a/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
@@ -37,7 +37,7 @@ import { CardApi } from "metabase/services";
 import mainReducers from "metabase/reducers-main";
 
 import { getDashCardById } from "../selectors";
-import { replaceCard } from "./cards";
+import { replaceCard } from "./cards-typed";
 
 const DATE_PARAMETER = createMockParameter({
   id: "1",

--- a/frontend/src/metabase/dashboard/actions/index.ts
+++ b/frontend/src/metabase/dashboard/actions/index.ts
@@ -1,3 +1,4 @@
+export * from "./cards-typed";
 export * from "./cards";
 export * from "./core";
 export * from "./data-fetching";

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -24,9 +24,12 @@ import { addUndo } from "metabase/redux/undo";
 import { INITIAL_DASHBOARD_STATE } from "../constants";
 import { getDashCardById } from "../selectors";
 import { trackCardMoved } from "../analytics";
-import { calculateDashCardRowAfterUndo, isVirtualDashCard } from "../utils";
+import {
+  calculateDashCardRowAfterUndo,
+  generateTemporaryDashcardId,
+  isVirtualDashCard,
+} from "../utils";
 import { getDashCardMoveToTabUndoMessage, getExistingDashCards } from "./utils";
-import { generateTemporaryDashcardId } from "./cards-typed";
 
 type CreateNewTabPayload = { tabId: DashboardTabId };
 type DuplicateTabPayload = {

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -26,7 +26,7 @@ import { getDashCardById } from "../selectors";
 import { trackCardMoved } from "../analytics";
 import { calculateDashCardRowAfterUndo, isVirtualDashCard } from "../utils";
 import { getDashCardMoveToTabUndoMessage, getExistingDashCards } from "./utils";
-import { generateTemporaryDashcardId } from "./cards";
+import { generateTemporaryDashcardId } from "./cards-typed";
 
 type CreateNewTabPayload = { tabId: DashboardTabId };
 type DuplicateTabPayload = {

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -19,7 +19,10 @@ export const trackExportDashboardToPDF = (dashboardId: DashboardId) => {
 
 type CardTypes = "text" | "heading" | "link" | "action";
 
-export const trackCardCreated = (type: CardTypes, dashboard_id: number) => {
+export const trackCardCreated = (
+  type: CardTypes,
+  dashboard_id: DashboardId,
+) => {
   if (!type) {
     return;
   }

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/use-duplicate-dashcard.ts
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/use-duplicate-dashcard.ts
@@ -11,10 +11,12 @@ import {
 import {
   FETCH_CARD_DATA,
   addDashCardToDashboard,
-  generateTemporaryDashcardId,
 } from "metabase/dashboard/actions";
 import { getExistingDashCards } from "metabase/dashboard/actions/utils";
-import { isVirtualDashCard } from "metabase/dashboard/utils";
+import {
+  generateTemporaryDashcardId,
+  isVirtualDashCard,
+} from "metabase/dashboard/utils";
 import type { Dashboard, DashboardCard } from "metabase-types/api";
 import { trackDashcardDuplicated } from "metabase/dashboard/analytics";
 

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/test-utils.ts
@@ -1,4 +1,7 @@
-import { createMockCard } from "metabase-types/api/mocks";
+import {
+  createMockCard,
+  createMockDashboardCard,
+} from "metabase-types/api/mocks";
 import { ORDERS_ID, SAMPLE_DB_ID } from "metabase-types/api/mocks/presets";
 import { INITIAL_DASHBOARD_STATE } from "metabase/dashboard/constants";
 import type { DashboardState } from "metabase-types/store";
@@ -14,29 +17,6 @@ const TEST_CARD = createMockCard({
     },
   },
 });
-
-function createMockDashCard({
-  dashCardId,
-  tabId,
-}: {
-  dashCardId: number;
-  tabId: number | undefined;
-}) {
-  return {
-    id: dashCardId,
-    dashboard_id: 1,
-    dashboard_tab_id: tabId,
-    card_id: 1,
-    size_x: 4,
-    size_y: 4,
-    col: 0,
-    row: 0,
-    entity_id: "",
-    created_at: "",
-    updated_at: "",
-    card: TEST_CARD,
-  };
-}
 
 export const TEST_DASHBOARD_STATE: DashboardState = {
   ...INITIAL_DASHBOARD_STATE,
@@ -69,8 +49,20 @@ export const TEST_DASHBOARD_STATE: DashboardState = {
     },
   },
   dashcards: {
-    1: createMockDashCard({ dashCardId: 1, tabId: 1 }),
-    2: createMockDashCard({ dashCardId: 2, tabId: 2 }),
+    1: createMockDashboardCard({
+      id: 1,
+      dashboard_id: 1,
+      dashboard_tab_id: 1,
+      card_id: TEST_CARD.id,
+      card: TEST_CARD,
+    }),
+    2: createMockDashboardCard({
+      id: 2,
+      dashboard_id: 1,
+      dashboard_tab_id: 2,
+      card_id: TEST_CARD.id,
+      card: TEST_CARD,
+    }),
   },
   dashcardData: {
     1: { 1: null },

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -23,6 +23,7 @@ import type {
   DashCardDataMap,
   VirtualCard,
   VirtualDashboardCard,
+  VirtualCardDisplay,
 } from "metabase-types/api";
 import type { SelectedTabId } from "metabase-types/store";
 import {
@@ -320,3 +321,48 @@ export const getActionIsEnabledInDatabase = (
  */
 export const calculateDashCardRowAfterUndo = (originalRow: number) =>
   originalRow - 0.1;
+
+let tempId = -1;
+
+export function generateTemporaryDashcardId() {
+  return tempId--;
+}
+
+export function createDashCard<T extends BaseDashboardCard>(attrs: Partial<T>) {
+  return {
+    id: generateTemporaryDashcardId(),
+    card_id: null,
+    card: null,
+    series: [],
+    parameter_mappings: [],
+    visualization_settings: {},
+    ...attrs,
+  };
+}
+
+export function createVirtualDashCard({
+  display,
+  visualization_settings,
+}: {
+  display: VirtualCardDisplay;
+  visualization_settings?: Omit<
+    VirtualDashboardCard["visualization_settings"],
+    "virtual_card"
+  >;
+}): VirtualDashboardCard {
+  const virtualCard = {
+    name: null,
+    dataset_query: {},
+    display,
+    visualization_settings: {},
+    archived: false,
+  };
+
+  return createDashCard<VirtualDashboardCard>({
+    card: virtualCard,
+    visualization_settings: {
+      ...visualization_settings,
+      virtual_card: virtualCard,
+    },
+  });
+}

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -11,6 +11,7 @@ import type {
   Card,
   CardId,
   Dashboard,
+  DashboardCard,
   QuestionDashboardCard,
   Database,
   Dataset,
@@ -328,41 +329,35 @@ export function generateTemporaryDashcardId() {
   return tempId--;
 }
 
-export function createDashCard<T extends BaseDashboardCard>(attrs: Partial<T>) {
+type NewDashboardCard = Omit<
+  DashboardCard,
+  "entity_id" | "created_at" | "updated_at"
+>;
+
+type MandatoryDashboardCardAttrs = Pick<
+  DashboardCard,
+  "dashboard_id" | "card" | "col" | "row" | "size_x" | "size_y"
+>;
+
+export function createDashCard(
+  attrs: Partial<NewDashboardCard> & MandatoryDashboardCardAttrs,
+): NewDashboardCard {
   return {
     id: generateTemporaryDashcardId(),
+    dashboard_tab_id: null,
     card_id: null,
-    card: null,
-    series: [],
     parameter_mappings: [],
     visualization_settings: {},
     ...attrs,
   };
 }
 
-export function createVirtualDashCard({
-  display,
-  visualization_settings,
-}: {
-  display: VirtualCardDisplay;
-  visualization_settings?: Omit<
-    VirtualDashboardCard["visualization_settings"],
-    "virtual_card"
-  >;
-}): VirtualDashboardCard {
-  const virtualCard = {
+export function createVirtualCard(display: VirtualCardDisplay): VirtualCard {
+  return {
     name: null,
     dataset_query: {},
     display,
     visualization_settings: {},
     archived: false,
   };
-
-  return createDashCard<VirtualDashboardCard>({
-    card: virtualCard,
-    visualization_settings: {
-      ...visualization_settings,
-      virtual_card: virtualCard,
-    },
-  });
 }

--- a/frontend/src/metabase/visualizations/index.ts
+++ b/frontend/src/metabase/visualizations/index.ts
@@ -121,6 +121,11 @@ export function canSavePng(display: string) {
   return visualization?.canSavePng ?? true;
 }
 
+export function getDefaultSize(display: string) {
+  const visualization = visualizations.get(display);
+  return visualization?.defaultSize;
+}
+
 // removes columns with `remapped_from` property and adds a `remapping` to the appropriate column
 export const extractRemappedColumns = (data: DatasetData) => {
   const cols: RemappingHydratedDatasetColumn[] = data.cols.map(col => ({


### PR DESCRIPTION
Converts `metabase/dashboard/actions/cards` actions file to TypeScript, no functional changes are expected
**To verify:** CI should be green