### PR TITLE
Fix dashcard queries refetching

### DIFF
--- a/frontend/src/metabase/dashboard/actions/data-fetching.js
+++ b/frontend/src/metabase/dashboard/actions/data-fetching.js
@@ -447,26 +447,29 @@ export const fetchCardData = createThunkAction(
           dashcardBeforeEditing &&
           dashcardBeforeEditing.card_id !== dashcard.card_id;
 
-        // new dashcards and new additional series cards aren't yet saved to the dashboard, so they need to be run using the card query endpoint
-        const endpoint =
+        const shouldUseCardQueryEndpoint =
           isNewDashcard(dashcard) ||
           isNewAdditionalSeriesCard(card, dashcard) ||
-          hasReplacedCard
-            ? CardApi.query
-            : DashboardApi.cardQuery;
+          hasReplacedCard;
 
-        result = await fetchDataOrError(
-          maybeUsePivotEndpoint(endpoint, card)(
-            {
+        // new dashcards and new additional series cards aren't yet saved to the dashboard, so they need to be run using the card query endpoint
+        const endpoint = shouldUseCardQueryEndpoint
+          ? CardApi.query
+          : DashboardApi.cardQuery;
+
+        const requestBody = shouldUseCardQueryEndpoint
+          ? { cardId: card.id, ignore_cache: ignoreCache }
+          : {
               dashboardId: dashcard.dashboard_id,
               dashcardId: dashcard.id,
               cardId: card.id,
               parameters: datasetQuery.parameters,
               ignore_cache: ignoreCache,
               dashboard_id: dashcard.dashboard_id,
-            },
-            queryOptions,
-          ),
+            };
+
+        result = await fetchDataOrError(
+          maybeUsePivotEndpoint(endpoint, card)(requestBody, queryOptions),
         );
       }
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -367,18 +367,23 @@ function DashboardInner(props: DashboardProps) {
       });
       return;
     }
+
+    if (isEditing) {
+      return; // no refetching in edit mode
+    }
+
     if (previousTabId !== selectedTabId) {
-      if (!isEditing) {
-        fetchDashboardCardData();
-        fetchDashboardCardMetadata();
-      }
+      fetchDashboardCardData();
+      fetchDashboardCardMetadata();
       return;
     }
+
     const didDashboardLoad = !previousDashboard && dashboard;
     const didParameterValuesChange = !_.isEqual(
       previousParameterValues,
       parameterValues,
     );
+
     if (didDashboardLoad || didParameterValuesChange) {
       fetchDashboardCardData({ reload: false, clearCache: true });
     }


### PR DESCRIPTION
Follow-up on #38547 (issue #38245)

The change felt too risky for v49, so I'm extracting it into its own PR that we can merge later. It's doing two things:

**First:** turns off dashcard data and metadata refetching in dashboard editing mode
I don't think we have any good reasons to reload data in editing mode at all

**Second:** explicitly separates request data objects for dashcard vs. card query endpoints

Most of the time dashcards use the dashcard query endpoint to fetch data:
`POST /api/dashboard/:id/dashcard/:id/card/:id/query`

But when we're adding a new question on the dashboard, there's no ID to use yet, so we're using `POST /api/card/:id/query` to get some data for the preview

We used to provide the same request body to both endpoints (e.g. `dashboardId`, `dashcardId`, `dashboard_id` and `parameters`). But they're not used by the card query endpoint (there's even a [warning in BE code about it](https://github.com/metabase/metabase/blob/179a5d22dfcfdb752ada062f501e1b7f3e6dbe07/src/metabase/api/card.clj#L635))