### PR TITLE
Improve tooltips in navigation

### DIFF
--- a/e2e/test/scenarios/collections/collections.cy.spec.js
+++ b/e2e/test/scenarios/collections/collections.cy.spec.js
@@ -150,7 +150,9 @@ describe("scenarios > collection defaults", () => {
       // 2. Ensure we show the helpful tooltip with the full (long) collection name
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Fifth collection with a very long name").realHover();
-      popover().contains("Fifth collection with a very long name");
+      cy.findByRole("tooltip", {
+        name: /Fifth collection with a very long name/,
+      });
     });
 
     it("should be usable on mobile screen sizes (metabase#15006)", () => {

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
@@ -1,4 +1,6 @@
 import { t } from "ttag";
+import { useState, useEffect } from "react";
+import { useHover } from "@mantine/hooks";
 import { isMac } from "metabase/lib/browser";
 import { Tooltip } from "metabase/ui";
 import { SidebarButton, SidebarIcon } from "./AppBarToggle.styled";
@@ -18,28 +20,48 @@ export function AppBarToggle({
   isNavBarOpen,
   onToggleClick,
 }: AppBarToggleProps): JSX.Element | null {
+  const [disableTooltip, setDisableTooltip] = useState(false);
+  const { hovered, ref: hoverRef } = useHover();
+
+  // when user clicks the sidebar button, never show the
+  // tooltip as long as their cursor remains on the button
+  // but show it again next time they hover
+  useEffect(() => {
+    if (!hovered) {
+      setDisableTooltip(false);
+    }
+  }, [hovered]);
+
   if (!isNavBarEnabled) {
     return null;
   }
 
+  const handleToggleClick = () => {
+    setDisableTooltip(true);
+    onToggleClick?.();
+  };
+
   return (
-    <Tooltip
-      label={getSidebarTooltipLabel(isNavBarOpen)}
-      disabled={isSmallAppBar}
-      offset={-12}
-      openDelay={1000}
-    >
-      <SidebarButton
-        isSmallAppBar={isSmallAppBar}
-        isNavBarEnabled={isNavBarEnabled}
-        isLogoVisible={isLogoVisible}
-        onClick={onToggleClick}
-        data-testid="sidebar-toggle"
-        aria-label={t`Toggle sidebar`}
+    <div ref={hoverRef}>
+      <Tooltip
+        label={getSidebarTooltipLabel(isNavBarOpen)}
+        disabled={isSmallAppBar || disableTooltip}
+        withArrow
+        offset={-12}
+        openDelay={1000}
       >
-        <SidebarIcon isLogoVisible={isLogoVisible} size={20} name="burger" />
-      </SidebarButton>
-    </Tooltip>
+        <SidebarButton
+          isSmallAppBar={isSmallAppBar}
+          isNavBarEnabled={isNavBarEnabled}
+          isLogoVisible={isLogoVisible}
+          onClick={handleToggleClick}
+          data-testid="sidebar-toggle"
+          aria-label={t`Toggle sidebar`}
+        >
+          <SidebarIcon isLogoVisible={isLogoVisible} size={20} name="burger" />
+        </SidebarButton>
+      </Tooltip>
+    </div>
   );
 }
 

--- a/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarToggle.tsx
@@ -27,6 +27,7 @@ export function AppBarToggle({
       label={getSidebarTooltipLabel(isNavBarOpen)}
       disabled={isSmallAppBar}
       offset={-12}
+      openDelay={1000}
     >
       <SidebarButton
         isSmallAppBar={isSmallAppBar}

--- a/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/SidebarItems/SidebarItems.styled.tsx
@@ -1,9 +1,8 @@
 import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 
-import { Icon } from "metabase/ui";
+import { Icon, Tooltip } from "metabase/ui";
 import { TreeNode } from "metabase/components/tree/TreeNode";
-import Tooltip from "metabase/core/components/Tooltip";
 import Link from "metabase/core/components/Link";
 
 import { NAV_SIDEBAR_WIDTH } from "metabase/nav/constants";
@@ -119,7 +118,7 @@ export const ItemName = styled(TreeNode.NameContainer)`
 export function NameContainer({ children: itemName }: { children: string }) {
   if (itemName.length >= ITEM_NAME_LENGTH_TOOLTIP_THRESHOLD) {
     return (
-      <Tooltip tooltip={itemName} maxWidth="none">
+      <Tooltip label={itemName} withArrow maw="none">
         <ItemName>{itemName}</ItemName>
       </Tooltip>
     );


### PR DESCRIPTION
### Description

This PR does two things

1. Makes the sidebar navigation tooltips consistent with the one used by the main navigation
<img width="497" alt="Screenshot 2024-02-08 at 4 50 49 PM" src="https://github.com/metabase/metabase/assets/7104357/f5b85121-23b1-41d2-a347-7cbeab0db419">

2. Adds a delay for showing the open/close sidebar tooltip in the main navbar. Also the tooltip is no longer shown to the user if the user engages with the icon as long as the icon remains hovered (resets after user's cursor leaves the icon).
https://www.loom.com/share/2c0aca6a734b46099d3ce0ebd7ae9285?sid=aecc093b-534c-4805-a791-445a1444d405