### PR TITLE
Type routing in State

### DIFF
--- a/frontend/src/metabase-types/store/mocks/index.ts
+++ b/frontend/src/metabase-types/store/mocks/index.ts
@@ -7,6 +7,7 @@ export * from "./embed";
 export * from "./metabot";
 export * from "./parameters";
 export * from "./qb";
+export * from "./routing";
 export * from "./settings";
 export * from "./setup";
 export * from "./state";

--- a/frontend/src/metabase-types/store/mocks/routing.ts
+++ b/frontend/src/metabase-types/store/mocks/routing.ts
@@ -1,0 +1,26 @@
+import type { Location } from "history";
+import type { RouterState } from "react-router-redux";
+
+export const createMockRoutingState = (
+  opts?: Partial<RouterState>,
+): RouterState => {
+  return {
+    ...opts,
+    locationBeforeTransitions: createMockLocation(
+      opts?.locationBeforeTransitions,
+    ),
+  };
+};
+
+export const createMockLocation = (opts?: Partial<Location>): Location => {
+  return {
+    pathname: "/",
+    search: "",
+    query: {},
+    hash: "",
+    state: undefined,
+    action: "POP",
+    key: "", // can be null but react-router-redux@4.0.8 typings are inaccurate
+    ...opts,
+  };
+};

--- a/frontend/src/metabase-types/store/mocks/state.ts
+++ b/frontend/src/metabase-types/store/mocks/state.ts
@@ -9,6 +9,7 @@ import { createMockEmbedState } from "./embed";
 import { createMockMetabotState } from "./metabot";
 import { createMockParametersState } from "./parameters";
 import { createMockQueryBuilderState } from "./qb";
+import { createMockRoutingState } from "./routing";
 import { createMockSettingsState } from "./settings";
 import { createMockSetupState } from "./setup";
 import { createMockUploadState } from "./upload";
@@ -27,6 +28,7 @@ export const createMockState = (
   metabot: createMockMetabotState(),
   parameters: createMockParametersState(),
   qb: createMockQueryBuilderState(),
+  routing: createMockRoutingState(),
   settings: createMockSettingsState(),
   setup: createMockSetupState(),
   upload: createMockUploadState(),

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -1,3 +1,5 @@
+import type { RouterState } from "react-router-redux";
+
 import type { User } from "metabase-types/api";
 import type { AdminState } from "./admin";
 import type { AppState } from "./app";
@@ -21,8 +23,9 @@ export interface State {
   embed: EmbedState;
   entities: EntitiesState;
   metabot: MetabotState;
-  qb: QueryBuilderState;
   parameters: ParametersState;
+  qb: QueryBuilderState;
+  routing: RouterState;
   settings: SettingsState;
   setup: SetupState;
   upload: FileUploadState;

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -4,7 +4,7 @@ import { push, replace } from "react-router-redux";
 
 import { createThunkAction } from "metabase/lib/redux";
 import { equals } from "metabase/lib/utils";
-import { getRouting } from "metabase/selectors/routing";
+import { getLocation } from "metabase/selectors/routing";
 
 import { isEqualCard } from "metabase/lib/card";
 
@@ -41,7 +41,7 @@ export const popState = createThunkAction(
 
     const zoomedObjectId = getZoomedObjectId(getState());
     if (zoomedObjectId) {
-      const { locationBeforeTransitions = {} } = getRouting(getState());
+      const locationBeforeTransitions = getLocation(getState());
       const { state, query } = locationBeforeTransitions;
       const previouslyZoomedObjectId = state?.objectId || query?.objectId;
 

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -41,8 +41,7 @@ export const popState = createThunkAction(
 
     const zoomedObjectId = getZoomedObjectId(getState());
     if (zoomedObjectId) {
-      const locationBeforeTransitions = getLocation(getState());
-      const { state, query } = locationBeforeTransitions;
+      const { state, query } = getLocation(getState());
       const previouslyZoomedObjectId = state?.objectId || query?.objectId;
 
       if (

--- a/frontend/src/metabase/query_builder/actions/navigation.js
+++ b/frontend/src/metabase/query_builder/actions/navigation.js
@@ -4,6 +4,7 @@ import { push, replace } from "react-router-redux";
 
 import { createThunkAction } from "metabase/lib/redux";
 import { equals } from "metabase/lib/utils";
+import { getRouting } from "metabase/selectors/routing";
 
 import { isEqualCard } from "metabase/lib/card";
 
@@ -40,7 +41,7 @@ export const popState = createThunkAction(
 
     const zoomedObjectId = getZoomedObjectId(getState());
     if (zoomedObjectId) {
-      const { locationBeforeTransitions = {} } = getState().routing;
+      const { locationBeforeTransitions = {} } = getRouting(getState());
       const { state, query } = locationBeforeTransitions;
       const previouslyZoomedObjectId = state?.objectId || query?.objectId;
 

--- a/frontend/src/metabase/selectors/routing.ts
+++ b/frontend/src/metabase/selectors/routing.ts
@@ -1,6 +1,6 @@
 import type { State } from "metabase-types/store";
 
-export const getRouting = (state: State) => state.routing;
+const getRouting = (state: State) => state.routing;
 
 export const getLocation = (state: State) =>
   getRouting(state).locationBeforeTransitions;

--- a/frontend/src/metabase/selectors/routing.ts
+++ b/frontend/src/metabase/selectors/routing.ts
@@ -1,6 +1,4 @@
 import type { State } from "metabase-types/store";
 
-const getRouting = (state: State) => state.routing;
-
 export const getLocation = (state: State) =>
-  getRouting(state).locationBeforeTransitions;
+  state.routing.locationBeforeTransitions;

--- a/frontend/src/metabase/selectors/routing.ts
+++ b/frontend/src/metabase/selectors/routing.ts
@@ -1,0 +1,3 @@
+import type { State } from "metabase-types/store";
+
+export const getRouting = (state: State) => state.routing;

--- a/frontend/src/metabase/selectors/routing.ts
+++ b/frontend/src/metabase/selectors/routing.ts
@@ -1,3 +1,6 @@
 import type { State } from "metabase-types/store";
 
 export const getRouting = (state: State) => state.routing;
+
+export const getLocation = (state: State) =>
+  getRouting(state).locationBeforeTransitions;

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -53,7 +53,8 @@ export function renderWithProviders(
     ...options
   }: RenderWithProvidersOptions = {},
 ) {
-  let initialState = createMockState(storeInitialState);
+  let { routing, ...initialState }: Partial<State> =
+    createMockState(storeInitialState);
 
   if (mode === "public") {
     const publicReducerNames = Object.keys(publicReducers);
@@ -72,6 +73,7 @@ export function renderWithProviders(
 
   if (withRouter) {
     Object.assign(reducers, { routing: routerReducer });
+    Object.assign(initialState, { routing });
   }
   if (customReducers) {
     reducers = { ...reducers, ...customReducers };


### PR DESCRIPTION
### Description

Our `State` type does not have `routing` key, even though it's often there.
This PR adds it and updates related mocks.
