### PR TITLE
Deflake dashboard-filters-id by waiting for the card to finish loading

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-id.cy.spec.js
@@ -35,6 +35,7 @@ describe("scenarios > dashboard > filters > ID", () => {
 
       filterWidget().click();
       addWidgetStringFilter("15");
+      cy.findByTestId("loading-spinner").should("not.exist");
 
       cy.get(".Card").within(() => {
         cy.findByText("114.42");
@@ -47,6 +48,7 @@ describe("scenarios > dashboard > filters > ID", () => {
       addWidgetStringFilter("15");
 
       saveDashboard();
+      cy.findByTestId("loading-spinner").should("not.exist");
 
       cy.get(".Card").within(() => {
         cy.findByText("114.42");
@@ -64,6 +66,7 @@ describe("scenarios > dashboard > filters > ID", () => {
 
       filterWidget().click();
       addWidgetStringFilter("4");
+      cy.findByTestId("loading-spinner").should("not.exist");
 
       cy.get(".Card").within(() => {
         cy.findByText("47.68");
@@ -78,6 +81,7 @@ describe("scenarios > dashboard > filters > ID", () => {
       addWidgetStringFilter("4");
 
       saveDashboard();
+      cy.findByTestId("loading-spinner").should("not.exist");
 
       cy.get(".Card").within(() => {
         cy.findByText("47.68");
@@ -99,6 +103,7 @@ describe("scenarios > dashboard > filters > ID", () => {
 
       filterWidget().click();
       addWidgetStringFilter("10");
+      cy.findByTestId("loading-spinner").should("not.exist");
 
       cy.get(".Card").within(() => {
         cy.findByText("6.75");
@@ -111,6 +116,7 @@ describe("scenarios > dashboard > filters > ID", () => {
       addWidgetStringFilter("10");
 
       saveDashboard();
+      cy.findByTestId("loading-spinner").should("not.exist");
 
       cy.get(".Card").within(() => {
         cy.findByText("6.75");


### PR DESCRIPTION
This test has been flaky due to checking its assertion before waiting
for the cards on the dashboard to refresh based on the newly added or
set filter.

This waits for the hourglass icon `loading-spinner` to be gone before
checking that the table is properly filtered.

[Example failure](https://app.replay.io/recording/e2etestscenariosdashboard-filtersdashboard-filters-idcyspecjs--83043eb8-690e-482e-9108-a24455b4942f)

