### PR TITLE
Use report timezone setting macro with cleanup

### DIFF
--- a/test/metabase/query_processor_test/date_time_zone_functions_test.clj
+++ b/test/metabase/query_processor_test/date_time_zone_functions_test.clj
@@ -417,7 +417,7 @@
     (testing "should return the current time"
       ;; Allow a 30 second window for the current time to account for any difference between the time in Clojure and the DB
       (doseq [timezone [nil "America/Los_Angeles"]]
-        (mt/with-temporary-setting-values [report-timezone timezone]
+        (mt/with-report-timezone-id timezone
           (is (= true
                  (-> (mt/run-mbql-query venues
                        {:expressions {"1" [:now]}


### PR DESCRIPTION
Closes #38219

### Description

Make use of `with-report-timezone-id` which does pre and post cleanup. I believe that test was flaking because session was reused with report timezone set. This change ensures that sessions are restarted after modifications to report timezone.