### PR TITLE
Update release script to trigger ops issue creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -507,11 +507,11 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.OPS_UPDATE_TOKEN }}
+          github-token: ${{ secrets.METABASE_AUTOMATION_USER_TOKEN }}
           script: |
             github.rest.repos.createDispatchEvent({
               owner: '${{ github.repository_owner }}',
-              repo: '${{ secrets.OPS_REPO }}',
+              repo: '${{ vars.OPS_REPO }}',
               event_type: 'create-release-issues',
               client_payload: {
                 version: '${{ inputs.version }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -500,6 +500,24 @@ jobs:
               }
             });
 
+  trigger-cloud-issues:
+    needs: push-tags
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.OPS_UPDATE_TOKEN }}
+          script: |
+            github.rest.repos.createDispatchEvent({
+              owner: '${{ github.repository_owner }}',
+              repo: '${{ secrets.OPS_REPO }}',
+              event_type: 'create-release-issues',
+              client_payload: {
+                version: '${{ inputs.version }}'
+              }
+            });
+
   draft-release-notes:
     if: ${{ inputs.skip-release-notes != true }}
     needs: push-tags


### PR DESCRIPTION
Resolves https://github.com/metabase/metabase-private/issues/178

Triggers cloud upgrade issue creation in our internal ops repository after release.

![Screen Shot 2024-06-12 at 5 08 56 PM](https://github.com/metabase/metabase/assets/30528226/b3387a26-eac3-457d-a761-3c0e11f48893)

test main repo run: https://github.com/iethree/metabase/actions/runs/9484698529/job/26136223750
test ops repo run: https://github.com/iethree/metabase-ops/actions/runs/9485103473/job/26136232145


> [!important]
> need a new actions repository variable:`OPS_REPO`


