### PR TITLE
Browse models: Sort official collections to the top

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "master"
-      - "models-in-browse-data-polish"
     paths-ignore:
       # config files
       - ".**"

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -238,7 +238,7 @@ const CollectionHeader = ({
         <CollectionHeaderLink to={Urls.collection(collection)}>
           <Group spacing=".25rem">
             <Icon {...icon} />
-            <Text weight="bold" color="text-medium">
+            <Text weight="bold" color="text-dark">
               {getCollectionName(collection)}
             </Text>
           </Group>

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -201,7 +201,7 @@ const ModelCell = ({ model, collectionHtmlId }: ModelCellProps) => {
         <Box mb="auto">
           <Icon name="model" size={20} color={color("brand")} />
         </Box>
-        <Title order={4} lh="1rem" mb=".5rem">
+        <Title mb=".25rem" size="1rem">
           <MultilineEllipsified tooltipMaxWidth="20rem" id={headingId}>
             {model.name}
           </MultilineEllipsified>

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -200,7 +200,7 @@ const ModelCell = ({ model, collectionHtmlId }: ModelCellProps) => {
         <Box mb="auto">
           <Icon name="model" size={20} color={color("brand")} />
         </Box>
-        <Title lh="1rem" mb=".25rem" size="1rem">
+        <Title order={4} lh="1rem" mb=".5rem">
           <MultilineEllipsified tooltipMaxWidth="20rem" id={headingId}>
             {model.name}
           </MultilineEllipsified>

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -11,6 +11,7 @@ import * as Urls from "metabase/lib/urls";
 
 import Link from "metabase/core/components/Link";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import Search from "metabase/entities/search";
 
 import type { useSearchListQuery } from "metabase/common/hooks";
 
@@ -220,6 +221,11 @@ const CollectionHeader = ({
   id: string;
   fixPaddingUnderBanner: boolean;
 }) => {
+  const dispatch = useDispatch();
+  const wrappable = { ...collection, model: "collection" };
+  const wrappedCollection = Search.wrapEntity(wrappable, dispatch);
+  const icon = wrappedCollection.getIcon();
+
   return (
     <CollectionHeaderContainer
       id={id}
@@ -231,7 +237,7 @@ const CollectionHeader = ({
       <CollectionHeaderGroup grow noWrap>
         <CollectionHeaderLink to={Urls.collection(collection)}>
           <Group spacing=".25rem">
-            <Icon name="folder" color="text-dark" size={16} />
+            <Icon {...icon} />
             <Text weight="bold" color="text-medium">
               {getCollectionName(collection)}
             </Text>

--- a/frontend/src/metabase/browse/utils.ts
+++ b/frontend/src/metabase/browse/utils.ts
@@ -32,6 +32,18 @@ export const groupModels = (
   const sortFunction = (a: SearchResult[], b: SearchResult[]) => {
     const collection1 = a[0].collection;
     const collection2 = b[0].collection;
+
+    const collection1AL = collection1.authority_level;
+    const collection2AL = collection2.authority_level;
+    if (collection1AL !== collection2AL) {
+      if (!collection1AL) {
+        return 1;
+      }
+      if (!collection2AL) {
+        return -1;
+      }
+    }
+
     const name1 = getCollectionName(collection1);
     const name2 = getCollectionName(collection2);
     return name1.localeCompare(name2, locale);


### PR DESCRIPTION
This PR sorts official collections to the top, on the Browse models page