### PR TITLE
Allow binning field refs from expressions

### DIFF
--- a/src/metabase/query_processor/middleware/binning.clj
+++ b/src/metabase/query_processor/middleware/binning.clj
@@ -18,29 +18,29 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private FieldID->Filters
-  [:map-of [:ref ::lib.schema.id/field] [:sequential mbql.s/Filter]])
+(def ^:private FieldIDOrName->Filters
+  [:map-of [:or ::lib.schema.id/field ::lib.schema.common/non-blank-string] [:sequential mbql.s/Filter]])
 
-(mu/defn ^:private filter->field-map :- FieldID->Filters
-  "Find any comparison or `:between` filter and return a map of referenced Field ID -> all the clauses the reference
+(mu/defn ^:private filter->field-map :- FieldIDOrName->Filters
+  "Find any comparison or `:between` filter and return a map of referenced Field ID or Name -> all the clauses the reference
   it."
   [filter-clause :- [:maybe mbql.s/Filter]]
   (reduce
    (partial merge-with concat)
    {}
    (for [subclause (mbql.u/match filter-clause #{:between :< :<= :> :>=})
-         field-id  (mbql.u/match subclause [:field (field-id :guard integer?) _] field-id)]
-     {field-id [subclause]})))
+         field-id-or-name (mbql.u/match subclause [:field field-id-or-name _] field-id-or-name)]
+     {field-id-or-name [subclause]})))
 
 (mu/defn ^:private extract-bounds :- [:map [:min-value number?] [:max-value number?]]
   "Given query criteria, find a min/max value for the binning strategy using the greatest user specified min value and
   the smallest user specified max value. When a user specified min or max is not found, use the global min/max for the
   given field."
-  [field-id          :- [:maybe ::lib.schema.common/positive-int]
+  [field-id-or-name  :- [:maybe [:or ::lib.schema.id/field ::lib.schema.common/non-blank-string]]
    fingerprint       :- [:maybe :map]
-   field-id->filters :- FieldID->Filters]
+   field-id-or-name->filters :- FieldIDOrName->Filters]
   (let [{global-min :min, global-max :max} (get-in fingerprint [:type :type/Number])
-        filter-clauses                     (get field-id->filters field-id)
+        filter-clauses                     (get field-id-or-name->filters field-id-or-name)
         ;; [:between <field> <min> <max>] or [:< <field> <x>]
         user-maxes                         (mbql.u/match filter-clauses
                                              [(_ :guard #{:< :<= :between}) & args] (last args))
@@ -54,8 +54,8 @@
                                                global-max)]
     (when-not (and min-value max-value)
       (throw (ex-info (tru "Unable to bin Field without a min/max value (missing or incomplete fingerprint)")
-               {:type        qp.error-type/invalid-query
-                :field-id    field-id
+               {:type qp.error-type/invalid-query
+                :field-id-or-name field-id-or-name
                 :fingerprint fingerprint})))
     {:min-value min-value, :max-value max-value}))
 
@@ -96,12 +96,12 @@
   and calculate the number of bins and bin width for this field. `field-id->filters` contains related criteria that
   could narrow the domain for the field. This info is saved as part of each `binning-strategy` clause."
   [{:keys [source-metadata], :as _inner-query}
-   field-id->filters                          :- FieldID->Filters
+   field-id-or-name->filters                  :- FieldIDOrName->Filters
    [_ id-or-name {:keys [binning], :as opts}] :- mbql.s/field]
   (let [metadata                                   (matching-metadata id-or-name source-metadata)
-        {:keys [min-value max-value], :as min-max} (extract-bounds (when (integer? id-or-name) id-or-name)
+        {:keys [min-value max-value], :as min-max} (extract-bounds id-or-name
                                                                    (:fingerprint metadata)
-                                                                   field-id->filters)
+                                                                   field-id-or-name->filters)
         [new-strategy resolved-options]            (lib.binning.util/resolve-options (qp.store/metadata-provider)
                                                                                      (:strategy binning)
                                                                                      (get binning (:strategy binning))
@@ -116,11 +116,11 @@
 (defn update-binning-strategy-in-inner-query
   "Update `:field` clauses with `:binning` strategy options in an `inner` [MBQL] query."
   [{filters :filter, :as inner-query}]
-  (let [field-id->filters (filter->field-map filters)]
+  (let [field-id-or-name->filters (filter->field-map filters)]
     (mbql.u/replace inner-query
       [:field _ (_ :guard :binning)]
       (try
-        (update-binned-field inner-query field-id->filters &match)
+        (update-binned-field inner-query field-id-or-name->filters &match)
         (catch Throwable e
           (throw (ex-info (.getMessage e) {:clause &match} e)))))))
 

--- a/test/metabase/query_processor/middleware/binning_test.clj
+++ b/test/metabase/query_processor/middleware/binning_test.clj
@@ -6,6 +6,7 @@
    [metabase.lib.card :as lib.card]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.jvm :as lib.metadata.jvm]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
@@ -14,6 +15,7 @@
    [metabase.query-processor.middleware.binning :as binning]
    [metabase.query-processor.preprocess :as qp.preprocess]
    [metabase.query-processor.store :as qp.store]
+   [metabase.query-processor.test-util :as qp.test-util]
    [metabase.test :as mt]))
 
 (deftest ^:parallel filter->field-map-test
@@ -55,6 +57,11 @@
 
     {1 [[:> [:field 1 nil] 200] [:< [:field 1 nil] 800] [:between [:field 1 nil] 600 700]]}
     {:min-value 600, :max-value 700}))
+
+(deftest ^:parallel extract-bounds-field-name-test
+  (testing "Should be able to adjust min max based on filters against named field refs. (#26202)"
+    (is (= {:min-value 1, :max-value 10}
+           (#'binning/extract-bounds "foo" test-min-max-fingerprint {"foo" [[:> [:field 1 nil] 1] [:< [:field 1 nil] 10]]})))))
 
 ;; Try an end-to-end test of the middleware
 (defn- mock-field-metadata-provider []
@@ -209,3 +216,35 @@
                                                     :max-value -60.0
                                                     :num-bins  6}}]]}}
                   (binning/update-binning-strategy legacy-query))))))))
