### PR TITLE
Extend param substitution to handle datetimes

### DIFF
--- a/src/metabase/driver/sql/parameters/substitution.clj
+++ b/src/metabase/driver/sql/parameters/substitution.clj
@@ -22,6 +22,7 @@
     :as qp.wrap-value-literals]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.query-processor.util.add-alias-info :as add]
+   [metabase.shared.util.time :as shared.ut]
    [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
    [metabase.util.i18n :refer [tru]]
@@ -115,9 +116,14 @@
     :day))
 
 (defmethod align-temporal-unit-with-param-type-and-value :default
-  [driver field param-type _value]
-  #_{:clj-kondo/ignore [:deprecated-var]}
-  (align-temporal-unit-with-param-type driver field param-type))
+  [_driver _field param-type value]
+  (when (params.dates/date-type? param-type)
+    (let [value* (if (params.dates/not-single-date-type? param-type)
+                   (:start (params.dates/date-string->range value))
+                   value)]
+      (if (re-matches shared.ut/local-date-regex value*)
+        :day
+        :minute))))
 
 ;;; ------------------------------------------- ->replacement-snippet-info -------------------------------------------
 

--- a/test/metabase/driver/sql/parameters/substitute_test.clj
+++ b/test/metabase/driver/sql/parameters/substitute_test.clj
@@ -81,31 +81,31 @@
   information about"
   []
   (params/map->FieldFilter
-   {:field (meta/field-metadata :checkins :date)
+   {:field (meta/field-metadata :orders :created-at)
     :value {:type  :date/single
-            :value (t/offset-date-time "2019-09-20T19:52:00.000-07:00")}}))
+            :value (str (t/offset-date-time "2019-09-20T19:52:00.000-07:00"))}}))
 
 (deftest ^:parallel substitute-field-filter-test
   (testing "field-filters"
     (testing "non-optional"
-      (let [query ["select * from checkins where " (param "date")]]
+      (let [query ["select * from orders where " (param "created_at")]]
         (testing "param is present"
-          (is (= ["select * from checkins where \"PUBLIC\".\"CHECKINS\".\"DATE\" = ?"
+          (is (= ["select * from orders where DATE_TRUNC('minute', \"PUBLIC\".\"ORDERS\".\"CREATED_AT\") = ?"
                   [(t/offset-date-time "2019-09-20T19:52:00.000-07:00")]]
-                 (substitute query {"date" (date-field-filter-value)}))))
+                 (substitute query {"created_at" (date-field-filter-value)}))))
         (testing "param is missing"
-          (is (= ["select * from checkins where 1 = 1" []]
-                 (substitute query {"date" (assoc (date-field-filter-value) :value params/no-value)}))
+          (is (= ["select * from orders where 1 = 1" []]
+                 (substitute query {"created_at" (assoc (date-field-filter-value) :value params/no-value)}))
               "should be replaced with 1 = 1"))))
     (testing "optional"
-      (let [query ["select * from checkins " (optional "where " (param "date"))]]
+      (let [query ["select * from orders " (optional "where " (param "created_at"))]]
         (testing "param is present"
-          (is (= ["select * from checkins where \"PUBLIC\".\"CHECKINS\".\"DATE\" = ?"
+          (is (= ["select * from orders where DATE_TRUNC('minute', \"PUBLIC\".\"ORDERS\".\"CREATED_AT\") = ?"
                   [#t "2019-09-20T19:52:00.000-07:00"]]
-                 (substitute query {"date" (date-field-filter-value)}))))
+                 (substitute query {"created_at" (date-field-filter-value)}))))
         (testing "param is missing — should be omitted entirely"
-          (is (= ["select * from checkins" nil]
-                 (substitute query {"date" (assoc (date-field-filter-value) :value params/no-value)}))))))))
+          (is (= ["select * from orders" nil]
+                 (substitute query {"created_at" (assoc (date-field-filter-value) :value params/no-value)}))))))))
 
 (deftest ^:parallel substitute-field-filter-test-2
   (testing "new operators"
@@ -736,8 +736,9 @@
     (testing (str "test that excluding date parts work correctly. It should be enough to try just one type of exclusion "
                   "here, since handling them gets delegated to the functions in `metabase.driver.common.parameters.dates`, "
                   "which is fully-tested :D")
-      (doseq [[exclusion-string expected] {"exclude-months-Jan"     14
-                                           "exclude-months-Jan-Feb" 13}]
+      (doseq [[exclusion-string expected] {"exclude-months-Jan" 14
+                                           "exclude-months-Jan-Feb" 13
+                                           "exclude-hours-0-1-2-3-4-5-6-7-8-9-10-11-12" 5}]
         (testing (format "test that excluding dates with %s works correctly" exclusion-string)
           (is (= [expected]
                  (mt/first-row

--- a/test/metabase/driver/sql/parameters/substitution_test.clj
+++ b/test/metabase/driver/sql/parameters/substitution_test.clj
@@ -14,7 +14,7 @@
    [metabase.test :as mt]
    [metabase.util.honey-sql-2 :as h2x])
   (:import
-   (java.time LocalDateTime)))
+   (java.time LocalDate LocalDateTime)))
 
 (set! *warn-on-reflection* true)
 
@@ -83,8 +83,10 @@
   [_driver _field _param-type _value]
   nil)
 
-;; The original implementation will call this method despite the value being past30minutes. This is likely a bug.
-;; However, `metabase.query-processor-test.alternative-date-test/substitute-native-parameters-test` depends on it.
+(defmethod sql.qp/date [::temporal-unit-alignment-original :minute]
+  [_driver _unit expr]
+  (h2x/minute expr))
+
 (defmethod sql.qp/date [::temporal-unit-alignment-original :day]
   [_driver _unit expr]
   (h2x/day expr))
@@ -92,20 +94,39 @@
 (deftest ^:parallel align-temporal-unit-with-param-type-test
   (mt/with-clock #t "2018-07-01T12:30:00.000Z"
     (mt/with-metadata-provider meta/metadata-provider
-      (let [field-filter (params/map->FieldFilter
-                          {:field (lib.metadata/field (qp.store/metadata-provider) (meta/id :orders :created-at))
-                           :value {:type :date/all-options, :value "past30minutes"}})
-            expected-args [(LocalDateTime/of 2018 7 1 12 00 00)
-                           (LocalDateTime/of 2018 7 1 12 29 00)]]
-        (testing "default implementation"
-          (driver/with-driver ::temporal-unit-alignment-original
-            (is (= {:prepared-statement-args expected-args
-                    ;; `sql.qp/date [driver :day]` was called due to `:day` returned from the multimethod by default
-                    :replacement-snippet "DAY(\"PUBLIC\".\"CHECKINS\".\"DATE\") BETWEEN ? AND ?"}
-                   (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-original field-filter)))))
-        (testing "override"
-          (driver/with-driver ::temporal-unit-alignment-override
-            (is (= {:prepared-statement-args expected-args
-                    ;; no extra `sql.qp/date` calls due to `nil` returned from the override
-                    :replacement-snippet "\"PUBLIC\".\"CHECKINS\".\"DATE\" BETWEEN ? AND ?"}
-                   (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-override field-filter)))))))))
+      (testing "date"
+        (let [field-filter (params/map->FieldFilter
+                             {:field (lib.metadata/field (qp.store/metadata-provider) (meta/id :orders :created-at))
+                              :value {:type :date/all-options, :value "next3days"}})
+              expected-args [(LocalDate/of 2018 7 2)
+                             (LocalDate/of 2018 7 4)]]
+          (testing "default implementation"
+            (driver/with-driver ::temporal-unit-alignment-original
+              (is (= {:prepared-statement-args expected-args
+                      ;; `sql.qp/date [driver :day]` was called due to `:day` returned from the multimethod by default
+                      :replacement-snippet "DAY(\"PUBLIC\".\"ORDERS\".\"CREATED_AT\") BETWEEN ? AND ?"}
+                     (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-original field-filter)))))
+          (testing "override"
+            (driver/with-driver ::temporal-unit-alignment-override
+              (is (= {:prepared-statement-args expected-args
+                      ;; no extra `sql.qp/date` calls due to `nil` returned from the override
+                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"}
+                     (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-override field-filter)))))))
+      (testing "datetime"
+        (let [field-filter (params/map->FieldFilter
+                             {:field (lib.metadata/field (qp.store/metadata-provider) (meta/id :orders :created-at))
+                              :value {:type :date/all-options, :value "past30minutes"}})
+              expected-args [(LocalDateTime/of 2018 7 1 12 00 00)
+                             (LocalDateTime/of 2018 7 1 12 29 00)]]
+          (testing "default implementation"
+            (driver/with-driver ::temporal-unit-alignment-original
+              (is (= {:prepared-statement-args expected-args
+                      ;; `sql.qp/date [driver :day]` was called due to `:day` returned from the multimethod by default
+                      :replacement-snippet "MINUTE(\"PUBLIC\".\"ORDERS\".\"CREATED_AT\") BETWEEN ? AND ?"}
+                     (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-original field-filter)))))
+          (testing "override"
+            (driver/with-driver ::temporal-unit-alignment-override
+              (is (= {:prepared-statement-args expected-args
+                      ;; no extra `sql.qp/date` calls due to `nil` returned from the override
+                      :replacement-snippet "\"PUBLIC\".\"ORDERS\".\"CREATED_AT\" BETWEEN ? AND ?"}
+                     (sql.params.substitution/->replacement-snippet-info ::temporal-unit-alignment-override field-filter))))))))))

--- a/test/metabase/driver/sql/parameters/substitution_test.clj
+++ b/test/metabase/driver/sql/parameters/substitution_test.clj
@@ -93,7 +93,7 @@
   (mt/with-clock #t "2018-07-01T12:30:00.000Z"
     (mt/with-metadata-provider meta/metadata-provider
       (let [field-filter (params/map->FieldFilter
-                          {:field (lib.metadata/field (qp.store/metadata-provider) (meta/id :checkins :date))
+                          {:field (lib.metadata/field (qp.store/metadata-provider) (meta/id :orders :created-at))
                            :value {:type :date/all-options, :value "past30minutes"}})
             expected-args [(LocalDateTime/of 2018 7 1 12 00 00)
                            (LocalDateTime/of 2018 7 1 12 29 00)]]

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1202,6 +1202,63 @@
                   {:filter   [:time-interval $date -4 :month]
                    :breakout [!day.date]})))))))))
 
