### PR TITLE
Improve look of models in Browse data

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "models-in-browse-data-polish"
     paths-ignore:
       # config files
       - ".**"

--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "models-in-browse-data-polish"
     paths-ignore:
       # config files
       - ".**"

--- a/frontend/src/metabase/browse/components/BrowseModels.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.styled.tsx
@@ -20,15 +20,16 @@ export const ModelCard = styled(Card)`
   align-items: flex-start;
 
   border: 1px solid ${color("border")};
-  box-shadow: 0 1px 0.25rem 0 rgba(0, 0, 0, 0.06);
+
+  box-shadow: none;
   &:hover {
-    box-shadow: 0 1px 0.25rem 0 rgba(0, 0, 0, 0.14);
-    h4 {
+    h1 {
       color: ${color("brand")};
     }
   }
   transition: box-shadow 0.15s;
-  h4 {
+
+  h1 {
     transition: color 0.15s;
   }
 `;
@@ -50,8 +51,9 @@ export const MultilineEllipsified = styled(Ellipsified)`
 
 export const GridContainer = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+  gap: 1.5rem 1rem;
+  margin-top: 1rem;
   width: 100%;
 
   ${breakpointMinSmall} {
@@ -65,7 +67,7 @@ export const GridContainer = styled.div`
 export const CollectionHeaderContainer = styled.div`
   grid-column: 1 / -1;
   align-items: center;
-  padding-top: 0.5rem;
+  padding-top: 1rem;
   margin-right: 1rem;
   &:not(:first-of-type) {
     border-top: 1px solid #f0f0f0;

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -148,7 +148,7 @@ const ModelCell = ({ model, collectionHtmlId }: ModelCellProps) => {
     >
       <ModelCard>
         <Box mb="auto">
-          <Icon name="model" size={20} className={color("brand")} />
+          <Icon name="model" size={20} color={color("brand")} />
         </Box>
         <Title lh="1rem" mb=".25rem" size="1rem">
           <MultilineEllipsified tooltipMaxWidth="20rem" id={headingId}>

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -1,6 +1,5 @@
 import _ from "underscore";
-import cx from "classnames";
-import { c, t } from "ttag";
+import { t } from "ttag";
 
 import type {
   Card,
@@ -140,9 +139,9 @@ const ModelCell = ({ model, collectionHtmlId }: ModelCellProps) => {
     model.last_editor_common_name ?? model.creator_common_name;
   const timestamp = model.last_edited_at ?? model.created_at ?? "";
 
-  const noDescription = c(
-    "Indicates that a model has no description associated with it",
-  ).t`No description.`;
+  // const noDescription = c(
+  //   "Indicates that a model has no description associated with it",
+  // ).t`No description.`;
   return (
     <Link
       aria-labelledby={`${collectionHtmlId} ${headingId}`}
@@ -150,19 +149,14 @@ const ModelCell = ({ model, collectionHtmlId }: ModelCellProps) => {
       to={Urls.model(model as unknown as Partial<Card>)}
     >
       <ModelCard>
-        <Title order={4} className="text-wrap" lh="1rem" mb=".5rem">
+        <Box mb="auto">
+          <Icon name="model" size={20} className="text-brand" />
+        </Box>
+        <Title className="text-wrap" lh="1rem" mb=".25rem" size="1rem">
           <MultilineEllipsified tooltipMaxWidth="20rem" id={headingId}>
             {model.name}
           </MultilineEllipsified>
         </Title>
-        <Text h="2rem" size="xs" mb="auto">
-          <MultilineEllipsified
-            tooltipMaxWidth="20rem"
-            className={cx({ "text-light": !model.description })}
-          >
-            {model.description || noDescription}{" "}
-          </MultilineEllipsified>
-        </Text>
         <LastEdited editorFullName={lastEditorFullName} timestamp={timestamp} />
       </ModelCard>
     </Link>
@@ -182,7 +176,9 @@ const CollectionHeader = ({
         <CollectionHeaderLink to={Urls.collection(collection)}>
           <Group spacing=".25rem">
             <Icon name="folder" color="text-dark" size={16} />
-            <Text weight="bold">{getCollectionName(collection)}</Text>
+            <Text weight="bold" color="text-medium">
+              {getCollectionName(collection)}
+            </Text>
           </Group>
         </CollectionHeaderLink>
       </CollectionHeaderGroup>

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -18,6 +18,7 @@ import NoResults from "assets/img/no_results.svg";
 import { useSelector } from "metabase/lib/redux";
 import { getLocale } from "metabase/setup/selectors";
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
+import { color } from "metabase/lib/colors";
 import { getCollectionName, groupModels } from "../utils";
 import { CenteredEmptyState } from "./BrowseApp.styled";
 import {
@@ -139,9 +140,6 @@ const ModelCell = ({ model, collectionHtmlId }: ModelCellProps) => {
     model.last_editor_common_name ?? model.creator_common_name;
   const timestamp = model.last_edited_at ?? model.created_at ?? "";
 
-  // const noDescription = c(
-  //   "Indicates that a model has no description associated with it",
-  // ).t`No description.`;
   return (
     <Link
       aria-labelledby={`${collectionHtmlId} ${headingId}`}
@@ -150,9 +148,9 @@ const ModelCell = ({ model, collectionHtmlId }: ModelCellProps) => {
     >
       <ModelCard>
         <Box mb="auto">
-          <Icon name="model" size={20} className="text-brand" />
+          <Icon name="model" size={20} className={color("brand")} />
         </Box>
-        <Title className="text-wrap" lh="1rem" mb=".25rem" size="1rem">
+        <Title lh="1rem" mb=".25rem" size="1rem">
           <MultilineEllipsified tooltipMaxWidth="20rem" id={headingId}>
             {model.name}
           </MultilineEllipsified>

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarView.tsx
@@ -102,6 +102,30 @@ function MainNavbarView({
             >
               {t`Home`}
             </PaddedSidebarLink>
+            {hasDataAccess && (
+              <>
+                <PaddedSidebarLink
+                  icon="database"
+                  url={BROWSE_URL}
+                  isSelected={nonEntityItem?.url?.startsWith(BROWSE_URL)}
+                  onClick={onItemSelect}
+                >
+                  {t`Browse data`}
+                </PaddedSidebarLink>
+                {!hasOwnDatabase && isAdmin && (
+                  <AddYourOwnDataLink
+                    icon="add"
+                    url={ADD_YOUR_OWN_DATA_URL}
+                    isSelected={nonEntityItem?.url?.startsWith(
+                      ADD_YOUR_OWN_DATA_URL,
+                    )}
+                    onClick={onItemSelect}
+                  >
+                    {t`Add your own data`}
+                  </AddYourOwnDataLink>
+                )}
+              </>
+            )}
           </ul>
         </SidebarSection>
 
@@ -130,36 +154,6 @@ function MainNavbarView({
             aria-label="collection-tree"
           />
         </SidebarSection>
-
-        {hasDataAccess && (
-          <SidebarSection>
-            <SidebarHeadingWrapper>
-              <SidebarHeading>{t`Data`}</SidebarHeading>
-            </SidebarHeadingWrapper>
-            <ul>
-              <PaddedSidebarLink
-                icon="database"
-                url={BROWSE_URL}
-                isSelected={nonEntityItem?.url?.startsWith(BROWSE_URL)}
-                onClick={onItemSelect}
-              >
-                {t`Browse data`}
-              </PaddedSidebarLink>
-              {!hasOwnDatabase && isAdmin && (
-                <AddYourOwnDataLink
-                  icon="add"
-                  url={ADD_YOUR_OWN_DATA_URL}
-                  isSelected={nonEntityItem?.url?.startsWith(
-                    ADD_YOUR_OWN_DATA_URL,
-                  )}
-                  onClick={onItemSelect}
-                >
-                  {t`Add your own data`}
-                </AddYourOwnDataLink>
-              )}
-            </ul>
-          </SidebarSection>
-        )}
       </div>
       <WhatsNewNotification />
     </SidebarContentRoot>


### PR DESCRIPTION
This PR improves the appearance of the Browse data page. Specifically, it makes the cards representing models in Browse data look more like the cards on Collections pages. It also brings the Browse data link to the top of the nav.

## Model card

### on `master`

![image](https://github.com/metabase/metabase/assets/130925/4821ad24-80ba-4419-9166-c4f72b77f5e0)

### on this branch

![image](https://github.com/metabase/metabase/assets/130925/c386e859-ee02-48cd-83d2-194dbb5fb67b)
