### PR TITLE
Fix custom destination to public dashboard not working on static embedding

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -11,6 +11,7 @@ import {
   getLinkCardDetails,
   getTextCardDetails,
   modal,
+  openStaticEmbeddingModal,
   popover,
   restore,
   saveDashboard,
@@ -18,6 +19,7 @@ import {
   updateDashboardCards,
   visitDashboard,
   visitEmbeddedPage,
+  visitIframe,
 } from "e2e/support/helpers";
 
 import {
@@ -1708,6 +1710,53 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
         .should("have.length", 2)
         .should("contain.text", POINT_COUNT)
         .should("contain.text", POINT_CREATED_AT_FORMATTED);
+    });
+  });
+
+  describe("static embedding", () => {
+    it("should navigate to public link URL (metabase#38640)", () => {
+      cy.createDashboard(TARGET_DASHBOARD)
+        .then(({ body: { id: dashboardId } }) => {
+          cy.log("create a public link for this dashboard");
+          cy.request("POST", `/api/dashboard/${dashboardId}/public_link`).then(
+            ({ body: { uuid } }) => {
+              cy.wrap(uuid);
+            },
+          );
+        })
+        .then(uuid => {
+          cy.createQuestionAndDashboard({
+            dashboardDetails: {
+              name: "Dashboard",
+              enable_embedding: true,
+            },
+            questionDetails: QUESTION_LINE_CHART,
+            cardDetails: {
+              // Set custom URL click behavior via API
+              visualization_settings: {
+                click_behavior: {
+                  type: "link",
+                  linkType: "url",
+                  linkTemplate: `http://localhost:4000/public/dashboard/${uuid}`,
+                },
+              },
+            },
+          });
+        })
+        .then(({ body: dashCard }) => {
+          visitDashboard(dashCard.dashboard_id);
+        });
+
+      openStaticEmbeddingModal({
+        activeTab: "parameters",
+        acceptTerms: false,
+      });
+      visitIframe();
+      clickLineChartPoint();
+
+      cy.findByRole("heading", { name: TARGET_DASHBOARD.name }).should(
+        "be.visible",
+      );
     });
   });
 });

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -1436,7 +1436,7 @@ describe("scenarios > dashboard > dashboard cards > click behavior", () => {
     });
   });
 
-  describe("full app embedding", () => {
+  describe("interactive embedding", () => {
     const questionDetails = QUESTION_LINE_CHART;
 
     beforeEach(() => {

--- a/frontend/src/metabase/lib/dom.js
+++ b/frontend/src/metabase/lib/dom.js
@@ -231,6 +231,17 @@ function isMetabaseUrl(url) {
     return true;
   }
 
+  const pathNameWithoutSubPath = getPathnameWithoutSubPath(urlPath);
+  const isPublicLink = pathNameWithoutSubPath.startsWith("/public/");
+  const isEmbedding = pathNameWithoutSubPath.startsWith("/embed/");
+  /**
+   * (metabase#38640) We don't want to use client-side navigation for public links or embedding
+   * because public app, or embed app are built using separate routes.
+   **/
+  if (isPublicLink || isEmbedding) {
+    return false;
+  }
+
   return isSameOrSiteUrlOrigin(url) && urlPath.startsWith(getSitePath());
 }
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38640

### Description

The problem stems from a fix for #33379. The fix was to navigate to custom URL which is the same URL as the Metabase instance using client-side. This caused a side-effect because `/embed/*` and `/public/*` serve different JS bundles which don't contain the route for each other. And they're meant to be standalone URLs.

So to fix this issue, I've extend the logic from the fix for #33379 to check that even we're navigating to the same Metabase URL, but to `/public/*` or `/embed/*` then we should open this as normal links.

Also, I've tested Metabase on subpath e.g. if Metabase is deployed on `/metabase` instead of `/` then the fix is still working correctly.

### How to verify

Follow the repro steps from #38640

### Demo

https://www.loom.com/share/1c4868e232974690bdf7cd4519d31dfc

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
