### PR TITLE
simulate time scale with category scale

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/dataset.ts
@@ -7,3 +7,5 @@ export const NEGATIVE_STACK_TOTAL_DATA_KEY = `${NULL_CHAR}_negativeStackTotal`;
 
 // Key of x-axis values
 export const X_AXIS_DATA_KEY = `${NULL_CHAR}_x`;
+
+export const ORIGINAL_DATUM_INDEX_KEY = `${NULL_CHAR}_original_index`;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -17,6 +17,7 @@ import {
   getSortedSeriesModels,
   applyVisualizationSettingsDataTransformations,
   sortDataset,
+  interpolateContinuousXValues as interpolateXValues,
 } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import {
   getXAxisModel,
@@ -95,7 +96,6 @@ export const getCartesianChartModel = (
       dataset = getJoinedCardsDataset(rawSeries, cardsColumns);
   }
   dataset = sortDataset(dataset, settings["graph.x_axis.scale"]);
-
   const xAxisModel = getXAxisModel(
     dimensionModel,
     rawSeries,
@@ -127,7 +127,11 @@ export const getCartesianChartModel = (
 
   return {
     dataset,
-    transformedDataset,
+    transformedDataset: interpolateXValues(
+      transformedDataset,
+      xAxisModel,
+      settings,
+    ),
     seriesModels,
     columnByDataKey,
     dimensionModel,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -1,4 +1,3 @@
-import type { OptionAxisType } from "echarts/types/src/coord/axisCommonTypes";
 import type { Dayjs } from "dayjs";
 import type { Insight } from "metabase-types/api/insight";
 
@@ -99,13 +98,34 @@ export type TimeSeriesInterval = {
   range?: DateRange;
 };
 
-export type XAxisModel = {
+export type NumericInterval = {
+  range: [number, number];
+  lengthInIntervals: number;
+};
+
+export type BaseXAxisModel = {
   label?: string;
   formatter: AxisFormatter;
-  axisType: OptionAxisType;
   canBrush?: boolean;
-  timeSeriesInterval?: TimeSeriesInterval;
 };
+
+export type OrdinalXAxisModel = BaseXAxisModel & {
+  isHistogram: boolean;
+};
+
+export type NumericXAxisModel = BaseXAxisModel & {
+  numericInterval: NumericInterval;
+  function: "linear" | "pow" | "log";
+};
+
+export type TimeSeriesXAxisModel = BaseXAxisModel & {
+  timeSeriesInterval: TimeSeriesInterval;
+};
+
+export type XAxisModel =
+  | OrdinalXAxisModel
+  | NumericXAxisModel
+  | TimeSeriesXAxisModel;
 
 export type YAxisModel = {
   seriesKeys: DataKey[];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -18,7 +18,6 @@ import { CHART_STYLE } from "metabase/visualizations/echarts/cartesian/constants
 
 import { getDimensionDisplayValueGetter } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import type { ChartMeasurements } from "metabase/visualizations/echarts/cartesian/option/types";
-import { getTimeSeriesMinInterval } from "metabase/visualizations/echarts/cartesian/utils/time-series";
 
 const NORMALIZED_RANGE = { min: 0, max: 1 };
 
@@ -110,12 +109,7 @@ export const buildDimensionAxis = (
   renderingContext: RenderingContext,
 ): AxisBaseOption => {
   const { getColor } = renderingContext;
-  const { axisType, formatter, timeSeriesInterval } = xAxisModel;
-
-  const boundaryGap =
-    axisType === "value" || axisType === "log"
-      ? undefined
-      : ([0.02, 0.02] as [number, number]);
+  const { formatter } = xAxisModel;
 
   const nameGap = getAxisNameGap(
     chartMeasurements.ticksDimensions.xTicksHeight,
@@ -133,11 +127,11 @@ export const buildDimensionAxis = (
     axisTick: {
       show: false,
     },
-    boundaryGap,
+    boundaryGap: [0.02, 0.02],
     splitLine: {
       show: false,
     },
-    type: axisType,
+    type: "category",
     axisLabel: {
       margin:
         CHART_STYLE.axisTicksMarginX +
@@ -154,10 +148,6 @@ export const buildDimensionAxis = (
         color: getColor("border"),
       },
     },
-    minInterval:
-      timeSeriesInterval != null
-        ? getTimeSeriesMinInterval(timeSeriesInterval)
-        : undefined,
   } as AxisBaseOption;
 };
 


### PR DESCRIPTION
## Description

An attempt to simulate continuous scales with a discrete one

- [x] correct spacing between data points
- [x] handle tiny granularities that are way less than 1 pixel
- [x] click behavior should work
- [ ] render only desired ticks on x-axis
- [ ] brushing should work