### PR TITLE
Clear undo stack when first opening native editor

### DIFF
--- a/e2e/test/scenarios/native/reproductions/35344-undo-in-native-editor-goes-to-far.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/35344-undo-in-native-editor-goes-to-far.cy.spec.js
@@ -1,0 +1,22 @@
+import { restore, focusNativeEditor } from "e2e/support/helpers";
+
+const questionDetails = {
+  name: "REVIEWS SQL",
+  native: { query: "select REVIEWER from REVIEWS" },
+};
+
+describe("issue 35344", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("should not allow the user to undo to the empty editor (metabase#35344)", () => {
+    cy.createNativeQuestion(questionDetails, { visitQuestion: true });
+
+    cy.findByTestId("query-builder-main").findByText("Open Editor").click();
+
+    focusNativeEditor().type("{meta}z");
+    expect(focusNativeEditor().findByText("select")).to.exist;
+  });
+});

--- a/e2e/test/scenarios/native/reproductions/35344-undo-in-native-editor-goes-to-far.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/35344-undo-in-native-editor-goes-to-far.cy.spec.js
@@ -16,6 +16,14 @@ describe("issue 35344", () => {
 
     cy.findByTestId("query-builder-main").findByText("Open Editor").click();
 
+    // make sure normal undo still works
+    focusNativeEditor().type("--");
+    expect(focusNativeEditor().findByText("--")).to.exist;
+
+    focusNativeEditor().type("{meta}z");
+    focusNativeEditor().findByText("--").should("not.exist");
+
+    // more undoing does not change to empty editor
     focusNativeEditor().type("{meta}z");
     expect(focusNativeEditor().findByText("select")).to.exist;
   });

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -418,6 +418,9 @@ export class NativeQueryEditor extends Component<
     this.handleQueryUpdate(query?.queryText() ?? "");
     editor.renderer.setScrollMargin(SCROLL_MARGIN, SCROLL_MARGIN, 0, 0);
 
+    // reset undo manager to prevent undoing to empty editor
+    editor.getSession().getUndoManager().reset();
+
     // hmmm, this could be dangerous
     if (!this.props.readOnly) {
       editor.focus();


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35344

### Description

When opening the native editor for a saved question, that question's query gets injected into the editor.

This creates an item on the undo stack, so a user could type <kbd>cmd</kbd> + <kbd>z</kbd> and undo to the empty state of the editor.

This PR removes the undo stack after first loading the editor to avoid this problem.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New Question → SQL Query
2. Type `SELECT * FROM "ORDERS"`
3. Save the question
4. Open the saved question
5. Click `Open Editor`
6. Focus the editor and type <kbd>cmd</kbd> + <kbd>z</kbd> a couple of times. The query should not dissapear
7. Add some text to the query and verify that typing <kbd>cmd</kbd>+<kbd>z</kbd> _will_ undo your changes

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
