### PR TITLE
analytics for meet-embedders

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
@@ -417,9 +417,14 @@ describeWithSnowplow("scenarios > setup", () => {
 
       cy.findByText("What will you use Metabase for?").should("exist");
       // 6 - setup/step_seen "usage_question"
+
+      cy.button("Next").click();
+
+      // 7 setup/usage_reason_selected
+      // 8 setup/step_seen "database"
     });
 
-    expectGoodSnowplowEvents(6);
+    expectGoodSnowplowEvents(8);
   });
 
   it("should ignore snowplow failures and work as normal", () => {

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
@@ -396,18 +396,30 @@ describeWithSnowplow("scenarios > setup", () => {
     // 2 - pageview
     cy.visit(`/setup`);
 
-    // 3 - setup/step_seen
+    // 3 - setup/step_seen "welcome"
     cy.findByTestId("welcome-page").within(() => {
       cy.findByText("Welcome to Metabase");
       cy.findByTextEnsureVisible("Let's get started").click();
     });
 
-    // 4 - setup/step_seen
-    cy.findByTestId("setup-forms").findByText(
-      "What's your preferred language?",
-    );
+    cy.findByTestId("setup-forms").within(() => {
+      // 4 - setup/step_seen  "language"
+      cy.findByText("What's your preferred language?");
+      cy.findByText("Next").click();
 
-    expectGoodSnowplowEvents(4);
+      // 5 - setup/step_seen "user_info"
+      cy.findByText("What should we call you?");
+      cy.findByLabelText("Email").type(admin.email);
+      cy.findByLabelText("Company or team name").type("Epic Team");
+      cy.findByLabelText("Create a password").type(admin.password);
+      cy.findByLabelText("Confirm your password").type(admin.password);
+      cy.button("Next").click();
+
+      cy.findByText("What will you use Metabase for?").should("exist");
+      // 6 - setup/step_seen "usage_question"
+    });
+
+    expectGoodSnowplowEvents(6);
   });
 
   it("should ignore snowplow failures and work as normal", () => {

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.js
@@ -367,6 +367,13 @@ describe("scenarios > setup", () => {
       .findByText("Get started with Embedding Metabase in your app")
       .should("exist");
 
+    main().findByRole("link", { name: "Learn more" }).should(
+      "have.attr",
+      "href",
+      // eslint-disable-next-line no-unconditional-metabase-links-render -- this is a test file
+      "https://www.metabase.com/docs/latest/embedding/start.html?utm_media=embed-minimal-homepage",
+    );
+
     cy.icon("close").click();
 
     main()

--- a/frontend/src/metabase/home/components/EmbedMinimalHomepage/EmbedMinimalHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedMinimalHomepage/EmbedMinimalHomepage.tsx
@@ -14,7 +14,7 @@ type EmbedMinimalHomepageProps = {
 export const EmbedMinimalHomepage = ({
   onDismiss,
 }: EmbedMinimalHomepageProps) => {
-  const learnMoreUrl = useSelector(state =>
+  const learnMoreBaseUrl = useSelector(state =>
     // eslint-disable-next-line no-unconditional-metabase-links-render -- this is only visible to admins
     getDocsUrl(state, { page: "embedding/start" }),
   );
@@ -64,7 +64,7 @@ export const EmbedMinimalHomepage = ({
 
             <Text>{jt`${(
               <ExternalLink
-                href={learnMoreUrl}
+                href={learnMoreBaseUrl + "?utm_media=embed-minimal-homepage"}
                 key="link"
               >{t`Learn more`}</ExternalLink>
             )} about embedding`}</Text>

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -13,6 +13,7 @@ import {
   trackAddDataLaterClicked,
   trackDatabaseSelected,
   trackTrackingChanged,
+  trackUsageReasonSelected,
 } from "./analytics";
 import {
   getAvailableLocales,
@@ -87,8 +88,8 @@ export const submitUser = createAsyncThunk(
 
 export const submitUsageReason = createAsyncThunk(
   "metabase/setup/SUBMIT_USAGE_REASON",
-  (_: UsageReason) => {
-    // TODO: add tracking
+  (usageReason: UsageReason) => {
+    trackUsageReasonSelected(usageReason);
   },
 );
 

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -12,10 +12,7 @@ import {
 import {
   trackAddDataLaterClicked,
   trackDatabaseSelected,
-  trackDatabaseStepCompleted,
   trackTrackingChanged,
-  trackUserStepCompleted,
-  trackWelcomeStepCompleted,
 } from "./analytics";
 import {
   getAvailableLocales,
@@ -72,11 +69,6 @@ export const loadDefaults = createAsyncThunk<void, void, ThunkConfig>(
 export const SELECT_STEP = "metabase/setup/SUBMIT_WELCOME_STEP";
 export const selectStep = createAction<SetupStep>(SELECT_STEP);
 
-export const SUBMIT_WELCOME = "metabase/setup/SUBMIT_WELCOME_STEP";
-export const submitWelcome = createAsyncThunk(SUBMIT_WELCOME, () => {
-  trackWelcomeStepCompleted();
-});
-
 export const UPDATE_LOCALE = "metabase/setup/UPDATE_LOCALE";
 export const updateLocale = createAsyncThunk(
   UPDATE_LOCALE,
@@ -90,9 +82,7 @@ export const submitLanguage = createAction(SUBMIT_LANGUAGE);
 
 export const submitUser = createAsyncThunk(
   "metabase/setup/SUBMIT_USER_INFO",
-  (_: UserInfo) => {
-    trackUserStepCompleted();
-  },
+  (_: UserInfo) => undefined,
 );
 
 export const submitUsageReason = createAsyncThunk(
@@ -139,12 +129,10 @@ export const submitDatabase = createAsyncThunk<
 
     try {
       await validateDatabase(token, sslDatabase);
-      trackDatabaseStepCompleted(database.engine);
       return sslDatabase;
     } catch (error1) {
       try {
         await validateDatabase(token, nonSslDatabase);
-        trackDatabaseStepCompleted(database.engine);
         return nonSslDatabase;
       } catch (error2) {
         return rejectWithValue(error2);
@@ -156,16 +144,13 @@ export const submitDatabase = createAsyncThunk<
 export const SUBMIT_USER_INVITE = "metabase/setup/SUBMIT_USER_INVITE";
 export const submitUserInvite = createAsyncThunk(
   SUBMIT_USER_INVITE,
-  (_: InviteInfo) => {
-    trackDatabaseStepCompleted();
-  },
+  (_: InviteInfo) => undefined,
 );
 
 export const SKIP_DATABASE = "metabase/setup/SKIP_DATABASE";
 export const skipDatabase = createAsyncThunk(
   SKIP_DATABASE,
   (engine?: string) => {
-    trackDatabaseStepCompleted();
     trackAddDataLaterClicked(engine);
   },
 );

--- a/frontend/src/metabase/setup/analytics.ts
+++ b/frontend/src/metabase/setup/analytics.ts
@@ -1,7 +1,7 @@
+import type { UsageReason } from "metabase-types/api";
 import { trackSchemaEvent } from "metabase/lib/analytics";
 
 const ONBOARDING_VERSION = "1.1.0";
-
 const SCHEMA_VERSION = "1-0-1";
 
 // TODO: make it accept {stepName, stepNumber} instead of just step
@@ -11,6 +11,14 @@ export const trackStepSeen = (step: any) => {
     version: "1.0.0",
     step: step, // TODO: will be fixed with the todo above
     step_number: step,
+  });
+};
+
+export const trackUsageReasonSelected = (usageReason: UsageReason) => {
+  trackSchemaEvent("setup", SCHEMA_VERSION, {
+    event: "usage_reason_selected",
+    version: ONBOARDING_VERSION,
+    usage_reason: usageReason,
   });
 };
 

--- a/frontend/src/metabase/setup/analytics.ts
+++ b/frontend/src/metabase/setup/analytics.ts
@@ -1,16 +1,22 @@
 import type { UsageReason } from "metabase-types/api";
 import { trackSchemaEvent } from "metabase/lib/analytics";
+import type { SetupStep } from "./types";
 
 const ONBOARDING_VERSION = "1.1.0";
 const SCHEMA_VERSION = "1-0-1";
 
-// TODO: make it accept {stepName, stepNumber} instead of just step
-export const trackStepSeen = (step: any) => {
+export const trackStepSeen = ({
+  stepName,
+  stepNumber,
+}: {
+  stepName: SetupStep;
+  stepNumber: number;
+}) => {
   trackSchemaEvent("setup", SCHEMA_VERSION, {
     event: "step_seen",
-    version: "1.0.0",
-    step: step, // TODO: will be fixed with the todo above
-    step_number: step,
+    version: ONBOARDING_VERSION,
+    step: stepName,
+    step_number: stepNumber,
   });
 };
 

--- a/frontend/src/metabase/setup/analytics.ts
+++ b/frontend/src/metabase/setup/analytics.ts
@@ -1,4 +1,4 @@
-import { trackSchemaEvent, trackStructEvent } from "metabase/lib/analytics";
+import { trackSchemaEvent } from "metabase/lib/analytics";
 
 const ONBOARDING_VERSION = "1.1.0";
 
@@ -37,32 +37,4 @@ export const trackTrackingChanged = (isTrackingAllowed: boolean) => {
       : "tracking_permission_disabled",
     source: "setup",
   });
-};
-
-export const trackWelcomeStepCompleted = () => {
-  trackStructEvent("Setup", "Welcome");
-};
-
-export const trackUserStepCompleted = () => {
-  trackStructEvent("Setup", "User Details Step");
-};
-
-export const trackDatabaseStepCompleted = (engine?: string) => {
-  trackStructEvent("Setup", "Database Step", engine);
-};
-
-export const trackPreferencesStepCompleted = (isTrackingAllowed: boolean) => {
-  trackStructEvent("Setup", "Preferences Step", isTrackingAllowed);
-};
-
-export const trackSetupCompleted = () => {
-  trackStructEvent("Setup", "Complete");
-};
-
-export const trackPasswordValidationError = () => {
-  trackStructEvent("Setup", "Error", "password validation");
-};
-
-export const trackDatabaseValidationError = (engine: string) => {
-  trackStructEvent("Setup", "Error", "database validation: " + engine);
 };

--- a/frontend/src/metabase/setup/analytics.ts
+++ b/frontend/src/metabase/setup/analytics.ts
@@ -3,7 +3,7 @@ import { trackSchemaEvent } from "metabase/lib/analytics";
 import type { SetupStep } from "./types";
 
 const ONBOARDING_VERSION = "1.1.0";
-const SCHEMA_VERSION = "1-0-1";
+const SCHEMA_VERSION = "1-0-2";
 
 export const trackStepSeen = ({
   stepName,

--- a/frontend/src/metabase/setup/analytics.ts
+++ b/frontend/src/metabase/setup/analytics.ts
@@ -1,8 +1,12 @@
 import { trackSchemaEvent, trackStructEvent } from "metabase/lib/analytics";
 
+const ONBOARDING_VERSION = "1.1.0";
+
+const SCHEMA_VERSION = "1-0-1";
+
 // TODO: make it accept {stepName, stepNumber} instead of just step
 export const trackStepSeen = (step: any) => {
-  trackSchemaEvent("setup", "1-0-1", {
+  trackSchemaEvent("setup", SCHEMA_VERSION, {
     event: "step_seen",
     version: "1.0.0",
     step: step, // TODO: will be fixed with the todo above
@@ -11,23 +15,23 @@ export const trackStepSeen = (step: any) => {
 };
 
 export const trackDatabaseSelected = (engine: string) => {
-  trackSchemaEvent("setup", "1-0-1", {
+  trackSchemaEvent("setup", SCHEMA_VERSION, {
     event: "database_selected",
-    version: "1.0.0",
+    version: ONBOARDING_VERSION,
     database: engine,
   });
 };
 
 export const trackAddDataLaterClicked = (engine?: string) => {
-  trackSchemaEvent("setup", "1-0-1", {
+  trackSchemaEvent("setup", SCHEMA_VERSION, {
     event: "add_data_later_clicked",
-    version: "1.0.0",
+    version: ONBOARDING_VERSION,
     source: engine ? "post_selection" : "pre_selection",
   });
 };
 
 export const trackTrackingChanged = (isTrackingAllowed: boolean) => {
-  trackSchemaEvent("settings", "1-0-1", {
+  trackSchemaEvent("settings", SCHEMA_VERSION, {
     event: isTrackingAllowed
       ? "tracking_permission_enabled"
       : "tracking_permission_disabled",

--- a/frontend/src/metabase/setup/components/Setup/Setup.tsx
+++ b/frontend/src/metabase/setup/components/Setup/Setup.tsx
@@ -2,18 +2,20 @@ import { useEffect } from "react";
 import { useUpdate } from "react-use";
 import { useSelector } from "metabase/lib/redux";
 import { trackStepSeen } from "../../analytics";
-import { getIsLocaleLoaded, getStep } from "../../selectors";
+import { getIsLocaleLoaded, getStep, getSteps } from "../../selectors";
 import { SettingsPage } from "../SettingsPage";
 import { WelcomePage } from "../WelcomePage";
 
 export const Setup = (): JSX.Element => {
   const step = useSelector(getStep);
+  const stepIndex = useSelector(getSteps).findIndex(({ key }) => key === step);
+
   const isLocaleLoaded = useSelector(getIsLocaleLoaded);
   const update = useUpdate();
 
   useEffect(() => {
-    trackStepSeen(step);
-  }, [step]);
+    trackStepSeen({ stepName: step, stepNumber: stepIndex });
+  }, [step, stepIndex]);
 
   useEffect(() => {
     if (isLocaleLoaded) {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-2
@@ -1,0 +1,88 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Setup flow",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "setup",
+    "format": "jsonschema",
+    "version": "1-0-1"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "step_seen",
+        "database_selected",
+        "add_data_later_clicked"
+      ],
+      "maxLength": 1024
+    },
+    "version": {
+      "description": "String describing the version of onboarding we're on",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "step": {
+      "description": "String describing the step that the set up step",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "welcome",
+        "language",
+        "user_info",
+        "db_connection",
+        "db_scheduling",
+        "data_usage",
+        "completed"
+      ],
+      "maxLength": 1024
+    },
+    "step_number": {
+      "description": "Integer describing the order of the referenced step",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "minimum": 0,
+      "maximum": 1024
+    },
+    "database": {
+      "description": "String with the database type that the user selected",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "source": {
+      "description": "String with the product location that the event took place",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "pre_selection",
+        "post_selection"
+      ],
+      "maxLength": 1024
+    }
+  },
+  "required": [
+    "event",
+    "version"
+  ],
+  "additionalProperties": true
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-2
@@ -14,6 +14,7 @@
       "type": "string",
       "enum": [
         "step_seen",
+        "usage_reason_selected",
         "database_selected",
         "add_data_later_clicked"
       ],
@@ -59,6 +60,20 @@
       ],
       "minimum": 0,
       "maximum": 1024
+    },
+    "usage_reason": {
+      "description": "Answer to the usage reason question",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "self-service-analytics",
+        "embedding",
+        "both",
+        "not-sure"
+      ],
+      "maxLength": 1024
     },
     "database": {
       "description": "String with the database type that the user selected",

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-2
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-2
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "setup",
     "format": "jsonschema",
-    "version": "1-0-1"
+    "version": "1-0-2"
   },
   "type": "object",
   "properties": {
@@ -35,6 +35,7 @@
         "language",
         "user_info",
         "db_connection",
+        "usage_question",
         "db_scheduling",
         "data_usage",
         "completed"


### PR DESCRIPTION
[[Epic] Meet embedders at the door - minimal edition](https://github.com/metabase/metabase/issues/38233)

### Description

This modifies the `trackStepSeen` function to accept both the step name and the step number, as the two are not linked anymore as we have conditional steps.

[slack thread about the above change](https://metaboat.slack.com/archives/C01MC2CKW2G/p1706719539434809), I'll also need to change the notion page for the event

It also adds a `trackUsageReasonSelected` function + event.

If read commit by commit it should be self describing, i made one commit to just copy the old schema to make it easier to see the changes.

I *think* that the new schema should be a patch update, as the new schema still accepts old events, but let me know if I got it wrong