### PR TITLE
Database `can-[read?,write?]` use DataPermissions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -22,6 +22,23 @@
                (database/table-id->database-id (:table_id instance)))
            (:table_id instance))))
 
+(defenterprise current-user-can-read-schema?
+  "Enterprise version. Returns a boolean whether the current user can read the given schema"
+  :feature :advanced-permissions
+  [db-id schema-name]
+  (= :yes (data-perms/schema-permission-for-user api/*current-user-id*
+                                                 :perms/manage-table-metadata
+                                                 db-id
+                                                 schema-name)))
+
+(defenterprise current-user-can-write-db?
+  "Enterprise version. Returns a boolean whether the current user can write the given db"
+  :feature :advanced-permissions
+  [db-id]
+  (= :yes (data-perms/database-permission-for-user api/*current-user-id*
+                                                   :perms/manage-database
+                                                   db-id)))
+
 (defn with-advanced-permissions
   "Adds to `user` a set of boolean flag indiciate whether or not current user has access to an advanced permissions.
   This function is meant to be used for GET /api/user/current "

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -18,9 +18,9 @@
    [metabase.models :refer [Database]]
    [metabase.models.card :as card]
    [metabase.models.collection :as collection]
+   [metabase.models.data-permissions :as data-perms]
    [metabase.models.humanization :as humanization]
    [metabase.models.interface :as mi]
-   [metabase.models.permissions :as perms]
    [metabase.models.table :as table]
    [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
@@ -479,8 +479,10 @@
              (driver/database-supports? (driver.u/database->driver db) :schemas db))
         (ex-info (tru "A schema has not been set.")
                  {:status-code 422})
-        (not (perms/set-has-full-permissions? @api/*current-user-permissions-set*
-                                              (perms/data-perms-path (u/the-id db) schema-name)))
+        (not= :unrestricted (data-perms/schema-permission-for-user api/*current-user-id*
+                                                                   :perms/data-access
+                                                                   (u/the-id db)
+                                                                   schema-name))
         (ex-info (tru "You don''t have permissions to do that.")
                  {:status-code 403})
         (and (some? schema-name)

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -478,10 +478,11 @@
                     (mt/user-http-request :crowberto :get 200 (format "dashboard/%d" (:id dashboard))))))
 
             (testing "should return restricted if user doesn't have permission to view the models"
-              (perms/revoke-data-perms! (perms-group/all-users) database-id)
-              (is (= #{{:restricted true} {:url "https://metabase.com"}}
+              (mt/with-no-data-perms-for-all-users!
+                (perms/revoke-data-perms! (perms-group/all-users) database-id)
+                (is (= #{{:restricted true} {:url "https://metabase.com"}}
                      (set (link-card-info-from-resp
-                           (mt/user-http-request :lucky :get 200 (format "dashboard/%d" (:id dashboard))))))))))))
+                           (mt/user-http-request :lucky :get 200 (format "dashboard/%d" (:id dashboard)))))))))))))
 
     (testing "fetch a dashboard with a param in it"
       (mt/with-temp [Table         {table-id :id} {}

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -750,11 +750,11 @@
       (testing "should reject requests for databases for which the user has no perms"
         (mt/with-temp [Database {database-id :id} {}
                        Card     _ (card-with-native-query "Maz Quote Views Per Month" :database_id database-id)] {}
-          (perms/revoke-data-perms! (perms-group/all-users) database-id)
-          (is (= "You don't have permissions to do that."
-                 (mt/user-http-request :rasta :get 403
-                                       (format "database/%d/card_autocomplete_suggestions" database-id)
-                                       :query "maz"))))))))
+          (mt/with-no-data-perms-for-all-users!
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :rasta :get 403
+                                         (format "database/%d/card_autocomplete_suggestions" database-id)
+                                         :query "maz")))))))))
 
 (driver/register! ::no-nested-query-support
                   :parent :sql-jdbc
@@ -1372,43 +1372,39 @@
     (mt/with-temp [Database {db-id :id} {}
                    Table    t1 {:db_id db-id :schema "schema1"}
                    Table    t2 {:db_id db-id :schema "schema1"}]
+
       (testing "should work if user has full DB perms..."
         (is (= ["schema1"]
-               (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)))))
-
-      (testing "...or full schema perms..."
-        (perms/revoke-data-perms! (perms-group/all-users) db-id)
-        (perms/grant-permissions!  (perms-group/all-users) db-id "schema1")
-        (is (= ["schema1"]
-               (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)))))
+               (mt/with-full-data-perms-for-all-users!
+                 (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id))))))
 
       (testing "...or just table read perms..."
-        (perms/revoke-data-perms! (perms-group/all-users) db-id)
-        (perms/revoke-data-perms! (perms-group/all-users) db-id "schema1")
-        (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t1)
-        (perms/grant-permissions!  (perms-group/all-users) db-id "schema1" t2)
-        (is (= ["schema1"]
-               (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)))))
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-perm-for-group-and-table! (perms-group/all-users) (u/the-id t1) :perms/data-access :unrestricted
+            (mt/with-perm-for-group-and-table! (perms-group/all-users) (u/the-id t2) :perms/data-access :unrestricted
+              (is (= ["schema1"]
+                     (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id))))))))
 
       (testing "should return a 403 for a user that doesn't have read permissions for the database"
-        (perms/revoke-data-perms! (perms-group/all-users) db-id)
-        (is (= "You don't have permissions to do that."
-               (mt/user-http-request :rasta :get 403 (format "database/%s/schemas" db-id)))))
+        (mt/with-no-data-perms-for-all-users!
+          (is (= "You don't have permissions to do that."
+               (mt/user-http-request :rasta :get 403 (format "database/%s/schemas" db-id))))))
 
       (testing "should return a 403 if there are no perms for any schema"
-        (perms/grant-full-data-permissions! (perms-group/all-users) db-id)
-        (perms/revoke-data-perms! (perms-group/all-users) db-id "schema1")
-        (is (= "You don't have permissions to do that."
-               (mt/user-http-request :rasta :get 403 (format "database/%s/schemas" db-id))))))
+        (mt/with-full-data-perms-for-all-users!
+          (mt/with-perm-for-group-and-table! (perms-group/all-users) (u/the-id t1) :perms/data-access :no-self-service
+            (mt/with-perm-for-group-and-table! (perms-group/all-users) (u/the-id t2) :perms/data-access :no-self-service
+              (is (= "You don't have permissions to do that."
+                     (mt/user-http-request :rasta :get 403 (format "database/%s/schemas" db-id)))))))))
 
     (testing "should exclude schemas for which the user has no perms"
       (mt/with-temp [Database {database-id :id} {}
-                     Table    _ {:db_id database-id :schema "schema-with-perms"}
+                     Table    {t1-id :id} {:db_id database-id :schema "schema-with-perms"}
                      Table    _ {:db_id database-id :schema "schema-without-perms"}]
-        (perms/revoke-data-perms! (perms-group/all-users) database-id)
-        (perms/grant-permissions! (perms-group/all-users) database-id "schema-with-perms")
-        (is (= ["schema-with-perms"]
-               (mt/user-http-request :rasta :get 200 (format "database/%s/schemas" database-id))))))))
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-perm-for-group-and-table! (perms-group/all-users) t1-id :perms/data-access :unrestricted
+            (is (= ["schema-with-perms"]
+                   (mt/user-http-request :rasta :get 200 (format "database/%s/schemas" database-id))))))))))
 
 (deftest get-schema-tables-test
   (testing "GET /api/database/:id/schema/:schema"
@@ -1559,39 +1555,33 @@
                    Table    _t2 {:db_id db-id :schema "schema2"}
                    Table    t3  {:db_id db-id :schema "schema1" :name "t3"}]
       (testing "if we have full DB perms"
-        (is (= ["t1" "t3"]
-               (map :name (mt/user-http-request :rasta :get 200 (format "database/%d/schema/%s" db-id "schema1"))))))
-
-      (testing "if we have full schema perms"
-        (perms/revoke-data-perms! (perms-group/all-users) db-id)
-        (perms/grant-permissions! (perms-group/all-users) db-id "schema1")
-        (is (= ["t1" "t3"]
-               (map :name (mt/user-http-request :rasta :get 200 (format "database/%d/schema/%s" db-id "schema1"))))))
-
-      (testing "if we have full Table perms"
-        (perms/revoke-data-perms! (perms-group/all-users) db-id)
-        (perms/revoke-data-perms! (perms-group/all-users) db-id "schema1")
-        (perms/grant-permissions! (perms-group/all-users) db-id "schema1" t1)
-        (perms/grant-permissions! (perms-group/all-users) db-id "schema1" t3)
-        (is (= ["t1" "t3"]
+        (mt/with-full-data-perms-for-all-users!
+          (is (= ["t1" "t3"]
                (map :name (mt/user-http-request :rasta :get 200 (format "database/%d/schema/%s" db-id "schema1")))))))
+
+      (testing "if we have Table perms for all tables in the schema"
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-perm-for-group-and-table! (perms-group/all-users) t1 :perms/data-access :unrestricted
+            (mt/with-perm-for-group-and-table! (perms-group/all-users) t3 :perms/data-access :unrestricted
+              (is (= ["t1" "t3"]
+                     (map :name (mt/user-http-request :rasta :get 200 (format "database/%d/schema/%s" db-id "schema1"))))))))))
 
     (testing "should return a 403 for a user that doesn't have read permissions"
       (testing "for the DB"
         (mt/with-temp [Database {database-id :id} {}
                        Table    _ {:db_id database-id :schema "test"}]
-          (perms/revoke-data-perms! (perms-group/all-users) database-id)
-          (is (= "You don't have permissions to do that."
-                 (mt/user-http-request :rasta :get 403 (format "database/%s/schema/%s" database-id "test"))))))
+          (mt/with-no-data-perms-for-all-users!
+            (is (= "You don't have permissions to do that."
+                   (mt/user-http-request :rasta :get 403 (format "database/%s/schema/%s" database-id "test")))))))
 
-      (testing "for the schema"
+      (testing "for all tables in the schema"
         (mt/with-temp [Database {database-id :id} {}
-                       Table    _ {:db_id database-id :schema "schema-with-perms"}
+                       Table    {t1-id :id} {:db_id database-id :schema "schema-with-perms"}
                        Table    _ {:db_id database-id :schema "schema-without-perms"}]
-          (perms/revoke-data-perms! (perms-group/all-users) database-id)
-          (perms/grant-permissions! (perms-group/all-users) database-id "schema-with-perms")
-          (is (= "You don't have permissions to do that."
-                 (mt/user-http-request :rasta :get 403 (format "database/%s/schema/%s" database-id "schema-without-perms")))))))))
+          (mt/with-no-data-perms-for-all-users!
+            (mt/with-perm-for-group-and-table! (perms-group/all-users) t1-id :perms/data-access :unrestricted
+              (is (= "You don't have permissions to do that."
+                     (mt/user-http-request :rasta :get 403 (format "database/%s/schema/%s" database-id "schema-without-perms")))))))))))
 
 (deftest slashes-in-identifiers-test
   (testing "We should handle Databases with slashes in identifiers correctly (#12450)"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -509,17 +509,17 @@
              (search-request-data :rasta :q "test")))))
 
   (testing "Databases for which the user does not have access to should not show up in results"
-    (mt/with-temp [Database db-1  {:name "db-1"}
+    (mt/with-temp [Database _db-1  {:name "db-1"}
                    Database _db-2 {:name "db-2"}]
       (is (set/subset? #{"db-2" "db-1"}
                        (->> (search-request-data-with sorted-results :rasta :q "db")
                             (map :name)
                             set)))
-      (perms/revoke-data-perms! (perms-group/all-users) (:id db-1))
-      (is (nil? ((->> (search-request-data-with sorted-results :rasta :q "db")
-                      (map :name)
-                      set)
-                 "db-1"))))))
+      (mt/with-no-data-perms-for-all-users!
+        (is (not (contains? (->> (search-request-data-with sorted-results :rasta :q "db")
+                                 (map :name)
+                                 set)
+                            "db-1")))))))
 
 (deftest bookmarks-test
   (testing "Bookmarks are per user, so other user's bookmarks don't cause search results to be altered"

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -169,7 +169,8 @@
   with-restored-data-perms-for-groups!
   with-no-data-perms-for-all-users!
   with-full-data-perms-for-all-users!
-  with-perm-for-group!]
+  with-perm-for-group!
+  with-perm-for-group-and-table!]
 
  [qp
   compile


### PR DESCRIPTION
Both DB `can-read?`/`can-write?` and the logic for determining whether a
user can upload need to check permissions in a way we haven't needed to
previously.

The logic is different for each.

For *schema-level* permissions (checking whether we can upload to a
schema), we want the *minimum* permission for any table in the schema:

- select the set of group-id/permission pairs for all tables within the
schema

- within each group, choose the MOST RESTRICTIVE permission (so a group
with `:unrestricted` access to one table and `:no-self-service` access
to another has `:no-self-service` access to the containing schema)

- of those permissions, choose the LEAST RESTRICTIVE permission (so if
one group has `:unrestricted` access and the other has
`:no-self-service`, the user ends up with `:unrestricted` access).

For database reads, on the other hand, the user has read permission if
they need it for any permissions they have on tables within that
database. In this case, we need to check the *most permissive*
permission for the user in the database - so if the user has
`:no-self-service` for every table in the database except one with
`:unrestricted` access, they should have read-access to the database.
