### PR TITLE
Update expression-parts to satisfy filter picker

### DIFF
--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -13,9 +13,8 @@
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
    [metabase.lib.util :as lib.util]
    [metabase.mbql.util :as mbql.u]
-   [metabase.shared.formatting.internal.date-builder :as shared.formatting.internal.builder]
+   [metabase.shared.formatting.date :as fmt.date]
    [metabase.shared.util.i18n :as i18n]
-   [metabase.shared.util.internal.time-common :as shared.ut.common]
    [metabase.shared.util.time :as shared.ut]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
@@ -54,10 +53,10 @@
    This functionality is backend approach to \"smaller solution\"."
   [[_operator options column-arg dt-arg :as _expression-clause]]
   (let [temporal-unit (:temporal-unit (lib.options/options column-arg))
-        interval (shared.ut.common/to-range (shared.ut/coerce-to-timestamp dt-arg) {:unit temporal-unit :n 1})
-        format' (cond-> [:year "-" :month-dd "-" :day-of-month-dd]
-                 (contains? expandable-time-units temporal-unit) (into ["T" :hour-24-dd ":" :minute-dd]))
-        formatter (shared.formatting.internal.builder/->formatter format')]
+        interval (shared.ut/to-range (shared.ut/coerce-to-timestamp dt-arg) {:unit temporal-unit :n 1})
+        formatter (if (contains? expandable-time-units temporal-unit)
+                    fmt.date/datetime->iso-string
+                    fmt.date/date->iso-string)]
     (into [:between options column-arg] (map formatter) interval)))
 
 (defn- maybe-expand-temporal-expression

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -34,12 +34,13 @@
   (into expandable-time-units expandable-date-units))
 
 (defn- expandable-temporal-expression?
-  [[operator _options & [maybe-clause-arg :as args]]]
+  [[operator _options & [maybe-clause-arg other-arg :as args]]]
   (boolean (and (= := operator)
                 (= 2 (count args))
                 (lib.util/clause? maybe-clause-arg)
                 (contains? expandable-temporal-units
-                           (:temporal-unit (lib.options/options maybe-clause-arg))))))
+                           (:temporal-unit (lib.options/options maybe-clause-arg)))
+                (shared.ut/timestamp-coercible? other-arg))))
 
 (defn- expand-temporal-expression
   "Modify expression in a way, that its resulting [[expression-parts]] are digestable by filter picker.

--- a/src/metabase/shared/formatting/date.cljc
+++ b/src/metabase/shared/formatting/date.cljc
@@ -83,3 +83,13 @@
       (format-range-with-unit value options)
 
       :else ((formatters/options->formatter options) t))))
+
+(defn ^:export date->iso-string
+  "Coerce date and format as big-endian-day string."
+  [d]
+  (formatters/big-endian-day (shared.ut/coerce-to-timestamp d)))
+
+(defn ^:export datetime->iso-string
+  "Coerce datetime and format as iso string."
+  [dt]
+  (formatters/->iso (shared.ut/coerce-to-timestamp dt)))

--- a/src/metabase/shared/formatting/internal/date_formatters.cljc
+++ b/src/metabase/shared/formatting/internal/date_formatters.cljc
@@ -55,8 +55,12 @@
      "dddd, MMMM D, YYYY" {:week    [:month-full " " :day-of-month-d ", " :year]
                            :month   mmm-y}}))
 
-(def ^:private fallback-iso-format
+(def ^:private iso-format
   [:year "-" :month-dd "-" :day-of-month-dd "T" :hour-24-dd ":" :minute-dd ":" :second-dd])
+
+(def ->iso
+  "Datetime iso formatter."
+  (builder/->formatter iso-format))
 
 (defn- resolve-date-style
   "The `:date-style` is transformed to a `:date-format` as follows:
@@ -73,7 +77,7 @@
       (do
         (log/warn "Unrecognized date style" {:date-style date-style
                                              :unit       unit})
-        fallback-iso-format)))
+        iso-format)))
 
 (defn- normalize-date-format [{:keys [date-format] :as options}]
   (merge options (get constants/known-datetime-styles date-format)))
