### PR TITLE
Do not create param_values on Dashboard Load, only fetch if they exist

### DIFF
--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -88,7 +88,7 @@
    (into {}
          (map (comp (juxt :field_id identity)
                     #(select-keys % [:field_id :human_readable_values :values])
-                    field-values/get-or-create-full-field-values!))
+                    #(field-values/get-latest-full-field-values (:id %))))
          (t2/hydrate (t2/select :model/Field :id [:in (set param-field-ids)]) :values))))
 
 (defn- field-ids->param-field-values
@@ -186,7 +186,7 @@
 
 
 (mu/defn ^:private param-field-ids->fields
-  "Get the Fields (as a map of Field ID -> Field) that shoudl be returned for hydrated `:param_fields` for a Card or
+  "Get the Fields (as a map of Field ID -> Field) that shoudld be returned for hydrated `:param_fields` for a Card or
   Dashboard. These only contain the minimal amount of information necessary needed to power public or embedded
   parameter widgets."
   [field-ids :- [:maybe [:set ms/PositiveInt]]]
@@ -204,7 +204,7 @@
 #_{:clj-kondo/ignore [:unused-private-var]}
 (mi/define-simple-hydration-method ^:private hydrate-param-values
   :param_values
-  "Hydration method for `:param_fields`."
+  "Hydration method for `:param_values`."
   [instance]
   (param-values instance))
 

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -186,7 +186,7 @@
 
 
 (mu/defn ^:private param-field-ids->fields
-  "Get the Fields (as a map of Field ID -> Field) that shoudld be returned for hydrated `:param_fields` for a Card or
+  "Get the Fields (as a map of Field ID -> Field) that should be returned for hydrated `:param_fields` for a Card or
   Dashboard. These only contain the minimal amount of information necessary needed to power public or embedded
   parameter widgets."
   [field-ids :- [:maybe [:set ms/PositiveInt]]]

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -50,8 +50,9 @@
      (let [fields       (-> (t2/select :model/Field :id [:in (set field-ids)])
                             (field/readable-fields-only)
                             (t2/hydrate :values))
-           field-values (->> (map #(select-keys (field-values/get-or-create-full-field-values! %)
-                                                [:field_id :human_readable_values :values])
+           field-values (->> (map #(select-keys
+                                    (field-values/get-latest-full-field-values (:id %))
+                                    [:field_id :human_readable_values :values])
                                   fields)
                              (keep not-empty))]
        (m/index-by :field_id field-values)))))

--- a/src/metabase/models/params/field_values.clj
+++ b/src/metabase/models/params/field_values.clj
@@ -50,8 +50,7 @@
      (let [fields       (-> (t2/select :model/Field :id [:in (set field-ids)])
                             (field/readable-fields-only)
                             (t2/hydrate :values))
-           field-values (->> (map #(select-keys
-                                    (field-values/get-latest-full-field-values (:id %))
+           field-values (->> (map #(select-keys (field-values/get-latest-full-field-values (:id %))
                                     [:field_id :human_readable_values :values])
                                   fields)
                              (keep not-empty))]

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -627,28 +627,6 @@
              (mt/with-log-messages-for-level ['metabase.models.params :error]
                (is (some? (mt/user-http-request :rasta :get 200 (str "dashboard/" dash-id))))))))))
 
