### PR TITLE
Fixing bad pulses when bad params exist

### DIFF
--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -630,15 +630,15 @@
     (let [{:keys [resolved-params]} (t2/hydrate
                                       (t2/select-one [:model/Dashboard :id :parameters] dashboard-id)
                                       :resolved-params)
-          dashboard-params (set (keys resolved-params))
-          dashboard-pulses (t2/select :model/Pulse :dashboard_id dashboard-id :archived false)]
-      (->> dashboard-pulses
+          dashboard-params (set (keys resolved-params))]
+      (->> (t2/select :model/Pulse :dashboard_id dashboard-id :archived false)
            (keep (fn [{:keys [parameters] :as pulse}]
                    (let [bad-params (filterv
                                       (fn [{param-id :id}] (not (contains? dashboard-params param-id)))
                                       parameters)]
                      (when (seq bad-params)
-                       (assoc pulse :parameters bad-params)))))))))
+                       (assoc pulse :parameters bad-params)))))
+           seq))))
 
 (defn- broken-subscription-data
   "Given a dashboard id and original parameters, return data (if any) on any broken subscriptions. This will be a seq

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -679,6 +679,7 @@
       (for [broken-pulse (t2/select :model/Pulse :id [:in (params->pulse-ids broken-link-ids)])]
         (assoc
           (bad-pulse-notification-data broken-pulse broken-link-ids)
+          :dashboard-id dashboard-id
           :dashboard-name dashboard-name
           :dashboard-description dashboard-description
           :dashboard-creator (select-keys dashboard-creator [:first_name :last_name :email :common_name]))))))

--- a/src/metabase/email/broken_subscription_notification.mustache
+++ b/src/metabase/email/broken_subscription_notification.mustache
@@ -1,24 +1,75 @@
 {{> metabase/email/_header }}
-  <div style="text-align: center; margin: 0 auto; max-width: 500px">
-    <div style="text-align: left">
-      <h2 style="font-weight: normal; color: #4C545B; line-height: 34px;">Subscription to {{dashboardName}} has been removed</h2>
-      <p>A subscription created by <a href="mailto:{{subscriptionCreatorEmail}}">{{subscriptionCreatorName}}</a>
-      to the dashboard "{{dashboardName}}", created by <a href="mailto:{{dashboardCreatorEmail}}">{{dashboardCreatorName}}</a>,
-      was removed because one or more dashboard parameters were removed that are used by the subscription.</p>
+<div class="card-container">
+  <h2
+    style="margin: 0; padding: 0; font-weight: 700; font-size: 1.5em; color: {{colorTextDark}}; line-height: 1.5em;"
+  >
+    Subscription to {{dashboardName}} deleted
+  </h2>
 
