### PR TITLE
Dashboard width revision message should handle nil

### DIFF
--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -89,6 +89,9 @@
     [:result_metadata _ _]
     (deferred-tru "edited the metadata")
 
+    [:width nil _]
+    (deferred-tru "changed the width setting to {0}" (name v2))
+
     [:width _ _]
     (deferred-tru "changed the width setting from {0} to {1}" (name v1) (name v2))
 

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -89,8 +89,10 @@
     [:result_metadata _ _]
     (deferred-tru "edited the metadata")
 
-    [:width (_ :guard some?) (_ :guard some?)]
-    (deferred-tru "changed the width setting from {0} to {1}" (name v1) (name v2))
+    [:width v1 v2]
+    (if (and v1 v2)
+      (deferred-tru "changed the width setting from {0} to {1}" (name v1) (name v2))
+      (deferred-tru "changed the width setting"))
 
     ;;  whenever database_id, query_type, table_id changed,
     ;; the dataset_query will changed so we don't need a description for this

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -89,10 +89,7 @@
     [:result_metadata _ _]
     (deferred-tru "edited the metadata")
 
-    [:width nil _]
-    (deferred-tru "changed the width setting to {0}" (name v2))
-
-    [:width _ _]
+    [:width (_ :guard some?) (_ :guard some?)]
     (deferred-tru "changed the width setting from {0} to {1}" (name v1) (name v2))
 
     ;;  whenever database_id, query_type, table_id changed,

--- a/test/metabase/api/revision_test.clj
+++ b/test/metabase/api/revision_test.clj
@@ -310,6 +310,28 @@
              (map #(select-keys % [:description :has_multiple_changes])
                   (mt/user-http-request :crowberto :get 200 "revision" :entity "dashboard" :id dashboard-id)))))))
 
+(deftest dashboard-width-revision-diff-test
+  (testing "The Dashboard's revision history correctly reports dashboard width changes (#38910)"
+    (t2.with-temp/with-temp
+        [Dashboard  {dashboard-id :id :as dash} {:name "A dashboard"}
+         Revision   _ {:model    "Dashboard"
+                       :model_id dashboard-id
+                       :user_id  (mt/user->id :crowberto)
+                       :object   (assoc dash :width nil)}
+         Revision   _ {:model    "Dashboard"
+                       :model_id dashboard-id
+                       :user_id  (mt/user->id :crowberto)
+                       :object   (assoc dash :width "full")}
+         Revision   _ {:model    "Dashboard"
+                       :model_id dashboard-id
+                       :user_id  (mt/user->id :crowberto)
+                       :object   (assoc dash :width "fixed")}]
+        (is (= ["changed the width setting from full to fixed."
+                "changed the width setting."
+                "modified this."]
+               (map :description
+                    (mt/user-http-request :crowberto :get 200 "revision" :entity "dashboard" :id dashboard-id)))))))
+
 (deftest card-revision-description-test
   (testing "revision description for card are generated correctly"
     (t2.with-temp/with-temp


### PR DESCRIPTION
Fixes: #38910

Even though there shouldn't be `nil` values in `:width` keys on the dashboard, (because the migration populates w/ the default value of `full`), it is still true that because of the version before the migration, revisions  can have `nil` for the width
value. The diff string impl didn't consider this, causing an NPE with `(name nil)`.

This change should guard the diff string from trying to run on these `nil` values.