### PR TITLE
Update text for visualisation loading state

### DIFF
--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.tsx
@@ -23,13 +23,11 @@ function SlowQueryView({ expectedDuration, isSlow }: LoadingViewProps) {
         <div>
           {jt`This usually takes an average of ${(
             <Duration>{duration(expectedDuration)}</Duration>
-          )}.`}
-          <br />
-          {t`(This is a bit long for a dashboard)`}
+          )}, but is currently taking longer.`}
         </div>
       ) : (
         <div>
-          {t`This is usually pretty fast but seems to be taking a while right now.`}
+          {t`This usually loads immediately, but is currently taking longer.`}
         </div>
       )}
     </SlowQueryMessageContainer>

--- a/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/LoadingView/LoadingView.unit.spec.tsx
@@ -1,0 +1,39 @@
+import { screen, renderWithProviders } from "__support__/ui";
+
+import LoadingView from "./LoadingView";
+
+type SetupOpts = {
+  expectedDuration: number;
+  isSlow: "usually-slow" | boolean;
+};
+
+function setup(opts: SetupOpts) {
+  renderWithProviders(<LoadingView {...opts} />);
+}
+
+describe("LoadingView", () => {
+  it("should only render the spinner when the query is usually fast", () => {
+    setup({
+      expectedDuration: 10,
+      isSlow: false,
+    });
+
+    expect(screen.queryByText("Still Waiting…")).not.toBeInTheDocument();
+  });
+
+  it("should show 'Still waiting' when the query is usually slow", () => {
+    setup({
+      expectedDuration: 10_000,
+      isSlow: "usually-slow",
+    });
+
+    expect(screen.getByText("Still Waiting…")).toBeInTheDocument();
+    expect(
+      screen.getByText(/This usually takes an average of/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("10 seconds")).toBeInTheDocument();
+    expect(
+      screen.getByText(/but is currently taking longer./),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39620

### Description

Updates the loading copy for slow-loading queries on the dashboard cards.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open a dashboard with slow-running card
2. Verify that the text on the card shows: `This usually takes an average of 5 seconds, but is currently taking longer.`


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
