### PR TITLE
Fix click behavior when routing to a different tab on the same dashboard

### DIFF
--- a/frontend/src/metabase-lib/queries/drills/dashboard-click-drill.js
+++ b/frontend/src/metabase-lib/queries/drills/dashboard-click-drill.js
@@ -20,7 +20,7 @@ export function getDashboardDrillType(clicked) {
     return null;
   }
 
-  const { type, linkType, targetId, tabId, extraData } = getClickBehaviorData(
+  const { type, linkType, targetId, extraData } = getClickBehaviorData(
     clicked,
     clickBehavior,
   );
@@ -34,10 +34,7 @@ export function getDashboardDrillType(clicked) {
     if (linkType === "url") {
       return "link-url";
     } else if (linkType === "dashboard") {
-      if (
-        extraData.dashboard.id === targetId &&
-        extraData.dashcard.dashboard_tab_id === tabId
-      ) {
+      if (extraData.dashboard.id === targetId) {
         return "dashboard-reset";
       } else {
         return "dashboard-url";
@@ -48,6 +45,13 @@ export function getDashboardDrillType(clicked) {
   }
 
   return null;
+}
+
+export function getDashboardDrillTab(clicked) {
+  const clickBehavior = getClickBehavior(clicked);
+  const { tabId } = getClickBehaviorData(clicked, clickBehavior);
+
+  return tabId;
 }
 
 export function getDashboardDrillParameters(clicked) {

--- a/frontend/src/metabase-lib/queries/drills/dashboard-click-drill.js
+++ b/frontend/src/metabase-lib/queries/drills/dashboard-click-drill.js
@@ -20,7 +20,7 @@ export function getDashboardDrillType(clicked) {
     return null;
   }
 
-  const { type, linkType, targetId, extraData } = getClickBehaviorData(
+  const { type, linkType, targetId, tabId, extraData } = getClickBehaviorData(
     clicked,
     clickBehavior,
   );
@@ -34,7 +34,10 @@ export function getDashboardDrillType(clicked) {
     if (linkType === "url") {
       return "link-url";
     } else if (linkType === "dashboard") {
-      if (extraData.dashboard.id === targetId) {
+      if (
+        extraData.dashboard.id === targetId &&
+        extraData.dashcard.dashboard_tab_id === tabId
+      ) {
         return "dashboard-reset";
       } else {
         return "dashboard-url";
@@ -141,10 +144,10 @@ function getClickBehavior(clicked) {
 
 function getClickBehaviorData(clicked, clickBehavior) {
   const data = getDataFromClicked(clicked);
-  const { type, linkType, parameterMapping, targetId } = clickBehavior;
+  const { type, linkType, parameterMapping, tabId, targetId } = clickBehavior;
   const { extraData } = clicked || {};
 
-  return { type, linkType, data, extraData, parameterMapping, targetId };
+  return { type, linkType, data, extraData, parameterMapping, tabId, targetId };
 }
 
 function getParameterIdValuePairs(

--- a/frontend/src/metabase/visualizations/click-actions/actions/DashboardClickAction.tsx
+++ b/frontend/src/metabase/visualizations/click-actions/actions/DashboardClickAction.tsx
@@ -1,4 +1,5 @@
 import {
+  selectTab,
   setOrUnsetParameterValues,
   setParameterValue,
 } from "metabase/dashboard/actions";
@@ -13,6 +14,7 @@ import {
   getDashboardDrillLinkUrl,
   getDashboardDrillParameters,
   getDashboardDrillQuestionUrl,
+  getDashboardDrillTab,
   getDashboardDrillType,
   getDashboardDrillUrl,
 } from "metabase-lib/queries/drills/dashboard-click-drill";
@@ -40,7 +42,9 @@ function getAction(
         url: () => getDashboardDrillQuestionUrl(question, clicked),
       };
     case "dashboard-url":
-      return { url: () => getDashboardDrillUrl(clicked) };
+      return {
+        url: () => getDashboardDrillUrl(clicked),
+      };
     case "dashboard-filter":
       return {
         action: () => {
@@ -51,6 +55,12 @@ function getAction(
     case "dashboard-reset":
       return {
         action: () => dispatch => {
+          const tabId = getDashboardDrillTab(clicked);
+
+          if (tabId) {
+            dispatch(selectTab({ tabId }));
+          }
+
           const parameterIdValuePairs = getDashboardDrillParameters(clicked);
           parameterIdValuePairs
             .map(([id, value]) => setParameterValue(id, value))


### PR DESCRIPTION
- Closes: https://github.com/metabase/metabase/issues/38455

---
### How to Manually Verify the Solution

1. Create a dashboard with two tabs
2. Put a card on each of the tabs
3. Create a filter that is attached to a card on both of the tabs
4. Configure click behavior on the card on the first tab to route to the 2nd tab on this same dashboard
  ![image](https://github.com/metabase/metabase/assets/22608765/a7446956-bcaa-4f4f-9a29-639a1601922d)
5. Save and check that clicking routes you to the 2nd tab
  ![Screenshot from 2024-02-29 12-44-31](https://github.com/metabase/metabase/assets/22608765/88328aa1-2efa-4a4a-ac49-a2f0a9ca511d)
  ![image](https://github.com/metabase/metabase/assets/22608765/8c983c66-affa-4c99-b7d7-2ca7d2ccc1d8)
