### PR TITLE
[QP] Fix confusion of expressions with the same name as columns

### DIFF
--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -215,7 +215,7 @@
   (testing "Make sure duplicate identifiers (even with different cases) get unique aliases"
     (mt/test-driver :sqlite
       (mt/dataset test-data
-        (is (= '{:select   [source.CATEGORY_2 AS CATEGORY_2
+        (is (= '{:select   [source.CATEGORY_2 AS CATEGORY
                             COUNT (*)         AS count]
                  :from     [{:select [products.category       AS category
                                       products.category || ?  AS CATEGORY_2]

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -24,7 +24,6 @@
    [metabase.mbql.util :as mbql.u]
    [metabase.shared.util.i18n :as i18n]
    [metabase.types :as types]
-   [metabase.util :as u]
    [metabase.util.malli :as mu]
    [metabase.util.malli.registry :as mr]))
 
@@ -190,11 +189,11 @@
   [query stage-number [_coalesce _opts expr _null-expr]]
   (lib.metadata.calculation/column-name query stage-number expr))
 
-(defn- conflicting-name? [query stage-number expression-name]
-  (let [stage     (lib.util/query-stage query stage-number)
-        cols      (lib.metadata.calculation/visible-columns query stage-number stage)
-        expr-name (u/lower-case-en expression-name)]
-    (some #(-> % :name u/lower-case-en (= expr-name)) cols)))
+#_(defn- conflicting-name? [query stage-number expression-name]
+    (let [stage     (lib.util/query-stage query stage-number)
+          cols      (lib.metadata.calculation/visible-columns query stage-number stage)
+          expr-name (u/lower-case-en expression-name)]
+      (some #(-> % :name u/lower-case-en (= expr-name)) cols)))
 
 (defn- add-expression-to-stage
   [stage expression]
@@ -213,14 +212,17 @@
     expression-name      :- ::lib.schema.common/non-blank-string
     expressionable]
    (let [stage-number (or stage-number -1)]
-     (when (conflicting-name? query stage-number expression-name)
-       (throw (ex-info "Expression name conflicts with a column in the same query stage"
-                       {:expression-name expression-name})))
+     ;; TODO: This logic was removed as part of fixing #39059. We might want to bring it back for collisions with other
+     ;; expressions in the same stage; probably not with tables or earlier stages. De-duplicating names is supported by
+     ;; the QP code, and it should be powered by MLv2 in due course.
+     #_(when (conflicting-name? query stage-number expression-name)
+         (throw (ex-info "Expression name conflicts with a column in the same query stage"
+                         {:expression-name expression-name})))
      (lib.util/update-query-stage
-      query stage-number
-      add-expression-to-stage
-      (-> (lib.common/->op-arg expressionable)
-          (lib.util/top-level-expression-clause expression-name))))))
+       query stage-number
+       add-expression-to-stage
+       (-> (lib.common/->op-arg expressionable)
+           (lib.util/top-level-expression-clause expression-name))))))
 
 (lib.common/defop + [x y & more])
 (lib.common/defop - [x y & more])

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -87,10 +87,14 @@
         {base-type :base_type}       (some-> expression-definition annotate/infer-expression-type)
         {::add/keys [desired-alias]} (mbql.u/match-one source-query
                                        [:expression (_ :guard (partial = expression-name)) source-opts]
-                                       source-opts)]
+                                       source-opts)
+        source-alias                 (or desired-alias expression-name)]
     [:field
-     (or desired-alias expression-name)
-     (assoc opts :base-type (or base-type :type/*))]))
+     source-alias
+     (-> opts
+         (assoc :base-type          (or base-type :type/*)
+                ::add/source-table  ::add/source
+                ::add/source-alias  source-alias))]))
 
 (defn- rewrite-fields-and-expressions [query]
   (mbql.u/replace query

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -720,7 +720,7 @@
 
 (deftest ^:parallel expression-with-duplicate-column-name-test
   (testing "Can we use expression with same column name as table (#14267)"
-    (is (= '{:select   [source.CATEGORY_2 AS CATEGORY_2
+    (is (= '{:select   [source.CATEGORY_2 AS CATEGORY
                         COUNT (*)         AS count]
              :from     [{:select [PRODUCTS.CATEGORY            AS CATEGORY
                                   CONCAT (PRODUCTS.CATEGORY ?) AS CATEGORY_2]

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -251,7 +251,10 @@
                 (lib/expression "expr" (lib/absolute-datetime "2020" :month))
                 lib/expressions
                 (->> (map (fn [expr] (lib/display-info lib.tu/venues-query expr))))))))
-  (testing "collisions with other column names are detected and rejected"
+  ;; TODO: This logic was removed as part of fixing #39059. We might want to bring it back for collisions with other
+  ;; expressions in the same stage; probably not with tables or earlier stages. De-duplicating names is supported by the
+  ;; QP code, and it should be powered by MLv2 in due course.
+  #_(testing "collisions with other column names are detected and rejected"
     (let [query (lib/query meta/metadata-provider (meta/table-metadata :categories))
           ex    (try
                   (lib/expression query "ID" (meta/field-metadata :categories :name))

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -695,7 +695,8 @@
         (is (= {:field-name              "CREATED_AT"
                 :join-is-this-level?     "Q2"
                 :alias-from-join         "Products__CREATED_AT"
-                :alias-from-source-query nil}
+                :alias-from-source-query nil
+                :override-alias?         false}
                (#'add/expensive-field-info
                 (lib.tu.macros/$ids nil
                   {:source-table $$reviews


### PR DESCRIPTION
When determining column aliases in `add-alias-info`, reuse an existing
desired column alias if one is present.

Fixes #39059. Might fix #25931.

