### PR TITLE
Clean QueryBuilder props [PoC]

### DIFF
--- a/frontend/src/metabase/query_builder/components/QueryModals.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.tsx
@@ -8,7 +8,7 @@ import QuestionSavedModal from "metabase/components/QuestionSavedModal";
 import { ConnectedAddToDashSelectDashModal } from "metabase/containers/AddToDashSelectDashModal";
 import { CollectionMoveModal } from "metabase/containers/CollectionMoveModal";
 import { SaveQuestionModal } from "metabase/containers/SaveQuestionModal";
-import { ROOT_COLLECTION } from "metabase/entities/collections";
+import Collections, { ROOT_COLLECTION } from "metabase/entities/collections";
 import EntityCopyModal from "metabase/entities/containers/EntityCopyModal";
 import Questions from "metabase/entities/questions";
 import { CreateAlertModalContent } from "metabase/query_builder/components/AlertModals";
@@ -40,8 +40,12 @@ const mapDispatchToProps = {
   setQuestionCollection: Questions.actions.setCollection,
 };
 
-const mapStateToProps = (state: State) => ({
+const mapStateToProps = (state: State, props: QueryModalsProps) => ({
   questionWithParameters: getQuestionWithParameters(state) as Question,
+  initialCollectionId: Collections.selectors.getInitialCollectionId(
+    state,
+    props,
+  ),
 });
 
 type ModalType = typeof MODAL_TYPES[keyof typeof MODAL_TYPES];

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -49,7 +49,6 @@ import {
   getParameters,
   getDatabaseFields,
   getSampleDatabaseId,
-  getNativeDatabases,
   getIsRunnable,
   getIsResultDirty,
   getMode,
@@ -114,7 +113,6 @@ const mapStateToProps = (state, props) => {
     card: getCard(state),
     originalCard: getOriginalCard(state),
     databases: getDatabasesList(state),
-    nativeDatabases: getNativeDatabases(state),
     tables: getTables(state),
 
     metadata: getMetadata(state),

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -8,7 +8,6 @@ import _ from "underscore";
 
 import { LeaveConfirmationModal } from "metabase/components/LeaveConfirmationModal";
 import Bookmark from "metabase/entities/bookmarks";
-import Collections from "metabase/entities/collections";
 import Timelines from "metabase/entities/timelines";
 import favicon from "metabase/hoc/Favicon";
 import title from "metabase/hoc/Title";
@@ -161,10 +160,6 @@ const mapStateToProps = (state, props) => {
     autocompleteResultsFn: getAutocompleteResultsFn(state),
     cardAutocompleteResultsFn: getCardAutocompleteResultsFn(state),
 
-    initialCollectionId: Collections.selectors.getInitialCollectionId(
-      state,
-      props,
-    ),
     queryStartTime: getQueryStartTime(state),
     nativeEditorCursorOffset: getNativeEditorCursorOffset(state),
     nativeEditorSelectedText: getNativeEditorSelectedText(state),

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -211,12 +211,6 @@ export const getTables = createSelector(
   },
 );
 
-export const getNativeDatabases = createSelector(
-  [getDatabasesList],
-  databases =>
-    databases && databases.filter(db => db.native_permissions === "write"),
-);
-
 export const getTableMetadata = createSelector(
   [getTableId, getMetadata],
   (tableId, metadata) => metadata.table(tableId),


### PR DESCRIPTION
This PR is just a PoC, and a preview of what we could (should?) do with the QueryBuilder.
It currently fetches way more data than it needs, and stores it in props . This leads to prop drilling that's hard to track.

We can identify where some of these props are used and move the fetching logic closer to the place it's needed.
By doing this examination, we might also find some completely unused props, like it happened [here](https://github.com/metabase/metabase/pull/39070/commits/ac20ea224d784ba48aac66204afd161b1189721a).