### PR TITLE
Add run-cloverage tag to run Cloverage on non-master branches

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,7 +6,7 @@ on:
       - "master"
       - "release-**"
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
@@ -65,7 +65,8 @@ jobs:
 
   be-linter-cloverage:
     needs: files-changed
-    if: github.ref_name == 'master' && needs.files-changed.outputs.backend_all == 'true'
+    if: (github.ref_name == 'master' && needs.files-changed.outputs.backend_all == 'true')
+        || contains(github.event.pull_request.labels.*.name, 'run-cloverage')
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     steps:


### PR DESCRIPTION
Adds support for a `run-cloverage` tag which can be used to optionally run Cloverage on PRs before they are merged to master. This is useful because currently Cloverage runs tests in a different order than the main test suite (due to using a different test runner), so tests sometimes fail on master but were never detected on the PR.

Ultimately it would be better to fix this test ordering issue, or encapsulate test state better, but this is an easy addition which allows us to detect these issues on large feature branches before they are merged.

Credit to @iethree for the suggestion