### PR TITLE
[MLv2] Migrate `usesMetric` using new question filter from the `GET /api/card` endpoint

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1029,6 +1029,14 @@ class Question {
     return getIn(this, ["_card", "moderation_reviews"]) || [];
   }
 
+  getCreator(): string {
+    return getIn(this, ["_card", "creator"]) || "";
+  }
+
+  getCreatedAt(): string {
+    return getIn(this, ["_card", "created_at"]) || "";
+  }
+
   /**
    * TODO Atte Keinänen 6/13/17: Discussed with Tom that we could use the default Question constructor instead,
    * but it would require changing the constructor signature so that `card` is an optional parameter and has a default value

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -38,7 +38,6 @@ import type {
   Dataset,
 } from "metabase-types/api";
 
-import * as AGGREGATION from "metabase-lib/queries/utils/aggregation";
 import * as FILTER from "metabase-lib/queries/utils/filter";
 import * as QUERY from "metabase-lib/queries/utils/query";
 
@@ -483,20 +482,6 @@ class Question {
    * Although most of these are essentially a way to modify the current query, having them as a part
    * of Question interface instead of Query interface makes it more convenient to also change the current visualization
    */
-  usesMetric(metricId): boolean {
-    const { isNative } = Lib.queryDisplayInfo(this.query());
-    return (
-      !isNative &&
-      _.any(
-        QUERY.getAggregations(
-          this.legacyQuery({ useStructuredQuery: true }).legacyQuery({
-            useStructuredQuery: true,
-          }),
-        ),
-        aggregation => AGGREGATION.getMetric(aggregation) === metricId,
-      )
-    );
-  }
 
   usesSegment(segmentId): boolean {
     const { isNative } = Lib.queryDisplayInfo(this.query());

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -49,6 +49,12 @@ const mapDispatchToProps = {
   ...metadataActions,
 };
 
+const getDescription = question => {
+  const timestamp = moment(question.getCreatedAt()).fromNow();
+  const author = question.getCreator().common_name;
+  return t`Created ${timestamp} by ${author}`;
+};
+
 export const MetricQuestions = ({ style, table, metric, metadata }) => {
   const {
     data = [],
@@ -72,20 +78,14 @@ export const MetricQuestions = ({ style, table, metric, metadata }) => {
             <div className="wrapper wrapper--trim">
               <List>
                 {data.map(question => {
-                  const card = question.card();
-                  return (
-                    question.id() &&
-                    question.displayName() && (
-                      <ListItem
-                        key={question.id()}
-                        name={question.displayName()}
-                        description={t`Created ${moment(
-                          card.created_at,
-                        ).fromNow()} by ${card.creator.common_name}`}
-                        url={Urls.question(card)}
-                        icon={visualizations.get(question.display()).iconName}
-                      />
-                    )
+                  question.id() && question.displayName() && (
+                    <ListItem
+                      key={question.id()}
+                      name={question.displayName()}
+                      description={getDescription(question)}
+                      url={Urls.question(question.card())}
+                      icon={visualizations.get(question.display()).iconName}
+                    />
                   );
                 })}
               </List>

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -77,17 +77,19 @@ export const MetricQuestions = ({ style, table, metric, metadata }) => {
           data.length > 0 ? (
             <div className="wrapper wrapper--trim">
               <List>
-                {data.map(question => {
-                  question.id() && question.displayName() && (
-                    <ListItem
-                      key={question.id()}
-                      name={question.displayName()}
-                      description={getDescription(question)}
-                      url={Urls.question(question.card())}
-                      icon={visualizations.get(question.display()).iconName}
-                    />
-                  );
-                })}
+                {data.map(
+                  question =>
+                    question.id() &&
+                    question.displayName() && (
+                      <ListItem
+                        key={question.id()}
+                        name={question.displayName()}
+                        description={getDescription(question)}
+                        url={Urls.question(question.card())}
+                        icon={visualizations.get(question.display()).iconName}
+                      />
+                    ),
+                )}
               </List>
             </div>
           ) : (

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -106,9 +106,9 @@ export const MetricQuestions = ({ style, table, metric, metadata }) => {
 };
 
 MetricQuestions.propTypes = {
-  metric: PropTypes.object,
   table: PropTypes.object,
   style: PropTypes.object.isRequired,
+  metric: PropTypes.object.isRequired,
   metadata: PropTypes.object.isRequired,
 };
 

--- a/frontend/src/metabase/reference/selectors.js
+++ b/frontend/src/metabase/reference/selectors.js
@@ -113,14 +113,6 @@ export const getFieldBySegment = createSelector(
 const getQuestions = (state, props) =>
   getIn(state, ["entities", "questions"]) || {};
 
-export const getMetricQuestions = createSelector(
-  [getMetricId, getQuestions],
-  (metricId, questions) =>
-    Object.values(questions)
-      .filter(question => new Question(question).usesMetric(metricId))
-      .reduce((map, question) => assoc(map, question.id, question), {}),
-);
-
 const getRevisions = (state, props) => state.revisions;
 
 export const getMetricRevisions = createSelector(


### PR DESCRIPTION
Prerequisite for this PR was https://github.com/metabase/metabase/issues/37688. It's been merged to `master`.

### What does this PR do?
Migrates `usesMetric` method on the `Question` prototype using new question filter from the `GET /api/card endpoint`

It achieves this by relying on our entities framework, and by directly loading filtered questions using `Questions.loadList()`.
Both the selector `getMetricQuestions` and the Question method `usesMetric ` are not needed anymore so this PR removes them.

### How to test?
- Create at least one metric[^1]
- Create a few questions that use that metric and save them
- Navigate to `/reference/metrics/:metric-id/questions` and make sure that only questions that use this segment are displayed
- Additionally, all tests should still pass
![image](https://github.com/metabase/metabase/assets/31325167/e6f88205-41c2-444c-a0e5-cf8639e3517c)

Resolves #37510

[^1]: https://www.metabase.com/docs/latest/data-modeling/segments-and-metrics