### PR TITLE
Add unit tests for `useModelIndexesListQuery` hook

### DIFF
--- a/frontend/src/metabase-types/api/modelIndexes.ts
+++ b/frontend/src/metabase-types/api/modelIndexes.ts
@@ -29,5 +29,3 @@ export type IndexedEntity = {
 export type ModelIndexesListQuery = {
   model_id: CardId | null;
 };
-
-export type ModelIndexesListResult = ModelIndex[];

--- a/frontend/src/metabase/common/hooks/use-model-indexes-list-query/use-model-indexes-list-query.ts
+++ b/frontend/src/metabase/common/hooks/use-model-indexes-list-query/use-model-indexes-list-query.ts
@@ -4,14 +4,11 @@ import type {
 } from "metabase/common/hooks/use-entity-list-query";
 import { useEntityListQuery } from "metabase/common/hooks/use-entity-list-query";
 import { ModelIndexes } from "metabase/entities/model-indexes";
-import type {
-  ModelIndexesListQuery,
-  ModelIndexesListResult,
-} from "metabase-types/api";
+import type { ModelIndexesListQuery, ModelIndex } from "metabase-types/api";
 
 export const useModelIndexesListQuery = (
   props: UseEntityListQueryProps<ModelIndexesListQuery> = {},
-): UseEntityListQueryResult<ModelIndexesListResult> => {
+): UseEntityListQueryResult<ModelIndex> => {
   return useEntityListQuery(props, {
     fetchList: ModelIndexes.actions.fetchList,
     getList: ModelIndexes.selectors.getList,

--- a/frontend/src/metabase/common/hooks/use-model-indexes-list-query/use-model-indexes-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-model-indexes-list-query/use-model-indexes-list-query.unit.spec.tsx
@@ -10,7 +10,8 @@ import { createMockModelIndex } from "metabase-types/api/mocks";
 
 import { useModelIndexesListQuery } from "./use-model-indexes-list-query";
 
-const TEST_ITEM = createMockModelIndex();
+const model_id = 1;
+const TEST_ITEM = createMockModelIndex({ model_id });
 
 const TestComponent = () => {
   const {
@@ -18,7 +19,7 @@ const TestComponent = () => {
     metadata,
     isLoading,
     error,
-  } = useModelIndexesListQuery({ query: { model_id: 1 } });
+  } = useModelIndexesListQuery({ query: { model_id } });
 
   if (isLoading || error) {
     return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
@@ -38,7 +39,7 @@ const TestComponent = () => {
 };
 
 const setup = () => {
-  setupModelIndexEndpoints(1, [TEST_ITEM]);
+  setupModelIndexEndpoints(model_id, [TEST_ITEM]);
   renderWithProviders(<TestComponent />);
 };
 

--- a/frontend/src/metabase/common/hooks/use-model-indexes-list-query/use-model-indexes-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-model-indexes-list-query/use-model-indexes-list-query.unit.spec.tsx
@@ -54,6 +54,7 @@ describe("useModelIndexesListQuery", () => {
     await waitForLoaderToBeRemoved();
     expect(screen.getByText(TEST_ITEM.state)).toBeInTheDocument();
   });
+
   it("should not have any metadata in the response", async () => {
     setup();
     await waitForLoaderToBeRemoved();

--- a/frontend/src/metabase/common/hooks/use-model-indexes-list-query/use-model-indexes-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-model-indexes-list-query/use-model-indexes-list-query.unit.spec.tsx
@@ -1,0 +1,63 @@
+import { setupModelIndexEndpoints } from "__support__/server-mocks";
+import {
+  renderWithProviders,
+  screen,
+  waitForLoaderToBeRemoved,
+  within,
+} from "__support__/ui";
+import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
+import { createMockModelIndex } from "metabase-types/api/mocks";
+
+import { useModelIndexesListQuery } from "./use-model-indexes-list-query";
+
+const TEST_ITEM = createMockModelIndex();
+
+const TestComponent = () => {
+  const {
+    data = [],
+    metadata,
+    isLoading,
+    error,
+  } = useModelIndexesListQuery({ query: { model_id: 1 } });
+
+  if (isLoading || error) {
+    return <LoadingAndErrorWrapper loading={isLoading} error={error} />;
+  }
+
+  return (
+    <div>
+      {data.map((item, index) => (
+        <span key={index}>{item.state}</span>
+      ))}
+
+      <div data-testid="metadata">
+        {(!metadata || Object.keys(metadata).length === 0) && "No metadata"}
+      </div>
+    </div>
+  );
+};
+
+const setup = () => {
+  setupModelIndexEndpoints(1, [TEST_ITEM]);
+  renderWithProviders(<TestComponent />);
+};
+
+describe("useModelIndexesListQuery", () => {
+  it("should be initially loading", () => {
+    setup();
+    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+  });
+
+  it("should show data from the response", async () => {
+    setup();
+    await waitForLoaderToBeRemoved();
+    expect(screen.getByText(TEST_ITEM.state)).toBeInTheDocument();
+  });
+  it("should not have any metadata in the response", async () => {
+    setup();
+    await waitForLoaderToBeRemoved();
+    expect(
+      within(screen.getByTestId("metadata")).getByText("No metadata"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
This PR adds missing unit tests for `useModelIndexesListQuery` hook that was introduced in #38664.