### PR TITLE
Add internal setting for table render row limit (#36996)

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -684,6 +684,10 @@
   [_setting-type setting-definition-or-name]
   (get-raw-value setting-definition-or-name integer? #(Long/parseLong ^String %)))
 
+(defmethod get-value-of-type :positive-integer
+  [_setting-type setting-definition-or-name]
+  (get-raw-value setting-definition-or-name pos-int? #(Long/parseLong ^String %)))
+
 (defmethod get-value-of-type :double
   [_setting-type setting-definition-or-name]
   (get-raw-value setting-definition-or-name double? #(Double/parseDouble ^String %)))
@@ -849,6 +853,16 @@
      (assert (or (integer? new-value)
                  (and (string? new-value)
                       (re-matches #"^-?\d+$" new-value))))
+     (str new-value))))
+
+(defmethod set-value-of-type! :positive-integer
+  [_setting-type setting-definition-or-name new-value]
+  (set-value-of-type!
+   :string setting-definition-or-name
+   (when new-value
+     (assert (or (pos-int? new-value)
+                 (and (string? new-value)
+                      (re-matches #"^[1-9]\d*$" new-value))))
      (str new-value))))
 
 (defmethod set-value-of-type! :double

--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -1463,6 +1463,7 @@
 ;; Number parsing exceptions will quote the entire input
 (defmethod may-contain-raw-token? :double [_ _] true)
 (defmethod may-contain-raw-token? :integer [_ _] true)
+(defmethod may-contain-raw-token? :positive-integer [_ _] true)
 
 ;; Date parsing may quote the entire input, or a particular sub-portion, e.g. a misspelled month name
 (defmethod may-contain-raw-token? :timestamp [_ _] true)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -701,3 +701,15 @@
   :visibility :authenticated
   :type       :string
   :audit      :getter)
+
+(defsetting attachment-table-row-limit
+  (deferred-tru "Maximum number of rows to render in an alert or subscription image.")
+  :visibility :internal
+  :type       :positive-integer
+  :default    20
+  :audit      :getter
+  :getter     (fn []
+                (let [value (setting/get-value-of-type :positive-integer :attachment-table-row-limit)]
+                  (if-not (pos-int? value)
+                    20
+                    value))))

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -169,6 +169,10 @@
                                                 [fmt-fn maybe-remapped-row-cell])]]
               (fmt-fn row-cell))})))
 
+(def rows-limit
+  "Maximum number of rows to render in a Pulse image."
+  (min (public-settings/attachment-table-row-limit) 100))
+
 (s/defn ^:private prep-for-html-rendering
   "Convert the query results (`cols` and `rows`) into a formatted seq of rows (list of strings) that can be rendered as
   HTML"
@@ -183,7 +187,7 @@
        timezone-id
        remapping-lookup
        cols
-       (take (min (public-settings/attachment-table-row-limit) 100) rows)
+       (take rows-limit rows)
        viz-settings
        data-attributes)))))
 
@@ -241,7 +245,7 @@
                                       (color/make-color-selector data viz-settings)
                                       (mapv :name ordered-cols)
                                       (prep-for-html-rendering timezone-id card data))
-                                     (render-truncation-warning (public-settings/attachment-table-row-limit) (count rows))]]
+                                     (render-truncation-warning rows-limit (count rows))]]
     {:attachments
      nil
 

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -52,10 +52,6 @@
                           :padding     :16px})}
            (trs "An error occurred while displaying this card.")]}))
 
-(def rows-limit
-  "Maximum number of rows to render in a Pulse image."
-  10)
-
 ;; NOTE: hiccup does not escape content by default so be sure to use "h" to escape any user-controlled content :-/
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -187,7 +183,7 @@
        timezone-id
        remapping-lookup
        cols
-       (take rows-limit rows)
+       (take (min (public-settings/attachment-table-row-limit) 100) rows)
        viz-settings
        data-attributes)))))
 
@@ -245,7 +241,7 @@
                                       (color/make-color-selector data viz-settings)
                                       (mapv :name ordered-cols)
                                       (prep-for-html-rendering timezone-id card data))
