### PR TITLE
Fix applying default values for a pinned sql question

### DIFF
--- a/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-pinned-overview.cy.spec.js
@@ -38,7 +38,7 @@ const PIVOT_QUESTION_DETAILS = {
   },
 };
 
-const SQL_QUESTION_DETAILS = {
+const SQL_QUESTION_DETAILS_REQUIRED_PARAMETER = {
   name: "SQL with parameters",
   display: "scalar",
   native: {
@@ -52,6 +52,25 @@ const SQL_QUESTION_DETAILS = {
       },
     },
     query: "select {{filter}}",
+  },
+};
+
+const SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE = {
+  name: "SQL with parameters",
+  display: "scalar",
+  native: {
+    "template-tags": {
+      filter: {
+        type: "dimension",
+        name: "filter",
+        id: "4b77cc1f-ea70-4ef6-84db-58432fce6928",
+        "display-name": "date",
+        default: "1999-02-26~2024-02-26",
+        dimension: ["field", 18 /* PEOPLE.BIRTH_DATE */, null],
+        "widget-type": "date/range",
+      },
+    },
+    query: "select count(*) from people where {{filter}}",
   },
 };
 
@@ -213,15 +232,37 @@ describe("scenarios > collection pinned items overview", () => {
     });
   });
 
-  it("should automatically hide the visualization for pinned native questions with missing required parameters", () => {
-    cy.createNativeQuestion(SQL_QUESTION_DETAILS).then(({ body: { id } }) => {
-      cy.request("PUT", `/api/card/${id}`, { collection_position: 1 });
+  describe("native questions", () => {
+    it("should automatically hide the visualization for pinned native questions with missing required parameters", () => {
+      cy.createNativeQuestion(SQL_QUESTION_DETAILS_REQUIRED_PARAMETER).then(
+        ({ body: { id } }) => {
+          cy.request("PUT", `/api/card/${id}`, { collection_position: 1 });
+        },
+      );
+
+      openRootCollection();
+      getPinnedSection().within(() => {
+        cy.findByText(SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE.name).should(
+          "be.visible",
+        );
+        cy.findByText("A question").should("be.visible");
+      });
     });
 
-    openRootCollection();
-    getPinnedSection().within(() => {
-      cy.findByText(SQL_QUESTION_DETAILS.name).should("be.visible");
-      cy.findByText("A question").should("be.visible");
+    it("should apply default value of variable for pinned native questions (metabase#37831)", () => {
+      cy.createNativeQuestion(SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE).then(
+        ({ body: { id } }) => {
+          cy.request("PUT", `/api/card/${id}`, { collection_position: 1 });
+        },
+      );
+
+      openRootCollection();
+      getPinnedSection().within(() => {
+        cy.findByText(SQL_QUESTION_DETAILS_WITH_DEFAULT_VALUE.name).should(
+          "be.visible",
+        );
+        cy.findByTestId("scalar-value").should("have.text", "68");
+      });
     });
   });
 

--- a/frontend/src/metabase-lib/Question.ts
+++ b/frontend/src/metabase-lib/Question.ts
@@ -770,11 +770,13 @@ class Question {
     return question;
   }
 
-  parameters(): ParameterObject[] {
+  parameters({ collectionPreview } = {}): ParameterObject[] {
     return getCardUiParameters(
       this.card(),
       this.metadata(),
       this._parameterValues,
+      undefined,
+      collectionPreview,
     );
   }
 

--- a/frontend/src/metabase-lib/parameters/utils/cards.ts
+++ b/frontend/src/metabase-lib/parameters/utils/cards.ts
@@ -15,6 +15,7 @@ export function getCardUiParameters(
   metadata: Metadata,
   parameterValues: { [key: string]: any } = {},
   parameters = getParametersFromCard(card),
+  collectionPreview?: boolean,
 ): UiParameter[] {
   if (!card) {
     return [];
@@ -22,7 +23,11 @@ export function getCardUiParameters(
 
   const valuePopulatedParameters: (Parameter[] | ParameterWithTarget[]) & {
     value?: any;
-  } = getValuePopulatedParameters({ parameters, values: parameterValues });
+  } = getValuePopulatedParameters({
+    parameters,
+    values: parameterValues,
+    collectionPreview,
+  });
   const question = new Question(card, metadata);
 
   return valuePopulatedParameters.map(parameter => {

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -34,6 +34,9 @@ export function getValuePopulatedParameters({
   defaultRequired = false,
   collectionPreview = false,
 }) {
+  // pinned native question can have default values on parameters, usually we
+  // get them from URL, which is not the case for collection preview. to force
+  // BE to apply default values to those filters, empty array is provided
   if (collectionPreview) {
     return [];
   }

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -32,7 +32,7 @@ export function getValuePopulatedParameters({
   parameters,
   values = {},
   defaultRequired = false,
-  collectionPreview,
+  collectionPreview = false,
 }) {
   if (collectionPreview) {
     return [];

--- a/frontend/src/metabase-lib/parameters/utils/parameter-values.js
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-values.js
@@ -32,7 +32,12 @@ export function getValuePopulatedParameters({
   parameters,
   values = {},
   defaultRequired = false,
+  collectionPreview,
 }) {
+  if (collectionPreview) {
+    return [];
+  }
+
   return parameters.map(parameter => ({
     ...parameter,
     value: getParameterValue({

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -96,7 +96,9 @@ export async function runQuestionQuery(
   } = {},
 ) {
   const canUseCardApiEndpoint = !isDirty && question.isSaved();
-  const parameters = normalizeParameters(question.parameters());
+  const parameters = normalizeParameters(
+    question.parameters({ collectionPreview }),
+  );
   const card = question.card();
 
   if (canUseCardApiEndpoint) {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37831

### Description

For an SQL question, which is pinned to the collection, we need to run query applying the default parameters values.
To achieve this we pass an empty array as a value for `parameters` in `/api/card/:id/query` POST request

### How to verify
follow steps from e2e test or

- create a new sql question with parameter e.g. `select count(*) from people where {{date}}`
- add a filter mapping (field filter type) to the people -> birth date
- select a default value (e.g. `1999-02-26~2024-02-26`)
- save a question and put it to the root collection
- pin this question (it should appear on the top of collection) - make sure the filter is applied

### Demo


https://github.com/metabase/metabase/assets/125459446/1238b880-7571-4e0e-83f9-a7cf50bd4c39



### Checklist

- [x] Tests have been added/updated to cover changes in this PR
