### PR TITLE
Add hovercard to column picker in sandbox filter

### DIFF
--- a/frontend/src/metabase/parameters/components/ParameterTargetList.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterTargetList.jsx
@@ -2,8 +2,12 @@
 import { Component } from "react";
 import _ from "underscore";
 
+import {
+  QueryColumnInfoIcon,
+  HoverParent,
+} from "metabase/components/MetadataInfo/ColumnInfoIcon";
 import AccordionList from "metabase/core/components/AccordionList";
-import { Icon } from "metabase/ui";
+import { DelayGroup, Icon } from "metabase/ui";
 
 export default class ParameterTargetList extends Component {
   props;
@@ -21,18 +25,41 @@ export default class ParameterTargetList extends Component {
     }));
 
     return (
-      <AccordionList
-        className="text-brand"
-        maxHeight={this.props.maxHeight || 600}
-        sections={sections}
-        onChange={item => this.props.onChange(item.target)}
-        itemIsSelected={item => _.isEqual(item.target, target)}
-        renderItemIcon={item => (
-          <Icon name={item.icon || "unknown"} size={18} />
-        )}
-        alwaysExpanded={true}
-        hideSingleSectionTitle={!hasForeignOption}
-      />
+      <DelayGroup>
+        <AccordionList
+          className="text-brand"
+          maxHeight={this.props.maxHeight || 600}
+          sections={sections}
+          onChange={item => this.props.onChange(item.target)}
+          itemIsSelected={item => _.isEqual(item.target, target)}
+          renderItemIcon={item => (
+            <Icon name={item.icon || "unknown"} size={18} />
+          )}
+          renderItemExtra={renderItemExtra}
+          renderItemWrapper={renderItemWrapper}
+          alwaysExpanded={true}
+          hideSingleSectionTitle={!hasForeignOption}
+        />
+      </DelayGroup>
     );
   }
+}
+
+function renderItemExtra(item) {
+  if (!item.query || item.stageIndex === undefined || !item.column) {
+    return null;
+  }
+
+  return (
+    <QueryColumnInfoIcon
+      query={item.query}
+      stageIndex={item.stageIndex}
+      column={item.column}
+      position="right"
+    />
+  );
+}
+
+function renderItemWrapper(content) {
+  return <HoverParent>{content}</HoverParent>;
 }

--- a/frontend/src/metabase/parameters/components/ParameterTargetList.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterTargetList.unit.spec.tsx
@@ -1,0 +1,42 @@
+import { createMockMetadata } from "__support__/metadata";
+import { renderWithProviders, screen } from "__support__/ui";
+import * as Lib from "metabase-lib";
+import { columnFinder, createQuery } from "metabase-lib/test-helpers";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import ParameterTargetList from "./ParameterTargetList";
+
+const METADATA = createMockMetadata({
+  databases: [createSampleDatabase()],
+});
+
+function setup() {
+  const query = createQuery({ metadata: METADATA });
+  const stageIndex = 0;
+
+  const availableColumns = Lib.filterableColumns(query, stageIndex);
+  const findColumn = columnFinder(query, availableColumns);
+  const column = findColumn("ORDERS", "ID");
+
+  const mappingOptions = [
+    {
+      section: "Order",
+      sectionName: "Order",
+      name: "ID",
+      icon: "label",
+      isForeign: false,
+      query,
+      stageIndex,
+      column,
+    },
+  ];
+
+  renderWithProviders(<ParameterTargetList mappingOptions={mappingOptions} />);
+}
+
+describe("ParameterTargetList", () => {
+  test("should render the column info icon", () => {
+    setup();
+    expect(screen.getByLabelText("More info")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -36,6 +36,9 @@ export type StructuredQuerySectionOption = {
   icon: string;
   target: StructuredParameterDimensionTarget;
   isForeign: boolean;
+  query?: Lib.Query;
+  stageIndex?: number;
+  column?: Lib.ColumnMetadata;
 };
 
 function buildStructuredQuerySectionOptions(
@@ -55,6 +58,9 @@ function buildStructuredQuerySectionOptions(
       icon: getColumnIcon(column),
       target: buildColumnTarget(query, stageIndex, column),
       isForeign: columnInfo.isFromJoin || columnInfo.isImplicitlyJoinable,
+      query,
+      stageIndex,
+      column,
     };
   });
 }

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -36,9 +36,9 @@ export type StructuredQuerySectionOption = {
   icon: string;
   target: StructuredParameterDimensionTarget;
   isForeign: boolean;
-  query?: Lib.Query;
-  stageIndex?: number;
-  column?: Lib.ColumnMetadata;
+  query: Lib.Query;
+  stageIndex: number;
+  column: Lib.ColumnMetadata;
 };
 
 function buildStructuredQuerySectionOptions(


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39240

### Description

Adds the info icon to the columns in the column picker in the sandbox permission editor.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Admin → Permissions → Databases → Sample Database → Orders
2. For "All Users" select "Sandboxed"
3. In the popover select "Limit access"
4. Select "Filter by a column in the table"
5. Click "Pick a column"
6. In the popover, verify that all items have an info icon on hover
7. Verify that the info shown in the popover is correct when hovering an icon

### Demo

<img width="678" alt="Screenshot 2024-02-28 at 16 42 33" src="https://github.com/metabase/metabase/assets/1250185/d940f529-1387-4ac2-80ff-ed43adadf509">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
