### PR TITLE
serialization: snowplow events for export/import

### DIFF
--- a/docs/installation-and-operation/commands.md
+++ b/docs/installation-and-operation/commands.md
@@ -73,9 +73,7 @@ Show this help message listing valid Metabase commands.
 
 {% include plans-blockquote.html feature="Serialization" self-hosted-only="true" %}
 
-Load serialized Metabase instance as created by the export command from directory `path`. Options:
-
--e, --abort-on-error Stops import on any errors, default is to continue.
+Load serialized Metabase instance as created by the export command from directory `path`. Has no options.
 
 ## `load path & options`
 

--- a/docs/installation-and-operation/serialization.md
+++ b/docs/installation-and-operation/serialization.md
@@ -206,13 +206,7 @@ Which prints out:
 ```
 import path & options
          Load serialized Metabase instance as created by the [[export]] command from directory `path`.
-         Options:
-           -e, --abort-on-error  Stops import on any errors, default is to continue.
 ```
-
-### `--abort-on-error`
-
-The `--abort-on-error` flag (alias `-e`) is an optional flag that allows you to specify how the import process should handle errors. Metabase will ignore errors by default.
 
 ## Avoid using serialization for backups
 

--- a/enterprise/backend/src/metabase_enterprise/serialization/api.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/api.clj
@@ -1,12 +1,14 @@
 (ns metabase-enterprise.serialization.api
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [compojure.core :refer [POST]]
    [java-time.api :as t]
    [metabase-enterprise.serialization.v2.extract :as extract]
    [metabase-enterprise.serialization.v2.ingest :as v2.ingest]
    [metabase-enterprise.serialization.v2.load :as v2.load]
    [metabase-enterprise.serialization.v2.storage :as storage]
+   [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.api.routes.common :refer [+auth]]
    [metabase.logger :as logger]
@@ -20,7 +22,7 @@
    [metabase.util.random :as u.random]
    [ring.core.protocols :as ring.protocols])
   (:import
-   (java.io File ByteArrayOutputStream)))
+   (java.io ByteArrayOutputStream File)))
 
 (set! *warn-on-reflection* true)
 
