### PR TITLE
backported "[QP] Fix confusion of expressions with the same name as columns"

### DIFF
--- a/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
+++ b/modules/drivers/sqlite/test/metabase/driver/sqlite_test.clj
@@ -215,7 +215,7 @@
   (testing "Make sure duplicate identifiers (even with different cases) get unique aliases"
     (mt/test-driver :sqlite
       (mt/dataset sample-dataset
-        (is (= '{:select   [source.CATEGORY_2 AS CATEGORY_2
+        (is (= '{:select   [source.CATEGORY_2 AS CATEGORY
                             COUNT (*)         AS count]
                  :from     [{:select [products.category       AS category
                                       products.category || ?  AS CATEGORY_2]

--- a/src/metabase/query_processor/util/nest_query.clj
+++ b/src/metabase/query_processor/util/nest_query.clj
@@ -89,10 +89,14 @@
         {base-type :base_type}       (some-> expression-definition annotate/infer-expression-type)
         {::add/keys [desired-alias]} (mbql.u/match-one source-query
                                        [:expression (_ :guard (partial = expression-name)) source-opts]
-                                       source-opts)]
+                                       source-opts)
+        source-alias                 (or desired-alias expression-name)]
     [:field
-     (or desired-alias expression-name)
-     (assoc opts :base-type (or base-type :type/*))]))
+     source-alias
+     (-> opts
+         (assoc :base-type          (or base-type :type/*)
+                ::add/source-table  ::add/source
+                ::add/source-alias  source-alias))]))
 
 (defn- rewrite-fields-and-expressions [query]
   (mbql.u/replace query

--- a/test/metabase/driver/sql/query_processor_test.clj
+++ b/test/metabase/driver/sql/query_processor_test.clj
@@ -728,7 +728,7 @@
 
 (deftest ^:parallel expression-with-duplicate-column-name-test
   (testing "Can we use expression with same column name as table (#14267)"
-    (is (= '{:select   [source.CATEGORY_2 AS CATEGORY_2
+    (is (= '{:select   [source.CATEGORY_2 AS CATEGORY
                         COUNT (*)         AS count]
              :from     [{:select [PRODUCTS.CATEGORY            AS CATEGORY
                                   CONCAT (PRODUCTS.CATEGORY ?) AS CATEGORY_2]

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -248,20 +248,7 @@
            (-> lib.tu/venues-query
                (lib/expression "expr" (lib/absolute-datetime "2020" :month))
                lib/expressions
-               (->> (map lib/expression-name))))))
-  (testing "collisions with other column names are detected and rejected"
-    (let [query (lib/query meta/metadata-provider (meta/table-metadata :categories))
-          ex    (try
-                  (lib/expression query "ID" (meta/field-metadata :categories :name))
-                  nil
-                  (catch #?(:clj clojure.lang.ExceptionInfo :cljs js/Error) e
-                    e))]
-      (is (some? ex)
-          "Expected adding a conflicting expression to throw")
-      (is (= "Expression name conflicts with a column in the same query stage"
-             (ex-message ex)))
-      (is (= {:expression-name "ID"}
-             (ex-data ex))))))
+               (->> (map lib/expression-name)))))))
 
 (deftest ^:parallel literal-expression-test
   (is (=? [{:lib/type :metadata/column,

--- a/test/metabase/query_processor/util/add_alias_info_test.clj
+++ b/test/metabase/query_processor/util/add_alias_info_test.clj
@@ -692,7 +692,8 @@
         (is (= {:field-name              "CREATED_AT"
                 :join-is-this-level?     "Q2"
                 :alias-from-join         "Products__CREATED_AT"
-                :alias-from-source-query nil}
+                :alias-from-source-query nil
+                :override-alias?         false}
                (#'add/expensive-field-info
                 (lib.tu.macros/$ids nil
                   {:source-table $$reviews

--- a/test/metabase/query_processor/util/nest_query_test.clj
+++ b/test/metabase/query_processor/util/nest_query_test.clj
@@ -664,7 +664,7 @@
                          :breakout           [[:field "CATEGORY_2" {:base-type          :type/Text
                                                                     ::add/source-table  ::add/source
                                                                     ::add/source-alias  "CATEGORY_2"
-                                                                    ::add/desired-alias "CATEGORY_2"
+                                                                    ::add/desired-alias "CATEGORY"
                                                                     ::add/position      0}]]
                          :aggregation        [[:aggregation-options [:count] {:name               "count"
                                                                               ::add/desired-alias "count"
@@ -672,7 +672,7 @@
                          :order-by           [[:asc [:field "CATEGORY_2" {:base-type          :type/Text
                                                                           ::add/source-table  ::add/source
                                                                           ::add/source-alias  "CATEGORY_2"
-                                                                          ::add/desired-alias "CATEGORY_2"
+                                                                          ::add/desired-alias "CATEGORY"
                                                                           ::add/position      0}]]]
                          :limit              1})
                       (-> (lib.tu.macros/mbql-query products
@@ -684,4 +684,43 @@
                           qp/preprocess
                           add/add-alias-info
                           :query
-                          nest-query/nest-expressions)))))))
+                          nest-query/nest-expressions)))
+
+        (testing "multi-stage query with an expression name that matches a table column (#39059)"
+          (is (=? (lib.tu.macros/$ids orders
+                    {:source-query {:fields       [[:field %id          {}]
+                                                   [:field %subtotal    {}]
+                                                   ;; Then exported as DISCOUNT from the middle layer.
+                                                   [:field "DISCOUNT_2" {:base-type          :type/Float
+                                                                         ::add/source-alias  "DISCOUNT_2"
+                                                                         ::add/desired-alias "DISCOUNT"}]]
+                                    :source-query {:expressions  {"DISCOUNT" [:coalesce [:field %discount {}] 0]}
+                                                   :fields       [[:field %id {::add/desired-alias "ID"}]
+                                                                  [:field %subtotal {::add/desired-alias "SUBTOTAL"}]
+                                                                  [:field %discount {::add/desired-alias "DISCOUNT"}]
+                                                                  ;; Exported as DISCOUNT_2 from this inner query.
+                                                                  [:expression "DISCOUNT"
+                                                                   {::add/desired-alias "DISCOUNT_2"}]]
+                                                   :source-table $$orders}}
+                     :source-query/model? true
+                     :fields              [[:field %id        {}]
+                                           [:field %subtotal  {}]
+                                           [:field "DISCOUNT" {:base-type          :type/Float
+                                                               ::add/source-alias  "DISCOUNT"
+                                                               ::add/desired-alias "DISCOUNT"}]]})
+                  (-> (lib.tu.macros/$ids orders
+                        {:type     :query
+                         :database (meta/id)
+                         :query    {:source-query {:expressions  {"DISCOUNT" [:coalesce $discount 0]}
+                                                   :fields       [$id
+                                                                  $subtotal
+                                                                  [:expression "DISCOUNT"]]
+                                                   :source-table $$orders}
+                                    :source-query/model? true
+                                    :fields              [[:field "ID"       {:base-type :type/Integer}]
+                                                          [:field "SUBTOTAL" {:base-type :type/Float}]
+                                                          [:field "DISCOUNT" {:base-type :type/Float}]]}})
+                      qp/preprocess
+                      add/add-alias-info
+                      :query
+                      nest-query/nest-expressions))))))))


### PR DESCRIPTION
Manual backport of #39255 to 48.

