### PR TITLE
Dashboard filter editor sidebar & param value widget: use & mimic Mantine

### DIFF
--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -91,12 +91,22 @@ export function normalizeParameters(parameters) {
     }));
 }
 
+// This distinguishes between empty value (deliberately unset), which is null,
+// and no value, which is undefined. Needed in API requests.
+// TODO reconcile with hasNoValueToShow
 export function isParameterValueEmpty(value) {
   return (
     value === PULSE_PARAM_EMPTY ||
     (Array.isArray(value) && value.length === 0) ||
     value === ""
   );
+}
+
+// This is a UI-bound function used to render filter widget.
+// Should treat undefined and null equally.
+// TODO reconcile with isParameterValueEmpty
+export function parameterHasNoDisplayValue(value) {
+  return !value || value === "" || (Array.isArray(value) && value.length === 0);
 }
 
 export function normalizeParameterValue(type, value) {

--- a/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
+++ b/frontend/src/metabase/parameters/components/FormattedParameterValue/FormattedParameterValue.tsx
@@ -7,6 +7,7 @@ import {
   isFieldFilterUiParameter,
 } from "metabase-lib/parameters/utils/parameter-fields";
 import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
+import { parameterHasNoDisplayValue } from "metabase-lib/parameters/utils/parameter-values";
 
 type FormattedParameterValueProps = {
   parameter: UiParameter;
@@ -19,7 +20,7 @@ function FormattedParameterValue({
   value,
   placeholder,
 }: FormattedParameterValueProps) {
-  if (value == null) {
+  if (parameterHasNoDisplayValue(value)) {
     return placeholder;
   }
 

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useLayoutEffect, useState } from "react";
 import { t } from "ttag";
 
-import Radio from "metabase/core/components/Radio";
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
-import { Text, TextInput } from "metabase/ui";
+import { Radio, Stack, Text, TextInput } from "metabase/ui";
 import { canUseCustomSource } from "metabase-lib/parameters/utils/parameter-source";
+import { parameterHasNoDisplayValue } from "metabase-lib/parameters/utils/parameter-values";
 import type {
   Parameter,
   ValuesQueryType,
@@ -83,6 +83,7 @@ export const ParameterSettings = ({
   );
 
   const isEmbeddedDisabled = embeddedParameterVisibility === "disabled";
+  const isMultiValue = getIsMultiSelect(parameter) ? "multi" : "single";
 
   return (
     <SettingsRoot>
@@ -110,24 +111,33 @@ export const ParameterSettings = ({
       {isSingleOrMultiSelectable(parameter) && (
         <SettingSection>
           <SettingLabel>{t`People can pick`}</SettingLabel>
-          <Radio
-            value={getIsMultiSelect(parameter)}
-            options={[
-              { name: t`Multiple values`, value: true },
-              { name: t`A single value`, value: false },
-            ]}
-            vertical
-            onChange={onChangeIsMultiSelect}
-          />
+          <Radio.Group
+            value={isMultiValue}
+            onChange={val => onChangeIsMultiSelect(val === "multi")}
+          >
+            <Stack spacing="xs">
+              <Radio
+                checked={isMultiValue === "multi"}
+                label={t`Multiple values`}
+                value="multi"
+              />
+              <Radio
+                checked={isMultiValue === "single"}
+                label={t`A single value`}
+                value="single"
+              />
+            </Stack>
+          </Radio.Group>
         </SettingSection>
       )}
 
       <SettingSection>
         <SettingLabel>
           {t`Default value`}
-          {parameter.required && !parameter.default && (
-            <SettingLabelError>({t`required`})</SettingLabelError>
-          )}
+          {parameter.required &&
+            parameterHasNoDisplayValue(parameter.default) && (
+              <SettingLabelError>({t`required`})</SettingLabelError>
+            )}
         </SettingLabel>
 
         <SettingValueWidget
@@ -136,6 +146,7 @@ export const ParameterSettings = ({
           value={parameter.default}
           placeholder={t`No default`}
           setValue={onChangeDefaultValue}
+          mimicMantine
         />
 
         <RequiredParamToggle

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -30,9 +30,13 @@ import {
   isDateParameter,
   isNumberParameter,
 } from "metabase-lib/parameters/utils/parameter-type";
-import { areParameterValuesIdentical } from "metabase-lib/parameters/utils/parameter-values";
+import {
+  areParameterValuesIdentical,
+  parameterHasNoDisplayValue,
+} from "metabase-lib/parameters/utils/parameter-values";
 
 import S from "./ParameterValueWidget.css";
+import { ParameterValueWidgetTrigger } from "./ParameterValueWidgetTrigger";
 import ParameterFieldWidget from "./widgets/ParameterFieldWidget/ParameterFieldWidget";
 
 class ParameterValueWidget extends Component {
@@ -55,6 +59,7 @@ class ParameterValueWidget extends Component {
     // Should be used for dashboards and native questions in the parameter bar,
     // Don't use in settings sidebars.
     enableRequiredBehavior: PropTypes.bool,
+    mimicMantine: PropTypes.bool,
   };
 
   state = { isFocused: false };
@@ -150,20 +155,25 @@ class ParameterValueWidget extends Component {
   }
 
   render() {
-    const { parameter, value, isEditing, placeholder, className } = this.props;
+    const {
+      parameter,
+      value,
+      isEditing,
+      placeholder,
+      className,
+      mimicMantine,
+    } = this.props;
     const { isFocused } = this.state;
-    const hasValue = value != null;
+    const hasValue = !parameterHasNoDisplayValue(value);
     const noPopover = hasNoPopover(parameter);
     const parameterTypeIcon = getParameterIconName(parameter);
     const showTypeIcon = !isEditing && !hasValue && !isFocused;
 
     if (noPopover) {
       return (
-        <div
-          ref={this.trigger}
-          className={cx(S.parameter, S.noPopover, className, {
-            [S.selected]: hasValue,
-          })}
+        <ParameterValueWidgetTrigger
+          className={cx(S.noPopover, className)}
+          hasValue={hasValue}
         >
           {showTypeIcon && (
             <Icon
@@ -179,7 +189,7 @@ class ParameterValueWidget extends Component {
             onPopoverClose={this.onPopoverClose}
           />
           {this.getActionIcon()}
-        </div>
+        </ParameterValueWidgetTrigger>
       );
     }
 
@@ -194,13 +204,12 @@ class ParameterValueWidget extends Component {
         ref={this.valuePopover}
         targetOffsetX={16}
         triggerElement={
-          <div
+          <ParameterValueWidgetTrigger
             ref={this.trigger}
-            className={cx(S.parameter, className, {
-              [S.selected]: hasValue,
-            })}
-            role="button"
-            aria-label={placeholder}
+            hasValue={hasValue}
+            className={className}
+            ariaLabel={placeholder}
+            mimicMantine={mimicMantine}
           >
             {showTypeIcon && (
               <Icon
@@ -217,7 +226,7 @@ class ParameterValueWidget extends Component {
               />
             </div>
             {this.getActionIcon()}
-          </div>
+          </ParameterValueWidgetTrigger>
         }
         target={this.getTargetRef}
         // make sure the full date picker will expand to fit the dual calendars

--- a/frontend/src/metabase/parameters/components/ParameterValueWidgetTrigger.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidgetTrigger.styled.tsx
@@ -1,0 +1,16 @@
+import styled from "@emotion/styled";
+
+import { color } from "metabase/lib/colors";
+import { space } from "metabase/styled-components/theme";
+
+export const TriggerContainer = styled.div<{ hasValue: boolean }>`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  position: relative;
+  padding: 0.6875rem;
+  border: 1px solid
+    ${props => (props.hasValue ? color("brand") : color("border"))};
+  border-radius: ${space(0)};
+  cursor: pointer;
+`;

--- a/frontend/src/metabase/parameters/components/ParameterValueWidgetTrigger.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidgetTrigger.tsx
@@ -1,0 +1,47 @@
+import classnames from "classnames";
+import { forwardRef, type ReactNode, type Ref } from "react";
+
+import styles from "./ParameterValueWidget.css";
+import { TriggerContainer } from "./ParameterValueWidgetTrigger.styled";
+
+export const ParameterValueWidgetTrigger = forwardRef(
+  ParameterValueWidgetTriggerInner,
+);
+
+function ParameterValueWidgetTriggerInner(
+  {
+    children,
+    hasValue,
+    ariaLabel,
+    className,
+    mimicMantine = false,
+  }: {
+    children: ReactNode;
+    hasValue: boolean;
+    ariaLabel: string;
+    className?: string;
+    mimicMantine?: boolean;
+  },
+  ref: Ref<HTMLDivElement>,
+) {
+  if (mimicMantine) {
+    return (
+      <TriggerContainer ref={ref} hasValue={hasValue}>
+        {children}
+      </TriggerContainer>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={classnames(styles.parameter, className, {
+        [styles.selected]: hasValue,
+      })}
+      role="button"
+      aria-label={ariaLabel}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
@@ -57,6 +57,7 @@ export function DefaultRequiredValueControl({
           setValue={onChangeDefaultValue}
           isEditing
           commitImmediately
+          mimicMantine
         />
 
         <RequiredParamToggle


### PR DESCRIPTION
This PR follows the previous ones that change the look & feel of the components related to required parameters.

## Changes
<img width="1312" alt="Screenshot 2024-02-26 at 15 51 16" src="https://github.com/metabase/metabase/assets/2196347/6b017696-6da7-450b-92a3-4b2b77dc580b">

We're updating 2 components on the screenshot.
Note that the last one, value picker, isn't updated internally — all its popups, lists of checkboxes, etc remain the same.
This update is outside the scope of this PR.

## Tests
As nothing changes logic-wise, we don't update tests.