### PR TITLE
Browse models: only show 'Learn about our data' on the databases tab (very small PR)

### DIFF
--- a/.github/workflows/uberjar.yml
+++ b/.github/workflows/uberjar.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "master"
+      - "models-in-browse-data-polish"
     paths-ignore:
       # config files
       - ".**"

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
@@ -32,6 +32,7 @@ describe("scenarios > browse data", () => {
   it("can visit 'Learn about our data' page", () => {
     cy.visit("/");
     cy.findByRole("listitem", { name: "Browse data" }).click();
+    cy.findByRole("tab", { name: "Databases" }).click();
     cy.findByRole("link", { name: /Learn about our data/ }).click();
     cy.location("pathname").should("eq", "/reference/databases");
     cy.go("back");

--- a/frontend/src/metabase/browse/components/BrowseApp.tsx
+++ b/frontend/src/metabase/browse/components/BrowseApp.tsx
@@ -55,27 +55,29 @@ export const BrowseApp = ({
         <BrowseDataHeader>
           <BrowseSectionContainer>
             <h2>{t`Browse data`}</h2>
-            <div
-              className="flex flex-align-right"
-              style={{ flexBasis: "40.0%" }}
-            >
-              <Link className="flex flex-align-right" to="reference">
-                <BrowseHeaderIconContainer>
-                  <Icon
-                    className="flex align-center"
-                    size={14}
-                    name="reference"
-                  />
-                  <Text
-                    size="md"
-                    lh="1"
-                    className="ml1 flex align-center text-bold"
-                  >
-                    {t`Learn about our data`}
-                  </Text>
-                </BrowseHeaderIconContainer>
-              </Link>
-            </div>
+            {tab === "databases" && (
+              <div
+                className="flex flex-align-right"
+                style={{ flexBasis: "40.0%" }}
+              >
+                <Link className="flex flex-align-right" to="reference">
+                  <BrowseHeaderIconContainer>
+                    <Icon
+                      className="flex align-center"
+                      size={14}
+                      name="reference"
+                    />
+                    <Text
+                      size="md"
+                      lh="1"
+                      className="ml1 flex align-center text-bold"
+                    >
+                      {t`Learn about our data`}
+                    </Text>
+                  </BrowseHeaderIconContainer>
+                </Link>
+              </div>
+            )}
           </BrowseSectionContainer>
         </BrowseDataHeader>
         <BrowseTabs

--- a/frontend/src/metabase/browse/components/BrowseApp.tsx
+++ b/frontend/src/metabase/browse/components/BrowseApp.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 import { push } from "react-router-redux";
-import { Icon, Text } from "metabase/ui";
+import { Flex, Icon, Text } from "metabase/ui";
 import {
   useDatabaseListQuery,
   useSearchListQuery,
@@ -56,11 +56,8 @@ export const BrowseApp = ({
           <BrowseSectionContainer>
             <h2>{t`Browse data`}</h2>
             {tab === "databases" && (
-              <div
-                className="flex flex-align-right"
-                style={{ flexBasis: "40.0%" }}
-              >
-                <Link className="flex flex-align-right" to="reference">
+              <Flex ml="auto" justify="right" style={{ flexBasis: "40.0%" }}>
+                <Link to="reference">
                   <BrowseHeaderIconContainer>
                     <Icon
                       className="flex align-center"
@@ -76,7 +73,7 @@ export const BrowseApp = ({
                     </Text>
                   </BrowseHeaderIconContainer>
                 </Link>
-              </div>
+              </Flex>
             )}
           </BrowseSectionContainer>
         </BrowseDataHeader>

--- a/frontend/src/metabase/browse/components/BrowseApp.tsx
+++ b/frontend/src/metabase/browse/components/BrowseApp.tsx
@@ -59,16 +59,8 @@ export const BrowseApp = ({
               <Flex ml="auto" justify="right" style={{ flexBasis: "40.0%" }}>
                 <Link to="reference">
                   <BrowseHeaderIconContainer>
-                    <Icon
-                      className="flex align-center"
-                      size={14}
-                      name="reference"
-                    />
-                    <Text
-                      size="md"
-                      lh="1"
-                      className="ml1 flex align-center text-bold"
-                    >
+                    <Icon size={14} name="reference" />
+                    <Text size="md" lh="1" fw="bold" ml=".5rem" c="inherit">
                       {t`Learn about our data`}
                     </Text>
                   </BrowseHeaderIconContainer>


### PR DESCRIPTION
This PR affects the Browse Data page. It ensures that the "Learn about our data" link appears on the Databases tab, not on the Models tab.