### PR TITLE
Add info popover to custom expression popover

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -6,6 +6,7 @@ import {
   filter,
   filterField,
   getNotebookStep,
+  hovercard,
   join,
   openNotebook,
   openOrdersTable,
@@ -236,30 +237,28 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     cy.contains("Showing 175 rows");
   });
 
-  // flaky test (#19454)
-  it.skip("should show an info popover for dimensions listened by the custom expression editor", () => {
+  it("should show an info popover for dimensions listened by the custom expression editor", () => {
     // start a custom question with orders
-    startNewQuestion();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Sample Database").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.contains("Orders").click();
+    openOrdersTable({ mode: "notebook" });
+    filter({ mode: "notebook" });
 
-    // type a dimension name
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Add filters to narrow your answer").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Custom Expression").click();
-    enterCustomColumnDetails({ formula: "Total" });
+    popover().contains("Custom Expression").click();
+
+    cy.findByTestId("expression-editor-textfield").within(() => {
+      cy.get(".ace_text-input").focus().type("[");
+    });
 
     // hover over option in the suggestion list
     cy.findByTestId("expression-suggestions-list")
-      .findByText("Total")
-      .trigger("mouseenter");
+      .findByText("Created At")
+      .parents("li")
+      .findByLabelText("More info")
+      .realHover();
 
-    // confirm that the popover is shown
-    popover().contains("The total billed amount.");
-    popover().contains("80.36");
+    hovercard().within(() => {
+      cy.contains("The date and time an order was submitted.");
+      cy.contains("Creation timestamp");
+    });
   });
 
   describe.skip("popover rendering issues (metabase#15502)", () => {

--- a/frontend/src/metabase-lib/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/expressions/suggest.ts
@@ -32,6 +32,7 @@ export type Suggestion = {
   icon: string | null | undefined;
   order: number;
   range?: [number, number];
+  column?: Lib.ColumnMetadata;
 };
 
 const suggestionText = (func: MBQLClauseFunctionConfig) => {
@@ -167,6 +168,7 @@ export function suggest({
             index: targetOffset,
             icon: getColumnIcon(column),
             order: 2,
+            column,
             ...column,
           };
         },

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -141,6 +141,7 @@ function ExpressionEditorSuggestionsListItem({
         isHighlighted={isHighlighted}
         className="hover-parent hover--inherit"
         data-ignore-outside-clicks
+        data-testid="expression-suggestions-list-item"
       >
         <Icon
           name={icon}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -3,14 +3,17 @@ import { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import _ from "underscore";
 import { color } from "metabase/lib/colors";
-import { Icon } from "metabase/ui";
+import { DelayGroup, Icon } from "metabase/ui";
 import { isObscured } from "metabase/lib/dom";
+import { HoverParent } from "metabase/components/MetadataInfo/ColumnInfoIcon";
 import {
   ExpressionListItem,
   ExpressionList,
   ExpressionPopover,
   SuggestionSpanContent,
   SuggestionSpanRoot,
+  SuggestionTitle,
+  QueryColumnInfoIcon,
 } from "./ExpressionEditorSuggestions.styled";
 
 const SuggestionSpan = ({ suggestion, isHighlighted }) => {
@@ -80,7 +83,8 @@ export default class ExpressionEditorSuggestions extends Component {
   });
 
   render() {
-    const { suggestions, highlightedIndex, target } = this.props;
+    const { query, stageIndex, suggestions, highlightedIndex, target } =
+      this.props;
 
     if (!suggestions.length || !target) {
       return null;
@@ -88,35 +92,41 @@ export default class ExpressionEditorSuggestions extends Component {
 
     return (
       /* data-ignore-outside-clicks is required until this expression editor is migrated to the mantine's Popover */
-      <ExpressionPopover
-        placement="bottom-start"
-        sizeToFit
-        visible
-        reference={target}
-        zIndex={300}
-        content={
-          <ExpressionList
-            data-testid="expression-suggestions-list"
-            className="pb1"
-            data-ignore-outside-clicks
-          >
-            {suggestions.map((suggestion, i) => (
-              <Fragment key={`$suggestion-${i}`}>
-                <ExpressionEditorSuggestionsListItem
-                  suggestion={suggestion}
-                  isHighlighted={i === highlightedIndex}
-                  onMouseDownCapture={this.createOnMouseDownHandler(i)}
-                />
-              </Fragment>
-            ))}
-          </ExpressionList>
-        }
-      />
+      <DelayGroup>
+        <ExpressionPopover
+          placement="bottom-start"
+          sizeToFit
+          visible
+          reference={target}
+          zIndex={300}
+          content={
+            <ExpressionList
+              data-testid="expression-suggestions-list"
+              className="pb1"
+              data-ignore-outside-clicks
+            >
+              {suggestions.map((suggestion, i) => (
+                <Fragment key={`$suggestion-${i}`}>
+                  <ExpressionEditorSuggestionsListItem
+                    query={query}
+                    stageIndex={stageIndex}
+                    suggestion={suggestion}
+                    isHighlighted={i === highlightedIndex}
+                    onMouseDownCapture={this.createOnMouseDownHandler(i)}
+                  />
+                </Fragment>
+              ))}
+            </ExpressionList>
+          }
+        />
+      </DelayGroup>
     );
   }
 }
 
 function ExpressionEditorSuggestionsListItem({
+  query,
+  stageIndex,
   suggestion,
   isHighlighted,
   onMouseDownCapture,
@@ -125,23 +135,33 @@ function ExpressionEditorSuggestionsListItem({
   const { normal, highlighted } = colorForIcon(icon);
 
   return (
-    <ExpressionListItem
-      onMouseDownCapture={onMouseDownCapture}
-      isHighlighted={isHighlighted}
-      className="hover-parent hover--inherit"
-      data-ignore-outside-clicks
-    >
-      <Icon
-        name={icon}
-        color={isHighlighted ? highlighted : normal}
-        className="mr1"
-        data-ignore-outside-clicks
-      />
-      <SuggestionSpan
-        suggestion={suggestion}
+    <HoverParent>
+      <ExpressionListItem
+        onMouseDownCapture={onMouseDownCapture}
         isHighlighted={isHighlighted}
+        className="hover-parent hover--inherit"
         data-ignore-outside-clicks
-      />
-    </ExpressionListItem>
+      >
+        <Icon
+          name={icon}
+          color={isHighlighted ? highlighted : normal}
+          className="mr1"
+          data-ignore-outside-clicks
+        />
+        <SuggestionTitle>
+          <SuggestionSpan
+            suggestion={suggestion}
+            isHighlighted={isHighlighted}
+            data-ignore-outside-clicks
+          />
+        </SuggestionTitle>
+        <QueryColumnInfoIcon
+          query={query}
+          stageIndex={stageIndex}
+          column={suggestion}
+          position="right"
+        />
+      </ExpressionListItem>
+    </HoverParent>
   );
 }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -49,6 +49,8 @@ function colorForIcon(icon) {
 }
 export default class ExpressionEditorSuggestions extends Component {
   static propTypes = {
+    query: PropTypes.object.isRequired,
+    stageIndex: PropTypes.number.isRequired,
     suggestions: PropTypes.array,
     onSuggestionMouseDown: PropTypes.func, // signature is f(index)
     highlightedIndex: PropTypes.number.isRequired,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -158,7 +158,7 @@ function ExpressionEditorSuggestionsListItem({
         <QueryColumnInfoIcon
           query={query}
           stageIndex={stageIndex}
-          column={suggestion}
+          column={suggestion.column}
           position="right"
         />
       </ExpressionListItem>

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { css } from "@emotion/react";
 import { alpha, color } from "metabase/lib/colors";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
+import { QueryColumnInfoIcon as BaseQueryColumnInfoIcon } from "metabase/components/MetadataInfo/ColumnInfoIcon";
 
 export const ExpressionPopover = styled(TippyPopover)`
   border-color: ${alpha("accent2", 0.2)};
@@ -16,7 +17,8 @@ export const ExpressionList = styled.ul`
 export const ExpressionListItem = styled.li<{ isHighlighted: boolean }>`
   display: flex;
   align-items: center;
-  padding: 0.3125rem 0.875rem;
+  padding: 0 0.875rem;
+  padding-right: 0.5rem;
   cursor: pointer;
 
   &:hover {
@@ -45,4 +47,14 @@ export const SuggestionSpanContent = styled.span<SuggestionSpanContentProps>`
     props.isHighlighted ? color("white") : color("text-dark")};
   font-weight: bold;
   background-color: ${props => props.isHighlighted && color("brand")};
+`;
+
+export const SuggestionTitle = styled.span`
+  margin-right: 1.5em;
+`;
+
+export const QueryColumnInfoIcon = styled(BaseQueryColumnInfoIcon)`
+  padding: 0;
+  margin-left: auto;
+  padding: 0.3125rem 0;
 `;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -1,0 +1,73 @@
+import { useRef } from "react";
+import { renderWithProviders, screen, within } from "__support__/ui";
+
+import { createMockMetadata } from "__support__/metadata";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { getColumnIcon } from "metabase/common/utils/columns";
+import type * as Lib from "metabase-lib";
+import { createQuery } from "metabase-lib/test-helpers";
+import type { Suggestion } from "metabase-lib/expressions/suggest";
+import { suggest } from "metabase-lib/expressions/suggest";
+
+import ExpressionEditorSuggestions from "./ExpressionEditorSuggestions";
+
+const METADATA = createMockMetadata({
+  databases: [createSampleDatabase()],
+});
+
+type WrapperProps = {
+  query: Lib.Query;
+  stageIndex: number;
+  suggestions?: Suggestion[];
+  highlightedIndex: number;
+  onSuggestionMouseDown: () => void;
+};
+
+function Wrapper(props: WrapperProps) {
+  const ref = useRef(null);
+  return (
+    <div ref={ref}>
+      <ExpressionEditorSuggestions {...props} target={ref.current} />
+    </div>
+  );
+}
+
+function setup() {
+  const query = createQuery({ metadata: METADATA });
+  const stageIndex = 0;
+  const { suggestions } = suggest({
+    source: "[",
+    query,
+    stageIndex,
+    metadata: METADATA,
+    startRule: "expression",
+    getColumnIcon,
+  });
+
+  const props = {
+    query,
+    stageIndex,
+    suggestions,
+    onSuggestionMouseDown: jest.fn(),
+    highlightedIndex: -1,
+  };
+
+  const { rerender } = renderWithProviders(<Wrapper {...props} />);
+
+  // force rerender to make sure the target prop has a value
+  rerender(<Wrapper {...props} />);
+}
+
+describe("ExpressionEditorSuggestions", () => {
+  test("suggestions items should show column info icon", async () => {
+    setup();
+    const items = await screen.findAllByTestId(
+      "expression-suggestions-list-item",
+    );
+
+    items.forEach(item => {
+      expect(within(item).getByLabelText("More info")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -555,7 +555,7 @@ class ExpressionEditorTextfield extends React.Component<
   ];
 
   render() {
-    const { helpTextTarget, width } = this.props;
+    const { helpTextTarget, width, query, stageIndex } = this.props;
     const {
       source,
       suggestions,
@@ -593,6 +593,8 @@ class ExpressionEditorTextfield extends React.Component<
             width="100%"
           />
           <ExpressionEditorSuggestions
+            query={query}
+            stageIndex={stageIndex}
             target={this.suggestionTarget.current}
             suggestions={suggestions}
             onSuggestionMouseDown={this.onSuggestionSelected}


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/38869

### Description

Adds the info popover to suggestion in the custom expression editor.

### How to verify
1. New question → Sample Dataset → Orders
2. Add filters to narrow your answer → Custom Expression
3. In the input type `[`, a popover list of suggestions should appear
4. Hover items in the suggestion popover, the info icon should appear.
5. Hover the info icons, the correct description should appear in the card

### Demo

<img width="624" alt="Screenshot 2024-02-16 at 17 58 26" src="https://github.com/metabase/metabase/assets/1250185/22b7bb18-0f13-407f-9bb9-00edd9e0e903">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
