### PR TITLE
Use toposort to simplify and fix CSV column type operations

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -92,7 +92,7 @@
       (derive ::varchar-255 ::text)))
 
 (def ^:private abstract->concrete
-  "Not all value types do not correspond to concrete database column types."
+  "Not all value types correspond to database types. For those that don't, this maps to their concrete ancestor."
   {::boolean-or-int ::boolean})
 
 (def ^:private value-types

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -208,8 +208,8 @@
                                                new-tag))))))
 
 (defn- coalesce-types
-  "Given two collections of types tags, find the first-common-ancestor for each pair.
-  If one of the collections is longer, we resolve to its literal value for the remaining length."
+  "Given two collections of type tags, find the most specific common ancestor for each pair.
+  If one of the collections is longer, we return its existing tags for the remaining length."
   [types-a types-b]
   (u/map-all most-specific-common-ancestor types-a types-b))
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -100,7 +100,7 @@
   (ordered-hierarchy/sorted-tags h))
 
 (def ^:private column-types
-  "All type tags that correspond to concrete column types. An ordered set from most to least specialized."
+  "All type tags that correspond to concrete column types."
   (into #{} (remove abstract->concrete) value-types))
 
 (defn ^:private column-type

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -195,7 +195,7 @@
     ::text            (constantly true)}))
 
 (defn- value->type
-  "Determine the most specific type that could  given value.
+  "Determine the most specific type that is compatible with the given value.
   Numbers are assumed to use separators corresponding to the locale defined in the application settings"
   [type->check value]
   (when-not (str/blank? value)

--- a/src/metabase/util.cljc
+++ b/src/metabase/util.cljc
@@ -887,3 +887,24 @@
   "Given two maps, are any keys on which they disagree? We only consider keys that are present in both."
   [m1 m2]
   (boolean (some identity (conflicting-keys m1 m2))))
+
+(defn- map-all*
+  [f colls]
+  (lazy-seq
+   (if (some seq colls)
+     (cons (apply f (map first colls))
+           (map-all* f (map rest colls)))
+     ())))
+
+(defn map-all
+  "Similar to [[clojure.core/map]], but instead of short-circuiting it continues until the end of the longest
+  collection, using nil for collection(s) that have already been exhausted."
+  ([f coll] (map f coll))
+  ([f c1 c2]
+   (lazy-seq
+    (let [s1 (seq c1) s2 (seq c2)]
+      (when (or s1 s2)
+        (cons (f (first s1) (first s2))
+              (map-all f (rest s1) (rest s2)))))))
+  ([f c1 c2 & colls]
+   (map-all* f (list* c1 c2 colls))))

--- a/src/metabase/util/ordered_hierarchy.clj
+++ b/src/metabase/util/ordered_hierarchy.clj
@@ -3,7 +3,8 @@
   (:refer-clojure :exclude [ancestors derive descendants make-hierarchy parents])
   (:require
    [flatland.ordered.map :refer [ordered-map]]
-   [flatland.ordered.set :refer [ordered-set]]))
+   [flatland.ordered.set :refer [ordered-set]]
+   [medley.core :as m]))
 
 (defn make-hierarchy
   "Similar to [[clojure.core/make-hierarchy]], but the returned hierarchy will supports ordered derivations.
@@ -13,9 +14,11 @@
   []
   ^::ordered?
   {:parents     (ordered-map)
+   :ancestors   {}
+   :descendants {}
+   ;; additional fields
    :children    (ordered-map)
-   :descendants (ordered-map)
-   :ancestors   (ordered-map)})
+   :sorted-tags (ordered-map)})
 
 (defn ancestors
   "Returns the immediate and indirect parents of tag, as established via derive. Earlier derivations are shown first.
@@ -35,89 +38,10 @@
   [h tag]
   (clojure.core/parents h tag))
 
-(defn parent
-  "Determine the most specific parent node. Nil for a root node."
-  [h child]
-  (first (parents h child)))
-
 (defn children
   "Returns the immediate children of tag, as established via derive. Later derivations are shown first."
   [h tag]
   (-> h :children tag))
