### PR TITLE
FE - Migrate dataset: true to enum value in Card autocomplete suggestions

### DIFF
--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.tsx
@@ -64,6 +64,7 @@ import { ACE_ELEMENT_ID, SCROLL_MARGIN, MIN_HEIGHT_LINES } from "./constants";
 import {
   calcInitialEditorHeight,
   formatQuery,
+  getAutocompleteResultMeta,
   getEditorLineHeight,
   getMaxAutoSizeLines,
 } from "./utils";
@@ -71,11 +72,7 @@ import {
 const AUTOCOMPLETE_DEBOUNCE_DURATION = 700;
 const AUTOCOMPLETE_CACHE_DURATION = AUTOCOMPLETE_DEBOUNCE_DURATION * 1.2; // tolerate 20%
 
-type CardCompletionItem = Pick<Card, "id" | "name"> & {
-  /**
-   * TODO: migrate `dataset` to `type` attribute
-   */
-  dataset: boolean;
+type CardCompletionItem = Pick<Card, "id" | "name" | "type"> & {
   collection_name: string;
 };
 
@@ -618,16 +615,15 @@ export class NativeQueryEditor extends Component<
       callback(null, []);
     }
     const apiResults = await this.props.cardAutocompleteResultsFn(prefix);
+
     const resultsForAce = apiResults.map(
-      ({ id, name, dataset, collection_name }) => {
+      ({ id, name, type, collection_name }) => {
         const collectionName = collection_name || t`Our analytics`;
         return {
           name: `${id}-${slugg(name)}`,
           value: `${id}-${slugg(name)}`,
-          meta: dataset
-            ? t`Model in ${collectionName}`
-            : t`Question in ${collectionName}`,
-          score: dataset ? 100000 : 0, // prioritize models above questions
+          meta: getAutocompleteResultMeta(type, collectionName),
+          score: type === "model" ? 100000 : 0, // prioritize models above questions
         };
       },
     );

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/utils.ts
@@ -1,9 +1,11 @@
 import type { FormatOptionsWithLanguage, SqlLanguage } from "sql-formatter";
+import { t } from "ttag";
 
 import { getEngineNativeType } from "metabase/lib/engine";
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
+import type { CardType } from "metabase-types/api";
 
-import { SCROLL_MARGIN, MIN_HEIGHT_LINES } from "./constants";
+import { MIN_HEIGHT_LINES, SCROLL_MARGIN } from "./constants";
 
 const LINE_HEIGHT = 16;
 
@@ -113,3 +115,18 @@ export function formatQuery(queryText: string, engine: string) {
     },
   });
 }
+
+export const getAutocompleteResultMeta = (
+  type: CardType,
+  collectionName: string,
+) => {
+  if (type === "question") {
+    return t`Question in ${collectionName}`;
+  }
+
+  if (type === "model") {
+    return t`Model in ${collectionName}`;
+  }
+
+  throw new Error(`Unknown question.type(): ${type}`);
+};


### PR DESCRIPTION
Closes #38808

Depends on #38981

### Description

The [target PR](https://github.com/metabase/metabase/pull/38981) has some failing tests, that's why this PR does not pass CI 100%.
However, this PR should make `E2E Tests / e2e-tests-native-ee` suite pass.