### PR TITLE
Disable immer auto freeze

### DIFF
--- a/frontend/src/metabase/store.js
+++ b/frontend/src/metabase/store.js
@@ -1,9 +1,18 @@
 import { configureStore, combineReducers } from "@reduxjs/toolkit";
+import { setAutoFreeze } from "immer";
 import { routerReducer as routing, routerMiddleware } from "react-router-redux";
 import promise from "redux-promise";
 import { PLUGIN_REDUX_MIDDLEWARES } from "metabase/plugins";
 
-export function getStore(reducers, history, intialState) {
+/**
+ * MLv2 modifies passed values and adds a new property for caching objects
+ * to speed up calculations. RTK uses immer under the hood and freezes
+ * state automatically, which leads to the error on cljs side.
+ * As a workaround, we disable immer's auto-freeze
+ */
+setAutoFreeze(false);
+
+export function getStore(reducers, history, initialState) {
   const reducer = combineReducers({
     ...reducers,
     routing,
@@ -11,7 +20,7 @@ export function getStore(reducers, history, intialState) {
 
   return configureStore({
     reducer,
-    preloadedState: intialState,
+    preloadedState: initialState,
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware({
         immutableCheck: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -12518,12 +12518,7 @@ image-size@^1.0.0:
   dependencies:
     queue "6.0.2"
 
-immer@^9.0.16:
-  version "9.0.17"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.17.tgz#7cfe8fbb8b461096444e9da7a5ec4a67c6c4adf4"
-  integrity sha512-+hBruaLSQvkPfxRiTLK/mi4vLH+/VQS6z2KJahdoxlleFOI8ARqzOF17uy12eFDlqWmPoygwc5evgwcp+dlHhg==
-
-immer@^9.0.17:
+immer@^9.0.16, immer@^9.0.17:
   version "9.0.21"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.21.tgz#1e025ea31a40f24fb064f1fef23e931496330176"
   integrity sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==


### PR DESCRIPTION
### Description

#### TL;DR

MLv2 modifies values which are passed as arguments and adds a new property for caching objects to speed up calculations. RTK uses immer under the hood and freezes state automatically, which leads to the error on cljs side.

#### Longer explanation

[PR](https://github.com/metabase/metabase/pull/38168) highlighted the problem of MLv2 which can't handle frozen objects which we get after RTK's state modifications. immer has auto-freeze option ([enabled by default](https://github.com/immerjs/immer/blob/f6736a4beef727c6e5b41c312ce1b202ad3afb23/src/core/immerClass.ts#L152-L159)) which also freezes the state to prevent implicit state modifications. 

[Even if it's a recommended approach](https://github.com/reduxjs/redux-toolkit/discussions/1189#discussioncomment-884343) which can save developers from shooting a foot, we follow the same approach across application and avoid implicit state modifications. 
You can't implicitly modify state inside reducers with RTK (because it uses immer under the hood and generates a new state even if you modify the old), but it doesn't save you from modifying state inside components by reference.

But I'd recommend disabling auto-freeze because freezing can result in such unexpected errors which really hard to debug when MLv2 accepts a frozen or partially frozen object.

As an example, here is what I got after passing a frozen object as a parameter
<img width="518" alt="image" src="https://github.com/metabase/metabase/assets/125459446/edeeb046-2001-4c72-bacf-7ec51f5e5ee4">

and I was able to reproduce it locally only in fast 3g simulation

### How to verify

tests should pass


### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
