### PR TITLE
Add caching for data permissions

### DIFF
--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -84,6 +84,34 @@
     (throw (ex-info (tru "Permission type {0} cannot be set to {1}" perm-type perm-value)
                     {perm-type (Permissions perm-type)}))))
 
+;;; ---------------------------------------- Caching ------------------------------------------------------------------
+
+(defn relevant-permissions-for-user
+  "Returns all relevant rows for permissions for the user"
+  [user-id]
+  (group-by (juxt :perm_type :db_id)
+            (t2/select :model/DataPermissions
+                       {:select [:p.*]
+                        :from [[:permissions_group_membership :pgm]]
+                        :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                               [:data_permissions :p] [:= :p.group_id :pg.id]]
+                        :where [:and
+                                [:= :pgm.user_id user-id]]})))
+
+(def ^:dynamic *permissions-for-user*
+  "Filled by `with-relevant-permissions-for-user` with the output of `(relevant-permissions-for-user [user-id])`. A map
+  with keys like `[perm_type db_id]`, because nearly always we want to get permissions for a particular permission
+  type and database id. Values are collections of rows of DataPermissions."
+  nil)
+
+(defmacro with-relevant-permissions-for-user
+  "Populates the `*permissions-for-user*` dynamic var for use by the cache-aware functions in this namespace."
+  [user-id & body]
+  `(binding [*permissions-for-user* (relevant-permissions-for-user ~user-id)]
+     ~@body))
+
+(defn- use-cached-values? [user-id]
+  (and (= user-id api/*current-user-id*) (seq *permissions-for-user*)))
 
 ;;; ---------------------------------------- Fetching a user's permissions --------------------------------------------
 
@@ -136,16 +164,20 @@
                     {perm-type (Permissions perm-type)})))
   (if (is-superuser? user-id)
     (most-permissive-value perm-type)
-    (let [perm-values (t2/select-fn-set :value
-                                        :model/DataPermissions
-                                        {:select [[:p.perm_value :value]]
-                                         :from [[:permissions_group_membership :pgm]]
-                                         :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
-                                                [:data_permissions :p]   [:= :p.group_id :pg.id]]
-                                         :where [:and
-                                                 [:= :pgm.user_id user-id]
-                                                 [:= :p.perm_type (u/qualified-name perm-type)]
-                                                 [:= :p.db_id database-id]]})]
+    (let [perm-values (if (use-cached-values? user-id)
+                        (->> (get *permissions-for-user* [perm-type database-id])
+                             (map :perm_value)
+                             (into #{}))
+                        (t2/select-fn-set :value
+                                          :model/DataPermissions
+                                          {:select [[:p.perm_value :value]]
+                                           :from [[:permissions_group_membership :pgm]]
+                                           :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                                                  [:data_permissions :p]   [:= :p.group_id :pg.id]]
+                                           :where [:and
+                                                   [:= :pgm.user_id user-id]
+                                                   [:= :p.perm_type (u/qualified-name perm-type)]
+                                                   [:= :p.db_id database-id]]}))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -200,19 +232,25 @@
                     {perm-type (Permissions perm-type)})))
   (if (is-superuser? user-id)
     (most-permissive-value perm-type)
-    (let [perm-values (t2/select-fn-set :value
-                                        :model/DataPermissions
-                                        {:select [[:p.perm_value :value]]
-                                         :from [[:permissions_group_membership :pgm]]
-                                         :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
-                                                [:data_permissions :p]   [:= :p.group_id :pg.id]]
-                                         :where [:and
-                                                 [:= :pgm.user_id user-id]
-                                                 [:= :p.perm_type (u/qualified-name perm-type)]
-                                                 [:= :p.db_id database-id]
-                                                 [:or
-                                                  [:= :table_id table-id]
-                                                  [:= :table_id nil]]]})]
+    (let [perm-values (if (use-cached-values? user-id)
+                        (->> (get *permissions-for-user* [perm-type database-id])
+                             (filter #(or (= (:table_id %) table-id)
+                                          (nil? (:table_id %))))
+                             (map :perm_value)
+                             (into #{}))
+                        (t2/select-fn-set :value
+                                          :model/DataPermissions
+                                          {:select [[:p.perm_value :value]]
+                                           :from [[:permissions_group_membership :pgm]]
+                                           :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                                                  [:data_permissions :p]   [:= :p.group_id :pg.id]]
+                                           :where [:and
+                                                   [:= :pgm.user_id user-id]
+                                                   [:= :p.perm_type (u/qualified-name perm-type)]
+                                                   [:= :p.db_id database-id]
+                                                   [:or
+                                                    [:= :table_id table-id]
+                                                    [:= :table_id nil]]]}))]
       (or (coalesce perm-type (conj perm-values (get-additional-table-permission! {:db-id database-id :table-id table-id}
                                                                             perm-type)))
           (least-permissive-value perm-type)))))
@@ -243,21 +281,26 @@
     ;; restrictive group permission.
     (let [perm-values (most-restrictive-per-group
                        perm-type
-                       (t2/select :model/DataPermissions
-                                  {:select [[:p.group_id :group-id]
-                                            [:p.perm_value :value]
-                                            :p.table_id
-                                            :p.group_id]
-                                   :from [[:permissions_group_membership :pgm]]
-                                   :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
-                                          [:data_permissions :p]   [:= :p.group_id :pg.id]]
-                                   :where [:and
-                                           [:= :pgm.user_id user-id]
-                                           [:= :p.perm_type (u/qualified-name perm-type)]
-                                           [:= :p.db_id database-id]
-                                           [:or
-                                            [:= :schema_name schema-name]
-                                            [:= :table_id nil]]]}))]
+                       (if (use-cached-values? user-id)
+                         (->> (get *permissions-for-user* [perm-type database-id])
+                              (filter #(or (= (:schema_name %) schema-name)
+                                           (nil? (:table_id %))))
+                              (map #(set/rename-keys % {:group_id :group-id
+                                                        :perm_value :value}))
+                              (map #(select-keys % [:group-id :value])))
+                         (t2/select :model/DataPermissions
+                                    {:select [[:p.group_id :group-id]
+                                              [:p.perm_value :value]]
+                                     :from [[:permissions_group_membership :pgm]]
+                                     :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                                            [:data_permissions :p]   [:= :p.group_id :pg.id]]
+                                     :where [:and
+                                             [:= :pgm.user_id user-id]
+                                             [:= :p.perm_type (u/qualified-name perm-type)]
+                                             [:= :p.db_id database-id]
+                                             [:or
+                                              [:= :schema_name schema-name]
+                                              [:= :table_id nil]]]})))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -274,18 +317,24 @@
     ;; The schema-level permission is the most-restrictive table-level permission within a schema. So for each group,
     ;; select the most-restrictive table-level permission. Then use normal coalesce logic to select the *least*
     ;; restrictive group permission.
-    (let [perm-values (t2/select-fn-set :value :model/DataPermissions
-                                        {:select [[:p.perm_value :value]]
-                                         :from [[:permissions_group_membership :pgm]]
-                                         :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
-                                                [:data_permissions :p]   [:= :p.group_id :pg.id]]
-                                         :where [:and
-                                                 [:= :pgm.user_id user-id]
-                                                 [:= :p.perm_type (u/qualified-name perm-type)]
-                                                 [:= :p.db_id database-id]
-                                                 [:or
-                                                  [:= :schema_name schema-name]
-                                                  [:= :table_id nil]]]})]
+    (let [perm-values (if (use-cached-values? user-id)
+                        (->> (get *permissions-for-user* [perm-type database-id])
+                             (filter #(or (= (:schema_name %) schema-name)
+                                          (nil? (:table_id %))))
+                             (map :perm_value)
+                             (into #{}))
+                        (t2/select-fn-set :value :model/DataPermissions
+                                          {:select [[:p.perm_value :value]]
+                                           :from [[:permissions_group_membership :pgm]]
+                                           :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                                                  [:data_permissions :p]   [:= :p.group_id :pg.id]]
+                                           :where [:and
+                                                   [:= :pgm.user_id user-id]
+                                                   [:= :p.perm_type (u/qualified-name perm-type)]
+                                                   [:= :p.db_id database-id]
+                                                   [:or
+                                                    [:= :schema_name schema-name]
+                                                    [:= :table_id nil]]]}))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -298,17 +347,21 @@
                     {perm-type (Permissions perm-type)})))
   (if (is-superuser? user-id)
     (most-permissive-value perm-type)
-    (let [perm-values (t2/select-fn-set
-                       :value
-                       :model/DataPermissions
-                       {:select [[:p.perm_value :value]]
-                        :from [[:permissions_group_membership :pgm]]
-                        :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
-                               [:data_permissions :p]   [:= :p.group_id :pg.id]]
-                        :where [:and
-                                [:= :pgm.user_id user-id]
-                                [:= :p.perm_type (u/qualified-name perm-type)]
-                                [:= :p.db_id database-id]]})]
+    (let [perm-values (if (use-cached-values? user-id)
+                        (->> (get *permissions-for-user* [perm-type database-id])
+                             (map :perm_value)
+                             (into #{}))
+                        (t2/select-fn-set
+                         :value
+                         :model/DataPermissions
+                         {:select [[:p.perm_value :value]]
+                          :from [[:permissions_group_membership :pgm]]
+                          :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                                 [:data_permissions :p]   [:= :p.group_id :pg.id]]
+                          :where [:and
+                                  [:= :pgm.user_id user-id]
+                                  [:= :p.perm_type (u/qualified-name perm-type)]
+                                  [:= :p.db_id database-id]]}))]
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
@@ -320,16 +373,22 @@
   (if (is-superuser? user-id)
     (most-permissive-value :perms/download-results)
     (let [perm-values
-          (t2/select :model/DataPermissions
-                     {:select [[:p.perm_value :value]
-                               [:p.group_id :group_id]]
-                      :from [[:permissions_group_membership :pgm]]
-                      :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
-                             [:data_permissions :p]   [:= :p.group_id :pg.id]]
-                      :where [:and
-                              [:= :pgm.user_id user-id]
-                              [:= :p.perm_type (u/qualified-name :perms/download-results)]
-                              [:= :p.db_id database-id]]})
+          (if (use-cached-values? user-id)
+            (->> (get *permissions-for-user* [:perms/download-results database-id])
+                 (map (fn [{:keys [perm_value group_id]}]
+                        {:group_id group_id :value perm_value}))
+                 first)
+            (t2/select :model/DataPermissions
+                       {:select [[:p.perm_value :value]
+                                 [:p.group_id :group_id]]
+                        :from [[:permissions_group_membership :pgm]]
+                        :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                               [:data_permissions :p]   [:= :p.group_id :pg.id]]
+                        :where [:and
+                                [:= :pgm.user_id user-id]
+                                [:= :p.perm_type (u/qualified-name :perms/download-results)]
+                                [:= :p.db_id database-id]]}))
+
           value-by-group
           (-> (group-by :group_id perm-values)
               (update-vals (fn [perms]
@@ -345,16 +404,21 @@
   [user-id database-id]
   (if (is-superuser? user-id)
     false
-    (let [perm-values (t2/select-fn-set :value
-                                        :model/DataPermissions
-                                        {:select [[:p.perm_value :value]]
-                                         :from [[:permissions_group_membership :pgm]]
-                                         :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
-                                                [:data_permissions :p]   [:= :p.group_id :pg.id]]
-                                         :where [:and
-                                                 [:= :pgm.user_id user-id]
-                                                 [:= :p.perm_type (u/qualified-name :perms/data-access)]
-                                                 [:= :p.db_id database-id]]})]
+    (let [perm-values
+          (if (use-cached-values? user-id)
+            (->> (get *permissions-for-user* [:perms/data-access database-id])
+                 (map :perm_value)
+                 (into #{}))
+            (t2/select-fn-set :value
+                              :model/DataPermissions
+                              {:select [[:p.perm_value :value]]
+                               :from [[:permissions_group_membership :pgm]]
+                               :join [[:permissions_group :pg] [:= :pg.id :pgm.group_id]
+                                      [:data_permissions :p]   [:= :p.group_id :pg.id]]
+                               :where [:and
+                                       [:= :pgm.user_id user-id]
+                                       [:= :p.perm_type (u/qualified-name :perms/data-access)]
+                                       [:= :p.db_id database-id]]}))]
       (= (coalesce :perms/data-access perm-values)
          :block))))
 

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -329,8 +329,7 @@
     (let [perm-values
           (->> (get-permissions user-id :perms/download-results database-id)
                (map (fn [{:keys [perm_value group_id]}]
-                      {:group_id group_id :value perm_value}))
-               first)
+                      {:group_id group_id :value perm_value})))
 
           value-by-group
           (-> (group-by :group_id perm-values)

--- a/src/metabase/server/middleware/session.clj
+++ b/src/metabase/server/middleware/session.clj
@@ -28,6 +28,7 @@
    [metabase.db :as mdb]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.models.api-key :as api-key]
+   [metabase.models.data-permissions :as data-perms]
    [metabase.models.setting
     :as setting
     :refer [*user-local-values* defsetting]]
@@ -413,7 +414,8 @@
                                              (delay (atom (or settings
                                                               (user/user-local-settings metabase-user-id)))))
             *user-local-values-user-id*    metabase-user-id]
-    (thunk)))
+    (data-perms/with-relevant-permissions-for-user metabase-user-id
+      (thunk))))
 
 (defmacro ^:private with-current-user-for-request
   [request & body]

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -1,6 +1,7 @@
 (ns metabase.models.data-permissions-test
   (:require
    [clojure.test :refer :all]
+   [metabase.api.common :as api]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.test :as mt]
@@ -138,7 +139,20 @@
         (is (= :no (data-perms/database-permission-for-user user-id :perms/native-query-editing database-id-2))))
 
       (testing "Admins always have the most permissive value, regardless of group membership"
-        (is (= :yes (data-perms/database-permission-for-user (mt/user->id :crowberto) :perms/native-query-editing database-id-2)))))))
+        (is (= :yes (data-perms/database-permission-for-user (mt/user->id :crowberto) :perms/native-query-editing database-id-2)))))
+    (testing "caching works as expected"
+      (binding [api/*current-user-id* user-id]
+        (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
+          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
+          (data-perms/with-relevant-permissions-for-user user-id
+            ;; retrieve the cache now so it doesn't get counted in the call-count
+            @data-perms/*permissions-for-user*
+            ;; make the cache wrong
+            (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :no)
+            ;; the cached value is used
+            (t2/with-call-count [call-count]
+              (is (= :yes (data-perms/database-permission-for-user user-id :perms/native-query-editing database-id-1)))
+              (is (zero? (call-count))))))))))
 
 (deftest table-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}  {}
@@ -151,6 +165,7 @@
                  :model/Database                   {database-id :id} {}
                  :model/Table                      {table-id-1 :id}  {:db_id database-id}
                  :model/Table                      {table-id-2 :id}  {:db_id database-id}]
+    ;; for cache
     (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
       (testing "`table-permission-for-user` coalesces permissions from all groups a user is in"
         (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
@@ -162,7 +177,20 @@
         (is (= :block (data-perms/table-permission-for-user user-id :perms/data-access database-id table-id-2))))
 
       (testing "Admins always have the most permissive value, regardless of group membership"
-        (is (= :unrestricted (data-perms/table-permission-for-user (mt/user->id :crowberto) :perms/data-access database-id table-id-2)))))))
+        (is (= :unrestricted (data-perms/table-permission-for-user (mt/user->id :crowberto) :perms/data-access database-id table-id-2)))))
+      (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
+        (testing "caching works as expected"
+          (binding [api/*current-user-id* user-id]
+            (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
+            (data-perms/with-relevant-permissions-for-user user-id
+              ;; retrieve the cache now so it doesn't get counted in the call count
+              @data-perms/*permissions-for-user*
+              ;; make the cache wrong
+              (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
+              ;; the cached value is used
+              (t2/with-call-count [call-count]
+                (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/data-access database-id table-id-1)))
+                (is (zero? (call-count))))))))))
 
 (deftest permissions-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}


### PR DESCRIPTION
This caching is:

- thread-local. It's intended to be used just like
`api/*current-user-permission-set*` (although less directly): we use
middleware to wrap a single request/response handling cycle in
`with-relevant-permissions-for-user` to populate the cache, and then the
cache is used.

- scoped to a particular user. It will not be used if the
`api/*current-user-id*` isn't equal to the `user-id` in a particular
permissions query. The `user-id` is also used as an index when
retrieving permissions to prevent any possibility of accidentally using
cached permissions for a different user than intended.

- "indexed" by `[user-id, perm-type, db-id]` - the former for the above
reason, the latter two (perm-type and db-id) because essentially every
time we need to retrieve permissions we filter by these two columns.

To avoid having multiple codepaths for filtering permissions (e.g. one for cached vs. another for uncached), for now I'm retrieving all of a user's relevant permissions in *both* cases, then filtering them down when we calculate a given permission. Less efficient, yes, but this way we are always testing the same logic, where otherwise we might have subtle bugs where we filtered permissions differently in SQL vs from the cache. And I don't think we *ever* calculate permissions in production that *aren't* for the currently logged in user, so this shouldn't have any negative performance impact in prod.

(Edit: I actually decided that instead of select all of the user's relevant permissions, we could just select the ones related to the perm_type and db_id we're interested in.)

Closes [38040](https://github.com/metabase/metabase/issues/38040)