### PR TITLE
Disable redshift support for uploads (again)

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -63,7 +63,6 @@
                               :persist-models           true
                               :table-privileges         true
                               :schemas                  true
-                              :uploads                  true
                               :connection-impersonation true}]
   (defmethod driver/database-supports? [:postgres feature] [_driver _feature _db] supported?))
 
@@ -74,6 +73,7 @@
 ;; Features that are supported by postgres only
 (doseq [feature [:actions
                  :actions/custom
+                 :uploads
                  :index-info]]
   (defmethod driver/database-supports? [:postgres feature]
     [driver _feat _db]


### PR DESCRIPTION
Disables redshift support for uploads, following https://github.com/metabase/metabase/pull/38567

Past time this happened: https://github.com/metabase/metabase/pull/38583