### PR TITLE
Look for field metadata in the qp.store

### DIFF
--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -564,7 +564,7 @@
     (binding [*compared-field-options*
               (when (and (vector? field)
                          (= (get field 0) :field))
-                (merge (let [field-id-or-name (field 1)]
+                (merge (let [field-id-or-name (get field 1)]
                          (when (integer? field-id-or-name)
                            (lib.metadata.protocols/field (qp.store/metadata-provider)
                                                          field-id-or-name)))

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -17,8 +17,10 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.sql.util.unprepare :as unprepare]
+   [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.mbql.util :as mbql.u]
    [metabase.query-processor.interface :as qp.i]
+   [metabase.query-processor.store :as qp.store]
    [metabase.query-processor.timezone :as qp.timezone]
    [metabase.util :as u]
    #_{:clj-kondo/ignore [:deprecated-namespace]}
@@ -559,9 +561,11 @@
 (doseq [op [:= :!= :< :<= :> :>= :between]]
   (defmethod sql.qp/->honeysql [:sqlserver op]
     [driver [_ field :as clause]]
-    (binding [*compared-field-options* (when (and (vector? field)
-                                                  (= (get field 0) :field))
-                                         (get field 2))]
+    (binding [*compared-field-options*
+              (when (and (vector? field)
+                         (= (get field 0) :field))
+                (merge (lib.metadata.protocols/field (qp.store/metadata-provider) (field 1))
+                       (get field 2)))]
       ((get-method sql.qp/->honeysql [:sql-jdbc op]) driver clause))))
 
 (defmethod driver/db-default-timezone :sqlserver

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -564,7 +564,10 @@
     (binding [*compared-field-options*
               (when (and (vector? field)
                          (= (get field 0) :field))
-                (merge (lib.metadata.protocols/field (qp.store/metadata-provider) (field 1))
+                (merge (let [field-id-or-name (field 1)]
+                         (when (integer? field-id-or-name)
+                           (lib.metadata.protocols/field (qp.store/metadata-provider)
+                                                         field-id-or-name)))
                        (get field 2)))]
       ((get-method sql.qp/->honeysql [:sql-jdbc op]) driver clause))))
 


### PR DESCRIPTION
Fixes #30454 for x.48.x.

We have considered #30454 fixed already, but it turns out that the fix implemented on `master` doesn't quite work for `x.48.x` because the `base-type` metadata is missing from the field reference. This PR takes this info from the qp.store.