### PR TITLE
Browse models: refactoring

### DIFF
--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
@@ -49,28 +49,6 @@ describe("scenarios > browse data", () => {
     );
     cy.location("pathname").should("eq", "/browse/models");
     cy.findByRole("tab", { name: "Databases" }).click();
-    cy.findByRole("heading", { name: "Sample Database" }).click();
-    cy.findByRole("listitem", { name: "Browse data" }).click();
-    cy.log(
-      "/browse/ now defaults to /browse/databases/ because it was the last tab visited",
-    );
-    cy.location("pathname").should("eq", "/browse/databases");
-    cy.findByRole("tab", { name: "Models" }).click();
-    cy.findByRole("heading", { name: "Orders Model" });
-    cy.findByRole("listitem", { name: "Browse data" }).click();
-    cy.log(
-      "/browse/ now defaults to /browse/models/ because it was the last tab visited",
-    );
-    cy.location("pathname").should("eq", "/browse/models");
-  });
-  it("the Browse data page shows the last-used tab by default", () => {
-    cy.visit("/");
-    cy.findByRole("listitem", { name: "Browse data" }).click();
-    cy.log(
-      "/browse/ defaults to /browse/models/ because no tabs have been visited yet and there are some models to show",
-    );
-    cy.location("pathname").should("eq", "/browse/models");
-    cy.findByRole("tab", { name: "Databases" }).click();
     cy.findByRole("listitem", { name: "Browse data" }).click();
     cy.log(
       "/browse/ now defaults to /browse/databases/ because it was the last tab visited",

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/ModelFilterControls.styled.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/ModelFilterControls.styled.tsx
@@ -1,0 +1,9 @@
+import styled from "@emotion/styled";
+import { Text } from "metabase/ui";
+
+export const ModelFilterControlSwitchLabel = styled(Text)`
+  text-align: right;
+  font-weight: bold;
+  line-height: 1rem;
+  padding: 0 0.75rem;
+`;

--- a/enterprise/frontend/src/metabase-enterprise/content_verification/ModelFilterControls.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/content_verification/ModelFilterControls.tsx
@@ -27,6 +27,7 @@ export const ModelFilterControls = ({
       size="sm"
       labelPosition="left"
       styles={{
+        root: { display: "flex", alignItems: "center" },
         body: {
           alignItems: "center",
           // Align with tab labels:

--- a/frontend/src/metabase/browse/components/BrowseApp.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseApp.styled.tsx
@@ -1,7 +1,11 @@
 import styled from "@emotion/styled";
-import { Icon, Tabs } from "metabase/ui";
+import { Grid, Icon, Tabs } from "metabase/ui";
 import { color } from "metabase/lib/colors";
 import EmptyState from "metabase/components/EmptyState";
+import {
+  breakpointMinMedium,
+  breakpointMinSmall,
+} from "metabase/styled-components/theme";
 
 export const BrowseAppRoot = styled.div`
   flex: 1;
@@ -24,7 +28,8 @@ export const BrowseTab = styled(Tabs.Tab)`
   top: 1px;
   margin-bottom: 1px;
   border-bottom-width: 3px !important;
-  padding: 10px;
+  padding: 10px 0;
+  margin-right: 10px;
   &:hover {
     color: ${color("brand")};
     background-color: inherit;
@@ -53,6 +58,21 @@ export const BrowseDataHeader = styled.header`
   padding-bottom: 0.375rem;
   color: ${color("dark")};
   background-color: ${color("white")};
+`;
+
+export const BrowseGrid = styled(Grid)`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
+  gap: 1.5rem 1rem;
+  margin: 0;
+  width: 100%;
+
+  ${breakpointMinSmall} {
+    padding-bottom: 2.5rem;
+  }
+  ${breakpointMinMedium} {
+    padding-bottom: 3rem;
+  }
 `;
 
 export const CenteredEmptyState = styled(EmptyState)`

--- a/frontend/src/metabase/browse/components/BrowseApp.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseApp.styled.tsx
@@ -1,11 +1,11 @@
 import styled from "@emotion/styled";
-import { Grid, Icon, Tabs } from "metabase/ui";
-import { color } from "metabase/lib/colors";
 import EmptyState from "metabase/components/EmptyState";
+import { color } from "metabase/lib/colors";
 import {
   breakpointMinMedium,
   breakpointMinSmall,
 } from "metabase/styled-components/theme";
+import { Grid, Icon, Tabs } from "metabase/ui";
 
 export const BrowseAppRoot = styled.div`
   flex: 1;
@@ -28,7 +28,7 @@ export const BrowseTab = styled(Tabs.Tab)`
   top: 1px;
   margin-bottom: 1px;
   border-bottom-width: 3px !important;
-  padding: 10px 0;
+  padding: 10px 0px;
   margin-right: 10px;
   &:hover {
     color: ${color("brand")};

--- a/frontend/src/metabase/browse/components/BrowseApp.tsx
+++ b/frontend/src/metabase/browse/components/BrowseApp.tsx
@@ -49,9 +49,7 @@ export const BrowseApp = ({
   const databasesResult = useDatabaseListQuery();
 
   useEffect(() => {
-    if (isValidBrowseTab(tab)) {
-      localStorage.setItem("defaultBrowseTab", tab);
-    }
+    localStorage.setItem("defaultBrowseTab", tab);
   }, [tab]);
 
   const getInitialModelFilters = () => {
@@ -97,10 +95,6 @@ export const BrowseApp = ({
     },
     [setActualModelFilters],
   );
-
-  if (!isValidBrowseTab(tab)) {
-    return <LoadingAndErrorWrapper error />;
-  }
 
   return (
     <BrowseAppRoot data-testid="browse-app">

--- a/frontend/src/metabase/browse/components/BrowseApp.tsx
+++ b/frontend/src/metabase/browse/components/BrowseApp.tsx
@@ -11,7 +11,6 @@ import { useDispatch } from "metabase/lib/redux";
 import type { FlexProps } from "metabase/ui";
 import { Flex, Text } from "metabase/ui";
 
-import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import Link from "metabase/core/components/Link";
 import { PLUGIN_CONTENT_VERIFICATION } from "metabase/plugins";
 import type { ActualModelFilters } from "../utils";

--- a/frontend/src/metabase/browse/components/BrowseApp.tsx
+++ b/frontend/src/metabase/browse/components/BrowseApp.tsx
@@ -167,7 +167,7 @@ const BrowseTabContent = ({
 };
 
 const LearnAboutDataLink = () => (
-  <Flex ml="auto" justify="right" style={{ flexBasis: "40.0%" }}>
+  <Flex ml="auto" justify="right" align="center" style={{ flexBasis: "40.0%" }}>
     <Link to="reference">
       <BrowseHeaderIconContainer>
         <LearnAboutDataIcon size={14} name="reference" />
@@ -180,5 +180,5 @@ const LearnAboutDataLink = () => (
 );
 
 const BrowseSection = (props: FlexProps) => (
-  <Flex maw="64rem" m="0 auto" w="100%" align="center" {...props} />
+  <Flex maw="64rem" m="0 auto" w="100%" {...props} />
 );

--- a/frontend/src/metabase/browse/components/BrowseDatabases.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseDatabases.styled.tsx
@@ -9,8 +9,7 @@ export const DatabaseGrid = styled(BrowseGrid)`
 
 export const DatabaseCard = styled(Card)`
   padding: 1.5rem;
-  box-shadow: 0px 1px 4px 0px rgba(0, 0, 0, 0.06) !important;
-
+  box-shadow: none;
   &:hover {
     color: ${color("brand")};
   }

--- a/frontend/src/metabase/browse/components/BrowseDatabases.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseDatabases.styled.tsx
@@ -1,14 +1,10 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import {
-  breakpointMinMedium,
-  breakpointMinSmall,
-} from "metabase/styled-components/theme";
 import Card from "metabase/components/Card";
-import { GridItem, Grid } from "metabase/components/Grid";
+import { BrowseGrid } from "./BrowseApp.styled";
 
-export const DatabaseGrid = styled(Grid)`
-  width: 100%;
+export const DatabaseGrid = styled(BrowseGrid)`
+  margin-top: 1rem;
 `;
 
 export const DatabaseCard = styled(Card)`
@@ -20,18 +16,8 @@ export const DatabaseCard = styled(Card)`
   }
 `;
 
-export const DatabaseGridItem = styled(GridItem)`
-  width: 100%;
-
+export const DatabaseGridItem = styled.div`
   &:hover {
     color: ${color("brand")};
-  }
-
-  ${breakpointMinSmall} {
-    width: 50%;
-  }
-
-  ${breakpointMinMedium} {
-    width: 33.33%;
   }
 `;

--- a/frontend/src/metabase/browse/components/BrowseDatabases.tsx
+++ b/frontend/src/metabase/browse/components/BrowseDatabases.tsx
@@ -1,22 +1,21 @@
-import _ from "underscore";
 import { t } from "ttag";
 
-import * as Urls from "metabase/lib/urls";
 import { color } from "metabase/lib/colors";
+import * as Urls from "metabase/lib/urls";
 
-import { Icon, Box } from "metabase/ui";
-import Link from "metabase/core/components/Link";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import Link from "metabase/core/components/Link";
+import { Box, Icon, Title } from "metabase/ui";
 
 import type { useDatabaseListQuery } from "metabase/common/hooks";
 
 import NoResults from "assets/img/no_results.svg";
+import { CenteredEmptyState } from "./BrowseApp.styled";
 import {
   DatabaseCard,
   DatabaseGrid,
   DatabaseGridItem,
 } from "./BrowseDatabases.styled";
-import { CenteredEmptyState } from "./BrowseApp.styled";
 
 export const BrowseDatabases = ({
   databasesResult,
@@ -45,7 +44,9 @@ export const BrowseDatabases = ({
                 className="mb3"
                 size={32}
               />
-              <h3 className="text-wrap">{database.name}</h3>
+              <Title order={2} size="1rem" lh="1rem">
+                {database.name}
+              </Title>
             </DatabaseCard>
           </Link>
         </DatabaseGridItem>

--- a/frontend/src/metabase/browse/components/BrowseModels.styled.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.styled.tsx
@@ -1,14 +1,11 @@
 import styled from "@emotion/styled";
 import { color } from "metabase/lib/colors";
-import {
-  breakpointMinMedium,
-  breakpointMinSmall,
-} from "metabase/styled-components/theme";
 import Card from "metabase/components/Card";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import Link from "metabase/core/components/Link";
-import { Flex, Grid, Group, Icon } from "metabase/ui";
+import { Flex, Group, Icon } from "metabase/ui";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
+import { BrowseGrid } from "./BrowseApp.styled";
 
 export const ModelCard = styled(Card)`
   padding: 1.5rem;
@@ -50,20 +47,7 @@ export const MultilineEllipsified = styled(Ellipsified)`
   padding-bottom: 1px;
 `;
 
-export const GridContainer = styled(Grid)`
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
-  gap: 1.5rem 1rem;
-  margin: 0;
-  width: 100%;
-
-  ${breakpointMinSmall} {
-    padding-bottom: 2.5rem;
-  }
-  ${breakpointMinMedium} {
-    padding-bottom: 3rem;
-  }
-`;
+export const ModelGrid = styled(BrowseGrid)``;
 
 export const CollectionHeaderContainer = styled(Flex)`
   grid-column: 1 / -1;

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -14,7 +14,7 @@ import { getLocale } from "metabase/setup/selectors";
 import { groupModels } from "../utils";
 
 import { CenteredEmptyState } from "./BrowseApp.styled";
-import { GridContainer } from "./BrowseModels.styled";
+import { ModelGrid } from "./BrowseModels.styled";
 import { ModelExplanationBanner } from "./ModelExplanationBanner";
 import { ModelGroup } from "./ModelGroup";
 
@@ -43,7 +43,7 @@ export const BrowseModels = ({
     return (
       <>
         <ModelExplanationBanner />
-        <GridContainer role="grid">
+        <ModelGrid role="grid">
           {groupsOfModels.map(groupOfModels => (
             <ModelGroup
               models={groupOfModels}
@@ -51,7 +51,7 @@ export const BrowseModels = ({
               localeCode={localeCode}
             />
           ))}
-        </GridContainer>
+        </ModelGrid>
       </>
     );
   }

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -1,38 +1,24 @@
 import { t } from "ttag";
 
-import type {
-  Card,
-  CollectionEssentials,
-  SearchResult,
-} from "metabase-types/api";
-import * as Urls from "metabase/lib/urls";
+import type { SearchResult } from "metabase-types/api";
 
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
-import Link from "metabase/core/components/Link";
 import { useSelector } from "metabase/lib/redux";
 
 import type { useSearchListQuery } from "metabase/common/hooks";
 
 import NoResults from "assets/img/no_results.svg";
-import { Box, Group, Icon, Text, Title } from "metabase/ui";
+import { Box } from "metabase/ui";
 
-import { getCollectionIcon } from "metabase/entities/collections";
 import { getLocale } from "metabase/setup/selectors";
-import { entityForObject } from "metabase/lib/schema";
-import { color } from "metabase/lib/colors";
-import { getCollectionName, groupModels, sortModels } from "../utils";
+import { groupModels } from "../utils";
+
+
 
 import { CenteredEmptyState } from "./BrowseApp.styled";
-import {
-  CollectionHeaderContainer,
-  CollectionHeaderGroup,
-  CollectionHeaderLink,
-  GridContainer,
-  ModelCard,
-  MultilineEllipsified,
-} from "./BrowseModels.styled";
-import { LastEdited } from "./LastEdited";
+import { GridContainer } from "./BrowseModels.styled";
 import { ModelExplanationBanner } from "./ModelExplanationBanner";
+import { ModelGroup } from "./ModelGroup";
 
 export const BrowseModels = ({
   modelsResult,
@@ -84,103 +70,5 @@ export const BrowseModels = ({
         </Box>
       }
     />
-  );
-};
-
-const ModelGroup = ({
-  models,
-  localeCode,
-}: {
-  models: SearchResult[];
-  localeCode: string | undefined;
-}) => {
-  const sortedModels = models.sort((a, b) => sortModels(a, b, localeCode));
-  const collection = models[0].collection;
-
-  /** This id is used by aria-labelledby */
-  const collectionHtmlId = `collection-${collection.id}`;
-
-  return (
-    <>
-      <CollectionHeader
-        collection={collection}
-        key={collectionHtmlId}
-        id={collectionHtmlId}
-      />
-      {sortedModels.map(model => (
-        <ModelCell
-          model={model}
-          collectionHtmlId={collectionHtmlId}
-          key={`model-${model.id}`}
-        />
-      ))}
-    </>
-  );
-};
-
-interface ModelCellProps {
-  model: SearchResult;
-  collectionHtmlId: string;
-}
-
-const ModelCell = ({ model, collectionHtmlId }: ModelCellProps) => {
-  const headingId = `heading-for-model-${model.id}`;
-
-  const lastEditorFullName =
-    model.last_editor_common_name ?? model.creator_common_name;
-  const timestamp = model.last_edited_at ?? model.created_at ?? "";
-
-  const entity = entityForObject(model);
-  const icon = entity?.objectSelectors?.getIcon?.(model);
-
-  return (
-    <Link
-      aria-labelledby={`${collectionHtmlId} ${headingId}`}
-      key={model.id}
-      to={Urls.model(model as unknown as Partial<Card>)}
-    >
-      <ModelCard>
-        <Box mb="auto">
-          <Icon {...icon} size={20} color={color("brand")} />
-        </Box>
-        <Title mb=".25rem" size="1rem">
-          <MultilineEllipsified tooltipMaxWidth="20rem" id={headingId}>
-            {model.name}
-          </MultilineEllipsified>
-        </Title>
-        <LastEdited editorFullName={lastEditorFullName} timestamp={timestamp} />
-      </ModelCard>
-    </Link>
-  );
-};
-
-const CollectionHeader = ({
-  collection,
-  id,
-}: {
-  collection: CollectionEssentials;
-  id: string;
-}) => {
-  const icon = getCollectionIcon(collection);
-
-  return (
-    <CollectionHeaderContainer
-      id={id}
-      role="heading"
-      pt={"1rem"}
-      mr="1rem"
-      align="center"
-    >
-      <CollectionHeaderGroup grow noWrap>
-        <CollectionHeaderLink to={Urls.collection(collection)}>
-          <Group spacing=".25rem">
-            <Icon {...icon} />
-            <Text weight="bold" color="text-dark">
-              {getCollectionName(collection)}
-            </Text>
-          </Group>
-        </CollectionHeaderLink>
-      </CollectionHeaderGroup>
-    </CollectionHeaderContainer>
   );
 };

--- a/frontend/src/metabase/browse/components/BrowseModels.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.tsx
@@ -13,8 +13,6 @@ import { Box } from "metabase/ui";
 import { getLocale } from "metabase/setup/selectors";
 import { groupModels } from "../utils";
 
-
-
 import { CenteredEmptyState } from "./BrowseApp.styled";
 import { GridContainer } from "./BrowseModels.styled";
 import { ModelExplanationBanner } from "./ModelExplanationBanner";

--- a/frontend/src/metabase/browse/components/ModelGroup.tsx
+++ b/frontend/src/metabase/browse/components/ModelGroup.tsx
@@ -12,7 +12,7 @@ import { useDispatch } from "metabase/lib/redux";
 import { Box, Group, Icon, Text, Title } from "metabase/ui";
 
 import { color } from "metabase/lib/colors";
-import { getCollectionName } from "../utils";
+import { getCollectionName, sortModels } from "../utils";
 import {
   CollectionHeaderContainer,
   CollectionHeaderGroup,
@@ -29,20 +29,7 @@ export const ModelGroup = ({
   models: SearchResult[];
   localeCode: string | undefined;
 }) => {
-  const sortedModels = models.sort((a, b) => {
-    if (!a.name && b.name) {
-      return 1;
-    }
-    if (a.name && !b.name) {
-      return -1;
-    }
-    if (!a.name && !b.name) {
-      return 0;
-    }
-    const nameA = a.name.toLowerCase();
-    const nameB = b.name.toLowerCase();
-    return nameA.localeCompare(nameB, localeCode);
-  });
+  const sortedModels = models.sort((a, b) => sortModels(a, b, localeCode));
   const collection = models[0].collection;
 
   /** This id is used by aria-labelledby */

--- a/frontend/src/metabase/browse/components/ModelGroup.tsx
+++ b/frontend/src/metabase/browse/components/ModelGroup.tsx
@@ -35,7 +35,6 @@ export const ModelGroup = ({
   /** This id is used by aria-labelledby */
   const collectionHtmlId = `collection-${collection.id}`;
 
-  // TODO: Check padding above the collection header
   return (
     <>
       <CollectionHeader

--- a/frontend/src/metabase/browse/components/ModelGroup.tsx
+++ b/frontend/src/metabase/browse/components/ModelGroup.tsx
@@ -1,0 +1,135 @@
+import type {
+  Card,
+  CollectionEssentials,
+  SearchResult,
+} from "metabase-types/api";
+import * as Urls from "metabase/lib/urls";
+
+import Link from "metabase/core/components/Link";
+import Search from "metabase/entities/search";
+import { useDispatch } from "metabase/lib/redux";
+
+import { Box, Group, Icon, Text, Title } from "metabase/ui";
+
+import { color } from "metabase/lib/colors";
+import { getCollectionName } from "../utils";
+import {
+  CollectionHeaderContainer,
+  CollectionHeaderGroup,
+  CollectionHeaderLink,
+  ModelCard,
+  MultilineEllipsified,
+} from "./BrowseModels.styled";
+import { LastEdited } from "./LastEdited";
+
+export const ModelGroup = ({
+  models,
+  localeCode,
+}: {
+  models: SearchResult[];
+  localeCode: string | undefined;
+}) => {
+  const sortedModels = models.sort((a, b) => {
+    if (!a.name && b.name) {
+      return 1;
+    }
+    if (a.name && !b.name) {
+      return -1;
+    }
+    if (!a.name && !b.name) {
+      return 0;
+    }
+    const nameA = a.name.toLowerCase();
+    const nameB = b.name.toLowerCase();
+    return nameA.localeCompare(nameB, localeCode);
+  });
+  const collection = models[0].collection;
+
+  /** This id is used by aria-labelledby */
+  const collectionHtmlId = `collection-${collection.id}`;
+
+  // TODO: Check padding above the collection header
+  return (
+    <>
+      <CollectionHeader
+        collection={collection}
+        key={collectionHtmlId}
+        id={collectionHtmlId}
+      />
+      {sortedModels.map(model => (
+        <ModelCell
+          model={model}
+          collectionHtmlId={collectionHtmlId}
+          key={`model-${model.id}`}
+        />
+      ))}
+    </>
+  );
+};
+
+interface ModelCellProps {
+  model: SearchResult;
+  collectionHtmlId: string;
+}
+
+const ModelCell = ({ model, collectionHtmlId }: ModelCellProps) => {
+  const headingId = `heading-for-model-${model.id}`;
+
+  const lastEditorFullName =
+    model.last_editor_common_name ?? model.creator_common_name;
+  const timestamp = model.last_edited_at ?? model.created_at ?? "";
+
+  return (
+    <Link
+      aria-labelledby={`${collectionHtmlId} ${headingId}`}
+      key={model.id}
+      to={Urls.model(model as unknown as Partial<Card>)}
+    >
+      <ModelCard>
+        <Box mb="auto">
+          <Icon name="model" size={20} color={color("brand")} />
+        </Box>
+        <Title mb=".25rem" size="1rem">
+          <MultilineEllipsified tooltipMaxWidth="20rem" id={headingId}>
+            {model.name}
+          </MultilineEllipsified>
+        </Title>
+        <LastEdited editorFullName={lastEditorFullName} timestamp={timestamp} />
+      </ModelCard>
+    </Link>
+  );
+};
+
+const CollectionHeader = ({
+  collection,
+  id,
+}: {
+  collection: CollectionEssentials;
+  id: string;
+}) => {
+  const dispatch = useDispatch();
+  const wrappable = { ...collection, model: "collection" };
+  const wrappedCollection = Search.wrapEntity(wrappable, dispatch);
+  const icon = wrappedCollection.getIcon();
+
+  return (
+    <CollectionHeaderContainer
+      id={id}
+      role="heading"
+      pt={"1rem"}
+      mr="1rem"
+      align="center"
+    >
+      <CollectionHeaderGroup grow noWrap>
+        <CollectionHeaderLink to={Urls.collection(collection)}>
+          <Group spacing=".25rem">
+            <Icon {...icon} />
+            <Text weight="bold" color="text-dark">
+              {getCollectionName(collection)}
+            </Text>
+          </Group>
+        </CollectionHeaderLink>
+      </CollectionHeaderGroup>
+    </CollectionHeaderContainer>
+  );
+};


### PR DESCRIPTION
This PR refactors some of the Browse models code to improve maintainability

It also changes:
1. The padding on the Browse data tabs. The tabs are now aligned visually with the text above and the elements below.
2. The schema browser crumbs. These were getting centered by mistake.