### PR TITLE
Fail number parsing if it is only a substring

### DIFF
--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1634,11 +1634,12 @@
         (binding [driver/*insert-chunk-rows* 1]
           (doseq [{:keys [upload-type uncoerced coerced fail-msg] :as args}
                   [{:upload-type ::upload/int,     :uncoerced "2.1", :fail-msg "'2.1' is not an integer"}
-                   {:upload-type ::upload/int,     :uncoerced "2.0", :coerced 2}
-                   {:upload-type ::upload/float,   :uncoerced "2",   :coerced 2.0}
-                   {:upload-type ::upload/boolean, :uncoerced "0",   :coerced false}
-                   {:upload-type ::upload/boolean, :uncoerced "1.0", :fail-msg "'1.0' is not a recognizable boolean"}
-                   {:upload-type ::upload/boolean, :uncoerced "0.0", :fail-msg "'0.0' is not a recognizable boolean"}]]
+                   {:upload-type ::upload/int,     :uncoerced "2.0",        :coerced 2}
+                   {:upload-type ::upload/float,   :uncoerced "2",          :coerced 2.0}
+                   {:upload-type ::upload/boolean, :uncoerced "0",          :coerced false}
+                   {:upload-type ::upload/boolean, :uncoerced "1.0",        :fail-msg "'1.0' is not a recognizable boolean"}
+                   {:upload-type ::upload/boolean, :uncoerced "0.0",        :fail-msg "'0.0' is not a recognizable boolean"}
+                   {:upload-type ::upload/int,     :uncoerced "01/01/2012", :fail-msg "'01/01/2012' is not a recognizable number"}]]
             (with-upload-table!
               [table (create-upload-table! {:col->upload-type (ordered-map/ordered-map
                                                                upload/auto-pk-column-keyword ::upload/auto-incrementing-int-pk


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38956

### Description

This fixes an issue where we would silently coerce date strings to integers when parsing them as such.

This change should fix this relaxed coercion for any non-number that incidentally starts with something numeric.

### How to verify

1. Upload a CSV with an integer column
2. Append a CSV with a date in the same column

Previously the append would have succeeded, by treating the first chunk of the date (e.g. day) as the value.

With this change the upload will fail due to type incompatibility.