### PR TITLE
keep token visible when going back

### DIFF
--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenForm.tsx
@@ -7,13 +7,15 @@ import { Box, Button, Flex, Text, TextInput } from "metabase/ui";
 type LicenseTokenFormProps = {
   onValidSubmit: (token: string) => void;
   onSkip: () => void;
+  initialValue?: string;
 };
 
 export const LicenseTokenForm = ({
   onValidSubmit,
   onSkip,
+  initialValue = "",
 }: LicenseTokenFormProps) => {
-  const [token, setToken] = useState("");
+  const [token, setToken] = useState(initialValue);
   const [status, setStatus] = useState<
     "idle" | "loading" | "success" | "error"
   >("idle");

--- a/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
+++ b/frontend/src/metabase/setup/components/LicenseTokenStep/LicenseTokenStep.tsx
@@ -56,7 +56,11 @@ export const LicenseTokenStep = ({ stepLabel }: NumberedStepProps) => {
         color={color("text-light")}
       >{t`Unlock access to your paid features before starting`}</Text>
 
-      <LicenseTokenForm onValidSubmit={handleValidSubmit} onSkip={skipStep} />
+      <LicenseTokenForm
+        onValidSubmit={handleValidSubmit}
+        onSkip={skipStep}
+        initialValue={storeToken ?? ""}
+      />
     </ActiveStep>
   );
 };

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -188,6 +188,12 @@ describe("setup (EE, no token)", () => {
         "aria-current",
         "step",
       );
+
+      screen.getByText("Commercial license active").click();
+
+      expect(screen.getByRole("textbox", { name: "Token" })).toHaveValue(
+        sampleToken,
+      );
     });
 
     it("should be possible to skip the step without a token", async () => {


### PR DESCRIPTION
Part of [[Epic] Add license activation in the initial setup](https://github.com/metabase/metabase/issues/38867)

### Description

Based on feedback on the [slack thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1709288042496439?thread_ts=1709224918.522439&cid=C063Q3F1HPF)

Before this, when going back the input was empty, this keeps the token there.

### How to verify
As usual the license token step only pops up when running EE code without a token in the ENV

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