@@ -59,47 +61,56 @@
 ;;; Logic
 
 (defn- serialize&pack ^File [{:keys [dirname] :as opts}]
-  (let [dirname (or dirname
-                    (format "%s-%s"
-                            (u/slugify (public-settings/site-name))
-                            (u.date/format "YYYY-MM-dd_HH-mm" (t/local-date-time))))
+  (let [dirname  (or dirname
+                     (format "%s-%s"
+                             (u/slugify (public-settings/site-name))
+                             (u.date/format "YYYY-MM-dd_HH-mm" (t/local-date-time))))
         path     (io/file parent-dir dirname)
         dst      (io/file (str (.getPath path) ".tar.gz"))
-        log-file (io/file path "export.log")]
-    (with-open [_logger (logger/for-ns 'metabase-enterprise.serialization log-file)]
-      (try                              ; try/catch inside logging to log errors
-        (serdes/with-cache
-          (-> (extract/extract opts)
-              (storage/store! path)))
-        ;; not removing storage immediately to save some time before response
-        (u.compress/tgz path dst)
-        (catch Exception e
-          (log/error e "Error during serialization"))))
-    {:archive  (when (.exists dst)
-                 dst)
-     :log-file (when (.exists log-file)
-                 log-file)
-     :callback (fn []
-                 (when (.exists path)
-                   (run! io/delete-file (reverse (file-seq path))))
-                 (when (.exists dst)
-                   (io/delete-file dst)))}))
+        log-file (io/file path "export.log")
+        err      (atom nil)
+        report   (with-open [_logger (logger/for-ns 'metabase-enterprise.serialization log-file)]
+                   (try                 ; try/catch inside logging to log errors
+                     (let [report (serdes/with-cache
+                                    (-> (extract/extract opts)
+                                        (storage/store! path)))]
+                       ;; not removing dumped yamls immediately to save some time before response
+                       (u.compress/tgz path dst)
+                       report)
+                     (catch Exception e
+                       (reset! err e)
+                       (log/error e "Error during serialization"))))]
+    {:archive       (when (.exists dst)
+                      dst)
+     :log-file      (when (.exists log-file)
+                      log-file)
+     :report        report
+     :error-message (some-> @err str)
+     :callback      (fn []
+                      (when (.exists path)
+                        (run! io/delete-file (reverse (file-seq path))))
+                      (when (.exists dst)
+                        (io/delete-file dst)))}))
 
 (defn- unpack&import [^File file & [size]]
   (let [dst      (io/file parent-dir (u.random/random-name))
-        log-file (io/file dst "import.log")]
-    (with-open [_logger (logger/for-ns 'metabase-enterprise.serialization log-file)]
-      (try                              ; try/catch inside logging to log errors
-        (log/infof "Serdes import, size %s" size)
-        (let [path (u.compress/untgz file dst)]
-          (serdes/with-cache
-            (-> (v2.ingest/ingest-yaml (.getPath (io/file dst path)))
-                (v2.load/load-metabase! {:abort-on-error true}))))
-        (catch Exception e
-          (log/error e "Error during serialization"))))
-    {:log-file log-file
-     :callback #(when (.exists dst)
-                  (run! io/delete-file (reverse (file-seq dst))))}))
+        log-file (io/file dst "import.log")
+        err      (atom nil)
+        report   (with-open [_logger (logger/for-ns 'metabase-enterprise.serialization log-file)]
+                   (try                 ; try/catch inside logging to log errors
+                     (log/infof "Serdes import, size %s" size)
+                     (let [path (u.compress/untgz file dst)]
+                       (serdes/with-cache
+                         (-> (v2.ingest/ingest-yaml (.getPath (io/file dst path)))
+                             (v2.load/load-metabase!))))
+                     (catch Exception e
+                       (reset! err (str e))
+                       (log/error e "Error during serialization"))))]
+    {:log-file      log-file
+     :error-message @err
+     :report        report
+     :callback      #(when (.exists dst)
+                       (run! io/delete-file (reverse (file-seq dst))))}))
 
 ;;; HTTP API
 
@@ -129,7 +140,8 @@
    field_values     [:maybe ms/BooleanValue]
    database_secrets [:maybe ms/BooleanValue]}
   (api/check-superuser)
-  (let [opts               {:targets                  (mapv #(vector "Collection" %)
+  (let [start              (System/currentTimeMillis)
+        opts               {:targets                  (mapv #(vector "Collection" %)
                                                             collection)
                             :no-collections           (and (empty? collection)
                                                            (not all_collections))
@@ -140,7 +152,22 @@
                             :dirname                  dirname}
         {:keys [archive
                 log-file
+                report
+                error-message
                 callback]} (serialize&pack opts)]
+    (snowplow/track-event! ::snowplow/serialization-export api/*current-user-id*
+                           {:source          "api"
+                            :duration        (long (/ (- (System/currentTimeMillis) start) 1000))
+                            :count           (count (:seen report))
+                            :collection      (str/join "," (map str collection))
+                            :all_collections (and (empty? collection)
+                                                  (not (:no-collections opts)))
+                            :data_model      (not (:no-data-model opts))
+                            :settings        (not (:no-settings opts))
+                            :field_values    (:include-field-values opts)
+                            :secrets         (:include-database-secrets opts)
+                            :success         (boolean archive)
+                            :error_message   error-message})
     (if archive
       {:status  200
        :headers {"Content-Type"        "application/gzip"
@@ -160,8 +187,22 @@
   [:as {raw-params :params}]
   (api/check-superuser)
   (try
-    (let [{:keys [log-file callback]} (unpack&import (get-in raw-params ["file" :tempfile])
-                                                     (get-in raw-params ["file" :size]))]
+    (let [start              (System/currentTimeMillis)
+          {:keys [log-file
+                  error-message
+                  report
+                  callback]} (unpack&import (get-in raw-params ["file" :tempfile])
+                                            (get-in raw-params ["file" :size]))
+          imported           (set (map (comp :model last) (:seen report)))]
+      (snowplow/track-event! ::snowplow/serialization-import api/*current-user-id*
+                             {:source        "api"
+                              :duration      (long (/ (- (System/currentTimeMillis) start) 1000))
+                              :models        (str/join "," imported)
+                              :count         (if (contains? imported "Setting")
+                                               (inc (count (remove #(= "Setting" (:model (first %))) (:seen report))))
+                                               (count (:seen report)))
+                              :success       (not error-message)
+                              :error_message error-message})
       {:status  200
        :headers {"Content-Type" "text/plain"}
        :body    (on-response! log-file callback)})

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -124,7 +124,8 @@
                             :success       (nil? @err)
                             :error_message (some-> @err str)})
     (when @err
-      (throw @err))))
+      (throw @err))
+    imported))
 
 (defn- select-entities-in-collections
   ([model collections]
@@ -257,9 +258,9 @@
                             :success         (nil? @err)
                             :error_message   (some-> @err str)})
     (when @err
-      (throw @err)))
-  (log/info (trs "Export to {0} complete!" path) (u/emoji "🚛💨 📦"))
-  ::v2-dump-complete)
+      (throw @err))
+    (log/info (format "Export to '%s' complete!" path) (u/emoji "🚛💨 📦"))
+    report))
 
 (defn seed-entity-ids!
   "Add entity IDs for instances of serializable models that don't already have them.

--- a/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/cmd.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [load])
   (:require
    [clojure.java.io :as io]
+   [clojure.string :as str]
    [metabase-enterprise.serialization.dump :as dump]
    [metabase-enterprise.serialization.load :as load]
    [metabase-enterprise.serialization.v2.entity-ids :as v2.entity-ids]
@@ -9,6 +10,7 @@
    [metabase-enterprise.serialization.v2.ingest :as v2.ingest]
    [metabase-enterprise.serialization.v2.load :as v2.load]
    [metabase-enterprise.serialization.v2.storage :as v2.storage]
+   [metabase.analytics.snowplow :as snowplow]
    [metabase.db :as mdb]
    [metabase.models.card :refer [Card]]
    [metabase.models.collection :refer [Collection]]
@@ -83,7 +85,6 @@
   `opts` are passed to [[v2.load/load-metabase]]."
   [path :- :string
    opts :- [:map
-            [:abort-on-error {:optional true} [:maybe :boolean]]
             [:backfill? {:optional true} [:maybe :boolean]]]
    ;; Deliberately separate from the opts so it can't be set from the CLI.
    & {:keys [token-check?]
@@ -105,9 +106,25 @@
    opts are passed to load-metabase"
   [path :- :string
    opts :- [:map
-            [:abort-on-error {:optional true} [:maybe :boolean]]
             [:backfill? {:optional true} [:maybe :boolean]]]]
-  (v2-load-internal! path opts :token-check? true))
+  (let [start    (System/currentTimeMillis)
+        err      (atom nil)
+        report   (try
+                   (v2-load-internal! path opts :token-check? true)
+                   (catch Exception e
+                     (reset! err e)))
+        imported (set (map (comp :model last) (:seen report)))]
+    (snowplow/track-event! ::snowplow/serialization-import nil
+                           {:source        "cli"
+                            :duration      (long (/ (- (System/currentTimeMillis) start) 1000))
+                            :models        (str/join "," imported)
+                            :count         (if (contains? imported "Setting")
+                                             (inc (count (remove #(= "Setting" (:model (first %))) (:seen report))))
+                                             (count (:seen report)))
+                            :success       (nil? @err)
+                            :error_message (some-> @err str)})
+    (when err
+      (throw err))))
 
 (defn- select-entities-in-collections
   ([model collections]
@@ -215,11 +232,32 @@
     (.mkdirs f)
     (when-not (.canWrite f)
       (throw (ex-info (format "Destination path is not writeable: %s" path) {:filename path}))))
-  (serdes/with-cache
-    (-> (cond-> opts
-          (seq collection-ids) (assoc :targets (v2.extract/make-targets-of-type "Collection" collection-ids)))
-        v2.extract/extract
-        (v2.storage/store! path)))
+  (let [start  (System/currentTimeMillis)
+        err    (atom nil)
+        report (try
+                 (serdes/with-cache
+                   (-> (cond-> opts
+                         (seq collection-ids)
+                         (assoc :targets (v2.extract/make-targets-of-type "Collection" collection-ids)))
+                       v2.extract/extract
+                       (v2.storage/store! path)))
+                 (catch Exception e
+                   (reset! err e)))]
+    (snowplow/track-event! ::snowplow/serialization-export nil
+                           {:source          "api"
+                            :duration        (long (/ (- (System/currentTimeMillis) start) 1000))
+                            :count           (count (:seen report))
+                            :collection      (str/join "," (map str collection-ids))
+                            :all_collections (and (empty? collection-ids)
+                                                  (not (:no-collections opts)))
+                            :data_model      (not (:no-data-model opts))
+                            :settings        (not (:no-settings opts))
+                            :field_values    (boolean (:include-field-values opts))
+                            :secrets         (boolean (:include-database-secrets opts))
+                            :success         (nil? @err)
+                            :error_message   (some-> @err str)})
+    (when err
+      (throw err)))
   (log/info (trs "Export to {0} complete!" path) (u/emoji "🚛💨 📦"))
   ::v2-dump-complete)
 

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -4,9 +4,9 @@
    [clojure.string :as str]
    [clojure.test :refer :all]
    [metabase-enterprise.serialization.api :as api.serialization]
+   [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.models :refer [Card Collection Dashboard]]
    [metabase.test :as mt]
-   [metabase.util :as u]
    [metabase.util.compress :as u.compress]
    [toucan2.core :as t2])
   (:import
@@ -40,7 +40,6 @@
   [lines]
   (->> lines
        (keep #(second (re-find #"(?:Loading|Storing) (\w+)" %)))
-       (map (comp keyword u/lower-case-en))
        set))
 
 (defn- tar-file-types [f]
@@ -85,7 +84,7 @@
                                                     :collection (:id coll) :data_model false :settings false)
                         lines (str/split-lines (slurp (io/input-stream res)))]
                     (testing "First three lines for coll+dash+card, and then error during compression"
-                      (is (= #{:collection :dashboard :card}
+                      (is (= #{"Collection" "Dashboard" "Card"}
                              (log-types (take 3 lines))))
                       (is (re-find #"ERROR" (nth lines 3)))))))
 
@@ -103,47 +102,93 @@
 (deftest export-import-test
   (testing "Serialization API e2e"
     (let [known-files (set (.list (io/file api.serialization/parent-dir)))]
-      (mt/with-premium-features #{:serialization}
-        (testing "POST /api/ee/serialization/export"
-          (mt/with-temp [Collection coll  {}
-                         Dashboard  _dash {:collection_id (:id coll)}
-                         Card       card  {:collection_id (:id coll)}]
-            (let [res    (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
-                                               :collection (:id coll) :data_model false :settings false)
-                  files* (atom [])
-                  ;; to avoid input stream closure
-                  ba     (#'api.serialization/ba-copy (io/input-stream res))]
-              (with-open [tar (open-tar ba)]
-                (doseq [^TarArchiveEntry e (u.compress/entries tar)]
-                  (when (.isFile e)
-                    (swap! files* conj (.getName e)))
-                  (condp re-find (.getName e)
-                    #"/export.log$" (testing "Three lines in a log for data files"
-                                      (is (= 3 (count (line-seq (io/reader tar))))))
-                    nil)))
+      (snowplow-test/with-fake-snowplow-collector
+        (mt/with-premium-features #{:serialization}
+          (testing "POST /api/ee/serialization/export"
+            (mt/with-temp [Collection coll  {}
+                           Dashboard  _dash {:collection_id (:id coll)}
+                           Card       card  {:collection_id (:id coll)}]
 
-              (testing "We get only our data and a log file in an archive"
-                (is (= 4 (count @files*))))
+              (let [res    (mt/user-http-request :crowberto :post 200 "ee/serialization/export"
+                                                 :collection (:id coll) :data_model false :settings false)
+                    files* (atom [])
+                    ;; to avoid input stream closure
+                    ba     (#'api.serialization/ba-copy (io/input-stream res))]
+                (with-open [tar (open-tar ba)]
+                  (doseq [^TarArchiveEntry e (u.compress/entries tar)]
+                    (when (.isFile e)
+                      (swap! files* conj (.getName e)))
+                    (condp re-find (.getName e)
+                      #"/export.log$" (testing "Three lines in a log for data files"
+                                        (is (= 3 (count (line-seq (io/reader tar))))))
+                      nil)))
 
-              (testing "POST /api/ee/serialization/import"
-                (t2/update! :model/Card {:id (:id card)} {:name (str "qwe_" (:name card))})
+                (testing "We get only our data and a log file in an archive"
+                  (is (= 4 (count @files*))))
 
-                (let [res (mt/user-http-request :crowberto :post 200 "ee/serialization/import"
-                                                {:request-options {:headers {"content-type" "multipart/form-data"}}}
-                                                {:file ba})]
-                  (testing "We get our data items back"
-                    (is (= #{:collection :dashboard :card :database}
-                           (->> (line-seq (io/reader (io/input-stream res)))
-                                log-types))))
-                  (testing "And they hit the db"
-                    (is (= (:name card)
-                           (t2/select-one-fn :name :model/Card :id (:id card))))))))
+                (testing "Snowplow export event was sent"
+                  (is (= {"event"           "serialization_export"
+                          "collection"      (str (:id coll))
+                          "all_collections" false
+                          "data_model"      false
+                          "settings"        false
+                          "field_values"    false
+                          "duration"        0
+                          "count"           3
+                          "source"          "api"
+                          "secrets"         false
+                          "success"         true
+                          "error_message"   nil}
+                         (-> (snowplow-test/pop-event-data-and-user-id!) first :data))))
 
-            (testing "Only admins can export/import"
-              (is (= "You don't have permissions to do that."
-                     (mt/user-http-request :rasta :post 403 "ee/serialization/export")))
-              (is (= "You don't have permissions to do that."
-                     (mt/user-http-request :rasta :post 403 "ee/serialization/import")))))))
+                (testing "POST /api/ee/serialization/import"
+                  (t2/update! :model/Card {:id (:id card)} {:name (str "qwe_" (:name card))})
+
+                  (let [res (mt/user-http-request :crowberto :post 200 "ee/serialization/import"
+                                                  {:request-options {:headers {"content-type" "multipart/form-data"}}}
+                                                  {:file ba})]
+                    (testing "We get our data items back"
+                      (is (= #{"Collection" "Dashboard" "Card" "Database"}
+                             (log-types (line-seq (io/reader (io/input-stream res)))))))
+                    (testing "And they hit the db"
+                      (is (= (:name card)
+                             (t2/select-one-fn :name :model/Card :id (:id card)))))
+                    (testing "Snowplow import event was sent"
+                      (is (= {"event"         "serialization_import"
+                              "duration"      0
+                              "source"        "api"
+                              "models"        "Dashboard,Card,Collection"
+                              "count"         3
+                              "success"       true
+                              "error_message" nil}
+                             (-> (snowplow-test/pop-event-data-and-user-id!) first :data)))))))
+
+              (testing "ERROR /api/ee/serialization/export"
+                (with-redefs [u.compress/tgz (fn [& _] (throw (ex-info "Just an error" {})))]
+                  (is (-> (mt/user-http-request :crowberto :post 500 "ee/serialization/export"
+                                                :collection (:id coll) :data_model false :settings false)
+                          ;; consume response to remove on-disk data
+                          io/input-stream))
+                  (testing "Snowplow event about error was sent"
+                    (is (= {"event"           "serialization_export"
+                            "duration"        0
+                            "source"          "api"
+                            "count"           0
+                            "collection"      (str (:id coll))
+                            "all_collections" false
+                            "data_model"      false
+                            "settings"        false
+                            "field_values"    false
+                            "secrets"         false
+                            "success"         false
+                            "error_message"   "clojure.lang.ExceptionInfo: Just an error {}"}
+                           (-> (snowplow-test/pop-event-data-and-user-id!) first :data))))))
+
+              (testing "Only admins can export/import"
+                (is (= "You don't have permissions to do that."
+                       (mt/user-http-request :rasta :post 403 "ee/serialization/export")))
+                (is (= "You don't have permissions to do that."
+                       (mt/user-http-request :rasta :post 403 "ee/serialization/import"))))))))
       (testing "We've left no new files, every request is cleaned up"
         ;; if this breaks, check if you consumed every response with io/input-stream. Or `future` is taking too long
         ;; in `api/on-response!`, so maybe add some Thread/sleep here.

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -157,7 +157,7 @@
                       (is (=? {"event"         "serialization_import"
                                "duration_ms"   pos?
                                "source"        "api"
-                               "models"        "Dashboard,Card,Collection"
+                               "models"        "Card,Collection,Dashboard"
                                "count"         3
                                "success"       true
                                "error_message" nil}

--- a/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/api_test.clj
@@ -127,19 +127,19 @@
                   (is (= 4 (count @files*))))
 
                 (testing "Snowplow export event was sent"
-                  (is (= {"event"           "serialization_export"
-                          "collection"      (str (:id coll))
-                          "all_collections" false
-                          "data_model"      false
-                          "settings"        false
-                          "field_values"    false
-                          "duration"        0
-                          "count"           3
-                          "source"          "api"
-                          "secrets"         false
-                          "success"         true
-                          "error_message"   nil}
-                         (-> (snowplow-test/pop-event-data-and-user-id!) first :data))))
+                  (is (=? {"event"           "serialization_export"
+                           "collection"      (str (:id coll))
+                           "all_collections" false
+                           "data_model"      false
+                           "settings"        false
+                           "field_values"    false
+                           "duration_ms"     pos?
+                           "count"           3
+                           "source"          "api"
+                           "secrets"         false
+                           "success"         true
+                           "error_message"   nil}
+                          (-> (snowplow-test/pop-event-data-and-user-id!) first :data))))
 
                 (testing "POST /api/ee/serialization/import"
                   (t2/update! :model/Card {:id (:id card)} {:name (str "qwe_" (:name card))})
@@ -154,14 +154,14 @@
                       (is (= (:name card)
                              (t2/select-one-fn :name :model/Card :id (:id card)))))
                     (testing "Snowplow import event was sent"
-                      (is (= {"event"         "serialization_import"
-                              "duration"      0
-                              "source"        "api"
-                              "models"        "Dashboard,Card,Collection"
-                              "count"         3
-                              "success"       true
-                              "error_message" nil}
-                             (-> (snowplow-test/pop-event-data-and-user-id!) first :data)))))))
+                      (is (=? {"event"         "serialization_import"
+                               "duration_ms"   pos?
+                               "source"        "api"
+                               "models"        "Dashboard,Card,Collection"
+                               "count"         3
+                               "success"       true
+                               "error_message" nil}
+                              (-> (snowplow-test/pop-event-data-and-user-id!) first :data)))))))
 
               (testing "ERROR /api/ee/serialization/export"
                 (with-redefs [u.compress/tgz (fn [& _] (throw (ex-info "Just an error" {})))]
@@ -170,18 +170,18 @@
                           ;; consume response to remove on-disk data
                           io/input-stream))
                   (testing "Snowplow event about error was sent"
-                    (is (= {"event"           "serialization_export"
-                            "duration"        0
-                            "source"          "api"
-                            "count"           0
-                            "collection"      (str (:id coll))
-                            "all_collections" false
-                            "data_model"      false
-                            "settings"        false
-                            "field_values"    false
-                            "secrets"         false
-                            "success"         false
-                            "error_message"   "clojure.lang.ExceptionInfo: Just an error {}"}
+                    (is (=? {"event"           "serialization_export"
+                             "duration_ms"     pos?
+                             "source"          "api"
+                             "count"           0
+                             "collection"      (str (:id coll))
+                             "all_collections" false
+                             "data_model"      false
+                             "settings"        false
+                             "field_values"    false
+                             "secrets"         false
+                             "success"         false
+                             "error_message"   "clojure.lang.ExceptionInfo: Just an error {}"}
                            (-> (snowplow-test/pop-event-data-and-user-id!) first :data))))))
 
               (testing "Only admins can export/import"

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -5,8 +5,11 @@
    [metabase-enterprise.serialization.load :as load]
    [metabase-enterprise.serialization.test-util :as ts]
    [metabase-enterprise.serialization.v2.extract :as v2.extract]
+   [metabase-enterprise.serialization.v2.load :as v2.load]
+   [metabase-enterprise.serialization.v2.storage :as v2.storage]
+   [metabase.analytics.snowplow-test :as snowplow-test]
    [metabase.cmd :as cmd]
-   [metabase.models :refer [Card Dashboard DashboardCard Database User]]
+   [metabase.models :refer [Card Collection Dashboard DashboardCard Database User]]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
@@ -162,3 +165,78 @@
                                            (throw (ex-info "Do not call me!" {})))]
           (is (thrown-with-msg? Exception #"Destination path is not writeable: "
                                 (cmd/export dump-dir))))))))
+
+(deftest snowplow-events-test
+  (testing "Snowplow events are correctly sent"
+    (mt/with-premium-features #{:serialization}
+      (mt/with-empty-h2-app-db
+        (snowplow-test/with-fake-snowplow-collector
+          (ts/with-random-dump-dir [dump-dir "serdesv2-"]
+            (let [coll (ts/create! Collection :name "coll")
+                  _card (ts/create! Card :name "card" :collection_id (:id coll))]
+              (cmd/export dump-dir "--collection" (str (:id coll)) "--no-data-model")
+              (testing "Snowplow export event was sent"
+                (is (= {"event"           "serialization_export"
+                        "collection"      (str (:id coll))
+                        "all_collections" false
+                        "data_model"      false
+                        "settings"        true
+                        "field_values"    false
+                        "duration"        0
+                        "count"           3
+                        "source"          "api"
+                        "secrets"         false
+                        "success"         true
+                        "error_message"   nil}
+                       (->> (map :data (snowplow-test/pop-event-data-and-user-id!))
+                            (filter #(= "serialization_export" (get % "event")))
+                            first))))
+
+              (cmd/import dump-dir)
+              (testing "Snowplow import event was sent"
+                (is (= {"event"         "serialization_import"
+                        "duration"      0
+                        "source"        "cli"
+                        "models"        "Setting,Card,Collection"
+                        "count"         3
+                        "success"       true
+                        "error_message" nil}
+                       (-> (snowplow-test/pop-event-data-and-user-id!) first :data))))
+
+              (with-redefs [v2.storage/store-settings! (fn [_opts _settings]
+                                                         (throw (ex-info "Cannot load settings" {})))]
+                (is (thrown? Exception
+                             (cmd/export dump-dir "--collection" (str (:id coll)) "--no-data-model")))
+                (testing "Snowplow export event about error was sent"
+                  (is (= {"event"           "serialization_export"
+                          "collection"      (str (:id coll))
+                          "all_collections" false
+                          "data_model"      false
+                          "settings"        true
+                          "field_values"    false
+                          "duration"        0
+                          "count"           0
+                          "source"          "api"
+                          "secrets"         false
+                          "success"         false
+                          "error_message"   "clojure.lang.ExceptionInfo: Cannot load settings {}"}
+                         (->> (map :data (snowplow-test/pop-event-data-and-user-id!))
+                              (filter #(= "serialization_export" (get % "event")))
+                              first)))))
+
+              (let [load-one! @#'v2.load/load-one!]
+                (with-redefs [v2.load/load-one! (fn [ctx path]
+                                                  (when (= "Collection" (-> path first :model))
+                                                    (throw (ex-info "Cannot import Collection" {})))
+                                                  (load-one! ctx path))]
+                  (is (thrown? Exception
+                               (cmd/import dump-dir)))
+                  (testing "Snowplow import event about error was sent"
+                    (is (= {"event"         "serialization_import"
+                            "duration"      0
+                            "source"        "cli"
+                            "models"        ""
+                            "count"         0
+                            "success"       false
+                            "error_message" "clojure.lang.ExceptionInfo: Cannot import Collection {}"}
+                           (-> (snowplow-test/pop-event-data-and-user-id!) first :data)))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/cmd_test.clj
@@ -184,7 +184,7 @@
                          "field_values"    false
                          "duration_ms"     pos?
                          "count"           3
-                         "source"          "api"
+                         "source"          "cli"
                          "secrets"         false
                          "success"         true
                          "error_message"   nil}
@@ -216,7 +216,7 @@
                            "field_values"    false
                            "duration_ms"     pos?
                            "count"           0
-                           "source"          "api"
+                           "source"          "cli"
                            "secrets"         false
                            "success"         false
                            "error_message"   "java.lang.Exception: Cannot load settings"}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/serialization_export/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/serialization_export/jsonschema/1-0-0
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Serialization operation",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "database",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "required": ["event", "source", "duration", "success"],
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": ["serialization_export"],
+      "maxLength": 1024
+    },
+    "source": {
+      "description": "The way export was triggered",
+      "type": "string",
+      "enum": ["cli", "api"]
+    },
+    "duration": {
+      "description": "Time in seconds it took to generate an export",
+      "type": "integer"
+    },
+    "success": {
+      "description": "If export succeeded or failed",
+      "type": "boolean"
+    },
+    "error_message": {
+      "description": "Why export failed",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "count": {
+      "description": "Total count of exported entities",
+      "type": "integer"
+    },
+    "collection": {
+      "description": "Which collections were exported",
+      "type": ["string", "null"],
+      "maxLength": 1024
+    },
+    "all_collections": {
+      "description": "If all collections were exported",
+      "type": "boolean"
+    },
+    "settings": {
+      "description": "If settings were exported",
+      "type": "boolean"
+    },
+    "field_values": {
+      "description": "If field values were exported",
+      "type": "boolean"
+    },
+    "secrets": {
+      "description": "If database secrets were included",
+      "type": "boolean"
+    }
+  }
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/serialization_export/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/serialization_export/jsonschema/1-0-0
@@ -21,8 +21,8 @@
       "type": "string",
       "enum": ["cli", "api"]
     },
-    "duration": {
-      "description": "Time in seconds it took to generate an export",
+    "duration_ms": {
+      "description": "Time in milliseconds it took to generate an export",
       "type": "integer"
     },
     "success": {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/serialization_import/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/serialization_import/jsonschema/1-0-0
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Serialization operation",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "database",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "required": ["event", "source", "duration", "success"],
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": ["serialization_import"],
+      "maxLength": 1024
+    },
+    "source": {
+      "description": "The way import was triggered",
+      "type": "string",
+      "enum": ["cli", "api"]
+    },
+    "duration": {
+      "description": "Time in seconds it took to generate an export",
+      "type": "integer"
+    },
+    "success": {
+      "description": "If import succeeded or failed",
+      "type": "boolean"
+    },
+    "error_message": {
+      "description": "Why import failed",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "models": {
+      "description": "Which models were imported",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "count": {
+      "description": "Total count of imported entities",
+      "type": "integer"
+    }
+  }
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/serialization_import/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/serialization_import/jsonschema/1-0-0
@@ -21,8 +21,8 @@
       "type": "string",
       "enum": ["cli", "api"]
     },
-    "duration": {
-      "description": "Time in seconds it took to generate an export",
+    "duration_ms": {
+      "description": "Time in milliseconds it took to generate an export",
       "type": "integer"
     },
     "success": {

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -29,19 +29,21 @@
 (def ^:private schema->version
   "The most recent version for each event schema. This should be updated whenever a new version of a schema is added
   to SnowcatCloud, at the same time that the data sent to the collector is updated."
-  {::account      "1-0-1"
-   ::invite       "1-0-1"
-   ::csvupload    "1-0-0"
-   ::dashboard    "1-1-3"
-   ::database     "1-0-1"
-   ::instance     "1-1-2"
-   ::metabot      "1-0-1"
-   ::search       "1-0-1"
-   ::model        "1-0-0"
-   ::timeline     "1-0-0"
-   ::task         "1-0-0"
-   ::action       "1-0-0"
-   ::embed_share  "1-0-0"})
+  {::account              "1-0-1"
+   ::invite               "1-0-1"
+   ::csvupload            "1-0-0"
+   ::dashboard            "1-1-3"
+   ::database             "1-0-1"
+   ::instance             "1-1-2"
+   ::metabot              "1-0-1"
+   ::search               "1-0-1"
+   ::model                "1-0-0"
+   ::timeline             "1-0-0"
+   ::task                 "1-0-0"
+   ::action               "1-0-0"
+   ::embed_share          "1-0-0"
+   ::serialization_export "1-0-0"
+   ::serialization_import "1-0-0"})
 
 (def ^:private event->schema
   "The schema to use for each analytics event."
@@ -67,7 +69,9 @@
    ::csv-upload-failed              ::csvupload
    ::metabot-feedback-received      ::metabot
    ::embedding-enabled              ::embed_share
-   ::embedding-disabled             ::embed_share})
+   ::embedding-disabled             ::embed_share
+   ::serialization-export           ::serialization_export
+   ::serialization-import           ::serialization_import})
 
 (defsetting analytics-uuid
   (deferred-tru

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -114,7 +114,7 @@
      (when doc
        (doseq [doc-line (str/split doc #"\n\s+")]
          (println "\t" doc-line)))
-     (when arg-spec
+     (when (seq arg-spec)
        (println "\t" "Options:")
        (doseq [opt-line (str/split (:summary (cli/parse-opts [] arg-spec)) #"\n")]
          (println "\t" opt-line)))))
@@ -186,8 +186,7 @@
   (call-enterprise 'metabase-enterprise.serialization.cmd/v1-load! path (get-parsed-options #'load options)))
 
 (defn ^:command import
-  {:doc "Load serialized Metabase instance as created by the [[export]] command from directory `path`."
-   :arg-spec [["-e" "--abort-on-error" "Stops import on any errors, default is to continue."]]}
+  {:doc "Load serialized Metabase instance as created by the [[export]] command from directory `path`."}
   [path & options]
   (call-enterprise 'metabase-enterprise.serialization.cmd/v2-load! path (get-parsed-options #'import options)))
 

--- a/test/metabase/cmd_test.clj
+++ b/test/metabase/cmd_test.clj
@@ -30,10 +30,7 @@
    (fn []
      (testing "with no options"
        (is (= '(metabase-enterprise.serialization.cmd/v2-load! "/path/" {})
-              (cmd/import "/path/"))))
-     (testing "with options"
-       (is (= '(metabase-enterprise.serialization.cmd/v2-load! "/path/" {:abort-on-error true})
-              (cmd/import "/path/" "--abort-on-error")))))))
+              (cmd/import "/path/")))))))
 
 (deftest dump-command-test
   (do-with-captured-call-enterprise-calls!


### PR DESCRIPTION
Resolves #38359

It also removes `abort-on-error` option, which never was false: it was either supplied and options map contained `{:abort-on-error true}`, or was not and option map was `{}`, and so default value of `true` in `load-metabase!` took precedence. Agreed with @luizarakaki.