### PR TITLE
Disable table-privileges feature for MySQL

### DIFF
--- a/src/metabase/driver/mysql.clj
+++ b/src/metabase/driver/mysql.clj
@@ -87,8 +87,10 @@
   (-> database :dbms_version :flavor (= "MariaDB")))
 
 (defmethod driver/database-supports? [:mysql :table-privileges]
-  [driver _feat db]
-  (and (= driver :mysql) (not (mariadb? db))))
+  [_driver _feat _db]
+  ;; Disabled completely due to errors when dealing with partial revokes (metabase#38499)
+  false
+  #_(and (= driver :mysql) (not (mariadb? db))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             metabase.driver impls                                              |


### PR DESCRIPTION
Refences:
- https://github.com/metabase/metabase/issues/38509
- https://github.com/metabase/metabase/issues/38499

### Description

Currently the application is unable to parse table permissions for MySQL when [partial revokes](https://dev.mysql.com/doc/refman/8.0/en/partial-revokes.html) are being used. 

Since there is no critical functionality that relies on this feature, and it has the potential to break synchronization for MySQL, we are choosing to simply disable it for now.