### PR TITLE
[MLv2] `remove-field` throws given aggregation, breakout, or expression

### DIFF
--- a/test/metabase/lib/field_test.cljc
+++ b/test/metabase/lib/field_test.cljc
@@ -1244,31 +1244,12 @@
     (let [query      (-> (lib/query meta/metadata-provider (meta/table-metadata :orders))
                          (lib/aggregate -1 (lib/sum (meta/field-metadata :orders :subtotal)))
                          (lib/breakout -1 (lib/with-temporal-bucket (meta/field-metadata :orders :created-at) :month)))
-          stage      (lib.util/query-stage query -1)
-          columns    (lib/returned-columns query)
-          created-at [:field {} (meta/id :orders :created-at)]
-          sum        [:aggregation {} (-> stage :aggregation first lib.options/uuid)]]
+          columns    (lib/returned-columns query)]
       (testing "removing each field"
-        (is (=? [sum]
-                (-> query
-                    (lib/remove-field -1 (first columns))
-                    fields-of)))
-        (is (=? [created-at]
-                (-> query
-                    (lib/remove-field -1 (second columns))
-                    fields-of))))
-
-      (testing "removing and adding each field"
-        (is (nil? (-> query
-                      (lib/remove-field -1 (first columns))
-                      (lib/add-field    -1 (first columns))
-                      (lib.util/query-stage -1)
-                      :fields)))
-        (is (nil? (-> query
-                      (lib/remove-field -1 (second columns))
-                      (lib/add-field    -1 (second columns))
-                      (lib.util/query-stage -1)
-                      :fields)))))))
+        (is (thrown-with-msg? #?(:cljs :default :clj Exception) #"Only source columns"
+                              (lib/remove-field query -1 (first columns))))
+        (is (thrown-with-msg? #?(:cljs :default :clj Exception) #"Only source columns"
+                              (lib/remove-field query -1 (second columns))))))))
 
 (deftest ^:parallel find-visible-column-for-ref-test
   (testing "precise references"


### PR DESCRIPTION
`metabase.lib.field/remove-field` is intended for manipulating the
`:fields` list. That list controls which fields from the source,
previous stage, explicit join, or implicit join should be included in
the results.

All aggregations, breakouts, and custom expressions are always included
in the return columns for that stage, so they cannot be removed with the
`:fields` clause. The UI does not attempt to do this, but this check is
a guardrail for future changes. Trying to hide an aggregation from the
`:fields` clause can silently create a broken query.

Fixes #34321.
