### PR TITLE
Migrate search API to DataPermissions

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -5,11 +5,9 @@
    [metabase.driver :as driver]
    [metabase.models
     :refer [Dashboard DashboardCard Database Field FieldValues Table]]
-   [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.database :as database]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
-   [metabase.permissions.test-util :as perms.test-util]
    [metabase.sync.concurrent :as sync.concurrent]
    [metabase.test :as mt]
    [metabase.test.data.sql :as sql.tx]
@@ -20,26 +18,6 @@
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (use-fixtures :once (fixtures/initialize :db :test-users))
-
-;; TODO: change this namespace to use the version in metabase.test
-(defn- do-with-all-user-data-perms!
-  "Implementation for [[with-all-users-data-perms]]"
-  [graph f]
-  (let [all-users-group-id  (u/the-id (perms-group/all-users))]
-    (mt/with-additional-premium-features #{:advanced-permissions}
-      (perms.test-util/with-no-data-perms-for-all-users!
-        (perms.test-util/with-restored-perms!
-          (perms.test-util/with-restored-data-perms!
-            (@#'perms/update-group-permissions! all-users-group-id graph)
-            (data-perms.graph/update-data-perms-graph! {all-users-group-id graph})
-            (f)))))))
-
-(defmacro ^:private with-all-users-data-perms!
-  "Runs `body` with perms for the All Users group temporarily set to the values in `graph`. Also enables the advanced
-  permissions feature flag, and clears the (5 second TTL) cache used for Field permissions, for convenience."
-  {:style/indent 1}
-  [graph & body]
-  `(do-with-all-user-data-perms! ~graph (fn [] ~@body)))
 
 (deftest current-user-test
   (testing "GET /api/user/current returns additional fields if advanced-permissions is enabled"
@@ -67,16 +45,16 @@
 
         (testing "can_access_data_model is true if a user has any data model perms"
           (let [[id-1 id-2 id-3 id-4] (map u/the-id (database/tables (mt/db)))]
-            (with-all-users-data-perms! {(mt/id) {:data       {:schemas :all :native :write}
-                                                  :data-model {:schemas {"PUBLIC" {id-1 :all
-                                                                                   id-2 :none
-                                                                                   id-3 :none
-                                                                                   id-4 :none}}}}}
+            (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :all :native :write}
+                                                           :data-model {:schemas {"PUBLIC" {id-1 :all
+                                                                                            id-2 :none
+                                                                                            id-3 :none
+                                                                                            id-4 :none}}}}}
               (is (partial= {:can_access_data_model true}
                             (user-permissions :rasta))))))
 
         (testing "can_access_db_details is true if a user has any details perms"
-          (with-all-users-data-perms! {(mt/id) {:details :yes}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:details :yes}}
             (is (partial= {:can_access_db_details true}
                           (user-permissions :rasta)))))))))
 
@@ -93,22 +71,22 @@
                           (filter (fn [db] (= (mt/id) (:id db))))
                           first)))]
       (testing "Sanity check: a non-admin can fetch a DB when they have full data access and data model perms"
-        (with-all-users-data-perms! {(mt/id) {:data       {:schemas :all :native :write}
-                                              :data-model {:schemas :all}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :all :native :write}
+                                                       :data-model {:schemas :all}}}
           (is (partial= {:id (mt/id)} (get-test-db)))))
 
       (testing "A non-admin cannot fetch a DB for which they do not have data model perms if
                include_editable_data_model=true"
-        (with-all-users-data-perms! {(mt/id) {:data       {:schemas :all :native :write}
-                                              :data-model {:schemas :none}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :all :native :write}
+                                                       :data-model {:schemas :none}}}
           (is (= nil (get-test-db)))))
 
       (let [[id-1 id-2 id-3 id-4] (map u/the-id (database/tables (mt/db)))]
-        (with-all-users-data-perms! {(mt/id) {:data       {:schemas :all :native :write}
-                                              :data-model {:schemas {"PUBLIC" {id-1 :all
-                                                                               id-2 :none
-                                                                               id-3 :none
-                                                                               id-4 :none}}}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :all :native :write}
+                                                       :data-model {:schemas {"PUBLIC" {id-1 :all
+                                                                                        id-2 :none
+                                                                                        id-3 :none
+                                                                                        id-4 :none}}}}}
           (testing "If a non-admin has data model perms for a single table in a DB, the DB is returned when listing
                    all DBs"
             (is (partial= {:id (mt/id)} (get-test-db))))
@@ -127,33 +105,33 @@
                             (filter (fn [db] (= (mt/id) (:id db))))
                             first)))]
         (testing "Sanity check: a non-admin can fetch a DB when they have 'manage' access"
-          (with-all-users-data-perms! {(mt/id) {:details :yes}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:details :yes}}
             (is (partial= {:id (mt/id)} (get-test-db)))))
 
         (testing "A non-admin cannot fetch a DB for which they do not not have 'manage' access"
-          (with-all-users-data-perms! {(mt/id) {:details :no}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:details :no}}
             (is (= nil (get-test-db)))))))))
 
 (deftest fetch-database-test
   (testing "GET /api/database/:id?include_editable_data_model=true"
     (testing "A non-admin without data model perms for a DB cannot fetch the DB when include_editable_data_model=true"
-      (with-all-users-data-perms! {(mt/id) {:data       {:native :write :schemas :all}
-                                            :data-model {:schemas :none}}}
+      (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:native :write :schemas :all}
+                                                     :data-model {:schemas :none}}}
         (mt/user-http-request :rasta :get 403 (format "database/%d?include_editable_data_model=true" (mt/id)))))
 
     (testing "A non-admin with only data model perms for a DB can fetch the DB when include_editable_data_model=true"
-      (with-all-users-data-perms! {(mt/id) {:data       {:native :none :schemas :none}
-                                            :data-model {:schemas :all}}}
+      (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:native :none :schemas :none}
+                                                     :data-model {:schemas :all}}}
         (mt/user-http-request :rasta :get 200 (format "database/%d?include_editable_data_model=true" (mt/id)))))))
 
 (deftest fetch-database-metadata-test
   (testing "GET /api/database/:id/metadata?include_editable_data_model=true"
     (let [[id-1 id-2 id-3 id-4] (map u/the-id (database/tables (mt/db)))]
-      (with-all-users-data-perms! {(mt/id) {:data       {:schemas :all :native :write}
-                                            :data-model {:schemas {"PUBLIC" {id-1 :all
-                                                                             id-2 :none
-                                                                             id-3 :none
-                                                                             id-4 :none}}}}}
+      (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :all :native :write}
+                                                     :data-model {:schemas {"PUBLIC" {id-1 :all
+                                                                                      id-2 :none
+                                                                                      id-3 :none
+                                                                                      id-4 :none}}}}}
         (let [tables (->> (mt/user-http-request :rasta
                                                 :get
                                                 200
@@ -163,11 +141,11 @@
 
     (testing "A user with data model perms can still fetch a DB name and tables if they have block perms for a DB"
       (let [[id-1 id-2 id-3 id-4] (map u/the-id (database/tables (mt/db)))]
-        (with-all-users-data-perms! {(mt/id) {:data       {:schemas :block :native :none}
-                                              :data-model {:schemas {"PUBLIC" {id-1 :all
-                                                                               id-2 :none
-                                                                               id-3 :none
-                                                                               id-4 :none}}}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :block :native :none}
+                                                       :data-model {:schemas {"PUBLIC" {id-1 :all
+                                                                                        id-2 :none
+                                                                                        id-3 :none
+                                                                                        id-4 :none}}}}}
           (let [result (mt/user-http-request :rasta
                                              :get
                                              200
@@ -178,13 +156,13 @@
 (deftest fetch-id-fields-test
   (testing "GET /api/database/:id/idfields?include_editable_data_model=true"
     (testing "A non-admin without data model perms for a DB cannot fetch id fields when include_editable_data_model=true"
-      (with-all-users-data-perms! {(mt/id) {:data       {:native :write :schemas :all}
-                                            :data-model {:schemas :none}}}
+      (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:native :write :schemas :all}
+                                                     :data-model {:schemas :none}}}
         (mt/user-http-request :rasta :get 403 (format "database/%d/idfields?include_editable_data_model=true" (mt/id)))))
 
     (testing "A non-admin with only data model perms for a DB can fetch id fields when include_editable_data_model=true"
-      (with-all-users-data-perms! {(mt/id) {:data       {:native :none :schemas :none}
-                                            :data-model {:schemas :all}}}
+      (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:native :none :schemas :none}
+                                                     :data-model {:schemas :all}}}
         (mt/user-http-request :rasta :get 200 (format "database/%d/idfields?include_editable_data_model=true" (mt/id)))))))
 
 (deftest get-schema-with-advanced-perms-test
@@ -194,8 +172,8 @@
                    Table    _t2         {:db_id db-id :schema "schema2"}
                    Table    t3          {:db_id db-id :schema "schema1" :name "t3"}]
       (testing "If a non-admin has data model perms, but no data perms"
-        (with-all-users-data-perms! {db-id {:data       {:schemas :block :native :none}
-                                            :data-model {:schemas :all}}}
+        (mt/with-all-users-data-perms-graph! {db-id {:data       {:schemas :block :native :none}
+                                                     :data-model {:schemas :all}}}
           (testing "and if data permissions are revoked, it should be a 403"
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :rasta :get 403 (format "database/%d/schema/%s" db-id "schema1")))))
@@ -206,17 +184,17 @@
 
       (testing "If include_editable_data_model=true and a non-admin does not have data model perms, it should respond
                 with a 404"
-        (with-all-users-data-perms! {db-id {:data       {:schemas :block :native :none}
-                                            :data-model {:schemas :none}}}
+        (mt/with-all-users-data-perms-graph! {db-id {:data       {:schemas :block :native :none}
+                                                     :data-model {:schemas :none}}}
           (is (= "Not found."
                  (mt/user-http-request :rasta :get 404 (format "database/%d/schema/%s" db-id "schema1")
                                        :include_editable_data_model true)))))
 
       (testing "If include_editable_data_model=true and a non-admin has data model perms for a single table in a schema,
                 the table is returned"
-        (with-all-users-data-perms! {db-id {:data       {:schemas :block :native :none}
-                                            :data-model {:schemas {"schema1" {(u/the-id t1) :all
-                                                                              (u/the-id t3) :none}}}}}
+        (mt/with-all-users-data-perms-graph! {db-id {:data       {:schemas :block :native :none}
+                                                     :data-model {:schemas {"schema1" {(u/the-id t1) :all
+                                                                                       (u/the-id t3) :none}}}}}
           (is (= ["t1"]
                  (map :name (mt/user-http-request :rasta :get 200 (format "database/%d/schema/%s" db-id "schema1")
                                                   :include_editable_data_model true)))))))))
@@ -227,8 +205,8 @@
                    Table    t1 {:db_id db-id :schema nil :name "t1"}
                    Table    _t2 {:db_id db-id :schema "public"}
                    Table    t3 {:db_id db-id :schema "" :name "t3"}]
-      (with-all-users-data-perms! {db-id {:data       {:schemas :block :native :none}
-                                          :data-model {:schemas :all}}}
+      (mt/with-all-users-data-perms-graph! {db-id {:data       {:schemas :block :native :none}
+                                                   :data-model {:schemas :all}}}
         (testing "If data permissions are revoked, it should be a 403"
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :get 403 (format "database/%d/schema/" db-id)))))
@@ -240,17 +218,17 @@
 
       (testing "If include_editable_data_model=true and a non-admin does not have data model perms, it should respond
                 with a 404"
-        (with-all-users-data-perms! {db-id {:data       {:schemas :block :native :none}
-                                            :data-model {:schemas :none}}}
+        (mt/with-all-users-data-perms-graph! {db-id {:data       {:schemas :block :native :none}
+                                                     :data-model {:schemas :none}}}
           (is (= "Not found."
                  (mt/user-http-request :rasta :get 404 (format "database/%d/schema/" db-id)
                                        :include_editable_data_model true)))))
 
       (testing "If include_editable_data_model=true and a non-admin has data model perms for a single table in an empty
                 string schema, it should return the table"
-        (with-all-users-data-perms! {db-id {:data       {:schemas :block :native :none}
-                                            :data-model {:schemas {"" {(u/the-id t1) :all
-                                                                       (u/the-id t3) :none}}}}}
+        (mt/with-all-users-data-perms-graph! {db-id {:data       {:schemas :block :native :none}
+                                                     :data-model {:schemas {"" {(u/the-id t1) :all
+                                                                                (u/the-id t3) :none}}}}}
           (is (= ["t1"]
                  (map :name (mt/user-http-request :rasta :get 200 (format "database/%d/schema/" db-id)
                                                   :include_editable_data_model true)))))))))
@@ -262,8 +240,8 @@
                    Table    _t2 {:db_id db-id, :schema "schema2"}
                    Table    _t3 {:db_id db-id, :schema "schema1", :name "t3"}]
       (testing "If a non-admin has data model perms, but no data perms"
-        (with-all-users-data-perms! {db-id {:data       {:schemas :block :native :none}
-                                            :data-model {:schemas :all}}}
+        (mt/with-all-users-data-perms-graph! {db-id {:data       {:schemas :block :native :none}
+                                                     :data-model {:schemas :all}}}
           (testing "if include_editable_data_model=nil, it should be a 403"
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :rasta :get 403 (format "database/%d/schemas" db-id)))))
@@ -276,22 +254,22 @@
                    (mt/user-http-request :rasta :get 404 (format "database/%d/schemas" Integer/MAX_VALUE)
                                          :include_editable_data_model true))))))
       (testing "If include_editable_data_model=true and a non-admin does not have data model perms, it should return []"
-        (with-all-users-data-perms! {db-id {:data       {:schemas :block :native :none}
-                                            :data-model {:schemas :none}}}
+        (mt/with-all-users-data-perms-graph! {db-id {:data       {:schemas :block :native :none}
+                                                     :data-model {:schemas :none}}}
           (is (= []
                  (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
                                        :include_editable_data_model true)))))
       (testing "If include_editable_data_model=true and a non-admin has data model perms for a schema,
                   it should return the schema"
-        (with-all-users-data-perms! {db-id {:data       {:schemas :block :native :none}
-                                            :data-model {:schemas {"schema1" :all}}}}
+        (mt/with-all-users-data-perms-graph! {db-id {:data       {:schemas :block :native :none}
+                                                     :data-model {:schemas {"schema1" :all}}}}
           (is (= ["schema1"]
                  (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
                                        :include_editable_data_model true)))))
       (testing "If include_editable_data_model=true and a non-admin has data model perms for a single table in a schema,
                   it should return the schema"
-        (with-all-users-data-perms! {db-id {:data       {:schemas :block :native :none}
-                                            :data-model {:schemas {"schema1" {(u/the-id t1) :all}}}}}
+        (mt/with-all-users-data-perms-graph! {db-id {:data       {:schemas :block :native :none}
+                                                     :data-model {:schemas {"schema1" {(u/the-id t1) :all}}}}}
           (is (= ["schema1"]
                  (mt/user-http-request :rasta :get 200 (format "database/%d/schemas" db-id)
                                        :include_editable_data_model true))))))))
@@ -311,20 +289,20 @@
             get-field       (fn []
                               (mt/user-http-request :rasta :get 200 (format "field/%d?include_editable_data_model=true" (:id field))))]
         (testing "target should be hydrated if a non-admin has data model perms for the DB"
-          (with-all-users-data-perms! {db-id {:data-model {:schemas :all}}}
+          (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas :all}}}
             (is (= expected-target
                    (:target (get-field))))))
         (testing "target should not be hydrated if a non-admin does not have data model perms for the target's schema"
-          (with-all-users-data-perms! {db-id {:data-model {:schemas {"schema1" :none
-                                                                     "schema2" :all}}}}
+          (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {"schema1" :none
+                                                                              "schema2" :all}}}}
             (is (nil? (:target (get-field))))))
         (testing "target should not be hydrated if a non-admin does not have data model perms for the target's table"
-          (with-all-users-data-perms! {db-id {:data-model {:schemas {"schema1" {(:id table1) :none}
-                                                                     "schema2" {(:id table2) :all}}}}}
+          (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {"schema1" {(:id table1) :none}
+                                                                              "schema2" {(:id table2) :all}}}}}
             (is (nil? (:target (get-field))))))
         (testing "target should be hydrated if a non-admin does have data model perms for the target's table"
-          (with-all-users-data-perms! {db-id {:data-model {:schemas {"schema1" {(:id table1) :all}
-                                                                     "schema2" {(:id table2) :all}}}}}
+          (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {"schema1" {(:id table1) :all}
+                                                                              "schema2" {(:id table2) :all}}}}}
             (is (= expected-target
                    (:target (get-field))))))))))
 
@@ -345,23 +323,23 @@
             update-target   (fn []
                               (mt/user-http-request :rasta :put 200 (format "field/%d" (:id field)) (assoc field :fk_target_field_id (:id fk-field-2))))]
         (testing "target should be hydrated if a non-admin has data model perms for the DB"
-          (with-all-users-data-perms! {db-id {:data-model {:schemas :all}}}
+          (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas :all}}}
             (is (= expected-target
                    (:target (update-target))))))
         (testing "target should not be hydrated if a non-admin does not have data model perms for the target's schema"
-          (with-all-users-data-perms! {db-id {:data-model {:schemas {"schema1" :none
-                                                                     "schema2" :none
-                                                                     "schema3" :all}}}}
+          (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {"schema1" :none
+                                                                              "schema2" :none
+                                                                              "schema3" :all}}}}
             (is (nil? (:target (update-target))))))
         (testing "target should not be hydrated if a non-admin does not have data model perms for the target's table"
-          (with-all-users-data-perms! {db-id {:data-model {:schemas {"schema1" {(:id table1) :all}
-                                                                     "schema2" {(:id table2) :none}
-                                                                     "schema3" {(:id table3) :all}}}}}
+          (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {"schema1" {(:id table1) :all}
+                                                                              "schema2" {(:id table2) :none}
+                                                                              "schema3" {(:id table3) :all}}}}}
             (is (nil? (:target (update-target))))))
         (testing "target should be hydrated if a non-admin does have data model perms for the target's table"
-          (with-all-users-data-perms! {db-id {:data-model {:schemas {"schema1" {(:id table1) :none}
-                                                                     "schema2" {(:id table2) :all}
-                                                                     "schema3" {(:id table3) :all}}}}}
+          (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {"schema1" {(:id table1) :none}
+                                                                              "schema2" {(:id table2) :all}
+                                                                              "schema3" {(:id table3) :all}}}}}
             (is (= expected-target
                    (:target (update-target))))))))))
 
@@ -373,78 +351,78 @@
       (testing "PUT /api/field/:id"
         (let [endpoint (format "field/%d" field-id)]
           (testing "a non-admin cannot update field metadata if the advanced-permissions feature flag is not present"
-            (with-all-users-data-perms! {db-id {:data-model {:schemas {schema {table-id :all}}}}}
+            (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {schema {table-id :all}}}}}
               (mt/with-premium-features #{}
                 (mt/user-http-request :rasta :put 403 endpoint {:name "Field Test 4"}))))
 
           (testing "a non-admin cannot update field metadata if they have no data model permissions for the DB"
-            (with-all-users-data-perms! {db-id {:data-model {:schemas :none}}}
+            (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas :none}}}
               (mt/user-http-request :rasta :put 403 endpoint {:name "Field Test 2"})))
 
           (testing "a non-admin cannot update field metadata if they only have data model permissions for other schemas"
-            (with-all-users-data-perms! {db-id {:data-model {:schemas {schema             :none
-                                                                       "different schema" :all}}}}
+            (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {schema             :none
+                                                                                "different schema" :all}}}}
 
               (mt/user-http-request :rasta :put 403 endpoint {:name "Field Test 2"})))
 
           (testing "a non-admin cannot update field metadata if they only have data model permissions for other tables"
-            (with-all-users-data-perms! {db-id {:data-model {:schemas {schema {table-id   :none
-                                                                               table-id-2 :all}}}}}
+            (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {schema {table-id   :none
+                                                                                        table-id-2 :all}}}}}
               (mt/user-http-request :rasta :put 403 endpoint {:name "Field Test 2"})))
 
           (testing "a non-admin can update field metadata if they have data model perms for the DB"
-            (with-all-users-data-perms! {db-id {:data-model {:schemas :all}}}
+            (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas :all}}}
               (mt/user-http-request :rasta :put 200 endpoint {:name "Field Test 2"})))
 
           (testing "a non-admin can update field metadata if they have data model perms for the schema"
-            (with-all-users-data-perms! {db-id {:data-model {:schemas {schema :all}}}}
+            (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {schema :all}}}}
               (mt/user-http-request :rasta :put 200 endpoint {:name "Field Test 3"})))
 
           (testing "a non-admin can update field metadata if they have data model perms for the table"
-            (with-all-users-data-perms! {db-id {:data-model {:schemas {schema {table-id :all}}}}}
+            (mt/with-all-users-data-perms-graph! {db-id {:data-model {:schemas {schema {table-id :all}}}}}
               (mt/user-http-request :rasta :put 200 endpoint {:name "Field Test 3"})))))
 
       (testing "POST /api/field/:id/rescan_values"
         (testing "A non-admin can trigger a rescan of field values if they have data model perms for the table"
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {schema {table-id :none}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {schema {table-id :none}}}}}
             (mt/user-http-request :rasta :post 403 (format "field/%d/rescan_values" field-id)))
 
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {schema {table-id :all}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {schema {table-id :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "field/%d/rescan_values" field-id))))
 
         (testing "A non-admin with no data access can trigger a re-scan of field values if they have data model perms"
           (t2/delete! FieldValues :field_id (mt/id :venues :price))
           (is (= nil (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))
-          (with-all-users-data-perms! {(mt/id) {:data       {:schemas :block :native :none}
-                                                :data-model {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :block :native :none}
+                                                         :data-model {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "field/%d/rescan_values" (mt/id :venues :price))))
           (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))))
 
       (testing "POST /api/field/:id/discard_values"
         (testing "A non-admin can discard field values if they have data model perms for the table"
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {schema {table-id :none}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {schema {table-id :none}}}}}
             (mt/user-http-request :rasta :post 403 (format "field/%d/discard_values" field-id)))
 
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {schema {table-id :all}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {schema {table-id :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "field/%d/discard_values" field-id))))
 
         (testing "A non-admin with no data access can discard field values if they have data model perms"
           (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))
-          (with-all-users-data-perms! {(mt/id) {:data       {:schemas :block :native :none}
-                                                :data-model {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :block :native :none}
+                                                         :data-model {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "field/%d/discard_values" (mt/id :venues :price))))
           (is (= nil (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price)))))))))
 
 (deftest get-field-with-advanced-perms-test
   (testing "GET /api/field/:id?include_editable_data_model=true"
     (testing "A non-admin can fetch a field when they have data model perms if include_editable_data_model=true"
-      (with-all-users-data-perms! {(mt/id) {:data       {:schemas :block :native :none}
-                                            :data-model {:schemas :all}}}
+      (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :block :native :none}
+                                                     :data-model {:schemas :all}}}
         (is (partial= {:id (mt/id :users :name)}
                       (mt/user-http-request :rasta :get 200 (format "field/%d?include_editable_data_model=true" (mt/id :users :name)))))))
-    (with-all-users-data-perms! {(mt/id) {:data       {:schemas :all :native :write}
-                                          :data-model {:schemas {"PUBLIC" {(mt/id :categories) :all
-                                                                           (mt/id :users)      :none}}}}}
+    (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :all :native :write}
+                                                   :data-model {:schemas {"PUBLIC" {(mt/id :categories) :all
+                                                                                    (mt/id :users)      :none}}}}}
       (testing "A non-admin can fetch a field for which they have data model perms if include_editable_data_model=true"
         (is (partial= {:id (mt/id :categories :name)}
                       (mt/user-http-request :rasta :get 200 (format "field/%d?include_editable_data_model=true" (mt/id :categories :name))))))
@@ -458,70 +436,70 @@
     (testing "PUT /api/table/:id"
       (let [endpoint (format "table/%d" table-id)]
         (testing "a non-admin cannot update table metadata if the advanced-permissions feature flag is not present"
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas :all}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas :all}}}
             (mt/with-premium-features #{}
               (mt/user-http-request :rasta :put 403 endpoint {:name "Table Test 2"}))))
 
         (testing "a non-admin cannot update table metadata if they have no data model permissions for the DB"
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas :none}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas :none}}}
             (mt/user-http-request :rasta :put 403 endpoint {:name "Table Test 2"})))
 
         (testing "a non-admin cannot update table metadata if they only have data model permissions for other schemas"
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC"           :none
-                                                                       "different schema" :all}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC"           :none
+                                                                                "different schema" :all}}}}
             (mt/user-http-request :rasta :put 403 endpoint {:name "Table Test 2"})))
 
         (testing "a non-admin cannot update table metadata if they only have data model permissions for other tables"
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id   :none
-                                                                                 table-id-2 :all}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id   :none
+                                                                                          table-id-2 :all}}}}}
             (mt/user-http-request :rasta :put 403 endpoint {:name "Table Test 2"})))
 
         (testing "a non-admin can update table metadata if they have data model perms for the DB"
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas :all}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas :all}}}
             (mt/user-http-request :rasta :put 200 endpoint {:name "Table Test 2"})))
 
         (testing "a non-admin can update table metadata if they have data model perms for the schema"
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC" :all}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC" :all}}}}
             (mt/user-http-request :rasta :put 200 endpoint {:name "Table Test 3"})))
 
         (testing "a non-admin can update table metadata if they have data model perms for the table"
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
             (mt/user-http-request :rasta :put 200 endpoint {:name "Table Test 3"})))))
 
     (testing "POST /api/table/:id/rescan_values"
       (testing "A non-admin can trigger a rescan of field values if they have data model perms for the table"
-        (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :none}}}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :none}}}}}
           (mt/user-http-request :rasta :post 403 (format "table/%d/rescan_values" table-id)))
 
-        (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
           (mt/user-http-request :rasta :post 200 (format "table/%d/rescan_values" table-id))))
 
       (testing "A non-admin with no data access can trigger a re-scan of field values if they have data model perms"
         (t2/delete! FieldValues :field_id (mt/id :venues :price))
         (is (= nil (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))
         (with-redefs [sync.concurrent/submit-task (fn [task] (task))]
-          (with-all-users-data-perms! {(mt/id) {:data       {:schemas :block :native :none}
-                                                :data-model {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:schemas :block :native :none}
+                                                         :data-model {:schemas {"PUBLIC" {(mt/id :venues) :all}}}}}
             (mt/user-http-request :rasta :post 200 (format "table/%d/rescan_values" (mt/id :venues)))))
         (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))))
 
     (testing "POST /api/table/:id/discard_values"
       (testing "A non-admin can discard field values if they have data model perms for the table"
-        (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :none}}}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :none}}}}}
           (mt/user-http-request :rasta :post 403 (format "table/%d/discard_values" table-id)))
 
-        (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
           (mt/user-http-request :rasta :post 200 (format "table/%d/discard_values" table-id)))))
 
     (testing "POST /api/table/:id/fields/order"
       (testing "A non-admin can set a custom field ordering if they have data model perms for the table"
         (mt/with-temp [Field {field-1-id :id} {:table_id table-id}
                        Field {field-2-id :id} {:table_id table-id}]
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :none}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :none}}}}}
             (mt/user-http-request :rasta :put 403 (format "table/%d/fields/order" table-id)
                                   [field-2-id field-1-id]))
 
-          (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
             (mt/user-http-request :rasta :put 200 (format "table/%d/fields/order" table-id)
                                   [field-2-id field-1-id])))))))
 
@@ -529,7 +507,7 @@
   (t2.with-temp/with-temp [Table {table-id :id} {:db_id (mt/id) :schema "PUBLIC"}]
     (testing "An audit log entry is generated when a manually triggered re-scan occurs"
       (mt/with-additional-premium-features #{:audit-app}
-        (with-all-users-data-perms! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data-model {:schemas {"PUBLIC" {table-id :all}}}}}
           (mt/user-http-request :rasta :post 200 (format "table/%d/rescan_values" table-id))))
       (is (= table-id (:model_id (mt/latest-audit-log-entry :table-manual-scan))))
       (is (= table-id (-> (mt/latest-audit-log-entry :table-manual-scan) :details :id))))))
@@ -538,25 +516,25 @@
   (testing "GET /api/table/:id"
     (t2.with-temp/with-temp [Table {table-id :id} {:db_id (mt/id) :schema "PUBLIC"}]
       (testing "A non-admin without self-service perms for a table cannot fetch the table normally"
-        (with-all-users-data-perms! {(mt/id) {:data {:native :none :schemas :none}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data {:native :none :schemas :none}}}
           (mt/user-http-request :rasta :get 403 (format "table/%d?include_editable_data_model=true" table-id))))
 
       (testing "A non-admin without self-service perms for a table can fetch the table if they have data model perms for
                the DB"
-        (with-all-users-data-perms! {(mt/id) {:data       {:native :none :schemas :none}
-                                              :data-model {:schemas :all}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:native :none :schemas :none}
+                                                       :data-model {:schemas :all}}}
           (mt/user-http-request :rasta :get 200 (format "table/%d?include_editable_data_model=true" table-id))))
 
       (testing "A non-admin without self-service perms for a table can fetch the table if they have data model perms for
                the schema"
-        (with-all-users-data-perms! {(mt/id) {:data       {:native :none :schemas :none}
-                                              :data-model {:schemas {"PUBLIC" :all}}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:native :none :schemas :none}
+                                                       :data-model {:schemas {"PUBLIC" :all}}}}
           (mt/user-http-request :rasta :get 200 (format "table/%d?include_editable_data_model=true" table-id))))
 
       (testing "A non-admin without self-service perms for a table can fetch the table if they have data model perms for
                the table"
-        (with-all-users-data-perms! {(mt/id) {:data       {:native :none :schemas :none}
-                                              :data-model {:schemas {"PUBLIC" {table-id :all}}}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:native :none :schemas :none}
+                                                       :data-model {:schemas {"PUBLIC" {table-id :all}}}}}
           (mt/user-http-request :rasta :get 200 (format "table/%d?include_editable_data_model=true" table-id)))))))
 
 (deftest fetch-query-metadata-test
@@ -564,15 +542,15 @@
     (t2.with-temp/with-temp [Table {table-id :id} {:db_id (mt/id) :schema "PUBLIC"}]
       (testing "A non-admin without data model perms for a table cannot fetch the query metadata when
                include_editable_data_model=true"
-        (with-all-users-data-perms! {(mt/id) {:data       {:native :write :schemas :all}
-                                              :data-model {:schemas :none}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:native :write :schemas :all}
+                                                       :data-model {:schemas :none}}}
           (mt/user-http-request :rasta :get 403
                                 (format "table/%d/query_metadata?include_editable_data_model=true" table-id))))
 
       (testing "A non-admin with only data model perms for a table can fetch the query metadata when
                include_editable_data_model=true"
-        (with-all-users-data-perms! {(mt/id) {:data       {:native :none :schemas :none}
-                                              :data-model {:schemas :all}}}
+        (mt/with-all-users-data-perms-graph! {(mt/id) {:data       {:native :none :schemas :none}
+                                                       :data-model {:schemas :all}}}
           (mt/user-http-request :rasta :get 200
                                 (format "table/%d/query_metadata?include_editable_data_model=true" table-id)))))))
 
@@ -584,25 +562,25 @@
   (testing "PUT /api/database/:id"
     (t2.with-temp/with-temp [Database {db-id :id}]
       (testing "A non-admin cannot update database metadata if the advanced-permissions feature flag is not present"
-        (with-all-users-data-perms! {db-id {:details :yes}}
+        (mt/with-all-users-data-perms-graph! {db-id {:details :yes}}
           (mt/with-premium-features #{}
             (is (= "You don't have permissions to do that."
                    (mt/user-http-request :rasta :put 403 (format "database/%d" db-id) {:name "Database Test"}))))))
 
       (testing "A non-admin cannot update database metadata if they do not have DB details permissions"
-        (with-all-users-data-perms! {db-id {:details :no}}
+        (mt/with-all-users-data-perms-graph! {db-id {:details :no}}
           (is (= "You don't have permissions to do that."
                  (mt/user-http-request :rasta :put 403 (format "database/%d" db-id) {:name "Database Test"})))))
 
       (testing "A non-admin can update database metadata if they have DB details permissions"
-        (with-all-users-data-perms! {db-id {:details :yes}}
+        (mt/with-all-users-data-perms-graph! {db-id {:details :yes}}
           (is (=? {:id db-id}
                   (mt/user-http-request :rasta :put 200 (format "database/%d" db-id) {:name "Database Test"}))))))))
 
 (deftest delete-database-test
   (t2.with-temp/with-temp [Database {db-id :id}]
     (testing "A non-admin cannot delete a database even if they have DB details permissions"
-      (with-all-users-data-perms! {db-id {:details :yes}}
+      (mt/with-all-users-data-perms-graph! {db-id {:details :yes}}
         (mt/user-http-request :rasta :delete 403 (format "database/%d" db-id))))))
 
 (deftest db-operations-test
@@ -613,53 +591,53 @@
                    FieldValues {values-id :id} {:field_id field-id, :values [1 2 3 4]}]
       (with-redefs [api.database/*rescan-values-async* false]
         (testing "A non-admin can trigger a sync of the DB schema if they have DB details permissions"
-          (with-all-users-data-perms! {db-id {:details :yes}}
+          (mt/with-all-users-data-perms-graph! {db-id {:details :yes}}
             (mt/user-http-request :rasta :post 200 (format "database/%d/sync_schema" db-id))))
 
         (testing "A non-admin can discard saved field values if they have DB details permissions"
-          (with-all-users-data-perms! {db-id {:details :yes}}
+          (mt/with-all-users-data-perms-graph! {db-id {:details :yes}}
             (mt/user-http-request :rasta :post 200 (format "database/%d/discard_values" db-id))))
 
         (testing "A non-admin with no data access can discard field values if they have DB details perms"
           (t2/insert! FieldValues :id values-id :field_id field-id :values [1 2 3 4])
-          (with-all-users-data-perms! {db-id {:data    {:schemas :block :native :none}
-                                              :details :yes}}
+          (mt/with-all-users-data-perms-graph! {db-id {:data    {:schemas :block :native :none}
+                                                       :details :yes}}
             (mt/user-http-request :rasta :post 200 (format "database/%d/discard_values" db-id)))
           (is (= nil (t2/select-one-fn :values FieldValues, :field_id field-id)))
           (mt/user-http-request :crowberto :post 200 (format "database/%d/rescan_values" db-id)))
 
         ;; Use test database for rescan_values tests so we can verify that scan actually succeeds
         (testing "A non-admin can trigger a re-scan of field values if they have DB details permissions"
-          (with-all-users-data-perms! {(mt/id) {:details :yes}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:details :yes}}
             (mt/user-http-request :rasta :post 200 (format "database/%d/rescan_values" (mt/id)))))
 
         (testing "A non-admin with no data access can trigger a re-scan of field values if they have DB details perms"
           (t2/delete! FieldValues :field_id (mt/id :venues :price))
           (is (= nil (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price))))
-          (with-all-users-data-perms! {(mt/id) {:data    {:schemas :block :native :none}
-                                                :details :yes}}
+          (mt/with-all-users-data-perms-graph! {(mt/id) {:data    {:schemas :block :native :none}
+                                                         :details :yes}}
             (mt/user-http-request :rasta :post 200 (format "database/%d/rescan_values" (mt/id))))
           (is (= [1 2 3 4] (t2/select-one-fn :values FieldValues, :field_id (mt/id :venues :price)))))))))
 
 (deftest fetch-db-test
   (t2.with-temp/with-temp [Database {db-id :id}]
     (testing "A non-admin without self-service perms for a DB cannot fetch the DB normally"
-      (with-all-users-data-perms! {db-id {:data {:native :none :schemas :none}}}
+      (mt/with-all-users-data-perms-graph! {db-id {:data {:native :none :schemas :none}}}
         (mt/user-http-request :rasta :get 403 (format "database/%d?exclude_uneditable_details=true" db-id))))
 
     (testing "A non-admin without self-service perms for a DB can fetch the DB if they have DB details permissions"
-      (with-all-users-data-perms! {db-id {:data    {:native :none :schemas :none}
-                                          :details :yes}}
+      (mt/with-all-users-data-perms-graph! {db-id {:data    {:native :none :schemas :none}
+                                                   :details :yes}}
         (mt/user-http-request :rasta :get 200 (format "database/%d?exclude_uneditable_details=true" db-id))))
 
     (testing "A non-admin with block perms for a DB can fetch the DB if they have DB details permissions"
-      (with-all-users-data-perms! {db-id {:data    {:native :none :schemas :block}
-                                          :details :yes}}
+      (mt/with-all-users-data-perms-graph! {db-id {:data    {:native :none :schemas :block}
+                                                   :details :yes}}
         (mt/user-http-request :rasta :get 200 (format "database/%d?exclude_uneditable_details=true" db-id))))
 
     (testing "The returned database contains a :details field for a user with DB details permissions"
-      (with-all-users-data-perms! {db-id {:data    {:native :none :schemas :block}
-                                          :details :yes}}
+      (mt/with-all-users-data-perms-graph! {db-id {:data    {:native :none :schemas :block}
+                                                   :details :yes}}
         (is (partial= {:details {}}
                       (mt/user-http-request :rasta :get 200 (format "database/%d?exclude_uneditable_details=true" db-id))))))))
 
@@ -682,8 +660,8 @@
                            (mt/user-http-request :rasta :post 200 execute-path
                                                  {:parameters {"id" 1}})))))
                 (testing "Fails with access to the DB blocked"
-                  (with-all-users-data-perms! {(u/the-id (mt/db)) {:data {:native :none :schemas :block}
-                                                                   :details :yes}}
+                  (mt/with-all-users-data-perms-graph! {(u/the-id (mt/db)) {:data {:native :none :schemas :block}
+                                                                            :details :yes}}
                     (mt/with-actions-enabled
                       (is (partial= {:message "You don't have permissions to do that."}
                                     (mt/user-http-request :rasta :post 403 execute-path
@@ -692,10 +670,10 @@
 (deftest settings-managers-can-have-uploads-db-access-revoked
   (perms/grant-application-permissions! (perms-group/all-users) :setting)
   (testing "Upload DB can be set with the right permission"
-    (with-all-users-data-perms! {(mt/id) {:details :yes}}
+    (mt/with-all-users-data-perms-graph! {(mt/id) {:details :yes}}
       (mt/user-http-request :rasta :put 204 "setting/" {:uploads-database-id (mt/id)})))
   (testing "Upload DB cannot be set without the right permission"
-    (with-all-users-data-perms! {(mt/id) {:details :no}}
+    (mt/with-all-users-data-perms-graph! {(mt/id) {:details :no}}
       (mt/user-http-request :rasta :put 403 "setting/" {:uploads-database-id (mt/id)})))
   (perms/revoke-application-permissions! (perms-group/all-users) :setting))
 
@@ -715,15 +693,15 @@
                      [:none              false "No data permissions on schema should fail"]
                      [{(:id table) :all} false "Data permissions on table should fail"]]]
               (testing description
-                (with-all-users-data-perms! {db-id {:data {:native :none, :schemas {"some_schema" :all
-                                                                                    schema-name   schema-perms}}}}
+                (mt/with-all-users-data-perms-graph! {db-id {:data {:native :none, :schemas {"some_schema" :all
+                                                                                             schema-name   schema-perms}}}}
                   (if can-upload?
                     (is (some? (upload-csv!)))
                     (is (thrown-with-msg?
                          clojure.lang.ExceptionInfo
                          #"You don't have permissions to do that\."
                          (upload-csv!)))))))
-            (with-all-users-data-perms! {db-id {:data {:native :write, :schemas :all}}}
+            (mt/with-all-users-data-perms-graph! {db-id {:data {:native :write, :schemas :all}}}
               (is (some? (upload-csv!))))))))))
 
 (deftest append-csv-data-perms-test
@@ -744,13 +722,13 @@
                        [{(:id table-a) :all} true        "Data permissions on table should succeed"]
                        [{(:id table-b) :all} false       "Data permissions only on another table in the same schema should fail"]]]
                 (testing test-string
-                  (with-all-users-data-perms! {db-id {:data {:native :none, :schemas {(or schema-name "") schema-perms}}}}
+                  (mt/with-all-users-data-perms-graph! {db-id {:data {:native :none, :schemas {(or schema-name "") schema-perms}}}}
                     (if can-append?
                       (is (some? (append-csv!)))
                       (is (thrown-with-msg?
-                            clojure.lang.ExceptionInfo
-                            #"You don't have permissions to do that\."
-                            (append-csv!))))))))))))))
+                           clojure.lang.ExceptionInfo
+                           #"You don't have permissions to do that\."
+                           (append-csv!))))))))))))))
 
 (deftest append-csv-block-perms-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
@@ -762,7 +740,7 @@
                             :table-id (:id table-a)
                             :user-id (mt/user->id :rasta))]
           (testing "With blocked perms it should fail"
-            (with-all-users-data-perms! {db-id {:data {:native :none, :schemas :block}}}
+            (mt/with-all-users-data-perms-graph! {db-id {:data {:native :none, :schemas :block}}}
               (is (thrown-with-msg?
                    clojure.lang.ExceptionInfo
                    #"You don't have permissions to do that\."
@@ -785,9 +763,9 @@
                                                       {(:id table) :all} false}]
                     (testing (format "can_upload should be %s if the user has %s access to the upload schema"
                                      can-upload? schema-perms)
-                      (with-all-users-data-perms! {db-id {:data {:native :none
-                                                                 :schemas {"some_schema" :all
-                                                                           schema-name   schema-perms}}}}
+                      (mt/with-all-users-data-perms-graph! {db-id {:data {:native :none
+                                                                          :schemas {"some_schema" :all
+                                                                                    schema-name   schema-perms}}}}
                         (testing "GET /api/database"
                           (let [result (->> (mt/user-http-request :rasta :get 200 "database")
                                             :data

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -9,6 +9,8 @@
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
    [metabase.models.collection :as collection]
+   [metabase.models.data-permissions :as data-perms]
+   [metabase.models.database :as database]
    [metabase.models.interface :as mi]
    [metabase.models.permissions :as perms]
    [metabase.public-settings.premium-features :as premium-features]
@@ -283,19 +285,9 @@
         has-perm-clause (fn [x y z] [:in (build-path x y z) current-user-perms])]
     (if (contains? current-user-perms "/")
       query
-      ;; Select indexed rows if user has /db/:id/ OR (/db/:id/native/ AND /db/:id/schema/) - aka full access to the database
-      ;; in at least one group. (Access to only a subset of tables isn't enough, since models can be based on native
-      ;; queries.)
-      ;; AND
-      ;; User has /collection/:id/ or /collection/:id/read/ for the collection the model is in.
-      (let [data-perm-clause
-            [:or
-             (has-perm-clause "/db/" :model.database_id "/")
-             [:and
-              (has-perm-clause "/db/" :model.database_id "/native/")
-              (has-perm-clause "/db/" :model.database_id "/schema/")]]
-
-            has-root-access?
+      ;; User has /collection/:id/ or /collection/:id/read/ for the collection the model is in. We will check
+      ;; permissions on the database after the query is complete, in `check-permissions-for-model`
+      (let [has-root-access?
             (or (contains? current-user-perms "/collection/root/")
                 (contains? current-user-perms "/collection/root/read/"))
 
@@ -309,7 +301,7 @@
                (has-perm-clause "/collection/" :model.collection_id "/read/")]]]]
         (sql.helpers/where
          query
-         [:and data-perm-clause collection-perm-clause])))))
+         collection-perm-clause)))))
 
 (defmethod search-query-for-model "indexed-entity"
   [model {:keys [current-user-perms] :as search-ctx}]
@@ -330,27 +322,7 @@
   (when (seq current-user-perms)
     (let [base-query (base-query-for-model model search-ctx)]
       (add-table-db-id-clause
-       (if (contains? current-user-perms "/")
-         base-query
-         (let [data-perms (filter #(re-find #"^/db/*" %) current-user-perms)]
-           {:select (:select base-query)
-            :from   [[(merge
-                       base-query
-                       {:select [:id :schema :db_id :name :description :display_name :created_at :updated_at :initial_sync_status
-                                 [(h2x/concat (h2x/literal "/db/")
-                                              :db_id
-                                              (h2x/literal "/schema/")
-                                              [:case
-                                               [:not= :schema nil] :schema
-                                               :else               (h2x/literal "")]
-                                              (h2x/literal "/table/") :id
-                                              (h2x/literal "/read/"))
-                                  :path]]})
-                      :table]]
-            :where  (if (seq data-perms)
-                      (into [:or] (for [path data-perms]
-                                    [:like :path (str path "%")]))
-                      [:inline [:= 0 1]])}))
+       base-query
        table-db-id))))
 
 (defn order-clause
@@ -378,6 +350,20 @@
     (mi/can-write? instance)
     ;; We filter what we can (ie. everything that is in a collection) out already when querying
     true))
+
+(defmethod check-permissions-for-model :table
+  [_archived instance]
+  ;; we've already filtered out tables w/o collection permissions in the query itself.
+  (= :unrestricted (data-perms/table-permission-for-user api/*current-user-id*
+                                                         :perms/data-access
+                                                         (database/table-id->database-id (:id instance))
+                                                         (:id instance))))
+
+(defmethod check-permissions-for-model :indexed-entity
+  [_archived? instance]
+  (and
+   (= :yes (data-perms/database-permission-for-user api/*current-user-id* :perms/native-query-editing (:database_id instance)))
+   (= :unrestricted (data-perms/full-db-permission-for-user api/*current-user-id* :perms/data-access (:database_id instance)))))
 
 (defmethod check-permissions-for-model :metric
   [archived? instance]

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -285,6 +285,29 @@
       (or (coalesce perm-type perm-values)
           (least-permissive-value perm-type)))))
 
+
+(mu/defn full-db-permission-for-user :- PermissionValue
+  "Returns the effective *db-level* permission value for a given user, permission type, and database ID. If the user
+  has multiple permissions for the given type in different groups, they are coalesced into a single value. The
+  db-level permission is the *most* restrictive table-level permission within that schema."
+  [user-id perm-type database-id]
+  (when (not= :model/Table (model-by-perm-type perm-type))
+    (throw (ex-info (tru "Permission type {0} is not a table-level permission." perm-type)
+                    {perm-type (Permissions perm-type)})))
+  (if (is-superuser? user-id)
+    (most-permissive-value perm-type)
+    ;; The schema-level permission is the most-restrictive table-level permission within a schema. So for each group,
+    ;; select the most-restrictive table-level permission. Then use normal coalesce logic to select the *least*
+    ;; restrictive group permission.
+    (let [perm-values (most-restrictive-per-group
+                       perm-type
+                       (->> (get-permissions user-id perm-type database-id)
+                            (map #(set/rename-keys % {:group_id :group-id
+                                                      :perm_value :value}))
+                            (map #(select-keys % [:group-id :value]))))]
+      (or (coalesce perm-type perm-values)
+          (least-permissive-value perm-type)))))
+
 (mu/defn schema-permission-for-user :- PermissionValue
   "Returns the effective *schema-level* permission value for a given user, permission type, and database ID, and
   schema name. If the user has multiple permissions for the given type in different groups, they are coalesced into a

--- a/test/metabase/test.clj
+++ b/test/metabase/test.clj
@@ -251,7 +251,7 @@
   with-non-admin-groups-no-root-collection-for-namespace-perms
   with-non-admin-groups-no-root-collection-perms
   with-non-admin-groups-no-collection-perms
-  with-all-users-data-perms-graph
+  with-all-users-data-perms-graph!
   with-temp-env-var-value!
   with-temp-dir
   with-temp-file

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -43,6 +43,7 @@
    [metabase.test.fixtures :as fixtures]
    [metabase.test.initialize :as initialize]
    [metabase.test.util.log :as tu.log]
+   [metabase.test.util.public-settings]
    [metabase.util :as u]
    [metabase.util.files :as u.files]
    [metabase.util.random :as u.random]
@@ -986,15 +987,16 @@
   "Implementation for [[with-all-users-data-perms]]"
   [graph f]
   (let [all-users-group-id  (u/the-id (perms-group/all-users))]
-    (perms.test-util/with-no-data-perms-for-all-users!
-      (perms.test-util/with-restored-perms!
-        (perms.test-util/with-restored-data-perms!
-          ;; TODO: stop ignoring exceptions here! (But this is vestigial code, so hopefully will be deleted soon
-          ;; anyway...)
-          (u/ignore-exceptions
-            (@#'perms/update-group-permissions! all-users-group-id graph))
-          (data-perms.graph/update-data-perms-graph! {all-users-group-id graph})
-          (f))))))
+    (metabase.test.util.public-settings/with-additional-premium-features #{:advanced-permissions}
+      (perms.test-util/with-no-data-perms-for-all-users!
+        (perms.test-util/with-restored-perms!
+          (perms.test-util/with-restored-data-perms!
+            ;; TODO: stop ignoring exceptions here! (But this is vestigial code, so hopefully will be deleted soon
+            ;; anyway...)
+            (u/ignore-exceptions
+              (@#'perms/update-group-permissions! all-users-group-id graph))
+            (data-perms.graph/update-data-perms-graph! {all-users-group-id graph})
+            (f)))))))
 
 (defmacro with-all-users-data-perms-graph!
   "Runs `body` with data perms for the All Users group temporarily set to the values in `graph`."

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -989,7 +989,10 @@
     (perms.test-util/with-no-data-perms-for-all-users!
       (perms.test-util/with-restored-perms!
         (perms.test-util/with-restored-data-perms!
-          (@#'perms/update-group-permissions! all-users-group-id graph)
+          ;; TODO: stop ignoring exceptions here! (But this is vestigial code, so hopefully will be deleted soon
+          ;; anyway...)
+          (u/ignore-exceptions
+            (@#'perms/update-group-permissions! all-users-group-id graph))
           (data-perms.graph/update-data-perms-graph! {all-users-group-id graph})
           (f))))))
 

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -27,6 +27,7 @@
             Table
             User]]
    [metabase.models.collection :as collection]
+   [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.interface :as mi]
    [metabase.models.moderation-review :as moderation-review]
    [metabase.models.permissions :as perms]
@@ -34,6 +35,7 @@
    [metabase.models.setting :as setting]
    [metabase.models.setting.cache :as setting.cache]
    [metabase.models.timeline-event :as timeline-event]
+   [metabase.permissions.test-util :as perms.test-util]
    [metabase.plugins.classloader :as classloader]
    [metabase.task :as task]
    [metabase.test-runner.assert-exprs :as test-runner.assert-exprs]
@@ -980,24 +982,21 @@
                                           :object permission-path}]
     (f)))
 
-(defn do-with-all-user-data-perms-graph
+(defn do-with-all-user-data-perms-graph!
   "Implementation for [[with-all-users-data-perms]]"
   [graph f]
-  (let [all-users-group-id  (u/the-id (perms-group/all-users))
-        current-graph       (get-in (perms/data-perms-graph) [:groups all-users-group-id])]
-    (try
-      (with-model-cleanup [Permissions]
-        (u/ignore-exceptions
-         (@#'perms/update-group-permissions! all-users-group-id graph))
-        (f))
-      (finally
-        (u/ignore-exceptions
-         (@#'perms/update-group-permissions! all-users-group-id current-graph))))))
+  (let [all-users-group-id  (u/the-id (perms-group/all-users))]
+    (perms.test-util/with-no-data-perms-for-all-users!
+      (perms.test-util/with-restored-perms!
+        (perms.test-util/with-restored-data-perms!
+          (@#'perms/update-group-permissions! all-users-group-id graph)
+          (data-perms.graph/update-data-perms-graph! {all-users-group-id graph})
+          (f))))))
 
-(defmacro with-all-users-data-perms-graph
+(defmacro with-all-users-data-perms-graph!
   "Runs `body` with data perms for the All Users group temporarily set to the values in `graph`."
   [graph & body]
-  `(do-with-all-user-data-perms-graph ~graph (fn [] ~@body)))
+  `(do-with-all-user-data-perms-graph! ~graph (fn [] ~@body)))
 
 (defmacro with-all-users-permission
   "Run `body` with the ''All Users'' group being granted the permission


### PR DESCRIPTION
First, I added a new function to `models.data-permissions`, `full-database-permission-for-user`, that is equivalent to `full-schema-permission-for-user` but for an entire database rather than a table. For each group, it gets the *least* permissive permission in the database, then coalesces the result like  normal.

If permissions look like this:

```
id  |    object     | group_id
-----+---------------+----------
 156 | /db/1/native/ |        1
 155 | /db/1/schema/ |        2
 154 | /db/1/        |        3
 158 | /db/1/schema/ |        4
 159 | /db/1/native/ |        4
```

DataPermissions end up looking like this:

```
id  | group_id |          perm_type          | db_id | schema_name | table_id |   perm_value
-----+----------+-----------------------------+-------+-------------+----------+-----------------
 809 |        1 | perms/data-access           |     1 |             |          | no-self-service
 816 |        1 | perms/download-results      |     1 |             |          | no
 825 |        1 | perms/manage-database       |     1 |             |          | no
 832 |        1 | perms/manage-table-metadata |     1 |             |          | no
 841 |        1 | perms/native-query-editing  |     1 |             |          | yes
 813 |        2 | perms/data-access           |     1 |             |          | unrestricted
 818 |        2 | perms/download-results      |     1 |             |          | no
 829 |        2 | perms/manage-database       |     1 |             |          | no
 834 |        2 | perms/manage-table-metadata |     1 |             |          | no
 845 |        2 | perms/native-query-editing  |     1 |             |          | no
 811 |        3 | perms/data-access           |     1 |             |          | unrestricted
 817 |        3 | perms/download-results      |     1 |             |          | no
 827 |        3 | perms/manage-database       |     1 |             |          | no
 833 |        3 | perms/manage-table-metadata |     1 |             |          | no
 843 |        3 | perms/native-query-editing  |     1 |             |          | yes
 815 |        4 | perms/data-access           |     1 |             |          | unrestricted
 819 |        4 | perms/download-results      |     1 |             |          | no
 831 |        4 | perms/manage-database       |     1 |             |          | no
 835 |        4 | perms/manage-table-metadata |     1 |             |          | no
 847 |        4 | perms/native-query-editing  |     1 |             |          | yes
```

So to match the existing logic (matching permissions to `/db/:id/` OR BOTH OF `/db/:id/native/` and `/db/:id/schema`) we can just check that the user has `yes` for `native-query-editing`, plus unrestricted `data-access`, for *every* table in the database.

Note that we are now filtering tables after selecting them from the database. There is an existing comment in `metabase.api.search` saying:

> We get to do this slicing and dicing with the result data because the
> pagination of search is for UI improvement, not for performance. We
> intend for the cardinality of the search results to be below the default
> max before this slicing occurs

So I think this ok.