### PR TITLE
Use constant x-axis dataKey and fix dataset unit specs

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
@@ -1,2 +1,4 @@
 export const POSITIVE_STACK_TOTAL_DATA_KEY = "positiveStackTotal";
 export const NEGATIVE_STACK_TOTAL_DATA_KEY = "negativeStackTotal";
+
+export const X_AXIS_DATA_KEY = "$$__x";

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -9,11 +9,11 @@ import type {
 import type {
   CartesianChartModel,
   DataKey,
-  DimensionModel,
   Extent,
   ChartDataset,
   SeriesExtents,
   SeriesModel,
+  Datum,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
@@ -25,6 +25,7 @@ import { isNotNull } from "metabase/lib/types";
 import {
   NEGATIVE_STACK_TOTAL_DATA_KEY,
   POSITIVE_STACK_TOTAL_DATA_KEY,
+  X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import { isMetric, isNumeric } from "metabase-lib/types/utils/isa";
 
@@ -84,6 +85,7 @@ export const getDatasetKey = (
  * @param {DatasetColumn[]} columns - The columns of the raw dataset.
  * @param {RowValue[]} row - The raw row of values.
  * @param {number} cardId - The ID of the card.
+ * @param dimensionIndex — Index of the dimension column of a card
  * @param {number} breakoutIndex - The breakout column index for charts with two dimension columns selected.
  */
 const aggregateColumnValuesForDatum = (
@@ -95,24 +97,18 @@ const aggregateColumnValuesForDatum = (
   breakoutIndex?: number,
 ): void => {
   columns.forEach((column, columnIndex) => {
-    // The dimension values should not be aggregated, only metrics
-    if (columnIndex === dimensionIndex) {
-      return;
-    }
     const rowValue = row[columnIndex];
+    const isDimensionColumn = columnIndex === dimensionIndex;
 
-    if (breakoutIndex == null || columnIndex === breakoutIndex) {
-      const seriesKey = getDatasetKey(column, cardId);
-      datum[seriesKey] = isMetric(column)
+    const seriesKey =
+      breakoutIndex == null
+        ? getDatasetKey(column, cardId)
+        : getDatasetKey(column, cardId, row[breakoutIndex]);
+
+    datum[seriesKey] =
+      isMetric(column) && !isDimensionColumn // The dimension values should not be aggregated, only metrics
         ? sumMetric(datum[seriesKey], rowValue)
         : rowValue;
-    } else {
-      const breakoutValue = row[breakoutIndex];
-      const breakoutSeriesKey = getDatasetKey(column, cardId, breakoutValue);
-      datum[breakoutSeriesKey] = isMetric(column)
-        ? sumMetric(datum[breakoutSeriesKey], rowValue)
-        : rowValue;
-    }
   });
 };
 
@@ -132,14 +128,7 @@ export const getJoinedCardsDataset = (
     return [];
   }
 
-  const groupedData = new Map<RowValue, Record<DataKey, RowValue>>();
-  const [mainCardColumns] = cardsColumns;
-  const [mainSeries] = rawSeries;
-
-  const dimensionDataKey = getDatasetKey(
-    mainCardColumns.dimension.column,
-    mainSeries.card.id,
-  );
+  const groupedData = new Map<RowValue, Datum>();
 
   rawSeries.forEach((cardSeries, index) => {
     const {
@@ -157,7 +146,7 @@ export const getJoinedCardsDataset = (
 
       // Get the existing datum by the dimension value if exists
       const datum = groupedData.get(dimensionValue) ?? {
-        [dimensionDataKey]: dimensionValue,
+        [X_AXIS_DATA_KEY]: dimensionValue,
       };
 
       if (!groupedData.has(dimensionValue)) {
@@ -179,10 +168,10 @@ export const getJoinedCardsDataset = (
 };
 
 type TransformFn = (
-  record: Record<DataKey, RowValue>,
+  record: Datum,
   index: number,
   dataset: ChartDataset,
-) => Record<DataKey, RowValue>;
+) => Datum;
 
 type ConditionalTransform = {
   condition: boolean;
@@ -207,31 +196,31 @@ export const transformDataset = (
     .filter(isNotNull);
 
   // Apply the filtered transforms
-  return dataset.map((record, index) => {
-    return effectiveTransforms.reduce((acc, transform) => {
-      return transform(acc, index, dataset);
-    }, record);
+  return dataset.map((datum, index) => {
+    return effectiveTransforms.reduce(
+      (transformedDatum, transform: TransformFn) => {
+        return transform(transformedDatum, index, dataset);
+      },
+      datum,
+    );
   });
 };
 
 const getNumberOrZero = (value: RowValue): number =>
   typeof value === "number" ? value : 0;
 
-export const computeTotal = (
-  row: Record<DataKey, RowValue>,
-  keys: DataKey[],
-): number => keys.reduce((total, key) => total + getNumberOrZero(row[key]), 0);
+export const computeTotal = (datum: Datum, keys: DataKey[]): number =>
+  keys.reduce((total, key) => total + getNumberOrZero(datum[key]), 0);
 
 export const getNormalizedDatasetTransform = (
   seriesDataKeys: DataKey[],
-  dimensionKey: DataKey,
 ): TransformFn => {
   return datum => {
     const total = computeTotal(datum, seriesDataKeys);
 
     // Copy the dimension value
-    const normalizedDatum: Record<DataKey, RowValue> = {
-      [dimensionKey]: datum[dimensionKey],
+    const normalizedDatum: Datum = {
+      [X_AXIS_DATA_KEY]: datum[X_AXIS_DATA_KEY],
     };
 
     // Compute normalized values for metrics
@@ -288,7 +277,7 @@ export const getNullReplacerTransform = (
 
 export const applySquareRootScaling = (value: RowValue): RowValue => {
   if (typeof value === "number") {
-    const sign = value > 0 ? 1 : -1;
+    const sign = value >= 0 ? 1 : -1;
     return sign * Math.sqrt(Math.abs(value));
   }
 
@@ -301,14 +290,12 @@ export const applySquareRootScaling = (value: RowValue): RowValue => {
  * @param {ChartDataset} dataset The dataset to be transformed.
  * @param {SeriesModel[]} seriesModels Array of series models.
  * @param {ComputedVisualizationSettings} settings Computed visualization settings.
- * @param {DimensionModel} dimensionModel The dimension model.
  * @returns {ChartDataset} A transformed dataset.
  */
-export const getTransformedDataset = (
+export const applyVisualizationSettingsDataTransformations = (
   dataset: ChartDataset,
   seriesModels: SeriesModel[],
   settings: ComputedVisualizationSettings,
-  dimensionModel: DimensionModel,
 ): ChartDataset => {
   const seriesDataKeys = seriesModels.map(seriesModel => seriesModel.dataKey);
 
@@ -316,7 +303,7 @@ export const getTransformedDataset = (
     getNullReplacerTransform(settings, seriesModels),
     {
       condition: settings["stackable.stack_type"] === "normalized",
-      fn: getNormalizedDatasetTransform(seriesDataKeys, dimensionModel.dataKey),
+      fn: getNormalizedDatasetTransform(seriesDataKeys),
     },
     {
       condition: settings["graph.y_axis.scale"] === "pow",
@@ -325,12 +312,12 @@ export const getTransformedDataset = (
     {
       condition: settings["graph.x_axis.scale"] === "pow",
       fn: getKeyBasedDatasetTransform(
-        [dimensionModel.dataKey],
+        [X_AXIS_DATA_KEY],
         applySquareRootScaling,
       ),
     },
     {
-      condition: settings["stackable.stack_type"] != null,
+      condition: settings["stackable.stack_type"] === "stacked",
       fn: datum => {
         return {
           ...datum,
@@ -342,13 +329,9 @@ export const getTransformedDataset = (
   ]);
 };
 
-export const sortDataset = (
-  dataset: ChartDataset,
-  dimensionKey: DataKey,
-  xAxisScale?: XAxisScale,
-) => {
+export const sortDataset = (dataset: ChartDataset, xAxisScale?: XAxisScale) => {
   if (xAxisScale === "timeseries") {
-    return sortByDimension(dataset, dimensionKey, (left, right) => {
+    return sortByDimension(dataset, (left, right) => {
       if (typeof left === "string" && typeof right === "string") {
         return dayjs(left).valueOf() - dayjs(right).valueOf();
       }
@@ -357,7 +340,7 @@ export const sortDataset = (
   }
 
   if (xAxisScale !== "ordinal") {
-    return sortByDimension(dataset, dimensionKey, (left, right) => {
+    return sortByDimension(dataset, (left, right) => {
       if (typeof left === "number" && typeof right === "number") {
         return left - right;
       }
@@ -371,17 +354,15 @@ export const sortDataset = (
 /**
  * Sorts a dataset by the specified time-series dimension.
  * @param {Record<DataKey, RowValue>[]} dataset The dataset to be sorted.
- * @param {DataKey} dimensionKey The time-series dimension key.
  * @param compareFn Sort compare function.
  * @returns A sorted dataset.
  */
 const sortByDimension = (
   dataset: Record<DataKey, RowValue>[],
-  dimensionKey: DataKey,
   compareFn: (a: RowValue, b: RowValue) => number,
 ): Record<DataKey, RowValue>[] => {
   return dataset.sort((left, right) => {
-    return compareFn(left[dimensionKey], right[dimensionKey]);
+    return compareFn(left[X_AXIS_DATA_KEY], right[X_AXIS_DATA_KEY]);
   });
 };
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -15,7 +15,7 @@ import {
   getCardsColumnByDataKeyMap,
   getJoinedCardsDataset,
   getSortedSeriesModels,
-  getTransformedDataset,
+  applyVisualizationSettingsDataTransformations,
   sortDataset,
 } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import {
@@ -98,17 +98,12 @@ export const getCartesianChartModel = (
     default:
       dataset = getJoinedCardsDataset(rawSeries, cardsColumns);
   }
-  dataset = sortDataset(
-    dataset,
-    dimensionModel.dataKey,
-    settings["graph.x_axis.scale"],
-  );
+  dataset = sortDataset(dataset, settings["graph.x_axis.scale"]);
 
-  const transformedDataset = getTransformedDataset(
+  const transformedDataset = applyVisualizationSettingsDataTransformations(
     dataset,
     seriesModels,
     settings,
-    dimensionModel,
   );
 
   const isAutoSplitSupported = SUPPORTED_AUTO_SPLIT_TYPES.includes(

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -2,8 +2,9 @@ import type { Insight } from "metabase-types/api/insight";
 
 import type { CardId, DatasetColumn, RowValue } from "metabase-types/api";
 import type {
-  NEGATIVE_STACK_TOTAL_DATA_KEY,
-  POSITIVE_STACK_TOTAL_DATA_KEY,
+  X_AXIS_DATA_KEY,
+  type NEGATIVE_STACK_TOTAL_DATA_KEY,
+  type POSITIVE_STACK_TOTAL_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 
 export type BreakoutValue = RowValue;
@@ -58,12 +59,11 @@ export type SeriesModel =
   | ScatterSeriesModel;
 
 export type DimensionModel = {
-  dataKey: DataKey;
   column: DatasetColumn;
   columnIndex: number;
 };
 
-export type Datum = Record<DataKey, RowValue>;
+export type Datum = Record<DataKey, RowValue> & { [X_AXIS_DATA_KEY]: RowValue };
 export type ChartDataset = Datum[];
 export type Extent = [number, number];
 export type SeriesExtents = Record<DataKey, Extent>;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -14,6 +14,7 @@ import type { TimelineEventId } from "metabase-types/api";
 import {
   NEGATIVE_STACK_TOTAL_DATA_KEY,
   POSITIVE_STACK_TOTAL_DATA_KEY,
+  X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import { getGoalLineSeriesOption } from "./goal-line";
 import { getTrendLineOptionsAndDatasets } from "./trend-line";
@@ -67,7 +68,7 @@ export const getCartesianChartOption = (
 
   // dataset option
   const dimensions = [
-    chartModel.dimensionModel.dataKey,
+    X_AXIS_DATA_KEY,
     ...chartModel.seriesModels.map(seriesModel => seriesModel.dataKey),
     ...[POSITIVE_STACK_TOTAL_DATA_KEY, NEGATIVE_STACK_TOTAL_DATA_KEY],
   ];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -23,6 +23,7 @@ import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants
 
 import { getObjectValues } from "metabase/lib/objects";
 import type { EChartsSeriesOption } from "metabase/visualizations/echarts/cartesian/option/types";
+import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import { buildEChartsScatterSeries } from "../scatter/series";
 import { buildEChartsWaterfallSeries } from "../waterfall/series";
 import { checkWaterfallChartModel } from "../waterfall/utils";
@@ -79,7 +80,6 @@ const buildEChartsBarSeries = (
   dataset: ChartDataset,
   seriesModel: SeriesModel,
   settings: ComputedVisualizationSettings,
-  dimensionDataKey: string,
   yAxisIndex: number,
   barSeriesCount: number,
   hasMultipleSeries: boolean,
@@ -115,7 +115,7 @@ const buildEChartsBarSeries = (
     barWidth,
     encode: {
       y: seriesModel.dataKey,
-      x: dimensionDataKey,
+      x: X_AXIS_DATA_KEY,
     },
     label: buildEChartsLabelOptions(
       seriesModel,
@@ -182,7 +182,6 @@ const buildEChartsLineAreaSeries = (
   seriesSettings: SeriesSettings,
   dataset: ChartDataset,
   settings: ComputedVisualizationSettings,
-  dimensionDataKey: string,
   yAxisIndex: number,
   hasMultipleSeries: boolean,
   chartWidth: number,
@@ -229,7 +228,7 @@ const buildEChartsLineAreaSeries = (
     areaStyle: display === "area" ? { opacity: 0.3 } : undefined,
     encode: {
       y: seriesModel.dataKey,
-      x: dimensionDataKey,
+      x: X_AXIS_DATA_KEY,
     },
     label: buildEChartsLabelOptions(
       seriesModel,
@@ -278,7 +277,7 @@ const generateStackOption = (
     stack: stackName,
     encode: {
       y: signKey,
-      x: chartModel.dimensionModel.dataKey,
+      x: X_AXIS_DATA_KEY,
     },
     label: {
       ...seriesOptionFromStack.label,
@@ -394,7 +393,6 @@ export const buildEChartsSeries = (
             seriesSettings,
             chartModel.dataset,
             settings,
-            chartModel.dimensionModel.dataKey,
             yAxisIndex,
             hasMultipleSeries,
             chartWidth,
@@ -405,7 +403,6 @@ export const buildEChartsSeries = (
             chartModel.transformedDataset,
             seriesModel,
             settings,
-            chartModel.dimensionModel.dataKey,
             yAxisIndex,
             barSeriesCount,
             hasMultipleSeries,
@@ -415,8 +412,6 @@ export const buildEChartsSeries = (
           return buildEChartsScatterSeries(
             seriesModel,
             chartModel.bubbleSizeDomain,
-            chartModel.dataset,
-            chartModel.dimensionModel.dataKey,
             yAxisIndex,
             renderingContext,
           );

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/trend-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/trend-line.ts
@@ -13,6 +13,7 @@ import type {
 import type { RowValue, SeriesSettings } from "metabase-types/api";
 import type { Insight } from "metabase-types/api/insight";
 
+import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import { applySquareRootScaling, replaceValues } from "../model/dataset";
 import type { CartesianChartModel, DataKey } from "../model/types";
 import { getSeriesYAxisIndex } from "./utils";
@@ -37,7 +38,7 @@ function getSingleSeriesTrendDataset(
 ): TrendDataset {
   const xValues = chartModel.dataset.map(
     // We know the value is a string because it has to be a timeseries aggregation
-    row => moment(row[chartModel.dimensionModel.dataKey] as string),
+    row => moment(row[X_AXIS_DATA_KEY] as string),
   );
   const trendDataPoints = getTrendDataPointsFromInsight(
     insight,
@@ -46,8 +47,7 @@ function getSingleSeriesTrendDataset(
   );
 
   return trendDataPoints.map(([_x, y], rowIndex) => ({
-    [chartModel.dimensionModel.dataKey]:
-      chartModel.dataset[rowIndex][chartModel.dimensionModel.dataKey],
+    [X_AXIS_DATA_KEY]: chartModel.dataset[rowIndex][X_AXIS_DATA_KEY],
     [TREND_LINE_DATA_KEY]: y,
   }));
 }
@@ -162,7 +162,7 @@ export function getTrendLineOptionsAndDatasets(
       datasetIndex: index + 1, // offset to account for the chart's dataset (e.g. question results)
       yAxisIndex: getSeriesYAxisIndex(seriesModel, chartModel),
       encode: {
-        x: chartModel.dimensionModel.dataKey,
+        x: X_AXIS_DATA_KEY,
         y: TREND_LINE_DATA_KEY,
       },
       showSymbol: false,
@@ -190,7 +190,7 @@ export function getTrendLineOptionsAndDatasets(
   return {
     options,
     datasets: scaledDatasets.map(dataset => ({
-      dimensions: [chartModel.dimensionModel.dataKey, TREND_LINE_DATA_KEY],
+      dimensions: [X_AXIS_DATA_KEY, TREND_LINE_DATA_KEY],
       source: dataset,
     })) as EChartsOption["dataset"][],
   };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model.ts
@@ -1,6 +1,7 @@
 import type { RawSeries, RowValue } from "metabase-types/api";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 
+import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type { DataKey } from "../model/types";
 import { getDatasetKey } from "../model/dataset";
 
@@ -32,6 +33,7 @@ export function getScatterPlotDataset(
         }
 
         if (columnIndex === dimensionIndex || breakoutIndex === undefined) {
+          datum[X_AXIS_DATA_KEY] = rowValue;
           datum[getDatasetKey(column, card.id)] = rowValue;
         } else {
           datum[getDatasetKey(column, card.id, row[breakoutIndex])] = rowValue;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/model.ts
@@ -22,22 +22,17 @@ export function getScatterPlotDataset(
       const datum: Record<DataKey, RowValue> = {};
 
       cols.forEach((column, columnIndex) => {
-        const rowValue = row[columnIndex];
+        const value = row[columnIndex];
 
-        const dimensionIndex = columnDescs.dimension.index;
-        const breakoutIndex =
-          "breakout" in columnDescs ? columnDescs.breakout.index : undefined;
-
-        if (columnIndex === breakoutIndex) {
-          return;
+        if (columnIndex === columnDescs.dimension.index) {
+          datum[X_AXIS_DATA_KEY] = value;
         }
+        const seriesKey =
+          "breakout" in columnDescs
+            ? getDatasetKey(column, card.id, row[columnDescs.breakout.index])
+            : getDatasetKey(column, card.id);
 
-        if (columnIndex === dimensionIndex || breakoutIndex === undefined) {
-          datum[X_AXIS_DATA_KEY] = rowValue;
-          datum[getDatasetKey(column, card.id)] = rowValue;
-        } else {
-          datum[getDatasetKey(column, card.id, row[breakoutIndex])] = rowValue;
-        }
+        datum[seriesKey] = value;
       });
 
       dataset.push(datum);

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/series.ts
@@ -3,13 +3,8 @@ import type { RegisteredSeriesOption } from "echarts/types/dist/shared";
 
 import type { RenderingContext } from "metabase/visualizations/types";
 
-import type {
-  DataKey,
-  Datum,
-  Extent,
-  ChartDataset,
-  SeriesModel,
-} from "../model/types";
+import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import type { DataKey, Datum, Extent, SeriesModel } from "../model/types";
 
 const BUBBLE_SCALE_FACTOR_MAX = 64;
 
@@ -34,8 +29,6 @@ function getBubbleSizeScale(
 export function buildEChartsScatterSeries(
   seriesModel: SeriesModel,
   bubbleSizeDomain: Extent | null,
-  dataset: ChartDataset,
-  dimensionDataKey: DataKey,
   yAxisIndex: number,
   renderingContext: RenderingContext,
 ): RegisteredSeriesOption["scatter"] {
@@ -50,7 +43,7 @@ export function buildEChartsScatterSeries(
     symbolSize: getBubbleSizeScale(bubbleSizeDomain, bubbleSizeDataKey),
     encode: {
       y: seriesModel.dataKey,
-      x: dimensionDataKey,
+      x: X_AXIS_DATA_KEY,
     },
     itemStyle: {
       color: seriesModel.color,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/model.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/model.ts
@@ -13,6 +13,7 @@ import type {
   RenderingContext,
 } from "metabase/visualizations/types";
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
+import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type { ChartMeasurements } from "../option/types";
 
 const tryGetDate = (rowValue: RowValue): Dayjs | null => {
@@ -26,18 +27,15 @@ const tryGetDate = (rowValue: RowValue): Dayjs | null => {
 const getDimensionRange = (
   chartModel: CartesianChartModel,
 ): DateRange | null => {
-  const {
-    transformedDataset,
-    dimensionModel: { dataKey: dimensionKey },
-  } = chartModel;
+  const { transformedDataset } = chartModel;
   if (chartModel.transformedDataset.length === 0) {
     return null;
   }
 
   // Assume the dataset is sorted
-  const minDate = tryGetDate(transformedDataset[0][dimensionKey]);
+  const minDate = tryGetDate(transformedDataset[0][X_AXIS_DATA_KEY]);
   const maxDate = tryGetDate(
-    transformedDataset[transformedDataset.length - 1][dimensionKey],
+    transformedDataset[transformedDataset.length - 1][X_AXIS_DATA_KEY],
   );
 
   if (minDate == null || maxDate == null) {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/utils/layout.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/utils/layout.ts
@@ -12,6 +12,8 @@ import type {
   ChartMeasurements,
   Padding,
 } from "metabase/visualizations/echarts/cartesian/option/types";
+import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import { isNotNull } from "metabase/lib/types";
 
 const getYAxisTicksWidth = (
   axisModel: YAxisModel,
@@ -33,7 +35,7 @@ const getYAxisTicksWidth = (
     const customRangeValues = [
       settings["graph.y_axis.min"],
       settings["graph.y_axis.max"],
-    ].filter(value => typeof value === "number");
+    ].filter(isNotNull);
 
     valuesToMeasure.push(...customRangeValues);
   }
@@ -42,7 +44,7 @@ const getYAxisTicksWidth = (
     const customRangeValues = [
       settings["graph.y_axis.min"],
       settings["graph.y_axis.max"],
-    ].filter(value => typeof value === "number");
+    ].filter(isNotNull);
 
     valuesToMeasure.push(...customRangeValues);
   }
@@ -85,13 +87,10 @@ const getXAxisTicksHeight = (
   }
 
   const tickWidths = chartModel.dataset.map(datum => {
-    return renderingContext.measureText(
-      formatter(datum[chartModel.dimensionModel.dataKey]),
-      {
-        ...CHART_STYLE.axisTicks,
-        family: renderingContext.fontFamily,
-      },
-    );
+    return renderingContext.measureText(formatter(datum[X_AXIS_DATA_KEY]), {
+      ...CHART_STYLE.axisTicks,
+      family: renderingContext.fontFamily,
+    });
   });
 
   const maxTickWidth = Math.max(...tickWidths);


### PR DESCRIPTION
### Description

This PR removes `DimensionModel.dataKey` in favor of using a constant dataKey for x-axis values because:
1) It simplifies the code: no need to pass dimensionModel to get dimension value from a dataset or specify data key for x-axis when building options.
2) It keeps actual dimension values of each card in dataset correct when joining multiple cards with different sets of dimension values. For example Card 1 has dimension values: [1, 4, 5], and Card 2 has [2, 3]. Since ECharts require one fixed key for x-axis values, previously we would consider the dimension of the first card as the main one and populate it with joined values from the second card dimension which would make its values [1, 2, 3, 4, 5].
3) Now we need to interpolate x-axis values to simulate `linear` scale with `categorical` one, so instead of interpolating the first card dimension values which is logically incorrect, we would to it for the new special x-axis key.

Also, this PR fixes dataset unit specs.

### How to verify

Ensure the behavior has not changed in any way. Visual specs should pass.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
