### PR TITLE
Do not fetch app settings when updating user-local setting

### DIFF
--- a/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.js
@@ -15,21 +15,15 @@ describe("issue 39221", () => {
     });
   });
 
-  it("admins should fetch site settings", () => {
-    startNewNativeQuestion();
-    popover().findByText("Sample Database").click();
-    cy.wait("@sessionProperties");
+  ["admin", "normal"].forEach(user => {
+    it(`${user.toUpperCase()}: updating user-specific setting should not result in fetching all site settings (metabase#39221)`, () => {
+      user === "normal" ? cy.signInAsNormalUser() : null;
 
-    cy.get("@siteSettings").should("not.be.null");
-  });
+      startNewNativeQuestion();
+      popover().findByText("Sample Database").click();
+      cy.wait("@sessionProperties");
 
-  it("non-admins should not fetch site settings (metabase#39221)", () => {
-    cy.signInAsNormalUser();
-
-    startNewNativeQuestion();
-    popover().findByText("Sample Database").click();
-    cy.wait("@sessionProperties");
-
-    cy.get("@siteSettings").should("be.null");
+      cy.get("@siteSettings").should("be.null");
+    });
   });
 });

--- a/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.js
@@ -1,0 +1,35 @@
+import { restore, startNewNativeQuestion, popover } from "e2e/support/helpers";
+
+describe("issue 39221", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "/api/setting").as("siteSettings");
+    cy.intercept("GET", "/api/session/properties").as("sessionProperties");
+
+    restore();
+    cy.signInAsAdmin();
+
+    cy.request("POST", "/api/database", {
+      engine: "sqlite",
+      name: "sqlite",
+      details: { db: "./resources/sqlite-fixture.db" },
+    });
+  });
+
+  it("admins should fetch site settings", () => {
+    startNewNativeQuestion();
+    popover().findByText("Sample Database").click();
+    cy.wait("@sessionProperties");
+
+    cy.get("@siteSettings").should("not.be.null");
+  });
+
+  it("non-admins should not fetch site settings (metabase#39221)", () => {
+    cy.signInAsNormalUser();
+
+    startNewNativeQuestion();
+    popover().findByText("Sample Database").click();
+    cy.wait("@sessionProperties");
+
+    cy.get("@siteSettings").should("be.null");
+  });
+});

--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -5,7 +5,6 @@ import {
   combineReducers,
 } from "metabase/lib/redux";
 import { refreshSiteSettings } from "metabase/redux/settings";
-import { getUserIsAdmin } from "metabase/selectors/user";
 import {
   SettingsApi,
   EmailApi,
@@ -18,11 +17,8 @@ import {
 // ACTION TYPES AND ACTION CREATORS
 
 export const reloadSettings = () => async (dispatch, getState) => {
-  const isAdmin = getUserIsAdmin(getState());
-
   await Promise.all([
-    // Calling `GET /api/setting` returns `403` for non-admins
-    isAdmin ? dispatch(refreshSettingsList()) : Promise.resolve(),
+    dispatch(refreshSettingsList()),
     dispatch(refreshSiteSettings()),
   ]);
 };

--- a/frontend/src/metabase/admin/settings/settings.js
+++ b/frontend/src/metabase/admin/settings/settings.js
@@ -5,6 +5,7 @@ import {
   combineReducers,
 } from "metabase/lib/redux";
 import { refreshSiteSettings } from "metabase/redux/settings";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import {
   SettingsApi,
   EmailApi,
@@ -17,8 +18,11 @@ import {
 // ACTION TYPES AND ACTION CREATORS
 
 export const reloadSettings = () => async (dispatch, getState) => {
+  const isAdmin = getUserIsAdmin(getState());
+
   await Promise.all([
-    dispatch(refreshSettingsList()),
+    // Calling `GET /api/setting` returns `403` for non-admins
+    isAdmin ? dispatch(refreshSettingsList()) : Promise.resolve(),
     dispatch(refreshSiteSettings()),
   ]);
 };

--- a/frontend/src/metabase/query_builder/actions/native.ts
+++ b/frontend/src/metabase/query_builder/actions/native.ts
@@ -1,9 +1,9 @@
 import { createAction } from "redux-actions";
 
-import { updateSetting } from "metabase/admin/settings/settings";
 import Questions from "metabase/entities/questions";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { createThunkAction } from "metabase/lib/redux";
+import { updateUserSetting } from "metabase/redux/settings";
 import { getMetadata } from "metabase/selectors/metadata";
 import type NativeQuery from "metabase-lib/queries/NativeQuery";
 import type {
@@ -197,7 +197,7 @@ export const setTemplateTagConfig = createThunkAction(
 );
 
 export const rememberLastUsedDatabase = (id: DatabaseId) =>
-  updateSetting({
+  updateUserSetting({
     key: "last-used-native-database-id",
     value: id,
   });

--- a/frontend/src/metabase/redux/settings.ts
+++ b/frontend/src/metabase/redux/settings.ts
@@ -1,7 +1,8 @@
 import { createAsyncThunk, createReducer } from "@reduxjs/toolkit";
 
+import { createThunkAction } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
-import { SessionApi } from "metabase/services";
+import { SessionApi, SettingsApi } from "metabase/services";
 
 export const REFRESH_SITE_SETTINGS = "metabase/settings/REFRESH_SITE_SETTINGS";
 
@@ -30,5 +31,22 @@ export const settings = createReducer(
     builder.addCase(refreshSiteSettings.rejected, state => {
       state.loading = false;
     });
+  },
+);
+
+export const UPDATE_USER_SETTING = "metabase/settings/UPDATE_USER_SETTING";
+export const updateUserSetting = createThunkAction(
+  UPDATE_USER_SETTING,
+  function (setting) {
+    return async function (dispatch) {
+      try {
+        await SettingsApi.put(setting);
+      } catch (error) {
+        console.error("error updating user setting", setting, error);
+        throw error;
+      } finally {
+        await dispatch(refreshSiteSettings({}));
+      }
+    };
   },
 );


### PR DESCRIPTION
### Description

As explained in the [original issue](https://github.com/metabase/metabase/issues/39221), we have two types of settings. App, or site, settings are accessible only by admins. OTOH, there are user-local settings that should be accessible to non-admins.

Before this PR
- Updating any setting (app or user) would result in fetching all settings

Now
- Updating admin settings results in fetching all settings (we're not changing this)
- Updating a user-local setting results in fetching only settings available to all users (we get these from `/api/session/properties` endpoint)

### How to verify
- Log in as non-admin user
- Start a new native query or a new native model
- Choose a database
- Make sure there is no `GET /api/setting` call in your browser's network tab (previously resulted in `403`)

or

Simply run a provided E2E reproduction.

### Demo
Before
![image](https://github.com/metabase/metabase/assets/31325167/81ec6908-a451-43c0-a634-e9075b790924)

After
![image](https://github.com/metabase/metabase/assets/31325167/1f651c79-03f0-47c3-9869-c60cb3c4c0d5)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR


Fixes #39221.