### PR TITLE
[MLv2] Add drill-thru test coverage for nil-valued bins

### DIFF
--- a/src/metabase/lib/drill_thru/pivot.cljc
+++ b/src/metabase/lib/drill_thru/pivot.cljc
@@ -13,8 +13,7 @@
 
   For different query types/shapes different breakout columns are allowed:
 
-  - No aggregations and no breakouts - `type/Date`, `type/Address`, and `type/Category` (only which are not also
-    `type/Address`)
+  - No breakouts - `type/Date`, `type/Address`, and `type/Category` (only which are not also `type/Address`)
 
   - At least 1 aggregation and exactly 1 breakout based on `Address` column - `Date`, `Category`
 

--- a/test/metabase/lib/drill_thru/zoom_in_geographic_test.cljc
+++ b/test/metabase/lib/drill_thru/zoom_in_geographic_test.cljc
@@ -55,7 +55,16 @@
                                                    (meta/id :people :longitude)]]
                                    :filters      [[:= {}
                                                    [:field {} 1]
-                                                   "United States"]]}]}}))))
+                                                   "United States"]]}]}})
+      (testing "nil breakout value means we can't zoom in"
+        (lib.drill-thru.tu/test-drill-not-returned
+          {:click-type     :cell
+           :query-type     :aggregated
+           :custom-query   query
+           :custom-row     {"count"   100
+                            "COUNTRY" nil}
+           :column-name    "count"
+           :drill-type     :drill-thru/zoom-in.geographic})))))
 
 (deftest ^:parallel state-test
   (testing "State => Binned LatLon"
@@ -88,7 +97,16 @@
                                                    (meta/id :people :longitude)]]
                                    :filters      [[:= {}
                                                    [:field {} (meta/id :people :state)]
-                                                   "California"]]}]}}))))
+                                                   "California"]]}]}})
+      (testing "nil breakout value means we can't zoom in"
+        (lib.drill-thru.tu/test-drill-not-returned
+          {:click-type     :cell
+           :query-type     :aggregated
+           :custom-query   query
+           :custom-row     {"count" 100
+                            "STATE" nil}
+           :column-name    "count"
+           :drill-type     :drill-thru/zoom-in.geographic})))))
 
 (deftest ^:parallel update-existing-breakouts-on-lat-lon-test
   (testing "If there are already breakouts on lat/lon, we should update them rather than append new ones (#34874)"
@@ -163,7 +181,16 @@
                                                    (meta/id :people :longitude)]]
                                    :filters      [[:= {}
                                                    [:field {} (meta/id :people :city)]
-                                                   "Long Beach"]]}]}}))))
+                                                   "Long Beach"]]}]}})
+      (testing "nil breakout value means we can't zoom in"
+        (lib.drill-thru.tu/test-drill-not-returned
+          {:click-type     :cell
+           :query-type     :aggregated
+           :custom-query   query
+           :custom-row     {"count" 100
+                            "CITY"  nil}
+           :column-name    "count"
+           :drill-type     :drill-thru/zoom-in.geographic})))))
 
 (deftest ^:parallel binned-lat-lon-large-bin-size-test
   (testing "Binned LatLon (width >= 20) => Binned LatLon (width = 10)"
@@ -345,6 +372,50 @@
                                         60.0]]}]}
               (lib/drill-thru query -1 drill))))))
 
+(deftest ^:parallel binned-lat-lon-nil-value-test
+  (testing "Binned LatLon (default 'Auto-Bin') with nil values - no zoom-in drill"
+    (let [query         (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+                            (lib/aggregate (lib/count))
+                            (lib/breakout (-> (meta/field-metadata :people :latitude)
+                                              (lib/with-binning {:strategy :default})))
+                            (lib/breakout (-> (meta/field-metadata :people :longitude)
+                                              (lib/with-binning {:strategy :default}))))
+          col-count     (m/find-first #(= (:name %) "count")
+                                      (lib/returned-columns query))
+          _             (is (some? col-count))
+          col-latitude  (m/find-first #(= (:name %) "LATITUDE")
+                                      (lib/returned-columns query))
+          _             (is (some? col-latitude))
+          col-longitude (m/find-first #(= (:name %) "LONGITUDE")
+                                      (lib/returned-columns query))
+          _             (is (some? col-longitude))
+          base-context  {:column     col-count
+                         :column-ref (lib/ref col-count)
+                         :value      10
+                         :row        [{:column     col-latitude
+                                       :column-ref (lib/ref col-latitude)
+                                       :value      20.0}
+                                      {:column     col-longitude
+                                       :column-ref (lib/ref col-longitude)
+                                       :value      50.0}
+                                      {:column     col-count
+                                       :column-ref (lib/ref col-count)
+                                       :value      10}]
+                         :dimensions [{:column     col-latitude
+                                       :column-ref (lib/ref col-latitude)
+                                       :value      20.0}
+                                      {:column     col-longitude
+                                       :column-ref (lib/ref col-longitude)
+                                       :value      50.0}]}]
+      (testing "for nil latitude"
+        (let [context (assoc-in base-context [:row 0 :value] nil)]
+          (is (nil? (m/find-first #(= (:type %) :drill-thru/zoom-in.geographic)
+                                  (lib/available-drill-thrus query context))))))
+      (testing "for nil longitude"
+        (let [context (assoc-in base-context [:row 1 :value] nil)]
+          (is (nil? (m/find-first #(= (:type %) :drill-thru/zoom-in.geographic)
+                                  (lib/available-drill-thrus query context)))))))))
+
 (deftest ^:parallel zoom-in-on-join-test
   (testing "#11210"
     (let [base       (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
@@ -398,6 +469,7 @@
                                                    [:field {} (meta/id :people :longitude)]
                                                    60]]}]}}))))
 
+;; This actually tests pivots as well.
 (deftest ^:parallel zoom-in-on-legend-state-test
   (let [query      (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                        (lib/join (meta/table-metadata :people))


### PR DESCRIPTION
Zoom-in drills are not available for such bins, and this is now tested.

Also updates a few comments:
- Pivot drills work for **one** aggregation and 0 breakouts, not for 0.
- Legend clicks and pivot cell clicks look the same, so some tests
  cover both cases and this is now noted by comments.