-#_(deftest dashboard-param-link-to-a-field-without-full-field-values-test
-  (testing "GET /api/dashboard/:id"
-    (t2.with-temp/with-temp
-      [:model/Dashboard {dashboard-id :id} {:name "Test Dashboard"}
-       :model/Card {card-id :id} {:name "Dashboard Test Card"}
-       :model/DashboardCard _ {:dashboard_id       dashboard-id
-                               :card_id            card-id
-                               :parameter_mappings [{:card_id      card-id
-                                                     :parameter_id "foo"
-                                                     :target       [:dimension
-                                                                    [:field (mt/id :venues :name) nil]]}]}]
-      (t2/delete! :model/FieldValues :field_id (mt/id :venues :name) :type :full)
-      (testing "Request triggers computation of field values if missing (#30218)"
-        (is (= {(mt/id :venues :name) {:values                ["20th Century Cafe"
-                                                               "25°"
-                                                               "33 Taps"]
-                                       :field_id              (mt/id :venues :name)
-                                       :human_readable_values []}}
-               (let [response (:param_values (mt/user-http-request :rasta :get 200 (str "dashboard/" dashboard-id)))]
-                 (into {} (for [[field-id m] response]
-                            [field-id (update m :values (partial take 3))])))))))))
-
 (deftest param-values-not-fetched-on-load-test
   (testing "Param values are not needed on initial dashboard load and should not be fetched. #38826"
     (t2.with-temp/with-temp

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -646,7 +646,7 @@
               _                (t2/delete! :model/FieldValues :field_id (mt/id :venues :name) :type :full)
               dashboard-load-b (mt/user-http-request :rasta :get 200 (str "dashboard/" dashboard-id))
               param-values     (mt/user-http-request :rasta :get 200 (format "dashboard/%s/params/%s/values" dashboard-id "foo"))]
-          (testing "The initial dashboard-load doesn't fetch parameter values (#38826)"
+          (testing "The initial dashboard-load fetches parameter values only if they already exist (#38826)"
             (is (some? (:param_values dashboard-load-a)))
             (is (nil? (:param_values dashboard-load-b))))
           (testing "Request to values endpoint triggers computation of field values if missing."

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -627,7 +627,7 @@
              (mt/with-log-messages-for-level ['metabase.models.params :error]
                (is (some? (mt/user-http-request :rasta :get 200 (str "dashboard/" dash-id))))))))))
 
-(deftest dashboard-param-link-to-a-field-without-full-field-values-test
+#_(deftest dashboard-param-link-to-a-field-without-full-field-values-test
   (testing "GET /api/dashboard/:id"
     (t2.with-temp/with-temp
       [:model/Dashboard {dashboard-id :id} {:name "Test Dashboard"}
@@ -649,6 +649,32 @@
                  (into {} (for [[field-id m] response]
                             [field-id (update m :values (partial take 3))])))))))))
 
+(deftest param-values-not-fetched-on-load-test
+  (testing "Param values are not needed on initial dashboard load and should not be fetched. #38826"
+    (t2.with-temp/with-temp
+        [:model/Dashboard {dashboard-id :id} {:name       "Test Dashboard"
+                                              :parameters [{:name      "FOO"
+                                                            :id        "foo"
+                                                            :type      :string/=
+                                                            :sectionId "string"}]}
+         :model/Card {card-id :id} {:name "Dashboard Test Card"}
+         :model/DashboardCard _ {:dashboard_id       dashboard-id
+                                 :card_id            card-id
+                                 :parameter_mappings [{:card_id      card-id
+                                                       :parameter_id "foo"
+                                                       :target       [:dimension
+                                                                      [:field (mt/id :venues :name) nil]]}]}]
+        (let [dashboard-load-a (mt/user-http-request :rasta :get 200 (str "dashboard/" dashboard-id))
+              _                (t2/delete! :model/FieldValues :field_id (mt/id :venues :name) :type :full)
+              dashboard-load-b (mt/user-http-request :rasta :get 200 (str "dashboard/" dashboard-id))
+              param-values     (mt/user-http-request :rasta :get 200 (format "dashboard/%s/params/%s/values" dashboard-id "foo"))]
+          (testing "The initial dashboard-load doesn't fetch parameter values (#38826)"
+            (is (some? (:param_values dashboard-load-a)))
+            (is (nil? (:param_values dashboard-load-b))))
+          (testing "Request to values endpoint triggers computation of field values if missing."
+            (is (= ["20th Century Cafe" "25°" "33 Taps"]
+                   (take 3 (apply concat (:values param-values))))))))))
+
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                             PUT /api/dashboard/:id                                             |
 ;;; +----------------------------------------------------------------------------------------------------------------+
@@ -666,11 +692,11 @@
 
         (testing "PUT response"
           (let [put-response (mt/user-http-request :rasta :put 200 (str "dashboard/" dashboard-id)
-                                               {:name        "My Cool Dashboard"
-                                                :description "Some awesome description"
-                                                :cache_ttl   1234
-                                                ;; these things should fail to update
-                                                :creator_id  (mt/user->id :trashbird)})
+                                                   {:name        "My Cool Dashboard"
+                                                    :description "Some awesome description"
+                                                    :cache_ttl   1234
+                                                    ;; these things should fail to update
+                                                    :creator_id  (mt/user->id :trashbird)})
                 get-response (mt/user-http-request :rasta :get 200 (format "dashboard/%d" dashboard-id))]
             (is (=? (merge dashboard-defaults {:name           "My Cool Dashboard"
                                                :dashcards      []

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -616,7 +616,7 @@
                        :parameters}
                      (set (keys public-action))))))))))))
 
