### PR TITLE
Ensure table-level perms are set correctly for API graph when incorporating sandboxes

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5752,7 +5752,7 @@ databaseChangeLog:
       comment: Clear data permission paths
       changes:
         - sql: >-
-            DELETE FROM permissions WHERE object LIKE '/db/%' OR object LIKE '/block/db/%' OR object LIKE '/data/%' OR object LIKE '/query/%';
+            DELETE FROM permissions WHERE object LIKE '%/db/%';
       rollback: # not needed; handled by the permission migrations above
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5752,7 +5752,7 @@ databaseChangeLog:
       comment: Clear data permission paths
       changes:
         - sql: >-
-            DELETE FROM permissions WHERE object LIKE '/db/%' OR object LIKE '/data/%' OR object LIKE '/query/%';
+            DELETE FROM permissions WHERE object LIKE '/db/%' OR object LIKE '/block/db/%' OR object LIKE '/data/%' OR object LIKE '/query/%';
       rollback: # not needed; handled by the permission migrations above
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<

--- a/resources/migrations/permissions/rollback/data_access.sql
+++ b/resources/migrations/permissions/rollback/data_access.sql
@@ -1,4 +1,5 @@
 DELETE FROM permissions WHERE object LIKE '/db/%' AND object NOT LIKE '/db/%/native/';
+DELETE FROM permissions WHERE object LIKE '/block/db/%';
 
 INSERT INTO permissions (object, group_id)
 SELECT concat('/db/', dp.db_id, '/schema/'),

--- a/resources/migrations/permissions/rollback/download_results.sql
+++ b/resources/migrations/permissions/rollback/download_results.sql
@@ -1,4 +1,4 @@
-DELETE FROM permissions WHERE object LIKE '/download/db/%';
+DELETE FROM permissions WHERE object LIKE '/download/%';
 
 INSERT INTO permissions (object, group_id)
 SELECT concat('/download/db/', dp.db_id, '/'),


### PR DESCRIPTION
When returning the API-style permissions graph to the FE, we need to add any sandboxes to the graph during post-processing, represented by `{:query :segmented, :read :all}` perms for the table.

In the process, we may need to add perms for all the other tables in the database or schema, if the permission was previously set at the database- or schema-level. Essentially we're "breaking out" perms set at the database- or schema-level to the table-level.

This code was working for perms set at the database-level, but not at the schema-level. I've fixed that in this PR and added a couple more tests.