### PR TITLE
FE followup — LLMs for Question and Dashboard Titles and Descriptions #38298

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
@@ -6,7 +6,6 @@ import { POST } from "metabase/lib/api";
 import { color } from "metabase/lib/colors";
 import { useSelector } from "metabase/lib/redux";
 import type { TLLMIndicatorProps } from "metabase/plugins/types";
-import { getSubmittableQuestion } from "metabase/query_builder/selectors";
 import { getSetting } from "metabase/selectors/settings";
 import { Button, Icon, Tooltip } from "metabase/ui";
 
@@ -27,10 +26,7 @@ export const LLMSuggestQuestionInfo = ({
     if (inactive) {
       return { name: undefined, description: undefined };
     }
-
-    const submittableQuestion = getSubmittableQuestion(state, question);
-    const response = await postSummarizeCard(submittableQuestion.card());
-
+    const response = await postSummarizeCard(question.card());
     return {
       name: response?.summary?.title ?? undefined,
       description: response?.summary?.description ?? undefined,

--- a/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
@@ -32,7 +32,7 @@ export const LLMSuggestQuestionInfo = ({
       name: response?.summary?.title ?? undefined,
       description: response?.summary?.description ?? undefined,
     };
-  }, [question]);
+  }, [isActive]);
 
   const handleClick = () => {
     if (value) {

--- a/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
@@ -17,13 +17,14 @@ export const LLMSuggestQuestionInfo = ({
   question,
   onAccept,
 }: TLLMIndicatorProps) => {
-  const state = useSelector(state => state);
-  const inactive = !getSetting(state, "ee-openai-api-key");
-
   const [acceptedSuggestion, setAcceptedSuggestion] = useState(false);
 
+  const isActive = useSelector(
+    state => !!getSetting(state, "ee-openai-api-key"),
+  );
+
   const { loading, value } = useAsync(async () => {
-    if (inactive) {
+    if (!isActive) {
       return { name: undefined, description: undefined };
     }
     const response = await postSummarizeCard(question.card());
@@ -40,7 +41,7 @@ export const LLMSuggestQuestionInfo = ({
     }
   };
 
-  if (inactive || acceptedSuggestion) {
+  if (!isActive || acceptedSuggestion) {
     return null;
   }
 

--- a/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
@@ -13,16 +13,12 @@ import {
   getTransformedSeries,
 } from "metabase/query_builder/selectors";
 import { getSetting } from "metabase/selectors/settings";
-import { Flex, Tooltip, Icon, Button } from "metabase/ui";
-import "./loading.css";
+import { Button, Icon, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
-const postSummarizeCard = POST("/api/ee/autodescribe/card/summarize");
+import "./loading.css";
 
-type TSummarizeCardResponse = () => Promise<{
-  name?: string;
-  description?: string;
-}>;
+const postSummarizeCard = POST("/api/ee/autodescribe/card/summarize");
 
 export const LLMSuggestQuestionInfo = ({
   question,
@@ -31,7 +27,9 @@ export const LLMSuggestQuestionInfo = ({
   const state = useSelector(state => state);
   const inactive = !getSetting(state, "ee-openai-api-key");
 
-  const { loading, value } = useAsync<TSummarizeCardResponse>(async () => {
+  const [acceptedSuggestion, setAcceptedSuggestion] = useState(false);
+
+  const { loading, value } = useAsync(async () => {
     if (inactive) {
       return { name: undefined, description: undefined };
     }
@@ -60,8 +58,6 @@ export const LLMSuggestQuestionInfo = ({
     };
   }, [question]);
 
-  const [acceptedSuggestion, setAcceptedSuggestion] = useState(false);
-
   const handleClick = () => {
     if (value) {
       setAcceptedSuggestion(true);
@@ -73,32 +69,21 @@ export const LLMSuggestQuestionInfo = ({
     return null;
   }
 
-  if (loading) {
-    return (
-      <Flex justify="flex-end">
-        <Tooltip
-          label={t`Generating descriptions`}
-          className="llm-pulse-icon"
-          position="top-end"
-        >
-          <Button variant="unstyled" p="xs">
-            <Icon name="ai" size={16} />
-          </Button>
-        </Tooltip>
-      </Flex>
-    );
-  }
+  const tooltip = loading
+    ? t`Generating descriptions`
+    : t`Description generated. Click to auto-fill.`;
+
+  const className = loading ? "llm-pulse-icon" : undefined;
+  const iconColor = loading ? color("text-medium") : color("brand");
 
   return (
-    <Flex justify="flex-end">
-      <Tooltip
-        label={t`Description generated. Click to auto-fill.`}
-        position="top-end"
-      >
-        <Button onClick={handleClick} variant="unstyled" p="xs">
-          <Icon name="ai" color={color("brand")} size={16} />
-        </Button>
-      </Tooltip>
-    </Flex>
+    <Tooltip label={tooltip} position="top-end">
+      <Button
+        onClick={handleClick}
+        className={className}
+        leftIcon={<Icon name="ai" color={iconColor} />}
+        variant="subtle"
+      />
+    </Tooltip>
   );
 };

--- a/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
@@ -6,15 +6,9 @@ import { POST } from "metabase/lib/api";
 import { color } from "metabase/lib/colors";
 import { useSelector } from "metabase/lib/redux";
 import type { TLLMIndicatorProps } from "metabase/plugins/types";
-import { getQuestionWithDefaultVisualizationSettings } from "metabase/query_builder/actions/core/utils";
-import {
-  getIsResultDirty,
-  getResultsMetadata,
-  getTransformedSeries,
-} from "metabase/query_builder/selectors";
+import { getSubmittableQuestion } from "metabase/query_builder/selectors";
 import { getSetting } from "metabase/selectors/settings";
 import { Button, Icon, Tooltip } from "metabase/ui";
-import * as Lib from "metabase-lib";
 
 import "./loading.css";
 
@@ -34,23 +28,8 @@ export const LLMSuggestQuestionInfo = ({
       return { name: undefined, description: undefined };
     }
 
-    let questionWithVizSettings = question;
-    const series = getTransformedSeries(state);
-    if (series) {
-      questionWithVizSettings = getQuestionWithDefaultVisualizationSettings(
-        question,
-        series,
-      );
-    }
-
-    const resultsMetadata = getResultsMetadata(state);
-    const isResultDirty = getIsResultDirty(state);
-    const cleanQuery = Lib.dropEmptyStages(questionWithVizSettings.query());
-    questionWithVizSettings
-      .setQuery(cleanQuery)
-      .setResultsMetadata(isResultDirty ? null : resultsMetadata);
-
-    const response = await postSummarizeCard(questionWithVizSettings.card());
+    const submittableQuestion = getSubmittableQuestion(state, question);
+    const response = await postSummarizeCard(submittableQuestion.card());
 
     return {
       name: response?.summary?.title ?? undefined,

--- a/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
@@ -5,7 +5,7 @@ import { t } from "ttag";
 import { POST } from "metabase/lib/api";
 import { color } from "metabase/lib/colors";
 import { useSelector } from "metabase/lib/redux";
-import type { TLLMIndicatorProps } from "metabase/plugins/types";
+import type { LLMIndicatorProps } from "metabase/plugins/types";
 import { getSetting } from "metabase/selectors/settings";
 import { Button, Icon, Tooltip } from "metabase/ui";
 
@@ -16,7 +16,7 @@ const postSummarizeCard = POST("/api/ee/autodescribe/card/summarize");
 export const LLMSuggestQuestionInfo = ({
   question,
   onAccept,
-}: TLLMIndicatorProps) => {
+}: LLMIndicatorProps) => {
   const [acceptedSuggestion, setAcceptedSuggestion] = useState(false);
 
   const isActive = useSelector(

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -691,13 +691,13 @@ export const ADMIN_SETTINGS_SECTIONS = {
   },
   llm: {
     name: t`AI Features`,
-    getHidden: settings => !PLUGIN_IS_EE_BUILD.isEEBuild(),
+    getHidden: () => !PLUGIN_IS_EE_BUILD.isEEBuild(),
     order: 131,
     settings: [
       {
         key: "ee-openai-api-key",
         display_name: t`EE OpenAI API Key`,
-        description: "API key used for Enterprise AI features",
+        description: t`API key used for Enterprise AI features`,
         type: "string",
       },
     ],

--- a/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
+++ b/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
@@ -14,7 +14,7 @@ import { CreateCollectionForm } from "../components/CreateCollectionForm";
 
 interface CreateCollectionModalOwnProps
   extends Omit<CreateCollectionFormOwnProps, "onCancel"> {
-  onClose?: () => void;
+  onClose: () => void;
 }
 
 interface CreateCollectionModalDispatchProps {
@@ -38,7 +38,7 @@ function CreateCollectionModal({
       if (typeof onCreate === "function") {
         onCreate(collection);
       } else {
-        onClose?.();
+        onClose();
         onChangeLocation(Urls.collection(collection));
       }
     },
@@ -48,7 +48,7 @@ function CreateCollectionModal({
   return (
     <Modal.Root
       opened
-      onClose={onClose ?? (() => undefined)}
+      onClose={onClose}
       size="lg"
       data-testid="new-collection-modal"
     >

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -22,7 +22,10 @@ import { Form, FormProvider } from "metabase/forms";
 import * as Errors from "metabase/lib/errors";
 import { useSelector } from "metabase/lib/redux";
 import { PLUGIN_LLM_AUTODESCRIPTION } from "metabase/plugins";
-import { getIsSavedQuestionChanged } from "metabase/query_builder/selectors";
+import {
+  getIsSavedQuestionChanged,
+  getSubmittableQuestion,
+} from "metabase/query_builder/selectors";
 import { Flex, Modal, DEFAULT_MODAL_Z_INDEX } from "metabase/ui";
 import type Question from "metabase-lib/Question";
 import type { CollectionId } from "metabase-types/api";
@@ -141,6 +144,10 @@ export const SaveQuestionModal = ({
   const questionWithCollectionId: Question =
     question.setCollectionId(collectionId);
 
+  const submittableQuestion = useSelector(state =>
+    getSubmittableQuestion(state, questionWithCollectionId),
+  );
+
   const handleOverwrite = useCallback(
     async (originalQuestion: Question) => {
       const collectionId = canonicalCollectionId(
@@ -222,7 +229,7 @@ export const SaveQuestionModal = ({
                   <Modal.Title>{title}</Modal.Title>
                   <Flex align="center" justify="flex-end" gap="sm">
                     <PLUGIN_LLM_AUTODESCRIPTION.LLMSuggestQuestionInfo
-                      question={questionWithCollectionId}
+                      question={submittableQuestion}
                       onAccept={nextValues =>
                         setValues({ ...values, ...nextValues })
                       }

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -216,15 +216,16 @@ export const SaveQuestionModal = ({
             validationSchema={SAVE_QUESTION_SCHEMA}
             enableReinitialize
           >
-            {({ values, setFieldValue, validateForm }) => (
+            {({ values, setValues }) => (
               <Modal.Content p="md" data-testid="save-question-modal">
                 <Modal.Header>
                   <Modal.Title>{title}</Modal.Title>
                   <Flex align="center" gap="sm">
                     <PLUGIN_LLM_AUTODESCRIPTION.LLMSuggestQuestionInfo
                       question={questionWithCollectionId}
-                      setFieldValue={setFieldValue}
-                      validateForm={validateForm}
+                      onAccept={nextValues =>
+                        setValues({ ...values, ...nextValues })
+                      }
                     />
                     <Modal.CloseButton />
                   </Flex>

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -192,13 +192,6 @@ export const SaveQuestionModal = ({
     [originalQuestion, handleOverwrite, handleCreate],
   );
 
-  if (collections && isInInstanceAnalyticsQuestion) {
-    const customCollection = getInstanceAnalyticsCustomCollection(collections);
-    if (customCollection) {
-      initialCollectionId = customCollection.id;
-    }
-  }
-
   const isSavedQuestionChanged = useSelector(getIsSavedQuestionChanged);
   const showSaveType =
     isSavedQuestionChanged &&
@@ -209,6 +202,7 @@ export const SaveQuestionModal = ({
     question,
     showSaveType,
   );
+
   const title = multiStep ? multiStepTitle : singleStepTitle;
 
   return (

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -72,7 +72,7 @@ interface SaveQuestionModalProps {
   initialCollectionId?: CollectionId;
 }
 
-export interface FormValues {
+interface FormValues {
   saveType: string;
   collection_id: CollectionId | null | undefined;
   name: string;

--- a/frontend/src/metabase/containers/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal.tsx
@@ -220,7 +220,7 @@ export const SaveQuestionModal = ({
               <Modal.Content p="md" data-testid="save-question-modal">
                 <Modal.Header>
                   <Modal.Title>{title}</Modal.Title>
-                  <Flex align="center" gap="sm">
+                  <Flex align="center" justify="flex-end" gap="sm">
                     <PLUGIN_LLM_AUTODESCRIPTION.LLMSuggestQuestionInfo
                       question={questionWithCollectionId}
                       onAccept={nextValues =>

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -153,9 +153,8 @@ export const PLUGIN_DASHBOARD_SUBSCRIPTION_PARAMETERS_SECTION_OVERRIDE = {
   Component: undefined,
 };
 
-// llm autodescription
 export const PLUGIN_LLM_AUTODESCRIPTION: PluginLLMAutoDescription = {
-  LLMSuggestQuestionInfo: () => null,
+  LLMSuggestQuestionInfo: PluginPlaceholder,
 };
 
 const AUTHORITY_LEVEL_REGULAR: CollectionAuthorityLevelConfig = {

--- a/frontend/src/metabase/plugins/types.ts
+++ b/frontend/src/metabase/plugins/types.ts
@@ -54,15 +54,15 @@ export type PluginGroupManagersType = {
   confirmUpdateMembershipAction: any;
 };
 
-export type TLLMIndicatorProps = {
+export type LLMIndicatorProps = {
   question: Question;
   onAccept: (values: { name?: string; description?: string }) => void;
 };
 
-export type TLLMSuggestQuestionInfo = (
-  props: TLLMIndicatorProps,
+export type LLMSuggestQuestionInfo = (
+  props: LLMIndicatorProps,
 ) => JSX.Element | null;
 
 export type PluginLLMAutoDescription = {
-  LLMSuggestQuestionInfo: TLLMSuggestQuestionInfo;
+  LLMSuggestQuestionInfo: LLMSuggestQuestionInfo;
 };

--- a/frontend/src/metabase/plugins/types.ts
+++ b/frontend/src/metabase/plugins/types.ts
@@ -56,15 +56,12 @@ export type PluginGroupManagersType = {
 
 export type TLLMIndicatorProps = {
   question: Question;
-  setFieldValue: (field: string, value: string) => void;
-  validateForm: (values?: Record<string, boolean>) => void;
+  onAccept: (values: { name?: string; description?: string }) => void;
 };
 
-export type TLLMSuggestQuestionInfo = ({
-  question,
-  setFieldValue,
-  validateForm,
-}: TLLMIndicatorProps) => JSX.Element | null;
+export type TLLMSuggestQuestionInfo = (
+  props: TLLMIndicatorProps,
+) => JSX.Element | null;
 
 export type PluginLLMAutoDescription = {
   LLMSuggestQuestionInfo: TLLMSuggestQuestionInfo;

--- a/frontend/src/metabase/query_builder/actions/core/core.js
+++ b/frontend/src/metabase/query_builder/actions/core/core.js
@@ -32,9 +32,9 @@ import {
   getOriginalQuestion,
   getQuestion,
   getResultsMetadata,
-  getTransformedSeries,
   isBasedOnExistingQuestion,
   getParameters,
+  getSubmittableQuestion,
 } from "../../selectors";
 import { updateUrl } from "../navigation";
 import { zoomInRow } from "../object-detail";
@@ -42,7 +42,6 @@ import { clearQueryResult, runQuestionQuery } from "../querying";
 import { onCloseSidebars } from "../ui";
 
 import { updateQuestion } from "./updateQuestion";
-import { getQuestionWithDefaultVisualizationSettings } from "./utils";
 
 export const RESET_QB = "metabase/qb/RESET_QB";
 export const resetQB = createAction(RESET_QB);
@@ -194,20 +193,9 @@ export const setDatasetQuery =
 export const API_CREATE_QUESTION = "metabase/qb/API_CREATE_QUESTION";
 export const apiCreateQuestion = question => {
   return async (dispatch, getState) => {
-    // Needed for persisting visualization columns for pulses/alerts, see #6749
-    const series = getTransformedSeries(getState());
-    const questionWithVizSettings = series
-      ? getQuestionWithDefaultVisualizationSettings(question, series)
-      : question;
-
-    const resultsMetadata = getResultsMetadata(getState());
-    const isResultDirty = getIsResultDirty(getState());
-    const cleanQuery = Lib.dropEmptyStages(question.query());
-    const questionToCreate = questionWithVizSettings
-      .setQuery(cleanQuery)
-      .setResultsMetadata(isResultDirty ? null : resultsMetadata);
+    const submittableQuestion = getSubmittableQuestion(getState(), question);
     const createdQuestion = await reduxCreateQuestion(
-      questionToCreate,
+      submittableQuestion,
       dispatch,
     );
 
@@ -263,22 +251,13 @@ export const apiUpdateQuestion = (question, { rerunQuery } = {}) => {
       rerunQuery = rerunQuery ?? isResultDirty;
     }
 
-    // Needed for persisting visualization columns for pulses/alerts, see #6749
-    const series = getTransformedSeries(getState());
-    const questionWithVizSettings = series
-      ? getQuestionWithDefaultVisualizationSettings(question, series)
-      : question;
-
-    const cleanQuery = Lib.dropEmptyStages(question.query());
-    const questionToUpdate = questionWithVizSettings
-      .setQuery(cleanQuery)
-      .setResultsMetadata(isResultDirty ? null : resultsMetadata);
+    const submittableQuestion = getSubmittableQuestion(getState(), question);
 
     // When viewing a dataset, its dataset_query is swapped with a clean query using the dataset as a source table
     // (it's necessary for datasets to behave like tables opened in simple mode)
     // When doing updates like changing name, description, etc., we need to omit the dataset_query in the request body
     const updatedQuestion = await reduxUpdateQuestion(
-      questionToUpdate,
+      submittableQuestion,
       dispatch,
       {
         excludeDatasetQuery: isAdHocModelQuestion(question, originalQuestion),

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -41,6 +41,7 @@ import {
 import Question from "metabase-lib/Question";
 import { getIsPKFromTablePredicate } from "metabase-lib/types/utils/isa";
 import { LOAD_COMPLETE_FAVICON } from "metabase/hoc/Favicon";
+import { getQuestionWithDefaultVisualizationSettings } from "./actions/core/utils";
 
 export const getUiControls = state => state.qb.uiControls;
 const getQueryStatus = state => state.qb.queryStatus;
@@ -1052,3 +1053,25 @@ export function getEmbeddedParameterVisibility(state, slug) {
   const embeddingParams = card.embedding_params ?? {};
   return embeddingParams[slug] ?? "disabled";
 }
+
+export const getSubmittableQuestion = (state, question) => {
+  const series = getTransformedSeries(state);
+  const resultsMetadata = getResultsMetadata(state);
+  const isResultDirty = getIsResultDirty(state);
+
+  let submittableQuestion = question;
+
+  if (series) {
+    submittableQuestion = getQuestionWithDefaultVisualizationSettings(
+      submittableQuestion,
+      series,
+    );
+  }
+
+  const cleanQuery = Lib.dropEmptyStages(submittableQuestion.query());
+  submittableQuestion = submittableQuestion
+    .setQuery(cleanQuery)
+    .setResultsMetadata(isResultDirty ? null : resultsMetadata);
+
+  return submittableQuestion;
+};


### PR DESCRIPTION
A FE followup on #38298, main changes:

* fixed opening the save question modal was firing a few requests to the summarize endpoint
* extracted some common QB logic into `getSubmittableQuestion` function