### PR TITLE
Do not create questions for dashcards with permission errors

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardParameterMapper/DashCardCardParameterMapper.tsx
@@ -150,17 +150,17 @@ export function DashCardCardParameterMapper({
     }
 
     // virtual or action dashcard
-    if (!question) {
+    if (!isQuestionDashCard(dashcard)) {
       return true;
     }
 
-    if (!card.dataset_query) {
+    if (!question || !card.dataset_query) {
       return false;
     }
 
     const { isEditable } = Lib.queryDisplayInfo(question.query());
     return isEditable;
-  }, [isVirtual, card.dataset_query, question]);
+  }, [isVirtual, dashcard, card.dataset_query, question]);
 
   const { buttonVariant, buttonTooltip, buttonText, buttonIcon } =
     useMemo(() => {

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -7,6 +7,7 @@ import { t } from "ttag";
 import { WithVizSettingsData } from "metabase/dashboard/hoc/WithVizSettingsData";
 import {
   getVirtualCardType,
+  isQuestionCard,
   isVirtualDashCard,
 } from "metabase/dashboard/utils";
 import type { IconName, IconProps } from "metabase/ui";
@@ -125,7 +126,7 @@ export function DashCardVisualization({
   onUpdateVisualizationSettings,
 }: DashCardVisualizationProps) {
   const question = useMemo(() => {
-    return dashcard.card.dataset_query
+    return isQuestionCard(dashcard.card)
       ? new Question(dashcard.card, metadata)
       : null;
   }, [dashcard.card, metadata]);

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardVisualization.tsx
@@ -125,7 +125,9 @@ export function DashCardVisualization({
   onUpdateVisualizationSettings,
 }: DashCardVisualizationProps) {
   const question = useMemo(() => {
-    return new Question(dashcard.card, metadata);
+    return dashcard.card.dataset_query
+      ? new Question(dashcard.card, metadata)
+      : null;
   }, [dashcard.card, metadata]);
 
   const renderVisualizationOverlay = useCallback(() => {
@@ -183,8 +185,11 @@ export function DashCardVisualization({
   ]);
 
   const renderActionButtons = useCallback(() => {
-    const mainSeries = series[0] as unknown as Dataset;
+    if (!question) {
+      return null;
+    }
 
+    const mainSeries = series[0] as unknown as Dataset;
     const shouldShowDashCardMenu = DashCardMenuConnected.shouldRender({
       question,
       result: mainSeries,

--- a/frontend/src/metabase/dashboard/selectors.ts
+++ b/frontend/src/metabase/dashboard/selectors.ts
@@ -27,7 +27,7 @@ import type {
   State,
 } from "metabase-types/store";
 
-import { isQuestionDashCard } from "./utils";
+import { isQuestionCard, isQuestionDashCard } from "./utils";
 
 type SidebarState = State["dashboard"]["sidebar"];
 
@@ -313,7 +313,10 @@ export const getQuestions = (state: State) => {
         const cards = [dashcard.card, ...(dashcard.series ?? [])];
 
         for (const card of cards) {
-          acc[card.id] = getQuestionByCard(state, { card });
+          const question = getQuestionByCard(state, { card });
+          if (question) {
+            acc[card.id] = question;
+          }
         }
       }
 
@@ -366,7 +369,7 @@ export const getMissingRequiredParameters = createSelector(
 export const getQuestionByCard = createCachedSelector(
   [(_state: State, props: { card: Card }) => props.card, getMetadata],
   (card, metadata) => {
-    return new Question(card, metadata);
+    return isQuestionCard(card) ? new Question(card, metadata) : undefined;
   },
 )((_state, props) => {
   return props.card.id;

--- a/frontend/src/metabase/dashboard/utils.ts
+++ b/frontend/src/metabase/dashboard/utils.ts
@@ -83,6 +83,10 @@ export function expandInlineCard(card?: Card | VirtualCard) {
   };
 }
 
+export function isQuestionCard(card: Card | VirtualCard) {
+  return card.dataset_query != null;
+}
+
 export function isQuestionDashCard(
   dashcard: BaseDashboardCard,
 ): dashcard is QuestionDashboardCard {

--- a/frontend/src/metabase/parameters/utils/dashboards.ts
+++ b/frontend/src/metabase/parameters/utils/dashboards.ts
@@ -1,6 +1,6 @@
 import _ from "underscore";
 
-import { isQuestionDashCard } from "metabase/dashboard/utils";
+import { isQuestionCard, isQuestionDashCard } from "metabase/dashboard/utils";
 import { slugify } from "metabase/lib/formatting";
 import { generateParameterId } from "metabase/parameters/utils/parameter-id";
 import Question from "metabase-lib/Question";
@@ -166,8 +166,14 @@ function buildFieldFilterUiParameter(
 
   const mappedFields = uniqueMappingsForParameters.map(mapping => {
     const { target, card } = mapping;
-    const question = questions[card.id] ?? new Question(card, metadata);
+    if (!isQuestionCard(card)) {
+      return {
+        field: null,
+        shouldResolveFkField: false,
+      };
+    }
 
+    const question = questions[card.id] ?? new Question(card, metadata);
     try {
       const field = getParameterTargetField(target, question);
 

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -120,7 +120,7 @@ export type ParameterMappingOption =
   | NativeParameterMappingOption;
 
 export function getParameterMappingOptions(
-  question: Question,
+  question: Question | undefined,
   parameter: Parameter | null | undefined = null,
   card: Card,
   dashcard: BaseDashboardCard | null | undefined = null,
@@ -144,7 +144,11 @@ export function getParameterMappingOptions(
     return actionParams || [];
   }
 
-  if (!card.dataset_query || (dashcard && isVirtualDashCard(dashcard))) {
+  if (
+    !question ||
+    !card.dataset_query ||
+    (dashcard && isVirtualDashCard(dashcard))
+  ) {
     return [];
   }
 


### PR DESCRIPTION
Spotted by https://github.com/metabase/metabase/pull/39682

We should never create an MLv2 query from `dataset_query: null`.