### PR TITLE
Add new dashboard analytics events

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -530,68 +530,6 @@ describe("scenarios > dashboard", () => {
         getDashboardCards().eq(1).contains("bottom");
       },
     );
-
-    it("should allow the creator to change the dashboard width to 'fixed' or 'full'", () => {
-      const TAB_1 = {
-        id: 1,
-        name: "Tab 1",
-      };
-      const TAB_2 = {
-        id: 2,
-        name: "Tab 2",
-      };
-      const DASHBOARD_TEXT_FILTER = {
-        id: "94f9e513",
-        name: "Text filter",
-        slug: "filter-text",
-        type: "string/contains",
-      };
-
-      createDashboardWithTabs({
-        tabs: [TAB_1, TAB_2],
-        parameters: [{ ...DASHBOARD_TEXT_FILTER, default: "Example Input" }],
-        dashcards: [
-          createMockVirtualDashCard({
-            id: -1,
-            dashboard_tab_id: TAB_1.id,
-            size_x: GRID_WIDTH,
-            parameter_mappings: [
-              { parameter_id: "94f9e513", target: ["text-tag", "Name"] },
-            ],
-            card: createMockVirtualCard({ display: "text" }),
-            visualization_settings: {
-              text: "Top: {{Name}}",
-            },
-          }),
-          createMockVirtualDashCard({
-            id: -2,
-            size_x: GRID_WIDTH,
-            dashboard_tab_id: TAB_1.id,
-            card: createMockVirtualCard({ display: "text" }),
-            visualization_settings: {
-              text: "Bottom",
-            },
-          }),
-        ],
-      }).then(dashboard => visitDashboard(dashboard.id));
-
-      // new dashboards should default to 'fixed' width
-      assertDashboardFixedWidth();
-
-      editDashboard();
-
-      // toggle full-width
-      cy.findByLabelText("Toggle width").click();
-      popover().findByText("Full width").click();
-
-      assertDashboardFullWidth();
-
-      // confirm it saves the state after saving and refreshing
-      saveDashboard();
-      cy.reload();
-
-      assertDashboardFullWidth();
-    });
   });
 
   it("should add a filter", () => {
@@ -1111,6 +1049,79 @@ describeWithSnowplow("scenarios > dashboard", () => {
         },
         2,
       );
+    });
+  });
+
+  it("should allow the creator to change the dashboard width to 'fixed' or 'full'", () => {
+    const TAB_1 = {
+      id: 1,
+      name: "Tab 1",
+    };
+    const TAB_2 = {
+      id: 2,
+      name: "Tab 2",
+    };
+    const DASHBOARD_TEXT_FILTER = {
+      id: "94f9e513",
+      name: "Text filter",
+      slug: "filter-text",
+      type: "string/contains",
+    };
+
+    createDashboardWithTabs({
+      tabs: [TAB_1, TAB_2],
+      parameters: [{ ...DASHBOARD_TEXT_FILTER, default: "Example Input" }],
+      dashcards: [
+        createMockVirtualDashCard({
+          id: -1,
+          dashboard_tab_id: TAB_1.id,
+          size_x: GRID_WIDTH,
+          parameter_mappings: [
+            { parameter_id: "94f9e513", target: ["text-tag", "Name"] },
+          ],
+          card: createMockVirtualCard({ display: "text" }),
+          visualization_settings: {
+            text: "Top: {{Name}}",
+          },
+        }),
+        createMockVirtualDashCard({
+          id: -2,
+          size_x: GRID_WIDTH,
+          dashboard_tab_id: TAB_1.id,
+          card: createMockVirtualCard({ display: "text" }),
+          visualization_settings: {
+            text: "Bottom",
+          },
+        }),
+      ],
+    }).then(dashboard => visitDashboard(dashboard.id));
+
+    // new dashboards should default to 'fixed' width
+    assertDashboardFixedWidth();
+
+    // toggle full-width
+    editDashboard();
+    cy.findByLabelText("Toggle width").click();
+    popover().findByText("Full width").click();
+    assertDashboardFullWidth();
+    expectGoodSnowplowEvent({
+      event: "dashboard_width_toggled",
+      full_width: true,
+    });
+
+    // confirm it saves the state after saving and refreshing
+    saveDashboard();
+    cy.reload();
+    assertDashboardFullWidth();
+
+    // toggle back to fixed
+    editDashboard();
+    cy.findByLabelText("Toggle width").click();
+    popover().findByText("Full width").click();
+    assertDashboardFixedWidth();
+    expectGoodSnowplowEvent({
+      event: "dashboard_width_toggled",
+      full_width: false,
     });
   });
 });

