### PR TITLE
[MLv2] Prescribe the order for `metabase.lib.column-group/group-columns`

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -94,7 +94,10 @@ describe("scenarios > dashboard > filters > ID", () => {
   describe("should work on the implicit join", () => {
     beforeEach(() => {
       popover().within(() => {
-        cy.findAllByText("ID").last().click();
+        // There are three of these, and the order is fixed:
+        // "own" column first, then implicit join on People and User alphabetically.
+        // We select index 1 to get the Product.ID.
+        cy.findAllByText("ID").eq(1).click();
       });
     });
 


### PR DESCRIPTION
The desired order is: own columns, explicitly joined, implicitly joined.
Explicit joins are ordered among themselves by join alias. Implicit
joins are ordered by the join alias of the FK (own columns first), then
by the name of the FK column.

Previously this order has usually been at least close to the desired
order by accident, since it's close to the iteration order of
`visible-columns`. However, `group-columns` uses `group-by`, which
returns a map. If there are enough groups (more than 8 I think) the map
implementation will switch from a `[key1 value1 key2 value2 ...]` array
to a real map, and the iteration order is undefined.

This change enforces the desired order, including a test that `shuffle`s
the columns. (And fixing the expectations for a few other tests.)

Fixes #38329.
