### PR TITLE
Change the Next button to skip for the license activation step

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -450,7 +450,7 @@ describeWithSnowplow("scenarios > setup", () => {
           step: "license_token",
         });
 
-        cy.button("Next").click();
+        cy.button("Skip").click();
         goodEvents++; // 11/12 - setup/step_seen "commercial_license"
         expectGoodSnowplowEvent({
           event: "license_token_step_submitted",

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -540,6 +540,6 @@ const fillUserAndContinue = ({
 
 const skipLicenseStepOnEE = () => {
   if (isEE) {
-    cy.button("Next").click();
+    cy.button("Skip").click();
   }
 };

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
@@ -2,13 +2,17 @@ import { useState } from "react";
 import { t } from "ttag";
 
 import { SetupApi } from "metabase/services";
-import { Box, Button, Text, TextInput } from "metabase/ui";
+import { Box, Button, Flex, Text, TextInput } from "metabase/ui";
 
 type LicenseTokenFormProps = {
   onValidSubmit: (token: string) => void;
+  onSkip: () => void;
 };
 
-export const LicenseTokenForm = ({ onValidSubmit }: LicenseTokenFormProps) => {
+export const LicenseTokenForm = ({
+  onValidSubmit,
+  onSkip,
+}: LicenseTokenFormProps) => {
   const [token, setToken] = useState("");
   const [status, setStatus] = useState<
     "idle" | "loading" | "success" | "error"
@@ -45,11 +49,15 @@ export const LicenseTokenForm = ({ onValidSubmit }: LicenseTokenFormProps) => {
           <Text color="error">{t`This token doesn’t seem to be valid. Double-check it, then contact support if you think it should be working`}</Text>
         )}
       </Box>
-      <Button
-        variant={isInputCorrectLength ? "filled" : "default"}
-        loading={status === "loading"}
-        onClick={submit}
-      >{t`Activate`}</Button>
+      <Flex gap="lg">
+        <Button onClick={onSkip}>{t`Skip`}</Button>
+        <Button
+          disabled={!isInputCorrectLength}
+          loading={status === "loading"}
+          variant="filled"
+          onClick={submit}
+        >{t`Activate`}</Button>
+      </Flex>
     </>
   );
 };

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
@@ -42,7 +42,7 @@ export const LicenseTokenForm = ({
           aria-label={t`Token`}
           placeholder={t`Paste your token here`}
           value={token}
-          onChange={e => setToken(e.target.value)}
+          onChange={e => setToken(e.target.value.trim())}
           error={status === "error"}
         />
         {status === "error" && (

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
@@ -4,7 +4,7 @@ import { color } from "metabase/lib/colors";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { addUndo } from "metabase/redux/undo";
 import { useStep } from "metabase/setup/useStep";
-import { Button, Divider, Text } from "metabase/ui";
+import { Text } from "metabase/ui";
 
 import { submitLicenseToken } from "../../actions";
 import { ActiveStep } from "../ActiveStep";
@@ -30,7 +30,7 @@ export const LicenseTokenStep = ({ stepLabel }: NumberedStepProps) => {
     dispatch(submitLicenseToken(token));
   };
 
-  const handleNext = () => {
+  const skipStep = () => {
     dispatch(submitLicenseToken(null));
   };
 
@@ -56,13 +56,7 @@ export const LicenseTokenStep = ({ stepLabel }: NumberedStepProps) => {
         color={color("text-light")}
       >{t`Unlock access to your paid features before starting`}</Text>
 
-      <LicenseTokenForm onValidSubmit={handleValidSubmit} />
-
-      <Divider my="xl" />
-
-      <Button variant="filled" onClick={handleNext}>
-        {t`Next`}
-      </Button>
+      <LicenseTokenForm onValidSubmit={handleValidSubmit} onSkip={skipStep} />
     </ActiveStep>
   );
 };

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -131,6 +131,28 @@ describe("setup (EE, no token)", () => {
       expect(screen.getByRole("button", { name: "Activate" })).toBeDisabled();
     });
 
+    it("should ignore whitespace around the token", async () => {
+      await setupForLicenseStep();
+
+      const token = "a".repeat(64);
+
+      userEvent.paste(
+        screen.getByRole("textbox", { name: "Token" }),
+        `    ${token}   `,
+      );
+
+      expect(screen.getByRole("button", { name: "Activate" })).toBeEnabled();
+
+      setupForTokenCheckEndpoint({ valid: true });
+
+      screen.getByRole("button", { name: "Activate" }).click();
+
+      const url = fetchMock.lastCall(`path:/api/setup/token-check`)?.request
+        ?.url;
+      const sentToken = url?.split("token=")[1];
+      expect(sentToken).toMatch(token);
+    });
+
     it("should go to the next step when activating a valid token", async () => {
       await setupForLicenseStep();
 

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -100,7 +100,7 @@ describe("setup (EE, no token)", () => {
         "This token doesn’t seem to be valid. Double-check it, then contact support if you think it should be working",
       );
 
-      clickNextStep();
+      clickOnSkip();
 
       expect(trackLicenseTokenStepSubmitted).toHaveBeenCalledWith(false);
 
@@ -110,6 +110,25 @@ describe("setup (EE, no token)", () => {
       expect(await setupCall?.request?.json()).not.toHaveProperty(
         "license_token",
       );
+    });
+
+    it("should have the Activate button disabled when the token is not 64 characters long", async () => {
+      await setupForLicenseStep();
+
+      userEvent.paste(
+        screen.getByRole("textbox", { name: "Token" }),
+        "a".repeat(63),
+      );
+
+      expect(screen.getByRole("button", { name: "Activate" })).toBeDisabled();
+
+      userEvent.type(screen.getByRole("textbox", { name: "Token" }), "a"); //64 characters
+
+      expect(screen.getByRole("button", { name: "Activate" })).toBeEnabled();
+
+      userEvent.type(screen.getByRole("textbox", { name: "Token" }), "a"); //65 characters
+
+      expect(screen.getByRole("button", { name: "Activate" })).toBeDisabled();
     });
 
     it("should go to the next step when activating a valid token", async () => {
@@ -141,7 +160,7 @@ describe("setup (EE, no token)", () => {
     it("should be possible to skip the step without a token", async () => {
       await setupForLicenseStep();
 
-      clickNextStep();
+      clickOnSkip();
 
       expect(trackLicenseTokenStepSubmitted).toHaveBeenCalledWith(false);
 
@@ -172,3 +191,6 @@ describe("setup (EE, no token)", () => {
     });
   });
 });
+
+const clickOnSkip = () =>
+  userEvent.click(screen.getByRole("button", { name: "Skip" }));


### PR DESCRIPTION
Part of [[Epic] Add license activation in the initial setup](https://github.com/metabase/metabase/issues/38867)


### Description
[slack thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1709059357662279?thread_ts=1708450167.898109&cid=C063Q3F1HPF) and [updated design on figma](https://www.figma.com/file/UFay4YjWyUMyl23T1cXzeC/Meet-first-time-embedders-at-the-door-with-a-dashboard?type=design&node-id=1847-13653&mode=design&t=dWeAxl5hIjnDJtIS-4)

I also trimmed the input, so that if people paste the token with extra white-space it would still allow them to activate it

### How to verify

- Run the EE without an env from env
- the license step should look as from design
  - the Activate button should only be enabled if the input is of 64chars length



### Demo

<img width="914" alt="image" src="https://github.com/metabase/metabase/assets/1914270/2bd153a5-2d7e-4eb7-b321-83a00da39fb0">
<img width="913" alt="image" src="https://github.com/metabase/metabase/assets/1914270/ed3f9775-58ca-4243-8f63-2485748c8bda">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
