### PR TITLE
Fix applying default values for a pinned question

### DIFF
--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -13,7 +13,7 @@ import {
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 
-const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+const { ORDERS, ORDERS_ID, PEOPLE } = SAMPLE_DATABASE;
 
 const DASHBOARD_NAME = "Orders in a dashboard";
 const QUESTION_NAME = "Orders, Count";
@@ -66,7 +66,7 @@ const SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE = {
         id: "4b77cc1f-ea70-4ef6-84db-58432fce6928",
         "display-name": "date",
         default: "1999-02-26~2024-02-26",
-        dimension: ["field", 35 /* PEOPLE.BIRTH_DATE */, null],
+        dimension: ["field", PEOPLE.BIRTH_DATE, null],
         "widget-type": "date/range",
       },
     },

--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -66,7 +66,7 @@ const SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE = {
         id: "4b77cc1f-ea70-4ef6-84db-58432fce6928",
         "display-name": "date",
         default: "1999-02-26~2024-02-26",
-        dimension: ["field", 18 /* PEOPLE.BIRTH_DATE */, null],
+        dimension: ["field", 35 /* PEOPLE.BIRTH_DATE */, null],
         "widget-type": "date/range",
       },
     },

--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -55,6 +55,25 @@ const SQL_QUESTION_DETAILS = {
   },
 };
 
+const SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE = {
+  name: "SQL with parameters",
+  display: "scalar",
+  native: {
+    "template-tags": {
+      filter: {
+        type: "dimension",
+        name: "filter",
+        id: "4b77cc1f-ea70-4ef6-84db-58432fce6928",
+        "display-name": "date",
+        default: "1999-02-26~2024-02-26",
+        dimension: ["field", 18 /* PEOPLE.BIRTH_DATE */, null],
+        "widget-type": "date/range",
+      },
+    },
+    query: "select count(*) from people where {{filter}}",
+  },
+};
+
 describe("scenarios > collection pinned items overview", () => {
   beforeEach(() => {
     restore();
@@ -222,6 +241,22 @@ describe("scenarios > collection pinned items overview", () => {
     getPinnedSection().within(() => {
       cy.findByText(SQL_QUESTION_DETAILS.name).should("be.visible");
       cy.findByText("A question").should("be.visible");
+    });
+  });
+
+  it("should apply default value of variable for pinned native questions (metabase#37831)", () => {
+    cy.createNativeQuestion(SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE).then(
+      ({ body: { id } }) => {
+        cy.request("PUT", `/api/card/${id}`, { collection_position: 1 });
+      },
+    );
+
+    openRootCollection();
+    getPinnedSection().within(() => {
+      cy.findByText(SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE.name).should(
+        "be.visible",
+      );
+      cy.findByTestId("scalar-value").should("have.text", "68");
     });
   });
 

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -1090,12 +1090,13 @@ class Question {
     return question;
   }
 
-  // TODO: Fix incorrect Flow signature
-  parameters(): ParameterObject[] {
+  parameters({ collectionPreview } = {}): ParameterObject[] {
     return getCardUiParameters(
       this.card(),
       this.metadata(),
       this._parameterValues,
+      undefined,
+      collectionPreview,
     );
   }
 

--- a/frontend/src/metabase-lib/parameters/utils/cards.ts
+++ b/frontend/src/metabase-lib/parameters/utils/cards.ts
@@ -14,6 +14,7 @@ export function getCardUiParameters(
   metadata: Metadata,
   parameterValues: { [key: string]: any } = {},
   parameters = getParametersFromCard(card),
+  collectionPreview = false,
 ): UiParameter[] {
   if (!card) {
     return [];
@@ -21,7 +22,11 @@ export function getCardUiParameters(
 
   const valuePopulatedParameters: (Parameter[] | ParameterWithTarget[]) & {
     value?: any;
-  } = getValuePopulatedParameters(parameters, parameterValues);
+  } = getValuePopulatedParameters(
+    parameters,
+    parameterValues,
+    collectionPreview,
+  );
   const question = new Question(card, metadata);
 
   return valuePopulatedParameters.map(parameter => {

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -14,20 +14,11 @@ export function getValuePopulatedParameters(
   parameterValues,
   collectionPreview,
 ) {
-  // when it's collection preview (pinned question), we cannot use URL to get
-  // parameter values without value populated in other cases `value: null` will
-  // be handled on BE
+  // pinned native question can have default values on parameters, usually we
+  // get them from URL, which is not the case for collection preview. to force
+  // BE to apply default values to those filters, empty array is provided
   if (collectionPreview) {
-    return parameterValues
-      ? parameters.map(parameter => {
-          return parameter.id in parameterValues
-            ? {
-                ...parameter,
-                value: parameterValues[parameter.id],
-              }
-            : parameter;
-        })
-      : parameters;
+    return [];
   }
 
   return parameters.map(parameter => ({

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -9,7 +9,27 @@ import {
 export const PULSE_PARAM_EMPTY = null;
 export const PULSE_PARAM_USE_DEFAULT = undefined;
 
-export function getValuePopulatedParameters(parameters, parameterValues) {
+export function getValuePopulatedParameters(
+  parameters,
+  parameterValues,
+  collectionPreview,
+) {
+  // when it's collection preview (pinned question), we cannot use URL to get
+  // parameter values without value populated in other cases `value: null` will
+  // be handled on BE
+  if (collectionPreview) {
+    return parameterValues
+      ? parameters.map(parameter => {
+          return parameter.id in parameterValues
+            ? {
+                ...parameter,
+                value: parameterValues[parameter.id],
+              }
+            : parameter;
+        })
+      : parameters;
+  }
+
   return parameters.map(parameter => ({
     ...parameter,
     value: parameterValues?.[parameter.id] ?? null,

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -93,7 +93,9 @@ export async function runQuestionQuery(
   } = {},
 ) {
   const canUseCardApiEndpoint = !isDirty && question.isSaved();
-  const parameters = normalizeParameters(question.parameters());
+  const parameters = normalizeParameters(
+    question.parameters({ collectionPreview }),
+  );
   const card = question.card();
 
   if (canUseCardApiEndpoint) {


### PR DESCRIPTION
should fix #37831 in v48, but not in master

### Description

https://github.com/metabase/metabase/pull/31891 changed the way of preparing parameters for BE - we started adding `{value: null}` if value wasn't presented.

> The point of the change is so we can differentiate between value: null (which means the no value should be applied even if it has a default) and the absence of a value key (which means we should apply the default value)

That comment made me think there could be a problem of handling cases like this on BE.

This PR adds a check whether it's collection preview or not, uses old way of calculating parameters (with value: null) for collection preview and the way introduced in #31891 for other cases.

Code in master has changed comparing to v48, so we need to provide a slightly different solution there