### PR TITLE
Prevent custom expressions from being removed from the query

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table-column-settings.cy.spec.js
@@ -496,8 +496,6 @@ describe("scenarios > visualizations > table column settings", () => {
 
       _hideColumn(testData);
       _showColumn(testData);
-      _removeColumn(testData);
-      _addColumn(testData);
     });
 
     it("should be able to show and hide custom expressions for a table with selected fields", () => {
@@ -515,8 +513,6 @@ describe("scenarios > visualizations > table column settings", () => {
 
       _hideColumn(testData);
       _showColumn(testData);
-      _removeColumn(testData);
-      _addColumn(testData);
     });
 
     it("should be able to show and hide columns from aggregations", () => {

--- a/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
@@ -2,7 +2,7 @@ import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
 import { renderWithProviders, screen } from "__support__/ui";
-import type * as Lib from "metabase-lib";
+import * as Lib from "metabase-lib";
 import { createQuery } from "metabase-lib/test-helpers";
 
 import { FieldPanel } from "./FieldPanel";
@@ -114,6 +114,22 @@ describe("QueryColumnPicker", () => {
     userEvent.click(orderGroup);
     expect(firstColumn).toBeChecked();
     expect(firstColumn).toBeEnabled();
+  });
+
+  it("should not allow to remove custom columns", () => {
+    const query = Lib.expression(
+      createQuery(),
+      -1,
+      "Custom",
+      Lib.expressionClause("+", [1, 2]),
+    );
+    setup({ query });
+    const [orderGroup] = screen.getAllByRole("checkbox");
+    const customColumn = screen.getByRole("checkbox", { name: "Custom" });
+    expect(orderGroup).toBeChecked();
+    expect(orderGroup).toBeDisabled();
+    expect(customColumn).toBeChecked();
+    expect(customColumn).toBeDisabled();
   });
 
   it("should allow to search for columns", () => {

--- a/frontend/src/metabase/querying/components/FieldPanel/utils.ts
+++ b/frontend/src/metabase/querying/components/FieldPanel/utils.ts
@@ -24,7 +24,10 @@ function getColumnItems(
       column,
       displayName: columnInfo.displayName,
       isSelected: columnInfo.selected ?? false,
-      isDisabled: columnInfo.isAggregation || columnInfo.isBreakout,
+      isDisabled:
+        columnInfo.isAggregation ||
+        columnInfo.isBreakout ||
+        columnInfo.isCalculated,
     };
   });
 }


### PR DESCRIPTION
Currently removing a custom expression column from the query has no effect. Let's disable the checkbox in this case as we do for aggregation and breakout columns.

How to verify:
- New -> Orders -> Custom column -> 1 + 2 -> Visualize
- Table viz settings (gear icon) -> Add or remove columns
- Make sure that the column is selected and cannot be removed

<img width="663" alt="Screenshot 2024-03-04 at 15 49 20" src="https://github.com/metabase/metabase/assets/8542534/e59f9a95-030b-42b6-b3dd-a87da01ea2c3">
<img width="662" alt="Screenshot 2024-03-04 at 15 49 15" src="https://github.com/metabase/metabase/assets/8542534/14efb477-d381-4daf-8445-21501ce56fa7">
