### PR TITLE
Use malli to ensure all column types are covered

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -179,6 +179,7 @@
   #{::auto-incrementing-int-pk})
 
 (def ^:private type->check-schema
+  "Every inferable value-type needs to have a detection function registered."
   (into [:map] (map #(vector % :fn) (remove non-inferable-types value-types))))
 
 (mu/defn ^:private settings->type->check :- type->check-schema

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -178,23 +178,20 @@
 (def ^:private non-inferable-types
   #{::auto-incrementing-int-pk})
 
-(defn- assert-all-types-checks-present
-  [type->check]
-  (assert (every? type->check (remove non-inferable-types value-types))
-          "Every value-type must be registered in settings->type->check")
-  type->check)
+(def ^:private type->check-schema
+  (into [:map] (map #(vector % :fn) (remove non-inferable-types value-types))))
 
-(defn- settings->type->check [{:keys [number-separators] :as _settings}]
-  (assert-all-types-checks-present
-   {::boolean-or-int  boolean-or-int-string?
-    ::boolean         boolean-string?
-    ::offset-datetime offset-datetime-string?
-    ::date            date-string?
-    ::datetime        datetime-string?
-    ::int             (partial re-matches (int-regex number-separators))
-    ::float           (partial re-matches (float-regex number-separators))
-    ::varchar-255     varchar-255?
-    ::text            (constantly true)}))
+(mu/defn ^:private settings->type->check :- type->check-schema
+  [{:keys [number-separators] :as _settings}]
+  {::boolean-or-int  boolean-or-int-string?
+   ::boolean         boolean-string?
+   ::offset-datetime offset-datetime-string?
+   ::date            date-string?
+   ::datetime        datetime-string?
+   ::int             (partial re-matches (int-regex number-separators))
+   ::float           (partial re-matches (float-regex number-separators))
+   ::varchar-255     varchar-255?
+   ::text            (constantly true)})
 
 (defn- value->type
   "Determine the most specific type that is compatible with the given value.

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -172,6 +172,10 @@
 (defn- varchar-255? [s]
   (<= (count s) 255))
 
+(defn- regex-matcher [regex]
+  (fn [s]
+    (boolean (re-matches regex s))))
+
 ;; end [[value->type]] helpers
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -180,7 +184,8 @@
 
 (def ^:private type->check-schema
   "Every inferable value-type needs to have a detection function registered."
-  (into [:map] (map #(vector % :fn) (remove non-inferable-types value-types))))
+  (into [:map] (map #(vector % [:=> [:cat :string] :boolean])
+                    (remove non-inferable-types value-types))))
 
 (mu/defn ^:private settings->type->check :- type->check-schema
   [{:keys [number-separators] :as _settings}]
@@ -189,8 +194,8 @@
    ::offset-datetime offset-datetime-string?
    ::date            date-string?
    ::datetime        datetime-string?
-   ::int             (partial re-matches (int-regex number-separators))
-   ::float           (partial re-matches (float-regex number-separators))
+   ::int             (regex-matcher (int-regex number-separators))
+   ::float           (regex-matcher (float-regex number-separators))
    ::varchar-255     varchar-255?
    ::text            (constantly true)})
 


### PR DESCRIPTION
### Description

This is an alternate to using an assert. 

#### Pros
- Know for sure that the check is turned off in production.
- Code reads a bit better.
- Really comprehensive, standardised error message.

#### Cons
- Confuses Cursive (I seem to have to say this a lot)
- ~~Generates an unhelpful exception message without enough context~~ (Thanks @escherize for helping)