### PR TITLE
Add the step in the FE and pass the token to the setup api call

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -456,7 +456,7 @@ describeWithSnowplow("scenarios > setup", () => {
       goodEvents++; // 10/11 - setup/step_seen "data_usage"
       expectGoodSnowplowEvent({
         event: "step_seen",
-        step_number: 5 + (isEE ? 1 : 0),
+        step_number: isEE ? 6 : 5,
         step: "data_usage",
       });
 
@@ -466,7 +466,7 @@ describeWithSnowplow("scenarios > setup", () => {
       goodEvents++; // 12/13- setup/step_seen "completed"
       expectGoodSnowplowEvent({
         event: "step_seen",
-        step_number: 6 + (isEE ? 1 : 0),
+        step_number: isEE ? 7 : 6,
         step: "completed",
       });
 

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -127,6 +127,8 @@ describe("scenarios > setup", () => {
           // test database setup help card is hidden on the next step
           cy.findByText("Need help connecting?").should("not.be.visible");
 
+          skipLicenseStepOnEE();
+
           // ================
           // Data Preferences
           // ================
@@ -187,6 +189,8 @@ describe("scenarios > setup", () => {
       // Database
       cy.findByText("Add your data");
       cy.findByText("I'll add my data later").click();
+
+      skipLicenseStepOnEE();
 
       // Turns off anonymous data collection
       cy.findByLabelText(
@@ -265,10 +269,7 @@ describe("scenarios > setup", () => {
       cy.button("Connect database").click();
     });
 
-    if (isEE) {
-      // license_token
-      cy.button("Next").click();
-    }
+    skipLicenseStepOnEE();
 
     // usage data
     cy.get("section").last().button("Finish").click();
@@ -315,6 +316,8 @@ describe("scenarios > setup", () => {
 
       // Database
       cy.findByText("Add your data").should("not.exist");
+
+      skipLicenseStepOnEE();
 
       // Turns off anonymous data collection
       cy.findByLabelText(
@@ -528,4 +531,10 @@ const fillUserAndContinue = ({
     cy.findByLabelText("Confirm your password").type(password);
   }
   cy.button("Next").click();
+};
+
+const skipLicenseStepOnEE = () => {
+  if (isEE) {
+    cy.button("Next").click();
+  }
 };

--- a/frontend/src/metabase-types/store/mocks/setup.ts
+++ b/frontend/src/metabase-types/store/mocks/setup.ts
@@ -41,6 +41,7 @@ export const createMockSubscribeInfo = (
 export const createMockSetupState = (
   opts?: Partial<SetupState>,
 ): SetupState => ({
+  isPaidPlan: false,
   step: "welcome",
   isLocaleLoaded: false,
   isTrackingAllowed: false,

--- a/frontend/src/metabase-types/store/setup.ts
+++ b/frontend/src/metabase-types/store/setup.ts
@@ -35,4 +35,5 @@ export interface SetupState {
   invite?: InviteInfo;
   isLocaleLoaded: boolean;
   isTrackingAllowed: boolean;
+  licenseToken?: string | null;
 }

--- a/frontend/src/metabase-types/store/setup.ts
+++ b/frontend/src/metabase-types/store/setup.ts
@@ -26,6 +26,7 @@ export interface SubscribeInfo {
 }
 
 export interface SetupState {
+  isPaidPlan: boolean;
   step: SetupStep;
   locale?: Locale;
   user?: UserInfo;

--- a/frontend/src/metabase-types/store/setup.ts
+++ b/frontend/src/metabase-types/store/setup.ts
@@ -1,4 +1,3 @@
-import type { SetupStep } from "metabase/setup/types";
 import type { DatabaseData, UsageReason } from "metabase-types/api";
 
 export interface Locale {
@@ -26,7 +25,7 @@ export interface SubscribeInfo {
 }
 
 export interface SetupState {
-  step: SetupStep;
+  step: number;
   locale?: Locale;
   user?: UserInfo;
   usageReason?: UsageReason;

--- a/frontend/src/metabase-types/store/setup.ts
+++ b/frontend/src/metabase-types/store/setup.ts
@@ -1,3 +1,4 @@
+import type { SetupStep } from "metabase/setup/types";
 import type { DatabaseData, UsageReason } from "metabase-types/api";
 
 export interface Locale {
@@ -25,7 +26,7 @@ export interface SubscribeInfo {
 }
 
 export interface SetupState {
-  step: number;
+  step: SetupStep;
   locale?: Locale;
   user?: UserInfo;
   usageReason?: UsageReason;

--- a/frontend/src/metabase/selectors/settings.ts
+++ b/frontend/src/metabase/selectors/settings.ts
@@ -103,6 +103,9 @@ export const getUpgradeUrl = createSelector(
   },
 );
 
+/**
+ * ! The tokenStatus is only visible to admins
+ */
 export const getIsPaidPlan = createSelector(
   (state: State) => getSetting(state, "token-status"),
   (tokenStatus: TokenStatus | null) => {

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -482,6 +482,7 @@ export const SetupApi = {
   validate_db: POST("/api/setup/validate"),
   admin_checklist: GET("/api/setup/admin_checklist"),
   user_defaults: GET("/api/setup/user_defaults"),
+  validate_token: GET("/api/setup/token-check"),
 };
 
 export const UserApi = {

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -23,6 +23,7 @@ import {
   getIsTrackingAllowed,
   getLocale,
   getSetupToken,
+  getSteps,
   getUsageReason,
   getUser,
 } from "./selectors";
@@ -68,8 +69,18 @@ export const loadDefaults = createAsyncThunk<void, void, ThunkConfig>(
   },
 );
 
-export const SELECT_STEP = "metabase/setup/SUBMIT_WELCOME_STEP";
-export const selectStep = createAction<SetupStep>(SELECT_STEP);
+export const selectStepByIndex = createAction<number>(
+  "metabase/setup/SELECT_STEP_BY_INDEX",
+);
+
+export const selectStep = createAsyncThunk(
+  "metabase/setup/SELECT_STEP",
+  (stepKey: SetupStep, thunkApi) => {
+    const steps = getSteps(thunkApi.getState() as State);
+    const stepIndex = steps.findIndex(step => step.key === stepKey);
+    thunkApi.dispatch(selectStepByIndex(stepIndex));
+  },
+);
 
 export const UPDATE_LOCALE = "metabase/setup/UPDATE_LOCALE";
 export const updateLocale = createAsyncThunk(

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -94,6 +94,13 @@ export const submitUsageReason = createAsyncThunk(
   },
 );
 
+export const submitLicenseToken = createAsyncThunk(
+  "metabase/setup/SUBMIT_LICENSE_TOKEN",
+  (_token: string | null) => {
+    // TODO: add analytics
+  },
+);
+
 export const UPDATE_DATABASE_ENGINE = "metabase/setup/UPDATE_DATABASE_ENGINE";
 export const updateDatabaseEngine = createAsyncThunk(
   UPDATE_DATABASE_ENGINE,

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -6,6 +6,7 @@ import {
 } from "metabase/home/utils";
 import { loadLocalization } from "metabase/lib/i18n";
 import MetabaseSettings from "metabase/lib/settings";
+import { getSetting } from "metabase/selectors/settings";
 import { SetupApi } from "metabase/services";
 import type { DatabaseData, UsageReason } from "metabase-types/api";
 import type { InviteInfo, Locale, State, UserInfo } from "metabase-types/store";
@@ -210,5 +211,20 @@ export const submitSetup = createAsyncThunk<void, void, ThunkConfig>(
     } catch (error) {
       return rejectWithValue(error);
     }
+  },
+);
+
+export const initSetup = createAsyncThunk(
+  "metabase/setup/INIT_SETUP",
+  async (_, thunkApi) => {
+    const state = thunkApi.getState() as State;
+
+    const tokenFeatures = getSetting(state, "token-features");
+
+    const hasAnyFeature =
+      tokenFeatures &&
+      Object.values(tokenFeatures).some(value => value === true);
+
+    return { isPaidPlan: hasAnyFeature };
   },
 );

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -23,7 +23,6 @@ import {
   getIsTrackingAllowed,
   getLocale,
   getSetupToken,
-  getSteps,
   getUsageReason,
   getUser,
 } from "./selectors";
@@ -69,18 +68,8 @@ export const loadDefaults = createAsyncThunk<void, void, ThunkConfig>(
   },
 );
 
-export const selectStepByIndex = createAction<number>(
-  "metabase/setup/SELECT_STEP_BY_INDEX",
-);
-
-export const selectStep = createAsyncThunk(
-  "metabase/setup/SELECT_STEP",
-  (stepKey: SetupStep, thunkApi) => {
-    const steps = getSteps(thunkApi.getState() as State);
-    const stepIndex = steps.findIndex(step => step.key === stepKey);
-    thunkApi.dispatch(selectStepByIndex(stepIndex));
-  },
-);
+export const SELECT_STEP = "metabase/setup/SUBMIT_WELCOME_STEP";
+export const selectStep = createAction<SetupStep>(SELECT_STEP);
 
 export const UPDATE_LOCALE = "metabase/setup/UPDATE_LOCALE";
 export const updateLocale = createAsyncThunk(

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -186,6 +186,7 @@ export const submitSetup = createAsyncThunk<void, void, ThunkConfig>(
     const invite = getInvite(getState());
     const isTrackingAllowed = getIsTrackingAllowed(getState());
     const usageReason = getUsageReason(getState());
+    const licenseToken = getState().setup.licenseToken;
 
     try {
       await SetupApi.create({
@@ -198,6 +199,7 @@ export const submitSetup = createAsyncThunk<void, void, ThunkConfig>(
           site_locale: locale?.code,
           allow_tracking: isTrackingAllowed.toString(),
         },
+        license_token: licenseToken,
       });
 
       if (usageReason === "embedding" || usageReason === "both") {

--- a/frontend/src/metabase/setup/analytics.ts
+++ b/frontend/src/metabase/setup/analytics.ts
@@ -4,7 +4,7 @@ import type { UsageReason } from "metabase-types/api";
 import type { SetupStep } from "./types";
 
 const ONBOARDING_VERSION = "1.1.0";
-const SCHEMA_VERSION = "1-0-2";
+const SCHEMA_VERSION = "1-0-3";
 
 export const trackStepSeen = ({
   stepName,

--- a/frontend/src/metabase/setup/components/CloudMigrationHelp/CloudMigrationHelp.tsx
+++ b/frontend/src/metabase/setup/components/CloudMigrationHelp/CloudMigrationHelp.tsx
@@ -4,14 +4,14 @@ import HelpCard from "metabase/components/HelpCard";
 import { useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 
-import { getIsHosted, getIsStepActive } from "../../selectors";
+import { getIsHosted } from "../../selectors";
+import { useStep } from "../../useStep";
 import { SetupCardContainer } from "../SetupCardContainer";
 
 export const CloudMigrationHelp = () => {
+  const { isStepActive } = useStep("completed");
   const isHosted = useSelector(getIsHosted);
-  const isStepActive = useSelector(state =>
-    getIsStepActive(state, "completed"),
-  );
+
   const isVisible = isHosted && isStepActive;
 
   return (

--- a/frontend/src/metabase/setup/components/DataUsageStep/DataUsageStep.tsx
+++ b/frontend/src/metabase/setup/components/DataUsageStep/DataUsageStep.tsx
@@ -26,7 +26,7 @@ import {
 export const DataUsageStep = ({
   stepLabel,
 }: NumberedStepProps): JSX.Element => {
-  const { isStepActive, isStepCompleted, selectThisStep } =
+  const { isStepActive, isStepCompleted, handleStepSelect } =
     useStep("data_usage");
   const [errorMessage, setErrorMessage] = useState<string>();
   const isTrackingAllowed = useSelector(getIsTrackingAllowed);
@@ -35,10 +35,6 @@ export const DataUsageStep = ({
 
   const handleTrackingChange = (isTrackingAllowed: boolean) => {
     dispatch(updateTracking(isTrackingAllowed));
-  };
-
-  const handleStepSelect = () => {
-    selectThisStep();
   };
 
   const handleStepSubmit = async () => {

--- a/frontend/src/metabase/setup/components/DataUsageStep/DataUsageStep.tsx
+++ b/frontend/src/metabase/setup/components/DataUsageStep/DataUsageStep.tsx
@@ -1,43 +1,35 @@
 import { getIn } from "icepick";
 import { useState } from "react";
-import { t, jt } from "ttag";
+import { jt, t } from "ttag";
 
 import ActionButton from "metabase/components/ActionButton";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import Settings from "metabase/lib/settings";
 
-import { selectStep, submitSetup, updateTracking } from "../../actions";
-import {
-  getIsSetupCompleted,
-  getIsStepActive,
-  getIsStepCompleted,
-  getIsTrackingAllowed,
-} from "../../selectors";
+import { submitSetup, updateTracking } from "../../actions";
+import { getIsSetupCompleted, getIsTrackingAllowed } from "../../selectors";
+import { useStep } from "../../useStep";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InactiveStep";
 import type { NumberedStepProps } from "../types";
 
 import {
   StepDescription,
+  StepError,
+  StepInfoList,
+  StepToggle,
   StepToggleContainer,
   StepToggleLabel,
-  StepInfoList,
-  StepError,
-  StepToggle,
 } from "./DataUsageStep.styled";
 
 export const DataUsageStep = ({
   stepLabel,
 }: NumberedStepProps): JSX.Element => {
+  const { isStepActive, isStepCompleted, selectThisStep } =
+    useStep("data_usage");
   const [errorMessage, setErrorMessage] = useState<string>();
   const isTrackingAllowed = useSelector(getIsTrackingAllowed);
-  const isStepActive = useSelector(state =>
-    getIsStepActive(state, "data_usage"),
-  );
-  const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, "data_usage"),
-  );
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
 
@@ -46,7 +38,7 @@ export const DataUsageStep = ({
   };
 
   const handleStepSelect = () => {
-    dispatch(selectStep("data_usage"));
+    selectThisStep();
   };
 
   const handleStepSubmit = async () => {

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -7,7 +7,6 @@ import type { DatabaseData } from "metabase-types/api";
 import type { InviteInfo } from "metabase-types/store";
 
 import {
-  selectStep,
   skipDatabase,
   submitDatabase,
   submitUserInvite,
@@ -19,10 +18,9 @@ import {
   getInvite,
   getIsEmailConfigured,
   getIsSetupCompleted,
-  getIsStepActive,
-  getIsStepCompleted,
   getUser,
 } from "../../selectors";
+import { useStep } from "../../useStep";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InactiveStep";
 import { InviteUserForm } from "../InviteUserForm";
@@ -32,17 +30,14 @@ import type { NumberedStepProps } from "../types";
 import { StepDescription } from "./DatabaseStep.styled";
 
 export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
+  const { isStepActive, isStepCompleted, selectThisStep } =
+    useStep("db_connection");
   const user = useSelector(getUser);
   const database = useSelector(getDatabase);
   const engine = useSelector(getDatabaseEngine);
   const invite = useSelector(getInvite);
   const isEmailConfigured = useSelector(getIsEmailConfigured);
-  const isStepActive = useSelector(state =>
-    getIsStepActive(state, "db_connection"),
-  );
-  const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, "db_connection"),
-  );
+
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
 
@@ -63,7 +58,7 @@ export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   };
 
   const handleStepSelect = () => {
-    dispatch(selectStep("db_connection"));
+    selectThisStep();
   };
 
   const handleStepCancel = () => {

--- a/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
+++ b/frontend/src/metabase/setup/components/DatabaseStep/DatabaseStep.tsx
@@ -30,7 +30,7 @@ import type { NumberedStepProps } from "../types";
 import { StepDescription } from "./DatabaseStep.styled";
 
 export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
-  const { isStepActive, isStepCompleted, selectThisStep } =
+  const { isStepActive, isStepCompleted, handleStepSelect } =
     useStep("db_connection");
   const user = useSelector(getUser);
   const database = useSelector(getDatabase);
@@ -55,10 +55,6 @@ export const DatabaseStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
 
   const handleInviteSubmit = (invite: InviteInfo) => {
     dispatch(submitUserInvite(invite));
-  };
-
-  const handleStepSelect = () => {
-    selectThisStep();
   };
 
   const handleStepCancel = () => {

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
@@ -6,13 +6,13 @@ import Button from "metabase/core/components/Button";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import type { Locale } from "metabase-types/store";
 
-import { useStep } from "../..//useStep";
 import { selectStep, updateLocale } from "../../actions";
 import {
   getAvailableLocales,
   getIsSetupCompleted,
   getLocale,
 } from "../../selectors";
+import { useStep } from "../../useStep";
 import { getLocales } from "../../utils";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InactiveStep";

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
@@ -6,12 +6,11 @@ import Button from "metabase/core/components/Button";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import type { Locale } from "metabase-types/store";
 
+import { useStep } from "../..//useStep";
 import { selectStep, updateLocale } from "../../actions";
 import {
   getAvailableLocales,
   getIsSetupCompleted,
-  getIsStepActive,
-  getIsStepCompleted,
   getLocale,
 } from "../../selectors";
 import { getLocales } from "../../utils";
@@ -20,20 +19,17 @@ import { InactiveStep } from "../InactiveStep";
 import type { NumberedStepProps } from "../types";
 
 import {
+  LocaleButton,
   LocaleGroup,
   LocaleInput,
   LocaleLabel,
-  LocaleButton,
   StepDescription,
 } from "./LanguageStep.styled";
 
 export const LanguageStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
+  const { isStepActive, isStepCompleted } = useStep("language");
   const locale = useSelector(getLocale);
   const localeData = useSelector(getAvailableLocales);
-  const isStepActive = useSelector(state => getIsStepActive(state, "language"));
-  const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, "language"),
-  );
   const isSetupCompleted = useSelector(state => getIsSetupCompleted(state));
   const fieldId = useMemo(() => _.uniqueId(), []);
   const locales = useMemo(() => getLocales(localeData), [localeData]);

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
@@ -35,6 +35,7 @@ export const LicenseTokenForm = ({ onValidSubmit }: LicenseTokenFormProps) => {
     <>
       <Box mb="md">
         <TextInput
+          aria-label={t`Token`}
           placeholder={t`Paste your token here`}
           value={token}
           onChange={e => setToken(e.target.value)}

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import { SetupApi } from "metabase/services";
+import { Box, Button, Text, TextInput } from "metabase/ui";
+
+type LicenseTokenFormProps = {
+  onValidSubmit: (token: string) => void;
+};
+
+export const LicenseTokenForm = ({ onValidSubmit }: LicenseTokenFormProps) => {
+  const [token, setToken] = useState("");
+  const [status, setStatus] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle");
+
+  const isInputCorrectLength = token.length === 64;
+
+  const submit = async () => {
+    setStatus("loading");
+    try {
+      const response = await SetupApi.validate_token({ token });
+      if (response.valid) {
+        setStatus("success");
+        onValidSubmit(token);
+      } else {
+        setStatus("error");
+      }
+    } catch (e) {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <>
+      <Box mb="md">
+        <TextInput
+          placeholder={t`Paste your token here`}
+          value={token}
+          onChange={e => setToken(e.target.value)}
+          error={status === "error"}
+        />
+        {status === "error" && (
+          <Text color="error">{t`This token doesn’t seem to be valid. Double-check it, then contact support if you think it should be working`}</Text>
+        )}
+      </Box>
+      <Button
+        variant={isInputCorrectLength ? "filled" : "default"}
+        loading={status === "loading"}
+        onClick={submit}
+      >{t`Activate`}</Button>
+    </>
+  );
+};

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
@@ -7,7 +7,6 @@ import { useStep } from "metabase/setup/useStep";
 import { Button, Divider, Text } from "metabase/ui";
 
 import { submitLicenseToken } from "../../actions";
-import { getIsSetupCompleted } from "../../selectors";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InactiveStep";
 import type { NumberedStepProps } from "../types";
@@ -15,12 +14,11 @@ import type { NumberedStepProps } from "../types";
 import { LicenseTokenForm } from "./LicenseTokenForm";
 
 export const LicenseTokenStep = ({ stepLabel }: NumberedStepProps) => {
-  const { isStepActive, isStepCompleted, handleStepSelect } =
+  const { isStepActive, isStepCompleted, handleStepSelect, isSetupCompleted } =
     useStep("license_token");
 
   const storeToken = useSelector(state => state.setup.licenseToken);
 
-  const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
 
   const handleValidSubmit = (token: string | null) => {

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
@@ -41,14 +41,12 @@ export const LicenseTokenStep = ({ stepLabel }: NumberedStepProps) => {
   };
 
   if (!isStepActive) {
-    const title = isStepCompleted
-      ? storeToken
-        ? t`Commercial license active`
-        : t`I'll activate my commercial license later`
-      : t`Activate your commercial license`;
     return (
       <InactiveStep
-        title={title}
+        title={getInactiveStepTitle({
+          isStepCompleted,
+          hasStoreToken: Boolean(storeToken),
+        })}
         label={stepLabel}
         isStepCompleted={isStepCompleted}
         isSetupCompleted={isSetupCompleted}
@@ -73,4 +71,22 @@ export const LicenseTokenStep = ({ stepLabel }: NumberedStepProps) => {
       </Button>
     </ActiveStep>
   );
+};
+
+const getInactiveStepTitle = ({
+  isStepCompleted,
+  hasStoreToken,
+}: {
+  isStepCompleted: boolean;
+  hasStoreToken: boolean;
+}) => {
+  if (isStepCompleted) {
+    if (hasStoreToken) {
+      return t`Commercial license active`;
+    } else {
+      return t`I'll activate my commercial license later`;
+    }
+  } else {
+    return t`Activate your commercial license`;
+  }
 };

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
@@ -15,17 +15,13 @@ import type { NumberedStepProps } from "../types";
 import { LicenseTokenForm } from "./LicenseTokenForm";
 
 export const LicenseTokenStep = ({ stepLabel }: NumberedStepProps) => {
-  const { isStepActive, isStepCompleted, selectThisStep } =
+  const { isStepActive, isStepCompleted, handleStepSelect } =
     useStep("license_token");
 
   const storeToken = useSelector(state => state.setup.licenseToken);
 
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
-
-  const handleStepSelect = () => {
-    selectThisStep();
-  };
 
   const handleValidSubmit = (token: string | null) => {
     dispatch(

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
@@ -3,14 +3,11 @@ import { t } from "ttag";
 import { color } from "metabase/lib/colors";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { addUndo } from "metabase/redux/undo";
+import { useStep } from "metabase/setup/useStep";
 import { Button, Divider, Text } from "metabase/ui";
 
-import { selectStep, submitLicenseToken } from "../../actions";
-import {
-  getIsSetupCompleted,
-  getIsStepActive,
-  getIsStepCompleted,
-} from "../../selectors";
+import { submitLicenseToken } from "../../actions";
+import { getIsSetupCompleted } from "../../selectors";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InactiveStep";
 import type { NumberedStepProps } from "../types";
@@ -18,19 +15,16 @@ import type { NumberedStepProps } from "../types";
 import { LicenseTokenForm } from "./LicenseTokenForm";
 
 export const LicenseTokenStep = ({ stepLabel }: NumberedStepProps) => {
+  const { isStepActive, isStepCompleted, selectThisStep } =
+    useStep("license_token");
+
   const storeToken = useSelector(state => state.setup.licenseToken);
 
-  const isStepActive = useSelector(state =>
-    getIsStepActive(state, "license_token"),
-  );
-  const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, "license_token"),
-  );
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
 
   const handleStepSelect = () => {
-    dispatch(selectStep("license_token"));
+    selectThisStep();
   };
 
   const handleValidSubmit = (token: string | null) => {

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
@@ -1,0 +1,82 @@
+import { t } from "ttag";
+
+import { color } from "metabase/lib/colors";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { addUndo } from "metabase/redux/undo";
+import { Button, Divider, Text } from "metabase/ui";
+
+import { selectStep, submitLicenseToken } from "../../actions";
+import {
+  getIsSetupCompleted,
+  getIsStepActive,
+  getIsStepCompleted,
+} from "../../selectors";
+import { ActiveStep } from "../ActiveStep";
+import { InactiveStep } from "../InactiveStep";
+import type { NumberedStepProps } from "../types";
+
+import { LicenseTokenForm } from "./LicenseTokenForm";
+
+export const LicenseTokenStep = ({ stepLabel }: NumberedStepProps) => {
+  const storeToken = useSelector(state => state.setup.licenseToken);
+
+  const isStepActive = useSelector(state =>
+    getIsStepActive(state, "license_token"),
+  );
+  const isStepCompleted = useSelector(state =>
+    getIsStepCompleted(state, "license_token"),
+  );
+  const isSetupCompleted = useSelector(getIsSetupCompleted);
+  const dispatch = useDispatch();
+
+  const handleStepSelect = () => {
+    dispatch(selectStep("license_token"));
+  };
+
+  const handleValidSubmit = (token: string | null) => {
+    dispatch(
+      addUndo({
+        message: t`Your license is activated`,
+      }),
+    );
+    dispatch(submitLicenseToken(token));
+  };
+
+  const handleNext = () => {
+    dispatch(submitLicenseToken(null));
+  };
+
+  if (!isStepActive) {
+    const title = isStepCompleted
+      ? storeToken
+        ? t`Commercial license active`
+        : t`I'll activate my commercial license later`
+      : t`Activate your commercial license`;
+    return (
+      <InactiveStep
+        title={title}
+        label={stepLabel}
+        isStepCompleted={isStepCompleted}
+        isSetupCompleted={isSetupCompleted}
+        onStepSelect={handleStepSelect}
+      />
+    );
+  }
+
+  return (
+    <ActiveStep title={t`Activate your commercial license`} label={stepLabel}>
+      <Text
+        mb="lg"
+        color={color("text-light")}
+      >{t`Unlock access to your paid features before starting`}</Text>
+
+      <LicenseTokenForm onValidSubmit={handleValidSubmit} />
+
+      <Divider my="xl" />
+
+      <Button variant="filled" onClick={handleNext}>
+        {t`Next`}
+      </Button>
+    </ActiveStep>
+  );
+};

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/index.ts
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/index.ts
@@ -1,0 +1,1 @@
+export { LicenseTokenStep } from "./LicenseTokenStep";

--- a/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
+++ b/frontend/src/metabase/setup/components/SettingsPage/SettingsPage.tsx
@@ -1,6 +1,7 @@
 import LogoIcon from "metabase/components/LogoIcon";
 import { useSelector } from "metabase/lib/redux";
 import { getSteps } from "metabase/setup/selectors";
+import type { SetupStep } from "metabase/setup/types";
 
 import { CloudMigrationHelp } from "../CloudMigrationHelp";
 import { CompletedStep } from "../CompletedStep";
@@ -8,6 +9,7 @@ import { DataUsageStep } from "../DataUsageStep";
 import { DatabaseHelp } from "../DatabaseHelp";
 import { DatabaseStep } from "../DatabaseStep";
 import { LanguageStep } from "../LanguageStep";
+import { LicenseTokenStep } from "../LicenseTokenStep";
 import { SetupHelp } from "../SetupHelp";
 import { UsageQuestionStep } from "../UsageQuestionStep";
 import { UserStep } from "../UserStep";
@@ -15,14 +17,14 @@ import type { NumberedStepProps } from "../types";
 
 import { PageBody, PageHeader } from "./SettingsPage.styled";
 
-const STEP_COMPONENTS: Record<
-  string,
-  (props: NumberedStepProps) => React.ReactElement
+const STEP_COMPONENTS: Partial<
+  Record<SetupStep, (props: NumberedStepProps) => React.ReactElement>
 > = {
   language: LanguageStep,
   user_info: UserStep,
   usage_question: UsageQuestionStep,
   db_connection: DatabaseStep,
+  license_token: LicenseTokenStep,
   data_usage: DataUsageStep,
 };
 

--- a/frontend/src/metabase/setup/components/Setup/Setup.tsx
+++ b/frontend/src/metabase/setup/components/Setup/Setup.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from "react";
 import { useUpdate } from "react-use";
 
-import { useSelector } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { initSetup } from "metabase/setup/actions";
 
 import { trackStepSeen } from "../../analytics";
 import { getIsLocaleLoaded, getStep, getSteps } from "../../selectors";
@@ -11,9 +12,14 @@ import { WelcomePage } from "../WelcomePage";
 export const Setup = (): JSX.Element => {
   const step = useSelector(getStep);
   const stepIndex = useSelector(getSteps).findIndex(({ key }) => key === step);
+  const dispatch = useDispatch();
 
   const isLocaleLoaded = useSelector(getIsLocaleLoaded);
   const update = useUpdate();
+
+  useEffect(() => {
+    dispatch(initSetup());
+  });
 
   useEffect(() => {
     trackStepSeen({ stepName: step, stepNumber: stepIndex });

--- a/frontend/src/metabase/setup/components/UsageQuestionStep/UsageQuestionStep.tsx
+++ b/frontend/src/metabase/setup/components/UsageQuestionStep/UsageQuestionStep.tsx
@@ -21,7 +21,7 @@ const COMPLETED_STEP_TITLE: Record<UsageReason, string> = {
 };
 
 export const UsageQuestionStep = ({ stepLabel }: NumberedStepProps) => {
-  const { isStepActive, isStepCompleted, selectThisStep } =
+  const { isStepActive, isStepCompleted, handleStepSelect } =
     useStep("usage_question");
   const [usageReason, setUsageReason] = useState<UsageReason>(
     "self-service-analytics",
@@ -29,10 +29,6 @@ export const UsageQuestionStep = ({ stepLabel }: NumberedStepProps) => {
 
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
-
-  const handleStepSelect = () => {
-    selectThisStep();
-  };
 
   const handleSubmit = () => {
     dispatch(submitUsageReason(usageReason));

--- a/frontend/src/metabase/setup/components/UsageQuestionStep/UsageQuestionStep.tsx
+++ b/frontend/src/metabase/setup/components/UsageQuestionStep/UsageQuestionStep.tsx
@@ -6,12 +6,9 @@ import { useDispatch, useSelector } from "metabase/lib/redux";
 import { Divider, Radio, Stack, Text } from "metabase/ui";
 import type { UsageReason } from "metabase-types/api";
 
-import { selectStep, submitUsageReason } from "../../actions";
-import {
-  getIsSetupCompleted,
-  getIsStepActive,
-  getIsStepCompleted,
-} from "../../selectors";
+import { submitUsageReason } from "../../actions";
+import { getIsSetupCompleted } from "../../selectors";
+import { useStep } from "../../useStep";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InactiveStep";
 import type { NumberedStepProps } from "../types";
@@ -24,21 +21,17 @@ const COMPLETED_STEP_TITLE: Record<UsageReason, string> = {
 };
 
 export const UsageQuestionStep = ({ stepLabel }: NumberedStepProps) => {
+  const { isStepActive, isStepCompleted, selectThisStep } =
+    useStep("usage_question");
   const [usageReason, setUsageReason] = useState<UsageReason>(
     "self-service-analytics",
   );
 
-  const isStepActive = useSelector(state =>
-    getIsStepActive(state, "usage_question"),
-  );
-  const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, "usage_question"),
-  );
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
 
   const handleStepSelect = () => {
-    dispatch(selectStep("usage_question"));
+    selectThisStep();
   };
 
   const handleSubmit = () => {

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
@@ -15,16 +15,12 @@ import type { NumberedStepProps } from "../types";
 import { StepDescription } from "./UserStep.styled";
 
 export const UserStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
-  const { isStepActive, isStepCompleted, selectThisStep, isSetupCompleted } =
+  const { isStepActive, isStepCompleted, handleStepSelect, isSetupCompleted } =
     useStep("user_info");
   const user = useSelector(getUser);
   const isHosted = useSelector(getIsHosted);
 
   const dispatch = useDispatch();
-
-  const handleStepSelect = () => {
-    selectThisStep();
-  };
 
   const handleSubmit = (user: UserInfo) => {
     dispatch(submitUser(user));

--- a/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
+++ b/frontend/src/metabase/setup/components/UserStep/UserStep.tsx
@@ -3,14 +3,9 @@ import { t } from "ttag";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import type { UserInfo } from "metabase-types/store";
 
-import { selectStep, submitUser } from "../../actions";
-import {
-  getIsHosted,
-  getIsSetupCompleted,
-  getIsStepActive,
-  getIsStepCompleted,
-  getUser,
-} from "../../selectors";
+import { submitUser } from "../../actions";
+import { getIsHosted, getUser } from "../../selectors";
+import { useStep } from "../../useStep";
 import { validatePassword } from "../../utils";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InactiveStep";
@@ -20,19 +15,15 @@ import type { NumberedStepProps } from "../types";
 import { StepDescription } from "./UserStep.styled";
 
 export const UserStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
+  const { isStepActive, isStepCompleted, selectThisStep, isSetupCompleted } =
+    useStep("user_info");
   const user = useSelector(getUser);
   const isHosted = useSelector(getIsHosted);
-  const isStepActive = useSelector(state =>
-    getIsStepActive(state, "user_info"),
-  );
-  const isStepCompleted = useSelector(state =>
-    getIsStepCompleted(state, "user_info"),
-  );
-  const isSetupCompleted = useSelector(getIsSetupCompleted);
+
   const dispatch = useDispatch();
 
   const handleStepSelect = () => {
-    dispatch(selectStep("user_info"));
+    selectThisStep();
   };
 
   const handleSubmit = (user: UserInfo) => {

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -15,6 +15,7 @@ import {
   updateTracking,
   submitSetup,
   submitUsageReason,
+  submitLicenseToken,
 } from "./actions";
 import { getNextStep } from "./selectors";
 
@@ -54,6 +55,12 @@ export const reducer = createReducer(initialState, builder => {
     state.usageReason = usageReason;
     state.step = getNextStep({ setup: state } as State);
   });
+  builder.addCase(submitLicenseToken.pending, (state, { meta }) => {
+    const token = meta.arg;
+    state.licenseToken = token;
+    state.step = getNextStep({ setup: state } as State);
+  });
+
   builder.addCase(updateDatabaseEngine.pending, (state, { meta }) => {
     state.databaseEngine = meta.arg;
   });

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -1,11 +1,12 @@
 import { createReducer } from "@reduxjs/toolkit";
 
-import type { SetupState } from "metabase-types/store";
+import type { SetupState, State } from "metabase-types/store";
 
 import {
   skipDatabase,
   loadLocaleDefaults,
   loadUserDefaults,
+  selectStep,
   submitDatabase,
   submitUser,
   submitUserInvite,
@@ -14,11 +15,11 @@ import {
   updateTracking,
   submitSetup,
   submitUsageReason,
-  selectStepByIndex,
 } from "./actions";
+import { getNextStep } from "./selectors";
 
 const initialState: SetupState = {
-  step: 0,
+  step: "welcome",
   isLocaleLoaded: false,
   isTrackingAllowed: true,
 };
@@ -34,7 +35,7 @@ export const reducer = createReducer(initialState, builder => {
       state.isLocaleLoaded = true;
     },
   );
-  builder.addCase(selectStepByIndex, (state, { payload: step }) => {
+  builder.addCase(selectStep, (state, { payload: step }) => {
     state.step = step;
   });
   builder.addCase(updateLocale.pending, (state, { meta }) => {
@@ -46,12 +47,12 @@ export const reducer = createReducer(initialState, builder => {
   });
   builder.addCase(submitUser.pending, (state, { meta }) => {
     state.user = meta.arg;
-    state.step += 1;
+    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(submitUsageReason.pending, (state, { meta }) => {
     const usageReason = meta.arg;
     state.usageReason = usageReason;
-    state.step += 1;
+    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(updateDatabaseEngine.pending, (state, { meta }) => {
     state.databaseEngine = meta.arg;
@@ -59,22 +60,22 @@ export const reducer = createReducer(initialState, builder => {
   builder.addCase(submitDatabase.fulfilled, (state, { payload: database }) => {
     state.database = database;
     state.invite = undefined;
-    state.step += 1;
+    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(submitUserInvite.pending, (state, { meta }) => {
     state.database = undefined;
     state.invite = meta.arg;
-    state.step += 1;
+    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(skipDatabase.pending, state => {
     state.database = undefined;
     state.invite = undefined;
-    state.step += 1;
+    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(updateTracking.pending, (state, { meta }) => {
     state.isTrackingAllowed = meta.arg;
   });
   builder.addCase(submitSetup.fulfilled, state => {
-    state.step += 1;
+    state.step = "completed";
   });
 });

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -16,6 +16,7 @@ import {
   submitSetup,
   submitUsageReason,
   submitLicenseToken,
+  initSetup,
 } from "./actions";
 import { getNextStep } from "./selectors";
 
@@ -23,9 +24,13 @@ const initialState: SetupState = {
   step: "welcome",
   isLocaleLoaded: false,
   isTrackingAllowed: true,
+  isPaidPlan: false,
 };
 
 export const reducer = createReducer(initialState, builder => {
+  builder.addCase(initSetup.fulfilled, (state, { payload: { isPaidPlan } }) => {
+    state.isPaidPlan = isPaidPlan;
+  });
   builder.addCase(loadUserDefaults.fulfilled, (state, { payload: user }) => {
     state.user = user;
   });

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -1,12 +1,11 @@
 import { createReducer } from "@reduxjs/toolkit";
 
-import type { SetupState, State } from "metabase-types/store";
+import type { SetupState } from "metabase-types/store";
 
 import {
   skipDatabase,
   loadLocaleDefaults,
   loadUserDefaults,
-  selectStep,
   submitDatabase,
   submitUser,
   submitUserInvite,
@@ -15,11 +14,11 @@ import {
   updateTracking,
   submitSetup,
   submitUsageReason,
+  selectStepByIndex,
 } from "./actions";
-import { getNextStep } from "./selectors";
 
 const initialState: SetupState = {
-  step: "welcome",
+  step: 0,
   isLocaleLoaded: false,
   isTrackingAllowed: true,
 };
@@ -35,7 +34,7 @@ export const reducer = createReducer(initialState, builder => {
       state.isLocaleLoaded = true;
     },
   );
-  builder.addCase(selectStep, (state, { payload: step }) => {
+  builder.addCase(selectStepByIndex, (state, { payload: step }) => {
     state.step = step;
   });
   builder.addCase(updateLocale.pending, (state, { meta }) => {
@@ -47,12 +46,12 @@ export const reducer = createReducer(initialState, builder => {
   });
   builder.addCase(submitUser.pending, (state, { meta }) => {
     state.user = meta.arg;
-    state.step = getNextStep({ setup: state } as State);
+    state.step += 1;
   });
   builder.addCase(submitUsageReason.pending, (state, { meta }) => {
     const usageReason = meta.arg;
     state.usageReason = usageReason;
-    state.step = getNextStep({ setup: state } as State);
+    state.step += 1;
   });
   builder.addCase(updateDatabaseEngine.pending, (state, { meta }) => {
     state.databaseEngine = meta.arg;
@@ -60,22 +59,22 @@ export const reducer = createReducer(initialState, builder => {
   builder.addCase(submitDatabase.fulfilled, (state, { payload: database }) => {
     state.database = database;
     state.invite = undefined;
-    state.step = getNextStep({ setup: state } as State);
+    state.step += 1;
   });
   builder.addCase(submitUserInvite.pending, (state, { meta }) => {
     state.database = undefined;
     state.invite = meta.arg;
-    state.step = getNextStep({ setup: state } as State);
+    state.step += 1;
   });
   builder.addCase(skipDatabase.pending, state => {
     state.database = undefined;
     state.invite = undefined;
-    state.step = getNextStep({ setup: state } as State);
+    state.step += 1;
   });
   builder.addCase(updateTracking.pending, (state, { meta }) => {
     state.isTrackingAllowed = meta.arg;
   });
   builder.addCase(submitSetup.fulfilled, state => {
-    state.step = "completed";
+    state.step += 1;
   });
 });

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -1,4 +1,3 @@
-import MetabaseSettings from "metabase/lib/settings";
 import { isEEBuild } from "metabase/lib/utils";
 import { getSetting } from "metabase/selectors/settings";
 import type { DatabaseData, LocaleData } from "metabase-types/api";
@@ -83,12 +82,7 @@ export const getIsEmailConfigured = (state: State): boolean => {
 export const getSteps = (state: State) => {
   const usageReason = getUsageReason(state);
   const activeStep = getStep(state);
-
-  // TODO: avoid using MetabaseSettings in a selector
-  // we can't do it right now as this selector is used in the reducer that doesn't have access to the whole state
-  const tokenFeatures = MetabaseSettings.get("token-features");
-  const isPaidPlan =
-    tokenFeatures && Object.values(tokenFeatures).some(value => value === true);
+  const isPaidPlan = state.setup.isPaidPlan;
 
   const shouldShowDBConnectionStep = usageReason !== "embedding";
   const shouldShowLicenseStep = isEEBuild() && !isPaidPlan;

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -8,9 +8,7 @@ import type { SetupStep } from "./types";
 const DEFAULT_LOCALES: LocaleData[] = [];
 
 export const getStep = (state: State): SetupStep => {
-  const index = state.setup.step;
-  const steps = getSteps(state);
-  return steps[index].key;
+  return state.setup.step;
 };
 
 export const getLocale = (state: State): Locale | undefined => {
@@ -82,7 +80,7 @@ export const getIsEmailConfigured = (state: State): boolean => {
 
 export const getSteps = (state: State) => {
   const usageReason = getUsageReason(state);
-  const activeStepIndex = state.setup.step;
+  const activeStep = getStep(state);
 
   const steps: { key: SetupStep; isActiveStep: boolean }[] = [
     { key: "welcome" as const },
@@ -96,9 +94,9 @@ export const getSteps = (state: State) => {
     { key: "completed" as const },
   ]
     .filter(isNotFalsy)
-    .map(({ key }, index) => ({
+    .map(({ key }) => ({
       key,
-      isActiveStep: activeStepIndex === index,
+      isActiveStep: activeStep === key,
     }));
 
   return steps;

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -8,7 +8,9 @@ import type { SetupStep } from "./types";
 const DEFAULT_LOCALES: LocaleData[] = [];
 
 export const getStep = (state: State): SetupStep => {
-  return state.setup.step;
+  const index = state.setup.step;
+  const steps = getSteps(state);
+  return steps[index].key;
 };
 
 export const getLocale = (state: State): Locale | undefined => {
@@ -80,7 +82,7 @@ export const getIsEmailConfigured = (state: State): boolean => {
 
 export const getSteps = (state: State) => {
   const usageReason = getUsageReason(state);
-  const activeStep = getStep(state);
+  const activeStepIndex = state.setup.step;
 
   const steps: { key: SetupStep; isActiveStep: boolean }[] = [
     { key: "welcome" as const },
@@ -94,9 +96,9 @@ export const getSteps = (state: State) => {
     { key: "completed" as const },
   ]
     .filter(isNotFalsy)
-    .map(({ key }) => ({
+    .map(({ key }, index) => ({
       key,
-      isActiveStep: activeStep === key,
+      isActiveStep: activeStepIndex === index,
     }));
 
   return steps;

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -79,7 +79,7 @@ export const getAvailableLocales = (state: State): LocaleData[] => {
 export const getIsEmailConfigured = (state: State): boolean => {
   return getSetting(state, "email-configured?");
 };
-``;
+
 export const getSteps = (state: State) => {
   const usageReason = getUsageReason(state);
   const activeStep = getStep(state);

--- a/frontend/src/metabase/setup/setup.unit.spec.tsx
+++ b/frontend/src/metabase/setup/setup.unit.spec.tsx
@@ -13,8 +13,9 @@ import {
 } from "metabase-types/store/mocks";
 
 import { Setup } from "./components/Setup";
+import type { SetupStep } from "./types";
 
-async function setup({ step = 0 }: { step?: number } = {}) {
+async function setup({ step = "welcome" }: { step?: SetupStep } = {}) {
   localStorage.clear();
   jest.clearAllMocks();
 

--- a/frontend/src/metabase/setup/setup.unit.spec.tsx
+++ b/frontend/src/metabase/setup/setup.unit.spec.tsx
@@ -13,9 +13,8 @@ import {
 } from "metabase-types/store/mocks";
 
 import { Setup } from "./components/Setup";
-import type { SetupStep } from "./types";
 
-async function setup({ step = "welcome" }: { step?: SetupStep } = {}) {
+async function setup({ step = 0 }: { step?: number } = {}) {
   localStorage.clear();
   jest.clearAllMocks();
 

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -1,11 +1,22 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSectionToHaveLabel", "expectSectionsToHaveLabelsInOrder"] }] */
 
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupForTokenCheckEndpoint } from "__support__/server-mocks";
+
 import type { SetupOpts } from "./setup";
 import {
+  clickNextStep,
   expectSectionsToHaveLabelsInOrder,
   expectSectionToHaveLabel,
+  getSection,
+  selectUsageReason,
   setup,
+  skipLanguageStep,
   skipWelcomeScreen,
+  submitUserInfoStep,
 } from "./setup";
 
 const setupEnterprise = (opts?: SetupOpts) => {
@@ -15,7 +26,9 @@ const setupEnterprise = (opts?: SetupOpts) => {
   });
 };
 
-describe("setup (E, no token)", () => {
+const sampleToken = "a".repeat(64);
+
+describe("setup (EE, no token)", () => {
   it("default step order should be correct, with the commercial step in place", async () => {
     await setupEnterprise();
     skipWelcomeScreen();
@@ -27,5 +40,106 @@ describe("setup (E, no token)", () => {
     expectSectionToHaveLabel("Usage data preferences", "6");
 
     expectSectionsToHaveLabelsInOrder();
+  });
+
+  describe("License activation step", () => {
+    async function setupForLicenseStep() {
+      await setup();
+      skipWelcomeScreen();
+      skipLanguageStep();
+      await submitUserInfoStep();
+      selectUsageReason("embedding"); // to skip the db connection step
+      clickNextStep();
+
+      await screen.findByText(
+        "Unlock access to your paid features before starting",
+      );
+    }
+
+    it("should display an error in case of invalid token", async () => {
+      await setupForLicenseStep();
+
+      setupForTokenCheckEndpoint({ valid: false });
+
+      userEvent.paste(
+        screen.getByRole("textbox", { name: "Token" }),
+        sampleToken,
+      );
+
+      screen.getByRole("button", { name: "Activate" }).click();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Activate" }),
+        ).not.toHaveProperty("data-loading", true);
+      });
+
+      expect(
+        screen.getByText(
+          "This token doesn’t seem to be valid. Double-check it, then contact support if you think it should be working",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("should go to the next step when activating a valid token", async () => {
+      await setupForLicenseStep();
+
+      setupForTokenCheckEndpoint({ valid: true });
+
+      userEvent.paste(
+        screen.getByRole("textbox", { name: "Token" }),
+        sampleToken,
+      );
+
+      screen.getByRole("button", { name: "Activate" }).click();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Activate" }),
+        ).not.toHaveProperty("data-loading", true);
+      });
+
+      expect(getSection("Usage data preferences")).toHaveAttribute(
+        "aria-current",
+        "step",
+      );
+    });
+
+    it("should be possible to skip the step without a token", async () => {
+      await setupForLicenseStep();
+
+      clickNextStep();
+
+      expect(getSection("Usage data preferences")).toHaveAttribute(
+        "aria-current",
+        "step",
+      );
+    });
+
+    it("should pass the token to the setup endpoint", async () => {
+      await setupForLicenseStep();
+
+      setupForTokenCheckEndpoint({ valid: true });
+
+      userEvent.paste(
+        screen.getByRole("textbox", { name: "Token" }),
+        sampleToken,
+      );
+
+      screen.getByRole("button", { name: "Activate" }).click();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Activate" }),
+        ).not.toHaveProperty("data-loading", true);
+      });
+
+      screen.getByRole("button", { name: "Finish" }).click();
+
+      const setupCall = fetchMock.lastCall(`path:/api/setup`);
+      expect(await setupCall?.request?.json()).toMatchObject({
+        license_token: sampleToken,
+      });
+    });
   });
 });

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -70,14 +70,8 @@ describe("setup (EE, no token)", () => {
 
       screen.getByRole("button", { name: "Activate" }).click();
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("button", { name: "Activate" }),
-        ).not.toHaveProperty("data-loading", true);
-      });
-
       expect(
-        screen.getByText(
+        await screen.findByText(
           "This token doesn’t seem to be valid. Double-check it, then contact support if you think it should be working",
         ),
       ).toBeInTheDocument();
@@ -130,13 +124,7 @@ describe("setup (EE, no token)", () => {
 
       screen.getByRole("button", { name: "Activate" }).click();
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("button", { name: "Activate" }),
-        ).not.toHaveProperty("data-loading", true);
-      });
-
-      screen.getByRole("button", { name: "Finish" }).click();
+      (await screen.findByRole("button", { name: "Finish" })).click();
 
       const setupCall = fetchMock.lastCall(`path:/api/setup`);
       expect(await setupCall?.request?.json()).toMatchObject({

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -51,9 +51,11 @@ describe("setup (EE, no token)", () => {
       selectUsageReason("embedding"); // to skip the db connection step
       clickNextStep();
 
-      await screen.findByText(
-        "Unlock access to your paid features before starting",
-      );
+      expect(
+        await screen.findByText(
+          "Unlock access to your paid features before starting",
+        ),
+      ).toBeInTheDocument();
     }
 
     it("should display an error in case of invalid token", async () => {

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -1,0 +1,31 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSectionToHaveLabel", "expectSectionsToHaveLabelsInOrder"] }] */
+
+import type { SetupOpts } from "./setup";
+import {
+  expectSectionsToHaveLabelsInOrder,
+  expectSectionToHaveLabel,
+  setup,
+  skipWelcomeScreen,
+} from "./setup";
+
+const setupEnterprise = (opts?: SetupOpts) => {
+  return setup({
+    ...opts,
+    hasEnterprisePlugins: true,
+  });
+};
+
+describe("setup (E, no token)", () => {
+  it("default step order should be correct, with the commercial step in place", async () => {
+    await setupEnterprise();
+    skipWelcomeScreen();
+    expectSectionToHaveLabel("What's your preferred language?", "1");
+    expectSectionToHaveLabel("What should we call you?", "2");
+    expectSectionToHaveLabel("What will you use Metabase for?", "3");
+    expectSectionToHaveLabel("Add your data", "4");
+    expectSectionToHaveLabel("Activate your commercial license", "5");
+    expectSectionToHaveLabel("Usage data preferences", "6");
+
+    expectSectionsToHaveLabelsInOrder();
+  });
+});

--- a/frontend/src/metabase/setup/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium.unit.spec.tsx
@@ -1,0 +1,33 @@
+/* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSectionToHaveLabel", "expectSectionsToHaveLabelsInOrder"] }] */
+
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+
+import type { SetupOpts } from "./setup";
+import {
+  expectSectionsToHaveLabelsInOrder,
+  expectSectionToHaveLabel,
+  setup,
+  skipWelcomeScreen,
+} from "./setup";
+
+const setupPremium = (opts?: SetupOpts) => {
+  return setup({
+    ...opts,
+    hasEnterprisePlugins: true,
+    tokenFeatures: createMockTokenFeatures({ hosting: true }),
+  });
+};
+
+describe("setup (EE, hosting feature)", () => {
+  it("default step order should be correct, without the commercial step", async () => {
+    await setupPremium();
+    skipWelcomeScreen();
+    expectSectionToHaveLabel("What's your preferred language?", "1");
+    expectSectionToHaveLabel("What should we call you?", "2");
+    expectSectionToHaveLabel("What will you use Metabase for?", "3");
+    expectSectionToHaveLabel("Add your data", "4");
+    expectSectionToHaveLabel("Usage data preferences", "5");
+
+    expectSectionsToHaveLabelsInOrder();
+  });
+});

--- a/frontend/src/metabase/setup/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium.unit.spec.tsx
@@ -1,5 +1,7 @@
 /* eslint jest/expect-expect: ["error", { "assertFunctionNames": ["expect", "expectSectionToHaveLabel", "expectSectionsToHaveLabelsInOrder"] }] */
 
+import { screen } from "@testing-library/react";
+
 import { createMockTokenFeatures } from "metabase-types/api/mocks";
 
 import type { SetupOpts } from "./setup";
@@ -29,5 +31,13 @@ describe("setup (EE, hosting feature)", () => {
     expectSectionToHaveLabel("Usage data preferences", "5");
 
     expectSectionsToHaveLabelsInOrder();
+  });
+
+  it("should not render the license activation step", async () => {
+    await setupPremium();
+    skipWelcomeScreen();
+    expect(
+      screen.queryByText("Activate your commercial license"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/setup/tests/setup.tsx
+++ b/frontend/src/metabase/setup/tests/setup.tsx
@@ -1,0 +1,122 @@
+import { waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
+import { setupEnterprisePlugins } from "__support__/enterprise";
+import { renderWithProviders, screen } from "__support__/ui";
+import type { TokenFeatures, UsageReason } from "metabase-types/api";
+import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import {
+  createMockSettingsState,
+  createMockSetupState,
+  createMockState,
+} from "metabase-types/store/mocks";
+
+import { Setup } from "../components/Setup";
+import type { SetupStep } from "../types";
+
+export interface SetupOpts {
+  step?: SetupStep;
+  tokenFeatures?: TokenFeatures;
+  hasEnterprisePlugins?: boolean;
+}
+
+export async function setup({
+  tokenFeatures = createMockTokenFeatures(),
+  hasEnterprisePlugins = false,
+}: SetupOpts = {}) {
+  localStorage.clear();
+  jest.clearAllMocks();
+
+  const state = createMockState({
+    setup: createMockSetupState({
+      step: "welcome",
+    }),
+    settings: createMockSettingsState({
+      "token-features": tokenFeatures,
+      "available-locales": [["en", "English"]],
+    }),
+  });
+
+  if (hasEnterprisePlugins) {
+    setupEnterprisePlugins();
+  }
+
+  fetchMock.post("path:/api/util/password_check", { valid: true });
+  fetchMock.post("path:/api/setup", {});
+
+  renderWithProviders(<Setup />, { storeInitialState: state });
+
+  // there is some async stuff going on with the locale loading
+  await screen.findByText("Let's get started");
+
+  return;
+}
+
+export const getSection = (name: string) =>
+  screen.getByRole("listitem", { name });
+
+export const clickNextStep = () =>
+  userEvent.click(screen.getByRole("button", { name: "Next" }));
+
+export const skipWelcomeScreen = () =>
+  userEvent.click(screen.getByText("Let's get started"));
+
+export const skipLanguageStep = () => clickNextStep();
+
+export const submitUserInfoStep = async ({
+  firstName = "John",
+  lastName = "Smith",
+  email = "john@example.org",
+  companyName = "Acme",
+  password = "Monkeyabc123",
+} = {}) => {
+  userEvent.type(screen.getByLabelText("First name"), firstName);
+  userEvent.type(screen.getByLabelText("Last name"), lastName);
+  userEvent.type(screen.getByLabelText("Email"), email);
+  userEvent.type(screen.getByLabelText("Company or team name"), companyName);
+  userEvent.type(screen.getByLabelText("Create a password"), password);
+  userEvent.type(screen.getByLabelText("Confirm your password"), password);
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: "Next" })).toBeEnabled(),
+  );
+  clickNextStep();
+  // formik+yup validation is async, we need to wait for the submit to finish
+  await waitFor(() =>
+    expect(
+      screen.queryByText("What should we call you?"),
+    ).not.toBeInTheDocument(),
+  );
+};
+
+export const selectUsageReason = (usageReason: UsageReason) => {
+  const label = {
+    "self-service-analytics": "Self-service analytics for my own company",
+    embedding: "Embedding analytics into my application",
+    both: "A bit of both",
+    "not-sure": "Not sure yet",
+  }[usageReason];
+
+  userEvent.click(screen.getByLabelText(label));
+};
+
+export const expectSectionToHaveLabel = (
+  sectionName: string,
+  label: string,
+) => {
+  const section = getSection(sectionName);
+
+  expect(within(section).getByText(label)).toBeInTheDocument();
+};
+
+export const expectSectionsToHaveLabelsInOrder = ({
+  from = 0,
+}: {
+  from?: number;
+} = {}): void => {
+  screen.getAllByRole("listitem").forEach((section, index) => {
+    if (index >= from) {
+      expect(within(section).getByText(`${index + 1}`)).toBeInTheDocument();
+    }
+  });
+};

--- a/frontend/src/metabase/setup/types.ts
+++ b/frontend/src/metabase/setup/types.ts
@@ -4,5 +4,6 @@ export type SetupStep =
   | "user_info"
   | "usage_question"
   | "db_connection"
+  | "license_token"
   | "data_usage"
   | "completed";

--- a/frontend/src/metabase/setup/useStep.ts
+++ b/frontend/src/metabase/setup/useStep.ts
@@ -16,9 +16,9 @@ export const useStep = (stepName: SetupStep) => {
   const isSetupCompleted = useSelector(getIsSetupCompleted);
   const dispatch = useDispatch();
 
-  const selectThisStep = () => {
+  const handleStepSelect = () => {
     dispatch(selectStep(stepName));
   };
 
-  return { isStepActive, isStepCompleted, selectThisStep, isSetupCompleted };
+  return { isStepActive, isStepCompleted, handleStepSelect, isSetupCompleted };
 };

--- a/frontend/src/metabase/setup/useStep.ts
+++ b/frontend/src/metabase/setup/useStep.ts
@@ -1,0 +1,24 @@
+import { useDispatch, useSelector } from "metabase/lib/redux";
+
+import { selectStep } from "./actions";
+import {
+  getIsSetupCompleted,
+  getIsStepActive,
+  getIsStepCompleted,
+} from "./selectors";
+import type { SetupStep } from "./types";
+
+export const useStep = (stepName: SetupStep) => {
+  const isStepActive = useSelector(state => getIsStepActive(state, stepName));
+  const isStepCompleted = useSelector(state =>
+    getIsStepCompleted(state, stepName),
+  );
+  const isSetupCompleted = useSelector(getIsSetupCompleted);
+  const dispatch = useDispatch();
+
+  const selectThisStep = () => {
+    dispatch(selectStep(stepName));
+  };
+
+  return { isStepActive, isStepCompleted, selectThisStep, isSetupCompleted };
+};

--- a/frontend/test/__support__/server-mocks/setup.ts
+++ b/frontend/test/__support__/server-mocks/setup.ts
@@ -9,3 +9,7 @@ export function setupErrorSetupEndpoints() {
 export function setupAdminCheckListEndpoint(items: SetupCheckListItem[]) {
   fetchMock.get("path:/api/setup/admin_checklist", items);
 }
+
+export function setupForTokenCheckEndpoint(response: { valid: boolean }) {
+  fetchMock.get("path:/api/setup/token-check", response);
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-3
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-3
@@ -1,0 +1,104 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Setup flow",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "setup",
+    "format": "jsonschema",
+    "version": "1-0-2"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "step_seen",
+        "usage_reason_selected",
+        "database_selected",
+        "add_data_later_clicked"
+      ],
+      "maxLength": 1024
+    },
+    "version": {
+      "description": "String describing the version of onboarding we're on",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "step": {
+      "description": "String describing the step that the set up step",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "welcome",
+        "language",
+        "user_info",
+        "db_connection",
+        "usage_question",
+        "db_scheduling",
+        "data_usage",
+        "completed"
+      ],
+      "maxLength": 1024
+    },
+    "step_number": {
+      "description": "Integer describing the order of the referenced step",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ],
+      "minimum": 0,
+      "maximum": 1024
+    },
+    "usage_reason": {
+      "description": "Answer to the usage reason question",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "self-service-analytics",
+        "embedding",
+        "both",
+        "not-sure"
+      ],
+      "maxLength": 1024
+    },
+    "database": {
+      "description": "String with the database type that the user selected",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "source": {
+      "description": "String with the product location that the event took place",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "pre_selection",
+        "post_selection"
+      ],
+      "maxLength": 1024
+    }
+  },
+  "required": [
+    "event",
+    "version"
+  ],
+  "additionalProperties": true
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-3
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-3
@@ -37,6 +37,7 @@
         "user_info",
         "db_connection",
         "usage_question",
+        "license_token",
         "db_scheduling",
         "data_usage",
         "completed"
@@ -56,7 +57,8 @@
         3,
         4,
         5,
-        6
+        6,
+        7
       ],
       "minimum": 0,
       "maximum": 1024


### PR DESCRIPTION
Part of [[Epic] Add license activation in the initial setup](https://github.com/metabase/metabase/issues/38867)

During development I encountered an issue, the getSteps selector that I introduced in the previous epic was being used in reducers. All good until it started needing access to global state, that the reducers don't have access to..
I did a little hacky solution to that in 0318a55b22b189af9e30d4a8116bacfb0365fcd2 with a initSetup function that copies the global piece of stat needed in the slice so that it's all good.
It's... a solution.. it works but meh

I tried to find other solutions and I opened two prs for them:

- [goToNextStep in all thunks (+42 −56)](https://github.com/metabase/metabase/pull/39103)
    - very simple, it works and is probably a good compromise
- [dispatchAndGoNextStep (+119 −108)](https://github.com/metabase/metabase/pull/39121)
    - I tried to be smarter, it backfired in tests failing because of async stuff 🤷 🤷 🤷
    - considering all the failures in the tests, I don't think it's worth going with this route)

Let me know which of the three solutions (initSetup + 2 in the prs) you want to go with 

 # other notable changes/commits in the PR
- ea045e93c1fb8932d3675d686065f57f7c203645 to see what I changed in the events schema
- 1d8d592072971a6a4119210323c055874c5c9aba useStep hook


# Things still missing that will come in future PRs
- analytics event
- handling of the error when the BE cannot connect to the token check server, I already started working on the BE for that [here](https://github.com/metabase/metabase/pull/39067) 
 