-        <p>These parameters and values were removed and are no longer valid:</p>
-        <ul>
-          {{#badParameters}}
-            <li>Parameter: {{name}} (Value: {{value}})</li>
-          {{/badParameters}}
-        </ul>
+  <p
+    style="font-weight: 600; font-size: 0.875em; line-height: 1.375em; color: {{colorTextMedium}};"
+  >
+    A filter was removed from this dashboard that was used by a subscription, so the subscription was deleted.
+    Here is the removed filter and user information.
+  </p>
 
-        <p>These recipients will no longer receive this subscription:</p>
-        <ul>
-          {{#affectedUsers}}
-            <li><a href="mailto:{{email}}">{{common_name}}</a></li>
-          {{/affectedUsers}}
-        </ul>
-    </div>
+  <table
+    cellpadding="0"
+    cellspacing="0"
+    border="0"
+    width="100%"
+    style="border-collapse: separate; border-spacing: 0 2em;"
+  >
+    <tr>
+      <td
+        style="font-weight: 600; font-size: 0.875em; color: {{colorTextMedium}}; line-height: 1.375em;"
+      >
+        Filter Name
+      </td>
+      <td
+        style="font-weight: 600; font-size: 0.875em; color: {{colorTextMedium}}; line-height: 1.375em;"
+      >
+        Filter Value
+      </td>
+    </tr>
+    {{#badParameters}}
+      <tr>
+        <td style="text-align: left;">{{name}}</td>
+        <td style="text-align: left;">{{value}}</td>
+      </tr>
+    {{/badParameters}}
+    <tr/>
+    <tr>
+      <td
+        style="font-weight: 600; font-size: 0.875em; color: {{colorTextMedium}}; line-height: 1.375em;"
+      >
+        User
+      </td>
+      <td
+        style="font-weight: 600; font-size: 0.875em; color: {{colorTextMedium}}; line-height: 1.375em;"
+      >
+        Role
+      </td>
+    </tr>
+    {{#affectedUsers}}
+      <tr>
+        <td><a href="mailto:{{email}}">{{common_name}}</a></td>
+        <td>{{role}}</td>
+      </tr>
+    {{/affectedUsers}}
+  </table>
+
+  <div style="text-align: center;">
+    <a
+      href="{{dashboardUrl}}"
+      style="display: inline-block; padding: 0.75rem 1.125em; background-color: {{applicationColor}};
+        color: #FFF; border-radius: 6px; font-size: 0.875em; font-weight: 700; text-decoration: none;"
+    >
+      Visit this dashboard
+    </a>
   </div>
+  <div
+    style="height: 1px; width: 100%; background-color: #F0F0F0; margin-top: 2em;"
+  ></div>
+</div>
 {{> metabase/email/_footer }}

--- a/src/metabase/email/broken_subscription_notification.mustache
+++ b/src/metabase/email/broken_subscription_notification.mustache
@@ -1,0 +1,24 @@
+{{> metabase/email/_header }}
+  <div style="text-align: center; margin: 0 auto; max-width: 500px">
+    <div style="text-align: left">
+      <h2 style="font-weight: normal; color: #4C545B; line-height: 34px;">Subscription to {{dashboardName}} has been removed</h2>
+      <p>A subscription created by <a href="mailto:{{subscriptionCreatorEmail}}">{{subscriptionCreatorName}}</a>
+      to the dashboard "{{dashboardName}}", created by <a href="mailto:{{dashboardCreatorEmail}}">{{dashboardCreatorName}}</a>,
+      was removed because one or more dashboard parameters were removed that are used by the subscription.</p>
+
+        <p>These parameters and values were removed and are no longer valid:</p>
+        <ul>
+          {{#badParameters}}
+            <li>Parameter: {{name}} (Value: {{value}})</li>
+          {{/badParameters}}
+        </ul>
+
+        <p>These recipients will no longer receive this subscription:</p>
+        <ul>
+          {{#affectedUsers}}
+            <li><a href="mailto:{{email}}">{{common_name}}</a></li>
+          {{/affectedUsers}}
+        </ul>
+    </div>
+  </div>
+{{> metabase/email/_footer }}

--- a/src/metabase/email/broken_subscription_notification.mustache
+++ b/src/metabase/email/broken_subscription_notification.mustache
@@ -3,7 +3,7 @@
   <h2
     style="margin: 0; padding: 0; font-weight: 700; font-size: 1.5em; color: {{colorTextDark}}; line-height: 1.5em;"
   >
-    Subscription to {{dashboardName}} deleted
+    Subscription to {{dashboardName}} removed
   </h2>
 
   <p
@@ -53,7 +53,7 @@
     </tr>
     {{#affectedUsers}}
       <tr>
-        <td><a href="mailto:{{email}}">{{common_name}}</a></td>
+        <td>{{common_name}}</td>
         <td>{{role}}</td>
       </tr>
     {{/affectedUsers}}

--- a/src/metabase/email/broken_subscription_notification.mustache
+++ b/src/metabase/email/broken_subscription_notification.mustache
@@ -38,12 +38,17 @@
         <td style="text-align: left;">{{value}}</td>
       </tr>
     {{/badParameters}}
-    <tr/>
+    <tr />
     <tr>
       <td
         style="font-weight: 600; font-size: 0.875em; color: {{colorTextMedium}}; line-height: 1.375em;"
       >
-        User
+        Notification Type
+      </td>
+      <td
+        style="font-weight: 600; font-size: 0.875em; color: {{colorTextMedium}}; line-height: 1.375em;"
+      >
+        Recipient
       </td>
       <td
         style="font-weight: 600; font-size: 0.875em; color: {{colorTextMedium}}; line-height: 1.375em;"
@@ -53,7 +58,8 @@
     </tr>
     {{#affectedUsers}}
       <tr>
-        <td>{{common_name}}</td>
+        <td>{{notification-type}}</td>
+        <td>{{recipient}}</td>
         <td>{{role}}</td>
       </tr>
     {{/affectedUsers}}

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -718,7 +718,7 @@
   [{:keys [dashboard-id dashboard-name pulse-creator dashboard-creator affected-users bad-parameters]}]
   (let [{:keys [siteUrl] :as context} (common-context)]
     (email/send-message!
-      :subject (trs "Dashboard subscription removed")
+      :subject (trs "Subscription to {0} removed" dashboard-name)
       :recipients (distinct (map :email [pulse-creator dashboard-creator]))
       :message-type :html
       :message (stencil/render-file

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -733,12 +733,17 @@
                                                                            (i18n/tru "or")
                                                                            %))))
                                                      bad-parameters)
-                         :dashboardCreatorName     (:common_name dashboard-creator)
-                         :dashboardCreatorEmail    (:email dashboard-creator)
-                         :subscriptionCreatorName  (:common_name pulse-creator)
-                         :subscriptionCreatorEmail (:email pulse-creator)
-                         :affectedUsers            (into
-                                                     [(assoc dashboard-creator :role "Dashboard Creator")
-                                                      (assoc pulse-creator :role "Subscription Creator")]
-                                                     (map #(assoc % :role "Subscriber") affected-users))
+                         :affectedUsers            (map
+                                                     (fn [{:keys [notification-type] :as m}]
+                                                       (cond-> m
+                                                         notification-type
+                                                         (update :notification-type name)))
+                                                     (into
+                                                       [{:notification-type :email
+                                                         :recipient         (:common_name dashboard-creator)
+                                                         :role              "Dashboard Creator"}
+                                                        {:notification-type :email
+                                                         :recipient         (:common_name pulse-creator)
+                                                         :role              "Subscription Creator"}]
+                                                       (map #(assoc % :role "Subscriber") affected-users)))
                          :dashboardUrl             (format "%s/dashboard/%s" siteUrl dashboard-id)})))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4141,9 +4141,8 @@
                                                                                 [:field (mt/id :people :source)
                                                                                  {:base-type :type/Text}]]}}
                                       :dataset       true}
-           :model/Dashboard {dash-id :id
-                             :as     dashboard} {:name       "My Awesome Dashboard"
-                                                 :parameters [param]}
+           :model/Dashboard {dash-id :id} {:name       "My Awesome Dashboard"
+                                           :parameters [param]}
            :model/DashboardCard {dash-card-id :id} {:dashboard_id       dash-id
                                                     :card_id            card-id
                                                     :parameter_mappings [{:parameter_id "_SOURCE_PARAM_ID_"
@@ -4172,7 +4171,7 @@
             (mt/with-expected-messages 2
               (let [{:keys [parameters]} (dashboard-response (mt/user-http-request
                                                                :rasta :put 200 (str "dashboard/" dash-id)
-                                                               (assoc dashboard :parameters [])))
+                                                               {:parameters []}))
                     inbox     @mt/inbox
                     html-body (get-in inbox ["rasta@metabase.com" 0 :body 0 :content])]
                 (testing "The dashboard parameters were removed"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4180,7 +4180,7 @@
                                         (filterv (comp #{"Dashboard subscription removed"} :subject) messages)))
                     email-received? (fn [recipient-email]
                                       (true? (some-> (get-in inbox [recipient-email 0 :body 0 :content])
-                                                     (str/includes? "Subscription to My Awesome Dashboard has been removed"))))]
+                                                     (str/includes? "Subscription to My Awesome Dashboard deleted"))))]
                 (testing "The dashboard parameters were removed"
                   (is (empty? parameters)))
                 (testing "The broken pulse was archived"

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4168,18 +4168,17 @@
           (testing "The pulse is active"
             (is (false? (t2/select-one-fn :archived :model/Pulse pulse-id))))
           (mt/with-fake-inbox
-            (u/with-timeout 5000
-              (mt/with-expected-messages 2
-                (let [{:keys [parameters]} (dashboard-response (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
-                                                                                     {:parameters []}))
-                      inbox     @mt/inbox
-                      html-body (get-in inbox ["rasta@metabase.com" 0 :body 0 :content])]
-                  (testing "The dashboard parameters were removed"
-                    (is (empty? parameters)))
-                  (testing "The broken pulse was archived"
-                    (is (true? (t2/select-one-fn :archived :model/Pulse pulse-id))))
-                  (testing "A notification email was sent that the subscription was removed"
-                    (is (true? (str/includes? html-body "Subscription to My Awesome Dashboard has been removed"))))
-                  (testing "The dashboard and pulse creators were emailed about the removed pulse"
-                    (is (= #{"trashbird@metabase.com" "rasta@metabase.com"}
-                           (set (keys inbox))))))))))))))
+            (mt/with-expected-messages 2
+              (let [{:keys [parameters]} (dashboard-response (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
+                                                                                   {:parameters []}))
+                    inbox     @mt/inbox
+                    html-body (get-in inbox ["rasta@metabase.com" 0 :body 0 :content])]
+                (testing "The dashboard parameters were removed"
+                  (is (empty? parameters)))
+                (testing "The broken pulse was archived"
+                  (is (true? (t2/select-one-fn :archived :model/Pulse pulse-id))))
+                (testing "A notification email was sent that the subscription was removed"
+                  (is (true? (some-> html-body (str/includes? "Subscription to My Awesome Dashboard has been removed")))))
+                (testing "The dashboard and pulse creators were emailed about the removed pulse"
+                  (is (= #{"trashbird@metabase.com" "rasta@metabase.com"}
+                         (set (keys inbox)))))))))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -1,59 +1,59 @@
 (ns metabase.api.dashboard-test
   "Tests for /api/dashboard endpoints."
   (:require
-    [cheshire.core :as json]
-    [clojure.set :as set]
-    [clojure.string :as str]
-    [clojure.test :refer :all]
-    [clojure.walk :as walk]
-    [medley.core :as m]
-    [metabase.analytics.snowplow-test :as snowplow-test]
-    [metabase.api.card-test :as api.card-test]
-    [metabase.api.common :as api]
-    [metabase.api.dashboard :as api.dashboard]
-    [metabase.api.pivots :as api.pivots]
-    [metabase.config :as config]
-    [metabase.dashboard-subscription-test :as dashboard-subscription-test]
-    [metabase.http-client :as client]
-    [metabase.models
-     :refer [Action
-             Card
-             Collection
-             Dashboard
-             DashboardCard
-             DashboardCardSeries
-             Database
-             Field
-             FieldValues
-             PermissionsGroup
-             PermissionsGroupMembership
-             Pulse
-             Revision
-             Table
-             User]]
-    [metabase.models.collection :as collection]
-    [metabase.models.dashboard :as dashboard]
-    [metabase.models.dashboard-card :as dashboard-card]
-    [metabase.models.dashboard-test :as dashboard-test]
-    [metabase.models.field-values :as field-values]
-    [metabase.models.interface :as mi]
-    [metabase.models.params.chain-filter :as chain-filter]
-    [metabase.models.params.chain-filter-test :as chain-filter-test]
-    [metabase.models.permissions :as perms]
-    [metabase.models.permissions-group :as perms-group]
-    [metabase.models.pulse :as pulse]
-    [metabase.models.revision :as revision]
-    [metabase.query-processor :as qp]
-    [metabase.query-processor.middleware.permissions :as qp.perms]
-    [metabase.query-processor.streaming.test-util :as streaming.test-util]
-    [metabase.server.middleware.util :as mw.util]
-    [metabase.test :as mt]
-    [metabase.test.fixtures :as fixtures]
-    [metabase.util :as u]
-    [ring.util.codec :as codec]
-    [toucan2.core :as t2]
-    [toucan2.protocols :as t2.protocols]
-    [toucan2.tools.with-temp :as t2.with-temp]))
+   [cheshire.core :as json]
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [clojure.test :refer :all]
+   [clojure.walk :as walk]
+   [medley.core :as m]
+   [metabase.analytics.snowplow-test :as snowplow-test]
+   [metabase.api.card-test :as api.card-test]
+   [metabase.api.common :as api]
+   [metabase.api.dashboard :as api.dashboard]
+   [metabase.api.pivots :as api.pivots]
+   [metabase.config :as config]
+   [metabase.dashboard-subscription-test :as dashboard-subscription-test]
+   [metabase.http-client :as client]
+   [metabase.models
+    :refer [Action
+            Card
+            Collection
+            Dashboard
+            DashboardCard
+            DashboardCardSeries
+            Database
+            Field
+            FieldValues
+            PermissionsGroup
+            PermissionsGroupMembership
+            Pulse
+            Revision
+            Table
+            User]]
+   [metabase.models.collection :as collection]
+   [metabase.models.dashboard :as dashboard]
+   [metabase.models.dashboard-card :as dashboard-card]
+   [metabase.models.dashboard-test :as dashboard-test]
+   [metabase.models.field-values :as field-values]
+   [metabase.models.interface :as mi]
+   [metabase.models.params.chain-filter :as chain-filter]
+   [metabase.models.params.chain-filter-test :as chain-filter-test]
+   [metabase.models.permissions :as perms]
+   [metabase.models.permissions-group :as perms-group]
+   [metabase.models.pulse :as pulse]
+   [metabase.models.revision :as revision]
+   [metabase.query-processor :as qp]
+   [metabase.query-processor.middleware.permissions :as qp.perms]
+   [metabase.query-processor.streaming.test-util :as streaming.test-util]
+   [metabase.server.middleware.util :as mw.util]
+   [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u]
+   [ring.util.codec :as codec]
+   [toucan2.core :as t2]
+   [toucan2.protocols :as t2.protocols]
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4168,15 +4168,18 @@
           (testing "The pulse is active"
             (is (false? (t2/select-one-fn :archived :model/Pulse pulse-id))))
           (mt/with-fake-inbox
-            (let [{:keys [parameters]} (dashboard-response (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
-                                                                                 {:parameters []}))
-                  html-body (get-in @mt/inbox ["rasta@metabase.com" 0 :body 0 :content])]
-              (testing "The dashboard parameters were removed"
-                (is (empty? parameters)))
-              (testing "The broken pulse was archived"
-                (is (true? (t2/select-one-fn :archived :model/Pulse pulse-id))))
-              (testing "A notification email was sent that the subscription was removed"
-                (is (true? (str/includes? html-body "Subscription to My Awesome Dashboard has been removed"))))
-              (testing "The dashboard and pulse creators were emailed about the removed pulse"
-                (is (= #{"trashbird@metabase.com" "rasta@metabase.com"}
-                       (set (keys @mt/inbox))))))))))))
+            (u/with-timeout 5000
+              (mt/with-expected-messages 2
+                (let [{:keys [parameters]} (dashboard-response (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
+                                                                                     {:parameters []}))
+                      inbox     @mt/inbox
+                      html-body (get-in inbox ["rasta@metabase.com" 0 :body 0 :content])]
+                  (testing "The dashboard parameters were removed"
+                    (is (empty? parameters)))
+                  (testing "The broken pulse was archived"
+                    (is (true? (t2/select-one-fn :archived :model/Pulse pulse-id))))
+                  (testing "A notification email was sent that the subscription was removed"
+                    (is (true? (str/includes? html-body "Subscription to My Awesome Dashboard has been removed"))))
+                  (testing "The dashboard and pulse creators were emailed about the removed pulse"
+                    (is (= #{"trashbird@metabase.com" "rasta@metabase.com"}
+                           (set (keys inbox))))))))))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -4141,8 +4141,9 @@
                                                                                 [:field (mt/id :people :source)
                                                                                  {:base-type :type/Text}]]}}
                                       :dataset       true}
