### PR TITLE
Separate redaction from json encoding

### DIFF
--- a/src/metabase/models/action.clj
+++ b/src/metabase/models/action.clj
@@ -63,9 +63,9 @@
 (def ^:private transform-json-with-nested-parameters
   {:in  (comp mi/json-in
               (fn [template]
-                (u/update-if-exists template :parameters mi/normalize-parameters-list)))
+                (m/update-existing template :parameters mi/normalize-parameters-list)))
    :out (comp (fn [template]
-                (u/update-if-exists template :parameters (mi/catch-normalization-exceptions mi/normalize-parameters-list)))
+                (m/update-existing template :parameters (mi/catch-normalization-exceptions mi/normalize-parameters-list)))
               mi/json-out-with-keywordization)})
 
 (t2/deftransforms :model/HTTPAction

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -303,12 +303,12 @@
   "**MetabasePass**")
 
 (def ^:const protected-db-details
-  "The string to replace details with when serializing Databases."
-  "**MetabaseDatabaseDetails**")
+  "The map to replace details with when serializing Databases."
+  {:metabase/redacted "db/details"})
 
 (def ^:const protected-db-settings
-  "The string to replace settings with when serializing Databases."
-  "**MetabaseDatabaseSettings**")
+  "The map to replace settings with when serializing Databases."
+  {:metabase/redacted "db/settings"})
 
 (defn sensitive-fields-for-db
   "Gets all sensitive fields that should be redacted in API responses for a given database. Delegates to
@@ -332,7 +332,7 @@
                                       (sensitive-fields-for-db db))))))
 
 (defn- redact-settings [settings]
-  (if-not (map? settings)
+  (if-not (or (nil? settings) (map? settings))
     protected-db-settings
     (m/filter-keys
      (fn [setting-name]

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -357,7 +357,8 @@
   Also remove settings that the User doesn't have read perms for."
   [db json-generator]
   (next-method
-   (-> db redact-db-details (m/update-existing :settings redact-settings))
+   (-> (redact-db-details db)
+       (m/update-existing :settings redact-settings))
    json-generator))
 
 ;;; ------------------------------------------------ Serialization ----------------------------------------------------

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -15,7 +15,6 @@
    [metabase.query-processor.streaming :as qp.streaming]
    [metabase.shared.models.visualization-settings :as mb.viz]
    [metabase.types :as types]
-   [metabase.util :as u]
    [metabase.util.i18n :refer [trs tru]]
    [metabase.util.ui-logic :as ui-logic]
    [schema.core :as s])
@@ -277,7 +276,7 @@
   [col-settings col]
   (-> (m/map-keys (fn [k] (-> k name (str/replace #"-" "_") keyword)) col-settings)
       (backfill-currency)
-      (u/update-if-exists :date_style update-date-style (:unit col) col-settings)))
+      (m/update-existing :date_style update-date-style (:unit col) col-settings)))
 
 (defn- settings-from-column
   [col column-settings]

--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -96,7 +96,7 @@
 (defn- hoist-database-for-snippet-tags
   "Assocs the `:database` ID from `query` in all snippet template tags."
   [query]
-  (u/update-in-if-exists query [:native :template-tags] (partial assoc-db-in-snippet-tag (:database query))))
+  (m/update-existing-in query [:native :template-tags] (partial assoc-db-in-snippet-tag (:database query))))
 
 (defn substitute-parameters
   "Substitute Dashboard or Card-supplied parameters in a query, replacing the param placeholers with appropriate values

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -532,22 +532,6 @@
        :cljs (js/Math.floor (/ (js/Math.log (abs x))
                                (js/Math.log 10))))))
 
-(defn update-if-exists
-  "Like `clojure.core/update` but does not create a new key if it does not exist. Useful when you don't want to create
-  cruft."
-  [m k f & args]
-  (if (contains? m k)
-    (apply update m k f args)
-    m))
-
-(defn update-in-if-exists
-  "Like `clojure.core/update-in` but does not create new keys if they do not exist. Useful when you don't want to create
-  cruft."
-  [m ks f & args]
-  (if (not= ::not-found (get-in m ks ::not-found))
-    (apply update-in m ks f args)
-    m))
-
 (defn index-of
   "Return index of the first element in `coll` for which `pred` reutrns true."
   [pred coll]
@@ -889,3 +873,11 @@
   "Given two maps, are any keys on which they disagree? We only consider keys that are present in both."
   [m1 m2]
   (boolean (some identity (conflicting-keys m1 m2))))
+
+(defn assoc-existing
+  "Updates a value in a map to a given value, if and only if the key already exists in the map.
+   See: [[clojure.core/assoc]] and [[medley.core/update-existing]]."
+  [m k v]
+  (if (contains? m k)
+    (assoc m k v)
+    m))

--- a/src/metabase/util/redact.clj
+++ b/src/metabase/util/redact.clj
@@ -1,0 +1,52 @@
+(ns metabase.util.redact
+  (:require
+   [medley.core :as m]))
+
+(set! *warn-on-reflection* true)
+
+(defmulti redact*
+  "Replace sensitive info before exposing data, e.g. via the API. The precise format may depend on the current user."
+  (fn [sensitivity-info _data] (:type sensitivity-info)))
+
+(defn- info [x]
+  (:metabase/sensitive (meta x)))
+
+(defn- strip-info [x]
+  (if (meta x)
+    (vary-meta x dissoc :metabase/sensitive)
+    x))
+
+(defn mark-sensitive
+  "Tag the given value with metadata indicating that it is sensitive."
+  [x type-key & {:as options}]
+  (vary-meta x assoc :metabase/sensitive (assoc options :type type-key)))
+
+(defn sensitive?
+  "Is the given datum sensitive?"
+  [x]
+  (boolean (info x)))
+
+(defn- lazy-pre-walk*
+  "Similar to [[clojure.core/walk]], but only support pre-walks, and aims to be fully lazy.
+   It gives up on preserving types, but it preserve toucan instances as their original model."
+  [f form]
+  (cond
+    (map? form) (m/map-vals f form)
+    (seq? form) (map f form)
+    (coll? form) (map f form)
+    :else form))
+
+(defn- lazy-pre-walk
+  "Similar to [[clojure.core/prewalk]], but avoids consuming seqs with doall."
+  [f form]
+  (lazy-pre-walk* (partial lazy-pre-walk f) (f form)))
+
+(defn redact
+  "Replace sensitive info before exposing data, e.g. via the API. The precise format may depend on the current user."
+  [data]
+  (lazy-pre-walk
+   (fn [x]
+     (if-let [i (info x)]
+       (strip-info (redact* i x))
+       x))
+   data))

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -86,7 +86,7 @@
                 "settings"    {"database-enable-actions"      true
                                "unaggregated-query-row-limit" 2000}
                 "id"          3
-                "details"     "**MetabaseDatabaseDetails**"}
+                "details"     (encode-decode database/protected-db-details)}
                (encode-decode pg-db)))))
     (testing "non-authenticated users shouldn't see settings with authenticated visibility"
       (mw.session/with-current-user nil
@@ -94,7 +94,7 @@
                 "name"        "testpg"
                 "settings"    {"database-enable-actions" true}
                 "id"          3
-                "details"     "**MetabaseDatabaseDetails**"}
+                "details"     (encode-decode database/protected-db-details)}
                (encode-decode pg-db)))))))
 
 (deftest driver-supports-actions-and-database-enable-actions-test
@@ -160,14 +160,14 @@
                     "engine"      "postgres"
                     "settings"    {"database-enable-actions" true}
                     "id"          3
-                    "details"     "**MetabaseDatabaseDetails**"}
+                    "details"     (encode-decode database/protected-db-details)}
                    (encode-decode pg-db))))
           (is (= {"description" nil
                   "name"        "testbq"
                   "id"          2
                   "engine"      "bigquery-cloud-sdk"
                   "settings"    {"database-enable-actions" true}
-                  "details"     "**MetabaseDatabaseDetails**"}
+                  "details"     (encode-decode database/protected-db-details)}
                  (encode-decode bq-db)))))
 
       (testing "details are obfuscated for admin users"
@@ -209,16 +209,16 @@
         (let [redact (fn [m] (encode-decode (mi/instance :model/Database m)))]
           (is (= {"id" 1 "name" "testbg"}
                  (redact {:id 1 :name "testbg"})))
-          (is (= {"id" 1 "name" "testbg" "details" "**MetabaseDatabaseDetails**"}
+          (is (= {"id" 1 "name" "testbg" "details" (encode-decode database/protected-db-details)}
                  (redact {:id 1 :name "testbg" :details {}})))
-          (is (= {"id" 1 "name" "testbg" "settings" "**MetabaseDatabaseSettings**"}
+          (is (= {"id" 1 "name" "testbg" "settings" (encode-decode database/protected-db-settings)}
                  (redact {:id 1 :name "testbg" :settings "not-a-map"})))
           (is (= {"id" 1 "name" "testbg" "settings" {}}
                  (redact {:id 1 :name "testbg" :settings {}})))
           (is (= {"id" 1
                   "name" "testbg"
-                  "details" "**MetabaseDatabaseDetails**"
-                  "settings" "**MetabaseDatabaseSettings**"}
+                  "details" (encode-decode database/protected-db-details)
+                  "settings" (encode-decode database/protected-db-settings)}
                  (redact {:id 1 :name "testbg" :details {} :settings "not-a-map"}))))))))
 
 ;; register a dummy "driver" for the sole purpose of running sensitive-fields-test

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -75,24 +75,26 @@
                        {:description nil
                         :name        "testpg"
                         :details     {}
-                        :settings    {:database-enable-actions          true   ; visibility: :public
-                                      :unaggregated-query-row-limit 2000}  ; visibility: :authenticated
+                        :settings    {:database-enable-actions      true  ; visibility: :public
+                                      :unaggregated-query-row-limit 2000} ; visibility: :authenticated
                         :id          3})]
     (testing "authenticated users should see settings with authenticated visibility"
       (mw.session/with-current-user
         (mt/user->id :rasta)
         (is (= {"description" nil
                 "name"        "testpg"
-                "settings"    {"database-enable-actions"          true
+                "settings"    {"database-enable-actions"      true
                                "unaggregated-query-row-limit" 2000}
-                "id"          3}
+                "id"          3
+                "details"     "**MetabaseDatabaseDetails**"}
                (encode-decode pg-db)))))
     (testing "non-authenticated users shouldn't see settings with authenticated visibility"
       (mw.session/with-current-user nil
         (is (= {"description" nil
                 "name"        "testpg"
                 "settings"    {"database-enable-actions" true}
-                "id"          3}
+                "id"          3
+                "details"     "**MetabaseDatabaseDetails**"}
                (encode-decode pg-db)))))))
 
 (deftest driver-supports-actions-and-database-enable-actions-test
@@ -157,13 +159,15 @@
                     "name"        "testpg"
                     "engine"      "postgres"
                     "settings"    {"database-enable-actions" true}
-                    "id"          3}
+                    "id"          3
+                    "details"     "**MetabaseDatabaseDetails**"}
                    (encode-decode pg-db))))
           (is (= {"description" nil
                   "name"        "testbq"
                   "id"          2
                   "engine"      "bigquery-cloud-sdk"
-                  "settings"    {"database-enable-actions" true}}
+                  "settings"    {"database-enable-actions" true}
+                  "details"     "**MetabaseDatabaseDetails**"}
                  (encode-decode bq-db)))))
 
       (testing "details are obfuscated for admin users"

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -203,7 +203,23 @@
                   "id"          2
                   "settings"    {"database-enable-actions" true}
                   "engine"      "bigquery-cloud-sdk"}
