### PR TITLE
Allow official collections inside personal collections

### DIFF
--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -107,26 +107,35 @@ describeEE("official collections", () => {
       });
     });
 
-    it("should not be able to manage collection authority level for personal collections and their children", () => {
+    it("should be able to manage collection authority level for personal collections and their children (metabase#30236)", () => {
       cy.visit("/collection/root");
 
       openCollection("Your personal collection");
       getCollectionActions().within(() => {
-        cy.icon("ellipsis").should("not.exist");
+        cy.icon("ellipsis").should("exist");
+        cy.icon("ellipsis").click();
       });
+
+      popover().findByText("Make collection official").should("exist");
 
       openNewCollectionItemFlowFor("collection");
       modal().within(() => {
-        assertNoCollectionTypeInput();
+        assertHasCollectionTypeInput();
         cy.findByLabelText("Name").type("Personal collection child");
         cy.button("Create").click();
       });
 
       openCollection("Personal collection child");
 
+      getCollectionActions().within(() => {
+        cy.icon("ellipsis").should("exist");
+        cy.icon("ellipsis").click();
+      });
+      popover().findByText("Make collection official").should("exist");
+
       openNewCollectionItemFlowFor("collection");
       modal().within(() => {
-        assertNoCollectionTypeInput();
+        assertHasCollectionTypeInput();
         cy.icon("close").click();
       });
     });
@@ -261,6 +270,12 @@ function assertNoCollectionTypeInput() {
   cy.findByText(/Collection type/i).should("not.exist");
   cy.findByText("Regular").should("not.exist");
   cy.findByText("Official").should("not.exist");
+}
+
+function assertHasCollectionTypeInput() {
+  cy.findByText(/Collection type/i).should("exist");
+  cy.findByText("Regular").should("exist");
+  cy.findByText("Official").should("exist");
 }
 
 function assertNoCollectionTypeOption() {

--- a/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/content_management/api/collection_test.clj
@@ -1,7 +1,6 @@
 (ns metabase-enterprise.content-management.api.collection-test
   (:require
    [clojure.test :refer :all]
-   [metabase.models.collection :as collection]
    [metabase.test :as mt]
    [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]
@@ -57,15 +56,9 @@
             [:model/Collection {id :id} {:authority_level nil}]
             (is (= "official"
                    (:authority_level (mt/user-http-request :crowberto :put 200 (format "collection/%d" id) {:authority_level "official"}))))
-            (is (= :official (t2/select-one-fn :authority_level :model/Collection id))))
+            (is (= :official (t2/select-one-fn :authority_level :model/Collection id)))))
 
-          (testing "but cannot update for personal collection"
-            (let [personal-coll (collection/user->personal-collection (mt/user->id :crowberto))]
-              (mt/user-http-request :crowberto :put 403 (str "collection/" (:id personal-coll))
-                                    {:authority_level "official"})
-              (is (nil? (t2/select-one-fn :authority_level :model/Collection :id (:id personal-coll)))))))
-
-        (testing "Non-adminds can patch without the :authority_level"
+        (testing "Non-admins can patch without the :authority_level"
           (t2.with-temp/with-temp [:model/Collection collection {:name "whatever" :authority_level "official"}]
             (is (= "official"
                    (-> (mt/user-http-request :rasta :put 200 (str "collection/" (:id collection))

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -34,8 +34,8 @@ export const CollectionMenu = ({
   if (
     isAdmin &&
     !isRoot &&
-    !isPersonal &&
-    !isPersonalCollectionChild &&
+    // !isPersonal &&
+    // !isPersonalCollectionChild &&
     canWrite
   ) {
     items.push(

--- a/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/CollectionMenu.tsx
@@ -31,13 +31,7 @@ export const CollectionMenu = ({
     isInstanceAnalyticsCustomCollection(collection);
   const canWrite = collection.can_write;
 
-  if (
-    isAdmin &&
-    !isRoot &&
-    // !isPersonal &&
-    // !isPersonalCollectionChild &&
-    canWrite
-  ) {
+  if (isAdmin && !isRoot && canWrite) {
     items.push(
       ...PLUGIN_COLLECTIONS.getAuthorityLevelMenuItems(
         collection,

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
@@ -1,11 +1,10 @@
 import userEvent from "@testing-library/user-event";
 
-import { getIcon, queryIcon, screen } from "__support__/ui";
+import { getIcon, screen } from "__support__/ui";
 import {
   createMockCollection,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
-
 import type { SetupOpts } from "./setup";
 import { setup } from "./setup";
 
@@ -82,7 +81,7 @@ describe("CollectionMenu", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should not be able to make the collection official if it's a personal collection", () => {
+  it("should be able to make the collection official if it's a personal collection", async () => {
     const collection = createMockCollection({
       personal_owner_id: 1,
       can_write: true,
@@ -92,7 +91,10 @@ describe("CollectionMenu", () => {
       isAdmin: true,
     });
 
-    expect(queryIcon("ellipsis")).not.toBeInTheDocument();
+    userEvent.click(getIcon("ellipsis"));
+    expect(
+      await screen.findByText("Make collection official"),
+    ).toBeInTheDocument();
   });
 
   it("should not be able to make the collection official if it's a personal collection child", () => {

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
@@ -5,6 +5,7 @@ import {
   createMockCollection,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
+
 import type { SetupOpts } from "./setup";
 import { setup } from "./setup";
 

--- a/frontend/src/metabase/collections/containers/FormAuthorityLevelFieldContainer.tsx
+++ b/frontend/src/metabase/collections/containers/FormAuthorityLevelFieldContainer.tsx
@@ -1,15 +1,11 @@
-import { useMemo } from "react";
 import { connect } from "react-redux";
 import _ from "underscore";
 
-import { canManageCollectionAuthorityLevel } from "metabase/collections/utils";
 import Collections from "metabase/entities/collections";
 import { PLUGIN_COLLECTION_COMPONENTS } from "metabase/plugins";
 import { getUserIsAdmin } from "metabase/selectors/user";
 import type { Collection } from "metabase-types/api";
 import type { State } from "metabase-types/store";
-
-type CollectionsMap = Partial<Record<Collection["id"], Collection>>;
 
 interface OwnProps {
   collectionParentId: Collection["id"];
@@ -17,22 +13,17 @@ interface OwnProps {
 
 interface StateProps {
   isAdmin: boolean;
-  collectionsMap: CollectionsMap;
 }
 
 type FormAuthorityLevelFieldContainerProps = OwnProps & StateProps;
 
 function mapStateToProps(state: State): StateProps {
-  const { collections } = state.entities;
   return {
     isAdmin: getUserIsAdmin(state),
-    collectionsMap: collections || ({} as CollectionsMap),
   };
 }
 
 function FormAuthorityLevelFieldContainer({
-  collectionParentId,
-  collectionsMap,
   isAdmin,
 }: FormAuthorityLevelFieldContainerProps) {
   if (!isAdmin) {

--- a/frontend/src/metabase/collections/containers/FormAuthorityLevelFieldContainer.tsx
+++ b/frontend/src/metabase/collections/containers/FormAuthorityLevelFieldContainer.tsx
@@ -35,17 +35,7 @@ function FormAuthorityLevelFieldContainer({
   collectionsMap,
   isAdmin,
 }: FormAuthorityLevelFieldContainerProps) {
-  const canManageAuthorityLevel = useMemo(
-    () =>
-      isAdmin &&
-      canManageCollectionAuthorityLevel(
-        { parent_id: collectionParentId },
-        collectionsMap,
-      ),
-    [collectionParentId, collectionsMap, isAdmin],
-  );
-
-  if (!canManageAuthorityLevel) {
+  if (!isAdmin) {
     return null;
   }
 

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -219,14 +219,17 @@ export function canManageCollectionAuthorityLevel(
   collection: Partial<Collection>,
   collectionMap: Partial<Record<CollectionId, Collection>>,
 ) {
-  if (isRootPersonalCollection(collection)) {
-    return false;
-  }
+  // if (isRootPersonalCollection(collection)) {
+  //   return false;
+  // }
   const parentId = coerceCollectionId(collection.parent_id);
   const parentCollection = collectionMap[parentId];
-  const collections = Object.values(collectionMap).filter(isNotNull);
+  // const collections = Object.values(collectionMap).filter(isNotNull);
+
+  console.log(parentCollection, collection)
+
   return (
-    parentCollection &&
-    !isPersonalOrPersonalChild(parentCollection, collections)
+    !!parentCollection 
+    // && !isPersonalOrPersonalChild(parentCollection, collections)
   );
 }

--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -1,6 +1,5 @@
 import { t } from "ttag";
 
-import { isNotNull } from "metabase/lib/types";
 import { PLUGIN_COLLECTIONS } from "metabase/plugins";
 import type {
   Collection,
@@ -200,36 +199,4 @@ export function isValidCollectionId(
 ): boolean {
   const id = canonicalCollectionId(collectionId);
   return id === null || typeof id === "number";
-}
-
-function isPersonalOrPersonalChild(
-  collection: Collection,
-  collections: Collection[],
-) {
-  if (!collection) {
-    return false;
-  }
-  return (
-    isRootPersonalCollection(collection) ||
-    isPersonalCollectionChild(collection, collections)
-  );
-}
-
-export function canManageCollectionAuthorityLevel(
-  collection: Partial<Collection>,
-  collectionMap: Partial<Record<CollectionId, Collection>>,
-) {
-  // if (isRootPersonalCollection(collection)) {
-  //   return false;
-  // }
-  const parentId = coerceCollectionId(collection.parent_id);
-  const parentCollection = collectionMap[parentId];
-  // const collections = Object.values(collectionMap).filter(isNotNull);
-
-  console.log(parentCollection, collection)
-
-  return (
-    !!parentCollection 
-    // && !isPersonalOrPersonalChild(parentCollection, collections)
-  );
 }

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -966,11 +966,7 @@
     (when (and (contains? collection-updates :authority_level)
                (not= (keyword authority_level) (:authority_level collection-before-update)))
       (premium-features/assert-has-feature :official-collections (tru "Official Collections"))
-      (api/check-403 (and api/*is-superuser?*
-                          ;; pre-update of model checks if the collection is a personal collection and rejects changes
-                          ;; to authority_level, but it doesn't check if it is a sub-collection of a personal one so we add that
-                          ;; here
-                          (not (collection/is-personal-collection-or-descendant-of-one? collection-before-update)))))
+      (api/check-403 api/*is-superuser?*))
     ;; ok, go ahead and update it! Only update keys that were specified in the `body`. But not `parent_id` since
     ;; that's not actually a property of Collection, and since we handle moving a Collection separately below.
     (let [updates (u/select-keys-when collection-updates :present [:name :description :archived :authority_level])]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/30236

### Description
PR to remove the restriction that official collections cannot exist inside of personal collections. The original issue revolved around forms keeping the `authority_level` prop after hiding the input, but after discussion with the product team it was decided that we should remove this restriction entierly. This change updates the form, as well as restores the "Make Official" buttons in the collection header (being an admin is still a restriction).

### How to verify

1. Go to New -> Collection and set your personal collection to be the parent
2. Note that the authority level picker is still present. Create the collection
3. Now in the collection header you should be able to toggle between normal and official collections


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
