### PR TITLE
adds /api/setup/token-check and add license-token to POST /api/setup

### DIFF
--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -127,10 +127,10 @@
          {invited_first_name :first_name,
           invited_last_name  :last_name,
           invited_email      :email}                    :invite
-          license-token                                 :license-token
+          license_token                                 :license_token
          {:keys [allow_tracking site_name site_locale]} :prefs} :body, :as request}]
   {token              SetupToken
-   license-token      [:maybe ms/NonBlankString]
+   license_token      [:maybe ms/NonBlankString]
    site_name          ms/NonBlankString
    site_locale        [:maybe ms/ValidLocale]
    first_name         [:maybe ms/NonBlankString]
@@ -160,7 +160,7 @@
                                                        {:email email, :first_name first_name})
                   (setup-set-settings!
                    request
-                   {:email email, :site-name site_name, :site-locale site_locale, :allow-tracking? allow_tracking, :license-token license-token})
+                   {:email email, :site-name site_name, :site-locale site_locale, :allow-tracking? allow_tracking, :license-token license_token})
                   (assoc user-info :database db)))
               (catch Throwable e
                 ;; if the transaction fails, restore the Settings cache from the DB again so any changes made in this

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -102,10 +102,12 @@
                                              (when schedules
                                                (sync.schedules/schedule-map->cron-strings schedules)))))))
 
-(defn- setup-set-settings! [_request {:keys [email site-name site-locale allow-tracking?]}]
+(defn- setup-set-settings! [_request {:keys [email site-name site-locale allow-tracking? license-token]}]
   ;; set a couple preferences
   (public-settings/site-name! site-name)
   (public-settings/admin-email! email)
+  (when (not (premium-features/premium-embedding-token))
+    (premium-features/premium-embedding-token! license-token))
   (when site-locale
     (public-settings/site-locale! site-locale))
   ;; default to `true` if allow_tracking isn't specified. The setting will set itself correctly whether a boolean or
@@ -125,8 +127,10 @@
          {invited_first_name :first_name,
           invited_last_name  :last_name,
           invited_email      :email}                    :invite
+          license-token                                 :license-token
          {:keys [allow_tracking site_name site_locale]} :prefs} :body, :as request}]
   {token              SetupToken
+   license-token      [:maybe ms/NonBlankString]
    site_name          ms/NonBlankString
    site_locale        [:maybe ms/ValidLocale]
    first_name         [:maybe ms/NonBlankString]
@@ -156,7 +160,7 @@
                                                        {:email email, :first_name first_name})
                   (setup-set-settings!
                    request
-                   {:email email, :site-name site_name, :site-locale site_locale, :allow-tracking? allow_tracking})
+                   {:email email, :site-name site_name, :site-locale site_locale, :allow-tracking? allow_tracking, :license-token license-token})
                   (assoc user-info :database db)))
               (catch Throwable e
                 ;; if the transaction fails, restore the Settings cache from the DB again so any changes made in this
@@ -347,5 +351,15 @@
     (api/check-404 config-token)
     (api/check-403 (= token config-token))
     (dissoc defaults :token)))
+
+(api/defendpoint GET "/token-check"
+  "Check if the token is valid, only available before the initial setup as it's an unauthenticated endpoint"
+  [token]
+  (if (setup/has-user-setup)
+    (throw (ex-info
+            (tru "This endpoint can only be used before the initial setup.")
+            {:status-code 403}))
+    (let [status (premium-features/fetch-token-status token)]
+      {:valid (:valid status)})))
 
 (api/define-routes)

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -111,7 +111,7 @@
                                                            :trial    false})]
         (let [license-token random-fake-token]
           (with-setup! {:license_token license-token}
-            (testing "Creating a new admin user should set the `admin-email` Setting"
+            (testing "Should set the premium-embedding-token"
               (is (= license-token (premium-features/premium-embedding-token))))))))))
 
 

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -29,6 +29,9 @@
 ;; if it attempts to delete this user and it is the only admin test user
 (use-fixtures :once (fixtures/initialize :test-users))
 
+(def random-fake-token
+  "d7ad0b5f9ddfd1953b1b427b75d620e4ba91d38e7bcbc09d8982480863dbc611")
+
 (defn- wait-for-result
   "Call thunk up to 10 times, until it returns a truthy value. Wait 50ms between tries. Useful for waiting for something
   asynchronous to happen."
@@ -106,7 +109,7 @@
                                                            :status   "fake"
                                                            :features ["test" "fixture"]
                                                            :trial    false})]
-        (let [license-token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"]
+        (let [license-token random-fake-token]
           (with-setup! {:license-token license-token}
             (testing "Creating a new admin user should set the `admin-email` Setting"
               (is (= license-token (premium-features/premium-embedding-token))))))))))
