### PR TITLE
Show filters without values in fullscreen mode

### DIFF
--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -90,12 +90,18 @@ export const CardsContainer = styled(FullWidthContainer)`
   margin-top: 8px;
 `;
 
+function getParametersWidgetBgColor(isNightMode: boolean) {
+  return isNightMode ? color("bg-black") : color("bg-light");
+}
+
 export const ParametersWidgetContainer = styled(FullWidthContainer)<{
   isSticky: boolean;
   hasScroll: boolean;
+  isNightMode: boolean;
 }>`
-  background-color: ${color("bg-light")};
-  border-bottom: 1px solid ${color("bg-light")};
+  background-color: ${props => getParametersWidgetBgColor(props.isNightMode)};
+  border-bottom: 1px solid
+    ${props => getParametersWidgetBgColor(props.isNightMode)};
   padding-top: ${space(1)};
   padding-bottom: ${space(1)};
   /* z-index should be higher than in dashcards */
@@ -104,12 +110,12 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
   left: 0;
 
   /* isSticky is calculated mostly for border showing, otherwise it could be replaced with css only */
-  ${({ isSticky, hasScroll }) =>
+  ${({ isNightMode, isSticky, hasScroll }) =>
     isSticky &&
     css`
       position: sticky;
       border-bottom: 1px solid
