### PR TITLE
Fix search result display for items with large strings without word breaks

### DIFF
--- a/e2e/test/scenarios/onboarding/search/search.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/search/search.cy.spec.js
@@ -197,13 +197,13 @@ describe("scenarios > search", () => {
         description: `![alt](https://upload.wikimedia.org/wikipedia/commons/a/a2/Cat_outside.jpg)
 
         Lorem ipsum dolor sit amet.
-        
+
         ----
-        
+
         ## Heading 1
-        
+
         This is a [link](https://upload.wikimedia.org/wikipedia/commons/a/a2/Cat_outside.jpg).
-        
+
         Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. `,
       }).then(() => {
         cy.signInAsNormalUser();
@@ -220,6 +220,33 @@ describe("scenarios > search", () => {
       cy.findByTestId("result-description")
         .findByRole("img")
         .should("not.exist");
+    });
+
+    it("should not overflow container if results contain descriptions with large unborken strings", () => {
+      cy.createQuestion({
+        name: "Description Test",
+        query: { "source-table": ORDERS_ID },
+        description: `testingtestingtestingtestingtestingtestingtestingtesting testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtesting testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtesting`,
+      }).then(() => {
+        cy.signInAsNormalUser();
+        cy.visit("/");
+        getSearchBar().type("Test");
+      });
+
+      const resultDescription = cy.findByTestId("result-description");
+      const parentContainer = cy.findByTestId(
+        "search-results-floating-container",
+      );
+
+      parentContainer.invoke("outerWidth").then(parentWidth => {
+        resultDescription
+          .invoke("outerWidth")
+          .should(
+            "be.lessThan",
+            parentWidth,
+            "Result description width should not exceed parent container width",
+          );
+      });
     });
 
     it("should not dismiss when a dashboard finishes loading (metabase#35009)", () => {

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.styled.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.styled.tsx
@@ -49,7 +49,7 @@ export const SearchResultContainer = styled(Box, {
   display: grid;
   grid-template-columns: auto 1fr auto auto;
   justify-content: center;
-  align-items: center;
+  align-items: start;
   gap: 0.5rem 0.75rem;
 
   padding: ${({ theme }) => theme.spacing.sm};
@@ -106,7 +106,7 @@ export const XRayButton = styled(Button)<
 `;
 
 export const DescriptionSection = styled(Box)`
-  grid-column-start: 2;
+  margin-top: 0.5rem;
 `;
 
 export const DescriptionDivider = styled(Divider)`

--- a/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/SearchResult.tsx
@@ -112,6 +112,25 @@ export function SearchResult({
           <ModerationIcon status={moderated_status} filled size={14} />
         </Group>
         <InfoText showLinks={!onClick} result={result} isCompact={compact} />
+        {description && showDescription && (
+          <DescriptionSection>
+            <Group noWrap spacing="sm" data-testid="result-description">
+              <DescriptionDivider
+                size="md"
+                color="focus"
+                orientation="vertical"
+              />
+              <SearchResultDescription
+                dark
+                unwrapDisallowed
+                unstyleLinks
+                allowedElements={[]}
+              >
+                {description}
+              </SearchResultDescription>
+            </Group>
+          </DescriptionSection>
+        )}
       </ResultNameSection>
       {isLoading && (
         <LoadingSection px="xs">
@@ -122,25 +141,6 @@ export function SearchResult({
         <XRaySection>
           <XRayButton leftIcon={<Icon name="bolt" />} onClick={onXRayClick} />
         </XRaySection>
-      )}
-      {description && showDescription && (
-        <DescriptionSection>
-          <Group noWrap spacing="sm" data-testid="result-description">
-            <DescriptionDivider
-              size="md"
-              color="focus"
-              orientation="vertical"
-            />
-            <SearchResultDescription
-              dark
-              unwrapDisallowed
-              unstyleLinks
-              allowedElements={[]}
-            >
-              {description}
-            </SearchResultDescription>
-          </Group>
-        </DescriptionSection>
       )}
     </SearchResultContainer>
   );


### PR DESCRIPTION
### Description

<img width="398" alt="before" src="https://github.com/metabase/metabase/assets/7104357/e5a6e33b-4929-4abd-bf69-6494887f1b84">

You can see the (redacted) text above overflows the width of the container element. This is a product of using css grid's `auto` value with the `grid-template-columns` property in combination with long strings without word breaks. This typically appears when a user has text containing a long url in the description of the search result item.

Moving the description section inside the `ResultNameSection` puts it in a flex content which squishes the content in a way we would expect. The final result is more of what we're after

<img width="397" alt="after" src="https://github.com/metabase/metabase/assets/7104357/bb52a954-7523-48a7-870f-cf47c8a9e2e2">

The downside to this approach is that we're not solving that any item who happens be to be large could break this layout since grid doesn't force it's children to shrink the same way something like flex does. It might be worth revisiting the layout of this component unless grid could be coerced to do something similar (I'm not familiar with grid at all really, so maybe it can). 

### Callout

Not sure if this is desired, but grid's unused columns on the right for items that do not have the xray or loading icon have some extra padding from the grid's gap. Just noting that in case this is another display bug worth fixing:

<img width="398" alt="callout" src="https://github.com/metabase/metabase/assets/7104357/8ad83a54-03ad-4e23-a5ad-68d402d34176">

### How to verify

- Modify a question/dashboard/model's description to contain a really long like
```
testingtestingtestingtestingtestingtestingtestingtestingt estingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtesting testingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtestingtesting
```
- Search for that entity in the search bar


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