@@ -647,22 +650,13 @@
                                                              :features ["test" "fixture"]
                                                              :trial    false})]
           (is (= {:valid true}
-                 (client/client :get "setup/token-check?license-token=aaa"))))))
+                 (client/client :get (str "setup/token-check?license-token=" random-fake-token)))))))
     (testing "Check that returns {valid: false} for invalid token"
       (mt/with-temporary-setting-values [has-user-setup false]
-        (with-redefs [premium-features/fetch-token-status (fn [_x]
-                                                            {:valid    false
-                                                             :status   "fake"
-                                                             :features []
-                                                             :trial    false})]
+        (with-redefs [premium-features/fetch-token-status (fn [_x] {:valid false})]
           (is (= {:valid false}
-                 (client/client :get "setup/token-check?license-token=aaa")))))
+                 (client/client :get (str "setup/token-check?license-token=" random-fake-token))))))
       (testing "Check that returns {valid: false} for invalid token"
         (mt/with-temporary-setting-values [has-user-setup true]
-          (with-redefs [premium-features/fetch-token-status (fn [_x]
-                                                              {:valid    false
-                                                               :status   "fake"
-                                                               :features []
-                                                               :trial    false})]
             (is (= "This endpoint can only be used before the initial setup."
-                (client/client :get "setup/token-check?license-token=aaa")))))))))
+                (client/client :get (str "setup/token-check?license-token=" random-fake-token)))))))))

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -103,14 +103,14 @@
 
 (deftest set-license-token-test
   (testing "POST /api/setup"
-    (testing "Check that we accept a license-token in the ssetup endpoint"
+    (testing "Check that we accept a license_token in the setup endpoint"
        (with-redefs [premium-features/fetch-token-status (fn [_x]
                                                           {:valid    true
                                                            :status   "fake"
                                                            :features ["test" "fixture"]
                                                            :trial    false})]
         (let [license-token random-fake-token]
-          (with-setup! {:license-token license-token}
+          (with-setup! {:license_token license-token}
             (testing "Creating a new admin user should set the `admin-email` Setting"
               (is (= license-token (premium-features/premium-embedding-token))))))))))
 
@@ -650,13 +650,13 @@
                                                              :features ["test" "fixture"]
                                                              :trial    false})]
           (is (= {:valid true}
-                 (client/client :get (str "setup/token-check?license-token=" random-fake-token)))))))
+                 (client/client :get (str "setup/token-check?license_token=" random-fake-token)))))))
     (testing "Check that returns {valid: false} for invalid token"
       (mt/with-temporary-setting-values [has-user-setup false]
         (with-redefs [premium-features/fetch-token-status (fn [_x] {:valid false})]
           (is (= {:valid false}
-                 (client/client :get (str "setup/token-check?license-token=" random-fake-token))))))
+                 (client/client :get (str "setup/token-check?license_token=" random-fake-token))))))
       (testing "Check that returns {valid: false} for invalid token"
         (mt/with-temporary-setting-values [has-user-setup true]
             (is (= "This endpoint can only be used before the initial setup."
-                (client/client :get (str "setup/token-check?license-token=" random-fake-token)))))))))
+                (client/client :get (str "setup/token-check?license_token=" random-fake-token)))))))))

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -650,13 +650,13 @@
                                                              :features ["test" "fixture"]
                                                              :trial    false})]
           (is (= {:valid true}
-                 (client/client :get (str "setup/token-check?license_token=" random-fake-token)))))))
-    (testing "Check that returns {valid: false} for invalid token"
-      (mt/with-temporary-setting-values [has-user-setup false]
-        (with-redefs [premium-features/fetch-token-status (fn [_x] {:valid false})]
-          (is (= {:valid false}
-                 (client/client :get (str "setup/token-check?license_token=" random-fake-token))))))
-      (testing "Check that returns {valid: false} for invalid token"
-        (mt/with-temporary-setting-values [has-user-setup true]
+                 (client/client :get (str "setup/token-check?license_token=" random-fake-token)))))
+        (testing "Check that returns {valid: false} for invalid token"
+          (mt/with-temporary-setting-values [has-user-setup false]
+            (with-redefs [premium-features/fetch-token-status (fn [_x] {:valid false})]
+              (is (= {:valid false}
+                     (client/client :get (str "setup/token-check?license_token=" random-fake-token)))))))
+        (testing "Check that returns {valid: false} for invalid token"
+          (mt/with-temporary-setting-values [has-user-setup true]
             (is (= "This endpoint can only be used before the initial setup."
-                (client/client :get (str "setup/token-check?license_token=" random-fake-token)))))))))
+                   (client/client :get (str "setup/token-check?license_token=" random-fake-token))))))))))


### PR DESCRIPTION
### Description

Part of  [[Epic] Add license activation in the initial setup](https://github.com/metabase/metabase/issues/38867)

We're adding an _optional_ license activation step in the setup, only for people running EE code and without an already set license (so hosted people won't see it).

This PR adds a new endpoint `GET /api/setup/token-check` that checks if a token is valid.
This will be used to validate the input on the frontend. This endpoint won't work after the setup.

It also adds a field in `POST /api/setup` to accept the token and store it.

I tried to code it myself, but let me know if I'm too much off track and if this needs to be picked up by a BE team