### PR TITLE
Remove reminder to clean up changelog in release notes

### DIFF
--- a/release/src/release-notes.ts
+++ b/release/src/release-notes.ts
@@ -7,8 +7,7 @@ import {
 
 import type { ReleaseProps, Issue } from "./types";
 
-const releaseTemplate = `# NOTE: clean up 'Enhancements' and 'Bug fixes' sections and remove this line before publishing!
-**Upgrading**
+const releaseTemplate = `**Upgrading**
 
 You can download a .jar of the release, or get the latest on Docker. Make sure to back up your Metabase
 database before you upgrade! Need help? Check out our [upgrading instructions](https://metabase.com/docs/latest/operations-guide/upgrading-metabase.html).


### PR DESCRIPTION
This removes a reminder from the release notes to clean up the changelog. It isn't as useful now that changelog entries are mostly automated and it comes with the risk that the release manager doesn't actually delete it.

[Slack context](https://metaboat.slack.com/archives/C864UT5CZ/p1708636367042959?thread_ts=1708635004.078429&cid=C864UT5CZ)