### PR TITLE
Show models correctly in the data source picker

### DIFF
--- a/e2e/test/scenarios/question/reproductions/39699-notebook-data-source-models.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/39699-notebook-data-source-models.cy.spec.js
@@ -1,0 +1,50 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { SECOND_COLLECTION_ID } from "e2e/support/cypress_sample_instance_data";
+import { restore, openNotebook } from "e2e/support/helpers";
+
+const { REVIEWS_ID } = SAMPLE_DATABASE;
+
+const modelDetails = {
+  name: "GUI Model",
+  query: { "source-table": REVIEWS_ID, limit: 1 },
+  display: "table",
+  type: "model",
+  collection_id: SECOND_COLLECTION_ID,
+};
+
+describe("issue 39699", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+
+    cy.createQuestion(modelDetails, { visitQuestion: true });
+  });
+
+  it("data selector should properly show a model as the source (metabase#39699)", () => {
+    openNotebook();
+    cy.findByTestId("data-step-cell")
+      .should("have.text", modelDetails.name)
+      .click();
+
+    cy.findByTestId("saved-entity-back-navigation").should(
+      "have.text",
+      "Models",
+    );
+
+    cy.findByTestId("saved-entity-collection-tree").within(() => {
+      cy.findByLabelText("Our analytics")
+        .should("have.attr", "aria-expanded", "false")
+        .and("have.attr", "aria-selected", "false");
+      cy.findByLabelText("First collection")
+        .should("have.attr", "aria-expanded", "true")
+        .and("have.attr", "aria-selected", "false");
+      cy.findByLabelText("Second collection")
+        .should("have.attr", "aria-expanded", "false")
+        .and("have.attr", "aria-selected", "true");
+    });
+
+    cy.findByTestId("select-list")
+      .findByLabelText(modelDetails.name)
+      .should("have.attr", "aria-selected", "true");
+  });
+});

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -330,7 +330,6 @@ export class UnconnectedDataSelector extends Component {
       fetchFields,
       fetchQuestion,
       selectedDataBucketId,
-      selectedQuestion,
       selectedTableId: sourceId,
     } = this.props;
 
@@ -345,10 +344,10 @@ export class UnconnectedDataSelector extends Component {
     if (sourceId) {
       await fetchFields(sourceId);
       if (this.isSavedEntitySelected()) {
-        fetchQuestion(sourceId);
+        await fetchQuestion(sourceId);
 
         this.showSavedEntityPicker({
-          entityType: selectedQuestion?.type(),
+          entityType: this.props.selectedQuestion?.type(),
         });
       }
     }

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -326,23 +326,29 @@ export class UnconnectedDataSelector extends Component {
 
   async componentDidMount() {
     const { activeStep } = this.state;
-    const sourceId = this.props.selectedTableId;
+    const {
+      fetchFields,
+      fetchQuestion,
+      selectedDataBucketId,
+      selectedQuestion,
+      selectedTableId: sourceId,
+    } = this.props;
 
     if (!this.isLoadingDatasets() && !activeStep) {
       await this.hydrateActiveStep();
     }
 
-    if (this.props.selectedDataBucketId === DATA_BUCKET.MODELS) {
+    if (selectedDataBucketId === DATA_BUCKET.MODELS) {
       this.showSavedEntityPicker({ entityType: "model" });
     }
 
     if (sourceId) {
-      await this.props.fetchFields(sourceId);
+      await fetchFields(sourceId);
       if (this.isSavedEntitySelected()) {
-        this.props.fetchQuestion(sourceId);
+        fetchQuestion(sourceId);
 
         this.showSavedEntityPicker({
-          entityType: this.props.selectedQuestion?.type(),
+          entityType: selectedQuestion?.type(),
         });
       }
     }

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -12,6 +12,7 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import { DATA_BUCKET, getDataTypes } from "metabase/containers/DataPicker";
 import Databases from "metabase/entities/databases";
+import Questions from "metabase/entities/questions";
 import Schemas from "metabase/entities/schemas";
 import Search from "metabase/entities/search";
 import Tables from "metabase/entities/tables";
@@ -338,10 +339,11 @@ export class UnconnectedDataSelector extends Component {
     if (sourceId) {
       await this.props.fetchFields(sourceId);
       if (this.isSavedEntitySelected()) {
-        const id = getQuestionIdFromVirtualTableId(sourceId);
-        const question = this.props.metadata?.question(id);
+        this.props.fetchQuestion(sourceId);
 
-        this.showSavedEntityPicker({ entityType: question?.type() });
+        this.showSavedEntityPicker({
+          entityType: this.props.selectedQuestion?.type(),
+        });
       }
     }
   }
@@ -1070,6 +1072,9 @@ const DataSelector = _.compose(
       }),
       hasDataAccess: getHasDataAccess(ownProps.allDatabases ?? []),
       hasNestedQueriesEnabled: getSetting(state, "enable-nested-queries"),
+      selectedQuestion: Questions.selectors.getObject(state, {
+        entityId: getQuestionIdFromVirtualTableId(ownProps.selectedTableId),
+      }),
     }),
     {
       fetchDatabases: databaseQuery =>
@@ -1078,6 +1083,10 @@ const DataSelector = _.compose(
         Schemas.actions.fetchList({ dbId: databaseId }),
       fetchSchemaTables: schemaId => Schemas.actions.fetch({ id: schemaId }),
       fetchFields: tableId => Tables.actions.fetchMetadata({ id: tableId }),
+      fetchQuestion: id =>
+        Questions.actions.fetch({
+          id: getQuestionIdFromVirtualTableId(id),
+        }),
     },
   ),
 )(UnconnectedDataSelector);

--- a/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/saved-entity-picker/SavedEntityPicker.jsx
@@ -118,11 +118,11 @@ function SavedEntityPicker({
   return (
     <SavedEntityPickerRoot>
       <CollectionsContainer>
-        <BackButton onClick={onBack}>
+        <BackButton onClick={onBack} data-testid="saved-entity-back-navigation">
           <Icon name="chevronleft" className="mr1" />
           {isDatasets ? t`Models` : t`Saved Questions`}
         </BackButton>
-        <TreeContainer>
+        <TreeContainer data-testid="saved-entity-collection-tree">
           <Tree
             data={collectionTree}
             onSelect={handleSelect}


### PR DESCRIPTION
Models were supported in the data selector (data picker) only when starting the "New > Question" or a "New > Model" flow. But once you save that model and want to see its source, the data picker didn't work anymore. This was due to this check (that is passed as a prop to many child components):
```jsx
isDatasets={ selectedDataBucketId === DATA_BUCKET.MODELS }
```

But when you are opening a saved entity, this data bucket doesn't exist, and the component doesn't know what to display, so it always defaulted to "Saved Questions". Luckily, there is already an information (`id`) about the saved entity we're opening. This PR introduces a fetching logic that uses said `id` to fetch a question, and it then checks its `type`. The type can either be a question or a model (for now).

Now our previous logic that determines whether we're showing models in the data picker becomes:
```js
const isDatasets =
  // Are we in the "New > ___" mode
  selectedDataBucketId === DATA_BUCKET.MODELS ||
  // or do we open an already saved entity?
  savedEntityType === "model";
```

### Tests
An E2E reproduction has been added for now, until I figure out how much can I cover with FE unit/integration tests.

Reproduces and fixes #39699