### PR TITLE
fix goal line blur style

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
@@ -33,4 +33,9 @@ export const CHART_STYLE = {
     countLabelMargin: 4,
     zIndex: 1,
   },
+  opacity: {
+    blur: 0.3,
+    area: 0.3,
+    scatter: 0.8,
+  },
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -158,7 +158,7 @@ const buildEChartsBarSeries = (
         show: settings["graph.show_values"] && !hasMultipleSeries,
       },
       itemStyle: {
-        opacity: 0.3,
+        opacity: CHART_STYLE.opacity.blur,
       },
     },
     type: "bar",
@@ -233,7 +233,7 @@ const buildEChartsLineAreaSeries = (
     chartWidth,
   );
 
-  const blurOpacity = hasMultipleSeries ? 0.3 : 1;
+  const blurOpacity = hasMultipleSeries ? CHART_STYLE.opacity.blur : 1;
 
   return {
     emphasis: {
@@ -264,7 +264,8 @@ const buildEChartsLineAreaSeries = (
     step:
       seriesSettings["line.interpolate"] === "step-after" ? "end" : undefined,
     stack: stackName,
-    areaStyle: display === "area" ? { opacity: 0.3 } : undefined,
+    areaStyle:
+      display === "area" ? { opacity: CHART_STYLE.opacity.area } : undefined,
     encode: {
       y: seriesModel.dataKey,
       x: X_AXIS_DATA_KEY,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/scatter/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/scatter/series.ts
@@ -5,6 +5,7 @@ import type { RenderingContext } from "metabase/visualizations/types";
 
 import { X_AXIS_DATA_KEY } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import type { DataKey, Datum, Extent, SeriesModel } from "../model/types";
+import { CHART_STYLE } from "../constants/style";
 
 const MIN_BUBBLE_DIAMETER = 15;
 const MAX_BUBBLE_DIAMETER = 75;
@@ -66,9 +67,17 @@ export function buildEChartsScatterSeries(
     },
     itemStyle: {
       color: seriesModel.color,
-      opacity: 0.8,
+      opacity: CHART_STYLE.opacity.scatter,
       borderColor: renderingContext.getColor("white"),
       borderWidth: 1,
+    },
+    emphasis: {
+      focus: "series", // there is no blur for single series scatter plot
+    },
+    blur: {
+      itemStyle: {
+        opacity: CHART_STYLE.opacity.blur,
+      },
     },
   };
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38939

### Description

Adds a lower different opacity for the blur state for the scatter plot.

### Demo

![Screenshot 2024-02-20 at 3.00.17 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/2abbff5a-eb99-4042-a027-61f77d4b93ca.png)