--- a/frontend/src/metabase/dashboard/actions/cards-typed.ts
+++ b/frontend/src/metabase/dashboard/actions/cards-typed.ts
@@ -19,7 +19,11 @@ import {
 } from "metabase/lib/dashboard_grid";
 
 import type { SectionLayout } from "../sections";
-import { trackCardCreated, trackQuestionReplaced } from "../analytics";
+import {
+  trackCardCreated,
+  trackQuestionReplaced,
+  trackSectionAdded,
+} from "../analytics";
 import { getDashCardById, getDashboardId } from "../selectors";
 import {
   createDashCard,
@@ -129,6 +133,7 @@ export const addSectionToDashboard =
       );
 
     dispatch(_addManyDashCards(sectionDashcards));
+    trackSectionAdded(dashId, sectionLayout.id);
   };
 
 type AddCardToDashboardOpts = NewDashCardOpts & {

--- a/frontend/src/metabase/dashboard/actions/ui.ts
+++ b/frontend/src/metabase/dashboard/actions/ui.ts
@@ -6,6 +6,7 @@ import type {
   Dispatch,
   GetState,
 } from "metabase-types/store";
+import { trackDashboardWidthChange } from "../analytics";
 import { getDashboardId, getSidebar } from "../selectors";
 import { closeAutoApplyFiltersToast } from "./parameters";
 import { setDashboardAttributes } from "./core";
@@ -13,7 +14,10 @@ import { setDashboardAttributes } from "./core";
 export const setDashboardWidth =
   (width: DashboardWidth) => (dispatch: Dispatch, getState: GetState) => {
     const id = getDashboardId(getState());
-    dispatch(setDashboardAttributes({ id, attributes: { width } }));
+    if (id) {
+      dispatch(setDashboardAttributes({ id, attributes: { width } }));
+      trackDashboardWidthChange(id, width);
+    }
   };
 
 export const SET_SIDEBAR = "metabase/dashboard/SET_SIDEBAR";

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -1,5 +1,5 @@
 import { trackSchemaEvent } from "metabase/lib/analytics";
-import type { DashboardId } from "metabase-types/api";
+import type { DashboardId, DashboardWidth } from "metabase-types/api";
 
 const DASHBOARD_SCHEMA_VERSION = "1-1-3";
 
@@ -14,6 +14,17 @@ export const trackExportDashboardToPDF = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
     event: "dashboard_pdf_exported",
     dashboard_id: dashboardId,
+  });
+};
+
+export const trackDashboardWidthChange = (
+  dashboardId: DashboardId,
+  width: DashboardWidth,
+) => {
+  trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
+    event: "dashboard_width_toggled",
+    dashboard_id: dashboardId,
+    full_width: width === "full",
   });
 };
 

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -1,5 +1,6 @@
 import { trackSchemaEvent } from "metabase/lib/analytics";
 import type { DashboardId, DashboardWidth } from "metabase-types/api";
+import type { SectionId } from "./sections";
 
 const DASHBOARD_SCHEMA_VERSION = "1-1-3";
 
@@ -40,6 +41,17 @@ export const trackCardCreated = (
   trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
     event: `new_${type}_card_created`,
     dashboard_id,
+  });
+};
+
+export const trackSectionAdded = (
+  dashboardId: DashboardId,
+  sectionId: SectionId,
+) => {
+  trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
+    event: "dashboard_section_added",
+    dashboard_id: dashboardId,
+    section_layout: sectionId,
   });
 };
 

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -2,7 +2,7 @@ import { trackSchemaEvent } from "metabase/lib/analytics";
 import type { DashboardId, DashboardWidth } from "metabase-types/api";
 import type { SectionId } from "./sections";
 
