### PR TITLE
Force reload in `ensure-audit-db-installed!`

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/permissions_test.clj
@@ -125,7 +125,10 @@
         cards (t2/exists? :model/Card :collection_id default-audit-id)
         dashboards (t2/exists? :model/Dashboard :collection_id default-audit-id)]
     (when-not (and coll cards dashboards)
-      (mbc/ensure-audit-db-installed!))))
+      ;; Force audit db to load, even if the checksum has not changed. Sometimes analytics bits get removed by tests,
+      ;; but next time we go to load analytics data, we find the existing checksum and don't bother loading it again.
+      (mt/with-temporary-setting-values [last-analytics-checksum -1]
+        (mbc/ensure-audit-db-installed!)))))
 
 (deftest can-write-false-for-audit-card-content-test
   (install-audit-db-if-needed!)


### PR DESCRIPTION
Sometimes analytics bits get removed by other tests (e.g. deleting all cards, dashboards, users, etc.). When we run
`ensure-audit-db-installed!`, though, the checksum hasn't changed (since the underlying analytics files didn't change), so we skip reloading the data.

This sets `last-analytics-checksum` to `-1` (meaning: skip the checksum and just load the analytics data) when running
`ensure-audit-db-installed!` in the tests that we've seen flake.
