### PR TITLE
Don't provision SSO users before the instance has been setup

### DIFF
--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -97,8 +97,6 @@
      (contains? allowed-user-types user-type)))
   (when locale
     (assert (i18n/available-locale? locale) (tru "Invalid locale: {0}" (pr-str locale))))
-  (def user user)
-  (def setup? (setup/has-user-setup))
   (when (and sso_source (not (setup/has-user-setup)))
     ;; Only allow SSO users to be provisioned if the setup flow has been completed and an admin has been created
     (throw (Exception. (trs "Instance has not been initialized"))))

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -21,6 +21,7 @@
    [metabase.plugins.classloader :as classloader]
    [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
+   [metabase.setup :as setup]
    [metabase.util :as u]
    [metabase.util.i18n :as i18n :refer [deferred-tru trs tru]]
    [metabase.util.log :as log]
@@ -87,7 +88,7 @@
      {})))
 
 (t2/define-before-insert :model/User
-  [{:keys [email password reset_token locale], :as user}]
+  [{:keys [email password reset_token locale sso_source], :as user}]
   ;; these assertions aren't meant to be user-facing, the API endpoints should be validation these as well.
   (assert (u/email? email))
   (assert ((every-pred string? (complement str/blank?)) password))
@@ -96,6 +97,11 @@
      (contains? allowed-user-types user-type)))
   (when locale
     (assert (i18n/available-locale? locale) (tru "Invalid locale: {0}" (pr-str locale))))
+  (def user user)
+  (def setup? (setup/has-user-setup))
+  (when (and sso_source (not (setup/has-user-setup)))
+    ;; Only allow SSO users to be provisioned if the setup flow has been completed and an admin has been created
+    (throw (Exception. (trs "Instance has not been initialized"))))
   (merge
    insert-default-values
    user

--- a/src/metabase/setup.clj
+++ b/src/metabase/setup.clj
@@ -36,7 +36,6 @@
       (t2/select-one-fn :value Setting :key "setup-token")
       (setting/set-value-of-type! :string :setup-token (str (random-uuid)))))
 
-
 (defsetting has-user-setup
   (deferred-tru "A value that is true iff the metabase instance has one or more users registered.")
   :visibility :public


### PR DESCRIPTION
Block the creation of users with `sso_source` if the instance has not been setup yet, to avoid a situation where no admin exists and the instance is locked out.

Resolves https://github.com/metabase/metabase-private/issues/201