### PR TITLE
Fix mistake in API changelog: type can be "question" not "query"

### DIFF
--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -7,4 +7,4 @@ title: API changelog
 ## Metabase 0.49.0
 - `POST /api/card` and `PUT /api/card/:id`
 
-  The `dataset` key is deprecated and will be removed in a future version, most likely 50. In its place we have added a new key: `type` which is equivalent in that it distinguishes Models from Questions. `type="model"` is equivalent to `dataset=true` and `type="query"` is equivalent to `dataset=false`.
+  The `dataset` key is deprecated and will be removed in a future version, most likely 50. In its place we have added a new key: `type` which is equivalent in that it distinguishes Models from Questions. `type="model"` is equivalent to `dataset=true` and `type="question"` is equivalent to `dataset=false`.


### PR DESCRIPTION
This PR fixes a mistake in the API changelog: type can be "question" not "query".