-           :model/Dashboard {dash-id :id} {:name       "My Awesome Dashboard"
-                                           :parameters [param]}
+           :model/Dashboard {dash-id :id
+                             :as     dashboard} {:name       "My Awesome Dashboard"
+                                                 :parameters [param]}
            :model/DashboardCard {dash-card-id :id} {:dashboard_id       dash-id
                                                     :card_id            card-id
                                                     :parameter_mappings [{:parameter_id "_SOURCE_PARAM_ID_"
@@ -4169,8 +4170,9 @@
             (is (false? (t2/select-one-fn :archived :model/Pulse pulse-id))))
           (mt/with-fake-inbox
             (mt/with-expected-messages 2
-              (let [{:keys [parameters]} (dashboard-response (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
-                                                                                   {:parameters []}))
+              (let [{:keys [parameters]} (dashboard-response (mt/user-http-request
+                                                               :rasta :put 200 (str "dashboard/" dash-id)
+                                                               (assoc dashboard :parameters [])))
                     inbox     @mt/inbox
                     html-body (get-in inbox ["rasta@metabase.com" 0 :body 0 :content])]
                 (testing "The dashboard parameters were removed"


### PR DESCRIPTION
Previously, when a dashboard parameter was removed that was depended upon by a subscription, the subscription went into a broken state that was unfixable (the removed param was still attached to the notification but not visible in the UI for editing). Rather than remove that parameter, which could potentially lead to data leaks, we just archive the pulse.

Now, when a dashboard is saved that would break a pulse/subscription, we archive the pulse and send an email the the dashboard and pulse creators to notify them that the pulse has been removed. The email also contains which params were removed as well as a list of who will no longer be receiving the messages.

One code consideration when writing the query logic to determine the blast radius of the bad pulse was whether to write a large join query then reorganize the results or do N+1 queries starting from the pulse id (The logic requires hitting all of pulse, pulse channel, pulse channel recipients, and user tables). I started with a full join query along the lines of what is shown below, but opted for the N+1 query as broken pulses should be a very rare occurrence so readability was preferred over performance.

```clojure
  (let [parameter-ids ["a3d043d5"]]
    (when (seq parameter-ids)
      (t2/query
        (sql/format
          {:with   [[:params {:select [[:id]
                                       [[:raw "json_array_elements(parameters::json) ->> 'id'"]
                                        :parameter_id]]
                              :from   :pulse}]
                    [:pulse_ids {:select-distinct [[:id :pulse_id]]
                                 :where           [:in :parameter_id parameter-ids]
                                 :from            :params}]]
           :select [[:p.id :pulse_id]
                    [:pc.id :pulse_channel_id]
                    [:pcr.id :pulse_channel_recipient_id]
                    [:creator.first_name :creator_first_name]
                    [:creator.last_name :creator_last_name]
                    [:creator.email :creator_email]
                    [:recipient.first_name :recipient_first_name]
                    [:recipient.last_name :recipient_last_name]
                    [:recipient.email :recipient_email]]
           :from   [[:pulse :p]]
           :join   [:pulse_ids [:= :p.id :pulse_ids.pulse_id]
                    [:pulse_channel :pc] [:= :pc.pulse_id :p.id]
                    [:pulse_channel_recipient :pcr] [:= :pcr.pulse_channel_id :pc.id]
                    ;; Get the pulse creator
                    [:core_user :creator] [:= :creator.id :p.creator_id]
                    ;; Get the pulse recipient
                    [:core_user :recipient] [:= :recipient.id :pcr.user_id]]}))))
```

The new behavior can be easily tested with this ns:

```clojure
(ns tickets.30100-subscriptions-fail-no-param
  "Subscriptions will fail when parameter doesn't exists #30100
  https://github.com/metabase/metabase/issues/30100"
  (:require
    [clojure.test :refer :all]
    [metabase.api.dashboard-test :as dashboard-test]
    [metabase.test :as mt]))

(comment
  (let [param {:name "Source"
               :slug "source"
               :id   "_SOURCE_PARAM_ID_"
               :type :string/=}]
    (mt/dataset test-data
      (mt/with-temp
        [:model/Card {card-id :id
                      query   :dataset_query} {:name          "Native card"
                                               :database_id   (mt/id)
                                               :dataset_query {:database (mt/id)
                                                               :type     :query
                                                               :query    {:source-table (mt/id :people)
                                                                          :limit        5
                                                                          :fields       [[:field (mt/id :people :id)
                                                                                          {:base-type :type/BigInteger}]
                                                                                         [:field (mt/id :people :name)
                                                                                          {:base-type :type/Text}]
                                                                                         [:field (mt/id :people :source)
                                                                                          {:base-type :type/Text}]]}}
                                               :dataset       true}
         :model/Dashboard {dash-id :id} {:name       "My Awesome Dashboard"
                                         :parameters [param]}
         :model/DashboardCard {dash-card-id :id} {:dashboard_id       dash-id
                                                  :card_id            card-id
                                                  :parameter_mappings [{:parameter_id "_SOURCE_PARAM_ID_"
                                                                        :card_id      card-id
                                                                        :target       [:dimension
                                                                                       [:field (mt/id :people :source)
                                                                                        {:base-type :type/Text}]]
                                                                        }]}
         :model/Pulse {bad-slack-pulse-id :id} {:name         "Bad Slack Pulse"
                                                :dashboard_id dash-id
                                                :creator_id   (mt/user->id :trashbird)
                                                :parameters   [(assoc param :value ["LinkedIn"])]}
         :model/PulseCard _ {:pulse_id          bad-slack-pulse-id
                             :card_id           card-id
                             :dashboard_card_id dash-card-id}
         :model/PulseChannel {bad-slack-pulse-channel-id :id} {:channel_type :slack
                                                               :pulse_id     bad-slack-pulse-id
                                                               :details      {:channel "#my-channel"}
                                                               :enabled      true}
         :model/Pulse {pulse-id :id :as pulse} {:name         "Test Pulse"
                                                :dashboard_id dash-id
                                                :creator_id   (mt/user->id :trashbird)
                                                :parameters   [(assoc param :value ["Twitter", "Facebook"])
                                                               {:name "Froob"
                                                                :slug "froob"
                                                                :id   "_FROOB_PARAM_ID_"
                                                                :type :string/=
                                                                :value Math/PI}]}
         :model/PulseCard _ {:pulse_id          pulse-id
                             :card_id           card-id
                             :dashboard_card_id dash-card-id}
         :model/PulseChannel {pulse-channel-id :id} {:channel_type :email
                                                     :pulse_id     pulse-id
                                                     :enabled      true}
         :model/PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
                                         :user_id          (mt/user->id :rasta)}
         :model/PulseChannelRecipient _ {:pulse_channel_id pulse-channel-id
                                         :user_id          (mt/user->id :crowberto)}]
        (#'dashboard-test/dashboard-response
          (mt/user-http-request :rasta :put 200 (str "dashboard/" dash-id)
                                {:parameters []}))))))

```

Fixes #30100