### PR TITLE
Update devcontainer Dockerile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,10 +2,10 @@ FROM mcr.microsoft.com/vscode/devcontainers/java:11
 
 # Set up nodesource, install node, yarn, fontconfig for static viz, rlwrap for dev ergonomics
 
-RUN ( curl -fsSL https://deb.nodesource.com/setup_14.x | bash ) \
+RUN ( curl -fsSL https://deb.nodesource.com/setup_18.x | bash ) \
   && export DEBIAN_FRONTEND=noninteractive \
   && apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com \
   && apt-get update && apt-get -y install --no-install-recommends nodejs yarn rlwrap fontconfig
 
 # install Clojure
-RUN curl https://download.clojure.org/install/linux-install-1.11.0.1100.sh | bash
+RUN curl https://download.clojure.org/install/linux-install-1.11.1.1262.sh | bash


### PR DESCRIPTION
### Description

While running VSCode dev containers locally, I realized that it is actually broken. 
When comparing against the root Dockerfile, I saw that the versions are different.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open the repo in VSCode and start a devcontainer
2. Run the Task: Run Build Task command


### Checklist

~~- [ ] Tests have been added/updated to cover changes in this PR~~
