### PR TITLE
Add analytics events for browse data

### DIFF
--- a/e2e/support/cypress_sample_instance_data.js
+++ b/e2e/support/cypress_sample_instance_data.js
@@ -14,6 +14,10 @@ export const ORDERS_QUESTION_ID = _.findWhere(SAMPLE_INSTANCE_DATA.questions, {
   name: "Orders",
 }).id;
 
+export const ORDERS_MODEL_ID = _.findWhere(SAMPLE_INSTANCE_DATA.questions, {
+  name: "Orders Model",
+}).id;
+
 export const ORDERS_COUNT_QUESTION_ID = _.findWhere(
   SAMPLE_INSTANCE_DATA.questions,
   { name: "Orders, Count" },

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
@@ -1,8 +1,16 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";
-import { restore, setTokenFeatures , describeWithSnowplow, expectGoodSnowplowEvent, resetSnowplow, expectNoBadSnowplowEvents, enableTracking } from "e2e/support/helpers";
+import {
+  restore,
+  setTokenFeatures,
+  describeWithSnowplow,
+  expectGoodSnowplowEvent,
+  resetSnowplow,
+  expectNoBadSnowplowEvents,
+  enableTracking,
+} from "e2e/support/helpers";
 
-const {PRODUCTS_ID} = SAMPLE_DATABASE;
+const { PRODUCTS_ID } = SAMPLE_DATABASE;
 
 describeWithSnowplow("scenarios > browse data", () => {
   beforeEach(() => {
@@ -22,7 +30,7 @@ describeWithSnowplow("scenarios > browse data", () => {
     expectNoBadSnowplowEvents();
     expectGoodSnowplowEvent({
       event: "browse_data_model_clicked",
-      model_id: ORDERS_MODEL_ID
+      model_id: ORDERS_MODEL_ID,
     });
   });
   it("can browse to a table", () => {
@@ -36,9 +44,8 @@ describeWithSnowplow("scenarios > browse data", () => {
     expectNoBadSnowplowEvents();
     expectGoodSnowplowEvent({
       event: "browse_data_table_clicked",
-      table_id: PRODUCTS_ID
+      table_id: PRODUCTS_ID,
     });
-
   });
   it("can visit 'Learn about our data' page", () => {
     cy.visit("/");

--- a/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/home/browse.cy.spec.js
@@ -1,9 +1,15 @@
-import { restore, setTokenFeatures } from "e2e/support/helpers";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";
+import { restore, setTokenFeatures , describeWithSnowplow, expectGoodSnowplowEvent, resetSnowplow, expectNoBadSnowplowEvents, enableTracking } from "e2e/support/helpers";
 
-describe("scenarios > browse data", () => {
+const {PRODUCTS_ID} = SAMPLE_DATABASE;
+
+describeWithSnowplow("scenarios > browse data", () => {
   beforeEach(() => {
+    resetSnowplow();
     restore();
     cy.signInAsAdmin();
+    enableTracking();
   });
 
   it("can browse to a model", () => {
@@ -12,9 +18,14 @@ describe("scenarios > browse data", () => {
     cy.location("pathname").should("eq", "/browse/models");
     cy.findByTestId("browse-app").findByText("Browse data");
     cy.findByRole("heading", { name: "Orders Model" }).click();
-    cy.findByRole("button", { name: "Filter" });
+    cy.url().should("include", `/model/${ORDERS_MODEL_ID}-`);
+    expectNoBadSnowplowEvents();
+    expectGoodSnowplowEvent({
+      event: "browse_data_model_clicked",
+      model_id: ORDERS_MODEL_ID
+    });
   });
-  it("can browse to a database", () => {
+  it("can browse to a table", () => {
     cy.visit("/");
     cy.findByRole("listitem", { name: "Browse data" }).click();
     cy.findByRole("tab", { name: "Databases" }).click();
@@ -22,6 +33,12 @@ describe("scenarios > browse data", () => {
     cy.findByRole("heading", { name: "Products" }).click();
     cy.findByRole("button", { name: "Summarize" });
     cy.findByRole("link", { name: /Sample Database/ }).click();
+    expectNoBadSnowplowEvents();
+    expectGoodSnowplowEvent({
+      event: "browse_data_table_clicked",
+      table_id: PRODUCTS_ID
+    });
+
   });
   it("can visit 'Learn about our data' page", () => {
     cy.visit("/");

--- a/frontend/src/metabase/browse/analytics.ts
+++ b/frontend/src/metabase/browse/analytics.ts
@@ -1,0 +1,13 @@
+import { trackSchemaEvent } from "metabase/lib/analytics";
+
+export const trackModelClick = (modelId: number) =>
+  trackSchemaEvent("browse_data", "1-0-0", {
+    event: "browse_data_model_click",
+    model_id: modelId,
+  });
+
+export const trackTableClick = (tableId: number) =>
+  trackSchemaEvent("browse_data", "1-0-0", {
+    event: "browse_data_table_click",
+    table_id: tableId,
+  });

--- a/frontend/src/metabase/browse/analytics.ts
+++ b/frontend/src/metabase/browse/analytics.ts
@@ -2,12 +2,12 @@ import { trackSchemaEvent } from "metabase/lib/analytics";
 
 export const trackModelClick = (modelId: number) =>
   trackSchemaEvent("browse_data", "1-0-0", {
-    event: "browse_data_model_click",
+    event: "browse_data_model_clicked",
     model_id: modelId,
   });
 
 export const trackTableClick = (tableId: number) =>
   trackSchemaEvent("browse_data", "1-0-0", {
-    event: "browse_data_table_click",
+    event: "browse_data_table_clicked",
     table_id: tableId,
   });

--- a/frontend/src/metabase/browse/components/ModelGroup.tsx
+++ b/frontend/src/metabase/browse/components/ModelGroup.tsx
@@ -10,6 +10,7 @@ import type {
   CollectionEssentials,
 } from "metabase-types/api";
 
+import { trackModelClick } from "../analytics";
 import { getCollectionName, sortModels, getIcon } from "../utils";
 
 import {
@@ -190,6 +191,7 @@ const ModelCell = ({ model, collectionHtmlId }: ModelCellProps) => {
       aria-labelledby={`${collectionHtmlId} ${headingId}`}
       key={model.id}
       to={Urls.model(model as unknown as Partial<Card>)}
+      onClick={() => trackModelClick(model.id)}
     >
       <ModelCard>
         <Box mb="auto">

--- a/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.jsx
+++ b/frontend/src/metabase/browse/components/TableBrowser/TableBrowser.jsx
@@ -14,6 +14,7 @@ import {
   SAVED_QUESTIONS_VIRTUAL_DB_ID,
 } from "metabase-lib/metadata/utils/saved-questions";
 
+import { trackTableClick } from "../../analytics";
 import { BrowseHeaderContent } from "../BrowseHeader.styled";
 
 import {
@@ -64,6 +65,7 @@ const TableBrowser = ({
                 to={
                   !isSyncInProgress(table) ? getTableUrl(table, metadata) : ""
                 }
+                onClick={() => trackTableClick(table.id)}
               >
                 <TableBrowserItem
                   database={database}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/browse_data/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/browse_data/1-0-0
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Schema for tracking clicks on the Browse Data page",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "browse_data",
+    "format": "jsonschema",
+    "version": "1-0-0"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "browse_data_model_clicked",
+        "browse_data_table_clicked"
+      ],
+      "maxLength": 1024
+    },
+    "model_id": {
+      "description": "Unique identifier for the model within the Metabase instance",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "table_id": {
+      "description": "Unique identifier for the table within the Metabase instance",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    }
+  },
+  "required": ["event"],
+  "additionalProperties": true,
+  "oneOf": [
+    {
+      "required": ["model_id"]
+    },
+    {
+      "required": ["table_id"]
+    }
+  ]
+}

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/browse_data/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/browse_data/jsonschema/1-0-0
@@ -32,13 +32,5 @@
     }
   },
   "required": ["event"],
-  "additionalProperties": true,
-  "oneOf": [
-    {
-      "required": ["model_id"]
-    },
-    {
-      "required": ["table_id"]
-    }
-  ]
+  "additionalProperties": true
 }

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/browse_data/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/browse_data/jsonschema/1-0-0
@@ -20,13 +20,13 @@
     },
     "model_id": {
       "description": "Unique identifier for the model within the Metabase instance",
-      "type": "integer",
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 2147483647
     },
     "table_id": {
       "description": "Unique identifier for the table within the Metabase instance",
-      "type": "integer",
+      "type": ["integer", "null"],
       "minimum": 0,
       "maximum": 2147483647
     }

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -30,6 +30,7 @@
   "The most recent version for each event schema. This should be updated whenever a new version of a schema is added
   to SnowcatCloud, at the same time that the data sent to the collector is updated."
   {::account              "1-0-1"
+   ::browse_data          "1-0-0"
    ::invite               "1-0-1"
    ::csvupload            "1-0-0"
    ::dashboard            "1-1-3"
@@ -49,6 +50,8 @@
   "The schema to use for each analytics event."
   {::new-instance-created           ::account
    ::new-user-created               ::account
+   ::browse_data_model_clicked      ::browse_data
+   ::browse_data_table_clicked      ::browse_data
    ::invite-sent                    ::invite
    ::index-model-entities-enabled   ::model
    ::dashboard-created              ::dashboard


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/36368

Adds two Snowplow click tracking events to the Browse Data page, for clicks on models and tables, per @cdeweyx's [request](https://metaboat.slack.com/archives/C064EB1UE5P/p1705676820030029?thread_ts=1705674700.235379&cid=C064EB1UE5P)

- [x] add schema file
- [x] add to backend
- [x] add to frontend
- [x] add tests