### PR TITLE
Use `updateUserSetting` for user-local settings

### DIFF
--- a/frontend/src/metabase/browse/components/ModelExplanationBanner.tsx
+++ b/frontend/src/metabase/browse/components/ModelExplanationBanner.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { t } from "ttag";
 
-import { updateSetting } from "metabase/admin/settings/settings";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import { updateUserSetting } from "metabase/redux/settings";
 import { getSetting } from "metabase/selectors/settings";
 import { Flex, Paper, Icon, Text } from "metabase/ui";
 
@@ -19,7 +19,7 @@ export function ModelExplanationBanner() {
   const dismissBanner = () => {
     setShouldShowBanner(false);
     dispatch(
-      updateSetting({
+      updateUserSetting({
         key: "dismissed-browse-models-banner",
         value: true,
       }),

--- a/frontend/src/metabase/home/components/HomePage/HomePage.tsx
+++ b/frontend/src/metabase/home/components/HomePage/HomePage.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { replace } from "react-router-redux";
 import { t } from "ttag";
 
-import { updateSetting } from "metabase/admin/settings/settings";
 import {
   useDashboardQuery,
   useDatabaseListQuery,
@@ -11,6 +10,7 @@ import {
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { canUseMetabotOnDatabase } from "metabase/metabot/utils";
+import { updateUserSetting } from "metabase/redux/settings";
 import { addUndo } from "metabase/redux/undo";
 import { getSettingsLoading } from "metabase/selectors/settings";
 import type Database from "metabase-lib/metadata/Database";
@@ -112,7 +112,7 @@ const useDashboardPage = () => {
             icon: "info",
             timeout: 10000,
             actions: [
-              updateSetting({
+              updateUserSetting({
                 key: "dismissed-custom-dashboard-toast",
                 value: true,
               }),


### PR DESCRIPTION
### Description

After merging #39251, I realized that there are two more user-local settings that are still using the `updateSetting` instead of our fresh new `updateUserSetting`. This means that updating these settings would result in trying to fetch all settings, which leads to `403`

### How to verify

**`dismissed-browse-models-banner`**
1. As a non-admin user, go to `browse/models`
2. Dismiss "Models help curate data..." banner
![image](https://github.com/metabase/metabase/assets/31325167/97271991-fe17-4683-9ae0-7e6ab5c4c631)
3. Make sure that no `GET /api/setting` happens in the network tab

Before
https://github.com/metabase/metabase/assets/31325167/c90e697f-be7e-46ca-a9ea-1cd77d253af5

After
https://github.com/metabase/metabase/assets/31325167/e3d23568-4ac6-4770-98f6-ed66091cf7f9

---

**`dismissed-custom-dashboard-toast`**
1. As an admin enable and set the custom homepage using any of the existing dashboards
2. As a non-admin, go to the home page
3. Dismiss the toast that says "Your admin has set this dashboard as your homepage"
![Screenshot 2024-02-29 at 20 26 57](https://github.com/metabase/metabase/assets/31325167/5dec3caf-83d8-4323-b82d-4f525d202713)
4. Make sure that no `GET /api/setting` happens in the network tab
![image](https://github.com/metabase/metabase/assets/31325167/510cd947-1de6-434e-a9b2-4683acb2006e)



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR

I can add E2E tests for this to the existing https://github.com/metabase/metabase/blob/master/e2e/test/scenarios/permissions/reproductions/39221-fetch-settings-only-if-admin.cy.spec.js but it feels like an overkill. Adding types in #39223 should be enough, IMO.

Closes #39221 

## Additional Notes:
I'll have to create a manual backport that combines #39251 and this PR.
