### PR TITLE
Fix CI failure on master due to selector changes

### DIFF
--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 import _ from "underscore";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Stack, Tabs } from "metabase/ui";
 import { useSelector } from "metabase/lib/redux";
 import { getSetting } from "metabase/selectors/settings";
@@ -73,14 +73,29 @@ export const StaticEmbedSetupPane = ({
     DEFAULT_DISPLAY_OPTIONS,
   );
 
+  /**
+   * This is a hack to prevent `getParameter` return value from
+   * causing the preview embed to rerender unnecessarily in tests.
+   *
+   * This will likely be safe to removed once (metabase#38502)
+   * is implemented.
+   */
+  const [memoizedResourceParameters, setMemoizedResourceParameters] =
+    useState(resourceParameters);
+  useEffect(() => {
+    if (!_.isEqual(memoizedResourceParameters, resourceParameters)) {
+      setMemoizedResourceParameters(resourceParameters);
+    }
+  }, [memoizedResourceParameters, resourceParameters]);
+
   const previewParametersBySlug = useMemo(
     () =>
       getPreviewParamsBySlug({
-        resourceParameters,
+        resourceParameters: memoizedResourceParameters,
         embeddingParams,
         parameterValues,
       }),
-    [embeddingParams, parameterValues, resourceParameters],
+    [embeddingParams, memoizedResourceParameters, parameterValues],
   );
   const initialPreviewParameters = getPreviewParamsBySlug({
     resourceParameters,


### PR DESCRIPTION
Related to #38502
Likely caused by #38425

### Description

`getParameters` now return a new reference despite having thet same value.

The fix is temporary by introducing another cache layer in embedding modal to deep compare the value of `parameters` instead of relying on the reference change alone.

### How to verify

Run tests in `e2e/test/scenarios/embedding/reproductions/37914-embed-preview-parameter-values-not-working.cy.spec.js` and it should pass.

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
