### PR TITLE
Fix dispatch error in `with-model-cleanup`

### DIFF
--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -643,7 +643,7 @@
   "Additional conditions that should be used to restrict which instances automatically get deleted by
   `with-model-cleanup`. Conditions should be a HoneySQL `:where` clause."
   {:arglists '([model])}
-  mi/model)
+  identity)
 
 (defmethod with-model-cleanup-additional-conditions :default
   [_]


### PR DESCRIPTION
`with-model-cleanup` is called like so:

```
(with-model-cleanup [:model/User]
 ...)
```

This ends up calling:

```
(with-model-cleanup-additional-conditions model)
```

to get the additional conditions necessary when "cleaning up" the model. This multimethod dispatched on `mi/model`.

But `(mi/model :model/User)` is `nil`. Instead, we *already have* the model, not an instance of it, so we want to dispatch on that to properly clean up after ourselves.