### PR TITLE
Fix previews for multi-stage queries

### DIFF
--- a/e2e/test/scenarios/question/reproductions/39102-multi-stage-preview.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/39102-multi-stage-preview.cy.spec.js
@@ -1,0 +1,63 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { getNotebookStep, openNotebook, restore } from "e2e/support/helpers";
+
+const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
+
+const questionDetails = {
+  name: "39102",
+  query: {
+    "source-query": {
+      "source-table": ORDERS_ID,
+      aggregation: ["count"],
+      breakout: [["field", ORDERS.CREATED_AT, { "temporal-unit": "year" }]],
+    },
+    filter: [">", ["field", "count", { "base-type": "type/Integer" }], 1000],
+    aggregation: ["count"],
+  },
+  type: "question",
+};
+
+describe("issue 39102", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("should be able to preview a multi-stage query (metabase#39102)", () => {
+    cy.createQuestion(questionDetails, { visitQuestion: true });
+    openNotebook();
+
+    getNotebookStep("data", { stage: 0 }).icon("play").click();
+    cy.wait("@dataset");
+    cy.findByTestId("preview-root").within(() => {
+      cy.findByText("Tax").should("be.visible");
+      cy.icon("close").click();
+    });
+
+    getNotebookStep("summarize", { stage: 0 }).icon("play").click();
+    cy.wait("@dataset");
+    cy.findByTestId("preview-root").within(() => {
+      cy.findByText("Count").should("be.visible");
+      cy.findByText("3,610").should("be.visible");
+      cy.findByText("744").should("be.visible");
+      cy.icon("close").click();
+    });
+
+    getNotebookStep("filter", { stage: 1 }).icon("play").click();
+    cy.wait("@dataset");
+    cy.findByTestId("preview-root").within(() => {
+      cy.findByText("Count").should("be.visible");
+      cy.findByText("3,610").should("be.visible");
+      cy.findByText("744").should("not.exist");
+      cy.icon("close").click();
+    });
+
+    getNotebookStep("summarize", { stage: 1 }).icon("play").click();
+    cy.wait("@dataset");
+    cy.findByTestId("preview-root").within(() => {
+      cy.findByText("Count").should("be.visible");
+      cy.findByText("4").should("be.visible");
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.ts
@@ -275,7 +275,10 @@ function getStageSteps(
     }),
   );
 
-  let previewQuery: Lib.Query | null = query;
+  let previewQuery = _.range(Lib.stageCount(query) - 1, stageIndex, -1).reduce(
+    Lib.dropStage,
+    query,
+  );
 
   let actions = [];
   // iterate over steps in reverse so we can revert query for previewing and accumulate valid actions
@@ -302,7 +305,7 @@ function getStageSteps(
       steps.splice(i, 1);
     }
     // revert the previewQuery for this step
-    if (step.revert && previewQuery) {
+    if (step.revert) {
       previewQuery = step.revert(
         previewQuery,
         step.stageIndex,

--- a/frontend/src/metabase/query_builder/components/notebook/lib/steps.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/lib/steps.unit.spec.ts
@@ -46,6 +46,7 @@ const filteredAndSummarizedQuery: StructuredQueryObject = {
 const postAggregationFilterQuery: StructuredQueryObject = {
   "source-query": filteredAndSummarizedQuery,
   filter: [">", ["field", "count", { "base-type": "type/Integer" }], 10],
+  aggregation: [["count"]],
 };
 
 const getQuestionStepsForMBQLQuery = (query: StructuredQueryObject) => {
@@ -137,12 +138,13 @@ describe("filtered and summarized query with post-aggregation filter", () => {
     steps;
 
   describe("getQuestionSteps", () => {
-    it("`getQuestionSteps()` should return data, filter, summarize, and filter steps", () => {
+    it("`getQuestionSteps()` should return [data, filter, summarize] and [filter, summarize] steps", () => {
       expect(steps.map(s => s.type)).toEqual([
         "data",
         "filter",
         "summarize",
         "filter",
+        "summarize",
       ]);
     });
   });
@@ -161,28 +163,39 @@ describe("filtered and summarized query with post-aggregation filter", () => {
     it("shouldn't include filter, summarize, or post-aggregation filter for data step", () => {
       const previewQuery = checkNotNull(dataStep.previewQuery);
 
+      expect(Lib.stageCount(previewQuery)).toBe(1);
       expect(Lib.aggregations(previewQuery, 0)).toHaveLength(0);
       expect(Lib.breakouts(previewQuery, 0)).toHaveLength(0);
       expect(Lib.filters(previewQuery, 0)).toHaveLength(0);
-      expect(Lib.filters(previewQuery, 1)).toHaveLength(0);
     });
 
     it("shouldn't include summarize or post-aggregation filter for filter step", () => {
       const previewQuery = checkNotNull(filterStep.previewQuery);
 
+      expect(Lib.stageCount(previewQuery)).toBe(1);
       expect(Lib.aggregations(previewQuery, 0)).toHaveLength(0);
       expect(Lib.breakouts(previewQuery, 0)).toHaveLength(0);
       expect(Lib.filters(previewQuery, 0)).toHaveLength(1);
-      expect(Lib.filters(previewQuery, 1)).toHaveLength(0);
     });
 
-    it("should be the original query for post-aggregation filter step", () => {
+    it("shouldn't include filters from the next stages for summarizeStep", () => {
+      const previewQuery = checkNotNull(summarizeStep.previewQuery);
+
+      expect(Lib.stageCount(previewQuery)).toBe(1);
+      expect(Lib.aggregations(previewQuery, 0)).toHaveLength(1);
+      expect(Lib.breakouts(previewQuery, 0)).toHaveLength(1);
+      expect(Lib.filters(previewQuery, 0)).toHaveLength(1);
+    });
+
+    it("shouldn't include aggregations for post-aggregation filter step", () => {
       const previewQuery = checkNotNull(postAggregationFilterStep.previewQuery);
 
+      expect(Lib.stageCount(previewQuery)).toBe(2);
       expect(Lib.aggregations(previewQuery, 0)).toHaveLength(1);
       expect(Lib.breakouts(previewQuery, 0)).toHaveLength(1);
       expect(Lib.filters(previewQuery, 0)).toHaveLength(1);
       expect(Lib.filters(previewQuery, 1)).toHaveLength(1);
+      expect(Lib.aggregations(previewQuery, 1)).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/39102

Previously we didn't drop stages correctly when constructing a preview query for a multi-stage query for intermediate stages.

How to verify:
- CI green
- The new E2E test follows the steps from the issue