### PR TITLE
Add hovercard on notebook filters

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -6,6 +6,7 @@ import {
   filter,
   filterField,
   getNotebookStep,
+  hovercard,
   join,
   openNotebook,
   openOrdersTable,
@@ -260,6 +261,27 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     // confirm that the popover is shown
     popover().contains("The total billed amount.");
     popover().contains("80.36");
+  });
+
+  it("should show an info card filter columns in the popover", () => {
+    openOrdersTable({ mode: "notebook" });
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Filter").click();
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Add filters to narrow your answer").click();
+
+    cy.findByRole("tree")
+      .findByText("User ID")
+      .parents("[data-testid='dimension-list-item']")
+      .findByLabelText("More info")
+      .realHover();
+
+    hovercard().within(() => {
+      cy.contains("Foreign Key");
+      cy.findByText(/The id of the user/);
+    });
   });
 
   describe.skip("popover rendering issues (metabase#15502)", () => {

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -7,11 +7,15 @@ import {
   getColumnGroupName,
 } from "metabase/common/utils/column-groups";
 
-import { Icon } from "metabase/ui";
+import { DelayGroup, Icon } from "metabase/ui";
 import type { IconName } from "metabase/ui";
 
 import * as Lib from "metabase-lib";
 
+import {
+  QueryColumnInfoIcon,
+  HoverParent,
+} from "metabase/components/MetadataInfo/ColumnInfoIcon";
 import type { ColumnListItem, SegmentListItem } from "../types";
 import { StyledAccordionList } from "./FilterColumnPicker.styled";
 
@@ -66,6 +70,8 @@ export function FilterColumnPicker({
       const columnItems = Lib.getColumnsFromColumnGroup(group).map(column => ({
         ...Lib.displayInfo(query, stageIndex, column),
         column,
+        query,
+        stageIndex,
       }));
 
       const includeSegments = groupInfo.isSourceTable;
@@ -102,21 +108,25 @@ export function FilterColumnPicker({
   };
 
   return (
-    <StyledAccordionList
-      sections={sections}
-      onChange={handleSelect}
-      onChangeSection={handleSectionChange}
-      itemIsSelected={checkItemIsSelected}
-      renderItemName={renderItemName}
-      renderItemDescription={omitItemDescription}
-      renderItemIcon={renderItemIcon}
-      // disable scrollbars inside the list
-      style={{ overflow: "visible" }}
-      maxHeight={Infinity}
-      // Compat with E2E tests around MLv1-based components
-      // Prefer using a11y role selectors
-      itemTestId="dimension-list-item"
-    />
+    <DelayGroup>
+      <StyledAccordionList
+        sections={sections}
+        onChange={handleSelect}
+        onChangeSection={handleSectionChange}
+        itemIsSelected={checkItemIsSelected}
+        renderItemWrapper={renderItemWrapper}
+        renderItemName={renderItemName}
+        renderItemDescription={omitItemDescription}
+        renderItemIcon={renderItemIcon}
+        renderItemExtra={renderItemExtra}
+        // disable scrollbars inside the list
+        style={{ overflow: "visible" }}
+        maxHeight={Infinity}
+        // Compat with E2E tests around MLv1-based components
+        // Prefer using a11y role selectors
+        itemTestId="dimension-list-item"
+      />
+    </DelayGroup>
   );
 }
 
@@ -136,4 +146,24 @@ function renderItemIcon(item: ColumnListItem | SegmentListItem) {
   if (item.column) {
     return <Icon name={getColumnIcon(item.column)} size={18} />;
   }
+}
+
+function renderItemWrapper(content: React.ReactNode) {
+  return <HoverParent>{content}</HoverParent>;
+}
+
+function renderItemExtra(item: ColumnListItem | SegmentListItem) {
+  if (isSegmentListItem(item)) {
+    return null;
+  }
+
+  const { query, stageIndex, column } = item;
+  return (
+    <QueryColumnInfoIcon
+      query={query}
+      stageIndex={stageIndex}
+      column={column}
+      position="right"
+    />
+  );
 }

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.unit.spec.tsx
@@ -1,0 +1,37 @@
+import { renderWithProviders, screen, within } from "__support__/ui";
+import { setupFieldsValuesEndpoints } from "__support__/server-mocks";
+import { SAMPLE_DB_FIELD_VALUES } from "metabase-types/api/mocks/presets";
+import type * as Lib from "metabase-lib";
+import { createQuery } from "metabase-lib/test-helpers";
+import { FilterColumnPicker } from "./FilterColumnPicker";
+
+interface SetupOpts {
+  query: Lib.Query;
+  stageIndex: number;
+}
+
+function setup({ query, stageIndex }: SetupOpts) {
+  setupFieldsValuesEndpoints(SAMPLE_DB_FIELD_VALUES);
+  renderWithProviders(
+    <FilterColumnPicker
+      query={query}
+      stageIndex={stageIndex}
+      checkItemIsSelected={() => false}
+      onColumnSelect={jest.fn()}
+      onSegmentSelect={jest.fn()}
+      onExpressionSelect={jest.fn()}
+    />,
+  );
+}
+
+describe("FilterModal", () => {
+  const query = createQuery();
+  const stageIndex = 0;
+  setup({ query, stageIndex });
+
+  test("The info icon should exist on each column", async () => {
+    screen.getAllByTestId("dimension-list-item").forEach(function (item) {
+      expect(within(item).getByLabelText("More info")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/querying/components/FilterPicker/types.ts
+++ b/frontend/src/metabase/querying/components/FilterPicker/types.ts
@@ -20,6 +20,8 @@ export interface PickerOperatorOption<Operator> {
 
 export type ColumnListItem = Lib.ColumnDisplayInfo & {
   column: Lib.ColumnMetadata;
+  query: Lib.Query;
+  stageIndex: number;
 };
 
 export type SegmentListItem = Lib.SegmentDisplayInfo & {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38845

### Description

Adds the info hovercard to the items in the filter popover.

### How to verify

1. New question → Sample Dataset → Orders
2. Click on "Add filters to narrow your answer"
3. Hover the items in the dropdown and make sure the info icon appears
4. Hover the info icons and make sure the correct hovercard appears

### Demo

<img width="709" alt="Screenshot 2024-02-16 at 13 03 01" src="https://github.com/metabase/metabase/assets/1250185/b4da6835-ec83-40bb-89df-f8530b9651e5">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
