### PR TITLE
Update existing foreign keys during metadata sync

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -237,6 +237,7 @@
     jonase/eastwood              {:mvn/version "1.4.2"                      ; inspects namespaces and reports possible problems using tools.analyzer
                                   :exclusions
                                   [org.ow2.asm/asm-all]}
+    criterium/criterium          {:mvn/version "0.4.6"}                     ; benchmarking library
     lambdaisland/deep-diff2      {:mvn/version "2.10.211"}                  ; way better diffs
     methodical/methodical        {:mvn/version "0.15.1"}                    ; drop-in replacements for Clojure multimethods and adds several advanced features
     org.clojure/algo.generic     {:mvn/version "0.1.3"}

--- a/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo_test.clj
@@ -379,16 +379,16 @@
     (with-redefs [metadata-queries/nested-field-sample-limit 2]
       (binding [tdm/*remove-nil?* true]
         (mt/with-temp-test-data
-          ["bird_species"
-           [{:field-name "name", :base-type :type/Text}
-            {:field-name "favorite_snack", :base-type :type/Text}
-            {:field-name "max_wingspan", :base-type :type/Integer}]
-           [["Sharp-shinned Hawk" nil 68]
-            ["Tropicbird" nil 112]
-            ["House Finch" nil nil]
-            ["Mourning Dove" nil nil]
-            ["Common Blackbird" "earthworms" nil]
-            ["Silvereye" "cherries" nil]]]
+          [["bird_species"
+            [{:field-name "name", :base-type :type/Text}
+             {:field-name "favorite_snack", :base-type :type/Text}
+             {:field-name "max_wingspan", :base-type :type/Integer}]
+            [["Sharp-shinned Hawk" nil 68]
+             ["Tropicbird" nil 112]
+             ["House Finch" nil nil]
+             ["Mourning Dove" nil nil]
+             ["Common Blackbird" "earthworms" nil]
+             ["Silvereye" "cherries" nil]]]]
           ;; do a full sync on the DB to get the correct semantic type info
           (sync/sync-database! (mt/db))
           (is (= #{{:name "_id", :database_type "java.lang.Long", :base_type :type/Integer, :semantic_type :type/PK}

--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -41,7 +41,9 @@
                                   :semantic_type      "type/FK"}
                             :where [:and
                                     [:= :f.id fk-field-id-query]
-                                    dest-field-id-query]})
+                                    [:or
+                                     [:= :f.fk_target_field_id nil]
+                                     [:not= :f.fk_target_field_id dest-field-id-query]]]})
       (when (= <> 1)
         (log/info (u/format-color 'cyan "Marking foreign key from %s %s -> %s %s"
                                   (sync-util/table-name-for-logging table)

--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -8,7 +8,8 @@
    [metabase.util :as u]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2]
+   [toucan2.realize :as t2.realize]))
 
 (mu/defn ^:private mark-fk!
   "Updates the `fk_target_field_id` of a Field. Returns 1 if the Field was successfully updated, 0 otherwise."
@@ -64,7 +65,8 @@
   DB based on values from the `FKMetadata` returned by [[metabase.driver/describe-table-fks]]."
   [database :- i/DatabaseInstance]
   (reduce (fn [update-info table]
-            (let [table-fk-info (sync-fks-for-table! database table)]
+            (let [table         (t2.realize/realize table)
+                  table-fk-info (sync-fks-for-table! database table)]
               ;; Mark the table as done with its initial sync once this step is done even if it failed, because only
               ;; sync-aborting errors should be surfaced to the UI (see
               ;; `:metabase.sync.util/exception-classes-not-to-retry`).
@@ -75,4 +77,4 @@
           {:total-fks    0
            :updated-fks  0
            :total-failed 0}
-          (sync-util/db->sync-tables database)))
+          (sync-util/db->reducible-sync-tables database)))

--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -17,7 +17,11 @@
    table    :- i/TableInstance
    fk       :- i/FKMetadataEntry]
   (let [field-id-query (fn [db-id table-schema table-name column-name]
-                             {:select [:f.id]
+                             {:select [[[:min :f.id] :id]]
+                              ;; Cal 2024-03-04: We use `min` to limit this subquery to one result
+                              ;; because it's possible for schema, table, or column names to be non-unique when
+                              ;; lower-cased for some DBs. We have been doing case-insensitive matching since #39679
+                              ;; so this preserves behaviour to avoid possible regressions.
                               :from   [[:metabase_field :f]]
                               :join   [[:metabase_table :t] [:= :f.table_id :t.id]]
                               :where  [:and
@@ -27,13 +31,8 @@
                                        [:= [:lower :t.schema] (some-> table-schema u/lower-case-en)]
                                        [:= :f.active true]
                                        [:not= :f.visibility_type "retired"]
-                                       [:= :t.active nil]
-                                       [:= :t.visibility_type nil]]
-                              ;; Cal 2024-03-04: We need to limit to 1 because it's possible for schema, table, or
-                              ;; column names to be non-unique when lower-cased. We have been doing case-insensitive
-                              ;; matching since #39679 (2017), and so let's preserves this behaviour for now to avoid
-                              ;; regressions.
-                              :limit  1})
+                                       [:= :t.active true]
+                                       [:= :t.visibility_type nil]]})
         fk-field-id-query (field-id-query (:id database)
                                           (:schema table)
                                           (:name table)

--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -37,7 +37,8 @@
                                             (:name (:dest-table fk))
                                             (:dest-column-name fk))]
     (u/prog1 (t2/query-one {:update [:metabase_field :f]
-                            :set {:fk_target_field_id dest-field-id-query}
+                            :set {:fk_target_field_id dest-field-id-query
+                                  :semantic_type      "type/FK"}
                             :where [:= :f.id fk-field-id-query]})
       (when (= <> 1)
         (log/info (u/format-color 'cyan "Marking foreign key from %s %s -> %s %s"

--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -49,9 +49,10 @@
                       ;; - fk_target_field_id is NULL and the new target is not NULL
                       ;; - fk_target_field_id is not NULL but the new target is different and not NULL
                       [pk-field-id-query :pk]
-                      [:or
-                       [:= :f.fk_target_field_id nil]
-                       [:not= :f.fk_target_field_id :pk.id]]]
+                      [:and
+                       [:or
+                        [:= :f.fk_target_field_id nil]
+                        [:not= :f.fk_target_field_id :pk.id]]]]
              :set    {:fk_target_field_id :pk.id
                       :semantic_type      "type/FK"}}
             :postgres

--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -27,7 +27,8 @@
                           ;; Cal 2024-03-04: We use `min` to limit this subquery to one result (limit 1 isn't allowed
                           ;; in subqueries in MySQL) because it's possible for schema, table, or column names to be
                           ;; non-unique when lower-cased for some DBs. We have been doing case-insensitive matching
-                          ;; since #39679 so this preserves behaviour to avoid possible regressions.
+                          ;; since #5510 so this preserves behaviour to avoid possible regressions.
+                          ;; It's possible this is to avoid
                           :from   [[:metabase_field :f]]
                           :join   [[:metabase_table :t] [:= :f.table_id :t.id]]
                           :where  [:and

--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -39,7 +39,9 @@
     (u/prog1 (t2/query-one {:update [:metabase_field :f]
                             :set {:fk_target_field_id dest-field-id-query
                                   :semantic_type      "type/FK"}
-                            :where [:= :f.id fk-field-id-query]})
+                            :where [:and
+                                    [:= :f.id fk-field-id-query]
+                                    dest-field-id-query]})
       (when (= <> 1)
         (log/info (u/format-color 'cyan "Marking foreign key from %s %s -> %s %s"
                                   (sync-util/table-name-for-logging table)

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -324,6 +324,11 @@
   [database-or-id]
   (t2/select :model/Table, :db_id (u/the-id database-or-id), :active true, :visibility_type nil))
 
+(defn db->reducible-sync-tables
+  "Returns a reducible of all the Tables that should go through the sync processes for `database-or-id`."
+  [database-or-id]
+  (t2/reducible-select :model/Table, :db_id (u/the-id database-or-id), :active true, :visibility_type nil))
+
 (defmulti name-for-logging
   "Return an appropriate string for logging an object in sync logging messages. Should be something like
 

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -338,11 +338,21 @@
   [{database-name :name, id :id, engine :engine,}]
   (format "%s Database %s ''%s''" (name engine) (str (or id "")) database-name))
 
-(defmethod name-for-logging :model/Table [{schema :schema, id :id, table-name :name}]
-  (format "Table %s ''%s''" (or (str id) "") (str (when (seq schema) (str schema ".")) table-name)))
+(defn table-name-for-logging
+  "Return an appropriate string for logging a table in sync logging messages."
+  [& {:keys [id schema name]}]
+  (format "Table %s ''%s''" (or (str id) "") (str (when (seq schema) (str schema ".")) name)))
 
-(defmethod name-for-logging Field [{field-name :name, id :id}]
-  (format "Field %s ''%s''" (or (str id) "") field-name))
+(defmethod name-for-logging :model/Table [table]
+  (table-name-for-logging table))
+
+(defn field-name-for-logging
+  "Return an appropriate string for logging a field in sync logging messages."
+  [& {:keys [id name]}]
+  (format "Field %s ''%s''" (or (str id) "") name))
+
+(defmethod name-for-logging Field [field]
+  (field-name-for-logging field))
 
 ;;; this is used for result metadata stuff.
 (defmethod name-for-logging :default [{field-name :name}]

--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -319,15 +319,19 @@
 ;;; |                                          OTHER SYNC UTILITY FUNCTIONS                                          |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
+(def ^:private sync-tables-clause
+  [:and [:= :active true]
+        [:= :visibility_type nil]])
+
 (defn db->sync-tables
   "Return all the Tables that should go through the sync processes for `database-or-id`."
   [database-or-id]
-  (t2/select :model/Table, :db_id (u/the-id database-or-id), :active true, :visibility_type nil))
+  (t2/select :model/Table, :db_id (u/the-id database-or-id), {:where sync-tables-clause}))
 
 (defn db->reducible-sync-tables
   "Returns a reducible of all the Tables that should go through the sync processes for `database-or-id`."
   [database-or-id]
-  (t2/reducible-select :model/Table, :db_id (u/the-id database-or-id), :active true, :visibility_type nil))
+  (t2/reducible-select :model/Table, :db_id (u/the-id database-or-id), {:where sync-tables-clause}))
 
 (defmulti name-for-logging
   "Return an appropriate string for logging an object in sync logging messages. Should be something like

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -106,8 +106,8 @@
   "Sets the current dataset to a freshly created dataset-definition that gets destroyed at the conclusion of `body`.
    Use this to test destructive actions that may modify the data."
   {:style/indent :defn}
-  [dataset-definition & body]
-  `(do-with-dataset-definition (tx/dataset-definition ~(str (gensym)) ~dataset-definition) (fn [] ~@body)))
+  [table-definitions & body]
+  `(do-with-dataset-definition (tx/dataset-definition ~(str (gensym)) ~@table-definitions) (fn [] ~@body)))
 
 (defmacro with-empty-db
   "Sets the current dataset to a freshly created db that gets destroyed at the conclusion of `body`.

--- a/test/metabase/actions/test_util.clj
+++ b/test/metabase/actions/test_util.clj
@@ -107,7 +107,7 @@
    Use this to test destructive actions that may modify the data."
   {:style/indent :defn}
   [table-definitions & body]
-  `(do-with-dataset-definition (tx/dataset-definition ~(str (gensym)) ~@table-definitions) (fn [] ~@body)))
+  `(do-with-dataset-definition (apply tx/dataset-definition ~(str (gensym)) ~table-definitions) (fn [] ~@body)))
 
 (defmacro with-empty-db
   "Sets the current dataset to a freshly created db that gets destroyed at the conclusion of `body`.

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -3764,9 +3764,9 @@
                  ;; Difference between h2 and postgres, in and out
                  {:field-name "adatetimetz" :base-type :type/DateTimeWithTZ #_#_::good "2020-02-02 14:39:59-0700" ::bad "not date"}]]
       (mt/with-temp-test-data
-        ["types"
-         (map #(dissoc % ::good ::bad) types)
-         [["init"]]]
+        [["types"
+          (map #(dissoc % ::good ::bad) types)
+          [["init"]]]]
         (mt/with-actions-enabled
           (mt/with-actions [{card-id :id} {:type :model :dataset_query (mt/mbql-query types)}
                             {:keys [action-id]} {:type :implicit :kind "row/create"}]

--- a/test/metabase/query_processor_test/timezones_test.clj
+++ b/test/metabase/query_processor_test/timezones_test.clj
@@ -303,9 +303,9 @@
   (mt/test-drivers (set-timezone-drivers)
     (testing "Relative to current date"
       (let [expected-datetime (u.date/truncate (t/zoned-date-time) :second)]
-        (mt/with-temp-test-data ["relative_filter"
-                                 [{:field-name "created", :base-type :type/DateTimeWithTZ}]
-                                 [[expected-datetime]]]
+        (mt/with-temp-test-data [["relative_filter"
+                                  [{:field-name "created", :base-type :type/DateTimeWithTZ}]
+                                  [[expected-datetime]]]]
           (doseq [timezone ["UTC" "America/Los_Angeles"]]
             (mt/with-temporary-setting-values [report-timezone timezone]
               (let [query (mt/mbql-query relative_filter {:fields [$created]
@@ -327,9 +327,9 @@
   (mt/test-drivers (set-timezone-drivers)
     (testing "Relative to days since"
       (let [expected-datetime (u.date/truncate (u.date/add (t/zoned-date-time) :day -1) :second)]
-        (mt/with-temp-test-data ["relative_filter"
-                                 [{:field-name "created", :base-type :type/DateTimeWithTZ}]
-                                 [[expected-datetime]]]
+        (mt/with-temp-test-data [["relative_filter"
+                                  [{:field-name "created", :base-type :type/DateTimeWithTZ}]
+                                  [[expected-datetime]]]]
           (doseq [timezone ["UTC" "Asia/Hong_Kong" "US/Hawaii" "America/Puerto_Rico"]]
             (mt/with-temporary-setting-values [report-timezone timezone]
               (let [query (mt/mbql-query relative_filter {:fields [$created]

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -55,7 +55,7 @@
              {:name "ID", :semantic_type :type/PK, :last_analyzed false}
              {:name "PRICE", :semantic_type :type/Category, :last_analyzed true}
              {:name "LONGITUDE", :semantic_type :type/Longitude, :last_analyzed true}
-             {:name "CATEGORY_ID", :semantic_type :type/Category, :last_analyzed true}
+             {:name "CATEGORY_ID", :semantic_type :type/FK, :last_analyzed true}
              {:name "NAME", :semantic_type :type/Name, :last_analyzed true}}
            (set (for [field (t2/select [Field :name :semantic_type :last_analyzed] :table_id (u/the-id table))]
                   (into {} (update field :last_analyzed boolean))))))))

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -55,7 +55,7 @@
              {:name "ID", :semantic_type :type/PK, :last_analyzed false}
              {:name "PRICE", :semantic_type :type/Category, :last_analyzed true}
              {:name "LONGITUDE", :semantic_type :type/Longitude, :last_analyzed true}
-             {:name "CATEGORY_ID", :semantic_type :type/FK, :last_analyzed true}
+             {:name "CATEGORY_ID", :semantic_type :type/Category, :last_analyzed true}
              {:name "NAME", :semantic_type :type/Name, :last_analyzed true}}
            (set (for [field (t2/select [Field :name :semantic_type :last_analyzed] :table_id (u/the-id table))]
                   (into {} (update field :last_analyzed boolean))))))))

--- a/test/metabase/sync/analyze_test.clj
+++ b/test/metabase/sync/analyze_test.clj
@@ -44,12 +44,14 @@
 
 ;; ...but they *SHOULD* get analyzed if they ARE newly created (expcept for PK which we skip)
 (deftest analyze-table-test
-  (t2.with-temp/with-temp [Database db    {:engine "h2", :details (:details (data/db))}
-                           Table    table {:name "VENUES", :db_id (u/the-id db)}]
+  (t2.with-temp/with-temp [Database db         {:engine "h2",       :details (:details (data/db))}
+                           Table    categories {:name "CATEGORIES", :db_id (:id db) :schema "PUBLIC"}
+                           Table    venues     {:name "VENUES",     :db_id (:id db) :schema "PUBLIC"}]
+    (sync-metadata/sync-table-metadata! categories)
     ;; sync the metadata, but DON't do analysis YET
-    (sync-metadata/sync-table-metadata! table)
+    (sync-metadata/sync-table-metadata! venues)
     ;; ok, NOW run the analysis process
-    (analyze/analyze-table! table)
+    (analyze/analyze-table! venues)
     ;; fields *SHOULD* have semantic types now
     (is (= #{{:name "LATITUDE", :semantic_type :type/Latitude, :last_analyzed true}
              {:name "ID", :semantic_type :type/PK, :last_analyzed false}
@@ -57,7 +59,7 @@
              {:name "LONGITUDE", :semantic_type :type/Longitude, :last_analyzed true}
              {:name "CATEGORY_ID", :semantic_type :type/FK, :last_analyzed true}
              {:name "NAME", :semantic_type :type/Name, :last_analyzed true}}
-           (set (for [field (t2/select [Field :name :semantic_type :last_analyzed] :table_id (u/the-id table))]
+           (set (for [field (t2/select [Field :name :semantic_type :last_analyzed] :table_id (:id venues))]
                   (into {} (update field :last_analyzed boolean))))))))
 
 (deftest mark-fields-as-analyzed-test

--- a/test/metabase/sync/sync_metadata/fields/sync_metadata_test.clj
+++ b/test/metabase/sync/sync_metadata/fields/sync_metadata_test.clj
@@ -263,10 +263,10 @@
                     :effective-type :type/Integer}))))
 
     (testing "and sync will re-fingerprint and analyze this field"
-      (mt/with-temp-test-data ["table"
-                               [{:field-name "field"
-                                 :base-type  :type/Text}]
-                               [["ngoc@metabase.com"]]]
+      (mt/with-temp-test-data [["table"
+                                [{:field-name "field"
+                                  :base-type  :type/Text}]
+                                [["ngoc@metabase.com"]]]]
         (try
          (sync/sync-table! (t2/select-one :model/Table (mt/id :table)))
          (let [original-field (t2/select-one :model/Field (mt/id :table :field))]

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -224,25 +224,29 @@
           [name-field-def {:field-name "continent_id", :base-type :type/Integer}]
           []]]
         (let [db            (mt/db)
-              get-fk-target #(t2/select-one-fn :fk_target_field_id :model/Field (mt/id :country :continent_id))]
+              get-fk #(t2/select-one :model/Field (mt/id :country :continent_id))]
           ;; 1. add FK relationship in the database targeting continent_1
           (t2/query-one db "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_1(id);")
           (sync/sync-database! db {:scan :schema})
           (testing "initially country's continent_id is targeting continent_1"
-            (is (= (mt/id :continent_1 :id)
-                   (get-fk-target))))
+            (is (=? {:fk_target_field_id (mt/id :continent_1 :id)
+                     :semantic_type      :type/FK}
+                    (get-fk))))
           ;; 2. drop the FK relationship in the database with SQL
           (t2/query-one db "ALTER TABLE country DROP CONSTRAINT country_continent_id_fkey;")
           (sync/sync-database! db {:scan :schema})
           ;; FIXME: The following test fails. The FK relationship is still there in the Metabase database (metabase#39687)
           #_(testing "after dropping the FK relationship, country's continent_id is targeting nothing"
-              (is (nil? (get-fk-target))))
+              (is (=? {:fk_target_field_id nil
+                       :semantic_type      :type/Category}
+                      (get-fk))))
           ;; 3. add back the FK relationship but targeting continent_2
           (t2/query-one db "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_2(id);")
           (sync/sync-database! db {:scan :schema})
           (testing "initially country's continent_id is targeting continent_2"
-            (is (= (mt/id :continent_2 :id)
-                   (get-fk-target)))))))))
+            (is (=? {:fk_target_field_id (mt/id :continent_2 :id)
+                     :semantic_type      :type/FK}
+                    (get-fk)))))))))
 
 (deftest sync-table-fks-test
   (testing "Check that sync-table! causes FKs to be set like we'd expect"

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -263,8 +263,8 @@
                    :semantic-type     semantic_type
                    :fk-target-exists? (t2/exists? Field :id fk_target_field_id)}))]
         (testing "before"
-          (is (= {:step-info         {:total-fks 6, :updated-fks 6, :total-failed 0}
-                  :task-details      {:total-fks 6, :updated-fks 6, :total-failed 0}
+          (is (= {:step-info         {:total-fks 6, :updated-fks 0, :total-failed 0}
+                  :task-details      {:total-fks 6, :updated-fks 0, :total-failed 0}
                   :semantic-type     :type/FK
                   :fk-target-exists? true}
                  (state))))

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -5,6 +5,7 @@
    [clojure.java.jdbc :as jdbc]
    [clojure.test :refer :all]
    [medley.core :as m]
+   [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.models :refer [Field Table]]
    [metabase.query-processor :as qp]
    [metabase.sync :as sync]
@@ -223,17 +224,18 @@
          ["country"
           [name-field-def {:field-name "continent_id", :base-type :type/Integer}]
           []]]
-        (let [db            (mt/db)
+        (let [db (mt/db)
+              db-spec (sql-jdbc.conn/db->pooled-connection-spec db)
               get-fk #(t2/select-one :model/Field (mt/id :country :continent_id))]
           ;; 1. add FK relationship in the database targeting continent_1
-          (t2/query-one db "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_1(id);")
+          (jdbc/execute! db-spec "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_1(id);")
           (sync/sync-database! db {:scan :schema})
           (testing "initially country's continent_id is targeting continent_1"
             (is (=? {:fk_target_field_id (mt/id :continent_1 :id)
                      :semantic_type      :type/FK}
                     (get-fk))))
           ;; 2. drop the FK relationship in the database with SQL
-          (t2/query-one db "ALTER TABLE country DROP CONSTRAINT country_continent_id_fkey;")
+          (jdbc/execute! db-spec "ALTER TABLE country DROP CONSTRAINT country_continent_id_fkey;")
           (sync/sync-database! db {:scan :schema})
           ;; FIXME: The following test fails. The FK relationship is still there in the Metabase database (metabase#39687)
           #_(testing "after dropping the FK relationship, country's continent_id is targeting nothing"
@@ -241,7 +243,7 @@
                        :semantic_type      :type/Category}
                       (get-fk))))
           ;; 3. add back the FK relationship but targeting continent_2
-          (t2/query-one db "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_2(id);")
+          (jdbc/execute! db-spec "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_2(id);")
           (sync/sync-database! db {:scan :schema})
           (testing "initially country's continent_id is targeting continent_2"
             (is (=? {:fk_target_field_id (mt/id :continent_2 :id)

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -263,8 +263,8 @@
                    :semantic-type     semantic_type
                    :fk-target-exists? (t2/exists? Field :id fk_target_field_id)}))]
         (testing "before"
-          (is (= {:step-info         {:total-fks 6, :updated-fks 0, :total-failed 0}
-                  :task-details      {:total-fks 6, :updated-fks 0, :total-failed 0}
+          (is (= {:step-info         {:total-fks 6, :updated-fks 6, :total-failed 0}
+                  :task-details      {:total-fks 6, :updated-fks 6, :total-failed 0}
                   :semantic-type     :type/FK
                   :fk-target-exists? true}
                  (state))))

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -209,6 +209,40 @@
       (is (= (mt/id :categories :id)
              (t2/select-one-fn :fk_target_field_id Field, :id (mt/id :venues :category_id)))))))
 
+(deftest update-fk-relationships-test
+  (testing "Check that Foreign Key relationships can be updated"
+    (mt/with-temp-test-data
+      [["continent_1"
+        [{:field-name "name", :base-type :type/Text}]
+        []]
+       ["continent_2"
+        [{:field-name "name", :base-type :type/Text}]
+        []]
+       ["country"
+        [{:field-name "name", :base-type :type/Text}
+         {:field-name "continent_id", :base-type :type/Integer}]
+        []]]
+      (let [db (mt/db)
+            get-fk-target #(t2/select-one-fn :fk_target_field_id :model/Field (mt/id :country :continent_id))]
+        ;; add the FK relationship in the database with SQL so we can name it
+        (t2/query-one db "ALTER TABLE country ADD CONSTRAINT IF NOT EXISTS country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_1(id);")
+        (sync/sync-database! db {:scan :schema})
+        (testing "initially country's continent_id is targeting continent_1"
+          (is (= (mt/id :continent_1 :id)
+                 (get-fk-target))))
+        ;; drop the FK relationship in the database with SQL
+        (t2/query-one db "ALTER TABLE country DROP CONSTRAINT country_continent_id_fkey;")
+        (sync/sync-database! db {:scan :schema})
+        (testing "This reproduces a bug where if FK relationships are dropped, we don't sync the change"
+          (is (= (mt/id :continent_1 :id)
+                 (get-fk-target))))
+        ;; add back the FK relationship but targeting continent_2
+        (t2/query-one db "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_2(id);")
+        (sync/sync-database! db {:scan :schema})
+        (testing "initially country's continent_id is targeting continent_2"
+          (is (= (mt/id :continent_2 :id)
+                 (get-fk-target))))))))
+
 (deftest sync-table-fks-test
   (testing "Check that sync-table! causes FKs to be set like we'd expect"
     (mt/with-temp-copy-of-db

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -267,21 +267,6 @@
                   :fk-target-exists? true}
                  (state))))))))
 
-(t2/with-call-count [call-count]
-  (mt/with-temp-test-data
-    [["continent_1"
-      [{:field-name "name", :base-type :type/Text}]
-      []]
-     ["continent_2"
-      [{:field-name "name", :base-type :type/Text}]
-      []]
-     ["country"
-      [{:field-name "name", :base-type :type/Text}
-       {:field-name "continent_id", :base-type :type/Integer}]
-      []]]
-    (mt/db))
-  (is (= 1 (call-count))))
-
 (deftest case-sensitive-conflict-test
   (testing "Two columns with same lower-case name can be synced (#17387)"
     (one-off-dbs/with-blank-db

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -214,11 +214,14 @@
     (let [; dataset tables need at least one field other than the ID column, so just add a dummy field
           name-field-def {:field-name "dummy", :base-type :type/Text}]
       (mt/with-temp-test-data
-        [["continent_1" [name-field-def]
+        [["continent_1"
+          [name-field-def]
           []]
-         ["continent_2" [name-field-def]
+         ["continent_2"
+          [name-field-def]
           []]
-         ["country" [name-field-def {:field-name "continent_id", :base-type :type/Integer}]
+         ["country"
+          [name-field-def {:field-name "continent_id", :base-type :type/Integer}]
           []]]
         (let [db            (mt/db)
               get-fk-target #(t2/select-one-fn :fk_target_field_id :model/Field (mt/id :country :continent_id))]

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -231,7 +231,7 @@
           ;; 2. drop the FK relationship in the database with SQL
           (t2/query-one db "ALTER TABLE country DROP CONSTRAINT country_continent_id_fkey;")
           (sync/sync-database! db {:scan :schema})
-          ;; FIXME: The following test fails. The FK relationship is still there in the Metabase database.
+          ;; FIXME: The following test fails. The FK relationship is still there in the Metabase database (metabase#39687)
           #_(testing "after dropping the FK relationship, country's continent_id is targeting nothing"
               (is (nil? (get-fk-target))))
           ;; 3. add back the FK relationship but targeting continent_2

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -222,7 +222,7 @@
           []]]
         (let [db            (mt/db)
               get-fk-target #(t2/select-one-fn :fk_target_field_id :model/Field (mt/id :country :continent_id))]
-          ;; 1. add the FK relationship in the database with SQL so we can name it
+          ;; 1. add FK relationship in the database targeting continent_1
           (t2/query-one db "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_1(id);")
           (sync/sync-database! db {:scan :schema})
           (testing "initially country's continent_id is targeting continent_1"
@@ -231,9 +231,9 @@
           ;; 2. drop the FK relationship in the database with SQL
           (t2/query-one db "ALTER TABLE country DROP CONSTRAINT country_continent_id_fkey;")
           (sync/sync-database! db {:scan :schema})
-          (testing "This reproduces a bug where if FK relationships are dropped, we don't sync the change"
-            (is (= (mt/id :continent_1 :id)
-                   (get-fk-target))))
+          ;; FIXME: The following test fails. The FK relationship is still there in the Metabase database.
+          #_(testing "after dropping the FK relationship, country's continent_id is targeting nothing"
+              (is (nil? (get-fk-target))))
           ;; 3. add back the FK relationship but targeting continent_2
           (t2/query-one db "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_2(id);")
           (sync/sync-database! db {:scan :schema})

--- a/test/metabase/sync_test.clj
+++ b/test/metabase/sync_test.clj
@@ -231,8 +231,10 @@
 
 (deftest sync-table-test
   (binding [sync-util/*log-exceptions-and-continue?* false]
-    (mt/with-temp [Database db {:engine ::sync-test}
-                   Table    table {:name "movie", :schema "default", :db_id (u/the-id db)}]
+    (mt/with-temp [Database db            {:engine ::sync-test}
+                   Table    table         {:name "movie", :schema "default", :db_id (u/the-id db)}
+                   Table    studio-table {:name "studio", :schema nil, :db_id (u/the-id db)}]
+      (sync/sync-table! studio-table)
       (sync/sync-table! table)
       (is (= (merge
               (table-defaults)
@@ -241,10 +243,7 @@
                :display_name        "Movie"
                :initial_sync_status "complete"
                :fields              [(field:movie-id)
-                                     (assoc (field:movie-studio)
-                                            :fk_target_field_id false
-                                            :semantic_type nil
-                                            :has_field_values :auto-list)
+                                     (field:movie-studio)
                                      (field:movie-title)]})
              (table-details (t2/select-one Table :id (:id table))))))))
 

--- a/test/metabase/sync_test.clj
+++ b/test/metabase/sync_test.clj
@@ -231,8 +231,8 @@
 
 (deftest sync-table-test
   (binding [sync-util/*log-exceptions-and-continue?* false]
-    (mt/with-temp [Database db            {:engine ::sync-test}
-                   Table    table         {:name "movie", :schema "default", :db_id (u/the-id db)}
+    (mt/with-temp [Database db           {:engine ::sync-test}
+                   Table    table        {:name "movie", :schema "default", :db_id (u/the-id db)}
                    Table    studio-table {:name "studio", :schema nil, :db_id (u/the-id db)}]
       (sync/sync-table! studio-table)
       (sync/sync-table! table)


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/39685

This is also a pre-requisite for [Faster sync-fks](https://github.com/metabase/metabase/pull/38970), because the approach I'm taking there will use more memory without this change.

It also reduces the memory footprint of the "sync-fks" step for databases with many tables. Previously we would allocate all of the tables of a database every time in a vector.

I tested the impact on speed using the below criterium benchmark, which simulates the `sync-fks!` step for a database with 100 foreign keys:
```clojure
(let [n-foreign-keys 100]
  (mt/with-temp-test-data
    (mapcat
     (fn [i]
       [[(str "continent_" i)
         [{:field-name "name", :base-type :type/Text}]
         []]
        [(str "country_" i)
         [{:field-name "name", :base-type :type/Text}
          {:field-name "continent_id", :base-type :type/Integer}]
         []]])
     (range n-foreign-keys))
    (metabase.sync/sync-database! (mt/db) {:scan :schema})
    (doseq [i (range n-foreign-keys)]
      (t2/query-one (mt/db) (str "ALTER TABLE country_" i " ADD CONSTRAINT contraint_" i " FOREIGN KEY (continent_id) REFERENCES continent_" i "(id);")))
    (t2/with-call-count [call-count]
      (criterium.core/quick-bench (metabase.sync.sync-metadata.fks/sync-fks! (mt/db)))
      (call-count))))
```

Using a local postgres app DB and an H2 test DB:

Before:
Evaluation count : 12 in 6 samples of 2 calls.
Execution time mean : 73.440179 ms
After: 
Evaluation count : 6 in 6 samples of 1 calls.
Execution time mean : 132.344456 ms

I'd need to dive into the reason behind the difference in performance, but it gives me enough confidence to move on to [Faster sync-fks](https://github.com/metabase/metabase/pull/38970), which is where the real performance improvement will come from and more than make up for it.