### PR TITLE
goToNextStep in all thunks

### DIFF
--- a/frontend/src/metabase-types/store/mocks/setup.ts
+++ b/frontend/src/metabase-types/store/mocks/setup.ts
@@ -41,7 +41,6 @@ export const createMockSubscribeInfo = (
 export const createMockSetupState = (
   opts?: Partial<SetupState>,
 ): SetupState => ({
-  isPaidPlan: false,
   step: "welcome",
   isLocaleLoaded: false,
   isTrackingAllowed: false,

--- a/frontend/src/metabase-types/store/setup.ts
+++ b/frontend/src/metabase-types/store/setup.ts
@@ -26,7 +26,6 @@ export interface SubscribeInfo {
 }
 
 export interface SetupState {
-  isPaidPlan: boolean;
   step: SetupStep;
   locale?: Locale;
   user?: UserInfo;

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -6,7 +6,6 @@ import {
 } from "metabase/home/utils";
 import { loadLocalization } from "metabase/lib/i18n";
 import MetabaseSettings from "metabase/lib/settings";
-import { getSetting } from "metabase/selectors/settings";
 import { SetupApi } from "metabase/services";
 import type { DatabaseData, UsageReason } from "metabase-types/api";
 import type { InviteInfo, Locale, State, UserInfo } from "metabase-types/store";
@@ -213,20 +212,5 @@ export const submitSetup = createAsyncThunk<void, void, ThunkConfig>(
     } catch (error) {
       return rejectWithValue(error);
     }
-  },
-);
-
-export const initSetup = createAsyncThunk(
-  "metabase/setup/INIT_SETUP",
-  async (_, thunkApi) => {
-    const state = thunkApi.getState() as State;
-
-    const tokenFeatures = getSetting(state, "token-features");
-
-    const hasAnyFeature =
-      tokenFeatures &&
-      Object.values(tokenFeatures).some(value => value === true);
-
-    return { isPaidPlan: hasAnyFeature };
   },
 );

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.tsx
@@ -6,13 +6,13 @@ import Button from "metabase/core/components/Button";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import type { Locale } from "metabase-types/store";
 
-import { selectStep, updateLocale } from "../../actions";
+import { useStep } from "../..//useStep";
+import { goToNextStep, selectStep, updateLocale } from "../../actions";
 import {
   getAvailableLocales,
   getIsSetupCompleted,
   getLocale,
 } from "../../selectors";
-import { useStep } from "../../useStep";
 import { getLocales } from "../../utils";
 import { ActiveStep } from "../ActiveStep";
 import { InactiveStep } from "../InactiveStep";
@@ -44,7 +44,7 @@ export const LanguageStep = ({ stepLabel }: NumberedStepProps): JSX.Element => {
   };
 
   const handleStepSubmit = () => {
-    dispatch(selectStep("user_info"));
+    dispatch(goToNextStep());
   };
 
   if (!isStepActive) {

--- a/frontend/src/metabase/setup/components/Setup/Setup.tsx
+++ b/frontend/src/metabase/setup/components/Setup/Setup.tsx
@@ -1,8 +1,7 @@
 import { useEffect } from "react";
 import { useUpdate } from "react-use";
 
-import { useDispatch, useSelector } from "metabase/lib/redux";
-import { initSetup } from "metabase/setup/actions";
+import { useSelector } from "metabase/lib/redux";
 
 import { trackStepSeen } from "../../analytics";
 import { getIsLocaleLoaded, getStep, getSteps } from "../../selectors";
@@ -12,14 +11,9 @@ import { WelcomePage } from "../WelcomePage";
 export const Setup = (): JSX.Element => {
   const step = useSelector(getStep);
   const stepIndex = useSelector(getSteps).findIndex(({ key }) => key === step);
-  const dispatch = useDispatch();
 
   const isLocaleLoaded = useSelector(getIsLocaleLoaded);
   const update = useUpdate();
-
-  useEffect(() => {
-    dispatch(initSetup());
-  });
 
   useEffect(() => {
     trackStepSeen({ stepName: step, stepNumber: stepIndex });

--- a/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.tsx
+++ b/frontend/src/metabase/setup/components/WelcomePage/WelcomePage.tsx
@@ -5,17 +5,17 @@ import { t } from "ttag";
 import LogoIcon from "metabase/components/LogoIcon";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 
-import { loadDefaults, selectStep } from "../../actions";
+import { goToNextStep, loadDefaults } from "../../actions";
 import { LOCALE_TIMEOUT } from "../../constants";
 import { getIsLocaleLoaded } from "../../selectors";
 import { SetupHelp } from "../SetupHelp";
 
 import {
-  PageRoot,
-  PageMain,
-  PageTitle,
   PageBody,
   PageButton,
+  PageMain,
+  PageRoot,
+  PageTitle,
 } from "./WelcomePage.styled";
 
 export const WelcomePage = (): JSX.Element | null => {
@@ -24,7 +24,7 @@ export const WelcomePage = (): JSX.Element | null => {
   const dispatch = useDispatch();
 
   const handleStepSubmit = () => {
-    dispatch(selectStep("language"));
+    dispatch(goToNextStep());
   };
 
   useEffect(() => {

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -16,7 +16,6 @@ import {
   submitSetup,
   submitUsageReason,
   submitLicenseToken,
-  initSetup,
 } from "./actions";
 import { getNextStep } from "./selectors";
 
@@ -24,13 +23,9 @@ const initialState: SetupState = {
   step: "welcome",
   isLocaleLoaded: false,
   isTrackingAllowed: true,
-  isPaidPlan: false,
 };
 
 export const reducer = createReducer(initialState, builder => {
-  builder.addCase(initSetup.fulfilled, (state, { payload: { isPaidPlan } }) => {
-    state.isPaidPlan = isPaidPlan;
-  });
   builder.addCase(loadUserDefaults.fulfilled, (state, { payload: user }) => {
     state.user = user;
   });

--- a/frontend/src/metabase/setup/reducers.ts
+++ b/frontend/src/metabase/setup/reducers.ts
@@ -1,23 +1,22 @@
 import { createReducer } from "@reduxjs/toolkit";
 
-import type { SetupState, State } from "metabase-types/store";
+import type { SetupState } from "metabase-types/store";
 
 import {
-  skipDatabase,
   loadLocaleDefaults,
   loadUserDefaults,
   selectStep,
+  skipDatabase,
   submitDatabase,
+  submitLicenseToken,
+  submitSetup,
+  submitUsageReason,
   submitUser,
   submitUserInvite,
   updateDatabaseEngine,
   updateLocale,
   updateTracking,
-  submitSetup,
-  submitUsageReason,
-  submitLicenseToken,
 } from "./actions";
-import { getNextStep } from "./selectors";
 
 const initialState: SetupState = {
   step: "welcome",
@@ -48,17 +47,14 @@ export const reducer = createReducer(initialState, builder => {
   });
   builder.addCase(submitUser.pending, (state, { meta }) => {
     state.user = meta.arg;
-    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(submitUsageReason.pending, (state, { meta }) => {
     const usageReason = meta.arg;
     state.usageReason = usageReason;
-    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(submitLicenseToken.pending, (state, { meta }) => {
     const token = meta.arg;
     state.licenseToken = token;
-    state.step = getNextStep({ setup: state } as State);
   });
 
   builder.addCase(updateDatabaseEngine.pending, (state, { meta }) => {
@@ -67,17 +63,14 @@ export const reducer = createReducer(initialState, builder => {
   builder.addCase(submitDatabase.fulfilled, (state, { payload: database }) => {
     state.database = database;
     state.invite = undefined;
-    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(submitUserInvite.pending, (state, { meta }) => {
     state.database = undefined;
     state.invite = meta.arg;
-    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(skipDatabase.pending, state => {
     state.database = undefined;
     state.invite = undefined;
-    state.step = getNextStep({ setup: state } as State);
   });
   builder.addCase(updateTracking.pending, (state, { meta }) => {
     state.isTrackingAllowed = meta.arg;

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -1,4 +1,3 @@
-import MetabaseSettings from "metabase/lib/settings";
 import { isEEBuild } from "metabase/lib/utils";
 import { getSetting } from "metabase/selectors/settings";
 import type { DatabaseData, LocaleData } from "metabase-types/api";
@@ -83,10 +82,8 @@ export const getIsEmailConfigured = (state: State): boolean => {
 export const getSteps = (state: State) => {
   const usageReason = getUsageReason(state);
   const activeStep = getStep(state);
+  const tokenFeatures = getSetting(state, "token-features");
 
-  // TODO: avoid using MetabaseSettings in a selector
-  // we can't do it right now as this selector is used in the reducer that doesn't have access to the whole state
-  const tokenFeatures = MetabaseSettings.get("token-features");
   const isPaidPlan =
     tokenFeatures && Object.values(tokenFeatures).some(value => value === true);
 

--- a/frontend/src/metabase/setup/selectors.ts
+++ b/frontend/src/metabase/setup/selectors.ts
@@ -1,3 +1,4 @@
+import MetabaseSettings from "metabase/lib/settings";
 import { isEEBuild } from "metabase/lib/utils";
 import { getSetting } from "metabase/selectors/settings";
 import type { DatabaseData, LocaleData } from "metabase-types/api";
@@ -82,7 +83,12 @@ export const getIsEmailConfigured = (state: State): boolean => {
 export const getSteps = (state: State) => {
   const usageReason = getUsageReason(state);
   const activeStep = getStep(state);
-  const isPaidPlan = state.setup.isPaidPlan;
+
+  // TODO: avoid using MetabaseSettings in a selector
+  // we can't do it right now as this selector is used in the reducer that doesn't have access to the whole state
+  const tokenFeatures = MetabaseSettings.get("token-features");
+  const isPaidPlan =
+    tokenFeatures && Object.values(tokenFeatures).some(value => value === true);
 
   const shouldShowDBConnectionStep = usageReason !== "embedding";
   const shouldShowLicenseStep = isEEBuild() && !isPaidPlan;


### PR DESCRIPTION
This is a refactor on the redux issue described in the description of  [Add the step in the FE and pass the token to the setup api call](https://github.com/metabase/metabase/pull/38953)

It works by reverting the initSetup action and manually dispatching `goToNextStep` in all thunks that should advance the step. Thunks can access the global redux state so we don't have to worry about how to access the token-features anymore.