-        ${hasScroll ? color("border") : color("bg-light")};
+        ${hasScroll ? color("border") : getParametersWidgetBgColor(isNightMode)};
     `}
 `;
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.styled.tsx
@@ -109,6 +109,9 @@ export const ParametersWidgetContainer = styled(FullWidthContainer)<{
   top: 0;
   left: 0;
 
+  transition: background-color 1s linear, border-color 1s linear,
+    color 1s linear;
+
   /* isSticky is calculated mostly for border showing, otherwise it could be replaced with css only */
   ${({ isNightMode, isSticky, hasScroll }) =>
     isSticky &&

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -467,6 +467,45 @@ function DashboardInner(props: DashboardProps) {
     />
   );
 
+  const renderParameterList = () => {
+    if (!hasVisibleParameters) {
+      return null;
+    }
+
+    if (isEditing) {
+      return (
+        <ParametersWidgetContainer
+          hasScroll
+          isSticky
+          data-testid="edit-dashboard-parameters-widget-container"
+        >
+          <FixedWidthContainer
+            isFixedWidth={dashboard?.width === "fixed"}
+            data-testid="fixed-width-filters"
+          >
+            {parametersWidget}
+          </FixedWidthContainer>
+        </ParametersWidgetContainer>
+      );
+    }
+
+    return (
+      <ParametersWidgetContainer
+        hasScroll={hasScroll}
+        isSticky={isParametersWidgetContainersSticky(visibleParameters.length)}
+        data-testid="dashboard-parameters-widget-container"
+      >
+        <ParametersFixedWidthContainer
+          isFixedWidth={dashboard?.width === "fixed"}
+          data-testid="fixed-width-filters"
+        >
+          {parametersWidget}
+          <FilterApplyButton />
+        </ParametersFixedWidthContainer>
+      </ParametersWidgetContainer>
+    );
+  };
+
   return (
     <DashboardLoadingAndErrorWrapper
       isFullHeight={isEditing || isSharing}
@@ -503,37 +542,7 @@ function DashboardInner(props: DashboardProps) {
                 !isFullscreen && (isEditing || isSharing)
               }
             >
-              {isEditing && hasVisibleParameters && (
-                <ParametersWidgetContainer
-                  data-testid="edit-dashboard-parameters-widget-container"
-                  hasScroll={true}
-                  isSticky={true}
-                >
-                  <FixedWidthContainer
-                    isFixedWidth={dashboard?.width === "fixed"}
-                    data-testid="fixed-width-filters"
-                  >
-                    {parametersWidget}
-                  </FixedWidthContainer>
-                </ParametersWidgetContainer>
-              )}
-              {!isEditing && hasVisibleParameters && (
-                <ParametersWidgetContainer
-                  data-testid="dashboard-parameters-widget-container"
-                  hasScroll={hasScroll}
-                  isSticky={isParametersWidgetContainersSticky(
-                    visibleParameters.length,
-                  )}
-                >
-                  <ParametersFixedWidthContainer
-                    isFixedWidth={dashboard?.width === "fixed"}
-                    data-testid="fixed-width-filters"
-                  >
-                    {parametersWidget}
-                    <FilterApplyButton />
-                  </ParametersFixedWidthContainer>
-                </ParametersWidgetContainer>
-              )}
+              {renderParameterList()}
               <CardsContainer id="Dashboard-Cards-Container">
                 {renderContent()}
               </CardsContainer>

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -274,12 +274,6 @@ function DashboardInner(props: DashboardProps) {
 
   const shouldRenderAsNightMode = isNightMode && isFullscreen;
 
-  const shouldRenderParametersWidgetInViewMode =
-    !isEditing && hasVisibleParameters;
-
-  const shouldRenderParametersWidgetInEditMode =
-    isEditing && hasVisibleParameters;
-
   const handleSetDashboardAttribute = useCallback(
     <Key extends keyof IDashboard>(attribute: Key, value: IDashboard[Key]) => {
       setDashboardAttributes({
@@ -509,7 +503,7 @@ function DashboardInner(props: DashboardProps) {
                 !isFullscreen && (isEditing || isSharing)
               }
             >
-              {shouldRenderParametersWidgetInEditMode && (
+              {isEditing && hasVisibleParameters && (
                 <ParametersWidgetContainer
                   data-testid="edit-dashboard-parameters-widget-container"
                   hasScroll={true}
@@ -523,7 +517,7 @@ function DashboardInner(props: DashboardProps) {
                   </FixedWidthContainer>
                 </ParametersWidgetContainer>
               )}
-              {shouldRenderParametersWidgetInViewMode && (
+              {!isEditing && hasVisibleParameters && (
                 <ParametersWidgetContainer
                   data-testid="dashboard-parameters-widget-container"
                   hasScroll={hasScroll}

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -497,7 +497,6 @@ function DashboardInner(props: DashboardProps) {
               onEditingChange={handleSetEditing}
               setDashboardAttribute={handleSetDashboardAttribute}
               addParameter={addParameter}
-              parametersWidget={parametersWidget}
               onSharingClick={handleToggleSharing}
             />
           </DashboardHeaderContainer>

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -275,7 +275,7 @@ function DashboardInner(props: DashboardProps) {
   const shouldRenderAsNightMode = isNightMode && isFullscreen;
 
   const shouldRenderParametersWidgetInViewMode =
-    !isEditing && !isFullscreen && hasVisibleParameters;
+    !isEditing && hasVisibleParameters;
 
   const shouldRenderParametersWidgetInEditMode =
     isEditing && hasVisibleParameters;

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -477,6 +477,7 @@ function DashboardInner(props: DashboardProps) {
         <ParametersWidgetContainer
           hasScroll
           isSticky
+          isNightMode={shouldRenderAsNightMode}
           data-testid="edit-dashboard-parameters-widget-container"
         >
           <FixedWidthContainer
@@ -492,6 +493,7 @@ function DashboardInner(props: DashboardProps) {
     return (
       <ParametersWidgetContainer
         hasScroll={hasScroll}
+        isNightMode={shouldRenderAsNightMode}
         isSticky={isParametersWidgetContainersSticky(visibleParameters.length)}
         data-testid="dashboard-parameters-widget-container"
       >

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -1,5 +1,5 @@
 import type { Location, LocationDescriptor } from "history";
-import type { MouseEvent, ReactNode } from "react";
+import type { MouseEvent } from "react";
 import { Component, Fragment } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
@@ -95,7 +95,6 @@ interface OwnProps {
   isAddParameterPopoverOpen: boolean;
   canManageSubscriptions: boolean;
   hasNightModeToggle: boolean;
-  parametersWidget: ReactNode;
 
   addCardToDashboard: (opts: {
     dashId: DashboardId;
@@ -338,7 +337,6 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
   getHeaderButtons() {
     const {
       dashboard,
-      parametersWidget,
       isBookmarked,
       isEditing,
       isFullscreen,
@@ -364,10 +362,6 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
 
     const buttons = [];
     const extraButtons = [];
-
-    if (isFullscreen && parametersWidget) {
-      buttons.push(parametersWidget);
-    }
 
     if (isEditing) {
       const activeSidebarName = sidebar.name;

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
@@ -124,13 +124,9 @@ export class ParameterWidget extends Component {
     );
 
     if (isFullscreen) {
-      if (parameter.value != null) {
-        return (
-          <div style={{ fontSize: "0.833em" }}>{renderFieldInNormalMode()}</div>
-        );
-      } else {
-        return <span className="hide" />;
-      }
+      return (
+        <div style={{ fontSize: "0.833em" }}>{renderFieldInNormalMode()}</div>
+      );
     } else if (isEditing && setEditingParameter) {
       return renderEditing();
     } else {


### PR DESCRIPTION
Fixes #35038

### To reproduce

1. Open a dashboard with filters
2. Set a value for a few filters and leave a few more empty
3. Enter fullscreen mode (click "More" at the top right and then "Fullscreen")
4. Ensure you can see all filters (with and without values)

### Demo

![full-screen-new](https://github.com/metabase/metabase/assets/17258145/35f8318b-6e86-4e0a-ac24-df7fb873b30c)
