### PR TITLE
Don't send release reminders on weekends

### DIFF
--- a/.github/workflows/release-status.yml
+++ b/.github/workflows/release-status.yml
@@ -3,7 +3,7 @@ name: Release Status Check
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 13 * * *' # every day at 8am US eastern time
+    - cron: '0 11 * * 1-5' # every weekday at 6am US eastern time
 
 jobs:
   check-release-status:


### PR DESCRIPTION
github actions cron docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule

also moves it a couple hours earlier