### PR TITLE
Convert column to float when appending floats to an integer column

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,6 +6,9 @@ title: Driver interface changelog
 
 ## Metabase 0.49.0
 
+- The multimethod `metabase.driver/alter-columns!` has been added. This method is used to alter a table's columns in the
+  database. This is currently only required for drivers that support the `:uploads` feature.
+
 - The multimethod `metabase.driver.sql-jdbc.sync.interface/current-user-table-privileges` has been added.
   JDBC-based drivers can implement this to improve the performance of the default SQL JDBC implementation of
   `metabase.driver/describe-database`. It needs to be implemented if the database supports the `:table-privileges`

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,8 +6,8 @@ title: Driver interface changelog
 
 ## Metabase 0.49.0
 
-- The multimethod `metabase.driver.sql-jdbc/alter-columns-sql` has been added. This method can be used to override the
-  default SQL statement generated for JDBC-based drivers.
+- The multimethod `metabase.driver.sql-jdbc.sync.interface/alter-columns-sql` has been added. This method can be used to
+  override the default SQL statement generated for JDBC-based drivers.
 
 - The multimethod `metabase.driver/alter-columns!` has been added. This method is used to alter a table's columns in the
   database. This is currently only required for drivers that support the `:uploads` feature, and has a default

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,12 +6,12 @@ title: Driver interface changelog
 
 ## Metabase 0.49.0
 
-- The multimethod `metabase.driver.sql-jdbc.sync.interface/alter-columns-sql` has been added. This method can be used to
-  override the default SQL statement generated for JDBC-based drivers.
-
 - The multimethod `metabase.driver/alter-columns!` has been added. This method is used to alter a table's columns in the
   database. This is currently only required for drivers that support the `:uploads` feature, and has a default
   implementation for JDBC-based drivers.
+
+- The multimethod `metabase.driver.sql-jdbc.sync.interface/alter-columns-sql` has been added. The method
+  allows you to customize the query used by the default JDBC implementation of `metabase.driver/alter-columns!`.
 
 - The multimethod `metabase.driver.sql-jdbc.sync.interface/current-user-table-privileges` has been added.
   JDBC-based drivers can implement this to improve the performance of the default SQL JDBC implementation of

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,8 +6,12 @@ title: Driver interface changelog
 
 ## Metabase 0.49.0
 
+- The multimethod `metabase.driver.sql-jdbc/alter-columns-sql` has been added. This method can be used to override the
+  default SQL statement generated for JDBC-based drivers.
+
 - The multimethod `metabase.driver/alter-columns!` has been added. This method is used to alter a table's columns in the
