### PR TITLE
Fix dashboard header adjustment

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeaderView.tsx
@@ -117,7 +117,10 @@ export function DashboardHeaderComponent({
           <span>{editWarning}</span>
         </EditWarning>
       )}
-      <HeaderContainer isSidebarOpen={isSidebarOpen}>
+      <HeaderContainer
+        isFixedWidth={dashboard?.width === "fixed"}
+        isSidebarOpen={isSidebarOpen}
+      >
         <HeaderRow
           className={cx("QueryBuilder-section", headerClassName)}
           data-testid="dashboard-header"

--- a/frontend/src/metabase/dashboard/components/DashboardHeaderView.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeaderView.styled.tsx
@@ -40,8 +40,12 @@ export const HeaderFixedWidthContainer = styled(
   }
 `;
 
-export const HeaderContainer = styled.div<{ isSidebarOpen: boolean }>`
+export const HeaderContainer = styled.div<{
+  isSidebarOpen: boolean;
+  isFixedWidth: boolean;
+}>`
   ${props =>
+    props.isFixedWidth &&
     props.isSidebarOpen &&
     css`
       margin-right: ${SIDEBAR_WIDTH}px;

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.styled.tsx
@@ -8,6 +8,7 @@ import FormField from "metabase/core/components/FormField/FormField";
 import { SIDEBAR_WIDTH } from "../Sidebar";
 
 export const DashboardInfoSidebarRoot = styled.aside`
+  width: ${SIDEBAR_WIDTH}px;
   min-width: ${SIDEBAR_WIDTH}px;
   padding: 0 2rem 0.5rem;
   background: ${color("white")};


### PR DESCRIPTION
### Problem
Dashboard headers have a margin-right updated whenever a dashboard sidebar is open or closed. This feature was intended to create alignment between fixed width dashboard body and dashboard header. It unintentionally was not disabled for full-width dashboards. Also, this PR updates the info sidebar widths to align with the other sidebar widths

---
### Desired Behavior / Acceptance Criteria
**Before**

https://github.com/metabase/metabase/assets/22608765/3d6a8501-d456-42b1-8bb0-de09e533ea0b

**After**

https://github.com/metabase/metabase/assets/22608765/37b93dd9-cc4d-4451-88d8-4e7a469a2a62

---
### Context
- Part of the https://github.com/metabase/metabase/issues/38446 work

