### PR TITLE
Optimize some parts of Notebook editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookSteps/NotebookSteps.tsx
@@ -63,12 +63,17 @@ function NotebookSteps({
     setLastOpenedStep(id);
   }, []);
 
-  const handleStepClose = useCallback((id: INotebookStep["id"]) => {
-    setOpenSteps(openSteps => ({ ...openSteps, [id]: false }));
-    setLastOpenedStep(lastOpenedStep =>
-      lastOpenedStep === id ? null : lastOpenedStep,
-    );
-  }, []);
+  const handleStepClose = useCallback(
+    (id: INotebookStep["id"]) => {
+      if (openSteps[id]) {
+        setOpenSteps(openSteps => ({ ...openSteps, [id]: false }));
+      }
+      setLastOpenedStep(lastOpenedStep =>
+        lastOpenedStep === id ? null : lastOpenedStep,
+      );
+    },
+    [openSteps],
+  );
 
   const handleQueryChange = useCallback(
     async (query: Query, step: INotebookStep) => {

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
@@ -62,10 +62,6 @@ export function JoinConditionColumnPicker({
     [isNewCondition],
   );
 
-  const handleCellItemChange = useCallback(() => {
-    onOpenedChange(!isOpened);
-  }, [isOpened, onOpenedChange]);
-
   return (
     <Popover opened={isOpened} onChange={onOpenedChange}>
       <Popover.Target>
@@ -75,7 +71,7 @@ export function JoinConditionColumnPicker({
           columnName={columnInfo?.displayName}
           label={label}
           readOnly={readOnly}
-          onClick={handleCellItemChange}
+          onClick={() => onOpenedChange(!isOpened)}
         />
       </Popover.Target>
       <Popover.Dropdown>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinConditionColumnPicker/JoinConditionColumnPicker.tsx
@@ -62,6 +62,10 @@ export function JoinConditionColumnPicker({
     [isNewCondition],
   );
 
+  const handleCellItemChange = useCallback(() => {
+    onOpenedChange(!isOpened);
+  }, [isOpened, onOpenedChange]);
+
   return (
     <Popover opened={isOpened} onChange={onOpenedChange}>
       <Popover.Target>
@@ -71,7 +75,7 @@ export function JoinConditionColumnPicker({
           columnName={columnInfo?.displayName}
           label={label}
           readOnly={readOnly}
-          onClick={() => onOpenedChange(!isOpened)}
+          onClick={handleCellItemChange}
         />
       </Popover.Target>
       <Popover.Dropdown>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.tsx
@@ -282,7 +282,7 @@ function JoinCondition({
     setOperator,
     setLHSColumn,
     setRHSColumn,
-  } = useJoinCondition(query, stageIndex, table, join, condition);
+  } = useJoinCondition(query, stageIndex, condition);
 
   const getLhsColumnGroup = () => {
     const lhsColumns = Lib.joinConditionLHSColumns(

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join-condition.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/use-join-condition.ts
@@ -6,8 +6,6 @@ import * as Lib from "metabase-lib";
 export function useJoinCondition(
   query: Lib.Query,
   stageIndex: number,
-  table: Lib.Joinable,
-  join?: Lib.Join,
   condition?: Lib.JoinCondition,
 ) {
   const previousCondition = usePrevious(condition);

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -265,8 +265,14 @@ class View extends Component {
   };
 
   renderMain = ({ leftSidebar, rightSidebar }) => {
-    const { question, mode, parameters, isLiveResizable, setParameterValue } =
-      this.props;
+    const {
+      question,
+      mode,
+      parameters,
+      isLiveResizable,
+      setParameterValue,
+      queryBuilderMode,
+    } = this.props;
 
     const queryMode = mode && mode.queryMode();
     const { isNative } = Lib.queryDisplayInfo(question.query());
@@ -295,7 +301,13 @@ class View extends Component {
             mode={queryMode}
           />
         </StyledDebouncedFrame>
-        <TimeseriesChrome {...this.props} className="flex-no-shrink" />
+        {queryBuilderMode === "view" && (
+          <TimeseriesChrome
+            question={this.props.question}
+            updateQuestion={this.props.updateQuestion}
+            className="flex-no-shrink"
+          />
+        )}
         <ViewFooter {...this.props} className="flex-no-shrink" />
       </QueryBuilderMain>
     );

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -274,6 +274,11 @@ class View extends Component {
       queryBuilderMode,
     } = this.props;
 
+    if (queryBuilderMode === "notebook") {
+      // we need to render main only in view mode
+      return;
+    }
+
     const queryMode = mode && mode.queryMode();
     const { isNative } = Lib.queryDisplayInfo(question.query());
     const isSidebarOpen = leftSidebar || rightSidebar;
@@ -301,13 +306,11 @@ class View extends Component {
             mode={queryMode}
           />
         </StyledDebouncedFrame>
-        {queryBuilderMode === "view" && (
-          <TimeseriesChrome
-            question={this.props.question}
-            updateQuestion={this.props.updateQuestion}
-            className="flex-no-shrink"
-          />
-        )}
+        <TimeseriesChrome
+          question={this.props.question}
+          updateQuestion={this.props.updateQuestion}
+          className="flex-no-shrink"
+        />
         <ViewFooter {...this.props} className="flex-no-shrink" />
       </QueryBuilderMain>
     );

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -460,11 +460,12 @@ function ViewTitleHeaderRightSide(props) {
     [isRunning],
   );
 
-  const isSaveDisabled = !question.canRun() || !isEditable;
+  const canRun = question.canRun();
+  const isSaveDisabled = !canRun || !isEditable;
   const disabledSaveTooltip = getDisabledSaveTooltip(
-    question,
     isEditable,
     requiredTemplateTags,
+    canRun,
   );
 
   return (
@@ -555,11 +556,7 @@ function ViewTitleHeaderRightSide(props) {
 
 ViewTitleHeader.propTypes = viewTitleHeaderPropTypes;
 
-function getDisabledSaveTooltip(
-  question,
-  isEditable,
-  requiredTemplateTags = [],
-) {
+function getDisabledSaveTooltip(isEditable, requiredTemplateTags = [], canRun) {
   if (!isEditable) {
     return t`You don't have permission to save this question.`;
   }
@@ -568,7 +565,7 @@ function getDisabledSaveTooltip(
     tag => tag.required && !tag.default,
   );
 
-  if (!question.canRun()) {
+  if (!canRun) {
     return getMissingRequiredTemplateTagsTooltip(missingValueRequiredTTags);
   }
 


### PR DESCRIPTION
### Description

This PR addresses several perf problems, hovewer other problems seems cannot be addressed because of a nature of cljs and data immutability together with probably missing methods and some perf problems in cljs code.

### Problems we addressed
1. `NotebookSteps` component tracks in his state a list of opened steps - steps which user added compared to the saved state or all steps for a new question. There was added a premature optimization to close an opened step on query change, but we didn't track was the step opened and not and with MLv2 we get a new query instance in many cases (e.g. when some specific column is selected/unselected in the join step). So even if no steps were opened, we updated a state of `NotebookSteps` component and triggered re-rendering of all children components down by the tree.

🔧 Check if the step is opened, and do not update state if it's not

2. `TimeSeriesChrome` component is not shown in Notebook mode, but it performs calculations under the hood. 

🔧 Do not render `TimeSeriesChrome` component in Notebook mode

3. `ViewTitleHeaderRightSide` components triggers `question.canRun()` method, which is extremely expensive for some reason, twice for the same question.

🔧 trigger `question.canRun()` once and reuse the result


### What can't be updated, but it would help

- `JoinStep` is re-rendered because of results of `Lib.joinStrategy(join)` and `Lib.joinConditions(join)`. As query reference is new every time, joinStrategy and joinConditions return a new reference every time causing re-rendering of the component
- `JoinCondition` is re-rendered because of JoinStep and `Lib.joinConditionParts`, which returns new references for `lhsColumn` and `rhsColumn`
- `question.canRun` should be faster (maybe cached)

### How to verify

tests should pass

play with QB with multiple steps (especially several join steps)

### Demo

All tests were done on the same question and with CPU throttling emulation x6, performing one click on the dropdown

#### Before

<img width="783" alt="image" src="https://github.com/metabase/metabase/assets/125459446/2356ee3f-92d3-4e9a-a3f0-d4450f7560a4">

<img width="1920" alt="image" src="https://github.com/metabase/metabase/assets/125459446/88440db7-605d-49a1-aec7-6eb19095d07b">


#### After

<img width="793" alt="image" src="https://github.com/metabase/metabase/assets/125459446/135f88b1-01e2-4143-b83c-17cbce67e80a">

<img width="1920" alt="image" src="https://github.com/metabase/metabase/assets/125459446/ba290076-7a2d-4d60-a709-e4d7e15c5b27">
