### PR TITLE
Differentiate `UserSettings` type from the rest of the `Settings`

### DIFF
--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -8,7 +8,6 @@ import type {
   Settings,
   TokenFeatures,
   TokenStatus,
-  UserSettings,
   Version,
   VersionInfo,
   VersionInfoRecord,
@@ -134,7 +133,7 @@ export const createMockSettingDefinition = (
 });
 
 export const createMockSettings = (
-  opts?: Partial<Settings | EnterpriseSettings | UserSettings>,
+  opts?: Partial<Settings | EnterpriseSettings>,
 ): EnterpriseSettings => ({
   "admin-email": "admin@metabase.test",
   "anon-tracking-enabled": false,

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -8,6 +8,7 @@ import type {
   Settings,
   TokenFeatures,
   TokenStatus,
+  UserSettings,
   Version,
   VersionInfo,
   VersionInfoRecord,
@@ -133,7 +134,7 @@ export const createMockSettingDefinition = (
 });
 
 export const createMockSettings = (
-  opts?: Partial<Settings | EnterpriseSettings>,
+  opts?: Partial<Settings | EnterpriseSettings | UserSettings>,
 ): EnterpriseSettings => ({
   "admin-email": "admin@metabase.test",
   "anon-tracking-enabled": false,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -190,7 +190,7 @@ export interface OpenAiModel {
 
 export type HelpLinkSetting = "metabase" | "hidden" | "custom";
 
-export interface Settings extends UserSettings {
+interface InstanceSettings {
   "active-users-count"?: number;
   "admin-email": string;
   "anon-tracking-enabled": boolean;
@@ -290,6 +290,8 @@ export interface UserSettings {
   "dismissed-custom-dashboard-toast"?: boolean;
   "last-used-native-database-id"?: number | null;
 }
+
+export type Settings = InstanceSettings & UserSettings;
 
 export type SettingKey = keyof Settings;
 

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -190,7 +190,7 @@ export interface OpenAiModel {
 
 export type HelpLinkSetting = "metabase" | "hidden" | "custom";
 
-export interface Settings {
+export interface Settings extends UserSettings {
   "active-users-count"?: number;
   "admin-email": string;
   "anon-tracking-enabled": boolean;

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -205,8 +205,6 @@ export interface Settings {
   "custom-homepage": boolean;
   "custom-homepage-dashboard": number | null;
   "deprecation-notice-version"?: string;
-  "dismissed-browse-models-banner"?: boolean;
-  "dismissed-custom-dashboard-toast"?: boolean;
   "ee-openai-api-key"?: string;
   "email-configured?": boolean;
   "embedding-app-origin": string;
@@ -285,6 +283,11 @@ export interface Settings {
   "user-visibility": string | null;
   "last-acknowledged-version": string | null;
   "show-static-embed-terms": boolean | null;
+}
+
+export interface UserSettings {
+  "dismissed-browse-models-banner"?: boolean;
+  "dismissed-custom-dashboard-toast"?: boolean;
   "last-used-native-database-id"?: number | null;
 }
 

--- a/frontend/src/metabase/redux/settings.ts
+++ b/frontend/src/metabase/redux/settings.ts
@@ -3,6 +3,7 @@ import { createAsyncThunk, createReducer } from "@reduxjs/toolkit";
 import { createThunkAction } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 import { SessionApi, SettingsApi } from "metabase/services";
+import type { UserSettings } from "metabase-types/api";
 
 export const REFRESH_SITE_SETTINGS = "metabase/settings/REFRESH_SITE_SETTINGS";
 
@@ -37,7 +38,10 @@ export const settings = createReducer(
 export const UPDATE_USER_SETTING = "metabase/settings/UPDATE_USER_SETTING";
 export const updateUserSetting = createThunkAction(
   UPDATE_USER_SETTING,
-  function (setting) {
+  function <K extends keyof UserSettings>(setting: {
+    key: K;
+    value: UserSettings[K];
+  }) {
     return async function (dispatch) {
       try {
         await SettingsApi.put(setting);


### PR DESCRIPTION
### Description

This PR introduces a new type called `UserSettings` to differentiate it from the rest of the `Settings`.
It also brings type safety to the `updateUserSetting` action.

### How to verify

Try passing a wrong key or a wrong value to the `updateUserSetting` action. TS should complain.

### Demo

Wrong key:
![image](https://github.com/metabase/metabase/assets/31325167/599f1d91-dd5b-452c-ae59-66d3f0eb584f)

Correct key, wrong value
![image](https://github.com/metabase/metabase/assets/31325167/b486c14d-7799-4cc1-9202-56efaf66cb9d)

### Additional Info
This is a follow-up after #39251 and #39359