### PR TITLE
[MLv2] Handle `Object.isFrozen()` legacy columns as input

### DIFF
--- a/frontend/src/metabase-lib/comparison.ts
+++ b/frontend/src/metabase-lib/comparison.ts
@@ -2,7 +2,7 @@ import * as ML from "cljs/metabase.lib.js";
 import type {
   DatasetColumn,
   DatasetQuery,
-  FieldReference,
+  DimensionReference,
 } from "metabase-types/api";
 
 import type { ColumnMetadata, Query } from "./types";
@@ -28,7 +28,7 @@ export function findColumnIndexesFromLegacyRefs(
   query: Query,
   stageIndex: number,
   columns: ColumnMetadata[] | DatasetColumn[],
-  fieldRefs: FieldReference[],
+  fieldRefs: DimensionReference[],
 ): number[] {
   return ML.find_column_indexes_from_legacy_refs(
     query,

--- a/frontend/src/metabase-lib/comparison.unit.spec.ts
+++ b/frontend/src/metabase-lib/comparison.unit.spec.ts
@@ -1,0 +1,29 @@
+import { freeze } from "immer";
+
+import { createMockMetadata } from "__support__/metadata";
+import * as Lib from "metabase-lib";
+import Question from "metabase-lib/Question";
+import { createMockCard } from "metabase-types/api/mocks";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+describe("findColumnIndexesFromLegacyRefs", () => {
+  const metadata = createMockMetadata({
+    databases: [createSampleDatabase()],
+  });
+
+  it("works even on frozen columns and refs", () => {
+    const card = createMockCard({});
+    const question = new Question(card, metadata);
+
+    const columns = question._legacyQuery().columns();
+
+    const frozen = freeze(columns, true /* deep */);
+    expect(Object.isFrozen(frozen[6])).toBe(true);
+    expect(Object.isFrozen(frozen[6].field_ref)).toBe(true);
+    expect(
+      Lib.findColumnIndexesFromLegacyRefs(question.query(), -1, frozen, [
+        frozen[6].field_ref,
+      ]),
+    ).toEqual([6]);
+  });
+});

--- a/frontend/src/metabase-lib/comparison.unit.spec.ts
+++ b/frontend/src/metabase-lib/comparison.unit.spec.ts
@@ -1,29 +1,30 @@
 import { freeze } from "immer";
 
-import { createMockMetadata } from "__support__/metadata";
 import * as Lib from "metabase-lib";
-import Question from "metabase-lib/Question";
-import { createMockCard } from "metabase-types/api/mocks";
-import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+import { createQuery } from "metabase-lib/test-helpers";
+import {
+  createOrdersTaxDatasetColumn,
+  createOrdersTotalDatasetColumn,
+} from "metabase-types/api/mocks/presets";
 
 describe("findColumnIndexesFromLegacyRefs", () => {
-  const metadata = createMockMetadata({
-    databases: [createSampleDatabase()],
-  });
-
   it("works even on frozen columns and refs", () => {
-    const card = createMockCard({});
-    const question = new Question(card, metadata);
+    const query = createQuery();
+    const stageIndex = -1;
+    const columns = freeze(
+      [createOrdersTotalDatasetColumn(), createOrdersTaxDatasetColumn()],
+      true,
+    );
 
-    const columns = question._legacyQuery().columns();
+    const columnIndexes = Lib.findColumnIndexesFromLegacyRefs(
+      query,
+      stageIndex,
+      columns,
+      columns.map(({ field_ref }) => field_ref!),
+    );
 
-    const frozen = freeze(columns, true /* deep */);
-    expect(Object.isFrozen(frozen[6])).toBe(true);
-    expect(Object.isFrozen(frozen[6].field_ref)).toBe(true);
-    expect(
-      Lib.findColumnIndexesFromLegacyRefs(question.query(), -1, frozen, [
-        frozen[6].field_ref,
-      ]),
-    ).toEqual([6]);
+    expect(Object.isFrozen(columns[0])).toBe(true);
+    expect(Object.isFrozen(columns[1])).toBe(true);
+    expect(columnIndexes).toEqual([0, 1]);
   });
 });

--- a/frontend/src/metabase-lib/queries/utils/dataset.ts
+++ b/frontend/src/metabase-lib/queries/utils/dataset.ts
@@ -1,4 +1,3 @@
-import cloneDeep from "lodash.clonedeep";
 import _ from "underscore";
 
 import * as Lib from "metabase-lib";
@@ -41,11 +40,8 @@ export function findColumnIndexForColumnSetting(
     const [columnIndex] = Lib.findColumnIndexesFromLegacyRefs(
       query,
       stageIndex,
-      // we make a deep clone to unfreeze objects as
-      // cljs adds a unique id to every object
-      // and it's not possible with frozen objects
-      cloneDeep(columns),
-      [cloneDeep(normalizedFieldRef)],
+      columns,
+      [normalizedFieldRef],
     );
 
     if (columnIndex >= 0) {


### PR DESCRIPTION
`cljs.core/hash` mutates vanilla JS arrays to attach a UID to them for
hashing purposes. Before this change, given a `DatasetColumn` with a
frozen `field_ref` array, we would use it directly on the
`:metadata/column`, and `(hash column)` would try to mutate the frozen
array and throw.

This clones the array while converting the legacy column to MLv2 form,
so there's no issue with mutating it.

Fixes the `closure_uid_123456789` issue.
