### PR TITLE
Fix errors happening after canceling a new dashboard tab creation

### DIFF
--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -41,6 +41,9 @@ import {
   filterWidget,
   popover,
   createDashboardWithTabs,
+  dashboardGrid,
+  modal,
+  addHeadingWhileEditing,
 } from "e2e/support/helpers";
 import { createMockDashboardCard } from "metabase-types/api/mocks";
 
@@ -176,6 +179,31 @@ describe("scenarios > dashboard > tabs", () => {
       [DASHBOARD_NUMBER_FILTER, 20],
       [DASHBOARD_LOCATION_FILTER, undefined],
     ]);
+  });
+
+  it("should handle canceling adding a new tab (#38055, #38278)", () => {
+    visitDashboardAndCreateTab({
+      dashboardId: ORDERS_DASHBOARD_ID,
+      save: false,
+    });
+
+    cy.findByTestId("edit-bar").button("Cancel").click();
+    modal().button("Discard changes").click();
+
+    // Reproduces #38055
+    dashboardGrid().within(() => {
+      cy.findByText(/There's nothing here/).should("not.exist");
+      getDashboardCards().should("have.length", 1);
+    });
+
+    // Reproduces #38278
+    editDashboard();
+    addHeadingWhileEditing("New heading");
+    saveDashboard();
+    dashboardGrid().within(() => {
+      cy.findByText("New heading").should("exist");
+      getDashboardCards().should("have.length", 2);
+    });
   });
 
   it("should allow undoing a tab deletion", () => {

--- a/frontend/src/metabase/dashboard/actions/core.ts
+++ b/frontend/src/metabase/dashboard/actions/core.ts
@@ -6,6 +6,7 @@ import type {
   DashboardCard,
   DashboardId,
 } from "metabase-types/api";
+import type { Dispatch } from "metabase-types/store";
 
 export const INITIALIZE = "metabase/dashboard/INITIALIZE";
 export const initialize = createAction(INITIALIZE);
@@ -17,6 +18,13 @@ export const SET_EDITING_DASHBOARD = "metabase/dashboard/SET_EDITING_DASHBOARD";
 export const setEditingDashboard = createAction<Dashboard | null>(
   SET_EDITING_DASHBOARD,
 );
+
+export const CANCEL_EDITING_DASHBOARD =
+  "metabase/dashboard/CANCEL_EDITING_DASHBOARD";
+export const cancelEditingDashboard = () => (dispatch: Dispatch) => {
+  dispatch(setEditingDashboard(null));
+  dispatch({ type: CANCEL_EDITING_DASHBOARD });
+};
 
 export type SetDashboardAttributesOpts = {
   id: DashboardId;

--- a/frontend/src/metabase/dashboard/actions/tabs.ts
+++ b/frontend/src/metabase/dashboard/actions/tabs.ts
@@ -3,7 +3,10 @@ import type { Draft } from "@reduxjs/toolkit";
 import { createAction, createReducer } from "@reduxjs/toolkit";
 import { t } from "ttag";
 
-import { INITIALIZE } from "metabase/dashboard/actions/core";
+import {
+  CANCEL_EDITING_DASHBOARD,
+  INITIALIZE,
+} from "metabase/dashboard/actions/core";
 import Dashboards from "metabase/entities/dashboards";
 import { getPositionForNewDashCard } from "metabase/lib/dashboard_grid";
 import { checkNotNull } from "metabase/lib/types";
@@ -542,6 +545,15 @@ export const tabsReducer = createReducer<DashboardState>(
         tab => tab.id === state.selectedTabId,
       );
       state.selectedTabId = (newTabs && newTabs[selectedTabIndex]?.id) ?? null;
+    });
+
+    builder.addCase(CANCEL_EDITING_DASHBOARD, state => {
+      const { editingDashboard, selectedTabId } = state;
+      const tabs = editingDashboard?.tabs ?? [];
+      const hasTab = tabs.some(tab => tab.id === selectedTabId);
+      if (!hasTab) {
+        state.selectedTabId = tabs[0]?.id ?? null;
+      }
     });
 
     builder.addCase<

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -20,6 +20,7 @@ import type { NewDashCardOpts } from "metabase/dashboard/actions";
 import {
   addActionToDashboard,
   addSectionToDashboard,
+  cancelEditingDashboard,
   toggleSidebar,
 } from "metabase/dashboard/actions";
 import { trackExportDashboardToPDF } from "metabase/dashboard/analytics";
@@ -279,7 +280,7 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
 
   const onCancel = () => {
     onRevert();
-    onDoneEditing();
+    dispatch(cancelEditingDashboard());
   };
 
   const saveAsPDF = async () => {


### PR DESCRIPTION
Fixes #38278, fixes #38055
Based on #39472

We didn't reset `state.dashboard.selectedTabId` when canceling dashboard editing. As a result, if we added a new tab and canceled the edits, we'd have `selectedTabId` pointing to a tab that doesn't exist, causing different problems.

### To verify

1. New > Dashboad > Add a card and save
2. Start editing > Add a new tab > Cancel editing
3. Ensure you're back to the 1st tab with your card on it
4. Start editing > Add a new card > Save
5. Ensure the save was successful and the changes are persisted