### PR TITLE
Fix missing bucket picker on selected item

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/BreakoutColumnList/BreakoutColumnListItem/BreakoutColumnListItem.styled.tsx
@@ -79,8 +79,8 @@ const selectedStyle = css`
   }
 
   ${BucketPickerPopover.TriggerButton} {
-    opacity: 0;
-    color: ${alpha("white", 0.5)};
+    opacity: 1;
+    color: ${alpha("white", 0.65)};
     padding-left: 0;
     border-left: 0;
   }


### PR DESCRIPTION
Fixes an issue where the bucket popover was not visible when the summarize items is selected.

<img width="427" alt="Screenshot 2024-02-28 at 12 54 56" src="https://github.com/metabase/metabase/assets/1250185/74ea3225-ec5d-4adb-a513-665cbb936c34">
