### PR TITLE
[Metrics v2] Add the ability to edit a Metric definition page

### DIFF
--- a/frontend/src/metabase-types/api/modelIndexes.ts
+++ b/frontend/src/metabase-types/api/modelIndexes.ts
@@ -25,3 +25,9 @@ export type IndexedEntity = {
   name: string;
   pk_ref: FieldReference;
 };
+
+export type ModelIndexesListQuery = {
+  model_id: CardId | null;
+};
+
+export type ModelIndexesListResult = ModelIndex[];

--- a/frontend/src/metabase/common/hooks/index.ts
+++ b/frontend/src/metabase/common/hooks/index.ts
@@ -11,6 +11,7 @@ export * from "./use-field-values-query";
 export * from "./use-group-list-query";
 export * from "./use-metric-list-query";
 export * from "./use-metric-query";
+export * from "./use-model-indexes-list-query";
 export * from "./use-popular-item-list-query";
 export * from "./use-question-list-query";
 export * from "./use-question-query";

--- a/frontend/src/metabase/common/hooks/use-model-indexes-list-query/index.ts
+++ b/frontend/src/metabase/common/hooks/use-model-indexes-list-query/index.ts
@@ -1,0 +1,1 @@
+export * from "./use-model-indexes-list-query";

--- a/frontend/src/metabase/common/hooks/use-model-indexes-list-query/use-model-indexes-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-model-indexes-list-query/use-model-indexes-list-query.ts
@@ -1,0 +1,23 @@
+import { ModelIndexes } from "metabase/entities/model-indexes";
+import type {
+  UseEntityListQueryProps,
+  UseEntityListQueryResult,
+} from "metabase/common/hooks/use-entity-list-query";
+import { useEntityListQuery } from "metabase/common/hooks/use-entity-list-query";
+import type {
+  ModelIndexesListQuery,
+  ModelIndexesListResult,
+} from "metabase-types/api";
+
+export const useModelIndexesListQuery = (
+  props: UseEntityListQueryProps<ModelIndexesListQuery> = {},
+): UseEntityListQueryResult<ModelIndexesListResult> => {
+  return useEntityListQuery(props, {
+    fetchList: ModelIndexes.actions.fetchList,
+    getList: ModelIndexes.selectors.getList,
+    getLoading: ModelIndexes.selectors.getLoading,
+    getLoaded: ModelIndexes.selectors.getLoaded,
+    getError: ModelIndexes.selectors.getError,
+    getListMetadata: ModelIndexes.selectors.getListMetadata,
+  });
+};

--- a/frontend/src/metabase/entities/model-indexes/model-indexes.ts
+++ b/frontend/src/metabase/entities/model-indexes/model-indexes.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IndexedEntity } from "metabase-types/api/modelIndexes";
+import type { CardType } from "metabase-types/api";
 
 import { createEntity } from "metabase/lib/entities";
 import { ModelIndexApi } from "metabase/services";
