### PR TITLE
[QP] Use the alias for unfolded JSON columns from previous stages

### DIFF
--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -494,7 +494,8 @@
       (pg-conversion identifier :numeric)
 
       (lib.field/json-field? stored-field)
-      (if (::sql.qp/forced-alias opts)
+      (if (or (::sql.qp/forced-alias opts)
+              (= (::add/source-table opts) ::add/source))
         (keyword (::add/source-alias opts))
         (walk/postwalk #(if (h2x/identifier? %)
                           (sql.qp/json-query :postgres % stored-field)


### PR DESCRIPTION
In the legacy QP the `:fields` of the outer query has the ID,
`[:field 100 {}]` so the JSON unfolding is written out again.

With this change, the `source-alias` is used for columns coming from
previous stages.

Fixes #34930. Fixes #35636.

