### PR TITLE
Add env var to hide built-in geojson

### DIFF
--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -37,17 +37,29 @@
 
 (def ^:private CustomGeoJSONValidator (mc/validator CustomGeoJSON))
 
-(def ^:private builtin-geojson
-  {:us_states       {:name        "United States"
-                     :url         "app/assets/geojson/us-states.json"
-                     :region_key  "STATE"
-                     :region_name "NAME"
-                     :builtin     true}
-   :world_countries {:name        "World"
-                     :url         "app/assets/geojson/world.json"
-                     :region_key  "ISO_A2"
-                     :region_name "NAME"
-                     :builtin     true}})
+(defsetting default-maps-enabled
+  (deferred-tru "Whether or not the default GeoJSON maps are enabled.")
+  :visibility :admin
+  :export?    true
+  :type       :boolean
+  :setter     :none
+  :default    true
+  :audit      :getter)
+
+(defn- builtin-geojson
+  []
+  (if (default-maps-enabled)
+    {:us_states       {:name        "United States"
+                       :url         "app/assets/geojson/us-states.json"
+                       :region_key  "STATE"
+                       :region_name "NAME"
+                       :builtin     true}
+     :world_countries {:name        "World"
+                       :url         "app/assets/geojson/world.json"
+                       :region_key  "ISO_A2"
+                       :region_name "NAME"
+                       :builtin     true}}
+    {}))
 
 (defn- invalid-location-msg []
   (str (tru "Invalid GeoJSON file location: must either start with http:// or https:// or be a relative path to a file on the classpath.")
@@ -101,10 +113,10 @@
   (deferred-tru "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON.")
   :type    :json
   :default {}
-  :getter  (fn [] (merge (setting/get-value-of-type :json :custom-geojson) builtin-geojson))
+  :getter  (fn [] (merge (setting/get-value-of-type :json :custom-geojson) (builtin-geojson)))
   :setter  (fn [new-value]
              ;; remove the built-in keys you can't override them and we don't want those to be subject to validation.
-             (let [new-value (not-empty (reduce dissoc new-value (keys builtin-geojson)))]
+             (let [new-value (not-empty (reduce dissoc new-value (keys (builtin-geojson))))]
                (when new-value
                  (validate-geojson new-value))
                (setting/set-value-of-type! :json :custom-geojson new-value)))
@@ -132,7 +144,7 @@
   file specified for `key`)."
   [{{:keys [key]} :params} respond raise]
   {key ms/NonBlankString}
-  (when-not (or (custom-geojson-enabled) (builtin-geojson (keyword key)))
+  (when-not (or (custom-geojson-enabled) ((builtin-geojson) (keyword key)))
     (raise (ex-info (tru "Custom GeoJSON is not enabled") {:status-code 400})))
   (if-let [url (get-in (custom-geojson) [(keyword key) :url])]
     (try

--- a/src/metabase/api/geojson.clj
+++ b/src/metabase/api/geojson.clj
@@ -112,7 +112,6 @@
 (defsetting custom-geojson
   (deferred-tru "JSON containing information about custom GeoJSON files for use in map visualizations instead of the default US State or World GeoJSON.")
   :type    :json
-  :default {}
   :getter  (fn [] (merge (setting/get-value-of-type :json :custom-geojson) (builtin-geojson)))
   :setter  (fn [new-value]
              ;; remove the built-in keys you can't override them and we don't want those to be subject to validation.

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -93,7 +93,7 @@
 (deftest custom-geojson-disallow-overriding-builtins-test
   (testing "We shouldn't let people override the builtin GeoJSON and put weird stuff in there; ignore changes to them"
     (mt/with-temporary-setting-values [custom-geojson nil]
-      (let [built-in @#'api.geojson/builtin-geojson]
+      (let [built-in (@#'api.geojson/builtin-geojson)]
         (testing "Make sure the built-in entries still look like what we expect so our test still makes sense."
           (is (=? {:us_states {:name "United States"}}
                   built-in))
@@ -108,7 +108,7 @@
 (deftest update-endpoint-test
   (testing "PUT /api/setting/custom-geojson"
     (testing "test that we can set the value of api.geojson/custom-geojson via the normal routes"
-      (is (= (merge @#'api.geojson/builtin-geojson test-custom-geojson)
+      (is (= (merge (@#'api.geojson/builtin-geojson) test-custom-geojson)
              ;; try this up to 3 times since Circle's outbound connections likes to randomly stop working
              (u/auto-retry 3
                ;; bind a temporary value so it will get set back to its old value here after the API calls are done
@@ -126,7 +126,7 @@
       (let [resource-geojson {(first (keys test-custom-geojson))
                               (assoc (first (vals test-custom-geojson))
                                      :url "c3p0.properties")}]
-        (is (= (merge @#'api.geojson/builtin-geojson resource-geojson)
+        (is (= (merge (@#'api.geojson/builtin-geojson) resource-geojson)
                (u/auto-retry 3
                  (mt/with-temporary-setting-values [custom-geojson nil]
                    (mt/user-http-request :crowberto :put 204 "setting/custom-geojson"
@@ -213,7 +213,7 @@
                              :url         "https://raw.githubusercontent.com/metabase/metabase/master/resources/frontend_client/app/assets/geojson/us-states.json"
                              :region_key  "STATE"
                              :region_name "NAME"}}
-            expected-value (merge @#'api.geojson/builtin-geojson custom-geojson)]
+            expected-value (merge (@#'api.geojson/builtin-geojson) custom-geojson)]
         (mt/with-temporary-setting-values [custom-geojson nil]
           (mt/with-temp-env-var-value! [mb-custom-geojson (json/generate-string custom-geojson)]
             (binding [setting/*disable-cache* true]
@@ -247,3 +247,11 @@
         (testing "Should not be able to fetch custom GeoJSON via key proxy endpoint"
           (is (= "Custom GeoJSON is not enabled"
                  (mt/user-real-request :crowberto :get 400 "geojson/middle-earth"))))))))
+
+(deftest disable-default-maps-test
+  (testing "Should be able to disable the default GeoJSON maps by env var"
+    (mt/with-temp-env-var-value! [mb-default-maps-enabled false]
+      (is (= {}
+             (@#'api.geojson/builtin-geojson)))
+      (is (= "Invalid custom GeoJSON key: us_states"
+             (mt/user-real-request :crowberto :get 400 "geojson/us_states"))))));)

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -254,4 +254,4 @@
       (is (= {}
              (@#'api.geojson/builtin-geojson)))
       (is (= "Invalid custom GeoJSON key: us_states"
-             (mt/user-real-request :crowberto :get 400 "geojson/us_states"))))));)
+             (mt/user-real-request :crowberto :get 400 "geojson/us_states"))))))


### PR DESCRIPTION
Adds an environment variable to hide the built-in geojson maps, per [product request](https://metaboat.slack.com/archives/C05MPF0TM3L/p1708636681879369). Closes https://github.com/metabase/metabase/issues/39079