### PR TITLE
Persist last selected database in the native query editor for a user

### DIFF
--- a/.clj-kondo/hooks/metabase/models/setting.clj
+++ b/.clj-kondo/hooks/metabase/models/setting.clj
@@ -65,6 +65,7 @@
      jwt-user-provisioning-enabled?
      jwt-shared-secret
      last-acknowledged-version
+     last-used-database-id
      ldap-attribute-email
      ldap-attribute-firstname
      ldap-attribute-lastname

--- a/.clj-kondo/hooks/metabase/models/setting.clj
+++ b/.clj-kondo/hooks/metabase/models/setting.clj
@@ -65,7 +65,7 @@
      jwt-user-provisioning-enabled?
      jwt-shared-secret
      last-acknowledged-version
-     last-used-database-id
+     last-used-native-database-id
      ldap-attribute-email
      ldap-attribute-firstname
      ldap-attribute-lastname

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -1,3 +1,4 @@
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import {
   restore,
   popover,
@@ -88,6 +89,22 @@ describe(
         "Sample Database",
       );
     });
+
+    it("should not update the setting when the same database is selected again", () => {
+      cy.request("PUT", "/api/setting/last-used-database-id", {
+        value: SAMPLE_DB_ID,
+      });
+
+      startNativeQuestion();
+      cy.findByTestId("selected-database")
+        .should("have.text", "Sample Database")
+        .click();
+
+      cy.log("Pick the same database again");
+      selectDatabase("Sample Database");
+      cy.get("@persistDatabase").should("be.null");
+    });
+
     describe("permissions", () => {
       it("users with 'No self-service' data permissions should be able to choose only the databases they can query against", () => {
         cy.signIn("nodata");

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -8,6 +8,7 @@ import {
 
 const PG_DB_ID = 2;
 const mongoName = "QA Mongo";
+const postgresName = "QA Postgres12";
 const additionalPG = "New Database";
 
 const { DATA_GROUP } = USER_GROUPS;
@@ -26,7 +27,7 @@ describe(
     });
 
     it("smoketest: persisting last used database should work, and it should be user-specific setting", () => {
-      const adminPersistedDatabase = "QA Postgres12";
+      const adminPersistedDatabase = postgresName;
       const userPersistedDatabase = "Sample Database";
 
       startNativeQuestion();
@@ -76,10 +77,10 @@ describe(
       startNativeModel();
       assertNoDatabaseSelected();
 
-      selectDatabase("QA Postgres12");
+      selectDatabase(postgresName);
 
       startNativeQuestion();
-      assertSelectedDatabase("QA Postgres12").click();
+      assertSelectedDatabase(postgresName).click();
       selectDatabase("Sample Database");
 
       startNativeModel();
@@ -123,7 +124,7 @@ describe(
       cy.log(
         "Persisting a database for a native model should not affect actions",
       );
-      selectDatabase("QA Postgres12");
+      selectDatabase(postgresName);
       cy.wait("@persistDatabase");
 
       startNewAction();
@@ -137,7 +138,7 @@ describe(
         startNativeQuestion();
         cy.wait("@persistDatabase");
         cy.findByTestId("selected-database")
-          .should("have.text", "QA Postgres12")
+          .should("have.text", postgresName)
           .click();
 
         cy.get(POPOVER_ELEMENT).should("not.exist");
@@ -151,11 +152,11 @@ describe(
         startNativeQuestion();
 
         cy.findByTestId("selected-database")
-          .should("have.text", "QA Postgres12")
+          .should("have.text", postgresName)
           .click();
 
         popover()
-          .should("contain", "QA Postgres12")
+          .should("contain", postgresName)
           .and("contain", "New Database");
       });
     });
@@ -166,7 +167,7 @@ describe(
       startNativeQuestion();
       cy.wait("@persistDatabase");
       cy.findByTestId("selected-database")
-        .should("have.text", "QA Postgres12")
+        .should("have.text", postgresName)
         .click();
 
       cy.get(POPOVER_ELEMENT).should("not.exist");
@@ -189,7 +190,7 @@ describe(
       cy.signInAsNormalUser();
       startNativeQuestion();
       // Postgres will be automatically selected because it's the only dataabse this user can query
-      assertSelectedDatabase("QA Postgres12");
+      assertSelectedDatabase(postgresName);
     });
   },
 );

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -10,13 +10,16 @@ describe(
     });
 
     it("smoketest: persisting last used database should work, and it should be user-specific setting", () => {
+      const adminPersistedDatabase = "QA Postgres12";
+      const userPersistedDatabase = "Sample Database";
+
       startNativeQuestion();
       assertNoDatabaseSelected();
 
-      selectDatabase("QA Postgres12");
+      selectDatabase(adminPersistedDatabase);
 
       startNativeQuestion();
-      assertSelectedDatabase("QA Postgres12");
+      assertSelectedDatabase(adminPersistedDatabase);
 
       cy.signOut();
       cy.signInAsNormalUser();
@@ -24,16 +27,16 @@ describe(
       startNativeQuestion();
       assertNoDatabaseSelected();
 
-      selectDatabase("Sample Database");
+      selectDatabase(userPersistedDatabase);
 
       startNativeQuestion();
-      assertSelectedDatabase("Sample Database");
+      assertSelectedDatabase(userPersistedDatabase);
 
       cy.signOut();
       cy.signInAsAdmin();
 
       startNativeQuestion();
-      assertSelectedDatabase("Sample Database");
+      assertSelectedDatabase(adminPersistedDatabase);
     });
 
     it("deleting previously persisted database should result in the new database selection prompt", () => {

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -82,10 +82,41 @@ describe(
   },
 );
 
+describe("mongo as the default database", { tags: "@mongo" }, () => {
+  beforeEach(() => {
+    restore("mongo-5");
+    cy.signInAsAdmin();
+  });
+
+  const MONGO_DB_NAME = "QA Mongo";
+
+  it("should persist Mongo database, but not its selected table", () => {
+    startNativeQuestion();
+    assertNoDatabaseSelected();
+
+    selectDatabase(MONGO_DB_NAME);
+    cy.findByTestId("native-query-top-bar")
+      .findByText("Select a table")
+      .click();
+    popover().findByText("Reviews").click();
+    cy.findByTestId("native-query-top-bar").should(
+      "not.contain",
+      "Select a table",
+    );
+
+    startNativeQuestion();
+
+    assertSelectedDatabase(MONGO_DB_NAME);
+    cy.findByTestId("native-query-top-bar").should("contain", "Select a table");
+  });
+});
+
 function startNativeQuestion() {
   cy.visit("/");
   cy.findByTestId("app-bar").findByText("New").click();
-  popover().findByTextEnsureVisible("SQL query").click();
+  popover()
+    .findByTextEnsureVisible(/(SQL|Native) query/)
+    .click();
 }
 
 function startNativeModel() {

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -1,4 +1,4 @@
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
 import {
   restore,
   popover,
@@ -9,6 +9,8 @@ import {
 const PG_DB_ID = 2;
 const mongoName = "QA Mongo";
 const additionalPG = "New Database";
+
+const { DATA_GROUP } = USER_GROUPS;
 
 describe(
   "scenarios > question > native > database source",
@@ -168,6 +170,26 @@ describe(
         .click();
 
       cy.get(POPOVER_ELEMENT).should("not.exist");
+    });
+
+    it("users that lose permissions to the last used database should not have that database preselected anymore", () => {
+      cy.signInAsNormalUser();
+      startNativeQuestion();
+      selectDatabase("Sample Database");
+
+      cy.signOut();
+      cy.signInAsAdmin();
+      cy.updatePermissionsGraph({
+        [DATA_GROUP]: {
+          [SAMPLE_DB_ID]: { data: { schemas: "none", native: "none" } },
+        },
+      });
+
+      cy.signOut();
+      cy.signInAsNormalUser();
+      startNativeQuestion();
+      // Postgres will be automatically selected because it's the only dataabse this user can query
+      assertSelectedDatabase("QA Postgres12");
     });
   },
 );

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -1,0 +1,113 @@
+import { restore, popover, addPostgresDatabase } from "e2e/support/helpers";
+
+describe(
+  "scenarios > question > native > database source",
+  { tags: "@external" },
+  () => {
+    beforeEach(() => {
+      restore("postgres-12");
+      cy.signInAsAdmin();
+    });
+
+    it("smoketest: persisting last used database should work, and it should be user-specific setting", () => {
+      startNativeQuestion();
+      assertNoDatabaseSelected();
+
+      selectDatabase("QA Postgres12");
+
+      startNativeQuestion();
+      assertSelectedDatabase("QA Postgres12");
+
+      cy.signOut();
+      cy.signInAsNormalUser();
+
+      startNativeQuestion();
+      assertNoDatabaseSelected();
+
+      selectDatabase("Sample Database");
+
+      startNativeQuestion();
+      assertSelectedDatabase("Sample Database");
+
+      cy.signOut();
+      cy.signInAsAdmin();
+
+      startNativeQuestion();
+      assertSelectedDatabase("Sample Database");
+    });
+
+    it("deleting previously persisted database should result in the new database selection prompt", () => {
+      const additionalPG = "New Dataabse";
+
+      addPostgresDatabase(additionalPG);
+
+      startNativeQuestion();
+      assertNoDatabaseSelected();
+
+      selectDatabase(additionalPG);
+
+      cy.log("Delete previously persisted database.");
+      cy.get("@postgresID").then(databaseId => {
+        cy.request("DELETE", `/api/database/${databaseId}`);
+      });
+
+      startNativeQuestion();
+      assertNoDatabaseSelected();
+    });
+
+    it("persisting a database source should work between native models and questions intechangeably", () => {
+      startNativeModel();
+      assertNoDatabaseSelected();
+
+      selectDatabase("QA Postgres12");
+
+      startNativeQuestion();
+      assertSelectedDatabase("QA Postgres12").click();
+      selectDatabase("Sample Database");
+
+      startNativeModel();
+
+      cy.findByTestId("native-query-top-bar").should(
+        "not.contain",
+        "Select a database",
+      );
+      cy.findByTestId("selected-database").should(
+        "have.text",
+        "Sample Database",
+      );
+    });
+  },
+);
+
+function startNativeQuestion() {
+  cy.visit("/");
+  cy.findByTestId("app-bar").findByText("New").click();
+  popover().findByTextEnsureVisible("SQL query").click();
+}
+
+function startNativeModel() {
+  cy.visit("/model/new");
+  cy.findByRole("heading", { name: "Use a native query" }).click();
+}
+
+function assertNoDatabaseSelected() {
+  cy.findByTestId("selected-database").should("not.exist");
+  cy.findByTestId("native-query-top-bar").should(
+    "contain",
+    "Select a database",
+  );
+}
+
+function selectDatabase(database) {
+  popover().findByText(database).click();
+  cy.findByTestId("selected-database").should("have.text", database);
+}
+
+function assertSelectedDatabase(name) {
+  cy.findByTestId("native-query-top-bar").should(
+    "not.contain",
+    "Select a database",
+  );
+
+  return cy.findByTestId("selected-database").should("have.text", name);
+}

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -40,7 +40,7 @@ describe(
     });
 
     it("deleting previously persisted database should result in the new database selection prompt", () => {
-      const additionalPG = "New Dataabse";
+      const additionalPG = "New Database";
 
       addPostgresDatabase(additionalPG);
 

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -15,7 +15,7 @@ describe(
   { tags: "@external" },
   () => {
     beforeEach(() => {
-      cy.intercept("PUT", "/api/setting/last-used-database-id").as(
+      cy.intercept("PUT", "/api/setting/last-used-native-database-id").as(
         "persistDatabase",
       );
 
@@ -93,7 +93,7 @@ describe(
     });
 
     it("should not update the setting when the same database is selected again", () => {
-      cy.request("PUT", "/api/setting/last-used-database-id", {
+      cy.request("PUT", "/api/setting/last-used-native-database-id", {
         value: SAMPLE_DB_ID,
       });
 

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -7,6 +7,8 @@ import {
 } from "e2e/support/helpers";
 
 const PG_DB_ID = 2;
+const mongoName = "QA Mongo";
+const additionalPG = "New Database";
 
 describe(
   "scenarios > question > native > database source",
@@ -52,8 +54,6 @@ describe(
     });
 
     it("deleting previously persisted database should result in the new database selection prompt", () => {
-      const additionalPG = "New Database";
-
       addPostgresDatabase(additionalPG);
 
       startNativeQuestion();
@@ -142,7 +142,6 @@ describe(
 
         cy.signOut();
         cy.signInAsAdmin();
-        const additionalPG = "New Database";
 
         addPostgresDatabase(additionalPG);
 
@@ -179,13 +178,11 @@ describe("mongo as the default database", { tags: "@mongo" }, () => {
     cy.signInAsAdmin();
   });
 
-  const MONGO_DB_NAME = "QA Mongo";
-
   it("should persist Mongo database, but not its selected table", () => {
     startNativeQuestion();
     assertNoDatabaseSelected();
 
-    selectDatabase(MONGO_DB_NAME);
+    selectDatabase(mongoName);
     cy.findByTestId("native-query-top-bar")
       .findByText("Select a table")
       .click();
@@ -197,7 +194,7 @@ describe("mongo as the default database", { tags: "@mongo" }, () => {
 
     startNativeQuestion();
 
-    assertSelectedDatabase(MONGO_DB_NAME);
+    assertSelectedDatabase(mongoName);
     cy.findByTestId("native-query-top-bar").should("contain", "Select a table");
   });
 });

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -227,6 +227,6 @@ export const createMockSettings = (
   "uploads-schema-name": null,
   "user-visibility": null,
   "last-acknowledged-version": "v1",
-  "last-used-database-id": 1,
+  "last-used-native-database-id": 1,
   ...opts,
 });

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -227,5 +227,6 @@ export const createMockSettings = (
   "uploads-schema-name": null,
   "user-visibility": null,
   "last-acknowledged-version": "v1",
+  "last-used-database-id": 1,
   ...opts,
 });

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -285,6 +285,7 @@ export interface Settings {
   "user-visibility": string | null;
   "last-acknowledged-version": string | null;
   "show-static-embed-terms": boolean | null;
+  "last-used-database-id": number | null;
 }
 
 export type SettingKey = keyof Settings;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -285,7 +285,7 @@ export interface Settings {
   "user-visibility": string | null;
   "last-acknowledged-version": string | null;
   "show-static-embed-terms": boolean | null;
-  "last-used-database-id": number | null;
+  "last-used-database-id"?: number | null;
 }
 
 export type SettingKey = keyof Settings;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -285,7 +285,7 @@ export interface Settings {
   "user-visibility": string | null;
   "last-acknowledged-version": string | null;
   "show-static-embed-terms": boolean | null;
-  "last-used-database-id"?: number | null;
+  "last-used-native-database-id"?: number | null;
 }
 
 export type SettingKey = keyof Settings;

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -8,7 +8,9 @@ import CreateCollectionModal from "metabase/collections/containers/CreateCollect
 import EntityMenu from "metabase/components/EntityMenu";
 import Modal from "metabase/components/Modal";
 import { CreateDashboardModalConnected } from "metabase/dashboard/containers/CreateDashboardModal";
+import { useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { getSetting } from "metabase/selectors/settings";
 import type { CollectionId, WritebackAction } from "metabase-types/api";
 
 type ModalType = "new-action" | "new-dashboard" | "new-collection";
@@ -53,6 +55,10 @@ const NewItemMenu = ({
 }: NewItemMenuProps) => {
   const [modal, setModal] = useState<ModalType>();
 
+  const lastUsedDatabaseId = useSelector(state =>
+    getSetting(state, "last-used-database-id"),
+  );
+
   const handleModalClose = useCallback(() => {
     setModal(undefined);
   }, []);
@@ -91,6 +97,7 @@ const NewItemMenu = ({
           creationType: "native_question",
           collectionId,
           cardType: "question",
+          databaseId: lastUsedDatabaseId || undefined,
         }),
         onClose: onCloseNavbar,
       });
@@ -138,6 +145,7 @@ const NewItemMenu = ({
     collectionId,
     onCloseNavbar,
     hasDatabaseWithJsonEngine,
+    lastUsedDatabaseId,
   ]);
 
   return (

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -56,7 +56,7 @@ const NewItemMenu = ({
   const [modal, setModal] = useState<ModalType>();
 
   const lastUsedDatabaseId = useSelector(state =>
-    getSetting(state, "last-used-database-id"),
+    getSetting(state, "last-used-native-database-id"),
   );
 
   const handleModalClose = useCallback(() => {

--- a/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
@@ -10,6 +10,7 @@ import * as Urls from "metabase/lib/urls";
 import NewModelOption from "metabase/models/components/NewModelOption";
 import { NoDatabasesEmptyState } from "metabase/reference/databases/NoDatabasesEmptyState";
 import { getHasDataAccess, getHasNativeWrite } from "metabase/selectors/data";
+import { getSetting } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import type Database from "metabase-lib/metadata/Database";
 
@@ -32,6 +33,10 @@ const NewModelOptions = (props: NewModelOptionsProps) => {
   );
   const hasNativeWrite = useSelector(() =>
     getHasNativeWrite(props.databases ?? []),
+  );
+
+  const lastUsedDatabaseId = useSelector(state =>
+    getSetting(state, "last-used-database-id"),
   );
 
   const collectionId = Urls.extractEntityId(
@@ -82,6 +87,7 @@ const NewModelOptions = (props: NewModelOptionsProps) => {
                 creationType: "native_question",
                 cardType: "model",
                 collectionId,
+                databaseId: lastUsedDatabaseId || undefined,
               })}
               width={180}
             />

--- a/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
+++ b/frontend/src/metabase/models/containers/NewModelOptions/NewModelOptions.tsx
@@ -36,7 +36,7 @@ const NewModelOptions = (props: NewModelOptionsProps) => {
   );
 
   const lastUsedDatabaseId = useSelector(state =>
-    getSetting(state, "last-used-database-id"),
+    getSetting(state, "last-used-native-database-id"),
   );
 
   const collectionId = Urls.extractEntityId(

--- a/frontend/src/metabase/query_builder/actions/native.ts
+++ b/frontend/src/metabase/query_builder/actions/native.ts
@@ -1,5 +1,6 @@
 import { createAction } from "redux-actions";
 
+import { updateSetting } from "metabase/admin/settings/settings";
 import Questions from "metabase/entities/questions";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { createThunkAction } from "metabase/lib/redux";
@@ -10,6 +11,7 @@ import type {
   NativeQuerySnippet,
   Parameter,
   TemplateTag,
+  DatabaseId,
 } from "metabase-types/api";
 import type { Dispatch, GetState } from "metabase-types/store";
 
@@ -193,3 +195,9 @@ export const setTemplateTagConfig = createThunkAction(
     };
   },
 );
+
+export const rememberLastUsedDatabase = (id: DatabaseId) =>
+  updateSetting({
+    key: "last-used-database-id",
+    value: id,
+  });

--- a/frontend/src/metabase/query_builder/actions/native.ts
+++ b/frontend/src/metabase/query_builder/actions/native.ts
@@ -198,6 +198,6 @@ export const setTemplateTagConfig = createThunkAction(
 
 export const rememberLastUsedDatabase = (id: DatabaseId) =>
   updateSetting({
-    key: "last-used-database-id",
+    key: "last-used-native-database-id",
     value: id,
   });

--- a/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
@@ -80,7 +80,12 @@ export function FieldTrigger({
 
 export function DatabaseTrigger({ database }: { database: Database }) {
   return database ? (
-    <span className="text-wrap text-grey no-decoration">{database.name}</span>
+    <span
+      className="text-wrap text-grey no-decoration"
+      data-testid="selected-database"
+    >
+      {database.name}
+    </span>
   ) : (
     <span className="text-medium no-decoration">{t`Select a database`}</span>
   );

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
@@ -18,9 +18,16 @@ const propTypes = {
   question: PropTypes.object.isRequired,
   isActive: PropTypes.bool.isRequired, // if QB mode is set to "query"
   height: PropTypes.number.isRequired,
+  onSetDatabaseId: PropTypes.func,
 };
 
-function DatasetQueryEditor({ question, isActive, height, ...props }) {
+function DatasetQueryEditor({
+  question,
+  isActive,
+  height,
+  onSetDatabaseId,
+  ...props
+}) {
   const { isNative } = Lib.queryDisplayInfo(question.query());
 
   const [isResizing, setResizing] = useState(false);
@@ -73,7 +80,7 @@ function DatasetQueryEditor({ question, isActive, height, ...props }) {
           // which can also cancel the expected query rerun
           // (see https://github.com/metabase/metabase/issues/19180)
           cancelQueryOnLeave={false}
-          shouldPersistLastUsedDatabase={true}
+          onSetDatabaseId={onSetDatabaseId}
         />
       ) : (
         <ResizableNotebook

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.jsx
@@ -73,6 +73,7 @@ function DatasetQueryEditor({ question, isActive, height, ...props }) {
           // which can also cancel the expected query rerun
           // (see https://github.com/metabase/metabase/issues/19180)
           cancelQueryOnLeave={false}
+          shouldPersistLastUsedDatabase={true}
         />
       ) : (
         <ResizableNotebook

--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetQueryEditor.unit.spec.tsx
@@ -65,6 +65,7 @@ const setup = async ({
   const question = checkNotNull(metadata.question(card.id));
   const query = question.legacyQuery({ useStructuredQuery: true });
   const DatasetQueryEditor = await importDatasetQueryEditor();
+  const onSetDatabaseId = jest.fn();
 
   const { rerender } = renderWithProviders(
     <DatasetQueryEditor
@@ -74,6 +75,7 @@ const setup = async ({
       question={question}
       readOnly={readOnly}
       onResizeStop={_.noop}
+      onSetDatabaseId={onSetDatabaseId}
     />,
   );
 
@@ -147,6 +149,7 @@ describe("DatasetQueryEditor", () => {
       isActive: true,
     });
     const DatasetQueryEditor = await importDatasetQueryEditor();
+    const onSetDatabaseId = jest.fn();
 
     expect(
       screen.getByTestId("native-query-editor-sidebar"),
@@ -160,6 +163,7 @@ describe("DatasetQueryEditor", () => {
         question={question}
         readOnly={false}
         onResizeStop={_.noop}
+        onSetDatabaseId={onSetDatabaseId}
       />,
     );
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -16,6 +16,7 @@ const DataSourceSelectorsPropTypes = {
   setDatabaseId: PropTypes.func,
   setTableId: PropTypes.func,
   editorContext: PropTypes.oneOf(["action", "question"]),
+  lastUsedDatabaseId: PropTypes.number,
 };
 
 const PopulatedDataSourceSelectorsPropTypes = {
@@ -59,9 +60,8 @@ const DataSourceSelectors = ({
   setDatabaseId,
   setTableId,
   editorContext,
+  lastUsedDatabaseId,
 }) => {
-  const database = question.database();
-
   const databases = useMemo(() => {
     const allDatabases = query
       .metadata()
@@ -73,6 +73,12 @@ const DataSourceSelectors = ({
 
     return allDatabases;
   }, [query, editorContext]);
+
+  const [preselectedDatabase] = databases.filter(
+    d => d.id === lastUsedDatabaseId,
+  );
+
+  const database = question.database() || preselectedDatabase;
 
   if (
     !isNativeEditorOpen ||

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -16,7 +16,6 @@ const DataSourceSelectorsPropTypes = {
   setDatabaseId: PropTypes.func,
   setTableId: PropTypes.func,
   editorContext: PropTypes.oneOf(["action", "question"]),
-  lastUsedDatabaseId: PropTypes.number,
 };
 
 const PopulatedDataSourceSelectorsPropTypes = {
@@ -60,7 +59,6 @@ const DataSourceSelectors = ({
   setDatabaseId,
   setTableId,
   editorContext,
-  lastUsedDatabaseId,
 }) => {
   const databases = useMemo(() => {
     const allDatabases = query
@@ -74,11 +72,7 @@ const DataSourceSelectors = ({
     return allDatabases;
   }, [query, editorContext]);
 
-  const [preselectedDatabase] = databases.filter(
-    d => d.id === lastUsedDatabaseId,
-  );
-
-  const database = question.database() || preselectedDatabase;
+  const database = question.database();
 
   if (
     !isNativeEditorOpen ||

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -164,7 +164,9 @@ const DatabaseSelector = ({ database, databases, readOnly, setDatabaseId }) => (
 DatabaseSelector.propTypes = DatabaseSelectorPropTypes;
 
 const SingleDatabaseName = ({ database }) => (
-  <div className="p2 text-bold text-grey">{database.name}</div>
+  <div className="p2 text-bold text-grey" data-testid="selected-database">
+    {database.name}
+  </div>
 );
 
 SingleDatabaseName.propTypes = SingleDatabaseNamePropTypes;

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -60,6 +60,8 @@ const DataSourceSelectors = ({
   setTableId,
   editorContext,
 }) => {
+  const database = question.database();
+
   const databases = useMemo(() => {
     const allDatabases = query
       .metadata()
@@ -71,8 +73,6 @@ const DataSourceSelectors = ({
 
     return allDatabases;
   }, [query, editorContext]);
-
-  const database = question.database();
 
   if (
     !isNativeEditorOpen ||

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -218,6 +218,7 @@ export class NativeQueryEditor extends Component<
       snippets: true,
       promptInput: true,
     },
+    shouldPersistLastUsedDatabase: false,
   };
 
   UNSAFE_componentWillMount() {
@@ -690,11 +691,18 @@ export class NativeQueryEditor extends Component<
 
   // Change the Database we're currently editing a query for.
   setDatabaseId = (databaseId: DatabaseId) => {
-    const { query, setDatasetQuery, question, onSetDatabaseId } = this.props;
+    const {
+      query,
+      setDatasetQuery,
+      question,
+      onSetDatabaseId,
+      shouldPersistLastUsedDatabase,
+    } = this.props;
+
     if (question.databaseId() !== databaseId) {
       setDatasetQuery(query.setDatabaseId(databaseId).setDefaultCollection());
 
-      onSetDatabaseId(databaseId);
+      shouldPersistLastUsedDatabase && onSetDatabaseId(databaseId);
       if (!this.props.readOnly) {
         // HACK: the cursor doesn't blink without this intended small delay
         setTimeout(() => this._editor?.focus(), 50);

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -16,7 +16,6 @@ import "ace/snippets/text";
 import "ace/snippets/sql";
 import "ace/snippets/json";
 
-import { updateSetting } from "metabase/admin/settings/settings";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Modal from "metabase/components/Modal";
 import Databases from "metabase/entities/databases";
@@ -141,7 +140,7 @@ type OwnProps = typeof NativeQueryEditor.defaultProps & {
   toggleSnippetSidebar: () => void;
   cancelQuery?: () => void;
   closeSnippetModal: () => void;
-  onSetDatabaseId: (id: DatabaseId) => void;
+  onSetDatabaseId?: (id: DatabaseId) => void;
 };
 
 interface StateProps {
@@ -218,7 +217,6 @@ export class NativeQueryEditor extends Component<
       snippets: true,
       promptInput: true,
     },
-    shouldPersistLastUsedDatabase: false,
   };
 
   UNSAFE_componentWillMount() {
@@ -691,18 +689,12 @@ export class NativeQueryEditor extends Component<
 
   // Change the Database we're currently editing a query for.
   setDatabaseId = (databaseId: DatabaseId) => {
-    const {
-      query,
-      setDatasetQuery,
-      question,
-      onSetDatabaseId,
-      shouldPersistLastUsedDatabase,
-    } = this.props;
+    const { query, setDatasetQuery, question, onSetDatabaseId } = this.props;
 
     if (question.databaseId() !== databaseId) {
       setDatasetQuery(query.setDatabaseId(databaseId).setDefaultCollection());
 
-      shouldPersistLastUsedDatabase && onSetDatabaseId(databaseId);
+      onSetDatabaseId?.(databaseId);
       if (!this.props.readOnly) {
         // HACK: the cursor doesn't blink without this intended small delay
         setTimeout(() => this._editor?.focus(), 50);
@@ -927,14 +919,6 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       ),
     );
     return Questions.HACK_getObjectFromAction(action);
-  },
-  onSetDatabaseId: (id: DatabaseId) => {
-    dispatch(
-      updateSetting({
-        key: "last-used-database-id",
-        value: id,
-      }),
-    );
   },
 });
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -142,6 +142,7 @@ type OwnProps = typeof NativeQueryEditor.defaultProps & {
   cancelQuery?: () => void;
   closeSnippetModal: () => void;
   onSetDatabaseId: (id: DatabaseId) => void;
+  lastUsedDatabaseId: DatabaseId | null;
 };
 
 interface StateProps {
@@ -688,7 +689,7 @@ export class NativeQueryEditor extends Component<
     this.props.setIsNativeEditorOpen?.(!this.props.isNativeEditorOpen);
   };
 
-  /// Change the Database we're currently editing a query for.
+  // Change the Database we're currently editing a query for.
   setDatabaseId = (databaseId: DatabaseId) => {
     const { query, setDatasetQuery, question, onSetDatabaseId } = this.props;
     if (question.databaseId() !== databaseId) {
@@ -779,6 +780,7 @@ export class NativeQueryEditor extends Component<
       sidebarFeatures,
       canChangeDatabase,
       setParameterValueToDefault,
+      lastUsedDatabaseId,
     } = this.props;
 
     const isPromptInputVisible = this.isPromptInputVisible();
@@ -803,6 +805,7 @@ export class NativeQueryEditor extends Component<
               <DataSourceSelectors
                 isNativeEditorOpen={isNativeEditorOpen}
                 query={query}
+                lastUsedDatabaseId={lastUsedDatabaseId}
                 question={question}
                 readOnly={readOnly}
                 setDatabaseId={this.setDatabaseId}

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -16,6 +16,7 @@ import "ace/snippets/text";
 import "ace/snippets/sql";
 import "ace/snippets/json";
 
+import { updateSetting } from "metabase/admin/settings/settings";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import Modal from "metabase/components/Modal";
 import Databases from "metabase/entities/databases";
@@ -140,6 +141,7 @@ type OwnProps = typeof NativeQueryEditor.defaultProps & {
   toggleSnippetSidebar: () => void;
   cancelQuery?: () => void;
   closeSnippetModal: () => void;
+  onSetDatabaseId: (id: DatabaseId) => void;
 };
 
 interface StateProps {
@@ -688,9 +690,10 @@ export class NativeQueryEditor extends Component<
 
   /// Change the Database we're currently editing a query for.
   setDatabaseId = (databaseId: DatabaseId) => {
-    const { query, setDatasetQuery, question } = this.props;
+    const { query, setDatasetQuery, question, onSetDatabaseId } = this.props;
     if (question.databaseId() !== databaseId) {
       setDatasetQuery(query.setDatabaseId(databaseId).setDefaultCollection());
+      onSetDatabaseId(databaseId);
       if (!this.props.readOnly) {
         // HACK: the cursor doesn't blink without this intended small delay
         setTimeout(() => this._editor?.focus(), 50);
@@ -915,6 +918,14 @@ const mapDispatchToProps = (dispatch: Dispatch) => ({
       ),
     );
     return Questions.HACK_getObjectFromAction(action);
+  },
+  onSetDatabaseId: (id: DatabaseId) => {
+    dispatch(
+      updateSetting({
+        key: "last-used-database-id",
+        value: id,
+      }),
+    );
   },
 });
 

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -142,7 +142,6 @@ type OwnProps = typeof NativeQueryEditor.defaultProps & {
   cancelQuery?: () => void;
   closeSnippetModal: () => void;
   onSetDatabaseId: (id: DatabaseId) => void;
-  lastUsedDatabaseId: DatabaseId | null;
 };
 
 interface StateProps {
@@ -694,6 +693,7 @@ export class NativeQueryEditor extends Component<
     const { query, setDatasetQuery, question, onSetDatabaseId } = this.props;
     if (question.databaseId() !== databaseId) {
       setDatasetQuery(query.setDatabaseId(databaseId).setDefaultCollection());
+
       onSetDatabaseId(databaseId);
       if (!this.props.readOnly) {
         // HACK: the cursor doesn't blink without this intended small delay
@@ -780,7 +780,6 @@ export class NativeQueryEditor extends Component<
       sidebarFeatures,
       canChangeDatabase,
       setParameterValueToDefault,
-      lastUsedDatabaseId,
     } = this.props;
 
     const isPromptInputVisible = this.isPromptInputVisible();
@@ -805,7 +804,6 @@ export class NativeQueryEditor extends Component<
               <DataSourceSelectors
                 isNativeEditorOpen={isNativeEditorOpen}
                 query={query}
-                lastUsedDatabaseId={lastUsedDatabaseId}
                 question={question}
                 readOnly={readOnly}
                 setDatabaseId={this.setDatabaseId}

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -5,10 +5,10 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { updateSetting } from "metabase/admin/settings/settings";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import Toaster from "metabase/components/Toaster";
+import { rememberLastUsedDatabase } from "metabase/query_builder/actions";
 import { SIDEBAR_SIZES } from "metabase/query_builder/constants";
 import { TimeseriesChrome } from "metabase/querying";
 import * as Lib from "metabase-lib";
@@ -404,14 +404,7 @@ class View extends Component {
 }
 
 const mapDispatchToProps = dispatch => ({
-  onSetDatabaseId: id => {
-    dispatch(
-      updateSetting({
-        key: "last-used-database-id",
-        value: id,
-      }),
-    );
-  },
+  onSetDatabaseId: id => dispatch(rememberLastUsedDatabase(id)),
 });
 
 export default _.compose(

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -1,8 +1,11 @@
 /* eslint-disable react/prop-types */
 import { Component } from "react";
 import { Motion, spring } from "react-motion";
+import { connect } from "react-redux";
 import { t } from "ttag";
+import _ from "underscore";
 
+import { updateSetting } from "metabase/admin/settings/settings";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import Toaster from "metabase/components/Toaster";
@@ -228,6 +231,7 @@ class View extends Component {
       isDirty,
       isNativeEditorOpen,
       setParameterValueToDefault,
+      onSetDatabaseId,
     } = this.props;
 
     const legacyQuery = question.legacyQuery();
@@ -254,7 +258,7 @@ class View extends Component {
           isInitiallyOpen={isNativeEditorOpen}
           datasetQuery={card && card.dataset_query}
           setParameterValueToDefault={setParameterValueToDefault}
-          shouldPersistLastUsedDatabase={true}
+          onSetDatabaseId={onSetDatabaseId}
         />
       </NativeQueryEditorContainer>
     );
@@ -399,4 +403,18 @@ class View extends Component {
   }
 }
 
-export default ExplicitSize({ refreshMode: "debounceLeading" })(View);
+const mapDispatchToProps = dispatch => ({
+  onSetDatabaseId: id => {
+    dispatch(
+      updateSetting({
+        key: "last-used-database-id",
+        value: id,
+      }),
+    );
+  },
+});
+
+export default _.compose(
+  ExplicitSize({ refreshMode: "debounceLeading" }),
+  connect(null, mapDispatchToProps),
+)(View);

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -228,12 +228,9 @@ class View extends Component {
       isDirty,
       isNativeEditorOpen,
       setParameterValueToDefault,
-      lastUsedDatabaseId,
     } = this.props;
 
-    const legacyQuery = lastUsedDatabaseId
-      ? question.legacyQuery().setDatabaseId(lastUsedDatabaseId)
-      : question.legacyQuery();
+    const legacyQuery = question.legacyQuery();
 
     // Normally, when users open native models,
     // they open an ad-hoc GUI question using the model as a data source

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -254,6 +254,7 @@ class View extends Component {
           isInitiallyOpen={isNativeEditorOpen}
           datasetQuery={card && card.dataset_query}
           setParameterValueToDefault={setParameterValueToDefault}
+          shouldPersistLastUsedDatabase={true}
         />
       </NativeQueryEditorContainer>
     );

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -228,8 +228,12 @@ class View extends Component {
       isDirty,
       isNativeEditorOpen,
       setParameterValueToDefault,
+      lastUsedDatabaseId,
     } = this.props;
-    const legacyQuery = question.legacyQuery();
+
+    const legacyQuery = lastUsedDatabaseId
+      ? question.legacyQuery().setDatabaseId(lastUsedDatabaseId)
+      : question.legacyQuery();
 
     // Normally, when users open native models,
     // they open an ad-hoc GUI question using the model as a data source

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -173,6 +173,7 @@ const mapStateToProps = (state, props) => {
     requiredTemplateTags: getRequiredTemplateTags(state),
     getEmbeddedParameterVisibility: slug =>
       getEmbeddedParameterVisibility(state, slug),
+    lastUsedDatabaseId: getSetting(state, "last-used-database-id"),
   };
 };
 

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -173,7 +173,6 @@ const mapStateToProps = (state, props) => {
     requiredTemplateTags: getRequiredTemplateTags(state),
     getEmbeddedParameterVisibility: slug =>
       getEmbeddedParameterVisibility(state, slug),
-    lastUsedDatabaseId: getSetting(state, "last-used-database-id"),
   };
 };
 

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -440,7 +440,7 @@
   :type :string)
 
 (defsetting last-used-native-database-id
-  (deferred-tru "The last database a user has used for a native query.")
+  (deferred-tru "The last database a user has selected for a native query or a native model.")
   :user-local :only
   :visibility :authenticated
   :type :integer)

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -442,6 +442,7 @@
 (defsetting last-used-database-id
   (deferred-tru "The last database a user has used for a native query.")
   :user-local :only
+  :visibility :authenticated
   :type :integer)
 
 ;;; ## ------------------------------------------ AUDIT LOG ------------------------------------------

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -439,6 +439,11 @@
   :user-local :only
   :type :string)
 
+(defsetting last-used-database-id
+  (deferred-tru "The last database a user has used for a native query.")
+  :user-local :only
+  :type :integer)
+
 ;;; ## ------------------------------------------ AUDIT LOG ------------------------------------------
 
 (defmethod audit-log/model-details :model/User

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -439,7 +439,7 @@
   :user-local :only
   :type :string)
 
-(defsetting last-used-database-id
+(defsetting last-used-native-database-id
   (deferred-tru "The last database a user has used for a native query.")
   :user-local :only
   :visibility :authenticated

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -535,6 +535,18 @@
         (mw.session/with-current-user user-id
           (is (= "v0.47.1" (setting/get :last-acknowledged-version))))))))
 
+(deftest last-used-database-id-can-be-read-and-set
+  (testing "last-used-database-id can be read and set"
+    (mt/with-test-user :rasta
+      (let [old-db-id (user/last-used-database-id)
+            new-db-id 42]
+        (try
+          (is (not= new-db-id old-db-id))
+          (user/last-used-database-id! new-db-id)
+          (is (= new-db-id (user/last-used-database-id)))
+          (finally
+            (user/last-used-database-id! old-db-id)))))))
+
 (deftest common-name-test
   (testing "common_name should be present depending on what is selected"
     (mt/with-temp [User user {:first_name "John"

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -535,32 +535,32 @@
         (mw.session/with-current-user user-id
           (is (= "v0.47.1" (setting/get :last-acknowledged-version))))))))
 
-(deftest last-used-database-id-can-be-read-and-set
-  (testing "last-used-database-id can be read and set"
+(deftest last-used-native-database-id-can-be-read-and-set
+  (testing "last-used-native-database-id can be read and set"
     (mt/with-test-user :rasta
-      (let [old-db-id (user/last-used-database-id)
+      (let [old-db-id (user/last-used-native-database-id)
             new-db-id 42]
         (try
           (is (not= new-db-id old-db-id))
-          (user/last-used-database-id! new-db-id)
-          (is (= new-db-id (user/last-used-database-id)))
+          (user/last-used-native-database-id! new-db-id)
+          (is (= new-db-id (user/last-used-native-database-id)))
           (finally
-            (user/last-used-database-id! old-db-id))))))
+            (user/last-used-native-database-id! old-db-id))))))
 
-  (testing "last-used-database-id should be a user-local setting"
+  (testing "last-used-native-database-id should be a user-local setting"
     (is (=? {:user-local :only}
             (setting/resolve-setting :last-acknowledged-version)))
     (mt/with-test-user :rasta
-      (let [old-db-id (user/last-used-database-id)]
-        (user/last-used-database-id! 42)
+      (let [old-db-id (user/last-used-native-database-id)]
+        (user/last-used-native-database-id! 42)
         (mt/with-test-user :crowberto
-          (let [old-db-id (user/last-used-database-id)]
-            (user/last-used-database-id! 21)
-            (is (= (user/last-used-database-id) 21))
+          (let [old-db-id (user/last-used-native-database-id)]
+            (user/last-used-native-database-id! 21)
+            (is (= (user/last-used-native-database-id) 21))
             (mt/with-test-user :rasta
-              (is (= (user/last-used-database-id) 42)))
-            (user/last-used-database-id! old-db-id)))
-        (user/last-used-database-id! old-db-id)))))
+              (is (= (user/last-used-native-database-id) 42)))
+            (user/last-used-native-database-id! old-db-id)))
+        (user/last-used-native-database-id! old-db-id)))))
 
   (deftest common-name-test
     (testing "common_name should be present depending on what is selected"


### PR DESCRIPTION
## Info
|||
|-|-|
| 📝 | [Product Doc](https://www.notion.so/metabase/Default-to-the-last-selected-database-in-native-queries-3bf8f844a6e8407a998bbf11a04f106b) |
| 🧪 | [Testing Plan](https://github.com/metabase/metabase/issues/39035) |

## What does PR accomplish?
This PR resolves #8780 by introducing a user-level setting for remembering the last used database in the native query.
Closes #39035.

```[tasklist]
### Tasks
- [x] Add new user-level setting to the backend
- [x] Wire native query editor to remember the last used database
- [x] Narrow the scope to just native questions and native models
- [x] Write unit tests
- [x] Write E2E tests
```

## Details
### About the `last-used-database` setting
- It should be user-local only
- It should work for any authenticated user; frontend ensures that a user without sufficient native permissions is not even offered to select and persist the last used database
- The information about the last used database currently should not be included in the audit information

> [!Note]
> The backend currently does have any additional checks to make sure the previously used database is still present. Frontend simply falls back to no database selected and prompts the user to select a new one.