+
+(deftest ^:parallel match-named-field-ref-filter
+  (testing "fields referencing source expressions can still properly update binning strategies (#26202)"
+    (mt/with-temp [:model/Card card (-> orders
+                                        (mt/mbql-query {:fields [$total [:expression "foo"]]
+                                                        :expressions {"foo" [:+ $total 0]}})
+                                        qp.test-util/card-with-source-metadata-for-query
+                                        (assoc-in [:result_metadata 1 :semantic_type] :type/Quantity))]
+      (let [mp (lib.metadata.jvm/application-database-metadata-provider (mt/id))
+            query (lib/query mp (lib.metadata/card mp (:id card)))
+            expr-col (m/find-first #(= (:name %) "foo") (lib/breakoutable-columns query))
+            _ (is (some? expr-col))
+            binning-strategy (m/find-first #(= (:display-name %) "10 bins")
+                                           (lib/available-binning-strategies query expr-col))
+            _ (is (some? binning-strategy))
+            query (-> query
+                      (lib/breakout (lib/with-binning expr-col binning-strategy)))]
+        (qp.store/with-metadata-provider mp
+          (testing "without filter"
+            (is (=? {:query {:breakout [[:field
+                                         "foo"
+                                         {:base-type :type/Float,
+                                          :binning {:strategy :num-bins, :num-bins 10, :min-value -50.0, :max-value 175.0, :bin-width 25.0}}]]}}
+                    (binning/update-binning-strategy (-> (lib.convert/->legacy-MBQL query)
+                                                         (assoc-in [:query :source-metadata] (:result_metadata card)))))))
+          (testing "with filter"
+            (is (=? {:query {:breakout [[:field
+                                         "foo"
+                                         {:base-type :type/Float,
+                                          :binning {:strategy :num-bins, :num-bins 10, :min-value 20.0, :max-value 40.0, :bin-width 2.0}}]]}}
+                    (binning/update-binning-strategy (-> (lib.convert/->legacy-MBQL (lib/filter query (lib/between expr-col 20 40)))
+                                                         (assoc-in [:query :source-metadata] (:result_metadata card))))))))))))


### PR DESCRIPTION
Fixes #26202

Previously we only looked for binned field-ids in order to update binning strategies in qp. With this change we also look for field-name refs. This allows expressions to be binned in models.
