### PR TITLE
Partially revert 'Remove N+1 in sync'

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -26,10 +26,6 @@ title: Driver interface changelog
   `metabase.driver.sql.query-processor/honey-sql-version` is now deprecated and no longer called. All drivers are
   assumed to use Honey SQL 2.
 
-- The method `metabase.driver.sql-jdbc.sync.interface/active-tables` that we added in 47 has been updated to require
-  an additional argument: `database`.
-  The new function arglist is `[driver database connection schema-inclusion-filters schema-exclusion-filters]`.
-
 - The method `metabase.driver.sql.parameters.substitution/align-temporal-unit-with-param-type` is now deprecated.
   Use `metabase.driver.sql.parameters.substitution/align-temporal-unit-with-param-type-and-value` instead,
   which has access to `value` and therefore provides more flexibility for choosing the right conversion unit.

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -61,7 +61,8 @@
                               :datetime-diff            true
                               :now                      true
                               :persist-models           true
-                              :table-privileges         true
+                              ;; disabled for now, pending investigation into some issues
+                              :table-privileges         false
                               :schemas                  true
                               :connection-impersonation true
                               :uploads                  true}]

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -122,6 +122,7 @@
               [schema table]))
        set))
 
+#_{:clj-kondo/ignore [:unused-private-var]}
 (defn- have-select-privilege-fn
   "Returns a function that take a map with 3 keys [:schema, :name, :type], return true if we can do a select query on the table.
 
@@ -180,7 +181,7 @@
    (db-tables driver (.getMetaData conn) nil db-name-or-nil)))
 
 (defn- db-or-id-or-spec->database [db-or-id-or-spec]
-  (cond (mi/instance-of? Database db-or-id-or-spec)
+  (cond (mi/instance-of? :model/Database db-or-id-or-spec)
         db-or-id-or-spec
 
         (int? db-or-id-or-spec)

--- a/src/metabase/driver/sql_jdbc/sync/describe_database.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_database.clj
@@ -159,7 +159,8 @@
      (comp (mapcat (fn [schema]
                      (db-tables driver metadata schema db-name-or-nil)))
            (filter (fn [{table-schema :schema table-name :name}]
-                     (sql-jdbc.sync.interface/have-select-privilege? driver conn table-schema table-name))))
+                     (sql-jdbc.sync.interface/have-select-privilege? driver conn table-schema table-name)))
+           (map #(dissoc % :type)))
      (sql-jdbc.sync.interface/filtered-syncable-schemas driver conn metadata
                                                         schema-inclusion-filters schema-exclusion-filters))))
 

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -9,9 +9,7 @@
 
   Two different implementations are provided in this namespace: `fast-active-tables` (the default), and
   `post-filtered-active-tables`. You should be fine using the default, but refer to the documentation for those
-  functions for more details on the differences.
-
-  `metabase` is an instance of `DatabaseMetaData`."
+  functions for more details on the differences."
   {:added "0.37.1"
    :arglists '([driver
                 ^java.sql.Connection connection

--- a/src/metabase/driver/sql_jdbc/sync/interface.clj
+++ b/src/metabase/driver/sql_jdbc/sync/interface.clj
@@ -9,10 +9,11 @@
 
   Two different implementations are provided in this namespace: `fast-active-tables` (the default), and
   `post-filtered-active-tables`. You should be fine using the default, but refer to the documentation for those
-  functions for more details on the differences."
+  functions for more details on the differences.
+
+  `metabase` is an instance of `DatabaseMetaData`."
   {:added "0.37.1"
    :arglists '([driver
-                database
                 ^java.sql.Connection connection
                 ^String schema-inclusion-filters
                 ^String schema-exclusion-filters])}

--- a/src/metabase/sync/sync_metadata/sync_table_privileges.clj
+++ b/src/metabase/sync/sync_metadata/sync_table_privileges.clj
@@ -15,8 +15,7 @@
   [database :- (mi/InstanceOf :model/Database)]
   (let [driver (driver.u/database->driver database)]
     (when (and (not= :redshift driver)
-               ;; redshift does support table-privileges, but we don't want to sync it now because table privileges are
-               ;; meant to enhance action features, but redshift does not support actions for now, so we skip it here.
+               ;; redshift does not support actions yet, so there is no reason to run table-privileges for now
                (driver/database-supports? driver :table-privileges database))
       (let [rows               (driver/current-user-table-privileges driver database)
             schema+table->id   (t2/select-fn->pk (fn [t] {:schema (:schema t), :table (:name t)}) :model/Table :db_id (:id database))

--- a/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_database_test.clj
@@ -59,7 +59,7 @@
           (fn [^java.sql.Connection conn]
             ;; We have to mock this to make it work with all DBs
             (with-redefs [sql-jdbc.describe-database/all-schemas (constantly #{"PUBLIC"})]
-              (->> (into [] (sql-jdbc.describe-database/fast-active-tables (or driver/*driver* :h2) (mt/db) conn nil nil))
+              (->> (into [] (sql-jdbc.describe-database/fast-active-tables (or driver/*driver* :h2) conn nil nil))
                    (map :name)
                    sort)))))))
 
@@ -70,7 +70,7 @@
           (mt/db)
           nil
           (fn [^java.sql.Connection conn]
-            (->> (into [] (sql-jdbc.describe-database/post-filtered-active-tables :h2 (mt/db) conn nil nil))
+            (->> (into [] (sql-jdbc.describe-database/post-filtered-active-tables :h2 conn nil nil))
                  (map :name)
                  sort))))))
 
@@ -104,8 +104,8 @@
        driver
        db
        nil
-       (fn [_conn]
-         (sql-jdbc.describe-database/describe-database driver db)
+       (fn [conn]
+         (sql-jdbc.describe-database/describe-database driver {:connection conn})
          (reduce + (for [^ResultSet rs @resultsets]
                      (if (.isClosed rs) 0 1))))))))
 


### PR DESCRIPTION
Refences:
- https://github.com/metabase/metabase/issues/38509
- https://github.com/metabase/metabase/issues/38499

### Description

This PR reverts some components of https://github.com/metabase/metabase/pull/37439/

1. We rollback the breaking changes `metabase.driver.sql-jdbc.sync.interface/active-tables` which added a new argument. We will need to maintain backwards compatibility for 3 releases, so will need to introduce a new multi-method instead.
2. We remove the select privileges check from those methods, which required the breaking change, and which we believe is responsible for the two issues linked above.
3. We disable `:table-privileges`for Redshift for now, but leave the queries.