### PR TITLE
[QC] Remove unused utils and methods on the `Join` prototype

### DIFF
--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -270,13 +270,6 @@ class StructuredQuery extends AtomicQuery {
     );
   });
 
-  /**
-   * @deprecated use metabase-lib v2 to manage joins
-   */
-  updateJoin(index, join) {
-    return this._updateQuery(Q.updateJoin, [index, unwrapJoin(join)]);
-  }
-
   // AGGREGATIONS
 
   /**

--- a/frontend/src/metabase-lib/queries/StructuredQuery.ts
+++ b/frontend/src/metabase-lib/queries/StructuredQuery.ts
@@ -277,13 +277,6 @@ class StructuredQuery extends AtomicQuery {
     return this._updateQuery(Q.updateJoin, [index, unwrapJoin(join)]);
   }
 
-  /**
-   * @deprecated use metabase-lib v2 to manage joins
-   */
-  removeJoin(_index) {
-    return this._updateQuery(Q.removeJoin, arguments);
-  }
-
   // AGGREGATIONS
 
   /**

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -1,11 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
-import type {
-  JoinFields,
-  JoinAlias,
-  JoinCondition,
-  JoinedFieldReference,
-} from "metabase-types/api";
+import type { JoinFields, JoinAlias, JoinCondition } from "metabase-types/api";
 import DimensionOptions from "metabase-lib/DimensionOptions";
 import type Dimension from "metabase-lib/Dimension";
 import { FieldDimension } from "metabase-lib/Dimension";
@@ -25,32 +20,8 @@ class Join extends MBQLObjectClause {
   /**
    * @deprecated use metabase-lib v2 to manage joins
    */
-  set(join: any): Join {
-    return super.set(join);
-  }
-
-  /**
-   * @deprecated use metabase-lib v2 to manage joins
-   */
   displayName() {
     return this.alias;
-  }
-
-  private setFields(fields: JoinFields) {
-    return this.set({ ...this, fields });
-  }
-
-  /**
-   * @deprecated use metabase-lib v2 to manage joins
-   */
-  addField(field: JoinedFieldReference) {
-    if (Array.isArray(this.fields)) {
-      return this.setFields([...this.fields, field]);
-    } else if (this.fields === "none") {
-      return this.setFields([field]);
-    } else {
-      return this;
-    }
   }
 
   private isSingleConditionJoin() {
@@ -190,15 +161,6 @@ class Join extends MBQLObjectClause {
           foreignTables: false,
         })
       : [];
-  }
-
-  /**
-   * @deprecated use metabase-lib v2 to manage joins
-   */
-  isValid() {
-    // MLv2 should ensure there's a valid condition, etc.
-    const parentTable = this.legacyQuery?.().table?.();
-    return !!parentTable && !!this.joinedTable();
   }
 }
 

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -68,13 +68,6 @@ class Join extends MBQLObjectClause {
     }
   }
 
-  /**
-   * @deprecated use metabase-lib v2 to manage joins
-   */
-  clearFields() {
-    return this.setFields("none");
-  }
-
   private isSingleConditionJoin() {
     const { condition } = this;
     return Array.isArray(condition) && JOIN_OPERATORS.includes(condition[0]);

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import type {
-  Join as JoinObject,
   JoinFields,
   JoinAlias,
   JoinCondition,
@@ -28,13 +27,6 @@ class Join extends MBQLObjectClause {
    */
   set(join: any): Join {
     return super.set(join);
-  }
-
-  /**
-   * @deprecated use metabase-lib v2 to manage joins
-   */
-  replace(join: Join | JoinObject): StructuredQuery {
-    return this._query.updateJoin(this._index, join);
   }
 
   /**

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -84,7 +84,7 @@ class Join extends MBQLObjectClause {
   /**
    * @deprecated use metabase-lib v2 to manage joins
    */
-  joinedTable() {
+  private joinedTable() {
     return this?.joinedQuery?.().table?.();
   }
 

--- a/frontend/src/metabase-lib/queries/structured/Join.ts
+++ b/frontend/src/metabase-lib/queries/structured/Join.ts
@@ -33,13 +33,6 @@ class Join extends MBQLObjectClause {
   /**
    * @deprecated use metabase-lib v2 to manage joins
    */
-  remove(): StructuredQuery {
-    return this._query.removeJoin(this._index);
-  }
-
-  /**
-   * @deprecated use metabase-lib v2 to manage joins
-   */
   replace(join: Join | JoinObject): StructuredQuery {
     return this._query.updateJoin(this._index, join);
   }

--- a/frontend/src/metabase-lib/queries/utils/join.js
+++ b/frontend/src/metabase-lib/queries/utils/join.js
@@ -1,4 +1,4 @@
-import { add, update, remove } from "./util";
+import { add, update } from "./util";
 
 // returns canonical list of Joins, with nulls removed
 export function getJoins(joins) {
@@ -20,7 +20,4 @@ export function addJoin(join, newJoin) {
 }
 export function updateJoin(join, index, updatedJoin) {
   return getJoinClause(update(getJoins(join), index, updatedJoin));
-}
-export function removeJoin(join, index) {
-  return getJoinClause(remove(getJoins(join), index));
 }

--- a/frontend/src/metabase-lib/queries/utils/join.js
+++ b/frontend/src/metabase-lib/queries/utils/join.js
@@ -1,4 +1,4 @@
-import { add, update } from "./util";
+import { add } from "./util";
 
 // returns canonical list of Joins, with nulls removed
 export function getJoins(joins) {
@@ -17,7 +17,4 @@ function getJoinClause(joins) {
 
 export function addJoin(join, newJoin) {
   return getJoinClause(add(getJoins(join), newJoin));
-}
-export function updateJoin(join, index, updatedJoin) {
-  return getJoinClause(update(getJoins(join), index, updatedJoin));
 }

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -90,8 +90,6 @@ export const addJoin = (query, join) =>
   setJoinClause(query, J.addJoin(query.joins, join));
 export const updateJoin = (query, index, join) =>
   setJoinClause(query, J.updateJoin(query.joins, index, join));
-export const removeJoin = (query, index) =>
-  setJoinClause(query, J.removeJoin(query.joins, index));
 
 // ORDER_BY
 

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -88,8 +88,6 @@ export { getFilterClause } from "./filter";
 export const getJoins = query => J.getJoins(query.joins);
 export const addJoin = (query, join) =>
   setJoinClause(query, J.addJoin(query.joins, join));
-export const updateJoin = (query, index, join) =>
-  setJoinClause(query, J.updateJoin(query.joins, index, join));
 
 // ORDER_BY
 


### PR DESCRIPTION
These are all unused and can be safely removed.

I tried to remove `addJoin` but some unit tests still depend on the `join()` method on the StructuredQuery prototype that use `addJoin` under the hood.

We decided to wait until the `dependentMetadata` work is done.
[Slack thread](https://metaboat.slack.com/archives/C04CYTEL9N2/p1707495276101359).