### PR TITLE
Move jetty timeout default to metabase.config

### DIFF
--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -52,7 +52,7 @@
    :mb-colorize-logs                (str (not is-windows?)) ; since PowerShell and cmd.exe don't support ANSI color escape codes or emoji,
    :mb-emoji-in-logs                (str (not is-windows?)) ; disable them by default when running on Windows. Otherwise they're enabled
    :mb-qp-cache-backend             "db"
-   :mb-jetty-async-response-timeout (str (* 10 60 1000))})  ; 10s
+   :mb-jetty-async-response-timeout (str (* 10 60 1000))})  ; 10m
 
 ;; separate map for EE stuff so merge conflicts aren't annoying.
 (def ^:private ee-app-defaults

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -34,24 +34,25 @@
 
 (def ^:private app-defaults
   "Global application defaults"
-  {:mb-run-mode            "prod"
+  {:mb-run-mode                     "prod"
    ;; DB Settings
-   :mb-db-type             "h2"
-   :mb-db-file             "metabase.db"
-   :mb-db-automigrate      "true"
-   :mb-db-logging          "true"
+   :mb-db-type                      "h2"
+   :mb-db-file                      "metabase.db"
+   :mb-db-automigrate               "true"
+   :mb-db-logging                   "true"
    ;; Jetty Settings. Full list of options is available here: https://github.com/ring-clojure/ring/blob/master/ring-jetty-adapter/src/ring/adapter/jetty.clj
-   :mb-jetty-port          "3000"
-   :mb-jetty-join          "true"
+   :mb-jetty-port                   "3000"
+   :mb-jetty-join                   "true"
    ;; other application settings
-   :mb-password-complexity "normal"
-   :mb-version-info-url    "https://static.metabase.com/version-info.json"
-   :mb-version-info-ee-url "https://static.metabase.com/version-info-ee.json"
-   :mb-ns-trace            ""                                             ; comma-separated namespaces to trace
-   :max-session-age        "20160"                                        ; session length in minutes (14 days)
-   :mb-colorize-logs       (str (not is-windows?))                        ; since PowerShell and cmd.exe don't support ANSI color escape codes or emoji,
-   :mb-emoji-in-logs       (str (not is-windows?))                        ; disable them by default when running on Windows. Otherwise they're enabled
-   :mb-qp-cache-backend    "db"})
+   :mb-password-complexity          "normal"
+   :mb-version-info-url             "https://static.metabase.com/version-info.json"
+   :mb-version-info-ee-url          "https://static.metabase.com/version-info-ee.json"
+   :mb-ns-trace                     ""                      ; comma-separated namespaces to trace
+   :max-session-age                 "20160"                 ; session length in minutes (14 days)
+   :mb-colorize-logs                (str (not is-windows?)) ; since PowerShell and cmd.exe don't support ANSI color escape codes or emoji,
+   :mb-emoji-in-logs                (str (not is-windows?)) ; disable them by default when running on Windows. Otherwise they're enabled
+   :mb-qp-cache-backend             "db"
+   :mb-jetty-async-response-timeout (str (* 10 60 1000))})  ; 10s
 
 ;; separate map for EE stuff so merge conflicts aren't annoying.
 (def ^:private ee-app-defaults

--- a/src/metabase/server.clj
+++ b/src/metabase/server.clj
@@ -97,11 +97,8 @@
   ;; if any API endpoint functions aren't at the very least returning a channel to fetch the results later after 10
   ;; minutes we're in serious trouble. (Almost everything 'slow' should be returning a channel before then, but
   ;; some things like CSV downloads don't currently return channels at this time)
-  ;;
-  ;; TODO - I suppose the default value should be moved to the `metabase.config` namespace?
-  (let [timeout (or (config/config-int :mb-jetty-async-response-timeout)
-                    (* 10 60 1000))
-        handler (async-proxy-handler handler timeout)
+  (let [timeout       (config/config-int :mb-jetty-async-response-timeout)
+        handler       (async-proxy-handler handler timeout)
         stats-handler (doto (StatisticsHandler.)
                         (.setHandler handler))]
     (doto ^Server (#'ring-jetty/create-server (assoc options :async? true))


### PR DESCRIPTION
### Description

Actions a trivial TODO - use the standard mechanism to define the default jetty timeout.