### PR TITLE
Add info icon to parameter field mapping

### DIFF
--- a/e2e/test/scenarios/dashboard-filters/reproductions/27356-navigation-between-two-dashboards.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/27356-navigation-between-two-dashboards.cy.spec.js
@@ -46,13 +46,13 @@ describe("issue 27356", () => {
 
     openNavigationSidebar();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(regularDashboard.name).click();
+    cy.findByText(regularDashboard.name).click({ force: true });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
 
     openNavigationSidebar();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(paramDashboard.name).click();
+    cy.findByText(paramDashboard.name).click({ force: true });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("This dashboard is looking empty.");
   });

--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -156,7 +156,7 @@ describe("scenarios > filters > bulk filtering", () => {
     filter();
 
     modal().within(() => {
-      cy.findByText("Product").click();
+      cy.findByText("Product").click({ force: true });
       filterField("Category").findByText("Gadget").click();
     });
 

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -13,7 +13,7 @@ import { PLUGIN_MODERATION } from "metabase/plugins";
 import {
   API_UPDATE_QUESTION,
   SOFT_RELOAD_CARD,
-} from "metabase/query_builder/actions";
+} from "metabase/query_builder/actions/core/types";
 import {
   getMetadata,
   getMetadataUnfiltered,

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -41,6 +41,7 @@ import { zoomInRow } from "../object-detail";
 import { clearQueryResult, runQuestionQuery } from "../querying";
 import { onCloseSidebars } from "../ui";
 
+import { SOFT_RELOAD_CARD, API_UPDATE_QUESTION } from "./types";
 import { updateQuestion } from "./updateQuestion";
 import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 
@@ -48,7 +49,7 @@ export const RESET_QB = "metabase/qb/RESET_QB";
 export const resetQB = createAction(RESET_QB);
 
 // refreshes the card without triggering a run of the card's query
-export const SOFT_RELOAD_CARD = "metabase/qb/SOFT_RELOAD_CARD";
+export { SOFT_RELOAD_CARD };
 export const softReloadCard = createThunkAction(SOFT_RELOAD_CARD, () => {
   return async (dispatch, getState) => {
     const outdatedCard = getCard(getState());
@@ -241,7 +242,7 @@ export const apiCreateQuestion = question => {
   };
 };
 
-export const API_UPDATE_QUESTION = "metabase/qb/API_UPDATE_QUESTION";
+export { API_UPDATE_QUESTION };
 export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
   return async (dispatch, getState) => {
     const originalQuestion = getOriginalQuestion(getState());

--- a/frontend/src/metabase/query_builder/actions/core/types.js
+++ b/frontend/src/metabase/query_builder/actions/core/types.js
@@ -1,0 +1,2 @@
+export const SOFT_RELOAD_CARD = "metabase/qb/SOFT_RELOAD_CARD";
+export const API_UPDATE_QUESTION = "metabase/qb/API_UPDATE_QUESTION";

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
@@ -1,8 +1,12 @@
 import { t } from "ttag";
 
+import {
+  HoverParent,
+  TableColumnInfoIcon,
+} from "metabase/components/MetadataInfo/ColumnInfoIcon";
 import AccordionList from "metabase/core/components/AccordionList";
 import type { IconName } from "metabase/ui";
-import { Icon } from "metabase/ui";
+import { Icon, DelayGroup } from "metabase/ui";
 import type Field from "metabase-lib/metadata/Field";
 import type Table from "metabase-lib/metadata/Table";
 
@@ -74,23 +78,35 @@ const DataSelectorFieldPicker = ({
 
   return (
     <Container>
-      <AccordionList
-        id="FieldPicker"
-        key="fieldPicker"
-        className="text-brand"
-        hasInitialFocus={hasInitialFocus}
-        sections={sections}
-        maxHeight={Infinity}
-        width="100%"
-        searchable={hasFiltering}
-        onChange={(item: { field: Field }) => onChangeField(item.field)}
-        itemIsSelected={checkIfItemIsSelected}
-        itemIsClickable={(item: FieldWithName) => item.field}
-        renderItemIcon={renderItemIcon}
-      />
+      <DelayGroup>
+        <AccordionList
+          id="FieldPicker"
+          key="fieldPicker"
+          className="text-brand"
+          hasInitialFocus={hasInitialFocus}
+          sections={sections}
+          maxHeight={Infinity}
+          width="100%"
+          searchable={hasFiltering}
+          onChange={(item: { field: Field }) => onChangeField(item.field)}
+          itemIsSelected={checkIfItemIsSelected}
+          itemIsClickable={(item: FieldWithName) => item.field}
+          renderItemWrapper={renderItemWrapper}
+          renderItemIcon={renderItemIcon}
+          renderItemExtra={renderItemExtra}
+        />
+      </DelayGroup>
     </Container>
   );
 };
+
+function renderItemWrapper(content: React.ReactNode) {
+  return <HoverParent>{content}</HoverParent>;
+}
+
+function renderItemExtra(item: FieldWithName) {
+  return <TableColumnInfoIcon field={item.field} position="top-end" />;
+}
 
 const Header = ({ onBack, selectedTable }: HeaderProps) => (
   <HeaderContainer onClick={onBack}>

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { t } from "ttag";
 
 import {
@@ -100,7 +101,7 @@ const DataSelectorFieldPicker = ({
   );
 };
 
-function renderItemWrapper(content: React.ReactNode) {
+function renderItemWrapper(content: ReactNode) {
   return <HoverParent>{content}</HoverParent>;
 }
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.unit.spec.tsx
@@ -72,6 +72,7 @@ describe("DataSelectorFieldPicker", () => {
 
       expect(screen.getByText(tableDisplayName)).toBeInTheDocument();
       expect(screen.getByText("Product ID")).toBeInTheDocument();
+      expect(screen.getByLabelText("More Info")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorFieldPicker/DataSelectorFieldPicker.unit.spec.tsx
@@ -72,7 +72,7 @@ describe("DataSelectorFieldPicker", () => {
 
       expect(screen.getByText(tableDisplayName)).toBeInTheDocument();
       expect(screen.getByText("Product ID")).toBeInTheDocument();
-      expect(screen.getByLabelText("More Info")).toBeInTheDocument();
+      expect(screen.getByLabelText("More info")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/querying/utils/drills/filter-drill/filter-drill.tsx
+++ b/frontend/src/metabase/querying/utils/drills/filter-drill/filter-drill.tsx
@@ -1,4 +1,4 @@
-import { FilterPickerBody } from "metabase/querying/components/FilterPicker";
+import { FilterPickerBody } from "metabase/querying/components/FilterPicker/FilterPickerBody";
 import type { ClickActionPopoverProps } from "metabase/visualizations/types";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/Question";

--- a/frontend/src/metabase/redux/metadata.unit.spec.js
+++ b/frontend/src/metabase/redux/metadata.unit.spec.js
@@ -1,5 +1,6 @@
-import Fields from "metabase/entities/fields";
+/* eslint-disable import/order */
 import Tables from "metabase/entities/tables";
+import Fields from "metabase/entities/fields";
 
 import { fetchField, loadMetadataForDependentItems } from "./metadata";
 

--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -1,4 +1,4 @@
-import { queryDrill } from "metabase/querying";
+import { queryDrill } from "metabase/querying/utils/drills/query-drill";
 import type Question from "metabase-lib/Question";
 
 import type {

--- a/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
+++ b/frontend/src/metabase/visualizations/click-actions/Mode/Mode.ts
@@ -1,4 +1,4 @@
-import { queryDrill } from "metabase/querying/utils/drills/query-drill";
+import { queryDrill } from "metabase/querying";
 import type Question from "metabase-lib/Question";
 
 import type {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39042

### Description

Adds the info icon to the parameter field mapping selector.

### How to verify

1. Native Query → Sample Dataset
2. Type ```{{ where }}```
3. In the variable sidebar, select `Field Filter` for `Variable Type`
4. In the `Field to map to` dropdown, select `Orders`
5. In the dropdown, hover each item to see the info icon
6. Hover the info icons and make sure the description and types are correct 

### Demo
<img width="522" alt="Screenshot 2024-02-23 at 11 15 52" src="https://github.com/metabase/metabase/assets/1250185/022bf6c0-ad7c-4063-ae30-d44dd5331aa4">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
