### PR TITLE
Auto focus search input in question picker modal

### DIFF
--- a/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.jsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPicker/QuestionPicker.jsx
@@ -61,6 +61,7 @@ function QuestionPickerInner({ onSelect, collectionsById, getCollectionIcon }) {
       <SearchInput
         fullWidth
         autoFocus
+        data-autofocus
         placeholder={t`Search…`}
         value={searchText}
         icon={<Icon name="search" size={16} />}


### PR DESCRIPTION
IIRC, Mantine keeps its `Modal` components mounted, so `autoFocus` on inputs doesn't really work. It's expected to use a `data-autofocus` attribute instead (see [docs](https://v6.mantine.dev/core/modal/#initial-focus))

### Demo

https://github.com/metabase/metabase/assets/17258145/48cb4bbe-9232-4f30-966c-109555c2969c

