### PR TITLE
switch back to ring-jetty-adapter - addresses security issue

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -71,7 +71,6 @@
   environ/environ                           {:mvn/version "1.2.0"}              ; env vars/Java properties abstraction
   hiccup/hiccup                             {:mvn/version "1.0.5"}              ; HTML templating
   inflections/inflections                   {:mvn/version "0.14.1"}             ; Clojure/Script library used for prularizing words
-  info.sunng/ring-jetty9-adapter            {:mvn/version "0.22.4"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver (Jetty 12 requires JDK 17+).
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
   clj-commons/clj-yaml                      {:mvn/version "1.0.27"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.537"}
@@ -151,7 +150,8 @@
   org.clojure/tools.namespace               {:mvn/version "1.4.4"}
   org.clojure/tools.reader                  {:mvn/version "1.3.7"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.17"}            ; web server
+  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.20"}            ; web server
+  org.eclipse.jetty.websocket/websocket-jetty-server {:mvn/version "11.0.20"}   ; ring-jetty-adapter needs that
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.5"}             ; JavaScript engine
   org.jsoup/jsoup                           {:mvn/version "1.17.2"}             ; required by hickory
@@ -171,7 +171,10 @@
   prismatic/schema                          {:mvn/version "1.4.1"}              ; Data schema declaration and validation library
   redux/redux                               {:mvn/version "0.1.4"}              ; Utility functions for building and composing transducers
   riddley/riddley                           {:mvn/version "0.2.0"}              ; code walking lib -- used interally by Potemkin, manifold, etc.
-  ring/ring-core                            {:mvn/version "1.10.0"}             ; web server (Jetty wrapper)
+  ring/ring-core                            {:mvn/version "1.11.0"}             ; HTTP abstraction
+  ring/ring-jetty-adapter                   {:mvn/version "1.11.0"              ; Jetty adapter
+                                             :exclusions [org.eclipse.jetty/jetty-server
+                                                          org.eclipse.jetty.websocket/websocket-jetty-server]}
   ring/ring-json                            {:mvn/version "0.5.1"}              ; Ring middleware for reading/writing JSON automatically
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -17,7 +17,7 @@
    [metabase.util.log :as log]
    [potemkin :as p]
    [potemkin.types :as p.types]
-   [ring.adapter.jetty9 :as ring-jetty])
+   [ring.adapter.jetty :as ring-jetty])
   (:import
    (io.prometheus.client Collector GaugeMetricFamily)
    (io.prometheus.client.hotspot GarbageCollectorExports MemoryPoolsExports StandardExports ThreadExports)

--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -11,7 +11,7 @@
    [metabase.util.log :as log]
    [potemkin.types :as p.types]
    [pretty.core :as pretty]
-   [ring.adapter.jetty9.common :as common]
+   [ring.util.jakarta.servlet :as servlet]
    [ring.util.response :as response])
   (:import
    (java.io BufferedWriter OutputStream OutputStreamWriter)
@@ -189,7 +189,7 @@
       (let [gzip?   (should-gzip-response? request-map)
             headers (cond-> (assoc (merge headers (:headers response-map)) "Content-Type" content-type)
                       gzip? (assoc "Content-Encoding" "gzip"))]
-        (#'common/set-headers response headers)
+        (#'servlet/set-headers response headers)
         (let [output-stream-delay (output-stream-delay gzip? response)
               delay-os            (delay-output-stream output-stream-delay)]
           (start-async-cancel-loop! request finished-chan canceled-chan)

--- a/src/metabase/server.clj
+++ b/src/metabase/server.clj
@@ -9,8 +9,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
-   [ring.adapter.jetty9 :as ring-jetty]
-   [ring.adapter.jetty9.servlet :as servlet])
+   [ring.adapter.jetty :as ring-jetty]
+   [ring.util.jakarta.servlet :as servlet])
   (:import
    (jakarta.servlet AsyncContext)
    (jakarta.servlet.http HttpServletRequest HttpServletResponse)

--- a/src/metabase/server/protocols.clj
+++ b/src/metabase/server/protocols.clj
@@ -1,7 +1,7 @@
 (ns metabase.server.protocols
   (:require
    [potemkin.types :as p.types]
-   [ring.adapter.jetty9.servlet :as servlet]))
+   [ring.util.jakarta.servlet :as servlet]))
 
 (p.types/defprotocol+ Respond
   "Protocol for converting API endpoint responses to something Jetty can handle."

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -15,7 +15,7 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
-   [ring.adapter.jetty9 :as jetty]
+   [ring.adapter.jetty :as jetty]
    [ring.middleware.params :refer [wrap-params]])
   (:import
    (org.eclipse.jetty.server Server)))

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -8,7 +8,7 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
-   [ring.adapter.jetty9 :as ring-jetty])
+   [ring.adapter.jetty :as ring-jetty])
   (:import
    (org.eclipse.jetty.server Server)))
 


### PR DESCRIPTION
Since jetty is still a security issue, and ring-jetty9-adapter actually pulls http2-server - which we don't use and don't need in our deps.