### PR TITLE
Bump Bigquery driver to v2.37.1

### DIFF
--- a/modules/drivers/bigquery-cloud-sdk/deps.edn
+++ b/modules/drivers/bigquery-cloud-sdk/deps.edn
@@ -3,7 +3,7 @@
 
  :deps
  ;; TODO: figure out how to be able to leave off this version string and use the version from the BOM
- {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.35.0"}
+ {com.google.cloud/google-cloud-bigquery      {:mvn/version "2.37.1"}
   com.google.guava/guava                      {:mvn/version "32.1.3-jre"} ; specified separately so that Snyk is happy
   com.google.code.gson/gson                   {:mvn/version "2.10.1"}
   com.google.oauth-client/google-oauth-client {:mvn/version "1.34.1"}}}


### PR DESCRIPTION
On 2.36, Bigquery fixed some issue around the location where the jobid was being sent. This will allow us to do https://github.com/metabase/metabase/issues/21309

changelog https://github.com/googleapis/java-bigquery/blob/main/CHANGELOG.md