### PR TITLE
[WIP]: Less ambiguous loading state

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -305,6 +305,28 @@ describe("scenarios > visualizations > table", () => {
       expect(isScrollableHorizontally($popover[0])).to.be.false;
     });
   });
+
+  it(
+    "should show the slow loading text when the query is taking too long",
+    { tags: ["@slow"] },
+    () => {
+      openOrdersTable({ mode: "notebook" });
+
+      cy.intercept("POST", "/api/dataset", req => {
+        req.on("response", res => {
+          res.setDelay(6000);
+        });
+      });
+
+      cy.button("Visualize").click();
+
+      cy.findByTestId("query-builder-main").findByText("Doing science...");
+      cy.findByTestId("query-builder-main").findByText(
+        "Talking to the database...",
+        { timeout: 6000 },
+      );
+    },
+  );
 });
 
 describe("scenarios > visualizations > table > conditional formatting", () => {

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/loading-message.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/loading-message.ts
@@ -1,9 +1,18 @@
 import { t } from "ttag";
 
 export const LOADING_MESSAGE_BY_SETTING = {
-  "doing-science": t`Doing science...`,
-  "running-query": t`Running query...`,
-  "loading-results": t`Loading results...`,
+  "doing-science": {
+    initial: t`Doing science...`,
+    slow: t`Talking to the database...`,
+  },
+  "running-query": {
+    initial: t`Running query...`,
+    slow: t`Talking to the database...`,
+  },
+  "loading-results": {
+    initial: t`Loading results...`,
+    slow: t`Talking to the database...`,
+  },
 };
 
 export const getLoadingMessageOptions = () =>

--- a/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
@@ -28,7 +28,10 @@ import {
 } from "./MetabotQueryBuilder.styled";
 
 interface StateProps {
-  loadingMessage: string;
+  loadingMessage: {
+    initial: string;
+    slow: string;
+  };
   queryStatus: MetabotQueryStatus;
   queryResults: [Dataset] | null;
   queryError: unknown;
@@ -82,7 +85,10 @@ const QueryIdleState = () => {
 };
 
 interface QueryRunningStateProps {
-  loadingMessage: string;
+  loadingMessage: {
+    initial: string;
+    slow: string;
+  };
 }
 
 const QueryRunningState = ({ loadingMessage }: QueryRunningStateProps) => {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -133,7 +133,10 @@ export const PLUGIN_IS_PASSWORD_USER: ((user: User) => boolean)[] = [];
 // selectors that customize behavior between app versions
 export const PLUGIN_SELECTORS = {
   canWhitelabel: (_state: State) => false,
-  getLoadingMessage: (_state: State) => t`Doing science...`,
+  getLoadingMessage: (_state: State) => ({
+    initial: t`Doing science...`,
+    slow: t`Talking to the database...`,
+  }),
   getIsWhiteLabeling: (_state: State) => false,
   // eslint-disable-next-line no-literal-metabase-strings -- This is the actual Metabase name, so we don't want to translate it.
   getApplicationName: (_state: State) => "Metabase",

--- a/frontend/src/metabase/query_builder/actions/querying.js
+++ b/frontend/src/metabase/query_builder/actions/querying.js
@@ -148,8 +148,8 @@ const loadStartUIControls = createThunkAction(
   () => (dispatch, getState) => {
     const loadingMessage = getWhiteLabeledLoadingMessage(getState());
     const title = {
-      onceQueryIsRun: loadingMessage,
-      ifQueryTakesLong: t`Still Here...`,
+      onceQueryIsRun: loadingMessage.initial,
+      ifQueryTakesLong: loadingMessage.slow,
     };
 
     dispatch(setDocumentTitle(title.onceQueryIsRun));

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
 import { useState } from "react";
+import { useTimeout } from "react-use";
 import { t } from "ttag";
 
 import LoadingSpinner from "metabase/components/LoadingSpinner";
@@ -10,6 +11,8 @@ import RunButtonWithTooltip from "./RunButtonWithTooltip";
 import { VisualizationError } from "./VisualizationError";
 import VisualizationResult from "./VisualizationResult";
 import Warnings from "./Warnings";
+
+const SLOW_QUERY_TIMEOUT = 4000;
 
 export default function QueryVisualization(props) {
   const {
@@ -80,22 +83,24 @@ export const VisualizationEmptyState = ({ className }) => (
   </div>
 );
 
-export const VisualizationRunningState = ({
-  className = "",
-  loadingMessage,
-}) => (
-  <div
-    className={cx(
-      className,
-      "Loading flex flex-column layout-centered text-brand",
-    )}
-  >
-    <LoadingSpinner />
-    <h2 className="Loading-message text-brand text-uppercase my3">
-      {loadingMessage}
-    </h2>
-  </div>
-);
+export function VisualizationRunningState({ className = "", loadingMessage }) {
+  const [isSlow] = useTimeout(SLOW_QUERY_TIMEOUT);
+  const message = loadingMessage[isSlow() ? "slow" : "initial"];
+
+  return (
+    <div
+      className={cx(
+        className,
+        "Loading flex flex-column layout-centered text-brand",
+      )}
+    >
+      <LoadingSpinner />
+      <h2 className="Loading-message text-brand text-uppercase my3">
+        {message}
+      </h2>
+    </div>
+  );
+}
 
 export const VisualizationDirtyState = ({
   className,

--- a/frontend/src/metabase/selectors/whitelabel/index.ts
+++ b/frontend/src/metabase/selectors/whitelabel/index.ts
@@ -2,7 +2,16 @@ import { PLUGIN_SELECTORS } from "metabase/plugins";
 import type { State } from "metabase-types/store";
 
 export function getWhiteLabeledLoadingMessage(state: State) {
-  return PLUGIN_SELECTORS.getLoadingMessage(state);
+  const message = PLUGIN_SELECTORS.getLoadingMessage(state);
+
+  if (typeof message === "string") {
+    return {
+      initial: message,
+      slow: message,
+    };
+  }
+
+  return message;
 }
 
 export function getIsWhiteLabeling(state: State) {

--- a/frontend/src/metabase/selectors/whitelabel/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/common.unit.spec.ts
@@ -12,19 +12,28 @@ describe("getWhiteLabeledLoadingMessage (OSS)", () => {
   it("should return 'Doing science...' when loading-message is set to 'doing-science'", () => {
     const { getState } = setup({ loadingMessage: "doing-science" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())).toEqual({
+      initial: "Doing science...",
+      slow: "Talking to the database...",
+    });
   });
 
   it("should return 'Doing science...' when loading-message is set to 'loading-results'", () => {
     const { getState } = setup({ loadingMessage: "loading-results" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())).toEqual({
+      initial: "Doing science...",
+      slow: "Talking to the database...",
+    });
   });
 
   it("should return 'Doing science...' when loading-message is set to 'running-query'", () => {
     const { getState } = setup({ loadingMessage: "running-query" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())).toEqual({
+      initial: "Doing science...",
+      slow: "Talking to the database...",
+    });
   });
 });
 

--- a/frontend/src/metabase/selectors/whitelabel/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/enterprise.unit.spec.ts
@@ -17,19 +17,28 @@ describe("getWhiteLabeledLoadingMessage (EE without token)", () => {
   it("should return 'Doing science...' when loading-message is set to 'doing-science'", () => {
     const { getState } = setup({ loadingMessage: "doing-science" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())).toEqual({
+      initial: "Doing science...",
+      slow: "Talking to the database...",
+    });
   });
 
   it("should return 'Doing science...' when loading-message is set to 'loading-results'", () => {
     const { getState } = setup({ loadingMessage: "loading-results" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())).toEqual({
+      initial: "Doing science...",
+      slow: "Talking to the database...",
+    });
   });
 
   it("should return 'Doing science...' when loading-message is set to 'running-query'", () => {
     const { getState } = setup({ loadingMessage: "running-query" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())).toEqual({
+      initial: "Doing science...",
+      slow: "Talking to the database...",
+    });
   });
 });
 

--- a/frontend/src/metabase/selectors/whitelabel/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/premium.unit.spec.ts
@@ -21,21 +21,28 @@ describe("getWhiteLabeledLoadingMessage (EE with token)", () => {
   it("should return 'Doing science...' when loading-message is set to 'doing-science'", () => {
     const { getState } = setup({ loadingMessage: "doing-science" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())).toEqual({
+      initial: "Doing science...",
+      slow: "Talking to the database...",
+    });
   });
 
   it("should return 'Loading results...' when loading-message is set to 'loading-results'", () => {
     const { getState } = setup({ loadingMessage: "loading-results" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe(
-      "Loading results...",
-    );
+    expect(getWhiteLabeledLoadingMessage(getState())).toEqual({
+      initial: "Loading results...",
+      slow: "Talking to the database...",
+    });
   });
 
   it("should return 'Running query...' when loading-message is set to 'running-query'", () => {
     const { getState } = setup({ loadingMessage: "running-query" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Running query...");
+    expect(getWhiteLabeledLoadingMessage(getState())).toEqual({
+      initial: "Running query...",
+      slow: "Talking to the database...",
+    });
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39503
### Description

Allows the `getLoadingMessage` option to return a function which is parametrised on the elapsed query time.

### How to verify

1. Open a new query that loads very slowly
2. Verify that the loading message changes from `Doing Science...` to `Talking to the database...` after 4 seconds

### Demo

<div>
    <a href="https://www.loom.com/share/61345929d1574e398551fc2350a29fff">
      <p>Question · Metabase - 4 March 2024 - Watch Video</p>
    </a>
    <a href="https://www.loom.com/share/61345929d1574e398551fc2350a29fff">
      <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/61345929d1574e398551fc2350a29fff-with-play.gif">
    </a>
  </div>

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