-(deftest public-dashboard-param-link-to-a-field-without-full-field-values-test
+#_(deftest public-dashboard-param-link-to-a-field-without-full-field-values-test
   (testing "GET /api/public/dashboard/:uuid"
     (mt/with-temporary-setting-values [enable-public-sharing true]
       (t2.with-temp/with-temp

--- a/test/metabase/api/public_test.clj
+++ b/test/metabase/api/public_test.clj
@@ -616,39 +616,6 @@
                        :parameters}
                      (set (keys public-action))))))))))))
 
-#_(deftest public-dashboard-param-link-to-a-field-without-full-field-values-test
-  (testing "GET /api/public/dashboard/:uuid"
-    (mt/with-temporary-setting-values [enable-public-sharing true]
-      (t2.with-temp/with-temp
-        [:model/Dashboard
-         {dashboard-id :id
-          uuid         :public_uuid}
-         {:name        "Test Dashboard"
-          :public_uuid (str (java.util.UUID/randomUUID))}
-
-         :model/Card
-         {card-id :id}
-         {:name "Dashboard Test Card"}
-
-         :model/DashboardCard
-         _
-         {:dashboard_id       dashboard-id
-          :card_id            card-id
-          :parameter_mappings [{:card_id      card-id
-                                :parameter_id "foo"
-                                :target       [:dimension
-                                               [:field (mt/id :venues :name) nil]]}]}]
-        (t2/delete! :model/FieldValues :field_id (mt/id :venues :name) :type :full)
-        (testing "Request triggers computation of field values if missing (#30218)"
-          (is (= {(mt/id :venues :name) {:values                ["20th Century Cafe"
-                                                                 "25°"
-                                                                 "33 Taps"]
-                                         :field_id              (mt/id :venues :name)
-                                         :human_readable_values []}}
-                 (let [response (:param_values (mt/user-http-request :rasta :get 200 (str "public/dashboard/" uuid)))]
-                   (into {} (for [[field-id m] response]
-                              [field-id (update m :values (partial take 3))]))))))))))
-
 ;;; --------------------------------- GET /api/public/dashboard/:uuid/card/:card-id ----------------------------------
 
 (defn- dashcard-url


### PR DESCRIPTION
Fixes: #38826

This change removes the *-or-create* behaviour of `field-ids->param-field-values`. This means that on Dashboard Load, if the param values already exist, they'll be grabbed. But, if they don't, we won't try to fetch or create them.

The changes introduced while fixing #30218, via #32299 seem to be the source of this and actually added 2 tests that assert behaviour we don't want so I've removed those 2 tests.

The test I've added does check that the `GET /api/dashboard/:id/params/:param_id/values` endpoint does indeed result in Field Value creation, so we're still able to properly load the values, just at time of Filter usage instead.

```clojure
(deftest param-values-not-fetched-on-load-test
  (testing "Param values are not needed on initial dashboard load and should not be fetched. #38826"
    (t2.with-temp/with-temp
        [:model/Dashboard {dashboard-id :id} {:name       "Test Dashboard"
                                              :parameters [{:name      "FOO"
                                                            :id        "foo"
                                                            :type      :string/=
                                                            :sectionId "string"}]}
         :model/Card {card-id :id} {:name "Dashboard Test Card"}
         :model/DashboardCard _ {:dashboard_id       dashboard-id
                                 :card_id            card-id
                                 :parameter_mappings [{:card_id      card-id
                                                       :parameter_id "foo"
                                                       :target       [:dimension
                                                                      [:field (mt/id :venues :name) nil]]}]}]
        (let [dashboard-load-a (mt/user-http-request :rasta :get 200 (str "dashboard/" dashboard-id))
              _                (t2/delete! :model/FieldValues :field_id (mt/id :venues :name) :type :full)
              dashboard-load-b (mt/user-http-request :rasta :get 200 (str "dashboard/" dashboard-id))
              param-values     (mt/user-http-request :rasta :get 200 (format "dashboard/%s/params/%s/values" dashboard-id "foo"))]
          (testing "The initial dashboard-load doesn't fetch parameter values (#38826)"
            (is (some? (:param_values dashboard-load-a)))
            (is (nil? (:param_values dashboard-load-b))))
          (testing "Request to values endpoint triggers computation of field values if missing."
            (is (= ["20th Century Cafe" "25°" "33 Taps"]
                   (take 3 (apply concat (:values param-values))))))))))
```