### PR TITLE
hide error when the user changes the token

### DIFF
--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
@@ -42,7 +42,12 @@ export const LicenseTokenForm = ({
           aria-label={t`Token`}
           placeholder={t`Paste your token here`}
           value={token}
-          onChange={e => setToken(e.target.value.trim())}
+          onChange={e => {
+            setToken(e.target.value.trim());
+            setStatus(oldState =>
+              oldState !== "loading" ? "idle" : "loading",
+            );
+          }}
           error={status === "error"}
         />
         {status === "error" && (

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -100,6 +100,17 @@ describe("setup (EE, no token)", () => {
         "This token doesn’t seem to be valid. Double-check it, then contact support if you think it should be working",
       );
 
+      userEvent.type(
+        screen.getByRole("textbox", { name: "Token" }),
+        "{backspace}b",
+      );
+
+      expect(
+        screen.queryByText("This token doesn’t seem to be valid.", {
+          exact: false,
+        }),
+      ).not.toBeInTheDocument();
+
       clickOnSkip();
 
       expect(trackLicenseTokenStepSubmitted).toHaveBeenCalledWith(false);


### PR DESCRIPTION
[[Epic] Add license activation in the initial setup](https://github.com/metabase/metabase/issues/38867)

### Description

The error was persisted when the user changed the token, this addresses that.
[Slack thread where the feedback was given](https://metaboat.slack.com/archives/C063Q3F1HPF/p1709244578414609?thread_ts=1709224918.522439&cid=C063Q3F1HPF)

### How to verify

- Run ee code without a token as env
- type a non valid token
- press active
- you should see the error
- change the token
- the error should go away


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
