### PR TITLE
Fix invisible text in custom homepage toast

### DIFF
--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -47,11 +47,13 @@ export const CustomHomePageModal = ({
           <Box ml="0.5rem" mr="2.5rem">
             <Text
               span
+              c="white"
               fw={700}
             >{t`This dashboard has been set as your homepage.`}</Text>
             <br />
             <Text
               span
+              c="white"
             >{t`You can change this in Admin > Settings > General.`}</Text>
           </Box>
         ),


### PR DESCRIPTION
Fixes #38722

Fixes custom homepage toast text was invisible for CSS reasons

### Demo

https://github.com/metabase/metabase/assets/17258145/f0f51813-1983-4d2a-8316-28e14f8ddbd0

