### PR TITLE
Updating Feature Flag Meta for LLM

### DIFF
--- a/src/metabase/public_settings/premium_features.clj
+++ b/src/metabase/public_settings/premium_features.clj
@@ -407,7 +407,7 @@
   "Enable restrict email recipients?"
   :email-restrict-recipients)
 
-(define-premium-feature ^{:added "0.49.0"} enable-llm-autodescription?
+(define-premium-feature ^{:added "0.50.0"} enable-llm-autodescription?
   "Enable automatic descriptions of questions and dashboards by LLMs?"
   :llm-autodescription)
 


### PR DESCRIPTION
This just bumps the metadata version of the `enable-llm-autodescription?` feature flag to 50 (`^{:added "0.50.0"}`).
