### PR TITLE
[QC] Remove `hasAnyClauses` method from `StructuredQuery` prototype

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -315,10 +315,6 @@ class StructuredQuery extends AtomicQuery {
     return !!this.table();
   }
 
-  hasExpressions() {
-    return Object.keys(this.expressions()).length > 0;
-  }
-
   hasFilters() {
     return this.filters().length > 0;
   }

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -315,26 +315,6 @@ class StructuredQuery extends AtomicQuery {
     return !!this.table();
   }
 
-  hasAnyClauses() {
-    // this list should be kept in sync with BE in `metabase.models.card/model-supports-implicit-actions?`
-
-    const query = this.getMLv2Query();
-    const stageIndex = this.getQueryStageIndex();
-
-    const hasJoins = Lib.joins(query, stageIndex).length > 0;
-
-    return (
-      hasJoins ||
-      this.hasExpressions() ||
-      this.hasFilters() ||
-      this.hasAggregations() ||
-      this.hasBreakouts() ||
-      this._hasSorts() ||
-      this.hasLimit() ||
-      this._hasFields()
-    );
-  }
-
   hasExpressions() {
     return Object.keys(this.expressions()).length > 0;
   }

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -323,11 +323,6 @@ class StructuredQuery extends AtomicQuery {
     return this.breakouts().length > 0;
   }
 
-  hasLimit(stageIndex = this.queries().length - 1) {
-    const query = this.getMLv2Query();
-    return Lib.hasLimit(query, stageIndex);
-  }
-
   _hasFields() {
     return this.fields().length > 0;
   }

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -315,10 +315,6 @@ class StructuredQuery extends AtomicQuery {
     return !!this.table();
   }
 
-  hasFilters() {
-    return this.filters().length > 0;
-  }
-
   hasAggregations() {
     return this.aggregations().length > 0;
   }

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -777,10 +777,6 @@ class StructuredQuery extends AtomicQuery {
     return query;
   }
 
-  _indexOfField(fieldRef) {
-    return this.fields().findIndex(f => _.isEqual(f, fieldRef));
-  }
-
   // FIELDS
   fields() {
     // FIMXE: implement field functions in query lib

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -323,11 +323,6 @@ class StructuredQuery extends AtomicQuery {
     return this.breakouts().length > 0;
   }
 
-  _hasSorts() {
-    const query = this.getMLv2Query();
-    return Lib.orderBys(query).length > 0;
-  }
-
   hasLimit(stageIndex = this.queries().length - 1) {
     const query = this.getMLv2Query();
     return Lib.hasLimit(query, stageIndex);

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery-filters.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery-filters.unit.spec.js
@@ -16,18 +16,6 @@ const ordersTable = metadata.table(ORDERS_ID);
 const FILTER = ["=", ["field", ORDERS.TOTAL, null], 42];
 
 describe("StructuredQuery", () => {
-  describe("hasFilters", () => {
-    it("should return false for queries without filters", () => {
-      const q = ordersTable.legacyQuery({ useStructuredQuery: true });
-      expect(q.hasFilters()).toBe(false);
-    });
-    it("should return true for queries with filters", () => {
-      const q = ordersTable
-        .legacyQuery({ useStructuredQuery: true })
-        .filter(FILTER);
-      expect(q.hasFilters()).toBe(true);
-    });
-  });
   describe("filters", () => {
     it("should work as raw MBQL", () => {
       const q = ordersTable


### PR DESCRIPTION
This PR removes a lot of unused methods from the `StructuredQuery` prototype.

It starts by removing `hasAnyClauses` which hasn't been used anywhere, and then proceeds to remove (mostly internal) methods that were used by it.

The only "alien" in this list is `_indexOfField` method. It doesn't logically belong to this group, but it wasn't used literally anywhere so I just removed it.