### PR TITLE
Fix card query endpoint usage on dashboards

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/duplicate-dashcards-tabs.cy.spec.js
@@ -118,6 +118,11 @@ describeWithSnowplow("scenarios > dashboard cards > duplicate", () => {
 
     duplicateTab("Tab 1");
     expectGoodSnowplowEvent(EVENTS.duplicateTab);
+    getDashboardCard().within(() => {
+      cy.findByText("Products").should("exist");
+      cy.findByText("Category").should("exist");
+      cy.findByText(/(Problem|Error)/i).should("not.exist");
+    });
     saveDashboard();
     expectGoodSnowplowEvent(EVENTS.saveDashboard);
 

--- a/e2e/test/scenarios/dashboard-filters/reproductions/38245-negative-dashcard-id-switching-tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/38245-negative-dashcard-id-switching-tabs.cy.spec.js
@@ -3,8 +3,8 @@ import {
   getDashboardCard,
   goToTab,
   openQuestionsSidebar,
-  popover,
   restore,
+  selectDashboardFilter,
   sidebar,
   visitDashboard,
 } from "e2e/support/helpers";
@@ -26,7 +26,7 @@ const DASHBOARD_TEXT_FILTER = {
   type: "string/contains",
 };
 
-describe.skip("issue 38245", () => {
+describe("issue 38245", () => {
   beforeEach(() => {
     cy.intercept("POST", "/api/card/*/query").as("cardQuery");
     restore();
@@ -47,24 +47,21 @@ describe.skip("issue 38245", () => {
 
     cy.wait("@cardQuery");
 
-    cy.findByTestId("edit-dashboard-parameters-widget-container")
-      .findByText(DASHBOARD_TEXT_FILTER.name)
-      .click();
-
-    getDashboardCard().within(() => {
-      cy.findByText("Column to filter on");
-      cy.findByText("Select…").click();
-    });
-
-    popover().findByText("Source").click();
+    mapDashCardToFilter(
+      getDashboardCard(),
+      DASHBOARD_TEXT_FILTER.name,
+      "Source",
+    );
 
     goToTab(TAB_2.name);
     goToTab(TAB_1.name);
 
-    cy.log("cardQuery with not saved parameters leads to 500 response");
-    cy.wait("@cardQuery");
-
-    cy.get("@cardQuery.all").should("have.length", 2);
+    getDashboardCard().within(() => {
+      cy.findByText("Orders").should("exist");
+      cy.findByText("Product ID").should("exist");
+      cy.findByText(/(Problem|Error)/i).should("not.exist");
+    });
+    cy.get("@cardQuery.all").should("have.length", 1);
     cy.get("@cardQuery").should(({ response }) => {
       expect(response.statusCode).not.to.eq(500);
     });
@@ -79,4 +76,14 @@ function createDashboardWithTabs({ dashcards, tabs, ...dashboardDetails }) {
       tabs,
     }).then(({ body: dashboard }) => cy.wrap(dashboard));
   });
+}
+
+function filterPanel() {
+  return cy.findByTestId("edit-dashboard-parameters-widget-container");
+}
+
+function mapDashCardToFilter(dashcardElement, filterName, columnName) {
+  filterPanel().findByText(filterName).click();
+  selectDashboardFilter(dashcardElement, columnName);
+  sidebar().button("Done").click();
 }

--- a/e2e/test/scenarios/dashboard-filters/reproductions/38245-negative-dashcard-id-switching-tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/38245-negative-dashcard-id-switching-tabs.cy.spec.js
@@ -61,7 +61,8 @@ describe("issue 38245", () => {
       cy.findByText("Product ID").should("exist");
       cy.findByText(/(Problem|Error)/i).should("not.exist");
     });
-    cy.get("@cardQuery.all").should("have.length", 1);
+
+    cy.get("@cardQuery.all").should("have.length", 2);
     cy.get("@cardQuery").should(({ response }) => {
       expect(response.statusCode).not.to.eq(500);
     });

--- a/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
+++ b/frontend/src/metabase/dashboard/actions/cards.unit.spec.ts
@@ -249,12 +249,7 @@ describe("dashboard/actions/cards", () => {
       // It's important to ensure the `/card/:id/query` endpoint is called
       // Regular dashcard query endpoint won't work with a new `card_id`
       expect(cardQueryEndpointSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          dashboardId: DASHBOARD.id,
-          dashcardId: TABLE_DASHCARD.id,
-          cardId: ORDERS_LINE_CHART_CARD.id,
-          parameters: [],
-        }),
+        { cardId: ORDERS_LINE_CHART_CARD.id },
         expect.anything(), // abort signal
       );
     });

--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -447,26 +447,29 @@ export const fetchCardData = createThunkAction(
           dashcardBeforeEditing &&
           dashcardBeforeEditing.card_id !== dashcard.card_id;
 
-        // new dashcards and new additional series cards aren't yet saved to the dashboard, so they need to be run using the card query endpoint
-        const endpoint =
+        const shouldUseCardQueryEndpoint =
           isNewDashcard(dashcard) ||
           isNewAdditionalSeriesCard(card, dashcard) ||
-          hasReplacedCard
-            ? CardApi.query
-            : DashboardApi.cardQuery;
+          hasReplacedCard;
 
-        result = await fetchDataOrError(
-          maybeUsePivotEndpoint(endpoint, card)(
-            {
+        // new dashcards and new additional series cards aren't yet saved to the dashboard, so they need to be run using the card query endpoint
+        const endpoint = shouldUseCardQueryEndpoint
+          ? CardApi.query
+          : DashboardApi.cardQuery;
+
+        const requestBody = shouldUseCardQueryEndpoint
+          ? { cardId: card.id, ignore_cache: ignoreCache }
+          : {
               dashboardId: dashcard.dashboard_id,
               dashcardId: dashcard.id,
               cardId: card.id,
               parameters: datasetQuery.parameters,
               ignore_cache: ignoreCache,
               dashboard_id: dashcard.dashboard_id,
-            },
-            queryOptions,
-          ),
+            };
+
+        result = await fetchDataOrError(
+          maybeUsePivotEndpoint(endpoint, card)(requestBody, queryOptions),
         );
       }
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -367,18 +367,23 @@ function DashboardInner(props: DashboardProps) {
       });
       return;
     }
+
+    if (isEditing) {
+      return; // no refetching in edit mode
+    }
+
     if (previousTabId !== selectedTabId) {
-      if (!isEditing) {
-        fetchDashboardCardData();
-        fetchDashboardCardMetadata();
-      }
+      fetchDashboardCardData();
+      fetchDashboardCardMetadata();
       return;
     }
+
     const didDashboardLoad = !previousDashboard && dashboard;
     const didParameterValuesChange = !_.isEqual(
       previousParameterValues,
       parameterValues,
     );
+
     if (didDashboardLoad || didParameterValuesChange) {
       fetchDashboardCardData({ reload: false, clearCache: true });
     }

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -367,30 +367,22 @@ function DashboardInner(props: DashboardProps) {
       });
       return;
     }
-
-    if (isEditing) {
-      return; // no refetching in edit mode
-    }
-
     if (previousTabId !== selectedTabId) {
       fetchDashboardCardData();
       fetchDashboardCardMetadata();
       return;
     }
-
     const didDashboardLoad = !previousDashboard && dashboard;
     const didParameterValuesChange = !_.isEqual(
       previousParameterValues,
       parameterValues,
     );
-
     if (didDashboardLoad || didParameterValuesChange) {
       fetchDashboardCardData({ reload: false, clearCache: true });
     }
   }, [
     dashboard,
     dashboardId,
-    isEditing,
     fetchDashboardCardData,
     fetchDashboardCardMetadata,
     handleLoadDashboard,

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -368,8 +368,10 @@ function DashboardInner(props: DashboardProps) {
       return;
     }
     if (previousTabId !== selectedTabId) {
-      fetchDashboardCardData();
-      fetchDashboardCardMetadata();
+      if (!isEditing) {
+        fetchDashboardCardData();
+        fetchDashboardCardMetadata();
+      }
       return;
     }
     const didDashboardLoad = !previousDashboard && dashboard;
@@ -383,6 +385,7 @@ function DashboardInner(props: DashboardProps) {
   }, [
     dashboard,
     dashboardId,
+    isEditing,
     fetchDashboardCardData,
     fetchDashboardCardMetadata,
     handleLoadDashboard,


### PR DESCRIPTION
Fixes #38245 

Fixes an issue around dashcard data fetching with two main scenarios:

1. Dashboard with filters and cards > edit > duplicate tab > all cards mapped to a parameter error out
2. Dashboard with filters > edit > add card > map to filter > change tab > go back > new card errors out

[Switching to another tab refetches questions on the tab](https://github.com/metabase/metabase/blob/43c1895afa40833e97e7cea7113588449c869301/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx#L371). New dashboard cards don't have an ID yet, so [we're using a `POST /api/card/:id/query` for them](https://github.com/metabase/metabase/blob/c141463eadc9a33cdbdb90421268414a18ed15d9/frontend/src/metabase/dashboard/actions/data-fetching.js#L451). We're also passing the same [request body](https://github.com/metabase/metabase/blob/c141463eadc9a33cdbdb90421268414a18ed15d9/frontend/src/metabase/dashboard/actions/data-fetching.js#L460) we normally use for the daschard query endpoint (`POST /api/dashboard/:id/dashcard/:id/card/:id/query`), including `parameters`. But `POST /api/card/:id/query` endpoint is using `parameters` only for the native query editor, so here it's erroring out.

Fixed by excluding irrelevant parameters from `POST /api/card/:id/query` request body. As a side note, it doesn't make sense to reload these cards while in edit mode, but it's not a simple change with our data fetching mechanism for now

### To verify

1. Open a dashboard with a few filters and dashcards
2. Enter the editing mode and duplicate a dashboard tab
3. Ensure nothing is erroring out

### Demo

**Before**

https://github.com/metabase/metabase/assets/17258145/a9e742bf-2ffe-4b58-84ae-6b1338d8ca1c


**After**

https://github.com/metabase/metabase/assets/17258145/51b0d5b2-1476-43ce-9822-09f6eead4266
