### PR TITLE
Update `group-by-week-test` to use database timezone id

### DIFF
--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -704,7 +704,7 @@
   ;; The exclusions here are databases that give incorrect answers when the JVM timezone doesn't match the databases
   ;; timezone (TIMEZONE FIXME)
   (testing "Database timezone override set to Pacific"
-    (mt/test-drivers (mt/normal-drivers-except #{:h2 :sqlserver :redshift :sparksql :mongo :bigquery-cloud-sdk})
+    (mt/test-drivers (mt/normal-drivers-except #{:sparksql})
       (is (= (cond
                (= :sqlite driver/*driver*)
                (results-by-week u.date/parse

--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -697,12 +697,13 @@
                                   [46 47 40 60 7]))
 
                (sad-toucan-incidents-with-bucketing :week :eastern))))))
-  ;; Setting the JVM timezone will change how the datetime results are displayed but don't impact the calculation of the
-  ;; begin/end of the week
+  ;; Setting database timezone id will change how the datetime results are displayed, unless report timezone is set.
+  ;; If so, the report timezone takes precedence and result values are formatted according to that. Overriding
+  ;; database timezone id has no impact on beginning/end of week during calculation.
   ;;
   ;; The exclusions here are databases that give incorrect answers when the JVM timezone doesn't match the databases
   ;; timezone (TIMEZONE FIXME)
-  (testing "JVM timezone set to Pacific"
+  (testing "Database timezone override set to Pacific"
     (mt/test-drivers (mt/normal-drivers-except #{:h2 :sqlserver :redshift :sparksql :mongo :bigquery-cloud-sdk})
       (is (= (cond
                (= :sqlite driver/*driver*)
@@ -725,7 +726,7 @@
                (results-by-week u.date/parse
                                 (format-in-timezone-fn :pacific)
                                 [46 47 40 60 7]))
-             (mt/with-system-timezone-id (timezone :pacific)
+             (mt/with-database-timezone-id (timezone :pacific)
                (sad-toucan-incidents-with-bucketing :week :pacific)))))))
 
 (deftest group-by-week-of-year-test


### PR DESCRIPTION
We've been notified that `metabase.query-processor-test.date-bucketing-test/group-by-week-test` started failing with clickhouse on `v0.49.0-RC1` [this slack thread](https://metaboat.slack.com/archives/C0439QDFHFZ/p1707926284763319).

This PR is attempt to address that. 49 is first major that contains PR #36413. With that PR merged, timezone used for formatting results is the one of database, if available, not of the system -- if report timezone is not set or not supported. Result formatting happens in [wrap_value_literals.clj](https://github.com/metabase/metabase/blob/6415e86cbc9d757e9302413d304332c6f18e641f/src/metabase/query_processor/middleware/wrap_value_literals.clj#L100). `results-timezone-id` on linked line is now returning database timezone and I believe that is the source of mentioned failure.