### PR TITLE
fix funnel bar breaking in app

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/Funnel/funnel-bar-transform.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/funnel-bar-transform.ts
@@ -32,6 +32,7 @@ export const funnelToBarTransform: TransformSeries = (
           "stackable.stack_type": "stacked" as const,
           "graph.dimensions": [settings["funnel.dimension"]],
           "graph.metrics": [settings["funnel.metric"]],
+          "graph.y_axis.auto_split": false,
         },
       },
       data: {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39361

### Description

The issue was caused by a bad y-axis split. For some reason both `left` and `right` axis arrays were empty, no series was assigned to any. We forgoe this problem by setting the auto split y-axis setting to false for Funnel charts, since the user cannot set this setting themself and it doesn't make sense for this chart (there's only one real dimension and metric).

### Demo


![Screenshot 2024-03-01 at 4.42.28 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/4677006b-5bc2-47a5-83e2-03e219b7b31d.png)


A separate issue has been filed for the misaligned bars https://github.com/metabase/metabase/issues/39483