### PR TITLE
Enterprise api calls cleanup

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
@@ -11,13 +11,13 @@ import { getParentPath } from "metabase/hoc/ModalRoute";
 import { useDispatch } from "metabase/lib/redux";
 import { updateImpersonation } from "metabase-enterprise/advanced_permissions/reducer";
 import { getImpersonation } from "metabase-enterprise/advanced_permissions/selectors";
-import { ImpersonationApi } from "metabase-enterprise/advanced_permissions/services";
 import type {
   AdvancedPermissionsStoreState,
   ImpersonationModalParams,
   ImpersonationParams,
 } from "metabase-enterprise/advanced_permissions/types";
 import { getImpersonatedDatabaseId } from "metabase-enterprise/advanced_permissions/utils";
+import { ImpersonationApi } from "metabase-enterprise/services";
 import { fetchUserAttributes } from "metabase-enterprise/shared/reducer";
 import { getUserAttributes } from "metabase-enterprise/shared/selectors";
 import type { Impersonation } from "metabase-types/api";

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/containers/UnsubscribeUserModal/UnsubscribeUserModal.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/containers/UnsubscribeUserModal/UnsubscribeUserModal.jsx
@@ -4,9 +4,9 @@ import _ from "underscore";
 
 import Users from "metabase/entities/users";
 import { addUndo } from "metabase/redux/undo";
+import { AuditApi } from "metabase-enterprise/services";
 
 import UnsubscribeUserForm from "../../components/UnsubscribeUserForm";
-import { AuditApi } from "../../lib/services";
 
 const mapDispatchToProps = dispatch => ({
   onUnsubscribe: async ({ id }) => {

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/lib/services.js
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/lib/services.js
@@ -1,5 +1,0 @@
-import { DELETE } from "metabase/lib/api";
-
-export const AuditApi = {
-  unsubscribe_user: DELETE("/api/ee/audit-app/user/:id/subscriptions"),
-};

--- a/enterprise/frontend/src/metabase-enterprise/audit_app/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/audit_app/reducer.ts
@@ -1,12 +1,10 @@
 import { createReducer } from "@reduxjs/toolkit";
 
-import { GET } from "metabase/lib/api";
 import { createAsyncThunk } from "metabase/lib/redux";
+import { AuditApi } from "metabase-enterprise/services";
 
 import { isAuditInfoComplete } from "./selectors";
 import type { AuditInfoState } from "./types/state";
-
-const getAuditInfo = GET("/api/ee/audit-app/user/audit-info");
 
 const LOAD_AUDIT_INFO = "metabase-enterprise/audit/FETCH_AUDIT_INFO";
 
@@ -16,7 +14,7 @@ export const loadInfo = createAsyncThunk(
     const state = getState() as AuditInfoState;
     const isComplete = isAuditInfoComplete(state);
     if (!isComplete) {
-      const data = await getAuditInfo();
+      const data = await AuditApi.getAuditInfo();
       return data;
     }
   },

--- a/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/llm_autodescription/LLMSuggestQuestionInfo.tsx
@@ -2,16 +2,14 @@ import { useState } from "react";
 import { useAsync } from "react-use";
 import { t } from "ttag";
 
-import { POST } from "metabase/lib/api";
 import { color } from "metabase/lib/colors";
 import { useSelector } from "metabase/lib/redux";
 import type { LLMIndicatorProps } from "metabase/plugins/types";
 import { getSetting } from "metabase/selectors/settings";
 import { Button, Icon, Tooltip } from "metabase/ui";
+import { AutoDescribeApi } from "metabase-enterprise/services";
 
 import "./loading.css";
-
-const postSummarizeCard = POST("/api/ee/autodescribe/card/summarize");
 
 export const LLMSuggestQuestionInfo = ({
   question,
@@ -27,7 +25,7 @@ export const LLMSuggestQuestionInfo = ({
     if (!isActive) {
       return { name: undefined, description: undefined };
     }
-    const response = await postSummarizeCard(question.card());
+    const response = await AutoDescribeApi.summarizeCard(question.card());
     return {
       name: response?.summary?.title ?? undefined,
       description: response?.summary?.description ?? undefined,

--- a/enterprise/frontend/src/metabase-enterprise/services.ts
+++ b/enterprise/frontend/src/metabase-enterprise/services.ts
@@ -1,0 +1,14 @@
+import { DELETE, POST, GET } from "metabase/lib/api";
+
+export const AuditApi = {
+  unsubscribe_user: DELETE("/api/ee/audit-app/user/:id/subscriptions"),
+  getAuditInfo: GET("/api/ee/audit-app/user/audit-info"),
+};
+
+export const AutoDescribeApi = {
+  summarizeCard: POST("/api/ee/auto-describe/summarize-card"),
+};
+
+export const ImpersonationApi = {
+  get: GET("/api/ee/advanced-permissions/impersonation"),
+};


### PR DESCRIPTION
related to https://github.com/metabase/metabase/issues/38686

### Description

I found a handful of places where we are defining endpoints ad-hoc in application code. This happened in enterprise code where there wasn't an obvious place to put it all. I consolidated them in a common `services` file mirroring the structure we have in the OSS directory.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR (existing tests should cover this reorganization)
