### PR TITLE
[MLv2] Migrate `usesSegment` using new question filter from the `GET /api/card endpoint`

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -38,9 +38,6 @@ import type {
   Dataset,
 } from "metabase-types/api";
 
-import * as FILTER from "metabase-lib/queries/utils/filter";
-import * as QUERY from "metabase-lib/queries/utils/query";
-
 // TODO: remove these dependencies
 import { getCardUiParameters } from "metabase-lib/parameters/utils/cards";
 import { utf8_to_b64url } from "metabase/lib/encoding";
@@ -482,18 +479,6 @@ class Question {
    * Although most of these are essentially a way to modify the current query, having them as a part
    * of Question interface instead of Query interface makes it more convenient to also change the current visualization
    */
-
-  usesSegment(segmentId): boolean {
-    const { isNative } = Lib.queryDisplayInfo(this.query());
-    return (
-      !isNative &&
-      QUERY.getFilters(
-        this.legacyQuery({ useStructuredQuery: true }).legacyQuery({
-          useStructuredQuery: true,
-        }),
-      ).some(filter => FILTER.isSegment(filter) && filter[1] === segmentId)
-    );
-  }
 
   composeThisQuery(): Question | null | undefined {
     if (this.id()) {

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -54,7 +54,6 @@ export const MetricQuestions = ({ style, table, metric, metadata }) => {
     error,
   } = useQuestionListQuery({
     query: { f: "using_metric", model_id: metric.id },
-    enabled: true,
   });
 
   return (

--- a/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
+++ b/frontend/src/metabase/reference/metrics/MetricQuestions.jsx
@@ -1,8 +1,6 @@
 /* eslint "react/prop-types": "warn" */
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-// eslint-disable-next-line no-restricted-imports -- deprecated usage
-import moment from "moment-timezone";
 import { t } from "ttag";
 import visualizations from "metabase/visualizations";
 import * as Urls from "metabase/lib/urls";
@@ -21,7 +19,7 @@ import { getMetadata } from "metabase/selectors/metadata";
 
 import ReferenceHeader from "../components/ReferenceHeader";
 
-import { getQuestionUrl } from "../utils";
+import { getQuestionUrl, getDescription } from "../utils";
 
 import { getTable, getMetric } from "../selectors";
 
@@ -47,12 +45,6 @@ const mapStateToProps = (state, props) => ({
 
 const mapDispatchToProps = {
   ...metadataActions,
-};
-
-const getDescription = question => {
-  const timestamp = moment(question.getCreatedAt()).fromNow();
-  const author = question.getCreator().common_name;
-  return t`Created ${timestamp} by ${author}`;
 };
 
 export const MetricQuestions = ({ style, table, metric, metadata }) => {

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
@@ -1,7 +1,6 @@
 /* eslint "react/prop-types": "warn" */
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import _ from "underscore";
 // eslint-disable-next-line no-restricted-imports -- deprecated usage
 import moment from "moment-timezone";
 import { t } from "ttag";

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
@@ -1,8 +1,6 @@
 /* eslint "react/prop-types": "warn" */
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-// eslint-disable-next-line no-restricted-imports -- deprecated usage
-import moment from "moment-timezone";
 import { t } from "ttag";
 import visualizations from "metabase/visualizations";
 import * as Urls from "metabase/lib/urls";
@@ -19,7 +17,7 @@ import * as metadataActions from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 import ReferenceHeader from "../components/ReferenceHeader";
 
-import { getQuestionUrl } from "../utils";
+import { getQuestionUrl, getDescription } from "../utils";
 
 import { getTableBySegment, getSegment } from "../selectors";
 
@@ -68,24 +66,19 @@ export const SegmentQuestions = ({ style, table, segment, metadata }) => {
           data.length > 0 ? (
             <div className="wrapper wrapper--trim">
               <List>
-                {data.map(question => {
-                  const card = question.card();
-
-                  return (
+                {data.map(
+                  question =>
                     question.id() &&
                     question.displayName() && (
                       <ListItem
                         key={question.id()}
                         name={question.displayName()}
-                        description={t`Created ${moment(
-                          card.created_at,
-                        ).fromNow()} by ${card.creator.common_name}`}
-                        url={Urls.question(card)}
+                        description={getDescription(question)}
+                        url={Urls.question(question.card())}
                         icon={visualizations.get(question.display()).iconName}
                       />
-                    )
-                  );
-                })}
+                    ),
+                )}
               </List>
             </div>
           ) : (

--- a/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
+++ b/frontend/src/metabase/reference/segments/SegmentQuestions.jsx
@@ -51,7 +51,6 @@ export const SegmentQuestions = ({ style, table, segment, metadata }) => {
     error,
   } = useQuestionListQuery({
     query: { f: "using_segment", model_id: segment.id },
-    enabled: true,
   });
 
   return (

--- a/frontend/src/metabase/reference/selectors.js
+++ b/frontend/src/metabase/reference/selectors.js
@@ -125,14 +125,6 @@ export const getSegmentRevisions = createSelector(
   (segmentId, revisions) => getIn(revisions, ["segment", segmentId]) || {},
 );
 
-export const getSegmentQuestions = createSelector(
-  [getSegmentId, getQuestions],
-  (segmentId, questions) =>
-    Object.values(questions)
-      .filter(question => new Question(question).usesSegment(segmentId))
-      .reduce((map, question) => assoc(map, question.id, question), {}),
-);
-
 export const getTableQuestions = createSelector(
   [getTable, getQuestions],
   (table, questions) =>

--- a/frontend/src/metabase/reference/selectors.js
+++ b/frontend/src/metabase/reference/selectors.js
@@ -1,5 +1,5 @@
 import { createSelector } from "@reduxjs/toolkit";
-import { assoc, getIn } from "icepick";
+import { getIn } from "icepick";
 
 import Dashboards from "metabase/entities/dashboards";
 
@@ -11,8 +11,6 @@ import {
   getShallowMetrics as getMetrics,
   getShallowSegments as getSegments,
 } from "metabase/selectors/metadata";
-
-import Question from "metabase-lib/Question";
 
 import { idsToObjectMap, databaseToForeignKeys } from "./utils";
 

--- a/frontend/src/metabase/reference/utils.js
+++ b/frontend/src/metabase/reference/utils.js
@@ -1,5 +1,7 @@
 import { assoc } from "icepick";
-
+// eslint-disable-next-line no-restricted-imports -- deprecated usage
+import moment from "moment-timezone";
+import { t } from "ttag";
 import { titleize, humanize } from "metabase/lib/formatting";
 import * as Urls from "metabase/lib/urls";
 import * as Lib from "metabase-lib";
@@ -136,3 +138,9 @@ export const getQuestionUrl = getQuestionArgs =>
 // little utility function to determine if we 'has' things, useful
 // for handling entity empty states
 export const has = entity => entity && entity.length > 0;
+
+export const getDescription = question => {
+  const timestamp = moment(question.getCreatedAt()).fromNow();
+  const author = question.getCreator().common_name;
+  return t`Created ${timestamp} by ${author}`;
+};


### PR DESCRIPTION
Prerequisite for this PR was https://github.com/metabase/metabase/issues/37688. It's been merged to `master`.

### What does this PR do?
Migrates `usesSegment` method on the `Question` prototype using new question filter from the `GET /api/card endpoint`

It achieves this by relying on our entities framework, and by directly loading filtered questions using `Questions.loadList()`.
Both the selector `getSegmentQuestions` and the Question method `usesSegment ` are not needed anymore so this PR removes them.

### How to test?
- Create at least one segment[^1]
- Create a few questions that use that segment and save them
- Navigate to `/reference/segments/:segment-id/questions` and make sure that only questions that use this segment are displayed
- Additionally, all tests should still pass
![image](https://github.com/metabase/metabase/assets/31325167/61d621dc-6cf1-4f47-8105-86501eb89e2b)

Resolves #37511 

[^1]: https://www.metabase.com/docs/latest/data-modeling/segments-and-metrics