### PR TITLE
🍒 Manual backport "fix incorrect tooltip value in pie chart (#39180)" to 48

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/utils.ts
@@ -33,6 +33,9 @@ export function getMaxLabelDimension(
 interface SliceData {
   key: string;
   value: number;
+  displayValue: number;
+  percentage: number;
+  rowIndex: number;
   color: string;
 }
 
@@ -46,7 +49,7 @@ export const getTooltipModel = (
 ): StackedTooltipModel => {
   const rows = slices.map(slice => ({
     name: dimensionFormatter(slice.key),
-    value: slice.value,
+    value: slice.displayValue,
     color: slice.color,
     formatter: metricFormatter,
   }));

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/utils.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/utils.unit.spec.ts
@@ -4,12 +4,109 @@ const slices = [
   {
     key: "foo",
     value: 100,
+    displayValue: 100,
+    percentage: 0.34,
+    rowIndex: 0,
     color: "green",
   },
   {
     key: "bar",
     value: 200,
+    displayValue: 200,
+    percentage: 0.66,
+    rowIndex: 1,
     color: "red",
+  },
+];
+
+const stateSlices = [
+  {
+    key: "AK",
+    value: 474,
+    displayValue: 474,
+    percentage: 0.06519944979367263,
+    rowIndex: 0,
+    color: "#509EE3",
+  },
+  {
+    key: "AL",
+    value: 504,
+    displayValue: 504,
+    percentage: 0.06932599724896836,
+    rowIndex: 1,
+    color: "#227FD2",
+  },
+  {
+    key: "CA",
+    value: 613,
+    displayValue: 613,
+    percentage: 0.08431911966987621,
+    rowIndex: 2,
+    color: "#88BF4D",
+  },
+  {
+    key: "CO",
+    value: 732,
+    displayValue: 732,
+    percentage: 0.10068775790921596,
+    rowIndex: 3,
+    color: "#689636",
+  },
+  {
+    key: "IA",
+    value: 583,
+    displayValue: 583,
+    percentage: 0.08019257221458047,
+    rowIndex: 5,
+    color: "#8A5EB0",
+  },
+  {
+    key: "MN",
+    value: 788,
+    displayValue: 788,
+    percentage: 0.10839064649243467,
+    rowIndex: 6,
+    color: "#EF8C8C",
+  },
+  {
+    key: "MT",
+    value: 872,
+    displayValue: 872,
+    percentage: 0.11994497936726273,
+    rowIndex: 7,
+    color: "#E75454",
+  },
+  {
+    key: "NY",
+    value: 635,
+    displayValue: 635,
+    percentage: 0.0873452544704264,
+    rowIndex: 8,
+    color: "#F9D45C",
+  },
+  {
+    key: "TX",
+    value: 1342,
+    displayValue: 1342,
+    percentage: 0.18459422283356258,
+    rowIndex: 9,
+    color: "#F7C41F",
+  },
+  {
+    key: "WI",
+    value: 706,
+    displayValue: 706,
+    percentage: 0.09711141678129298,
+    rowIndex: 10,
+    color: "#F2A86F",
+  },
+  {
+    key: "DE",
+    value: 21.81,
+    displayValue: 21,
+    percentage: 0.0028885832187070153,
+    rowIndex: 4,
+    color: "#A989C5",
   },
 ];
 
@@ -47,6 +144,21 @@ describe("utils", () => {
       ]);
       expect(showTotal).toBe(true);
       expect(showPercentages).toBe(true);
+    });
+
+    it("is not affected by minimum slice percentage setting #32430 #33342", () => {
+      const smallSliceIndex = stateSlices.length - 1;
+      const { headerRows } = getTooltipModel(
+        stateSlices,
+        smallSliceIndex,
+        dimensionColumnName,
+        dimensionFormatter,
+        metricFormatter,
+      );
+
+      expect(headerRows[0].value).toBe(
+        stateSlices[smallSliceIndex].displayValue,
+      );
     });
   });
 });


### PR DESCRIPTION
### Description

Backporting https://github.com/metabase/metabase/pull/39180 to 48. Code is exactly the same as the original PR, just doing a manual backport since the auto-backport is for 49.