### PR TITLE
Dont alert slack on failing backport branches

### DIFF
--- a/.github/workflows/rerun-workflows.yml
+++ b/.github/workflows/rerun-workflows.yml
@@ -45,7 +45,7 @@ jobs:
                 repo: context.repo.repo,
                 run_id: ${{ github.event.workflow_run.id }},
               });
-            } else {
+            } else if (!BRANCH.includes('backport-')) {
               // notify slack of repeated failure
               const { WebClient } = require('@slack/web-api');
               const slack = new WebClient('${{ secrets.SLACK_BOT_TOKEN }}');


### PR DESCRIPTION
These notifications were getting way too noisy. [discussion](https://metaboat.slack.com/archives/C5XHN8GLW/p1709566953350209) This will disable slack notifications for test failures on backport branches.

Separately, I'll open a PR to notify about open backports.