### PR TITLE
Use all hidden parameters to determine parameter container visibility

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -165,7 +165,7 @@ function EmbedFrame({
 
   const hasParameters = Array.isArray(parameters) && parameters.length > 0;
   const visibleParameters = hasParameters
-    ? getVisibleParameters(parameters, hiddenParameterSlugs)
+    ? getVisibleParameters(parameters, hideParameters)
     : [];
   const hasVisibleParameters = visibleParameters.length > 0;
 


### PR DESCRIPTION
Updates `visibleParameters` check to use all hidden parameters: both query string supplied `#hide_parameters=...` and `hiddenParameterSlugs` supplied.

- Closes: https://github.com/metabase/metabase/issues/13934

**Before**
![image](https://github.com/metabase/metabase/assets/22608765/e3523113-39ab-4fbf-a6df-21f1e42afd35)


**After**
![image](https://github.com/metabase/metabase/assets/22608765/554bb8c9-64d7-4194-a568-181a67d3b1e4)
