### PR TITLE
Setting x-ray dashboard width to 24

### DIFF
--- a/src/metabase/automagic_dashboards/populate.clj
+++ b/src/metabase/automagic_dashboards/populate.clj
@@ -18,7 +18,7 @@
 
 (def ^Long grid-width
   "Total grid width."
-  18)
+  24)
 
 (def ^Long default-card-width
   "Default card width."

--- a/test/metabase/automagic_dashboards/core_test.clj
+++ b/test/metabase/automagic_dashboards/core_test.clj
@@ -1745,17 +1745,16 @@
                          transient_name))
                   (is (= "Automatically generated comparison dashboard comparing Number of 15655 where SOURCE is Affiliate and \"15655\", all 15655"
                          comparison-description))
-                  (is (= (take 10
-                               [{:group-name nil, :card-name "SOURCE by CITY"}
-                                {:group-name nil, :card-name "SOURCE by CITY"}
-                                {:group-name nil, :card-name "SOURCE by NAME"}
-                                {:group-name nil, :card-name "SOURCE by NAME"}
-                                {:group-name "## How the SOURCE fields is distributed", :card-name nil}
-                                {:group-name nil, :card-name "How the SOURCE is distributed (Number of 15655 where SOURCE is Affiliate)"}
-                                {:group-name nil, :card-name "Distinct values"}
-                                {:group-name nil, :card-name "Distinct values"}
-                                {:group-name nil, :card-name "Null values"}
-                                {:group-name nil, :card-name "Null values"}])
+                  (is (= [{:group-name nil, :card-name "SOURCE by CITY"}
+                          {:group-name nil, :card-name "SOURCE by CITY"}
+                          {:group-name nil, :card-name "SOURCE by NAME"}
+                          {:group-name nil, :card-name "SOURCE by NAME"}
+                          {:group-name "## How the SOURCE fields is distributed", :card-name nil}
+                          {:group-name nil, :card-name "Distinct values"}
+                          {:group-name nil, :card-name "Distinct values"}
+                          {:group-name nil, :card-name "How the SOURCE is distributed (Number of 15655 where SOURCE is Affiliate)"}
+                          {:group-name nil, :card-name "Null values"}
+                          {:group-name nil, :card-name "Null values"}]
                          (->> comparison-dashcards
                               (take 10)
                               (map (fn [dashcard]


### PR DESCRIPTION
This just updates the `grid-width` parameter in `metabase.automagic-dashboards.populate` to be consistent with new FE work.

