### PR TITLE
Data reference info hovercards

### DIFF
--- a/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter-bulk.cy.spec.js
@@ -156,7 +156,7 @@ describe("scenarios > filters > bulk filtering", () => {
     filter();
 
     modal().within(() => {
-      cy.findByText("Product").click();
+      cy.findByText("Product").click({ force: true });
       filterField("Category").findByText("Gadget").click();
     });
 

--- a/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
@@ -4,6 +4,7 @@ import type { IconName } from "metabase/ui";
 import type Field from "metabase-lib/metadata/Field";
 
 import {
+  NodeListItem,
   NodeListItemLink,
   NodeListItemName,
   NodeListItemIcon,
@@ -11,6 +12,7 @@ import {
   NodeListContainer,
   NodeListIcon,
   NodeListTitleText,
+  NodeListInfoIcon,
 } from "./NodeList.styled";
 
 interface FieldListProps {
@@ -36,12 +38,13 @@ const FieldList = ({ fields, onFieldClick }: FieldListProps) => (
       const iconName = field.icon() as IconName;
       const tooltip = iconName === "unknown" ? t`Unknown type` : null;
       return (
-        <li key={field.getUniqueId()}>
+        <NodeListItem as="li" key={field.getUniqueId()}>
           <NodeListItemLink onClick={() => onFieldClick(field)}>
             <NodeListItemIcon name={iconName} tooltip={tooltip} />
             <NodeListItemName>{field.name}</NodeListItemName>
+            <NodeListInfoIcon field={field} position="top-end" />
           </NodeListItemLink>
-        </li>
+        </NodeListItem>
       );
     })}
   </NodeListContainer>

--- a/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldList.tsx
@@ -1,6 +1,7 @@
 import { t, ngettext, msgid } from "ttag";
 
 import type { IconName } from "metabase/ui";
+import { DelayGroup } from "metabase/ui";
 import type Field from "metabase-lib/metadata/Field";
 
 import {
@@ -21,33 +22,35 @@ interface FieldListProps {
 }
 
 const FieldList = ({ fields, onFieldClick }: FieldListProps) => (
-  <NodeListContainer>
-    <NodeListTitle>
-      <NodeListIcon name="table2" size="12" />
-      <NodeListTitleText>
-        {ngettext(
-          msgid`${fields.length} column`,
-          `${fields.length} columns`,
-          fields.length,
-        )}
-      </NodeListTitleText>
-    </NodeListTitle>
-    {fields.map(field => {
-      // field.icon() cannot be annotated to return IconName
-      // because metabase-lib cannot import from metabase.
-      const iconName = field.icon() as IconName;
-      const tooltip = iconName === "unknown" ? t`Unknown type` : null;
-      return (
-        <NodeListItem as="li" key={field.getUniqueId()}>
-          <NodeListItemLink onClick={() => onFieldClick(field)}>
-            <NodeListItemIcon name={iconName} tooltip={tooltip} />
-            <NodeListItemName>{field.name}</NodeListItemName>
-            <NodeListInfoIcon field={field} position="top-end" />
-          </NodeListItemLink>
-        </NodeListItem>
-      );
-    })}
-  </NodeListContainer>
+  <DelayGroup>
+    <NodeListContainer>
+      <NodeListTitle>
+        <NodeListIcon name="table2" size="12" />
+        <NodeListTitleText>
+          {ngettext(
+            msgid`${fields.length} column`,
+            `${fields.length} columns`,
+            fields.length,
+          )}
+        </NodeListTitleText>
+      </NodeListTitle>
+      {fields.map(field => {
+        // field.icon() cannot be annotated to return IconName
+        // because metabase-lib cannot import from metabase.
+        const iconName = field.icon() as IconName;
+        const tooltip = iconName === "unknown" ? t`Unknown type` : null;
+        return (
+          <NodeListItem as="li" key={field.getUniqueId()}>
+            <NodeListItemLink onClick={() => onFieldClick(field)}>
+              <NodeListItemIcon name={iconName} tooltip={tooltip} />
+              <NodeListItemName>{field.name}</NodeListItemName>
+              <NodeListInfoIcon field={field} position="top-end" />
+            </NodeListItemLink>
+          </NodeListItem>
+        );
+      })}
+    </NodeListContainer>
+  </DelayGroup>
 );
 
 // eslint-disable-next-line import/no-default-export -- deprecated usage

--- a/frontend/src/metabase/query_builder/components/dataref/FieldList.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/FieldList.unit.spec.tsx
@@ -1,0 +1,23 @@
+import { createMockMetadata } from "__support__/metadata";
+import { renderWithProviders, screen } from "__support__/ui";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import FieldList from "./FieldList";
+
+const database = createSampleDatabase();
+
+const metadata = createMockMetadata({
+  databases: [database],
+});
+
+function setup() {
+  const fields = [Object.values(metadata.fields)[0]];
+  renderWithProviders(<FieldList fields={fields} onFieldClick={jest.fn()} />);
+}
+
+describe("FieldList", () => {
+  it("should render the info icon", () => {
+    setup();
+    expect(screen.getByLabelText("More info")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/query_builder/components/dataref/NodeList.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/NodeList.styled.tsx
@@ -1,6 +1,10 @@
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
+import {
+  HoverParent,
+  TableColumnInfoIcon,
+} from "metabase/components/MetadataInfo/ColumnInfoIcon";
 import { color } from "metabase/lib/colors";
 import { space } from "metabase/styled-components/theme";
 import { Icon } from "metabase/ui";
@@ -73,4 +77,16 @@ export const QuestionId = styled.span`
   font-size: 0.75rem;
   color: ${color("text-medium")};
   margin-left: ${space(0)};
+`;
+
+export const NodeListInfoIcon = styled(TableColumnInfoIcon)`
+  margin-left: auto;
+`;
+
+export const NodeListItem = styled(HoverParent)`
+  ${NodeListItemLink} {
+    padding-top: 0;
+    padding-bottom: 0;
+    padding-right: 0;
+  }
 `;

--- a/frontend/src/metabase/redux/metadata.unit.spec.js
+++ b/frontend/src/metabase/redux/metadata.unit.spec.js
@@ -1,5 +1,6 @@
-import Fields from "metabase/entities/fields";
+/* eslint-disable import/order */
 import Tables from "metabase/entities/tables";
+import Fields from "metabase/entities/fields";
 
 import { fetchField, loadMetadataForDependentItems } from "./metadata";
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39114

### Description

Adds the hovercards on the native editor datareference fields.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New → Native query → Sample Dataset
2. Click "Learn about your data" → Sample Dataset → Orders
3. Each of the items in the list should show the info icon when hovered
4. Verify that the info icons show the correct info in the hovercard when hovered


### Demo

<img width="471" alt="Screenshot 2024-02-26 at 09 58 12" src="https://github.com/metabase/metabase/assets/1250185/3657c5d1-e0fc-4e67-955c-beef4af79cc3">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