-                                     (render-truncation-warning rows-limit (count rows))]]
+                                     (render-truncation-warning (public-settings/attachment-table-row-limit) (count rows))]]
     {:attachments
      nil
 

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -187,7 +187,7 @@
        timezone-id
        remapping-lookup
        cols
-       (take rows-limit rows)
+       (take (min (public-settings/attachment-table-row-limit) 100) rows)
        viz-settings
        data-attributes)))))
 

--- a/test/metabase/models/setting_test.clj
+++ b/test/metabase/models/setting_test.clj
@@ -1447,6 +1447,21 @@
           #_"For input string: \"{raw-value}\""
           :integer ex "Error of type class java.lang.NumberFormatException thrown while parsing a setting")))))
 
+(define-setting-for-type :positive-integer)
+
+(deftest valid-positive-Integer-setting-test
+  (testing "Validation is a no-op if the string represents a positive-integer"
+    (is (nil? (get-parse-exception :integer "1")))
+    (is (nil? (get-parse-exception :integer "0")))))
+
+(deftest invalid-positive-integer-setting-test
+  (doseq [raw-value ["a" "2.4" "1e9" "1.2.3" "0x3" "[2]"]]
+    (testing (format "Validation will throw an exception when trying to parse %s as a positive-integer" raw-value)
+      (let [ex (get-parse-exception :positive-integer raw-value)]
+        (assert-parser-exception!
+         #_"For input string: \"{raw-value}\""
+         :positive-integer ex "Error of type class java.lang.NumberFormatException thrown while parsing a setting")))))
+
 (define-setting-for-type :timestamp)
 
 (deftest valid-timestamp-setting-test

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -759,8 +759,8 @@
             no-viz-render     (renderfn {})
             viz-a-render      (renderfn {:graph.y_axis.max 14
                                          :graph.y_axis.min -14})
-            nodes-without-viz (mapv #(last (last (render.tu/nodes-with-text no-viz-render %))) to-find)
-            nodes-with-viz    (mapv #(last (last (render.tu/nodes-with-text viz-a-render %))) to-find)]
+            nodes-without-viz (mapv #(last (last (render.tu/nodes-with-exact-text no-viz-render %))) to-find)
+            nodes-with-viz    (mapv #(last (last (render.tu/nodes-with-exact-text viz-a-render %))) to-find)]
         ;; we only see 14/-14 in the render where min and max are explicitly set.
         ;; this is because the data's min and max values are only -3 and 6, and the viz will minimize the axis range
         ;; without cutting off the chart's actual values
@@ -772,7 +772,7 @@
       (let [viz-b-render   (renderfn {:graph.y_axis.max 1
                                       :graph.y_axis.min -1})
             to-find        ["14" "2" "-2" "-14"]
-            nodes-with-viz (mapv #(last (last (render.tu/nodes-with-text viz-b-render %))) to-find)]
+            nodes-with-viz (mapv #(last (last (render.tu/nodes-with-exact-text viz-b-render %))) to-find)]
         (is (= ["2" "-2"] (remove nil? nodes-with-viz)))))))
 
 (deftest invalid-graph-dim-render-test

--- a/test/metabase/pulse/render/table_test.clj
+++ b/test/metabase/pulse/render/table_test.clj
@@ -6,7 +6,10 @@
    [metabase.pulse.render.common :as common]
    [metabase.pulse.render.table :as table]
    [metabase.pulse.render.test-util :as render.tu]
-   [metabase.test :as mt]))
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (defn- query-results->header+rows
   "Makes pulse header and data rows with no bar-width. Including bar-width just adds extra HTML that will be ignored."
@@ -212,7 +215,7 @@
                           :base_type    :type/BigInteger
                           :semantic_type nil}]
                   :rows [[2 1] [4 3]]}}))))
-    (testing "visibility_type is respected in render."
+  (testing "visibility_type is respected in render."
     (is (=
          (render-table
           {:visualization_settings {:table.columns
@@ -237,3 +240,24 @@
                           :base_type    :type/BigInteger
                           :semantic_type nil}]
                   :rows [[1 2] [3 4]]}})))))
