### PR TITLE
Refactor `cy.archiveQuestion`, `cy.createQuestion` & `cy.createNativeQuestion` to TypeScript

### DIFF
--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -12,6 +12,14 @@ declare global {
       archiveQuestion(
         id: Card["id"],
       ): Cypress.Chainable<Cypress.Response<Card>>;
+      createQuestion(
+        questionDetails: StructuredQuestionDetails,
+        options: Options,
+      ): Cypress.Chainable<Cypress.Response<Card>>;
+      createNativeQuestion(
+        questionDetails: NativeQuestionDetails,
+        options: Options,
+      ): Cypress.Chainable<Cypress.Response<Card>>;
     }
   }
 }

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -179,12 +179,16 @@ function question(
     });
 }
 
-/**
- *
- * @param {string} title - A title used to log the Cypress action/request that follows it.
- * @param {string} [questionName] - Optional question name.
- */
-function logAction(title, questionName) {
+function logAction(
+  /**
+   * A title used to log the Cypress action/request that follows it.
+   */
+  title: string,
+  /**
+   * Optional question name.
+   */
+  questionName?: string,
+) {
   const fullTitle = `${title}: ${questionName}`;
   const message = questionName ? fullTitle : title;
 

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -1,4 +1,5 @@
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import type { Card, DatasetQuery } from "metabase-types/api";
 
 Cypress.Commands.add("createQuestion", (questionDetails, customOptions) => {
   const { name, query } = questionDetails;
@@ -28,6 +29,46 @@ Cypress.Commands.add(
   },
 );
 
+type QueryType = "query" | "native";
+
+interface QuestionDetails {
+  /**
+   * Defaults to "test question"
+   */
+  name?: Card["name"];
+  description?: Card["description"];
+  /**
+   * Entity type.
+   * Defaults to "question"
+   */
+  type?: Card["type"];
+  native: any; // TODO: make its presence depend on type
+  query: any; // TODO: make its presence depend on type
+  /**
+   * Defaults to SAMPLE_DB_ID
+   */
+  database?: DatasetQuery["database"];
+  /**
+   * Defaults to "table"
+   */
+  display?: Card["display"];
+  parameters?: Card["parameters"];
+  visualization_settings?: Card["visualization_settings"];
+  /**
+   * Parent collection in which to store this question.
+   */
+  collection_id?: Card["collection_id"];
+  /**
+   * Used on the frontend to determine whether the question is pinned or not.
+   */
+  collection_position?: Card["collection_position"];
+  embedding_params?: Card["embedding_params"]; // TODO: make its presence depend on type - only for models
+  /**
+   * Defaults to false
+   */
+  enable_embedding?: Card["enable_embedding"];
+}
+
 /**
  *
  * @param {("query"|"native")} queryType
@@ -52,7 +93,7 @@ Cypress.Commands.add(
  * @param {string} customOptions.interceptAlias - We need distinctive endpoint aliases for cases where we have multiple questions or nested questions.
  */
 function question(
-  queryType,
+  queryType: QueryType,
   {
     name = "test question",
     description,

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -93,6 +93,14 @@ interface Options {
   interceptAlias?: string;
 }
 
+Cypress.Commands.add("archiveQuestion", (id: Card["id"]) => {
+  cy.log(`Archiving a question with id: ${id}`);
+
+  return cy.request("PUT", `/api/card/${id}`, {
+    archived: true,
+  });
+});
+
 Cypress.Commands.add(
   "createQuestion",
   (questionDetails: StructuredQuestionDetails, options: Options) => {
@@ -113,14 +121,6 @@ Cypress.Commands.add(
     );
   },
 );
-
-Cypress.Commands.add("archiveQuestion", (id: Card["id"]) => {
-  cy.log(`Archiving a question with id: ${id}`);
-
-  return cy.request("PUT", `/api/card/${id}`, {
-    archived: true,
-  });
-});
 
 Cypress.Commands.add(
   "createNativeQuestion",

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -91,7 +91,7 @@ interface Options {
   wrapId?: boolean;
   /**
    * Alias a question id in order to use it later with `cy.get("@" + alias).
-   * Defaults to "questionid".
+   * Defaults to "questionId".
    */
   idAlias?: string;
   /**
@@ -151,7 +151,7 @@ Cypress.Commands.add(
   },
 );
 
-function question(
+const question = (
   {
     name = "test question",
     description,
@@ -172,7 +172,7 @@ function question(
     idAlias = "questionId",
     interceptAlias = "cardQuery",
   }: Options = {},
-) {
+) => {
   return cy
     .request("POST", "/api/card", {
       name,
@@ -220,9 +220,9 @@ function question(
         }
       }
     });
-}
+};
 
-function logAction(
+const logAction = (
   /**
    * A title used to log the Cypress action/request that follows it.
    */
@@ -231,9 +231,9 @@ function logAction(
    * Optional question name.
    */
   questionName?: string,
-) {
+) => {
   const fullTitle = `${title}: ${questionName}`;
   const message = questionName ? fullTitle : title;
 
   cy.log(message);
-}
+};

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -14,11 +14,11 @@ declare global {
       ): Cypress.Chainable<Cypress.Response<Card>>;
       createQuestion(
         questionDetails: StructuredQuestionDetails,
-        options: Options,
+        options?: Options,
       ): Cypress.Chainable<Cypress.Response<Card>>;
       createNativeQuestion(
         questionDetails: NativeQuestionDetails,
-        options: Options,
+        options?: Options,
       ): Cypress.Chainable<Cypress.Response<Card>>;
     }
   }
@@ -111,7 +111,7 @@ Cypress.Commands.add("archiveQuestion", (id: Card["id"]) => {
 
 Cypress.Commands.add(
   "createQuestion",
-  (questionDetails: StructuredQuestionDetails, options: Options) => {
+  (questionDetails: StructuredQuestionDetails, options?: Options) => {
     const { database = SAMPLE_DB_ID, name, query } = questionDetails;
 
     if (!query) {
@@ -132,7 +132,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add(
   "createNativeQuestion",
-  (questionDetails: NativeQuestionDetails, options: Options) => {
+  (questionDetails: NativeQuestionDetails, options?: Options) => {
     const { database = SAMPLE_DB_ID, name, native } = questionDetails;
 
     if (!native) {

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -112,7 +112,7 @@ Cypress.Commands.add(
     }
 
     logAction("Create a native question", name);
-    question("native", questionDetails, options);
+    return question("native", questionDetails, options);
   },
 );
 

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -80,19 +80,23 @@ type QuestionDetails<Type extends QueryType> = Type extends "native"
   ? NativeQuestionDetails
   : StructuredQuestionDetails;
 
-Cypress.Commands.add("createQuestion", (questionDetails, customOptions) => {
-  const { name, query } = questionDetails;
+Cypress.Commands.add(
+  "createQuestion",
+  (questionDetails: StructuredQuestionDetails, options: Options) => {
+    const { name, query } = questionDetails;
 
-  if (!query) {
-    throw new Error('"query" attribute missing in questionDetails');
-  }
+    if (!query) {
+      throw new Error('"query" attribute missing in questionDetails');
+    }
 
-  logAction("Create a QB question", name);
-  return question("query", questionDetails, customOptions);
-});
+    logAction("Create a QB question", name);
+    return question("query", questionDetails, options);
+  },
+);
 
-Cypress.Commands.add("archiveQuestion", id => {
+Cypress.Commands.add("archiveQuestion", (id: Card["id"]) => {
   cy.log(`Archiving a question with id: ${id}`);
+
   return cy.request("PUT", `/api/card/${id}`, {
     archived: true,
   });
@@ -100,7 +104,7 @@ Cypress.Commands.add("archiveQuestion", id => {
 
 Cypress.Commands.add(
   "createNativeQuestion",
-  (questionDetails, customOptions) => {
+  (questionDetails: NativeQuestionDetails, options: Options) => {
     const { name, native } = questionDetails;
 
     if (!native) {
@@ -108,7 +112,7 @@ Cypress.Commands.add(
     }
 
     logAction("Create a native question", name);
-    question("native", questionDetails, customOptions);
+    question("native", questionDetails, options);
   },
 );
 

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -50,7 +50,7 @@ type QuestionDetails = {
    * Used on the frontend to determine whether the question is pinned or not.
    */
   collection_position?: Card["collection_position"];
-  embedding_params?: Card["embedding_params"]; // TODO: make its presence depend on type only for models
+  embedding_params?: Card["embedding_params"];
   /**
    * Defaults to false.
    */

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -1,34 +1,6 @@
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import type { Card, DatasetQuery } from "metabase-types/api";
 
-Cypress.Commands.add("createQuestion", (questionDetails, customOptions) => {
-  const { name, query } = questionDetails;
-
-  throwIfNotPresent(query);
-
-  logAction("Create a QB question", name);
-  return question("query", questionDetails, customOptions);
-});
-
-Cypress.Commands.add("archiveQuestion", id => {
-  cy.log(`Archiving a question with id: ${id}`);
-  return cy.request("PUT", `/api/card/${id}`, {
-    archived: true,
-  });
-});
-
-Cypress.Commands.add(
-  "createNativeQuestion",
-  (questionDetails, customOptions) => {
-    const { name, native } = questionDetails;
-
-    throwIfNotPresent(native);
-
-    logAction("Create a native question", name);
-    question("native", questionDetails, customOptions);
-  },
-);
-
 type QueryType = "query" | "native";
 
 interface QuestionDetails {
@@ -96,6 +68,34 @@ interface Options {
    */
   interceptAlias?: string;
 }
+
+Cypress.Commands.add("createQuestion", (questionDetails, customOptions) => {
+  const { name, query } = questionDetails;
+
+  throwIfNotPresent(query);
+
+  logAction("Create a QB question", name);
+  return question("query", questionDetails, customOptions);
+});
+
+Cypress.Commands.add("archiveQuestion", id => {
+  cy.log(`Archiving a question with id: ${id}`);
+  return cy.request("PUT", `/api/card/${id}`, {
+    archived: true,
+  });
+});
+
+Cypress.Commands.add(
+  "createNativeQuestion",
+  (questionDetails, customOptions) => {
+    const { name, native } = questionDetails;
+
+    throwIfNotPresent(native);
+
+    logAction("Create a native question", name);
+    question("native", questionDetails, customOptions);
+  },
+);
 
 function question(
   queryType: QueryType,

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -72,7 +72,9 @@ interface Options {
 Cypress.Commands.add("createQuestion", (questionDetails, customOptions) => {
   const { name, query } = questionDetails;
 
-  throwIfNotPresent(query);
+  if (!query) {
+    throw new Error('"query" attribute missing in questionDetails');
+  }
 
   logAction("Create a QB question", name);
   return question("query", questionDetails, customOptions);
@@ -90,7 +92,9 @@ Cypress.Commands.add(
   (questionDetails, customOptions) => {
     const { name, native } = questionDetails;
 
-    throwIfNotPresent(native);
+    if (!native) {
+      throw new Error('"native" attribute missing in questionDetails');
+    }
 
     logAction("Create a native question", name);
     question("native", questionDetails, customOptions);
@@ -173,12 +177,6 @@ function question(
         }
       }
     });
-}
-
-function throwIfNotPresent(param) {
-  if (!param) {
-    throw new Error('Wrong key! Expected "query" or "native".');
-  }
 }
 
 /**

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -73,7 +73,7 @@ type NativeQuestionDetails = Omit<QuestionDetails, "dataset_query"> & {
   native: NativeQuery;
 };
 
-interface Options {
+type Options = {
   /**
    * Whether to visit the question in order to load its metadata.
    * Defaults to false.
@@ -99,7 +99,7 @@ interface Options {
    * Defaults to "cardQuery".
    */
   interceptAlias?: string;
-}
+};
 
 Cypress.Commands.add("archiveQuestion", (id: Card["id"]) => {
   cy.log(`Archiving a question with id: ${id}`);

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -33,23 +33,23 @@ type QueryType = "query" | "native";
 
 interface QuestionDetails {
   /**
-   * Defaults to "test question"
+   * Defaults to "test question".
    */
   name?: Card["name"];
   description?: Card["description"];
   /**
    * Entity type.
-   * Defaults to "question"
+   * Defaults to "question".
    */
   type?: Card["type"];
   native: any; // TODO: make its presence depend on type
   query: any; // TODO: make its presence depend on type
   /**
-   * Defaults to SAMPLE_DB_ID
+   * Defaults to SAMPLE_DB_ID.
    */
   database?: DatasetQuery["database"];
   /**
-   * Defaults to "table"
+   * Defaults to "table".
    */
   display?: Card["display"];
   parameters?: Card["parameters"];
@@ -62,36 +62,41 @@ interface QuestionDetails {
    * Used on the frontend to determine whether the question is pinned or not.
    */
   collection_position?: Card["collection_position"];
-  embedding_params?: Card["embedding_params"]; // TODO: make its presence depend on type - only for models
+  embedding_params?: Card["embedding_params"]; // TODO: make its presence depend on type only for models
   /**
-   * Defaults to false
+   * Defaults to false.
    */
   enable_embedding?: Card["enable_embedding"];
 }
 
-/**
- *
- * @param {("query"|"native")} queryType
- *
- * @param {object} questionDetails
- * @param {string} [questionDetails.name="test question"]
- * @param {string} questionDetails.description
- * @param {("question"|"model")} questionDetails.type Entity type
- * @param {object} questionDetails.native
- * @param {object} questionDetails.query
- * @param {number} [questionDetails.database=1]
- * @param {string} [questionDetails.display="table"]
- * @param {object} [questionDetails.visualization_settings={}]
- * @param {number} [questionDetails.collection_id] - Parent collection in which to store this question.
- * @param {number} [questionDetails.collection_position] - used on the frontend to determine whether the question is pinned or not.
- *
- * @param {object} customOptions
- * @param {boolean} customOptions.loadMetadata - Whether to visit the question in order to load its metadata.
- * @param {boolean} customOptions.visitQuestion - Whether to visit the question after the creation or not.
- * @param {boolean} customOptions.wrapId - Whether to wrap a question id, to make it available outside of this scope.
- * @param {string} customOptions.idAlias - Alias a question id in order to use it later with `cy.get("@" + alias).
- * @param {string} customOptions.interceptAlias - We need distinctive endpoint aliases for cases where we have multiple questions or nested questions.
- */
+interface Options {
+  /**
+   * Whether to visit the question in order to load its metadata.
+   * Defaults to false.
+   */
+  loadMetadata?: boolean;
+  /**
+   * Whether to visit the question after the creation or not.
+   * Defaults to false.
+   */
+  visitQuestion?: boolean;
+  /**
+   * Whether to wrap a question id, to make it available outside of this scope.
+   * Defaults to false.
+   */
+  wrapId?: boolean;
+  /**
+   * Alias a question id in order to use it later with `cy.get("@" + alias).
+   * Defaults to "questionid".
+   */
+  idAlias?: string;
+  /**
+   * We need distinctive endpoint aliases for cases where we have multiple questions or nested questions.
+   * Defaults to "cardQuery".
+   */
+  interceptAlias?: string;
+}
+
 function question(
   queryType: QueryType,
   {
@@ -108,14 +113,14 @@ function question(
     collection_position,
     embedding_params,
     enable_embedding = false,
-  } = {},
+  }: QuestionDetails,
   {
     loadMetadata = false,
     visitQuestion = false,
     wrapId = false,
     idAlias = "questionId",
     interceptAlias = "cardQuery",
-  } = {},
+  }: Options = {},
 ) {
   return cy
     .request("POST", "/api/card", {

--- a/e2e/support/commands/api/question.ts
+++ b/e2e/support/commands/api/question.ts
@@ -6,6 +6,16 @@ import type {
   StructuredQuery,
 } from "metabase-types/api";
 
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      archiveQuestion(
+        id: Card["id"],
+      ): Cypress.Chainable<Cypress.Response<Card>>;
+    }
+  }
+}
+
 type QuestionDetails = {
   dataset_query: DatasetQuery;
   /**

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -1,3 +1,5 @@
+import type { EmbeddingParameters } from "metabase/public/lib/types";
+
 import type { Collection } from "./collection";
 import type { DashboardId, DashCardId } from "./dashboard";
 import type { DatabaseId } from "./database";
@@ -26,12 +28,14 @@ export interface Card<Q extends DatasetQuery = DatasetQuery>
 
   /* Indicates whether static embedding for this card has been published */
   enable_embedding: boolean;
+  embedding_params?: EmbeddingParameters | null;
   can_write: boolean;
   initially_published_at: string | null;
 
   database_id?: DatabaseId;
   collection?: Collection | null;
   collection_id: number | null;
+  collection_position: number | null;
 
   result_metadata: Field[];
   moderation_reviews?: ModerationReview[];

--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -28,7 +28,7 @@ export interface Card<Q extends DatasetQuery = DatasetQuery>
 
   /* Indicates whether static embedding for this card has been published */
   enable_embedding: boolean;
-  embedding_params?: EmbeddingParameters | null;
+  embedding_params: EmbeddingParameters | null;
   can_write: boolean;
   initially_published_at: string | null;
 

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -37,6 +37,7 @@ export const createMockCard = (opts?: Partial<Card>): Card => ({
   based_on_upload: null,
   archived: false,
   enable_embedding: false,
+  embedding_params: null,
   initially_published_at: null,
   ...opts,
 });

--- a/frontend/src/metabase-types/api/mocks/card.ts
+++ b/frontend/src/metabase-types/api/mocks/card.ts
@@ -31,6 +31,7 @@ export const createMockCard = (opts?: Partial<Card>): Card => ({
   cache_ttl: null,
   collection: null,
   collection_id: null,
+  collection_position: null,
   last_query_start: null,
   average_query_time: null,
   based_on_upload: null,

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
@@ -69,6 +69,7 @@ function convertActionToQuestionCard(
     can_write: true,
     public_uuid: null,
     collection_id: null,
+    collection_position: null,
     result_metadata: [],
     cache_ttl: null,
     last_query_start: null,

--- a/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/ActionContext/QueryActionContextProvider/QueryActionContextProvider.tsx
@@ -76,6 +76,7 @@ function convertActionToQuestionCard(
     average_query_time: null,
     archived: false,
     enable_embedding: false,
+    embedding_params: null,
     initially_published_at: null,
   };
 }


### PR DESCRIPTION
### Description

`cy.archiveQuestion`  + `cy.createQuestion` + `cy.createNativeQuestion` are now defined in TS.

### How to verify

1. Checkout the branch: `refactor/create-question-ts`
2. Open `16584-run-selected-text-does-not-preserve-parameter-values.cy.spec.ts`
3. Type `cy.createQuestion({` and enjoy your type hints