### PR TITLE
Fix update hook and add select hook

### DIFF
--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -193,7 +193,7 @@
 (defn values
   "Return the `FieldValues` associated with this `field`."
   [{:keys [id]}]
-  (t2/select [FieldValues :field_id :values], :field_id id))
+  (t2/select [FieldValues :field_id :values], :field_id id :type :full))
 
 (mu/defn nested-field-names->field-id :- [:maybe ms/PositiveInt]
   "Recusively find the field id for a nested field name, return nil if not found.

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -111,7 +111,7 @@
     (when-not (contains? field-values-types type)
       (throw (ex-info (tru "Invalid field-values type.")
                       {:type        type
-                       :stauts-code 400})))
+                       :status-code 400})))
 
     (when (and (= type :full)
                hash_key)
@@ -142,7 +142,8 @@
   (u/prog1 (merge {:type :full}
                   field-values)
     (assert-valid-human-readable-values field-values)
-    (assert-valid-type-hash-combo field-values)
+    ;; Take into account that :type has a default value in the database
+    (assert-valid-type-hash-combo (update field-values :type #(or % :full)))
     ;; if inserting a new full fieldvalues, make sure all the advanced field-values of this field are deleted
     (when (= (:type <>) :full)
       (clear-advanced-field-values-for-field! field_id))))
@@ -158,8 +159,7 @@
                          :hash_key    hash_key
                          :status-code 400})))
       ;; if we're updating the values of a Full FieldValues, delete all Advanced FieldValues of this field
-      (when (and (contains? field-values :values)
-                 (= :full (:type (t2/select-one FieldValues (:id field-values)))))
+      (when (and (contains? field-values :values) (= :full (:type field-values)))
         (clear-advanced-field-values-for-field! (:field_id field-values))))))
 
 (t2/define-before-select :model/FieldValues

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -179,7 +179,7 @@
       (throw (ex-info "Invalid query - Advanced FieldValues must have a hash_key"
                       {:field-values field-values})))))
 
-(defn- add-defensive-type-mismatch-filter [{:keys [type] :as field-values}]
+(defn- add-mismatched-hash-filter [{:keys [type] :as field-values}]
   (cond
     (= :full type) (assoc field-values :hash_key nil)
     (some? type)   (update field-values :hash_key #(or % [:not= nil]))
@@ -188,8 +188,7 @@
 (t2/define-before-select :model/FieldValues
   [{:keys [kv-args] :as query}]
   (assert-coherent-query kv-args)
-  ;; Ensure that query filters out invalid rows
-  (update query :kv-args add-defensive-type-mismatch-filter))
+  (update query :kv-args add-mismatched-hash-filter))
 
 (t2/define-after-select :model/FieldValues
   [field-values]

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -176,7 +176,7 @@
                       {:field-values field-values})))
 
     (and (contains? field-values :hash_key) (nil? hash_key))
-    (throw (ex-info "Invalid query - Advanced FieldValues can only specify a non-nil hash_key"
+    (throw (ex-info "Invalid query - Advanced FieldValues can only specify a non-empty hash_key"
                     {:field-values field-values}))))
 
 (defn- add-mismatched-hash-filter [{:keys [type] :as field-values}]

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -155,7 +155,7 @@
   [{:keys [field_id] :as field-values}]
   (u/prog1 (merge {:type :full} field-values)
     (assert-valid-human-readable-values field-values)
-    (assert-valid-type-hash-combo field-values)
+    (assert-valid-type-hash-combo <>)
     ;; if inserting a new full fieldvalues, make sure all the advanced field-values of this field are deleted
     (when (= :full (keyword (:type <>)))
       (clear-advanced-field-values-for-field! field_id))))

--- a/src/metabase/models/field_values.clj
+++ b/src/metabase/models/field_values.clj
@@ -23,6 +23,7 @@
   There is also more written about how these are used for remapping in the docstrings
   for [[metabase.models.params.chain-filter]] and [[metabase.query-processor.middleware.add-dimension-projections]]."
   (:require
+   [clojure.string :as str]
    [java-time.api :as t]
    [malli.core :as mc]
    [medley.core :as m]
@@ -112,16 +113,14 @@
                     {:type        type
                      :status-code 400})))
 
