### PR TITLE
Required filters: track when a filter is made required

### DIFF
--- a/frontend/src/metabase/dashboard/actions/parameters.ts
+++ b/frontend/src/metabase/dashboard/actions/parameters.ts
@@ -34,7 +34,10 @@ import type {
 } from "metabase-types/api";
 import type { Dispatch, GetState } from "metabase-types/store";
 
-import { trackAutoApplyFiltersDisabled } from "../analytics";
+import {
+  trackAutoApplyFiltersDisabled,
+  trackFilterRequired,
+} from "../analytics";
 import {
   getAutoApplyFiltersToastId,
   getDashboard,
@@ -297,6 +300,13 @@ export const setParameterRequired = createThunkAction(
         ...parameter,
         required,
       }));
+    }
+
+    if (required) {
+      const dashboardId = getDashboardId(getState());
+      if (dashboardId) {
+        trackFilterRequired(dashboardId);
+      }
     }
   },
 );

--- a/frontend/src/metabase/dashboard/analytics.ts
+++ b/frontend/src/metabase/dashboard/analytics.ts
@@ -3,7 +3,7 @@ import type { DashboardId, DashboardWidth } from "metabase-types/api";
 
 import type { SectionId } from "./sections";
 
-const DASHBOARD_SCHEMA_VERSION = "1-1-3";
+const DASHBOARD_SCHEMA_VERSION = "1-1-4";
 
 export const trackAutoApplyFiltersDisabled = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
@@ -94,6 +94,13 @@ export const trackDashcardDuplicated = (dashboardId: DashboardId) => {
 export const trackTabDuplicated = (dashboardId: DashboardId) => {
   trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
     event: "dashboard_tab_duplicated",
+    dashboard_id: dashboardId,
+  });
+};
+
+export const trackFilterRequired = (dashboardId: DashboardId) => {
+  trackSchemaEvent("dashboard", DASHBOARD_SCHEMA_VERSION, {
+    event: "dashboard_filter_required",
     dashboard_id: dashboardId,
   });
 };

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-4
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/dashboard/jsonschema/1-1-4
@@ -1,0 +1,101 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Dashboard events",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "dashboard",
+    "format": "jsonschema",
+    "version": "1-1-4"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "dashboard_created",
+        "dashboard_saved",
+        "question_added_to_dashboard",
+        "auto_apply_filters_disabled",
+        "dashboard_tab_created",
+        "dashboard_tab_deleted",
+        "dashboard_tab_duplicated",
+        "new_text_card_created",
+        "new_heading_card_created",
+        "new_link_card_created",
+        "new_action_card_created",
+        "card_set_to_hide_when_no_results",
+        "dashboard_pdf_exported",
+        "card_moved_to_tab",
+        "dashboard_card_duplicated",
+        "dashboard_card_replaced",
+        "dashboard_section_added",
+        "dashboard_width_toggled",
+        "dashboard_filter_required"
+      ],
+      "maxLength": 1024
+    },
+    "dashboard_id": {
+      "description": "Unique identifier for a dashboard within the Metabase instance",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "question_id": {
+      "description": "Unique identifier for a question added to a dashboard",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "num_tabs": {
+      "description": "Number of tabs affected after the event",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "total_num_tabs": {
+      "description": "Total number of active tabs after the events",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "duration_milliseconds": {
+      "description": "Duration the action took to complete in milliseconds",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "section_layout": {
+      "description": "String describing the layout that was selected from the pre-built options",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "full_width": {
+      "description": "Boolean set to True if the dashboard was toggled to full width and False if full width was disabled.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "event",
+    "dashboard_id"
+  ],
+  "additionalProperties": true
+}

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -32,7 +32,7 @@
   {::account              "1-0-1"
    ::invite               "1-0-1"
    ::csvupload            "1-0-0"
-   ::dashboard            "1-1-3"
+   ::dashboard            "1-1-4"
    ::database             "1-0-1"
    ::instance             "1-1-2"
    ::metabot              "1-0-1"


### PR DESCRIPTION
Adds the `dashboard_filter_required` event and updates schemas. Closes #39066 

## What exactly is tracked
Every time the toggle is flipped to required, we will log an event.
[Confirmed by Conor](https://metaboat.slack.com/archives/C0645JP1W81/p1708963461276029?thread_ts=1708961675.462709&cid=C0645JP1W81) on Slack. 

## Testing
Tracking works locally with a setup described [here](https://www.notion.so/metabase/Snowplow-integration-5da1f874beda4153b4fccfa6c1e77caa).