-
-(defn tags*
-  "An unordered set of all the tags within a given hierarchy. This will work with regular hierarchies too."
-  [h]
-  (into (set (keys (:parents h))) (keys (:children h))))
-
-(defn- bfs [h ->next tag]
-  (loop [up-next (list tag)
-         visited (ordered-set)]
-    (if (empty? up-next)
-      visited
-      (let [next-tags (mapcat (partial ->next h) up-next)]
-        (recur next-tags (into visited next-tags))))))
-
-(defn- map-to-vals [f ks]
-  (zipmap ks (map f ks)))
-
-(defn derive
-  "Establishes a parent/child relationship between two keyword tags, similar to [[clojure.core/derive]].
-  Where it differs is that the order in which we derive keys is significant - it determines the order in which we return
-  its parents. Ancestors are returned according to a breadth first traversal of these parents, with duplicates removed,
-  and descendants are likewise returned in the opposite order."
-  [h tag parent]
-  (assert (not= tag parent))
-  (assert (keyword tag))
-  (assert (keyword? parent))
-  (assert (::ordered? (meta h)) "This operation requires an ordered hierarchy.")
-
-  (let [tp (:parents h)
-        tc (:children h)
-        ta (:ancestors h)]
-    (if (contains? (tp tag) parent)
-      h
-      (do (when (contains? (ta tag) parent)
-            (throw (Exception. (print-str tag "already has" parent "as ancestor"))))
-          (when (contains? (ta parent) tag)
-            (throw (Exception. (print-str "Cyclic derivation:" parent "has" tag "as ancestor"))))
-
-          (let [h  (assoc h
-                     :parents (update tp tag #(conj (or % (ordered-set)) parent))
-                     :children (update tc parent #(into (ordered-set tag) %)))
-                ts (tags* h)]
-            (with-meta
-             ;; This could be optimized by being selective over which tags are updated, and performing incremental
-             ;; updates to the corresponding sets. We're doing it this way purely for simplicity.
-             (assoc h
-               :ancestors (map-to-vals (partial bfs h parents) ts)
-               :descendants (map-to-vals (partial bfs h children) ts))
-             {::ordered? true}))))))
-
-(defn- first-common-tag
-  "Given two ordered sets corresponding to ancestor in a hierarchy, return the first ancestor of tag-a which is also an
-  ancestor of tag-b.
-  Returns nil if there is no such intersection."
-  [ancestors-a ancestors-b]
-  ;; I suspect this is not commutative, so this ordering is important - we care more about being close to tag-a.
-  (some ancestors-b ancestors-a))
-
-(defn first-common-ancestor
-  "Given two tags, return the first \"ancestor\" of the first tag which is also an \"ancestor\" of tag-b.
-  We use a more relaxed definition of \"ancestor\" here than usual, which includes the tag itself.
-  Returns nil if there is no common ancestor."
-  [h tag-a tag-b]
-  (let [ancestors-a (ancestors h tag-a)
-        ancestors-b (ancestors h tag-b)]
-    (cond
-      (nil? tag-a) tag-b
-      (nil? tag-b) tag-a
-      (= tag-a tag-b) tag-a
-      ;; This ordering is important - we want first ancestor of tag-a that is common, even if there are common
-      ;; ancestor which are closer to tag-b.
-      (contains? ancestors-b tag-a) tag-a
-      (contains? ancestors-a tag-b) tag-b
-      :else (first-common-tag ancestors-a ancestors-b))))
 
 (defn- toposort-visit [g state n]
   (let [{:keys [processing processed]} state]
@@ -156,3 +80,58 @@
                       (into (ordered-set) (keys (:children h)))
                       (keys (:parents h)))]
     (toposort roots (:children h))))
+
+(defn- calculate-derived-fields [h]
+  (let [ts          (sorted-tags h)
+        re-sort     (fn [m sorted] (m/map-vals #(into (ordered-set) (filter % sorted)) m))
+        ancestors   (re-sort (:ancestors h) ts)
+        descendants (re-sort (:descendants h) (reverse ts))]
+    (assoc h
+      :sorted-tags ts
+      :ancestors ancestors
+      :descendants descendants)))
+
+(defn derive
+  "Establishes a parent/child relationship between two keyword tags, similar to [[clojure.core/derive]].
+  Where it differs is that the order in which we derive keys is significant - it determines the order in which we return
+  its parents. Ancestors are returned according to a toposort, and descendants are returned in the opposite order."
+  [h tag parent]
+  (assert (not= tag parent))
+  (assert (keyword tag))
+  (assert (keyword? parent))
+  (assert (::ordered? (meta h)) "This operation requires an ordered hierarchy.")
+
+  (let [tp (:parents h)
+        tc (:children h)]
+    (if (contains? (tp tag) parent)
+      h
+      (-> (assoc h :parents (update tp tag #(or % (ordered-set))))
+          (clojure.core/derive tag parent)
+          (assoc :children (update tc parent #(into (ordered-set tag) %)))
+          calculate-derived-fields
+          (with-meta {::ordered? true})))))
+
+(defn- first-common-tag
+  "Given two ordered sets corresponding to ancestor in a hierarchy, return the first ancestor of tag-a which is also an
+  ancestor of tag-b.
+  Returns nil if there is no such intersection."
+  [ancestors-a ancestors-b]
+  ;; I suspect this is not commutative, so this ordering is important - we care more about being close to tag-a.
+  (some ancestors-b ancestors-a))
+
+(defn first-common-ancestor
+  "Given two tags, return the first \"ancestor\" of the first tag which is also an \"ancestor\" of tag-b.
+  We use a more relaxed definition of \"ancestor\" here than usual, which includes the tag itself.
+  Returns nil if there is no common ancestor."
+  [h tag-a tag-b]
+  (let [ancestors-a (ancestors h tag-a)
+        ancestors-b (ancestors h tag-b)]
+    (cond
+      (nil? tag-a) tag-b
+      (nil? tag-b) tag-a
+      (= tag-a tag-b) tag-a
+      ;; This ordering is important - we want first ancestor of tag-a that is common, even if there are common
+      ;; ancestor which are closer to tag-b.
+      (contains? ancestors-b tag-a) tag-a
+      (contains? ancestors-a tag-b) tag-b
+      :else (first-common-tag ancestors-a ancestors-b))))

--- a/src/metabase/util/ordered_hierarchy.clj
+++ b/src/metabase/util/ordered_hierarchy.clj
@@ -1,0 +1,115 @@
+;;; A specialization of Clojure hierarchies that preserves the ordering of insertions.
+(ns metabase.util.ordered-hierarchy
+  (:refer-clojure :exclude [ancestors derive descendants make-hierarchy parents])
+  (:require
+   [flatland.ordered.set :refer [ordered-set]]))
+
+(defn make-hierarchy
+  "Similar to [[clojure.core/make-hierarchy]], but the returned hierarchy will supports ordered derivations.
+
+  !! WARNING !!
+  Using [[clojure.core/derive]] with this will corrupt the ordering - you must use the implementation from this ns."
+  []
+  (vary-meta (clojure.core/make-hierarchy) assoc ::ordered? true))
+
+(defn ancestors
+  "Returns the immediate and indirect parents of tag, as established via derive. Earlier derivations are shown first.
+   This method is just a proxy, it exists only to prevent accidentally using the global hierarchy."
+  [h tag]
+  (clojure.core/ancestors h tag))
+
+(defn descendants
+  "Returns the immediate and indirect children of tag, as established via derive. Earlier derivations are shown later.
+   This method is just a proxy, it exists only to prevent accidentally using the global hierarchy."
+  [h tag]
+  (clojure.core/descendants h tag))
+
+(defn parents
+  "Returns the immediate parents of tag, as established via derive. Earlier derivations are shown first.
+   This method is just a proxy, it exists only to prevent accidentally using the global hierarchy."
+  [h tag]
+  (clojure.core/parents h tag))
+
+(defn parent
+  "Determine the most specific parent node. Nil for a root node."
+  [h child]
+  (first (parents h child)))
+
+(defn children
+  "Returns the immediate children of tag, as established via derive. Later derivations are shown first."
+  [h tag]
+  (-> h :children tag))
+
+(defn tags
+  "An unordered set of all the tags within a given hierarchy. This will work with regular hierarchies too."
+  [h]
+  (into (set (keys (:parents h))) (keys (:children h))))
+
+(defn- bfs [h ->next tag]
+  (loop [up-next (list tag)
+         visited (ordered-set)]
+    (if (empty? up-next)
+      visited
+      (let [next-tags (mapcat (partial ->next h) up-next)]
+        (recur next-tags (into visited next-tags))))))
+
+(defn- map-to-vals [f ks]
+  (zipmap ks (map f ks)))
+
+(defn derive
+  "Establishes a parent/child relationship between two keyword tags, similar to [[clojure.core/derive]].
+  Where it differs is that the order in which we derive keys is significant - it determines the order in which we return
+  its parents. Ancestors are returned according to a breadth first traversal of these parents, with duplicates removed,
+  and descendants are likewise returned in the opposite order."
+  [h tag parent]
+  (assert (not= tag parent))
+  (assert (keyword tag))
+  (assert (keyword? parent))
+  (assert (::ordered? (meta h)) "This operation requires an ordered hierarchy.")
+
+  (let [tp (:parents h)
+        tc (:children h)
+        ta (:ancestors h)]
+    (if (contains? (tp tag) parent)
+      h
+      (do (when (contains? (ta tag) parent)
+            (throw (Exception. (print-str tag "already has" parent "as ancestor"))))
+          (when (contains? (ta parent) tag)
+            (throw (Exception. (print-str "Cyclic derivation:" parent "has" tag "as ancestor"))))
+
+          (let [h  (assoc h
+                     :parents (update tp tag #(conj (or % (ordered-set)) parent))
+                     :children (update tc parent #(into (ordered-set tag) %)))
+                ts (tags h)]
+            (with-meta
+             ;; This could be optimized by being selective over which tags are updated, and performing incremental
+             ;; updates to the corresponding sets. We're doing it this way purely for simplicity.
+             (assoc h
+               :ancestors (map-to-vals (partial bfs h parents) ts)
+               :descendants (map-to-vals (partial bfs h children) ts))
+             {::ordered? true}))))))
+
+(defn- first-common-tag
+  "Given two ordered sets corresponding to ancestor in a hierarchy, return the first ancestor of tag-a which is also an
+  ancestor of tag-b.
+  Returns nil if there is no such intersection."
+  [ancestors-a ancestors-b]
+  ;; I suspect this is not commutative, so this ordering is important - we care more about being close to tag-a.
+  (some ancestors-b ancestors-a))
+
+(defn first-common-ancestor
+  "Given two tags, return the first \"ancestor\" of the first tag which is also an \"ancestor\" of tag-b.
+  We use a more relaxed definition of \"ancestor\" here than usual, which includes the tag itself.
+  Returns nil if there is no common ancestor."
+  [h tag-a tag-b]
+  (let [ancestors-a (ancestors h tag-a)
+        ancestors-b (ancestors h tag-b)]
+    (cond
+      (nil? tag-a) tag-b
+      (nil? tag-b) tag-a
+      (= tag-a tag-b) tag-a
+      ;; This ordering is important - we want first ancestor of tag-a that is common, even if there are common
+      ;; ancestor which are closer to tag-b.
+      (contains? ancestors-b tag-a) tag-a
+      (contains? ancestors-a tag-b) tag-b
+      :else (first-common-tag ancestors-a ancestors-b))))

--- a/src/metabase/util/ordered_hierarchy.clj
+++ b/src/metabase/util/ordered_hierarchy.clj
@@ -117,8 +117,9 @@
   "Given two tags, return the first tag in the ancestral lineage of tag-a that's also in the ancestral lineage of tag-b.
   Returns nil if there is no common ancestor.
 
-  NOTE: It's possible that this node is also always a Least Common Ancestor, but I'm not sure.
-        If it does it would be worth renaming this method to use standard terminology."
+  NOTE: this is very similar to the notion of a Least Common Ancestor in a graph, but I'm not sure that its result
+        will always satisfy that property. We also want to emphasize the way it relates to the total ordering, hence
+        using different terminology."
   [h tag-a tag-b]
   (let [ancestors-a (ancestors h tag-a)
         ancestors-b (ancestors h tag-b)]

--- a/src/metabase/util/ordered_hierarchy.clj
+++ b/src/metabase/util/ordered_hierarchy.clj
@@ -46,7 +46,7 @@
                                         :graph      g})))
     (if (contains? processed n)
       state
-      (let [children (get g n)
+      (let [children   (get g n)
             init-state (update state :processing conj n)
             post-state (reduce (partial toposort-visit g)
                                init-state

--- a/src/metabase/util/ordered_hierarchy.clj
+++ b/src/metabase/util/ordered_hierarchy.clj
@@ -2,7 +2,6 @@
 (ns metabase.util.ordered-hierarchy
   (:refer-clojure :exclude [ancestors derive descendants make-hierarchy parents])
   (:require
-   [flatland.ordered.map :refer [ordered-map]]
    [flatland.ordered.set :refer [ordered-set]]
    [medley.core :as m]))
 
@@ -12,13 +11,8 @@
   !! WARNING !!
   Using [[clojure.core/derive]] with this will corrupt the ordering - you must use the implementation from this ns."
   []
-  ^::ordered?
-  {:parents     (ordered-map)
-   :ancestors   {}
-   :descendants {}
-   ;; additional fields
-   :children    (ordered-map)
-   :sorted-tags (ordered-map)})
+  (-> (clojure.core/make-hierarchy)
+      (with-meta {::ordered? true})))
 
 (defn ancestors
   "Returns the immediate and indirect parents of tag, as established via derive. Earlier derivations are shown first.

--- a/src/metabase/util/ordered_hierarchy.clj
+++ b/src/metabase/util/ordered_hierarchy.clj
@@ -106,17 +106,19 @@
           (with-meta {::ordered? true})))))
 
 (defn- first-common-tag
-  "Given two ordered sets corresponding to ancestor in a hierarchy, return the first ancestor of tag-a which is also an
-  ancestor of tag-b.
+  "Given two ordered sets corresponding to ancestors of two tags in a hierarchy, return the first ancestor of tag-a
+  which is also an ancestor of tag-b.
   Returns nil if there is no such intersection."
   [ancestors-a ancestors-b]
   ;; I suspect this is not commutative, so this ordering is important - we care more about being close to tag-a.
   (some ancestors-b ancestors-a))
 
 (defn first-common-ancestor
-  "Given two tags, return the first \"ancestor\" of the first tag which is also an \"ancestor\" of tag-b.
-  We use a more relaxed definition of \"ancestor\" here than usual, which includes the tag itself.
-  Returns nil if there is no common ancestor."
+  "Given two tags, return the first tag in the ancestral lineage of tag-a that's also in the ancestral lineage of tag-b.
+  Returns nil if there is no common ancestor.
+
+  NOTE: It's possible that this node is also always a Least Common Ancestor, but I'm not sure.
+        If it does it would be worth renaming this method to use standard terminology."
   [h tag-a tag-b]
   (let [ancestors-a (ancestors h tag-a)
         ancestors-b (ancestors h tag-b)]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1665,3 +1665,27 @@
                           (re-pattern (str "^" fail-msg "$"))
                           (append!)))))
                 (io/delete-file file)))))))))
