### PR TITLE
Avoid unnecessary re-renderings in because of getQuestions selector

### DIFF
--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
@@ -1,4 +1,3 @@
-import _ from "underscore";
 import type { Dashboard } from "metabase-types/api";
 import type { EmbedOptions } from "metabase-types/store";
 import { useDispatch, useSelector } from "metabase/lib/redux";

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
@@ -1,3 +1,4 @@
+import _ from "underscore";
 import type { Dashboard } from "metabase-types/api";
 import type { EmbedOptions } from "metabase-types/store";
 import { useDispatch, useSelector } from "metabase/lib/redux";
@@ -27,7 +28,9 @@ export const DashboardSharingEmbeddingModal = (
 ) => {
   const { className, dashboard, isOpen, onClose } = props;
 
-  const parameters = useSelector(getParameters);
+  // TODO: _.isEqual is added to avoid unnecessary re-renderings
+  // should be safe to remove when (metabase#38502) is completed
+  const parameters = useSelector(getParameters, _.isEqual);
 
   const dispatch = useDispatch();
 

--- a/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardSharingEmbeddingModal/DashboardSharingEmbeddingModal.tsx
@@ -28,9 +28,7 @@ export const DashboardSharingEmbeddingModal = (
 ) => {
   const { className, dashboard, isOpen, onClose } = props;
 
-  // TODO: _.isEqual is added to avoid unnecessary re-renderings
-  // should be safe to remove when (metabase#38502) is completed
-  const parameters = useSelector(getParameters, _.isEqual);
+  const parameters = useSelector(getParameters);
 
   const dispatch = useDispatch();
 

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -363,7 +363,7 @@ export const getMissingRequiredParameters = createSelector(
 );
 
 /**
- * It's a memoized version, it uses LRU cache per dashboard identified by id
+ * It's a memoized version, it uses LRU cache per card identified by id
  */
 export const getQuestionByCard = createCachedSelector(
   [(_state: State, props: { card: Card }) => props.card, getMetadata],

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -1,6 +1,7 @@
 import _ from "underscore";
 import { createSelector } from "@reduxjs/toolkit";
 import { createCachedSelector } from "re-reselect";
+import { createSelectorCreator, lruMemoize } from "reselect";
 
 import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
 import { getMetadata } from "metabase/selectors/metadata";
@@ -43,6 +44,8 @@ function isEditParameterSidebar(
 ): sidebar is EditParameterSidebarState {
   return sidebar.name === SIDEBAR_NAME.editParameter;
 }
+
+const createDeepEqualSelector = createSelectorCreator(lruMemoize, _.isEqual);
 
 export const getDashboardBeforeEditing = (state: State) =>
   state.dashboard.isEditing;
@@ -336,8 +339,17 @@ export const getQuestions = (state: State) => {
   return questionsById;
 };
 
+// getQuestions selector returns an array with stable references to the questions
+// but array itself is always new, so it may cause troubles in re-renderings
+const getQuestionsMemoized = createDeepEqualSelector(
+  [getQuestions],
+  questions => {
+    return questions;
+  },
+);
+
 export const getParameters = createSelector(
-  [getDashboardComplete, getMetadata, getQuestions],
+  [getDashboardComplete, getMetadata, getQuestionsMemoized],
   (dashboard, metadata, questions) => {
     if (!dashboard || !metadata) {
       return [];

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "regenerator-runtime": "^0.14.1",
     "rehype-external-links": "^2.0.1",
     "remark-gfm": "1.0.0",
+    "reselect": "^5.1.0",
     "screenfull": "^4.2.1",
     "server-text-width": "^1.0.2",
     "simple-statistics": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19133,6 +19133,11 @@ reselect@^4.1.7:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.7.tgz#56480d9ff3d3188970ee2b76527bd94a95567a42"
   integrity sha512-Zu1xbUt3/OPwsXL46hvOOoQrap2azE7ZQbokq61BQfiXvhewsKDwhMeZjTX9sX0nvw1t/U5Audyn1I9P/m9z0A==
 
+reselect@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.0.tgz#c479139ab9dd91be4d9c764a7f3868210ef8cd21"
+  integrity sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg==
+
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz#0e9020dd3d21024458d4ebd27e23e40269810464"


### PR DESCRIPTION
### Description

`getParameters` selector depends on `getQuestions`, which returns a new object for every update.

deep equality selector solves the problem with `getParameters` unnecessary re-calculations and re-renderings of components which use `getParameters` with `useSelector`.

[stress test run](https://github.com/metabase/metabase/actions/runs/7830252277)

### How to verify

tests should pass

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
