### PR TITLE
[serdes-v1] can now dump/load entity_id

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
+++ b/enterprise/backend/src/metabase_enterprise/serialization/serialize.clj
@@ -36,6 +36,10 @@
   ;; version 2 - start adding namespace portion to /collections/ paths
   2)
 
+(def ^:dynamic *include-entity-id*
+  "If entity_id should be included in v1 serialization dump"
+  false)
+
 (def ^:private ^{:arglists '([form])} mbql-entity-reference?
   "Is given form an MBQL entity reference?"
   (partial mbql.normalize/is-clause? #{:field :field-id :fk-> :metric :segment}))
@@ -103,7 +107,8 @@
   [entity]
   (cond-> (dissoc entity :id :creator_id :created_at :updated_at :db_id :location
                   :dashboard_id :fields_hash :personal_owner_id :made_public_by_id :collection_id
-                  :pulse_id :result_metadata :entity_id :action_id)
+                  :pulse_id :result_metadata :action_id)
+    (not *include-entity-id*)   (dissoc :entity_id)
     (some #(instance? % entity) (map type [Metric Field Segment])) (dissoc :table_id)))
 
 (defmulti ^:private serialize-one

--- a/src/metabase/cmd.clj
+++ b/src/metabase/cmd.clj
@@ -198,7 +198,8 @@
                :default      :all
                :default-desc "all"
                :parse-fn     mbql.u/normalize-token
-               :validate     [#{:active :all} "Must be 'active' or 'all'"]]]}
+               :validate     [#{:active :all} "Must be 'active' or 'all'"]]
+              [nil "--include-entity-id"   "Include entity_id property in all dumped entities. Default: false."]]}
   [path & options]
   (log/warn (u/colorize :red (trs "''dump'' is deprecated and will be removed in a future release. Please migrate to ''export''.")))
   (call-enterprise 'metabase-enterprise.serialization.cmd/v1-dump! path (get-parsed-options #'dump options)))


### PR DESCRIPTION
Specifying `--include-entity-id` to a serdes v1 dump command will dump `entity_id` field into yamls. Load will use this field with no options though - but it'll check if it is present in data to use as one of markers that data has changed.

I decided not to add an option to load since right now it will use all data provided, just the markers that say "data has changed" were changed.

Resolves #38961 