### PR TITLE
[QC] Remove `setDatabase` and `setDatabaseID` methods

### DIFF
--- a/frontend/src/metabase-lib/queries/NativeQuery.ts
+++ b/frontend/src/metabase-lib/queries/NativeQuery.ts
@@ -153,13 +153,6 @@ export default class NativeQuery extends AtomicQuery {
 
   /* Methods unique to this query type */
 
-  /**
-   * @returns a new query with the provided Database set.
-   */
-  setDatabase(database: Database): NativeQuery {
-    return this.setDatabaseId(database.id);
-  }
-
   setDatabaseId(databaseId: DatabaseId): NativeQuery {
     if (databaseId !== this._databaseId()) {
       // TODO: this should reset the rest of the query?

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -197,13 +197,6 @@ class StructuredQuery extends AtomicQuery {
   }
 
   /**
-   * @returns a new query with the provided Database set.
-   */
-  setDatabase(database: Database): StructuredQuery {
-    return this.setDatabaseId(database.id);
-  }
-
-  /**
    * @returns the table ID, if a table is selected.
    * @deprecated Use MLv2
    */

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -204,24 +204,6 @@ class StructuredQuery extends AtomicQuery {
   }
 
   /**
-   * @returns a new query with the provided Database ID set.
-   */
-  setDatabaseId(databaseId: DatabaseId): StructuredQuery {
-    if (databaseId !== this._databaseId()) {
-      // TODO: this should reset the rest of the query?
-      return new StructuredQuery(
-        this._originalQuestion,
-        chain(this.datasetQuery())
-          .assoc("database", databaseId)
-          .assoc("query", {})
-          .value(),
-      );
-    } else {
-      return this;
-    }
-  }
-
-  /**
    * @returns the table ID, if a table is selected.
    * @deprecated Use MLv2
    */

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -1,3 +1,4 @@
+import { chain } from "icepick";
 import { createMockMetadata } from "__support__/metadata";
 import {
   createMockDatabase,
@@ -277,9 +278,15 @@ describe("StructuredQuery", () => {
 
       describe("when the query is missing a database", () => {
         it("should not include db schemas in dependent  metadata", () => {
-          const dependentMetadata = query
-            .setDatabaseId(null)
-            .dependentMetadata();
+          const queryWithoutDatabase = new StructuredQuery(
+            query._originalQuestion,
+            chain(query.datasetQuery())
+              .assoc("database", null)
+              .assoc("query", {})
+              .value(),
+          );
+
+          const dependentMetadata = queryWithoutDatabase.dependentMetadata();
 
           expect(dependentMetadata.some(({ type }) => type === "schema")).toBe(
             false,

--- a/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
+++ b/frontend/test/metabase-lib/lib/queries/StructuredQuery.unit.spec.js
@@ -309,12 +309,6 @@ describe("StructuredQuery", () => {
         ).toBe(ORDERS_ID);
       });
     });
-    describe("setDatabase", () => {
-      it("allows you to set a new database", () => {
-        const db = metadata.database(ANOTHER_DB_ID);
-        expect(query.setDatabase(db)._database().id).toBe(db.id);
-      });
-    });
     describe("_sourceTableId", () => {
       it("Return the right table id", () => {
         expect(query._sourceTableId()).toBe(ORDERS_ID);


### PR DESCRIPTION
This PR removes `setDatabase` method from both StructuredQuery and NativeQuery.
That cleanup left `setDatabaseID` open for deletion because it was used in one place only - in a unit test. And even that unit test will be removed in #38303.

I've patched the test temporarily so we don't lose confidence.