### PR TITLE
Cleanup creator sentiment and follow up email code

### DIFF
--- a/.clj-kondo/hooks/metabase/models/setting.clj
+++ b/.clj-kondo/hooks/metabase/models/setting.clj
@@ -92,7 +92,6 @@
      metabot-prompt-generator-token-limit
      multi-setting-read-only
      notification-link-base-url
-     no-surveys
      num-metabot-choices
      openai-api-key
      openai-available-models

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -102,6 +102,14 @@
   :getter     #(boolean (email-smtp-host))
   :doc        false)
 
+(setting/defsetting no-surveys
+  (deferred-tru "Enable or disable surveys")
+  :type       :boolean
+  :default    false
+  :export?    false
+  :visibility :internal
+  :audit      :getter)
+
 (defn- add-ssl-settings [m ssl-setting]
   (merge
    m

--- a/src/metabase/email.clj
+++ b/src/metabase/email.clj
@@ -102,10 +102,10 @@
   :getter     #(boolean (email-smtp-host))
   :doc        false)
 
-(setting/defsetting no-surveys
+(setting/defsetting surveys-enabled
   (deferred-tru "Enable or disable surveys")
   :type       :boolean
-  :default    false
+  :default    true
   :export?    false
   :visibility :internal
   :audit      :getter)

--- a/src/metabase/task/creator_sentiment_emails.clj
+++ b/src/metabase/task/creator_sentiment_emails.clj
@@ -75,9 +75,13 @@
              (email/surveys-enabled))
     (let [instance-data (when (public-settings/anon-tracking-enabled)
                           (fetch-instance-data))
-          creators      (fetch-creators (premium-features/enable-whitelabeling?))
-          month         (- (.getValue (t/month)) 1)]
-      (doseq [creator creators]
+          all-creators  (fetch-creators (premium-features/enable-whitelabeling?))
+          month         (- (.getValue (t/month)) 1)
+          this-month    (fn [c] (= month (-> c :email hash (mod 12))))
+          recipients    (filter this-month all-creators)]
+      (log/infof "Sending surveys to %d creators of a total %d"
+                 (count all-creators) (count recipients))
+      (doseq [creator recipients]
         ;; Send the email if the creator's email hash matches the current month
         (when (= (-> creator :email hash (mod 12)) month)
           (try

--- a/src/metabase/task/creator_sentiment_emails.clj
+++ b/src/metabase/task/creator_sentiment_emails.clj
@@ -10,22 +10,13 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.email :as email]
    [metabase.email.messages :as messages]
-   [metabase.models.setting :as setting]
    [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.task :as task]
-   [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
    [toucan2.core :as t2]))
 
 (set! *warn-on-reflection* true)
-
-(setting/defsetting ^:private no-surveys
-  (deferred-tru "Enable or disable creator sentiment emails")
-  :type       :boolean
-  :default    false
-  :visibility :internal
-  :audit      :getter)
 
 (defn- fetch-creators
   "Fetch the creators who are eligible for a creator sentiment email. Which are users who, in the past 2 months:
@@ -59,11 +50,13 @@
   "Figure out what plan this Metabase instance is on."
   []
   (cond
-    (and config/ee-available? (premium-features/is-hosted?) (premium-features/has-any-features?)) "pro-cloud/enterprise-cloud"
-    (and config/ee-available? (premium-features/is-hosted?) (not (premium-features/has-any-features?))) "starter"
-    (and config/ee-available? (not (premium-features/is-hosted?))) "pro-self-hosted/enterprise-self-hosted"
-    (not config/ee-available?) "oss"
-    :else "unknown"))
+    (and config/ee-available? (premium-features/is-hosted?))
+    (if (premium-features/has-any-features?)
+      "pro-cloud/enterprise-cloud"
+      "starter")
+
+    config/ee-available? "pro-self-hosted/enterprise-self-hosted"
+    :else                "unknown"))
 
 (defn- fetch-instance-data []
   {:created_at     (snowplow/instance-creation)
@@ -79,17 +72,18 @@
   []
   ;; we need access to email AND the instance must have surveys enabled.
   (when (and (email/email-configured?)
-             (not (no-surveys)))
-    (let [instance-data (when (public-settings/anon-tracking-enabled) (fetch-instance-data))
-          creators (fetch-creators (premium-features/enable-whitelabeling?))
-          month (- (.getValue (t/month)) 1)]
+             (not (email/no-surveys)))
+    (let [instance-data (when (public-settings/anon-tracking-enabled)
+                          (fetch-instance-data))
+          creators      (fetch-creators (premium-features/enable-whitelabeling?))
+          month         (- (.getValue (t/month)) 1)]
       (doseq [creator creators]
         ;; Send the email if the creator's email hash matches the current month
         (when (= (-> creator :email hash (mod 12)) month)
           (try
             (messages/send-creator-sentiment-email! creator instance-data)
             (catch Throwable e
-              (log/error "Problem sending creator sentiment email:" e))))))))
+              (log/error e "Problem sending creator sentiment email:"))))))))
 
 (jobs/defjob ^{:doc "Sends out a monthly survey to a portion of the creators."} CreatorSentimentEmail [_]
   (send-creator-sentiment-emails!))
