### PR TITLE
Native query tag editor field mapper: mimic Mantine

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -58,41 +58,49 @@ const TABLE_STEP = "TABLE";
 // chooses a table field (table has already been selected)
 const FIELD_STEP = "FIELD";
 
-export const DataSourceSelector = props => (
-  <DataSelector
-    steps={[DATA_BUCKET_STEP, DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
-    combineDatabaseSchemaSteps
-    getTriggerElementContent={TableTrigger}
-    {...props}
-  />
-);
+export function DataSourceSelector(props) {
+  return (
+    <DataSelector
+      steps={[DATA_BUCKET_STEP, DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
+      combineDatabaseSchemaSteps
+      getTriggerElementContent={TableTrigger}
+      {...props}
+    />
+  );
+}
 
-export const DatabaseDataSelector = props => (
-  <DataSelector
-    steps={[DATABASE_STEP]}
-    getTriggerElementContent={DatabaseTrigger}
-    {...props}
-  />
-);
+export function DatabaseDataSelector(props) {
+  return (
+    <DataSelector
+      steps={[DATABASE_STEP]}
+      getTriggerElementContent={DatabaseTrigger}
+      {...props}
+    />
+  );
+}
 
-export const DatabaseSchemaAndTableDataSelector = props => (
-  <DataSelector
-    steps={[DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
-    combineDatabaseSchemaSteps
-    getTriggerElementContent={TableTrigger}
-    {...props}
-  />
-);
+export function DatabaseSchemaAndTableDataSelector(props) {
+  return (
+    <DataSelector
+      steps={[DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
+      combineDatabaseSchemaSteps
+      getTriggerElementContent={TableTrigger}
+      {...props}
+    />
+  );
+}
 
-export const SchemaAndTableDataSelector = props => (
-  <DataSelector
-    steps={[SCHEMA_STEP, TABLE_STEP]}
-    getTriggerElementContent={TableTrigger}
-    {...props}
-  />
-);
+export function SchemaAndTableDataSelector(props) {
+  return (
+    <DataSelector
+      steps={[SCHEMA_STEP, TABLE_STEP]}
+      getTriggerElementContent={TableTrigger}
+      {...props}
+    />
+  );
+}
 
-export const SchemaTableAndFieldDataSelector = props => {
+export function SchemaTableAndFieldDataSelector(props) {
   return (
     <DataSelector
       steps={[SCHEMA_STEP, TABLE_STEP, FIELD_STEP]}
@@ -102,7 +110,7 @@ export const SchemaTableAndFieldDataSelector = props => {
       {...props}
     />
   );
-};
+}
 
 export class UnconnectedDataSelector extends Component {
   constructor(props) {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -93,13 +93,12 @@ export const SchemaAndTableDataSelector = props => (
 );
 
 export const SchemaTableAndFieldDataSelector = props => (
-  // <div style={{ outline: "2px solid rgba(255,0,0,.4)" }}>
   <DataSelector
     steps={[SCHEMA_STEP, TABLE_STEP, FIELD_STEP]}
     getTriggerElementContent={FieldTrigger}
+    isMantine={true}
     {...props}
   />
-  // </div>
 );
 
 export class UnconnectedDataSelector extends Component {
@@ -174,6 +173,7 @@ export class UnconnectedDataSelector extends Component {
     canChangeDatabase: true,
     hasTriggerExpandControl: true,
     isPopover: true,
+    isMantine: false,
   };
 
   // computes selected metadata objects (`selectedDatabase`, etc) and options (`databases`, etc)
@@ -720,6 +720,8 @@ export class UnconnectedDataSelector extends Component {
       triggerElement,
       getTriggerElementContent: TriggerComponent,
       hasTriggerExpandControl,
+      readOnly,
+      isMantine,
     } = this.props;
 
     if (triggerElement) {
@@ -732,8 +734,9 @@ export class UnconnectedDataSelector extends Component {
       <Trigger
         className={className}
         style={style}
-        showDropdownIcon={!this.props.readOnly && hasTriggerExpandControl}
-        iconSize={triggerIconSize}
+        showDropdownIcon={!readOnly && hasTriggerExpandControl}
+        iconSize={isMantine ? "1rem" : triggerIconSize}
+        isMantine={isMantine}
       >
         <TriggerComponent
           database={selectedDatabase}

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
 import PropTypes from "prop-types";
-import { createRef, createElement, Component } from "react";
+import { createRef, Component } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 import _ from "underscore";
@@ -18,7 +18,6 @@ import Tables from "metabase/entities/tables";
 import { getHasDataAccess } from "metabase/selectors/data";
 import { getMetadata } from "metabase/selectors/metadata";
 import { getSetting } from "metabase/selectors/settings";
-import { Icon } from "metabase/ui";
 import {
   isVirtualCardId,
   SAVED_QUESTIONS_VIRTUAL_DB_ID,
@@ -35,6 +34,12 @@ import DatabaseSchemaPicker from "./DataSelectorDatabaseSchemaPicker";
 import FieldPicker from "./DataSelectorFieldPicker";
 import SchemaPicker from "./DataSelectorSchemaPicker";
 import TablePicker from "./DataSelectorTablePicker";
+import {
+  FieldTrigger,
+  DatabaseTrigger,
+  TableTrigger,
+  Trigger,
+} from "./TriggerComponents";
 import { SearchResults, getSearchItemTableOrCardId } from "./data-search";
 import SavedQuestionPicker from "./saved-question-picker/SavedQuestionPicker";
 
@@ -57,7 +62,7 @@ export const DataSourceSelector = props => (
   <DataSelector
     steps={[DATA_BUCKET_STEP, DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
     combineDatabaseSchemaSteps
-    getTriggerElementContent={TableTriggerContent}
+    getTriggerElementContent={TableTrigger}
     {...props}
   />
 );
@@ -65,7 +70,7 @@ export const DataSourceSelector = props => (
 export const DatabaseDataSelector = props => (
   <DataSelector
     steps={[DATABASE_STEP]}
-    getTriggerElementContent={DatabaseTriggerContent}
+    getTriggerElementContent={DatabaseTrigger}
     {...props}
   />
 );
@@ -74,7 +79,7 @@ export const DatabaseSchemaAndTableDataSelector = props => (
   <DataSelector
     steps={[DATABASE_STEP, SCHEMA_STEP, TABLE_STEP]}
     combineDatabaseSchemaSteps
-    getTriggerElementContent={TableTriggerContent}
+    getTriggerElementContent={TableTrigger}
     {...props}
   />
 );
@@ -82,112 +87,20 @@ export const DatabaseSchemaAndTableDataSelector = props => (
 export const SchemaAndTableDataSelector = props => (
   <DataSelector
     steps={[SCHEMA_STEP, TABLE_STEP]}
-    getTriggerElementContent={TableTriggerContent}
+    getTriggerElementContent={TableTrigger}
     {...props}
   />
 );
 
 export const SchemaTableAndFieldDataSelector = props => (
+  // <div style={{ outline: "2px solid rgba(255,0,0,.4)" }}>
   <DataSelector
     steps={[SCHEMA_STEP, TABLE_STEP, FIELD_STEP]}
-    getTriggerElementContent={FieldTriggerContent}
+    getTriggerElementContent={FieldTrigger}
     {...props}
   />
+  // </div>
 );
-
-const DatabaseTriggerContent = ({ selectedDatabase }) =>
-  selectedDatabase ? (
-    <span className="text-wrap text-grey no-decoration">
-      {selectedDatabase.name}
-    </span>
-  ) : (
-    <span className="text-medium no-decoration">{t`Select a database`}</span>
-  );
-
-const TableTriggerContent = ({ selectedTable }) =>
-  selectedTable ? (
-    <span className="text-wrap text-grey no-decoration">
-      {selectedTable.display_name || selectedTable.name}
-    </span>
-  ) : (
-    <span className="text-medium no-decoration">{t`Select a table`}</span>
-  );
-
-const FieldTriggerContent = ({ selectedDatabase, selectedField }) => {
-  if (!selectedField || !selectedField.table) {
-    return (
-      <span className="flex-full text-medium no-decoration">{t`Select...`}</span>
-    );
-  } else {
-    const hasMultipleSchemas =
-      selectedDatabase &&
-      _.uniq(selectedDatabase.tables, t => t.schema_name).length > 1;
-    return (
-      <div className="flex-full cursor-pointer">
-        <div className="h6 text-bold text-uppercase text-light">
-          {hasMultipleSchemas && selectedField.table.schema_name + " > "}
-          {selectedField.table.display_name}
-        </div>
-        <div className="h4 text-bold text-default">
-          {selectedField.display_name}
-        </div>
-      </div>
-    );
-  }
-};
-
-class DataSelectorInner extends Component {
-  render() {
-    return <UnconnectedDataSelector {...this.props} />;
-  }
-}
-
-const DataSelector = _.compose(
-  Databases.loadList({
-    loadingAndErrorWrapper: false,
-    listName: "allDatabases",
-  }),
-  Search.loadList({
-    // If there is at least one dataset,
-    // we want to display a slightly different data picker view
-    // (see DATA_BUCKET step)
-    query: {
-      models: "dataset",
-      limit: 1,
-    },
-    loadingAndErrorWrapper: false,
-  }),
-  connect(
-    (state, ownProps) => ({
-      metadata: getMetadata(state),
-      databases:
-        ownProps.databases ||
-        Databases.selectors.getList(state, {
-          entityQuery: ownProps.databaseQuery,
-        }) ||
-        [],
-      hasLoadedDatabasesWithTablesSaved: Databases.selectors.getLoaded(state, {
-        entityQuery: { include: "tables", saved: true },
-      }),
-      hasLoadedDatabasesWithSaved: Databases.selectors.getLoaded(state, {
-        entityQuery: { saved: true },
-      }),
-      hasLoadedDatabasesWithTables: Databases.selectors.getLoaded(state, {
-        entityQuery: { include: "tables" },
-      }),
-      hasDataAccess: getHasDataAccess(ownProps.allDatabases ?? []),
-      hasNestedQueriesEnabled: getSetting(state, "enable-nested-queries"),
-    }),
-    {
-      fetchDatabases: databaseQuery =>
-        Databases.actions.fetchList(databaseQuery),
-      fetchSchemas: databaseId =>
-        Schemas.actions.fetchList({ dbId: databaseId }),
-      fetchSchemaTables: schemaId => Schemas.actions.fetch({ id: schemaId }),
-      fetchFields: tableId => Tables.actions.fetchMetadata({ id: tableId }),
-    },
-  ),
-)(DataSelectorInner);
 
 export class UnconnectedDataSelector extends Component {
   constructor(props) {
@@ -228,7 +141,6 @@ export class UnconnectedDataSelector extends Component {
     useOnlyAvailableDatabase: PropTypes.bool,
     useOnlyAvailableSchema: PropTypes.bool,
     isInitiallyOpen: PropTypes.bool,
-    renderAsSelect: PropTypes.bool,
     tableFilter: PropTypes.func,
     hasTableSearch: PropTypes.bool,
     canChangeDatabase: PropTypes.bool,
@@ -254,7 +166,6 @@ export class UnconnectedDataSelector extends Component {
 
   static defaultProps = {
     isInitiallyOpen: false,
-    renderAsSelect: false,
     useOnlyAvailableDatabase: true,
     useOnlyAvailableSchema: true,
     hideSingleSchema: true,
@@ -807,7 +718,7 @@ export class UnconnectedDataSelector extends Component {
       style,
       triggerIconSize,
       triggerElement,
-      getTriggerElementContent,
+      getTriggerElementContent: TriggerComponent,
       hasTriggerExpandControl,
     } = this.props;
 
@@ -818,35 +729,25 @@ export class UnconnectedDataSelector extends Component {
     const { selectedDatabase, selectedTable, selectedField } = this.state;
 
     return (
-      <span
-        className={className || "px2 py2 text-bold cursor-pointer text-default"}
+      <Trigger
+        className={className}
         style={style}
+        showDropdownIcon={!this.props.readOnly && hasTriggerExpandControl}
+        iconSize={triggerIconSize}
       >
-        {createElement(getTriggerElementContent, {
-          selectedDatabase,
-          selectedTable,
-          selectedField,
-          ...triggerProps,
-        })}
-        {!this.props.readOnly && hasTriggerExpandControl && (
-          <Icon
-            className="ml1"
-            name="chevrondown"
-            size={triggerIconSize || 8}
-          />
-        )}
-      </span>
+        <TriggerComponent
+          database={selectedDatabase}
+          table={selectedTable}
+          field={selectedField}
+          {...triggerProps}
+        />
+      </Trigger>
     );
   };
 
   getTriggerClasses() {
-    const { readOnly, triggerClasses, renderAsSelect } = this.props;
-    if (triggerClasses) {
-      return cx(triggerClasses, { disabled: readOnly });
-    }
-    return renderAsSelect
-      ? cx("border-medium bg-white block no-decoration", { disabled: readOnly })
-      : cx("flex align-center", { disabled: readOnly });
+    const { readOnly, triggerClasses } = this.props;
+    return cx(triggerClasses ?? "flex align-center", { disabled: readOnly });
   }
 
   handleSavedQuestionPickerClose = () => {
@@ -1105,3 +1006,50 @@ export class UnconnectedDataSelector extends Component {
     return this.renderContent();
   }
 }
+
+const DataSelector = _.compose(
+  Databases.loadList({
+    loadingAndErrorWrapper: false,
+    listName: "allDatabases",
+  }),
+  Search.loadList({
+    // If there is at least one dataset,
+    // we want to display a slightly different data picker view
+    // (see DATA_BUCKET step)
+    query: {
+      models: "dataset",
+      limit: 1,
+    },
+    loadingAndErrorWrapper: false,
+  }),
+  connect(
+    (state, ownProps) => ({
+      metadata: getMetadata(state),
+      databases:
+        ownProps.databases ||
+        Databases.selectors.getList(state, {
+          entityQuery: ownProps.databaseQuery,
+        }) ||
+        [],
+      hasLoadedDatabasesWithTablesSaved: Databases.selectors.getLoaded(state, {
+        entityQuery: { include: "tables", saved: true },
+      }),
+      hasLoadedDatabasesWithSaved: Databases.selectors.getLoaded(state, {
+        entityQuery: { saved: true },
+      }),
+      hasLoadedDatabasesWithTables: Databases.selectors.getLoaded(state, {
+        entityQuery: { include: "tables" },
+      }),
+      hasDataAccess: getHasDataAccess(ownProps.allDatabases ?? []),
+      hasNestedQueriesEnabled: getSetting(state, "enable-nested-queries"),
+    }),
+    {
+      fetchDatabases: databaseQuery =>
+        Databases.actions.fetchList(databaseQuery),
+      fetchSchemas: databaseId =>
+        Schemas.actions.fetchList({ dbId: databaseId }),
+      fetchSchemaTables: schemaId => Schemas.actions.fetch({ id: schemaId }),
+      fetchFields: tableId => Tables.actions.fetchMetadata({ id: tableId }),
+    },
+  ),
+)(UnconnectedDataSelector);

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -92,14 +92,17 @@ export const SchemaAndTableDataSelector = props => (
   />
 );
 
-export const SchemaTableAndFieldDataSelector = props => (
-  <DataSelector
-    steps={[SCHEMA_STEP, TABLE_STEP, FIELD_STEP]}
-    getTriggerElementContent={FieldTrigger}
-    isMantine={true}
-    {...props}
-  />
-);
+export const SchemaTableAndFieldDataSelector = props => {
+  return (
+    <DataSelector
+      steps={[SCHEMA_STEP, TABLE_STEP, FIELD_STEP]}
+      getTriggerElementContent={FieldTrigger}
+      // We don't want to change styles when there's a different trigger element
+      isMantine={!props.getTriggerElementContent}
+      {...props}
+    />
+  );
+};
 
 export class UnconnectedDataSelector extends Component {
   constructor(props) {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.styled.tsx
@@ -96,3 +96,23 @@ export const EmptyStateContainer = styled.div`
 export const TableSearchContainer = styled.div`
   padding: 0.5rem;
 `;
+
+export const TriggerContainer = styled.div`
+  width: 100%;
+  position: relative;
+  padding: 0.5rem 2.625rem 0.5rem 0.6875rem;
+  border: 1px solid ${color("border")};
+  border-radius: ${space(0)};
+  cursor: pointer;
+`;
+
+export const TriggerContainerIcon = styled.div`
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  right: -1px;
+  top: 0;
+  width: 2.5rem;
+  height: 100%;
+`;

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.styled.tsx
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import SelectList from "metabase/components/SelectList";
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
-import { Icon } from "metabase/ui";
+import { Icon, Text } from "metabase/ui";
 
 export const DataSelectorSection = styled.section`
   width: 300px;
@@ -115,4 +115,12 @@ export const TriggerContainerIcon = styled.div`
   top: 0;
   width: 2.5rem;
   height: 100%;
+`;
+
+export const TextSchema = styled(Text)`
+  font-size: 0.75em;
+  color: ${color("text-light")};
+  line-height: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 `;

--- a/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
@@ -7,6 +7,8 @@ import type Database from "metabase-lib/metadata/Database";
 import type Field from "metabase-lib/metadata/Field";
 import type Table from "metabase-lib/metadata/Table";
 
+import { TriggerContainer, TriggerContainerIcon } from "./DataSelector.styled";
+
 export function Trigger({
   className,
   style,
@@ -21,14 +23,25 @@ export function Trigger({
   mantine?: boolean;
   children: ReactNode;
 }) {
+  const icon = showDropdownIcon && <Icon name="chevrondown" size={iconSize} />;
+
+  if (style || className) {
+    return (
+      <span
+        className={className || "px2 py2 text-bold cursor-pointer text-default"}
+        style={style}
+      >
+        {children}
+        {icon}
+      </span>
+    );
+  }
+
   return (
-    <span
-      className={className || "px2 py2 text-bold cursor-pointer text-default"}
-      style={style}
-    >
+    <TriggerContainer>
       {children}
-      {showDropdownIcon && <Icon name="chevrondown" size={iconSize} />}
-    </span>
+      {icon && <TriggerContainerIcon>{icon}</TriggerContainerIcon>}
+    </TriggerContainer>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties, ReactNode } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { Icon, Text } from "metabase/ui";
+import { Icon } from "metabase/ui";
 import type Database from "metabase-lib/metadata/Database";
 import type Field from "metabase-lib/metadata/Field";
 import type Table from "metabase-lib/metadata/Table";
@@ -15,33 +15,38 @@ export function Trigger({
   showDropdownIcon = false,
   iconSize = 8,
   children,
+  isMantine = false,
 }: {
   className?: string;
   style?: CSSProperties;
   showDropdownIcon?: boolean;
   iconSize?: number;
-  mantine?: boolean;
+  isMantine?: boolean;
   children: ReactNode;
 }) {
-  const icon = showDropdownIcon && <Icon name="chevrondown" size={iconSize} />;
-
-  if (style || className) {
+  if (isMantine) {
     return (
-      <span
-        className={className || "px2 py2 text-bold cursor-pointer text-default"}
-        style={style}
-      >
+      <TriggerContainer>
         {children}
-        {icon}
-      </span>
+        {showDropdownIcon && (
+          <TriggerContainerIcon>
+            <Icon name="chevrondown" size={iconSize} />
+          </TriggerContainerIcon>
+        )}
+      </TriggerContainer>
     );
   }
 
   return (
-    <TriggerContainer>
+    <span
+      className={className || "px2 py2 text-bold cursor-pointer text-default"}
+      style={style}
+    >
       {children}
-      {icon && <TriggerContainerIcon>{icon}</TriggerContainerIcon>}
-    </TriggerContainer>
+      {showDropdownIcon && (
+        <Icon className="ml1" name="chevrondown" size={iconSize} />
+      )}
+    </span>
   );
 }
 
@@ -53,7 +58,9 @@ export function FieldTrigger({
   field: Field;
 }) {
   if (!field || !field.table) {
-    return <Text w="100%">{t`Select...`}</Text>;
+    return (
+      <span className="flex-full text-medium no-decoration">{t`Select...`}</span>
+    );
   }
   const hasMultipleSchemas =
     _.uniq(database?.tables ?? [], t => t.schema_name).length > 1;

--- a/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
@@ -1,0 +1,74 @@
+import type { CSSProperties, ReactNode } from "react";
+import { t } from "ttag";
+import _ from "underscore";
+
+import { Icon, Text } from "metabase/ui";
+import type Database from "metabase-lib/metadata/Database";
+import type Field from "metabase-lib/metadata/Field";
+import type Table from "metabase-lib/metadata/Table";
+
+export function Trigger({
+  className,
+  style,
+  showDropdownIcon = false,
+  iconSize = 8,
+  children,
+}: {
+  className?: string;
+  style?: CSSProperties;
+  showDropdownIcon?: boolean;
+  iconSize?: number;
+  mantine?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className={className || "px2 py2 text-bold cursor-pointer text-default"}
+      style={style}
+    >
+      {children}
+      {showDropdownIcon && <Icon name="chevrondown" size={iconSize} />}
+    </span>
+  );
+}
+
+export function FieldTrigger({
+  database,
+  field,
+}: {
+  database: Database;
+  field: Field;
+}) {
+  if (!field || !field.table) {
+    return <Text w="100%">{t`Select...`}</Text>;
+  }
+  const hasMultipleSchemas =
+    _.uniq(database?.tables ?? [], t => t.schema_name).length > 1;
+  return (
+    <div className="flex-full cursor-pointer">
+      <div className="h6 text-bold text-uppercase text-light">
+        {hasMultipleSchemas && field.table.schema_name + " > "}
+        {field.table.display_name}
+      </div>
+      <div className="h4 text-bold text-default">{field.display_name}</div>
+    </div>
+  );
+}
+
+export function DatabaseTrigger({ database }: { database: Database }) {
+  return database ? (
+    <span className="text-wrap text-grey no-decoration">{database.name}</span>
+  ) : (
+    <span className="text-medium no-decoration">{t`Select a database`}</span>
+  );
+}
+
+export function TableTrigger({ table }: { table: Table }) {
+  return table ? (
+    <span className="text-wrap text-grey no-decoration">
+      {table.display_name || table.name}
+    </span>
+  ) : (
+    <span className="text-medium no-decoration">{t`Select a table`}</span>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/TriggerComponents.tsx
@@ -2,12 +2,16 @@ import type { CSSProperties, ReactNode } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-import { Icon } from "metabase/ui";
+import { Icon, Text } from "metabase/ui";
 import type Database from "metabase-lib/metadata/Database";
 import type Field from "metabase-lib/metadata/Field";
 import type Table from "metabase-lib/metadata/Table";
 
-import { TriggerContainer, TriggerContainerIcon } from "./DataSelector.styled";
+import {
+  TextSchema,
+  TriggerContainer,
+  TriggerContainerIcon,
+} from "./DataSelector.styled";
 
 export function Trigger({
   className,
@@ -58,19 +62,18 @@ export function FieldTrigger({
   field: Field;
 }) {
   if (!field || !field.table) {
-    return (
-      <span className="flex-full text-medium no-decoration">{t`Select...`}</span>
-    );
+    return <Text>{t`Select...`}</Text>;
   }
   const hasMultipleSchemas =
     _.uniq(database?.tables ?? [], t => t.schema_name).length > 1;
+
   return (
-    <div className="flex-full cursor-pointer">
-      <div className="h6 text-bold text-uppercase text-light">
+    <div>
+      <TextSchema>
         {hasMultipleSchemas && field.table.schema_name + " > "}
         {field.table.display_name}
-      </div>
-      <div className="h4 text-bold text-default">{field.display_name}</div>
+      </TextSchema>
+      <Text lh="1.2rem">{field.display_name}</Text>
     </div>
   );
 }

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import { Component, useMemo } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 import _ from "underscore";

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -1,4 +1,4 @@
-import { Component, useMemo } from "react";
+import { Component } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 import _ from "underscore";

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
@@ -54,7 +54,6 @@ export function FieldMappingSelect({
                 hasSelectedDimensionField ? tag?.dimension?.[1] : null
               }
               setFieldFn={setFieldFn}
-              className="AdminSelect flex align-center"
               isInitiallyOpen={!tag.dimension}
               triggerIconSize={"1rem"} // this is inline with Mantine select icon size
             />

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
@@ -55,7 +55,6 @@ export function FieldMappingSelect({
               }
               setFieldFn={setFieldFn}
               isInitiallyOpen={!tag.dimension}
-              triggerIconSize={"1rem"} // this is inline with Mantine select icon size
             />
           )}
         </Schemas.Loader>

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FieldMappingSelect.tsx
@@ -56,8 +56,7 @@ export function FieldMappingSelect({
               setFieldFn={setFieldFn}
               className="AdminSelect flex align-center"
               isInitiallyOpen={!tag.dimension}
-              triggerIconSize={12}
-              renderAsSelect={true}
+              triggerIconSize={"1rem"} // this is inline with Mantine select icon size
             />
           )}
         </Schemas.Loader>

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FilterWidgetTypeSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FilterWidgetTypeSelect.tsx
@@ -39,7 +39,7 @@ export function FilterWidgetTypeSelect({
 
   return (
     <InputContainer>
-      <ContainerLabel smallPaddingBottom>
+      <ContainerLabel>
         {t`Filter widget type`}
         {hasNoWidgetType && <ErrorSpan>({t`required`})</ErrorSpan>}
       </ContainerLabel>

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TagEditorParam.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/TagEditorParam.styled.tsx
@@ -17,15 +17,14 @@ export const TagName = styled.h3`
 
 interface ContainerLabelProps {
   paddingTop?: boolean;
-  smallPaddingBottom?: boolean;
 }
 
 export const ContainerLabel = styled.div<ContainerLabelProps>`
   display: block;
-  font-weight: 700;
-  padding-bottom: ${props => (props.smallPaddingBottom ? "0.25rem" : "0.5rem")};
-  color: ${color("text-medium")};
+  margin-bottom: 0.5em;
   padding-top: ${props => (props.paddingTop ? "0.5rem" : "0")};
+  color: ${color("text-medium")};
+  font-weight: 700;
 `;
 
 export const ErrorSpan = styled.span`

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/VariableTypeSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/VariableTypeSelect.tsx
@@ -11,7 +11,7 @@ export function VariableTypeSelect(props: {
 }) {
   return (
     <InputContainer>
-      <ContainerLabel smallPaddingBottom>{t`Variable type`}</ContainerLabel>
+      <ContainerLabel>{t`Variable type`}</ContainerLabel>
       <Select
         value={props.value}
         placeholder={t`Select…`}


### PR DESCRIPTION
Following the https://github.com/metabase/metabase/pull/38906, we're now updating the field mapper component to match new Mantine select styles. This PR only updates the way it looks from the outside, without touching the dropdown, which seems to be a larger undertaking due to the complexity of the `DataSelector` component.

I had to take a very cautious approach and be explicit in passing `isMantine` prop from `SchemaTableAndFieldDataSelector` since this set of components (`DatePicker`) is used in multiple places, and I don't want accidental changes.

## How it looks like
Before:
<img width="1113" alt="Screenshot 2024-02-21 at 11 34 58" src="https://github.com/metabase/metabase/assets/2196347/0e5d8f79-3e8c-408d-81b0-5399aeab2c1f">

After: 
<img width="1114" alt="Screenshot 2024-02-21 at 11 33 56" src="https://github.com/metabase/metabase/assets/2196347/cf988950-faf8-42c2-80a3-a5ce162cea4d">

# No changes in the model metadata sidebar
<img width="1098" alt="Screenshot 2024-02-21 at 12 15 14" src="https://github.com/metabase/metabase/assets/2196347/e6c3911f-fcd0-479d-be50-4b7be692d2a7">

<img width="1097" alt="Screenshot 2024-02-21 at 12 15 20" src="https://github.com/metabase/metabase/assets/2196347/c5a4965e-8477-4082-a67d-61a971d3f6d2">
