### PR TITLE
Align paths in Prettier & ESLint scripts

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
 frontend/src/cljs
 frontend/src/cljs_release
+e2e/support/cypress_sample_database.js
+e2e/support/cypress_sample_instance_data.js

--- a/e2e/runner/cypress-runner-backend.js
+++ b/e2e/runner/cypress-runner-backend.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-const fs = require("fs");
 const { spawn } = require("child_process");
-const os = require("os");
-const path = require("path");
+const fs = require("fs");
 
 const http = require("http");
+const os = require("os");
+const path = require("path");
 
 const CypressBackend = {
   createServer(port = 4000) {

--- a/e2e/runner/cypress-runner-get-version.js
+++ b/e2e/runner/cypress-runner-get-version.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+
 const { printBold, printCyan } = require("./cypress-runner-utils.js");
 
 const getVersion = async () => {

--- a/e2e/runner/cypress-runner-utils.js
+++ b/e2e/runner/cypress-runner-utils.js
@@ -1,4 +1,5 @@
 const { exec } = require("child_process");
+
 const arg = require("arg");
 const chalk = require("chalk");
 const cypress = require("cypress");

--- a/e2e/runner/run_cypress_tests.js
+++ b/e2e/runner/run_cypress_tests.js
@@ -1,8 +1,8 @@
-const { printBold } = require("./cypress-runner-utils");
-const runCypress = require("./cypress-runner-run-tests");
-const getVersion = require("./cypress-runner-get-version");
-const generateSnapshots = require("./cypress-runner-generate-snapshots");
 const CypressBackend = require("./cypress-runner-backend");
+const generateSnapshots = require("./cypress-runner-generate-snapshots");
+const getVersion = require("./cypress-runner-get-version");
+const runCypress = require("./cypress-runner-run-tests");
+const { printBold } = require("./cypress-runner-utils");
 
 const e2eHost = process.env["E2E_HOST"];
 

--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -1,5 +1,5 @@
 import _ from "underscore";
-import { snapshot, restore, withSampleDatabase } from "e2e/support/helpers";
+
 import {
   USERS,
   USER_GROUPS,
@@ -7,6 +7,7 @@ import {
   SAMPLE_DB_TABLES,
   METABASE_SECRET_KEY,
 } from "e2e/support/cypress_data";
+import { snapshot, restore, withSampleDatabase } from "e2e/support/helpers";
 
 const {
   STATIC_ORDERS_ID,

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -1,9 +1,10 @@
 import * as dbTasks from "./db_tasks";
-const replay = require("@replayio/cypress");
-const { verifyDownloadTasks } = require("cy-verify-downloads");
+
 const {
   NodeModulesPolyfillPlugin,
 } = require("@esbuild-plugins/node-modules-polyfill");
+const replay = require("@replayio/cypress");
+const { verifyDownloadTasks } = require("cy-verify-downloads");
 
 const isEnterprise = process.env["MB_EDITION"] === "ee";
 
@@ -23,6 +24,7 @@ const feHealthcheckEnabled = process.env["CYPRESS_FE_HEALTHCHECK"] === "true";
 // the project's config changing)
 
 const createBundler = require("@bahmutov/cypress-esbuild-preprocessor");
+
 const {
   removeDirectory,
 } = require("./commands/downloads/deleteDownloadsFolder");

--- a/e2e/support/config.js
+++ b/e2e/support/config.js
@@ -1,10 +1,15 @@
 import * as dbTasks from "./db_tasks";
 
+const createBundler = require("@bahmutov/cypress-esbuild-preprocessor"); // This function is called when a project is opened or re-opened (e.g. due to the project's config changing)
 const {
   NodeModulesPolyfillPlugin,
 } = require("@esbuild-plugins/node-modules-polyfill");
 const replay = require("@replayio/cypress");
 const { verifyDownloadTasks } = require("cy-verify-downloads");
+
+const {
+  removeDirectory,
+} = require("./commands/downloads/deleteDownloadsFolder");
 
 const isEnterprise = process.env["MB_EDITION"] === "ee";
 
@@ -19,15 +24,6 @@ const targetVersion = process.env["CROSS_VERSION_TARGET"];
 const runWithReplay = process.env["CYPRESS_REPLAYIO_ENABLED"];
 
 const feHealthcheckEnabled = process.env["CYPRESS_FE_HEALTHCHECK"] === "true";
-
-// This function is called when a project is opened or re-opened (e.g. due to
-// the project's config changing)
-
-const createBundler = require("@bahmutov/cypress-esbuild-preprocessor");
-
-const {
-  removeDirectory,
-} = require("./commands/downloads/deleteDownloadsFolder");
 
 const convertStringToInt = string =>
   string.split("").reduce((acc, char) => acc + char.charCodeAt(0), 0);

--- a/e2e/support/cypress-snapshots.config.js
+++ b/e2e/support/cypress-snapshots.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require("cypress");
+
 const { snapshotsConfig } = require("./config");
 
 module.exports = defineConfig({ e2e: snapshotsConfig });

--- a/e2e/support/cypress-stress-test.config.js
+++ b/e2e/support/cypress-stress-test.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require("cypress");
+
 const { stressTestConfig } = require("./config");
 
 module.exports = defineConfig({ e2e: stressTestConfig });

--- a/e2e/support/cypress.config.js
+++ b/e2e/support/cypress.config.js
@@ -1,4 +1,5 @@
 const { defineConfig } = require("cypress");
+
 const { mainConfig } = require("./config");
 
 module.exports = defineConfig({ e2e: mainConfig });

--- a/e2e/support/cypress.js
+++ b/e2e/support/cypress.js
@@ -1,11 +1,11 @@
-import registerCypressGrep from "@cypress/grep";
+import registerCypressGrep from "@cypress/grep"; // eslint-disable-line import/order
 registerCypressGrep();
 
-import addContext from "mochawesome/addContext";
-import "@testing-library/cypress/add-commands";
-import "cypress-real-events/support";
 import "@cypress/skip-test/support";
 import "@percy/cypress";
+import "@testing-library/cypress/add-commands";
+import "cypress-real-events/support";
+import addContext from "mochawesome/addContext";
 import "./commands";
 
 const runWithReplay = Cypress.env("REPLAYIO_ENABLED");

--- a/e2e/support/cypress_sample_database.js
+++ b/e2e/support/cypress_sample_database.js
@@ -7,4 +7,4 @@
  */
 
 //
-export { default as SAMPLE_DATABASE } from "./cypress_sample_database.json"; // eslint-disable-line import/no-unresolved
+export { default as SAMPLE_DATABASE } from "./cypress_sample_database.json";

--- a/e2e/support/cypress_sample_instance_data.js
+++ b/e2e/support/cypress_sample_instance_data.js
@@ -8,7 +8,6 @@
 
 import _ from "underscore";
 
-// eslint-disable-next-line import/no-unresolved
 import SAMPLE_INSTANCE_DATA from "./cypress_sample_instance_data.json";
 
 export const ORDERS_QUESTION_ID = _.findWhere(SAMPLE_INSTANCE_DATA.questions, {

--- a/e2e/support/db_tasks.js
+++ b/e2e/support/db_tasks.js
@@ -1,7 +1,8 @@
 import Knex from "knex";
+
 import { WRITABLE_DB_CONFIG, QA_DB_CONFIG } from "./cypress_data";
-import * as testTables from "./test_tables";
 import { Roles } from "./test_roles";
+import * as testTables from "./test_tables";
 
 const dbClients = {};
 

--- a/e2e/support/external/e2e-jwt-sign.js
+++ b/e2e/support/external/e2e-jwt-sign.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-/*eslint-disable import/no-commonjs */
 
 const jwt = require("jsonwebtoken");
 const process = require("process");

--- a/e2e/support/external/e2e-jwt-sign.js
+++ b/e2e/support/external/e2e-jwt-sign.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /*eslint-disable import/no-commonjs */
 
-const process = require("process");
 const jwt = require("jsonwebtoken");
+const process = require("process");
 
 const payload = process.argv[2];
 const METABASE_SECRET_KEY = process.argv[3];

--- a/e2e/support/helpers/e2e-notebook-helpers.ts
+++ b/e2e/support/helpers/e2e-notebook-helpers.ts
@@ -1,4 +1,5 @@
 import type { CyHttpMessages } from "cypress/types/net-stubbing";
+
 import { popover } from "e2e/support/helpers/e2e-ui-elements-helpers";
 import type { NotebookStepType } from "metabase/query_builder/components/notebook/types";
 

--- a/e2e/support/integration/visit-dashboard.cy.spec.js
+++ b/e2e/support/integration/visit-dashboard.cy.spec.js
@@ -1,5 +1,5 @@
-import { restore, visitDashboard } from "e2e/support/helpers";
 import { USERS } from "e2e/support/cypress_data";
+import { restore, visitDashboard } from "e2e/support/helpers";
 
 import { setup } from "./visit-dashboard";
 

--- a/e2e/validate-e2e-test-files.js
+++ b/e2e/validate-e2e-test-files.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 const { execSync } = require("child_process");
 
-const path = require("path");
-const glob = require("glob");
 const chalk = require("chalk");
+const glob = require("glob");
+const path = require("path");
 
 const E2E_FILE_EXTENSION = /\.cy\.spec\.(js|ts)$/;
 const E2E_HOME = "e2e/test/";
@@ -36,7 +36,7 @@ function validateAllFiles() {
 
 function getAllE2EFiles() {
   // Will match all files in the scenarios dir, except the ones in helpers and shared directories
-  const PATTERN = `${E2E_HOME}*/{*.js,!(helpers|shared)/*.js}`;
+  const PATTERN = `${E2E_HOME}*/{*.(js|ts),!(helpers|shared)/*.(js|ts)}`;
 
   return glob.sync(PATTERN);
 }

--- a/frontend/lint/tests/no-literal-metabase-strings.unit.spec.js
+++ b/frontend/lint/tests/no-literal-metabase-strings.unit.spec.js
@@ -1,4 +1,5 @@
 import { RuleTester } from "eslint";
+
 import noLiteralMetabaseString from "../eslint-rules/no-literal-metabase-strings";
 
 const ruleTester = new RuleTester({

--- a/frontend/lint/tests/no-unconditional-metabase-links-render.unit.spec.js
+++ b/frontend/lint/tests/no-unconditional-metabase-links-render.unit.spec.js
@@ -1,4 +1,5 @@
 import { RuleTester } from "eslint";
+
 import noUnconditionalMetabaseLinksRender from "../eslint-rules/no-unconditional-metabase-links-render";
 
 const ruleTester = new RuleTester({

--- a/frontend/lint/tests/no-unscoped-text-selectors.unit.spec.js
+++ b/frontend/lint/tests/no-unscoped-text-selectors.unit.spec.js
@@ -1,4 +1,5 @@
 import { RuleTester } from "eslint";
+
 import rule from "../eslint-rules/no-unscoped-text-selectors";
 
 const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2015 } });

--- a/frontend/parse-deps.js
+++ b/frontend/parse-deps.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
+/* eslint-disable import/no-commonjs, no-undef, no-console */
 const fs = require("fs");
-const path = require("path");
+const readline = require("readline");
 
+const babel = require("@babel/core");
 const glob = require("glob");
 const minimatch = require("minimatch");
-const babel = require("@babel/core");
-const readline = require("readline");
+const path = require("path");
 
 const PATTERN = "{enterprise/,}frontend/src/**/*.{js,jsx,ts,tsx}";
 
@@ -77,7 +78,7 @@ function getFilePathFromImportPath(name) {
   const scriptsExtensions = ["js", "ts"];
   const scriptsExtensionsWithJsx = [...scriptsExtensions, "jsx", "tsx"];
 
-  for (let extension of scriptsExtensionsWithJsx) {
+  for (const extension of scriptsExtensionsWithJsx) {
     const path = `${name}.${extension}`;
 
     if (fs.existsSync(path)) {
@@ -87,7 +88,7 @@ function getFilePathFromImportPath(name) {
 
   const isDirectory = fs.existsSync(name) && fs.lstatSync(name).isDirectory();
 
-  for (let extension of scriptsExtensions) {
+  for (const extension of scriptsExtensions) {
     const indexScriptPath = `${name}/index.${extension}`;
 
     if (isDirectory && fs.existsSync(indexScriptPath)) {
@@ -99,7 +100,7 @@ function getFilePathFromImportPath(name) {
 }
 
 function dependents() {
-  let dependents = {};
+  const dependents = {};
   dependencies().forEach(dep => {
     const { source, dependencies } = dep;
     dependencies.forEach(d => {
@@ -114,7 +115,7 @@ function dependents() {
 
 function getDependents(sources) {
   const allDependents = dependents();
-  let filteredDependents = [];
+  const filteredDependents = [];
 
   sources.forEach(name => {
     const list = allDependents[name];
@@ -130,7 +131,7 @@ function filterDependents() {
   const rl = readline.createInterface({ input: process.stdin });
 
   const start = async () => {
-    let sources = [];
+    const sources = [];
     for await (const line of rl) {
       const name = line.trim();
       if (name.length > 0) {
@@ -147,14 +148,14 @@ function filterAllDependents() {
   const rl = readline.createInterface({ input: process.stdin });
 
   const start = async () => {
-    let sources = [];
+    const sources = [];
     for await (const line of rl) {
       const name = line.trim();
       if (name.length > 0) {
         sources.push(name);
       }
     }
-    let filteredDependents = getDependents(sources);
+    const filteredDependents = getDependents(sources);
 
     const allDependents = dependents();
     for (let i = 0; i < filteredDependents.length; ++i) {
@@ -260,7 +261,7 @@ function main(args) {
   }
 }
 
-let args = process.argv;
+const args = process.argv;
 args.shift();
 args.shift();
 main(args);

--- a/package.json
+++ b/package.json
@@ -388,7 +388,6 @@
       "prettier --write"
     ],
     "e2e/test/scenarios/*/{*.(js|ts),!(helpers|shared)/*.(js|ts)}": [
-      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
       "node e2e/validate-e2e-test-files.js"
     ],
     "**/*.{clj,cljc,cljs,bb}": [

--- a/package.json
+++ b/package.json
@@ -340,14 +340,14 @@
     "lint": "yarn lint-eslint && yarn lint-prettier && yarn lint-docs-links && yarn lint-yaml && yarn type-check",
     "lint-docs-links": "yarn && ./bin/verify-doc-links",
     "lint-eslint": "yarn build:cljs && yarn lint-eslint-pure",
-    "lint-eslint-pure": "eslint --ext .js,.jsx,.ts,.tsx --rulesdir frontend/lint/eslint-rules --max-warnings 0 --report-unused-disable-directives enterprise/frontend/src frontend/src frontend/test e2e/test",
+    "lint-eslint-pure": "eslint --ext .js,.jsx,.ts,.tsx --rulesdir frontend/lint/eslint-rules --max-warnings 0 --report-unused-disable-directives enterprise/frontend frontend e2e",
     "lint-prettier": "yarn && yarn lint-prettier-pure",
-    "lint-prettier-pure": "prettier '{frontend,enterprise,e2e}/**/*.{js,jsx,ts,tsx,css}' --check",
+    "lint-prettier-pure": "prettier '{frontend,enterprise/frontend,e2e}/**/*.{js,jsx,ts,tsx,css}' --check",
     "lint-yaml": "yamllint **/*.{yaml,yml} --ignore=node_modules/**/*.{yaml,yml}",
     "precommit": "lint-staged",
     "preinstall": "echo $npm_execpath | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",
     "prepare": "husky install",
-    "prettier": "prettier --write '{frontend,enterprise,e2e}/**/*.{js,jsx,ts,tsx,css}'",
+    "prettier": "prettier --write '{frontend,enterprise/frontend,e2e}/**/*.{js,jsx,ts,tsx,css}'",
     "remove-webpack-cache": "rm -rf ./node_modules/.cache",
     "storybook": "yarn build:cljs && start-storybook -p 6006",
     "test": "yarn test-unit && yarn test-timezones && yarn test-cypress",
@@ -375,10 +375,10 @@
     "wait:cljs": "echo Waiting for first CLJS build; until [ -f target/cljs_dev/cljs.core.js ]; do sleep 1; done; echo CLJS build done"
   },
   "lint-staged": {
-    "+(enterprise|frontend)/**/*.css": [
+    "+(frontend|enterprise/frontend|e2e)/**/*.css": [
       "prettier --write"
     ],
-    "+(enterprise|frontend)/**/*.{js,jsx,ts,tsx}": [
+    "+(frontend|enterprise/frontend)/**/*.{js,jsx,ts,tsx}": [
       "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
       "prettier --write",
       "node ./bin/verify-doc-links"

--- a/package.json
+++ b/package.json
@@ -387,7 +387,7 @@
       "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
       "prettier --write"
     ],
-    "e2e/test/scenarios/*/{*.js,!(helpers|shared)/*.js}": [
+    "e2e/test/scenarios/*/{*.(js|ts),!(helpers|shared)/*.(js|ts)}": [
       "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
       "node e2e/validate-e2e-test-files.js"
     ],

--- a/package.json
+++ b/package.json
@@ -342,7 +342,7 @@
     "lint-eslint": "yarn build:cljs && yarn lint-eslint-pure",
     "lint-eslint-pure": "eslint --ext .js,.jsx,.ts,.tsx --rulesdir frontend/lint/eslint-rules --max-warnings 0 --report-unused-disable-directives enterprise/frontend frontend e2e",
     "lint-prettier": "yarn && yarn lint-prettier-pure",
-    "lint-prettier-pure": "prettier '{frontend,enterprise/frontend,e2e}/**/*.{js,jsx,ts,tsx,css}' --check",
+    "lint-prettier-pure": "prettier --check '{frontend,enterprise/frontend,e2e}/**/*.{js,jsx,ts,tsx,css}'",
     "lint-yaml": "yamllint **/*.{yaml,yml} --ignore=node_modules/**/*.{yaml,yml}",
     "precommit": "lint-staged",
     "preinstall": "echo $npm_execpath | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",


### PR DESCRIPTION
Follow-up on https://github.com/metabase/metabase/pull/38948#discussion_r1495513696

### Description

- enables ESLint in entire `e2e` dir (previously `e2e/test` only)
- enables ESLint in entire `frontend` dir (previously `frontend/src` only)
- fixes ESLint-reported issues in aformentioned directories
- enables Prettier for `*.css` files in `e2e` dir (for consistency of the paths; no CSS files exist in `e2e` dir yet)
- aligns paths in Prettier & ESLint `scripts` & `lint-staged` scripts
- ensures test scenarios written in TS are checked (none exist yet, but we do support [TS in e2e tests now](https://github.com/metabase/metabase/pull/36474))
