### PR TITLE
[QC] Remove unused metabase-lib (v1) utilities

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -891,13 +891,6 @@ class StructuredQuery extends AtomicQuery {
     return this._updateQuery(Q.removeFilter, arguments);
   }
 
-  /**
-   * @returns {StructuredQuery} new query with all filters removed.
-   */
-  clearFilters() {
-    return this._updateQuery(Q.clearFilters, arguments);
-  }
-
   // EXPRESSIONS
   expressions = _.once((): ExpressionClause => {
     return Q.getExpressions(this.legacyQuery({ useStructuredQuery: true }));

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -644,13 +644,6 @@ class StructuredQuery extends AtomicQuery {
     return this._updateQuery(Q.removeAggregation, arguments);
   }
 
-  /**
-   * @returns {StructuredQuery} new query with all aggregations removed.
-   */
-  clearAggregations(): StructuredQuery {
-    return this._updateQuery(Q.clearAggregations, arguments);
-  }
-
   // BREAKOUTS
 
   /**

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -903,26 +903,6 @@ class StructuredQuery extends AtomicQuery {
     return query;
   }
 
-  clearExpressions() {
-    let query = this._updateQuery(Q.clearExpressions, arguments);
-
-    // extra logic for removing expressions in fields clause
-    // TODO: push into query/expression?
-    for (const name of Object.keys(this.expressions())) {
-      const index = query._indexOfField(["expression", name]);
-
-      if (index >= 0) {
-        query = query.removeField(index);
-      }
-    }
-
-    if (this.isRaw() && this.sourceQuery()) {
-      query = query.clearFields();
-    }
-
-    return query;
-  }
-
   _indexOfField(fieldRef) {
     return this.fields().findIndex(f => _.isEqual(f, fieldRef));
   }

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -898,13 +898,6 @@ class StructuredQuery extends AtomicQuery {
     return this._updateQuery(Q.clearFilters, arguments);
   }
 
-  /**
-   * @returns {StructuredQuery} new query with all segment filters removed
-   */
-  clearSegments() {
-    return this._updateQuery(Q.clearSegments, arguments);
-  }
-
   // EXPRESSIONS
   expressions = _.once((): ExpressionClause => {
     return Q.getExpressions(this.legacyQuery({ useStructuredQuery: true }));

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -704,14 +704,6 @@ class StructuredQuery extends AtomicQuery {
   }
 
   /**
-   * @returns whether the current query has a valid breakout
-   */
-  hasValidBreakout() {
-    const breakouts = this.breakouts();
-    return breakouts.length > 0 && breakouts[0].isValid();
-  }
-
-  /**
    * @returns {StructuredQuery} new query with the provided MBQL @type {Breakout} added.
    */
   addBreakout(_breakout: Breakout) {

--- a/frontend/src/metabase-lib/queries/utils/aggregation.js
+++ b/frontend/src/metabase-lib/queries/utils/aggregation.js
@@ -1,6 +1,6 @@
 import { STANDARD_AGGREGATIONS } from "metabase-lib/expressions";
 import * as FieldRef from "./field-ref";
-import { add, update, remove, clear } from "./util";
+import { add, update, remove } from "./util";
 
 /**
  * Returns canonical list of Aggregations, i.e. with deprecated "rows" removed
@@ -54,13 +54,6 @@ export function updateAggregation(aggregation, index, updatedAggregation) {
  */
 export function removeAggregation(aggregation, index) {
   return getAggregationClause(remove(getAggregations(aggregation), index));
-}
-
-/**
- * @deprecated use MLv2
- */
-export function clearAggregations(ac) {
-  return getAggregationClause(clear());
 }
 
 // MISC

--- a/frontend/src/metabase-lib/queries/utils/expression.js
+++ b/frontend/src/metabase-lib/queries/utils/expression.js
@@ -7,9 +7,6 @@ export function getExpressions(expressions = {}) {
 export function addExpression(expressions = {}, name, expression) {
   return { ...expressions, [name]: expression };
 }
-export function clearExpressions(expressions) {
-  return {};
-}
 
 /**
  * Ensures expression's name uniqueness

--- a/frontend/src/metabase-lib/queries/utils/filter.js
+++ b/frontend/src/metabase-lib/queries/utils/filter.js
@@ -7,7 +7,7 @@ import {
 import { getOperatorByTypeAndName } from "metabase-lib/operators/utils";
 import { STRING } from "metabase-lib/types/constants";
 import { isStartingFrom } from "metabase-lib/queries/utils/query-time";
-import { op, args, noNullValues, add, update, remove, clear } from "./util";
+import { op, args, noNullValues, add, update, remove } from "./util";
 import { isValidField } from "./field-ref";
 
 // returns canonical list of Filters
@@ -40,9 +40,6 @@ export function updateFilter(filter, index, updatedFilter) {
 }
 export function removeFilter(filter, index) {
   return getFilterClause(remove(getFilters(filter), index));
-}
-export function clearFilters(filter) {
-  return getFilterClause(clear());
 }
 
 // MISC

--- a/frontend/src/metabase-lib/queries/utils/filter.js
+++ b/frontend/src/metabase-lib/queries/utils/filter.js
@@ -44,10 +44,6 @@ export function removeFilter(filter, index) {
 export function clearFilters(filter) {
   return getFilterClause(clear());
 }
-export function clearSegments(filters) {
-  const newFilters = filters.filter(f => !isSegment(f));
-  return getFilterClause(newFilters);
-}
 
 // MISC
 

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -121,8 +121,6 @@ export const addExpression = (query, name, expression) =>
     query,
     E.addExpression(query.expressions, name, expression),
   );
-export const clearExpressions = query =>
-  setExpressionClause(query, E.clearExpressions(query.expressions));
 
 // we can enforce various constraints in these functions:
 

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -86,8 +86,6 @@ export const removeFilter = (query, index) =>
   setFilterClause(query, F.removeFilter(query.filter, index));
 export const clearFilters = query =>
   setFilterClause(query, F.clearFilters(query.filter));
-export const clearSegments = query =>
-  setFilterClause(query, F.clearSegments(getFilters(query)));
 
 export const canAddFilter = query => F.canAddFilter(query.filter);
 

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -37,12 +37,6 @@ export const removeAggregation = (query, index) =>
 /**
  * @deprecated use MLv2
  */
-export const clearAggregations = query =>
-  setAggregationClause(query, A.clearAggregations(query.aggregation));
-
-/**
- * @deprecated use MLv2
- */
 export const isBareRows = query => A.isBareRows(query.aggregation);
 
 // BREAKOUT

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -84,8 +84,6 @@ export const updateFilter = (query, index, filter) =>
   setFilterClause(query, F.updateFilter(query.filter, index, filter));
 export const removeFilter = (query, index) =>
   setFilterClause(query, F.removeFilter(query.filter, index));
-export const clearFilters = query =>
-  setFilterClause(query, F.clearFilters(query.filter));
 
 export const canAddFilter = query => F.canAddFilter(query.filter);
 

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -576,15 +576,6 @@ describe("StructuredQuery", () => {
         );
       });
     });
-    describe("hasValidBreakout", () => {
-      it("should return false if there are no breakouts", () => {
-        expect(query.hasValidBreakout()).toBe(false);
-      });
-      it("should return true if there is at least one breakout", () => {
-        const ordersProductId = metadata.field(ORDERS.PRODUCT_ID);
-        expect(query.breakout(ordersProductId).hasValidBreakout()).toBe(true);
-      });
-    });
 
     it("excludes breakout that has the same base dimension as what is already used", () => {
       const breakout = [

--- a/frontend/test/metabase/lib/query/query.unit.spec.js
+++ b/frontend/test/metabase/lib/query/query.unit.spec.js
@@ -93,20 +93,6 @@ describe("Query", () => {
         .toEqual({});
     });
   });
-  describe("clearAggregations", () => {
-    it("should remove all aggregations", () => {
-      expect(Query.clearAggregations({ aggregation: [["count"]] })).toEqual({});
-      expect(
-        Query.clearAggregations({
-          aggregation: [["count"], ["sum", ["field", 1, null]]],
-        }),
-      ).toEqual({});
-    });
-    it("should remove all aggregations for deprecated form", () => {
-      expect(Query.clearAggregations({ aggregation: ["count"] })) // deprecated
-        .toEqual({});
-    });
-  });
 
   describe("updateBreakout", () => {
     it("should update the field", () => {


### PR DESCRIPTION
This PR removes old metabase-lib utilities that are not in use anymore.
Most of these were just calling each other, and re-exporting a util to be used as a method on a `StructuredQuery` prototype.

This PR ultimate removes all those unused methods as well.