### PR TITLE
Fix isNavigationAllowed

### DIFF
--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -87,7 +87,7 @@ export const isNavigationAllowed = ({
     .filter(Boolean)
     .map(String);
 
-  if (question.isDataset()) {
+  if (question.type() === "model") {
     if (isNewQuestion) {
       const allowedPathnames = ["/model/query", "/model/metadata"];
       return allowedPathnames.includes(pathname);

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -97,6 +97,7 @@ export const isNavigationAllowed = ({
       `/model/${slug}`,
       `/model/${slug}/query`,
       `/model/${slug}/metadata`,
+      `/model/${slug}/notebook`,
     ]);
 
     return allowedPathnames.includes(pathname);

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -88,17 +88,14 @@ export const isNavigationAllowed = ({
     .map(String);
 
   if (question.type() === "model") {
-    if (isNewQuestion) {
-      const allowedPathnames = ["/model/query", "/model/metadata"];
-      return allowedPathnames.includes(pathname);
-    }
-
-    const allowedPathnames = validSlugs.flatMap(slug => [
-      `/model/${slug}`,
-      `/model/${slug}/query`,
-      `/model/${slug}/metadata`,
-      `/model/${slug}/notebook`,
-    ]);
+    const allowedPathnames = isNewQuestion
+      ? ["/model/query", "/model/metadata"]
+      : validSlugs.flatMap(slug => [
+          `/model/${slug}`,
+          `/model/${slug}/query`,
+          `/model/${slug}/metadata`,
+          `/model/${slug}/notebook`,
+        ]);
 
     return allowedPathnames.includes(pathname);
   }

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -83,11 +83,6 @@ export const isNavigationAllowed = ({
 
   const { isNative } = Lib.queryDisplayInfo(question.query());
 
-  const runModelPathnames = !isNative
-    ? ["/model", "/model/notebook"]
-    : ["/model"];
-  const isRunningModel =
-    runModelPathnames.includes(pathname) && hash.length > 0;
   const validSlugs = [question.id(), question.slug()]
     .filter(Boolean)
     .map(String);
@@ -95,7 +90,7 @@ export const isNavigationAllowed = ({
   if (question.isDataset()) {
     if (isNewQuestion) {
       const allowedPathnames = ["/model/query", "/model/metadata"];
-      return isRunningModel || allowedPathnames.includes(pathname);
+      return allowedPathnames.includes(pathname);
     }
 
     const allowedPathnames = validSlugs.flatMap(slug => [
@@ -104,7 +99,7 @@ export const isNavigationAllowed = ({
       `/model/${slug}/metadata`,
     ]);
 
-    return isRunningModel || allowedPathnames.includes(pathname);
+    return allowedPathnames.includes(pathname);
   }
 
   if (isNative) {
@@ -125,9 +120,7 @@ export const isNavigationAllowed = ({
       `/question/${slug}/notebook`,
     ]);
 
-    return (
-      isRunningModel || isRunningQuestion || allowedPathnames.includes(pathname)
-    );
+    return isRunningQuestion || allowedPathnames.includes(pathname);
   }
 
   return true;

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -82,6 +82,7 @@ export const isNavigationAllowed = ({
   const { hash, pathname } = destination;
 
   const { isNative } = Lib.queryDisplayInfo(question.query());
+  const isRunningModel = pathname === "/model" && hash.length > 0;
 
   const validSlugs = [question.id(), question.slug()]
     .filter(Boolean)
@@ -97,7 +98,7 @@ export const isNavigationAllowed = ({
           `/model/${slug}/notebook`,
         ]);
 
-    return allowedPathnames.includes(pathname);
+    return isRunningModel || allowedPathnames.includes(pathname);
   }
 
   if (isNative) {
@@ -118,7 +119,9 @@ export const isNavigationAllowed = ({
       `/question/${slug}/notebook`,
     ]);
 
-    return isRunningQuestion || allowedPathnames.includes(pathname);
+    return (
+      isRunningModel || isRunningQuestion || allowedPathnames.includes(pathname)
+    );
   }
 
   return true;

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -73,6 +73,12 @@ const newModelMetadataTabLocation = createMockLocation({
   pathname: "/model/metadata",
 });
 
+const getRunModelLocation = (question: Question) =>
+  createMockLocation({
+    pathname: `/model/${question.id()}/query`,
+    hash: `#${serializeCardForUrl(nativeModelCard)}`,
+  });
+
 const getModelLocations = (model: Question) => [
   createMockLocation({ pathname: `/model/${model.id()}` }),
   createMockLocation({ pathname: `/model/${model.slug()}` }),
@@ -80,6 +86,7 @@ const getModelLocations = (model: Question) => [
   createMockLocation({ pathname: `/model/${model.slug()}/query` }),
   createMockLocation({ pathname: `/model/${model.id()}/metadata` }),
   createMockLocation({ pathname: `/model/${model.slug()}/metadata` }),
+  getRunModelLocation(model),
 ];
 
 const getStructuredQuestionLocations = (question: Question) => [
@@ -94,8 +101,8 @@ const getNativeQuestionLocations = (question: Question) => [
   createMockLocation({ pathname: `/question/${question.slug()}` }),
 ];
 
-const runModelLocation = createMockLocation({
-  pathname: "/model",
+const runNewModelLocation = createMockLocation({
+  pathname: "/model/query",
   hash: `#${serializeCardForUrl(nativeModelCard)}`,
 });
 
@@ -152,7 +159,7 @@ describe("isNavigationAllowed", () => {
       ...getNativeQuestionLocations(nativeQuestion),
       newModelQueryTabLocation,
       newModelMetadataTabLocation,
-      runModelLocation,
+      runNewModelLocation,
       runModelEditNotebookLocation,
       runQuestionLocation,
       runQuestionEditNotebookLocation,
@@ -179,7 +186,7 @@ describe("isNavigationAllowed", () => {
         ...getNativeQuestionLocations(nativeQuestion),
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
-        runModelLocation,
+        runNewModelLocation,
         runModelEditNotebookLocation,
         runQuestionLocation,
         runQuestionEditNotebookLocation,
@@ -212,7 +219,7 @@ describe("isNavigationAllowed", () => {
         ...getNativeQuestionLocations(nativeQuestion),
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
-        runModelLocation,
+        runNewModelLocation,
         runModelEditNotebookLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
@@ -291,7 +298,7 @@ describe("isNavigationAllowed", () => {
         ...getNativeQuestionLocations(nativeQuestion),
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
-        runModelLocation,
+        runNewModelLocation,
         runModelEditNotebookLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
@@ -318,15 +325,7 @@ describe("isNavigationAllowed", () => {
     });
 
     it("allows to run the model", () => {
-      const destination = runModelLocation;
-
-      expect(
-        isNavigationAllowed({ destination, question, isNewQuestion }),
-      ).toBe(true);
-    });
-
-    it("allows to run the model and then edit it again", () => {
-      const destination = runModelEditNotebookLocation;
+      const destination = runNewModelLocation;
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -363,15 +362,7 @@ describe("isNavigationAllowed", () => {
     });
 
     it("allows to run the model", () => {
-      const destination = runModelLocation;
-
-      expect(
-        isNavigationAllowed({ destination, question, isNewQuestion }),
-      ).toBe(true);
-    });
-
-    it("allows to run the model and then edit it again", () => {
-      const destination = runModelEditNotebookLocation;
+      const destination = getRunModelLocation(structuredModelQuestion);
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -408,7 +399,7 @@ describe("isNavigationAllowed", () => {
     });
 
     it("allows to run the model", () => {
-      const destination = runModelLocation;
+      const destination = getRunModelLocation(nativeModelQuestion);
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -1,12 +1,13 @@
 import { createMockLocation } from "__support__/location";
 import { createMockMetadata } from "__support__/metadata";
 import { getNextId } from "__support__/utils";
+import type { Card } from "metabase-types/api";
 import {
   createMockCard,
   createMockNativeDatasetQuery,
 } from "metabase-types/api/mocks";
-import { checkNotNull } from "metabase/lib/types";
 import { serializeCardForUrl } from "metabase/lib/card";
+import { checkNotNull } from "metabase/lib/types";
 import type Question from "metabase-lib/Question";
 
 import { isNavigationAllowed } from "./utils";
@@ -37,7 +38,7 @@ const nativeModelCard = createMockCard({
   dataset_query: createMockNativeDatasetQuery(),
 });
 
-const cards = [
+const cards: Card[] = [
   structuredCard,
   nativeCard,
   structuredModelCard,
@@ -56,7 +57,7 @@ const structuredModelQuestion = checkNotNull(
 
 const nativeModelQuestion = checkNotNull(metadata.question(nativeModelCard.id));
 
-const questions = [
+const questions: Question[] = [
   structuredQuestion,
   nativeQuestion,
   structuredModelQuestion,

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -367,7 +367,7 @@ describe("isNavigationAllowed", () => {
     });
 
     it("allows to run the model", () => {
-      const destination = getRunModelLocation(structuredModelQuestion);
+      const destination = runModelLocation;
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -375,7 +375,7 @@ describe("isNavigationAllowed", () => {
     });
 
     it("allows to run edited model", () => {
-      const destination = runModelLocation;
+      const destination = getRunModelLocation(structuredModelQuestion);
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -412,7 +412,7 @@ describe("isNavigationAllowed", () => {
     });
 
     it("allows to run the model", () => {
-      const destination = getRunModelLocation(nativeModelQuestion);
+      const destination = runModelLocation;
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),
@@ -420,7 +420,7 @@ describe("isNavigationAllowed", () => {
     });
 
     it("allows to run edited model", () => {
-      const destination = runModelLocation;
+      const destination = getRunModelLocation(nativeModelQuestion);
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -106,6 +106,11 @@ const getNativeQuestionLocations = (question: Question) => [
   createMockLocation({ pathname: `/question/${question.slug()}` }),
 ];
 
+const runModelLocation = createMockLocation({
+  pathname: "/model",
+  hash: `#${serializeCardForUrl(nativeModelCard)}`,
+});
+
 const runNewModelLocation = createMockLocation({
   pathname: "/model/query",
   hash: `#${serializeCardForUrl(nativeModelCard)}`,
@@ -159,6 +164,7 @@ describe("isNavigationAllowed", () => {
       ...getNativeQuestionLocations(nativeQuestion),
       newModelQueryTabLocation,
       newModelMetadataTabLocation,
+      runModelLocation,
       runNewModelLocation,
       runQuestionLocation,
       runQuestionEditNotebookLocation,
@@ -185,6 +191,7 @@ describe("isNavigationAllowed", () => {
         ...getNativeQuestionLocations(nativeQuestion),
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
+        runModelLocation,
         runNewModelLocation,
         runQuestionLocation,
         runQuestionEditNotebookLocation,
@@ -217,6 +224,7 @@ describe("isNavigationAllowed", () => {
         ...getNativeQuestionLocations(nativeQuestion),
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
+        runModelLocation,
         runNewModelLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
@@ -295,6 +303,7 @@ describe("isNavigationAllowed", () => {
         ...getNativeQuestionLocations(nativeQuestion),
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
+        runModelLocation,
         runNewModelLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
@@ -365,6 +374,14 @@ describe("isNavigationAllowed", () => {
       ).toBe(true);
     });
 
+    it("allows to run edited model", () => {
+      const destination = runModelLocation;
+
+      expect(
+        isNavigationAllowed({ destination, question, isNewQuestion }),
+      ).toBe(true);
+    });
+
     describe("disallows all other navigation", () => {
       it.each([
         anyLocation,
@@ -396,6 +413,14 @@ describe("isNavigationAllowed", () => {
 
     it("allows to run the model", () => {
       const destination = getRunModelLocation(nativeModelQuestion);
+
+      expect(
+        isNavigationAllowed({ destination, question, isNewQuestion }),
+      ).toBe(true);
+    });
+
+    it("allows to run edited model", () => {
+      const destination = runModelLocation;
 
       expect(
         isNavigationAllowed({ destination, question, isNewQuestion }),

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -106,11 +106,6 @@ const runNewModelLocation = createMockLocation({
   hash: `#${serializeCardForUrl(nativeModelCard)}`,
 });
 
-const runModelEditNotebookLocation = createMockLocation({
-  pathname: "/model/notebook",
-  hash: `#${serializeCardForUrl(nativeModelCard)}`,
-});
-
 const runQuestionLocation = createMockLocation({
   pathname: "/question",
   hash: `#${serializeCardForUrl(nativeCard)}`,
@@ -160,7 +155,6 @@ describe("isNavigationAllowed", () => {
       newModelQueryTabLocation,
       newModelMetadataTabLocation,
       runNewModelLocation,
-      runModelEditNotebookLocation,
       runQuestionLocation,
       runQuestionEditNotebookLocation,
     ])("allows navigating away to `$pathname`", destination => {
@@ -187,7 +181,6 @@ describe("isNavigationAllowed", () => {
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
         runNewModelLocation,
-        runModelEditNotebookLocation,
         runQuestionLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
@@ -220,7 +213,6 @@ describe("isNavigationAllowed", () => {
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
         runNewModelLocation,
-        runModelEditNotebookLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
@@ -299,7 +291,6 @@ describe("isNavigationAllowed", () => {
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
         runNewModelLocation,
-        runModelEditNotebookLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
@@ -414,7 +405,6 @@ describe("isNavigationAllowed", () => {
         ...getNativeQuestionLocations(nativeQuestion),
         newModelMetadataTabLocation,
         newModelQueryTabLocation,
-        runModelEditNotebookLocation,
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -243,14 +243,6 @@ describe("isNavigationAllowed", () => {
       ).toBe(true);
     });
 
-    it("allows to run a model", () => {
-      const destination = runModelLocation;
-
-      expect(
-        isNavigationAllowed({ destination, question, isNewQuestion }),
-      ).toBe(true);
-    });
-
     describe("allows to open the question and the notebook editor", () => {
       it.each(getStructuredQuestionLocations(question))(
         "to `$pathname`",

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -86,6 +86,8 @@ const getModelLocations = (model: Question) => [
   createMockLocation({ pathname: `/model/${model.slug()}/query` }),
   createMockLocation({ pathname: `/model/${model.id()}/metadata` }),
   createMockLocation({ pathname: `/model/${model.slug()}/metadata` }),
+  createMockLocation({ pathname: `/model/${model.id()}/notebook` }),
+  createMockLocation({ pathname: `/model/${model.slug()}/notebook` }),
   getRunModelLocation(model),
 ];
 

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -25,12 +25,14 @@ const nativeCard = createMockCard({
 const structuredModelCard = createMockCard({
   id: getNextId(),
   name: "structured model",
+  type: "model",
   dataset: true,
 });
 
 const nativeModelCard = createMockCard({
   id: getNextId(),
   name: "native model",
+  type: "model",
   dataset: true,
   dataset_query: createMockNativeDatasetQuery(),
 });

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -208,7 +208,6 @@ export const getRoutes = store => {
               title={t`New Model`}
               component={NewModelOptions}
             />
-            <Route path="notebook" component={QueryBuilder} />
             <Route path=":slug" component={QueryBuilder} />
             <Route path=":slug/notebook" component={QueryBuilder} />
             <Route path=":slug/query" component={QueryBuilder} />


### PR DESCRIPTION
Prerequisite for #37357

### Description

I got confused when working on #37357 as some of the existing things didn't make any sense. [Blame me](https://github.com/metabase/metabase/issues/33749). 
Luckily, nothing was really broken. More details below and in PR comments.

- Removed unused `/model/notebook` route
- Removed/updated invalid test cases
- Used `Question.prototype.type` instead `Question.prototype.isDataset`
- Ensured navigating to `/model/:id/notebook` is not prevented
  - This worked accidentally thanks to `getShouldShowUnsavedChangesWarning`
  - Added tests for it