### PR TITLE
WIP Bugfix: parameter values don't use default when set empty in the URL

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -10,35 +10,17 @@ import { getParameterType } from "./parameter-type";
 export const PULSE_PARAM_EMPTY = null;
 export const PULSE_PARAM_USE_DEFAULT = undefined;
 
-/**
- * In some cases, we need to use default parameter value in place of an absent one.
- * Please use this function when dealing with the required parameters.
- */
-export function getParameterValue({
-  parameter,
-  values = {},
-  defaultRequired = false,
-}) {
+export function getParameterValue({ parameter, values = {} }) {
   const value = values?.[parameter.id];
-  const useDefault = defaultRequired && parameter.required;
-  return value ?? (useDefault ? parameter.default : null);
+  return value ?? (parameter.required ? parameter.default : null);
 }
 
-/**
- * In some cases, we need to use default parameter value in place of an absent one.
- * Please use this function when dealing with the required parameters.
- */
-export function getValuePopulatedParameters({
-  parameters,
-  values = {},
-  defaultRequired = false,
-}) {
+export function getValuePopulatedParameters({ parameters, values = {} }) {
   return parameters.map(parameter => ({
     ...parameter,
     value: getParameterValue({
       parameter,
       values,
-      defaultRequired,
     }),
   }));
 }

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/ParametersSettings.tsx
@@ -44,7 +44,6 @@ export const ParametersSettings = ({
       getValuePopulatedParameters({
         parameters: lockedParameters,
         values: parameterValues,
-        defaultRequired: true,
       }) as EmbedResourceParameterWithValue[],
     [lockedParameters, parameterValues],
   );

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/StaticEmbedSetupPane.tsx
@@ -406,7 +406,6 @@ function getPreviewParamsBySlug({
       getParameterValue({
         parameter,
         values: parameterValues,
-        defaultRequired: true,
       }),
     ]),
   );


### PR DESCRIPTION
WIP Fixes [Dashboard + required filter: default isn't picked up when URL param is empty](https://github.com/metabase/metabase/issues/38857)

TODO:
- find a proper way of fixing it
- add tests 