@@ -20,7 +21,7 @@ export const ModelIndexes = createEntity({
   schema: ModelIndexSchema,
   api: {
     ...ModelIndexApi,
-    list: ({ model_id, type }: { model_id?: string | null; type: string }) =>
+    list: ({ model_id, type }: { model_id?: string | null; type: CardType }) =>
       model_id && type === "model"
         ? ModelIndexApi.list({ model_id })
         : { data: [] },

--- a/frontend/src/metabase/entities/model-indexes/model-indexes.ts
+++ b/frontend/src/metabase/entities/model-indexes/model-indexes.ts
@@ -20,8 +20,10 @@ export const ModelIndexes = createEntity({
   schema: ModelIndexSchema,
   api: {
     ...ModelIndexApi,
-    list: ({ model_id }: { model_id?: string | null }) =>
-      model_id ? ModelIndexApi.list({ model_id }) : { data: [] },
+    list: ({ model_id, type }: { model_id?: string | null; type: string }) =>
+      model_id && type === "model"
+        ? ModelIndexApi.list({ model_id })
+        : { data: [] },
   },
   actions,
   utils,

--- a/frontend/src/metabase/entities/model-indexes/model-indexes.ts
+++ b/frontend/src/metabase/entities/model-indexes/model-indexes.ts
@@ -5,7 +5,6 @@
  */
 
 import type { IndexedEntity } from "metabase-types/api/modelIndexes";
-import type { CardType } from "metabase-types/api";
 
 import { createEntity } from "metabase/lib/entities";
 import { ModelIndexApi } from "metabase/services";
@@ -21,10 +20,8 @@ export const ModelIndexes = createEntity({
   schema: ModelIndexSchema,
   api: {
     ...ModelIndexApi,
-    list: ({ model_id, type }: { model_id?: string | null; type: CardType }) =>
-      model_id && type === "model"
-        ? ModelIndexApi.list({ model_id })
-        : { data: [] },
+    list: ({ model_id }: { model_id?: string | null }) =>
+      model_id ? ModelIndexApi.list({ model_id }) : { data: [] },
   },
   actions,
   utils,

--- a/frontend/src/metabase/entities/model-indexes/utils.ts
+++ b/frontend/src/metabase/entities/model-indexes/utils.ts
@@ -24,7 +24,10 @@ export const canIndexField = (field: FieldEntity, model: Question): boolean => {
 
 export const getPkRef = (fields?: Field[]) => fields?.find(isPK)?.field_ref;
 
-export const fieldHasIndex = (modelIndexes: ModelIndex[], field: Field) =>
-  !!modelIndexes.some((index: any) =>
+export const fieldHasIndex = (
+  modelIndexes: ModelIndex[] | undefined,
+  field: Field,
+) =>
+  !!modelIndexes?.some((index: any) =>
     _.isEqual(index.value_ref, field.field_ref),
   );

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -20,7 +20,7 @@ import { TagEditorSidebar } from "metabase/query_builder/components/template_tag
 import { SnippetSidebar } from "metabase/query_builder/components/template_tags/SnippetSidebar/SnippetSidebar";
 import { calcInitialEditorHeight } from "metabase/query_builder/components/NativeQueryEditor/utils";
 
-import { modelIndexes } from "metabase/entities";
+import { useModelIndexesListQuery } from "metabase/common/hooks";
 
 import { setDatasetEditorTab } from "metabase/query_builder/actions";
 import {
@@ -75,7 +75,6 @@ const propTypes = {
   handleResize: PropTypes.func.isRequired,
   runQuestionQuery: PropTypes.func.isRequired,
   onOpenModal: PropTypes.func.isRequired,
-  modelIndexes: PropTypes.array.isRequired,
 
   // Native editor sidebars
   isShowingTemplateTagsEditor: PropTypes.bool.isRequired,
@@ -207,7 +206,6 @@ function DatasetEditor(props) {
     onSave,
     handleResize,
     onOpenModal,
-    modelIndexes = [],
   } = props;
 
   const isDirty = isModelQueryDirty || isMetadataDirty;
@@ -216,6 +214,11 @@ function DatasetEditor(props) {
     () => getSortedModelFields(question, resultsMetadata?.columns),
     [question, resultsMetadata],
   );
+
+  const { data: modelIndexes } = useModelIndexesListQuery({
+    query: { model_id: question.id() },
+    enabled: question.isSaved() && question.type() === "model",
+  });
 
   const isEditingQuery = datasetEditorTab === "query";
   const isEditingMetadata = datasetEditorTab === "metadata";
@@ -541,13 +544,4 @@ function DatasetEditor(props) {
 
 DatasetEditor.propTypes = propTypes;
 
-export default _.compose(
-  modelIndexes.loadList({
-    query: (_state, props) => ({
-      model_id: props?.question?.id(),
-      type: props?.question?.type(),
-    }),
-    loadingAndErrorWrapper: false,
-  }),
-  connect(mapStateToProps, mapDispatchToProps),
-)(DatasetEditor);
+export default connect(mapStateToProps, mapDispatchToProps)(DatasetEditor);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -543,7 +543,10 @@ DatasetEditor.propTypes = propTypes;
 
 export default _.compose(
   modelIndexes.loadList({
-    query: (_state, props) => ({ model_id: props?.question?.id() }),
+    query: (_state, props) => ({
+      model_id: props?.question?.id(),
+      type: props?.question?.type(),
+    }),
     loadingAndErrorWrapper: false,
   }),
   connect(mapStateToProps, mapDispatchToProps),

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
@@ -29,6 +29,8 @@ const mockSavedCard = createMockCard({
     },
   }),
 });
+const mockSavedModel = { ...mockSavedCard, type: "model" };
+const mockSavedMetric = { ...mockSavedCard, type: "metric" };
 const mockUnsavedCard = createMockUnsavedCard();
 
 const noop = () => null;
@@ -78,13 +80,23 @@ describe("DatasetEditor", () => {
   afterEach(() => {
     jest.restoreAllMocks();
   });
-  it("tries to load a model index when card is already saved", () => {
-    renderDatasetEditor(mockSavedCard);
+  it("tries to load a model index for a saved model", () => {
+    renderDatasetEditor(mockSavedModel);
     const calls = fetchMock.calls("path:/api/model-index");
     expect(calls).toHaveLength(1);
     expect(
       new URL(calls[0]?.request?.url ?? "").searchParams.get("model_id"),
-    ).toBe(`${mockSavedCard.id}`);
+    ).toBe(`${mockSavedModel.id}`);
+  });
+  it("does not try to load a model index for a saved question", () => {
+    renderDatasetEditor(mockSavedCard);
+    const calls = fetchMock.calls("path:/api/model-index");
+    expect(calls).toHaveLength(0);
+  });
+  it("does not try to load a model index for a saved metric", () => {
+    renderDatasetEditor(mockSavedMetric);
+    const calls = fetchMock.calls("path:/api/model-index");
+    expect(calls).toHaveLength(0);
   });
   it("does not try to load a model index when card is unsaved", () => {
     renderDatasetEditor(mockUnsavedCard);

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.unit.spec.tsx
@@ -64,11 +64,7 @@ const renderDatasetEditor = (card: Card | UnsavedCard) => {
   const question = new Question(card);
 
   renderWithProviders(
-    <DatasetEditor
-      {...defaultDatasetEditorProps}
-      question={question}
-      query={question.legacyQuery({ useStructuredQuery: true })}
-    />,
+    <DatasetEditor {...defaultDatasetEditorProps} question={question} />,
   );
 };
 

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetFieldMetadataSidebar/DatasetFieldMetadataSidebar.jsx
@@ -48,7 +48,7 @@ const propTypes = {
   isLastField: PropTypes.bool.isRequired,
   handleFirstFieldFocus: PropTypes.func.isRequired,
   onFieldMetadataChange: PropTypes.func.isRequired,
-  modelIndexes: PropTypes.array.isRequired,
+  modelIndexes: PropTypes.array,
 };
 
 function getVisibilityTypeName(visibilityType) {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
@@ -91,18 +91,19 @@ export const QuestionActions = ({
     ? color("brand")
     : undefined;
 
-  const isDataset = question.isDataset();
   const canWrite = question.canWrite();
   const isSaved = question.isSaved();
   const database = question.database();
   const canAppend = canUpload && canWrite && !!question._card.based_on_upload;
   const type = question.type() || "question";
+  const isModel = type === "model";
+  const isModelOrMetric = isModel || type === "metric";
 
   const canPersistDataset =
     PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled() &&
     canWrite &&
     isSaved &&
-    isDataset &&
+    isModel &&
     checkDatabaseCanPersistDatasets(question.database());
 
   const handleEditQuery = useCallback(() => {
@@ -129,7 +130,7 @@ export const QuestionActions = ({
 
   if (
     isMetabotEnabled &&
-    isDataset &&
+    isModel &&
     database &&
     canUseMetabotOnDatabase(database)
   ) {
@@ -148,14 +149,17 @@ export const QuestionActions = ({
     ),
   );
 
-  if (canWrite && isDataset) {
-    extraButtons.push(
-      {
+  if (canWrite) {
+    if (isModelOrMetric) {
+      extraButtons.push({
         title: t`Edit query definition`,
         icon: "notebook",
         action: handleEditQuery,
-      },
-      {
+      });
+    }
+
+    if (isModel) {
+      extraButtons.push({
         title: (
           <div>
             {t`Edit metadata`} <StrengthIndicator dataset={question} />
@@ -163,8 +167,8 @@ export const QuestionActions = ({
         ),
         icon: "label",
         action: handleEditMetadata,
-      },
-    );
+      });
+    }
   }
 
   if (canPersistDataset) {
@@ -177,7 +181,7 @@ export const QuestionActions = ({
     });
   }
 
-  if (!isDataset) {
+  if (!isModel) {
     extraButtons.push({
       title: t`Add to dashboard`,
       icon: "add_to_dash",
@@ -201,7 +205,7 @@ export const QuestionActions = ({
         testId: TURN_INTO_DATASET_TESTID,
       });
     }
-    if (isDataset) {
+    if (isModel) {
       extraButtons.push({
         title: t`Turn back to saved question`,
         icon: "insight",

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.unit.spec.tsx
@@ -85,7 +85,7 @@ describe("QuestionActions", () => {
   it("should allow to edit the model only with write permissions", async () => {
     setup({
       card: createMockCard({
-        dataset: true,
+        type: "model",
         can_write: true,
       }),
     });
@@ -100,7 +100,7 @@ describe("QuestionActions", () => {
   it("should not allow to edit the model without write permissions", async () => {
     setup({
       card: createMockCard({
-        dataset: true,
+        type: "model",
         can_write: false,
       }),
     });
@@ -115,7 +115,7 @@ describe("QuestionActions", () => {
   it("should not render the menu when there are no menu items", () => {
     setup({
       card: createMockCard({
-        dataset: true,
+        type: "model",
         can_write: false,
       }),
       databases: [],

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -358,17 +358,22 @@ function areLegacyQueriesEqual(queryA, queryB, tableMetadata) {
   );
 }
 
-// Model questions may be composed via the `composeDataset` method.
-// A composed model question should be treated as equivalent to its original form.
+// Models or metrics may be composed via the `composeDataset` method.
+// A composed entity should be treated as the equivalent to its original form.
 // We need to handle scenarios where both the `lastRunQuestion` and the `currentQuestion` are
 // in either form.
-function areModelsEquivalent({
+function areComposedEntitiesEquivalent({
   originalQuestion,
   lastRunQuestion,
   currentQuestion,
   tableMetadata,
 }) {
-  if (!lastRunQuestion || !currentQuestion || !originalQuestion?.isDataset()) {
+  if (
+    !lastRunQuestion ||
+    !currentQuestion ||
+    originalQuestion.type() !== "model" ||
+    originalQuestion.type() !== "metric"
+  ) {
     return false;
   }
 
@@ -416,7 +421,7 @@ function areQueriesEquivalent({
       currentQuestion?.datasetQuery(),
       tableMetadata,
     ) ||
-    areModelsEquivalent({
+    areComposedEntitiesEquivalent({
       originalQuestion,
       lastRunQuestion,
       currentQuestion,

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -368,12 +368,11 @@ function areComposedEntitiesEquivalent({
   currentQuestion,
   tableMetadata,
 }) {
-  if (
-    !lastRunQuestion ||
-    !currentQuestion ||
-    originalQuestion?.type() !== "model" ||
-    originalQuestion?.type() !== "metric"
-  ) {
+  const isModelOrMetric =
+    originalQuestion?.type() === "model" ||
+    originalQuestion?.type() === "metric";
+
+  if (!lastRunQuestion || !currentQuestion || !isModelOrMetric) {
     return false;
   }
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -371,8 +371,8 @@ function areComposedEntitiesEquivalent({
   if (
     !lastRunQuestion ||
     !currentQuestion ||
-    originalQuestion.type() !== "model" ||
-    originalQuestion.type() !== "metric"
+    originalQuestion?.type() !== "model" ||
+    originalQuestion?.type() !== "metric"
   ) {
     return false;
   }

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -226,6 +226,7 @@ export const getRoutes = store => {
             <Route path="query" component={QueryBuilder} />
             <Route path=":slug" component={QueryBuilder} />
             <Route path=":slug/notebook" component={QueryBuilder} />
+            <Route path=":slug/query" component={QueryBuilder} />
           </Route>
 
           <Route path="browse">


### PR DESCRIPTION
This PR introduces the "edit query" page for metrics.
The new route it uses is `/metric/:slug/query`.

This page is in many ways analogous to the existing "edit query" page for models.
One notable exception that we needed to make in this PR is to [prevent the page from fetching model indexes](https://github.com/metabase/metabase/pull/38664/commits/f9d2c9af717d9e768817f27c507364cbd5efc314).

As we add more pages, and as metrics find their way into different parts of our app, it's becoming evident that the old abstractions (and the old naming patterns) that were tailored specifically to models are insufficient. A lot of what we're doing to make metrics work is patching that old code. And it most cases, the crux of the change is going from `isModel` to `isModelOrMetric`.

### How to verify these changes work?
1. Open the existing metric
2. Click on the `...` menu
3. You should see "Edit query definition", and you should be able to click on it
4. After clicking on it, you should lang on `/metric/:slug/query` page

Please note that, unlike for models, we're currently NOT displaying "query" and "metadata" tabs. There are separate tasks for that in step 7 of the parent epic.

Closes #37354