### PR TITLE
Small bug fixes with data perms schema change

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5752,7 +5752,7 @@ databaseChangeLog:
       comment: Clear data permission paths
       changes:
         - sql: >-
-            DELETE FROM permissions WHERE object LIKE '/db/%' OR object LIKE '/block/db/%' OR object LIKE '/data/%' OR object LIKE '/query/%';
+            DELETE FROM permissions WHERE object LIKE '%/db/%';
       rollback: # not needed; handled by the permission migrations above
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5752,7 +5752,7 @@ databaseChangeLog:
       comment: Clear data permission paths
       changes:
         - sql: >-
-            DELETE FROM permissions WHERE object LIKE '/db/%' OR object LIKE '/data/%' OR object LIKE '/query/%';
+            DELETE FROM permissions WHERE object LIKE '/db/%' OR object LIKE '/block/db/%' OR object LIKE '/data/%' OR object LIKE '/query/%';
       rollback: # not needed; handled by the permission migrations above
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/permissions/rollback/data_access.sql
+++ b/resources/migrations/permissions/rollback/data_access.sql
@@ -1,4 +1,5 @@
 DELETE FROM permissions WHERE object LIKE '/db/%' AND object NOT LIKE '/db/%/native/';
+DELETE FROM permissions WHERE object LIKE '/block/db/%';
 
 INSERT INTO permissions (object, group_id)
 SELECT concat('/db/', dp.db_id, '/schema/'),

--- a/resources/migrations/permissions/rollback/download_results.sql
+++ b/resources/migrations/permissions/rollback/download_results.sql
@@ -1,4 +1,4 @@
-DELETE FROM permissions WHERE object LIKE '/download/db/%';
+DELETE FROM permissions WHERE object LIKE '/download/%';
 
 INSERT INTO permissions (object, group_id)
 SELECT concat('/download/db/', dp.db_id, '/'),


### PR DESCRIPTION
* Ensure we delete old block permission paths as part of cleanup and before doing a rollback
  * Edit: changed to just delete `%/db/%` which should be comprehensive
* Remove `:native :full` download perms from the admin graph since that key is not necessary
* Make sure admin perm graph respects the `audit?` option