### PR TITLE
Reset new dashboard subscription form state

### DIFF
--- a/e2e/test/scenarios/sharing/reproductions/30314-new-subscription-form-state.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/30314-new-subscription-form-state.cy.spec.js
@@ -1,0 +1,38 @@
+import { ORDERS_DASHBOARD_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  visitDashboard,
+  restore,
+  setupSMTP,
+  dashboardHeader,
+  sidebar,
+} from "e2e/support/helpers";
+
+describe("issue 30314", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    setupSMTP();
+  });
+
+  it("should clean the new subscription form on cancel (metabase#30314)", () => {
+    visitDashboard(ORDERS_DASHBOARD_ID);
+
+    dashboardHeader().findByLabelText("subscriptions").click();
+    sidebar().within(() => {
+      cy.findByText("Email it").click();
+
+      cy.findByLabelText("Attach results").should("not.be.checked").click();
+      cy.findByLabelText("Questions to attach")
+        .should("not.be.checked")
+        .click();
+
+      cy.button("Cancel").click();
+      cy.findByText("Email it").click();
+
+      cy.findByLabelText("Attach results").should("not.be.checked");
+      cy.findByText("Questions to attach").should("not.exist");
+      cy.findByText(".xlsx").should("not.exist");
+      cy.findByText(".csv").should("not.exist");
+    });
+  });
+});

--- a/frontend/src/metabase/pulse/actions.js
+++ b/frontend/src/metabase/pulse/actions.js
@@ -16,6 +16,7 @@ export const SET_EDITING_PULSE = "SET_EDITING_PULSE";
 export const UPDATE_EDITING_PULSE = "UPDATE_EDITING_PULSE";
 export const SAVE_PULSE = "SAVE_PULSE";
 export const SAVE_EDITING_PULSE = "SAVE_EDITING_PULSE";
+export const CANCEL_EDITING_PULSE = "CANCEL_EDITING_PULSE";
 export const TEST_PULSE = "TEST_PULSE";
 
 export const FETCH_PULSE_FORM_INPUT = "FETCH_PULSE_FORM_INPUT";
@@ -56,6 +57,7 @@ export const setEditingPulse = createThunkAction(
 );
 
 export const updateEditingPulse = createAction(UPDATE_EDITING_PULSE);
+export const cancelEditingPulse = createAction(CANCEL_EDITING_PULSE);
 
 export const saveEditingPulse = createThunkAction(
   SAVE_EDITING_PULSE,

--- a/frontend/src/metabase/pulse/reducers.js
+++ b/frontend/src/metabase/pulse/reducers.js
@@ -3,19 +3,23 @@ import { handleActions } from "redux-actions";
 import {
   SET_EDITING_PULSE,
   UPDATE_EDITING_PULSE,
+  CANCEL_EDITING_PULSE,
   SAVE_EDITING_PULSE,
   FETCH_PULSE_FORM_INPUT,
   FETCH_PULSE_CARD_PREVIEW,
   FETCH_PULSE_LIST_BY_DASHBOARD_ID,
 } from "./actions";
 
+const DEFAULT_EDITING_PULSE = { name: null, cards: [], channels: [] };
+
 export const editingPulse = handleActions(
   {
     [SET_EDITING_PULSE]: { next: (state, { payload }) => payload },
     [UPDATE_EDITING_PULSE]: { next: (state, { payload }) => payload },
     [SAVE_EDITING_PULSE]: { next: (state, { payload }) => payload },
+    [CANCEL_EDITING_PULSE]: { next: () => DEFAULT_EDITING_PULSE },
   },
-  { name: null, cards: [], channels: [] },
+  DEFAULT_EDITING_PULSE,
 );
 
 export const formInput = handleActions(

--- a/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
@@ -318,7 +318,7 @@ class SharingSidebarInner extends Component {
   // Because you can navigate down the sidebar, we need to wrap
   // onCancel from props and either call that or reset back a screen
   onCancel = () => {
-    const { onCancel } = this.props;
+    const { cancelEditingPulse, onCancel } = this.props;
     const { returnMode } = this.state;
     if (returnMode.length) {
       // set the current mode back to what it should be
@@ -329,6 +329,7 @@ class SharingSidebarInner extends Component {
     } else {
       onCancel();
     }
+    cancelEditingPulse();
   };
 
   render() {

--- a/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/SharingSidebar.jsx
@@ -16,6 +16,7 @@ import {
 import {
   updateEditingPulse,
   saveEditingPulse,
+  cancelEditingPulse,
   fetchPulseFormInput,
   testPulse,
 } from "metabase/pulse/actions";
@@ -110,6 +111,7 @@ const mapStateToProps = (state, props) => ({
 const mapDispatchToProps = {
   updateEditingPulse,
   saveEditingPulse,
+  cancelEditingPulse,
   fetchPulseFormInput,
   setPulseArchived: Pulses.actions.setArchived,
   testPulse,
@@ -134,6 +136,7 @@ class SharingSidebarInner extends Component {
     saveEditingPulse: PropTypes.func.isRequired,
     testPulse: PropTypes.func.isRequired,
     updateEditingPulse: PropTypes.func.isRequired,
+    cancelEditingPulse: PropTypes.func.isRequired,
     pulses: PropTypes.array,
     onCancel: PropTypes.func.isRequired,
     setPulseArchived: PropTypes.func.isRequired,


### PR DESCRIPTION
Reproduces #30314, fixes #30314

We keep a "new pulse" object in the redux state (`state.pulse.editingPulse`). But we never cleaned it up if a user made some changes and then clicked "Cancel." Because of that, the next time you open the new pulse form, you'll see stale data