### PR TITLE
Too eager unsaved changes warning when editing native questions

### DIFF
--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
@@ -516,6 +516,23 @@ describe("QueryBuilder - unsaved changes warning", () => {
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
 
+    it("does not show custom warning modal when leaving edited question via SPA navigation without changing the query", async () => {
+      const { history } = await setup({
+        card: TEST_NATIVE_CARD,
+        initialRoute: `/question/${TEST_NATIVE_CARD.id}`,
+      });
+
+      userEvent.click(screen.getByRole("button", { name: "Visualization" }));
+      userEvent.click(screen.getByTestId("Detail-button"));
+      await waitForSaveToBeEnabled();
+
+      history.push("/redirect");
+
+      expect(
+        screen.queryByTestId("leave-confirmation"),
+      ).not.toBeInTheDocument();
+    });
+
     it("does not show custom warning modal leaving with no changes via SPA navigation", async () => {
       const { history } = await setup({
         card: TEST_NATIVE_CARD,

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -635,12 +635,12 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
 
     if (isNative) {
       const isNewQuestion = !originalQuestion;
+      const rawQuery = Lib.rawNativeQuery(question.query());
 
       if (isNewQuestion) {
-        return !question.legacyQuery().isEmpty();
+        return rawQuery.length > 0;
       }
 
-      const rawQuery = Lib.rawNativeQuery(question.query());
       const rawOriginalQuery = Lib.rawNativeQuery(originalQuestion.query());
       const hasQueryChanged = rawQuery !== rawOriginalQuery;
       return hasQueryChanged;

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -613,7 +613,6 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
     getIsDirty,
     isResultsMetadataDirty,
     getQuestion,
-    getIsSavedQuestionChanged,
     getOriginalQuestion,
     getUiControls,
   ],
@@ -622,7 +621,6 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
     isDirty,
     isMetadataDirty,
     question,
-    isSavedQuestionChanged,
     originalQuestion,
     uiControls,
   ) => {
@@ -642,7 +640,10 @@ export const getShouldShowUnsavedChangesWarning = createSelector(
         return !question.legacyQuery().isEmpty();
       }
 
-      return isSavedQuestionChanged;
+      const rawQuery = Lib.rawNativeQuery(question.query());
+      const rawOriginalQuery = Lib.rawNativeQuery(originalQuestion.query());
+      const hasQueryChanged = rawQuery !== rawOriginalQuery;
+      return hasQueryChanged;
     }
 
     const isOriginalQuestionNative =

--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -103,7 +103,13 @@ export const isNavigationAllowed = ({
   }
 
   if (isNative) {
-    const isRunningQuestion = pathname === "/question" && hash.length > 0;
+    const allowedPathnames = [
+      ...validSlugs.map(slug => `/question/${slug}`),
+      "/question",
+    ];
+    const isRunningQuestion =
+      allowedPathnames.includes(pathname) && hash.length > 0;
+
     return isRunningQuestion;
   }
 

--- a/frontend/src/metabase/query_builder/utils.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/utils.unit.spec.ts
@@ -119,6 +119,17 @@ const runQuestionLocation = createMockLocation({
   hash: `#${serializeCardForUrl(nativeCard)}`,
 });
 
+const getRunQuestionLocations = (question: Question) => [
+  createMockLocation({
+    pathname: `/question/${question.id()}`,
+    hash: `#${serializeCardForUrl(nativeCard)}`,
+  }),
+  createMockLocation({
+    pathname: `/question/${question.slug()}`,
+    hash: `#${serializeCardForUrl(nativeCard)}`,
+  }),
+];
+
 const runQuestionEditNotebookLocation = createMockLocation({
   pathname: "/question/notebook",
   hash: `#${serializeCardForUrl(nativeCard)}`,
@@ -165,6 +176,8 @@ describe("isNavigationAllowed", () => {
       runModelLocation,
       runNewModelLocation,
       runQuestionLocation,
+      ...getRunQuestionLocations(structuredQuestion),
+      ...getRunQuestionLocations(nativeQuestion),
       runQuestionEditNotebookLocation,
     ])("allows navigating away to `$pathname`", destination => {
       expect(
@@ -192,6 +205,8 @@ describe("isNavigationAllowed", () => {
         runModelLocation,
         runNewModelLocation,
         runQuestionLocation,
+        ...getRunQuestionLocations(structuredQuestion),
+        ...getRunQuestionLocations(nativeQuestion),
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(
@@ -205,12 +220,15 @@ describe("isNavigationAllowed", () => {
     const isNewQuestion = true;
     const question = nativeQuestion;
 
-    it("allows to run the question", () => {
-      const destination = runQuestionLocation;
-
-      expect(
-        isNavigationAllowed({ destination, question, isNewQuestion }),
-      ).toBe(true);
+    describe("allows to run the question", () => {
+      it.each([
+        runQuestionLocation,
+        ...getRunQuestionLocations(nativeQuestion),
+      ])("to `$pathname`", destination => {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(true);
+      });
     });
 
     describe("disallows all other navigation", () => {
@@ -220,6 +238,7 @@ describe("isNavigationAllowed", () => {
         ...getModelLocations(nativeModelQuestion),
         ...getStructuredQuestionLocations(structuredQuestion),
         ...getNativeQuestionLocations(nativeQuestion),
+        ...getRunQuestionLocations(structuredQuestion),
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
         runModelLocation,
@@ -237,12 +256,15 @@ describe("isNavigationAllowed", () => {
     const isNewQuestion = false;
     const question = structuredQuestion;
 
-    it("allows to run the question", () => {
-      const destination = runQuestionLocation;
-
-      expect(
-        isNavigationAllowed({ destination, question, isNewQuestion }),
-      ).toBe(true);
+    describe("allows to run the question", () => {
+      it.each([
+        runQuestionLocation,
+        ...getRunQuestionLocations(structuredQuestion),
+      ])("to `$pathname`", destination => {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(true);
+      });
     });
 
     it("allows to run the question and then edit it again", () => {
@@ -270,6 +292,7 @@ describe("isNavigationAllowed", () => {
         ...getModelLocations(structuredModelQuestion),
         ...getModelLocations(nativeModelQuestion),
         ...getNativeQuestionLocations(nativeQuestion),
+        ...getRunQuestionLocations(nativeQuestion),
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
       ])("to `$pathname`", destination => {
@@ -284,12 +307,15 @@ describe("isNavigationAllowed", () => {
     const isNewQuestion = false;
     const question = nativeQuestion;
 
-    it("allows to run the question", () => {
-      const destination = runQuestionLocation;
-
-      expect(
-        isNavigationAllowed({ destination, question, isNewQuestion }),
-      ).toBe(true);
+    describe("allows to run the question", () => {
+      it.each([
+        runQuestionLocation,
+        ...getRunQuestionLocations(nativeQuestion),
+      ])("to `$pathname`", destination => {
+        expect(
+          isNavigationAllowed({ destination, question, isNewQuestion }),
+        ).toBe(true);
+      });
     });
 
     describe("disallows all other navigation", () => {
@@ -299,6 +325,7 @@ describe("isNavigationAllowed", () => {
         ...getModelLocations(nativeModelQuestion),
         ...getStructuredQuestionLocations(structuredQuestion),
         ...getNativeQuestionLocations(nativeQuestion),
+        ...getRunQuestionLocations(structuredQuestion),
         newModelQueryTabLocation,
         newModelMetadataTabLocation,
         runModelLocation,
@@ -343,6 +370,8 @@ describe("isNavigationAllowed", () => {
         ...getStructuredQuestionLocations(structuredQuestion),
         ...getNativeQuestionLocations(nativeQuestion),
         runQuestionLocation,
+        ...getRunQuestionLocations(structuredQuestion),
+        ...getRunQuestionLocations(nativeQuestion),
         runQuestionEditNotebookLocation,
       ])("to `$pathname`", destination => {
         expect(


### PR DESCRIPTION
Closes #39001

### Description

Previously, for native questions, unsaved changes warning was shown when anything about the question changed.
Now, for native questions, unsaved changes warning will be shown only when the native query changed.

### How to verify

Nothing should change for models.
Nothing should change for GUI questions.

#### Warning is not shown when anything beside query is changed in a question

1. Create and save a native question with `SELECT 1;` query
2. Change visualization type
3. Try to leave to another URL via navigation in sidebar

Expected result: unsaved changes warning **is not shown**

#### Warning is shown when query is changed

1. Create and save a native question with `SELECT 1;` query
2. Remove `;` from the query
3. Try to leave to another URL via navigation in sidebar

Expected result: unsaved changes warning **is shown**

### Demo

https://github.com/metabase/metabase/assets/6830683/b4be99d7-e17d-42fa-a4ab-26bfead78990


