### PR TITLE
Connection Impersonation UI for Redshift

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.unit.spec.tsx
@@ -115,6 +115,21 @@ describe("impersonation modal", () => {
     ).toHaveAttribute("href", "/admin/databases/1");
   });
 
+  it("should refer to 'users' instead of 'roles' for redshift impersonation", async () => {
+    await setup({ databaseDetails: { engine: "redshift" } });
+    expect(
+      await screen.findByText(
+        "Map a Metabase user attribute to database users",
+      ),
+    ).toBeInTheDocument();
+
+    expect(
+      await screen.findByText(
+        "When the person runs a query (including native queries), Metabase will impersonate the privileges of the database user you associate with the user attribute.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("should not update impersonation if it has not changed", async () => {
     const store = await setup({ userAttributes: ["foo"] });
 

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.styled.tsx
@@ -9,4 +9,5 @@ export const ImpersonationModalViewRoot = styled.div`
 
 export const ImpersonationDescription = styled.p`
   line-height: 1.4rem;
+  margin: 0.5rem 0;
 `;

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
@@ -70,11 +70,22 @@ export const ImpersonationModalView = ({
     database.features.includes("connection-impersonation-requires-role") &&
     database.details["role"] == null;
 
+  // for redshift, we impersonate using users, not roles
+  const impersonationUsesUsers = database.engine === "redshift";
+
+  const modalTitle = impersonationUsesUsers
+    ? t`Map a Metabase user attribute to database users`
+    : t`Map a user attribute to database roles`;
+
+  const modalMessage = impersonationUsesUsers
+    ? t`When the person runs a query (including native queries), Metabase will impersonate the privileges of the database user you associate with the user attribute.`
+    : t`When the person runs a query (including native queries), Metabase will impersonate the privileges of the database role you associate with the user attribute.`;
+
   return (
     <ImpersonationModalViewRoot>
-      <h2>{t`Map a user attribute to database roles`}</h2>
+      <h2>{modalTitle}</h2>
       <ImpersonationDescription>
-        {t`When the person runs a query (including native queries), Metabase will impersonate the privileges of the database role you associate with the user attribute.`}{" "}
+        {modalMessage}{" "}
         <ExternalLink
           className="link"
           // eslint-disable-next-line no-unconditional-metabase-links-render -- Admin settings

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { t } from "ttag";
+import { t, jt } from "ttag";
 import * as Yup from "yup";
 import FormSelect from "metabase/core/components/FormSelect";
 import { Form, FormProvider } from "metabase/forms";
@@ -8,6 +8,7 @@ import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 import MetabaseSettings from "metabase/lib/settings";
 import * as Errors from "metabase/lib/errors";
 import type { UserAttribute } from "metabase-types/api";
+import { BoldCode } from "metabase/components/Code";
 import Alert from "metabase/core/components/Alert";
 import FormFooter from "metabase/core/components/FormFooter";
 import Button from "metabase/core/components/Button";
@@ -81,6 +82,34 @@ export const ImpersonationModalView = ({
     ? t`When the person runs a query (including native queries), Metabase will impersonate the privileges of the database user you associate with the user attribute.`
     : t`When the person runs a query (including native queries), Metabase will impersonate the privileges of the database role you associate with the user attribute.`;
 
+  const modalExplanation = impersonationUsesUsers
+    ? jt`For example, you can add a user attribute called ${(
+        <BoldCode key="1" size={13}>
+          db_user
+        </BoldCode>
+      )} to people in this group. Whatever value you assign to this attribute (manually or via SSO) would be the database user Metabase would impersonate whenever that person queried your database. If the person's ${(
+        <BoldCode key="2" size={13}>
+          db_user
+        </BoldCode>
+      )} was set to ${(
+        <BoldCode key="3" size={13}>{t`Sales`}</BoldCode>
+      )}, Metabase would query the data as if it had the same privileges as the database user called ${(
+        <BoldCode key="4" size={13}>{t`Sales`}</BoldCode>
+      )}.`
+    : jt`For example, you can add a user attribute called ${(
+        <BoldCode key="1" size={13}>
+          db_role
+        </BoldCode>
+      )} to people in this group. Whatever value you assign to this attribute (manually or via SSO) would be the database user Metabase would impersonate whenever that person queried your database. If the person's ${(
+        <BoldCode key="2" size={13}>
+          db_role
+        </BoldCode>
+      )} was set to ${(
+        <BoldCode key="3" size={13}>{t`Sales`}</BoldCode>
+      )}, Metabase would query the data as if it had the same privileges as the database role called ${(
+        <BoldCode key="4" size={13}>{t`Sales`}</BoldCode>
+      )}.`;
+
   return (
     <ImpersonationModalViewRoot>
       <h2>{modalTitle}</h2>
@@ -92,7 +121,7 @@ export const ImpersonationModalView = ({
           href={MetabaseSettings.docsUrl("permissions/data")}
         >{t`Learn More`}</ExternalLink>
       </ImpersonationDescription>
-
+      <ImpersonationDescription>{modalExplanation}</ImpersonationDescription>
       {roleRequired ? (
         <>
           <Alert icon="warning" variant="warning">

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModalView.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { t, jt } from "ttag";
+import { t } from "ttag";
 import * as Yup from "yup";
 import FormSelect from "metabase/core/components/FormSelect";
 import { Form, FormProvider } from "metabase/forms";
@@ -8,7 +8,6 @@ import FormErrorMessage from "metabase/core/components/FormErrorMessage";
 import MetabaseSettings from "metabase/lib/settings";
 import * as Errors from "metabase/lib/errors";
 import type { UserAttribute } from "metabase-types/api";
-import { BoldCode } from "metabase/components/Code";
 import Alert from "metabase/core/components/Alert";
 import FormFooter from "metabase/core/components/FormFooter";
 import Button from "metabase/core/components/Button";
@@ -82,34 +81,6 @@ export const ImpersonationModalView = ({
     ? t`When the person runs a query (including native queries), Metabase will impersonate the privileges of the database user you associate with the user attribute.`
     : t`When the person runs a query (including native queries), Metabase will impersonate the privileges of the database role you associate with the user attribute.`;
 
-  const modalExplanation = impersonationUsesUsers
-    ? jt`For example, you can add a user attribute called ${(
-        <BoldCode key="1" size={13}>
-          db_user
-        </BoldCode>
-      )} to people in this group. Whatever value you assign to this attribute (manually or via SSO) would be the database user Metabase would impersonate whenever that person queried your database. If the person's ${(
-        <BoldCode key="2" size={13}>
-          db_user
-        </BoldCode>
-      )} was set to ${(
-        <BoldCode key="3" size={13}>{t`Sales`}</BoldCode>
-      )}, Metabase would query the data as if it had the same privileges as the database user called ${(
-        <BoldCode key="4" size={13}>{t`Sales`}</BoldCode>
-      )}.`
-    : jt`For example, you can add a user attribute called ${(
-        <BoldCode key="1" size={13}>
-          db_role
-        </BoldCode>
-      )} to people in this group. Whatever value you assign to this attribute (manually or via SSO) would be the database user Metabase would impersonate whenever that person queried your database. If the person's ${(
-        <BoldCode key="2" size={13}>
-          db_role
-        </BoldCode>
-      )} was set to ${(
-        <BoldCode key="3" size={13}>{t`Sales`}</BoldCode>
-      )}, Metabase would query the data as if it had the same privileges as the database role called ${(
-        <BoldCode key="4" size={13}>{t`Sales`}</BoldCode>
-      )}.`;
-
   return (
     <ImpersonationModalViewRoot>
       <h2>{modalTitle}</h2>
@@ -121,7 +92,6 @@ export const ImpersonationModalView = ({
           href={MetabaseSettings.docsUrl("permissions/data")}
         >{t`Learn More`}</ExternalLink>
       </ImpersonationDescription>
-      <ImpersonationDescription>{modalExplanation}</ImpersonationDescription>
       {roleRequired ? (
         <>
           <Alert icon="warning" variant="warning">

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationWarning/ImpersonationWarning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationWarning/ImpersonationWarning.tsx
@@ -1,5 +1,5 @@
-import { t } from "ttag";
-
+import { t, jt } from "ttag";
+import { BoldCode } from "metabase/components/Code";
 import * as Urls from "metabase/lib/urls";
 import Link from "metabase/core/components/Link";
 import { isEmpty } from "metabase/lib/validate";
@@ -17,7 +17,23 @@ export const ImpersonationWarning = ({
 
   const text = isEmpty(databaseUser)
     ? t`Make sure the main database credential has access to everything different user groups may need access to. It's what Metabase uses to sync table information.`
