### PR TITLE
Sidebar loading state regression fix

### DIFF
--- a/e2e/test/scenarios/navigation/navbar.cy.spec.js
+++ b/e2e/test/scenarios/navigation/navbar.cy.spec.js
@@ -20,6 +20,12 @@ describe("scenarios > navigation > navbar", () => {
       navigationSidebar().should("be.visible");
     });
 
+    it("should display error ui when data fetching fails", () => {
+      cy.intercept("GET", "/api/database", req => req.reply(500));
+      cy.visit("/");
+      navigationSidebar().findByText(/An error occurred/);
+    });
+
     it("state should preserve when clicking the mb logo", () => {
       cy.visit("/collection/root");
       navigationSidebar().should("be.visible");

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbar.styled.tsx
@@ -118,14 +118,14 @@ export const CollectionMenuList = styled.ul`
   padding: 0.5rem;
 `;
 
-export const LoadingContainer = styled.div`
+export const LoadingAndErrorContainer = styled.div`
   display: flex;
   flex: 1;
   align-items: center;
   justify-content: center;
 `;
 
-export const LoadingContent = styled.div`
+export const LoadingAndErrorContent = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -133,7 +133,7 @@ export const LoadingContent = styled.div`
   text-align: center;
 `;
 
-export const LoadingTitle = styled.h2`
+export const LoadingAndErrorTitle = styled.h2`
   color: ${color("text-light")};
   font-weight: 400;
   margin-top: ${space(1)};

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/MainNavbarContainer.tsx
@@ -30,7 +30,8 @@ import {
 import type Database from "metabase-lib/metadata/Database";
 
 import type { MainNavbarProps, SelectedItem } from "../types";
-import NavbarLoadingView from "../NavbarLoadingView";
+import { NavbarLoadingView } from "../NavbarLoadingView";
+import { NavbarErrorView } from "../NavbarErrorView";
 
 import MainNavbarView from "./MainNavbarView";
 
@@ -60,7 +61,8 @@ interface Props extends MainNavbarProps {
   rootCollection: Collection;
   hasDataAccess: boolean;
   hasOwnDatabase: boolean;
-  allLoading: boolean;
+  allError: boolean;
+  allFetched: boolean;
   logout: () => void;
   onReorderBookmarks: (bookmarks: Bookmark[]) => void;
   onChangeLocation: (location: LocationDescriptor) => void;
@@ -80,7 +82,8 @@ function MainNavbarContainer({
   collections = [],
   rootCollection,
   hasDataAccess,
-  allLoading,
+  allError,
+  allFetched,
   location,
   params,
   openNavbar,
@@ -153,7 +156,11 @@ function MainNavbarContainer({
     return null;
   }, [modal, closeModal, onChangeLocation]);
 
-  if (allLoading) {
+  if (allError) {
+    return <NavbarErrorView />;
+  }
+
+  if (!allFetched) {
     return <NavbarLoadingView />;
   }
 

--- a/frontend/src/metabase/nav/containers/MainNavbar/NavbarErrorView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/NavbarErrorView.tsx
@@ -1,17 +1,22 @@
 import { t } from "ttag";
-import { Icon } from "metabase/ui";
+import { Icon, Text } from "metabase/ui";
+import { color } from "metabase/lib/colors";
 import {
   LoadingAndErrorContainer,
   LoadingAndErrorContent,
-  LoadingAndErrorTitle,
 } from "./MainNavbar.styled";
 
 export function NavbarErrorView() {
   return (
     <LoadingAndErrorContainer>
       <LoadingAndErrorContent>
-        <Icon name="warning" size={32} />
-        <LoadingAndErrorTitle>{t`An error occurred`}</LoadingAndErrorTitle>
+        <Icon name="warning" size={24} />
+        <Text
+          fw={400}
+          mt="0.5rem"
+          color={color("text-light")}
+          size="lg"
+        >{t`An error occurred`}</Text>
       </LoadingAndErrorContent>
     </LoadingAndErrorContainer>
   );

--- a/frontend/src/metabase/nav/containers/MainNavbar/NavbarErrorView.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/NavbarErrorView.tsx
@@ -1,17 +1,17 @@
 import { t } from "ttag";
-import LoadingSpinner from "metabase/components/LoadingSpinner";
+import { Icon } from "metabase/ui";
 import {
   LoadingAndErrorContainer,
   LoadingAndErrorContent,
   LoadingAndErrorTitle,
 } from "./MainNavbar.styled";
 
-export function NavbarLoadingView() {
+export function NavbarErrorView() {
   return (
     <LoadingAndErrorContainer>
       <LoadingAndErrorContent>
-        <LoadingSpinner />
-        <LoadingAndErrorTitle>{t`Loading…`}</LoadingAndErrorTitle>
+        <Icon name="warning" size={32} />
+        <LoadingAndErrorTitle>{t`An error occurred`}</LoadingAndErrorTitle>
       </LoadingAndErrorContent>
     </LoadingAndErrorContainer>
   );


### PR DESCRIPTION
### Description

Needs design approval.

I introduced a regression in #38582 due to misunderstanding loading state for entities could become true whenever that entity's data is being revalidated from somewhere else in the UI. This results in a subpar experience that looks like this (focus on sidebar reloading from csv uploads and bookmarking):

https://github.com/metabase/metabase/assets/7104357/e12a8f39-d59f-42aa-8ea6-5976662f95d3

As part of this PR, when an error occurs I no longer try to render what we can with what valid data we have, but instead just display an error if any error occurs. Ideally in the future we can have separate state for loading / revalidating for entities, but for now this produces a much better user experience:

https://github.com/metabase/metabase/assets/7104357/5a15400e-32f3-4de2-af65-a5599cdaced8

In the case of an errors (say some 500 HTTP error occurs when fetching databases), we will now render this:
<img width="1491" alt="failure-to-load-database-endpoint" src="https://github.com/metabase/metabase/assets/7104357/c03f6f4b-0a9b-4822-9a29-d72ee94785c9">

### How to verify

1. Open browser devtools's network tab
2. Go to home page
3. Search for "database" in network requests
4. Right click the entry and select "Block request URL"
5. Refresh the page, you should see the error UI

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
