### PR TITLE
Update build requirements for v49

### DIFF
--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -115,6 +115,7 @@ export const versionRequirements: Record<
   46: { java: 11, node: 16 },
   47: { java: 11, node: 18 },
   48: { java: 11, node: 18 },
+  49: { java: 11, node: 18 },
 };
 
 export const getBuildRequirements = (version: string) => {


### PR DESCRIPTION
Updating for v49, there's no change, but it's worth saving that information.
