### PR TITLE
Enable source maps for CLJS in release builds

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -353,11 +353,8 @@
     io.github.metabase/hawk            {:git/url "https://github.com/metabase/hawk"
                                         :git/sha "59cba703e757bd94c0cc698dbf5338bf36276991"}
     org.clojars.mmb90/cljs-cache       {:mvn/version "0.1.4"}
-    ;; Forcibly targeting a newer release than ships by default with shadow-cljs 2.20.20.
-    ;; It fixes an issue where TypeScript can't parse the `cljs_env.js` output file.
-    org.clojure/google-closure-library {:mvn/version "0.0-20230227-c7c0a541"}
     refactor-nrepl/refactor-nrepl      {:mvn/version "3.9.1"}
-    thheller/shadow-cljs               {:mvn/version "2.26.5"}}}
+    thheller/shadow-cljs               {:mvn/version "2.27.4"}}}
 
   ;; for local dev -- include the drivers locally with :dev:drivers
   :drivers

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "promise-loader": "^1.0.0",
     "raf": "^3.4.0",
     "react-refresh": "^0.13.0",
-    "shadow-cljs": "2.26.5",
+    "shadow-cljs": "2.27.4",
     "source-map-loader": "^4.0.1",
     "terser-webpack-plugin": "^5.3.9",
     "typescript": "^4.7.2",
@@ -295,6 +295,7 @@
     "json5": "2.2.2",
     "nth-check": "2.0.1",
     "set-value": "4.0.1",
+    "source-map-js": "git+https://github.com/7rulnik/source-map-js#6e5dfccf75f84f619d3646188aef7ef7cf8f6376",
     "unset-value": "2.0.1"
   },
   "scripts": {

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -14,7 +14,8 @@
    :output-dir "target/cljs_release/"
    :dev        {:output-dir "target/cljs_dev/"
                 :compiler-options {:reader-features #{:cljs-dev}}}
-   :compiler-options {:reader-features #{:cljs-release}}
+   :compiler-options {:reader-features #{:cljs-release}
+                      :source-map      true}
    :entries    [metabase.domain-entities.queries.util
                 metabase.lib.column-group
                 metabase.lib.js

--- a/yarn.lock
+++ b/yarn.lock
@@ -19738,10 +19738,10 @@ shadow-cljs-jar@1.3.4:
   resolved "https://registry.yarnpkg.com/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz#0939d91c468b4bc5eab5a958f79e7ef5696fdf62"
   integrity sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA==
 
-shadow-cljs@2.26.5:
-  version "2.26.5"
-  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.26.5.tgz#978335510faeea81c32f70e8fe911ff5b0287a1b"
-  integrity sha512-3mWQefe1va6hjGxIIfLliw3N1ylJxH/qQLw5P3oJS40GO/6cRELXJT3pB9vSKr8SoRdt5mnfUMh1JkG2MGmrhw==
+shadow-cljs@2.27.4:
+  version "2.27.4"
+  resolved "https://registry.yarnpkg.com/shadow-cljs/-/shadow-cljs-2.27.4.tgz#92aab4d6119d132dd110d743fecc4611f1989077"
+  integrity sha512-NgLkdK1hpjDCCVAwQdBebz+0DzgaVYaGOw1ojUwY627DLL+kG/pwhw+qiDEFeJl+CWCMFiWJgnwVEM8d/Cit5g==
   dependencies:
     node-libs-browser "^2.2.1"
     readline-sync "^1.4.7"
@@ -19939,15 +19939,9 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-js@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-0.6.2.tgz#0bb5de631b41cfbda6cfba8bd05a80efdfd2385e"
-  integrity sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==
-
-source-map-js@^1.0.1, source-map-js@^1.0.2:
+source-map-js@^0.6.2, source-map-js@^1.0.1, source-map-js@^1.0.2, "source-map-js@git+https://github.com/7rulnik/source-map-js#6e5dfccf75f84f619d3646188aef7ef7cf8f6376":
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
-  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+  resolved "git+https://github.com/7rulnik/source-map-js#6e5dfccf75f84f619d3646188aef7ef7cf8f6376"
 
 source-map-loader@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
We do this for our JS and TS code. This change configures shadow-cljs to
emit the source maps in release mode, and bumps the versions of
shadow-cljs and the transitive dependency `source-maps-js` to enable
webpack to consume these source maps correctly.

(The output source maps have some quirks, and broke some consumers.
Mainly that inlining of CLJS functions can result in empty namespaces,
and while the file contents were correctly inlined,
`sourceContents: ""` looks falsy in JS. Webpack would try to read the
nonexistent source files and fail to build.)