-const DASHBOARD_SCHEMA_VERSION = "1-1-3";
+const DASHBOARD_SCHEMA_VERSION = "1-1-4";
 
 export const trackAutoApplyFiltersDisabled = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {

--- a/frontend/src/metabase/dashboard/sections.ts
+++ b/frontend/src/metabase/dashboard/sections.ts
@@ -18,8 +18,14 @@ type SectionDashboardCardAttrs = Partial<VirtualDashboardCard> &
 
 type LayoutFn = (position: Position) => Array<SectionDashboardCardAttrs>;
 
+// Note: these values are used in analytics and should not be changed
+export type SectionId =
+  | "kpi_grid"
+  | "large_chart_kpi_right"
+  | "kpi_chart_below";
+
 export type SectionLayout = {
-  id: string;
+  id: SectionId;
   label: string;
   getLayout: LayoutFn;
 };
@@ -190,17 +196,17 @@ const getKpiLargeChartBelowLayout: LayoutFn = position => {
 
 export const layoutOptions: SectionLayout[] = [
   {
-    id: "kpi-grid",
+    id: "kpi_grid",
     label: t`KPI grid`,
     getLayout: getKpiGridLayout,
   },
   {
-    id: "lg-chart-kpi-col",
+    id: "large_chart_kpi_right",
     label: t`Large chart w/ KPIs to the right`,
     getLayout: getLargeChartKpiColLayout,
   },
   {
-    id: "kpi-lg-chart-below",
+    id: "kpi_chart_below",
     label: t`KPIs w/ large chart below`,
     getLayout: getKpiLargeChartBelowLayout,
   },

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-4
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-4
@@ -1,0 +1,100 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Dashboard events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "dashboard",
+    "format": "jsonschema",
+    "version": "1-1-4"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "dashboard_created",
+        "dashboard_saved",
+        "question_added_to_dashboard",
+        "auto_apply_filters_disabled",
+        "dashboard_tab_created",
+        "dashboard_tab_deleted",
+        "dashboard_tab_duplicated",
+        "new_text_card_created",
+        "new_heading_card_created",
+        "new_link_card_created",
+        "new_action_card_created",
+        "card_set_to_hide_when_no_results",
+        "dashboard_pdf_exported",
+        "card_moved_to_tab",
+        "dashboard_card_duplicated",
+        "dashboard_card_replaced",
+        "dashboard_section_added",
+        "dashboard_width_toggled"
+      ],
+      "maxLength": 1024
+    },
+    "dashboard_id": {
+      "description": "Unique identifier for a dashboard within the Metabase instance",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "question_id": {
+      "description": "Unique identifier for a question added to a dashboard",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "num_tabs": {
+      "description": "Number of tabs affected after the event",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "total_num_tabs": {
+      "description": "Total number of active tabs after the events",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "duration_milliseconds": {
+      "description": "Duration the action took to complete in milliseconds",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "section_layout": {
+      "description": "String describing the layout that was selected from the pre-built options",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "full_width": {
+      "description": "Boolean set to True if the dashboard was toggled to full width and False if full width was disabled.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "event",
+    "dashboard_id"
+  ],
+  "additionalProperties": true
+}

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -32,7 +32,7 @@
   {::account              "1-0-1"
    ::invite               "1-0-1"
    ::csvupload            "1-0-0"
-   ::dashboard            "1-1-3"
+   ::dashboard            "1-1-4"
    ::database             "1-0-1"
    ::instance             "1-1-2"
    ::metabot              "1-0-1"


### PR DESCRIPTION
Adds two dashboard analytics events:

- `dashboard_width_toggled` (epic #38446)
- `dashboard_section_added` (followup on https://github.com/metabase/metabase/issues/38209)

Both events need new snowplow parameters (boolean `full_width` and string `section_layout`), so the PR adds a `1-1-4` snowplow schema file