### PR TITLE
add missing tests from meet embedders testing plan

### DIFF
--- a/frontend/src/metabase/home/components/HomeContent/HomeContent.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/HomeContent/HomeContent.unit.spec.tsx
@@ -33,6 +33,7 @@ interface SetupOpts {
   recentItems?: RecentItem[];
   popularItems?: PopularItem[];
   isXrayEnabled?: boolean;
+  hasEmbeddingHomepageFlag?: boolean;
 }
 
 const setup = async ({
@@ -41,6 +42,7 @@ const setup = async ({
   recentItems = [],
   popularItems = [],
   isXrayEnabled = true,
+  hasEmbeddingHomepageFlag = false,
 }: SetupOpts) => {
   const state = createMockState({
     currentUser: user,
@@ -48,6 +50,10 @@ const setup = async ({
       "enable-xrays": isXrayEnabled,
     }),
   });
+
+  if (hasEmbeddingHomepageFlag) {
+    localStorage.setItem("showEmbedHomepage", "true");
+  }
 
   setupDatabasesEndpoints(databases);
   setupRecentViewsEndpoints(recentItems);
@@ -63,6 +69,7 @@ describe("HomeContent", () => {
   beforeEach(() => {
     jest.useFakeTimers({ advanceTimers: true });
     jest.setSystemTime(new Date(2020, 0, 10));
+    localStorage.clear();
   });
 
   afterEach(() => {
@@ -172,5 +179,65 @@ describe("HomeContent", () => {
     expect(
       screen.queryByText(/Here are some explorations/),
     ).not.toBeInTheDocument();
+  });
+
+  describe("embed-focused homepage", () => {
+    it("should show it for admins if the localStorage flag is set", async () => {
+      await setup({
+        user: createMockUser({ is_superuser: true }),
+        hasEmbeddingHomepageFlag: true,
+      });
+
+      expect(
+        screen.getByText("Get started with Embedding Metabase in your app"),
+      ).toBeInTheDocument();
+    });
+
+    it("should not show it for non-admins even if the flag is set", async () => {
+      await setup({
+        user: createMockUser({ is_superuser: false }),
+        hasEmbeddingHomepageFlag: true,
+      });
+
+      expect(
+        screen.queryByText("Get started with Embedding Metabase in your app"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should be possible to dismiss it", async () => {
+      await setup({
+        user: createMockUser({ is_superuser: true }),
+        hasEmbeddingHomepageFlag: true,
+      });
+
+      screen.getByRole("button", { name: "close icon" }).click();
+
+      expect(
+        screen.queryByText("Get started with Embedding Metabase in your app"),
+      ).not.toBeInTheDocument();
+
+      expect(localStorage.getItem("showEmbedHomepage")).toBeNull();
+    });
+
+    it("should now show it if the user is not admin", async () => {
+      await setup({
+        user: createMockUser({ is_superuser: false }),
+        hasEmbeddingHomepageFlag: true,
+      });
+
+      expect(
+        screen.queryByText("Get started with Embedding Metabase in your app"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should now show it if the localStorage flag is not set", async () => {
+      await setup({
+        user: createMockUser({ is_superuser: true }),
+      });
+
+      expect(
+        screen.queryByText("Get started with Embedding Metabase in your app"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/metabase/home/components/HomeContent/HomeContent.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/HomeContent/HomeContent.unit.spec.tsx
@@ -219,7 +219,7 @@ describe("HomeContent", () => {
       expect(localStorage.getItem("showEmbedHomepage")).toBeNull();
     });
 
-    it("should now show it if the user is not admin", async () => {
+    it("should not show it if the user is not admin", async () => {
       await setup({
         user: createMockUser({ is_superuser: false }),
         hasEmbeddingHomepageFlag: true,
@@ -230,7 +230,7 @@ describe("HomeContent", () => {
       ).not.toBeInTheDocument();
     });
 
-    it("should now show it if the localStorage flag is not set", async () => {
+    it("should not show it if the localStorage flag is not set", async () => {
       await setup({
         user: createMockUser({ is_superuser: true }),
       });

--- a/frontend/src/metabase/setup/setup.unit.spec.tsx
+++ b/frontend/src/metabase/setup/setup.unit.spec.tsx
@@ -14,6 +14,9 @@ import { Setup } from "./components/Setup";
 import type { SetupStep } from "./types";
 
 async function setup({ step = "welcome" }: { step?: SetupStep } = {}) {
+  localStorage.clear();
+  jest.clearAllMocks();
+
   const state = createMockState({
     setup: createMockSetupState({
       step,
@@ -24,6 +27,7 @@ async function setup({ step = "welcome" }: { step?: SetupStep } = {}) {
   });
 
   fetchMock.post("path:/api/util/password_check", { valid: true });
+  fetchMock.post("path:/api/setup", {});
 
   renderWithProviders(<Setup />, { storeInitialState: state });
 
@@ -88,6 +92,20 @@ describe("setup", () => {
         expectSectionToHaveLabel("Add your data", "4");
         expectSectionToHaveLabel("Usage data preferences", "5");
       });
+
+      it("should not set the flag for the embedding homepage", async () => {
+        await setupForUsageQuestion();
+        selectUsageReason("self-service-analytics");
+        clickNextStep();
+
+        screen.getByText("I'll add my data later").click();
+
+        screen.getByRole("button", { name: "Finish" }).click();
+
+        await screen.findByRole("link", { name: "Take me to Metabase" });
+
+        expect(localStorage.getItem("showEmbedHomepage")).toBeNull();
+      });
     });
 
     describe("when selecting 'Embedding'", () => {
@@ -104,6 +122,18 @@ describe("setup", () => {
         );
 
         expectSectionToHaveLabel("Usage data preferences", "4");
+      });
+
+      it("should set the flag for the embed homepage in the local storage", async () => {
+        await setupForUsageQuestion();
+        selectUsageReason("embedding");
+        clickNextStep();
+
+        screen.getByRole("button", { name: "Finish" }).click();
+
+        await screen.findByRole("link", { name: "Take me to Metabase" });
+
+        expect(localStorage.getItem("showEmbedHomepage")).toBe("true");
       });
     });
 
@@ -123,6 +153,20 @@ describe("setup", () => {
         expectSectionToHaveLabel("Add your data", "4");
         expectSectionToHaveLabel("Usage data preferences", "5");
       });
+
+      it("should set the flag for the embed homepage in the local storage", async () => {
+        await setupForUsageQuestion();
+        selectUsageReason("both");
+        clickNextStep();
+
+        screen.getByText("I'll add my data later").click();
+
+        screen.getByRole("button", { name: "Finish" }).click();
+
+        await screen.findByRole("link", { name: "Take me to Metabase" });
+
+        expect(localStorage.getItem("showEmbedHomepage")).toBe("true");
+      });
     });
 
     describe("when selecting 'Not sure yet'", () => {
@@ -140,6 +184,20 @@ describe("setup", () => {
 
         expectSectionToHaveLabel("Add your data", "4");
         expectSectionToHaveLabel("Usage data preferences", "5");
+      });
+
+      it("should not set the flag for the embedding homepage", async () => {
+        await setupForUsageQuestion();
+        selectUsageReason("self-service-analytics");
+        clickNextStep();
+
+        screen.getByText("I'll add my data later").click();
+
+        screen.getByRole("button", { name: "Finish" }).click();
+
+        await screen.findByRole("link", { name: "Take me to Metabase" });
+
+        expect(localStorage.getItem("showEmbedHomepage")).toBeNull();
       });
     });
   });


### PR DESCRIPTION
Last bits of https://github.com/metabase/metabase/issues/38556
Closes https://github.com/metabase/metabase/issues/38556

### Description

Should add the missing tests from [Testing plan for v49](https://www.notion.so/metabase/Testing-plan-for-v49-d0e68bb6c94f4ff7b37860cd5b7faa35)
