### PR TITLE
Repro #23851 - Drill-through on a timestamp column binned as XofY fails unless sematic type is defined

### DIFF
--- a/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
+++ b/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
@@ -12,7 +12,7 @@ const CREATED_AT_BREAKOUT = [
   },
 ];
 
-describe("issue 23851", function () {
+describe("issue 23851", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();

--- a/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
+++ b/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
@@ -45,6 +45,7 @@ describe("issue 23851", () => {
       "have.text",
       "Created At: Day of week is equal to 6",
     );
+    cy.get(".cellData").should("contain", "109.22");
     cy.icon("notebook").click();
     getNotebookStep("filter")
       .findByText("Created At: Day of week is equal to 6")

--- a/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
+++ b/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
@@ -1,0 +1,53 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { getNotebookStep, popover, restore } from "e2e/support/helpers";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+const CREATED_AT_BREAKOUT = [
+  "field",
+  ORDERS.CREATED_AT,
+  {
+    "base-type": "type/DateTime",
+    "temporal-unit": "day-of-week",
+  },
+];
+
+describe("issue 23851", function () {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+  });
+
+  it("can drill through question with temporal extraction breakout without semantic type defined for the column (metabase#23851)", () => {
+    cy.request("PUT", `/api/field/${ORDERS.CREATED_AT}`, {
+      semantic_type: null,
+    });
+    cy.createQuestion(
+      {
+        query: {
+          "source-table": ORDERS_ID,
+          aggregation: [["count"]],
+          breakout: [CREATED_AT_BREAKOUT],
+        },
+        display: "bar",
+      },
+      { visitQuestion: true },
+    );
+
+    cy.get(".bar").should("have.length", 7);
+    cy.get(".bar").eq(5).click();
+    popover().findByText("See these Orders").click();
+
+    cy.wait("@dataset");
+
+    cy.findByTestId("qb-filters-panel").should(
+      "contain.text",
+      "Created At: Day of week is equal to 6",
+    );
+    cy.icon("notebook").click();
+    getNotebookStep("filter")
+      .findByText("Created At: Day of week is equal to 6")
+      .should("exist");
+  });
+});

--- a/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
+++ b/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
@@ -41,8 +41,8 @@ describe("issue 23851", () => {
 
     cy.wait("@dataset");
 
-    cy.findByTestId("qb-filters-panel").should(
-      "contain.text",
+    cy.findByTestId("filter-pill").should(
+      "have.text",
       "Created At: Day of week is equal to 6",
     );
     cy.icon("notebook").click();


### PR DESCRIPTION
Closes #23851

Stress test: https://github.com/metabase/metabase/actions/runs/8140165243