### PR TITLE
Disable redshift support for uploads

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -63,8 +63,7 @@
                               :persist-models           true
                               :table-privileges         true
                               :schemas                  true
-                              :connection-impersonation true
-                              :uploads                  true}]
+                              :connection-impersonation true}]
   (defmethod driver/database-supports? [:postgres feature] [_driver _feature _db] supported?))
 
 (defmethod driver/database-supports? [:postgres :nested-field-columns]
@@ -74,7 +73,8 @@
 ;; Features that are supported by postgres only
 (doseq [feature [:actions
                  :actions/custom
-                 :index-info]]
+                 :index-info
+                 :uploads]]
   (defmethod driver/database-supports? [:postgres feature]
     [driver _feat _db]
     (= driver :postgres)))


### PR DESCRIPTION
This PR disables redshift support for uploads in the hope that it unblocks CI.

Redshift support for uploads is targeting the 49 release, and hopefully once [#38567 Clean up tables created during redshift CSV upload tests](https://github.com/metabase/metabase/pull/38567) merges we can bring redshift uploads support back.