### PR TITLE
Move user-local settings to user model

### DIFF
--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -448,6 +448,23 @@
             (when-let [id (setting/get-value-of-type :integer :last-used-native-database-id)]
               (when (t2/exists? :model/Database :id id) id))))
 
+(defsetting dismissed-custom-dashboard-toast
+  (deferred-tru "Toggle which is true after a user has dismissed the custom dashboard toast.")
+  :user-local :only
+  :visibility :authenticated
+  :type       :boolean
+  :default    false
+  :audit      :never)
+
+(defsetting dismissed-browse-models-banner
+  (deferred-tru "Whether the user has dismissed the explanatory banner about models that appears on the Browse Data page")
+  :user-local :only
+  :export?    false
+  :visibility :authenticated
+  :type       :boolean
+  :default    false
+  :audit      :never)
+
 ;;; ## ------------------------------------------ AUDIT LOG ------------------------------------------
 
 (defmethod audit-log/model-details :model/User

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -113,23 +113,6 @@
   :visibility :public
   :audit      :getter)
 
-(defsetting dismissed-custom-dashboard-toast
-  (deferred-tru "Toggle which is true after a user has dismissed the custom dashboard toast.")
-  :user-local :only
-  :visibility :authenticated
-  :type       :boolean
-  :default    false
-  :audit      :never)
-
-(defsetting dismissed-browse-models-banner
-  (deferred-tru "Whether the user has dismissed the explanatory banner about models that appears on the Browse Data page")
-  :user-local :only
-  :export?    false
-  :visibility :authenticated
-  :type       :boolean
-  :default    false
-  :audit      :never)
-
 (defsetting site-uuid
   ;; Don't i18n this docstring because it's not user-facing! :)
   "Unique identifier used for this instance of {0}. This is set once and only once the first time it is fetched via


### PR DESCRIPTION
This PR simply moves a two user-local settings to the `public_settings` to the `user` model.
The previous location where these settings have been defined is misleading, IMO.