-    : t`${databaseUser} is the database user Metabase is using to connect to ${database.name}. Make sure that ${database.details.user} has access to everything in ${database.name} that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information.`;
+    : jt`${(
+        <BoldCode key="1" size={13}>
+          {databaseUser}
+        </BoldCode>
+      )} is the database user Metabase is using to connect to your  ${(
+        <BoldCode key="2" size={13}>
+          {database.name}
+        </BoldCode>
+      )} database. Make sure that ${(
+        <BoldCode key="3" size={13}>
+          {database.details.user}
+        </BoldCode>
+      )} has access to everything in ${(
+        <BoldCode key="4" size={13}>
+          {database.name}
+        </BoldCode>
+      )} that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information.`;
 
   return (
     <ImpersonationAlert icon="warning" variant="warning">

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationWarning/ImpersonationWarning.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationWarning/ImpersonationWarning.tsx
@@ -14,30 +14,47 @@ export const ImpersonationWarning = ({
   database,
 }: ImpersonationWarningProps) => {
   const databaseUser = database.details.user;
+  const isRedshift = database.engine === "redshift";
 
-  const text = isEmpty(databaseUser)
-    ? t`Make sure the main database credential has access to everything different user groups may need access to. It's what Metabase uses to sync table information.`
-    : jt`${(
-        <BoldCode key="1" size={13}>
-          {databaseUser}
-        </BoldCode>
-      )} is the database user Metabase is using to connect to your  ${(
-        <BoldCode key="2" size={13}>
-          {database.name}
-        </BoldCode>
-      )} database. Make sure that ${(
-        <BoldCode key="3" size={13}>
-          {database.details.user}
-        </BoldCode>
-      )} has access to everything in ${(
-        <BoldCode key="4" size={13}>
-          {database.name}
-        </BoldCode>
-      )} that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information.`;
+  const emptyText = t`Make sure the main database credential has access to everything different user groups may need access to. It's what Metabase uses to sync table information.`;
+
+  const redshiftWarning = jt`You’re connecting Metabase to the ${(
+    <BoldCode key="2" size={13}>
+      {database.name}
+    </BoldCode>
+  )} database using the credentials for the Redshift user ${(
+    <BoldCode key="3" size={13}>
+      {databaseUser}
+    </BoldCode>
+  )}. For impersonation to work,  ${(
+    <BoldCode key="3" size={13}>
+      {databaseUser}
+    </BoldCode>
+  )} must be a superuser in Redshift.`;
+
+  const regularWarning = jt`${(
+    <BoldCode key="1" size={13}>
+      {databaseUser}
+    </BoldCode>
+  )} is the database user Metabase is using to connect to your  ${(
+    <BoldCode key="2" size={13}>
+      {database.name}
+    </BoldCode>
+  )} database. Make sure that ${(
+    <BoldCode key="3" size={13}>
+      {databaseUser}
+    </BoldCode>
+  )} has access to everything in ${(
+    <BoldCode key="4" size={13}>
+      {database.name}
+    </BoldCode>
+  )} that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information.`;
+
+  const warningText = isRedshift ? redshiftWarning : regularWarning;
 
   return (
     <ImpersonationAlert icon="warning" variant="warning">
-      {text}{" "}
+      {isEmpty(databaseUser) ? emptyText : warningText}{" "}
       <Link
         className="link"
         to={Urls.editDatabase(database.id) + (databaseUser ? "#user" : "")}

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationWarning/ImpersonationWarning.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationWarning/ImpersonationWarning.unit.spec.tsx
@@ -49,7 +49,7 @@ describe("ImpersonationWarning", () => {
 
     expect(
       screen.getByText(
-        "metabase_user is the database user Metabase is using to connect to My Database. Make sure that metabase_user has access to everything in My Database that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information.",
+        /that all Metabase groups may need access to, as that database user account is what Metabase uses to sync table information./i,
       ),
     ).toBeInTheDocument();
 

--- a/frontend/src/metabase/components/Code/Code.jsx
+++ b/frontend/src/metabase/components/Code/Code.jsx
@@ -1,6 +1,13 @@
 /* eslint "react/prop-types": "warn" */
 import { Fragment } from "react";
 import PropTypes from "prop-types";
+import { Text } from "metabase/ui";
+
+export const BoldCode = ({ children, ...props }) => (
+  <Text fw="bold" color="brand" component="span" {...props}>
+    <code>{children}</code>
+  </Text>
+);
 
 const Code = ({ children, block }) => {
   if (block) {
@@ -21,6 +28,10 @@ const Code = ({ children, block }) => {
   } else {
     return <span className="text-code">{children}</span>;
   }
+};
+
+BoldCode.propTypes = {
+  children: PropTypes.any.isRequired,
 };
 
 Code.propTypes = {

--- a/frontend/src/metabase/components/Code/index.jsx
+++ b/frontend/src/metabase/components/Code/index.jsx
@@ -1,1 +1,2 @@
 export { default } from "./Code";
+export * from "./Code";


### PR DESCRIPTION
frontend for https://github.com/metabase/metabase/issues/38445

### Description

Our impersonation for redshift uses "users" rather than "roles" this updates the copy to reflect that.

Postgres | Redshift
--- | ---
![Screen Shot 2024-02-09 at 1 22 37 PM](https://github.com/metabase/metabase/assets/30528226/bc2bfd55-141f-4c0f-9c1b-979f9ad2446b) | ![Screen Shot 2024-02-09 at 1 22 24 PM](https://github.com/metabase/metabase/assets/30528226/06d13f74-9eb6-44a3-afd8-2396dd341afe)



### How to verify

a) run the unit test 😁
b) connect a redshift db and see that it changes the copy


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
