### PR TITLE
Support JWT and other SSO methods at the same time

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
@@ -3,11 +3,18 @@
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase.util.i18n :refer [tru]]))
 
+(defn- jwt-saml-both-enabled
+  [req]
+  (if (contains? (:params req) :jwt)
+    :jwt
+    :saml))
+
 (defn- sso-backend
   "Function that powers the defmulti in figuring out which SSO backend to use. It might be that we need to have more
   complex logic around this, but now it's just a simple priority. If SAML is configured use that otherwise JWT"
-  [_]
+  [req]
   (cond
+    (and (sso-settings/saml-enabled) (sso-settings/jwt-enabled)) (jwt-saml-both-enabled req)
     (sso-settings/saml-enabled) :saml
     (sso-settings/jwt-enabled)  :jwt
     :else                       nil))

--- a/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/api/interface.clj
@@ -3,7 +3,7 @@
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase.util.i18n :refer [tru]]))
 
-(defn- jwt-saml-both-enabled
+(defn- select-sso-backend
   [req]
   (if (contains? (:params req) :jwt)
     :jwt
@@ -14,7 +14,7 @@
   complex logic around this, but now it's just a simple priority. If SAML is configured use that otherwise JWT"
   [req]
   (cond
-    (and (sso-settings/saml-enabled) (sso-settings/jwt-enabled)) (jwt-saml-both-enabled req)
+    (and (sso-settings/saml-enabled) (sso-settings/jwt-enabled)) (select-sso-backend req)
     (sso-settings/saml-enabled) :saml
     (sso-settings/jwt-enabled)  :jwt
     :else                       nil))

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/saml_test.clj
@@ -3,7 +3,6 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
-   [metabase-enterprise.sso.integrations.jwt-test :as jwt-test]
    [metabase-enterprise.sso.integrations.saml :as saml.mt]
    [metabase-enterprise.sso.integrations.sso-settings :as sso-settings]
    [metabase.http-client :as client]
@@ -402,7 +401,7 @@
                    (saml-login-attributes "rasta@metabase.com")))))))))
 
 (deftest jwt-saml-both-enabled-saml-success-test
-  (jwt-test/with-sso-jwt-token
+  (mt/with-additional-premium-features #{:sso-jwt}
     (testing "with SAML and JWT configured, a GET request without JWT params successfully logins with SAML."
       (with-saml-default-setup
         (do-with-some-validators-disabled


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/18554
Closes https://github.com/metabase/metabase/issues/29492
Product doc: https://www.notion.so/metabase/Support-JWT-and-other-SSO-methods-at-the-same-time-7e3d1917b1104b1085ad8f87329fce63

### Description

Adds a if statement for if both JWT and SAML is enabled. 

Personally I think in the future we should split up SAML and JWT into separate endpoints and have two different buttons in the FE. 
- Other SSO methods are separate (Google, LDAP)
- Clears up the behavior of login instead of hiding the SSO method behind the query params
- Cleans up the BE code to have one layer less of indirection