### PR TITLE
Dashboard Header FC, using entity, select, and dispatch hooks

### DIFF
--- a/frontend/src/metabase/collections/utils.ts
+++ b/frontend/src/metabase/collections/utils.ts
@@ -33,10 +33,10 @@ export function isPublicCollection(
 }
 
 export function isInstanceAnalyticsCollection(
-  collection: Partial<Collection>,
+  collection?: Partial<Collection>,
 ): boolean {
   return (
-    collection &&
+    !!collection &&
     PLUGIN_COLLECTIONS.getCollectionType(collection).type ===
       "instance-analytics"
   );

--- a/frontend/src/metabase/dashboard/actions/cards.js
+++ b/frontend/src/metabase/dashboard/actions/cards.js
@@ -7,7 +7,7 @@ import { trackCardCreated } from "../analytics";
 import { addDashCardToDashboard } from "./cards-typed";
 
 export const addActionToDashboard =
-  async ({ dashId, tabId, action, displayType }) =>
+  ({ dashId, tabId, action, displayType }) =>
   dispatch => {
     trackCardCreated("action", dashId);
 

--- a/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/metabase/dashboard/components/Dashboard/Dashboard.tsx
@@ -17,7 +17,6 @@ import { FilterApplyButton } from "metabase/parameters/components/FilterApplyBut
 import SyncedParametersList from "metabase/parameters/components/SyncedParametersList/SyncedParametersList";
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import type { EmbeddingParameterVisibility } from "metabase/public/lib/types";
-//import type Database from "metabase-lib/metadata/Database";
 import type Metadata from "metabase-lib/metadata/Metadata";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import { getValuePopulatedParameters } from "metabase-lib/parameters/utils/parameter-values";

--- a/frontend/src/metabase/dashboard/components/DashboardActions.jsx
+++ b/frontend/src/metabase/dashboard/components/DashboardActions.jsx
@@ -10,9 +10,8 @@ import {
   RefreshWidgetButton,
 } from "./DashboardActions.styled";
 
-export const getDashboardActions = (
-  self,
-  {
+export const getDashboardActions = props => {
+  const {
     dashboard,
     isAdmin,
     canManageSubscriptions,
@@ -29,8 +28,7 @@ export const getDashboardActions = (
     onSharingClick,
     onFullscreenChange,
     hasNightModeToggle,
-  },
-) => {
+  } = props;
   const buttons = [];
 
   const isLoaded = !!dashboard;

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -33,6 +33,7 @@ import {
   getIsShowDashboardInfoSidebar,
   getMissingRequiredParameters,
 } from "metabase/dashboard/selectors";
+import type { FetchDashboardResult } from "metabase/dashboard/types";
 import {
   hasDatabaseActionsEnabled,
   getIsBookmarked,
@@ -49,11 +50,9 @@ import { Icon, Menu, Tooltip, Loader, Flex } from "metabase/ui";
 import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import type {
-  Bookmark as IBookmark,
   DashboardId,
   DashboardTabId,
   Dashboard,
-  Collection,
   DatabaseId,
   Database,
   CardId,
@@ -78,9 +77,7 @@ interface DashboardHeaderProps {
   dashboardId: DashboardId;
   dashboard: Dashboard;
   dashboardBeforeEditing?: Dashboard | null;
-  bookmarks: IBookmark[];
   databases: Record<DatabaseId, Database>;
-  collection: Collection;
   sidebar: DashboardSidebarState;
   location: Location;
   refreshPeriod: number | null;
@@ -93,7 +90,7 @@ interface DashboardHeaderProps {
   isAddParameterPopoverOpen: boolean;
   canManageSubscriptions: boolean;
   hasNightModeToggle: boolean;
-  parametersWidget: ReactNode;
+  parametersWidget?: ReactNode;
 
   addCardToDashboard: (opts: {
     dashId: DashboardId;
@@ -111,12 +108,12 @@ interface DashboardHeaderProps {
       clearCache?: boolean;
       preserveParameters?: boolean;
     };
-  }) => Promise<void>;
+  }) => Promise<FetchDashboardResult>;
   setDashboardAttribute: <Key extends keyof Dashboard>(
     key: Key,
     value: Dashboard[Key],
   ) => void;
-  setRefreshElapsedHook: (hook: (elapsed: number) => void) => void;
+  setRefreshElapsedHook?: (hook: (elapsed: number) => void) => void;
   updateDashboardAndCards: () => void;
 
   addParameter: (option: ParameterMappingOptions) => void;
@@ -560,7 +557,7 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
       }
     }
 
-    buttons.push(...getDashboardActions(this, { ...props, formInput }));
+    buttons.push(...getDashboardActions({ ...props, formInput }));
 
     if (!isEditing) {
       buttons.push(

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -1,12 +1,14 @@
-import type { Location, LocationDescriptor } from "history";
-import type { MouseEvent } from "react";
-import { Component, Fragment } from "react";
-import { connect } from "react-redux";
-import { push } from "react-router-redux";
+import type { Location } from "history";
+import { type MouseEvent, type ReactNode, useState, Fragment } from "react";
+import { useMount } from "react-use";
 import { msgid, ngettext, t } from "ttag";
 import _ from "underscore";
 
 import { isInstanceAnalyticsCollection } from "metabase/collections/utils";
+import {
+  useBookmarkListQuery,
+  useCollectionQuery,
+} from "metabase/common/hooks";
 import ActionButton from "metabase/components/ActionButton";
 import EntityMenu from "metabase/components/EntityMenu";
 import { LeaveConfirmationModalContent } from "metabase/components/LeaveConfirmationModal";
@@ -14,10 +16,7 @@ import Modal from "metabase/components/Modal";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import Button from "metabase/core/components/Button";
 import Link from "metabase/core/components/Link/Link";
-import type {
-  AddSectionOpts,
-  NewDashCardOpts,
-} from "metabase/dashboard/actions";
+import type { NewDashCardOpts } from "metabase/dashboard/actions";
 import {
   addActionToDashboard,
   addSectionToDashboard,
@@ -31,20 +30,22 @@ import { TextOptionsButton } from "metabase/dashboard/components/TextOptions/Tex
 import type { SectionLayout } from "metabase/dashboard/sections";
 import { layoutOptions } from "metabase/dashboard/sections";
 import {
-  getIsBookmarked,
   getIsShowDashboardInfoSidebar,
   getMissingRequiredParameters,
 } from "metabase/dashboard/selectors";
-import { hasDatabaseActionsEnabled } from "metabase/dashboard/utils";
+import {
+  hasDatabaseActionsEnabled,
+  getIsBookmarked,
+} from "metabase/dashboard/utils";
 import Bookmark from "metabase/entities/bookmarks";
-import Collections from "metabase/entities/collections/collections";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import { PLUGIN_DASHBOARD_HEADER } from "metabase/plugins";
 import { fetchPulseFormInput } from "metabase/pulse/actions";
 import { getPulseFormInput } from "metabase/pulse/selectors";
 import { dismissAllUndo } from "metabase/redux/undo";
 import { getIsNavbarOpen } from "metabase/selectors/app";
 import { getSetting } from "metabase/selectors/settings";
-import { Icon, Menu, Tooltip } from "metabase/ui";
+import { Icon, Menu, Tooltip, Loader, Flex } from "metabase/ui";
 import { saveDashboardPdf } from "metabase/visualizations/lib/save-dashboard-pdf";
 import type { UiParameter } from "metabase-lib/parameters/types";
 import type {
@@ -52,8 +53,6 @@ import type {
   DashboardId,
   DashboardTabId,
   Dashboard,
-  ActionDisplayType,
-  WritebackAction,
   Collection,
   DatabaseId,
   Database,
@@ -63,10 +62,9 @@ import type {
 import type {
   DashboardSidebarName,
   DashboardSidebarState,
-  State,
 } from "metabase-types/store";
 
-import { DASHBOARD_PDF_EXPORT_ROOT_ID, SIDEBAR_NAME } from "../../constants";
+import { SIDEBAR_NAME } from "../../constants";
 import { ExtraEditButtonsMenu } from "../ExtraEditButtonsMenu/ExtraEditButtonsMenu";
 
 import {
@@ -76,7 +74,7 @@ import {
 import { DashboardHeaderComponent } from "./DashboardHeaderView";
 import { SectionLayoutPreview } from "./SectionLayoutPreview";
 
-interface OwnProps {
+interface DashboardHeaderProps {
   dashboardId: DashboardId;
   dashboard: Dashboard;
   dashboardBeforeEditing?: Dashboard | null;
@@ -95,6 +93,7 @@ interface OwnProps {
   isAddParameterPopoverOpen: boolean;
   canManageSubscriptions: boolean;
   hasNightModeToggle: boolean;
+  parametersWidget: ReactNode;
 
   addCardToDashboard: (opts: {
     dashId: DashboardId;
@@ -104,7 +103,6 @@ interface OwnProps {
   addHeadingDashCardToDashboard: (opts: NewDashCardOpts) => void;
   addMarkdownDashCardToDashboard: (opts: NewDashCardOpts) => void;
   addLinkDashCardToDashboard: (opts: NewDashCardOpts) => void;
-  addSectionToDashboard: (opts: AddSectionOpts) => void;
 
   fetchDashboard: (opts: {
     dashId: DashboardId;
@@ -138,169 +136,175 @@ interface OwnProps {
   closeSidebar: () => void;
 }
 
-interface StateProps {
-  formInput: unknown;
-  selectedTabId: DashboardTabId | null;
-  isBookmarked: boolean;
-  isNavBarOpen: boolean;
-  isShowingDashboardInfoSidebar: boolean;
-  isHomepageDashboard: boolean;
-  missingRequiredParameters: UiParameter[];
-}
+export const DashboardHeader = (props: DashboardHeaderProps) => {
+  const {
+    onEditingChange,
+    addMarkdownDashCardToDashboard,
+    addHeadingDashCardToDashboard,
+    addLinkDashCardToDashboard,
+    fetchDashboard,
+    updateDashboardAndCards,
+    dashboardBeforeEditing,
+    isDirty,
+    isEditing,
+    location,
+    dashboard,
+    parametersWidget,
+    isFullscreen,
+    onFullscreenChange,
+    sidebar,
+    setSidebar,
+    closeSidebar,
+    databases,
+    isAddParameterPopoverOpen,
+    showAddParameterPopover,
+    hideAddParameterPopover,
+    addParameter,
+    isAdditionalInfoVisible,
+    setDashboardAttribute,
+  } = props;
 
-interface DispatchProps {
-  createBookmark: (args: { id: DashboardId }) => void;
-  deleteBookmark: (args: { id: DashboardId }) => void;
-  fetchPulseFormInput: () => void;
-  toggleSidebar: (sidebarName: DashboardSidebarName) => void;
-  onChangeLocation: (location: LocationDescriptor) => void;
-  addActionToDashboard: (
-    opts: NewDashCardOpts & {
-      action: Partial<WritebackAction>;
-      displayType: ActionDisplayType;
-    },
-  ) => void;
-  dismissAllUndo: () => void;
-}
+  const [showCancelWarning, setShowCancelWarning] = useState(false);
 
-type DashboardHeaderProps = OwnProps & StateProps & DispatchProps;
+  useMount(() => {
+    dispatch(fetchPulseFormInput());
+  });
 
-const mapStateToProps = (state: State, props: OwnProps): StateProps => {
-  return {
-    formInput: getPulseFormInput(state),
-    isBookmarked: getIsBookmarked(state, props),
-    isNavBarOpen: getIsNavbarOpen(state),
-    isShowingDashboardInfoSidebar: getIsShowDashboardInfoSidebar(state),
-    selectedTabId: state.dashboard.selectedTabId,
-    isHomepageDashboard:
+  const dispatch = useDispatch();
+
+  const formInput = useSelector(getPulseFormInput);
+  const isNavBarOpen = useSelector(getIsNavbarOpen);
+  const isShowingDashboardInfoSidebar = useSelector(
+    getIsShowDashboardInfoSidebar,
+  );
+  const selectedTabId = useSelector(state => state.dashboard.selectedTabId);
+  const isHomepageDashboard = useSelector(
+    state =>
       getSetting(state, "custom-homepage") &&
-      getSetting(state, "custom-homepage-dashboard") === props.dashboard?.id,
-    missingRequiredParameters: getMissingRequiredParameters(state),
-  };
-};
+      getSetting(state, "custom-homepage-dashboard") === dashboard?.id,
+  );
+  const missingRequiredParameters = useSelector(getMissingRequiredParameters);
 
-const mapDispatchToProps = {
-  createBookmark: ({ id }: { id: DashboardId }) =>
-    Bookmark.actions.create({ id, type: "dashboard" }),
-  deleteBookmark: ({ id }: { id: DashboardId }) =>
-    Bookmark.actions.delete({ id, type: "dashboard" }),
-  fetchPulseFormInput,
-  onChangeLocation: push,
-  toggleSidebar,
-  addActionToDashboard,
-  addSectionToDashboard,
-  dismissAllUndo,
-};
+  const { data: collection, isLoading: isLoadingCollection } =
+    useCollectionQuery({ id: dashboard.collection_id || "root" });
 
-class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
-  state = {
-    showCancelWarning: false,
+  const { data: bookmarks = [] } = useBookmarkListQuery();
+
+  const isBookmarked = getIsBookmarked({
+    dashboardId: dashboard.id,
+    bookmarks,
+  });
+
+  const handleEdit = (dashboard: Dashboard) => {
+    onEditingChange(dashboard);
   };
 
-  componentDidMount() {
-    this.props.fetchPulseFormInput();
-  }
-
-  handleEdit(dashboard: Dashboard) {
-    this.props.onEditingChange(dashboard);
-  }
-
-  handleCancelWarningClose = () => {
-    this.setState({ showCancelWarning: false });
+  const handleCancelWarningClose = () => {
+    setShowCancelWarning(false);
   };
 
-  onAddMarkdownBox() {
-    this.props.addMarkdownDashCardToDashboard({
-      dashId: this.props.dashboard.id,
-      tabId: this.props.selectedTabId,
+  const handleCreateBookmark = ({ id }: { id: DashboardId }) => {
+    dispatch(Bookmark.actions.create({ id, type: "dashboard" }));
+  };
+
+  const handleDeleteBookmark = ({ id }: { id: DashboardId }) => {
+    dispatch(Bookmark.actions.delete({ id, type: "dashboard" }));
+  };
+
+  const onAddMarkdownBox = () => {
+    addMarkdownDashCardToDashboard({
+      dashId: dashboard.id,
+      tabId: selectedTabId,
     });
-  }
+  };
 
-  onAddHeading() {
-    this.props.addHeadingDashCardToDashboard({
-      dashId: this.props.dashboard.id,
-      tabId: this.props.selectedTabId,
+  const onAddHeading = () => {
+    addHeadingDashCardToDashboard({
+      dashId: dashboard.id,
+      tabId: selectedTabId,
     });
-  }
+  };
 
-  onAddLinkCard() {
-    this.props.addLinkDashCardToDashboard({
-      dashId: this.props.dashboard.id,
-      tabId: this.props.selectedTabId,
+  const onAddLinkCard = () => {
+    addLinkDashCardToDashboard({
+      dashId: dashboard.id,
+      tabId: selectedTabId,
     });
-  }
+  };
 
-  onAddSection(sectionLayout: SectionLayout) {
-    this.props.addSectionToDashboard({
-      dashId: this.props.dashboard.id,
-      tabId: this.props.selectedTabId,
-      sectionLayout,
-    });
-  }
+  const onAddSection = (sectionLayout: SectionLayout) => {
+    dispatch(
+      addSectionToDashboard({
+        dashId: dashboard.id,
+        tabId: selectedTabId,
+        sectionLayout,
+      }),
+    );
+  };
 
-  onAddAction() {
-    this.props.addActionToDashboard({
-      dashId: this.props.dashboard.id,
-      tabId: this.props.selectedTabId,
-      displayType: "button",
-      action: {},
-    });
-  }
+  const onAddAction = () => {
+    dispatch(
+      addActionToDashboard({
+        dashId: dashboard.id,
+        tabId: selectedTabId,
+        displayType: "button",
+        action: {},
+      }),
+    );
+  };
 
-  onDoneEditing() {
-    this.props.onEditingChange(false);
-  }
+  const onDoneEditing = () => {
+    onEditingChange(false);
+  };
 
-  onRevert() {
-    this.props.fetchDashboard({
-      dashId: this.props.dashboard.id,
-      queryParams: this.props.location.query,
+  const onRevert = () => {
+    fetchDashboard({
+      dashId: dashboard.id,
+      queryParams: location.query,
       options: { preserveParameters: true },
     });
-  }
+  };
 
-  async onSave() {
+  const onSave = async () => {
     // optimistically dismissing all the undos before the saving has finished
     // clicking on them wouldn't do anything at this moment anyway
-    this.props.dismissAllUndo();
-    await this.props.updateDashboardAndCards();
-    this.onDoneEditing();
-  }
+    dispatch(dismissAllUndo());
+    await updateDashboardAndCards();
 
-  onRequestCancel = () => {
-    const { isDirty, isEditing } = this.props;
+    onDoneEditing();
+  };
 
+  const onRequestCancel = () => {
     if (isDirty && isEditing) {
-      this.setState({ showCancelWarning: true });
+      setShowCancelWarning(true);
     } else {
-      this.onCancel();
+      onCancel();
     }
   };
 
-  onCancel = () => {
-    this.onRevert();
-    this.onDoneEditing();
+  const onCancel = () => {
+    onRevert();
+    onDoneEditing();
   };
 
-  getEditWarning(dashboard: Dashboard) {
+  const getEditWarning = (dashboard: Dashboard) => {
     if (dashboard.embedding_params) {
       const currentSlugs = Object.keys(dashboard.embedding_params);
       // are all of the original embedding params keys in the current
       // embedding params keys?
       if (
-        this.props.isEditing &&
-        this.props.dashboardBeforeEditing?.embedding_params &&
-        Object.keys(this.props.dashboardBeforeEditing.embedding_params).some(
+        isEditing &&
+        dashboardBeforeEditing?.embedding_params &&
+        Object.keys(dashboardBeforeEditing.embedding_params).some(
           slug => !currentSlugs.includes(slug),
         )
       ) {
         return t`You've updated embedded params and will need to update your embed code.`;
       }
     }
-  }
+  };
 
-  getEditingButtons() {
-    const { missingRequiredParameters } = this.props;
+  const getEditingButtons = () => {
     const disabledSaveTooltip = getDisabledSaveButtonTooltip(
       missingRequiredParameters,
     );
@@ -310,7 +314,7 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
       <Button
         key="cancel"
         className="Button Button--small mr1"
-        onClick={this.onRequestCancel}
+        onClick={() => onRequestCancel()}
       >
         {t`Cancel`}
       </Button>,
@@ -321,7 +325,7 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
       >
         <span>
           <ActionButton
-            actionFn={() => this.onSave()}
+            actionFn={() => onSave()}
             className="Button Button--primary Button--small"
             normalText={t`Save`}
             activeText={t`Saving…`}
@@ -332,27 +336,9 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
         </span>
       </Tooltip>,
     ];
-  }
+  };
 
-  getHeaderButtons() {
-    const {
-      dashboard,
-      isBookmarked,
-      isEditing,
-      isFullscreen,
-      location,
-      onFullscreenChange,
-      createBookmark,
-      deleteBookmark,
-      sidebar,
-      setSidebar,
-      toggleSidebar,
-      isShowingDashboardInfoSidebar,
-      closeSidebar,
-      databases,
-      collection,
-    } = this.props;
-
+  const getHeaderButtons = () => {
     const canEdit = dashboard.can_write;
     const isAnalyticsDashboard = isInstanceAnalyticsCollection(collection);
 
@@ -362,6 +348,10 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
 
     const buttons = [];
     const extraButtons = [];
+
+    if (isFullscreen && parametersWidget) {
+      buttons.push(parametersWidget);
+    }
 
     if (isEditing) {
       const activeSidebarName = sidebar.name;
@@ -375,7 +365,7 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
           <DashboardHeaderButton
             icon="add"
             isActive={activeSidebarName === SIDEBAR_NAME.addQuestion}
-            onClick={() => toggleSidebar(SIDEBAR_NAME.addQuestion)}
+            onClick={() => dispatch(toggleSidebar(SIDEBAR_NAME.addQuestion))}
             aria-label={t`Add questions`}
           />
         </Tooltip>,
@@ -389,19 +379,20 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
         >
           <span>
             <TextOptionsButton
-              onAddMarkdown={() => this.onAddMarkdownBox()}
-              onAddHeading={() => this.onAddHeading()}
+              onAddMarkdown={() => onAddMarkdownBox()}
+              onAddHeading={() => onAddHeading()}
             />
           </span>
         </Tooltip>,
       );
 
       // Add link card button
+      const addLinkLabel = t`Add link card`;
       buttons.push(
-        <Tooltip key="add-link-card" label={t`Add link card`}>
+        <Tooltip key="add-link-card" label={addLinkLabel}>
           <DashboardHeaderButton
-            aria-label={t`Add link card`}
-            onClick={() => this.onAddLinkCard()}
+            aria-label={addLinkLabel}
+            onClick={() => onAddLinkCard()}
           >
             <Icon name="link" size={18} />
           </DashboardHeaderButton>
@@ -427,10 +418,7 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
                 position="left"
               >
                 <span>
-                  <Menu.Item
-                    onClick={() => this.onAddSection(layout)}
-                    fw="bold"
-                  >
+                  <Menu.Item onClick={() => onAddSection(layout)} fw="bold">
                     {layout.label}
                   </Menu.Item>
                 </span>
@@ -439,13 +427,6 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
           </Menu.Dropdown>
         </Menu>,
       );
-
-      const {
-        isAddParameterPopoverOpen,
-        showAddParameterPopover,
-        hideAddParameterPopover,
-        addParameter,
-      } = this.props;
 
       // Parameters
       buttons.push(
@@ -482,7 +463,7 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
             <DashboardHeaderActionDivider />
             <Tooltip key="add-action-button" label={t`Add action button`}>
               <DashboardHeaderButton
-                onClick={() => this.onAddAction()}
+                onClick={() => onAddAction()}
                 aria-label={t`Add action`}
               >
                 <Icon name="click" size={18} />
@@ -500,6 +481,7 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
         />,
       );
 
+      // I don't think this is used anymore
       extraButtons.push({
         title: t`Revision history`,
         icon: "history",
@@ -526,7 +508,7 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
             key="edit"
             aria-label={t`Edit dashboard`}
             icon="pencil"
-            onClick={() => this.handleEdit(dashboard)}
+            onClick={() => handleEdit(dashboard)}
           />
         </Tooltip>,
       );
@@ -555,7 +537,7 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
         icon: "document",
         testId: "dashboard-export-pdf-button",
         action: () => {
-          this.saveAsPDF();
+          saveAsPDF();
         },
       });
 
@@ -578,7 +560,7 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
       }
     }
 
-    buttons.push(...getDashboardActions(this, this.props));
+    buttons.push(...getDashboardActions(this, { ...props, formInput }));
 
     if (!isEditing) {
       buttons.push(
@@ -587,8 +569,8 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
           <DashboardBookmark
             key="dashboard-bookmark-button"
             dashboard={dashboard}
-            onCreateBookmark={createBookmark}
-            onDeleteBookmark={deleteBookmark}
+            onCreateBookmark={handleCreateBookmark}
+            onDeleteBookmark={handleDeleteBookmark}
             isBookmarked={isBookmarked}
           />,
           <Tooltip key="dashboard-info-button" label={t`More info`}>
@@ -630,68 +612,62 @@ class DashboardHeaderContainer extends Component<DashboardHeaderProps> {
       );
     }
 
-    return buttons;
-  }
+    return { buttons };
+  };
 
-  saveAsPDF = async () => {
-    const { dashboard } = this.props;
-    const cardNodeSelector = `#${DASHBOARD_PDF_EXPORT_ROOT_ID}`;
+  const saveAsPDF = async () => {
+    const cardNodeSelector = "#Dashboard-Cards-Container";
     await saveDashboardPdf(cardNodeSelector, dashboard.name).then(() => {
       trackExportDashboardToPDF(dashboard.id);
     });
   };
 
-  render() {
-    const {
-      dashboard,
-      collection,
-      isEditing,
-      isFullscreen,
-      isNavBarOpen,
-      isAdditionalInfoVisible,
-      setDashboardAttribute,
-      setSidebar,
-      isHomepageDashboard,
-    } = this.props;
-    const { showCancelWarning } = this.state;
-    const hasLastEditInfo = dashboard["last-edit-info"] != null;
-
+  if (isLoadingCollection || !collection) {
     return (
-      <>
-        <DashboardHeaderComponent
-          headerClassName="wrapper"
-          location={this.props.location}
-          dashboard={dashboard}
-          collection={collection}
-          isEditing={isEditing}
-          isBadgeVisible={
-            !isEditing && !isFullscreen && isAdditionalInfoVisible
-          }
-          isLastEditInfoVisible={hasLastEditInfo && isAdditionalInfoVisible}
-          isEditingInfo={isEditing}
-          isNavBarOpen={isNavBarOpen}
-          headerButtons={this.getHeaderButtons()}
-          editWarning={this.getEditWarning(dashboard)}
-          editingTitle={t`You're editing this dashboard.`.concat(
-            isHomepageDashboard
-              ? t` Remember that this dashboard is set as homepage.`
-              : "",
-          )}
-          editingButtons={this.getEditingButtons()}
-          setDashboardAttribute={setDashboardAttribute}
-          onLastEditInfoClick={() => setSidebar({ name: SIDEBAR_NAME.info })}
-        />
-
-        <Modal isOpen={showCancelWarning}>
-          <LeaveConfirmationModalContent
-            onAction={this.onCancel}
-            onClose={this.handleCancelWarningClose}
-          />
-        </Modal>
-      </>
+      <Flex justify="center" py="1.5rem">
+        <Loader size={29} />
+      </Flex>
     );
   }
-}
+
+  const hasLastEditInfo = dashboard["last-edit-info"] != null;
+
+  const { buttons: headerButtons } = getHeaderButtons();
+  const editingButtons = getEditingButtons();
+
+  return (
+    <>
+      <DashboardHeaderComponent
+        headerClassName="wrapper"
+        location={location}
+        dashboard={dashboard}
+        collection={collection}
+        isEditing={isEditing}
+        isBadgeVisible={!isEditing && !isFullscreen && isAdditionalInfoVisible}
+        isLastEditInfoVisible={hasLastEditInfo && isAdditionalInfoVisible}
+        isEditingInfo={isEditing}
+        isNavBarOpen={isNavBarOpen}
+        headerButtons={headerButtons}
+        editWarning={getEditWarning(dashboard)}
+        editingTitle={t`You're editing this dashboard.`.concat(
+          isHomepageDashboard
+            ? t` Remember that this dashboard is set as homepage.`
+            : "",
+        )}
+        editingButtons={editingButtons}
+        setDashboardAttribute={setDashboardAttribute}
+        onLastEditInfoClick={() => setSidebar({ name: SIDEBAR_NAME.info })}
+      />
+
+      <Modal isOpen={showCancelWarning}>
+        <LeaveConfirmationModalContent
+          onAction={onCancel}
+          onClose={handleCancelWarningClose}
+        />
+      </Modal>
+    </>
+  );
+};
 
 function getDisabledSaveButtonTooltip(
   missingRequiredParams: UiParameter[],
@@ -710,12 +686,3 @@ function getDisabledSaveButtonTooltip(
     missingRequiredParams.length,
   );
 }
-
-export const DashboardHeader = _.compose(
-  Bookmark.loadList(),
-  Collections.load({
-    id: (state: State, props: OwnProps) =>
-      props.dashboard.collection_id || "root",
-  }),
-  connect(mapStateToProps, mapDispatchToProps),
-)(DashboardHeaderContainer);

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/tests/setup.tsx
@@ -1,5 +1,4 @@
 import fetchMock from "fetch-mock";
-import type { Location } from "history";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
@@ -16,7 +15,10 @@ import {
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
 import type { DashboardSidebarName } from "metabase-types/store";
-import { createMockDashboardState } from "metabase-types/store/mocks";
+import {
+  createMockDashboardState,
+  createMockLocation,
+} from "metabase-types/store/mocks";
 
 import { DashboardHeader } from "../DashboardHeader";
 
@@ -130,9 +132,7 @@ export const setup = async ({
       name: "" as DashboardSidebarName,
       props: {},
     },
-    location: {
-      query: {},
-    } as Location,
+    location: createMockLocation(),
     setSidebar: jest.fn(),
     closeSidebar: jest.fn(),
     addActionToDashboard: jest.fn(),

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/tests/setup.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/tests/setup.tsx
@@ -1,4 +1,5 @@
 import fetchMock from "fetch-mock";
+import type { Location } from "history";
 
 import { setupEnterprisePlugins } from "__support__/enterprise";
 import {
@@ -14,6 +15,7 @@ import {
   createMockDashboardCard,
   createMockTokenFeatures,
 } from "metabase-types/api/mocks";
+import type { DashboardSidebarName } from "metabase-types/store";
 import { createMockDashboardState } from "metabase-types/store/mocks";
 
 import { DashboardHeader } from "../DashboardHeader";
@@ -98,11 +100,15 @@ export const setup = async ({
   const dashboardHeaderProps = {
     isAdmin,
     dashboard,
+    dashboardId: dashboard.id,
     canManageSubscriptions: true,
     isEditing: false,
     isFullscreen: false,
     isNavBarOpen: false,
     isNightMode: false,
+    isDirty: false,
+    isAddParameterPopoverOpen: false,
+    hasNightModeToggle: false,
     isAdditionalInfoVisible: false,
     refreshPeriod: 0,
     addMarkdownDashCardToDashboard: jest.fn(),
@@ -121,17 +127,20 @@ export const setup = async ({
     onChangeLocation: jest.fn(),
     toggleSidebar: jest.fn(),
     sidebar: {
-      name: "",
+      name: "" as DashboardSidebarName,
       props: {},
     },
     location: {
       query: {},
-    },
+    } as Location,
     setSidebar: jest.fn(),
     closeSidebar: jest.fn(),
     addActionToDashboard: jest.fn(),
     databases: {},
     params: { tabSlug: undefined },
+    addParameter: jest.fn(),
+    showAddParameterPopover: jest.fn(),
+    hideAddParameterPopover: jest.fn(),
   };
 
   renderWithProviders(<DashboardHeader {...dashboardHeaderProps} />, {

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -15,7 +15,6 @@ import { getEmbedOptions, getIsEmbedded } from "metabase/selectors/embed";
 import { getMetadata } from "metabase/selectors/metadata";
 import Question from "metabase-lib/Question";
 import type {
-  Bookmark,
   Card,
   CardId,
   DashboardId,
@@ -230,20 +229,6 @@ export const getDocumentTitle = (state: State) =>
 
 export const getIsNavigatingBackToDashboard = (state: State) =>
   state.dashboard.isNavigatingBackToDashboard;
-
-type IsBookmarkedSelectorProps = {
-  bookmarks: Bookmark[];
-  dashboardId: DashboardId;
-};
-
-export const getIsBookmarked = (
-  state: State,
-  { bookmarks, dashboardId }: IsBookmarkedSelectorProps,
-) =>
-  bookmarks.some(
-    bookmark =>
-      bookmark.type === "dashboard" && bookmark.item_id === dashboardId,
-  );
 
 export const getIsDirty = createSelector(
   [getDashboard, getDashcards],

--- a/frontend/src/metabase/dashboard/types.ts
+++ b/frontend/src/metabase/dashboard/types.ts
@@ -1,0 +1,10 @@
+import type { Dashboard } from "metabase-types/api";
+
+export type SuccessfulFetchDashboardResult = {
+  payload: { dashboard: Dashboard };
+};
+type FailedFetchDashboardResult = { error: unknown; payload: unknown };
+
+export type FetchDashboardResult =
+  | SuccessfulFetchDashboardResult
+  | FailedFetchDashboardResult;

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -14,13 +14,11 @@ import {
   isStringParameter,
 } from "metabase-lib/parameters/utils/parameter-type";
 import type {
-  Bookmark,
   Card,
   CardId,
   Dashboard,
   DashboardCard,
   DashboardCardLayoutAttrs,
-  DashboardId,
   QuestionDashboardCard,
   Database,
   Dataset,
@@ -366,17 +364,3 @@ export function createVirtualCard(display: VirtualCardDisplay): VirtualCard {
     archived: false,
   };
 }
-
-type IsBookmarkedSelectorProps = {
-  bookmarks: Bookmark[];
-  dashboardId: DashboardId;
-};
-
-export const getIsBookmarked = ({
-  bookmarks,
-  dashboardId,
-}: IsBookmarkedSelectorProps) =>
-  bookmarks.some(
-    bookmark =>
-      bookmark.type === "dashboard" && bookmark.item_id === dashboardId,
-  );

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -14,11 +14,13 @@ import {
   isStringParameter,
 } from "metabase-lib/parameters/utils/parameter-type";
 import type {
+  Bookmark,
   Card,
   CardId,
   Dashboard,
   DashboardCard,
   DashboardCardLayoutAttrs,
+  DashboardId,
   QuestionDashboardCard,
   Database,
   Dataset,
@@ -364,3 +366,17 @@ export function createVirtualCard(display: VirtualCardDisplay): VirtualCard {
     archived: false,
   };
 }
+
+type IsBookmarkedSelectorProps = {
+  bookmarks: Bookmark[];
+  dashboardId: DashboardId;
+};
+
+export const getIsBookmarked = ({
+  bookmarks,
+  dashboardId,
+}: IsBookmarkedSelectorProps) =>
+  bookmarks.some(
+    bookmark =>
+      bookmark.type === "dashboard" && bookmark.item_id === dashboardId,
+  );

--- a/frontend/src/metabase/public/containers/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard.jsx
@@ -156,7 +156,7 @@ class PublicDashboard extends Component {
     } = this.props;
 
     const buttons = !isWithinIframe()
-      ? getDashboardActions(this, { ...this.props, isPublic: true })
+      ? getDashboardActions({ ...this.props, isPublic: true })
       : [];
 
     const visibleDashcards = (dashboard?.dashcards ?? []).filter(


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39260

### Description
Migrating the Dashboard Header to be a functional component, leveraging entity hooks, as well as removing Redux Connect. This is largely done as we may have a need to use hooks in this component as part of https://github.com/metabase/metabase/issues/39259 . The experience should not change for the end user (save for a loading state while fetching the collection, which may be _slightly_ different).

### Checklist
Existing tests should cover this component and the functionality inside it
