### PR TITLE
refactor and tests for [meet embedders]

### DIFF
--- a/frontend/src/metabase-types/store/mocks/setup.ts
+++ b/frontend/src/metabase-types/store/mocks/setup.ts
@@ -41,7 +41,7 @@ export const createMockSubscribeInfo = (
 export const createMockSetupState = (
   opts?: Partial<SetupState>,
 ): SetupState => ({
-  step: 0,
+  step: "welcome",
   isLocaleLoaded: false,
   isTrackingAllowed: false,
   ...opts,

--- a/frontend/src/metabase-types/store/setup.ts
+++ b/frontend/src/metabase-types/store/setup.ts
@@ -1,4 +1,5 @@
 import type { DatabaseData, UsageReason } from "metabase-types/api";
+import type { SetupStep } from "metabase/setup/types";
 
 export interface Locale {
   name: string;
@@ -25,7 +26,7 @@ export interface SubscribeInfo {
 }
 
 export interface SetupState {
-  step: number;
+  step: SetupStep;
   locale?: Locale;
   user?: UserInfo;
   usageReason?: UsageReason;

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -69,7 +69,7 @@ export const loadDefaults = createAsyncThunk<void, void, ThunkConfig>(
 );
 
 export const SELECT_STEP = "metabase/setup/SUBMIT_WELCOME_STEP";
-export const selectStep = createAction<number>(SELECT_STEP);
+export const selectStep = createAction<SetupStep>(SELECT_STEP);
 
 export const SUBMIT_WELCOME = "metabase/setup/SUBMIT_WELCOME_STEP";
 export const submitWelcome = createAsyncThunk(SUBMIT_WELCOME, () => {

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -28,6 +28,7 @@ import {
   getUser,
 } from "./selectors";
 import { getDefaultLocale, getLocales, getUserToken } from "./utils";
+import type { SetupStep } from "./types";
 
 interface ThunkConfig {
   state: State;

--- a/frontend/src/metabase/setup/analytics.ts
+++ b/frontend/src/metabase/setup/analytics.ts
@@ -1,13 +1,11 @@
 import { trackSchemaEvent, trackStructEvent } from "metabase/lib/analytics";
-import { STEPS } from "./constants";
 
 // TODO: make it accept {stepName, stepNumber} instead of just step
 export const trackStepSeen = (step: any) => {
   trackSchemaEvent("setup", "1-0-1", {
     event: "step_seen",
     version: "1.0.0",
-    // @ts-expect-error -- tmp
-    step: STEPS[step],
+    step: step, // TODO: will be fixed with the todo above
     step_number: step,
   });
 };

--- a/frontend/src/metabase/setup/analytics.ts
+++ b/frontend/src/metabase/setup/analytics.ts
@@ -1,10 +1,12 @@
 import { trackSchemaEvent, trackStructEvent } from "metabase/lib/analytics";
 import { STEPS } from "./constants";
 
-export const trackStepSeen = (step: number) => {
+// TODO: make it accept {stepName, stepNumber} instead of just step
+export const trackStepSeen = (step: any) => {
   trackSchemaEvent("setup", "1-0-1", {
     event: "step_seen",
     version: "1.0.0",
+    // @ts-expect-error -- tmp
     step: STEPS[step],
     step_number: step,
   });

--- a/frontend/src/metabase/setup/components/CloudMigrationHelp/CloudMigrationHelp.tsx
+++ b/frontend/src/metabase/setup/components/CloudMigrationHelp/CloudMigrationHelp.tsx
@@ -2,14 +2,13 @@ import { t } from "ttag";
 import { useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 import HelpCard from "metabase/components/HelpCard";
-import { COMPLETED_STEP } from "../../constants";
 import { getIsHosted, getIsStepActive } from "../../selectors";
 import { SetupCardContainer } from "../SetupCardContainer";
 
 export const CloudMigrationHelp = () => {
   const isHosted = useSelector(getIsHosted);
   const isStepActive = useSelector(state =>
-    getIsStepActive(state, COMPLETED_STEP),
+    getIsStepActive(state, "completed"),
   );
   const isVisible = isHosted && isStepActive;
 

--- a/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.tsx
+++ b/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.tsx
@@ -1,6 +1,5 @@
 import { t } from "ttag";
 import { useSelector } from "metabase/lib/redux";
-import { COMPLETED_STEP } from "../../constants";
 import { getIsStepActive } from "../../selectors";
 import { NewsletterForm } from "../NewsletterForm";
 import {
@@ -12,7 +11,7 @@ import {
 
 export const CompletedStep = (): JSX.Element | null => {
   const isStepActive = useSelector(state =>
-    getIsStepActive(state, COMPLETED_STEP),
+    getIsStepActive(state, "completed"),
   );
   if (!isStepActive) {
     return null;

--- a/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.unit.spec.tsx
@@ -2,12 +2,13 @@ import {
   createMockSetupState,
   createMockState,
 } from "metabase-types/store/mocks";
+import type { SetupStep } from "metabase/setup/types";
 import { renderWithProviders, screen } from "__support__/ui";
 import { COMPLETED_STEP, USER_STEP } from "../../constants";
 import { CompletedStep } from "./CompletedStep";
 
 interface SetupOpts {
-  step?: number;
+  step?: SetupStep;
 }
 
 const setup = ({ step = COMPLETED_STEP }: SetupOpts = {}) => {

--- a/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/CompletedStep/CompletedStep.unit.spec.tsx
@@ -4,14 +4,13 @@ import {
 } from "metabase-types/store/mocks";
 import type { SetupStep } from "metabase/setup/types";
 import { renderWithProviders, screen } from "__support__/ui";
-import { COMPLETED_STEP, USER_STEP } from "../../constants";
 import { CompletedStep } from "./CompletedStep";
 
 interface SetupOpts {
   step?: SetupStep;
 }
 
-const setup = ({ step = COMPLETED_STEP }: SetupOpts = {}) => {
+const setup = ({ step = "completed" }: SetupOpts = {}) => {
   const state = createMockState({
     setup: createMockSetupState({
       step,
@@ -23,13 +22,13 @@ const setup = ({ step = COMPLETED_STEP }: SetupOpts = {}) => {
 
 describe("CompletedStep", () => {
   it("should render in inactive state", () => {
-    setup({ step: USER_STEP });
+    setup({ step: "user_info" });
 
     expect(screen.queryByText("You're all set up!")).not.toBeInTheDocument();
   });
 
   it("should show a newsletter form and a link to the app", () => {
-    setup({ step: COMPLETED_STEP });
+    setup({ step: "completed" });
 
     expect(screen.getByText("Metabase Newsletter")).toBeInTheDocument();
     expect(screen.getByText("Take me to Metabase")).toBeInTheDocument();

--- a/frontend/src/metabase/setup/components/DatabaseHelp/DatabaseHelp.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseHelp/DatabaseHelp.tsx
@@ -1,13 +1,12 @@
 import { useSelector } from "metabase/lib/redux";
 import { DatabaseHelpCard } from "metabase/databases/components/DatabaseHelpCard";
-import { DATABASE_STEP } from "../../constants";
 import { getDatabaseEngine, getIsStepActive } from "../../selectors";
 import { SetupCardContainer } from "../SetupCardContainer";
 
 export const DatabaseHelp = (): JSX.Element => {
   const engine = useSelector(getDatabaseEngine);
   const isStepActive = useSelector(state =>
-    getIsStepActive(state, DATABASE_STEP),
+    getIsStepActive(state, "db_connection"),
   );
   const isVisible = isStepActive && engine != null;
 

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -11,7 +11,6 @@ import {
   submitUserInvite,
   updateDatabaseEngine,
 } from "../../actions";
-import { DATABASE_STEP } from "../../constants";
 import {
   getDatabase,
   getDatabaseEngine,
@@ -36,10 +35,10 @@ export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const invite = useSelector(getInvite);
   const isEmailConfigured = useSelector(getIsEmailConfigured);
   const isStepActive = useSelector(state =>
-    getIsStepActive(state, DATABASE_STEP),
+    getIsStepActive(state, "db_connection"),
   );
   const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, DATABASE_STEP),
+    getIsStepCompleted(state, "db_connection"),
   );
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
@@ -61,7 +60,7 @@ export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   };
 
   const handleStepSelect = () => {
-    dispatch(selectStep(DATABASE_STEP));
+    dispatch(selectStep("db_connection"));
   };
 
   const handleStepCancel = () => {

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.unit.spec.tsx
@@ -7,7 +7,6 @@ import {
 } from "metabase-types/store/mocks";
 import type { SetupStep } from "metabase/setup/types";
 import { renderWithProviders, screen } from "__support__/ui";
-import { DATABASE_STEP, PREFERENCES_STEP } from "../../constants";
 import { DatabaseStep } from "./DatabaseStep";
 
 interface SetupOpts {
@@ -17,7 +16,7 @@ interface SetupOpts {
 }
 
 const setup = ({
-  step = DATABASE_STEP,
+  step = "db_connection",
   database,
   isEmailConfigured = false,
 }: SetupOpts = {}) => {
@@ -45,7 +44,7 @@ describe("DatabaseStep", () => {
 
   it("should render in completed state", () => {
     setup({
-      step: PREFERENCES_STEP,
+      step: "data_usage",
       database: createMockDatabaseData({ name: "Test" }),
     });
 

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.unit.spec.tsx
@@ -5,12 +5,13 @@ import {
   createMockSetupState,
   createMockState,
 } from "metabase-types/store/mocks";
+import type { SetupStep } from "metabase/setup/types";
 import { renderWithProviders, screen } from "__support__/ui";
 import { DATABASE_STEP, PREFERENCES_STEP } from "../../constants";
 import { DatabaseStep } from "./DatabaseStep";
 
 interface SetupOpts {
-  step?: number;
+  step?: SetupStep;
   database?: DatabaseData;
   isEmailConfigured?: boolean;
 }

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
@@ -5,7 +5,6 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import Button from "metabase/core/components/Button";
 import type { Locale } from "metabase-types/store";
 import { selectStep, updateLocale } from "../../actions";
-import { LANGUAGE_STEP, USER_STEP } from "../../constants";
 import {
   getAvailableLocales,
   getIsSetupCompleted,
@@ -28,11 +27,9 @@ import {
 export const LanguageStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const locale = useSelector(getLocale);
   const localeData = useSelector(getAvailableLocales);
-  const isStepActive = useSelector(state =>
-    getIsStepActive(state, LANGUAGE_STEP),
-  );
+  const isStepActive = useSelector(state => getIsStepActive(state, "language"));
   const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, LANGUAGE_STEP),
+    getIsStepCompleted(state, "language"),
   );
   const isSetupCompleted = useSelector(state => getIsSetupCompleted(state));
   const fieldId = useMemo(() => _.uniqueId(), []);
@@ -44,11 +41,11 @@ export const LanguageStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   };
 
   const handleStepSelect = () => {
-    dispatch(selectStep(LANGUAGE_STEP));
+    dispatch(selectStep("language"));
   };
 
   const handleStepSubmit = () => {
-    dispatch(selectStep(USER_STEP));
+    dispatch(selectStep("user_info"));
   };
 
   if (!isStepActive) {

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.unit.spec.tsx
@@ -8,7 +8,6 @@ import {
 } from "metabase-types/store/mocks";
 import type { SetupStep } from "metabase/setup/types";
 import { renderWithProviders, screen } from "__support__/ui";
-import { LANGUAGE_STEP, USER_STEP } from "../../constants";
 import { LanguageStep } from "./LanguageStep";
 
 interface SetupOpts {
@@ -16,7 +15,7 @@ interface SetupOpts {
   locale?: Locale;
 }
 
-const setup = ({ step = LANGUAGE_STEP, locale }: SetupOpts = {}) => {
+const setup = ({ step = "language", locale }: SetupOpts = {}) => {
   const state = createMockState({
     setup: createMockSetupState({
       step,
@@ -35,7 +34,7 @@ const setup = ({ step = LANGUAGE_STEP, locale }: SetupOpts = {}) => {
 describe("LanguageStep", () => {
   it("should render in inactive state", () => {
     setup({
-      step: USER_STEP,
+      step: "user_info",
       locale: createMockLocale({ name: "English" }),
     });
 
@@ -44,7 +43,7 @@ describe("LanguageStep", () => {
 
   it("should allow language selection", () => {
     setup({
-      step: LANGUAGE_STEP,
+      step: "language",
     });
 
     const option = screen.getByRole("radio", { name: "English" });

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.unit.spec.tsx
@@ -6,12 +6,13 @@ import {
   createMockSetupState,
   createMockState,
 } from "metabase-types/store/mocks";
+import type { SetupStep } from "metabase/setup/types";
 import { renderWithProviders, screen } from "__support__/ui";
 import { LANGUAGE_STEP, USER_STEP } from "../../constants";
 import { LanguageStep } from "./LanguageStep";
 
 interface SetupOpts {
-  step?: number;
+  step?: SetupStep;
   locale?: Locale;
 }
 

--- a/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.tsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.tsx
@@ -6,7 +6,6 @@ import Settings from "metabase/lib/settings";
 import ActionButton from "metabase/components/ActionButton";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { selectStep, submitSetup, updateTracking } from "../../actions";
-import { PREFERENCES_STEP } from "../../constants";
 import {
   getIsSetupCompleted,
   getIsStepActive,
@@ -31,10 +30,10 @@ export const PreferencesStep = ({
   const [errorMessage, setErrorMessage] = useState<string>();
   const isTrackingAllowed = useSelector(getIsTrackingAllowed);
   const isStepActive = useSelector(state =>
-    getIsStepActive(state, PREFERENCES_STEP),
+    getIsStepActive(state, "data_usage"),
   );
   const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, PREFERENCES_STEP),
+    getIsStepCompleted(state, "data_usage"),
   );
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
@@ -44,7 +43,7 @@ export const PreferencesStep = ({
   };
 
   const handleStepSelect = () => {
-    dispatch(selectStep(PREFERENCES_STEP));
+    dispatch(selectStep("data_usage"));
   };
 
   const handleStepSubmit = async () => {

--- a/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.unit.spec.tsx
@@ -3,13 +3,14 @@ import {
   createMockSetupState,
   createMockState,
 } from "metabase-types/store/mocks";
+import type { SetupStep } from "metabase/setup/types";
 import { setupErrorSetupEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { PREFERENCES_STEP, USER_STEP } from "../../constants";
 import { PreferencesStep } from "./PreferencesStep";
 
 interface SetupOpts {
-  step?: number;
+  step?: SetupStep;
 }
 
 const setup = ({ step = PREFERENCES_STEP }: SetupOpts = {}) => {

--- a/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/PreferencesStep/PreferencesStep.unit.spec.tsx
@@ -6,14 +6,13 @@ import {
 import type { SetupStep } from "metabase/setup/types";
 import { setupErrorSetupEndpoints } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
-import { PREFERENCES_STEP, USER_STEP } from "../../constants";
 import { PreferencesStep } from "./PreferencesStep";
 
 interface SetupOpts {
   step?: SetupStep;
 }
 
-const setup = ({ step = PREFERENCES_STEP }: SetupOpts = {}) => {
+const setup = ({ step = "data_usage" }: SetupOpts = {}) => {
   const state = createMockState({
     setup: createMockSetupState({
       step,
@@ -28,13 +27,13 @@ const setup = ({ step = PREFERENCES_STEP }: SetupOpts = {}) => {
 
 describe("PreferencesStep", () => {
   it("should render in inactive state", () => {
-    setup({ step: USER_STEP });
+    setup({ step: "user_info" });
 
     expect(screen.getByText("Usage data preferences")).toBeInTheDocument();
   });
 
   it("should allow toggling tracking permissions", () => {
-    setup({ step: PREFERENCES_STEP });
+    setup({ step: "data_usage" });
 
     const toggle = screen.getByRole("switch", { name: /Allow Metabase/ });
     userEvent.click(toggle);
@@ -43,7 +42,7 @@ describe("PreferencesStep", () => {
   });
 
   it("should show an error message on submit", async () => {
-    setup({ step: PREFERENCES_STEP });
+    setup({ step: "data_usage" });
 
     userEvent.click(screen.getByText("Finish"));
 

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -35,7 +35,9 @@ export const SettingsPage = (): JSX.Element => {
       <PageBody>
         {steps.map(({ key }, index) => {
           const Component = STEP_COMPONENTS[key];
-          return <Component key={key} stepLabel={index + 1} />;
+          if (Component) {
+            return <Component key={key} stepLabel={index} />;
+          }
         })}
         <CompletedStep />
         <CloudMigrationHelp />

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -1,31 +1,31 @@
 import LogoIcon from "metabase/components/LogoIcon";
-import { isNotFalsy } from "metabase/lib/types";
 import { useSelector } from "metabase/lib/redux";
-import { getUsageReason } from "metabase/setup/selectors";
+import { getSteps } from "metabase/setup/selectors";
 import { CloudMigrationHelp } from "../CloudMigrationHelp";
-import { DatabaseStep } from "../DatabaseStep";
 import { CompletedStep } from "../CompletedStep";
+import { DatabaseHelp } from "../DatabaseHelp";
+import { DatabaseStep } from "../DatabaseStep";
 import { LanguageStep } from "../LanguageStep";
 import { PreferencesStep } from "../PreferencesStep";
-import { UserStep } from "../UserStep";
 import { SetupHelp } from "../SetupHelp";
-import { DatabaseHelp } from "../DatabaseHelp";
+import type { NumberedStepProps } from "../types";
 import { UsageQuestionStep } from "../UsageQuestionStep";
+import { UserStep } from "../UserStep";
 import { PageBody, PageHeader } from "./SettingsPage.styled";
 
-export const SettingsPage = (): JSX.Element => {
-  const usageReason = useSelector(getUsageReason);
+const STEP_COMPONENTS: Record<
+  string,
+  (props: NumberedStepProps) => React.ReactElement
+> = {
+  language: LanguageStep,
+  user_info: UserStep,
+  usage_question: UsageQuestionStep,
+  db_connection: DatabaseStep,
+  data_usage: PreferencesStep,
+};
 
-  const numberedSteps = [
-    { component: LanguageStep, key: "language-step" },
-    { component: UserStep, key: "user-step" },
-    { component: UsageQuestionStep, key: "usage-question-step" },
-    usageReason !== "embedding" && {
-      component: DatabaseStep,
-      key: "database-step",
-    },
-    { component: PreferencesStep, key: "preferences-step" },
-  ].filter(isNotFalsy);
+export const SettingsPage = (): JSX.Element => {
+  const steps = useSelector(getSteps);
 
   return (
     <div data-testid="setup-forms">
@@ -33,9 +33,10 @@ export const SettingsPage = (): JSX.Element => {
         <LogoIcon height={51} />
       </PageHeader>
       <PageBody>
-        {numberedSteps.map(({ component: Component, key }, index) => (
-          <Component key={key} stepLabel={index + 1} />
-        ))}
+        {steps.map(({ key }, index) => {
+          const Component = STEP_COMPONENTS[key];
+          return <Component key={key} stepLabel={index + 1} />;
+        })}
         <CompletedStep />
         <CloudMigrationHelp />
         <SetupHelp />

--- a/frontend/src/metabase/setup/components/Setup/Setup.tsx
+++ b/frontend/src/metabase/setup/components/Setup/Setup.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { useUpdate } from "react-use";
 import { useSelector } from "metabase/lib/redux";
 import { trackStepSeen } from "../../analytics";
-import { WELCOME_STEP } from "../../constants";
 import { getIsLocaleLoaded, getStep } from "../../selectors";
 import { SettingsPage } from "../SettingsPage";
 import { WelcomePage } from "../WelcomePage";
@@ -22,7 +21,7 @@ export const Setup = (): JSX.Element => {
     }
   }, [update, isLocaleLoaded]);
 
-  if (step === WELCOME_STEP) {
+  if (step === "welcome") {
     return <WelcomePage />;
   } else {
     return <SettingsPage />;

--- a/frontend/src/metabase/setup/components/UsageQuestionStep/UsageQuestionStep.tsx
+++ b/frontend/src/metabase/setup/components/UsageQuestionStep/UsageQuestionStep.tsx
@@ -5,7 +5,6 @@ import { Divider, Radio, Stack, Text } from "metabase/ui";
 import Button from "metabase/core/components/Button";
 import type { UsageReason } from "metabase-types/api";
 import { selectStep, submitUsageReason } from "../../actions";
-import { USAGE_STEP } from "../../constants";
 import {
   getIsSetupCompleted,
   getIsStepActive,
@@ -27,15 +26,17 @@ export const UsageQuestionStep = ({ stepLabel }: NumberedStepProps) => {
     "self-service-analytics",
   );
 
-  const isStepActive = useSelector(state => getIsStepActive(state, USAGE_STEP));
+  const isStepActive = useSelector(state =>
+    getIsStepActive(state, "usage_question"),
+  );
   const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, USAGE_STEP),
+    getIsStepCompleted(state, "usage_question"),
   );
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
 
   const handleStepSelect = () => {
-    dispatch(selectStep(USAGE_STEP));
+    dispatch(selectStep("usage_question"));
   };
 
   const handleSubmit = () => {

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
@@ -5,7 +5,6 @@ import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InactiveStep";
 import { UserForm } from "../UserForm";
 import { selectStep, submitUser } from "../../actions";
-import { USER_STEP } from "../../constants";
 import {
   getIsHosted,
   getIsSetupCompleted,
@@ -20,15 +19,17 @@ import { StepDescription } from "./UserStep.styled";
 export const UserStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   const user = useSelector(getUser);
   const isHosted = useSelector(getIsHosted);
-  const isStepActive = useSelector(state => getIsStepActive(state, USER_STEP));
+  const isStepActive = useSelector(state =>
+    getIsStepActive(state, "user_info"),
+  );
   const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, USER_STEP),
+    getIsStepCompleted(state, "user_info"),
   );
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
 
   const handleStepSelect = () => {
-    dispatch(selectStep(USER_STEP));
+    dispatch(selectStep("user_info"));
   };
 
   const handleSubmit = (user: UserInfo) => {

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.unit.spec.tsx
@@ -5,11 +5,12 @@ import {
   createMockState,
   createMockUserInfo,
 } from "metabase-types/store/mocks";
+import type { SetupStep } from "metabase/setup/types";
 import { DATABASE_STEP, USER_STEP } from "../../constants";
 import { UserStep } from "./UserStep";
 
 interface SetupOpts {
-  step?: number;
+  step?: SetupStep;
   user?: UserInfo;
 }
 

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.unit.spec.tsx
@@ -6,7 +6,6 @@ import {
   createMockUserInfo,
 } from "metabase-types/store/mocks";
 import type { SetupStep } from "metabase/setup/types";
-import { DATABASE_STEP, USER_STEP } from "../../constants";
 import { UserStep } from "./UserStep";
 
 interface SetupOpts {
@@ -14,7 +13,7 @@ interface SetupOpts {
   user?: UserInfo;
 }
 
-const setup = ({ step = USER_STEP, user }: SetupOpts = {}) => {
+const setup = ({ step = "user_info", user }: SetupOpts = {}) => {
   const state = createMockState({
     setup: createMockSetupState({
       step,
@@ -27,14 +26,14 @@ const setup = ({ step = USER_STEP, user }: SetupOpts = {}) => {
 
 describe("UserStep", () => {
   it("should render in active state", () => {
-    setup({ step: USER_STEP });
+    setup({ step: "user_info" });
 
     expect(screen.getByText("What should we call you?")).toBeInTheDocument();
   });
 
   it("should render in completed state", () => {
     setup({
-      step: DATABASE_STEP,
+      step: "db_connection",
       user: createMockUserInfo({ first_name: "Testy" }),
     });
 

--- a/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.tsx
+++ b/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import LogoIcon from "metabase/components/LogoIcon";
 import { loadDefaults, selectStep } from "../../actions";
-import { LANGUAGE_STEP, LOCALE_TIMEOUT } from "../../constants";
+import { LOCALE_TIMEOUT } from "../../constants";
 import { getIsLocaleLoaded } from "../../selectors";
 import { SetupHelp } from "../SetupHelp";
 import {
@@ -21,7 +21,7 @@ export const WelcomePage = (): JSX.Element | null => {
   const dispatch = useDispatch();
 
   const handleStepSubmit = () => {
-    dispatch(selectStep(LANGUAGE_STEP));
+    dispatch(selectStep("language"));
   };
 
   useEffect(() => {

--- a/frontend/src/metabase/setup/constants.ts
+++ b/frontend/src/metabase/setup/constants.ts
@@ -1,17 +1,20 @@
+import type { SetupStep } from "./types";
+
 export const LOCALE_TIMEOUT = 300;
 
-export const WELCOME_STEP = 0;
-export const LANGUAGE_STEP = 1;
-export const USER_STEP = 2;
-export const USAGE_STEP = 3;
-export const DATABASE_STEP = 4;
-export const PREFERENCES_STEP = 5;
-export const COMPLETED_STEP = 6;
+export const WELCOME_STEP: SetupStep = "welcome";
+export const LANGUAGE_STEP: SetupStep = "language";
+export const USER_STEP: SetupStep = "user_info";
+export const USAGE_STEP: SetupStep = "usage_question";
+export const DATABASE_STEP: SetupStep = "db_connection";
+export const PREFERENCES_STEP: SetupStep = "data_usage";
+export const COMPLETED_STEP: SetupStep = "completed";
 
-export const STEPS: Record<number, string> = {
+export const STEPS: Record<SetupStep, SetupStep> = {
   [WELCOME_STEP]: "welcome",
   [LANGUAGE_STEP]: "language",
   [USER_STEP]: "user_info",
+  [USAGE_STEP]: "usage_question",
   [DATABASE_STEP]: "db_connection",
   [PREFERENCES_STEP]: "data_usage",
   [COMPLETED_STEP]: "completed",

--- a/frontend/src/metabase/setup/constants.ts
+++ b/frontend/src/metabase/setup/constants.ts
@@ -1,24 +1,4 @@
-import type { SetupStep } from "./types";
-
 export const LOCALE_TIMEOUT = 300;
-
-export const WELCOME_STEP: SetupStep = "welcome";
-export const LANGUAGE_STEP: SetupStep = "language";
-export const USER_STEP: SetupStep = "user_info";
-export const USAGE_STEP: SetupStep = "usage_question";
-export const DATABASE_STEP: SetupStep = "db_connection";
-export const PREFERENCES_STEP: SetupStep = "data_usage";
-export const COMPLETED_STEP: SetupStep = "completed";
-
-export const STEPS: Record<SetupStep, SetupStep> = {
-  [WELCOME_STEP]: "welcome",
-  [LANGUAGE_STEP]: "language",
-  [USER_STEP]: "user_info",
-  [USAGE_STEP]: "usage_question",
-  [DATABASE_STEP]: "db_connection",
-  [PREFERENCES_STEP]: "data_usage",
-  [COMPLETED_STEP]: "completed",
-};
 
 export const SUBSCRIBE_URL =
   "https://metabase.us10.list-manage.com/subscribe/post?u=869fec0e4689e8fd1db91e795&id=b9664113a8";

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -19,11 +19,10 @@ import {
   DATABASE_STEP,
   PREFERENCES_STEP,
   USAGE_STEP,
-  WELCOME_STEP,
 } from "./constants";
 
 const initialState: SetupState = {
-  step: WELCOME_STEP,
+  step: "welcome",
   isLocaleLoaded: false,
   isTrackingAllowed: true,
 };

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -1,5 +1,5 @@
 import { createReducer } from "@reduxjs/toolkit";
-import type { SetupState } from "metabase-types/store";
+import type { SetupState, State } from "metabase-types/store";
 import {
   skipDatabase,
   loadLocaleDefaults,
@@ -14,6 +14,7 @@ import {
   submitSetup,
   submitUsageReason,
 } from "./actions";
+import { getNextStep } from "./selectors";
 
 const initialState: SetupState = {
   step: "welcome",
@@ -44,13 +45,12 @@ export const reducer = createReducer(initialState, builder => {
   });
   builder.addCase(submitUser.pending, (state, { meta }) => {
     state.user = meta.arg;
-    state.step = "usage_question";
+    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(submitUsageReason.pending, (state, { meta }) => {
     const usageReason = meta.arg;
     state.usageReason = usageReason;
-    // this logic will be refactored before we introduce more steps, to be less fragile
-    state.step = usageReason === "embedding" ? "data_usage" : "db_connection";
+    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(updateDatabaseEngine.pending, (state, { meta }) => {
     state.databaseEngine = meta.arg;
@@ -58,17 +58,17 @@ export const reducer = createReducer(initialState, builder => {
   builder.addCase(submitDatabase.fulfilled, (state, { payload: database }) => {
     state.database = database;
     state.invite = undefined;
-    state.step = "data_usage";
+    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(submitUserInvite.pending, (state, { meta }) => {
     state.database = undefined;
     state.invite = meta.arg;
-    state.step = "data_usage";
+    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(skipDatabase.pending, state => {
     state.database = undefined;
     state.invite = undefined;
-    state.step = "data_usage";
+    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(updateTracking.pending, (state, { meta }) => {
     state.isTrackingAllowed = meta.arg;

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -14,12 +14,6 @@ import {
   submitSetup,
   submitUsageReason,
 } from "./actions";
-import {
-  COMPLETED_STEP,
-  DATABASE_STEP,
-  PREFERENCES_STEP,
-  USAGE_STEP,
-} from "./constants";
 
 const initialState: SetupState = {
   step: "welcome",
@@ -50,13 +44,13 @@ export const reducer = createReducer(initialState, builder => {
   });
   builder.addCase(submitUser.pending, (state, { meta }) => {
     state.user = meta.arg;
-    state.step = USAGE_STEP;
+    state.step = "usage_question";
   });
   builder.addCase(submitUsageReason.pending, (state, { meta }) => {
     const usageReason = meta.arg;
     state.usageReason = usageReason;
     // this logic will be refactored before we introduce more steps, to be less fragile
-    state.step = usageReason === "embedding" ? PREFERENCES_STEP : DATABASE_STEP;
+    state.step = usageReason === "embedding" ? "data_usage" : "db_connection";
   });
   builder.addCase(updateDatabaseEngine.pending, (state, { meta }) => {
     state.databaseEngine = meta.arg;
@@ -64,22 +58,22 @@ export const reducer = createReducer(initialState, builder => {
   builder.addCase(submitDatabase.fulfilled, (state, { payload: database }) => {
     state.database = database;
     state.invite = undefined;
-    state.step = PREFERENCES_STEP;
+    state.step = "data_usage";
   });
   builder.addCase(submitUserInvite.pending, (state, { meta }) => {
     state.database = undefined;
     state.invite = meta.arg;
-    state.step = PREFERENCES_STEP;
+    state.step = "data_usage";
   });
   builder.addCase(skipDatabase.pending, state => {
     state.database = undefined;
     state.invite = undefined;
-    state.step = PREFERENCES_STEP;
+    state.step = "data_usage";
   });
   builder.addCase(updateTracking.pending, (state, { meta }) => {
     state.isTrackingAllowed = meta.arg;
   });
   builder.addCase(submitSetup.fulfilled, state => {
-    state.step = COMPLETED_STEP;
+    state.step = "completed";
   });
 });

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -3,7 +3,6 @@ import type { InviteInfo, Locale, State, UserInfo } from "metabase-types/store";
 import { getSetting } from "metabase/selectors/settings";
 import { isNotFalsy } from "./../lib/types";
 import type { SetupStep } from "./types";
-import { COMPLETED_STEP } from "./constants";
 
 const DEFAULT_LOCALES: LocaleData[] = [];
 
@@ -55,7 +54,7 @@ export const getIsStepCompleted = (state: State, step: SetupStep): boolean => {
 };
 
 export const getIsSetupCompleted = (state: State): boolean => {
-  return getStep(state) === COMPLETED_STEP;
+  return getStep(state) === "completed";
 };
 
 export const getDatabaseEngine = (state: State): string | undefined => {

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -103,6 +103,6 @@ export const getSteps = (state: State) => {
 
 export const getNextStep = (state: State) => {
   const steps = getSteps(state);
-  const activeStepIndex = steps.findIndex(s => s.isActiveStep);
+  const activeStepIndex = steps.findIndex(step => step.isActiveStep);
   return steps[activeStepIndex + 1].key;
 };

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -95,3 +95,9 @@ export const getSteps = (state: State) => {
 
   return steps;
 };
+
+export const getNextStep = (state: State) => {
+  const steps = getSteps(state);
+  const activeStepIndex = steps.findIndex(s => s.isActiveStep);
+  return steps[activeStepIndex + 1].key;
+};

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -82,6 +82,7 @@ export const getSteps = (state: State) => {
   const activeStep = getStep(state);
 
   const steps: { key: SetupStep; isActiveStep: boolean }[] = [
+    { key: "welcome" as const },
     { key: "language" as const },
     { key: "user_info" as const },
     { key: "usage_question" as const },
@@ -89,9 +90,13 @@ export const getSteps = (state: State) => {
       key: "db_connection" as const,
     },
     { key: "data_usage" as const },
+    { key: "completed" as const },
   ]
     .filter(isNotFalsy)
-    .map(({ key }) => ({ key, isActiveStep: activeStep === key }));
+    .map(({ key }) => ({
+      key,
+      isActiveStep: activeStep === key,
+    }));
 
   return steps;
 };

--- a/frontend/src/metabase/setup/setup.unit.spec.tsx
+++ b/frontend/src/metabase/setup/setup.unit.spec.tsx
@@ -11,8 +11,9 @@ import {
 } from "metabase-types/store/mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { Setup } from "./components/Setup";
+import type { SetupStep } from "./types";
 
-async function setup({ step = 0 } = {}) {
+async function setup({ step = "welcome" }: { step?: SetupStep } = {}) {
   const state = createMockState({
     setup: createMockSetupState({
       step,

--- a/frontend/src/metabase/setup/types.ts
+++ b/frontend/src/metabase/setup/types.ts
@@ -1,0 +1,8 @@
+export type SetupStep =
+  | "welcome"
+  | "language"
+  | "user_info"
+  | "usage_question"
+  | "db_connection"
+  | "data_usage"
+  | "completed";


### PR DESCRIPTION
[[Epic] Meet embedders at the door - minimal edition](https://github.com/metabase/metabase/issues/38233)


### Description

This adds some tests and does some refactor, the main goal was to make navigating to the next step better than having to hardcode/calculate which step to go.
I introduced two selectors: `getSteps` that returns the enabled steps in order, and  `getNextStep` that returns the step to go to when one is submitted

*Note:* the snowplow testing is currently broken, and so a e2e fails. This will be fixed in a later PR

Commits with explanation:
- 65e5e0d5997a59f56737fbb721bf86489ce2e0f2
  - adds a test to check that all the numbers are in order in the setup settings/form
- 5b0fe4560074fc7cc6133837ddf9aedefb7de101 
  - introduce a `SetupStep` string union type and starts using it instead of the numbers
  - adds a `getSteps` selector that returns only the steps to show
- 1e28565d529973f1e545f4ae9593d5fa2b20cc11 
  - removes the `STEPS` map as it's not needed anymore since we're using strings for the steps, and strings no longer have a 1:1 mapping with the index
- e21ed01eb8f4874cb6ae0f119d345a84ec92b814
  - introduces `getNextStep`
- 990ad7e4608839231434467fa4e9b7f4d07230b3
  - after I started working on analytics, I realized that it would have been better to also return the `welcome` and `completed` steps from `getSteps`, so that in the analytics I could know which index to use for the `completed` step

### How to verify

Nothing should be broken (outside of the analytics E2E, I'll work on that on the analytics tasks)
