### PR TITLE
Rename query caching min TTL setting

### DIFF
--- a/.clj-kondo/hooks/metabase/models/setting.clj
+++ b/.clj-kondo/hooks/metabase/models/setting.clj
@@ -106,7 +106,7 @@
      prometheus-server-port
      query-caching-max-kb
      query-caching-max-ttl
-     query-caching-min-ttl
+     query-caching-min-duration
      query-caching-ttl-ratio
      redirect-all-requests-to-https
      reset-token-ttl-hours

--- a/docs/configuring-metabase/config-file.md
+++ b/docs/configuring-metabase/config-file.md
@@ -159,7 +159,7 @@ email-smtp-username
 start-of-week
 email-smtp-password
 email-smtp-port
-query-caching-min-ttl
+query-caching-min-duration
 email-from-name
 email-from-address
 email-reply-to

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -1043,7 +1043,7 @@
                         (let [results (qp/process-query (assoc query :cache-ttl 100))]
                           {:cached?  (boolean (:cached (:cache/details results)))
                            :num-rows (count (mt/rows results))}))]
-        (mt/with-temporary-setting-values [enable-query-caching  true
+        (mt/with-temporary-setting-values [enable-query-caching       true
                                            query-caching-min-duration 0]
           (testing "Make sure the underlying card for the GTAP returns cached results without sandboxing"
             (mt/with-current-user nil

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -1044,7 +1044,7 @@
                           {:cached?  (boolean (:cached (:cache/details results)))
                            :num-rows (count (mt/rows results))}))]
         (mt/with-temporary-setting-values [enable-query-caching  true
-                                           query-caching-min-ttl 0]
+                                           query-caching-min-duration 0]
           (testing "Make sure the underlying card for the GTAP returns cached results without sandboxing"
             (mt/with-current-user nil
               (testing "First run -- should not be cached"

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheTTLField/QuestionCacheTTLField.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheTTLField/QuestionCacheTTLField.unit.spec.js
@@ -20,7 +20,7 @@ function setup({
   mockSettings({
     "enable-query-caching": true,
     "query-caching-ttl-ratio": cacheTTLMultiplier,
-    "query-caching-min-ttl": minCacheThreshold,
+    "query-caching-min-duration": minCacheThreshold,
   });
 
   const question = {

--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.js
@@ -33,7 +33,7 @@ export function getQuestionsImplicitCacheTTL(question) {
 
 function checkQuestionWillBeCached(avgQueryDurationInSeconds) {
   const minQueryDurationThresholdSeconds = MetabaseSettings.get(
-    "query-caching-min-ttl",
+    "query-caching-min-duration",
   );
   return avgQueryDurationInSeconds > minQueryDurationThresholdSeconds;
 }

--- a/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/caching/utils.unit.spec.ts
@@ -52,7 +52,7 @@ describe("getQuestionsImplicitCacheTTL", () => {
     mockSettings({
       "enable-query-caching": cachingEnabled,
       "query-caching-ttl-ratio": cachingEnabled ? cacheTTLMultiplier : 10,
-      "query-caching-min-ttl": cachingEnabled ? minCacheThreshold : 60,
+      "query-caching-min-duration": cachingEnabled ? minCacheThreshold : 60,
     });
 
     const card = createMockCard({

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -161,7 +161,7 @@ export const createMockSettings = (
   "enable-nested-queries": true,
   "enable-query-caching": undefined,
   "query-caching-ttl-ratio": 10,
-  "query-caching-min-ttl": 60,
+  "query-caching-min-duration": 60,
   "enable-password-login": true,
   "enable-public-sharing": false,
   "enable-xrays": false,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -214,7 +214,7 @@ interface InstanceSettings {
   "enable-nested-queries": boolean;
   "enable-query-caching"?: boolean;
   "query-caching-ttl-ratio": number;
-  "query-caching-min-ttl": number;
+  "query-caching-min-duration": number;
   "enable-password-login": boolean;
   "enable-public-sharing": boolean;
   "enable-xrays": boolean;

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -569,7 +569,7 @@ export const ADMIN_SETTINGS_SECTIONS = {
         type: "boolean",
       },
       {
-        key: "query-caching-min-ttl",
+        key: "query-caching-min-duration",
         display_name: t`Minimum Query Duration`,
         type: "number",
         getHidden: settings => !settings["enable-query-caching"],

--- a/frontend/src/metabase/common/hooks/use-setting/use-setting.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/use-setting/use-setting.unit.spec.tsx
@@ -25,7 +25,7 @@ describe("useTableListQuery", () => {
 
   it("should get a number setting", async () => {
     renderWithProviders(
-      <TestComponent settingName={"query-caching-min-ttl"} />,
+      <TestComponent settingName={"query-caching-min-duration"} />,
     );
     expect(screen.getByText("60")).toBeInTheDocument();
     expect(screen.getByText("number")).toBeInTheDocument();

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -345,8 +345,7 @@
   :default (* 60.0 60.0 24.0 100.0) ; 100 days
   :audit   :getter)
 
-;; TODO -- this isn't really a TTL at all. Consider renaming to something like `-min-duration`
-(defsetting query-caching-min-ttl
+(defsetting query-caching-min-duration
   (deferred-tru "{0} will cache all saved questions with an average query execution time longer than this many seconds:"
                  (application-name-for-setting-descriptions))
   :type    :double

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -57,7 +57,7 @@
 (defn- min-duration-ms
   "Minimum duration it must take a query to complete in order for it to be eligible for caching."
   []
-  (* (public-settings/query-caching-min-ttl) 1000))
+  (* (public-settings/query-caching-min-duration) 1000))
 
 (def ^:private ^:dynamic *in-fn*
   "The `in-fn` provided by [[impl/do-with-serialization]]."

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -91,7 +91,7 @@
                           purge-chan (a/chan 10)]
     (mt/with-temporary-setting-values [enable-query-caching  true
                                        query-caching-max-ttl 60
-                                       query-caching-min-ttl 0]
+                                       query-caching-min-duration 0]
       (binding [cache/*backend* (test-backend save-chan purge-chan)
                 *save-chan*     save-chan
                 *purge-chan*    purge-chan]
@@ -241,18 +241,18 @@
       (is (= :cached (run-query))))))
 
 (deftest min-ttl-test
-  (testing "if the cache takes less than the min TTL to execute, it shouldn't be cached"
+  (testing "if the cache takes less than the min duration to execute, it shouldn't be cached"
     (with-mock-cache [save-chan]
-      (mt/with-temporary-setting-values [query-caching-min-ttl 60]
+      (mt/with-temporary-setting-values [query-caching-min-duration 60]
         (run-query)
         (is (= :metabase.test.util.async/timed-out
                (mt/wait-for-result save-chan)))
         (is (= :not-cached
                (run-query))))))
 
-  (testing "...but if it takes *longer* than the min TTL, it should be cached"
+  (testing "...but if it takes *longer* than the min duration, it should be cached"
     (with-mock-cache [save-chan]
-      (mt/with-temporary-setting-values [query-caching-min-ttl 0.1]
+      (mt/with-temporary-setting-values [query-caching-min-duration 0.1]
         (binding [*query-execution-delay-ms* 120]
           (run-query)
           (mt/wait-for-result save-chan)

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -89,8 +89,8 @@
 (defn do-with-mock-cache [f]
   (mt/with-open-channels [save-chan  (a/chan 10)
                           purge-chan (a/chan 10)]
-    (mt/with-temporary-setting-values [enable-query-caching  true
-                                       query-caching-max-ttl 60
+    (mt/with-temporary-setting-values [enable-query-caching       true
+                                       query-caching-max-ttl      60
                                        query-caching-min-duration 0]
       (binding [cache/*backend* (test-backend save-chan purge-chan)
                 *save-chan*     save-chan

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -12,7 +12,7 @@
     ;; make a copy of the `test-data` DB so there will be no cache entries from previous test runs possibly affecting
     ;; this test.
     (mt/with-temp-copy-of-db
-      (mt/with-temporary-setting-values [enable-query-caching  true
+      (mt/with-temporary-setting-values [enable-query-caching       true
                                          query-caching-min-duration 0]
         (let [query            (assoc (mt/mbql-query venues {:order-by [[:asc $id]], :limit 5})
                                       :cache-ttl 10)

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -13,7 +13,7 @@
     ;; this test.
     (mt/with-temp-copy-of-db
       (mt/with-temporary-setting-values [enable-query-caching  true
-                                         query-caching-min-ttl 0]
+                                         query-caching-min-duration 0]
         (let [query            (assoc (mt/mbql-query venues {:order-by [[:asc $id]], :limit 5})
                                       :cache-ttl 10)
               run-query        (fn []


### PR DESCRIPTION
> [!IMPORTANT]
> If you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details.

> **Warning**
>
> If that is your first contribution to Metabase, please sign the [Contributor License Agreement](https://docs.google.com/a/metabase.com/forms/d/1oV38o7b9ONFSwuzwmERRMi9SYrhYeOrkbmNaq9pOJ_E/viewform) (unless it's a tiny documentation change). Also, if you're attempting to fix a translation issue, please submit your changes to our [POEditor project](https://poeditor.com/join/project/ynjQmwSsGh) instead of opening a PR.

Closes https://github.com/metabase/metabase/issues/39435

### Description

This PR introduces a new name for the `query-caching-min-ttl` setting: `query-caching-min-duration` to more clearly represent the meaning behind it.

### How to verify

Use the new `query-caching-min-duration` through the code.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
