### PR TITLE
Remove flaky timeout in DelayGroup test

### DIFF
--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
@@ -25,7 +25,7 @@ function Child() {
 
 describe("DelayGroup", () => {
   it("should be delayed by default and only remove delay after a timeout", async () => {
-    const timeout = 50;
+    const timeout = 100;
     setup({ timeout });
 
     const button = screen.getByRole("button");
@@ -43,6 +43,6 @@ describe("DelayGroup", () => {
     });
 
     const elapsed = Date.now() - start;
-    expect(elapsed).toBeCloseTo(timeout, -1);
+    expect(elapsed).toBeGreaterThanOrEqual(timeout);
   });
 });

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { render, screen, waitFor } from "__support__/ui";
+import { render, screen, act } from "__support__/ui";
 import { DelayGroup, useDelayGroup } from "./DelayGroup";
 
 interface SetupOpts {
@@ -25,10 +25,13 @@ function Child() {
 
 describe("DelayGroup", () => {
   it("should be delayed by default and only remove delay after a timeout", async () => {
-    const timeout = 100;
+    jest.useFakeTimers();
+
+    const timeout = 500;
     setup({ timeout });
 
     const button = screen.getByRole("button");
+
     expect(button).toHaveTextContent("delay: true");
 
     userEvent.hover(button);
@@ -36,13 +39,13 @@ describe("DelayGroup", () => {
 
     userEvent.unhover(button);
     expect(button).toHaveTextContent("delay: false");
-    const start = Date.now();
 
-    await waitFor(function () {
+    act(function () {
+      jest.advanceTimersByTime(timeout / 2);
+      expect(button).toHaveTextContent("delay: false");
+
+      jest.advanceTimersByTime(timeout / 2 + 1);
       expect(button).toHaveTextContent("delay: true");
     });
-
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeGreaterThanOrEqual(timeout);
   });
 });


### PR DESCRIPTION
This PR removes a flaky test case that is breaking a lot of builds in CI.

All that's being tested is the fact that the timeout was reached, and a greater than assertion does the job just fine.

[Flaky test run seems to confirm this fix works](
https://github.com/metabase/metabase/actions/runs/7842196150/job/21400027071).