### PR TITLE
Update `ModelIndex` type

### DIFF
--- a/frontend/src/metabase-types/api/mocks/modelIndexes.ts
+++ b/frontend/src/metabase-types/api/mocks/modelIndexes.ts
@@ -8,10 +8,10 @@ export const createMockModelIndex = (
   pk_ref: ["field", 1, null],
   value_ref: ["field", 2, null],
   state: "indexed",
-  generation: 1,
   creator_id: 1,
   error: null,
   schedule: "0 0 22 * * ? *",
-  state_changed_at: "2020-01-01T00:00:00.000Z",
+  created_at: "2020-01-01T00:00:00.000Z",
+  indexed_at: "2020-01-01T00:01:00.000Z",
   ...opts,
 });

--- a/frontend/src/metabase-types/api/modelIndexes.ts
+++ b/frontend/src/metabase-types/api/modelIndexes.ts
@@ -10,11 +10,11 @@ export type ModelIndex = {
   value_ref: FieldReference;
   pk_ref: FieldReference;
   state: "indexed" | "pending";
-  generation: number;
   creator_id: number;
   error: string | null;
   schedule: string; // cron string
-  state_changed_at: string; // datetime
+  created_at: string; // datetime
+  indexed_at: string; // datetime
 };
 
 export type IndexedEntity = {


### PR DESCRIPTION
As discussed [here](https://github.com/metabase/metabase/pull/38664#discussion_r1490690821), the type for Modelndex seems to have changed. This PR updates the type to reflect those changes.

@dpsutton confirmed that the `generation` has gone. Still need to double-check the `state_changed_at`.

Relevant API documentation:
https://www.metabase.com/docs/latest/api/model-index

How to check?
If you have any model indexes, call `GET /api/model-index` and check for the responses for any of them. You can do this for an individual record if you know its id.

The response I'm seeing is:
```json
[
	{
		"value_ref": [
			"field",
			71,
			null
		],
		"schedule": "0 0 4 * * ? *",
		"pk_ref": [
			"field",
			68,
			null
		],
		"state": "indexed",
		"creator_id": 1,
		"model_id": 78,
		"id": 3,
		"indexed_at": "2024-02-15T10:12:08.806019+01:00",
		"error": null,
		"created_at": "2024-02-15T10:12:08.664025+01:00"
	}
]
```