### PR TITLE
Clean up and simplify MLv1 `clear*` utilities

### DIFF
--- a/frontend/src/metabase-lib/queries/utils/breakout.js
+++ b/frontend/src/metabase-lib/queries/utils/breakout.js
@@ -1,4 +1,4 @@
-import { add, update, remove, clear } from "./util";
+import { add, update, remove } from "./util";
 
 /**
  * Returns canonical list of Breakouts, with nulls removed
@@ -47,5 +47,5 @@ export function removeBreakout(breakout, index) {
  * @deprecated use MLv2
  */
 export function clearBreakouts() {
-  return getBreakoutClause(clear());
+  return getBreakoutClause([]);
 }

--- a/frontend/src/metabase-lib/queries/utils/breakout.js
+++ b/frontend/src/metabase-lib/queries/utils/breakout.js
@@ -46,6 +46,6 @@ export function removeBreakout(breakout, index) {
 /**
  * @deprecated use MLv2
  */
-export function clearBreakouts(breakout) {
+export function clearBreakouts() {
   return getBreakoutClause(clear());
 }

--- a/frontend/src/metabase-lib/queries/utils/breakout.js
+++ b/frontend/src/metabase-lib/queries/utils/breakout.js
@@ -42,10 +42,3 @@ export function updateBreakout(breakout, index, updatedBreakout) {
 export function removeBreakout(breakout, index) {
   return getBreakoutClause(remove(getBreakouts(breakout), index));
 }
-
-/**
- * @deprecated use MLv2
- */
-export function clearBreakouts() {
-  return undefined;
-}

--- a/frontend/src/metabase-lib/queries/utils/breakout.js
+++ b/frontend/src/metabase-lib/queries/utils/breakout.js
@@ -47,5 +47,5 @@ export function removeBreakout(breakout, index) {
  * @deprecated use MLv2
  */
 export function clearBreakouts() {
-  return getBreakoutClause([]);
+  return undefined;
 }

--- a/frontend/src/metabase-lib/queries/utils/field.js
+++ b/frontend/src/metabase-lib/queries/utils/field.js
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { add, update, remove, clear } from "./util";
+import { add, update, remove } from "./util";
 
 // returns canonical list of Fields, with nulls removed
 function getFields(fields) {
@@ -25,9 +25,6 @@ export function updateField(fields, index, updatedField) {
 }
 export function removeField(fields, index) {
   return getFieldClause(remove(getFields(fields), index));
-}
-export function clearFields(fields) {
-  return getFieldClause(clear());
 }
 
 // Metadata field "values" type is inconsistent

--- a/frontend/src/metabase-lib/queries/utils/order-by.js
+++ b/frontend/src/metabase-lib/queries/utils/order-by.js
@@ -1,4 +1,4 @@
-import { update, remove, clear } from "./util";
+import { update, remove } from "./util";
 
 // returns canonical list of OrderBys, with nulls removed
 export function getOrderBys(breakout) {
@@ -20,7 +20,4 @@ export function updateOrderBy(breakout, index, updatedOrderBy) {
 }
 export function removeOrderBy(breakout, index) {
   return getOrderByClause(remove(getOrderBys(breakout), index));
-}
-export function clearOrderBy(breakout) {
-  return getOrderByClause(clear());
 }

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -105,8 +105,7 @@ export const updateField = (query, index, field) =>
   setFieldsClause(query, FIELD.updateField(query.fields, index, field));
 export const removeField = (query, index) =>
   setFieldsClause(query, FIELD.removeField(query.fields, index));
-export const clearFields = query =>
-  setFieldsClause(query, FIELD.clearFields(query.fields));
+const clearFields = query => setFieldsClause(query);
 
 // EXPRESSIONS
 

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -66,8 +66,7 @@ export const removeBreakout = (query, index) =>
 /**
  * @deprecated use MLv2
  */
-export const clearBreakouts = query =>
-  setBreakoutClause(query, B.clearBreakouts(query.breakout));
+const clearBreakouts = query => setBreakoutClause(query);
 
 // FILTER
 

--- a/frontend/src/metabase-lib/queries/utils/query.js
+++ b/frontend/src/metabase-lib/queries/utils/query.js
@@ -95,8 +95,7 @@ const updateOrderBy = (query, index, orderBy) =>
   setOrderByClause(query, O.updateOrderBy(query["order-by"], index, orderBy));
 const removeOrderBy = (query, index) =>
   setOrderByClause(query, O.removeOrderBy(query["order-by"], index));
-const clearOrderBy = query =>
-  setOrderByClause(query, O.clearOrderBy(query["order-by"]));
+const clearOrderBy = query => setOrderByClause(query);
 
 // FIELD
 export const addField = (query, field) =>

--- a/frontend/src/metabase-lib/queries/utils/util.js
+++ b/frontend/src/metabase-lib/queries/utils/util.js
@@ -16,4 +16,3 @@ export const remove = (items, index) => [
   ...items.slice(0, index),
   ...items.slice(index + 1),
 ];
-export const clear = () => [];


### PR DESCRIPTION
This PR deals with outdated `clear*` utilities. Namely, these are:
1. `clearBreakouts`
2. `clearFields` and
3. `clearOrderBy`

### tl;dr
All of these helpers had unused parameter, so each of them returned `undefined`.

### Detailed explanation
First five commits break down the thinking and the cleanup processes in detail:
- [Remove unused breakout parameter](https://github.com/metabase/metabase/pull/38852/commits/2269ad92188098381cfd66838b94312fdf857aa3)
- [Evaluate clear() inline](https://github.com/metabase/metabase/pull/38852/commits/ec647a797d5fbc88aa2ce3d07154e16cd15d7fa6)
- [Evaluate getBreakoutClause([]) inline](https://github.com/metabase/metabase/pull/38852/commits/2aa85ddc0f7f564eb76b40fc371258efc4305513)
- [Simplify clearBreakouts query helper](https://github.com/metabase/metabase/pull/38852/commits/e4789f6d5643d9c884786355e4451839ca6f5152)
- [Remove unused clearBreakouts helper from breakout helpers](https://github.com/metabase/metabase/pull/38852/commits/06bcef2fd3a524106da5e8555b70e6b978b0589e)

The logic was the same for both `clearFields` and `clearOrderBy` utils.
In the end, there was no need for the `clear` utility so it was removed as well.


