### PR TITLE
Use mongo 5.0 for E2E tests

### DIFF
--- a/e2e/snapshot-creators/qa-db.cy.snap.js
+++ b/e2e/snapshot-creators/qa-db.cy.snap.js
@@ -15,7 +15,7 @@ describe("qa databases snapshots", { tags: "@external" }, () => {
   it("creates snapshots for supported qa databases", () => {
     if (Cypress.env("QA_DB_MONGO") === true) {
       addMongoDatabase();
-      snapshot("mongo-4");
+      snapshot("mongo-5");
       deleteDatabase("mongoID");
 
       restoreAndAuthenticate();

--- a/e2e/support/helpers/e2e-qa-databases-helpers.js
+++ b/e2e/support/helpers/e2e-qa-databases-helpers.js
@@ -12,7 +12,7 @@ import {
  **            QA DATABASES             **
  ******************************************/
 
-export function addMongoDatabase(name = "QA Mongo4") {
+export function addMongoDatabase(name = "QA Mongo") {
   // https://hub.docker.com/layers/metabase/qa-databases/mongo-sample-4.4/images/sha256-8cdeaacf28c6f0a6f9fde42ce004fcc90200d706ac6afa996bdd40db78ec0305
   addQADatabase("mongo", name, QA_MONGO_PORT);
 }

--- a/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
+++ b/e2e/test/scenarios/admin/databases/add-new-database.cy.spec.js
@@ -162,7 +162,7 @@ describe("admin > database > add", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.contains("Additional connection string options");
 
-        typeAndBlurUsingLabel("Display name", "QA Mongo4");
+        typeAndBlurUsingLabel("Display name", "QA Mongo");
         typeAndBlurUsingLabel("Host", "localhost");
         typeAndBlurUsingLabel("Port", QA_MONGO_PORT);
         typeAndBlurUsingLabel("Database name", "sample");
@@ -183,7 +183,7 @@ describe("admin > database > add", () => {
         });
 
         cy.findByRole("table").within(() => {
-          cy.findByText("QA Mongo4");
+          cy.findByText("QA Mongo");
         });
 
         cy.findByRole("status").within(() => {
@@ -205,7 +205,7 @@ describe("admin > database > add", () => {
 
         cy.findByTestId("database-form").within(() => {
           cy.findByText("Paste a connection string").click();
-          typeAndBlurUsingLabel("Display name", "QA Mongo4");
+          typeAndBlurUsingLabel("Display name", "QA Mongo");
           cy.findByLabelText("Port").should("not.exist");
           cy.findByLabelText("Paste your connection string").type(badDBString, {
             delay: 0,
@@ -244,7 +244,7 @@ describe("admin > database > add", () => {
         });
 
         cy.findByRole("table").within(() => {
-          cy.findByText("QA Mongo4");
+          cy.findByText("QA Mongo");
         });
 
         cy.findByRole("status").within(() => {

--- a/e2e/test/scenarios/docker-compose.yml
+++ b/e2e/test/scenarios/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: "3.9"
 
 services:
   postgres-sample:
@@ -6,9 +6,9 @@ services:
       - TZ=US/Pacific
     image: metabase/qa-databases:postgres-sample-12
     ports:
-      - "5404:5432"
+      - 5404:5432
   mongo-sample:
-    image: metabase/qa-databases:mongo-sample-4.0
+    image: metabase/qa-databases:mongo-sample-5.0
     ports:
       - 27004:27017
   mysql-sample:

--- a/e2e/test/scenarios/native/native-mongo.cy.spec.js
+++ b/e2e/test/scenarios/native/native-mongo.cy.spec.js
@@ -7,7 +7,7 @@ describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
     cy.intercept("POST", "/api/card").as("createQuestion");
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    restore("mongo-4");
+    restore("mongo-5");
     cy.signInAsNormalUser();
 
     cy.visit("/");

--- a/e2e/test/scenarios/native/native-mongo.cy.spec.js
+++ b/e2e/test/scenarios/native/native-mongo.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore } from "e2e/support/helpers";
 
-const MONGO_DB_NAME = "QA Mongo4";
+const MONGO_DB_NAME = "QA Mongo";
 
 describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
   before(() => {

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -459,7 +459,7 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
     "shows format query button only for sql queries",
     { tags: "@mongo" },
     () => {
-      const MONGO_DB_NAME = "QA Mongo4";
+      const MONGO_DB_NAME = "QA Mongo";
 
       cy.intercept("POST", "/api/card").as("createQuestion");
       cy.intercept("POST", "/api/dataset").as("dataset");

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -464,7 +464,7 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
       cy.intercept("POST", "/api/card").as("createQuestion");
       cy.intercept("POST", "/api/dataset").as("dataset");
 
-      restore("mongo-4");
+      restore("mongo-5");
       cy.signInAsNormalUser();
 
       openNativeEditor({ newMenuItemTitle: "Native query" });

--- a/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
@@ -1,6 +1,6 @@
 import { popover, restore, startNewQuestion } from "e2e/support/helpers";
 
-const MONGO_DB_NAME = "QA Mongo4";
+const MONGO_DB_NAME = "QA Mongo";
 
 describe("issue 15946", { tags: "@mongo" }, () => {
   before(() => {

--- a/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
@@ -4,7 +4,7 @@ const MONGO_DB_NAME = "QA Mongo4";
 
 describe("issue 15946", { tags: "@mongo" }, () => {
   before(() => {
-    restore("mongo-4");
+    restore("mongo-5");
     cy.signInAsAdmin();
 
     startNewQuestion();

--- a/e2e/test/scenarios/native/reproductions/32121-sql-source-query-can-explore-results.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/32121-sql-source-query-can-explore-results.cy.spec.js
@@ -1,6 +1,6 @@
 import { restore, saveQuestion, startNewQuestion } from "e2e/support/helpers";
 
-const MONGO_DB_NAME = "QA Mongo4";
+const MONGO_DB_NAME = "QA Mongo";
 
 describe("issue 32121", () => {
   describe("on SQL questions", () => {

--- a/e2e/test/scenarios/native/reproductions/32121-sql-source-query-can-explore-results.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/32121-sql-source-query-can-explore-results.cy.spec.js
@@ -39,7 +39,7 @@ describe("issue 32121", () => {
 
   describe("on native Mongo questions", { tags: "@mongo" }, () => {
     before(() => {
-      restore("mongo-4");
+      restore("mongo-5");
       cy.signInAsAdmin();
 
       startNewQuestion();

--- a/e2e/test/scenarios/question/query-external.cy.spec.js
+++ b/e2e/test/scenarios/question/query-external.cy.spec.js
@@ -5,7 +5,7 @@ const supportedDatabases = [
   {
     database: "Mongo",
     snapshotName: "mongo-5",
-    dbName: "QA Mongo4",
+    dbName: "QA Mongo",
   },
   {
     database: "MySQL",

--- a/e2e/test/scenarios/question/query-external.cy.spec.js
+++ b/e2e/test/scenarios/question/query-external.cy.spec.js
@@ -4,7 +4,7 @@ import { openTable, restore, visualize } from "e2e/support/helpers";
 const supportedDatabases = [
   {
     database: "Mongo",
-    snapshotName: "mongo-4",
+    snapshotName: "mongo-5",
     dbName: "QA Mongo4",
   },
   {

--- a/e2e/test/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
@@ -10,7 +10,7 @@ const MONGO_DB_ID = 2;
 
 describe("issue 13097", { tags: "@mongo" }, () => {
   beforeEach(() => {
-    restore("mongo-4");
+    restore("mongo-5");
     cy.signInAsAdmin();
 
     withDatabase(MONGO_DB_ID, ({ PEOPLE_ID }) => {

--- a/e2e/test/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17963-mongo-filter-expression-compare-two-fields.cy.spec.js
@@ -9,7 +9,7 @@ import {
 
 describe("issue 17963", { tags: "@mongo" }, () => {
   beforeEach(() => {
-    restore("mongo-4");
+    restore("mongo-5");
     cy.signInAsAdmin();
 
     cy.request(`/api/database/${WRITABLE_DB_ID}/schema/`).then(({ body }) => {

--- a/e2e/test/scenarios/visualizations-charts/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
@@ -9,7 +9,7 @@ const externalDatabaseId = 2;
 
 describe("issue 16170", { tags: "@mongo" }, () => {
   beforeEach(() => {
-    restore("mongo-4");
+    restore("mongo-5");
     cy.signInAsAdmin();
 
     withDatabase(externalDatabaseId, ({ ORDERS, ORDERS_ID }) => {


### PR DESCRIPTION
EOL for Mongo 4.0 was in April 2022.

This PR switches to using Mongo 5.0 in E2E tests.