### PR TITLE
Fix field-vales query to specify :full type

### DIFF
--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -144,7 +144,7 @@
                     :visibility_type "normal"
                     {:order-by field-order-rule})]
     (when (seq field-ids)
-      (t2/select-fn->fn :field_id :values FieldValues, :field_id [:in field-ids]))))
+      (t2/select-fn->fn :field_id :values FieldValues, :field_id [:in field-ids] :type :full))))
 
 (mi/define-simple-hydration-method ^{:arglists '([table])} pk-field-id
   :pk_field


### PR DESCRIPTION
References https://github.com/metabase/metabase/issues/668

### Description

This looks like yet another case which could accidentally return only a subset of the field values (one of the advanced sets).