### PR TITLE
Add boolean wrapper functions for perm checks

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -33,11 +33,7 @@
    :perms/manage-table-metadata
    :yes
    db-id
-   schema-name)
-  (= :yes (data-perms/schema-permission-for-user api/*current-user-id*
-                                                 :perms/manage-table-metadata
-                                                 db-id
-                                                 schema-name)))
+   schema-name))
 
 (defenterprise current-user-can-write-db?
   "Enterprise version. Returns a boolean whether the current user can write the given db"

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -91,10 +91,15 @@
   Permissions', all Cards' permissions are based on their parent Collection, removing the need for native read perms."
   [dbs :- [:maybe [:sequential :map]]]
   (for [db dbs]
-    (assoc db :native_permissions (if (= (data-perms/database-permission-for-user api/*current-user-id* :perms/native-query-editing (u/the-id db))
-                                         :yes)
-                                    :write
-                                    :none))))
+    (assoc db
+           :native_permissions
+           (if (data-perms/user-has-permission-for-database?
+                api/*current-user-id*
+                :perms/native-query-editing
+                :yes
+                (u/the-id db))
+             :write
+             :none))))
 
 (defn- card-database-supports-nested-queries? [{{database-id :database, :as database} :dataset_query, :as _card}]
   (when database-id

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -354,15 +354,17 @@
 (defmethod check-permissions-for-model :table
   [_archived instance]
   ;; we've already filtered out tables w/o collection permissions in the query itself.
-  (= :unrestricted (data-perms/table-permission-for-user api/*current-user-id*
-                                                         :perms/data-access
-                                                         (database/table-id->database-id (:id instance))
-                                                         (:id instance))))
+  (data-perms/user-has-permission-for-table?
+   api/*current-user-id*
+   :perms/data-access
+   :unrestricted
+   (database/table-id->database-id (:id instance))
+   (:id instance)))
 
 (defmethod check-permissions-for-model :indexed-entity
   [_archived? instance]
   (and
-   (= :yes (data-perms/database-permission-for-user api/*current-user-id* :perms/native-query-editing (:database_id instance)))
+   (data-perms/user-has-permission-for-database? api/*current-user-id* :perms/native-query-editing :yes (:database_id instance))
    (= :unrestricted (data-perms/full-db-permission-for-user api/*current-user-id* :perms/data-access (:database_id instance)))))
 
 (defmethod check-permissions-for-model :metric

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -228,7 +228,9 @@
                                          :group-by [:pgm.user_id]}
                                         mdb.query/query
                                         (mapv :user_id)))
-        user-ids (filter #(= :yes (data-perms/database-permission-for-user % :perms/manage-database database-id)) user-ids-with-monitoring)]
+        user-ids (filter
+                  #(data-perms/user-has-permission-for-database? % :perms/manage-database :yes database-id)
+                  user-ids-with-monitoring)]
     (into
       []
       (distinct)

--- a/src/metabase/models/field.clj
+++ b/src/metabase/models/field.clj
@@ -147,12 +147,12 @@
 
 (defmethod mi/can-read? :model/Field
   ([instance]
-   (= :unrestricted
-      (data-perms/table-permission-for-user
-       api/*current-user-id*
-       :perms/data-access
-       (field->db-id instance)
-       (:table_id instance))))
+   (data-perms/user-has-permission-for-table?
+    api/*current-user-id*
+    :perms/data-access
+    :unrestricted
+    (field->db-id instance)
+    (:table_id instance)))
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 

--- a/src/metabase/models/metric.clj
+++ b/src/metabase/models/metric.clj
@@ -46,12 +46,12 @@
 (defmethod mi/can-read? :model/Metric
   ([instance]
    (let [table (:table (t2/hydrate instance :table))]
-     (= :yes
-        (data-perms/table-permission-for-user
-         api/*current-user-id*
-         :perms/manage-table-metadata
-         (:db_id table)
-         (u/the-id table)))))
+     (data-perms/user-has-permission-for-table?
+      api/*current-user-id*
+      :perms/manage-table-metadata
+      :yes
+      (:db_id table)
+      (u/the-id table))))
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -207,14 +207,14 @@
     ;; Check native query access if required
     (when (= (:perms/native-query-editing required-perms) :yes)
       (or (= (:perms/native-query-editing gtap-perms) :yes)
-          (= (data-perms/database-permission-for-user api/*current-user-id* :perms/native-query-editing db-id) :yes)
+          (data-perms/user-has-permission-for-database? api/*current-user-id* :perms/native-query-editing :yes db-id)
           (throw (perms-exception {db-id {:perms/native-query-editing :yes}}))))
     ;; Check for unrestricted data access to any tables referenced by the query
     (when-let [table-ids (:perms/data-access required-perms)]
       (doseq [[table-id _] table-ids]
         (or
          (= (get-in gtap-perms [:perms/data-access table-id]) :unrestricted)
-         (= (data-perms/table-permission-for-user api/*current-user-id* :perms/data-access db-id table-id) :unrestricted)
+         (data-perms/user-has-permission-for-table? api/*current-user-id* :perms/data-access :unrestricted db-id table-id)
          (throw (perms-exception {db-id {:perms/data-access {table-id :unrestricted}}})))))
     true
     (catch clojure.lang.ExceptionInfo e

--- a/src/metabase/models/segment.clj
+++ b/src/metabase/models/segment.clj
@@ -49,12 +49,12 @@
 (defmethod mi/can-read? :model/Segment
   ([instance]
    (let [table (:table (t2/hydrate instance :table))]
-     (= :yes
-        (data-perms/table-permission-for-user
-         api/*current-user-id*
-         :perms/manage-table-metadata
-         (:db_id table)
-         (u/the-id table)))))
+     (data-perms/user-has-permission-for-table?
+      api/*current-user-id*
+      :perms/manage-table-metadata
+      :yes
+      (:db_id table)
+      (u/the-id table))))
   ([model pk]
    (mi/can-read? (t2/select-one model pk))))
 

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -91,11 +91,12 @@
 
 (defmethod mi/can-read? :model/Table
   ([instance]
-   (= :unrestricted (data-perms/table-permission-for-user
-                     api/*current-user-id*
-                     :perms/data-access
-                     (:db_id instance)
-                     (:id instance))))
+   (data-perms/user-has-permission-for-table?
+    api/*current-user-id*
+    :perms/data-access
+    :unrestricted
+    (:db_id instance)
+    (:id instance)))
   ([_ pk]
    (mi/can-read? (t2/select-one :model/Table pk))))
 

--- a/src/metabase/query_processor/middleware/permissions.clj
+++ b/src/metabase/query_processor/middleware/permissions.clj
@@ -155,8 +155,7 @@
   [{database-id :database, :as _query}]
   (or
    (not *current-user-id*)
-   (= (data-perms/database-permission-for-user *current-user-id* :perms/native-query-editing database-id)
-      :yes)))
+   (data-perms/user-has-permission-for-database? *current-user-id* :perms/native-query-editing :yes database-id)))
 
 (defn check-current-user-has-adhoc-native-query-perms
   "Check that the current user (if bound) has adhoc native query permissions to run `query`, or throw an

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -17,6 +17,18 @@
       :block           [:perms/data-access #{:block}]
       nil              [:perms/data-access #{}])))
 
+(deftest ^:parallel at-least-as-permissive?-test
+  (testing "at-least-as-permissive? correctly compares permission values"
+   (is (data-perms/at-least-as-permissive? :perms/data-access :unrestricted :unrestricted))
+   (is (data-perms/at-least-as-permissive? :perms/data-access :unrestricted :no-self-service))
+   (is (data-perms/at-least-as-permissive? :perms/data-access :unrestricted :block))
+   (is (not (data-perms/at-least-as-permissive? :perms/data-access :no-self-service :unrestricted)))
+   (is (data-perms/at-least-as-permissive? :perms/data-access :no-self-service :no-self-service))
+   (is (data-perms/at-least-as-permissive? :perms/data-access :no-self-service :block))
+   (is (not (data-perms/at-least-as-permissive? :perms/data-access :block :unrestricted)))
+   (is (not (data-perms/at-least-as-permissive? :perms/data-access :block :no-self-service)))
+   (is (data-perms/at-least-as-permissive? :perms/data-access :block :block))))
+
 (deftest set-database-permission!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}    {}
                  :model/Database         {database-id :id} {}]


### PR DESCRIPTION
Adds the following functions:
* `user-has-permission-for-database?`
* `user-has-permission-for-schema?`
* `user-has-permission-for-table?`

These are essentially wrappers for the existing permission check functions (like `table-permission-for-user`), but they take a permission value as an additional argument and return a Boolean indicating whether the user has at least that level of permissions. These should hopefully be a bit clearer and easier to use when doing permission checks. I've left the old functions as they are, since there are a few spots that still need to fetch the actual perm value for the user as a keyword.