### PR TITLE
Fix query builder query string parsing

### DIFF
--- a/frontend/src/metabase/query_builder/utils.ts
+++ b/frontend/src/metabase/query_builder/utils.ts
@@ -30,7 +30,7 @@ export function getPathNameFromQueryBuilderMode({
 export function getCurrentQueryParams() {
   const search =
     window.location.search.charAt(0) === "?"
-      ? window.location.search.slice(0)
+      ? window.location.search.slice(1)
       : window.location.search;
   return querystring.parse(search);
 }


### PR DESCRIPTION
**Problem:** The query string parser for the query builder is accidentally including the `?` after parsing the query string. It should be removing that character (using `.slice(1)` not `.slice(0)`), so that it can correctly parse the query parameters without the prepended `?`

**Before**

https://github.com/metabase/metabase/assets/22608765/08308eb2-1df4-4ff4-9541-c6b201e8a4f3

You can see the URL flickers with a `%3F` included after the `?`. `%3F` is a character encoding for `?`. i.e. Because we are including the `?` after parsing, the first parameter in the query string will have that character prepended.

The only reason we see it go back to normal is because `SyncedParametersList` receives the new parameter value (independent of the URL) and then updates the URL to reflect the current parameter state ([use-synced-list-query.ts](https://github.com/metabase/metabase/blob/master/frontend/src/metabase/hooks/use-synced-query-string.ts#L6))


**After**

https://github.com/metabase/metabase/assets/22608765/99c0793e-c67b-4589-8f42-0235db7f1bb7

