### PR TITLE
Use font fallbacks in the static-viz js

### DIFF
--- a/frontend/src/metabase/static-viz/index.js
+++ b/frontend/src/metabase/static-viz/index.js
@@ -20,7 +20,7 @@ export function RenderChart(rawSeries, dashcardSettings, colors) {
     getColor,
     formatValue: formatStaticValue,
     measureText: measureTextWidth,
-    fontFamily: "Lato",
+    fontFamily: "Lato, 'Helvetica Neue', Helvetica, Arial, sans-serif",
   };
 
   const props = {


### PR DESCRIPTION
Fixes: #38684 

The trend chart email was rendering incorrectly in gmail on iOS for some reason.

I think it happened because the Lato font was unavailable in the gmail+iOS context and this new :javascript_visualization (introduced with trend charts for the static-viz rendering pipeline) specified a font family of Lato with no fallbacks. It seems that CSS doesn't inherit font fallbacks from parent elements at all, so even though fallbacks were specified further up the tree, they weren't used.

This PR just adds the same fallbacks used elsewhere in static-viz render code.

Before:
![iOS-wrong-font](https://github.com/metabase/metabase/assets/21064735/069fb77f-10b7-4fd3-af98-5080792df759)

After:
![iOS-right-font](https://github.com/metabase/metabase/assets/21064735/48a47df9-40a0-4361-801e-2fe57bea64f0)
