### PR TITLE
Do not return value if the database id used for `last-used-native-database-id` does not exist (anymore)

### DIFF
--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -443,7 +443,10 @@
   (deferred-tru "The last database a user has selected for a native query or a native model.")
   :user-local :only
   :visibility :authenticated
-  :type :integer)
+  :type :integer
+  :getter (fn []
+            (when-let [id (setting/get-value-of-type :integer :last-used-native-database-id)]
+              (when (t2/exists? :model/Database :id id) id))))
 
 ;;; ## ------------------------------------------ AUDIT LOG ------------------------------------------
 

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -554,16 +554,14 @@
     (mt/with-temp [Database {id1 :id} {:name "DB1"}
                    Database {id2 :id} {:name "DB2"}]
       (mt/with-test-user :rasta
-        (let [old-db-id (user/last-used-native-database-id)]
+        (mt/discard-setting-changes [last-used-native-database-id]
           (user/last-used-native-database-id! id1)
           (mt/with-test-user :crowberto
-            (let [old-db-id (user/last-used-native-database-id)]
+            (mt/discard-setting-changes [last-used-native-database-id]
               (user/last-used-native-database-id! id2)
               (is (= (user/last-used-native-database-id) id2))
               (mt/with-test-user :rasta
-                (is (= (user/last-used-native-database-id) id1)))
-              (user/last-used-native-database-id! old-db-id)))
-          (user/last-used-native-database-id! old-db-id))))))
+                (is (= (user/last-used-native-database-id) id1))))))))))
 
   (deftest common-name-test
     (testing "common_name should be present depending on what is selected"

--- a/test/metabase/models/user_test.clj
+++ b/test/metabase/models/user_test.clj
@@ -540,7 +540,7 @@
     (mt/with-test-user :rasta
       (let [initial-value  (user/last-used-native-database-id)
             existing-db-id (:id (t2/select-one Database))
-            wrong-db-id    999]
+            wrong-db-id    -999]
         (is (nil? initial-value))
         (user/last-used-native-database-id! existing-db-id)
         (is (= existing-db-id (user/last-used-native-database-id)))


### PR DESCRIPTION
This PR is a follow up after #38986.

### Description

It is quite possible that a user persists a database (id), and that this database gets deleted afterwards.
Even though the frontend handles this pretty well (which is confirmed by the existing E2E test), we wanted to follow up with a custom `:getter` for this particular setting that would return `nil` if the persisted database doesn't exist anymore.

This PR tries to achieve exactly that.
It updates and expands the previously written backend unit tests to reflect this new condition.

### How to verify
At the very minimum, all tests should pass.

You can do this manually:
1.  Send a `PUT /api/setting/last-used-native-database-id`. For the `value` use a database id value that doesn't exist (e.g. 999)
2.  Call `GET /api/session/properties` and make sure that `last-used-native-database-id` is `null`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
