### PR TITLE
[MLv2] `joinable-columns` on a Join sets source and alias

### DIFF
--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -1094,11 +1094,15 @@
               cols  (lib/joinable-columns query -1 join)]
           (is (=? [{:name                         "ID"
                     :metabase.lib.join/join-alias "Cat"
+                    :source-alias                 "Cat"
+                    :lib/source                   :source/joins
                     :lib/source-column-alias      "ID"
                     :lib/desired-column-alias     "Cat__ID"
                     :selected?                    id-selected?}
                    {:name                         "NAME"
                     :metabase.lib.join/join-alias "Cat"
+                    :source-alias                 "Cat"
+                    :lib/source                   :source/joins
                     :lib/source-column-alias      "NAME"
                     :lib/desired-column-alias     "Cat__NAME"
                     :selected?                    name-selected?}]


### PR DESCRIPTION
`(joinable-columns query stage a-join)` previously returned
`:lib/source :source/table-defaults` and set
`:metabase.lib.join/join-alias` but not `:source-alias`.

This corrects both issues so that `joinable-columns` on a join returns
columns with the same shape as from `visible-columns`.

Also refactors a series of `mapv` transforms into a transducer pipeline.

Fixes #39514.
