### PR TITLE
Don't remove cards from dashboards on archive

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -1027,9 +1027,11 @@
    dashcard-id  ms/PositiveInt
    parameters   ms/JSONString}
   (api/read-check :model/Dashboard dashboard-id)
-  (actions.execution/fetch-values
-   (api/check-404 (action/dashcard->action dashcard-id))
-   (json/parse-string parameters)))
+  (-> (t2/select-one :model/DashboardCard :id dashcard-id)
+      api/check-not-archived
+      action/dashcard->action
+      api/check-404
+      (actions.execution/fetch-values (json/parse-string parameters))))
 
 (api/defendpoint POST "/:dashboard-id/dashcard/:dashcard-id/execute"
   "Execute the associated Action in the context of a `Dashboard` and `DashboardCard` that includes it.

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -295,6 +295,7 @@
    card-id     ms/PositiveInt
    parameters  [:maybe ms/JSONString]}
   (validation/check-public-sharing-enabled)
+  (api/check-not-archived (t2/select-one :model/Card :id card-id))
   (let [dashboard-id (api/check-404 (t2/select-one-pk Dashboard :public_uuid uuid, :archived false))]
     (public-dashcard-results-async
      :dashboard-id  dashboard-id

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -476,7 +476,7 @@
                                                      :where  [:= :action.model_id model-id]})]
     (t2/delete! 'Action :id [:in action-ids])))
 
-(defn- pre-update [{archived? :archived, id :id, :as changes}]
+(defn- pre-update [{id :id, :as changes}]
   ;; TODO - don't we need to be doing the same permissions check we do in `pre-insert` if the query gets changed? Or
   ;; does that happen in the `PUT` endpoint?
   (u/prog1 changes
@@ -485,9 +485,6 @@
                                   (:dataset_query changes)
                                   (get-in changes [:dataset_query :native]))
                           (t2/select-one [:model/Card :dataset_query :dataset] :id id))]
-      ;; if the Card is archived, then remove it from any Dashboards
-      (when archived?
-        (t2/delete! 'DashboardCard :card_id id))
       ;; if the template tag params for this Card have changed in any way we need to update the FieldValues for
       ;; On-Demand DB Fields
       (when (get-in changes [:dataset_query :native])

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -69,15 +69,6 @@
                                Dashboard   _                      {:parameters [(card-params card-id)]}]
         (is (= 3 (hydrated-count card)))))))
 
-(deftest remove-from-dashboards-when-archiving-test
-  (testing "Test that when somebody archives a Card, it is removed from any Dashboards it belongs to"
-    (t2.with-temp/with-temp [Dashboard     dashboard {}
-                             :model/Card   card      {}
-                             DashboardCard _dashcard {:dashboard_id (u/the-id dashboard), :card_id (u/the-id card)}]
-      (t2/update! :model/Card (u/the-id card) {:archived true})
-      (is (= 0
-             (t2/count DashboardCard :dashboard_id (u/the-id dashboard)))))))
-
 (deftest public-sharing-test
   (testing "test that a Card's :public_uuid comes back if public sharing is enabled..."
     (tu/with-temporary-setting-values [enable-public-sharing true]


### PR DESCRIPTION
I'm really tearing out chesterton's fence here because I'm not sure why we *would* remove cards from dashboards. As far as I could tell from playing around with this locally, an archived card does not appear in a dashboard even if the `DashboardCard` still exists...

I tested this in a few ways. Obviously the existing tests still pass (there were a few spots where we weren't actually checking whether cards were archived, which I fixed). I was worried that there might be issues with archived cards interfering with non-archived cards on a given dashboard (e.g. I archive a card in a given position on a dashboard, then put a new card on that same position - what happens?). Playing around with the UI, everything seems to work as expected.

Fixes #38646 