### PR TITLE
Add metrics to search

### DIFF
--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -9,14 +9,15 @@ export type EnabledSearchModelType =
   | "collection"
   | "dashboard"
   | "card"
+  | "metric"
+  | "dataset"
   | "database"
   | "table"
-  | "dataset"
   | "action"
   | "indexed-entity";
 
 export type SearchModelType =
-  | ("segment" | "metric" | "pulse" | "snippet")
+  | ("segment" | "pulse" | "snippet")
   | EnabledSearchModelType;
 
 export interface SearchScore {

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -222,12 +222,15 @@ const Questions = createEntity({
   forms,
 });
 
-export function getIcon(question) {
-  if (question.dataset || question.model === "dataset") {
+export function getIcon(card) {
+  if (card.type === "model" || card.model === "dataset") {
     return { name: "model" };
   }
+  if (card.type === "metric" || card.model === "metric") {
+    return { name: "metric" };
+  }
   const visualization = require("metabase/visualizations").default.get(
-    question.display,
+    card.display,
   );
   return {
     name: visualization?.iconName ?? "beaker",

--- a/frontend/src/metabase/lib/schema/schema.js
+++ b/frontend/src/metabase/lib/schema/schema.js
@@ -1,6 +1,6 @@
 // backend returns model = "card" instead of "question"
 export const entityTypeForModel = model => {
-  if (model === "card" || model === "dataset") {
+  if (model === "card" || model === "dataset" || model === "metric") {
     return "questions";
   }
   if (model === "indexed-entity") {

--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.unit.spec.tsx
@@ -20,10 +20,11 @@ import { TypeFilterContent } from "./TypeFilterContent";
 const MODEL_NAME: Record<EnabledSearchModelType, string> = {
   action: "Action",
   card: "Question",
+  metric: "Metric",
+  dataset: "Model",
   collection: "Collection",
   dashboard: "Dashboard",
   database: "Database",
-  dataset: "Model",
   table: "Table",
   "indexed-entity": "Indexed record",
 };

--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.unit.spec.tsx
@@ -32,6 +32,7 @@ const MODEL_NAME: Record<EnabledSearchModelType, string> = {
 const TEST_TYPES: Array<EnabledSearchModelType> = [
   "dashboard",
   "card",
+  "metric",
   "dataset",
   "collection",
   "database",

--- a/frontend/src/metabase/search/constants.ts
+++ b/frontend/src/metabase/search/constants.ts
@@ -13,6 +13,7 @@ export const SearchFilterKeys = {
 export const enabledSearchTypes: EnabledSearchModelType[] = [
   "dashboard",
   "card",
+  "metric",
   "dataset",
   "collection",
   "database",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37361
Closes https://github.com/metabase/metabase/issues/37362
Closes https://github.com/metabase/metabase/issues/37363

<img width="553" alt="Screenshot 2024-02-12 at 17 53 00" src="https://github.com/metabase/metabase/assets/8542534/6d94fb5b-0325-4cde-a831-80480bf8344c">
<img width="1392" alt="Screenshot 2024-02-12 at 17 53 05" src="https://github.com/metabase/metabase/assets/8542534/78355931-2f49-4897-a1ac-c09ed906c2af">


Doesn't really work without the BE changes. To make it appear, create a metric v1.