### PR TITLE
add support for networking errors in the token validation endpoint

### DIFF
--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
@@ -17,7 +17,7 @@ export const LicenseTokenForm = ({
 }: LicenseTokenFormProps) => {
   const [token, setToken] = useState(initialValue);
   const [status, setStatus] = useState<
-    "idle" | "loading" | "success" | "error"
+    "idle" | "loading" | "success" | "invalid_token" | "unable_to_validate"
   >("idle");
 
   const isInputCorrectLength = token.length === 64;
@@ -29,11 +29,13 @@ export const LicenseTokenForm = ({
       if (response.valid) {
         setStatus("success");
         onValidSubmit(token);
+      } else if (response.error_code === "unable_to_validate") {
+        setStatus("unable_to_validate");
       } else {
-        setStatus("error");
+        setStatus("invalid_token");
       }
     } catch (e) {
-      setStatus("error");
+      setStatus("unable_to_validate");
     }
   };
 
@@ -50,10 +52,16 @@ export const LicenseTokenForm = ({
               oldState !== "loading" ? "idle" : "loading",
             );
           }}
-          error={status === "error"}
+          error={status === "invalid_token"}
         />
-        {status === "error" && (
+        {status === "invalid_token" && (
           <Text color="error">{t`This token doesn’t seem to be valid. Double-check it, then contact support if you think it should be working`}</Text>
+        )}
+        {status === "unable_to_validate" && (
+          <>
+            <Text color="error">{t`We couldn’t connect to our servers to activate the license. Please try again.`}</Text>
+            <Text color="error">{t`You can also set this up at a later time in settings.`}</Text>
+          </>
         )}
       </Box>
       <Flex gap="lg">

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
@@ -52,7 +52,7 @@ export const LicenseTokenForm = ({
               oldState !== "loading" ? "idle" : "loading",
             );
           }}
-          error={status === "invalid_token"}
+          error={["invalid_token", "unable_to_validate"].includes(status)}
         />
         {status === "invalid_token" && (
           <Text color="error">{t`This token doesn’t seem to be valid. Double-check it, then contact support if you think it should be working`}</Text>

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -228,6 +228,34 @@ describe("setup (EE, no token)", () => {
         license_token: sampleToken,
       });
     });
+
+    it("should handle a response with error_code `unable_to_validate`", async () => {
+      await setupForLicenseStep();
+
+      setupForTokenCheckEndpoint({
+        valid: false,
+        error_code: "unable_to_validate",
+      });
+
+      userEvent.paste(
+        screen.getByRole("textbox", { name: "Token" }),
+        sampleToken,
+      );
+
+      screen.getByRole("button", { name: "Activate" }).click();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Activate" }),
+        ).not.toHaveProperty("data-loading", true);
+      });
+
+      expect(
+        screen.getByText(
+          "We couldn’t connect to our servers to activate the license. Please try again. You can also set this up at a later time in settings.",
+        ),
+      ).toBeInTheDocument();
+    });
   });
 });
 

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -252,7 +252,7 @@ describe("setup (EE, no token)", () => {
 
       expect(
         screen.getByText(
-          "We couldn’t connect to our servers to activate the license. Please try again. You can also set this up at a later time in settings.",
+          "We couldn’t connect to our servers to activate the license. Please try again.",
         ),
       ).toBeInTheDocument();
     });

--- a/frontend/test/__support__/server-mocks/setup.ts
+++ b/frontend/test/__support__/server-mocks/setup.ts
@@ -10,6 +10,9 @@ export function setupAdminCheckListEndpoint(items: SetupCheckListItem[]) {
   fetchMock.get("path:/api/setup/admin_checklist", items);
 }
 
-export function setupForTokenCheckEndpoint(response: { valid: boolean }) {
+export function setupForTokenCheckEndpoint(response: {
+  valid: boolean;
+  error_code?: string;
+}) {
   fetchMock.get("path:/api/setup/token-check", response);
 }

--- a/src/metabase/api/setup.clj
+++ b/src/metabase/api/setup.clj
@@ -360,6 +360,6 @@
             (tru "This endpoint can only be used before the initial setup.")
             {:status-code 403}))
     (let [status (premium-features/fetch-token-status token)]
-      {:valid (:valid status)})))
+      (select-keys status [:valid :error_code] ))))
 
 (api/define-routes)

--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -151,6 +151,7 @@
                         (or
                           body
                           {:valid         false
+                           :error_code    :unable_to_validate
                            :status        (tru "Unable to validate token")
                            :error-details (.getMessage e1)}))))))))))
 

--- a/test/metabase/public_settings/premium_features_test.clj
+++ b/test/metabase/public_settings/premium_features_test.clj
@@ -58,6 +58,7 @@
                                  ;; throw an ex-info here
                                  (throw (Exception. "network issues")))]
           (is (= {:valid         false
+                  :error_code    :unable_to_validate
                   :status        "Unable to validate token"
                   :error-details "network issues"}
                  (premium-features/fetch-token-status (apply str (repeat 64 "b")))))))


### PR DESCRIPTION
Part of [[Epic] Add license activation in the initial setup](https://github.com/metabase/metabase/issues/38867)

Follow up to  [adds /api/setup/token-check and add license-token to POST /api/setup](https://github.com/metabase/metabase/pull/38858) to allow us to tell between invalid token and an error while trying to validate it.

This changes the backend to return `error_code: "unable_to_validate"` when there's a network error or it's impossible to validate the token for other reasons.

The FE will display a custom error ([design on figma](https://www.figma.com/file/UFay4YjWyUMyl23T1cXzeC/Meet-first-time-embedders-at-the-door-with-a-dashboard?type=design&node-id=1757-9917&mode=design&t=LRD239xZS9jD37p7-4))


Note: this is stacked on top of the [frontend PR](https://github.com/metabase/metabase/pull/38953) which is still waiting review