### PR TITLE
Visualisation sidebar info icons

### DIFF
--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode, ReactElement } from "react";
 import type { SortableElementProps } from "react-sortable-hoc";
 
+import { HoverParent } from "metabase/components/MetadataInfo/ColumnInfoIcon";
 import {
   SortableContainer,
   SortableElement,
@@ -47,28 +48,30 @@ const SortableColumn = SortableElement(function SortableColumn<
   isDragDisabled = false,
 }: SortableColumnProps<T>) {
   return (
-    <ColumnItem
-      title={getItemName(item)}
-      extra={getItemExtra ? getItemExtra(item) : null}
-      onEdit={
-        onEdit
-          ? (targetElement: HTMLElement) => onEdit(item, targetElement)
-          : undefined
-      }
-      onRemove={onRemove && item.enabled ? () => onRemove(item) : undefined}
-      onClick={onClick ? () => onClick(item) : undefined}
-      onAdd={onAdd ? () => onAdd(item) : undefined}
-      onEnable={onEnable && !item.enabled ? () => onEnable(item) : undefined}
-      onColorChange={
-        onColorChange
-          ? (color: string) => onColorChange(item, color)
-          : undefined
-      }
-      color={item.color}
-      draggable={!isDragDisabled}
-      icon={item.icon}
-      role="listitem"
-    />
+    <HoverParent>
+      <ColumnItem
+        title={getItemName(item)}
+        extra={getItemExtra ? getItemExtra(item) : null}
+        onEdit={
+          onEdit
+            ? (targetElement: HTMLElement) => onEdit(item, targetElement)
+            : undefined
+        }
+        onRemove={onRemove && item.enabled ? () => onRemove(item) : undefined}
+        onClick={onClick ? () => onClick(item) : undefined}
+        onAdd={onAdd ? () => onAdd(item) : undefined}
+        onEnable={onEnable && !item.enabled ? () => onEnable(item) : undefined}
+        onColorChange={
+          onColorChange
+            ? (color: string) => onColorChange(item, color)
+            : undefined
+        }
+        color={item.color}
+        draggable={!isDragDisabled}
+        icon={item.icon}
+        role="listitem"
+      />
+    </HoverParent>
   );
 }) as unknown as <T extends SortableItem>(
   props: SortableColumnProps<T> & SortableElementProps,

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -23,7 +23,7 @@ interface SortableColumnFunctions<T> {
   onAdd?: (item: T) => void;
   onEnable?: (item: T) => void;
   getItemName: (item: T) => string;
-  getItemExtra: (item: T) => ReactNode;
+  getItemExtra?: (item: T) => ReactNode;
   onColorChange?: (item: T, color: string) => void;
 }
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import type { ReactNode, ReactElement } from "react";
 import type { SortableElementProps } from "react-sortable-hoc";
 
 import {
@@ -23,7 +23,7 @@ interface SortableColumnFunctions<T> {
   onAdd?: (item: T) => void;
   onEnable?: (item: T) => void;
   getItemName: (item: T) => string;
-  getItemExtra: (item: T) => React.ReactNode;
+  getItemExtra: (item: T) => ReactNode;
   onColorChange?: (item: T, color: string) => void;
 }
 
@@ -72,7 +72,7 @@ const SortableColumn = SortableElement(function SortableColumn<
   );
 }) as unknown as <T extends SortableItem>(
   props: SortableColumnProps<T> & SortableElementProps,
-) => React.ReactElement;
+) => ReactElement;
 
 interface SortableColumnListProps<T extends SortableItem>
   extends SortableColumnFunctions<T> {

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -6,6 +6,7 @@ import {
   SortableElement,
 } from "metabase/components/sortable";
 import type { IconProps } from "metabase/ui";
+import { DelayGroup } from "metabase/ui";
 
 import { ColumnItem } from "../ColumnItem";
 
@@ -22,6 +23,7 @@ interface SortableColumnFunctions<T> {
   onAdd?: (item: T) => void;
   onEnable?: (item: T) => void;
   getItemName: (item: T) => string;
+  getItemExtra: (item: T) => React.ReactNode;
   onColorChange?: (item: T, color: string) => void;
 }
 
@@ -35,6 +37,7 @@ const SortableColumn = SortableElement(function SortableColumn<
 >({
   item,
   getItemName,
+  getItemExtra,
   onEdit,
   onRemove,
   onClick,
@@ -46,6 +49,7 @@ const SortableColumn = SortableElement(function SortableColumn<
   return (
     <ColumnItem
       title={getItemName(item)}
+      extra={getItemExtra ? getItemExtra(item) : null}
       onEdit={
         onEdit
           ? (targetElement: HTMLElement) => onEdit(item, targetElement)
@@ -79,6 +83,7 @@ const SortableColumnList = SortableContainer(function SortableColumnList<
   T extends SortableItem,
 >({
   items,
+  getItemExtra,
   getItemName,
   onEdit,
   onRemove,
@@ -95,6 +100,7 @@ const SortableColumnList = SortableContainer(function SortableColumnList<
           key={`item-${index}`}
           index={index}
           item={item}
+          getItemExtra={getItemExtra}
           getItemName={getItemName}
           onEdit={onEdit}
           onRemove={onRemove}
@@ -130,22 +136,26 @@ export function ChartSettingOrderedItems<T extends SortableItem>({
   onEnable,
   onClick,
   getItemName,
+  getItemExtra,
   items,
   onColorChange,
 }: ChartSettingOrderedItemsProps<T>) {
   return (
-    <SortableColumnList
-      helperClass="dragging"
-      items={items}
-      getItemName={getItemName}
-      onEdit={onEdit}
-      onRemove={onRemove}
-      onAdd={onAdd}
-      onEnable={onEnable}
-      onClick={onClick}
-      onSortEnd={onSortEnd}
-      onColorChange={onColorChange}
-      distance={5}
-    />
+    <DelayGroup>
+      <SortableColumnList
+        helperClass="dragging"
+        items={items}
+        getItemName={getItemName}
+        getItemExtra={getItemExtra}
+        onEdit={onEdit}
+        onRemove={onRemove}
+        onAdd={onAdd}
+        onEnable={onEnable}
+        onClick={onClick}
+        onSortEnd={onSortEnd}
+        onColorChange={onColorChange}
+        distance={5}
+      />
+    </DelayGroup>
   );
 }

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.styled.tsx
@@ -4,6 +4,7 @@ import { TableColumnInfoIcon } from "metabase/components/MetadataInfo/ColumnInfo
 
 export const ColumnInfoIcon = styled(TableColumnInfoIcon)`
   padding: 0;
+  flex: 0 0 auto;
   margin-left: auto;
   padding: 0.65rem 0.25rem;
   position: relative;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.styled.tsx
@@ -1,0 +1,11 @@
+import styled from "@emotion/styled";
+
+import { TableColumnInfoIcon } from "metabase/components/MetadataInfo/ColumnInfoIcon";
+
+export const ColumnInfoIcon = styled(TableColumnInfoIcon)`
+  padding: 0;
+  margin-left: auto;
+  padding: 0.65rem 0.25rem;
+  position: relative;
+  left: 0.5em;
+`;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.tsx
@@ -8,6 +8,7 @@ import type {
 import { ChartSettingOrderedItems } from "../../ChartSettingOrderedItems";
 import type { EditWidgetData } from "../types";
 
+import { ColumnInfoIcon } from "./TableColumnPanel.styled";
 import type { ColumnItem, DragColumnProps } from "./types";
 import {
   getColumnItems,
@@ -65,6 +66,7 @@ export const TableColumnPanel = ({
           <ChartSettingOrderedItems
             items={columnItems}
             getItemName={getItemName}
+            getItemExtra={getItemExtra}
             distance={5}
             onEnable={handleEnableColumn}
             onRemove={handleDisableColumn}
@@ -76,3 +78,11 @@ export const TableColumnPanel = ({
     </div>
   );
 };
+
+function getItemExtra(columnItem: ColumnItem) {
+  if (!columnItem.column) {
+    return null;
+  }
+
+  return <ColumnInfoIcon field={columnItem.column} position="right" />;
+}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.unit.spec.tsx
@@ -103,10 +103,6 @@ describe("DatasetColumnSelector", () => {
     expect(items[1]).toHaveTextContent("ID");
     expect(items[2]).toHaveTextContent("Tax");
     expect(items[3]).toHaveTextContent("Subtotal");
-
-    items.forEach(item =>
-      expect(within(item).getByLabelText("More info")).toBeInTheDocument(),
-    );
   });
 
   it("should display columns without matching setting", () => {
@@ -139,6 +135,15 @@ describe("DatasetColumnSelector", () => {
     const newSettings = [...COLUMN_SETTINGS];
     newSettings[columnIndex] = { ...newSettings[columnIndex], enabled: false };
     expect(onChange).toHaveBeenCalledWith(newSettings);
+  });
+
+  it("should display the info icon on each column", () => {
+    setup();
+    const items = screen.getAllByTestId(/draggable-item/);
+
+    items.forEach(item =>
+      expect(within(item).getByLabelText("More info")).toBeInTheDocument(),
+    );
   });
 });
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { screen, renderWithProviders } from "__support__/ui";
+import { screen, renderWithProviders, within } from "__support__/ui";
 import type {
   DatasetColumn,
   TableColumnOrderSetting,
@@ -103,6 +103,10 @@ describe("DatasetColumnSelector", () => {
     expect(items[1]).toHaveTextContent("ID");
     expect(items[2]).toHaveTextContent("Tax");
     expect(items[3]).toHaveTextContent("Subtotal");
+
+    items.forEach(item =>
+      expect(within(item).getByLabelText("More info")).toBeInTheDocument(),
+    );
   });
 
   it("should display columns without matching setting", () => {

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.styled.tsx
@@ -40,6 +40,7 @@ export const ColumnItemRoot = styled.div<ColumnItemRootProps>`
 `;
 
 export const ColumnItemSpan = styled.span`
+  display: flex;
   word-break: break-word;
   word-wrap: anywhere;
   font-weight: 700;
@@ -49,6 +50,7 @@ export const ColumnItemSpan = styled.span`
   flex: auto;
   display: inline-flex;
   gap: 0.25rem;
+  align-items: center;
 `;
 
 export const ColumnItemContent = styled.div`
@@ -60,7 +62,7 @@ export const ColumnItemContent = styled.div`
 `;
 
 export const ColumnItemContainer = styled.div`
-  padding: 0.75rem 0.5rem;
+  padding: 0 0.5rem;
   position: relative;
   flex: auto;
   display: flex;
@@ -78,6 +80,7 @@ export const ColumnItemIcon = styled(Button)`
 
 export const ColumnItemDragHandle = styled(Icon)`
   flex-shrink: 0;
+  padding: 0.75rem 0;
 `;
 
 export const ColumnItemColorPicker = styled(ChartSettingColorPicker)`

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-import { HoverParent } from "metabase/components/MetadataInfo/ColumnInfoIcon";
 import type { IconProps } from "metabase/ui";
 import { Icon } from "metabase/ui";
 
@@ -46,63 +45,61 @@ const BaseColumnItem = ({
   onColorChange,
 }: ColumnItemProps) => {
   return (
-    <HoverParent>
-      <ColumnItemRoot
-        className={className}
-        role={role}
-        isDraggable={draggable}
-        onClick={onClick}
-        aria-label={role ? title : undefined}
-        data-testid={draggable ? `draggable-item-${title}` : null}
-        data-enabled={!!onRemove}
-      >
-        <ColumnItemContainer>
-          {draggable && <ColumnItemDragHandle name="grabber" />}
-          {onColorChange && color && (
-            <ColumnItemColorPicker
-              value={color}
-              onChange={onColorChange}
-              pillSize="small"
+    <ColumnItemRoot
+      className={className}
+      role={role}
+      isDraggable={draggable}
+      onClick={onClick}
+      aria-label={role ? title : undefined}
+      data-testid={draggable ? `draggable-item-${title}` : null}
+      data-enabled={!!onRemove}
+    >
+      <ColumnItemContainer>
+        {draggable && <ColumnItemDragHandle name="grabber" />}
+        {onColorChange && color && (
+          <ColumnItemColorPicker
+            value={color}
+            onChange={onColorChange}
+            pillSize="small"
+          />
+        )}
+        <ColumnItemContent>
+          <ColumnItemSpan>
+            {icon && <Icon name={icon} />}
+            {title}
+            {extra}
+          </ColumnItemSpan>
+          {onEdit && (
+            <ActionIcon
+              icon="ellipsis"
+              onClick={onEdit}
+              data-testid={`${title}-settings-button`}
             />
           )}
-          <ColumnItemContent>
-            <ColumnItemSpan>
-              {icon && <Icon name={icon} />}
-              {title}
-              {extra}
-            </ColumnItemSpan>
-            {onEdit && (
-              <ActionIcon
-                icon="ellipsis"
-                onClick={onEdit}
-                data-testid={`${title}-settings-button`}
-              />
-            )}
-            {onAdd && (
-              <ActionIcon
-                icon="add"
-                onClick={onAdd}
-                data-testid={`${title}-add-button`}
-              />
-            )}
-            {onRemove && (
-              <ActionIcon
-                icon="eye_outline"
-                onClick={onRemove}
-                data-testid={`${title}-hide-button`}
-              />
-            )}
-            {onEnable && (
-              <ActionIcon
-                icon="eye_crossed_out"
-                onClick={onEnable}
-                data-testid={`${title}-show-button`}
-              />
-            )}
-          </ColumnItemContent>
-        </ColumnItemContainer>
-      </ColumnItemRoot>
-    </HoverParent>
+          {onAdd && (
+            <ActionIcon
+              icon="add"
+              onClick={onAdd}
+              data-testid={`${title}-add-button`}
+            />
+          )}
+          {onRemove && (
+            <ActionIcon
+              icon="eye_outline"
+              onClick={onRemove}
+              data-testid={`${title}-hide-button`}
+            />
+          )}
+          {onEnable && (
+            <ActionIcon
+              icon="eye_crossed_out"
+              onClick={onEnable}
+              data-testid={`${title}-show-button`}
+            />
+          )}
+        </ColumnItemContent>
+      </ColumnItemContainer>
+    </ColumnItemRoot>
   );
 };
 

--- a/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ColumnItem/ColumnItem.tsx
@@ -1,3 +1,6 @@
+import type { ReactNode } from "react";
+
+import { HoverParent } from "metabase/components/MetadataInfo/ColumnInfoIcon";
 import type { IconProps } from "metabase/ui";
 import { Icon } from "metabase/ui";
 
@@ -13,6 +16,7 @@ import {
 
 interface ColumnItemProps {
   className?: string;
+  extra?: ReactNode;
   title: string;
   color?: string;
   role?: string;
@@ -29,6 +33,7 @@ interface ColumnItemProps {
 const BaseColumnItem = ({
   className,
   title,
+  extra,
   color,
   role,
   draggable = false,
@@ -41,60 +46,63 @@ const BaseColumnItem = ({
   onColorChange,
 }: ColumnItemProps) => {
   return (
-    <ColumnItemRoot
-      className={className}
-      role={role}
-      isDraggable={draggable}
-      onClick={onClick}
-      aria-label={role ? title : undefined}
-      data-testid={draggable ? `draggable-item-${title}` : null}
-      data-enabled={!!onRemove}
-    >
-      <ColumnItemContainer>
-        {draggable && <ColumnItemDragHandle name="grabber" />}
-        {onColorChange && color && (
-          <ColumnItemColorPicker
-            value={color}
-            onChange={onColorChange}
-            pillSize="small"
-          />
-        )}
-        <ColumnItemContent>
-          <ColumnItemSpan>
-            {icon && <Icon name={icon} />}
-            {title}
-          </ColumnItemSpan>
-          {onEdit && (
-            <ActionIcon
-              icon="ellipsis"
-              onClick={onEdit}
-              data-testid={`${title}-settings-button`}
+    <HoverParent>
+      <ColumnItemRoot
+        className={className}
+        role={role}
+        isDraggable={draggable}
+        onClick={onClick}
+        aria-label={role ? title : undefined}
+        data-testid={draggable ? `draggable-item-${title}` : null}
+        data-enabled={!!onRemove}
+      >
+        <ColumnItemContainer>
+          {draggable && <ColumnItemDragHandle name="grabber" />}
+          {onColorChange && color && (
+            <ColumnItemColorPicker
+              value={color}
+              onChange={onColorChange}
+              pillSize="small"
             />
           )}
-          {onAdd && (
-            <ActionIcon
-              icon="add"
-              onClick={onAdd}
-              data-testid={`${title}-add-button`}
-            />
-          )}
-          {onRemove && (
-            <ActionIcon
-              icon="eye_outline"
-              onClick={onRemove}
-              data-testid={`${title}-hide-button`}
-            />
-          )}
-          {onEnable && (
-            <ActionIcon
-              icon="eye_crossed_out"
-              onClick={onEnable}
-              data-testid={`${title}-show-button`}
-            />
-          )}
-        </ColumnItemContent>
-      </ColumnItemContainer>
-    </ColumnItemRoot>
+          <ColumnItemContent>
+            <ColumnItemSpan>
+              {icon && <Icon name={icon} />}
+              {title}
+              {extra}
+            </ColumnItemSpan>
+            {onEdit && (
+              <ActionIcon
+                icon="ellipsis"
+                onClick={onEdit}
+                data-testid={`${title}-settings-button`}
+              />
+            )}
+            {onAdd && (
+              <ActionIcon
+                icon="add"
+                onClick={onAdd}
+                data-testid={`${title}-add-button`}
+              />
+            )}
+            {onRemove && (
+              <ActionIcon
+                icon="eye_outline"
+                onClick={onRemove}
+                data-testid={`${title}-hide-button`}
+              />
+            )}
+            {onEnable && (
+              <ActionIcon
+                icon="eye_crossed_out"
+                onClick={onEnable}
+                data-testid={`${title}-show-button`}
+              />
+            )}
+          </ColumnItemContent>
+        </ColumnItemContainer>
+      </ColumnItemRoot>
+    </HoverParent>
   );
 };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38918

### Description

Add the column info icons to the columns in the visualisations sidebar.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Browse Data → Sample Database → Orders
2. Click the settings icon in the bottom left next to "Visualization"
3. On each of the columns, verify the info icon appears when hovering
4. Make sure the correct info is displayed when hovering the icon

### Demo

<img width="570" alt="Screenshot 2024-02-28 at 17 52 21" src="https://github.com/metabase/metabase/assets/1250185/5fb29f71-1c5e-4636-af3d-d47bcbad03bb">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
