### PR TITLE
Use hierarchy instead of home-rolled DAG structure

### DIFF
--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -889,3 +889,24 @@
   "Given two maps, are any keys on which they disagree? We only consider keys that are present in both."
   [m1 m2]
   (boolean (some identity (conflicting-keys m1 m2))))
+
+(defn- map-all*
+  [f colls]
+  (lazy-seq
+   (if (some seq colls)
+     (cons (apply f (map first colls))
+           (map-all* f (map rest colls)))
+     ())))
+
+(defn map-all
+  "Similar to [[clojure.core/map]], but instead of short-circuiting it continues until the end of the longest
+  collection, using nil for collection(s) that have already been exhausted."
+  ([f coll] (map f coll))
+  ([f c1 c2]
+   (lazy-seq
+    (let [s1 (seq c1) s2 (seq c2)]
+      (when (or s1 s2)
+        (cons (f (first s1) (first s2))
+              (map-all f (rest s1) (rest s2)))))))
+  ([f c1 c2 & colls]
+   (map-all* f (list* c1 c2 colls))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -267,7 +267,7 @@
            [datetime-type    text-type        text-type]
            [offset-dt-type   text-type        text-type]
            [vchar-type       text-type        text-type]]]
-    (is (= expected (#'upload/lowest-common-ancestor type-a type-b))
+    (is (= expected (#'upload/most-specific-common-ancestor type-a type-b))
         (format "%s + %s = %s" (name type-a) (name type-b) (name expected)))))
 
 (defn csv-file-with

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -1,6 +1,7 @@
 (ns ^:mb/once metabase.util-test
   "Tests for functions in `metabase.util`."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [are deftest is testing]]
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
@@ -459,7 +460,19 @@
     0 1250.0))
 
 (deftest conflicting-keys-test
-  (is (= [] (u/conflicting-keys {:a 1 :b 2}
-                                {:b 2 :c 3})))
-  (is (= [:c :e] (u/conflicting-keys {:a 1 :b 2 :c 3 :e nil}
-                                     {:b 2 :c 4 :d 5 :e 6}))))
+  (testing "non intersecting maps should not return any conflicts"
+    (is (= [] (u/conflicting-keys {:a 1 :b 2}
+                                  {:c 3 :d 4}))))
+  (testing "consistent maps should not return any conflicts"
+    (is (= [] (u/conflicting-keys {:a 1 :b 2}
+                                  {:b 2 :c 3}))))
+  (testing "conflicting maps should return the correct conflicts"
+    (is (= [:c :e] (u/conflicting-keys {:a 1 :b 2 :c 3 :e nil}
+                                       {:b 2 :c 4 :d 5 :e 6})))))
+
+(deftest map-all-test
+  (let [join (fn [& crumbs] (str/join ":" crumbs))]
+    (testing "map-all works with 2-arity"
+      (is (= ["0:0" "1:1" "2:2" "3:" "4:"] (u/map-all join (range 5) (range 3)))))
+    (testing "map-all works with higher arity"
+      (is (= ["0:0:0" "1:1:1" "2:2:2" "3::3" "::4"] (u/map-all join (range 4) (range 3) (range 5)))))))


### PR DESCRIPTION
### Description

Use the built-in hierarchy data structure rather than an order sensitive list. This sets us up to leverage verbs like `isa?` for upcoming feature work.