### PR TITLE
Disable animation on NewItemMenu

### DIFF
--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -14,7 +14,6 @@ class EntityMenu extends Component {
     open: false,
     freezeMenu: false,
     menuItemContent: null,
-    transition: "fade",
   };
 
   static defaultProps = {
@@ -26,8 +25,6 @@ class EntityMenu extends Component {
 
     // TODO: Remove this?
     this.rootRef = createRef();
-
-    this.popoverOLRef = createRef();
   }
 
   toggleMenu = () => {
@@ -47,18 +44,6 @@ class EntityMenu extends Component {
     this.setState({ menuItemContent });
   };
 
-  componentDidUpdate() {
-    setTimeout(() => {
-      if (open && !this.popoverOLRef) {
-        this.setState({ transition: null });
-        console.warn(
-          "disabling transition since it seems the popover was delayed",
-        );
-        return;
-      }
-    }, 200);
-  }
-
   render() {
     const {
       items,
@@ -74,16 +59,13 @@ class EntityMenu extends Component {
       triggerAriaLabel,
       tooltipPlacement,
     } = this.props;
-    const { open, menuItemContent, transition } = this.state;
+    const { open, menuItemContent } = this.state;
 
     return (
       <Popover
         opened={open}
         className={cx(className, open ? openClassNames : closedClassNames)}
-        transitionProps={{
-          duration: 300,
-          transition,
-        }}
+        transitionProps={undefined}
         onChange={() => this.toggleMenu()}
         position="bottom-end"
       >

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -65,6 +65,9 @@ class EntityMenu extends Component {
       <Popover
         opened={open}
         className={cx(className, open ? openClassNames : closedClassNames)}
+        // I've disabled this transition, since it results in the menu sometimes
+        // not appearing until complex content finishes loading on dashboard and questions pages
+        // TODO: Try to restore this transition once we upgrade to React 18 and can prioritize this update
         transitionProps={undefined}
         onChange={() => this.toggleMenu()}
         position="bottom-end"

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -6,6 +6,19 @@ import EntityMenuItem from "metabase/components/EntityMenuItem";
 import EntityMenuTrigger from "metabase/components/EntityMenuTrigger";
 import { Popover } from "metabase/ui";
 
+const checkForDelay = async () => {
+  const before = performance.now();
+  const sleep = 1000;
+  const threshold = 200;
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  const after = performance.now();
+  if (after - before > sleep + threshold) {
+    console.warn("checkForDelay: Delay detected");
+  } else {
+    console.warn("checkForDelay: No delay detected");
+  }
+};
+
 /**
  * @deprecated: use Menu from "metabase/ui"
  */
@@ -43,6 +56,10 @@ class EntityMenu extends Component {
     this.setState({ menuItemContent });
   };
 
+  componentDidMount = async () => {
+    await checkForDelay();
+  };
+
   render() {
     const {
       items,
@@ -59,11 +76,15 @@ class EntityMenu extends Component {
       tooltipPlacement,
     } = this.props;
     const { open, menuItemContent } = this.state;
+
     return (
       <Popover
         opened={open}
         className={cx(className, open ? openClassNames : closedClassNames)}
-        transitionProps={{ transition: "fade" }}
+        transitionProps={{
+          duration: 300,
+          transition: "fade",
+        }}
         onChange={() => this.toggleMenu()}
         position="bottom-end"
       >
@@ -87,7 +108,12 @@ class EntityMenu extends Component {
         </Popover.Target>
         <Popover.Dropdown>
           {menuItemContent || (
-            <ol className="p1" style={{ minWidth: minWidth ?? 184 }}>
+            <ol
+              className="p1"
+              style={{
+                minWidth: minWidth ?? 184,
+              }}
+            >
               {items.map(item => {
                 if (!item) {
                   return null;

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -92,13 +92,7 @@ class EntityMenu extends Component {
         </Popover.Target>
         <Popover.Dropdown>
           {menuItemContent || (
-            <ol
-              className="p1"
-              style={{
-                minWidth: minWidth ?? 184,
-              }}
-              ref={this.popoverOLRef}
-            >
+            <ol className="p1" style={{ minWidth: minWidth ?? 184 }}>
               {items.map(item => {
                 if (!item) {
                   return null;

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -23,7 +23,6 @@ class EntityMenu extends Component {
   constructor(props, context) {
     super(props, context);
 
-    // TODO: Remove this?
     this.rootRef = createRef();
   }
 
@@ -58,6 +57,7 @@ class EntityMenu extends Component {
       renderTrigger,
       triggerAriaLabel,
       tooltipPlacement,
+      transitionDuration = 300,
     } = this.props;
     const { open, menuItemContent } = this.state;
 
@@ -65,10 +65,7 @@ class EntityMenu extends Component {
       <Popover
         opened={open}
         className={cx(className, open ? openClassNames : closedClassNames)}
-        // I've disabled this transition, since it results in the menu sometimes
-        // not appearing until complex content finishes loading on dashboard and questions pages
-        // TODO: Try to restore this transition once we upgrade to React 18 and can prioritize this update
-        transitionProps={undefined}
+        transitionProps={{ duration: transitionDuration }}
         onChange={() => this.toggleMenu()}
         position="bottom-end"
       >

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -57,7 +57,7 @@ class EntityMenu extends Component {
       renderTrigger,
       triggerAriaLabel,
       tooltipPlacement,
-      transitionDuration = 300,
+      transitionDuration = 150,
     } = this.props;
     const { open, menuItemContent } = this.state;
 

--- a/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
+++ b/frontend/src/metabase/components/EntityMenu/EntityMenu.jsx
@@ -6,19 +6,6 @@ import EntityMenuItem from "metabase/components/EntityMenuItem";
 import EntityMenuTrigger from "metabase/components/EntityMenuTrigger";
 import { Popover } from "metabase/ui";
 
-const checkForDelay = async () => {
-  const before = performance.now();
-  const sleep = 1000;
-  const threshold = 200;
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  const after = performance.now();
-  if (after - before > sleep + threshold) {
-    console.warn("checkForDelay: Delay detected");
-  } else {
-    console.warn("checkForDelay: No delay detected");
-  }
-};
-
 /**
  * @deprecated: use Menu from "metabase/ui"
  */
@@ -27,6 +14,7 @@ class EntityMenu extends Component {
     open: false,
     freezeMenu: false,
     menuItemContent: null,
+    transition: "fade",
   };
 
   static defaultProps = {
@@ -36,7 +24,10 @@ class EntityMenu extends Component {
   constructor(props, context) {
     super(props, context);
 
+    // TODO: Remove this?
     this.rootRef = createRef();
+
+    this.popoverOLRef = createRef();
   }
 
   toggleMenu = () => {
@@ -56,9 +47,17 @@ class EntityMenu extends Component {
     this.setState({ menuItemContent });
   };
 
-  componentDidMount = async () => {
-    await checkForDelay();
-  };
+  componentDidUpdate() {
+    setTimeout(() => {
+      if (open && !this.popoverOLRef) {
+        this.setState({ transition: null });
+        console.warn(
+          "disabling transition since it seems the popover was delayed",
+        );
+        return;
+      }
+    }, 200);
+  }
 
   render() {
     const {
@@ -75,7 +74,7 @@ class EntityMenu extends Component {
       triggerAriaLabel,
       tooltipPlacement,
     } = this.props;
-    const { open, menuItemContent } = this.state;
+    const { open, menuItemContent, transition } = this.state;
 
     return (
       <Popover
@@ -83,7 +82,7 @@ class EntityMenu extends Component {
         className={cx(className, open ? openClassNames : closedClassNames)}
         transitionProps={{
           duration: 300,
-          transition: "fade",
+          transition,
         }}
         onChange={() => this.toggleMenu()}
         position="bottom-end"
@@ -113,6 +112,7 @@ class EntityMenu extends Component {
               style={{
                 minWidth: minWidth ?? 184,
               }}
+              ref={this.popoverOLRef}
             >
               {items.map(item => {
                 if (!item) {

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -156,6 +156,11 @@ const NewItemMenu = ({
         trigger={trigger}
         triggerIcon={triggerIcon}
         tooltip={triggerTooltip}
+        // I've disabled this transition, since it results in the menu
+        // sometimes not appearing until content finishes loading on complex
+        // dashboards and questions #39303
+        // TODO: Try to restore this transition once we upgrade to React 18 and can prioritize this update
+        transitionDuration={0}
       />
       {modal && (
         <>

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -590,6 +590,7 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
             items={extraButtons}
             triggerIcon="ellipsis"
             tooltip={t`Move, archive, and more...`}
+            transitionDuration={0}
           />,
         );
       }

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -590,7 +590,6 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
             items={extraButtons}
             triggerIcon="ellipsis"
             tooltip={t`Move, archive, and more...`}
-            transitionDuration={0}
           />,
         );
       }

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.jsx
@@ -97,6 +97,11 @@ function ProfileLink({ adminItems, onLogout }) {
             color: color("text-white"),
           },
         }}
+        // I've disabled this transition, since it results in the menu
+        // sometimes not appearing until content finishes loading on complex
+        // dashboards and questions #39303
+        // TODO: Try to restore this transition once we upgrade to React 18 and can prioritize this update
+        transitionDuration={0}
       />
       {modalOpen === "about" ? (
         <Modal small onClose={closeModal}>


### PR DESCRIPTION
Closes #39303

### Description

[Loom](https://www.loom.com/share/730ce6be841e4cbfaa926d8def8cb01f)

Bug: While a complex dashboard or question is loading, the right-hand buttons in the nav don't work.

The root cause of the bug is that the fade-in animation that Mantine applies to the popover is intensive enough that the browser postpones it until the main work on the page is done.

Some "smart" solutions exist for this problem, such as disabling the animation when a certain condition is met. Let me explain why I prefer the "dumb" approach of flatly disabling the animation.

The popover has a white background like the elements beneath it, so the visual impact of the animation is scarcely noticeable. The benefit of the fade-in is small. It's a decorative animation; it does not tell the user anything or usefully guide their eye to something they wouldn't have noticed otherwise.

However, if the New button fails to work, what is the impact on the user's experience? I think it is significant. This button is sometimes the most salient clickable thing on the page. If a homepage dashboard is complex, the user may find that one of the first things they try to do on Metabase just doesn't work. This is not a good first impression. To avoid this, I think it is worth unconditionally disabling the animation. Any condition we introduce might miss certain cases. Today we see that dashboards and questions can create this problem, but tomorrow other pages may create the problem.

If we could have the popover determine whether or not its animation is about to get postponed and only then disable the animation, that would be nice. Unfortunately, the popover's efforts to assess whether it is getting postponed will themselves get postponed while the main thread is busy.

The Collections "..." popover in the side nav can fade in while a complex dashboard is loading. It would be nice if we could make the Mantine popover animation more like this other animation, which is managed through Tippy. I spent some time trying to achieve this, by nudging the Mantine popover to use hardware acceleration, but I believe this is not worth continued effort.

To quote some authorities:

> "Before attempting to delight users with animations, designers should meet user’s base expectations and try to remove friction first" - Naema Baskanderi, ["UI Animation: Please Use Responsibly", 2017](https://uxdesign.cc/ui-animation-please-use-responsibly-e707dbdb12d5)

> "Our brains respond powerfully to movement, so use animation sparingly. If you can do without animation, avoid it. Your microinteraction will be faster and less cognitively challenging without it. That being said, tiny, brief animations can add interest and convey meaning if done well." - Dan Saffer, *Microinteractions: Designing with Details* (2013)