### PR TITLE
Fix use of perms API when populating :native_permissions on databases

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -91,7 +91,8 @@
   Permissions', all Cards' permissions are based on their parent Collection, removing the need for native read perms."
   [dbs :- [:maybe [:sequential :map]]]
   (for [db dbs]
-    (assoc db :native_permissions (if (data-perms/database-permission-for-user api/*current-user-id* :perms/native-query-editing (u/the-id db))
+    (assoc db :native_permissions (if (= (data-perms/database-permission-for-user api/*current-user-id* :perms/native-query-editing (u/the-id db))
+                                         :yes)
                                     :write
                                     :none))))
 


### PR DESCRIPTION
Here's another spot where `database-permission-for-user` was being used as if it returns a boolean, when it really returns a keyword representing the user's permission level. This was caught by an e2e test added recently in `master`. This should make the perms refactor feature branch green again.

This raises the question of if we should change the API (or add new APIs) to take a perm type _and_ value and return a Boolean? I'm concerned that it's hard to catch if this API is used incorrectly since keywords are valid truthy values. 