### PR TITLE
Fix native editor flakes

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -37,7 +37,11 @@ export function openNativeEditor({
 
   databaseName && cy.findByText(databaseName).click();
 
-  return cy.findByTestId("native-query-editor").as(alias).should("be.visible");
+  return cy
+    .findByTestId("native-query-editor")
+    .as(alias)
+    .should("be.visible")
+    .should("have.class", "ace_editor");
 }
 
 /**

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -37,9 +37,12 @@ export function openNativeEditor({
 
   databaseName && cy.findByText(databaseName).click();
 
+  return focusNativeEditor().as(alias);
+}
+
+export function focusNativeEditor() {
   return cy
     .findByTestId("native-query-editor")
-    .as(alias)
     .should("be.visible")
     .should("have.class", "ace_editor")
     .click()

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -41,7 +41,9 @@ export function openNativeEditor({
     .findByTestId("native-query-editor")
     .as(alias)
     .should("be.visible")
-    .should("have.class", "ace_editor");
+    .should("have.class", "ace_editor")
+    .click()
+    .should("have.class", "ace_focus");
 }
 
 /**

--- a/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -1,4 +1,4 @@
-import { filterWidget, popover } from "e2e/support/helpers";
+import { filterWidget, focusNativeEditor, popover } from "e2e/support/helpers";
 
 // FILTER TYPES
 
@@ -92,12 +92,11 @@ export function runQuery(xhrAlias = "dataset") {
  * @param {string} query
  */
 export function enterParameterizedQuery(query, options = {}) {
-  cy.get("@editor")
-    .should("have.class", "ace_editor")
-    .type(query, {
-      parseSpecialCharSequences: false,
-      ...options,
-    });
+  focusNativeEditor();
+  cy.get("@editor").type(query, {
+    parseSpecialCharSequences: false,
+    ...options,
+  });
 }
 
 export function getRunQueryButton() {

--- a/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
+++ b/e2e/test/scenarios/native-filters/helpers/e2e-sql-filter-helpers.js
@@ -92,15 +92,12 @@ export function runQuery(xhrAlias = "dataset") {
  * @param {string} query
  */
 export function enterParameterizedQuery(query, options = {}) {
-  // Both delay and a repeated sequence of `{arrowleft}{arrowright}` are there to prevent typing flakes
-  // Without them at least 1 in 10 test runs locally didn't type correctly
-  cy.get("@editor").type("{leftArrow}{rightArrow}{leftArrow}{rightArrow}", {
-    delay: 50,
-  });
-  cy.get("@editor").type(query, {
-    parseSpecialCharSequences: false,
-    ...options,
-  });
+  cy.get("@editor")
+    .should("have.class", "ace_editor")
+    .type(query, {
+      parseSpecialCharSequences: false,
+      ...options,
+    });
 }
 
 export function getRunQueryButton() {

--- a/e2e/test/scenarios/native/reproductions/18148-save-button-before-it-is-possible-to-save.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/18148-save-button-before-it-is-possible-to-save.cy.spec.js
@@ -16,9 +16,10 @@ describe("issue 18148", () => {
 
   it("should not offer to save the question before it is actually possible to save it (metabase#18148)", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Select a database");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").should("have.attr", "aria-disabled", "true");
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Select a database").click();
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(dbName).click();


### PR DESCRIPTION
Failed run https://github.com/metabase/metabase/actions/runs/7891864668/job/21538217755
Stress test 100 runs https://github.com/metabase/metabase/actions/runs/7900840466/job/21563205060

Waits for the ace editor to properly initialize before typing. Previously we didn't do that and some first characters could be lost.