### PR TITLE
Filter picker search free input

### DIFF
--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.tsx
@@ -29,7 +29,7 @@ interface FilterValuePickerProps<T> {
 
 interface FilterValuePickerOwnProps extends FilterValuePickerProps<string> {
   placeholder: string;
-  shouldCreate: (query: string) => boolean;
+  canAddValue: (query: string) => boolean;
 }
 
 function FilterValuePicker({
@@ -40,7 +40,7 @@ function FilterValuePicker({
   placeholder,
   autoFocus = false,
   compact = false,
-  shouldCreate,
+  canAddValue,
   onChange,
   onFocus,
   onBlur,
@@ -86,7 +86,7 @@ function FilterValuePicker({
         fieldValues={fieldData?.values ?? []}
         selectedValues={selectedValues}
         placeholder={t`Search by ${columnInfo.displayName}`}
-        shouldCreate={shouldCreate}
+        canAddValue={canAddValue}
         autoFocus={autoFocus}
         onChange={onChange}
       />
@@ -97,7 +97,7 @@ function FilterValuePicker({
     <StaticValuePicker
       selectedValues={selectedValues}
       placeholder={placeholder}
-      shouldCreate={shouldCreate}
+      canAddValue={canAddValue}
       autoFocus={autoFocus}
       onChange={onChange}
       onFocus={onFocus}
@@ -111,7 +111,7 @@ export function StringFilterValuePicker({
   values,
   ...props
 }: FilterValuePickerProps<string>) {
-  const shouldCreate = (query: string) => {
+  const canAddValue = (query: string) => {
     return query.trim().length > 0 && !values.includes(query);
   };
 
@@ -121,7 +121,7 @@ export function StringFilterValuePicker({
       column={column}
       values={values}
       placeholder={isKeyColumn(column) ? t`Enter an ID` : t`Enter some text`}
-      shouldCreate={shouldCreate}
+      canAddValue={canAddValue}
     />
   );
 }
@@ -132,7 +132,7 @@ export function NumberFilterValuePicker({
   onChange,
   ...props
 }: FilterValuePickerProps<number>) {
-  const shouldCreate = (query: string) => {
+  const canAddValue = (query: string) => {
     const number = parseFloat(query);
     return isFinite(number) && !values.includes(number);
   };
@@ -143,7 +143,7 @@ export function NumberFilterValuePicker({
       column={column}
       values={values.map(value => String(value))}
       placeholder={isKeyColumn(column) ? t`Enter an ID` : t`Enter a number`}
-      shouldCreate={shouldCreate}
+      canAddValue={canAddValue}
       onChange={newValue => onChange(newValue.map(value => parseFloat(value)))}
     />
   );

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.tsx
@@ -86,7 +86,7 @@ function FilterValuePicker({
         fieldValues={fieldData?.values ?? []}
         selectedValues={selectedValues}
         placeholder={t`Search by ${columnInfo.displayName}`}
-        nothingFound={t`No matching ${columnInfo.displayName} found.`}
+        shouldCreate={shouldCreate}
         autoFocus={autoFocus}
         onChange={onChange}
       />

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -407,6 +407,26 @@ describe("StringFilterValuePicker", () => {
       expect(screen.getByText("a@b.com")).toBeInTheDocument();
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    it("should not allow to create a value when there is the exact match in search results", async () => {
+      const { onChange } = await setupStringPicker({
+        query,
+        stageIndex,
+        column,
+        values: ["a@b.com"],
+        searchValues: {
+          "a@b.com": createMockFieldValues({
+            field_id: PEOPLE.EMAIL,
+            values: [["a@b.com"]],
+          }),
+        },
+      });
+
+      userEvent.type(screen.getByLabelText("Filter value"), "a@b.com");
+      act(() => jest.advanceTimersByTime(1000));
+      expect(screen.getByText("a@b.com")).toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
+    });
   });
 
   describe("no values", () => {

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -368,6 +368,26 @@ describe("StringFilterValuePicker", () => {
 
       expect(onChange).toHaveBeenLastCalledWith(["a-test"]);
     });
+
+    it("should allow free-form input without waiting for search results", async () => {
+      const { onChange } = await setupStringPicker({
+        query,
+        stageIndex,
+        column,
+        values: [],
+        searchValues: {
+          "a@b.com": createMockFieldValues({
+            field_id: PEOPLE.EMAIL,
+            values: [["testa@b.com"]],
+          }),
+        },
+      });
+
+      userEvent.type(screen.getByPlaceholderText("Search by Email"), "a@b.com");
+      userEvent.hover(screen.getByText("New a@b.com"));
+      userEvent.click(screen.getByText("New a@b.com"));
+      expect(onChange).toHaveBeenLastCalledWith(["a@b.com"]);
+    });
   });
 
   describe("no values", () => {

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -388,6 +388,25 @@ describe("StringFilterValuePicker", () => {
       userEvent.click(screen.getByText("New a@b.com"));
       expect(onChange).toHaveBeenLastCalledWith(["a@b.com"]);
     });
+
+    it("should not be able to create duplicates with free-form input", async () => {
+      const { onChange } = await setupStringPicker({
+        query,
+        stageIndex,
+        column,
+        values: ["a@b.com"],
+        searchValues: {
+          "a@b.com": createMockFieldValues({
+            field_id: PEOPLE.EMAIL,
+            values: [["testa@b.com"]],
+          }),
+        },
+      });
+
+      userEvent.type(screen.getByLabelText("Filter value"), "a@b.com");
+      expect(screen.queryByText("New a@b.com")).not.toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
+    });
   });
 
   describe("no values", () => {

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -384,8 +384,8 @@ describe("StringFilterValuePicker", () => {
       });
 
       userEvent.type(screen.getByPlaceholderText("Search by Email"), "a@b.com");
-      userEvent.hover(screen.getByText("New a@b.com"));
-      userEvent.click(screen.getByText("New a@b.com"));
+      userEvent.hover(screen.getByText("a@b.com"));
+      userEvent.click(screen.getByText("a@b.com"));
       expect(onChange).toHaveBeenLastCalledWith(["a@b.com"]);
     });
 
@@ -404,7 +404,7 @@ describe("StringFilterValuePicker", () => {
       });
 
       userEvent.type(screen.getByLabelText("Filter value"), "a@b.com");
-      expect(screen.queryByText("New a@b.com")).not.toBeInTheDocument();
+      expect(screen.getByText("a@b.com")).toBeInTheDocument();
       expect(onChange).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -13,7 +13,7 @@ interface SearchValuePickerProps {
   fieldValues: FieldValue[];
   selectedValues: string[];
   placeholder?: string;
-  nothingFound?: string;
+  shouldCreate: (query: string) => boolean;
   autoFocus?: boolean;
   onChange: (newValues: string[]) => void;
 }
@@ -24,14 +24,14 @@ export function SearchValuePicker({
   fieldValues: initialFieldValues,
   selectedValues,
   placeholder,
-  nothingFound,
+  shouldCreate,
   autoFocus,
   onChange,
 }: SearchValuePickerProps) {
   const [searchValue, setSearchValue] = useState("");
   const [searchQuery, setSearchQuery] = useState(searchValue);
 
-  const { value: fieldValues = initialFieldValues, loading } = useAsync(
+  const { value: fieldValues = initialFieldValues } = useAsync(
     () => getSearchValues(fieldId, searchFieldId, searchQuery),
     [fieldId, searchFieldId, searchQuery],
   );
@@ -54,7 +54,6 @@ export function SearchValuePicker({
     }
   };
 
-  const isSearched = searchQuery.length > 0 && !loading;
   useDebounce(handleSearchTimeout, SEARCH_DEBOUNCE, [searchValue]);
 
   return (
@@ -63,7 +62,9 @@ export function SearchValuePicker({
       value={selectedValues}
       searchValue={searchValue}
       placeholder={placeholder}
-      nothingFound={isSearched ? nothingFound : null}
+      shouldCreate={shouldCreate}
+      getCreateLabel={query => t`New ${query}`}
+      creatable
       searchable
       autoFocus={autoFocus}
       aria-label={t`Filter value`}

--- a/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -54,6 +54,11 @@ export function SearchValuePicker({
     }
   };
 
+  const handleCreate = (searchValue: string) => {
+    onChange([...selectedValues, searchValue]);
+    return searchValue;
+  };
+
   useDebounce(handleSearchTimeout, SEARCH_DEBOUNCE, [searchValue]);
 
   return (
@@ -63,13 +68,14 @@ export function SearchValuePicker({
       searchValue={searchValue}
       placeholder={placeholder}
       shouldCreate={shouldCreate}
-      getCreateLabel={query => t`New ${query}`}
+      getCreateLabel={searchValue => t`New ${searchValue}`}
       creatable
       searchable
       autoFocus={autoFocus}
       aria-label={t`Filter value`}
       onChange={onChange}
       onSearchChange={handleSearchChange}
+      onCreate={handleCreate}
     />
   );
 }

--- a/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -5,7 +5,7 @@ import type { FieldId, FieldValue } from "metabase-types/api";
 import { MultiSelect } from "metabase/ui";
 import { getEffectiveOptions } from "../utils";
 import { SEARCH_DEBOUNCE } from "./constants";
-import { shouldSearch, getSearchValues } from "./utils";
+import { shouldSearch, getSearchValues, getOptimisticOptions } from "./utils";
 
 interface SearchValuePickerProps {
   fieldId: FieldId;
@@ -54,35 +54,19 @@ export function SearchValuePicker({
     }
   };
 
-  const handleCreate = (searchValue: string) => {
-    onChange([...selectedValues, searchValue]);
-    return searchValue;
-  };
-
-  const shouldCreate = (searchValue: string) => {
-    return (
-      canAddValue(searchValue) &&
-      !options.some(option => option.label === searchValue)
-    );
-  };
-
   useDebounce(handleSearchTimeout, SEARCH_DEBOUNCE, [searchValue]);
 
   return (
     <MultiSelect
-      data={options}
+      data={getOptimisticOptions(options, searchValue, canAddValue)}
       value={selectedValues}
       searchValue={searchValue}
       placeholder={placeholder}
-      shouldCreate={shouldCreate}
-      getCreateLabel={searchValue => searchValue}
-      creatable
       searchable
       autoFocus={autoFocus}
       aria-label={t`Filter value`}
       onChange={onChange}
       onSearchChange={handleSearchChange}
-      onCreate={handleCreate}
     />
   );
 }

--- a/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/SearchValuePicker.tsx
@@ -13,7 +13,7 @@ interface SearchValuePickerProps {
   fieldValues: FieldValue[];
   selectedValues: string[];
   placeholder?: string;
-  shouldCreate: (query: string) => boolean;
+  canAddValue: (query: string) => boolean;
   autoFocus?: boolean;
   onChange: (newValues: string[]) => void;
 }
@@ -24,7 +24,7 @@ export function SearchValuePicker({
   fieldValues: initialFieldValues,
   selectedValues,
   placeholder,
-  shouldCreate,
+  canAddValue,
   autoFocus,
   onChange,
 }: SearchValuePickerProps) {
@@ -59,6 +59,13 @@ export function SearchValuePicker({
     return searchValue;
   };
 
+  const shouldCreate = (searchValue: string) => {
+    return (
+      canAddValue(searchValue) &&
+      !options.some(option => option.label === searchValue)
+    );
+  };
+
   useDebounce(handleSearchTimeout, SEARCH_DEBOUNCE, [searchValue]);
 
   return (
@@ -68,7 +75,7 @@ export function SearchValuePicker({
       searchValue={searchValue}
       placeholder={placeholder}
       shouldCreate={shouldCreate}
-      getCreateLabel={searchValue => t`New ${searchValue}`}
+      getCreateLabel={searchValue => searchValue}
       creatable
       searchable
       autoFocus={autoFocus}

--- a/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/utils.ts
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/SearchValuePicker/utils.ts
@@ -1,4 +1,5 @@
 import { MetabaseApi } from "metabase/services";
+import type { SelectItem } from "metabase/ui";
 import type { FieldId, FieldValue } from "metabase-types/api";
 import { SEARCH_LIMIT } from "./constants";
 
@@ -29,4 +30,17 @@ export function shouldSearch(
   const hasMoreValues = fieldValues.length === SEARCH_LIMIT;
 
   return !isExtensionOfLastSearch || hasMoreValues;
+}
+
+export function getOptimisticOptions(
+  options: SelectItem[],
+  searchValue: string,
+  canAddValue: (query: string) => boolean,
+) {
+  const isValid = canAddValue(searchValue);
+  const isExisting = options.some(({ label }) => label === searchValue);
+
+  return isValid && !isExisting
+    ? [{ value: searchValue, label: searchValue }, ...options]
+    : options;
 }

--- a/frontend/src/metabase/querying/components/FilterValuePicker/StaticValuePicker/StaticValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/StaticValuePicker/StaticValuePicker.tsx
@@ -48,8 +48,8 @@ export function StaticValuePicker({
   const handleSearchChange = (newSearchValue: string) => {
     setSearchValue(newSearchValue);
 
-    const canAdd = canAddValue(newSearchValue);
-    if (canAdd) {
+    const isValid = canAddValue(newSearchValue);
+    if (isValid) {
       onChange?.([...lastValues, newSearchValue]);
     } else {
       onChange?.(lastValues);

--- a/frontend/src/metabase/querying/components/FilterValuePicker/StaticValuePicker/StaticValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/StaticValuePicker/StaticValuePicker.tsx
@@ -6,7 +6,7 @@ import { MultiSelect } from "metabase/ui";
 interface StaticValuePickerProps {
   selectedValues: string[];
   placeholder?: string;
-  shouldCreate: (query: string) => boolean;
+  canAddValue: (query: string) => boolean;
   autoFocus?: boolean;
   onChange: (newValues: string[]) => void;
   onFocus?: (event: FocusEvent<HTMLInputElement>) => void;
@@ -16,7 +16,7 @@ interface StaticValuePickerProps {
 export function StaticValuePicker({
   selectedValues,
   placeholder,
-  shouldCreate,
+  canAddValue,
   autoFocus,
   onChange,
   onFocus,
@@ -48,8 +48,8 @@ export function StaticValuePicker({
   const handleSearchChange = (newSearchValue: string) => {
     setSearchValue(newSearchValue);
 
-    const isValid = shouldCreate(newSearchValue);
-    if (isValid) {
+    const canAdd = canAddValue(newSearchValue);
+    if (canAdd) {
       onChange?.([...lastValues, newSearchValue]);
     } else {
       onChange?.(lastValues);


### PR DESCRIPTION
Product doc https://www.notion.so/metabase/Free-up-text-input-performance-from-loading-values-in-filters-f70287f73d014794abb60653c6d28e39
Fixes https://github.com/metabase/metabase/issues/37906

Previously it wasn't possible to select a value not from the list for "searchable" columns. It becomes a problem when it takes a lot of time to load search results as they are **loaded from the customer DB directly**.  In this case the user is not able to create a filter at all. 

Now we allow entering any value, even without waiting for search results (but no duplicates). This is based on `creatable` property of the mantine's `MultiSelect`. I've decided to go with `New {input}` label but this is to be verified with Product.

How to verify:
- New -> Question -> People
- Filter by Email
- Trying adding filters

**Before**

With search results:
<img width="779" alt="Screenshot 2024-02-19 at 14 46 04" src="https://github.com/metabase/metabase/assets/8542534/6a271e90-7c3a-4bb4-b23d-3684180e9a43">

No search results:
<img width="844" alt="Screenshot 2024-02-19 at 14 46 10" src="https://github.com/metabase/metabase/assets/8542534/b7e8a91b-869c-440b-a365-0f473217f1b8">

**After**

With search results:
<img width="901" alt="Screenshot 2024-02-19 at 14 39 28" src="https://github.com/metabase/metabase/assets/8542534/cd09070b-ab93-460f-aac8-5a1a8ab6805d">

No search results:
<img width="819" alt="Screenshot 2024-02-19 at 14 39 09" src="https://github.com/metabase/metabase/assets/8542534/5d4390aa-c49c-40a6-b0f6-604891f62b0b">
