### PR TITLE
Update various TODO comments

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -159,7 +159,7 @@
                                                  :joinedUserName    (or (:first_name new-user) (:email new-user))
                                                  :joinedViaSSO      google-auth?
                                                  :joinedUserEmail   (:email new-user)
-                                                 :joinedDate        (t/format "EEEE, MMMM d" (t/zoned-date-time)) ; e.g. "Wednesday, July 13". TODO - is this what we want?
+                                                 :joinedDate        (t/format "EEEE, MMMM d" (t/zoned-date-time)) ; e.g. "Wednesday, July 13".
                                                  :adminEmail        (first recipients)
                                                  :joinedUserEditUrl (str (public-settings/site-url) "/admin/people")}))})))
 

--- a/src/metabase/shared/parameters/parameters.cljc
+++ b/src/metabase/shared/parameters/parameters.cljc
@@ -104,7 +104,7 @@
   [_ value locale]
   ;; Test value against a series of regexes (similar to those in metabase/parameters/utils/mbql.js) to determine
   ;; the appropriate formatting, since it is not encoded in the parameter type.
-  ;; TODO: this is a partial implementation that only handles simple dates
+  ;; TODO: this is incomplete, and only handles simple dates https://github.com/metabase/metabase/issues/39385
   (condp (fn [re value] (->> (re-find re value) second)) value
     #"^(this[a-z]+)$"          :>> #(formatted-value :date/relative % locale)
     #"^~?([0-9-T:]+)~?$"       :>> #(formatted-value :date/single % locale)

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -56,7 +56,6 @@
 
 ;;; -------------------------------------------------- Schemas --------------------------------------------------
 
-;;; TODO -- this does not actually ensure that the string cannot be BLANK at all!
 (def NonBlankString
   "Schema for a string that cannot be blank."
   (mu/with-api-error-message ::lib.schema.common/non-blank-string (deferred-tru "value must be a non-blank string.")))


### PR DESCRIPTION
### Description

- Remove a 2019 TODO with indecision about a date format - the ship has sailed.
- Remove an obsolete TODO around a schema that was fixed when moving to Malli.
- Link a TODO back to its corresponding issue - it's actually a bug, not just tech debt.