### PR TITLE
add submit snowplow event and increase the onboarding version in the events

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -451,9 +451,14 @@ describeWithSnowplow("scenarios > setup", () => {
         });
 
         cy.button("Next").click();
+        goodEvents++; // 11/12 - setup/step_seen "commercial_license"
+        expectGoodSnowplowEvent({
+          event: "license_token_step_submitted",
+          valid_token_present: false,
+        });
       }
 
-      goodEvents++; // 10/11 - setup/step_seen "data_usage"
+      goodEvents++; // 11/12 - setup/step_seen "data_usage"
       expectGoodSnowplowEvent({
         event: "step_seen",
         step_number: isEE ? 6 : 5,
@@ -461,9 +466,9 @@ describeWithSnowplow("scenarios > setup", () => {
       });
 
       cy.findByRole("button", { name: "Finish" }).click();
-      goodEvents++; // 11/12 - new_user_created (from BE)
+      goodEvents++; // 12/13- - new_user_created (from BE)
 
-      goodEvents++; // 12/13- setup/step_seen "completed"
+      goodEvents++; // 13/14- setup/step_seen "completed"
       expectGoodSnowplowEvent({
         event: "step_seen",
         step_number: isEE ? 7 : 6,

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -200,7 +200,7 @@ export const submitSetup = createAsyncThunk<void, void, ThunkConfig>(
           site_locale: locale?.code,
           allow_tracking: isTrackingAllowed.toString(),
         },
-        license_token: licenseToken,
+        license_token: licenseToken ?? undefined,
       });
 
       if (usageReason === "embedding" || usageReason === "both") {

--- a/frontend/src/metabase/setup/actions.ts
+++ b/frontend/src/metabase/setup/actions.ts
@@ -14,6 +14,7 @@ import type { InviteInfo, Locale, State, UserInfo } from "metabase-types/store";
 import {
   trackAddDataLaterClicked,
   trackDatabaseSelected,
+  trackLicenseTokenStepSubmitted,
   trackTrackingChanged,
   trackUsageReasonSelected,
 } from "./analytics";
@@ -97,8 +98,8 @@ export const submitUsageReason = createAsyncThunk(
 
 export const submitLicenseToken = createAsyncThunk(
   "metabase/setup/SUBMIT_LICENSE_TOKEN",
-  (_token: string | null) => {
-    // TODO: add analytics
+  (token: string | null) => {
+    trackLicenseTokenStepSubmitted(Boolean(token));
   },
 );
 

--- a/frontend/src/metabase/setup/analytics.ts
+++ b/frontend/src/metabase/setup/analytics.ts
@@ -3,7 +3,7 @@ import type { UsageReason } from "metabase-types/api";
 
 import type { SetupStep } from "./types";
 
-const ONBOARDING_VERSION = "1.1.0";
+const ONBOARDING_VERSION = "1.2.0";
 const SCHEMA_VERSION = "1-0-3";
 
 export const trackStepSeen = ({
@@ -26,6 +26,14 @@ export const trackUsageReasonSelected = (usageReason: UsageReason) => {
     event: "usage_reason_selected",
     version: ONBOARDING_VERSION,
     usage_reason: usageReason,
+  });
+};
+
+export const trackLicenseTokenStepSubmitted = (validTokenPresent: boolean) => {
+  trackSchemaEvent("setup", SCHEMA_VERSION, {
+    event: "license_token_step_submitted",
+    valid_token_present: validTokenPresent,
+    version: ONBOARDING_VERSION,
   });
 };
 

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -96,11 +96,9 @@ describe("setup (EE, no token)", () => {
 
       screen.getByRole("button", { name: "Activate" }).click();
 
-      await waitFor(() => {
-        expect(
-          screen.getByRole("button", { name: "Activate" }),
-        ).not.toHaveProperty("data-loading", true);
-      });
+      await screen.findByText(
+        "This token doesn’t seem to be valid. Double-check it, then contact support if you think it should be working",
+      );
 
       clickNextStep();
 

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -84,10 +84,11 @@ describe("setup (EE, no token)", () => {
       ).toBeInTheDocument();
     });
 
-    it("should not save the token if it's invalid", async () => {
+    it("should not send the token if it's invalid", async () => {
       await setupForLicenseStep();
 
       setupForTokenCheckEndpoint({ valid: false });
+
       userEvent.paste(
         screen.getByRole("textbox", { name: "Token" }),
         sampleToken,

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -84,6 +84,35 @@ describe("setup (EE, no token)", () => {
       ).toBeInTheDocument();
     });
 
+    it("should not save the token if it's invalid", async () => {
+      await setupForLicenseStep();
+
+      setupForTokenCheckEndpoint({ valid: false });
+      userEvent.paste(
+        screen.getByRole("textbox", { name: "Token" }),
+        sampleToken,
+      );
+
+      screen.getByRole("button", { name: "Activate" }).click();
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("button", { name: "Activate" }),
+        ).not.toHaveProperty("data-loading", true);
+      });
+
+      clickNextStep();
+
+      expect(trackLicenseTokenStepSubmitted).toHaveBeenCalledWith(false);
+
+      screen.getByRole("button", { name: "Finish" }).click();
+
+      const setupCall = fetchMock.lastCall(`path:/api/setup`);
+      expect(await setupCall?.request?.json()).not.toHaveProperty(
+        "license_token",
+      );
+    });
+
     it("should go to the next step when activating a valid token", async () => {
       await setupForLicenseStep();
 

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-3
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/setup/jsonschema/1-0-3
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "setup",
     "format": "jsonschema",
-    "version": "1-0-2"
+    "version": "1-0-3"
   },
   "type": "object",
   "properties": {
@@ -15,6 +15,7 @@
       "enum": [
         "step_seen",
         "usage_reason_selected",
+        "license_token_step_submitted",
         "database_selected",
         "add_data_later_clicked"
       ],
@@ -84,6 +85,13 @@
         "null"
       ],
       "maxLength": 1024
+    },
+    "valid_token_present": {
+      "description": "Boolean indicating if a valid token was submitted",
+      "type": [
+        "boolean",
+        "null"
+      ]
     },
     "source": {
       "description": "String with the product location that the event took place",


### PR DESCRIPTION
Part of [[Epic] Add license activation in the initial setup](https://github.com/metabase/metabase/issues/38867)

Adds the analytics event for when the step is submitted.

I still have to find a solution on how to test the full flow with a real token in e2e, so I added some jest test to see if it's called with `valid_token_present: true/false` correctly