### PR TITLE
Native query default parameter values: use ParameterValuePicker for single strings, numbers, and dates

### DIFF
--- a/e2e/test/scenarios/native-filters/reproductions/31606.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/31606.cy.spec.js
@@ -72,7 +72,9 @@ describe("issue 31606", { tags: "@external" }, () => {
       field: "ID",
     });
 
-    FieldFilter.setWidgetType("ID");
+    cy.findByTestId("filter-widget-type-select")
+      .should("have.value", "ID")
+      .should("be.disabled");
 
     FieldFilter.openEntryForm({ isFilterRequired: true });
     FieldFilter.addDefaultStringFilter("2");

--- a/e2e/test/scenarios/native-filters/sql-field-filter-date.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-date.cy.spec.js
@@ -74,7 +74,7 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
 
 function openDateFilterPicker(isFilterRequired) {
   const selector = isFilterRequired
-    ? cy.findByText("Select a default value…")
+    ? cy.findByPlaceholderText("Select a default value…")
     : cy.get("fieldset");
 
   return selector.click();

--- a/e2e/test/scenarios/native-filters/sql-field-filter-date.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-date.cy.spec.js
@@ -52,11 +52,6 @@ describe("scenarios > filters > sql filters > field filter > Date", () => {
 
       FieldFilter.setWidgetType(subType);
 
-      // When we run the first iteration, there will be no default filter value set
-      if (index !== 0) {
-        FieldFilter.clearDefaultFilterValue();
-      }
-
       dateFilterSelector({
         filterType: subType,
         filterValue: value,

--- a/e2e/test/scenarios/native-filters/sql-field-filter-number.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-number.cy.spec.js
@@ -51,11 +51,6 @@ describe("scenarios > filters > sql filters > field filter > Number", () => {
 
         FieldFilter.setWidgetType(subType);
 
-        // When we run the first iteration, there will be no default filter value set
-        if (index !== 0) {
-          FieldFilter.clearDefaultFilterValue();
-        }
-
         FieldFilter.openEntryForm({ isFilterRequired: true });
         FieldFilter.addDefaultNumberFilter(value);
 

--- a/e2e/test/scenarios/native-filters/sql-field-filter-string.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter-string.cy.spec.js
@@ -58,11 +58,6 @@ describe("scenarios > filters > sql filters > field filter > String", () => {
       ([subType, { searchTerm, value, representativeResult }], index) => {
         FieldFilter.setWidgetType(subType);
 
-        // When we run the first iteration, there will be no default filter value set
-        if (index !== 0) {
-          FieldFilter.clearDefaultFilterValue();
-        }
-
         FieldFilter.openEntryForm({ isFilterRequired: true });
 
         searchTerm

--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -35,7 +35,9 @@ describe("scenarios > filters > sql filters > field filter", () => {
         field: "ID",
       });
 
-      FieldFilter.setWidgetType("ID");
+      cy.findByTestId("filter-widget-type-select")
+        .should("have.value", "ID")
+        .should("be.disabled");
     });
 
     function setDefaultFieldValue(value) {
@@ -113,7 +115,9 @@ describe("scenarios > filters > sql filters > field filter", () => {
         field: "ID",
       });
 
-      FieldFilter.setWidgetType("ID");
+      cy.findByTestId("filter-widget-type-select")
+        .should("have.value", "ID")
+        .should("be.disabled");
     });
 
     it("should work when set initially as default value and then through the filter widget", () => {
@@ -149,8 +153,9 @@ describe("scenarios > filters > sql filters > field filter", () => {
         field: "Longitude",
       });
 
-      cy.findByTestId("filter-widget-type-select").click();
-      popover().findByText("None").should("be.visible");
+      cy.findByTestId("filter-widget-type-select")
+        .should("have.value", "None")
+        .should("be.disabled");
 
       filterWidget().should("not.exist");
     });

--- a/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
@@ -204,8 +204,9 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     it("when set as the default value for a required filter", () => {
       SQLFilter.toggleRequired();
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Select a default value…").click();
+      cy.findByTestId("sidebar-content")
+        .findByPlaceholderText("Select a default value…")
+        .click();
       popover().within(() => {
         cy.findByText("15").click();
         cy.findByText("Add filter").click();
@@ -220,7 +221,7 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
 
     function setDefaultDate(year = "2024", month = "01", day = "22") {
       cy.findByTestId("sidebar-content")
-        .findByText("Select a default value…")
+        .findByPlaceholderText("Select a default value…")
         .click();
       popover().within(() => {
         DateFilter.setSingleDate(`${month}/${day}/${year}`);

--- a/frontend/src/metabase-lib/parameters/utils/parameter-type.ts
+++ b/frontend/src/metabase-lib/parameters/utils/parameter-type.ts
@@ -42,6 +42,8 @@ export function isStringParameter(parameter: Parameter) {
   return type === "string";
 }
 
+// TODO this must be wrong because it returns true
+// for parameters without fields
 export function isFieldFilterParameter(parameter: Parameter) {
   const type = getParameterType(parameter);
   return FIELD_FILTER_PARAMETER_TYPES.includes(type);

--- a/frontend/src/metabase-lib/parameters/utils/template-tags.ts
+++ b/frontend/src/metabase-lib/parameters/utils/template-tags.ts
@@ -10,21 +10,26 @@ import type {
   TemplateTag,
 } from "metabase-types/api";
 
-function getTemplateTagType(tag: TemplateTag) {
+function getParameterType(tag: TemplateTag) {
+  if (tag["widget-type"]) {
+    return tag["widget-type"];
+  }
+
   const { type } = tag;
   if (type === "date") {
     return "date/single";
-    // @ts-expect-error -- preserving preexisting incorrect types (for now)
-  } else if (type === "string") {
-    return "string/=";
-  } else if (type === "number") {
-    return "number/=";
-  } else {
-    return "category";
   }
+  // @ts-expect-error -- preserving preexisting incorrect types (for now)
+  if (type === "string") {
+    return "string/=";
+  }
+  if (type === "number") {
+    return "number/=";
+  }
+  return "category";
 }
 
-function getTemplateTagParameterTarget(tag: TemplateTag): ParameterTarget {
+function getParameterTarget(tag: TemplateTag): ParameterTarget {
   return tag.type === "dimension"
     ? ["dimension", ["template-tag", tag.name]]
     : ["variable", ["template-tag", tag.name]];
@@ -36,8 +41,8 @@ export function getTemplateTagParameter(
 ): ParameterWithTarget {
   return {
     id: tag.id,
-    type: tag["widget-type"] || getTemplateTagType(tag),
-    target: getTemplateTagParameterTarget(tag),
+    type: getParameterType(tag),
+    target: getParameterTarget(tag),
     name: tag["display-name"],
     slug: tag.name,
     default: tag.default,

--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -156,4 +156,4 @@ export interface TemplateTag {
   "snippet-name"?: string;
 }
 
-export type TemplateTags = { [key: TemplateTagName]: TemplateTag };
+export type TemplateTags = Record<TemplateTagName, TemplateTag>;

--- a/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
@@ -17,6 +17,7 @@ interface DateAllOptionsWidgetProps {
   required?: boolean;
   onClose: () => void;
   disableOperatorSelection?: boolean;
+  hideTimeSelectors?: boolean;
 }
 
 export const DateAllOptionsWidget = ({
@@ -27,6 +28,7 @@ export const DateAllOptionsWidget = ({
   defaultValue,
   initialValue,
   required = false,
+  hideTimeSelectors = false,
 }: DateAllOptionsWidgetProps) => {
   const [filter, setFilter] = useState(
     initialValue != null
@@ -49,6 +51,7 @@ export const DateAllOptionsWidget = ({
         onCommit={commitAndClose}
         hideEmptinessOperators
         disableOperatorSelection={disableOperatorSelection}
+        hideTimeSelectors={hideTimeSelectors}
         supportsExpressions
       >
         <UpdateFilterButton

--- a/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
+++ b/frontend/src/metabase/components/DateAllOptionsWidget/DateAllOptionsWidget.tsx
@@ -17,7 +17,6 @@ interface DateAllOptionsWidgetProps {
   required?: boolean;
   onClose: () => void;
   disableOperatorSelection?: boolean;
-  hideTimeSelectors?: boolean;
 }
 
 export const DateAllOptionsWidget = ({
@@ -28,7 +27,6 @@ export const DateAllOptionsWidget = ({
   defaultValue,
   initialValue,
   required = false,
-  hideTimeSelectors = false,
 }: DateAllOptionsWidgetProps) => {
   const [filter, setFilter] = useState(
     initialValue != null
@@ -51,7 +49,6 @@ export const DateAllOptionsWidget = ({
         onCommit={commitAndClose}
         hideEmptinessOperators
         disableOperatorSelection={disableOperatorSelection}
-        hideTimeSelectors={hideTimeSelectors}
         supportsExpressions
       >
         <UpdateFilterButton

--- a/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.stories.tsx
+++ b/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.stories.tsx
@@ -1,7 +1,7 @@
 import { useArgs } from "@storybook/client-api";
 import type { ComponentStory } from "@storybook/react";
 
-import DateMonthYearWidget from "./DateMonthYearWidget";
+import { DateMonthYearWidget } from "./DateMonthYearWidget";
 
 export default {
   title: "Parameters/DateMonthYearWidget",

--- a/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
+++ b/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.tsx
@@ -21,7 +21,7 @@ type State = {
   year: number;
 };
 
-class DateMonthYearWidget extends Component<Props, State> {
+export class DateMonthYearWidget extends Component<Props, State> {
   state: State = {
     month: null,
     year: moment().year(),
@@ -92,6 +92,3 @@ const Month = ({ month, selected, onClick }: MonthProp) => (
     {moment().month(month).format("MMMM")}
   </MonthRoot>
 );
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DateMonthYearWidget;

--- a/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/DateMonthYearWidget/DateMonthYearWidget.unit.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
-import DateMonthYearWidget from "./DateMonthYearWidget";
+import { DateMonthYearWidget } from "./DateMonthYearWidget";
 
 describe("DateMonthYearWidget", () => {
   it("should render correctly", () => {

--- a/frontend/src/metabase/components/DateMonthYearWidget/index.ts
+++ b/frontend/src/metabase/components/DateMonthYearWidget/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DateMonthYearWidget";
+export { DateMonthYearWidget } from "./DateMonthYearWidget";

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.stories.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.stories.tsx
@@ -1,7 +1,7 @@
 import { useArgs } from "@storybook/addons";
 import type { ComponentStory } from "@storybook/react";
 
-import DateQuarterYearWidget from "./DateQuarterYearWidget";
+import { DateQuarterYearWidget } from "./DateQuarterYearWidget";
 
 export default {
   title: "Parameters/DateQuarterYearWidget",

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
@@ -59,7 +59,7 @@ export class DateQuarterYearWidget extends Component<Props, State> {
     const { quarter, year } = this.state;
     return (
       <div className="py2">
-        <div className="flex flex-column align-center px1">
+        <div className="flex flex-column align-center py1">
           <YearPicker
             value={year}
             onChange={year => this.setState({ year: year })}

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
@@ -60,10 +60,7 @@ export class DateQuarterYearWidget extends Component<Props, State> {
     return (
       <div className="py2">
         <div className="flex flex-column align-center py1">
-          <YearPicker
-            value={year}
-            onChange={year => this.setState({ year: year })}
-          />
+          <YearPicker value={year} onChange={year => this.setState({ year })} />
         </div>
         <ol
           className="flex flex-wrap bordered mx2 text-bold rounded"

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.tsx
@@ -21,7 +21,7 @@ type State = {
   year: number;
 };
 
-class DateQuarterYearWidget extends Component<Props, State> {
+export class DateQuarterYearWidget extends Component<Props, State> {
   state: State = {
     quarter: null,
     year: moment().year(),
@@ -94,6 +94,3 @@ const Quarter = ({ quarter, selected, onClick }: QuarterProps) => (
     {moment().quarter(quarter).format(QUARTER_FORMAT_STRING)}
   </QuarterRoot>
 );
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DateQuarterYearWidget;

--- a/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/DateQuarterYearWidget.unit.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
-import DateQuarterYearWidget from "./DateQuarterYearWidget";
+import { DateQuarterYearWidget } from "./DateQuarterYearWidget";
 
 describe("DateQuarterYearWidget", () => {
   it("should render correctly", () => {

--- a/frontend/src/metabase/components/DateQuarterYearWidget/index.ts
+++ b/frontend/src/metabase/components/DateQuarterYearWidget/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DateQuarterYearWidget";
+export { DateQuarterYearWidget } from "./DateQuarterYearWidget";

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.stories.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.stories.tsx
@@ -1,7 +1,7 @@
 import { useArgs } from "@storybook/addons";
 import type { ComponentStory } from "@storybook/react";
 
-import DateRelativeWidget from "./DateRelativeWidget";
+import { DateRelativeWidget } from "./DateRelativeWidget";
 
 export default {
   title: "Parameters/DateRelativeWidget",

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
@@ -157,7 +157,7 @@ type DateRelativeWidgetProps = {
   onClose: () => void;
 };
 
-class DateRelativeWidget extends Component<DateRelativeWidgetProps> {
+export class DateRelativeWidget extends Component<DateRelativeWidgetProps> {
   constructor(props: DateRelativeWidgetProps) {
     super(props);
   }
@@ -185,6 +185,3 @@ class DateRelativeWidget extends Component<DateRelativeWidgetProps> {
     );
   }
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default DateRelativeWidget;

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.tsx
@@ -158,10 +158,6 @@ type DateRelativeWidgetProps = {
 };
 
 export class DateRelativeWidget extends Component<DateRelativeWidgetProps> {
-  constructor(props: DateRelativeWidgetProps) {
-    super(props);
-  }
-
   render() {
     const { value, setValue, onClose } = this.props;
     return (

--- a/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/DateRelativeWidget/DateRelativeWidget.unit.spec.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 
-import DateRelativeWidget from "./DateRelativeWidget";
+import { DateRelativeWidget } from "./DateRelativeWidget";
 
 describe("DateRelativeWidget", () => {
   it("should render correctly", () => {

--- a/frontend/src/metabase/components/DateRelativeWidget/index.ts
+++ b/frontend/src/metabase/components/DateRelativeWidget/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./DateRelativeWidget";
+export { DateRelativeWidget } from "./DateRelativeWidget";

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/OwnDatePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/OwnDatePicker.tsx
@@ -15,7 +15,6 @@ import {
   TextInputTrirgger,
 } from "./ParameterValuePicker.styled";
 
-// TODO popover z-index (select inside dropdown)
 export function OwnDatePicker(props: {
   value: any;
   parameter: Parameter;
@@ -60,8 +59,11 @@ export function OwnDatePicker(props: {
     ? undefined
     : { style: { pointerEvents: "none" } };
 
+  // TODO this should be removed as soon as we reconcile all dropdowns and make them use Mantine
+  const Z_INDEX = 2;
+
   return (
-    <Popover opened={isOpen}>
+    <Popover opened={isOpen} zIndex={Z_INDEX}>
       <Popover.Target>
         <TextInputTrirgger
           ref={setTriggerRef}
@@ -79,7 +81,7 @@ export function OwnDatePicker(props: {
           {DateWidget ? (
             <DateWidget
               value={value}
-              initialValue={getInitialDateValue(
+              initialValue={DEPRECATED_getInitialDateValue(
                 value,
                 parameter.type as ParameterType,
               )}
@@ -95,7 +97,11 @@ export function OwnDatePicker(props: {
   );
 }
 
-function getInitialDateValue(value: any, parameterType: ParameterType) {
+// TODO this should be in the Lib or somewhere else
+function DEPRECATED_getInitialDateValue(
+  value: string | undefined,
+  parameterType: ParameterType,
+) {
   if (value == null) {
     if (parameterType === "date/single") {
       return getIsoDate();

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/OwnDatePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/OwnDatePicker.tsx
@@ -1,0 +1,115 @@
+import { useClickOutside } from "@mantine/hooks";
+import { useState } from "react";
+import { t } from "ttag";
+
+import { DateAllOptionsWidget } from "metabase/components/DateAllOptionsWidget";
+import { DateMonthYearWidget } from "metabase/components/DateMonthYearWidget";
+import { DateQuarterYearWidget } from "metabase/components/DateQuarterYearWidget";
+import { DateRelativeWidget } from "metabase/components/DateRelativeWidget";
+import { formatParameterValue } from "metabase/parameters/utils/formatting";
+import { Popover } from "metabase/ui";
+import type { Parameter, ParameterType } from "metabase-types/api";
+
+import {
+  TextInputIcon,
+  TextInputTrirgger,
+} from "./ParameterValuePicker.styled";
+
+// TODO popover z-index (select inside dropdown)
+export function OwnDatePicker(props: {
+  value: any;
+  parameter: Parameter;
+  onValueChange: (value: any) => void;
+}) {
+  const { value, parameter, onValueChange } = props;
+  const [isOpen, setIsOpen] = useState(false);
+  const formatted = formatParameterValue(value, parameter);
+
+  const DateWidget = {
+    "date/relative": DateRelativeWidget,
+    "date/month-year": DateMonthYearWidget,
+    "date/quarter-year": DateQuarterYearWidget,
+    // pickers
+    "date/single": DateAllOptionsWidget,
+    "date/range": DateAllOptionsWidget,
+    "date/all-options": DateAllOptionsWidget,
+  }[parameter.type];
+
+  const openPopover = () => setIsOpen(true);
+  const closePopover = () => setIsOpen(false);
+
+  const [triggerRef, setTriggerRef] = useState<HTMLDivElement | null>(null);
+  const ref = useClickOutside(closePopover, null, [triggerRef]);
+
+  // console.log("OwnDatePicker", value, formatted);
+
+  const icon = value ? (
+    <TextInputIcon
+      name="close"
+      onClick={() => {
+        onValueChange(null);
+        setIsOpen(false);
+      }}
+    />
+  ) : (
+    <TextInputIcon name="chevrondown" />
+  );
+  // This is required to allow clicking through the "chevrondown" icon.
+  // Must be replaced with `rightSectionPointerEvents=none` after upgrade
+  const rightSectionProps = value
+    ? undefined
+    : { style: { pointerEvents: "none" } };
+
+  return (
+    <Popover opened={isOpen}>
+      <Popover.Target>
+        <TextInputTrirgger
+          ref={setTriggerRef}
+          value={typeof formatted === "string" ? formatted : value ?? ""} // required by Mantine
+          readOnly
+          placeholder={t`Select a default value…`}
+          onClick={openPopover}
+          rightSection={icon}
+          rightSectionProps={rightSectionProps}
+        />
+      </Popover.Target>
+
+      <Popover.Dropdown>
+        <div ref={ref}>
+          {DateWidget ? (
+            <DateWidget
+              value={value}
+              initialValue={getInitialDateValue(
+                value,
+                parameter.type as ParameterType,
+              )}
+              onClose={closePopover}
+              setValue={onValueChange}
+            />
+          ) : (
+            "<none>"
+          )}
+        </div>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}
+
+function getInitialDateValue(value: any, parameterType: ParameterType) {
+  if (value == null) {
+    if (parameterType === "date/single") {
+      return getIsoDate();
+    }
+
+    if (parameterType === "date/range") {
+      const now = getIsoDate();
+      return `${now}~${now}`;
+    }
+  }
+
+  return value;
+}
+
+function getIsoDate() {
+  return new Date().toISOString().slice(0, 10);
+}

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/OwnDatePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/OwnDatePicker.tsx
@@ -111,10 +111,12 @@ function DateComponentRouter(props: {
 
     case "date/single":
     case "date/range":
-    case "date/all-options":
       return (
         <DateAllOptionsWidget disableOperatorSelection {...componentProps} />
       );
+
+    case "date/all-options":
+      return <DateAllOptionsWidget {...componentProps} />;
   }
 
   // should never happen

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/OwnDatePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/OwnDatePicker.tsx
@@ -40,7 +40,7 @@ export function OwnDatePicker(props: {
       name="close"
       onClick={() => {
         onValueChange(null);
-        setIsOpen(false);
+        closePopover();
       }}
     />
   ) : (

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.styled.tsx
@@ -1,0 +1,14 @@
+import styled from "@emotion/styled";
+
+import { Icon, TextInput } from "metabase/ui";
+
+export const TextInputTrirgger = styled(TextInput)`
+  cursor: pointer;
+  input {
+    cursor: pointer;
+  }
+`;
+
+export const TextInputIcon = styled(Icon)`
+  cursor: pointer;
+`;

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.styled.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.styled.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled";
 
+import { color } from "metabase/lib/colors";
 import { Icon, TextInput } from "metabase/ui";
 
 export const TextInputTrirgger = styled(TextInput)`
@@ -11,4 +12,5 @@ export const TextInputTrirgger = styled(TextInput)`
 
 export const TextInputIcon = styled(Icon)`
   cursor: pointer;
+  color: ${color("text-dark")};
 `;

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
@@ -1,0 +1,112 @@
+import type { ChangeEvent, KeyboardEvent } from "react";
+import { useState } from "react";
+import _ from "underscore";
+
+import { DefaultParameterValueWidget } from "metabase/query_builder/components/template_tags/TagEditorParamParts";
+import { TextInput } from "metabase/ui";
+import type { Parameter, TemplateTag } from "metabase-types/api";
+
+import { isPlainInput } from "./core";
+
+interface ParameterValuePickerProps {
+  tag: TemplateTag;
+  parameter: Parameter;
+  initialValue: any;
+  onValueChange: (value: any) => void;
+  placeholder?: string;
+}
+
+export function ParameterValuePicker(props: ParameterValuePickerProps) {
+  const { tag, parameter, initialValue, onValueChange, placeholder } = props;
+
+  if (!parameter) {
+    return null;
+  }
+
+  if (isPlainInput(parameter)) {
+    return (
+      <PlainValueInput
+        initialValue={initialValue}
+        onValueChange={onValueChange}
+        placeholder={placeholder}
+      />
+    );
+  }
+
+  // The fallback
+  return (
+    <DefaultParameterValueWidget
+      parameter={getAmendedParameter(tag, parameter)}
+      value={initialValue}
+      setValue={onValueChange}
+      isEditing
+      commitImmediately
+      mimicMantine
+    />
+  );
+}
+
+interface PlainValueInputProps {
+  initialValue: any;
+  onValueChange: (value: any) => void;
+  placeholder?: string;
+}
+
+function PlainValueInput(props: PlainValueInputProps) {
+  const { initialValue, onValueChange, placeholder } = props;
+  const [value, setValue] = useState(initialValue);
+
+  const commit = (newValue: any) => {
+    setValue(newValue);
+    onValueChange(newValue);
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    commit(event.currentTarget.value);
+  };
+
+  const handleKeyup = (event: KeyboardEvent<HTMLInputElement>) => {
+    const target = event.target as HTMLInputElement;
+
+    switch (event.key) {
+      case "Enter":
+        commit(value);
+        target.blur();
+        break;
+      case "Escape":
+        target.blur();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <TextInput
+      value={value}
+      onChange={handleChange}
+      onKeyUp={handleKeyup}
+      placeholder={placeholder}
+    />
+  );
+}
+
+function getAmendedParameter(tag: TemplateTag, parameter: Parameter) {
+  const amended =
+    tag.type === "text" || tag.type === "dimension"
+      ? parameter || {
+          fields: [],
+          ...tag,
+          type: tag["widget-type"] || null,
+        }
+      : {
+          fields: [],
+          hasVariableTemplateTagTarget: true,
+          type:
+            tag["widget-type"] || (tag.type === "date" ? "date/single" : null),
+        };
+
+  // We want to remove "default" and "required" so that it
+  // doesn't show up in the default value input icon
+  return _.omit(amended, "default", "required");
+}

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import _ from "underscore";
 
 import { DefaultParameterValueWidget } from "metabase/query_builder/components/template_tags/TagEditorParamParts";
-import { TextInput } from "metabase/ui";
+import { Icon, TextInput } from "metabase/ui";
 import type { Parameter, TemplateTag } from "metabase-types/api";
 
 import { isPlainInput } from "./core";
@@ -54,6 +54,7 @@ interface PlainValueInputProps {
 
 function PlainValueInput(props: PlainValueInputProps) {
   const { initialValue, onValueChange, placeholder } = props;
+  // TODO must change when changing filter types
   const [value, setValue] = useState(initialValue);
 
   const commit = (newValue: any) => {
@@ -67,10 +68,9 @@ function PlainValueInput(props: PlainValueInputProps) {
 
   const handleKeyup = (event: KeyboardEvent<HTMLInputElement>) => {
     const target = event.target as HTMLInputElement;
-
     switch (event.key) {
       case "Enter":
-        commit(value);
+        onValueChange(value);
         target.blur();
         break;
       case "Escape":
@@ -87,9 +87,22 @@ function PlainValueInput(props: PlainValueInputProps) {
       onChange={handleChange}
       onKeyUp={handleKeyup}
       placeholder={placeholder}
+      rightSection={
+        value ? (
+          // TODO value must be null
+          <Icon cursor="pointer" name="close" onClick={() => commit("")} />
+        ) : null
+      }
     />
   );
 }
+
+// function getFirstValue(value: any) {
+//   if (Array.isArray(value)) {
+//     return value[0] ?? null;
+//   }
+//   return value;
+// }
 
 function getAmendedParameter(tag: TemplateTag, parameter: Parameter) {
   const amended =

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
@@ -6,7 +6,7 @@ import { DefaultParameterValueWidget } from "metabase/query_builder/components/t
 import { Icon, TextInput } from "metabase/ui";
 import type { Parameter, TemplateTag } from "metabase-types/api";
 
-import { isPlainInput } from "./core";
+import { shouldUseNew } from "./core";
 
 interface ParameterValuePickerProps {
   tag: TemplateTag;
@@ -16,6 +16,7 @@ interface ParameterValuePickerProps {
   placeholder?: string;
 }
 
+// TODO must change value when type is changed
 export function ParameterValuePicker(props: ParameterValuePickerProps) {
   const { tag, parameter, initialValue, onValueChange, placeholder } = props;
 
@@ -23,7 +24,7 @@ export function ParameterValuePicker(props: ParameterValuePickerProps) {
     return null;
   }
 
-  if (isPlainInput(parameter)) {
+  if (shouldUseNew(parameter)) {
     return (
       <PlainValueInput
         initialValue={initialValue}

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
@@ -1,19 +1,19 @@
+import { useClickOutside } from "@mantine/hooks";
 import type { ChangeEvent, KeyboardEvent } from "react";
 import { useState } from "react";
 import _ from "underscore";
 
+import { DateAllOptionsWidget } from "metabase/components/DateAllOptionsWidget";
+import { DateMonthYearWidget } from "metabase/components/DateMonthYearWidget";
+import { DateQuarterYearWidget } from "metabase/components/DateQuarterYearWidget";
+import { DateRelativeWidget } from "metabase/components/DateRelativeWidget";
+import { formatParameterValue } from "metabase/parameters/utils/formatting";
 import { DefaultParameterValueWidget } from "metabase/query_builder/components/template_tags/TagEditorParamParts";
 import { Icon, Popover, TextInput } from "metabase/ui";
+import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
 import type { Parameter, ParameterType, TemplateTag } from "metabase-types/api";
 
 import { shouldShowPlainInput } from "./core";
-import { DateAllOptionsWidget } from "metabase/components/DateAllOptionsWidget";
-import { formatParameterValue } from "metabase/parameters/utils/formatting";
-import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
-import { DateRelativeWidget } from "metabase/components/DateRelativeWidget";
-import { DateMonthYearWidget } from "metabase/components/DateMonthYearWidget";
-import { DateQuarterYearWidget } from "metabase/components/DateQuarterYearWidget";
-import { useClickOutside } from "@mantine/hooks";
 
 interface ParameterValuePickerProps {
   tag: TemplateTag;
@@ -32,7 +32,7 @@ export function ParameterValuePicker(props: ParameterValuePickerProps) {
     return null;
   }
 
-  console.log("param", parameter);
+  // console.log("param", parameter);
 
   if (shouldShowPlainInput(parameter)) {
     return (
@@ -208,7 +208,6 @@ function OwnDatePicker(props: {
               )}
               onClose={() => setIsOpen(false)}
               setValue={onValueChange}
-              hideTimeSelectors
             />
           ) : (
             "<none>"
@@ -222,14 +221,18 @@ function OwnDatePicker(props: {
 function getInitialDateValue(value: any, parameterType: ParameterType) {
   if (value == null) {
     if (parameterType === "date/single") {
-      return new Date().toISOString().slice(0, 10);
+      return getIsoDate();
     }
 
     if (parameterType === "date/range") {
-      const now = new Date().toISOString().slice(0, 10);
+      const now = getIsoDate();
       return `${now}~${now}`;
     }
   }
 
   return value;
+}
+
+function getIsoDate() {
+  return new Date().toISOString().slice(0, 10);
 }

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
@@ -33,7 +33,7 @@ interface ParameterValuePickerProps {
 // TODO must change value when type is changed
 // TODO setting default value on blur/closing picker
 // TODO error states
-// TODO placeholders
+// TODO placeholders unification
 // TODO filter input for numbers
 export function ParameterValuePicker(props: ParameterValuePickerProps) {
   const {
@@ -143,6 +143,11 @@ function OwnDatePicker(props: {
   ) : (
     <TextInputIcon name="chevrondown" />
   );
+  // This is required to allow clicking through the "chevrondown" icon.
+  // Must be replaced with `rightSectionPointerEvents=none` after upgrade
+  const rightSectionProps = value
+    ? undefined
+    : { style: { pointerEvents: "none" } };
 
   return (
     <Popover opened={isOpen}>
@@ -154,6 +159,7 @@ function OwnDatePicker(props: {
           placeholder={t`Select a default value…`}
           onClick={openPopover}
           rightSection={icon}
+          rightSectionProps={rightSectionProps}
         />
       </Popover.Target>
 

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
@@ -33,8 +33,6 @@ export function ParameterValuePicker(props: ParameterValuePickerProps) {
     return null;
   }
 
-  // console.log("param", parameter);
-
   if (shouldShowPlainInput(parameter)) {
     return (
       <PlainValueInput

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
@@ -21,6 +21,7 @@ interface ParameterValuePickerProps {
 // TODO error states
 // TODO placeholders unification
 // TODO filter input for numbers
+
 /**
  * This component is designed to be controlled outside,
  * without keeping its own state.

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
@@ -1,6 +1,7 @@
 import { useClickOutside } from "@mantine/hooks";
 import type { ChangeEvent, KeyboardEvent } from "react";
 import { useState } from "react";
+import { t } from "ttag";
 import _ from "underscore";
 
 import { DateAllOptionsWidget } from "metabase/components/DateAllOptionsWidget";
@@ -25,6 +26,7 @@ interface ParameterValuePickerProps {
 
 // TODO make controlled outside
 // TODO must change value when type is changed
+// TODO setting default value on blur/closing picker
 export function ParameterValuePicker(props: ParameterValuePickerProps) {
   const { tag, parameter, initialValue, onValueChange, placeholder } = props;
 
@@ -177,7 +179,7 @@ function OwnDatePicker(props: {
           <TextInput
             value={typeof formatted === "string" ? formatted : value}
             readOnly
-            placeholder="Select a default value..."
+            placeholder={t`Select a default value…`}
             onClick={() => setIsOpen(true)}
             rightSection={
               value ? (

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
@@ -1,22 +1,10 @@
-import { useClickOutside } from "@mantine/hooks";
-import { useState } from "react";
-import { t } from "ttag";
 import _ from "underscore";
 
-import { DateAllOptionsWidget } from "metabase/components/DateAllOptionsWidget";
-import { DateMonthYearWidget } from "metabase/components/DateMonthYearWidget";
-import { DateQuarterYearWidget } from "metabase/components/DateQuarterYearWidget";
-import { DateRelativeWidget } from "metabase/components/DateRelativeWidget";
-import { formatParameterValue } from "metabase/parameters/utils/formatting";
 import { DefaultParameterValueWidget } from "metabase/query_builder/components/template_tags/TagEditorParamParts";
-import { Popover } from "metabase/ui";
 import { isDateParameter } from "metabase-lib/parameters/utils/parameter-type";
-import type { Parameter, ParameterType, TemplateTag } from "metabase-types/api";
+import type { Parameter, TemplateTag } from "metabase-types/api";
 
-import {
-  TextInputIcon,
-  TextInputTrirgger,
-} from "./ParameterValuePicker.styled";
+import { OwnDatePicker } from "./OwnDatePicker";
 import { PlainValueInput } from "./PlainValueInput";
 import { shouldShowPlainInput } from "./core";
 
@@ -29,20 +17,16 @@ interface ParameterValuePickerProps {
 }
 
 // TODO multiple value pickers
-// TODO make controlled outside
-// TODO must change value when type is changed
 // TODO setting default value on blur/closing picker
 // TODO error states
 // TODO placeholders unification
 // TODO filter input for numbers
+/**
+ * This component is designed to be controlled outside,
+ * without keeping its own state.
+ */
 export function ParameterValuePicker(props: ParameterValuePickerProps) {
-  const {
-    tag,
-    parameter,
-    value: initialValue,
-    onValueChange,
-    placeholder,
-  } = props;
+  const { tag, parameter, value, onValueChange, placeholder } = props;
 
   if (!parameter) {
     return null;
@@ -53,7 +37,7 @@ export function ParameterValuePicker(props: ParameterValuePickerProps) {
   if (shouldShowPlainInput(parameter)) {
     return (
       <PlainValueInput
-        value={initialValue}
+        value={value}
         onChange={onValueChange}
         placeholder={placeholder}
       />
@@ -63,7 +47,7 @@ export function ParameterValuePicker(props: ParameterValuePickerProps) {
   if (isDateParameter(parameter)) {
     return (
       <OwnDatePicker
-        value={initialValue}
+        value={value}
         parameter={parameter}
         onValueChange={onValueChange}
       />
@@ -73,8 +57,8 @@ export function ParameterValuePicker(props: ParameterValuePickerProps) {
   // The fallback
   return (
     <DefaultParameterValueWidget
-      parameter={getAmendedParameter(tag, parameter)}
-      value={initialValue}
+      parameter={DEPRECATED_getAmendedParameter(tag, parameter)}
+      value={value}
       setValue={onValueChange}
       isEditing
       commitImmediately
@@ -83,7 +67,10 @@ export function ParameterValuePicker(props: ParameterValuePickerProps) {
   );
 }
 
-function getAmendedParameter(tag: TemplateTag, parameter: Parameter) {
+function DEPRECATED_getAmendedParameter(
+  tag: TemplateTag,
+  parameter: Parameter,
+) {
   const amended =
     tag.type === "text" || tag.type === "dimension"
       ? parameter || {
@@ -101,103 +88,4 @@ function getAmendedParameter(tag: TemplateTag, parameter: Parameter) {
   // We want to remove "default" and "required" so that it
   // doesn't show up in the default value input icon
   return _.omit(amended, "default", "required");
-}
-
-// TODO popover z-index (select inside dropdown)
-function OwnDatePicker(props: {
-  value: any;
-  parameter: Parameter;
-  onValueChange: (value: any) => void;
-}) {
-  const { value, parameter, onValueChange } = props;
-  const [isOpen, setIsOpen] = useState(false);
-  const formatted = formatParameterValue(value, parameter);
-
-  const DateWidget = {
-    "date/relative": DateRelativeWidget,
-    "date/month-year": DateMonthYearWidget,
-    "date/quarter-year": DateQuarterYearWidget,
-    // pickers
-    "date/single": DateAllOptionsWidget,
-    "date/range": DateAllOptionsWidget,
-    "date/all-options": DateAllOptionsWidget,
-  }[parameter.type];
-
-  const openPopover = () => setIsOpen(true);
-  const closePopover = () => setIsOpen(false);
-
-  const [triggerRef, setTriggerRef] = useState<HTMLDivElement | null>(null);
-  const ref = useClickOutside(closePopover, null, [triggerRef]);
-
-  // console.log("OwnDatePicker", value, formatted);
-
-  const icon = value ? (
-    <TextInputIcon
-      name="close"
-      onClick={() => {
-        onValueChange(null);
-        setIsOpen(false);
-      }}
-    />
-  ) : (
-    <TextInputIcon name="chevrondown" />
-  );
-  // This is required to allow clicking through the "chevrondown" icon.
-  // Must be replaced with `rightSectionPointerEvents=none` after upgrade
-  const rightSectionProps = value
-    ? undefined
-    : { style: { pointerEvents: "none" } };
-
-  return (
-    <Popover opened={isOpen}>
-      <Popover.Target>
-        <TextInputTrirgger
-          ref={setTriggerRef}
-          value={typeof formatted === "string" ? formatted : value ?? ""} // required by Mantine
-          readOnly
-          placeholder={t`Select a default value…`}
-          onClick={openPopover}
-          rightSection={icon}
-          rightSectionProps={rightSectionProps}
-        />
-      </Popover.Target>
-
-      <Popover.Dropdown>
-        <div ref={ref}>
-          {DateWidget ? (
-            <DateWidget
-              value={value}
-              initialValue={getInitialDateValue(
-                value,
-                parameter.type as ParameterType,
-              )}
-              onClose={closePopover}
-              setValue={onValueChange}
-            />
-          ) : (
-            "<none>"
-          )}
-        </div>
-      </Popover.Dropdown>
-    </Popover>
-  );
-}
-
-function getInitialDateValue(value: any, parameterType: ParameterType) {
-  if (value == null) {
-    if (parameterType === "date/single") {
-      return getIsoDate();
-    }
-
-    if (parameterType === "date/range") {
-      const now = getIsoDate();
-      return `${now}~${now}`;
-    }
-  }
-
-  return value;
-}
-
-function getIsoDate() {
-  return new Date().toISOString().slice(0, 10);
 }

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ParameterValuePicker.tsx
@@ -103,7 +103,6 @@ function getAmendedParameter(tag: TemplateTag, parameter: Parameter) {
   return _.omit(amended, "default", "required");
 }
 
-// TODO value should reset when changing types
 // TODO popover z-index (select inside dropdown)
 function OwnDatePicker(props: {
   value: any;

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/PlainValueInput.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/PlainValueInput.tsx
@@ -1,0 +1,47 @@
+import type { ChangeEvent, KeyboardEvent } from "react";
+
+import { TextInput } from "metabase/ui";
+
+import { TextInputIcon } from "./ParameterValuePicker.styled";
+
+interface PlainValueInputProps {
+  value: string | null;
+  onChange: (value: string | null) => void;
+  placeholder?: string;
+}
+
+/**
+ * It is intentional that this input is controlled from the outside
+ * and doesn't have its own state.
+ */
+export function PlainValueInput(props: PlainValueInputProps) {
+  const { value, onChange, placeholder } = props;
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(event.currentTarget.value);
+  };
+
+  const handleKeyup = (event: KeyboardEvent<HTMLInputElement>) => {
+    const target = event.target as HTMLInputElement;
+    switch (event.key) {
+      // Values are "committed" immediately because it's controlled from the outside
+      case "Enter":
+      case "Escape":
+        target.blur();
+    }
+  };
+
+  const icon = value ? (
+    <TextInputIcon name="close" onClick={() => onChange(null)} />
+  ) : null;
+
+  return (
+    <TextInput
+      value={value ?? ""} // required by Mantine
+      onChange={handleChange}
+      onKeyUp={handleKeyup}
+      placeholder={placeholder}
+      rightSection={icon}
+    />
+  );
+}

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
@@ -1,27 +1,52 @@
+// import {
+//   getNumberParameterArity,
+//   getStringParameterArity,
+// } from "metabase-lib/parameters/utils/operators";
 import {
-  getNumberParameterArity,
-  getStringParameterArity,
-} from "metabase-lib/parameters/utils/operators";
-import {
+  getParameterSubType,
   isNumberParameter,
-  isStringParameter,
+  // isStringParameter,
 } from "metabase-lib/parameters/utils/parameter-type";
 import type { Parameter } from "metabase-types/api";
 
 export function isPlainInput(parameter: Parameter) {
-  if (
-    isStringParameter(parameter) &&
-    getStringParameterArity(parameter) === 1
-  ) {
-    return true;
+  // TODO this is a way to distinguish a field selector from the others
+  // isFieldFilterParameter or similar should be used here
+  const hasFields = Boolean((parameter as any).fields);
+  if (hasFields) {
+    return false;
   }
 
-  if (
-    isNumberParameter(parameter) &&
-    getNumberParameterArity(parameter) === 1
-  ) {
+  // TODO this is current behavior, although for number/= we MIGHT
+  // allow picking multiple values, so it should eventually take arity into account
+  if (isNumberParameter(parameter)) {
+    const subtype = getParameterSubType(parameter);
+    return subtype === "=";
+  }
+
+  // TODO this means "string" selected in native query tag editor
+  // sidebar.
+  // Although we did show a popup previously values_query_type in ('list', 'search'),
+  // it was still a single value
+  if (parameter.type === "category") {
     return true;
   }
 
   return false;
+
+  // if (
+  //   isStringParameter(parameter) &&
+  //   getStringParameterArity(parameter) === 1
+  // ) {
+  //   return true;
+  // }
+
+  // if (
+  //   isNumberParameter(parameter) &&
+  //   getNumberParameterArity(parameter) === 1
+  // ) {
+  //   return true;
+  // }
+
+  // return false;
 }

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
@@ -1,0 +1,27 @@
+import {
+  getNumberParameterArity,
+  getStringParameterArity,
+} from "metabase-lib/parameters/utils/operators";
+import {
+  isNumberParameter,
+  isStringParameter,
+} from "metabase-lib/parameters/utils/parameter-type";
+import type { Parameter } from "metabase-types/api";
+
+export function isPlainInput(parameter: Parameter) {
+  if (
+    isStringParameter(parameter) &&
+    getStringParameterArity(parameter) === 1
+  ) {
+    return true;
+  }
+
+  if (
+    isNumberParameter(parameter) &&
+    getNumberParameterArity(parameter) === 1
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
@@ -1,6 +1,5 @@
 import {
   getParameterSubType,
-  isDateParameter,
   isNumberParameter,
 } from "metabase-lib/parameters/utils/parameter-type";
 import type { Parameter } from "metabase-types/api";
@@ -33,10 +32,4 @@ export function shouldShowPlainInput(parameter: Parameter) {
   }
 
   return false;
-}
-
-export function shouldShowDatePicker(parameter: Parameter) {
-  return (
-    isDateParameter(parameter) && getParameterSubType(parameter) === "single"
-  );
 }

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
@@ -19,10 +19,7 @@ export function shouldShowPlainInput(parameter: Parameter) {
     return subtype === "=";
   }
 
-  // TODO this means "string" selected in native query tag editor
-  // sidebar.
-  // Although we did show a popup previously values_query_type in ('list', 'search'),
-  // it was still a single value
+  // TODO this means "string" + "input box" is selected
   if (
     parameter.type === "category" &&
     (parameter.values_query_type == null ||

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
@@ -1,15 +1,11 @@
-// import {
-//   getNumberParameterArity,
-//   getStringParameterArity,
-// } from "metabase-lib/parameters/utils/operators";
 import {
   getParameterSubType,
+  isDateParameter,
   isNumberParameter,
-  // isStringParameter,
 } from "metabase-lib/parameters/utils/parameter-type";
 import type { Parameter } from "metabase-types/api";
 
-export function shouldUseNew(parameter: Parameter) {
+export function shouldShowPlainInput(parameter: Parameter) {
   // TODO this is a way to distinguish a field selector from the others
   // isFieldFilterParameter or similar should be used here
   const hasFields = Boolean((parameter as any).fields);
@@ -37,20 +33,10 @@ export function shouldUseNew(parameter: Parameter) {
   }
 
   return false;
+}
 
-  // if (
-  //   isStringParameter(parameter) &&
-  //   getStringParameterArity(parameter) === 1
-  // ) {
-  //   return true;
-  // }
-
-  // if (
-  //   isNumberParameter(parameter) &&
-  //   getNumberParameterArity(parameter) === 1
-  // ) {
-  //   return true;
-  // }
-
-  // return false;
+export function shouldShowDatePicker(parameter: Parameter) {
+  return (
+    isDateParameter(parameter) && getParameterSubType(parameter) === "single"
+  );
 }

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
@@ -9,7 +9,7 @@ import {
 } from "metabase-lib/parameters/utils/parameter-type";
 import type { Parameter } from "metabase-types/api";
 
-export function isPlainInput(parameter: Parameter) {
+export function shouldUseNew(parameter: Parameter) {
   // TODO this is a way to distinguish a field selector from the others
   // isFieldFilterParameter or similar should be used here
   const hasFields = Boolean((parameter as any).fields);

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/core.ts
@@ -28,7 +28,11 @@ export function isPlainInput(parameter: Parameter) {
   // sidebar.
   // Although we did show a popup previously values_query_type in ('list', 'search'),
   // it was still a single value
-  if (parameter.type === "category") {
+  if (
+    parameter.type === "category" &&
+    (parameter.values_query_type == null ||
+      parameter.values_query_type === "none")
+  ) {
     return true;
   }
 

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/index.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/index.tsx
@@ -1,0 +1,1 @@
+export { ParameterValuePicker } from "./ParameterValuePicker";

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -1,6 +1,6 @@
 import cx from "classnames";
 import PropTypes from "prop-types";
-import { createRef, Component, useEffect } from "react";
+import { createRef, Component } from "react";
 import { t } from "ttag";
 
 import { DateAllOptionsWidget } from "metabase/components/DateAllOptionsWidget";

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -1,13 +1,13 @@
 import cx from "classnames";
 import PropTypes from "prop-types";
-import { createRef, Component } from "react";
+import { createRef, Component, useEffect } from "react";
 import { t } from "ttag";
 
 import { DateAllOptionsWidget } from "metabase/components/DateAllOptionsWidget";
-import DateMonthYearWidget from "metabase/components/DateMonthYearWidget";
-import DateQuarterYearWidget from "metabase/components/DateQuarterYearWidget";
+import { DateMonthYearWidget } from "metabase/components/DateMonthYearWidget";
+import { DateQuarterYearWidget } from "metabase/components/DateQuarterYearWidget";
 import { DateRangeWidget } from "metabase/components/DateRangeWidget";
-import DateRelativeWidget from "metabase/components/DateRelativeWidget";
+import { DateRelativeWidget } from "metabase/components/DateRelativeWidget";
 import { DateSingleWidget } from "metabase/components/DateSingleWidget";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import { TextWidget } from "metabase/components/TextWidget";

--- a/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
+++ b/frontend/src/metabase/query_builder/actions/core/updateQuestion.ts
@@ -88,9 +88,8 @@ function shouldTemplateTagEditorBeVisible({
     return true;
   } else if (nextTags.length === 0) {
     return false;
-  } else {
-    return isVisible;
   }
+  return isVisible;
 }
 
 export type UpdateQuestionOpts = {

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.tsx
@@ -103,6 +103,9 @@ class TagEditorParamInner extends Component<Props> {
 
       setTemplateTag({
         ...newTag,
+        // When we change widget types (e.g. date/relative -> date/single)
+        // the previous default is likely to be incorrect
+        default: null,
         options: getDefaultParameterOptions(newTag),
       });
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
@@ -227,6 +227,7 @@ describe("TagEditorParam", () => {
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
+        default: null,
         "widget-type": "string/contains",
         options: { "case-sensitive": false },
       });
@@ -248,6 +249,7 @@ describe("TagEditorParam", () => {
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
+        default: null,
         "widget-type": "string/=",
         options: undefined,
       });

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
@@ -1,15 +1,12 @@
 import { t } from "ttag";
 import _ from "underscore";
 
+import { ParameterValuePicker } from "metabase/parameters/components/ParameterValuePicker";
 import { RequiredParamToggle } from "metabase/parameters/components/RequiredParamToggle";
 import { Flex, Text } from "metabase/ui";
 import type { Parameter, TemplateTag } from "metabase-types/api";
 
-import {
-  ContainerLabel,
-  DefaultParameterValueWidget,
-  ErrorSpan,
-} from "./TagEditorParam.styled";
+import { ContainerLabel, ErrorSpan } from "./TagEditorParam.styled";
 
 export function DefaultRequiredValueControl({
   tag,
@@ -24,40 +21,22 @@ export function DefaultRequiredValueControl({
   onChangeDefaultValue: (value: any) => void;
   onChangeRequired: (value: boolean) => void;
 }) {
-  // We want to remove "default" and "required" so that it
-  // doesn't show up in the default value input update button
-  const parameterAmended = _.omit(
-    tag.type === "text" || tag.type === "dimension"
-      ? parameter || {
-          fields: [],
-          ...tag,
-          type: tag["widget-type"] || null,
-        }
-      : {
-          fields: [],
-          hasVariableTemplateTagTarget: true,
-          type:
-            tag["widget-type"] || (tag.type === "date" ? "date/single" : null),
-        },
-    "default",
-    "required",
-  );
+  const isMissing = tag.required && !tag.default;
 
   return (
     <div>
       <ContainerLabel>
         {t`Default filter widget value`}
-        {!tag.default && tag.required && <ErrorSpan>({t`required`})</ErrorSpan>}
+        {isMissing && <ErrorSpan>({t`required`})</ErrorSpan>}
       </ContainerLabel>
 
       <Flex gap="xs" direction="column">
-        <DefaultParameterValueWidget
-          parameter={parameterAmended}
-          value={tag.default}
-          setValue={onChangeDefaultValue}
-          isEditing
-          commitImmediately
-          mimicMantine
+        <ParameterValuePicker
+          tag={tag}
+          parameter={parameter}
+          initialValue={tag.default}
+          onValueChange={onChangeDefaultValue}
+          placeholder={t`Enter a default value…`}
         />
 
         <RequiredParamToggle

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
@@ -34,7 +34,7 @@ export function DefaultRequiredValueControl({
         <ParameterValuePicker
           tag={tag}
           parameter={parameter}
-          initialValue={tag.default}
+          value={parameter.value ?? tag.default}
           onValueChange={onChangeDefaultValue}
           placeholder={t`Enter a default value…`}
         />

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/DefaultRequiredValueControl.tsx
@@ -34,7 +34,7 @@ export function DefaultRequiredValueControl({
         <ParameterValuePicker
           tag={tag}
           parameter={parameter}
-          value={parameter.value ?? tag.default}
+          value={tag.default}
           onValueChange={onChangeDefaultValue}
           placeholder={t`Enter a default value…`}
         />

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FilterWidgetTypeSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FilterWidgetTypeSelect.tsx
@@ -41,6 +41,8 @@ export function FilterWidgetTypeSelect({
     <InputContainer>
       <ContainerLabel>
         {t`Filter widget type`}
+        {/* TODO this might be incorrect, because we allow running the query (see sql-field-filter e2e test)
+            but show "required" here despite it's None */}
         {hasNoWidgetType && <ErrorSpan>({t`required`})</ErrorSpan>}
       </ContainerLabel>
 

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FilterWidgetTypeSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/FilterWidgetTypeSelect.tsx
@@ -50,6 +50,7 @@ export function FilterWidgetTypeSelect({
         placeholder={t`Select…`}
         data={optionsOrDefault}
         data-testid="filter-widget-type-select"
+        disabled={optionsOrDefault.length === 1}
       />
 
       {!hasOptions && (

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/VariableTypeSelect.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParamParts/VariableTypeSelect.tsx
@@ -5,6 +5,13 @@ import type { TemplateTagType } from "metabase-types/api";
 
 import { ContainerLabel, InputContainer } from "./TagEditorParam.styled";
 
+const OPTIONS: Array<{ value: TemplateTagType; label: string }> = [
+  { value: "text", label: t`Text` },
+  { value: "number", label: t`Number` },
+  { value: "date", label: t`Date` },
+  { value: "dimension", label: t`Field Filter` },
+];
+
 export function VariableTypeSelect(props: {
   value: TemplateTagType;
   onChange: (value: TemplateTagType) => void;
@@ -16,12 +23,7 @@ export function VariableTypeSelect(props: {
         value={props.value}
         placeholder={t`Select…`}
         onChange={props.onChange}
-        data={[
-          { value: "text", label: t`Text` },
-          { value: "number", label: t`Number` },
-          { value: "date", label: t`Date` },
-          { value: "dimension", label: t`Field Filter` },
-        ]}
+        data={OPTIONS}
         data-testid="variable-type-select"
       ></Select>
     </InputContainer>


### PR DESCRIPTION
Part of [[Epic] Better UI/UX for picking default parameter values](https://github.com/metabase/metabase/issues/39211)

## What's done
We start from updating Default value picker in Native queries.

This PR does the following:

- 🐞 fixes: when we reset widget type (think `date/relative` -> `date/single`), reset the default value too
- 🐞 fixes ugly year picker lacking gap with the quarter selector in Quarter and Year picker
- disables Filter widget type when it has a single value (ID or None)
- uses Mantine for a single number (when you selected Number) or string (String + Input box)
- uses Mantine for date picker popovers
- stops using moment for generating ISO-style dates 2024-03-06
- tidies up `template-tags` utils

### How is it done
Instead of changing the original `ParameterValueWidget`, I have built a `ParameterValuePicker` component which reuses the former internally. 

```
tag, parameter -> ParameterValuePicker -> can I render it? ---YES--> do it
                                                          \---NO---> defer to ParameterValueWidget
```

With this approach, we can:
- precisely control what is rendered by the new component (it defaults to `false`)
- selectively roll out the change by choosing which components use `ParameterValuePicker`
- in case something breaks, easily revert the changes
- once we're done with Native queries, reuse the component for Dashboard parameters

### Component design
I deliberately made the component sub-tree (until it reaches `Date*` widgets) stateless. This way we don't struggle with the mismatch between the internal component state and what's coming to it from the store.

This was previously controlled by `commitImmediately` but as of this PR, I don't see why we would need internal state, which makes internals more complicated.

## Why it is done
- we still need to transition to Mantine and match UIs 
- there are multiple bugs and inadequacies in the current default value picking flow

## Screencast
Everything except shown in the screencast remains unchanged.

https://github.com/metabase/metabase/assets/2196347/9e9a9ba4-25ea-4310-8a3e-a8ca74ce954b

## Tests
- reset default value when changing widget type: covered by `sql-field-filter-[date|number|string].cy.spec.js`
- disabled widget type select: covered by `sql-field-filter.cy.spec.js`,  `31606.cy.spec.js`, `TagEditorParam.unit.spec.tsx`