+
+(defn- first-non-abstract-first-parent [value-type]
+  (cond (nil? value-type) nil
+
+        (#'upload/abstract->concrete value-type)
+        (recur (first (parents @#'upload/h value-type)))
+
+        :else value-type))
+
+(deftest column-type-test
+  (let [column-type #'upload/column-type]
+    (testing "Unknown value types are treated as text"
+      (is (= ::upload/text (column-type nil))))
+    (testing "Non-abstract value types resolve to themselves"
+      (let [ts @#'upload/column-types]
+        (is (= (zipmap ts ts)
+               (zipmap (map column-type ts) ts)))))
+    (testing "Abstract values are resolved using an explicit map, which is consistent with the hierarchy"
+      (doseq [[value-type expected-column-type] @#'upload/abstract->concrete]
+        (is (= expected-column-type (column-type value-type)))
+        ;; Strictly speaking we only require that there is a route from each abstract node to its column type which only
+        ;; traverses through abstract nodes, but it's much simpler to enforce this convention. This consistency also
+        ;; keeps the graph easier to reason about and may save us from future foot guns.
+        (is (= expected-column-type (first-non-abstract-first-parent value-type)))))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -226,11 +226,12 @@
            [" 2022-01-01T01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]
            [" 2022-01-01t01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]
            [" 2022-01-01 01:00:00.00Z "       (t/offset-date-time "2022-01-01T01:00+00:00") offset-dt-type]]]
-    (let [settings   {:number-separators (or seps ".,")}
-          value-type (#'upload/value->type string-value settings)
+    (let [settings    {:number-separators (or seps ".,")}
+          type->check (#'upload/settings->type->check settings)
+          value-type  (#'upload/value->type type->check string-value)
           ;; get the type of the column, if it were filled with only that value
-          col-type   (first (upload/column-types-from-rows settings 1 [[string-value]]))
-          parser     (upload-parsing/upload-type->parser col-type settings)]
+          col-type    (first (upload/column-types-from-rows settings 1 [[string-value]]))
+          parser      (upload-parsing/upload-type->parser col-type settings)]
       (testing (format "\"%s\" is a %s" string-value type)
         (is (= expected-type
                value-type)))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -267,7 +267,7 @@
            [datetime-type    text-type        text-type]
            [offset-dt-type   text-type        text-type]
            [vchar-type       text-type        text-type]]]
-    (is (= expected (#'upload/lowest-common-ancestor type-a type-b))
+    (is (= expected (#'upload/most-specific-common-ancestor type-a type-b))
         (format "%s + %s = %s" (name type-a) (name type-b) (name expected)))))
 
 (defn csv-file-with

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -109,7 +109,7 @@
     (t2/select-one :model/Table (:id table))))
 
 (deftest type-detection-and-parse-test
-  (doseq [[string-value  expected-value expected-type seps]
+  (doseq [[string-value expected-value expected-type seps]
           ;; Number-related
           [["0.0"        0              float-type "."]
            ["0.0"        0              float-type ".,"]

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -1,6 +1,7 @@
 (ns ^:mb/once metabase.util-test
   "Tests for functions in `metabase.util`."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [are deftest is testing]]
    [clojure.test.check.clojure-test :refer [defspec]]
    [clojure.test.check.generators :as gen]
@@ -459,7 +460,19 @@
     0 1250.0))
 
 (deftest conflicting-keys-test
-  (is (= [] (u/conflicting-keys {:a 1 :b 2}
-                                {:b 2 :c 3})))
-  (is (= [:c :e] (u/conflicting-keys {:a 1 :b 2 :c 3 :e nil}
-                                     {:b 2 :c 4 :d 5 :e 6}))))
+  (testing "non intersecting maps should not return any conflicts"
+    (is (= [] (u/conflicting-keys {:a 1 :b 2}
+                                  {:c 3 :d 4}))))
+  (testing "consistent maps should not return any conflicts"
+    (is (= [] (u/conflicting-keys {:a 1 :b 2}
+                                  {:b 2 :c 3}))))
+  (testing "conflicting maps should return the correct conflicts"
+    (is (= [:c :e] (u/conflicting-keys {:a 1 :b 2 :c 3 :e nil}
+                                       {:b 2 :c 4 :d 5 :e 6})))))
+
+(deftest map-all-test
+  (let [join (fn [& crumbs] (str/join ":" crumbs))]
+    (testing "map-all works with 2-arity"
+      (is (= ["0:0" "1:1" "2:2" "3:" "4:"] (u/map-all join (range 5) (range 3)))))
+    (testing "map-all works with higher arity"
+      (is (= ["0:0:0" "1:1:1" "2:2:2" "3::3" "::4"] (u/map-all join (range 4) (range 3) (range 5)))))))

--- a/test/metabase/util_test.cljc
+++ b/test/metabase/util_test.cljc
@@ -472,7 +472,9 @@
 
 (deftest map-all-test
   (let [join (fn [& crumbs] (str/join ":" crumbs))]
-    (testing "map-all works with 2-arity"
+    (testing "map-all with 1 collection is just map"
+      (is (= ["0" "1" "2" "3" "4"] (u/map-all join (range 5)))))
+    (testing "map-all works with 3 collections"
       (is (= ["0:0" "1:1" "2:2" "3:" "4:"] (u/map-all join (range 5) (range 3)))))
     (testing "map-all works with higher arity"
       (is (= ["0:0:0" "1:1:1" "2:2:2" "3::3" "::4"] (u/map-all join (range 4) (range 3) (range 5)))))))

--- a/test/ordered_hierarchy_test.clj
+++ b/test/ordered_hierarchy_test.clj
@@ -89,3 +89,10 @@
             ::varchar-255
             ::text]
            (vec (ordered-hierarchy/sorted-tags h))))))
+
+(deftest first-common-ancestor-test
+  (testing "The first-common-ancestor is the first tag in the lineage of tag-a that is also in the lineage of tag-b"
+    (is (= ::boolean-or-int (ordered-hierarchy/first-common-ancestor h ::boolean-or-int nil)))
+    (is (= ::boolean-or-int (ordered-hierarchy/first-common-ancestor h ::boolean-or-int ::boolean-or-int)))
+    (is (= ::boolean (ordered-hierarchy/first-common-ancestor h ::boolean-or-int ::boolean)))
+    (is (= ::varchar-255 (ordered-hierarchy/first-common-ancestor h ::boolean ::int)))))

--- a/test/ordered_hierarchy_test.clj
+++ b/test/ordered_hierarchy_test.clj
@@ -75,3 +75,17 @@
             ::boolean-or-int
             ::auto-incrementing-int-pk]
            (vec (descendants h ::text))))))
+
+(deftest tags-test
+  (testing "Tags are returned in a topologically sorted order that also preserves insert order"
+    (is (= [::boolean-or-int
+            ::boolean
+            ::auto-incrementing-int-pk
+            ::int
+            ::float
+            ::date
+            ::datetime
+            ::offset-datetime
+            ::varchar-255
+            ::text]
+           (vec (ordered-hierarchy/sorted-tags h))))))

--- a/test/ordered_hierarchy_test.clj
+++ b/test/ordered_hierarchy_test.clj
@@ -1,0 +1,77 @@
+(ns ordered-hierarchy-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [metabase.util.ordered-hierarchy :as ordered-hierarchy]))
+
+;;; It would be nice to have property tests, to expose any subtle edge cases.
+;;; For now, we use an extraction of the first real world usage in the app, at the time of writing.
+
+(def ^:private h
+  (-> (ordered-hierarchy/make-hierarchy)
+      (ordered-hierarchy/derive ::boolean-or-int ::boolean)
+      (ordered-hierarchy/derive ::boolean-or-int ::int)
+      (ordered-hierarchy/derive ::auto-incrementing-int-pk ::int)
+      (ordered-hierarchy/derive ::int ::float)
+      (ordered-hierarchy/derive ::date ::datetime)
+      (ordered-hierarchy/derive ::boolean ::varchar-255)
+      (ordered-hierarchy/derive ::float ::varchar-255)
+      (ordered-hierarchy/derive ::datetime ::varchar-255)
+      (ordered-hierarchy/derive ::offset-datetime ::varchar-255)
+      (ordered-hierarchy/derive ::varchar-255 ::text)))
+
+(-> (ordered-hierarchy/make-hierarchy)
+    (ordered-hierarchy/derive ::boolean-or-int ::boolean)
+    (ordered-hierarchy/derive ::boolean-or-int ::int)
+    (ordered-hierarchy/derive ::auto-incrementing-int-pk ::int)
+    (ordered-hierarchy/derive ::varchar-255 ::text)
+    :children
+    ::int)
+
+(deftest parents-test
+  (testing "Parents are listed according to the order that this tag was derived from each of them"
+    (is (nil? (parents h ::text)))
+    (is (= [::text] (vec (parents h ::varchar-255))))
+    (is (= [::float] (vec (parents h ::int))))
+    (is (= [::boolean ::int] (vec (parents h ::boolean-or-int))))))
+
+(deftest children-test
+  (testing "Children are listed in reverse order to when they were each derived from this tag"
+    (is (nil? (ordered-hierarchy/children h ::boolean-or-int)))
+    (is (= [::varchar-255] (vec (ordered-hierarchy/children h ::text))))
+    (is (= [::int] (vec (ordered-hierarchy/children h ::float))))
+    (is (= [::auto-incrementing-int-pk ::boolean-or-int] (vec (ordered-hierarchy/children h ::int))))))
+
+(deftest ancestors-test
+  (testing "Linear ancestors are listed in order"
+    (is (nil? (ancestors h ::text)))
+    (is (= [::text] (vec (ancestors h ::varchar-255))))
+    (is (= [::varchar-255 ::text] (vec (ancestors h ::boolean))))
+    (is (= [::float ::varchar-255 ::text] (vec (ancestors h ::int)))))
+
+  (testing "Non-linear ancestors are listed in breadth-first order"
+    ;; NB - it feels surprising that ::varchar-255 comes before ::float, as it is its parent.
+    ;; This does not seem to be what we want when we are using these "lists" find the most specific common ancestor!
+    ;; Moving to a topological sort would fix this.
+    (is (= [::boolean ::int ::varchar-255 ::float ::text] (vec (ancestors h ::boolean-or-int))))))
+
+(deftest descendants-test
+  (testing "Linear descendants are listed in order"
+    (is (nil? (descendants h ::boolean-or-int)))
+    (is (nil? (descendants h ::date)))
+    (is (= [::date] (vec (descendants h ::datetime))))
+    (is (= [::boolean-or-int] (vec (descendants h ::boolean)))))
+
+  (testing "Non-linear descendants are listed in breadth-first order"
+    (is (= [::int ::auto-incrementing-int-pk ::boolean-or-int] (vec (descendants h ::float))))
+    (is (= [::varchar-255
+            ::offset-datetime
+            ::datetime
+            ::float
+            ::boolean
+            ::date
+            ::int
+            ;; This ordering is unintuitive, as it's reversed according to how they appear as children of ::int
+            ;; Moving to a topological sort would NOT fix this, however.
+            ::boolean-or-int
+            ::auto-incrementing-int-pk]
+           (vec (descendants h ::text))))))

--- a/test/ordered_hierarchy_test.clj
+++ b/test/ordered_hierarchy_test.clj
@@ -19,14 +19,6 @@
       (ordered-hierarchy/derive ::offset-datetime ::varchar-255)
       (ordered-hierarchy/derive ::varchar-255 ::text)))
 
-(-> (ordered-hierarchy/make-hierarchy)
-    (ordered-hierarchy/derive ::boolean-or-int ::boolean)
-    (ordered-hierarchy/derive ::boolean-or-int ::int)
-    (ordered-hierarchy/derive ::auto-incrementing-int-pk ::int)
-    (ordered-hierarchy/derive ::varchar-255 ::text)
-    :children
-    ::int)
-
 (deftest parents-test
   (testing "Parents are listed according to the order that this tag was derived from each of them"
     (is (nil? (parents h ::text)))

--- a/test/ordered_hierarchy_test.clj
+++ b/test/ordered_hierarchy_test.clj
@@ -46,13 +46,16 @@
     (is (nil? (ancestors h ::text)))
     (is (= [::text] (vec (ancestors h ::varchar-255))))
     (is (= [::varchar-255 ::text] (vec (ancestors h ::boolean))))
-    (is (= [::float ::varchar-255 ::text] (vec (ancestors h ::int)))))
+    (is (= [::float ::varchar-255 ::text] (vec (ancestors h ::int))))
+    (is (= [::boolean
+            ::int
+            ::float
+            ::varchar-255
+            ::text]
+           (vec (ancestors h ::boolean-or-int)))))
 
   (testing "Non-linear ancestors are listed in breadth-first order"
-    ;; NB - it feels surprising that ::varchar-255 comes before ::float, as it is its parent.
-    ;; This does not seem to be what we want when we are using these "lists" find the most specific common ancestor!
-    ;; Moving to a topological sort would fix this.
-    (is (= [::boolean ::int ::varchar-255 ::float ::text] (vec (ancestors h ::boolean-or-int))))))
+    (is (= [::boolean ::int ::float ::varchar-255 ::text] (vec (ancestors h ::boolean-or-int))))))
 
 (deftest descendants-test
   (testing "Linear descendants are listed in order"
@@ -66,14 +69,12 @@
     (is (= [::varchar-255
             ::offset-datetime
             ::datetime
-            ::float
-            ::boolean
             ::date
+            ::float
             ::int
-            ;; This ordering is unintuitive, as it's reversed according to how they appear as children of ::int
-            ;; Moving to a topological sort would NOT fix this, however.
-            ::boolean-or-int
-            ::auto-incrementing-int-pk]
+            ::auto-incrementing-int-pk
+            ::boolean
+            ::boolean-or-int]
            (vec (descendants h ::text))))))
 
 (deftest tags-test

--- a/test/ordered_hierarchy_test.clj
+++ b/test/ordered_hierarchy_test.clj
@@ -46,16 +46,15 @@
     (is (nil? (ancestors h ::text)))
     (is (= [::text] (vec (ancestors h ::varchar-255))))
     (is (= [::varchar-255 ::text] (vec (ancestors h ::boolean))))
-    (is (= [::float ::varchar-255 ::text] (vec (ancestors h ::int))))
+    (is (= [::float ::varchar-255 ::text] (vec (ancestors h ::int)))))
+
+  (testing "Non-linear ancestors are listed in breadth-first order"
     (is (= [::boolean
             ::int
             ::float
             ::varchar-255
             ::text]
-           (vec (ancestors h ::boolean-or-int)))))
-
-  (testing "Non-linear ancestors are listed in breadth-first order"
-    (is (= [::boolean ::int ::float ::varchar-255 ::text] (vec (ancestors h ::boolean-or-int))))))
+           (vec (ancestors h ::boolean-or-int))))))
 
 (deftest descendants-test
   (testing "Linear descendants are listed in order"


### PR DESCRIPTION
### Description

This PR replaces the breadth first search, which gave an "unintuitive"[^1] ordering, with a topological sorting.

Given this stronger foundation, we can then replace the hard coded parsing order with a graph traversal. 

This also implicitly corrects a benign defect where `::date` and `::datetime` were out of order in value type inference.

[^1]: When traversing the ancestors of `::boolean-or-int`, we would reach `::varchar-255` before `::float`.