### PR TITLE
Ignore REVOKE commands when processing mysql grants

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -789,6 +789,9 @@
     :roles #{'example_role_1'@'%' 'example_role_2'@'%'}}"
   [grant]
   (condp re-find grant
+    ;; Typically these statements are used to revoke mutation rights, and for now we ignore them.
+    #"^REVOKE "
+    nil
     #"^GRANT PROXY ON "
     nil
     #"^GRANT (.+) ON FUNCTION "
@@ -823,7 +826,10 @@
     :>>
     (fn [[_ roles]]
       {:type  :roles
-       :roles (set (map u/lower-case-en (str/split roles #",")))})))
+       :roles (set (map u/lower-case-en (str/split roles #",")))})
+
+    (do (log/warnf "Ignoring grant with unrecognised pattern: %s" grant)
+        nil)))
 
 (defn- privilege-grants-for-user
   "Returns a list of parsed privilege grants for a user, taking into account the roles that the user has.

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -658,7 +658,11 @@
     (is (= {:type  :roles
             :roles #{"`example_role`@`%`" "`example_role_2`@`%`"}}
            (#'mysql/parse-grant "GRANT `example_role`@`%`,`example_role_2`@`%` TO 'metabase'@'localhost'")))
-    (is (nil? (#'mysql/parse-grant "GRANT PROXY ON 'metabase'@'localhost' TO 'metabase'@'localhost' WITH GRANT OPTION")))))
+    (is (nil? (#'mysql/parse-grant "GRANT PROXY ON 'metabase'@'localhost' TO 'metabase'@'localhost' WITH GRANT OPTION")))
+    (is (nil? (#'mysql/parse-grant "REVOKE INSERT, UPDATE, DELETE, CREATE, DROP, REFERENCES, INDEX, ALTER, CREATE
+                                    TEMPORARY TABLES, LOCK TABLES, EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE,
+                                    ALTER ROUTINE, EVENT, TRIGGER ON \"metrics_user_telegraf\".* FROM \"doadmin\"@\"%\"")))
+    (is (nil? (#'mysql/parse-grant "BEWILDER WITH BLEEDING EDGE GRANT STATEMENT FORMAT")))))
 
 (deftest table-name->privileges-test
   (testing "table-names->privileges should work correctly"


### PR DESCRIPTION
References https://github.com/metabase/metabase/issues/38499

### Description

A customer is experiencing a "hang" in the database sync process due to an exception being thrown while parsing the database grants.

Neither this area of the driver, nor any related Java dependencies, have changed since v0.48.3, so I cannot explain the customer was not seeing the same issue when connecting to the same database before.

This change adds a clause to explicitly ignore the relevant grant expression from the bug report, and also adds a catch-all case to "fail open" with a warning on any expressions we do not recognize in future.