+(deftest ^:parallel native-query-datetime-filter-test
+  (testing "Field Filters with datetime values should behave like gui questions (#33492)"
+    (are [native-type native-value mbql-filter expected-row-count]
+        (let [mbql-rows (-> (mt/mbql-query orders {:fields [$created_at]
+                                                   :filter mbql-filter
+                                                   :order-by [[:asc $created_at]]})
+                            qp/process-query
+                            mt/rows)
+              native-rows (-> (mt/native-query {:query (str "SELECT created_at "
+                                                            "FROM orders "
+                                                            "WHERE {{date}} "
+                                                            "ORDER BY created_at")
+                                                :template-tags {"date"
+                                                                {:name "date"
+                                                                 :display-name "Date"
+                                                                 :type :dimension
+                                                                 :widget-type native-type
+                                                                 :dimension (mt/$ids !minute.orders.created_at)}}
+                                                :parameters [{:type native-type
+                                                              :name "date"
+                                                              :target [:dimension [:template-tag "date"]]
+                                                              :value native-value}]})
+                              qp/process-query
+                              mt/rows)]
+          (is (= expected-row-count (count native-rows)))
+          (is (= mbql-rows native-rows)))
+
+        :date/range
+        "2020-03-04~2020-03-04"
+        [:between !day.created_at "2020-03-04" "2020-03-04"]
+        13
+
+        :date/range
+        "2020-03-04T07:19:00~2020-03-04T07:20:00"
+        [:between !minute.created_at "2020-03-04T07:19:00" "2020-03-04T07:20:00"]
+        2
+
+        :date/all-options
+        "2020-03-04~2020-03-04"
+        [:between !day.created_at "2020-03-04" "2020-03-04"]
+        13
+
+        :date/all-options
+        "2020-03-04T07:19:00~2020-03-04T07:20:00"
+        [:between !minute.created_at "2020-03-04T07:19:00" "2020-03-04T07:20:00"]
+        2
+
+        :date/single
+        "2020-03-04"
+        [:= !day.created_at "2020-03-04"]
+        13
+
+        :date/single
+        "2020-03-04T07:20:00"
+        [:= !minute.created_at "2020-03-04T07:20"]
+        2)))
+
 (deftest field-filter-start-of-week-test
   (testing "Field Filters with relative date ranges should respect the custom start of week setting (#14294)"
     (mt/dataset checkins:1-per-day


### PR DESCRIPTION
Fixes #38037
Fixes #33492

Prior to this only dates were supported as values for native timestamp field parameters. By properly aligning the temporal unit, we can ensure that native filters match gui filters.
