### PR TITLE
Adding nil-safe code in model-hydrate-based-on-upload

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -732,7 +732,7 @@
         based-on-upload      (fn [model]
                                (when-let [dataset_query (:dataset_query model)] ; dataset_query is sometimes null in tests
                                  (let [query (lib/->pMBQL dataset_query)]
-                                   (when (and (= (name (:query_type model)) "query")
+                                   (when (and (some-> model :query_type name (= "query"))
                                               (contains? uploadable-table-ids (:table_id model))
                                               (no-joins? query))
                                      (lib/source-table-id query)))))]


### PR DESCRIPTION
Commit 8201e5457fcb16922d2b040e13a98d8e626c6070 introduced failing tests (e.g. `clj -X:dev:ee:ee-dev:drivers:test :only metabase.api.card-test/update-card-with-type-and-dataset-test`).

They all seem to originate from NPEs in `model-hydrate-based-on-upload` on the first condition in the `and` clause in the `based-on-upload` anonymous function. This PR just makes that first condition null-safe with a `some->` threading macro.
