### PR TITLE
Migrate from legacy popover in notebook components

### DIFF
--- a/e2e/test/scenarios/binning/binning-options.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-options.cy.spec.js
@@ -325,7 +325,7 @@ function getAllOptions({ options, isSelected, shouldExpandList } = {}) {
     .last()
     .within(() => {
       if (shouldExpandList) {
-        cy.button("More…").click();
+        cy.findByText("More…").click();
       }
 
       regularOptions.forEach(option => {

--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -123,7 +123,7 @@ describe("binning related reproductions", () => {
       .findByRole("option", { name: "CREATED_AT" })
       .findByLabelText("Temporal bucket")
       .click();
-    cy.findByRole("menuitem", { name: "Quarter" }).click();
+    popover().last().findByText("Quarter").click();
 
     getNotebookStep("sort").findByText("CREATED_AT: Quarter");
   });

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -21,8 +21,6 @@ import {
   InfoIconContainer,
 } from "./AggregationPicker.styled";
 
-const DEFAULT_MAX_HEIGHT = 610;
-
 interface AggregationPickerProps {
   className?: string;
   query: Lib.Query;
@@ -30,7 +28,6 @@ interface AggregationPickerProps {
   stageIndex: number;
   operators: Lib.AggregationOperator[];
   hasExpressionInput?: boolean;
-  maxHeight?: number;
   onSelect: (operator: Lib.Aggregable) => void;
   onClose?: () => void;
 }
@@ -63,7 +60,6 @@ export function AggregationPicker({
   stageIndex,
   operators,
   hasExpressionInput = true,
-  maxHeight = DEFAULT_MAX_HEIGHT,
   onSelect,
   onClose,
 }: AggregationPickerProps) {
@@ -250,7 +246,6 @@ export function AggregationPicker({
     <Root className={className} color="summarize">
       <AccordionList
         sections={sections}
-        maxHeight={maxHeight}
         alwaysExpanded={false}
         onChange={handleChange}
         onChangeSection={handleSectionChange}
@@ -258,6 +253,9 @@ export function AggregationPicker({
         renderItemName={renderItemName}
         renderItemDescription={omitItemDescription}
         renderItemExtra={renderItemExtra}
+        // disable scrollbars inside the list
+        style={{ overflow: "visible" }}
+        maxHeight={Infinity}
       />
     </Root>
   );

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -232,7 +232,6 @@ export function AggregationPicker({
           stageIndex={stageIndex}
           columnGroups={columnGroups}
           hasTemporalBucketing
-          maxHeight={maxHeight}
           color="summarize"
           checkIsColumnSelected={checkColumnSelected}
           onSelect={handleColumnSelect}

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -90,11 +90,7 @@ function _BaseBucketPickerPopover({
     : items;
 
   return (
-    <Popover
-      opened={isOpened}
-      position="right"
-      onClose={() => setIsOpened(false)}
-    >
+    <Popover opened={isOpened} position="right" onChange={setIsOpened}>
       <Popover.Target>
         <TriggerButton
           aria-label={triggerLabel}

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -2,18 +2,18 @@ import type { ReactNode } from "react";
 import { useCallback, useMemo, useState } from "react";
 import { t } from "ttag";
 
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import SelectList from "metabase/components/SelectList";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import type { ColorName } from "metabase/lib/colors/types";
+import { Popover } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import {
   Content,
   MoreButton,
+  SelectListItem,
   TriggerButton,
   TriggerIcon,
-  SelectListItem,
 } from "./BaseBucketPickerPopover.styled";
 
 export const INITIALLY_VISIBLE_ITEMS_COUNT = 7;
@@ -54,6 +54,7 @@ function _BaseBucketPickerPopover({
   renderTriggerContent,
   onSelect,
 }: BaseBucketPickerPopoverProps) {
+  const [isOpened, setIsOpened] = useState(false);
   const [isExpanded, setIsExpanded] = useState(
     isInitiallyExpanded(items, selectedBucket, checkBucketIsSelected),
   );
@@ -74,6 +75,7 @@ function _BaseBucketPickerPopover({
       checkBucketIsSelected,
     );
     setIsExpanded(nextState);
+    setIsOpened(false);
   }, [items, selectedBucket, checkBucketIsSelected]);
 
   const triggerContentBucket = isEditing ? selectedBucket : defaultBucket;
@@ -88,25 +90,26 @@ function _BaseBucketPickerPopover({
     : items;
 
   return (
-    <PopoverWithTrigger
-      renderTrigger={({ onClick }) => (
+    <Popover
+      opened={isOpened}
+      position="right"
+      onClose={() => setIsOpened(false)}
+    >
+      <Popover.Target>
         <TriggerButton
           aria-label={triggerLabel}
-          onClick={event => {
-            event.stopPropagation();
-            onClick();
-          }}
           // Compat with E2E tests around MLv1-based components
           // Prefer using a11y role selectors
           data-testid="dimension-list-item-binning"
+          onClick={() => setIsOpened(!isOpened)}
         >
           <Ellipsified>
             {renderTriggerContent(triggerContentBucketDisplayInfo)}
           </Ellipsified>
           {hasArrowIcon && <TriggerIcon name="chevronright" />}
         </TriggerButton>
-      )}
-      popoverContent={({ closePopover }) => (
+      </Popover.Target>
+      <Popover.Dropdown>
         <Content>
           <SelectList>
             {visibleItems.map(item => (
@@ -118,7 +121,7 @@ function _BaseBucketPickerPopover({
                 isSelected={checkBucketIsSelected(item)}
                 onSelect={() => {
                   onSelect(item.bucket);
-                  closePopover();
+                  handlePopoverClose();
                 }}
               />
             ))}
@@ -127,9 +130,8 @@ function _BaseBucketPickerPopover({
             <MoreButton onClick={handleExpand}>{t`More…`}</MoreButton>
           )}
         </Content>
-      )}
-      onClose={handlePopoverClose}
-    />
+      </Popover.Dropdown>
+    </Popover>
   );
 }
 
@@ -143,11 +145,10 @@ function isInitiallyExpanded(
     return false;
   }
 
-  const isSelectedBucketAmongHiddenItems =
+  return (
     items.findIndex(item => checkBucketIsSelected(item)) >=
-    INITIALLY_VISIBLE_ITEMS_COUNT;
-
-  return isSelectedBucketAmongHiddenItems;
+    INITIALLY_VISIBLE_ITEMS_COUNT
+  );
 }
 
 export function getBucketListItem(

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -97,7 +97,10 @@ function _BaseBucketPickerPopover({
           // Compat with E2E tests around MLv1-based components
           // Prefer using a11y role selectors
           data-testid="dimension-list-item-binning"
-          onClick={() => setIsOpened(!isOpened)}
+          onClick={event => {
+            event.stopPropagation();
+            setIsOpened(!isOpened);
+          }}
         >
           <Ellipsified>
             {renderTriggerContent(triggerContentBucketDisplayInfo)}

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -118,7 +118,8 @@ function _BaseBucketPickerPopover({
                 name={item.displayName}
                 activeColor={color}
                 isSelected={checkBucketIsSelected(item)}
-                onSelect={() => {
+                onSelect={(_id, event) => {
+                  event.stopPropagation();
                   onSelect(item.bucket);
                   handlePopoverClose();
                 }}

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BaseBucketPickerPopover.tsx
@@ -90,7 +90,7 @@ function _BaseBucketPickerPopover({
     : items;
 
   return (
-    <Popover opened={isOpened} position="right" onChange={setIsOpened}>
+    <Popover opened={isOpened} position="right" onClose={handlePopoverClose}>
       <Popover.Target>
         <TriggerButton
           aria-label={triggerLabel}

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -30,6 +30,7 @@ export interface QueryColumnPickerProps {
   checkIsColumnSelected: (item: ColumnListItem) => boolean;
   onSelect: (column: Lib.ColumnMetadata) => void;
   onClose?: () => void;
+  "data-testid"?: string;
 }
 
 type Sections = {
@@ -50,6 +51,7 @@ export function QueryColumnPicker({
   checkIsColumnSelected,
   onSelect,
   onClose,
+  "data-testid": dataTestId,
 }: QueryColumnPickerProps) {
   const sections: Sections[] = useMemo(
     () =>
@@ -164,6 +166,7 @@ export function QueryColumnPicker({
       // disable scrollbars inside the list
       style={{ overflow: "visible" }}
       maxHeight={Infinity}
+      data-testid={dataTestId}
       // Compat with E2E tests around MLv1-based components
       // Prefer using a11y role selectors
       itemTestId="dimension-list-item"

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -13,8 +13,6 @@ import * as Lib from "metabase-lib";
 import { BucketPickerPopover } from "./BucketPickerPopover";
 import { StyledAccordionList } from "./QueryColumnPicker.styled";
 
-const DEFAULT_MAX_HEIGHT = 610;
-
 export type ColumnListItem = Lib.ColumnDisplayInfo & {
   column: Lib.ColumnMetadata;
 };
@@ -48,7 +46,6 @@ export function QueryColumnPicker({
   hasBinning = false,
   hasTemporalBucketing = false,
   withDefaultBucketing = true,
-  maxHeight = DEFAULT_MAX_HEIGHT,
   color = "brand",
   checkIsColumnSelected,
   onSelect,
@@ -156,7 +153,6 @@ export function QueryColumnPicker({
     <StyledAccordionList
       className={className}
       sections={sections}
-      maxHeight={maxHeight}
       alwaysExpanded={false}
       onChange={handleSelectColumn}
       itemIsSelected={checkIsColumnSelected}
@@ -165,6 +161,9 @@ export function QueryColumnPicker({
       renderItemIcon={renderItemIcon}
       renderItemExtra={renderItemExtra}
       color={color}
+      // disable scrollbars inside the list
+      style={{ overflow: "visible" }}
+      maxHeight={Infinity}
       // Compat with E2E tests around MLv1-based components
       // Prefer using a11y role selectors
       itemTestId="dimension-list-item"

--- a/frontend/src/metabase/components/SelectList/BaseSelectListItem.tsx
+++ b/frontend/src/metabase/components/SelectList/BaseSelectListItem.tsx
@@ -1,4 +1,9 @@
-import type * as React from "react";
+import type {
+  KeyboardEvent,
+  MouseEvent,
+  ReactNode,
+  SyntheticEvent,
+} from "react";
 
 import { useScrollOnMount } from "metabase/hooks/use-scroll-on-mount";
 
@@ -7,8 +12,8 @@ import { BaseItemRoot } from "./SelectListItem.styled";
 export interface BaseSelectListItemProps {
   id: string | number;
   name: string;
-  onSelect: (id: string | number) => void;
-  children: React.ReactNode;
+  onSelect: (id: string | number, event: SyntheticEvent) => void;
+  children: ReactNode;
   isSelected?: boolean;
   size?: "small" | "medium";
   className?: string;
@@ -37,8 +42,10 @@ export function BaseSelectListItem({
       role="menuitem"
       tabIndex={0}
       size={size}
-      onClick={() => onSelect(id)}
-      onKeyDown={(e: KeyboardEvent) => e.key === "Enter" && onSelect(id)}
+      onClick={(event: MouseEvent) => onSelect(id, event)}
+      onKeyDown={(event: KeyboardEvent) =>
+        event.key === "Enter" && onSelect(id, event)
+      }
       className={className}
       {...rest}
     >

--- a/frontend/src/metabase/components/SelectList/SelectList.unit.spec.tsx
+++ b/frontend/src/metabase/components/SelectList/SelectList.unit.spec.tsx
@@ -56,7 +56,7 @@ describe("Components > SelectList", () => {
 
     userEvent.click(screen.getByText("Item 2"));
 
-    expect(selectSpy).toHaveBeenCalledWith("2");
+    expect(selectSpy).toHaveBeenCalledWith("2", expect.anything());
   });
 
   describe("SelectList.Item", () => {

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.tsx
@@ -55,7 +55,7 @@ export const PublicLinkPopover = ({
   };
 
   return (
-    <Popover opened={isOpen} onClose={onClose} withinPortal>
+    <Popover opened={isOpen} onClose={isOpen ? onClose : undefined}>
       <Popover.Target>
         <Box onClick={isOpen ? onClose : undefined}>{target}</Box>
       </Popover.Target>

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.tsx
@@ -4,11 +4,10 @@ import { useAsyncFn } from "react-use";
 import { t } from "ttag";
 
 import LoadingSpinner from "metabase/components/LoadingSpinner";
-import Tooltip from "metabase/core/components/Tooltip";
 import { PLUGIN_FEATURE_LEVEL_PERMISSIONS } from "metabase/plugins";
 import type { DownloadQueryResultsOpts } from "metabase/query_builder/actions";
 import { downloadQueryResults } from "metabase/query_builder/actions";
-import { Flex, Popover } from "metabase/ui";
+import { Flex, Popover, Tooltip } from "metabase/ui";
 import type Question from "metabase-lib/Question";
 import type { Dataset, VisualizationSettings } from "metabase-types/api";
 
@@ -71,11 +70,11 @@ const QueryDownloadWidget = ({
       <Popover.Target>
         <Flex className={className}>
           {loading ? (
-            <Tooltip tooltip={t`Downloading…`}>
+            <Tooltip label={t`Downloading…`}>
               <LoadingSpinner size={18} />
             </Tooltip>
           ) : (
-            <Tooltip tooltip={t`Download full results`}>
+            <Tooltip label={t`Download full results`}>
               <DownloadIcon
                 onClick={() => setIsPopoverOpen(!isPopoverOpen)}
                 name="download"

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.unit.spec.tsx
@@ -54,6 +54,7 @@ describe("QueryDownloadWidget", () => {
     setup();
 
     userEvent.click(getIcon("download"));
+    userEvent.unhover(getIcon("download"));
 
     expect(
       await screen.findByText("Download full results"),

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
@@ -45,6 +45,7 @@ export const ExpressionEditorHelpText = ({
       reference={target}
       placement="bottom-start"
       visible
+      zIndex={300}
       content={
         <>
           {/* Prevent stealing focus from input box causing the help text to be closed (metabase#17548) */}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
@@ -40,7 +40,6 @@ export const ExpressionEditorHelpText = ({
   const { description, structure, args } = helpText;
 
   return (
-    /* data-ignore-outside-clicks is required until this expression editor is migrated to the mantine's Popover */
     <TippyPopover
       maxWidth={width}
       reference={target}
@@ -52,19 +51,15 @@ export const ExpressionEditorHelpText = ({
           <Container
             onMouseDown={e => e.preventDefault()}
             data-testid="expression-helper-popover"
-            data-ignore-outside-clicks
           >
-            <FunctionHelpCode
-              data-testid="expression-helper-popover-structure"
-              data-ignore-outside-clicks
-            >
+            <FunctionHelpCode data-testid="expression-helper-popover-structure">
               {structure}
               {args != null && (
                 <>
                   (
                   {args.map(({ name }, index) => (
-                    <span key={name} data-ignore-outside-clicks>
-                      <FunctionHelpCodeArgument data-ignore-outside-clicks>
+                    <span key={name}>
+                      <FunctionHelpCodeArgument>
                         {name}
                       </FunctionHelpCodeArgument>
                       {index + 1 < args.length && ", "}
@@ -74,43 +69,29 @@ export const ExpressionEditorHelpText = ({
                 </>
               )}
             </FunctionHelpCode>
-            <Divider data-ignore-outside-clicks />
+            <Divider />
 
-            <div data-ignore-outside-clicks>{description}</div>
+            <div>{description}</div>
 
             {args != null && (
-              <ArgumentsGrid
-                data-testid="expression-helper-popover-arguments"
-                data-ignore-outside-clicks
-              >
+              <ArgumentsGrid data-testid="expression-helper-popover-arguments">
                 {args.map(({ name, description: argDescription }) => (
                   <React.Fragment key={name}>
-                    <ArgumentTitle data-ignore-outside-clicks>
-                      {name}
-                    </ArgumentTitle>
-                    <div data-ignore-outside-clicks>{argDescription}</div>
+                    <ArgumentTitle>{name}</ArgumentTitle>
+                    <div>{argDescription}</div>
                   </React.Fragment>
                 ))}
               </ArgumentsGrid>
             )}
 
-            <BlockSubtitleText
-              data-ignore-outside-clicks
-            >{t`Example`}</BlockSubtitleText>
-            <ExampleCode data-ignore-outside-clicks>
-              {helpText.example}
-            </ExampleCode>
+            <BlockSubtitleText>{t`Example`}</BlockSubtitleText>
+            <ExampleCode>{helpText.example}</ExampleCode>
             {showMetabaseLinks && (
               <DocumentationLink
                 href={MetabaseSettings.docsUrl(getHelpDocsUrl(helpText))}
                 target="_blank"
-                data-ignore-outside-clicks
               >
-                <LearnMoreIcon
-                  name="reference"
-                  size={12}
-                  data-ignore-outside-clicks
-                />
+                <LearnMoreIcon name="reference" size={12} />
                 {t`Learn more`}
               </DocumentationLink>
             )}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -87,7 +87,6 @@ export default class ExpressionEditorSuggestions extends Component {
     }
 
     return (
-      /* data-ignore-outside-clicks is required until this expression editor is migrated to the mantine's Popover */
       <ExpressionPopover
         placement="bottom-start"
         sizeToFit
@@ -98,7 +97,6 @@ export default class ExpressionEditorSuggestions extends Component {
           <ExpressionList
             data-testid="expression-suggestions-list"
             className="pb1"
-            data-ignore-outside-clicks
           >
             {suggestions.map((suggestion, i) => (
               <Fragment key={`$suggestion-${i}`}>
@@ -129,19 +127,13 @@ function ExpressionEditorSuggestionsListItem({
       onMouseDownCapture={onMouseDownCapture}
       isHighlighted={isHighlighted}
       className="hover-parent hover--inherit"
-      data-ignore-outside-clicks
     >
       <Icon
         name={icon}
         color={isHighlighted ? highlighted : normal}
         className="mr1"
-        data-ignore-outside-clicks
       />
-      <SuggestionSpan
-        suggestion={suggestion}
-        isHighlighted={isHighlighted}
-        data-ignore-outside-clicks
-      />
+      <SuggestionSpan suggestion={suggestion} isHighlighted={isHighlighted} />
     </ExpressionListItem>
   );
 }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.styled.tsx
@@ -1,9 +1,7 @@
 import styled from "@emotion/styled";
 
 import Button from "metabase/core/components/Button";
-import ExternalLink from "metabase/core/components/ExternalLink";
 import { color } from "metabase/lib/colors";
-import { Icon } from "metabase/ui";
 
 export const Container = styled.div`
   width: 472px;
@@ -27,20 +25,6 @@ export const FieldLabel = styled.label`
   letter-spacing: 0.06em;
 
   color: ${color("text-light")};
-`;
-
-export const InfoLink = styled(ExternalLink)`
-  margin-left: 4px;
-
-  &:hover,
-  :focus {
-    color: ${color("brand")};
-  }
-`;
-
-export const StyledFieldTitleIcon = styled(Icon)`
-  width: 12px;
-  height: 12px;
 `;
 
 export const Footer = styled.div`

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/ExpressionWidgetInfo.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/ExpressionWidgetInfo.styled.tsx
@@ -1,0 +1,25 @@
+import styled from "@emotion/styled";
+
+import ExternalLink from "metabase/core/components/ExternalLink";
+import { color } from "metabase/lib/colors";
+import { Icon } from "metabase/ui";
+
+export const InfoLink = styled(ExternalLink)`
+  margin-left: 4px;
+
+  &:hover,
+  :focus {
+    color: ${color("brand")};
+  }
+`;
+
+export const FieldTitleIcon = styled(Icon)`
+  width: 12px;
+  height: 12px;
+`;
+
+export const TooltipLabel = styled.span`
+  display: inline-block;
+  max-width: 20.75rem;
+  white-space: normal;
+`;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/ExpressionWidgetInfo.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/ExpressionWidgetInfo.tsx
@@ -1,12 +1,15 @@
 import { t } from "ttag";
 
-import Tooltip from "metabase/core/components/Tooltip";
 import { useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
-import { Box } from "metabase/ui";
+import { Box, Tooltip } from "metabase/ui";
 
-import { InfoLink, StyledFieldTitleIcon } from "../ExpressionWidget.styled";
+import {
+  FieldTitleIcon,
+  InfoLink,
+  TooltipLabel,
+} from "./ExpressionWidgetInfo.styled";
 
 export const EXPRESSIONS_DOCUMENTATION_URL = MetabaseSettings.docsUrl(
   "questions/query-builder/expressions",
@@ -17,26 +20,33 @@ export function ExpressionWidgetInfo() {
 
   return showMetabaseLinks ? (
     <Tooltip
-      tooltip={t`You can reference columns here in functions or equations, like: floor([Price] - [Discount]). Click for documentation.`}
-      placement="right"
-      maxWidth={332}
+      label={
+        <TooltipLabel>
+          {t`You can reference columns here in functions or equations, like: floor([Price] - [Discount]). Click for documentation.`}
+        </TooltipLabel>
+      }
+      position="right"
     >
       <InfoLink
         target="_blank"
         href={EXPRESSIONS_DOCUMENTATION_URL}
+        tabIndex={-1}
         aria-label={t`Open expressions documentation`}
       >
-        <StyledFieldTitleIcon name="info" />
+        <FieldTitleIcon name="info" />
       </InfoLink>
     </Tooltip>
   ) : (
     <Tooltip
-      tooltip={t`You can reference columns here in functions or equations, like: floor([Price] - [Discount]).`}
-      placement="right"
-      maxWidth={332}
+      label={
+        <TooltipLabel>
+          {t`You can reference columns here in functions or equations, like: floor([Price] - [Discount]).`}
+        </TooltipLabel>
+      }
+      position="right"
     >
       <Box ml="0.25rem">
-        <StyledFieldTitleIcon name="info" />
+        <FieldTitleIcon name="info" />
       </Box>
     </Tooltip>
   );

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -7,18 +7,6 @@ import * as Lib from "metabase-lib";
 import type { NotebookStepUiComponentProps } from "../../types";
 import { ClauseStep } from "../ClauseStep";
 
-const aggTetherOptions = {
-  attachment: "top left",
-  targetAttachment: "bottom left",
-  offset: "0 10px",
-  constraints: [
-    {
-      to: "scrollParent",
-      attachment: "together",
-    },
-  ],
-};
-
 export function AggregateStep({
   query,
   step,
@@ -66,7 +54,6 @@ export function AggregateStep({
       readOnly={readOnly}
       color={color}
       isLastOpened={isLastOpened}
-      tetherOptions={aggTetherOptions}
       renderName={renderAggregationName}
       renderPopover={({ item: aggregation, index }) => (
         <AggregationPopover
@@ -80,7 +67,6 @@ export function AggregateStep({
       )}
       onRemove={handleRemoveAggregation}
       data-testid="aggregate-step"
-      withLegacyPopover
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.tsx
@@ -55,7 +55,7 @@ export function AggregateStep({
       color={color}
       isLastOpened={isLastOpened}
       renderName={renderAggregationName}
-      renderPopover={({ item: aggregation, index }) => (
+      renderPopover={({ item: aggregation, index, onClose }) => (
         <AggregationPopover
           query={query}
           stageIndex={stageIndex}
@@ -63,6 +63,7 @@ export function AggregateStep({
           clauseIndex={index}
           onAddAggregation={handleAddAggregation}
           onUpdateAggregation={handleUpdateAggregation}
+          onClose={onClose}
         />
       )}
       onRemove={handleRemoveAggregation}
@@ -83,8 +84,7 @@ interface AggregationPopoverProps {
 
   clauseIndex?: number;
 
-  // Implicitly passed by metabase/components/Triggerable
-  onClose?: () => void;
+  onClose: () => void;
 }
 
 function AggregationPopover({

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
@@ -7,18 +7,6 @@ import * as Lib from "metabase-lib";
 import type { NotebookStepUiComponentProps } from "../../types";
 import { ClauseStep } from "../ClauseStep";
 
-const breakoutTetherOptions = {
-  attachment: "top left",
-  targetAttachment: "bottom left",
-  offset: "10px 0",
-  constraints: [
-    {
-      to: "scrollParent",
-      attachment: "together",
-    },
-  ],
-};
-
 function BreakoutStep({
   query,
   step,
@@ -61,7 +49,6 @@ function BreakoutStep({
       readOnly={readOnly}
       color={color}
       isLastOpened={isLastOpened}
-      tetherOptions={breakoutTetherOptions}
       renderName={renderBreakoutName}
       renderPopover={({ item: breakout, index }) => (
         <BreakoutPopover
@@ -75,7 +62,6 @@ function BreakoutStep({
       )}
       onRemove={handleRemoveBreakout}
       data-testid="breakout-step"
-      withLegacyPopover
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.tsx
@@ -50,7 +50,7 @@ function BreakoutStep({
       color={color}
       isLastOpened={isLastOpened}
       renderName={renderBreakoutName}
-      renderPopover={({ item: breakout, index }) => (
+      renderPopover={({ item: breakout, index, onClose }) => (
         <BreakoutPopover
           query={query}
           stageIndex={stageIndex}
@@ -58,6 +58,7 @@ function BreakoutStep({
           breakoutIndex={index}
           onAddBreakout={handleAddBreakout}
           onUpdateBreakoutColumn={handleUpdateBreakoutColumn}
+          onClose={onClose}
         />
       )}
       onRemove={handleRemoveBreakout}
@@ -76,7 +77,7 @@ interface BreakoutPopoverProps {
     breakout: Lib.BreakoutClause,
     column: Lib.ColumnMetadata,
   ) => void;
-  onClose?: () => void;
+  onClose: () => void;
 }
 
 const BreakoutPopover = ({

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -92,14 +92,14 @@ describe("BreakoutStep", () => {
     expect(screen.getByText("Pick a column to group by")).toBeInTheDocument();
   });
 
-  it("should render a breakout correctly", () => {
+  it("should render a breakout correctly", async () => {
     const { query, columnInfo } = createQueryWithBreakout();
     const columnName = columnInfo.displayName;
     setup(createMockNotebookStep({ query }));
 
     userEvent.click(screen.getByText(columnName));
 
-    const listItem = screen.getByRole("option", { name: columnName });
+    const listItem = await screen.findByRole("option", { name: columnName });
     expect(listItem).toBeInTheDocument();
     expect(listItem).toHaveAttribute("aria-selected", "true");
   });
@@ -115,24 +115,24 @@ describe("BreakoutStep", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("should add a breakout", () => {
+  it("should add a breakout", async () => {
     const { getRecentBreakoutClause } = setup();
 
     userEvent.click(screen.getByText("Pick a column to group by"));
-    userEvent.click(screen.getByText("Created At"));
+    userEvent.click(await screen.findByText("Created At"));
 
     const breakout = getRecentBreakoutClause();
     expect(breakout.displayName).toBe("Created At: Month");
   });
 
-  it("should change a breakout column", () => {
+  it("should change a breakout column", async () => {
     const { query, columnInfo } = createQueryWithBreakout();
     const { getRecentBreakoutClause } = setup(
       createMockNotebookStep({ query }),
     );
 
     userEvent.click(screen.getByText(columnInfo.displayName));
-    userEvent.click(screen.getByText("Discount"));
+    userEvent.click(await screen.findByText("Discount"));
 
     const breakout = getRecentBreakoutClause();
     expect(breakout.displayName).toBe("Discount: Auto binned");
@@ -153,7 +153,7 @@ describe("BreakoutStep", () => {
       const { getRecentBreakoutClause } = setup();
 
       userEvent.click(screen.getByText("Pick a column to group by"));
-      const option = screen.getByRole("option", { name: "Total" });
+      const option = await screen.findByRole("option", { name: "Total" });
 
       expect(within(option).getByText("Auto bin")).toBeInTheDocument();
 
@@ -167,7 +167,7 @@ describe("BreakoutStep", () => {
       const { getRecentBreakoutClause } = setup();
 
       userEvent.click(screen.getByText("Pick a column to group by"));
-      const option = screen.getByRole("option", { name: "Total" });
+      const option = await screen.findByRole("option", { name: "Total" });
       userEvent.click(within(option).getByLabelText("Binning strategy"));
       userEvent.click(await screen.findByRole("menuitem", { name: "10 bins" }));
 
@@ -180,7 +180,7 @@ describe("BreakoutStep", () => {
       setup(createMockNotebookStep({ query }));
 
       userEvent.click(screen.getByText("Tax: 10 bins"));
-      const option = screen.getByRole("option", { name: "Tax" });
+      const option = await screen.findByRole("option", { name: "Tax" });
       userEvent.click(within(option).getByLabelText("Binning strategy"));
 
       expect(
@@ -193,7 +193,7 @@ describe("BreakoutStep", () => {
       const { updateQuery } = setup(createMockNotebookStep({ query }));
 
       userEvent.click(screen.getByText("Tax: 10 bins"));
-      userEvent.click(screen.getByText("Tax"));
+      userEvent.click(await screen.findByText("Tax"));
 
       expect(updateQuery).not.toHaveBeenCalled();
     });
@@ -203,7 +203,7 @@ describe("BreakoutStep", () => {
       setup(createMockNotebookStep({ query }));
 
       userEvent.click(screen.getByText(columnInfo.displayName));
-      const option = screen.getByRole("option", {
+      const option = await screen.findByRole("option", {
         name: columnInfo.displayName,
       });
 
@@ -219,7 +219,7 @@ describe("BreakoutStep", () => {
       const { getRecentBreakoutClause } = setup();
 
       userEvent.click(screen.getByText("Pick a column to group by"));
-      userEvent.click(screen.getByText("Created At"));
+      userEvent.click(await screen.findByText("Created At"));
 
       const breakout = getRecentBreakoutClause();
       expect(breakout.displayName).toBe("Created At: Month");
@@ -229,7 +229,7 @@ describe("BreakoutStep", () => {
       const { getRecentBreakoutClause } = setup();
 
       userEvent.click(screen.getByText("Pick a column to group by"));
-      const option = screen.getByRole("option", { name: "Created At" });
+      const option = await screen.findByRole("option", { name: "Created At" });
       userEvent.click(within(option).getByLabelText("Temporal bucket"));
 
       // For some reason, a click won't happen with `userEvent.click`
@@ -245,7 +245,7 @@ describe("BreakoutStep", () => {
       setup(createMockNotebookStep({ query }));
 
       userEvent.click(screen.getByText("Created At: Quarter"));
-      const option = screen.getByRole("option", { name: "Created At" });
+      const option = await screen.findByRole("option", { name: "Created At" });
       userEvent.click(within(option).getByLabelText("Temporal bucket"));
 
       expect(
@@ -258,7 +258,7 @@ describe("BreakoutStep", () => {
       setup(createMockNotebookStep({ query }));
 
       userEvent.click(screen.getByText("Created At"));
-      const option = screen.getByRole("option", {
+      const option = await screen.findByRole("option", {
         name: "Created At",
       });
 
@@ -280,7 +280,7 @@ describe("BreakoutStep", () => {
       const { updateQuery } = setup(createMockNotebookStep({ query }));
 
       userEvent.click(screen.getByText("Created At: Quarter"));
-      userEvent.click(screen.getByText("Created At"));
+      userEvent.click(await screen.findByText("Created At"));
 
       expect(updateQuery).not.toHaveBeenCalled();
     });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClausePopover.tsx
@@ -3,6 +3,11 @@ import { useCallback, useState } from "react";
 import type { PopoverBaseProps } from "metabase/ui";
 import { Popover } from "metabase/ui";
 
+const POPOVER_PROPS: PopoverBaseProps = {
+  position: "bottom-start",
+  offset: { mainAxis: 4 },
+};
+
 interface ClausePopoverProps extends PopoverBaseProps {
   isInitiallyOpen?: boolean;
   renderItem: (open: () => void) => JSX.Element | string;
@@ -13,7 +18,6 @@ export function ClausePopover({
   isInitiallyOpen = false,
   renderItem,
   renderPopover,
-  ...props
 }: ClausePopoverProps) {
   const [isOpen, setIsOpen] = useState(isInitiallyOpen);
 
@@ -26,7 +30,7 @@ export function ClausePopover({
   }, []);
 
   return (
-    <Popover trapFocus {...props} opened={isOpen} onClose={handleClose}>
+    <Popover trapFocus {...POPOVER_PROPS} opened={isOpen} onClose={handleClose}>
       <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
       <Popover.Dropdown>{renderPopover(handleClose)}</Popover.Dropdown>
     </Popover>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClausePopover.tsx
@@ -1,14 +1,8 @@
 import { useCallback, useState } from "react";
 
-import type { PopoverBaseProps } from "metabase/ui";
 import { Popover } from "metabase/ui";
 
-const POPOVER_PROPS: PopoverBaseProps = {
-  position: "bottom-start",
-  offset: { mainAxis: 4 },
-};
-
-interface ClausePopoverProps extends PopoverBaseProps {
+interface ClausePopoverProps {
   isInitiallyOpen?: boolean;
   renderItem: (open: () => void) => JSX.Element | string;
   renderPopover: (close: () => void) => JSX.Element | null;
@@ -30,7 +24,13 @@ export function ClausePopover({
   }, []);
 
   return (
-    <Popover trapFocus {...POPOVER_PROPS} opened={isOpen} onClose={handleClose}>
+    <Popover
+      opened={isOpen}
+      position="bottom-start"
+      offset={{ mainAxis: 4 }}
+      trapFocus
+      onClose={handleClose}
+    >
       <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
       <Popover.Dropdown>{renderPopover(handleClose)}</Popover.Dropdown>
     </Popover>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClausePopover.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClausePopover.tsx
@@ -9,8 +9,6 @@ interface ClausePopoverProps extends PopoverBaseProps {
   renderPopover: (close: () => void) => JSX.Element | null;
 }
 
-const NO_TRANSITION = { duration: 0 };
-
 export function ClausePopover({
   isInitiallyOpen = false,
   renderItem,
@@ -28,13 +26,7 @@ export function ClausePopover({
   }, []);
 
   return (
-    <Popover
-      trapFocus
-      transitionProps={NO_TRANSITION}
-      {...props}
-      opened={isOpen}
-      onClose={handleClose}
-    >
+    <Popover trapFocus {...props} opened={isOpen} onClose={handleClose}>
       <Popover.Target>{renderItem(handleOpen)}</Popover.Target>
       <Popover.Dropdown>{renderPopover(handleClose)}</Popover.Dropdown>
     </Popover>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
@@ -23,7 +23,7 @@ type RenderItemOpts<T> = {
 type RenderPopoverOpts<T> = {
   item?: T;
   index?: number;
-  onClose?: () => void;
+  onClose: () => void;
 };
 
 export interface ClauseStepProps<T> {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
@@ -1,4 +1,3 @@
-import type { PopoverBaseProps } from "metabase/ui";
 import { Icon } from "metabase/ui";
 
 import {
@@ -8,11 +7,6 @@ import {
 } from "../../NotebookCell";
 
 import { ClausePopover } from "./ClausePopover";
-
-const POPOVER_PROPS: PopoverBaseProps = {
-  position: "bottom-start",
-  offset: { mainAxis: 4 },
-};
 
 type RenderItemOpts<T> = {
   item: T;
@@ -79,7 +73,6 @@ export const ClauseStep = <T,>({
     <NotebookCell color={color} data-testid={props["data-testid"]}>
       {items.map((item, index) => (
         <ClausePopover
-          {...POPOVER_PROPS}
           key={index}
           renderItem={onOpen => renderItem({ item, index, onOpen })}
           renderPopover={onClose => renderPopover({ item, index, onClose })}
@@ -87,7 +80,6 @@ export const ClauseStep = <T,>({
       ))}
       {!readOnly && (
         <ClausePopover
-          {...POPOVER_PROPS}
           isInitiallyOpen={isLastOpened}
           renderItem={onOpen => renderNewItem({ onOpen })}
           renderPopover={onClose => renderPopover({ onClose })}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
@@ -1,6 +1,3 @@
-import type Tether from "tether";
-
-import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import type { PopoverBaseProps } from "metabase/ui";
 import { Icon } from "metabase/ui";
 
@@ -11,6 +8,11 @@ import {
 } from "../../NotebookCell";
 
 import { ClausePopover } from "./ClausePopover";
+
+const POPOVER_PROPS: PopoverBaseProps = {
+  position: "bottom-start",
+  offset: { mainAxis: 4 },
+};
 
 type RenderItemOpts<T> = {
   item: T;
@@ -29,10 +31,7 @@ export interface ClauseStepProps<T> {
   items: T[];
   isLastOpened?: boolean;
   initialAddText?: string | null;
-  tetherOptions?: Tether.ITetherOptions | null;
-  popoverProps?: PopoverBaseProps;
   readOnly?: boolean;
-  withLegacyPopover?: boolean;
   renderName: (item: T, index: number) => JSX.Element | string;
   renderPopover: (opts: RenderPopoverOpts<T>) => JSX.Element | null;
   canRemove?: (item: T) => boolean;
@@ -45,10 +44,7 @@ export const ClauseStep = <T,>({
   items,
   isLastOpened = false,
   initialAddText = null,
-  tetherOptions = null,
-  popoverProps = {},
   readOnly,
-  withLegacyPopover = false,
   renderName,
   renderPopover,
   canRemove,
@@ -79,38 +75,11 @@ export const ClauseStep = <T,>({
     </NotebookCellItem>
   );
 
-  if (withLegacyPopover) {
-    return (
-      <NotebookCell color={color} data-testid={props["data-testid"]}>
-        {items.map((item, index) => (
-          <PopoverWithTrigger
-            key={index}
-            triggerElement={renderItem({ item, index })}
-            tetherOptions={tetherOptions}
-            sizeToFit
-          >
-            {renderPopover({ item, index })}
-          </PopoverWithTrigger>
-        ))}
-        {!readOnly && (
-          <PopoverWithTrigger
-            isInitiallyOpen={isLastOpened}
-            triggerElement={renderNewItem({})}
-            tetherOptions={tetherOptions}
-            sizeToFit
-          >
-            {renderPopover({})}
-          </PopoverWithTrigger>
-        )}
-      </NotebookCell>
-    );
-  }
-
   return (
     <NotebookCell color={color} data-testid={props["data-testid"]}>
       {items.map((item, index) => (
         <ClausePopover
-          {...popoverProps}
+          {...POPOVER_PROPS}
           key={index}
           renderItem={onOpen => renderItem({ item, index, onOpen })}
           renderPopover={onClose => renderPopover({ item, index, onClose })}
@@ -118,7 +87,7 @@ export const ClauseStep = <T,>({
       ))}
       {!readOnly && (
         <ClausePopover
-          {...popoverProps}
+          {...POPOVER_PROPS}
           isInitiallyOpen={isLastOpened}
           renderItem={onOpen => renderNewItem({ onOpen })}
           renderPopover={onClose => renderPopover({ onClose })}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
@@ -74,7 +74,6 @@ export const ExpressionStep = ({
         const nextQuery = Lib.removeClause(query, stageIndex, clause);
         updateQuery(nextQuery);
       }}
-      withLegacyPopover
     />
   );
 };

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.tsx
@@ -26,7 +26,7 @@ export const ExpressionStep = ({
       items={expressions}
       renderName={renderExpressionName}
       readOnly={readOnly}
-      renderPopover={({ item, index: expressionPosition }) => (
+      renderPopover={({ item, index: expressionPosition, onClose }) => (
         <ExpressionWidget
           query={query}
           stageIndex={stageIndex}
@@ -67,6 +67,7 @@ export const ExpressionStep = ({
             }
           }}
           reportTimezone={reportTimezone}
+          onClose={onClose}
         />
       )}
       isLastOpened={isLastOpened}

--- a/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/FilterStep/FilterStep.tsx
@@ -3,16 +3,10 @@ import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import { FilterPicker } from "metabase/querying";
-import type { PopoverBaseProps } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import type { NotebookStepUiComponentProps } from "../../types";
 import { ClauseStep } from "../ClauseStep";
-
-const POPOVER_PROPS: PopoverBaseProps = {
-  position: "bottom-start",
-  offset: { mainAxis: 4 },
-};
 
 export function FilterStep({
   query,
@@ -65,7 +59,6 @@ export function FilterStep({
         readOnly={readOnly}
         color={color}
         isLastOpened={isLastOpened}
-        popoverProps={POPOVER_PROPS}
         renderName={renderFilterName}
         renderPopover={({ item: filter, index, onClose }) => (
           <FilterPopover

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
@@ -1,4 +1,3 @@
-import type { RefObject } from "react";
 import { forwardRef, useCallback, useMemo } from "react";
 import { t } from "ttag";
 
@@ -6,9 +5,7 @@ import type {
   QueryColumnPickerProps,
   ColumnListItem,
 } from "metabase/common/components/QueryColumnPicker";
-import type { TippyPopoverWithTriggerRef } from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
-import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
-import { Text } from "metabase/ui";
+import { Popover, Text } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import {
@@ -22,12 +19,10 @@ interface JoinConditionColumnPickerProps
   column?: Lib.ColumnMetadata;
   table?: Lib.Joinable;
   label?: string;
-  isInitiallyVisible?: boolean;
+  isOpened: boolean;
   readOnly?: boolean;
-  popoverRef?: RefObject<TippyPopoverWithTriggerRef>;
+  onOpenedChange: (isOpened: boolean) => void;
 }
-
-export type JoinConditionColumnPickerRef = TippyPopoverWithTriggerRef;
 
 export function JoinConditionColumnPicker({
   query,
@@ -36,9 +31,9 @@ export function JoinConditionColumnPicker({
   table,
   label,
   isNewCondition,
-  isInitiallyVisible = false,
+  isOpened,
   readOnly = false,
-  popoverRef,
+  onOpenedChange,
   ...props
 }: JoinConditionColumnPickerProps) {
   const columnInfo = column ? Lib.displayInfo(query, stageIndex, column) : null;
@@ -64,31 +59,28 @@ export function JoinConditionColumnPicker({
   );
 
   return (
-    <TippyPopoverWithTrigger
-      disabled={readOnly}
-      isInitiallyVisible={isInitiallyVisible}
-      renderTrigger={({ visible, onClick }) => (
+    <Popover opened={isOpened} onChange={onOpenedChange}>
+      <Popover.Target>
         <ColumnNotebookCellItem
-          isOpen={visible}
+          isOpen={isOpened}
           tableName={tableName}
           columnName={columnInfo?.displayName}
           label={label}
           readOnly={readOnly}
-          onClick={onClick}
+          onClick={() => onOpenedChange(!isOpened)}
         />
-      )}
-      popoverContent={({ closePopover }) => (
+      </Popover.Target>
+      <Popover.Dropdown>
         <StyledQueryColumnPicker
           {...props}
           query={query}
           stageIndex={stageIndex}
           hasTemporalBucketing
           checkIsColumnSelected={checkColumnSelected}
-          onClose={closePopover}
+          onClose={() => onOpenedChange(false)}
         />
-      )}
-      popoverRef={popoverRef}
-    />
+      </Popover.Dropdown>
+    </Popover>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
@@ -22,6 +22,7 @@ interface JoinConditionColumnPickerProps
   isOpened: boolean;
   readOnly?: boolean;
   onOpenedChange: (isOpened: boolean) => void;
+  "data-testid"?: string;
 }
 
 export function JoinConditionColumnPicker({

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { t } from "ttag";
 
 import { Box, Flex, Text, Icon } from "metabase/ui";
@@ -7,7 +7,6 @@ import * as Lib from "metabase-lib";
 import { NotebookCellAdd, NotebookCellItem } from "../../NotebookCell";
 import type { NotebookStepUiComponentProps } from "../../types";
 
-import type { JoinConditionColumnPickerRef } from "./JoinConditionColumnPicker";
 import { JoinConditionColumnPicker } from "./JoinConditionColumnPicker";
 import { JoinConditionOperatorPicker } from "./JoinConditionOperatorPicker";
 import {
@@ -287,13 +286,14 @@ function JoinCondition({
     setRHSColumn,
   } = useJoinCondition(query, stageIndex, table, join, condition);
 
-  const rhsColumnPicker = useRef<JoinConditionColumnPickerRef>(null);
-
   const lhsColumnGroup = Lib.groupColumns(lhsColumns);
   const rhsColumnGroup = Lib.groupColumns(rhsColumns);
 
   const isNewCondition = !condition;
   const isComplete = Boolean(lhsColumn && rhsColumn && operator);
+
+  const [isLHSPickerOpened, setIsLHSPickerOpened] = useState(isNewCondition);
+  const [isRHSPickerOpened, setIsRHSPickerOpened] = useState(false);
 
   const handleOperatorChange = (operator: Lib.JoinConditionOperator) => {
     const nextCondition = setOperator(operator);
@@ -307,7 +307,7 @@ function JoinCondition({
     if (nextCondition) {
       onChange(nextCondition);
     } else if (!rhsColumn) {
-      rhsColumnPicker.current?.open?.();
+      setIsRHSPickerOpened(true);
     }
     onChangeLHSColumn(lhsColumn);
   };
@@ -330,10 +330,11 @@ function JoinCondition({
             columnGroups={lhsColumnGroup}
             isNewCondition={isNewCondition}
             label={t`Left column`}
-            isInitiallyVisible={isNewCondition}
+            isOpened={isLHSPickerOpened}
             withDefaultBucketing={!rhsColumn}
             readOnly={readOnly}
             onSelect={handleLHSColumnChange}
+            onOpenedChange={setIsLHSPickerOpened}
           />
         </Box>
         <JoinConditionOperatorPicker
@@ -354,10 +355,11 @@ function JoinCondition({
             table={table}
             isNewCondition={isNewCondition}
             label={t`Right column`}
+            isOpened={isRHSPickerOpened}
             withDefaultBucketing={!lhsColumn}
             readOnly={readOnly}
-            popoverRef={rhsColumnPicker}
             onSelect={handleRHSColumnChange}
+            onOpenedChange={setIsRHSPickerOpened}
           />
         </Box>
       </Flex>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -335,6 +335,7 @@ function JoinCondition({
             readOnly={readOnly}
             onSelect={handleLHSColumnChange}
             onOpenedChange={setIsLHSPickerOpened}
+            data-testid="lhs-column-picker"
           />
         </Box>
         <JoinConditionOperatorPicker
@@ -360,6 +361,7 @@ function JoinCondition({
             readOnly={readOnly}
             onSelect={handleRHSColumnChange}
             onOpenedChange={setIsRHSPickerOpened}
+            data-testid="rhs-column-picker"
           />
         </Box>
       </Flex>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -233,7 +233,7 @@ describe("Notebook Editor > Join Step", () => {
     const tablePicker = await screen.findByTestId("popover");
     userEvent.click(await within(tablePicker).findByText("Reviews"));
 
-    const lhsColumnPicker = await screen.findByLabelText("grid");
+    const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
 
     expect(within(lhsColumnPicker).getByText("Order")).toBeInTheDocument();
     expect(within(lhsColumnPicker).getByText("Product ID")).toBeInTheDocument();
@@ -243,8 +243,7 @@ describe("Notebook Editor > Join Step", () => {
 
     userEvent.click(within(lhsColumnPicker).getByText("Total"));
 
-    await screen.findAllByLabelText("grid");
-    const [, rhsColumnPicker] = screen.getAllByLabelText("grid");
+    const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
 
     expect(within(rhsColumnPicker).getByText("Reviewer")).toBeInTheDocument();
     expect(within(rhsColumnPicker).getByText("Body")).toBeInTheDocument();
@@ -263,7 +262,7 @@ describe("Notebook Editor > Join Step", () => {
     setup(createMockNotebookStep({ query: getJoinedQuery() }));
 
     userEvent.click(screen.getByLabelText("Left column"));
-    const popover = await screen.findByLabelText("grid");
+    const popover = await screen.findByTestId("lhs-column-picker");
 
     expect(within(popover).getByLabelText("Product ID")).toHaveAttribute(
       "aria-selected",
@@ -279,7 +278,7 @@ describe("Notebook Editor > Join Step", () => {
     setup(createMockNotebookStep({ query: getJoinedQuery() }));
 
     userEvent.click(screen.getByLabelText("Right column"));
-    const popover = await screen.findByLabelText("grid");
+    const popover = await screen.findByTestId("rhs-column-picker");
 
     expect(within(popover).getByLabelText("ID")).toHaveAttribute(
       "aria-selected",
@@ -294,7 +293,7 @@ describe("Notebook Editor > Join Step", () => {
   it("should automatically open RHS table picker", async () => {
     setup();
 
-    const popover = screen.getByTestId("popover");
+    const popover = await screen.findByTestId("popover");
 
     expect(await within(popover).findByText("Products")).toBeInTheDocument();
     expect(within(popover).getByText("People")).toBeInTheDocument();
@@ -329,7 +328,7 @@ describe("Notebook Editor > Join Step", () => {
     const { getRecentJoin } = setup(createMockNotebookStep({ query }));
 
     userEvent.click(screen.getByLabelText("Left column"));
-    const popover = await screen.findByLabelText("grid");
+    const popover = await screen.findByTestId("lhs-column-picker");
     userEvent.click(within(popover).getByText("User ID"));
 
     const [condition] = getRecentJoin().conditions;
@@ -342,7 +341,7 @@ describe("Notebook Editor > Join Step", () => {
     const { getRecentJoin } = setup(createMockNotebookStep({ query }));
 
     userEvent.click(screen.getByLabelText("Right column"));
-    const popover = await screen.findByLabelText("grid");
+    const popover = await screen.findByTestId("rhs-column-picker");
     userEvent.click(within(popover).getByText("Price"));
 
     const [condition] = getRecentJoin().conditions;
@@ -364,7 +363,7 @@ describe("Notebook Editor > Join Step", () => {
     setup(createMockNotebookStep({ query: getJoinedQuery() }));
 
     userEvent.click(screen.getByLabelText("Left column"));
-    const popover = await screen.findByLabelText("grid");
+    const popover = await screen.findByTestId("lhs-column-picker");
     const numericColumn = within(popover).getByLabelText("Total");
     const dateTimeColumn = within(popover).getByLabelText("Created At");
 
@@ -391,7 +390,7 @@ describe("Notebook Editor > Join Step", () => {
 
     userEvent.click(rightJoin);
     await waitFor(() =>
-      expect(screen.queryByTestId("select-list")).not.toBeVisible(),
+      expect(screen.queryByTestId("select-list")).not.toBeInTheDocument(),
     );
 
     userEvent.click(screen.getByLabelText("Change join type"));
@@ -469,7 +468,7 @@ describe("Notebook Editor > Join Step", () => {
       userEvent.click(within(joinColumnsPicker).getByText("Reviewer"));
 
       userEvent.click(screen.getByLabelText("Left column"));
-      const lhsColumnPicker = await screen.findByLabelText("grid");
+      const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
       userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
       await waitFor(() =>
         expect(screen.getByLabelText("Left column")).toHaveTextContent(
@@ -477,7 +476,7 @@ describe("Notebook Editor > Join Step", () => {
         ),
       );
 
-      const [, rhsColumnPicker] = await screen.findAllByLabelText("grid");
+      const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
       userEvent.click(within(rhsColumnPicker).getByText("Rating"));
 
       const { query, fields } = getRecentJoin();
@@ -511,7 +510,7 @@ describe("Notebook Editor > Join Step", () => {
       userEvent.click(within(joinColumnsPicker).getByText("Select none"));
 
       userEvent.click(screen.getByLabelText("Left column"));
-      const lhsColumnPicker = await screen.findByLabelText("grid");
+      const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
       userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
       await waitFor(() =>
         expect(screen.getByLabelText("Left column")).toHaveTextContent(
@@ -519,7 +518,7 @@ describe("Notebook Editor > Join Step", () => {
         ),
       );
 
-      const [, rhsColumnPicker] = await screen.findAllByLabelText("grid");
+      const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
       userEvent.click(within(rhsColumnPicker).getByText("Rating"));
 
       const { fields } = getRecentJoin();
@@ -621,7 +620,7 @@ describe("Notebook Editor > Join Step", () => {
 
       expect(screen.queryByLabelText("Add condition")).not.toBeInTheDocument();
 
-      const lhsColumnPicker = await screen.findByLabelText("grid");
+      const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
       userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
       await waitFor(() =>
         expect(screen.getByLabelText("Left column")).toHaveTextContent(
@@ -631,8 +630,7 @@ describe("Notebook Editor > Join Step", () => {
 
       expect(screen.queryByLabelText("Add condition")).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByLabelText("Right column"));
-      const [, rhsColumnPicker] = await screen.findAllByLabelText("grid");
+      const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
       userEvent.click(within(rhsColumnPicker).getByText("Rating"));
 
       expect(screen.getByLabelText("Add condition")).toBeInTheDocument();
@@ -646,7 +644,7 @@ describe("Notebook Editor > Join Step", () => {
       userEvent.click(screen.getByLabelText("Add condition"));
       const conditionContainer = screen.getByTestId("new-join-condition");
 
-      const lhsColumnPicker = await screen.findByLabelText("grid");
+      const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
       userEvent.click(within(lhsColumnPicker).getByText("Created At"));
       await waitFor(() =>
         expect(
@@ -654,10 +652,7 @@ describe("Notebook Editor > Join Step", () => {
         ).toHaveTextContent("Created At"),
       );
 
-      userEvent.click(
-        within(conditionContainer).getByLabelText("Right column"),
-      );
-      const [, rhsColumnPicker] = await screen.findAllByLabelText("grid");
+      const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
       userEvent.click(within(rhsColumnPicker).getByText("Created At"));
 
       const { conditions } = getRecentJoin();
@@ -688,7 +683,7 @@ describe("Notebook Editor > Join Step", () => {
       userEvent.click(screen.getByLabelText("Add condition"));
       conditionContainer = screen.getByTestId("new-join-condition");
 
-      const lhsColumnPicker = await screen.findByLabelText("grid");
+      const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
       userEvent.click(within(lhsColumnPicker).getByText("Created At"));
       await waitFor(() =>
         expect(

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStrategyPicker/JoinStrategyPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStrategyPicker/JoinStrategyPicker.tsx
@@ -1,10 +1,10 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
-import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import SelectList from "metabase/components/SelectList";
 import type { IconName } from "metabase/ui";
+import { Popover } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { JoinStrategyIcon } from "./JoinStrategyPicker.styled";
@@ -33,6 +33,8 @@ export function JoinStrategyPicker({
     [query, stageIndex],
   );
 
+  const [isOpened, setIsOpened] = useState(false);
+
   const currentStrategyInfo = Lib.displayInfo(
     query,
     stageIndex,
@@ -41,11 +43,10 @@ export function JoinStrategyPicker({
   const currentStrategyIcon = JOIN_ICON[currentStrategyInfo.shortName];
 
   return (
-    <TippyPopoverWithTrigger
-      disabled={readOnly}
-      renderTrigger={({ onClick }) => (
+    <Popover opened={isOpened} onChange={setIsOpened}>
+      <Popover.Target>
         <IconButtonWrapper
-          onClick={onClick}
+          onClick={() => setIsOpened(!isOpened)}
           disabled={readOnly}
           aria-label={t`Change join type`}
         >
@@ -55,8 +56,8 @@ export function JoinStrategyPicker({
             size={32}
           />
         </IconButtonWrapper>
-      )}
-      popoverContent={({ closePopover }) => (
+      </Popover.Target>
+      <Popover.Dropdown>
         <SelectList className="p1">
           {items.map(item => (
             <SelectList.Item
@@ -67,13 +68,13 @@ export function JoinStrategyPicker({
               isSelected={currentStrategyInfo.shortName === item.shortName}
               onSelect={() => {
                 onChange(item.strategy);
-                closePopover();
+                setIsOpened(false);
               }}
             />
           ))}
         </SelectList>
-      )}
-    />
+      </Popover.Dropdown>
+    </Popover>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinTablePicker/JoinTablePicker.tsx
@@ -1,15 +1,13 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { t } from "ttag";
 
 import { FieldPicker } from "metabase/common/components/FieldPicker";
-import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
 import { DATA_BUCKET } from "metabase/containers/DataPicker";
-import Tooltip from "metabase/core/components/Tooltip";
 import Tables from "metabase/entities/tables";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
 import { getMetadata } from "metabase/selectors/metadata";
-import { Icon } from "metabase/ui";
+import { Icon, Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Table from "metabase-lib/metadata/Table";
 import type { TableId } from "metabase-types/api";
@@ -132,6 +130,7 @@ function JoinTableColumnsPicker({
   isColumnSelected,
   onChange,
 }: JoinTableColumnsPickerProps) {
+  const [isOpened, setIsOpened] = useState(false);
   const handleToggle = (changedIndex: number, isSelected: boolean) => {
     const nextColumns = columns.filter((_, currentIndex) =>
       currentIndex === changedIndex
@@ -150,8 +149,19 @@ function JoinTableColumnsPicker({
   };
 
   return (
-    <TippyPopoverWithTrigger
-      popoverContent={
+    <Popover opened={isOpened} onChange={setIsOpened}>
+      <Popover.Target>
+        <Tooltip label={t`Pick columns`}>
+          <ColumnPickerButton
+            onClick={() => setIsOpened(!isOpened)}
+            aria-label={t`Pick columns`}
+            data-testid="fields-picker"
+          >
+            <Icon name="chevrondown" />
+          </ColumnPickerButton>
+        </Tooltip>
+      </Popover.Target>
+      <Popover.Dropdown>
         <FieldPicker
           query={query}
           stageIndex={stageIndex}
@@ -162,20 +172,7 @@ function JoinTableColumnsPicker({
           onSelectNone={handleSelectNone}
           data-testid="join-columns-picker"
         />
-      }
-      renderTrigger={({ onClick }) => (
-        <div>
-          <Tooltip tooltip={t`Pick columns`}>
-            <ColumnPickerButton
-              onClick={onClick}
-              aria-label={t`Pick columns`}
-              data-testid="fields-picker"
-            >
-              <Icon name="chevrondown" />
-            </ColumnPickerButton>
-          </Tooltip>
-        </div>
-      )}
-    />
+      </Popover.Dropdown>
+    </Popover>
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
@@ -71,7 +71,6 @@ function SortStep({
         />
       )}
       onRemove={handleRemoveOrderBy}
-      withLegacyPopover
     />
   );
 }

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.tsx
@@ -60,7 +60,7 @@ function SortStep({
           onToggleSortDirection={() => handleToggleOrderByDirection(clause)}
         />
       )}
-      renderPopover={({ item: orderBy, index }) => (
+      renderPopover={({ item: orderBy, index, onClose }) => (
         <SortPopover
           query={query}
           stageIndex={stageIndex}
@@ -68,6 +68,7 @@ function SortStep({
           orderByIndex={index}
           onAddOrderBy={handleAddOrderBy}
           onUpdateOrderByColumn={handleUpdateOrderByColumn}
+          onClose={onClose}
         />
       )}
       onRemove={handleRemoveOrderBy}
@@ -85,7 +86,7 @@ interface SortPopoverProps {
     orderBy: Lib.OrderByClause,
     column: Lib.ColumnMetadata,
   ) => void;
-  onClose?: () => void;
+  onClose: () => void;
 }
 
 const SortPopover = ({

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.unit.spec.tsx
@@ -72,13 +72,13 @@ describe("SortStep", () => {
     expect(queryIcon("arrow_up")).not.toBeInTheDocument();
   });
 
-  it("should display orderable columns", () => {
+  it("should display orderable columns", async () => {
     setup();
 
     userEvent.click(getIcon("add"));
 
     // Tables
-    expect(screen.getByText("Order")).toBeInTheDocument();
+    expect(await screen.findByText("Order")).toBeInTheDocument();
     expect(screen.getByText("Product")).toBeInTheDocument();
     expect(screen.getByText("User")).toBeInTheDocument();
     // Order columns
@@ -90,11 +90,11 @@ describe("SortStep", () => {
     ).toBeInTheDocument();
   });
 
-  it("should add an order by", () => {
+  it("should add an order by", async () => {
     const { gerRecentOrderByClause } = setup();
 
     userEvent.click(getIcon("add"));
-    userEvent.click(screen.getByText("Created At"));
+    userEvent.click(await screen.findByText("Created At"));
 
     const orderBy = gerRecentOrderByClause();
     expect(orderBy.displayName).toBe("Created At");

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
@@ -1,7 +1,7 @@
+import { useState } from "react";
 import { t } from "ttag";
 
-import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
-import Tooltip from "metabase/core/components/Tooltip";
+import { Popover, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { AggregationPicker } from "../SummarizeSidebar.styled";
@@ -19,28 +19,26 @@ export function AddAggregationButton({
   query,
   onAddAggregation,
 }: AddAggregationButtonProps) {
+  const [isOpened, setIsOpened] = useState(false);
   const hasAggregations = Lib.aggregations(query, STAGE_INDEX).length > 0;
   const operators = Lib.availableAggregationOperators(query, STAGE_INDEX);
 
   return (
-    <TippyPopoverWithTrigger
-      renderTrigger={({ onClick }) => (
-        <div>
-          <Tooltip tooltip={t`Add a metric`} isEnabled={hasAggregations}>
-            <AddAggregationButtonRoot
-              icon="add"
-              borderless
-              onlyIcon={hasAggregations}
-              onClick={onClick}
-              aria-label={t`Add aggregation`}
-              data-testid="add-aggregation-button"
-            >
-              {hasAggregations ? null : t`Add a metric`}
-            </AddAggregationButtonRoot>
-          </Tooltip>
-        </div>
-      )}
-      popoverContent={({ closePopover }) => (
+    <Popover opened={isOpened} onChange={setIsOpened}>
+      <Popover.Target>
+        <Tooltip label={t`Add a metric`}>
+          <AddAggregationButtonRoot
+            icon="add"
+            borderless
+            onlyIcon={hasAggregations}
+            aria-label={t`Add aggregation`}
+            data-testid="add-aggregation-button"
+          >
+            {hasAggregations ? null : t`Add a metric`}
+          </AddAggregationButtonRoot>
+        </Tooltip>
+      </Popover.Target>
+      <Popover.Dropdown>
         <AggregationPicker
           query={query}
           stageIndex={STAGE_INDEX}
@@ -48,10 +46,10 @@ export function AddAggregationButton({
           hasExpressionInput={false}
           onSelect={aggregation => {
             onAddAggregation(aggregation);
-            closePopover();
+            setIsOpened(false);
           }}
         />
-      )}
-    />
+      </Popover.Dropdown>
+    </Popover>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useState } from "react";
 import { t } from "ttag";
 
@@ -23,10 +24,17 @@ export function AddAggregationButton({
   const hasAggregations = Lib.aggregations(query, STAGE_INDEX).length > 0;
   const operators = Lib.availableAggregationOperators(query, STAGE_INDEX);
 
+  const renderTooltip = (children: ReactNode) =>
+    hasAggregations ? (
+      <Tooltip label={t`Add metric`}>{children}</Tooltip>
+    ) : (
+      children
+    );
+
   return (
-    <Popover opened={isOpened} onClose={() => setIsOpened(false)}>
+    <Popover opened={isOpened} onChange={setIsOpened}>
       <Popover.Target>
-        <Tooltip label={t`Add a metric`}>
+        {renderTooltip(
           <AddAggregationButtonRoot
             icon="add"
             borderless
@@ -36,8 +44,8 @@ export function AddAggregationButton({
             data-testid="add-aggregation-button"
           >
             {hasAggregations ? null : t`Add a metric`}
-          </AddAggregationButtonRoot>
-        </Tooltip>
+          </AddAggregationButtonRoot>,
+        )}
       </Popover.Target>
       <Popover.Dropdown>
         <AggregationPicker

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AddAggregationButton/AddAggregationButton.tsx
@@ -24,13 +24,14 @@ export function AddAggregationButton({
   const operators = Lib.availableAggregationOperators(query, STAGE_INDEX);
 
   return (
-    <Popover opened={isOpened} onChange={setIsOpened}>
+    <Popover opened={isOpened} onClose={() => setIsOpened(false)}>
       <Popover.Target>
         <Tooltip label={t`Add a metric`}>
           <AddAggregationButtonRoot
             icon="add"
             borderless
             onlyIcon={hasAggregations}
+            onClick={() => setIsOpened(!isOpened)}
             aria-label={t`Add aggregation`}
             data-testid="add-aggregation-button"
           >

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
@@ -31,7 +31,7 @@ export function AggregationItem({
   );
 
   return (
-    <Popover opened={isOpened} onClose={() => setIsOpened(false)}>
+    <Popover opened={isOpened} onChange={setIsOpened}>
       <Popover.Target>
         <Root
           aria-label={displayName}

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
@@ -31,9 +31,13 @@ export function AggregationItem({
   );
 
   return (
-    <Popover opened={isOpened} onChange={setIsOpened}>
+    <Popover opened={isOpened} onClose={() => setIsOpened(false)}>
       <Popover.Target>
-        <Root aria-label={displayName} data-testid="aggregation-item">
+        <Root
+          aria-label={displayName}
+          data-testid="aggregation-item"
+          onClick={() => setIsOpened(!isOpened)}
+        >
           <AggregationName>{displayName}</AggregationName>
           <RemoveIcon name="close" onClick={onRemove} />
         </Root>

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/AggregationItem/AggregationItem.tsx
@@ -1,4 +1,6 @@
-import TippyPopoverWithTrigger from "metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger";
+import { useState } from "react";
+
+import { Popover } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import { AggregationPicker } from "../SummarizeSidebar.styled";
@@ -20,6 +22,7 @@ export function AggregationItem({
   onUpdate,
   onRemove,
 }: AggregationItemProps) {
+  const [isOpened, setIsOpened] = useState(false);
   const { displayName } = Lib.displayInfo(query, STAGE_INDEX, aggregation);
 
   const operators = Lib.selectedAggregationOperators(
@@ -28,18 +31,14 @@ export function AggregationItem({
   );
 
   return (
-    <TippyPopoverWithTrigger
-      renderTrigger={({ onClick }) => (
-        <Root
-          aria-label={displayName}
-          onClick={onClick}
-          data-testid="aggregation-item"
-        >
+    <Popover opened={isOpened} onChange={setIsOpened}>
+      <Popover.Target>
+        <Root aria-label={displayName} data-testid="aggregation-item">
           <AggregationName>{displayName}</AggregationName>
           <RemoveIcon name="close" onClick={onRemove} />
         </Root>
-      )}
-      popoverContent={({ closePopover }) => (
+      </Popover.Target>
+      <Popover.Dropdown>
         <AggregationPicker
           query={query}
           stageIndex={STAGE_INDEX}
@@ -48,10 +47,10 @@ export function AggregationItem({
           hasExpressionInput={false}
           onSelect={nextAggregation => {
             onUpdate(nextAggregation);
-            closePopover();
+            setIsOpened(false);
           }}
         />
-      )}
-    />
+      </Popover.Dropdown>
+    </Popover>
   );
 }

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -219,12 +219,8 @@ describe("SummarizeSidebar", () => {
     const { getNextAggregations } = setup({ withDefaultAggregation: false });
 
     userEvent.click(screen.getByLabelText("Add aggregation"));
-
-    let popover = await screen.findByLabelText("grid");
-    userEvent.click(within(popover).getByText("Average of ..."));
-
-    popover = await screen.findByLabelText("grid");
-    userEvent.click(within(popover).getByText("Total"));
+    userEvent.click(await screen.findByText("Average of ..."));
+    userEvent.click(await screen.findByText("Total"));
 
     await waitFor(() => {
       const [aggregation] = getNextAggregations();
@@ -237,9 +233,7 @@ describe("SummarizeSidebar", () => {
     const { getNextAggregations } = setup({ withDefaultAggregation: false });
 
     userEvent.click(screen.getByLabelText("Add aggregation"));
-
-    const popover = await screen.findByLabelText("grid");
-    userEvent.click(within(popover).getByText("Count of rows"));
+    userEvent.click(await screen.findByText("Count of rows"));
 
     await waitFor(() => {
       const [aggregation] = getNextAggregations();
@@ -253,23 +247,17 @@ describe("SummarizeSidebar", () => {
 
     userEvent.click(screen.getByLabelText("Add aggregation"));
 
-    const popover = await screen.findByLabelText("grid");
-    expect(
-      within(popover).queryByText(/Custom Expression/i),
-    ).not.toBeInTheDocument();
+    expect(await screen.findByText("Total")).toBeInTheDocument();
+    expect(screen.queryByText(/Custom Expression/i)).not.toBeInTheDocument();
   });
 
   it("shouldn't allow changing an aggregation to an expression", async () => {
     setup({ card: createSummarizedCard() });
 
     userEvent.click(screen.getByText("Max of Quantity"));
-    let popover = await screen.findByTestId("aggregation-column-picker");
-    userEvent.click(within(popover).getByLabelText("Back"));
-    popover = await screen.findByLabelText("grid");
+    userEvent.click(await screen.findByLabelText("Back"));
 
-    expect(
-      within(popover).queryByText(/Custom Expression/i),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Custom Expression/i)).not.toBeInTheDocument();
   });
 
   it("should add a breakout", async () => {

--- a/frontend/src/metabase/querying/components/FilterModal/CoordinateFilterEditor/CoordinateFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/CoordinateFilterEditor/CoordinateFilterEditor.unit.spec.tsx
@@ -1,10 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import {
-  renderWithProviders,
-  screen,
-  waitForElementToBeRemoved,
-} from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import { columnFinder, createQuery } from "metabase-lib/test-helpers";
 
@@ -43,7 +39,7 @@ function setup({ query, stageIndex, column, filter }: SetupOpts) {
   return { onChange, onInput, getNextFilterName };
 }
 
-describe("StringFilterEditor", () => {
+describe("CoordinateFilterEditor", () => {
   const query = createQuery();
   const stageIndex = 0;
   const availableColumns = Lib.filterableColumns(query, stageIndex);
@@ -60,7 +56,6 @@ describe("StringFilterEditor", () => {
 
       userEvent.click(screen.getByText("between"));
       userEvent.click(await screen.findByText("Is"));
-      await waitForElementToBeRemoved(() => screen.queryByRole("menu"));
       userEvent.type(screen.getByLabelText("Filter value"), "10");
       userEvent.tab();
       userEvent.type(screen.getByLabelText("Filter value"), "20");
@@ -79,7 +74,6 @@ describe("StringFilterEditor", () => {
 
       userEvent.click(screen.getByText("between"));
       userEvent.click(await screen.findByText("Greater than"));
-      await waitForElementToBeRemoved(() => screen.queryByRole("menu"));
       userEvent.type(screen.getByPlaceholderText("Enter a number"), "20");
       userEvent.tab();
 
@@ -111,7 +105,6 @@ describe("StringFilterEditor", () => {
 
       userEvent.click(screen.getByText("between"));
       userEvent.click(await screen.findByText("Inside"));
-      await waitForElementToBeRemoved(() => screen.queryByRole("menu"));
       userEvent.type(screen.getByPlaceholderText("Lower latitude"), "-10");
       userEvent.type(screen.getByPlaceholderText("Upper latitude"), "20");
       userEvent.type(screen.getByPlaceholderText("Left longitude"), "-30");

--- a/frontend/src/metabase/querying/components/FilterModal/NumberFilterEditor/NumberFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/NumberFilterEditor/NumberFilterEditor.unit.spec.tsx
@@ -1,11 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import { setupFieldValuesEndpoints } from "__support__/server-mocks";
-import {
-  renderWithProviders,
-  screen,
-  waitForElementToBeRemoved,
-} from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import { columnFinder, createQuery } from "metabase-lib/test-helpers";
 import type { FieldValuesResult } from "metabase-types/api";
@@ -88,7 +84,6 @@ describe("StringFilterEditor", () => {
 
       userEvent.click(screen.getByText("between"));
       userEvent.click(await screen.findByText("Equal to"));
-      await waitForElementToBeRemoved(() => screen.queryByRole("menu"));
       userEvent.type(screen.getByPlaceholderText("Enter a number"), "15");
       userEvent.tab();
 
@@ -131,7 +126,6 @@ describe("StringFilterEditor", () => {
 
       userEvent.click(screen.getByText("between"));
       userEvent.click(await screen.findByText("Less than"));
-      await waitForElementToBeRemoved(() => screen.queryByRole("menu"));
       userEvent.type(screen.getByPlaceholderText("Enter a number"), "20");
       userEvent.tab();
 

--- a/frontend/src/metabase/querying/components/FilterModal/StringFilterEditor/StringFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/StringFilterEditor/StringFilterEditor.unit.spec.tsx
@@ -4,12 +4,7 @@ import {
   setupFieldSearchValuesEndpoints,
   setupFieldValuesEndpoints,
 } from "__support__/server-mocks";
-import {
-  act,
-  renderWithProviders,
-  screen,
-  waitForElementToBeRemoved,
-} from "__support__/ui";
+import { act, renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import { columnFinder, createQuery } from "metabase-lib/test-helpers";
 import type { FieldValuesResult } from "metabase-types/api";
@@ -141,7 +136,6 @@ describe("StringFilterEditor", () => {
 
       userEvent.click(screen.getByText("is"));
       userEvent.click(await screen.findByText("Starts with"));
-      await waitForElementToBeRemoved(() => screen.queryByRole("menu"));
       userEvent.type(screen.getByPlaceholderText("Enter some text"), "Ga");
       userEvent.tab();
 

--- a/frontend/src/metabase/querying/components/FilterModal/TimeFilterEditor/TimeFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/TimeFilterEditor/TimeFilterEditor.unit.spec.tsx
@@ -1,11 +1,7 @@
 import userEvent from "@testing-library/user-event";
 
 import { createMockMetadata } from "__support__/metadata";
-import {
-  renderWithProviders,
-  screen,
-  waitForElementToBeRemoved,
-} from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import { columnFinder, createQuery } from "metabase-lib/test-helpers";
 import { createMockField } from "metabase-types/api/mocks";
@@ -105,7 +101,6 @@ describe("TimeFilterEditor", () => {
 
       userEvent.click(screen.getByText("before"));
       userEvent.click(await screen.findByText("Between"));
-      await waitForElementToBeRemoved(() => screen.queryByRole("menu"));
       userEvent.type(screen.getByPlaceholderText("Min"), "{selectall}10:15");
       userEvent.type(screen.getByPlaceholderText("Max"), "{selectall}20:40");
       userEvent.tab();

--- a/frontend/src/metabase/ui/components/overlays/Popover/Popover.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/Popover.styled.tsx
@@ -1,4 +1,5 @@
 import type { MantineThemeOverride } from "@mantine/core";
+import type { SyntheticEvent } from "react";
 
 export const getPopoverOverrides = (): MantineThemeOverride["components"] => ({
   Popover: {
@@ -7,6 +8,7 @@ export const getPopoverOverrides = (): MantineThemeOverride["components"] => ({
       shadow: "md",
       withinPortal: true,
       middlewares: { shift: true, flip: true, size: true },
+      transitionProps: { duration: 0 },
     },
     styles: () => ({
       dropdown: {
@@ -14,5 +16,14 @@ export const getPopoverOverrides = (): MantineThemeOverride["components"] => ({
         overflow: "auto",
       },
     }),
+  },
+  PopoverDropdown: {
+    defaultProps: {
+      onMouseDownCapture: (event: SyntheticEvent) => {
+        // prevent nested popovers from closing each other
+        // see useClickOutside in @mantine/hooks for the reference
+        event.nativeEvent.stopImmediatePropagation();
+      },
+    },
   },
 });


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/39210
https://github.com/metabase/metabase/actions/runs/8068495149/job/22041427386?pr=39200

In order to make it easier to implement a new feature, let's remove the old popover from notebook components.

The change triggered a lot changes in tests because the new popover is async. Also in terms of a11y it's somewhat different, so E2E tests are also affected.