### PR TITLE
Make the filter bar sticky for public dashboards

### DIFF
--- a/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-dashboard.cy.spec.js
@@ -207,7 +207,8 @@ describe("scenarios > embedding > dashboard parameters", () => {
 
       goToTab("Tab 2");
 
-      dashboardParametersContainer().within(() => {
+      dashboardParametersContainer().should("not.exist");
+      cy.findByTestId("embed-frame").within(() => {
         cy.findByText("Id").should("not.exist");
         cy.findByText("Name").should("not.exist");
         cy.findByText("Source").should("not.exist");

--- a/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-dashboard.cy.spec.js
@@ -220,7 +220,8 @@ describe("scenarios > public > dashboard", () => {
 
     goToTab(tab2.name);
 
-    dashboardParametersContainer().within(() => {
+    dashboardParametersContainer().should("not.exist");
+    cy.findByTestId("embed-frame").within(() => {
       cy.findByText(textFilter.name).should("not.exist");
       cy.findByText(unusedFilter.name).should("not.exist");
     });

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -103,8 +103,10 @@ const footerVariantStyles = {
 
 export const ParametersWidgetContainer = styled(FullWidthContainer)<{
   isSticky: boolean;
-  hasVisibleParameters: boolean;
 }>`
+  padding-top: ${space(1)};
+  padding-bottom: ${space(1)};
+
   ${props =>
     props.isSticky &&
     css`
@@ -115,13 +117,6 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
       z-index: 3;
 
       background-color: ${color("white")};
-    `}
-
-  ${props =>
-    props.hasVisibleParameters &&
-    css`
-      padding-top: ${space(1)};
-      padding-bottom: ${space(1)};
     `}
 `;
 

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -102,15 +102,20 @@ const footerVariantStyles = {
 };
 
 export const ParametersWidgetContainer = styled(FullWidthContainer)<{
+  isSticky: boolean;
   hasVisibleParameters: boolean;
 }>`
-  position: sticky;
-  top: 0;
-  left: 0;
-  width: 100%;
-  z-index: 3;
+  ${props =>
+    props.isSticky &&
+    css`
+      position: sticky;
+      top: 0;
+      left: 0;
+      width: 100%;
+      z-index: 3;
 
-  background-color: ${color("white")};
+      background-color: ${color("white")};
+    `}
 
   ${props =>
     props.hasVisibleParameters &&

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -102,10 +102,17 @@ const footerVariantStyles = {
 };
 
 export const ParametersWidgetContainer = styled(FullWidthContainer)<{
+  hasScroll: boolean;
   isSticky: boolean;
 }>`
   padding-top: ${space(1)};
   padding-bottom: ${space(1)};
+
+  ${props =>
+    props.hasScroll &&
+    css`
+      border-bottom: 1px solid ${color("border")};
+    `}
 
   ${props =>
     props.isSticky &&

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -36,13 +36,11 @@ export const Root = styled.div<{
     `}
 `;
 
-export const ContentContainer = styled.div<{ hasScroll: boolean }>`
+export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 0 auto;
   position: relative;
-
-  overflow-y: ${props => props.hasScroll && "auto"};
 `;
 
 export const Header = styled.header`
@@ -104,6 +102,14 @@ const footerVariantStyles = {
 };
 
 export const ParametersWidgetContainer = styled(FullWidthContainer)`
+  position: sticky;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 2;
+
+  background-color: ${color("white")};
+
   padding-top: ${space(1)};
   padding-bottom: ${space(1)};
 `;

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -101,7 +101,28 @@ const footerVariantStyles = {
   `,
 };
 
+function getParameterPanelBackgroundColor(theme?: string) {
+  if (theme === "night") {
+    return color("bg-black");
+  }
+  if (theme === "transparent") {
+    return "transparent";
+  }
+  return color("white");
+}
+
+function getParameterPanelBorderColor(theme?: string) {
+  if (theme === "night") {
+    return color("bg-dark");
+  }
+  if (theme === "transparent") {
+    return "transparent";
+  }
+  return color("border");
+}
+
 export const ParametersWidgetContainer = styled(FullWidthContainer)<{
+  embedFrameTheme?: string;
   hasScroll: boolean;
   isSticky: boolean;
 }>`
@@ -111,7 +132,8 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
   ${props =>
     props.hasScroll &&
     css`
-      border-bottom: 1px solid ${color("border")};
+      border-bottom: 1px solid
+        ${getParameterPanelBorderColor(props.embedFrameTheme)};
     `}
 
   ${props =>
@@ -123,7 +145,9 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
       width: 100%;
       z-index: 3;
 
-      background-color: ${color("white")};
+      background-color: ${getParameterPanelBackgroundColor(
+        props.embedFrameTheme,
+      )};
     `}
 `;
 

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -101,7 +101,9 @@ const footerVariantStyles = {
   `,
 };
 
-export const ParametersWidgetContainer = styled(FullWidthContainer)`
+export const ParametersWidgetContainer = styled(FullWidthContainer)<{
+  hasVisibleParameters: boolean;
+}>`
   position: sticky;
   top: 0;
   left: 0;
@@ -110,8 +112,12 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)`
 
   background-color: ${color("white")};
 
-  padding-top: ${space(1)};
-  padding-bottom: ${space(1)};
+  ${props =>
+    props.hasVisibleParameters &&
+    css`
+      padding-top: ${space(1)};
+      padding-bottom: ${space(1)};
+    `}
 `;
 
 export const Footer = styled.footer<{ variant: FooterVariant }>`

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.styled.tsx
@@ -108,7 +108,7 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
   top: 0;
   left: 0;
   width: 100%;
-  z-index: 2;
+  z-index: 3;
 
   background-color: ${color("white")};
 

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -155,7 +155,7 @@ function EmbedFrame({
       })}
       data-testid="embed-frame"
     >
-      <ContentContainer hasScroll={hasInnerScroll}>
+      <ContentContainer>
         {hasHeader && (
           <Header className="EmbedFrame-header">
             {finalName && (
@@ -183,33 +183,33 @@ function EmbedFrame({
               </DashboardTabsContainer>
             )}
             <Separator />
-            {hasParameters && (
-              <ParametersWidgetContainer data-testid="dashboard-parameters-widget-container">
-                <ParametersFixedWidthContainer
-                  data-testid="fixed-width-filters"
-                  isFixedWidth={dashboard?.width === "fixed"}
-                >
-                  <SyncedParametersList
-                    question={question}
-                    dashboard={dashboard}
-                    parameters={getValuePopulatedParameters({
-                      parameters,
-                      values: _.isEmpty(draftParameterValues)
-                        ? parameterValues
-                        : draftParameterValues,
-                    })}
-                    setParameterValue={setParameterValue}
-                    hideParameters={hideParameters}
-                    setParameterValueToDefault={setParameterValueToDefault}
-                    enableParameterRequiredBehavior={
-                      enableParameterRequiredBehavior
-                    }
-                  />
-                  {dashboard && <FilterApplyButton />}
-                </ParametersFixedWidthContainer>
-              </ParametersWidgetContainer>
-            )}
           </Header>
+        )}
+        {hasParameters && (
+          <ParametersWidgetContainer data-testid="dashboard-parameters-widget-container">
+            <ParametersFixedWidthContainer
+              data-testid="fixed-width-filters"
+              isFixedWidth={dashboard?.width === "fixed"}
+            >
+              <SyncedParametersList
+                question={question}
+                dashboard={dashboard}
+                parameters={getValuePopulatedParameters({
+                  parameters,
+                  values: _.isEmpty(draftParameterValues)
+                    ? parameterValues
+                    : draftParameterValues,
+                })}
+                setParameterValue={setParameterValue}
+                hideParameters={hideParameters}
+                setParameterValueToDefault={setParameterValueToDefault}
+                enableParameterRequiredBehavior={
+                  enableParameterRequiredBehavior
+                }
+              />
+              {dashboard && <FilterApplyButton />}
+            </ParametersFixedWidthContainer>
+          </ParametersWidgetContainer>
         )}
         <Body>{children}</Body>
       </ContentContainer>

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -171,7 +171,9 @@ function EmbedFrame({
 
   const hasHeader = Boolean(finalName || hasParameters);
   const isParameterPanelSticky =
-    !!dashboard && isParametersWidgetContainersSticky(visibleParameters.length);
+    !!dashboard &&
+    theme !== "transparent" && // https://github.com/metabase/metabase/pull/38766#discussion_r1491549200
+    isParametersWidgetContainersSticky(visibleParameters.length);
 
   return (
     <Root

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -119,11 +119,27 @@ function EmbedFrame({
   setParameterValueToDefault,
   enableParameterRequiredBehavior,
 }: Props) {
-  const [hasInnerScroll, setInnerScroll] = useState(true);
+  const [hasFrameScroll, setHasFrameScroll] = useState(true);
+  const [hasInnerScroll, setHasInnerScroll] = useState(
+    document.documentElement.scrollTop > 0,
+  );
 
   useMount(() => {
-    initializeIframeResizer(() => setInnerScroll(false));
+    initializeIframeResizer(() => setHasFrameScroll(false));
   });
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setHasInnerScroll(document.documentElement.scrollTop > 0);
+    };
+
+    document.addEventListener("scroll", handleScroll, {
+      capture: false,
+      passive: true,
+    });
+
+    return () => document.removeEventListener("scroll", handleScroll);
+  }, []);
 
   const dispatch = useDispatch();
   useEffect(() => {
@@ -159,7 +175,7 @@ function EmbedFrame({
 
   return (
     <Root
-      hasScroll={hasInnerScroll}
+      hasScroll={hasFrameScroll}
       isBordered={bordered}
       className={cx("EmbedFrame", className, {
         [`Theme--${theme}`]: !!theme,
@@ -198,6 +214,7 @@ function EmbedFrame({
         )}
         {hasVisibleParameters && (
           <ParametersWidgetContainer
+            hasScroll={hasInnerScroll}
             isSticky={isParameterPanelSticky}
             data-testid="dashboard-parameters-widget-container"
           >

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -14,6 +14,7 @@ import { getSetting } from "metabase/selectors/settings";
 import { isWithinIframe, initializeIframeResizer } from "metabase/lib/dom";
 import { parseHashOptions } from "metabase/lib/browser";
 
+import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
 import { FilterApplyButton } from "metabase/parameters/components/FilterApplyButton";
 
@@ -143,6 +144,9 @@ function EmbedFrame({
   const finalName = titled ? name : null;
 
   const hasParameters = Array.isArray(parameters) && parameters.length > 0;
+  const hasVisibleParameters =
+    hasParameters &&
+    getVisibleParameters(parameters, hiddenParameterSlugs).length > 0;
 
   const hasHeader = Boolean(finalName || hasParameters);
 
@@ -186,7 +190,10 @@ function EmbedFrame({
           </Header>
         )}
         {hasParameters && (
-          <ParametersWidgetContainer data-testid="dashboard-parameters-widget-container">
+          <ParametersWidgetContainer
+            hasVisibleParameters={hasVisibleParameters}
+            data-testid="dashboard-parameters-widget-container"
+          >
             <ParametersFixedWidthContainer
               data-testid="fixed-width-filters"
               isFixedWidth={dashboard?.width === "fixed"}

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -11,7 +11,11 @@ import { useMount } from "react-use";
 import TitleAndDescription from "metabase/components/TitleAndDescription";
 
 import { getSetting } from "metabase/selectors/settings";
-import { isWithinIframe, initializeIframeResizer } from "metabase/lib/dom";
+import {
+  isWithinIframe,
+  initializeIframeResizer,
+  isSmallScreen,
+} from "metabase/lib/dom";
 import { parseHashOptions } from "metabase/lib/browser";
 
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
@@ -144,11 +148,14 @@ function EmbedFrame({
   const finalName = titled ? name : null;
 
   const hasParameters = Array.isArray(parameters) && parameters.length > 0;
-  const hasVisibleParameters =
-    hasParameters &&
-    getVisibleParameters(parameters, hiddenParameterSlugs).length > 0;
+  const visibleParameters = hasParameters
+    ? getVisibleParameters(parameters, hiddenParameterSlugs)
+    : [];
+  const hasVisibleParameters = visibleParameters.length > 0;
 
   const hasHeader = Boolean(finalName || hasParameters);
+  const isParameterPanelSticky =
+    !!dashboard && isParametersWidgetContainersSticky(visibleParameters.length);
 
   return (
     <Root
@@ -191,6 +198,7 @@ function EmbedFrame({
         )}
         {hasParameters && (
           <ParametersWidgetContainer
+            isSticky={isParameterPanelSticky}
             hasVisibleParameters={hasVisibleParameters}
             data-testid="dashboard-parameters-widget-container"
           >
@@ -232,6 +240,16 @@ function EmbedFrame({
       )}
     </Root>
   );
+}
+
+function isParametersWidgetContainersSticky(parameterCount: number) {
+  if (!isSmallScreen()) {
+    return true;
+  }
+
+  // Sticky header with more than 5 parameters
+  // takes too much space on small screens
+  return parameterCount <= 5;
 }
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -196,10 +196,9 @@ function EmbedFrame({
             <Separator />
           </Header>
         )}
-        {hasParameters && (
+        {hasVisibleParameters && (
           <ParametersWidgetContainer
             isSticky={isParameterPanelSticky}
-            hasVisibleParameters={hasVisibleParameters}
             data-testid="dashboard-parameters-widget-container"
           >
             <ParametersFixedWidthContainer

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -214,6 +214,7 @@ function EmbedFrame({
         )}
         {hasVisibleParameters && (
           <ParametersWidgetContainer
+            embedFrameTheme={theme}
             hasScroll={hasInnerScroll}
             isSticky={isParameterPanelSticky}
             data-testid="dashboard-parameters-widget-container"


### PR DESCRIPTION
Epic #38446, closes #24726

### To verify

1. Sign in as admin
2. Enable public sharing at `/admin/settings/public-sharing`
3. Open a dashboard that has several filters
4. Click the sharing icon at the top right, generate a public link and open it
5. Ensure the filter bar stays at the top of the viewport when scrolling

### Demo

https://github.com/metabase/metabase/assets/17258145/f1bb7428-e86f-4c35-a845-b23960ad00ee

