### PR TITLE
Move refresh test helper into test namespace

### DIFF
--- a/src/metabase/task/persist_refresh.clj
+++ b/src/metabase/task/persist_refresh.clj
@@ -379,18 +379,6 @@
            :triggers
            (m/index-by (comp #(get % "db-id") qc/from-job-data :data))))
 
-;;; TODO -- this is only used in [[metabase.api.card-test]] now
-(defn job-info-for-individual-refresh
-  "Return a set of PersistedInfo ids of all jobs scheduled for individual refreshes."
-  []
-  (some->> refresh-job-key
-           task/job-info
-           :triggers
-           (map (comp qc/from-job-data :data))
-           (filter (comp #{"individual"} #(get % "type")))
-           (map #(get % "persisted-id"))
-           set))
-
 (defn unschedule-persistence-for-database!
   "Stop refreshing tables for a given database. Should only be called when marking the database as not
   persisting. Tables will be left over and up to the caller to clean up."


### PR DESCRIPTION
### Description

Actions a trivial TODO - we only use this function from a single test, so move it to the test namespace.