### PR TITLE
Chart Settings Table Formatting DnD kit

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -1,4 +1,5 @@
-import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   enterCustomColumnDetails,
   isScrollableHorizontally,
@@ -15,6 +16,8 @@ import {
   visitQuestionAdhoc,
   getTable,
   leftSidebar,
+  sidebar,
+  moveDnDKitColumnVertical,
 } from "e2e/support/helpers";
 
 describe("scenarios > visualizations > table", () => {
@@ -308,67 +311,163 @@ describe("scenarios > visualizations > table", () => {
 });
 
 describe("scenarios > visualizations > table > conditional formatting", () => {
-  beforeEach(() => {
-    resetTestTable({ type: "postgres", table: "many_data_types" });
-    restore("postgres-writable");
-    cy.signInAsAdmin();
-    resyncDatabase({
-      dbId: WRITABLE_DB_ID,
-      tableName: "many_data_types",
-    });
-
-    getTable({ name: "many_data_types" }).then(({ id: tableId, fields }) => {
-      const booleanField = fields.find(field => field.name === "boolean");
-      const stringField = fields.find(field => field.name === "string");
-      const idField = fields.find(field => field.name === "id");
+  describe("rules", () => {
+    beforeEach(() => {
+      restore();
+      cy.signInAsAdmin();
 
       visitQuestionAdhoc({
         dataset_query: {
-          database: WRITABLE_DB_ID,
+          database: SAMPLE_DB_ID,
           query: {
-            "source-table": tableId,
-            fields: [
-              ["field", idField.id, { "base-type": idField["base_type"] }],
-              [
-                "field",
-                stringField.id,
-                { "base-type": stringField["base_type"] },
-              ],
-              [
-                "field",
-                booleanField.id,
-                { "base-type": booleanField["base_type"] },
-              ],
-            ],
+            "source-table": SAMPLE_DATABASE.ORDERS_ID,
           },
           type: "query",
         },
-        display: "table",
+        visualization_settings: {
+          "table.column_formatting": [
+            {
+              id: 0,
+              type: "single",
+              operator: "<",
+              value: 3,
+              color: "#509EE3",
+              highlight_row: false,
+              columns: ["TAX"],
+            },
+            {
+              id: 1,
+              type: "single",
+              operator: "<",
+              value: 6,
+              color: "#88BF4D",
+              highlight_row: false,
+              columns: ["TAX"],
+            },
+            {
+              id: 2,
+              type: "single",
+              operator: "<",
+              value: 10,
+              color: "#EF8C8C",
+              highlight_row: false,
+              columns: ["TAX"],
+            },
+          ],
+        },
       });
+
+      cy.findByTestId("viz-settings-button").click();
+      sidebar().findByText("Conditional Formatting").click();
+    });
+
+    it("should be able to remove, add, and re-order rows", () => {
+      cy.findAllByTestId("formatting-rule-preview")
+        .first()
+        .should("contain.text", "is less than 3");
+      cy.findAllByTestId("formatting-rule-preview")
+        .first()
+        .findByRole("img", { name: /close/ })
+        .click();
+
+      cy.findAllByTestId("formatting-rule-preview")
+        .first()
+        .should("contain.text", "is less than 6");
+
+      cy.findByRole("button", { name: /add a rule/i }).click();
+      cy.findByRole("button", { name: /choose a column/i }).click();
+      popover().findByText("Subtotal").click();
+      cy.realPress("Escape");
+      cy.findByRole("button", { name: /is equal to/i }).click();
+      popover().findByText("is less than").click();
+
+      cy.findByTestId("conditional-formatting-value-input").type("20");
+      cy.findByTestId("conditional-formatting-color-selector").click();
+
+      popover()
+        .findByRole("generic", { name: /#F2A86F/i })
+        .click();
+
+      cy.button("Add rule").click();
+
+      cy.findAllByTestId("formatting-rule-preview")
+        .first()
+        .should("contain.text", "is less than 20");
+
+      moveDnDKitColumnVertical(
+        cy.findAllByTestId("formatting-rule-preview").eq(2),
+        -300,
+      );
+
+      cy.findAllByTestId("formatting-rule-preview")
+        .first()
+        .should("contain.text", "is less than 10");
     });
   });
 
-  it("should work with boolean columns", { tags: ["@external"] }, () => {
-    cy.findByTestId("viz-settings-button").click();
-    leftSidebar().findByText("Conditional Formatting").click();
-    cy.findByRole("button", { name: /add a rule/i }).click();
+  describe("operators", () => {
+    beforeEach(() => {
+      resetTestTable({ type: "postgres", table: "many_data_types" });
+      restore("postgres-writable");
+      cy.signInAsAdmin();
+      resyncDatabase({
+        dbId: WRITABLE_DB_ID,
+        tableName: "many_data_types",
+      });
 
-    popover().findByRole("option", { name: "Boolean" }).click();
+      getTable({ name: "many_data_types" }).then(({ id: tableId, fields }) => {
+        const booleanField = fields.find(field => field.name === "boolean");
+        const stringField = fields.find(field => field.name === "string");
+        const idField = fields.find(field => field.name === "id");
 
-    //Dismiss popover
-    leftSidebar().findByText("Which columns should be affected?").click();
+        visitQuestionAdhoc({
+          dataset_query: {
+            database: WRITABLE_DB_ID,
+            query: {
+              "source-table": tableId,
+              fields: [
+                ["field", idField.id, { "base-type": idField["base_type"] }],
+                [
+                  "field",
+                  stringField.id,
+                  { "base-type": stringField["base_type"] },
+                ],
+                [
+                  "field",
+                  booleanField.id,
+                  { "base-type": booleanField["base_type"] },
+                ],
+              ],
+            },
+            type: "query",
+          },
+          display: "table",
+        });
+      });
+    });
 
-    //Check that is-true was applied by default to boolean field rule
-    cy.findByTestId("conditional-formatting-value-operator-button").should(
-      "contain.text",
-      "is true",
-    );
+    it("should work with boolean columns", { tags: ["@external"] }, () => {
+      cy.findByTestId("viz-settings-button").click();
+      leftSidebar().findByText("Conditional Formatting").click();
+      cy.findByRole("button", { name: /add a rule/i }).click();
 
-    cy.findByRole("gridcell", { name: "true" }).should(
-      "have.css",
-      "background-color",
-      "rgba(80, 158, 227, 0.65)",
-    );
+      popover().findByRole("option", { name: "Boolean" }).click();
+
+      //Dismiss popover
+      leftSidebar().findByText("Which columns should be affected?").click();
+
+      //Check that is-true was applied by default to boolean field rule
+      cy.findByTestId("conditional-formatting-value-operator-button").should(
+        "contain.text",
+        "is true",
+      );
+
+      cy.findByRole("gridcell", { name: "true" }).should(
+        "have.css",
+        "background-color",
+        "rgba(80, 158, 227, 0.65)",
+      );
+    });
   });
 });
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -91,7 +91,7 @@ const INPUT_CLASSNAME = "mt1 full";
 const getValueForDescription = rule =>
   ["is-null", "not-null"].includes(rule.operator) ? "" : ` ${rule.value}`;
 
-const ChartSettingsTableFormatting = props => {
+export const ChartSettingsTableFormatting = props => {
   const [editingRule, setEditingRule] = useState();
   const [editingRuleIsNew, setEditingRuleIsNew] = useState();
 
@@ -134,7 +134,8 @@ const ChartSettingsTableFormatting = props => {
           setEditingRule(index);
           setEditingRuleIsNew(false);
         }}
-        //This needs to be
+        // This needs to be an async function so that onChange will complete (and value will be updated)
+        // Before we set the state values for the next render
         onAdd={async () => {
           await onChange([
             {
@@ -551,5 +552,3 @@ const RuleEditor = ({
     </div>
   );
 };
-
-export default ChartSettingsTableFormatting;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -1,14 +1,12 @@
 /* eslint-disable react/prop-types */
+import { PointerSensor, useSensor } from "@dnd-kit/core";
+import { arrayMove } from "@dnd-kit/sortable";
 import cx from "classnames";
-import { Component } from "react";
+import { useState, useMemo } from "react";
 import { t, jt, msgid, ngettext } from "ttag";
 import _ from "underscore";
 
 import NumericInput from "metabase/components/NumericInput";
-import {
-  SortableContainer,
-  SortableElement,
-} from "metabase/components/sortable";
 import Button from "metabase/core/components/Button";
 import ColorRange from "metabase/core/components/ColorRange";
 import ColorRangeSelector from "metabase/core/components/ColorRangeSelector";
@@ -16,6 +14,7 @@ import ColorSelector from "metabase/core/components/ColorSelector";
 import Input from "metabase/core/components/Input";
 import Radio from "metabase/core/components/Radio";
 import Select, { Option } from "metabase/core/components/Select";
+import { Sortable, SortableList } from "metabase/core/components/Sortable";
 import Toggle from "metabase/core/components/Toggle";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import {
@@ -92,106 +91,130 @@ const INPUT_CLASSNAME = "mt1 full";
 const getValueForDescription = rule =>
   ["is-null", "not-null"].includes(rule.operator) ? "" : ` ${rule.value}`;
 
-export default class ChartSettingsTableFormatting extends Component {
-  state = {
-    editingRule: null,
-    editingRuleIsNew: null,
+const ChartSettingsTableFormatting = props => {
+  const [editingRule, setEditingRule] = useState();
+  const [editingRuleIsNew, setEditingRuleIsNew] = useState();
+
+  const { value, onChange, cols, canHighlightRow } = props;
+
+  if (editingRule !== null && value[editingRule]) {
+    return (
+      <RuleEditor
+        canHighlightRow={canHighlightRow}
+        rule={value[editingRule]}
+        cols={cols}
+        isNew={editingRuleIsNew}
+        onChange={rule => {
+          onChange([
+            ...value.slice(0, editingRule),
+            rule,
+            ...value.slice(editingRule + 1),
+          ]);
+        }}
+        onRemove={() => {
+          onChange([
+            ...value.slice(0, editingRule),
+            ...value.slice(editingRule + 1),
+          ]);
+          setEditingRule(null);
+          setEditingRuleIsNew(null);
+        }}
+        onDone={() => {
+          setEditingRule(null);
+          setEditingRuleIsNew(null);
+        }}
+      />
+    );
+  } else {
+    return (
+      <RuleListing
+        rules={value}
+        cols={cols}
+        onEdit={index => {
+          setEditingRule(index);
+          setEditingRuleIsNew(false);
+        }}
+        onAdd={() => {
+          onChange([
+            {
+              ...DEFAULTS_BY_TYPE["single"],
+              // if there's a single column use that by default
+              columns: cols.length === 1 ? [cols[0].name] : [],
+              id: value.length,
+            },
+            ...value,
+          ]);
+          setEditingRule(0);
+          setEditingRuleIsNew(true);
+        }}
+        onRemove={index => {
+          onChange([...value.slice(0, index), ...value.slice(index + 1)]);
+          MetabaseAnalytics.trackStructEvent(
+            "Chart Settings",
+            "Table Formatting",
+            "Remove Rule",
+          );
+        }}
+        onMove={(from, to) => {
+          onChange(arrayMove(value, from, to));
+          MetabaseAnalytics.trackStructEvent(
+            "Chart Settings",
+            "Table Formatting",
+            "Move Rule",
+          );
+        }}
+      />
+    );
+  }
+};
+
+const SortableRuleList = ({ rules, cols, onEdit, onRemove, onMove }) => {
+  const rulesWithIDs = useMemo(
+    () => rules.map((rule, index) => ({ ...rule, id: index.toString() })),
+    [rules],
+  );
+
+  const getId = rule => rule.id.toString();
+
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: { distance: 0 },
+  });
+
+  const handleSortEnd = ({ id, newIndex }) => {
+    const oldIndex = rulesWithIDs.findIndex(rule => getId(rule) === id);
+
+    onMove(oldIndex, newIndex);
   };
 
-  render() {
-    const { value, onChange, cols, canHighlightRow } = this.props;
-    const { editingRule, editingRuleIsNew } = this.state;
-    if (editingRule !== null && value[editingRule]) {
-      return (
-        <RuleEditor
-          canHighlightRow={canHighlightRow}
-          rule={value[editingRule]}
-          cols={cols}
-          isNew={editingRuleIsNew}
-          onChange={rule => {
-            onChange([
-              ...value.slice(0, editingRule),
-              rule,
-              ...value.slice(editingRule + 1),
-            ]);
-          }}
-          onRemove={() => {
-            onChange([
-              ...value.slice(0, editingRule),
-              ...value.slice(editingRule + 1),
-            ]);
-            this.setState({ editingRule: null, editingRuleIsNew: null });
-          }}
-          onDone={() => {
-            this.setState({ editingRule: null, editingRuleIsNew: null });
-          }}
-        />
-      );
-    } else {
-      return (
-        <RuleListing
-          rules={value}
-          cols={cols}
-          onEdit={index => {
-            this.setState({ editingRule: index, editingRuleIsNew: false });
-          }}
-          onAdd={() => {
-            onChange([
-              {
-                ...DEFAULTS_BY_TYPE["single"],
-                // if there's a single column use that by default
-                columns: cols.length === 1 ? [cols[0].name] : [],
-              },
-              ...value,
-            ]);
-            this.setState({ editingRule: 0, editingRuleIsNew: true });
-          }}
-          onRemove={index => {
-            onChange([...value.slice(0, index), ...value.slice(index + 1)]);
-            MetabaseAnalytics.trackStructEvent(
-              "Chart Settings",
-              "Table Formatting",
-              "Remove Rule",
-            );
-          }}
-          onMove={(from, to) => {
-            const newValue = [...value];
-            newValue.splice(to, 0, newValue.splice(from, 1)[0]);
-            onChange(newValue);
-            MetabaseAnalytics.trackStructEvent(
-              "Chart Settings",
-              "Table Formatting",
-              "Move Rule",
-            );
-          }}
-        />
-      );
-    }
-  }
-}
+  const handleRemove = id =>
+    onRemove(rulesWithIDs.findIndex(rule => getId(rule) === id));
 
-const SortableRuleItem = SortableElement(({ rule, cols, onEdit, onRemove }) => (
-  <RulePreview rule={rule} cols={cols} onClick={onEdit} onRemove={onRemove} />
-));
+  const handleEdit = id =>
+    onEdit(rulesWithIDs.findIndex(rule => getId(rule) === id));
 
-const SortableRuleList = SortableContainer(
-  ({ rules, cols, onEdit, onRemove }) => {
-    return (
-      <div>
-        {rules.map((rule, index) => (
-          <SortableRuleItem
-            key={`item-${index}`}
-            index={index}
-            rule={rule}
-            cols={cols}
-            onEdit={() => onEdit(index)}
-            onRemove={() => onRemove(index)}
-          />
-        ))}
-      </div>
-    );
-  },
-);
+  const renderItem = ({ item, id }) => (
+    <Sortable id={id} draggingStyle={{ opacity: 0.5 }}>
+      <RulePreview
+        rule={item}
+        cols={cols}
+        onClick={() => handleEdit(id)}
+        onRemove={() => handleRemove(id)}
+      />
+    </Sortable>
+  );
+
+  return (
+    <div>
+      <SortableList
+        items={rulesWithIDs}
+        getId={getId}
+        renderItem={renderItem}
+        sensors={[pointerSensor]}
+        onSortEnd={handleSortEnd}
+      />
+    </div>
+  );
+};
 
 const RuleListing = ({ rules, cols, onEdit, onAdd, onRemove, onMove }) => (
   <div>
@@ -214,7 +237,7 @@ const RuleListing = ({ rules, cols, onEdit, onAdd, onRemove, onMove }) => (
           cols={cols}
           onEdit={onEdit}
           onRemove={onRemove}
-          onSortEnd={({ oldIndex, newIndex }) => onMove(oldIndex, newIndex)}
+          onMove={onMove}
           distance={10}
         />
       </div>
@@ -226,6 +249,7 @@ const RulePreview = ({ rule, cols, onClick, onRemove }) => (
   <div
     className="my2 bordered rounded shadowed cursor-pointer bg-white"
     onClick={onClick}
+    data-testid="formatting-rule-preview"
   >
     <div className="p1 border-bottom relative bg-light">
       <div className="px1 flex align-center relative">
@@ -429,6 +453,7 @@ const RuleEditor = ({
           ) : null}
           <h3 className="mt3 mb1">{t`…turn its background this color:`}</h3>
           <ColorSelector
+            data-testid="conditional-formatting-color-selector"
             value={rule.color}
             colors={COLORS}
             onChange={color => onChange({ ...rule, color })}
@@ -525,3 +550,5 @@ const RuleEditor = ({
     </div>
   );
 };
+
+export default ChartSettingsTableFormatting;

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -134,8 +134,9 @@ const ChartSettingsTableFormatting = props => {
           setEditingRule(index);
           setEditingRuleIsNew(false);
         }}
-        onAdd={() => {
-          onChange([
+        //This needs to be
+        onAdd={async () => {
+          await onChange([
             {
               ...DEFAULTS_BY_TYPE["single"],
               // if there's a single column use that by default
@@ -144,8 +145,8 @@ const ChartSettingsTableFormatting = props => {
             },
             ...value,
           ]);
-          setEditingRule(0);
           setEditingRuleIsNew(true);
+          setEditingRule(0);
         }}
         onRemove={index => {
           onChange([...value.slice(0, index), ...value.slice(index + 1)]);

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.unit.spec.js
@@ -79,42 +79,44 @@ const setup = props => {
 };
 
 describe("ChartSettingsTableFormatting", () => {
-  it("should allow you to add a rule", () => {
+  it("should allow you to add a rule", async () => {
     setup();
     expect(screen.getByText("Conditional formatting")).toBeInTheDocument();
-    userEvent.click(screen.getByText("Add a rule"));
-    userEvent.click(screen.getByText("String Column"));
+    userEvent.click(await screen.findByText("Add a rule"));
+    userEvent.click(await screen.findByText("String Column"));
     //Dismiss Popup
-    userEvent.click(screen.getByText("Which columns should be affected?"));
+    userEvent.click(
+      await screen.findByText("Which columns should be affected?"),
+    );
 
-    expect(screen.getByText("is equal to")).toBeInTheDocument();
+    expect(await screen.findByText("is equal to")).toBeInTheDocument();
 
     userEvent.type(
-      screen.getByTestId("conditional-formatting-value-input"),
+      await screen.findByTestId("conditional-formatting-value-input"),
       "toucan",
     );
-    userEvent.click(screen.getByText("Add rule"));
+    userEvent.click(await screen.findByText("Add rule"));
 
-    expect(screen.getByText("String Column")).toBeInTheDocument();
-    expect(screen.getByText(/is equal to toucan/g)).toBeInTheDocument();
+    expect(await screen.findByText("String Column")).toBeInTheDocument();
+    expect(await screen.findByText(/is equal to toucan/g)).toBeInTheDocument();
   });
 
-  it("should only let you choose columns of the same type for a rule", () => {
+  it("should only let you choose columns of the same type for a rule", async () => {
     setup();
     expect(screen.getByText("Conditional formatting")).toBeInTheDocument();
-    userEvent.click(screen.getByText("Add a rule"));
-    userEvent.click(screen.getByText("String Column"));
+    userEvent.click(await screen.findByText("Add a rule"));
+    userEvent.click(await screen.findByText("String Column"));
 
     expect(
-      screen.getByRole("option", { name: "Number Column" }),
+      await screen.findByRole("option", { name: "Number Column" }),
     ).toHaveAttribute("aria-disabled", "true");
 
     expect(
-      screen.getByRole("option", { name: "Boolean Column" }),
+      await screen.findByRole("option", { name: "Boolean Column" }),
     ).toHaveAttribute("aria-disabled", "true");
 
     expect(
-      screen.getByRole("option", { name: "String Column 2" }),
+      await screen.findByRole("option", { name: "String Column 2" }),
     ).toHaveAttribute("aria-disabled", "false");
   });
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.unit.spec.js
@@ -4,7 +4,7 @@ import { useState } from "react";
 
 import { createMockColumn } from "metabase-types/api/mocks";
 
-import ChartSettingsTableFormatting from "./ChartSettingsTableFormatting";
+import { ChartSettingsTableFormatting } from "./ChartSettingsTableFormatting";
 
 const STRING_COLUMN = createMockColumn({
   base_type: "type/Text",

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/settings.ts
@@ -14,7 +14,7 @@ import {
 } from "metabase/lib/data_grid";
 import { formatColumn } from "metabase/lib/formatting";
 import { ChartSettingIconRadio } from "metabase/visualizations/components/settings/ChartSettingIconRadio";
-import ChartSettingsTableFormatting from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
+import { ChartSettingsTableFormatting } from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 import { columnSettings } from "metabase/visualizations/lib/settings/column";
 import { isDimension } from "metabase-lib/types/utils/isa";
 import type {

--- a/frontend/src/metabase/visualizations/visualizations/Table.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Table.tsx
@@ -6,7 +6,8 @@ import _ from "underscore";
 import * as DataGrid from "metabase/lib/data_grid";
 import { formatColumn } from "metabase/lib/formatting";
 import ChartSettingLinkUrlInput from "metabase/visualizations/components/settings/ChartSettingLinkUrlInput";
-import ChartSettingsTableFormatting, {
+import {
+  ChartSettingsTableFormatting,
   isFormattable,
 } from "metabase/visualizations/components/settings/ChartSettingsTableFormatting";
 import {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39655

### Description
PR to transition DnD logic in `<ChartSettingsTableFormatting />`  from `react-sortable-hoc` to `@dnd-kit`. Needed to introduce the idea of an ID to formatting rules, but this should not impact user experience. Added e2e test for adding/removing/reordering formatting rules

### How to verify

1. Go to a table visualization, add / remove / reorder any formatting rules
2. Same for pivot table visualization.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
