### PR TITLE
ChartSettingOrderedItems using SortableList

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -168,6 +168,34 @@ export const moveColumnDown = (column, distance) => {
     .trigger("mouseup", 0, distance * 50, { force: true });
 };
 
+export const moveDnDKitColumnVertical = (column, distance) => {
+  column
+    .trigger("pointerdown", 0, 0, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .wait(200)
+    .trigger("pointermove", 5, 5, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .wait(200)
+    .trigger("pointermove", 0, distance, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .wait(200)
+    .trigger("pointerup", 0, distance, {
+      force: true,
+      isPrimary: true,
+      button: 0,
+    })
+    .wait(200);
+};
+
 export const queryBuilderMain = () => {
   return cy.findByTestId("query-builder-main");
 };

--- a/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/visualization-options.cy.spec.js
@@ -9,6 +9,8 @@ import {
   modal,
   saveDashboard,
   getDashboardCardMenu,
+  getDraggableElements,
+  moveDnDKitColumnVertical,
 } from "e2e/support/helpers";
 
 describe("scenarios > dashboard cards > visualization options", () => {
@@ -49,12 +51,7 @@ describe("scenarios > dashboard cards > visualization options", () => {
     getDashboardCard().realHover();
     cy.findByLabelText("Show visualization options").click();
     cy.findByTestId("chartsettings-sidebar").within(() => {
-      cy.findByText("ID")
-        .closest("[data-testid^=draggable-item]")
-        .trigger("mousedown", 0, 0, { force: true })
-        .trigger("mousemove", 5, 5, { force: true })
-        .trigger("mousemove", 0, 100, { force: true })
-        .trigger("mouseup", 0, 100, { force: true });
+      moveDnDKitColumnVertical(getDraggableElements().contains("ID"), 100);
 
       /**
        * When this issue gets fixed, it should be safe to uncomment the following assertion.

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -9,7 +9,7 @@ import {
   popover,
   modal,
   sidebar,
-  moveColumnDown,
+  moveDnDKitColumnVertical,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -100,7 +100,7 @@ describe("scenarios > question > settings", () => {
 
       getSidebarColumns().eq("5").as("total").contains("Total");
 
-      moveColumnDown(cy.get("@total"), -2);
+      moveDnDKitColumnVertical(cy.get("@total"), -100);
 
       getSidebarColumns().eq("3").should("contain.text", "Total");
 
@@ -114,12 +114,7 @@ describe("scenarios > question > settings", () => {
         expect($el.scrollTop).to.eql(0);
       });
 
-      cy.get("@title")
-        .trigger("mousedown", 0, 0, { force: true })
-        .trigger("mousemove", 5, 5, { force: true })
-        .trigger("mousemove", 0, 15, { force: true });
-      cy.wait(2000);
-      cy.get("@title").trigger("mouseup", 0, 15, { force: true });
+      moveDnDKitColumnVertical(cy.get("@title"), 15);
 
       cy.findByTestId("chartsettings-sidebar").should(([$el]) => {
         expect($el.scrollTop).to.be.greaterThan(0);
@@ -161,11 +156,7 @@ describe("scenarios > question > settings", () => {
         .contains(/Products? → Category/);
 
       // Drag and drop this column between "Tax" and "Discount" (index 5 in @sidebarColumns array)
-      cy.get("@prod-category")
-        .trigger("mousedown", 0, 0, { force: true })
-        .trigger("mousemove", 5, 5, { force: true })
-        .trigger("mousemove", 0, -350, { force: true })
-        .trigger("mouseup", 0, -350, { force: true });
+      moveDnDKitColumnVertical(cy.get("@prod-category"), -360);
 
       refreshResultsInHeader();
 
@@ -196,12 +187,7 @@ describe("scenarios > question > settings", () => {
       findColumnAtIndex("User → Address", -1).as("user-address");
 
       // Move it one place up
-      cy.get("@user-address")
-        .scrollIntoView()
-        .trigger("mousedown", 0, 0, { force: true })
-        .trigger("mousemove", 5, 5, { force: true })
-        .trigger("mousemove", 0, -100, { force: true })
-        .trigger("mouseup", 0, -100, { force: true });
+      moveDnDKitColumnVertical(cy.get("@user-address"), -100);
 
       findColumnAtIndex("User → Address", -3);
 

--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -5,10 +5,10 @@ import {
   visitQuestionAdhoc,
   sidebar,
   getDraggableElements,
-  moveColumnDown,
   popover,
   visitDashboard,
   cypressWaitAll,
+  moveDnDKitColumnVertical,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -143,12 +143,14 @@ describe("scenarios > visualizations > bar chart", () => {
     });
 
     it("should allow you to show/hide and reorder columns", () => {
-      moveColumnDown(getDraggableElements().eq(0), 2);
+      moveDnDKitColumnVertical(getDraggableElements().eq(0), 100);
 
-      getDraggableElements().each((element, index) => {
-        const draggableName = element[0].innerText;
-        cy.findAllByTestId("legend-item").eq(index).contains(draggableName);
-      });
+      cy.findAllByTestId("legend-item").eq(0).should("contain.text", "Gadget");
+      cy.findAllByTestId("legend-item").eq(1).should("contain.text", "Gizmo");
+      cy.findAllByTestId("legend-item")
+        .eq(2)
+        .should("contain.text", "Doohickey");
+      cy.findAllByTestId("legend-item").eq(3).should("contain.text", "Widget");
 
       const columnIndex = 1;
 
@@ -190,7 +192,7 @@ describe("scenarios > visualizations > bar chart", () => {
     });
 
     it("should gracefully handle removing filtered items, and adding new items to the end of the list", () => {
-      moveColumnDown(getDraggableElements().first(), 2);
+      moveDnDKitColumnVertical(getDraggableElements().first(), 100);
 
       getDraggableElements()
         .eq(1)

--- a/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/funnel.cy.spec.js
@@ -5,8 +5,8 @@ import {
   visitQuestionAdhoc,
   sidebar,
   getDraggableElements,
-  moveColumnDown,
   popover,
+  moveDnDKitColumnVertical,
 } from "e2e/support/helpers";
 
 const { PEOPLE_ID, PEOPLE } = SAMPLE_DATABASE;
@@ -32,7 +32,7 @@ describe("scenarios > visualizations > funnel chart", () => {
     sidebar().findByText("Data").click();
   });
 
-  it("hould allow you to reorder and show/hide rows", () => {
+  it("should allow you to reorder and show/hide rows", () => {
     cy.log("ensure that rows are shown");
     getDraggableElements().should("have.length", 5);
 
@@ -45,7 +45,7 @@ describe("scenarios > visualizations > funnel chart", () => {
           .first()
           .should("have.text", name);
 
-        moveColumnDown(getDraggableElements().first(), 2);
+        moveDnDKitColumnVertical(getDraggableElements().first(), 100);
 
         getDraggableElements().eq(2).should("have.text", name);
 
@@ -71,7 +71,7 @@ describe("scenarios > visualizations > funnel chart", () => {
   });
 
   it("should handle row items being filterd out and returned gracefully", () => {
-    moveColumnDown(getDraggableElements().first(), 2);
+    moveDnDKitColumnVertical(getDraggableElements().first(), 100);
 
     getDraggableElements()
       .eq(1)

--- a/e2e/test/scenarios/visualizations-tabular/reproductions/28311-sorting-table-columns.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/reproductions/28311-sorting-table-columns.cy.spec.js
@@ -4,6 +4,7 @@ import {
   restore,
   visitQuestionAdhoc,
   getDraggableElements,
+  moveDnDKitColumnVertical,
 } from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS } = SAMPLE_DATABASE;
@@ -61,15 +62,10 @@ describe("issue 25250", () => {
     cy.findByText("Product ID").should("be.visible");
 
     cy.findByTestId("viz-settings-button").click();
-    moveColumnUp(getDraggableElements().contains("Product ID"), 2);
+    moveDnDKitColumnVertical(
+      getDraggableElements().contains("Product ID"),
+      -100,
+    );
     getDraggableElements().eq(0).should("contain", "Product ID");
   });
 });
-
-function moveColumnUp(column, distance) {
-  column
-    .trigger("mousedown", 0, 0, { force: true })
-    .trigger("mousemove", 5, -5, { force: true })
-    .trigger("mousemove", 0, distance * -50, { force: true })
-    .trigger("mouseup", 0, distance * -50, { force: true });
-}

--- a/frontend/src/metabase/core/components/Sortable/SortableList.tsx
+++ b/frontend/src/metabase/core/components/Sortable/SortableList.tsx
@@ -12,6 +12,10 @@ import _ from "underscore";
 import { isNotNull } from "metabase/lib/types";
 
 type ItemId = number | string;
+export type DragEndEvent = {
+  id: ItemId;
+  newIndex: number;
+};
 
 interface RenderItemProps<T> {
   item: T;
@@ -23,7 +27,7 @@ interface useSortableListProps<T> {
   getId: (item: T) => ItemId;
   renderItem: ({ item, id, isDragOverlay }: RenderItemProps<T>) => JSX.Element;
   onSortStart?: (event: DragStartEvent) => void;
-  onSortEnd?: ({ id, newIndex }: { id: ItemId; newIndex: number }) => void;
+  onSortEnd?: ({ id, newIndex }: DragEndEvent) => void;
   sensors?: SensorDescriptor<any>[];
   modifiers?: Modifier[];
 }

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -1,10 +1,7 @@
-import type React from "react";
-import type { SortableElementProps } from "react-sortable-hoc";
+import { useSensor, PointerSensor } from "@dnd-kit/core";
+import { useCallback } from "react";
 
-import {
-  SortableContainer,
-  SortableElement,
-} from "metabase/components/sortable";
+import { Sortable, SortableList } from "metabase/core/components/Sortable";
 import type { IconProps } from "metabase/ui";
 
 import { ColumnItem } from "../ColumnItem";
@@ -24,102 +21,17 @@ interface SortableColumnFunctions<T> {
   getItemName: (item: T) => string;
   onColorChange?: (item: T, color: string) => void;
 }
-
-interface SortableColumnProps<T> extends SortableColumnFunctions<T> {
-  item: T;
-  isDragDisabled: boolean;
-}
-
-const SortableColumn = SortableElement(function SortableColumn<
-  T extends SortableItem,
->({
-  item,
-  getItemName,
-  onEdit,
-  onRemove,
-  onClick,
-  onAdd,
-  onEnable,
-  onColorChange,
-  isDragDisabled = false,
-}: SortableColumnProps<T>) {
-  return (
-    <ColumnItem
-      title={getItemName(item)}
-      onEdit={
-        onEdit
-          ? (targetElement: HTMLElement) => onEdit(item, targetElement)
-          : undefined
-      }
-      onRemove={onRemove && item.enabled ? () => onRemove(item) : undefined}
-      onClick={onClick ? () => onClick(item) : undefined}
-      onAdd={onAdd ? () => onAdd(item) : undefined}
-      onEnable={onEnable && !item.enabled ? () => onEnable(item) : undefined}
-      onColorChange={
-        onColorChange
-          ? (color: string) => onColorChange(item, color)
-          : undefined
-      }
-      color={item.color}
-      draggable={!isDragDisabled}
-      icon={item.icon}
-      role="listitem"
-    />
-  );
-}) as unknown as <T extends SortableItem>(
-  props: SortableColumnProps<T> & SortableElementProps,
-) => React.ReactElement;
-
-interface SortableColumnListProps<T extends SortableItem>
-  extends SortableColumnFunctions<T> {
-  items: T[];
-}
-
-const SortableColumnList = SortableContainer(function SortableColumnList<
-  T extends SortableItem,
->({
-  items,
-  getItemName,
-  onEdit,
-  onRemove,
-  onEnable,
-  onAdd,
-  onColorChange,
-}: SortableColumnListProps<T>) {
-  const isDragDisabled = items.length === 1;
-
-  return (
-    <div>
-      {items.map((item, index: number) => (
-        <SortableColumn
-          key={`item-${index}`}
-          index={index}
-          item={item}
-          getItemName={getItemName}
-          onEdit={onEdit}
-          onRemove={onRemove}
-          onEnable={onEnable}
-          onAdd={onAdd}
-          onColorChange={onColorChange}
-          disabled={isDragDisabled}
-          isDragDisabled={isDragDisabled}
-        />
-      ))}
-    </div>
-  );
-});
-
 interface ChartSettingOrderedItemsProps<T extends SortableItem>
   extends SortableColumnFunctions<T> {
   onSortEnd: ({
-    oldIndex,
+    id,
     newIndex,
   }: {
-    oldIndex: number;
+    id: number | string;
     newIndex: number;
   }) => void;
   items: T[];
-  distance: number;
+  getId: (item: T) => string | number;
 }
 
 export function ChartSettingOrderedItems<T extends SortableItem>({
@@ -132,20 +44,66 @@ export function ChartSettingOrderedItems<T extends SortableItem>({
   getItemName,
   items,
   onColorChange,
+  getId,
 }: ChartSettingOrderedItemsProps<T>) {
+  const isDragDisabled = items.length < 1;
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: { distance: 0 },
+  });
+
+  const renderItem = useCallback(
+    ({ item, id }: { item: T; id: string | number }) => (
+      <Sortable
+        id={id}
+        key={`sortable-${id}`}
+        disabled={isDragDisabled}
+        draggingStyle={{ opacity: 0.5 }}
+        role="listitem"
+      >
+        <ColumnItem
+          title={getItemName(item)}
+          onEdit={
+            onEdit
+              ? (targetElement: HTMLElement) => onEdit(item, targetElement)
+              : undefined
+          }
+          onRemove={onRemove && item.enabled ? () => onRemove(item) : undefined}
+          onClick={onClick ? () => onClick(item) : undefined}
+          onAdd={onAdd ? () => onAdd(item) : undefined}
+          onEnable={
+            onEnable && !item.enabled ? () => onEnable(item) : undefined
+          }
+          onColorChange={
+            onColorChange
+              ? (color: string) => onColorChange(item, color)
+              : undefined
+          }
+          color={item.color}
+          draggable={!isDragDisabled}
+          icon={item.icon}
+          role="listitem"
+        />
+      </Sortable>
+    ),
+    [
+      isDragDisabled,
+      getItemName,
+      onEdit,
+      onRemove,
+      onClick,
+      onAdd,
+      onEnable,
+      onColorChange,
+    ],
+  );
+
   return (
-    <SortableColumnList
-      helperClass="dragging"
+    <SortableList
+      getId={getId}
+      renderItem={renderItem}
       items={items}
-      getItemName={getItemName}
-      onEdit={onEdit}
-      onRemove={onRemove}
-      onAdd={onAdd}
-      onEnable={onEnable}
-      onClick={onClick}
       onSortEnd={onSortEnd}
-      onColorChange={onColorChange}
-      distance={5}
+      sensors={[pointerSensor]}
     />
   );
 }

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -58,7 +58,6 @@ export function ChartSettingOrderedItems<T extends SortableItem>({
         key={`sortable-${id}`}
         disabled={isDragDisabled}
         draggingStyle={{ opacity: 0.5 }}
-        role="listitem"
       >
         <ColumnItem
           title={getItemName(item)}

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 
+import type { DragEndEvent } from "metabase/core/components/Sortable";
 import type {
   DatasetColumn,
   TableColumnOrderSetting,
@@ -8,7 +9,7 @@ import type {
 import { ChartSettingOrderedItems } from "../../ChartSettingOrderedItems";
 import type { EditWidgetData } from "../types";
 
-import type { ColumnItem, DragColumnProps } from "./types";
+import type { ColumnItem } from "./types";
 import {
   getColumnItems,
   getEditWidgetData,
@@ -35,37 +36,57 @@ export const TableColumnPanel = ({
     return getColumnItems(columns, columnSettings);
   }, [columns, columnSettings]);
 
-  const getItemName = (columnItem: ColumnItem) => {
-    return getColumnName(columnItem.column);
-  };
+  const getItemName = useCallback(
+    (columnItem: ColumnItem) => {
+      return getColumnName(columnItem.column);
+    },
+    [getColumnName],
+  );
 
-  const handleEnableColumn = (columnItem: ColumnItem) => {
-    onChange(toggleColumnInSettings(columnItem, columnItems, true));
-  };
+  const handleEnableColumn = useCallback(
+    (columnItem: ColumnItem) => {
+      onChange(toggleColumnInSettings(columnItem, columnItems, true));
+    },
+    [onChange, columnItems],
+  );
 
-  const handleDisableColumn = (columnItem: ColumnItem) => {
-    onChange(toggleColumnInSettings(columnItem, columnItems, false));
-  };
+  const handleDisableColumn = useCallback(
+    (columnItem: ColumnItem) => {
+      onChange(toggleColumnInSettings(columnItem, columnItems, false));
+    },
+    [onChange, columnItems],
+  );
 
-  const handleDragColumn = ({ oldIndex, newIndex }: DragColumnProps) => {
-    onChange(moveColumnInSettings(columnItems, oldIndex, newIndex));
-  };
+  const handleDragColumn = useCallback(
+    ({ id, newIndex }: DragEndEvent) => {
+      const oldIndex = columnItems.findIndex(
+        columnItem => columnItem.columnSetting.key === id,
+      );
 
-  const handleEditColumn = (
-    columnItem: ColumnItem,
-    targetElement: HTMLElement,
-  ) => {
-    onShowWidget(getEditWidgetData(columnItem), targetElement);
-  };
+      onChange(moveColumnInSettings(columnItems, oldIndex, newIndex));
+    },
+    [columnItems, onChange],
+  );
+
+  const handleEditColumn = useCallback(
+    (columnItem: ColumnItem, targetElement: HTMLElement) => {
+      onShowWidget(getEditWidgetData(columnItem), targetElement);
+    },
+    [onShowWidget],
+  );
+
+  const getId = useCallback((columnItem: ColumnItem) => {
+    return columnItem.columnSetting.key;
+  }, []);
 
   return (
     <div role="list" data-testid="chart-settings-table-columns">
       {columns.length > 0 && (
         <div role="group" data-testid="visible-columns">
           <ChartSettingOrderedItems
+            getId={getId}
             items={columnItems}
             getItemName={getItemName}
-            distance={5}
             onEnable={handleEnableColumn}
             onRemove={handleDisableColumn}
             onEdit={handleEditColumn}

--- a/frontend/src/metabase/visualizations/visualizations/Table.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/Table.unit.spec.js
@@ -84,18 +84,17 @@ const setup = ({ vizType }) => {
       expect(within(userColumList).getByLabelText("State")).not.toBeChecked();
     });
 
-    it("should allow you to show and hide columns", () => {
+    it("should allow you to show and hide columns", async () => {
       setup({ vizType });
-      userEvent.click(screen.getByTestId("Tax-hide-button"));
+      userEvent.click(await screen.findByTestId("Tax-hide-button"));
 
-      expect(screen.getByRole("listitem", { name: "Tax" })).toHaveAttribute(
-        "data-enabled",
-        "false",
-      );
+      expect(
+        await screen.findByRole("listitem", { name: "Tax" }),
+      ).toHaveAttribute("data-enabled", "false");
 
-      userEvent.click(screen.getByTestId("Tax-show-button"));
+      userEvent.click(await screen.findByTestId("Tax-show-button"));
       //If we can see the hide button, then we know it's been added back in.
-      expect(screen.getByTestId("Tax-hide-button")).toBeInTheDocument();
+      expect(await screen.findByTestId("Tax-hide-button")).toBeInTheDocument();
     });
 
     it("should allow you to update a column name", async () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38293

### Description
As part of the push to prep for a react upgrade, and generally consolidate DnD libraries, this PR removes the dependency of `react-sortable-hoc` in `ChartSettingOrderedItems`, instead using the `SortableList` component. No changes should be obvious to end users

### How to verify
1. Go to a table visualization and re-order columns and hide/show. Should behave as normal
2. Go to a multi series visualization (orders, count grouped by created at: year, product -> category). You should be able to order / show / hide the series as expected

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
