### PR TITLE
Disable done button in Dashboard parameter editing for required param

### DIFF
--- a/e2e/support/helpers/e2e-dashboard-helpers.js
+++ b/e2e/support/helpers/e2e-dashboard-helpers.js
@@ -261,6 +261,10 @@ export function dashboardSaveButton() {
   return cy.findByTestId("edit-bar").findByRole("button", { name: "Save" });
 }
 
+export function dashboardParametersDoneButton() {
+  return cy.findByTestId("dashboard-parameter-sidebar").button("Done");
+}
+
 /**
  * @param {Object} option
  * @param {number=} option.id

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-date.cy.spec.js
@@ -17,6 +17,7 @@ import {
   ensureDashboardCardHasText,
   resetFilterWidgetToDefault,
   sidebar,
+  dashboardParametersDoneButton,
 } from "e2e/support/helpers";
 
 import * as DateFilter from "../native-filters/helpers/e2e-date-filter-helpers";
@@ -106,10 +107,17 @@ describe("scenarios > dashboard > filters > date", () => {
     toggleRequiredParameter();
     dashboardSaveButton().should("be.disabled");
     dashboardSaveButton().realHover();
-
     cy.findByRole("tooltip").should(
       "contain.text",
       'The "Month and Year" parameter requires a default value but none was provided.',
+    );
+
+    // Can't close sidebar without a default value
+    dashboardParametersDoneButton().should("be.disabled");
+    dashboardParametersDoneButton().realHover();
+    cy.findByRole("tooltip").should(
+      "contain.text",
+      "The parameter requires a default value but none was provided.",
     );
 
     sidebar().findByText("Default value").next().click();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-number.cy.spec.js
@@ -18,6 +18,7 @@ import {
   dashboardSaveButton,
   ensureDashboardCardHasText,
   sidebar,
+  dashboardParametersDoneButton,
 } from "e2e/support/helpers";
 
 import { addWidgetNumberFilter } from "../native-filters/helpers/e2e-field-filter-helpers";
@@ -96,10 +97,17 @@ describe("scenarios > dashboard > filters > number", () => {
     toggleRequiredParameter();
     dashboardSaveButton().should("be.disabled");
     dashboardSaveButton().realHover();
-
     cy.findByRole("tooltip").should(
       "contain.text",
       'The "Equal to" parameter requires a default value but none was provided.',
+    );
+
+    // Can't close sidebar without a default value
+    dashboardParametersDoneButton().should("be.disabled");
+    dashboardParametersDoneButton().realHover();
+    cy.findByRole("tooltip").should(
+      "contain.text",
+      "The parameter requires a default value but none was provided.",
     );
 
     sidebar().findByText("Default value").next().click();

--- a/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/dashboard-filters-text-category.cy.spec.js
@@ -17,6 +17,7 @@ import {
   ensureDashboardCardHasText,
   toggleFilterWidgetValues,
   resetFilterWidgetToDefault,
+  dashboardParametersDoneButton,
 } from "e2e/support/helpers";
 
 import {
@@ -150,6 +151,14 @@ describe("scenarios > dashboard > filters > text/category", () => {
     cy.findByRole("tooltip").should(
       "contain.text",
       'The "Text" parameter requires a default value but none was provided.',
+    );
+
+    // Can't close sidebar without a default value
+    dashboardParametersDoneButton().should("be.disabled");
+    dashboardParametersDoneButton().realHover();
+    cy.findByRole("tooltip").should(
+      "contain.text",
+      "The parameter requires a default value but none was provided.",
     );
 
     // Updates the filter value

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -557,7 +557,7 @@ describe("scenarios > dashboard", () => {
       cy.findByText("State").click();
     });
     cy.icon("close");
-    cy.get(".Button--primary").contains("Done").click();
+    cy.button("Done").click();
 
     saveDashboard();
 

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -756,8 +756,8 @@ function assignRecipients({
     .blur(); // blur is needed to close the popover
 }
 
-function clickButton(button_name) {
-  cy.contains(button_name).closest(".Button").should("not.be.disabled").click();
+function clickButton(name) {
+  cy.button(name).should("not.be.disabled").click();
 }
 
 function createEmailSubscription() {

--- a/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
+++ b/e2e/test/scenarios/sharing/subscriptions.cy.spec.js
@@ -165,10 +165,7 @@ describe("scenarios > dashboard > subscriptions", () => {
           cy.findByPlaceholderText("Enter user names or email addresses")
             .click()
             .type(`${normal.first_name} ${normal.last_name}{enter}`);
-          cy.contains("Done")
-            .closest(".Button")
-            .should("not.be.disabled")
-            .click();
+          clickButton("Done");
 
           cy.findByLabelText("add icon").click();
           cy.findByText("Email this dashboard").should("exist");

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/ClickBehaviorSidebar.tsx
@@ -104,7 +104,7 @@ export function ClickBehaviorSidebar({
     [clickBehavior],
   );
 
-  const closeIsDisabled = useMemo(
+  const isCloseDisabled = useMemo(
     () => !canSaveClickBehavior(clickBehavior, targetDashboard),
     [clickBehavior, targetDashboard],
   );
@@ -202,7 +202,7 @@ export function ClickBehaviorSidebar({
     <Sidebar
       onClose={hideClickBehaviorSidebar}
       onCancel={handleCancel}
-      closeIsDisabled={closeIsDisabled}
+      isCloseDisabled={isCloseDisabled}
     >
       <ClickBehaviorSidebarHeader
         dashcard={dashcard}

--- a/frontend/src/metabase/dashboard/components/Sidebar.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.styled.tsx
@@ -18,8 +18,10 @@ export const ChildrenContainer = styled.div`
   overflow-y: auto;
 `;
 
-export const ButtonContainer = styled.div`
+export const ButtonContainer = styled.div<{ spaceBetween?: boolean }>`
   display: flex;
+  justify-content: ${props =>
+    props.spaceBetween ? "space-between" : "flex-start"};
   align-items: center;
   gap: 20px;
   padding: 12px 32px;

--- a/frontend/src/metabase/dashboard/components/Sidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
 } from "./Sidebar.styled";
 
 interface SidebarProps {
-  closeIsDisabled?: boolean;
+  isCloseDisabled?: boolean;
   children: ReactNode;
   onClose?: () => void;
   onCancel?: () => void;
@@ -20,7 +20,7 @@ interface SidebarProps {
 
 export const SIDEBAR_WIDTH = 384;
 export function Sidebar({
-  closeIsDisabled,
+  isCloseDisabled,
   children,
   onClose,
   onCancel,
@@ -54,7 +54,7 @@ export function Sidebar({
           )}
           {onClose && (
             <Button
-              disabled={closeIsDisabled}
+              disabled={isCloseDisabled}
               onClick={onClose}
               variant="filled"
               aria-label={t`Done`}

--- a/frontend/src/metabase/dashboard/components/Sidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { t } from "ttag";
 
-import ButtonDeprecated from "metabase/core/components/Button";
 import { Button, Icon } from "metabase/ui";
 
 import {
@@ -32,7 +31,7 @@ export function Sidebar({
     <SidebarAside data-testid={dataTestId} $width={SIDEBAR_WIDTH}>
       <ChildrenContainer>{children}</ChildrenContainer>
       {(onClose || onCancel || onRemove) && (
-        <ButtonContainer>
+        <ButtonContainer spaceBetween>
           {onRemove && (
             <Button
               leftIcon={<Icon name="trash" />}
@@ -46,20 +45,20 @@ export function Sidebar({
             >{t`Remove`}</Button>
           )}
           {onCancel && (
-            <ButtonDeprecated
-              small
-              borderless
+            <Button
+              variant="subtle"
+              color="text-medium"
               onClick={onCancel}
-            >{t`Cancel`}</ButtonDeprecated>
+              aria-label={t`Cancel`}
+            >{t`Cancel`}</Button>
           )}
           {onClose && (
-            <ButtonDeprecated
-              primary
-              small
-              className="ml-auto"
-              onClick={onClose}
+            <Button
               disabled={closeIsDisabled}
-            >{t`Done`}</ButtonDeprecated>
+              onClick={onClose}
+              variant="filled"
+              aria-label={t`Done`}
+            >{t`Done`}</Button>
           )}
         </ButtonContainer>
       )}

--- a/frontend/src/metabase/dashboard/components/Sidebar.tsx
+++ b/frontend/src/metabase/dashboard/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { t } from "ttag";
 
-import { Button, Icon } from "metabase/ui";
+import { Button, Icon, Tooltip } from "metabase/ui";
 
 import {
   ButtonContainer,
@@ -10,11 +10,12 @@ import {
 } from "./Sidebar.styled";
 
 interface SidebarProps {
-  isCloseDisabled?: boolean;
   children: ReactNode;
   onClose?: () => void;
   onCancel?: () => void;
   onRemove?: () => void;
+  isCloseDisabled?: boolean;
+  closeTooltip?: string;
   "data-testid"?: string;
 }
 
@@ -25,6 +26,7 @@ export function Sidebar({
   onClose,
   onCancel,
   onRemove,
+  closeTooltip,
   "data-testid": dataTestId,
 }: SidebarProps) {
   return (
@@ -53,12 +55,17 @@ export function Sidebar({
             >{t`Cancel`}</Button>
           )}
           {onClose && (
-            <Button
-              disabled={isCloseDisabled}
-              onClick={onClose}
-              variant="filled"
-              aria-label={t`Done`}
-            >{t`Done`}</Button>
+            <Tooltip label={closeTooltip} hidden={!closeTooltip}>
+              {/* without a div we will need hacks to make tooltip work */}
+              <div>
+                <Button
+                  disabled={isCloseDisabled}
+                  onClick={onClose}
+                  variant="filled"
+                  aria-label={t`Done`}
+                >{t`Done`}</Button>
+              </div>
+            </Tooltip>
           )}
         </ButtonContainer>
       )}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -144,6 +144,11 @@ export const ParameterSidebar = ({
     <Sidebar
       onClose={onClose}
       isCloseDisabled={missingRequiredDefault}
+      closeTooltip={
+        missingRequiredDefault
+          ? t`The parameter requires a default value but none was provided.`
+          : undefined
+      }
       onRemove={handleRemove}
     >
       <SidebarHeader>

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -5,6 +5,7 @@ import Radio from "metabase/core/components/Radio";
 import { Sidebar } from "metabase/dashboard/components/Sidebar";
 import { slugify } from "metabase/lib/formatting";
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
+import { parameterHasNoDisplayValue } from "metabase-lib/parameters/utils/parameter-values";
 import type {
   Parameter,
   ParameterId,
@@ -73,6 +74,9 @@ export const ParameterSidebar = ({
   const tabs = useMemo(() => getTabs(parameter), [parameter]);
   const [tab, setTab] = useState(tabs[0].value);
 
+  const missingRequiredDefault =
+    parameter.required && parameterHasNoDisplayValue(parameter.default);
+
   const handleNameChange = useCallback(
     (name: string) => {
       onChangeName(parameterId, name);
@@ -137,7 +141,11 @@ export const ParameterSidebar = ({
     onChangeRequired(parameterId, value);
 
   return (
-    <Sidebar onClose={onClose} onRemove={handleRemove}>
+    <Sidebar
+      onClose={onClose}
+      closeIsDisabled={missingRequiredDefault}
+      onRemove={handleRemove}
+    >
       <SidebarHeader>
         <Radio
           value={tab}

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -150,6 +150,7 @@ export const ParameterSidebar = ({
           : undefined
       }
       onRemove={handleRemove}
+      data-testid="dashboard-parameter-sidebar"
     >
       <SidebarHeader>
         <Radio

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.tsx
@@ -143,7 +143,7 @@ export const ParameterSidebar = ({
   return (
     <Sidebar
       onClose={onClose}
-      closeIsDisabled={missingRequiredDefault}
+      isCloseDisabled={missingRequiredDefault}
       onRemove={handleRemove}
     >
       <SidebarHeader>

--- a/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditEmailSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditEmailSidebar.jsx
@@ -42,7 +42,7 @@ function _AddEditEmailSidebar({
 
   return (
     <Sidebar
-      closeIsDisabled={!isValid}
+      isCloseDisabled={!isValid}
       onClose={handleSave}
       onCancel={onCancel}
     >

--- a/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditSlackSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/AddEditSidebar/AddEditSlackSidebar.jsx
@@ -39,7 +39,7 @@ function _AddEditSlackSidebar({
 
   return (
     <Sidebar
-      closeIsDisabled={!isValid}
+      isCloseDisabled={!isValid}
       onClose={handleSave}
       onCancel={onCancel}
     >


### PR DESCRIPTION
The last from the [follow-ups list](https://github.com/metabase/metabase/issues/38603), this one disables Done button in the dashboard parameter sidebar when a parameter is required but doesn't have a default value.



https://github.com/metabase/metabase/assets/2196347/53c2ef28-ab36-4be1-b9e3-2bb561b244a4

