### PR TITLE
Mitigate BE flakes caused by redshift-lbv-sync-error-test and redshift-types-test

### DIFF
--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -235,7 +235,7 @@
              qual-tbl-nm
              qual-view-nm)
             ;; sync the schema again to pick up the new view (and table, though we aren't checking that)
-            (sync/sync-database! database)
+            (sync/sync-database! database {:scan :schema})
             (is (contains?
                  (t2/select-fn-set :name Table :db_id (u/the-id database)) ; the new view should have been synced
                  view-nm))
@@ -269,7 +269,7 @@
                   "CASE WHEN shop_status = 'open' THEN 11387.133 END AS case_when_numeric_inc_nulls "
                   "FROM test_data) WITH NO SCHEMA BINDING;")
              qual-view-nm)
-            (sync/sync-database! database)
+            (sync/sync-database! database {:scan :schema})
             (is (contains?
                  (t2/select-fn-set :name Table :db_id (u/the-id database)) ; the new view should have been synced without errors
                  view-nm))


### PR DESCRIPTION
This PR hopefully mitigates flakes on redshift in parallel tests.

I've seen a few flakes like [this](https://github.com/metabase/metabase/actions/runs/7991986113/job/21853226941?pr=39011#step:3:991) where the views / tables that are created in these tests are being picked up in other tests.

See this error output:

```
ERROR in metabase.query-processor-test.date-bucketing-test/filter-by-expression-time-interval-test (get_or_create.clj:159)
Uncaught exception, not in assertion.

                clojure.lang.ExceptionInfo: Failed to create :redshift 'checkins_interval_86400' test database: Failed to sync test database "checkins_interval_86400": Error in sync step Sync redshift Database 458 ''checkins_interval_86400'': Error in sync step Sync metadata for redshift Database 458 ''checkins_interval_86400'': ERROR: relation "2024_02_22_f82431ee_73f5_4652_a3f6_02a8caad6c85_schema.late_binding_view" does not exist
```

I suspect the problem is a race condition with parallel tests. This PR shortens the time it takes for the test to run, hopefully decreasing the likelihood that another parallel test will collide with it. After I'm done with escalations I'll circle back and fix the race conditions.