### PR TITLE
reuse chartMeasurements computation

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -5,6 +5,7 @@ import { getCartesianChartOption } from "metabase/visualizations/echarts/cartesi
 import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 import type { IsomorphicStaticChartProps } from "metabase/static-viz/containers/IsomorphicStaticChart/types";
 import { getLegendItems } from "metabase/visualizations/echarts/cartesian/model/legend";
+import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/chart-measurements";
 import { calculateLegendRows } from "../Legend/utils";
 import { Legend } from "../Legend";
 import { computeStaticComboChartSettings } from "./settings";
@@ -44,13 +45,22 @@ export const ComboChart = ({
   const { height: legendHeight, items: legendLayoutItems } =
     calculateLegendRows(legendItems, width, LEGEND_PADDING, LEGEND_PADDING);
 
+  const chartMeasurements = getChartMeasurements(
+    chartModel,
+    computedVisualizationSettings,
+    false,
+    width,
+    height,
+    renderingContext,
+  );
+
   const option = getCartesianChartOption(
     chartModel,
+    chartMeasurements,
     null,
     [],
     computedVisualizationSettings,
     WIDTH,
-    HEIGHT - legendHeight,
     renderingContext,
   );
 

--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -7,6 +7,7 @@ import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 import type { IsomorphicStaticChartProps } from "metabase/static-viz/containers/IsomorphicStaticChart/types";
 import { getLegendItems } from "metabase/visualizations/echarts/cartesian/model/legend";
 
+import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/chart-measurements";
 import { calculateLegendRows } from "../Legend/utils";
 import { Legend } from "../Legend";
 import { computeStaticComboChartSettings } from "../ComboChart/settings";
@@ -41,13 +42,22 @@ export function ScatterPlot({
   const { height: legendHeight, items: legendLayoutItems } =
     calculateLegendRows(legendItems, width, LEGEND_PADDING, LEGEND_PADDING);
 
+  const chartMeasurements = getChartMeasurements(
+    chartModel,
+    computedVisualizationSettings,
+    false,
+    width,
+    height,
+    renderingContext,
+  );
+
   const option = getCartesianChartOption(
     chartModel,
+    chartMeasurements,
     null,
     [],
     computedVisualizationSettings,
     WIDTH,
-    HEIGHT - legendHeight,
     renderingContext,
   );
   chart.setOption(option);

--- a/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.tsx
+++ b/frontend/src/metabase/static-viz/components/WaterfallChart/WaterfallChart.tsx
@@ -5,6 +5,7 @@ import { sanitizeSvgForBatik } from "metabase/static-viz/lib/svg";
 import { getWaterfallChartModel } from "metabase/visualizations/echarts/cartesian/waterfall/model";
 
 import { getWaterfallChartOption } from "metabase/visualizations/echarts/cartesian/waterfall/option";
+import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/chart-measurements";
 import { computeStaticWaterfallChartSettings } from "./settings";
 
 const WIDTH = 540;
@@ -28,13 +29,20 @@ export function WaterfallChart({
     computedVisualizationSettings,
     renderingContext,
   );
+  const chartMeasurements = getChartMeasurements(
+    chartModel,
+    computedVisualizationSettings,
+    false,
+    width,
+    height,
+    renderingContext,
+  );
   const option = getWaterfallChartOption(
     chartModel,
+    chartMeasurements,
     null,
     [],
     computedVisualizationSettings,
-    WIDTH,
-    HEIGHT,
     renderingContext,
   );
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/index.ts
@@ -1,6 +1,7 @@
 import type {
   AxisFormatter,
   BaseCartesianChartModel,
+  ChartDataset,
   YAxisModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type {
@@ -8,14 +9,15 @@ import type {
   RenderingContext,
 } from "metabase/visualizations/types";
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
+import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import { isNotNull } from "metabase/lib/types";
+
 import type {
   ChartBoundsCoords,
   ChartMeasurements,
   Padding,
   TicksDimensions,
-} from "metabase/visualizations/echarts/cartesian/option/types";
-import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
-import { isNotNull } from "metabase/lib/types";
+} from "./types";
 
 const getYAxisTicksWidth = (
   axisModel: YAxisModel,
@@ -64,7 +66,7 @@ const getYAxisTicksWidth = (
 };
 
 const getXAxisTicksHeight = (
-  chartModel: BaseCartesianChartModel,
+  dataset: ChartDataset,
   settings: ComputedVisualizationSettings,
   formatter: AxisFormatter,
   renderingContext: RenderingContext,
@@ -79,7 +81,7 @@ const getXAxisTicksHeight = (
     return CHART_STYLE.axisTicks.size;
   }
 
-  const tickWidths = chartModel.dataset.map(datum => {
+  const tickWidths = dataset.map(datum => {
     return renderingContext.measureText(formatter(datum[X_AXIS_DATA_KEY]), {
       ...CHART_STYLE.axisTicks,
       family: renderingContext.fontFamily,
@@ -107,7 +109,7 @@ export const getTicksDimensions = (
   hasTimelineEvents: boolean,
   renderingContext: RenderingContext,
 ) => {
-  const ticksDimensions = {
+  const ticksDimensions: TicksDimensions = {
     yTicksWidthLeft: 0,
     yTicksWidthRight: 0,
     xTicksHeight: 0,
@@ -132,7 +134,7 @@ export const getTicksDimensions = (
   if (hasBottomAxis) {
     ticksDimensions.xTicksHeight =
       getXAxisTicksHeight(
-        chartModel,
+        chartModel.dataset,
         settings,
         chartModel.xAxisModel.formatter,
         renderingContext,
@@ -175,7 +177,6 @@ export const getChartPadding = (
   }
 
   const hasXAxisName = settings["graph.x_axis.labels_enabled"];
-
   if (hasXAxisName) {
     padding.bottom +=
       CHART_STYLE.axisName.size / 2 + CHART_STYLE.axisNameMargin;
@@ -215,9 +216,17 @@ export const getChartMeasurements = (
   const padding = getChartPadding(chartModel, settings);
   const bounds = getChartBounds(width, height, padding, ticksDimensions);
 
+  const boundaryWidth =
+    width -
+    padding.left -
+    padding.right -
+    ticksDimensions.yTicksWidthLeft -
+    ticksDimensions.yTicksWidthRight;
+
   return {
     ticksDimensions,
     padding,
     bounds,
+    boundaryWidth,
   };
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/types.ts
@@ -1,0 +1,26 @@
+export interface Padding {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+}
+
+export interface TicksDimensions {
+  yTicksWidthLeft: number;
+  yTicksWidthRight: number;
+  xTicksHeight: number;
+}
+
+export interface ChartBoundsCoords {
+  top: number;
+  left: number;
+  bottom: number;
+  right: number;
+}
+
+export interface ChartMeasurements {
+  padding: Padding;
+  ticksDimensions: TicksDimensions;
+  bounds: ChartBoundsCoords;
+  boundaryWidth: number;
+}

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -96,14 +96,6 @@ export const getCartesianChartModel = (
   }
   dataset = sortDataset(dataset, settings["graph.x_axis.scale"]);
 
-  const xAxisModel = getXAxisModel(
-    dimensionModel,
-    rawSeries,
-    dataset,
-    settings,
-    renderingContext,
-  );
-
   const transformedDataset = applyVisualizationSettingsDataTransformations(
     dataset,
     seriesModels,
@@ -116,7 +108,15 @@ export const getCartesianChartModel = (
 
   const insights = rawSeries.flatMap(series => series.data.insights ?? []);
 
-  const yAxesModels = getYAxesModels(
+  const xAxisModel = getXAxisModel(
+    dimensionModel,
+    rawSeries,
+    dataset,
+    settings,
+    renderingContext,
+  );
+
+  const { leftAxisModel, rightAxisModel } = getYAxesModels(
     seriesModels,
     transformedDataset,
     settings,
@@ -133,7 +133,8 @@ export const getCartesianChartModel = (
     dimensionModel,
     insights,
     xAxisModel,
-    ...yAxesModels,
+    leftAxisModel,
+    rightAxisModel,
     bubbleSizeDomain: getBubbleSizeDomain(seriesModels, transformedDataset),
   };
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -10,15 +10,14 @@ import type {
 import type {
   BaseCartesianChartModel,
   Extent,
-  XAxisModel,
   YAxisModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
 
 import { getDimensionDisplayValueGetter } from "metabase/visualizations/echarts/cartesian/model/dataset";
-import type { ChartMeasurements } from "metabase/visualizations/echarts/cartesian/option/types";
 import { getTimeSeriesMinInterval } from "metabase/visualizations/echarts/cartesian/utils/time-series";
+import type { ChartMeasurements } from "../chart-measurements/types";
 
 const NORMALIZED_RANGE = { min: 0, max: 1 };
 
@@ -104,13 +103,12 @@ const getRotateAngle = (settings: ComputedVisualizationSettings) => {
 export const buildDimensionAxis = (
   chartModel: BaseCartesianChartModel,
   settings: ComputedVisualizationSettings,
-  xAxisModel: XAxisModel,
   chartMeasurements: ChartMeasurements,
   hasTimelineEvents: boolean,
   renderingContext: RenderingContext,
 ): AxisBaseOption => {
   const { getColor } = renderingContext;
-  const { axisType, formatter, timeSeriesInterval } = xAxisModel;
+  const { axisType, formatter, timeSeriesInterval } = chartModel.xAxisModel;
 
   const boundaryGap =
     axisType === "value" || axisType === "log"
@@ -211,8 +209,8 @@ export const buildMetricAxis = (
 
 const buildMetricsAxes = (
   chartModel: BaseCartesianChartModel,
-  settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
+  settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): CartesianAxisOption[] => {
   const axes: CartesianAxisOption[] = [];
@@ -249,8 +247,8 @@ const buildMetricsAxes = (
 
 export const buildAxes = (
   chartModel: BaseCartesianChartModel,
-  settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
+  settings: ComputedVisualizationSettings,
   hasTimelineEvents: boolean,
   renderingContext: RenderingContext,
 ) => {
@@ -258,15 +256,14 @@ export const buildAxes = (
     xAxis: buildDimensionAxis(
       chartModel,
       settings,
-      chartModel.xAxisModel,
       chartMeasurements,
       hasTimelineEvents,
       renderingContext,
     ),
     yAxis: buildMetricsAxes(
       chartModel,
-      settings,
       chartMeasurements,
+      settings,
       renderingContext,
     ),
   };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -7,7 +7,6 @@ import type {
 } from "metabase/visualizations/types";
 import { buildAxes } from "metabase/visualizations/echarts/cartesian/option/axis";
 
-import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/utils/layout";
 import type { TimelineEventsModel } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
 import { getTimelineEventsSeries } from "metabase/visualizations/echarts/cartesian/timeline-events/option";
 import type { TimelineEventId } from "metabase-types/api";
@@ -16,6 +15,7 @@ import {
   POSITIVE_STACK_TOTAL_DATA_KEY,
   X_AXIS_DATA_KEY,
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
+import type { ChartMeasurements } from "../chart-measurements/types";
 import { getGoalLineSeriesOption } from "./goal-line";
 import { getTrendLineOptionsAndDatasets } from "./trend-line";
 
@@ -35,22 +35,14 @@ export const getSharedEChartsOptions = () => ({
 
 export const getCartesianChartOption = (
   chartModel: CartesianChartModel,
+  chartMeasurements: ChartMeasurements,
   timelineEventsModel: TimelineEventsModel | null,
   selectedTimelineEventsIds: TimelineEventId[],
   settings: ComputedVisualizationSettings,
   chartWidth: number,
-  chartHeight: number,
   renderingContext: RenderingContext,
 ): EChartsOption => {
   const hasTimelineEvents = timelineEventsModel != null;
-  const chartMeasurements = getChartMeasurements(
-    chartModel,
-    settings,
-    hasTimelineEvents,
-    chartWidth,
-    chartHeight,
-    renderingContext,
-  );
   const timelineEventsSeries = hasTimelineEvents
     ? getTimelineEventsSeries(
         timelineEventsModel,
@@ -111,8 +103,8 @@ export const getCartesianChartOption = (
     series: seriesOption,
     ...buildAxes(
       chartModel,
-      settings,
       chartMeasurements,
+      settings,
       hasTimelineEvents,
       renderingContext,
     ),

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
@@ -1,31 +1,5 @@
 import type { RegisteredSeriesOption } from "echarts";
 
-export interface Padding {
-  top: number;
-  left: number;
-  bottom: number;
-  right: number;
-}
-
-export interface TicksDimensions {
-  yTicksWidthLeft: number;
-  yTicksWidthRight: number;
-  xTicksHeight: number;
-}
-
-export interface ChartBoundsCoords {
-  top: number;
-  left: number;
-  bottom: number;
-  right: number;
-}
-
-export interface ChartMeasurements {
-  padding: Padding;
-  ticksDimensions: TicksDimensions;
-  bounds: ChartBoundsCoords;
-}
-
 export type EChartsSeriesOption =
   | RegisteredSeriesOption["line"]
   | RegisteredSeriesOption["bar"]

--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/model.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/model.ts
@@ -7,29 +7,17 @@ import type {
   DateRange,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type { TimelineEventGroup } from "metabase/visualizations/echarts/cartesian/timeline-events/types";
-import { getChartMeasurements } from "metabase/visualizations/echarts/cartesian/utils/layout";
-import type {
-  ComputedVisualizationSettings,
-  RenderingContext,
-} from "metabase/visualizations/types";
+import type { RenderingContext } from "metabase/visualizations/types";
 import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants/style";
-import type { ChartMeasurements } from "../option/types";
+import type { ChartMeasurements } from "../chart-measurements/types";
 
 const getDayWidth = (
   range: DateRange,
   chartMeasurements: ChartMeasurements,
-  width: number,
 ) => {
   const daysCount = Math.abs(dayjs(range[1]).diff(range[0], "day"));
 
-  const boundaryWidth =
-    width -
-    chartMeasurements.padding.left -
-    chartMeasurements.padding.right -
-    chartMeasurements.ticksDimensions.yTicksWidthLeft -
-    chartMeasurements.ticksDimensions.yTicksWidthRight;
-
-  return boundaryWidth / daysCount;
+  return chartMeasurements.boundaryWidth / daysCount;
 };
 
 const groupEventsByUnitStart = (
@@ -141,10 +129,8 @@ const getTimelineEventsInsideRange = (
 
 export const getTimelineEventsModel = (
   chartModel: BaseCartesianChartModel,
+  chartMeasurements: ChartMeasurements,
   timelineEvents: TimelineEvent[],
-  settings: ComputedVisualizationSettings,
-  width: number,
-  height: number,
   renderingContext: RenderingContext,
 ) => {
   if (timelineEvents.length === 0) {
@@ -161,8 +147,8 @@ export const getTimelineEventsModel = (
     dimensionRange,
   );
 
-  const hasTimelineEvents = visibleTimelineEvents.length === 0;
-  if (hasTimelineEvents) {
+  const hasTimelineEvents = visibleTimelineEvents.length !== 0;
+  if (!hasTimelineEvents) {
     return null;
   }
 
@@ -171,16 +157,7 @@ export const getTimelineEventsModel = (
     chartModel.xAxisModel.timeSeriesInterval?.interval,
   );
 
-  const chartMeasurements = getChartMeasurements(
-    chartModel,
-    settings,
-    hasTimelineEvents,
-    width,
-    height,
-    renderingContext,
-  );
-
-  const dayWidth = getDayWidth(dimensionRange, chartMeasurements, width);
+  const dayWidth = getDayWidth(dimensionRange, chartMeasurements);
   return mergeOverlappingTimelineEventGroups(
     timelineEventsByUnitStart,
     dayWidth,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
@@ -32,9 +32,8 @@ import {
 } from "metabase/visualizations/echarts/cartesian/waterfall/constants";
 import type { TimelineEventId } from "metabase-types/api";
 import { getNumberOr } from "metabase/visualizations/lib/settings/row-values";
-import type { ChartMeasurements } from "../../option/types";
+import type { ChartMeasurements } from "../../chart-measurements/types";
 import type { TimelineEventsModel } from "../../timeline-events/types";
-import { getChartMeasurements } from "../../utils/layout";
 import { getTimelineEventsSeries } from "../../timeline-events/option";
 import { buildAxes } from "../../option/axis";
 import { getSharedEChartsOptions } from "../../option";
@@ -217,22 +216,13 @@ export const buildEChartsWaterfallSeries = (
 
 export const getWaterfallChartOption = (
   chartModel: BaseCartesianChartModel,
+  chartMeasurements: ChartMeasurements,
   timelineEventsModel: TimelineEventsModel | null,
   selectedTimelineEventsIds: TimelineEventId[],
   settings: ComputedVisualizationSettings,
-  chartWidth: number,
-  chartHeight: number,
   renderingContext: RenderingContext,
 ): EChartsOption => {
   const hasTimelineEvents = timelineEventsModel != null;
-  const chartMeasurements = getChartMeasurements(
-    chartModel,
-    settings,
-    hasTimelineEvents,
-    chartWidth,
-    chartHeight,
-    renderingContext,
-  );
   const timelineEventsSeries = hasTimelineEvents
     ? getTimelineEventsSeries(
         timelineEventsModel,
@@ -264,8 +254,8 @@ export const getWaterfallChartOption = (
     series: seriesOption as SeriesOption,
     ...buildAxes(
       chartModel,
-      settings,
       chartMeasurements,
+      settings,
       hasTimelineEvents,
       renderingContext,
     ),


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/37420

### Description

Refactors the `chartMeasurements` computation to the component level, so we no compute it multiples times in different places.

Also makes `boundaryWidth` a property of `chartMeasuresments` as opposed to computing it in `timeline-events/model.ts`, so we can later re-use it to fix https://github.com/metabase/metabase/issues/37420

### Demo

![Screenshot 2024-02-13 at 11.27.05 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/2fdede7d-dde9-413e-8c0f-70aa0e673e9e.png)

Charts still render and timeline event bucketing still works

### Checklist

~~- [ ] Tests have been added/updated to cover changes in this PR~~