-  database. This is currently only required for drivers that support the `:uploads` feature.
+  database. This is currently only required for drivers that support the `:uploads` feature, and has a default
+  implementation for JDBC-based drivers.
 
 - The multimethod `metabase.driver.sql-jdbc.sync.interface/current-user-table-privileges` has been added.
   JDBC-based drivers can implement this to improve the performance of the default SQL JDBC implementation of

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -924,7 +924,7 @@
 (defmulti alter-columns!
   "Alter columns given by `column-definitions` to a table named `table-name`. If the table doesn't exist it will throw an error.
   Currently we do not currently support changing the the primary key."
-  {:added "0.??.0", :arglists '([driver db-id table-name column-definitions])}
+  {:added "0.49.0", :arglists '([driver db-id table-name column-definitions])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -923,7 +923,7 @@
 
 (defmulti alter-columns!
   "Alter columns given by `column-definitions` to a table named `table-name`. If the table doesn't exist it will throw an error.
-  Currently we do not currently support changing the the primary key."
+  Currently we do not currently support changing the the primary key, or take any guidance on how to coerce values."
   {:added "0.49.0", :arglists '([driver db-id table-name column-definitions])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -921,6 +921,13 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
+(defmulti alter-columns!
+  "Alter columns given by `column-definitions` to a table named `table-name`. If the table doesn't exist it will throw an error.
+  Currently we do not currently support changing the the primary key."
+  {:added "0.??.0", :arglists '([driver db-id table-name column-definitions])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
 (defmulti syncable-schemas
   "Returns the set of syncable schemas in the database (as strings)."
   {:added "0.47.0", :arglists '([driver database])}

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -14,6 +14,7 @@
    [metabase.driver.postgres.actions :as postgres.actions]
    [metabase.driver.postgres.ddl :as postgres.ddl]
    [metabase.driver.sql :as driver.sql]
+   [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -789,6 +790,15 @@
 (defmethod driver/create-auto-pk-with-append-csv? :postgres
   [driver]
   (= driver :postgres))
+
+(defmethod sql-jdbc/alter-columns-sql :postgres
+  [driver table-name column-definitions]
+  (first (sql/format {:alter-table  (keyword table-name)
+                      :alter-column (map (fn [[column-name type-and-constraints]]
+                                           (vec (cons column-name (cons :type type-and-constraints))))
+                                         column-definitions)}
+                     :quoted true
+                     :dialect (sql.qp/quote-style driver))))
 
 (defmethod driver/table-name-length-limit :postgres
   [_driver]

--- a/src/metabase/driver/postgres.clj
+++ b/src/metabase/driver/postgres.clj
@@ -14,7 +14,6 @@
    [metabase.driver.postgres.actions :as postgres.actions]
    [metabase.driver.postgres.ddl :as postgres.ddl]
    [metabase.driver.sql :as driver.sql]
-   [metabase.driver.sql-jdbc :as sql-jdbc]
    [metabase.driver.sql-jdbc.common :as sql-jdbc.common]
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
@@ -791,7 +790,7 @@
   [driver]
   (= driver :postgres))
 
-(defmethod sql-jdbc/alter-columns-sql :postgres
+(defmethod sql-jdbc.sync/alter-columns-sql :postgres
   [driver table-name column-definitions]
   (first (sql/format {:alter-table  (keyword table-name)
                       :alter-column (map (fn [[column-name type-and-constraints]]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -180,7 +180,7 @@
   [driver db-id table-name column-definitions]
   (let [sql (first (sql/format {:alter-table  (keyword table-name)
                                 :alter-column (map (fn [[column-name type-and-constraints]]
-                                                     (vec (cons column-name type-and-constraints)))
+                                                     (vec (cons column-name (cons :type type-and-constraints))))
                                                    column-definitions)}
                                :quoted true
                                :dialect (sql.qp/quote-style driver)))]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -9,6 +9,7 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
+   [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sync :as driver.s]
    [metabase.query-processor.writeback :as qp.writeback]
@@ -176,24 +177,9 @@
                                :dialect (sql.qp/quote-style driver)))]
     (qp.writeback/execute-write-sql! db-id sql)))
 
-(defmulti alter-columns-sql
-  "Generate the query to be used with [[driver/alter-columns!]]."
-  {:added "0.49.0", :arglists '([driver db-id table-name column-definitions])}
-  driver/dispatch-on-initialized-driver
-  :hierarchy #'driver/hierarchy)
-
-(defmethod alter-columns-sql :sql-jdbc
-  [driver table-name column-definitions]
-  (first (sql/format {:alter-table  (keyword table-name)
-                      :alter-column (map (fn [[column-name type-and-constraints]]
-                                           (vec (cons column-name type-and-constraints)))
-                                         column-definitions)}
-                     :quoted true
-                     :dialect (sql.qp/quote-style driver))))
-
 (defmethod driver/alter-columns! :sql-jdbc
   [driver db-id table-name column-definitions]
-  (qp.writeback/execute-write-sql! db-id (alter-columns-sql driver table-name column-definitions)))
+  (qp.writeback/execute-write-sql! db-id (sql-jdbc.sync.interface/alter-columns-sql driver table-name column-definitions)))
 
 (defmethod driver/syncable-schemas :sql-jdbc
   [driver database]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -9,7 +9,6 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
-   [metabase.driver.sql-jdbc.sync.interface :as sql-jdbc.sync.interface]
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sync :as driver.s]
    [metabase.query-processor.writeback :as qp.writeback]
@@ -179,7 +178,7 @@
 
 (defmethod driver/alter-columns! :sql-jdbc
   [driver db-id table-name column-definitions]
-  (qp.writeback/execute-write-sql! db-id (sql-jdbc.sync.interface/alter-columns-sql driver table-name column-definitions)))
+  (qp.writeback/execute-write-sql! db-id (sql-jdbc.sync/alter-columns-sql driver table-name column-definitions)))
 
 (defmethod driver/syncable-schemas :sql-jdbc
   [driver database]

--- a/src/metabase/driver/sql_jdbc/sync.clj
+++ b/src/metabase/driver/sql_jdbc/sync.clj
@@ -15,6 +15,7 @@
 (p/import-vars
  [sql-jdbc.sync.interface
   active-tables
+  alter-columns-sql
   column->semantic-type
   current-user-table-privileges
   database-type->base-type

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -224,10 +224,9 @@
 (defn- type-relaxer
   "Given a map of {value-type -> predicate}, return a reducing fn which updates our inferred schema using the next row."
   [type->check]
-  (let [type->value->type (partial relax-type type->check)]
-    (fn [value-types row]
-      ;; It's important to realize this lazy sequence, because otherwise we can build a huge stack and overflow.
-      (vec (u/map-all (partial relax-type type->check) value-types row))))
+  (fn [value-types row]
+    ;; It's important to realize this lazy sequence, because otherwise we can build a huge stack and overflow.
+    (vec (u/map-all (partial relax-type type->check) value-types row))))
 
 (defn- relax-types [settings current-types rows]
   (let [type->check (settings->type->check settings)]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -658,7 +658,7 @@
                                      ;; we will instead throw an error when we try to parse as the old type
                                      (not (matching-or-upgradable? old-column-types common-types)))
                                old-column-types
-                               (let [fields (map normed-name->field normed-header)
+                               (let [fields          (map normed-name->field normed-header)
                                      field+new-types (changed-field+new-types fields old-column-types common-types)]
                                  (convert-columns! database table field+new-types)
                                  common-types))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1649,8 +1649,8 @@
         ;; inserted rows are rolled back
         (binding [driver/*insert-chunk-rows* 1]
           (doseq [{:keys [upload-type uncoerced coerced fail-msg] :as args}
-                  [{:upload-type ::upload/int,     :uncoerced "2.0",        :coerced 2}
-                   {:upload-type ::upload/int,     :uncoerced "2.1",        :coerced 2.1}
+                  [{:upload-type ::upload/int,     :uncoerced "2.0",        :coerced 2.0} ;; column is promoted to float
+                   {:upload-type ::upload/int,     :uncoerced "2.1",        :coerced 2.1} ;; column is promoted to float
                    {:upload-type ::upload/float,   :uncoerced "2",          :coerced 2.0}
                    {:upload-type ::upload/boolean, :uncoerced "0",          :coerced false}
                    {:upload-type ::upload/boolean, :uncoerced "1.0",        :fail-msg "'1.0' is not a recognizable boolean"}

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -296,7 +296,7 @@
   [rows]
   (with-open [reader (io/reader (csv-file-with rows))]
     (let [[header & rows] (csv/read-csv reader)]
-      (#'upload/detect-schema header rows))))
+      (#'upload/detect-schema (upload-parsing/get-settings) header rows))))
 
 (deftest ^:parallel detect-schema-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -23,6 +23,7 @@
    [metabase.upload :as upload]
    [metabase.upload.parsing :as upload-parsing]
    [metabase.util :as u]
+   [metabase.util.ordered-hierarchy :as ordered-hierarchy]
    [toucan2.core :as t2])
   (:import
    (java.io File)))
@@ -268,7 +269,7 @@
            [datetime-type    text-type        text-type]
            [offset-dt-type   text-type        text-type]
            [vchar-type       text-type        text-type]]]
-    (is (= expected (#'upload/most-specific-common-ancestor type-a type-b))
+    (is (= expected (#'ordered-hierarchy/first-common-ancestor @#'upload/h type-a type-b))
         (format "%s + %s = %s" (name type-a) (name type-b) (name expected)))))
 
 (defn csv-file-with

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1580,6 +1580,35 @@
                         (is (= 1 (count (rows-for-table table)))))
                       (io/delete-file file))))))))))))
 
+(deftest append-type-upgrade-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (with-mysql-local-infile-on-and-off
+     (testing "Append may upgrade integer columns to floats to avoid lossy import BLAH REWORD ME PLZ"
+       ;; for drivers that insert rows in chunks, we change the chunk size to 1 so that we can test that the
+       ;; inserted rows are rolled back
+       (binding [driver/*insert-chunk-rows* 1]
+         (doseq [auto-pk-column? [true false]]
+           (testing (str "\nFor a table that has " (if auto-pk-column? "an" " no") " automatically generated PK already")
+             (doseq [{:keys [basic specialized]}
+                     [{:basic 5 :specialized 1.4}]
+                     :let [upload-type (#'upload/value->type (str basic) (upload-parsing/get-settings))]]
+               (testing (str "\nTry to upload an invalid value for " ())
+                 (with-upload-table!
+                  [table (create-upload-table!
+                          {:col->upload-type (cond-> (ordered-map/ordered-map
+                                                      :test_column upload-type)
+                                               auto-pk-column?
+                                               (assoc upload/auto-pk-column-keyword ::upload/auto-incrementing-int-pk))
+                           :rows             [[(str basic)]]})]
+                  (let [;; The CSV contains 50 basic rows and 1 that is more specialized
+                        csv-rows `["test_column" ~@(repeat 5 (str basic)) ~(str specialized)]
+                        file     (csv-file-with csv-rows (mt/random-name))]
+                    (append-csv! {:file     file
+                                  :table-id (:id table)})
+                    (testing "\nCheck the data was not uploaded into the table"
+                      (is (= 7 (count (rows-for-table table)))))
+                    (io/delete-file file))))))))))))
+
 ;; FIXME: uploading to a varchar-255 column can fail if the text is too long
 ;; We ideally want to change the column type to text if we detect this will happen, but that's difficult
 ;; currently because we don't store the character length of the column. e.g. a varchar(255) column in postgres


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37069

### Description

This adds a type detection step during append which checks for columns that would need to be relaxed, and does so if we've configured that transition as OK.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Upload a CSV with an all integer column as a new table.
2. View the table and confirm it has integer type.
3. Append a CSV with the same column containing floats to the same table.
4. View the table and confirm it has a float type, and numbers were not truncated.

### Demo

[Watch it in action](https://www.loom.com/share/47b7d927c8d94e41bfd09b8d5d8a950c?sid=63f59a70-3008-4b46-b334-0008e4830831)
