### PR TITLE
[WIP] Disable saving native questions and models without result_metadata

### DIFF
--- a/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
+++ b/frontend/src/metabase/query_builder/components/DatasetEditor/DatasetEditor.jsx
@@ -416,7 +416,7 @@ function DatasetEditor(props) {
       ? Lib.databaseID(dataset.query()) == null
       : dataset.legacyQuery().isEmpty();
 
-    if (isEmpty) {
+    if (isEmpty || fields.length === 0) {
       return false;
     }
     const everyFieldHasDisplayName = fields.every(field => field.display_name);

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -536,7 +536,6 @@ function ViewTitleHeaderRightSide(props) {
           disabled={!isSaveEnabled}
           tooltip={{
             tooltip: disabledSaveReason,
-            isEnabled: !isSaveEnabled,
             placement: "left",
           }}
           onClick={() => onOpenModal("save")}

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -83,7 +83,6 @@ import {
   getCardAutocompleteResultsFn,
   isResultsMetadataDirty,
   getShouldShowUnsavedChangesWarning,
-  getRequiredTemplateTags,
   getEmbeddedParameterVisibility,
 } from "../selectors";
 import { isNavigationAllowed } from "../utils";
@@ -170,7 +169,6 @@ const mapStateToProps = (state, props) => {
 
     reportTimezone: getSetting(state, "report-timezone-long"),
 
-    requiredTemplateTags: getRequiredTemplateTags(state),
     getEmbeddedParameterVisibility: slug =>
       getEmbeddedParameterVisibility(state, slug),
   };

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1076,12 +1076,13 @@ export const getIsSaveEnabled = createSelector(
       return false;
     }
 
-    const { isEditable } = Lib.queryDisplayInfo(question.query());
+    const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
     return (
       isEditable &&
-      !isResultDirty &&
-      resultsMetadata != null &&
-      question.canRun()
+      question.canRun() &&
+      (!isNative ||
+        question.isSaved() ||
+        (!isResultDirty && resultsMetadata != null))
     );
   },
 );
@@ -1115,10 +1116,14 @@ export const getDisabledSaveReason = createSelector(
           missingValueRequiredTags.length,
         );
       }
-    }
 
-    if (question.canRun() && (isResultDirty || !resultsMetadata)) {
-      return t`You need to run the query to save this question`;
+      if (
+        !question.isSaved() &&
+        question.canRun() &&
+        (isResultDirty || !resultsMetadata)
+      ) {
+        return t`You need to run the query to save this question`;
+      }
     }
 
     return null;

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1080,9 +1080,7 @@ export const getIsSaveEnabled = createSelector(
     return (
       isEditable &&
       question.canRun() &&
-      (!isNative ||
-        question.isSaved() ||
-        (!isResultDirty && resultsMetadata != null))
+      (!isNative || (!isResultDirty && resultsMetadata != null))
     );
   },
 );
@@ -1117,11 +1115,7 @@ export const getDisabledSaveReason = createSelector(
         );
       }
 
-      if (
-        !question.isSaved() &&
-        question.canRun() &&
-        (isResultDirty || !resultsMetadata)
-      ) {
+      if (question.canRun() && (isResultDirty || !resultsMetadata)) {
         return t`You need to run the query to save this question`;
       }
     }

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1095,7 +1095,7 @@ export const getDisabledSaveReason = createSelector(
     const type = question.type() === "question" ? t`question` : t`model`;
     const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
     if (!isEditable) {
-      return t`You don't have permission to save this ${type}.`;
+      return t`You don't have permission to save this ${type}`;
     }
 
     if (isNative) {
@@ -1110,14 +1110,14 @@ export const getDisabledSaveReason = createSelector(
           .join(", ");
 
         return ngettext(
-          msgid`The ${names} variable requires a default value but none was provided.`,
-          `The ${names} variables require default values but none were provided.`,
+          msgid`The ${names} variable requires a default value but none was provided`,
+          `The ${names} variables require default values but none were provided`,
           missingValueRequiredTags.length,
         );
       }
 
       if (question.canRun() && (isResultDirty || !resultsMetadata)) {
-        return t`You need to run the query to save this ${type}.`;
+        return t`You need to run the query to save this ${type}`;
       }
     }
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1095,7 +1095,7 @@ export const getDisabledSaveReason = createSelector(
     const type = question.type() === "question" ? t`question` : t`model`;
     const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
     if (!isEditable) {
-      return t`You don't have permission to save this ${type}`;
+      return t`You don't have permission to save this ${type}.`;
     }
 
     if (isNative) {
@@ -1117,7 +1117,7 @@ export const getDisabledSaveReason = createSelector(
       }
 
       if (question.canRun() && (isResultDirty || !resultsMetadata)) {
-        return t`You need to run the query to save this ${type}`;
+        return t`You need to run the query to save this ${type}.`;
       }
     }
 

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1092,9 +1092,10 @@ export const getDisabledSaveReason = createSelector(
       return null;
     }
 
+    const type = question.type() === "question" ? t`question` : t`model`;
     const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
     if (!isEditable) {
-      return t`You don't have permission to save this question`;
+      return t`You don't have permission to save this ${type}`;
     }
 
     if (isNative) {
@@ -1116,7 +1117,6 @@ export const getDisabledSaveReason = createSelector(
       }
 
       if (question.canRun() && (isResultDirty || !resultsMetadata)) {
-        const type = question.type() === "question" ? t`question` : t`model`;
         return t`You need to run the query to save this ${type}`;
       }
     }

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1116,7 +1116,8 @@ export const getDisabledSaveReason = createSelector(
       }
 
       if (question.canRun() && (isResultDirty || !resultsMetadata)) {
-        return t`You need to run the query to save this question`;
+        const type = question.type() === "question" ? t`question` : t`model`;
+        return t`You need to run the query to save this ${type}`;
       }
     }
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/37009
Fixes https://github.com/metabase/metabase/issues/35039
See https://metaboat.slack.com/archives/C052ZBWRG3W/p1708955785300049

You're now required to run the native query before saving the question/model. Native questions without `result_metadata` are useless. Currently we try to workaround this issue by re-running the native query after some time, but that turned out to be error-prone. 

<img width="1054" alt="Screenshot 2024-02-29 at 14 45 01" src="https://github.com/metabase/metabase/assets/8542534/14c6a4e9-9fee-4d63-938d-53102f721807">
<img width="1726" alt="Screenshot 2024-02-29 at 15 14 15" src="https://github.com/metabase/metabase/assets/8542534/3d8d8497-e992-4e5a-b78f-87d5a643e7d5">