@@ -105,6 +99,6 @@
                  (triggers/with-identity (triggers/key creator-sentiment-emails-trigger-key))
                  (triggers/start-now)
                  (triggers/with-schedule
-                   ;; Fire at 9:15am on the 1st day of every month
-                   (cron/cron-schedule "0 15 9 1 * ?")))]
+                   ;; Fire at 2am on the second saturday of the month
+                   (cron/cron-schedule "0 0 2 ? * 7#2")))]
     (task/schedule-task! job trigger)))

--- a/src/metabase/task/creator_sentiment_emails.clj
+++ b/src/metabase/task/creator_sentiment_emails.clj
@@ -72,7 +72,7 @@
   []
   ;; we need access to email AND the instance must have surveys enabled.
   (when (and (email/email-configured?)
-             (not (email/no-surveys)))
+             (email/surveys-enabled))
     (let [instance-data (when (public-settings/anon-tracking-enabled)
                           (fetch-instance-data))
           creators      (fetch-creators (premium-features/enable-whitelabeling?))

--- a/src/metabase/task/follow_up_emails.clj
+++ b/src/metabase/task/follow_up_emails.clj
@@ -32,10 +32,10 @@
 (defn- send-follow-up-email!
   "Send an email to the instance admin following up on their experience with Metabase thus far."
   []
-  ;; we need access to email AND the instance must be opted into anonymous tracking. Make sure email hasn't been sent yet
+  ;; we need access to email AND the instance must be opted into anonymous tracking AND have surveys enabled. Make sure email hasn't been sent yet
   (when (and (email/email-configured?)
              (public-settings/anon-tracking-enabled)
-             (not (email/no-surveys))
+             (email/surveys-enabled)
              (not (follow-up-email-sent)))
     ;; grab the oldest admins email address (likely the user who created this MB instance), that's who we'll send to
     ;; TODO - Does it make to send to this user instead of `(public-settings/admin-email)`?

--- a/src/metabase/task/follow_up_emails.clj
+++ b/src/metabase/task/follow_up_emails.clj
@@ -35,6 +35,7 @@
   ;; we need access to email AND the instance must be opted into anonymous tracking. Make sure email hasn't been sent yet
   (when (and (email/email-configured?)
              (public-settings/anon-tracking-enabled)
+             (not (email/no-surveys))
              (not (follow-up-email-sent)))
     ;; grab the oldest admins email address (likely the user who created this MB instance), that's who we'll send to
     ;; TODO - Does it make to send to this user instead of `(public-settings/admin-email)`?
@@ -42,7 +43,7 @@
       (try
         (messages/send-follow-up-email! (:email admin))
         (catch Throwable e
-          (log/error "Problem sending follow-up email:" e))
+          (log/error e "Problem sending follow-up email:"))
         (finally
           (follow-up-email-sent! true))))))
 

--- a/test/metabase/task/creator_sentiment_emails_test.clj
+++ b/test/metabase/task/creator_sentiment_emails_test.clj
@@ -12,60 +12,64 @@
 (deftest send-creator-sentiment-emails!-test
   (mt/with-fake-inbox
     (testing "Make sure we only send emails when no surveys is false."
-      (with-redefs [creator-sentiment-emails/no-surveys (constantly true)]
-        (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-        (is (= 0
-               (-> @inbox vals first count)))))
+      (mt/with-temporary-setting-values [no-surveys true]
+        (with-redefs [creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}   ;; mods to 1, this email would be sent if no surveys was false (see below)
+                                                                       {:email "b@metabase.com"}   ;; mods to 4
+                                                                       {:email "c@metabase.com"}]) ;; mods to 2
+                      t/month (constantly (t/month 2))]
+          (#'creator-sentiment-emails/send-creator-sentiment-emails!)
+          (is (= 0
+                 (-> @inbox vals first count))))))
 
     (testing "Make sure that send-creator-sentiment-emails! only sends emails to creators with the correct month hash."
-      (with-redefs [creator-sentiment-emails/no-surveys (constantly false)
-                    creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"} ;; mods to 1
-                                                                     {:email "b@metabase.com"} ;; mods to 4
-                                                                     {:email "c@metabase.com"}]) ;; mods to 2
-                    t/month (constantly (t/month 2))]
-        (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-        (is (= 1
-               (-> @inbox vals first count)))))
+      (mt/with-temporary-setting-values [no-surveys false]
+        (with-redefs [creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}   ;; mods to 1
+                                                                       {:email "b@metabase.com"}   ;; mods to 4
+                                                                       {:email "c@metabase.com"}]) ;; mods to 2
+                      t/month (constantly (t/month 2))]
+          (#'creator-sentiment-emails/send-creator-sentiment-emails!)
+          (is (= 1
+                 (-> @inbox vals first count))))))
 
     (mt/reset-inbox!)
     (testing "Make sure context is included when anon tracking is enabled"
-      (with-redefs [public-settings/anon-tracking-enabled (constantly true)
-                    creator-sentiment-emails/no-surveys (constantly false)
-                    creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
-                    t/month (constantly (t/month 2))]
-        (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-        (is (= 1
-               (count (et/regex-email-bodies #"creator\?context="))))))
+      (mt/with-temporary-setting-values [no-surveys false]
+        (with-redefs [public-settings/anon-tracking-enabled (constantly true)
+                      creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
+                      t/month (constantly (t/month 2))]
+          (#'creator-sentiment-emails/send-creator-sentiment-emails!)
+          (is (= 1
+                 (count (et/regex-email-bodies #"creator\?context=")))))))
 
     (mt/reset-inbox!)
     (testing "Make sure context isn't included when anon tracking is enabled"
-      (with-redefs [public-settings/anon-tracking-enabled (constantly false)
-                    creator-sentiment-emails/no-surveys (constantly false)
-                    creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
-                    t/month (constantly (t/month 2))]
-        (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-        (is (= 0
-               (count (et/regex-email-bodies #"creator\?context="))))))
+      (mt/with-temporary-setting-values [no-surveys false]
+        (with-redefs [public-settings/anon-tracking-enabled (constantly false)
+                      creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
+                      t/month (constantly (t/month 2))]
+          (#'creator-sentiment-emails/send-creator-sentiment-emails!)
+          (is (= 0
+                 (count (et/regex-email-bodies #"creator\?context=")))))))
 
     (mt/reset-inbox!)
     (testing "Make sure external services message is included when is self hosted"
-      (with-redefs [premium-features/is-hosted? (constantly false)
-                    creator-sentiment-emails/no-surveys (constantly false)
-                    creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
-                    t/month (constantly (t/month 2))]
-        (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-        (is (= 1
-               (count (et/regex-email-bodies #"external services"))))))
+      (mt/with-temporary-setting-values [no-surveys false]
+        (with-redefs [premium-features/is-hosted? (constantly false)
+                      creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
+                      t/month (constantly (t/month 2))]
+          (#'creator-sentiment-emails/send-creator-sentiment-emails!)
+          (is (= 1
+                 (count (et/regex-email-bodies #"external services")))))))
 
     (mt/reset-inbox!)
     (testing "Make sure external services isn't included when not self hosted"
-      (with-redefs [premium-features/is-hosted? (constantly true)
-                    creator-sentiment-emails/no-surveys (constantly false)
-                    creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
-                    t/month (constantly (t/month 2))]
-        (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-        (is (= 0
-               (count (et/regex-email-bodies #"external services"))))))))
+      (mt/with-temporary-setting-values [no-surveys false]
+        (with-redefs [premium-features/is-hosted? (constantly true)
+                      creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
+                      t/month (constantly (t/month 2))]
+          (#'creator-sentiment-emails/send-creator-sentiment-emails!)
+          (is (= 0
+                 (count (et/regex-email-bodies #"external services")))))))))
 
 (deftest fetch-creators-test
   (let [creator-id 33

--- a/test/metabase/task/follow_up_emails_test.clj
+++ b/test/metabase/task/follow_up_emails_test.clj
@@ -19,11 +19,11 @@
       (is (= 1
              (-> @inbox vals first count))))))
 
-(deftest send-follow-up-email-no-survey-test
-  (testing "Make sure we don't send an email when no-surveys is true."
+(deftest send-follow-up-email-survey-not-enabled-test
+  (testing "Make sure we don't send an email when surveys-enabled is false."
    (mt/with-temporary-setting-values [anon-tracking-enabled true
                                       follow-up-email-sent  false
-                                      no-surveys            true]
+                                      surveys-enabled       false]
      (with-fake-inbox
        (#'follow-up-emails/send-follow-up-email!)
        (is (= 0

--- a/test/metabase/task/follow_up_emails_test.clj
+++ b/test/metabase/task/follow_up_emails_test.clj
@@ -23,7 +23,7 @@
   (testing "Make sure we don't send an email when no-surveys is true."
    (mt/with-temporary-setting-values [anon-tracking-enabled true
                                       follow-up-email-sent  false
-                                      no-surveys true]
+                                      no-surveys            true]
      (with-fake-inbox
        (#'follow-up-emails/send-follow-up-email!)
        (is (= 0

--- a/test/metabase/task/follow_up_emails_test.clj
+++ b/test/metabase/task/follow_up_emails_test.clj
@@ -4,17 +4,27 @@
    [metabase.email-test :refer [inbox with-fake-inbox]]
    [metabase.task.follow-up-emails :as follow-up-emails]
    [metabase.test.fixtures :as fixtures]
-   [metabase.test.util :as tu]))
+   [metabase.test.util :as mt]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
 
 (deftest send-follow-up-email-test
   (testing (str "Make sure that `send-follow-up-email!` only sends a single email instead even when triggered multiple "
                 "times (#4253) follow-up emails get sent to the oldest admin"))
-  (tu/with-temporary-setting-values [anon-tracking-enabled true
+  (mt/with-temporary-setting-values [anon-tracking-enabled true
                                      follow-up-email-sent  false]
     (with-fake-inbox
       (#'follow-up-emails/send-follow-up-email!)
       (#'follow-up-emails/send-follow-up-email!)
       (is (= 1
              (-> @inbox vals first count))))))
+
+(deftest send-follow-up-email-no-survey-test
+  (testing "Make sure we don't send an email when no-surveys is true."
+   (mt/with-temporary-setting-values [anon-tracking-enabled true
+                                      follow-up-email-sent  false
+                                      no-surveys true]
+     (with-fake-inbox
+       (#'follow-up-emails/send-follow-up-email!)
+       (is (= 0
+              (-> @inbox vals first count)))))))


### PR DESCRIPTION
### Description

- changes the cron string to be every 2nd saturday of the month at 2 am.
- some alignment and doc string changes
- cleaning up some logic in adding the context to the survey redirect url and the `fetch-plan-info` logic
- fixing `log/error e` "string"
- Fix `send-creator-sentiment-emails!-test`
- Change `no-surveys` to `surveys-enabled`
