### PR TITLE
Scroll dashboard tabs to the end when adding a tab

### DIFF
--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -83,7 +83,7 @@ function TabRowInner<T>({
     setShowScrollRight(
       Math.round(scrollPosition + width) < tabListRef.current?.scrollWidth,
     );
-  }, [children, scrollPosition, width]);
+  }, [scrollPosition, width]);
 
   const onDragEnd = (event: DragEndEvent) => {
     if (!event.over || !handleDragEnd) {

--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -13,7 +13,8 @@ import {
   SortableContext,
   horizontalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { useState, useRef, useEffect } from "react";
+import { useCallback, useState, useRef, useLayoutEffect } from "react";
+import { usePreviousDistinct } from "react-use";
 
 import ExplicitSize from "metabase/components/ExplicitSize";
 import { Icon } from "metabase/ui";
@@ -44,24 +45,8 @@ function TabRowInner<T>({
   const [showScrollRight, setShowScrollRight] = useState(false);
   const showScrollLeft = scrollPosition > 0;
 
-  useEffect(() => {
-    if (!width || !tabListRef.current) {
-      return;
-    }
-
-    setShowScrollRight(
-      Math.round(scrollPosition + width) < tabListRef.current?.scrollWidth,
-    );
-  }, [children, scrollPosition, width]);
-
-  const scroll = (direction: "left" | "right") => {
-    if (!tabListRef.current || !width) {
-      return;
-    }
-
-    const scrollDistance = width * (direction === "left" ? -1 : 1);
-    tabListRef.current.scrollBy(scrollDistance, 0);
-  };
+  const itemsCount = itemIds?.length ?? 0;
+  const previousItemsCount = usePreviousDistinct(itemsCount) ?? 0;
 
   const pointerSensor = useSensor(PointerSensor, {
     activationConstraint: { distance: 10 },
@@ -72,6 +57,33 @@ function TabRowInner<T>({
   const mouseSensor = useSensor(MouseSensor, {
     activationConstraint: { distance: 10 },
   });
+
+  const scroll = useCallback(
+    (direction: "left" | "right") => {
+      if (!tabListRef.current || !width) {
+        return;
+      }
+      const left = width * (direction === "left" ? -1 : 1);
+      tabListRef.current.scrollBy?.({ left, behavior: "instant" });
+    },
+    [width],
+  );
+
+  useLayoutEffect(() => {
+    if (itemsCount - previousItemsCount === 1) {
+      scroll("right");
+    }
+  }, [itemsCount, previousItemsCount, scroll]);
+
+  useLayoutEffect(() => {
+    if (!width || !tabListRef.current) {
+      return;
+    }
+
+    setShowScrollRight(
+      Math.round(scrollPosition + width) < tabListRef.current?.scrollWidth,
+    );
+  }, [children, scrollPosition, width]);
 
   const onDragEnd = (event: DragEndEvent) => {
     if (!event.over || !handleDragEnd) {

--- a/frontend/src/metabase/core/components/TabRow/TabRow.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.tsx
@@ -64,6 +64,7 @@ function TabRowInner<T>({
         return;
       }
       const left = width * (direction === "left" ? -1 : 1);
+      // @ts-expect-error — https://github.com/Microsoft/TypeScript/issues/28755
       tabListRef.current.scrollBy?.({ left, behavior: "instant" });
     },
     [width],


### PR DESCRIPTION
Fixes #38641 

When adding a new tab to a dashboard with many tabs, the new tab and the "new tab" button can get covered by the "scroll to the right" button. Now we'll be scrolling to the right automatically once a new tab is added; also makes the transition instant.

### Demo

**Before**

https://github.com/metabase/metabase/assets/17258145/39ad0d8b-96db-4d30-b8ec-bfc049bd787c

**After**

https://github.com/metabase/metabase/assets/17258145/22817111-f3b4-4f45-83aa-ed8fb7ef3c5b