-  (when (and (= type :full)
-             hash_key)
+  (when (and (= type :full) hash_key)
     (throw (ex-info (tru "Full FieldValues shouldn't have hash_key.")
                     {:type        type
                      :hash_key    hash_key
                      :status-code 400})))
 
-  (when (and (advanced-field-values-types type)
-             (empty? hash_key))
-    (throw (ex-info (tru "Advanced FieldValues requires a hash_key.")
+  (when (and (advanced-field-values-types type) (str/blank? hash_key))
+    (throw (ex-info (tru "Advanced FieldValues require a hash_key.")
                     {:type        type
                      :status-code 400}))))
 

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -347,7 +347,7 @@
     (t2/select :model/FieldValues :field_id 1)
     (t2/select :model/FieldValues :field_id 1 :type :full)
     (is (thrown-with-msg? ExceptionInfo
-                          #"Invalid query - :full FieldValues cannot have a hash_key"""
+                          #"Invalid query - :full FieldValues cannot have a hash_key"
                           (t2/select :model/FieldValues :field_id 1 :type :full :hash_key "12345")))
 
     (t2/select :model/FieldValues :field_id 1 :type :sandbox)

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -307,11 +307,13 @@
       (doseq [[id update-map] [[sandbox-id {:field_id 1}]
                                [sandbox-id {:type :full}]
                                [sandbox-id {:type nil}]
+                               ;; this one should be ok, but toucan doesn't give the hook enough info to know better
+                               [full-id {:type nil}]
                                [full-id {:type :sandbox}]
                                [sandbox-id {:hash_key "another-hash"}]
                                [sandbox-id {:hash_key nil}]
                                [full-id {:hash_key "random-hash"}]
-                               ; not even if it keeps type / hash consistency
+                               ;; not even if it keeps type / hash consistency
                                [sandbox-id {:type :full, :hash_key nil}]
                                [full-id {:type :sandbox, :hash_key "random-hash"}]]]
         (is (thrown-with-msg? ExceptionInfo
@@ -321,7 +323,6 @@
     (testing "The model hooks permits mention of the existing values"
       (doseq [[id update-map] [[full-id {:field_id (mt/id :venues :id)}]
                                [sandbox-id {:type :sandbox}]
-                               [full-id {:type nil}]
                                [full-id {:type :full}]
                                [sandbox-id {:hash_key "random-hash"}]
                                [full-id {:hash_key nil}]

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -292,7 +292,7 @@
                               (t2/insert! :model/FieldValues :field_id field-id :type :sandbox)))
         (is (thrown-with-msg? ExceptionInfo
                               #"Advanced FieldValues require a hash_key"
-                              (t2/insert! :model/FieldValues :field_id field-id :type :sandbox :hash_key "")))
+                              (t2/insert! :model/FieldValues :field_id field-id :type :sandbox :hash_key " ")))
         (finally
           ;; Clean up in case there were any failed assertions, and we ended up inserting values
           (t2/delete! :model/FieldValues :field_id field-id))))))
@@ -367,7 +367,7 @@
     (t2/select :model/FieldValues :field_id 1 :type :sandbox)
     (t2/select :model/FieldValues :field_id 1 :type :sandbox :hash_key "12345")
     (is (thrown-with-msg? ExceptionInfo
-                          #"Invalid query - Advanced FieldValues can only specify a non-nil hash_key"
+                          #"Invalid query - Advanced FieldValues can only specify a non-empty hash_key"
                           (t2/select :model/FieldValues :field_id 1 :type :sandbox :hash_key nil)))))
 
 (deftest select-safety-filter-test

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -288,8 +288,11 @@
                               #"Full FieldValues shouldnt have hash_key"
                               (t2/insert! :model/FieldValues :field_id field-id :type :full :hash_key "12345")))
         (is (thrown-with-msg? ExceptionInfo
-                              #"Advanced FieldValues requires a hash_key"
+                              #"Advanced FieldValues require a hash_key"
                               (t2/insert! :model/FieldValues :field_id field-id :type :sandbox)))
+        (is (thrown-with-msg? ExceptionInfo
+                              #"Advanced FieldValues require a hash_key"
+                              (t2/insert! :model/FieldValues :field_id field-id :type :sandbox :hash_key "")))
         (finally
           ;; Clean up in case there were any failed assertions, and we ended up inserting values
           (t2/delete! :model/FieldValues :field_id field-id))))))