-                 (encode-decode bq-db))))))))
+                 (encode-decode bq-db)))))
+
+      (testing "We avoid adding or removing the redacted fields"
+        (let [redact (fn [m] (encode-decode (mi/instance :model/Database m)))]
+          (is (= {"id" 1 "name" "testbg"}
+                 (redact {:id 1 :name "testbg"})))
+          (is (= {"id" 1 "name" "testbg" "details" "**MetabaseDatabaseDetails**"}
+                 (redact {:id 1 :name "testbg" :details {}})))
+          (is (= {"id" 1 "name" "testbg" "settings" "**MetabaseDatabaseSettings**"}
+                 (redact {:id 1 :name "testbg" :settings "not-a-map"})))
+          (is (= {"id" 1 "name" "testbg" "settings" {}}
+                 (redact {:id 1 :name "testbg" :settings {}})))
+          (is (= {"id" 1
+                  "name" "testbg"
+                  "details" "**MetabaseDatabaseDetails**"
+                  "settings" "**MetabaseDatabaseSettings**"}
+                 (redact {:id 1 :name "testbg" :details {} :settings "not-a-map"}))))))))
 
 ;; register a dummy "driver" for the sole purpose of running sensitive-fields-test
 (driver/register! :test-sensitive-driver, :parent #{:h2})


### PR DESCRIPTION
References https://github.com/metabase/metabase/issues/32822

This is a somewhat experimental refactoring, that seeks to separate redaction from json-ification.

I'm a bit nervous about memory usage and performance for larger API responses.
