### PR TITLE
Add configurable CSV delimiter to dashboard subscriptions

### DIFF
--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.jsx
@@ -14,13 +14,16 @@ import { Select } from "metabase/ui";
 const CSV_DELIMITER_OPTIONS = [
   { value: null, label: "Comma (,)" }, // Used by default (when the value is nil)
   { value: ";", label: "Semicolon (;)" },
+  { value: ":", label: "Colon (:)" },
   { value: "\t", label: "Tab" },
   { value: " ", label: "Space" },
+  { value: "|", label: "Pipe (|)" },
 ];
 
 const CSV_QUOTE_OPTIONS = [
   { value: null, label: 'Double quote (")' }, // Used by default (when the value is nil)
   { value: "'", label: "Single quote (')" },
+  { value: "`", label: "Backtick (`)" },
 ];
 
 const DELIMITER_FIELD = "csv_delimiter";

--- a/frontend/src/metabase/sharing/components/EmailAttachmentPicker.unit.spec.js
+++ b/frontend/src/metabase/sharing/components/EmailAttachmentPicker.unit.spec.js
@@ -1,5 +1,6 @@
 import { render, fireEvent, screen } from "@testing-library/react";
 
+import userEvent from "@testing-library/user-event";
 import EmailAttachmentPicker from "./EmailAttachmentPicker";
 
 function setup({ pulse = createPulse(), hasAttachments = false } = {}) {
@@ -52,6 +53,92 @@ describe("EmailAttachmentPicker", () => {
       const card2Checkbox = screen.getByLabelText("card2");
       expect(card2Checkbox).not.toBeChecked();
     });
+
+    describe("when csv file format is selected", () => {
+      it("should display csv options", () => {
+        setup();
+
+        const toggle = screen.getByLabelText("Attach results");
+        fireEvent.click(toggle);
+
+        const csvFormatInput = screen.getByLabelText(".csv");
+        fireEvent.click(csvFormatInput);
+
+        const csvDelimiterSelect = screen.getByLabelText("Delimiter symbol");
+        expect(csvDelimiterSelect).toBeInTheDocument();
+
+        const csvQuoteSelect = screen.getByLabelText("Quote symbol");
+        expect(csvQuoteSelect).toBeInTheDocument();
+      });
+
+      it("should call setPulse when picking delimiter symbol", () => {
+        const { setPulse } = setup();
+
+        const toggle = screen.getByLabelText("Attach results");
+        fireEvent.click(toggle);
+
+        const csvFormatInput = screen.getByLabelText(".csv");
+        fireEvent.click(csvFormatInput);
+
+        const toggleAllCheckbox = screen.getByLabelText("Questions to attach");
+        fireEvent.click(toggleAllCheckbox);
+
+        const csvDelimiterSelect = screen.getByLabelText("Delimiter symbol");
+        userEvent.click(csvDelimiterSelect);
+        userEvent.click(screen.getByText(/;/));
+
+        expect(setPulse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cards: expect.arrayContaining([
+              expect.objectContaining({ csv_delimiter: ";" }),
+            ]),
+          }),
+        );
+      });
+
+      it("should call setPulse when picking quote symbol", () => {
+        const { setPulse } = setup();
+
+        const toggle = screen.getByLabelText("Attach results");
+        fireEvent.click(toggle);
+
+        const csvFormatInput = screen.getByLabelText(".csv");
+        fireEvent.click(csvFormatInput);
+
+        const toggleAllCheckbox = screen.getByLabelText("Questions to attach");
+        fireEvent.click(toggleAllCheckbox);
+
+        const csvDelimiterSelect = screen.getByLabelText("Quote symbol");
+        userEvent.click(csvDelimiterSelect);
+        userEvent.click(screen.getByText(/\'/));
+
+        expect(setPulse).toHaveBeenCalledWith(
+          expect.objectContaining({
+            cards: expect.arrayContaining([
+              expect.objectContaining({ csv_quote: "'" }),
+            ]),
+          }),
+        );
+      });
+    });
+
+    describe("when xlsx file format is selected", () => {
+      it("should not display csv options", () => {
+        setup();
+
+        const toggle = screen.getByLabelText("Attach results");
+        fireEvent.click(toggle);
+
+        const csvFormatInput = screen.getByLabelText(".xlsx");
+        fireEvent.click(csvFormatInput);
+
+        const csvDelimiterSelect = screen.queryByLabelText("Delimiter symbol");
+        expect(csvDelimiterSelect).not.toBeInTheDocument();
+
+        const csvQuoteSelect = screen.queryByLabelText("Quote symbol");
+        expect(csvQuoteSelect).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe("when instantiated with cards with attachments", () => {
@@ -62,7 +149,7 @@ describe("EmailAttachmentPicker", () => {
       expect(toggle).toBeChecked();
     });
 
-    it("should have selected the xlsv format", () => {
+    it("should have selected the xlsx format", () => {
       setup({ hasAttachments: true });
       const csvFormatInput = screen.getByLabelText(".csv");
       expect(csvFormatInput).not.toBeChecked();

--- a/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
@@ -79,6 +79,8 @@ const cardsToPulseCards = (cards, pulseCards) => {
       ...card,
       include_csv: pulseCard.include_csv,
       include_xls: pulseCard.include_xls,
+      csv_delimiter: pulseCard.csv_delimiter,
+      csv_quote: pulseCard.csv_quote,
     };
   });
 };

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5969,6 +5969,27 @@ databaseChangeLog:
                 )
               );
 
+  - changeSet:
+      id: v50.2024-03-16T20:28:11
+      author: coder11
+      comment: Add csv_delimiter and csv_quote to pulse_card table
+      changes:
+        - addColumn:
+            columns:
+              - column:
+                  name: csv_delimiter
+                  type: char
+                  remarks: Symbol to separate values in the CSV record
+                  constraints:
+                    nullable: true
+              - column:
+                  name: csv_quote
+                  type: char
+                  remarks: Symbol which surrounds CSV fields with reserved characters
+                  constraints:
+                    nullable: true
+            tableName: pulse_card
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/models/pulse_card.clj
+++ b/src/metabase/models/pulse_card.clj
@@ -40,20 +40,24 @@
   [:dashboard_card_id                  ms/PositiveInt]
   [:position          {:optional true} [:maybe ms/IntGreaterThanOrEqualToZero]]
   [:include_csv       {:optional true} [:maybe :boolean]]
-  [:include_xls       {:optional true} [:maybe :boolean]]])
+  [:include_xls       {:optional true} [:maybe :boolean]]
+  [:csv_delimiter     {:optional true} [:maybe ms/SingleCharString]]
+  [:csv_quote         {:optional true} [:maybe ms/SingleCharString]]])
 
 (mu/defn bulk-create!
   "Creates new PulseCards, joining the given card, pulse, and dashboard card and setting appropriate defaults for other
   values if they're not provided."
   [new-pulse-cards :- [:sequential NewPulseCard]]
   (t2/insert! PulseCard
-    (for [{:keys [card_id pulse_id dashboard_card_id position include_csv include_xls]} new-pulse-cards]
+    (for [{:keys [card_id pulse_id dashboard_card_id position include_csv include_xls csv_delimiter csv_quote]} new-pulse-cards]
       {:card_id           card_id
        :pulse_id          pulse_id
        :dashboard_card_id dashboard_card_id
        :position          (u/or-with some? position (next-position-for pulse_id))
        :include_csv       (boolean include_csv)
-       :include_xls       (boolean include_xls)})))
+       :include_xls       (boolean include_xls)
+       :csv_delimiter     csv_delimiter
+       :csv_quote         csv_quote})))
 
 ; ----------------------------------------------------- Serialization -------------------------------------------------
 

