### PR TITLE
Join column hovercard

### DIFF
--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -164,10 +164,12 @@ describe("binning related reproductions", () => {
     popover().findByText("18646").click();
 
     popover().within(() => {
-      cy.findByRole("option", { name: "CREATED_AT" })
+      cy.findByRole("option", { name: /CREATED_AT/ })
         .findByText("by month")
         .should("exist");
-      cy.findByRole("option", { name: "CREATED_AT" }).click();
+      cy.findByRole("option", { name: /CREATED_AT/ }).click({
+        position: "left",
+      });
     });
 
     getNotebookStep("summarize").findByText(

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -156,7 +156,7 @@ describe("scenarios > filters > bulk filtering", () => {
     filter();
 
     modal().within(() => {
-      cy.findByText("Product").click();
+      cy.findByText("Product").click({ force: true });
       filterField("Category").findByText("Gadget").click();
     });
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
@@ -12,6 +12,14 @@ export const TriggerIcon = styled(Icon)`
   margin-left: 0.5rem;
 `;
 
+export const ChevronDown = styled(Icon)`
+  flex: 0 0 auto;
+  width: 8px;
+  margin-left: 0.25em;
+  color: currentColor;
+  opacity: 0.75;
+`;
+
 export const TriggerButton = styled.button<{ hasDot?: boolean }>`
   display: flex;
   align-items: center;
@@ -26,6 +34,10 @@ export const TriggerButton = styled.button<{ hasDot?: boolean }>`
 
   cursor: pointer;
 
+  ${ChevronDown} {
+    color: currentColor;
+  }
+
   &:hover {
     color: ${color("white")};
   }
@@ -38,15 +50,6 @@ export const Dot = styled.div`
   background: currentColor;
   border-radius: 100%;
   opacity: 0.25;
-`;
-
-export const ChevronDown = styled(Icon)`
-  flex: 0 0 auto;
-  width: 8px;
-  margin-left: 0.25em;
-  color: inherit;
-  opacity: 0.75;
-  color: currentColor !important;
 `;
 
 export const SelectListItem = styled(BaseSelectList.Item)<{

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.styled.tsx
@@ -16,7 +16,6 @@ export const TriggerButton = styled.button<{ hasDot?: boolean }>`
   display: flex;
   align-items: center;
   min-width: 0;
-  max-width: 50%;
 
   color: ${alpha(color("white"), 0.5)};
   font-weight: 700;
@@ -45,7 +44,9 @@ export const ChevronDown = styled(Icon)`
   flex: 0 0 auto;
   width: 8px;
   margin-left: 0.25em;
+  color: inherit;
   opacity: 0.75;
+  color: currentColor !important;
 `;
 
 export const SelectListItem = styled(BaseSelectList.Item)<{

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
@@ -22,7 +22,7 @@ export const NameAndBucketing = styled.div`
   ${TriggerButton} {
     height: 100%;
     padding: 0;
-    flex-shrink: 1;
+    flex-shrink: 2;
   }
 `;
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
@@ -4,6 +4,22 @@ import AccordionList from "metabase/core/components/AccordionList";
 import { color } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
 
+import { TriggerButton } from "./BucketPickerPopover/BaseBucketPickerPopover.styled";
+
 export const StyledAccordionList = styled(AccordionList)<{ color: ColorName }>`
   color: ${props => color(props.color)};
+`;
+
+export const ItemName = styled.div`
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  flex-grow: 1;
+  white-space: nowrap;
+
+  ${TriggerButton} {
+    height: 100%;
+    padding: 0;
+    margin-left: 0.25rem;
+  }
 `;

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
@@ -10,7 +10,7 @@ export const StyledAccordionList = styled(AccordionList)<{ color: ColorName }>`
   color: ${props => color(props.color)};
 `;
 
-export const ItemName = styled.div`
+export const NameAndBucketing = styled.div`
   display: flex;
   align-items: center;
   flex-shrink: 0;
@@ -20,6 +20,9 @@ export const ItemName = styled.div`
   ${TriggerButton} {
     height: 100%;
     padding: 0;
-    margin-left: 0.25rem;
   }
+`;
+
+export const ItemName = styled.div`
+  margin-right: 0.25rem;
 `;

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
@@ -1,6 +1,7 @@
 import styled from "@emotion/styled";
 
 import AccordionList from "metabase/core/components/AccordionList";
+import { Ellipsified } from "metabase/core/components/Ellipsified";
 import { color } from "metabase/lib/colors";
 import type { ColorName } from "metabase/lib/colors/types";
 
@@ -16,13 +17,19 @@ export const NameAndBucketing = styled.div`
   flex-shrink: 0;
   flex-grow: 1;
   white-space: nowrap;
+  overflow: hidden;
 
   ${TriggerButton} {
     height: 100%;
     padding: 0;
+    flex-shrink: 1;
   }
 `;
 
-export const ItemName = styled.div`
+export const ItemName = styled(Ellipsified)`
   margin-right: 0.25rem;
+  flex-shrink: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useCallback, useMemo } from "react";
 
 import {
@@ -5,13 +6,17 @@ import {
   getColumnGroupName,
 } from "metabase/common/utils/column-groups";
 import { getColumnIcon } from "metabase/common/utils/columns";
+import {
+  QueryColumnInfoIcon,
+  HoverParent,
+} from "metabase/components/MetadataInfo/ColumnInfoIcon";
 import type { ColorName } from "metabase/lib/colors/types";
 import type { IconName } from "metabase/ui";
-import { Icon } from "metabase/ui";
+import { Icon, DelayGroup } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { BucketPickerPopover } from "./BucketPickerPopover";
-import { StyledAccordionList } from "./QueryColumnPicker.styled";
+import { StyledAccordionList, ItemName } from "./QueryColumnPicker.styled";
 
 const DEFAULT_MAX_HEIGHT = 610;
 
@@ -27,6 +32,7 @@ export interface QueryColumnPickerProps {
   hasBinning?: boolean;
   hasTemporalBucketing?: boolean;
   withDefaultBucketing?: boolean;
+  withInfoIcons?: boolean;
   maxHeight?: number;
   color?: ColorName;
   checkIsColumnSelected: (item: ColumnListItem) => boolean;
@@ -48,6 +54,7 @@ export function QueryColumnPicker({
   hasBinning = false,
   hasTemporalBucketing = false,
   withDefaultBucketing = true,
+  withInfoIcons = false,
   maxHeight = DEFAULT_MAX_HEIGHT,
   color = "brand",
   checkIsColumnSelected,
@@ -127,20 +134,26 @@ export function QueryColumnPicker({
     ],
   );
 
-  const renderItemExtra = useCallback(
-    (item: ColumnListItem) =>
-      hasBinning || hasTemporalBucketing ? (
-        <BucketPickerPopover
-          query={query}
-          stageIndex={stageIndex}
-          column={item.column}
-          isEditing={checkIsColumnSelected(item)}
-          hasBinning={hasBinning}
-          hasTemporalBucketing={hasTemporalBucketing}
-          color={color}
-          onSelect={handleSelect}
-        />
-      ) : null,
+  const renderItemName = useCallback(
+    (item: ColumnListItem) => (
+      <ItemName>
+        {item.displayName}
+        {(hasBinning || hasTemporalBucketing) && (
+          <BucketPickerPopover
+            query={query}
+            stageIndex={stageIndex}
+            column={item.column}
+            isEditing={checkIsColumnSelected(item)}
+            hasBinning={hasBinning}
+            hasTemporalBucketing={hasTemporalBucketing}
+            hasDot={withInfoIcons}
+            hasChevronDown={withInfoIcons}
+            color={color}
+            onSelect={handleSelect}
+          />
+        )}
+      </ItemName>
+    ),
     [
       query,
       stageIndex,
@@ -149,31 +162,47 @@ export function QueryColumnPicker({
       color,
       checkIsColumnSelected,
       handleSelect,
+      withInfoIcons,
     ],
   );
 
+  const renderItemExtra = useCallback(
+    item => (
+      <QueryColumnInfoIcon
+        query={query}
+        stageIndex={stageIndex}
+        column={item.column}
+        position="top-start"
+      />
+    ),
+    [query, stageIndex],
+  );
+
   return (
-    <StyledAccordionList
-      className={className}
-      sections={sections}
-      maxHeight={maxHeight}
-      alwaysExpanded={false}
-      onChange={handleSelectColumn}
-      itemIsSelected={checkIsColumnSelected}
-      renderItemName={renderItemName}
-      renderItemDescription={omitItemDescription}
-      renderItemIcon={renderItemIcon}
-      renderItemExtra={renderItemExtra}
-      color={color}
-      // Compat with E2E tests around MLv1-based components
-      // Prefer using a11y role selectors
-      itemTestId="dimension-list-item"
-    />
+    <DelayGroup>
+      <StyledAccordionList
+        className={className}
+        sections={sections}
+        maxHeight={maxHeight}
+        alwaysExpanded={false}
+        onChange={handleSelectColumn}
+        itemIsSelected={checkIsColumnSelected}
+        renderItemWrapper={renderItemWrapper}
+        renderItemName={renderItemName}
+        renderItemDescription={omitItemDescription}
+        renderItemIcon={renderItemIcon}
+        renderItemExtra={renderItemExtra}
+        color={color}
+        // Compat with E2E tests around MLv1-based components
+        // Prefer using a11y role selectors
+        itemTestId="dimension-list-item"
+      />
+    </DelayGroup>
   );
 }
 
-function renderItemName(item: ColumnListItem) {
-  return item.displayName;
+function renderItemWrapper(content: ReactNode) {
+  return <HoverParent>{content}</HoverParent>;
 }
 
 function omitItemDescription() {

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -192,6 +192,7 @@ export function QueryColumnPicker({
         renderItemDescription={omitItemDescription}
         renderItemIcon={renderItemIcon}
         renderItemExtra={renderItemExtra}
+        renderItemLabel={renderItemLabel}
         color={color}
         // Compat with E2E tests around MLv1-based components
         // Prefer using a11y role selectors
@@ -199,6 +200,10 @@ export function QueryColumnPicker({
       />
     </DelayGroup>
   );
+}
+
+function renderItemLabel(item: ColumnListItem) {
+  return item.displayName;
 }
 
 function renderItemWrapper(content: ReactNode) {

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -176,7 +176,7 @@ export function QueryColumnPicker({
         query={query}
         stageIndex={stageIndex}
         column={item.column}
-        position="top-start"
+        position="right"
       />
     ),
     [query, stageIndex],

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -16,7 +16,11 @@ import { Icon, DelayGroup } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { BucketPickerPopover } from "./BucketPickerPopover";
-import { StyledAccordionList, ItemName } from "./QueryColumnPicker.styled";
+import {
+  StyledAccordionList,
+  NameAndBucketing,
+  ItemName,
+} from "./QueryColumnPicker.styled";
 
 const DEFAULT_MAX_HEIGHT = 610;
 
@@ -136,8 +140,8 @@ export function QueryColumnPicker({
 
   const renderItemName = useCallback(
     (item: ColumnListItem) => (
-      <ItemName>
-        {item.displayName}
+      <NameAndBucketing>
+        <ItemName>{item.displayName}</ItemName>
         {(hasBinning || hasTemporalBucketing) && (
           <BucketPickerPopover
             query={query}
@@ -152,7 +156,7 @@ export function QueryColumnPicker({
             onSelect={handleSelect}
           />
         )}
-      </ItemName>
+      </NameAndBucketing>
     ),
     [
       query,

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
@@ -94,6 +94,16 @@ describe("QueryColumnPicker", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("should render info icons", () => {
+    const { sampleColumnInfo } = setup();
+
+    expect(
+      within(
+        screen.getByLabelText(sampleColumnInfo.displayName),
+      ).getByLabelText("More info"),
+    ).toBeInTheDocument();
+  });
+
   it("should highlight column used in a given clause", () => {
     const { query, clauseInfo } = createQueryWithBreakout();
     setup({ query });

--- a/frontend/src/metabase/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.styled.tsx
@@ -5,6 +5,7 @@ import { Icon } from "metabase/ui";
 export const PopoverHoverTarget = styled(Icon)<{ hasDescription: boolean }>`
   padding: 0.7em 0.65em;
   visibility: hidden;
+  flex-shrink: 0;
   opacity: ${props => (props.hasDescription ? 0.6 : 0.3)};
 
   &[aria-expanded="true"] {

--- a/frontend/src/metabase/components/MetadataInfo/ColumnInfoPopover/ColumnInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnInfoPopover/ColumnInfoPopover.tsx
@@ -11,7 +11,7 @@ export const POPOVER_TRANSITION_DURATION = 150;
 
 // When switching to another hover target in the same delay group,
 // we don't closing immediatly but delay by a short amount to avoid flicker.
-export const POPOVER_CLOSE_DELAY = 25;
+export const POPOVER_CLOSE_DELAY = 10;
 
 export type QueryColumnInfoPopoverProps = QueryColumnInfoProps &
   Omit<PopoverProps, "content">;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -74,6 +74,7 @@ export default class AccordionList extends Component {
     itemIsSelected: PropTypes.func,
     itemIsClickable: PropTypes.func,
     renderItemName: PropTypes.func,
+    renderItemLabel: PropTypes.func,
     renderItemDescription: PropTypes.func,
     renderItemIcon: PropTypes.func,
     renderItemExtra: PropTypes.func,

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -155,7 +155,7 @@ export const AccordionListCell = ({
               {icon}
             </span>
           )}
-          <div>
+          <div className="List-item-content">
             {name && <h4 className="List-item-title ml1 text-wrap">{name}</h4>}
             {description && (
               <p className="List-item-description ml1 text-wrap">

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -26,6 +26,7 @@ export const AccordionListCell = ({
   alwaysExpanded,
   toggleSection,
   renderSectionIcon,
+  renderItemLabel,
   renderItemName,
   renderItemDescription,
   renderItemIcon,
@@ -124,10 +125,11 @@ export const AccordionListCell = ({
     const name = renderItemName(item);
     const description = renderItemDescription(item);
     const extra = renderItemExtra(item, isSelected);
+    const label = renderItemLabel ? renderItemLabel(item) : name;
     content = (
       <ListCellItem
         data-testid={itemTestId}
-        aria-label={name}
+        aria-label={label}
         role="option"
         aria-selected={isSelected}
         aria-disabled={!isClickable}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -20,4 +20,5 @@ export const Content = styled.div<{ isClickable: boolean }>`
   align-items: center;
   padding: 0.5rem;
   cursor: ${props => (props.isClickable ? "pointer" : "default")};
+  min-width: 0;
 `;

--- a/frontend/src/metabase/css/components/list.css
+++ b/frontend/src/metabase/css/components/list.css
@@ -66,8 +66,14 @@
   background-color: currentColor;
 }
 
+/* LIST ITEM CONTENT */
+.List-item-content {
+  min-width: 0;
+}
+
 /* LIST ITEM TITLE */
 .List-item-title {
+  min-width: 0;
   color: var(--color-text-dark);
 }
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
@@ -122,6 +122,7 @@ const BreakoutPopover = ({
       columnGroups={columnGroups}
       hasBinning
       hasTemporalBucketing
+      withInfoIcons
       color="summarize"
       checkIsColumnSelected={item => checkColumnSelected(item, breakoutIndex)}
       onSelect={(column: Lib.ColumnMetadata) => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
@@ -84,6 +84,7 @@ export function JoinConditionColumnPicker({
           stageIndex={stageIndex}
           hasTemporalBucketing
           checkIsColumnSelected={checkColumnSelected}
+          withInfoIcons
           onClose={closePopover}
         />
       )}

--- a/frontend/src/metabase/redux/metadata.unit.spec.js
+++ b/frontend/src/metabase/redux/metadata.unit.spec.js
@@ -1,5 +1,6 @@
-import Fields from "metabase/entities/fields";
+/* eslint-disable import/order */
 import Tables from "metabase/entities/tables";
+import Fields from "metabase/entities/fields";
 
 import { fetchField, loadMetadataForDependentItems } from "./metadata";
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38863

### Description

Add the column info icon to the join column picker.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question → Sample Dataset → Orders
2. Join data → Products
3. Click the column picker and verify each item in the dropdown has an info icon when hovered
4. Hover the info icon and verify it shows the correct information

### Demo

<img width="712" alt="Screenshot 2024-02-20 at 16 13 58" src="https://github.com/metabase/metabase/assets/1250185/950bb7af-6f1d-45c4-bc4a-084724f1392a">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
