### PR TITLE
Converted queries shouldn't change stage-metadata

### DIFF
--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -130,14 +130,14 @@
               (map (fn [[stage-number stage]]
                      (mbql.u/replace stage
                        [:field
-                        (opts :guard (complement (some-fn :base-type :effective-type)))
+                        (opts :guard (every-pred map? (complement (some-fn :base-type :effective-type))))
                         (field-id :guard (every-pred number? pos?))]
                        (let [found-ref (-> (lib.metadata/field metadata-provider field-id)
                                            (select-keys [:base-type :effective-type]))]
                          ;; Fallback if metadata is missing
                          [:field (merge found-ref opts) field-id])
                        [:expression
-                        (opts :guard (complement (some-fn :base-type :effective-type)))
+                        (opts :guard (every-pred map? (complement (some-fn :base-type :effective-type))))
                         expression-name]
                        (let [found-ref (try
                                          (m/remove-vals

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -3,6 +3,7 @@
    #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))
    [clojure.test :refer [are deftest is testing]]
    [clojure.walk :as walk]
+   [medley.core :as m]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
    [metabase.lib.metadata :as lib.metadata]
@@ -94,6 +95,31 @@
                                                  "CC"]]]}]}]}
 
               (lib/query meta/metadata-provider converted-query))))))
+
+(deftest ^:parallel converted-query-leaves-stage-metadata-refs-alone
+  (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :people))
+                  (lib/expression "BirthMonth" (lib/+ 1 1))
+                  (as-> $q (lib/breakout $q (m/find-first #(= (:name %) "BirthMonth") (lib/breakoutable-columns $q))))
+                  (lib/aggregate (lib/count))
+                  (lib/append-stage)
+                  (lib/aggregate (lib/count)))]
+    (is (=? {:stages [{:lib/stage-metadata {:columns [{:field-ref [:expression "BirthMonth" {:base-type :type/Integer}]} {}]}} {}]}
+          (lib/query meta/metadata-provider (assoc-in (lib.convert/->pMBQL (lib.convert/->legacy-MBQL query))
+                                                        [:stages 0 :lib/stage-metadata]
+                                                        {:columns [{:base-type :type/Float,
+                                                                    :display-name "BirthMonth",
+                                                                    :field-ref [:expression
+                                                                                "BirthMonth"
+                                                                                {:base-type :type/Integer}],
+                                                                    :name "BirthMonth",
+                                                                    :lib/type :metadata/column}
+                                                                   {:base-type :type/Integer,
+                                                                    :display-name "Count",
+                                                                    :field-ref [:aggregation 0],
+                                                                    :name "count",
+                                                                    :semantic-type :type/Quantity,
+                                                                    :lib/type :metadata/column}],
+                                                         :lib/type :metadata/results}))))))
 
 (deftest ^:parallel stage-count-test
   (is (= 1 (lib/stage-count lib.tu/venues-query)))


### PR DESCRIPTION
Fixes #39081

Converted queries need to fill in types of references converted from v1 to properly pass schemas. However legacy refs still exist in `:lib/stage-metadata` and these refs should not be touched. Checking that `map?` is in the second position of a ref is an easy way to determine which version ref we're looking at.
