### PR TITLE
Migrate connection impersonations to use DataPermissions

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -6,10 +6,11 @@
    [metabase.driver :as driver]
    [metabase.driver.sql :as driver.sql]
    [metabase.models.field :as field]
-   [metabase.models.permissions :as perms :refer [Permissions]]
    [metabase.models.permissions-group-membership
     :refer [PermissionsGroupMembership]]
-   [metabase.public-settings.premium-features :as premium-features :refer [defenterprise]]
+   [metabase.public-settings.premium-features
+    :as premium-features
+    :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
    [metabase.util.log :as log]
@@ -19,27 +20,23 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- enforce-impersonation?
-  "Takes the permission set for each group a user is in, and an impersonation policy, and determines whether the policy
-  should be enforced. This is done by checking whether the union of permissions in all *other* groups provides full
-  data access to the database. If so, we don't enforce the policy, because theo ther groups' permissions supercede it."
-  [group-id->perms-set {db-id :db_id}]
-  (let [perms-set (apply set/union (vals group-id->perms-set))]
-    (not (perms/set-has-full-permissions? perms-set (perms/all-schemas-path db-id)))))
-
-(defn- enforced-impersonations
+(defn- enforce-impersonations?
   "Given a list of Connection Impersonation policies and a list of permission group IDs that the current user is in,
-  filter the policies to only include ones that should be enforced for the current user. An impersonation policy is
-  not enforced if the user is in a different permission group that grants full access to the database."
-  [impersonations group-ids]
+  returns a Boolean indicating whether the policies should be enforced. They are not enforced if any of the *other*
+  groups the user is in provide unrestricted data access to the DB."
+  [db-or-id impersonations group-ids]
   (let [non-impersonated-group-ids (set/difference (set group-ids)
                                                    (set (map :group_id impersonations)))
         perms                      (when (seq non-impersonated-group-ids)
-                                     (t2/select Permissions {:where [:in :group_id non-impersonated-group-ids]}))
-        group-id->perms-set        (-> (group-by :group_id perms)
-                                       (update-vals (fn [perms] (into #{} (map :object) perms))))]
-    (filter (partial enforce-impersonation? group-id->perms-set)
-            impersonations)))
+                                     (t2/select :model/DataPermissions {:where
+                                                                        [:and
+                                                                         [:= :db_id (u/the-id db-or-id)]
+                                                                         [:= :table_id nil]
+                                                                         [:= :perm_type (u/qualified-name :perms/data-access)]
+                                                                         [:in :group_id non-impersonated-group-ids]]}))
+        perm-values                (into #{} (map :perm_value perms))]
+
+    (not (contains? perm-values :unrestricted))))
 
 (defn- impersonation-enabled-for-db?
   "Is impersonation enabled for the given database, for any groups?"
@@ -55,27 +52,26 @@
   [database-or-id]
   (when (and database-or-id (not api/*is-superuser?*))
     (let [group-ids           (t2/select-fn-set :group_id PermissionsGroupMembership :user_id api/*current-user-id*)
-          conn-impersonations (enforced-impersonations
-                               (when (seq group-ids)
-                                 (t2/select :model/ConnectionImpersonation
-                                            :group_id [:in group-ids]
-                                            :db_id (u/the-id database-or-id)))
-                               group-ids)
+          conn-impersonations (when (seq group-ids)
+                                (t2/select :model/ConnectionImpersonation
+                                           :group_id [:in group-ids]
+                                           :db_id (u/the-id database-or-id)))
           role-attributes     (set (map :attribute conn-impersonations))]
-      (when (> (count role-attributes) 1)
-        (throw (ex-info (tru "Multiple conflicting connection impersonation policies found for current user")
-                        {:user-id api/*current-user-id*
-                         :conn-impersonations conn-impersonations})))
-      (when (not-empty role-attributes)
-        (let [conn-impersonation (first conn-impersonations)
-              role-attribute     (:attribute conn-impersonation)
-              user-attributes    (:login_attributes @api/*current-user*)
-              role               (get user-attributes role-attribute)]
-          (if (str/blank? role)
-            (throw (ex-info (tru "User does not have attribute required for connection impersonation.")
-                            {:user-id api/*current-user-id*
-                             :conn-impersonations conn-impersonations}))
-            role))))))
+      (when (enforce-impersonations? database-or-id conn-impersonations group-ids)
+        (when (> (count role-attributes) 1)
+          (throw (ex-info (tru "Multiple conflicting connection impersonation policies found for current user")
+                          {:user-id api/*current-user-id*
+                           :conn-impersonations conn-impersonations})))
+        (when (not-empty role-attributes)
+          (let [conn-impersonation (first conn-impersonations)
+                role-attribute     (:attribute conn-impersonation)
+                user-attributes    (:login_attributes @api/*current-user*)
+                role               (get user-attributes role-attribute)]
+            (if (str/blank? role)
+              (throw (ex-info (tru "User does not have attribute required for connection impersonation.")
+                              {:user-id api/*current-user-id*
+                               :conn-impersonations conn-impersonations}))
+              role)))))))
 
 (defenterprise hash-key-for-impersonation
   "Returns a hash-key for FieldValues if the current user uses impersonation for the database."

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -36,6 +36,8 @@
                                                          [:= :table_id nil]
                                                          [:= :perm_type (u/qualified-name :perms/data-access)]
                                                          [:in :group_id non-impersonated-group-ids]]}))]
+    ;; Just check if any other non-impersonated groups have unrestricted access to the DB. We don't need to worry
+    ;; about block permissions here because it would have been enforced earlier in the QP middleware stack.
     (not (contains? perm-values :unrestricted))))
 
 (defn- impersonation-enabled-for-db?

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/driver/impersonation.clj
@@ -27,15 +27,15 @@
   [db-or-id impersonations group-ids]
   (let [non-impersonated-group-ids (set/difference (set group-ids)
                                                    (set (map :group_id impersonations)))
-        perms                      (when (seq non-impersonated-group-ids)
-                                     (t2/select :model/DataPermissions {:where
-                                                                        [:and
-                                                                         [:= :db_id (u/the-id db-or-id)]
-                                                                         [:= :table_id nil]
-                                                                         [:= :perm_type (u/qualified-name :perms/data-access)]
-                                                                         [:in :group_id non-impersonated-group-ids]]}))
-        perm-values                (into #{} (map :perm_value perms))]
-
+        perm-values                (when (seq non-impersonated-group-ids)
+                                     (t2/select-fn-set :perm_value
+                                                       :model/DataPermissions
+                                                       {:where
+                                                        [:and
+                                                         [:= :db_id (u/the-id db-or-id)]
+                                                         [:= :table_id nil]
+                                                         [:= :perm_type (u/qualified-name :perms/data-access)]
+                                                         [:in :group_id non-impersonated-group-ids]]}))]
     (not (contains? perm-values :unrestricted))))
 
 (defn- impersonation-enabled-for-db?

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/util_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/util_test.clj
@@ -5,8 +5,7 @@
     :as advanced-perms.api.u]
    [metabase-enterprise.sandbox.test-util :as met]
    [metabase.api.common :as api]
-   [metabase.models.permissions :as perms]
-   [metabase.models.permissions-group :as perms-group]
+   [metabase.models.data-permissions :as data-perms]
    [metabase.server.middleware.session :as mw.session]
    [metabase.test :as mt]
    [metabase.test.data :as data]
@@ -24,58 +23,56 @@
                                                                :attribute attribute}]
       (do-with-conn-impersonation-defs group more f))))
 
-(defn do-with-impersonations-for-user [args test-user-name-or-user-id f]
+(defn do-with-impersonations-for-user!
+  [args test-user-name-or-user-id f]
   (letfn [(thunk []
             ;; remove perms for All Users group
-            (perms/revoke-data-perms! (perms-group/all-users) (data/db))
-            ;; create new perms group
-            (test.users/with-group-for-user [group test-user-name-or-user-id]
-              ;; grant full data access to the group
-              (perms/update-data-perms-graph! [(u/the-id group) (data/id) :data :native] :write)
-              (perms/update-data-perms-graph! [(u/the-id group) (data/id) :data :schemas] :all)
-              (let [{:keys [impersonations attributes]} args]
-                ;; set user login_attributes
-                (met/with-user-attributes test-user-name-or-user-id attributes
-                  (do-with-conn-impersonation-defs group impersonations
-                    (fn []
-                      ;; bind user as current user, then run f
-                      (if (keyword? test-user-name-or-user-id)
-                        (test.users/with-test-user test-user-name-or-user-id
-                          (f group))
-                        (mw.session/with-current-user (u/the-id test-user-name-or-user-id)
-                          (f group))))))))
-            ;; re-grant perms for All Users group
-            (u/ignore-exceptions
-             (perms/grant-full-data-permissions! (perms-group/all-users) (data/db))))]
+            (mt/with-no-data-perms-for-all-users!
+              ;; create new perms group
+              (test.users/with-group-for-user [group test-user-name-or-user-id]
+                ;; grant full data access to the group
+                (data-perms/set-database-permission! group (data/id) :perms/data-access :unrestricted)
+                (data-perms/set-database-permission! group (data/id) :perms/native-query-editing :yes)
+                (let [{:keys [impersonations attributes]} args]
+                  ;; set user login_attributes
+                  (met/with-user-attributes test-user-name-or-user-id attributes
+                    (do-with-conn-impersonation-defs group impersonations
+                      (fn []
+                        ;; bind user as current user, then run f
+                        (if (keyword? test-user-name-or-user-id)
+                          (test.users/with-test-user test-user-name-or-user-id
+                            (f group))
+                          (mw.session/with-current-user (u/the-id test-user-name-or-user-id)
+                            (f group))))))))))]
     (thunk)))
 
-(defmacro with-impersonations-for-user
+(defmacro with-impersonations-for-user!
   "Like `with-impersonations`, but for an arbitrary User. `test-user-name-or-user-id` can be a predefined test user e.g.
   `:rasta` or an arbitrary User ID."
   [test-user-name-or-user-id impersonations-and-attributes-map & body]
-  `(do-with-impersonations-for-user ~impersonations-and-attributes-map
+  `(do-with-impersonations-for-user! ~impersonations-and-attributes-map
                                     ~test-user-name-or-user-id
                                     (fn [~'&group] ~@body)))
 
-(defmacro with-impersonations
+(defmacro with-impersonations!
   "Execute `body` with `impersonations` and optionally user `attributes` in effect for the :rasta test user, for the
   current test database. All underlying objects and permissions are created automatically.
 
   Introduces `&group` anaphor, bound to the PermissionsGroup associated with this Connection Impersonation policy."
   {:style/indent :defn}
   [impersonations-and-attributes-map & body]
-  `(do-with-impersonations-for-user ~impersonations-and-attributes-map :rasta (fn [~'&group] ~@body)))
+  `(do-with-impersonations-for-user! ~impersonations-and-attributes-map :rasta (fn [~'&group] ~@body)))
 
 (deftest impersonated-user-test
   (mt/with-premium-features #{:advanced-permissions}
     (testing "Returns true when a user has an active connection impersonation policy"
-      (with-impersonations {:impersonations [{:db-id (mt/id) :attribute "KEY"}]
-                            :attributes     {"KEY" "VAL"}}
+      (with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "KEY"}]
+                             :attributes     {"KEY" "VAL"}}
         (is (advanced-perms.api.u/impersonated-user?))))
 
     (testing "Returns true if current user is a superuser, even if they are in a group with an impersonation policy in place"
-      (with-impersonations-for-user :crowberto {:impersonations [{:db-id (mt/id) :attribute "KEY"}]
-                                                :attributes     {"KEY" "VAL"}}
+      (with-impersonations-for-user! :crowberto {:impersonations [{:db-id (mt/id) :attribute "KEY"}]
+                                                 :attributes     {"KEY" "VAL"}}
         (is (not (advanced-perms.api.u/impersonated-user?)))))
 
     (testing "An exception is thrown if no user is bound"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -17,53 +17,52 @@
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (deftest connection-impersonation-role-test
-  (mt/with-no-data-perms-for-all-users!
-    (testing "Returns nil when no impersonations are in effect"
-      (is (nil? (@#'impersonation/connection-impersonation-role (mt/db)))))
+  (testing "Returns nil when no impersonations are in effect"
+    (is (nil? (@#'impersonation/connection-impersonation-role (mt/db)))))
 
-    (testing "Correctly fetches the impersonation when one is in effect"
-      (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                  :attributes     {"impersonation_attr" "impersonation_role"}}
-        (is (= "impersonation_role"
-               (@#'impersonation/connection-impersonation-role (mt/db))))))
+  (testing "Correctly fetches the impersonation when one is in effect"
+    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
+      (is (= "impersonation_role"
+             (@#'impersonation/connection-impersonation-role (mt/db))))))
 
-    (testing "Throws exception if multiple conflicting impersonations are in effect"
-      ;; Use nested `with-impersonations` macros so that different groups are used
-      (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr_1"}]
-                                                  :attributes     {"impersonation_attr_1" "impersonation_role_1"}}
-        (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr_2"}]
-                                                    :attributes     {"impersonation_attr_2" "impersonation_role_2"}}
-          (is (thrown-with-msg?
-               clojure.lang.ExceptionInfo
-               #"Multiple conflicting connection impersonation policies found for current user"
-               (@#'impersonation/connection-impersonation-role (mt/db)))))))
-
-    (testing "Returns nil if the permissions in another group supercede the impersonation"
-      (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                  :attributes     {"impersonation_attr" "impersonation_role"}}
-        ;; `with-impersonations` creates a new group and revokes data perms in `all users`, so if we re-grant data perms
-        ;; for all users, it should supercede the impersonation policy in the new group
-        (mt/with-full-data-perms-for-all-users!
-          (is (nil? (@#'impersonation/connection-impersonation-role (mt/db)))))))
-
-    (testing "Returns nil for superuser, even if they are in a group with an impersonation policy defined"
-      (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                  :attributes     {"impersonation_attr" "impersonation_role"}}
-        (mw.session/as-admin
-         (is (nil? (@#'impersonation/connection-impersonation-role (mt/db)))))))
-
-    (testing "Does not throw an exception if passed a nil `database-or-id`"
-      (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                  :attributes     {"impersonation_attr" "impersonation_role"}}
-        (is (nil? (@#'impersonation/connection-impersonation-role nil)))))
-
-    (testing "Throws an exception if impersonation should be enforced, but the user doesn't have the required attribute"
-      (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                  :attributes     {}}
+  (testing "Throws exception if multiple conflicting impersonations are in effect"
+    ;; Use nested `with-impersonations!` macros so that different groups are used
+    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr_1"}]
+                                                 :attributes     {"impersonation_attr_1" "impersonation_role_1"}}
+      (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr_2"}]
+                                                   :attributes     {"impersonation_attr_2" "impersonation_role_2"}}
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             #"User does not have attribute required for connection impersonation."
-             (@#'impersonation/connection-impersonation-role (mt/db))))))))
+             #"Multiple conflicting connection impersonation policies found for current user"
+             (@#'impersonation/connection-impersonation-role (mt/db)))))))
+
+  (testing "Returns nil if the permissions in another group supercede the impersonation"
+    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
+      ;; `with-impersonations!` creates a new group and revokes data perms in `all users`, so if we re-grant data perms
+      ;; for all users, it should supercede the impersonation policy in the new group
+      (mt/with-full-data-perms-for-all-users!
+        (is (nil? (@#'impersonation/connection-impersonation-role (mt/db)))))))
+
+  (testing "Returns nil for superuser, even if they are in a group with an impersonation policy defined"
+    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
+      (mw.session/as-admin
+       (is (nil? (@#'impersonation/connection-impersonation-role (mt/db)))))))
+
+  (testing "Does not throw an exception if passed a nil `database-or-id`"
+    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                 :attributes     {"impersonation_attr" "impersonation_role"}}
+      (is (nil? (@#'impersonation/connection-impersonation-role nil)))))
+
+  (testing "Throws an exception if impersonation should be enforced, but the user doesn't have the required attribute"
+    (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                 :attributes     {}}
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"User does not have attribute required for connection impersonation."
+           (@#'impersonation/connection-impersonation-role (mt/db)))))))
 
 (deftest conn-impersonation-test-postgres
   (mt/test-driver :postgres
@@ -83,8 +82,8 @@
           (jdbc/execute! spec [statement]))
         (t2.with-temp/with-temp [Database database {:engine :postgres, :details details}]
           (mt/with-db database (sync/sync-database! database)
-            (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                        :attributes     {"impersonation_attr" "impersonation.role"}}
+            (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                         :attributes     {"impersonation_attr" "impersonation.role"}}
               (is (= []
                      (-> {:query "SELECT * FROM \"table_with_access\";"}
                          mt/native-query
@@ -140,8 +139,8 @@
 (deftest conn-impersonation-test-snowflake
   (mt/test-driver :snowflake
     (mt/with-premium-features #{:advanced-permissions}
-      (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                  :attributes     {"impersonation_attr" "LIMITED.ROLE"}}
+      (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                   :attributes     {"impersonation_attr" "LIMITED.ROLE"}}
         ;; Test database initially has no default role set. All queries should fail, even for non-impersonated users,
         ;; since there is no way to reset the connection after impersonation is applied.
         (is (thrown-with-msg?

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/driver/impersonation_test.clj
@@ -116,8 +116,8 @@
                                (format "GRANT SELECT ON TABLE %s.table_with_access TO %s;" schema user)]]
               (jdbc/execute! spec statement))
             (mt/with-db database (sync/sync-database! database)
-              (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                          :attributes     {"impersonation_attr" user}}
+              (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                           :attributes     {"impersonation_attr" user}}
                 (is (= []
                        (-> {:query (format "SELECT * FROM %s.table_with_access;" schema)}
                            mt/native-query

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/field_values_test.clj
@@ -13,11 +13,11 @@
 
 (deftest get-or-create-advanced-field-values!
   (mt/with-premium-features #{:advanced-permissions}
-    (let [field      (t2/select-one Field :id (mt/id :categories :id))]
+    (let [field (t2/select-one Field :id (mt/id :categories :id))]
       (try
         (testing "creates new field values for user using impersonation"
-          (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                      :attributes     {"impersonation_attr" "impersonation_role"}}
+          (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                       :attributes     {"impersonation_attr" "impersonation_role"}}
             (let [hash-key-1 (impersonation/hash-key-for-impersonation (u/the-id field))]
               (params.field-values/get-or-create-advanced-field-values! :impersonation field)
               (is (= #{hash-key-1}
@@ -29,8 +29,8 @@
                 (is (= 1 (t2/count FieldValues :field_id (u/the-id field) :type :impersonation))))
 
               (testing "changing the impersonation role creates new FieldValues"
-                (advanced-perms.api.tu/with-impersonations {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
-                                                            :attributes     {"impersonation_attr" "impersonation_role_2"}}
+                (advanced-perms.api.tu/with-impersonations! {:impersonations [{:db-id (mt/id) :attribute "impersonation_attr"}]
+                                                             :attributes     {"impersonation_attr" "impersonation_role_2"}}
                   (let [hash-key-2 (impersonation/hash-key-for-impersonation (u/the-id field))]
                     (params.field-values/get-or-create-advanced-field-values! :impersonation field)
                     (is (= #{hash-key-1 hash-key-2}


### PR DESCRIPTION
Migrates the logic to determine whether connection impersonations should be enforced to using the `DataPermissions` model. A little additional refactor/simplification of the logic as well.

This can't use the existing APIs because the logic is fairly specific to the needs of connection impersonation. This might justify a new API but for now I'm migrating it in-place.