### PR TITLE
Repro #29094 - Notebook filter field allows non boolean custom expressions

### DIFF
--- a/e2e/test/scenarios/filters/reproductions/29094-non-boolean-custom-expressions.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/29094-non-boolean-custom-expressions.cy.spec.js
@@ -6,7 +6,7 @@ import {
   startNewQuestion,
 } from "e2e/support/helpers";
 
-describe("issue 29094", function () {
+describe("issue 29094", () => {
   beforeEach(() => {
     restore();
     cy.signInAsNormalUser();

--- a/e2e/test/scenarios/filters/reproductions/29094-non-boolean-custom-expressions.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/29094-non-boolean-custom-expressions.cy.spec.js
@@ -1,0 +1,35 @@
+import {
+  enterCustomColumnDetails,
+  getNotebookStep,
+  popover,
+  restore,
+  startNewQuestion,
+} from "e2e/support/helpers";
+
+describe("issue 29094", function () {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+  });
+
+  it("disallows adding a filter using non-boolean custom expression (metabase#29094)", () => {
+    startNewQuestion();
+
+    popover().within(() => {
+      cy.findByText("Raw Data").click();
+      cy.findByText("Orders").click();
+    });
+
+    getNotebookStep("filter")
+      .findByText("Add filters to narrow your answer")
+      .click();
+
+    popover().within(() => {
+      cy.findByText("Custom Expression").click();
+      enterCustomColumnDetails({ formula: "[Tax] * 22" });
+      cy.realPress("Tab");
+      cy.button("Done").should("be.disabled");
+      cy.findByText("Invalid expression").should("exist");
+    });
+  });
+});


### PR DESCRIPTION
Closes #29094

No backport because in v49 it behaves slightly different than in `master`, see [comment](https://github.com/metabase/metabase/issues/29094#issuecomment-1976261054).

Stress test: https://github.com/metabase/metabase/actions/runs/8140145441