### PR TITLE
Split up "Doing science..." message

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -325,6 +325,28 @@ describe("scenarios > visualizations > table", () => {
       expect(isScrollableHorizontally($popover[0])).to.be.false;
     });
   });
+
+  it(
+    "should show the slow loading text when the query is taking too long",
+    { tags: ["@slow"] },
+    () => {
+      openOrdersTable({ mode: "notebook" });
+
+      cy.intercept("POST", "/api/dataset", req => {
+        req.on("response", res => {
+          res.setDelay(6000);
+        });
+      });
+
+      cy.button("Visualize").click();
+
+      cy.findByTestId("query-builder-main").findByText("Doing science...");
+      cy.findByTestId("query-builder-main").findByText(
+        "Talking to the database...",
+        { timeout: 6000 },
+      );
+    },
+  );
 });
 
 describe("scenarios > visualizations > table > conditional formatting", () => {

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -326,27 +326,24 @@ describe("scenarios > visualizations > table", () => {
     });
   });
 
-  it(
-    "should show the slow loading text when the query is taking too long",
-    { tags: ["@slow"] },
-    () => {
-      openOrdersTable({ mode: "notebook" });
+  it("should show the slow loading text when the query is taking too long", () => {
+    openOrdersTable({ mode: "notebook" });
 
-      cy.intercept("POST", "/api/dataset", req => {
-        req.on("response", res => {
-          res.setDelay(6000);
-        });
+    cy.intercept("POST", "/api/dataset", req => {
+      req.on("response", res => {
+        res.setDelay(10000);
       });
+    });
 
-      cy.button("Visualize").click();
+    cy.button("Visualize").click();
 
-      cy.findByTestId("query-builder-main").findByText("Doing science...");
-      cy.findByTestId("query-builder-main").findByText(
-        "Talking to the database...",
-        { timeout: 6000 },
-      );
-    },
-  );
+    cy.clock();
+    cy.tick(1000);
+    cy.findByTestId("query-builder-main").findByText("Doing science...");
+
+    cy.tick(5000);
+    cy.findByTestId("query-builder-main").findByText("Waiting for results...");
+  });
 });
 
 describe("scenarios > visualizations > table > conditional formatting", () => {

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.ts
@@ -17,8 +17,9 @@ const getCustomLogoUrl = (settingValues: EnterpriseSettings) => {
 export const getLogoUrl = (state: EnterpriseState) =>
   getCustomLogoUrl(getSettings(state));
 
-export const getLoadingMessage = (state: EnterpriseState) =>
-  LOADING_MESSAGE_BY_SETTING[getSetting(state, "loading-message")];
+export const getLoadingMessage = (state: EnterpriseState) => {
+  return LOADING_MESSAGE_BY_SETTING[getSetting(state, "loading-message")].value;
+};
 
 // eslint-disable-next-line no-literal-metabase-strings -- This is a Metabase string we want to keep. It's used for comparison.
 const DEFAULT_APPLICATION_NAME = "Metabase";

--- a/enterprise/frontend/src/metabase-enterprise/settings/selectors.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/settings/selectors.unit.spec.ts
@@ -50,7 +50,7 @@ describe("getLoadingMessage", () => {
 
     const expectedLoadingMessage = "Doing science...";
 
-    expect(getLoadingMessage(states)).toBe(expectedLoadingMessage);
+    expect(getLoadingMessage(states)(false)).toBe(expectedLoadingMessage);
   });
 
   it('should show correct loading message when "loading-message" is set to "running-query"', () => {
@@ -63,7 +63,7 @@ describe("getLoadingMessage", () => {
     const expectedLoadingMessage = "Loading results...";
     ("");
 
-    expect(getLoadingMessage(states)).toBe(expectedLoadingMessage);
+    expect(getLoadingMessage(states)(false)).toBe(expectedLoadingMessage);
   });
 
   it('should show correct loading message when "loading-message" is set to "loading-results"', () => {
@@ -75,7 +75,7 @@ describe("getLoadingMessage", () => {
 
     const expectedLoadingMessage = "Running query...";
 
-    expect(getLoadingMessage(states)).toBe(expectedLoadingMessage);
+    expect(getLoadingMessage(states)(false)).toBe(expectedLoadingMessage);
   });
 });
 

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/loading-message.ts
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/lib/loading-message.ts
@@ -1,13 +1,23 @@
 import { t } from "ttag";
 
 export const LOADING_MESSAGE_BY_SETTING = {
-  "doing-science": t`Doing science...`,
-  "running-query": t`Running query...`,
-  "loading-results": t`Loading results...`,
+  "doing-science": {
+    name: t`Doing science...`,
+    value: (isSlow: boolean) =>
+      isSlow ? t`Waiting for results...` : t`Doing science...`,
+  },
+  "running-query": {
+    name: t`Running query...`,
+    value: (_: boolean) => t`Running query...`,
+  },
+  "loading-results": {
+    name: t`Loading results...`,
+    value: (_: boolean) => t`Loading results...`,
+  },
 };
 
 export const getLoadingMessageOptions = () =>
-  Object.entries(LOADING_MESSAGE_BY_SETTING).map(([value, name]) => ({
+  Object.entries(LOADING_MESSAGE_BY_SETTING).map(([value, option]) => ({
+    name: option.name,
     value,
-    name,
   }));

--- a/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotQueryBuilder/MetabotQueryBuilder.tsx
@@ -2,7 +2,6 @@ import { connect } from "react-redux";
 import { t } from "ttag";
 
 import { getResponseErrorMessage } from "metabase/lib/errors";
-import { getWhiteLabeledLoadingMessage } from "metabase/selectors/whitelabel";
 import type { Dataset } from "metabase-types/api";
 import type { MetabotQueryStatus, State } from "metabase-types/store";
 
@@ -28,7 +27,6 @@ import {
 } from "./MetabotQueryBuilder.styled";
 
 interface StateProps {
-  loadingMessage: string;
   queryStatus: MetabotQueryStatus;
   queryResults: [Dataset] | null;
   queryError: unknown;
@@ -38,7 +36,6 @@ interface StateProps {
 type MetabotQueryBuilderProps = StateProps;
 
 const mapStateToProps = (state: State): StateProps => ({
-  loadingMessage: getWhiteLabeledLoadingMessage(state),
   queryStatus: getQueryStatus(state),
   queryResults: getQueryResults(state),
   queryError: getQueryError(state),
@@ -46,7 +43,6 @@ const mapStateToProps = (state: State): StateProps => ({
 });
 
 const MetabotQueryBuilder = ({
-  loadingMessage,
   queryStatus,
   queryResults,
   queryError,
@@ -60,7 +56,7 @@ const MetabotQueryBuilder = ({
     <QueryBuilderRoot>
       {hasResults && <MetabotQueryEditor />}
       {isRunning ? (
-        <QueryRunningState loadingMessage={loadingMessage} />
+        <RunningStateRoot />
       ) : hasErrors ? (
         <QueryErrorState queryError={queryError} />
       ) : hasResults ? (
@@ -79,14 +75,6 @@ const QueryIdleState = () => {
       <IdleStateIcon name="insight" />
     </IdleStateRoot>
   );
-};
-
-interface QueryRunningStateProps {
-  loadingMessage: string;
-}
-
-const QueryRunningState = ({ loadingMessage }: QueryRunningStateProps) => {
-  return <RunningStateRoot loadingMessage={loadingMessage} />;
 };
 
 interface QueryErrorStateProps {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -133,7 +133,8 @@ export const PLUGIN_IS_PASSWORD_USER: ((user: User) => boolean)[] = [];
 // selectors that customize behavior between app versions
 export const PLUGIN_SELECTORS = {
   canWhitelabel: (_state: State) => false,
-  getLoadingMessage: (_state: State) => t`Doing science...`,
+  getLoadingMessage: (_state: State) => (isSlow: boolean) =>
+    isSlow ? t`Waiting for results...` : t`Doing science...`,
   getIsWhiteLabeling: (_state: State) => false,
   // eslint-disable-next-line no-literal-metabase-strings -- This is the actual Metabase name, so we don't want to translate it.
   getApplicationName: (_state: State) => "Metabase",

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
 import { useState } from "react";
+import { useTimeout } from "react-use";
 import { t } from "ttag";
 
 import LoadingSpinner from "metabase/components/LoadingSpinner";
@@ -10,6 +11,8 @@ import RunButtonWithTooltip from "./RunButtonWithTooltip";
 import { VisualizationError } from "./VisualizationError";
 import VisualizationResult from "./VisualizationResult";
 import Warnings from "./Warnings";
+
+const SLOW_MESSAGE_TIMEOUT = 4000;
 
 export default function QueryVisualization(props) {
   const {
@@ -80,22 +83,25 @@ export const VisualizationEmptyState = ({ className }) => (
   </div>
 );
 
-export const VisualizationRunningState = ({
-  className = "",
-  loadingMessage,
-}) => (
-  <div
-    className={cx(
-      className,
-      "Loading flex flex-column layout-centered text-brand",
-    )}
-  >
-    <LoadingSpinner />
-    <h2 className="Loading-message text-brand text-uppercase my3">
-      {loadingMessage}
-    </h2>
-  </div>
-);
+export function VisualizationRunningState({ className = "", loadingMessage }) {
+  const [isSlow] = useTimeout(SLOW_MESSAGE_TIMEOUT);
+
+  const message = isSlow() ? t`Talking to the database...` : loadingMessage;
+
+  return (
+    <div
+      className={cx(
+        className,
+        "Loading flex flex-column layout-centered text-brand",
+      )}
+    >
+      <LoadingSpinner />
+      <h2 className="Loading-message text-brand text-uppercase my3">
+        {message}
+      </h2>
+    </div>
+  );
+}
 
 export const VisualizationDirtyState = ({
   className,

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -5,6 +5,8 @@ import { useTimeout } from "react-use";
 import { t } from "ttag";
 
 import LoadingSpinner from "metabase/components/LoadingSpinner";
+import { useSelector } from "metabase/lib/redux";
+import { getWhiteLabeledLoadingMessage } from "metabase/selectors/whitelabel";
 import { HARD_ROW_LIMIT } from "metabase-lib/queries/utils";
 
 import RunButtonWithTooltip from "./RunButtonWithTooltip";
@@ -23,7 +25,6 @@ export default function QueryVisualization(props) {
     isResultDirty,
     isNativeEditorOpen,
     result,
-    loadingMessage,
     maxTableRows = HARD_ROW_LIMIT,
   } = props;
 
@@ -31,12 +32,7 @@ export default function QueryVisualization(props) {
 
   return (
     <div className={cx(className, "relative stacking-context full-height")}>
-      {isRunning ? (
-        <VisualizationRunningState
-          className="spread z2"
-          loadingMessage={loadingMessage}
-        />
-      ) : null}
+      {isRunning ? <VisualizationRunningState className="spread z2" /> : null}
       <VisualizationDirtyState
         {...props}
         hidden={!isResultDirty || isRunning || isNativeEditorOpen}
@@ -83,15 +79,14 @@ export const VisualizationEmptyState = ({ className }) => (
   </div>
 );
 
-export function VisualizationRunningState({ className = "", loadingMessage }) {
+export function VisualizationRunningState({ className = "" }) {
   const [isSlow] = useTimeout(SLOW_MESSAGE_TIMEOUT);
+
+  const loadingMessage = useSelector(getWhiteLabeledLoadingMessage);
 
   // show the slower loading message only when the loadingMessage is
   // not customised
-  const message =
-    loadingMessage === "Doing science..." && isSlow()
-      ? t`Waiting for results...`
-      : loadingMessage;
+  const message = loadingMessage(isSlow());
 
   return (
     <div

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.jsx
@@ -86,7 +86,12 @@ export const VisualizationEmptyState = ({ className }) => (
 export function VisualizationRunningState({ className = "", loadingMessage }) {
   const [isSlow] = useTimeout(SLOW_MESSAGE_TIMEOUT);
 
-  const message = isSlow() ? t`Talking to the database...` : loadingMessage;
+  // show the slower loading message only when the loadingMessage is
+  // not customised
+  const message =
+    loadingMessage === "Doing science..." && isSlow()
+      ? t`Waiting for results...`
+      : loadingMessage;
 
   return (
     <div

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.unit.spec.tsx
@@ -1,0 +1,36 @@
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { VisualizationRunningState } from "./QueryVisualization";
+
+type SetupOpts = {
+  loadingMessage: string;
+};
+
+function setup({ loadingMessage }: SetupOpts) {
+  renderWithProviders(
+    <VisualizationRunningState loadingMessage={loadingMessage} />,
+  );
+}
+
+describe("VisualizationRunningState", () => {
+  it("should render the default loading message initially", () => {
+    setup({ loadingMessage: "Doing Science..." });
+    expect(screen.getByText("Doing Science...")).toBeInTheDocument();
+  });
+
+  it("should render a custom loading message initially", () => {
+    setup({ loadingMessage: "Thinking Hard..." });
+    expect(screen.getByText("Thinking Hard...")).toBeInTheDocument();
+  });
+
+  it("should render a different loading message after a timeout", () => {
+    jest.useFakeTimers();
+
+    setup({ loadingMessage: "Doing Science..." });
+    expect(screen.getByText("Doing Science...")).toBeInTheDocument();
+
+    jest.runAllTimers();
+
+    expect(screen.getByText("Talking to the database...")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/metabase/query_builder/components/QueryVisualization.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryVisualization.unit.spec.tsx
@@ -13,24 +13,21 @@ function setup({ loadingMessage }: SetupOpts) {
 }
 
 describe("VisualizationRunningState", () => {
-  it("should render the default loading message initially", () => {
-    setup({ loadingMessage: "Doing Science..." });
-    expect(screen.getByText("Doing Science...")).toBeInTheDocument();
-  });
-
-  it("should render a custom loading message initially", () => {
-    setup({ loadingMessage: "Thinking Hard..." });
-    expect(screen.getByText("Thinking Hard...")).toBeInTheDocument();
-  });
-
-  it("should render a different loading message after a timeout", () => {
+  it("should render the different loading messages after a while", () => {
     jest.useFakeTimers();
 
-    setup({ loadingMessage: "Doing Science..." });
-    expect(screen.getByText("Doing Science...")).toBeInTheDocument();
+    setup({ loadingMessage: "Doing science..." });
+    expect(screen.getByText("Doing science...")).toBeInTheDocument();
 
-    jest.runAllTimers();
+    jest.advanceTimersByTime(5000);
+    expect(screen.getByText("Waiting for results...")).toBeInTheDocument();
+  });
 
-    expect(screen.getByText("Talking to the database...")).toBeInTheDocument();
+  it("should only render the custom loading message when it was customized", () => {
+    setup({ loadingMessage: "Thinking hard..." });
+    expect(screen.getByText("Thinking hard...")).toBeInTheDocument();
+
+    jest.advanceTimersByTime(5000);
+    expect(screen.getByText("Thinking hard...")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -26,7 +26,6 @@ import {
   getUserIsAdmin,
   canManageSubscriptions,
 } from "metabase/selectors/user";
-import { getWhiteLabeledLoadingMessage } from "metabase/selectors/whitelabel";
 
 import * as actions from "../actions";
 import View from "../components/view/View";
@@ -166,7 +165,6 @@ const mapStateToProps = (state, props) => {
     documentTitle: getDocumentTitle(state),
     pageFavicon: getPageFavicon(state),
     isLoadingComplete: getIsLoadingComplete(state),
-    loadingMessage: getWhiteLabeledLoadingMessage(state),
 
     reportTimezone: getSetting(state, "report-timezone-long"),
 

--- a/frontend/src/metabase/selectors/whitelabel/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/common.unit.spec.ts
@@ -12,19 +12,34 @@ describe("getWhiteLabeledLoadingMessage (OSS)", () => {
   it("should return 'Doing science...' when loading-message is set to 'doing-science'", () => {
     const { getState } = setup({ loadingMessage: "doing-science" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())(false)).toBe(
+      "Doing science...",
+    );
+    expect(getWhiteLabeledLoadingMessage(getState())(true)).toBe(
+      "Waiting for results...",
+    );
   });
 
   it("should return 'Doing science...' when loading-message is set to 'loading-results'", () => {
     const { getState } = setup({ loadingMessage: "loading-results" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())(false)).toBe(
+      "Doing science...",
+    );
+    expect(getWhiteLabeledLoadingMessage(getState())(true)).toBe(
+      "Waiting for results...",
+    );
   });
 
   it("should return 'Doing science...' when loading-message is set to 'running-query'", () => {
     const { getState } = setup({ loadingMessage: "running-query" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())(false)).toBe(
+      "Doing science...",
+    );
+    expect(getWhiteLabeledLoadingMessage(getState())(true)).toBe(
+      "Waiting for results...",
+    );
   });
 });
 

--- a/frontend/src/metabase/selectors/whitelabel/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/enterprise.unit.spec.ts
@@ -17,19 +17,34 @@ describe("getWhiteLabeledLoadingMessage (EE without token)", () => {
   it("should return 'Doing science...' when loading-message is set to 'doing-science'", () => {
     const { getState } = setup({ loadingMessage: "doing-science" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())(false)).toBe(
+      "Doing science...",
+    );
+    expect(getWhiteLabeledLoadingMessage(getState())(true)).toBe(
+      "Waiting for results...",
+    );
   });
 
   it("should return 'Doing science...' when loading-message is set to 'loading-results'", () => {
     const { getState } = setup({ loadingMessage: "loading-results" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())(false)).toBe(
+      "Doing science...",
+    );
+    expect(getWhiteLabeledLoadingMessage(getState())(true)).toBe(
+      "Waiting for results...",
+    );
   });
 
   it("should return 'Doing science...' when loading-message is set to 'running-query'", () => {
     const { getState } = setup({ loadingMessage: "running-query" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())(false)).toBe(
+      "Doing science...",
+    );
+    expect(getWhiteLabeledLoadingMessage(getState())(true)).toBe(
+      "Waiting for results...",
+    );
   });
 });
 

--- a/frontend/src/metabase/selectors/whitelabel/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/selectors/whitelabel/tests/premium.unit.spec.ts
@@ -21,13 +21,21 @@ describe("getWhiteLabeledLoadingMessage (EE with token)", () => {
   it("should return 'Doing science...' when loading-message is set to 'doing-science'", () => {
     const { getState } = setup({ loadingMessage: "doing-science" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Doing science...");
+    expect(getWhiteLabeledLoadingMessage(getState())(false)).toBe(
+      "Doing science...",
+    );
+    expect(getWhiteLabeledLoadingMessage(getState())(true)).toBe(
+      "Waiting for results...",
+    );
   });
 
   it("should return 'Loading results...' when loading-message is set to 'loading-results'", () => {
     const { getState } = setup({ loadingMessage: "loading-results" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe(
+    expect(getWhiteLabeledLoadingMessage(getState())(false)).toBe(
+      "Loading results...",
+    );
+    expect(getWhiteLabeledLoadingMessage(getState())(true)).toBe(
       "Loading results...",
     );
   });
@@ -35,7 +43,12 @@ describe("getWhiteLabeledLoadingMessage (EE with token)", () => {
   it("should return 'Running query...' when loading-message is set to 'running-query'", () => {
     const { getState } = setup({ loadingMessage: "running-query" });
 
-    expect(getWhiteLabeledLoadingMessage(getState())).toBe("Running query...");
+    expect(getWhiteLabeledLoadingMessage(getState())(false)).toBe(
+      "Running query...",
+    );
+    expect(getWhiteLabeledLoadingMessage(getState())(true)).toBe(
+      "Running query...",
+    );
   });
 });
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39503
### Description

Allows the `getLoadingMessage` option to return a function which is parametrised on the elapsed query time.

### How to verify

1. Open a new query that loads very slowly
2. Verify that the loading message changes from `Doing Science...` to `Talking to the database...` after 4 seconds

### Demo
<div>
    <a href="https://www.loom.com/share/a05eea3db62c47b0b9e2ce010c8d33e6">
      <p>Question · Metabase - 6 March 2024 - Watch Video</p>
    </a>
</div>


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