@@ -201,7 +205,7 @@
                           time-format
                           (do
                             (log/warn "Unrecognized date/time format" options)
-                            fallback-iso-format)))]
+                            iso-format)))]
     (builder/->formatter format-list)))
 
 (def ^:private options->formatter-cache (atom {}))

--- a/src/metabase/shared/util/internal/time.clj
+++ b/src/metabase/shared/util/internal/time.clj
@@ -113,6 +113,12 @@
                   (t/adjust :first-day-of-month))]
     [value (minus-ms (t/plus value (t/months n)))]))
 
+(declare truncate add)
+
+(defmethod common/to-range :quarter [value {:keys [n] :or {n 1}}]
+  (let [value (truncate value :quarter)]
+    [value (minus-ms (add value :quarter n))]))
+
 (defmethod common/to-range :year [value {:keys [n] :or {n 1}}]
   (let [value (-> value
                   (t/truncate-to :days)

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -4,6 +4,7 @@
    [clojure.test :refer [are deftest is testing]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
+   [metabase.lib.fe-util :as lib.fe-util]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
    [metabase.lib.types.isa :as lib.types.isa]))
@@ -186,3 +187,24 @@
                        (lib/dependent-metadata query))
         query
         (lib/append-stage query)))))
+
+(deftest ^:parallel maybe-expand-temporal-expression-test
+  (let [update-temporal-unit (fn [expr temporal-type] (update-in expr [2 1] assoc :temporal-unit temporal-type))
+        expr [:=
+              {:lib/uuid "4fcaefe5-5c20-4cbc-98ed-6007b67843a4"}
+              [:field {:lib/uuid "3fcaefe5-5c20-4cbc-98ed-6007b67843a3"} 111]
+              "2024-05-13T16:35"]]
+    (testing "Expandable temporal units"
+      (are [unit start end] (=? [:between map? [:field {:temporal-unit unit} int?] start end]
+                                (#'lib.fe-util/maybe-expand-temporal-expression (update-temporal-unit expr unit)))
+        :hour "2024-05-13T16:00" "2024-05-13T16:59"
+        :week "2024-05-12" "2024-05-18"
+        :month "2024-05-01" "2024-05-31"
+        ;; TODO: `metabase.shared.util.internal.time-common/to-range` not yet implemented for `:quarter`.
+        #_#_#_:quarter "2024-04-01" "2024-06-31"
+        :year  "2024-01-01" "2024-12-31")
+      (testing "Non-expandable temporal units"
+        (are [unit] (let [expr (update-temporal-unit expr unit)]
+                      (= expr
+                         (#'lib.fe-util/maybe-expand-temporal-expression expr)))
+          :minute :day)))))

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -197,11 +197,10 @@
     (testing "Expandable temporal units"
       (are [unit start end] (=? [:between map? [:field {:temporal-unit unit} int?] start end]
                                 (#'lib.fe-util/maybe-expand-temporal-expression (update-temporal-unit expr unit)))
-        :hour "2024-05-13T16:00" "2024-05-13T16:59"
+        :hour "2024-05-13T16:00:00" "2024-05-13T16:59:59"
         :week "2024-05-12" "2024-05-18"
         :month "2024-05-01" "2024-05-31"
-        ;; TODO: `metabase.shared.util.internal.time-common/to-range` not yet implemented for `:quarter`.
-        #_#_#_:quarter "2024-04-01" "2024-06-31"
+        :quarter "2024-04-01" "2024-06-30"
         :year  "2024-01-01" "2024-12-31")
       (testing "Non-expandable temporal units"
         (are [unit] (let [expr (update-temporal-unit expr unit)]


### PR DESCRIPTION
Closes #12496

### Description

This PR is the backend implementation of "smaller fix" described in [this issue comment](https://github.com/metabase/metabase/issues/12496#issuecomment-1629317661).

`expression-parts` are used on FE to set filter picker for filter expression. Filter expressions that check equality of column with `:temporal-unit` set to value other than `:minute` or `:day` were handled incorrectly. Eg. `[:= {...} [:field {:temporal-unit :week} 111] "2024-05-12"]` would make FE use filter picker set to _on_ even though this equality effectively describes interval. Current filter picker implementation does not support that.

To overcome that, this PR expands the expressions that would require range to be rendered correctly in current filter picker to use `:between` instead of `:=`.
