### PR TITLE
Fix wrong sample db import

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -6,7 +6,27 @@
     "no-console": 0,
     "@typescript-eslint/no-namespace": "off",
     "cypress/no-async-tests": "error",
-    "quotes": ["error", "double", { "avoidEscape": true }]
+    "quotes": ["error", "double", { "avoidEscape": true }],
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "moment",
+            "message": "Moment is deprecated, please use dayjs"
+          },
+          {
+            "name": "moment-timezone",
+            "message": "Moment is deprecated, please use dayjs"
+          },
+          {
+            // mocks/presets is for unit tests
+            "name": "metabase-types/api/mocks/presets",
+            "message": "Please use e2e/support/cypress_sample_database instead"
+          }
+        ]
+      }
+    ]
   },
   "env": {
     "cypress/globals": true,

--- a/e2e/test/scenarios/sharing/reproductions/26988-embedding-dynamic-settings.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/26988-embedding-dynamic-settings.cy.spec.js
@@ -1,3 +1,4 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   describeEE,
   getIframeBody,
@@ -7,7 +8,8 @@ import {
   setTokenFeatures,
   visitDashboard,
 } from "e2e/support/helpers";
-import { ORDERS_ID } from "metabase-types/api/mocks/presets";
+
+const { ORDERS_ID } = SAMPLE_DATABASE;
 
 describeEE("issue 26988", () => {
   beforeEach(() => {


### PR DESCRIPTION
### Description

auto-import uses wrong location of the sample_database, let's forbid it

### How to check

- put `import { ORDERS_ID } from "metabase-types/api/mocks/presets";` to any of e2e files
- get an error from eslint

### Demo

<img width="679" alt="image" src="https://github.com/metabase/metabase/assets/125459446/0622090f-73d8-4d60-aa14-068b98601a2a">

### Checklist

~- [ ] Tests have been added/updated to cover changes in this PR~
