### PR TITLE
Add test for POST /api/card/:id/query for parameters with defaults

### DIFF
--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -224,10 +224,10 @@
                                                     :value  1}]}))))))
         (testing "the field filter should not apply if the parameter has a nil value"
           (is (= [[100]]
-                 (mt/rows (request {:parameters [{:id "_VENUE_ID_",
-                                                   :target ["dimension" ["template-tag" "venue_id"]],
-                                                   :type "id",
-                                                   :value nil}]})))))))))
+                 (mt/rows (request {:parameters [{:id     "_VENUE_ID_",
+                                                  :target ["dimension" ["template-tag" "venue_id"]],
+                                                  :type   "id",
+                                                  :value  nil}]})))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -189,6 +189,46 @@
                                 :target [:variable [:template-tag :category]]
                                 :value  2}]})))))))
 
+(deftest run-query-with-default-parameters-test
+  (testing "POST /api/card/:id/query with parameters with default values"
+    (mt/with-temp
+      [:model/Card card {:dataset_query
+                         {:database (mt/id)
+                          :type     :native
+                          :native   {:query         "SELECT count(*) AS Count FROM venues where {{venue_id}}"
+                                     :template-tags {"venue_id" {:dimension    [:field (mt/id :venues :id) nil],
+                                                                 :display-name "Venue ID",
+                                                                 :id           "_VENUE_ID_",
+                                                                 :name         "venue_id",
+                                                                 :required     false,
+                                                                 :default      1
+                                                                 :type         :dimension,
+                                                                 :widget-type  :id}}}}}]
+      (let [request (fn [body]
+                      (mt/user-http-request :rasta :post 202 (format "card/%d/query" (:id card)) body))]
+        (testing "the default can be overridden"
+          (is (= [[1]]
+                 (mt/rows (request {:parameters [{:id    "_VENUE_ID_"
+                                                  :name  "venue_id"
+                                                  :slug  "venue_id"
+                                                  :type  "number"
+                                                  :value 2}]})))))
+        (testing "the default should apply if no param value is provided"
+          (is (= [[1]]
+                 (mt/rows (request {:parameters []}))))
+          (testing "check this is the same result as when the default value is provided"
+            (is (= [[1]]
+                   (mt/rows (request {:parameters [{:id     "_VENUE_ID_",
+                                                    :target ["dimension" ["template-tag" "venue_id"]],
+                                                    :type   "id",
+                                                    :value  1}]}))))))
+        (testing "the field filter should not apply if the parameter has a nil value"
+          (is (= [[100]]
+                 (mt/rows (request {:parameters [{:id "_VENUE_ID_",
+                                                   :target ["dimension" ["template-tag" "venue_id"]],
+                                                   :type "id",
+                                                   :value nil}]})))))))))
+
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                           FETCHING CARDS & FILTERING                                           |

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -195,24 +195,23 @@
       [:model/Card card {:dataset_query
                          {:database (mt/id)
                           :type     :native
-                          :native   {:query         "SELECT count(*) AS Count FROM venues where {{venue_id}}"
+                          :native   {:query         "SELECT id FROM venues where {{venue_id}}"
                                      :template-tags {"venue_id" {:dimension    [:field (mt/id :venues :id) nil],
                                                                  :display-name "Venue ID",
                                                                  :id           "_VENUE_ID_",
                                                                  :name         "venue_id",
                                                                  :required     false,
-                                                                 :default      1
+                                                                 :default      [1]
                                                                  :type         :dimension,
                                                                  :widget-type  :id}}}}}]
       (let [request (fn [body]
                       (mt/user-http-request :rasta :post 202 (format "card/%d/query" (:id card)) body))]
         (testing "the default can be overridden"
-          (is (= [[1]]
-                 (mt/rows (request {:parameters [{:id    "_VENUE_ID_"
-                                                  :name  "venue_id"
-                                                  :slug  "venue_id"
-                                                  :type  "number"
-                                                  :value 2}]})))))
+          (is (= [[2]]
+                 (mt/rows (request {:parameters [{:id     "_VENUE_ID_",
+                                                  :target ["dimension" ["template-tag" "venue_id"]],
+                                                  :type   "id",
+                                                  :value  2}]})))))
         (testing "the default should apply if no param value is provided"
           (is (= [[1]]
                  (mt/rows (request {:parameters []}))))
@@ -223,11 +222,10 @@
                                                     :type   "id",
                                                     :value  1}]}))))))
         (testing "the field filter should not apply if the parameter has a nil value"
-          (is (= [[100]]
-                 (mt/rows (request {:parameters [{:id     "_VENUE_ID_",
-                                                  :target ["dimension" ["template-tag" "venue_id"]],
-                                                  :type   "id",
-                                                  :value  nil}]})))))))))
+          (is (= 100 (count (mt/rows (request {:parameters [{:id     "_VENUE_ID_",
+                                                             :target ["dimension" ["template-tag" "venue_id"]],
+                                                             :type   "id",
+                                                             :value  nil}]}))))))))))
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -189,8 +189,8 @@
                                 :target [:variable [:template-tag :category]]
                                 :value  2}]})))))))
 
-(deftest run-query-with-default-parameters-test
-  (testing "POST /api/card/:id/query with parameters with default values"
+(deftest execute-card-with-default-parameters-test
+  (testing "GET /api/card/:id/query with parameters with default values"
     (mt/with-temp
       [:model/Card card {:dataset_query
                          {:database (mt/id)
@@ -208,10 +208,10 @@
                       (mt/user-http-request :rasta :post 202 (format "card/%d/query" (:id card)) body))]
         (testing "the default can be overridden"
           (is (= [[2]]
-                 (mt/rows (request {:parameters [{:id     "_VENUE_ID_",
+                 (mt/rows (request {:parameters [{:id    "_VENUE_ID_"
                                                   :target ["dimension" ["template-tag" "venue_id"]],
-                                                  :type   "id",
-                                                  :value  2}]})))))
+                                                  :type  "id"
+                                                  :value 2}]})))))
         (testing "the default should apply if no param value is provided"
           (is (= [[1]]
                  (mt/rows (request {:parameters []}))))


### PR DESCRIPTION
This PR adds a test to clarify the BE behaviour of `POST /api/card/:id/query` when there are defaults applied to parameters. This behaviour was implemented in https://github.com/metabase/metabase/pull/31891, but there were no tests specifically for this endpoint.

The test is mostly redundant because the same code path is used for other endpoints e.g. `POST /api/dashboard/:dashboard-id/card/:card-id/query`, which are tested and the code that does default parameter substitution is tested [here](https://github.com/metabase/metabase/pull/31891/files#diff-ce58525a897b47b32a26ef9067c537a410de2e1e006ef9f6b1ec5443d1dd5bc1). But since it's pretty easy for the FE to use this endpoint incorrectly (see the confusion caused by https://github.com/metabase/metabase/issues/37831), I thought it would be nice to add a test for this endpoint to document and lock down it's behaviour.