### PR TITLE
Add build start slack message

### DIFF
--- a/.github/workflows/build-for-release.yml
+++ b/.github/workflows/build-for-release.yml
@@ -13,6 +13,34 @@ on:
         required: true
 
 jobs:
+  start-message:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          sparse-checkout: release
+      - name: Prepare build scripts
+        run: cd ${{ github.workspace }}/release && yarn && yarn build
+      - name: Send build start message
+        uses: actions/github-script@v6
+        env:
+          SLACK_RELEASE_CHANNEL: ${{ vars.SLACK_RELEASE_CHANNEL }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          script: | # js
+            const { sendReleaseMessage } = require('${{ github.workspace }}/release/dist/index.cjs');
+
+            await sendReleaseMessage({
+              stage: 'build-start',
+              github,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              version: '${{ inputs.version }}',
+              runId: '${{ github.run_id }}',
+              releaseSha: '${{ inputs.commit }}',
+            }).catch(console.error);
+
   check-version:
     runs-on: ubuntu-22.04
     timeout-minutes: 10

--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -36,6 +36,11 @@ export const getCanonicalVersion = (
     : getOSSVersion(versionString);
 };
 
+export const getGenericVersion = (versionString: string) => {
+  // turn v0.88.0 into 88.0
+  return getOSSVersion(versionString).replace(/v0\./, "");
+};
+
 export const getVersionType = (versionString: string) => {
   if (!isValidVersionString(versionString)) {
     throw new Error(`Invalid version string: ${versionString}`);

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -9,6 +9,7 @@ import {
   isLatestVersion,
   getBuildRequirements,
   getNextVersions,
+  getGenericVersion,
 } from "./version-helpers";
 
 describe("version-helpers", () => {
@@ -391,6 +392,40 @@ describe("version-helpers", () => {
       expect(() => getNextVersions("foo")).toThrow();
       expect(() => getNextVersions("v2.75")).toThrow();
       expect(() => getNextVersions("v0.75-RC2")).toThrow();
+    });
+  });
+
+  describe("getGenericVersion", () => {
+    it("should return the generic version for a valid OSS version string", () => {
+      const testCases: [string, string][] = [
+        ["v0.75.0", "75.0"],
+        ["v0.75.1", "75.1"],
+        ["v0.75.12", "75.12"],
+        ["v0.79.99", "79.99"],
+        ["v0.79.99.0", "79.99.0"],
+        ["v0.75.0-RC2", "75.0-RC2"],
+        ["v0.79.0-rc99", "79.0-rc99"],
+      ];
+
+      testCases.forEach(([input, expected]) => {
+        expect(getGenericVersion(input)).toEqual(expected);
+      });
+    });
+
+    it("should return the generic version for a valid EE version string", () => {
+      const testCases: [string, string][] = [
+        ["v1.75.0", "75.0"],
+        ["v1.75.1", "75.1"],
+        ["v1.75.12", "75.12"],
+        ["v1.79.99", "79.99"],
+        ["v1.79.99.0", "79.99.0"],
+        ["v1.75.0-RC2", "75.0-RC2"],
+        ["v1.79.0-rc99", "79.0-rc99"],
+      ];
+
+      testCases.forEach(([input, expected]) => {
+        expect(getGenericVersion(input)).toEqual(expected);
+      });
     });
   });
 });


### PR DESCRIPTION
Resurrecting a simple part of : https://github.com/metabase/metabase/pull/35186

First part of https://github.com/metabase/metabase-private/issues/174

### Description

Automates generating and posting the build-start slack message to the release channel 🥳 


![Screen Shot 2024-03-01 at 10 32 43 AM](https://github.com/metabase/metabase/assets/30528226/09d95369-14e6-4e1c-80c6-628edd8d330c)
