### PR TITLE
[Parameters] Cleanup types usage

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/targets.ts
+++ b/frontend/src/metabase-lib/parameters/utils/targets.ts
@@ -1,7 +1,6 @@
 import type {
-  ExpressionReference,
+  ConcreteFieldReference,
   FieldReference,
-  LocalFieldReference,
   NativeParameterDimensionTarget,
   ParameterTarget,
   ParameterTextTarget,
@@ -25,14 +24,8 @@ export function isParameterVariableTarget(
 
 function isConcreteFieldReference(
   reference: FieldReference,
-): reference is LocalFieldReference {
-  return reference[0] === "field";
-}
-
-function isExpressionReference(
-  reference: FieldReference,
-): reference is ExpressionReference {
-  return reference[0] === "expression";
+): reference is ConcreteFieldReference {
+  return reference[0] === "field" || reference[0] === "expression";
 }
 
 export function getTemplateTagFromTarget(target: ParameterTarget) {
@@ -74,7 +67,7 @@ export function buildColumnTarget(
 ): StructuredParameterDimensionTarget {
   const fieldRef = Lib.legacyRef(query, stageIndex, column);
 
-  if (!isConcreteFieldReference(fieldRef) && !isExpressionReference(fieldRef)) {
+  if (!isConcreteFieldReference(fieldRef)) {
     throw new Error(`Cannot build column target field reference: ${fieldRef}`);
   }
 

--- a/frontend/src/metabase-lib/parameters/utils/targets.unit.spec.ts
+++ b/frontend/src/metabase-lib/parameters/utils/targets.unit.spec.ts
@@ -27,8 +27,6 @@ describe("parameters/utils/targets", () => {
       expect(isDimensionTarget(["variable", ["template-tag", "foo"]])).toBe(
         false,
       );
-      // @ts-expect-error - this function is still used in untyped code -- making sure non-arrays don't blow up
-      expect(isDimensionTarget()).toBe(false);
     });
 
     it('should return true for a target that contains a "dimension" string in the first entry', () => {
@@ -67,10 +65,6 @@ describe("parameters/utils/targets", () => {
     });
 
     it("should return null for targets that are not template tags", () => {
-      // @ts-expect-error - this function is still used in untyped code -- making sure non-arrays don't blow up
-      expect(getTemplateTagFromTarget(["dimension"])).toBe(null);
-      // @ts-expect-error - this function is still used in untyped code -- making sure non-arrays don't blow up
-      expect(getTemplateTagFromTarget()).toBe(null);
       expect(
         getTemplateTagFromTarget(["dimension", ["field", 123, null]]),
       ).toBe(null);


### PR DESCRIPTION
Follow up of https://github.com/metabase/metabase/pull/38596

- Cleanup wrong usage in tests as we have all related places in TS already.
- Fix guard's usage (ExpressionReference is a part of ConcreteFieldReference, so no need for a second guard)