+
+(deftest attachment-rows-limit-test
+  (doseq [[test-explanation env-var-value expected]
+          [["defaults to 20 rows." nil 20]
+           ["is respected in table renders when below the default of 20." 5 5]
+           ["is respected in table renders when above the default of 20." 25 25]
+           ["is set to 20 when the value doesn't make sense." -20 20]
+           ["is limited to a max. of 100 rows." 200 100]]]
+    (testing (format "The `metabase.public-settings/attachment-rows-limit` %s" test-explanation)
+      (mt/with-temp-env-var-value ["MB_ATTACHMENT_TABLE_ROW_LIMIT" env-var-value]
+        (is (= expected
+               (count (-> (render-table
+                           {:visualization_settings {:table.columns
+                                                     [{:name "a" :enabled true}]}}
+                           {:data {:cols [{:name         "a",
+                                           :display_name "a",
+                                           :base_type    :type/BigInteger
+                                           :semantic_type nil}]
+                                   :rows (repeat 200 ["I will keep default limits."])}})
+                          :content
+                          (render.tu/nodes-with-text "I will keep default limits.")))))))))

--- a/test/metabase/pulse/render/test_util.clj
+++ b/test/metabase/pulse/render/test_util.clj
@@ -606,14 +606,24 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn nodes-with-text
-  "Returns a list of nodes from the `tree` that contain an exact match of `text` as the last entry of the node.
+  "Returns a list of nodes from the `tree` that includes text `text` as the last entry of the node.
   The tree is assumed to be a valid hiccup-style tree.
 
   `(nodes-with-text \"the text\" [:svg [:tspan [:text \"the text\"]]]) -> ([:text \"the text\"])`"
   [tree text]
   (->> tree
-       (tree-seq vector? (fn [s] (remove #(or (map? %) (string? %) (keyword? %)) s)))
-       (filter #(#{text} (last %)))))
+       (tree-seq #(and (seqable? %) (not (map? %))) (fn [s] (remove #(or (map? %) (string? %) (keyword? %)) s)))
+       (filter #(and (string? (last %)) (str/includes? (last %) text)))))
+
+(defn nodes-with-exact-text
+  "Returns a list of nodes from the `tree` that exactly matches text `text` as the last entry of the node.
+  The tree is assumed to be a valid hiccup-style tree.
+
+  `(nodes-with-text \"the text\" [:svg [:tspan [:text \"the text\"]]]) -> ([:text \"the text\"])`"
+  [tree text]
+  (->> tree
+       (tree-seq #(and (seqable? %) (not (map? %))) (fn [s] (remove #(or (map? %) (string? %) (keyword? %)) s)))
+       (filter #(and (string? (last %)) (= (last %) text)))))
 
 (defn nodes-with-tag
   "Returns a list of nodes from the `tree` that contain an exact match of `tag` as the first entry of the node.
@@ -622,7 +632,7 @@
   `(nodes-with-tag :tspan [:svg [:tspan [:text \"the text\"]]]) -> ([:tspan [:text \"the text\"]])`"
   [tree tag]
   (->> tree
-       (tree-seq vector? (fn [s] (remove #(or (map? %) (string? %) (keyword? %)) s)))
+       (tree-seq #(and (seqable? %) (not (map? %))) (fn [s] (remove #(or (map? %) (string? %) (keyword? %)) s)))
        (filter #(#{tag} (first %)))))
 
 (defn remove-attrs

--- a/test/metabase/pulse_test.clj
+++ b/test/metabase/pulse_test.clj
@@ -250,8 +250,8 @@
             (is (= [nil]
                    (pulse.test-util/output @#'body/attached-results-text))))))}}
 
-    "11 results results in a CSV being attached and a table being sent"
-    {:card (pulse.test-util/checkins-query-card {:aggregation nil, :limit 11})
+    "21 results results in a CSV being attached and a table being sent"
+    {:card (pulse.test-util/checkins-query-card {:aggregation nil, :limit 21})
 
      :assert
      {:email


### PR DESCRIPTION
This is a backport of https://github.com/metabase/metabase/pull/36996

Which has been reported as not working in issue #38320 

It's not actually a bug but a mistake on my part. The milestone was placed on the closed issue for 48.2 and so the feature was listed as part of that release. However, I marked 'no-backport' on the original PR and thus forgot to actually produce a backport!

This PR backports the feature to the next 48 point release and should then close the issue once the release is cut.
