### PR TITLE
Don't lower dashboard/question title when there is no last edit info

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -91,10 +91,12 @@ export function DashboardHeaderComponent({
 
   useEffect(() => {
     const timerId = setTimeout(() => {
-      setShowSubHeader(false);
+      if (isLastEditInfoVisible) {
+        setShowSubHeader(false);
+      }
     }, 4000);
     return () => clearTimeout(timerId);
-  }, []);
+  }, [isLastEditInfoVisible]);
 
   return (
     <div>

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -222,13 +222,6 @@ function SavedQuestionLeftSide(props) {
 
   const [showSubHeader, setShowSubHeader] = useState(true);
 
-  useEffect(() => {
-    const timerId = setTimeout(() => {
-      setShowSubHeader(false);
-    }, 4000);
-    return () => clearTimeout(timerId);
-  }, []);
-
   const hasLastEditInfo = question.lastEditInfo() != null;
   const isDataset = question.isDataset();
 
@@ -240,6 +233,18 @@ function SavedQuestionLeftSide(props) {
     },
     [question, onSave],
   );
+
+  const renderDataSource = QuestionDataSource.shouldRender(props) && !isDataset;
+  const renderLastEdit = hasLastEditInfo && isAdditionalInfoVisible;
+
+  useEffect(() => {
+    const timerId = setTimeout(() => {
+      if (isAdditionalInfoVisible && (renderDataSource || renderLastEdit)) {
+        setShowSubHeader(false);
+      }
+    }, 4000);
+    return () => clearTimeout(timerId);
+  }, [isAdditionalInfoVisible, renderDataSource, renderLastEdit]);
 
   return (
     <SavedQuestionLeftSideRoot


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38566

### Description
When a Dashboards or Questions / Models doesn't have any "last edit info" to show (such as things in the Metabase Analytics folder), the Entity title will start off in the correct position, but 4 seconds later will animate down, putting it out of place. This PR cancels that transition if we detect that no sub headers will be rendered

### How to verify

1. Go to any model or dashboard in Metabase Analytics and load the page
2. Observe the title in the header. It should not move after 4 seconds has passed
3. Now navigate to any Dashboard/Question/Model in out analytics
4. When the page loads, you should briefly see last edited info, possibly data source info as well. after 4 seconds, the title should lower and the sub header should fade away

### Demo
![chrome_ZUlIbnwauv](https://github.com/metabase/metabase/assets/1328979/1e916580-b947-4745-87d4-2a2db4419dcc)


### Checklist
No tests were added here, as it's unclear what type of testing would be helpful

- [ ] ~Tests have been added/updated to cover changes in this PR~