@@ -364,7 +367,7 @@
     (t2/select :model/FieldValues :field_id 1 :type :sandbox)
     (t2/select :model/FieldValues :field_id 1 :type :sandbox :hash_key "12345")
     (is (thrown-with-msg? ExceptionInfo
-                          #"Invalid query - Advanced FieldValues must have a hash_key"
+                          #"Invalid query - Advanced FieldValues can only specify a non-nil hash_key"
                           (t2/select :model/FieldValues :field_id 1 :type :sandbox :hash_key nil)))))
 
 (deftest select-safety-filter-test

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -296,23 +296,24 @@
 
 (deftest update-field-values-hook-test
   (testing "The model hooks prevent us changing the intrinsic identity of a field values"
-    (let [field-id (mt/id :venues :id)
-          fv-id    (t2/insert-returning-pk! :model/FieldValues :field_id field-id :type :sandbox :hash_key "12345")]
+    (t2.with-temp/with-temp [FieldValues {:keys [id]} {:field_id (mt/id :venues :id)
+                                                       :type     :sandbox
+                                                       :hash_key "random-hash"}]
       (is (thrown-with-msg? ExceptionInfo
                             #"Cant update field_id for a FieldValues."
-                            (t2/update! :model/FieldValues fv-id {:field_id 1})))
+                            (t2/update! :model/FieldValues id {:field_id 1})))
       (is (thrown-with-msg? ExceptionInfo
                             #"Cant update type or hash_key for a FieldValues."
-                            (t2/update! :model/FieldValues fv-id {:type :full})))
+                            (t2/update! :model/FieldValues id {:type :full})))
       (is (thrown-with-msg? ExceptionInfo
                             #"Cant update type or hash_key for a FieldValues."
-                            (t2/update! :model/FieldValues fv-id {:type nil})))
+                            (t2/update! :model/FieldValues id {:type nil})))
       (is (thrown-with-msg? ExceptionInfo
                             #"Cant update type or hash_key for a FieldValues."
-                            (t2/update! :model/FieldValues fv-id {:hash_key "54321"})))
+                            (t2/update! :model/FieldValues id {:hash_key "54321"})))
       (is (thrown-with-msg? ExceptionInfo
                             #"Cant update type or hash_key for a FieldValues."
-                            (t2/update! :model/FieldValues fv-id {:hash_key nil}))))))
+                            (t2/update! :model/FieldValues id {:hash_key nil}))))))
 
 (deftest insert-full-field-values-should-remove-all-cached-field-values
   (mt/with-temp [FieldValues sandbox-fv {:field_id (mt/id :venues :id)
@@ -343,14 +344,14 @@
 
 (deftest select-coherence-test
   (testing "We cannot perform queries with invalid mixes of type and hash_key, which would return nothing"
-    (is (t2/select :model/FieldValues :field_id 1))
-    (is (t2/select :model/FieldValues :field_id 1 :type :full))
+    (t2/select :model/FieldValues :field_id 1)
+    (t2/select :model/FieldValues :field_id 1 :type :full)
     (is (thrown-with-msg? ExceptionInfo
                           #"Invalid query - :full FieldValues cannot have a hash_key"""
                           (t2/select :model/FieldValues :field_id 1 :type :full :hash_key "12345")))
 
-    (is (t2/select :model/FieldValues :field_id 1 :type :sandbox))
-    (is (t2/select :model/FieldValues :field_id 1 :type :sandbox :hash_key "12345"))
+    (t2/select :model/FieldValues :field_id 1 :type :sandbox)
+    (t2/select :model/FieldValues :field_id 1 :type :sandbox :hash_key "12345")
     (is (thrown-with-msg? ExceptionInfo
                           #"Invalid query - Advanced FieldValues must have a hash_key"
                           (t2/select :model/FieldValues :field_id 1 :type :sandbox :hash_key nil)))))

--- a/test/metabase/models/field_values_test.clj
+++ b/test/metabase/models/field_values_test.clj
@@ -346,6 +346,15 @@
     (t2/update! FieldValues (:id fv) {:values [1 2 3]})
     (is (not (t2/exists? FieldValues :id (:id sandbox-fv))))))
 
+(deftest update-full-field-without-values-should-remove-not-all-cached-field-values
+  (mt/with-temp [FieldValues fv         {:field_id (mt/id :venues :id)
+                                         :type     :full}
+                 FieldValues sandbox-fv {:field_id (mt/id :venues :id)
+                                         :type     :sandbox
+                                         :hash_key "random-hash"}]
+    (t2/update! FieldValues (:id fv) {:updated_at (t/zoned-date-time)})
+    (is (t2/exists? FieldValues :id (:id sandbox-fv)))))
+
 (deftest identity-hash-test
   (testing "Field hashes are composed of the name and the table's identity-hash"
     (mt/with-temp [Database    db    {:name "field-db" :engine :h2}


### PR DESCRIPTION
References https://github.com/metabase/metabase/issues/668

### Description

Fix holes in the mutation hooks and coerce queries to filter out bad data that's already gotten into the db.

I really wanted to protect against `select-one` queries that don't full specify the identity, but I couldn't find a way to make the hook dependent on the type of select.