### PR TITLE
Refactor and use only `isAdHocModelQuestion` helper [WIP]

### DIFF
--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -497,18 +497,30 @@ class Question {
     }
   }
 
+  /**
+   * The name is somewhat misleading because this method applies not only
+   * for models (datasets) but also for metrics. When opening either one,
+   * we swap its `dataset_query` with a clean ad-hoc query to enable features
+   * that are available in the "simple mode".
+   * This query is "nested" by default because we use the underlying model's
+   * or metric's ID as the source table.
+   */
   composeDataset(): Question {
-    if (this.type() !== "model" || !this.isSaved()) {
+    const type = this.type() || "question";
+
+    if (type === "question" || !this.isSaved()) {
       return this;
     }
 
-    return this.setDatasetQuery({
+    const adHocQuery = {
       type: "query",
       database: this.databaseId(),
       query: {
         "source-table": getQuestionVirtualTableId(this.id()),
       },
-    });
+    };
+
+    return this.setDatasetQuery(adHocQuery);
   }
 
   private _syncStructuredQueryColumnsAndSettings(previousQuestion: Question) {

--- a/frontend/src/metabase-lib/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/metadata/utils/models.ts
@@ -124,7 +124,18 @@ export function isAdHocModelQuestionCard(card: Card, originalCard?: Card) {
   const isSelfReferencing =
     query["source-table"] === getQuestionVirtualTableId(originalCard.id);
 
-  return isModel && isSameCard && isSelfReferencing;
+  // TEMPORARY HACK to unblock #38554 and #38664!
+  // Once those two PRs are merged, an immediate proper solution will follow.
+  // Why is this a hack?
+  //   1. We need to make this helper work with both models and metrics
+  //   2. Helper consolidation is needed
+  //   3. We need to extract the helper to a different namespace
+  //   4. `isAdHocModelQuestionCard` is only used in TableInteractive.jsx
+  //   5. Ideally, we should have only one helper that accepts question instead of a card
+  const isMetric = card.type === "metric" || originalCard.type === "metric";
+  const isModelOrMetric = isModel || isMetric;
+
+  return isModelOrMetric && isSameCard && isSelfReferencing;
 }
 
 export function isAdHocModelQuestion(

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -110,11 +110,13 @@ export const runQuestionQuery = ({
       : true;
 
     if (shouldUpdateUrl) {
-      const isAdHocModel =
-        question.isDataset() &&
+      const isAdHocModelOrMetric =
+        (question.isDataset() || question.type() === "metric") &&
         isAdHocModelQuestion(question, originalQuestion);
 
-      dispatch(updateUrl(question, { dirty: !isAdHocModel && cardIsDirty }));
+      dispatch(
+        updateUrl(question, { dirty: !isAdHocModelOrMetric && cardIsDirty }),
+      );
     }
 
     const startTime = new Date();

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -224,6 +224,7 @@ function SavedQuestionLeftSide(props) {
 
   const hasLastEditInfo = question.lastEditInfo() != null;
   const isDataset = question.isDataset();
+  const type = question.type();
 
   const onHeaderChange = useCallback(
     name => {
@@ -256,11 +257,11 @@ function SavedQuestionLeftSide(props) {
           <HeadBreadcrumbs
             divider={<HeaderDivider>/</HeaderDivider>}
             parts={[
-              ...(isAdditionalInfoVisible && isDataset
+              ...(isAdditionalInfoVisible && type !== "question"
                 ? [
                     <DatasetCollectionBadge
                       key="collection"
-                      dataset={question}
+                      entity={question}
                     />,
                   ]
                 : []),
@@ -353,13 +354,14 @@ function AhHocQuestionLeftSide(props) {
 }
 
 DatasetCollectionBadge.propTypes = {
-  dataset: PropTypes.object.isRequired,
+  entity: PropTypes.object.isRequired,
 };
 
-function DatasetCollectionBadge({ dataset }) {
-  const { collection } = dataset.card();
+function DatasetCollectionBadge({ entity }) {
+  const { collection } = entity.card();
+  const icon = entity.type();
   return (
-    <HeadBreadcrumbs.Badge to={Urls.collection(collection)} icon="model">
+    <HeadBreadcrumbs.Badge to={Urls.collection(collection)} icon={icon}>
       {collection?.name || t`Our analytics`}
     </HeadBreadcrumbs.Badge>
   );

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -224,7 +224,8 @@ function SavedQuestionLeftSide(props) {
 
   const hasLastEditInfo = question.lastEditInfo() != null;
   const isDataset = question.isDataset();
-  const type = question.type() || "question";
+  const type = question.type();
+  const isModelOrMetric = isDataset || type === "metric";
 
   const onHeaderChange = useCallback(
     name => {
@@ -257,7 +258,7 @@ function SavedQuestionLeftSide(props) {
           <HeadBreadcrumbs
             divider={<HeaderDivider>/</HeaderDivider>}
             parts={[
-              ...(isAdditionalInfoVisible && type !== "question"
+              ...(isAdditionalInfoVisible && isModelOrMetric
                 ? [
                     <HeaderCollectionBadge
                       key="collection"

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -258,7 +258,12 @@ function SavedQuestionLeftSide(props) {
             divider={<HeaderDivider>/</HeaderDivider>}
             parts={[
               ...(isAdditionalInfoVisible && type !== "question"
-                ? [<HeaderCollectionBadge key="collection" entity={question} />]
+                ? [
+                    <HeaderCollectionBadge
+                      key="collection"
+                      question={question}
+                    />,
+                  ]
                 : []),
 
               <SavedQuestionHeaderButton
@@ -349,12 +354,12 @@ function AhHocQuestionLeftSide(props) {
 }
 
 HeaderCollectionBadge.propTypes = {
-  entity: PropTypes.object.isRequired,
+  question: PropTypes.object.isRequired,
 };
 
-function HeaderCollectionBadge({ entity }) {
-  const { collection } = entity.card();
-  const icon = entity.type();
+function HeaderCollectionBadge({ question }) {
+  const { collection } = question.card();
+  const icon = question.type();
   return (
     <HeadBreadcrumbs.Badge to={Urls.collection(collection)} icon={icon}>
       {collection?.name || t`Our analytics`}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -224,7 +224,7 @@ function SavedQuestionLeftSide(props) {
 
   const hasLastEditInfo = question.lastEditInfo() != null;
   const isDataset = question.isDataset();
-  const type = question.type();
+  const type = question.type() || "question";
 
   const onHeaderChange = useCallback(
     name => {

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -258,12 +258,7 @@ function SavedQuestionLeftSide(props) {
             divider={<HeaderDivider>/</HeaderDivider>}
             parts={[
               ...(isAdditionalInfoVisible && type !== "question"
-                ? [
-                    <DatasetCollectionBadge
-                      key="collection"
-                      entity={question}
-                    />,
-                  ]
+                ? [<HeaderCollectionBadge key="collection" entity={question} />]
                 : []),
 
               <SavedQuestionHeaderButton
@@ -353,11 +348,11 @@ function AhHocQuestionLeftSide(props) {
   );
 }
 
-DatasetCollectionBadge.propTypes = {
+HeaderCollectionBadge.propTypes = {
   entity: PropTypes.object.isRequired,
 };
 
-function DatasetCollectionBadge({ entity }) {
+function HeaderCollectionBadge({ entity }) {
   const { collection } = entity.card();
   const icon = entity.type();
   return (

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ConvertQueryButton/ConvertQueryButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ConvertQueryButton/ConvertQueryButton.tsx
@@ -47,8 +47,10 @@ ConvertQueryButton.shouldRender = ({
   queryBuilderMode,
 }: ConvertQueryButtonOpts) => {
   const { isNative } = Lib.queryDisplayInfo(question.query());
+  const isMetric = question.type() === "metric";
   return (
     !isNative &&
+    !isMetric &&
     question.database()?.native_permissions === "write" &&
     queryBuilderMode === "notebook"
   );

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
@@ -96,6 +96,7 @@ export const QuestionActions = ({
   const isSaved = question.isSaved();
   const database = question.database();
   const canAppend = canUpload && canWrite && !!question._card.based_on_upload;
+  const type = question.type();
 
   const canPersistDataset =
     PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled() &&
@@ -192,7 +193,7 @@ export const QuestionActions = ({
       action: () => onOpenModal(MODAL_TYPES.MOVE),
       testId: MOVE_TESTID,
     });
-    if (!isDataset) {
+    if (type === "question") {
       extraButtons.push({
         title: t`Turn into a model`,
         icon: "model",

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
@@ -96,7 +96,7 @@ export const QuestionActions = ({
   const isSaved = question.isSaved();
   const database = question.database();
   const canAppend = canUpload && canWrite && !!question._card.based_on_upload;
-  const type = question.type();
+  const type = question.type() || "question";
 
   const canPersistDataset =
     PLUGIN_MODEL_PERSISTENCE.isModelLevelPersistenceEnabled() &&

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -331,19 +331,20 @@ export const getQuestion = createSelector(
     if (!question) {
       return;
     }
+
     const isEditingModel = queryBuilderMode === "dataset";
     if (isEditingModel) {
       return question.lockDisplay();
     }
 
-    // When opening a model, we swap it's `dataset_query`
-    // with clean query using the model as a source table,
-    // to enable "simple mode" like features
-    // This has to be skipped for users without data permissions
-    // as it would be blocked by the backend as an ad-hoc query
-    // see https://github.com/metabase/metabase/issues/20042
-    const hasDataPermission = !!question.database();
-    return question.isDataset() && hasDataPermission && !isEditingModel
+    const type = question.type() || "question";
+    const { isEditable } = Lib.queryDisplayInfo(question.query());
+
+    // When opening a model or a metric, we construct a question
+    // with a clean, ad-hoc, query.
+    // This has to be skipped for users without data permissions.
+    // See https://github.com/metabase/metabase/issues/20042
+    return type !== "question" && isEditable && !isEditingModel
       ? question.composeDataset()
       : question;
   },

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -225,6 +225,7 @@ export const getRoutes = store => {
             <Route path="notebook" component={QueryBuilder} />
             <Route path="query" component={QueryBuilder} />
             <Route path=":slug" component={QueryBuilder} />
+            <Route path=":slug/notebook" component={QueryBuilder} />
           </Route>
 
           <Route path="browse">

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -224,6 +224,7 @@ export const getRoutes = store => {
             <IndexRoute component={QueryBuilder} />
             <Route path="notebook" component={QueryBuilder} />
             <Route path="query" component={QueryBuilder} />
+            <Route path=":slug" component={QueryBuilder} />
           </Route>
 
           <Route path="browse">

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -34,7 +34,7 @@ import FieldInfoPopover from "metabase/components/MetadataInfo/FieldInfoPopover"
 import { EmotionCacheProvider } from "metabase/styled-components/components/EmotionCacheProvider";
 import { isID, isPK, isFK } from "metabase-lib/types/utils/isa";
 import { memoizeClass } from "metabase-lib/utils";
-import { isAdHocModelQuestionCard } from "metabase-lib/metadata/utils/models";
+import { isAdHocModelQuestion } from "metabase-lib/metadata/utils/models";
 import MiniBar from "../MiniBar";
 import {
   TableDraggable,
@@ -141,16 +141,18 @@ class TableInteractive extends Component {
   }
 
   UNSAFE_componentWillReceiveProps(newProps) {
-    const { card, data } = this.props;
-    const { card: nextCard, data: nextData } = newProps;
+    const { card, data, metadata } = this.props;
+    const { card: newCard, data: newData, metadata: newMetadata } = newProps;
 
-    const isDataChange =
-      data && nextData && !_.isEqual(data.cols, nextData.cols);
-    const isDatasetStatusChange =
-      isAdHocModelQuestionCard(nextCard, card) ||
-      isAdHocModelQuestionCard(card, nextCard);
+    const question = newMetadata.question(newCard.id);
+    const originalQuestion = metadata.question(card.id);
 
-    if (isDataChange && !isDatasetStatusChange) {
+    const isDataChange = data && newData && !_.isEqual(data.cols, newData.cols);
+    const isModelOrMetricStatusChange =
+      isAdHocModelQuestion(question, originalQuestion) ||
+      isAdHocModelQuestion(originalQuestion, question);
+
+    if (isDataChange && !isModelOrMetricStatusChange) {
       this.resetColumnWidths();
     }
 
@@ -162,7 +164,7 @@ class TableInteractive extends Component {
     }
 
     if (isDataChange) {
-      this._findIDColumn(nextData, newProps.isPivoted);
+      this._findIDColumn(newData, newProps.isPivoted);
       this._showDetailShortcut(this.props.data, this.props.isPivoted);
     }
   }


### PR DESCRIPTION
This commit removes the previous hacky solution.
It also removes the duplication that was put in place to accommodate a scenario where only `card` is available (in TableInteractive).

