### PR TITLE
Optimize the CI milestone reminder

### DIFF
--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -26,8 +26,8 @@ jobs:
 
             // the github API doesn't expose linked issues, so we have to parse the body ourselves
             function getLinkedIssueId(pull) {
-              // https://regexr.com/7mjnp
-              const match = pull.data.body.match(/(\/issues\/|#)(\d+)/);
+              // https://regexr.com/7sk94
+              const match = pull.data.body.match(/(close(s|d)?|fixe?(s|d)?|resolve(s|d)?) (#|https?:\/\/github.com\/.+\/issues\/)(\d+)/);
               return match && match?.[2];
             }
 

--- a/.github/workflows/check-milestone.yml
+++ b/.github/workflows/check-milestone.yml
@@ -27,7 +27,7 @@ jobs:
             // the github API doesn't expose linked issues, so we have to parse the body ourselves
             function getLinkedIssueId(pull) {
               // https://regexr.com/7sk94
-              const match = pull.data.body.match(/(close(s|d)?|fixe?(s|d)?|resolve(s|d)?) (#|https?:\/\/github.com\/.+\/issues\/)(\d+)/);
+              const match = pull.data.body.match(/(close(s|d)?|fixe?(s|d)?|resolve(s|d)?) (#|https?:\/\/github.com\/.+\/issues\/)(\d+)/i);
               return match && match?.[2];
             }
 


### PR DESCRIPTION
This PR narrows down the matching pattern for the milestone reminder to only the descriptions that explicitly contain one of the closing keywords followed by the issue (number).

To verify that the proposed solution works, please check:
- https://regexr.com/7sk94

Also see the list of the closing keywords as defined by GitHub. https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
