### PR TITLE
More pervasive and atomic Liquibase locking 

### DIFF
--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -298,8 +298,7 @@
          log-iterator   (ChangeLogIterator. change-log ^"[Lliquibase.changelog.filter.ChangeSetFilter;" (into-array ChangeSetFilter change-set-filters))
          update-visitor (UpdateVisitor. database ^ChangeExecListener exec-listener)
          runtime-env    (RuntimeEnvironment. database (Contexts.) nil)]
-     (with-scope-locked liquibase
-       (.run ^ChangeLogIterator log-iterator update-visitor runtime-env)))))
+     (.run ^ChangeLogIterator log-iterator update-visitor runtime-env))))
 
 (mu/defn force-migrate-up-if-needed!
   "Force migrating up. This does three things differently from [[migrate-up-if-needed!]]:

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -235,7 +235,10 @@
   [^Liquibase liquibase f]
 
   (when (.hasChangeLogLock (lock-service liquibase))
-    (throw (Exception. "Taking a nested lock, please clean this up")))
+    ;; In production it's better to just take the lock again, it is re-entrant.
+    ;; Fail in dev and CI in order to clean up the code flow.
+    (when-not config/is-prod?
+      (throw (LockException. "Attempted to take a Liquibase lock, but we already are holding it."))))
 
   (let [database      (.getDatabase liquibase)
         scope-objects {(.name Scope$Attr/database)         database

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -74,10 +74,13 @@
     (log/info (trs "Setting up Liquibase..."))
     (liquibase/with-liquibase [liquibase conn]
       (try
+        ;; Consolidating the changeset requires the lock, so we may need to release it first.
        (when (= :force direction)
          (liquibase/release-lock-if-needed! liquibase))
+        ;; Releasing the locks does not depend on the changesets, so we skip this step as it might require locking.
        (when-not (= :release-locks direction)
          (liquibase/consolidate-liquibase-changesets! conn liquibase))
+
        (log/info (trs "Liquibase is ready."))
        (case direction
          :up            (liquibase/migrate-up-if-needed! liquibase data-source)

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -76,7 +76,8 @@
       (try
        (when (= :force direction)
          (liquibase/release-lock-if-needed! liquibase))
-       (liquibase/consolidate-liquibase-changesets! conn liquibase)
+       (when-not (= :release-locks direction)
+         (liquibase/consolidate-liquibase-changesets! conn liquibase))
        (log/info (trs "Liquibase is ready."))
        (case direction
          :up            (liquibase/migrate-up-if-needed! liquibase data-source)

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -74,7 +74,7 @@
     (log/info (trs "Setting up Liquibase..."))
     (liquibase/with-liquibase [liquibase conn]
       (try
-       (liquibase/consolidate-liquibase-changesets! conn)
+       (liquibase/consolidate-liquibase-changesets! conn liquibase)
        (log/info (trs "Liquibase is ready."))
        (case direction
          :up            (liquibase/migrate-up-if-needed! liquibase data-source)

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -74,6 +74,8 @@
     (log/info (trs "Setting up Liquibase..."))
     (liquibase/with-liquibase [liquibase conn]
       (try
+       (when (= :force direction)
+         (liquibase/release-lock-if-needed! liquibase))
        (liquibase/consolidate-liquibase-changesets! conn liquibase)
        (log/info (trs "Liquibase is ready."))
        (case direction

--- a/test/metabase/db/liquibase_test.clj
+++ b/test/metabase/db/liquibase_test.clj
@@ -67,9 +67,9 @@
       ;; fake a db where we ran all the migrations, including the legacy ones
       (with-redefs [liquibase/decide-liquibase-file (fn [& _args] @#'liquibase/changelog-legacy-file)]
         (liquibase/with-liquibase [liquibase conn]
-          (.update liquibase ""))
-        (t2/update! (liquibase/changelog-table-name conn) {:filename "migrations/000_migrations.yaml"})
-        (liquibase/consolidate-liquibase-changesets! conn)
+          (.update liquibase "")
+          (t2/update! (liquibase/changelog-table-name conn) {:filename "migrations/000_migrations.yaml"})
+          (liquibase/consolidate-liquibase-changesets! conn liquibase))
         (testing "makes sure the change log filename are correctly set"
           (is (= (set (liquibase-file->included-ids "migrations/000_legacy_migrations.yaml" driver/*driver*))
                  (t2/select-fn-set :id (liquibase/changelog-table-name conn) :filename "migrations/000_legacy_migrations.yaml")))

--- a/test/metabase/db/schema_migrations_test/impl.clj
+++ b/test/metabase/db/schema_migrations_test/impl.clj
@@ -189,8 +189,7 @@
                                                 accept?)
                                     (ChangeSetFilterResult. accept? "decision according to range" (class this)))))]
           change-log-service (.getChangeLogService (ChangeLogHistoryServiceFactory/getInstance) database)]
-      (liquibase/with-scope-locked
-       liquibase
+      (liquibase/with-scope-locked liquibase
        ;; Calling .listUnrunChangeSets has the side effect of creating the Liquibase tables
        ;; and initializing checksums so that they match the ones generated in production.
        (.listUnrunChangeSets liquibase nil (LabelExpression.))

--- a/test/metabase/db/schema_migrations_test/impl.clj
+++ b/test/metabase/db/schema_migrations_test/impl.clj
@@ -189,14 +189,13 @@
                                                 accept?)
                                     (ChangeSetFilterResult. accept? "decision according to range" (class this)))))]
           change-log-service (.getChangeLogService (ChangeLogHistoryServiceFactory/getInstance) database)]
-      (liquibase/run-in-scope-locked
+      (liquibase/with-scope-locked
        liquibase
-       (fn []
-         ;; Calling .listUnrunChangeSets has the side effect of creating the Liquibase tables
-         ;; and initializing checksums so that they match the ones generated in production.
-         (.listUnrunChangeSets liquibase nil (LabelExpression.))
-         (.generateDeploymentId change-log-service)
-         (liquibase/update-with-change-log liquibase {:change-set-filters change-set-filters}))))))
+       ;; Calling .listUnrunChangeSets has the side effect of creating the Liquibase tables
+       ;; and initializing checksums so that they match the ones generated in production.
+       (.listUnrunChangeSets liquibase nil (LabelExpression.))
+       (.generateDeploymentId change-log-service)
+       (liquibase/update-with-change-log liquibase {:change-set-filters change-set-filters})))))
 
 (defn- test-migrations-for-driver [driver [start-id end-id] f]
   (log/debug (u/format-color 'yellow "Testing migrations for driver %s..." driver))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37553

### Description

This change makes sure that we take locks before beginning mutation with Liquibase, in particular the consolidation of our changesets, and should hopefully fix some race conditions we have been seeing. 

~~The lock is re-entrant, so I have done this in a minimally invasive way. There is scope to coarsen the locking, and remove some redundancy. I'm on the fence about coarsening too much, as it's very easy to call into the internals.~~ I've coarsened the lock somewhat, and rely on a runtime assertion within the internals. There is scope to make it even more coarse, but I think this is good for now.

~~The linked ticket also calls for making the consolidation a no-op if the table is already up-to-date. I will do that in a separate PR.~~ I've ended up including this, because it tied in with taking the lock conditionally.

### How to verify

I haven't added any tests for these locks, as they would need to be very intrusive and mock out internals. 

Perhaps there's some prior art on a good way to do this? I wanted to first put this out for feedback before spending any time on tests, and to gauge how extensive we want to test it.