### PR TITLE
Add hover card metadata to summarize sidebar

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -258,6 +258,23 @@ describe("scenarios > visualizations > table", () => {
     });
   });
 
+  it("should show field metadata in a hovercard when hovering over a table column in the summarize sidebar", () => {
+    openOrdersTable({ limit: 2 });
+
+    summarize();
+
+    cy.findAllByTestId("dimension-list-item")
+      .contains("ID")
+      .parents("[data-testid='dimension-list-item']")
+      .within(() => {
+        cy.findByLabelText("More info").realHover();
+      });
+
+    hovercard().within(() => {
+      cy.contains("Entity Key");
+    });
+  });
+
   it("should show field metadata hovercards for native query tables", () => {
     openNativeEditor().type("select * from products");
     cy.findByTestId("native-query-editor-container").icon("play").click();

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
@@ -19,7 +19,7 @@ export const TriggerButton = styled.button`
 
   color: ${alpha(color("white"), 0.5)};
   font-weight: 700;
-  border-left: 2px solid ${alpha(color("border"), 0.1)};
+  border-left: 2px solid transparent;
   padding: 0.5rem;
   cursor: pointer;
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
@@ -8,24 +8,43 @@ import type { ColorName } from "metabase/lib/colors/types";
 export const TriggerIcon = styled(Icon)`
   color: ${color("white")} !important;
   flex: 0 0 auto;
+  margin-left: 0.5rem;
 `;
 
-export const TriggerButton = styled.button`
+export const TriggerButton = styled.button<{ hasDot?: boolean }>`
   display: flex;
   align-items: center;
   min-width: 0;
   max-width: 50%;
-  gap: 0.5rem;
 
   color: ${alpha(color("white"), 0.5)};
   font-weight: 700;
   border-left: 2px solid transparent;
   padding: 0.5rem;
+  border-left: 2px solid
+    ${props => (props.hasDot ? "transparent" : alpha(color("border"), 0.1))};
+
   cursor: pointer;
 
   &:hover {
     color: ${color("white")};
   }
+`;
+
+export const Dot = styled.div`
+  width: 3px;
+  height: 3px;
+  margin-right: 0.5em;
+  background: currentColor;
+  border-radius: 100%;
+  opacity: 0.25;
+`;
+
+export const ChevronDown = styled(Icon)`
+  flex: 0 0 auto;
+  width: 8px;
+  margin-left: 0.25em;
+  opacity: 0.75;
 `;
 
 export const SelectListItem = styled(BaseSelectList.Item)<{

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -8,6 +8,8 @@ import type { ColorName } from "metabase/lib/colors/types";
 import * as Lib from "metabase-lib";
 import {
   Content,
+  ChevronDown,
+  Dot,
   MoreButton,
   TriggerButton,
   TriggerIcon,
@@ -33,6 +35,8 @@ export interface BaseBucketPickerPopoverProps {
   isEditing: boolean;
   triggerLabel?: string;
   hasArrowIcon?: boolean;
+  hasDot?: boolean;
+  hasChevronDown?: boolean;
   color?: ColorName;
   checkBucketIsSelected: (item: BucketListItem) => boolean;
   renderTriggerContent: (bucket?: Lib.BucketDisplayInfo) => ReactNode;
@@ -51,6 +55,8 @@ function _BaseBucketPickerPopover({
   checkBucketIsSelected,
   renderTriggerContent,
   onSelect,
+  hasDot,
+  hasChevronDown,
 }: BaseBucketPickerPopoverProps) {
   const [isExpanded, setIsExpanded] = useState(
     isInitiallyExpanded(items, selectedBucket, checkBucketIsSelected),
@@ -94,14 +100,19 @@ function _BaseBucketPickerPopover({
             event.stopPropagation();
             onClick();
           }}
+          hasDot={hasDot}
           // Compat with E2E tests around MLv1-based components
           // Prefer using a11y role selectors
           data-testid="dimension-list-item-binning"
         >
+          {hasDot && <Dot />}
           <Ellipsified>
             {renderTriggerContent(triggerContentBucketDisplayInfo)}
           </Ellipsified>
-          {hasArrowIcon && <TriggerIcon name="chevronright" />}
+          {hasArrowIcon && !hasChevronDown && (
+            <TriggerIcon name="chevronright" />
+          )}
+          {hasChevronDown && <ChevronDown name="chevrondown" />}
         </TriggerButton>
       )}
       popoverContent={({ closePopover }) => (

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/types.ts
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/types.ts
@@ -3,7 +3,13 @@ import type { BaseBucketPickerPopoverProps } from "./BaseBucketPickerPopover";
 
 type CommonProps = Pick<
   BaseBucketPickerPopoverProps,
-  "query" | "stageIndex" | "isEditing" | "color" | "hasArrowIcon"
+  | "query"
+  | "stageIndex"
+  | "isEditing"
+  | "color"
+  | "hasArrowIcon"
+  | "hasDot"
+  | "hasChevronDown"
 >;
 
 export interface CommonBucketPickerProps extends CommonProps {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnList.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnList.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import _ from "underscore";
 import { t } from "ttag";
+import { DelayGroup } from "metabase/ui";
 import Input from "metabase/core/components/Input";
 import { getColumnGroupName } from "metabase/common/utils/column-groups";
 import { useDebouncedValue } from "metabase/hooks/use-debounced-value";
@@ -114,26 +115,28 @@ export function BreakoutColumnList({
         />
       </SearchContainer>
       {!isSearching && (
-        <ul data-testid="pinned-dimensions">
-          {pinnedItems.map(item => (
-            <BreakoutColumnListItem
-              key={item.longDisplayName}
-              query={query}
-              item={item}
-              breakout={item.breakout}
-              isPinned
-              onAddColumn={onAddBreakout}
-              onUpdateColumn={column => {
-                if (item.breakout) {
-                  onUpdateBreakout(item.breakout, column);
-                } else {
-                  onAddBreakout(column);
-                }
-              }}
-              onRemoveColumn={handleRemovePinnedBreakout}
-            />
-          ))}
-        </ul>
+        <DelayGroup>
+          <ul data-testid="pinned-dimensions">
+            {pinnedItems.map(item => (
+              <BreakoutColumnListItem
+                key={item.longDisplayName}
+                query={query}
+                item={item}
+                breakout={item.breakout}
+                isPinned
+                onAddColumn={onAddBreakout}
+                onUpdateColumn={column => {
+                  if (item.breakout) {
+                    onUpdateBreakout(item.breakout, column);
+                  } else {
+                    onAddBreakout(column);
+                  }
+                }}
+                onRemoveColumn={handleRemovePinnedBreakout}
+              />
+            ))}
+          </ul>
+        </DelayGroup>
       )}
       <ul data-testid="unpinned-dimensions">
         {sections.map(section => (

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
@@ -5,15 +5,11 @@ import { Icon } from "metabase/ui";
 import { BucketPickerPopover as BaseBucketPickerPopover } from "metabase/common/components/QueryColumnPicker/BucketPickerPopover";
 import { color, alpha } from "metabase/lib/colors";
 
-const triggerButtonStyle = css`
-  border-color: transparent;
-  visibility: hidden;
-  border-left-width: 1px;
-`;
-
 export const BucketPickerPopover = styled(BaseBucketPickerPopover)`
   ${BaseBucketPickerPopover.TriggerButton} {
-    ${triggerButtonStyle}
+    border-color: transparent;
+    visibility: hidden;
+    border-left-width: 1px;
   }
 `;
 

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
@@ -2,18 +2,8 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import Button from "metabase/core/components/Button";
 import { Icon } from "metabase/ui";
-import { BucketPickerPopover as BaseBucketPickerPopover } from "metabase/common/components/QueryColumnPicker/BucketPickerPopover";
+import { BucketPickerPopover } from "metabase/common/components/QueryColumnPicker/BucketPickerPopover";
 import { color, alpha } from "metabase/lib/colors";
-
-export const BucketPickerPopover = styled(BaseBucketPickerPopover)`
-  ${BaseBucketPickerPopover.TriggerButton} {
-    border-color: transparent;
-    visibility: hidden;
-    border-left-width: 1px;
-  }
-`;
-
-BucketPickerPopover.defaultProps = { color: "summarize" };
 
 export const Content = styled.div`
   display: flex;
@@ -26,7 +16,7 @@ export const TitleContainer = styled.div`
   display: flex;
   align-items: center;
   margin-left: 0.5rem;
-  padding: 0.5rem 0;
+  padding: 0;
   flex-grow: 1;
 `;
 
@@ -81,20 +71,24 @@ const selectedStyle = css`
     color: ${color("white")};
   }
 
-  ${BaseBucketPickerPopover.TriggerButton} {
-    visibility: visible;
+  ${BucketPickerPopover.TriggerButton} {
+    opacity: 0;
     color: ${alpha("white", 0.5)};
-    border-color: ${alpha("text-dark", 0.1)};
-    border-left-width: 1px;
   }
 
-  ${BaseBucketPickerPopover.TriggerButton}:hover {
+  ${BucketPickerPopover.TriggerButton}:hover {
     color: ${color("white")};
-    border-left-width: 1px;
+    opacity: 1;
   }
 `;
 
 const unselectedStyle = css`
+  ${BucketPickerPopover.TriggerButton} {
+    opacity: 0;
+    color: ${color("text-light")};
+    padding-left: 0;
+  }
+
   &:hover {
     ${Content},
     ${ColumnTypeIcon},
@@ -107,16 +101,13 @@ const unselectedStyle = css`
       background-color: ${color("bg-medium")};
     }
 
-    ${BaseBucketPickerPopover.TriggerButton} {
-      visibility: visible;
+    ${BucketPickerPopover.TriggerButton} {
+      opacity: 1;
       color: ${color("text-light")};
-      border-color: ${alpha("text-dark", 0.1)};
-      border-left-width: 1px;
     }
 
-    ${BaseBucketPickerPopover.TriggerButton}:hover {
+    ${BucketPickerPopover.TriggerButton}:hover {
       color: ${color("text-medium")};
-      border-left-width: 1px;
     }
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
@@ -80,6 +80,8 @@ const selectedStyle = css`
   ${BucketPickerPopover.TriggerButton} {
     opacity: 0;
     color: ${alpha("white", 0.5)};
+    padding-left: 0;
+    border-left: 0;
   }
 
   ${BucketPickerPopover.TriggerButton}:hover {
@@ -93,6 +95,7 @@ const unselectedStyle = css`
     opacity: 0;
     color: ${color("text-light")};
     padding-left: 0;
+    border-left: 0;
   }
 
   ${QueryColumnInfoIcon} {

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
@@ -4,6 +4,7 @@ import Button from "metabase/core/components/Button";
 import { Icon } from "metabase/ui";
 import { BucketPickerPopover } from "metabase/common/components/QueryColumnPicker/BucketPickerPopover";
 import { color, alpha } from "metabase/lib/colors";
+import { QueryColumnInfoIcon as BaseQueryColumnInfoIcon } from "metabase/components/MetadataInfo/ColumnInfoIcon";
 
 export const Content = styled.div`
   display: flex;
@@ -64,9 +65,14 @@ export const Title = styled.div`
   font-weight: 700;
 `;
 
+export const QueryColumnInfoIcon = styled(BaseQueryColumnInfoIcon)`
+  margin-left: auto;
+`;
+
 const selectedStyle = css`
   ${Content},
-  ${ColumnTypeIcon} {
+  ${ColumnTypeIcon},
+  ${QueryColumnInfoIcon} {
     background-color: ${color("summarize")};
     color: ${color("white")};
   }
@@ -87,6 +93,10 @@ const unselectedStyle = css`
     opacity: 0;
     color: ${color("text-light")};
     padding-left: 0;
+  }
+
+  ${QueryColumnInfoIcon} {
+    color: ${color("text-light")};
   }
 
   &:hover {
@@ -118,6 +128,7 @@ export const Root = styled.li<{ isSelected: boolean }>`
   cursor: pointer;
   margin: 0.25rem 0;
   min-height: 34px;
+  position: relative;
 
   ${props => (props.isSelected ? selectedStyle : unselectedStyle)}
 `;

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.tsx
@@ -4,6 +4,7 @@ import { t } from "ttag";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import Tooltip from "metabase/core/components/Tooltip";
 import { BucketPickerPopover } from "metabase/common/components/QueryColumnPicker/BucketPickerPopover";
+import { HoverParent } from "metabase/components/MetadataInfo/ColumnInfoIcon";
 import * as Lib from "metabase-lib";
 import {
   AddButton,
@@ -13,6 +14,7 @@ import {
   TitleContainer,
   RemoveButton,
   Root,
+  QueryColumnInfoIcon,
 } from "./BreakoutColumnListItem.styled";
 
 const STAGE_INDEX = -1;
@@ -59,9 +61,10 @@ export function BreakoutColumnListItem({
   const displayName = isPinned ? item.longDisplayName : item.displayName;
 
   return (
-    <Root
+    <HoverParent
+      as={Root}
+      {...{ isSelected }}
       aria-label={displayName}
-      isSelected={isSelected}
       aria-selected={isSelected}
       data-testid="dimension-list-item"
     >
@@ -83,6 +86,12 @@ export function BreakoutColumnListItem({
               breakout ? onUpdateColumn(column) : onAddColumn(column)
             }
           />
+          <QueryColumnInfoIcon
+            query={query}
+            stageIndex={STAGE_INDEX}
+            column={item.column}
+            position="top-end"
+          />
         </TitleContainer>
         {isSelected && (
           <RemoveButton
@@ -96,6 +105,6 @@ export function BreakoutColumnListItem({
           <AddButton aria-label={t`Add dimension`} onClick={handleAddClick} />
         </Tooltip>
       )}
-    </Root>
+    </HoverParent>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.tsx
@@ -56,24 +56,6 @@ export function BreakoutColumnListItem({
     [item.column, onRemoveColumn],
   );
 
-  const renderBucketPicker = useCallback(
-    () => (
-      <BucketPickerPopover
-        query={query}
-        stageIndex={STAGE_INDEX}
-        column={item.column}
-        isEditing={isSelected}
-        hasArrowIcon={false}
-        hasBinning
-        hasTemporalBucketing
-        onSelect={column =>
-          breakout ? onUpdateColumn(column) : onAddColumn(column)
-        }
-      />
-    ),
-    [query, breakout, item.column, isSelected, onAddColumn, onUpdateColumn],
-  );
-
   const displayName = isPinned ? item.longDisplayName : item.displayName;
 
   return (
@@ -88,7 +70,18 @@ export function BreakoutColumnListItem({
           <ColumnTypeIcon name={getColumnIcon(item.column)} size={18} />
           <Title data-testid="dimension-list-item-name">{displayName}</Title>
         </TitleContainer>
-        {renderBucketPicker()}
+        <BucketPickerPopover
+          query={query}
+          stageIndex={STAGE_INDEX}
+          column={item.column}
+          isEditing={isSelected}
+          hasArrowIcon={false}
+          hasBinning
+          hasTemporalBucketing
+          onSelect={column =>
+            breakout ? onUpdateColumn(column) : onAddColumn(column)
+          }
+        />
         {isSelected && (
           <RemoveButton
             onClick={handleRemoveColumn}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.tsx
@@ -3,10 +3,10 @@ import { useCallback } from "react";
 import { t } from "ttag";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import Tooltip from "metabase/core/components/Tooltip";
+import { BucketPickerPopover } from "metabase/common/components/QueryColumnPicker/BucketPickerPopover";
 import * as Lib from "metabase-lib";
 import {
   AddButton,
-  BucketPickerPopover,
   Content,
   ColumnTypeIcon,
   Title,
@@ -69,19 +69,21 @@ export function BreakoutColumnListItem({
         <TitleContainer>
           <ColumnTypeIcon name={getColumnIcon(item.column)} size={18} />
           <Title data-testid="dimension-list-item-name">{displayName}</Title>
+          <BucketPickerPopover
+            query={query}
+            stageIndex={STAGE_INDEX}
+            column={item.column}
+            color="summarize"
+            isEditing={isSelected}
+            hasDot
+            hasChevronDown
+            hasBinning
+            hasTemporalBucketing
+            onSelect={column =>
+              breakout ? onUpdateColumn(column) : onAddColumn(column)
+            }
+          />
         </TitleContainer>
-        <BucketPickerPopover
-          query={query}
-          stageIndex={STAGE_INDEX}
-          column={item.column}
-          isEditing={isSelected}
-          hasArrowIcon={false}
-          hasBinning
-          hasTemporalBucketing
-          onSelect={column =>
-            breakout ? onUpdateColumn(column) : onAddColumn(column)
-          }
-        />
         {isSelected && (
           <RemoveButton
             onClick={handleRemoveColumn}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -159,6 +159,14 @@ describe("SummarizeSidebar", () => {
     );
   });
 
+  it("should list render the info icon on breakout columns", () => {
+    setup();
+
+    screen.queryAllByTestId("dimension-list-item").forEach(item => {
+      expect(within(item).getByLabelText("More info")).toBeInTheDocument();
+    });
+  });
+
   it("shouldn't list breakout columns without an aggregation", () => {
     setup({ withDefaultAggregation: false });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38812

### Description

- Add more customization options to the bucket picker component
- Move the bucket picker to make space for the info icon
- Add the info icon

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Browse Data → Sample Database → Accounts
2. Summarize → Count
3. All items should have an info icon when hovering them
4. Hover the "Created At" item

### Demo

<img width="416" alt="Screenshot 2024-02-15 at 17 00 49" src="https://github.com/metabase/metabase/assets/1250185/cacdcbff-375c-45e3-908c-de5387c0ad37">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
