### PR TITLE
fix goal line fading

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -62,6 +62,14 @@ export function getGoalLineSeriesOption(
         type: [5, 5],
         width: 2,
       },
+      blur: {
+        lineStyle: {
+          opacity: 1,
+        },
+        label: {
+          opacity: 1,
+        },
+      },
     },
   };
 }

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -210,6 +210,8 @@ const buildEChartsLineAreaSeries = (
     chartWidth,
   );
 
+  const blurOpacity = hasMultipleSeries ? 0.3 : 1;
+
   return {
     emphasis: {
       focus: hasMultipleSeries ? "series" : "self",
@@ -222,10 +224,10 @@ const buildEChartsLineAreaSeries = (
         show: settings["graph.show_values"] && !hasMultipleSeries,
       },
       itemStyle: {
-        opacity: isSymbolVisible ? 0.3 : 0,
+        opacity: isSymbolVisible ? blurOpacity : 0,
       },
       lineStyle: {
-        opacity: 0.3,
+        opacity: blurOpacity,
       },
     },
     zlevel: CHART_STYLE.series.zIndex,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -222,7 +222,10 @@ const buildEChartsLineAreaSeries = (
         show: settings["graph.show_values"] && !hasMultipleSeries,
       },
       itemStyle: {
-        opacity: isSymbolVisible ? 1 : 0,
+        opacity: isSymbolVisible ? 0.3 : 0,
+      },
+      lineStyle: {
+        opacity: 0.3,
       },
     },
     zlevel: CHART_STYLE.series.zIndex,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37898

### Description

Prevents goal line from fading by setting opacity to 1 in blur options.

### Demo

_Click links to play videos, not sure why there is no preview :/_

| dc.js | echarts (this PR) |
| ----- | ----------------- |
| https://github.com/metabase/metabase/assets/37751258/85d439a6-b306-4dc6-98b7-dc553613cb64 |  https://github.com/metabase/metabase/assets/37751258/c19dee10-3e81-41aa-abbf-cc38c1fb59db |