--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -154,8 +154,8 @@
        :csv os
        (fn [rff]
          (qp/process-query query rff))))"
-  [export-format os f]
-  (let [results-writer (qp.si/streaming-results-writer export-format os)
+  [export-format os opts f]
+  (let [results-writer (qp.si/streaming-results-writer export-format os opts)
         rff            (streaming-rff results-writer)]
     (binding [qp.pipeline/*result* (streaming-result-fn results-writer os)]
       (f rff))))
@@ -165,7 +165,7 @@
   ^StreamingResponse [export-format filename-prefix f]
   (streaming-response/streaming-response (qp.si/stream-options export-format filename-prefix) [os canceled-chan]
     (do-with-streaming-rff
-     export-format os
+     export-format os {}
      (^:once fn* [rff]
       (let [result (try
                      (f rff)

--- a/src/metabase/query_processor/streaming/interface.clj
+++ b/src/metabase/query_processor/streaming/interface.clj
@@ -25,7 +25,8 @@
     finshed."))
 
 (defmulti streaming-results-writer
-  "Given a `export-format` and `java.io.Writer`, return an object that implements `StreamingResultsWriter`."
-  {:arglists '(^metabase.query_processor.streaming.interface.StreamingResultsWriter [export-format ^java.io.OutputStream os])}
-  (fn [export-format _os]
+  "Given a `export-format`, `java.io.Writer` and the options map, return an object that implements `StreamingResultsWriter`.
+   The options map is specific to each export format and is handled by the defmethod implementation."
+  {:arglists '(^metabase.query_processor.streaming.interface.StreamingResultsWriter [export-format ^java.io.OutputStream os opts])}
+  (fn [export-format _os _opts]
     (keyword export-format)))

--- a/src/metabase/query_processor/streaming/json.clj
+++ b/src/metabase/query_processor/streaming/json.clj
@@ -26,7 +26,7 @@
                                                  (u.date/format (t/zoned-date-time)))}}))
 
 (defmethod qp.si/streaming-results-writer :json
-  [_ ^OutputStream os]
+  [_ ^OutputStream os _opts]
   (let [writer             (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))
         col-names          (volatile! nil)
         ordered-formatters (volatile! nil)]
@@ -81,7 +81,7 @@
       (.substring s 1 (dec (count s))))))
 
 (defmethod qp.si/streaming-results-writer :api
-  [_ ^OutputStream os]
+  [_ ^OutputStream os _opts]
   (let [writer (BufferedWriter. (OutputStreamWriter. os StandardCharsets/UTF_8))]
     (reify qp.si/StreamingResultsWriter
       (begin! [_ _ _]

--- a/src/metabase/query_processor/streaming/xlsx.clj
+++ b/src/metabase/query_processor/streaming/xlsx.clj
@@ -447,7 +447,7 @@
     (.createFreezePane ^SXSSFSheet sheet 0 1)))
 
 (defmethod qp.si/streaming-results-writer :xlsx
-  [_ ^OutputStream os]
+  [_ ^OutputStream os _opts]
   (let [workbook    (SXSSFWorkbook.)
         sheet       (spreadsheet/add-sheet! workbook (tru "Query result"))
         data-format (. workbook createDataFormat)

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -91,6 +91,12 @@
     [:and number? pos?]
     (deferred-tru "value must be a number greater than zero.")))
 
+(def SingleCharString
+  "Schema representing a single character string."
+  (mu/with-api-error-message
+    [:and string? [:fn #(= 1 (count %))]]
+    (deferred-tru "value must be a single character")))
+
 (def KeywordOrString
   "Schema for something that can be either a `Keyword` or a `String`."
   (mu/with-api-error-message

--- a/test/metabase/api/alert_test.clj
+++ b/test/metabase/api/alert_test.clj
@@ -34,8 +34,8 @@
       (select-keys [:name :description :display])
       (update :display name)
       (update :collection_id boolean)
-      (assoc :id true, :include_csv false, :include_xls false, :dashboard_card_id false,
-             :dashboard_id false, :parameter_mappings nil)))
+      (assoc :id true, :include_csv false, :include_xls false, :csv_delimiter nil :csv_quote nil
+             :dashboard_card_id false :dashboard_id false, :parameter_mappings nil)))
 
 (defn- recipient-details [user-kwd]
   (-> user-kwd
@@ -221,10 +221,10 @@
           :rasta :post 400 "alert" {:alert_condition "rows"})))
 
   (is (= {:errors
-           {:card "value must be a map with the keys `id`, `include_csv`, `include_xls`, and `dashboard_card_id`."}
+           {:card "value must be a map with the keys `id`, `include_csv`, `include_xls`, `csv_delimiter`, `csv_quote` and `dashboard_card_id`."}
            :specific-errors
            {:card
-            ["value must be a map with the keys `include_csv`, `include_xls`, and `dashboard_card_id`., received: nil"]}}
+            ["value must be a map with the keys `include_csv`, `include_xls`, `csv_delimiter`, `csv_quote` and `dashboard_card_id`., received: nil"]}}
          (mt/user-http-request
           :rasta :post 400 "alert" {:alert_condition  "rows"
                                     :alert_first_only false})))
@@ -429,10 +429,10 @@
           :rasta :put 400 "alert/1" {:alert_first_only 1000})))
 
   (is (= {:errors
-           {:card "nullable value must be a map with the keys `id`, `include_csv`, `include_xls`, and `dashboard_card_id`."}
+           {:card "nullable value must be a map with the keys `id`, `include_csv`, `include_xls`, `csv_delimiter`, `csv_quote` and `dashboard_card_id`."}
            :specific-errors
            {:card
-            ["value must be a map with the keys `include_csv`, `include_xls`, and `dashboard_card_id`., received: \"foobar\""]}}
+            ["value must be a map with the keys `include_csv`, `include_xls`, `csv_delimiter`, `csv_quote` and `dashboard_card_id`., received: \"foobar\""]}}
          (mt/user-http-request
           :rasta :put 400 "alert/1" {:alert_condition  "rows"
                                      :alert_first_only false

--- a/test/metabase/api/pulse_test.clj
+++ b/test/metabase/api/pulse_test.clj
@@ -43,7 +43,7 @@
       (update :collection_id boolean)
       ;; why? these fields in this last assoc are from the PulseCard model and this function takes the Card model
       ;; because PulseCard is somewhat hidden behind the scenes
-      (assoc :include_csv false, :include_xls false, :dashboard_card_id nil, :dashboard_id nil,
+      (assoc :include_csv false, :include_xls false, :csv_delimiter nil, :csv_quote nil, :dashboard_card_id nil, :dashboard_id nil,
              :parameter_mappings nil)))
 
 (defn- pulse-channel-details [channel]
@@ -111,8 +111,8 @@
   {:errors
    {:cards (str "one or more value must be a map with the following keys "
                 "`(collection_id, description, display, id, include_csv, include_xls, name, dashboard_id, parameter_mappings)`, "
-                "or value must be a map with the keys `id`, `include_csv`, `include_xls`, and `dashboard_card_id`., "
-                "or value must be a map with the keys `include_csv`, `include_xls`, and `dashboard_card_id`.")}})
+                "or value must be a map with the keys `id`, `include_csv`, `include_xls`, `csv_delimiter`, `csv_quote` and `dashboard_card_id`., "
+                "or value must be a map with the keys `include_csv`, `include_xls`, `csv_delimiter`, `csv_quote` and `dashboard_card_id`.")}})
 
 (deftest create-pulse-validation-test
   (doseq [[input expected-error]
@@ -132,19 +132,19 @@
            default-post-card-ref-validation-error
 
            {:name  "abc"
-            :cards [{:id 100, :include_csv false, :include_xls false, :dashboard_card_id nil}
-                    {:id 200, :include_csv false, :include_xls false, :dashboard_card_id nil}]}
+            :cards [{:id 100, :include_csv false, :include_xls false, :csv_delimiter nil, :csv_quote nil, :dashboard_card_id nil}
+                    {:id 200, :include_csv false, :include_xls false, :csv_delimiter nil, :csv_quote nil, :dashboard_card_id nil}]}
            {:errors {:channels "one or more map"}}
 
            {:name     "abc"
-            :cards    [{:id 100, :include_csv false, :include_xls false, :dashboard_card_id nil}
-                       {:id 200, :include_csv false, :include_xls false, :dashboard_card_id nil}]
+            :cards    [{:id 100, :include_csv false, :include_xls false, :csv_delimiter nil, :csv_quote nil, :dashboard_card_id nil}
+                       {:id 200, :include_csv false, :include_xls false, :csv_delimiter nil, :csv_quote nil, :dashboard_card_id nil}]
             :channels "foobar"}
            {:errors {:channels "one or more map"}}
 
            {:name     "abc"
-            :cards    [{:id 100, :include_csv false, :include_xls false, :dashboard_card_id nil}
-                       {:id 200, :include_csv false, :include_xls false, :dashboard_card_id nil}]
+            :cards    [{:id 100, :include_csv false, :include_xls false, :csv_delimiter nil, :csv_quote nil, :dashboard_card_id nil}
+                       {:id 200, :include_csv false, :include_xls false, :csv_delimiter nil, :csv_quote nil, :dashboard_card_id nil}]
             :channels ["abc"]}
            {:errors {:channels "one or more map"}}}]
     (testing (pr-str input)
@@ -329,10 +329,14 @@
                                                                            :cards         [{:id                (u/the-id card-1)
                                                                                             :include_csv       true
                                                                                             :include_xls       true
+                                                                                            :csv_delimiter     nil
+                                                                                            :csv_quote         nil
                                                                                             :dashboard_card_id nil}
                                                                                            {:id                (u/the-id card-2)
                                                                                             :include_csv       false
                                                                                             :include_xls       false
+                                                                                            :csv_delimiter     nil
+                                                                                            :csv_quote         nil
                                                                                             :dashboard_card_id nil}]
                                                                            :channels      [daily-email-channel]
                                                                            :skip_if_empty false})
@@ -383,8 +387,8 @@
   {:errors
    {:cards (str "nullable one or more value must be a map with the following keys "
                 "`(collection_id, description, display, id, include_csv, include_xls, name, dashboard_id, parameter_mappings)`, "
-                "or value must be a map with the keys `id`, `include_csv`, `include_xls`, and `dashboard_card_id`., "
-                "or value must be a map with the keys `include_csv`, `include_xls`, and `dashboard_card_id`.")}})
+                "or value must be a map with the keys `id`, `include_csv`, `include_xls`, `csv_delimiter`, `csv_quote` and `dashboard_card_id`., "
+                "or value must be a map with the keys `include_csv`, `include_xls`, `csv_delimiter`, `csv_quote` and `dashboard_card_id`.")}})
 
 (deftest update-pulse-validation-test
   (testing "PUT /api/pulse/:id"
@@ -484,6 +488,8 @@
                                                                [{:id                (u/the-id card-2)
                                                                  :include_csv       false
                                                                  :include_xls       false
+                                                                 :csv_delimiter     nil
+                                                                 :csv_quote         nil
                                                                  :dashboard_card_id nil}])})
                          pulse-response
                          (update :channels remove-extra-channels-fields)))))))))))

--- a/test/metabase/models/pulse_test.clj
+++ b/test/metabase/models/pulse_test.clj
@@ -80,6 +80,8 @@
                              :display            :table
                              :include_csv        false
                              :include_xls        false
+                             :csv_quote          nil
+                             :csv_delimiter      nil
                              :dashboard_card_id  nil
                              :dashboard_id       nil
                              :parameter_mappings nil}]
@@ -166,6 +168,8 @@
                              :display            :table
                              :include_csv        false
                              :include_xls        false
+                             :csv_quote          nil
+                             :csv_delimiter      nil
                              :dashboard_card_id  nil
                              :dashboard_id       nil
                              :parameter_mappings nil}]})
@@ -256,6 +260,8 @@
                                    :display            :bar
                                    :include_csv        false
                                    :include_xls        false
+                                   :csv_quote          nil
+                                   :csv_delimiter      nil
                                    :dashboard_card_id  nil
                                    :dashboard_id       nil
                                    :parameter_mappings nil}
@@ -265,6 +271,8 @@
                                    :display            :table
                                    :include_csv        false
                                    :include_xls        false
+                                   :csv_quote          nil
+                                   :csv_delimiter      nil
                                    :dashboard_card_id  nil
                                    :dashboard_id       nil
                                    :parameter_mappings nil}]

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -381,7 +381,7 @@
                          :cache-ttl 100)]
         (with-open [os (java.io.ByteArrayOutputStream.)]
           (qp.streaming/do-with-streaming-rff
-           :csv os
+           :csv os {}
            (fn [rff]
              (qp/process-query query rff)))
           (mt/wait-for-result save-chan))
@@ -392,7 +392,7 @@
                                            istream (java.io.PipedInputStream. ostream)
                                            reader  (java.io.InputStreamReader. istream)]
                                  (qp.streaming/do-with-streaming-rff
-                                  :csv ostream
+                                  :csv ostream {}
                                   (fn [rff]
                                     (qp/process-query (dissoc query :cache-ttl) rff)))
                                  (vec (csv/read-csv reader)))]
@@ -402,7 +402,7 @@
                         istream (java.io.PipedInputStream. ostream)
                         reader  (java.io.InputStreamReader. istream)]
               (qp.streaming/do-with-streaming-rff
-               :csv ostream
+               :csv ostream {}
                (fn [rff]
                  (qp/process-query query rff)))
               (is (= uncached-results
@@ -420,7 +420,7 @@
         (let [query (assoc query :cache-ttl 100)]
           (with-open [os (java.io.ByteArrayOutputStream.)]
             (qp.streaming/do-with-streaming-rff
-             :csv os
+             :csv os {}
              (fn [rff]
                (is (= false
                      (boolean (:cached (qp/process-query query rff))))

--- a/test/metabase/query_processor/streaming/test_util.clj
+++ b/test/metabase/query_processor/streaming/test_util.clj
@@ -58,9 +58,9 @@
   (with-open [bos (ByteArrayOutputStream.)
               os  (BufferedOutputStream. bos)]
     (qp.streaming/do-with-streaming-rff
-     export-format os
+     export-format os {}
      (fn [rff]
-       (binding [qp.pipeline/*query-timeout-ms* (u/seconds->ms 15)]
+       (binding [qp.pipeline/*query-timeout-ms* (u/seconds->ms 15 {})]
          (is (=? {:status :completed}
                  (qp/process-query query rff))))))
     (.flush os)

--- a/test/metabase/query_processor/streaming/test_util.clj
+++ b/test/metabase/query_processor/streaming/test_util.clj
@@ -60,7 +60,7 @@
     (qp.streaming/do-with-streaming-rff
      export-format os {}
      (fn [rff]
-       (binding [qp.pipeline/*query-timeout-ms* (u/seconds->ms 15 {})]
+       (binding [qp.pipeline/*query-timeout-ms* (u/seconds->ms 15)]
          (is (=? {:status :completed}
                  (qp/process-query query rff))))))
     (.flush os)

--- a/test/metabase/query_processor/streaming/xlsx_test.clj
+++ b/test/metabase/query_processor/streaming/xlsx_test.clj
@@ -26,8 +26,8 @@
 
   ([format-settings col]
    (let [viz-settings (common/viz-settings-for-col
-                        (assoc col :field_ref [:field 1])
-                        {::mb.viz/column-settings {{::mb.viz/field-id 1} format-settings}})
+                       (assoc col :field_ref [:field 1])
+                       {::mb.viz/column-settings {{::mb.viz/field-id 1} format-settings}})
          format-strings (@#'qp.xlsx/format-settings->format-strings viz-settings col)]
      ;; If only one format string is returned (for datetimes) or both format strings
      ;; are equal, just return a single value to make tests more readable.
@@ -410,7 +410,7 @@
   ([ordered-cols viz-settings rows parse-fn]
    (with-open [bos (ByteArrayOutputStream.)
                os  (BufferedOutputStream. bos)]
-     (let [results-writer (qp.si/streaming-results-writer :xlsx os)]
+     (let [results-writer (qp.si/streaming-results-writer :xlsx os {})]
        (qp.si/begin! results-writer {:data {:ordered-cols ordered-cols}} viz-settings)
        (doall (map-indexed
                (fn [i row] (qp.si/write-row! results-writer row i ordered-cols viz-settings))
@@ -693,7 +693,7 @@
           ;; TODO -- shouldn't these be using `with-open`?!
           bos                     (ByteArrayOutputStream.)
           os                      (BufferedOutputStream. bos)
-          results-writer          (qp.si/streaming-results-writer :xlsx os)]
+          results-writer          (qp.si/streaming-results-writer :xlsx os {})]
       (.close os)
       (qp.si/begin! results-writer {:data {:ordered-cols []}} {})
       (qp.si/finish! results-writer {:row_count 0})

--- a/test/metabase/util/malli/schema_test.clj
+++ b/test/metabase/util/malli/schema_test.clj
@@ -18,6 +18,9 @@
            {:schema        ms/PositiveNum
             :failed-cases  [0 "1"]
             :success-cases [1.5 2]}
+           {:schema        ms/SingleCharString
+            :failed-cases  [0 "11" nil :kw]
+            :success-cases ["a"]}
            {:schema        ms/KeywordOrString
             :failed-cases  [1 [1] {:a 1}]
             :success-cases [:a "a"]}


### PR DESCRIPTION
Closes  #10256 (Hope this time correctly :))

### Description

Add options to specify the CSV delimiter symbol and the CSV quote symbol when creating a dashboard subscription with attached results in CSV format.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Go to any dashboard
2. Click on "Subscriptions"
3. Add a new subscription
4. Pick "Email it"
5. Fill the necessary fields, select "Attach results"
6. Specify a custom delimiter and (or) quote symbol
7. Click "Send email now"

The email with the attached CSV file (in the correct format) should be sent. 
Emails should also be sent according to the subscription schedule. The attached CSV should also be formatted correcrly.

**note**

I haven't actually received an email. Instead I've modified `send-pulse!` function in `metabase.pulse` namespace in the REPL to test that `send-notifications!` was called with the correct arguments. Also checked `send-pulses!` from `metabase.task.send-pulses` namespace to simulate sending emails on schedule.

### Demo

Two additional fields added when the CSV format is picked

![Screenshot from 2024-02-15 01-45-30](https://github.com/metabase/metabase/assets/1190257/4f3d1673-1a73-4b92-b94a-e5aa63bea848)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
