### PR TITLE
Show only native databases users can actually use

### DIFF
--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -161,7 +161,7 @@ describe(
       });
     });
 
-    it.skip("users with no native write permissions should be able to choose only the databases they can query against (metabase#39053)", () => {
+    it("users with no native write permissions should be able to choose only the databases they can query against (metabase#39053)", () => {
       cy.signIn("nosql");
 
       startNativeQuestion();

--- a/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
+++ b/frontend/src/metabase/query_builder/components/NativeQueryEditor/DataSourceSelectors/DataSourceSelectors.jsx
@@ -65,7 +65,8 @@ const DataSourceSelectors = ({
   const databases = useMemo(() => {
     const allDatabases = query
       .metadata()
-      .databasesList({ savedQuestions: false });
+      .databasesList({ savedQuestions: false })
+      .filter(db => db.canWrite());
 
     if (editorContext === "action") {
       return allDatabases.filter(database => database.hasActionsEnabled());


### PR DESCRIPTION
A follow-up after #38986 that revealed that we offer databases in a native query editor to users that do not have permissions to query them.

This PR fixes that wrong behavior. It also enables previously prepared E2E test which should confirm that the issue is actually fixed.

Fixes #39053.