### PR TITLE
Specify GH project board per team

### DIFF
--- a/.github/team.json
+++ b/.github/team.json
@@ -3,6 +3,7 @@
     {
       "name": "Querying Components",
       "label": ".Team/QueryingComponents",
+      "projectUrl": "https://github.com/orgs/metabase/projects/50/views/1",
       "members": [
         "ranquild",
         "uladzimirdev",
@@ -15,16 +16,12 @@
     {
       "name": "Embedding",
       "label": ".Team/Embedding",
-      "members": [
-        "WiNloSt",
-        "deniskaber",
-        "oisincoveney",
-        "npretto"
-      ]
+      "members": ["WiNloSt", "deniskaber", "oisincoveney", "npretto"]
     },
     {
       "name": "BEC",
       "label": ".Team/BackendComponents",
+      "projectUrl": "https://github.com/orgs/metabase/projects/50/views/1",
       "members": [
         "tsmacdonald",
         "qnkhuat",
@@ -36,13 +33,7 @@
     {
       "name": "Query Processor",
       "label": ".Team/QueryProcessor",
-      "members": [
-        "camsaul",
-        "snoe",
-        "bshepherdson",
-        "metamben",
-        "lbrdnk"
-      ]
+      "members": ["camsaul", "snoe", "bshepherdson", "metamben", "lbrdnk"]
     },
     {
       "name": "Admin Webapp",

--- a/.github/team.json
+++ b/.github/team.json
@@ -3,7 +3,7 @@
     {
       "name": "Querying Components",
       "label": ".Team/QueryingComponents",
-      "projectUrl": "https://github.com/orgs/metabase/projects/50/views/1",
+      "projectUrl": "https://github.com/orgs/metabase/projects/74",
       "members": [
         "ranquild",
         "uladzimirdev",
@@ -33,6 +33,7 @@
     {
       "name": "Query Processor",
       "label": ".Team/QueryProcessor",
+      "projectUrl": "https://github.com/orgs/metabase/projects/50/views/1",
       "members": ["camsaul", "snoe", "bshepherdson", "metamben", "lbrdnk"]
     },
     {

--- a/.github/team.json
+++ b/.github/team.json
@@ -3,7 +3,6 @@
     {
       "name": "Querying Components",
       "label": ".Team/QueryingComponents",
-      "projectUrl": "https://github.com/orgs/metabase/projects/74",
       "members": [
         "ranquild",
         "uladzimirdev",

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -30,7 +30,7 @@ jobs:
             const prNumber = context.payload.pull_request.number;
 
             if (prAuthor.endsWith('[bot]')) {
-              return false;
+              return null;
             }
 
             // Assign PR author
@@ -44,7 +44,7 @@ jobs:
             const team = teamConfig.teams.find(t => t.members.includes(prAuthor));
             if (!team) {
               console.log('You are not assigned to any team. If you need one, update .github/team.json');
-              return false;
+              return null;
             }
 
             try {
@@ -55,7 +55,7 @@ jobs:
               });
             } catch (e) {
               console.log(`The label ${team.label} does not exist, create it first`);
-              return false;
+              return null;
             }
 
             // Add team label
@@ -66,9 +66,9 @@ jobs:
               labels: [team.label]
             });
 
-            return true;
+            return team.projectUrl || null;
       - uses: actions/add-to-project@v0.5.0
-        if: ${{ fromJSON(steps.auto-assign.outputs.result) }}
+        if: ${{ steps.auto-assign.outputs.result != 'null' }}
         with:
-          project-url: https://github.com/orgs/metabase/projects/50/views/1
+          project-url: ${{ steps.auto-assign.outputs.result }}
           github-token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
### Description

Previously we all used a single board https://github.com/orgs/metabase/projects/50/views/1 but not only two team use it. In order not to pollute their board with PRs from other teams, now every team will specify their own board if needed.

### How to verify

Check the changes are sensible.
Example run where it did not add this PR to the board: https://github.com/metabase/metabase/actions/runs/8160443973/job/22307033268
