### PR TITLE
Update release notes template

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -173,7 +173,8 @@
         "frontend/lint/**/*",
         "*.stories.*",
         "e2e/**/*",
-        "**/tests/*"
+        "**/tests/*",
+        "release/**/*"
       ],
       "rules": {
         "no-unconditional-metabase-links-render": "off",

--- a/release/src/release-notes.ts
+++ b/release/src/release-notes.ts
@@ -8,14 +8,6 @@ import {
 import type { ReleaseProps, Issue } from "./types";
 
 const releaseTemplate = `# NOTE: clean up 'Enhancements' and 'Bug fixes' sections and remove this line before publishing!
-**Enhancements**
-
-{{enhancements}}
-
-**Bug fixes**
-
-{{bug-fixes}}
-
 **Upgrading**
 
 You can download a .jar of the release, or get the latest on Docker. Make sure to back up your Metabase
@@ -31,6 +23,20 @@ SHA-256 checksum for the {{version}} JAR:
 \`\`\`
 {{checksum}}
 \`\`\`
+
+<details>
+<summary><h2>Changelog</h2></summary>
+
+**Enhancements**
+
+{{enhancements}}
+
+**Bug fixes**
+
+{{bug-fixes}}
+
+</details>
+
 `;
 
 const isBugIssue = (issue: Issue) =>


### PR DESCRIPTION

Closes https://github.com/metabase/metabase-private/issues/189

### Description

When we have a long changelog, it pushes download links off the `/releases` page so you have to click into a given release to see the download links.

- put download links first
- collapse all changes into a collapsible "changelog" section that keeps the release page tighter.

![Screen Shot 2024-02-16 at 8 44 37 AM](https://github.com/metabase/metabase/assets/30528226/5f674be5-579d-4a75-92f2-ecf83cb3383e)


