### PR TITLE
Forcefully reload table/card metadata when there are no fields (yet)

### DIFF
--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -14,6 +14,7 @@ import {
   createThunkAction,
   withAction,
   withCachedDataAndRequestState,
+  withForceReload,
   withNormalize,
 } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
@@ -81,6 +82,10 @@ const Tables = createEntity({
     // loads `query_metadata` for a single table
     fetchMetadata: compose(
       withAction(FETCH_METADATA),
+      withForceReload((state, { id }) => {
+        const table = Tables.selectors.getObject(state, { entityId: id });
+        return table?.fields?.length === 0;
+      }),
       withCachedDataAndRequestState(
         ({ id }) => [...Tables.getObjectStatePath(id)],
         ({ id }) => [...Tables.getObjectStatePath(id), "fetchMetadata"],

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -83,6 +83,9 @@ const Tables = createEntity({
     fetchMetadata: compose(
       withAction(FETCH_METADATA),
       withForceReload((state, { id }) => {
+        // if there is a virtual table without fields,
+        // it might be due to a question with a long-running request that hasn't finished yet.
+        // in this case we should reload the metadata until we get the fields
         const table = Tables.selectors.getObject(state, { entityId: id });
         return table?.fields?.length === 0;
       }),

--- a/frontend/src/metabase/lib/redux/utils.js
+++ b/frontend/src/metabase/lib/redux/utils.js
@@ -253,6 +253,15 @@ export function withRequestState(getRequestStatePath, getQueryKey) {
     };
 }
 
+export function withForceReload(shouldReload) {
+  return thunkCreator => (data, options) => (dispatch, getState) => {
+    return thunkCreator(data, {
+      ...options,
+      reload: options?.reload || shouldReload(getState(), data),
+    })(dispatch, getState);
+  };
+}
+
 /**
  * Decorator that returns cached data if appropriate, otherwise calls the composed thunk.
  * Also tracks request state using withRequestState


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/37009
Fixes https://github.com/metabase/metabase/issues/35039

How to verify:

Create a native query model on PG with:

```
SELECT PG_SLEEP(20) as A, 1 as B
```

Try to create a saved based on this model. There would be no fields in Data selector.
Keep trying to select this model in data picker. Eventually you would get fields and will stop sending extra requests.

Please note that with this approach there are some duplicate requests happening for such tables without metadata, but hopefully that's acceptable here.