### PR TITLE
using CSS animations for notebook previews

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
@@ -38,16 +38,17 @@ const getPreviewQuestion = step => {
 };
 
 const NotebookStepPreview = ({ step, onClose }) => {
-  const [question, setQuestion] = useState(getPreviewQuestion(step));
+  const previewQuestion = useMemo(() => getPreviewQuestion(step), [step]);
+  const [activeQuestion, setActiveQuestion] = useState(previewQuestion);
 
   const refresh = () => {
-    setQuestion(getPreviewQuestion(step));
+    setActiveQuestion(previewQuestion);
   };
 
-  const isDirty = useMemo(() => {
-    const newQuestion = getPreviewQuestion(step);
-    return !_.isEqual(newQuestion.card(), question.card());
-  }, [step, question]);
+  const isDirty = useMemo(
+    () => activeQuestion.isDirtyComparedTo(previewQuestion),
+    [activeQuestion, previewQuestion],
+  );
 
   return (
     <PreviewRoot data-testid="preview-root">
@@ -66,7 +67,7 @@ const NotebookStepPreview = ({ step, onClose }) => {
           <Button onClick={refresh}>{t`Refresh`}</Button>
         </PreviewButtonContainer>
       ) : (
-        <QuestionResultLoader question={question}>
+        <QuestionResultLoader question={activeQuestion}>
           {({ rawSeries, result }) => (
             <VisualizationPreview rawSeries={rawSeries} result={result} />
           )}

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
@@ -1,12 +1,12 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
-import { Component } from "react";
-import { Motion, spring } from "react-motion";
+import { useState } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
 import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
 import Button from "metabase/core/components/Button";
+import { useModalOpen } from "metabase/hooks/use-modal-open";
 import { isReducedMotionPreferred } from "metabase/lib/dom";
 import { Icon } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
@@ -22,100 +22,85 @@ import {
 
 const PREVIEW_ROWS_LIMIT = 10;
 
-class NotebookStepPreview extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      question: this.getPreviewQuestion(props.step),
-    };
-  }
+const getPreviewQuestion = step => {
+  const { getPreviewQuery, stageIndex } = step;
+  const query = getPreviewQuery();
+  const limit = Lib.currentLimit(query, stageIndex);
+  const hasSuitableLimit = limit !== null && limit <= PREVIEW_ROWS_LIMIT;
+  const queryWithLimit = hasSuitableLimit
+    ? query
+    : Lib.limit(query, stageIndex, PREVIEW_ROWS_LIMIT);
 
-  refresh = () => {
-    this.setState({
-      question: this.getPreviewQuestion(this.props.step),
-    });
+  return Question.create()
+    .setQuery(queryWithLimit)
+    .setDisplay("table")
+    .setSettings({ "table.pivot": false });
+};
+
+const NotebookStepPreview = props => {
+  const { onClose } = props;
+  const [question, setQuestion] = useState(getPreviewQuestion(props.step));
+
+  const refresh = () => {
+    setQuestion(getPreviewQuestion(props.step));
   };
 
-  getPreviewQuestion(step) {
-    const { getPreviewQuery, stageIndex } = step;
-    const query = getPreviewQuery();
-    const limit = Lib.currentLimit(query, stageIndex);
-    const hasSuitableLimit = limit !== null && limit <= PREVIEW_ROWS_LIMIT;
-    const queryWithLimit = hasSuitableLimit
-      ? query
-      : Lib.limit(query, stageIndex, PREVIEW_ROWS_LIMIT);
+  const getIsDirty = () => {
+    const newQuestion = getPreviewQuestion(props.step);
+    return !_.isEqual(newQuestion.card(), question.card());
+  };
 
-    return Question.create()
-      .setQuery(queryWithLimit)
-      .setDisplay("table")
-      .setSettings({ "table.pivot": false });
-  }
+  const isDirty = getIsDirty();
 
-  getIsDirty() {
-    const newQuestion = this.getPreviewQuestion(this.props.step);
-    return !_.isEqual(newQuestion.card(), this.state.question.card());
-  }
+  return (
+    <PreviewRoot data-testid="preview-root">
+      <PreviewHeader>
+        <span className="text-bold">{t`Preview`}</span>
+        <PreviewIconContainer>
+          <Icon
+            name="close"
+            onClick={onClose}
+            className="text-light text-medium-hover cursor-pointer ml1"
+          />
+        </PreviewIconContainer>
+      </PreviewHeader>
+      {isDirty ? (
+        <PreviewButtonContainer className="bordered shadowed rounded bg-white p4">
+          <Button onClick={refresh}>{t`Refresh`}</Button>
+        </PreviewButtonContainer>
+      ) : (
+        <QuestionResultLoader question={question}>
+          {({ rawSeries, result }) => (
+            <VisualizationPreview rawSeries={rawSeries} result={result} />
+          )}
+        </QuestionResultLoader>
+      )}
+    </PreviewRoot>
+  );
+};
 
-  render() {
-    const { onClose } = this.props;
-    const { question } = this.state;
+const VisualizationPreview = ({ rawSeries, result }) => {
+  const { open } = useModalOpen();
+  const preferReducedMotion = isReducedMotionPreferred();
 
-    const isDirty = this.getIsDirty();
+  const transitionDuration = preferReducedMotion ? 80 : 700;
 
-    const preferReducedMotion = isReducedMotionPreferred();
-    const springOpts = preferReducedMotion
-      ? { stiffness: 500 }
-      : { stiffness: 170 };
-
-    return (
-      <PreviewRoot data-testid="preview-root">
-        <PreviewHeader>
-          <span className="text-bold">{t`Preview`}</span>
-          <PreviewIconContainer>
-            <Icon
-              name="close"
-              onClick={onClose}
-              className="text-light text-medium-hover cursor-pointer ml1"
-            />
-          </PreviewIconContainer>
-        </PreviewHeader>
-        {isDirty ? (
-          <PreviewButtonContainer className="bordered shadowed rounded bg-white p4">
-            <Button onClick={this.refresh}>{t`Refresh`}</Button>
-          </PreviewButtonContainer>
-        ) : (
-          <QuestionResultLoader question={question}>
-            {({ rawSeries, result }) => (
-              <Motion
-                defaultStyle={{ height: 36 }}
-                style={{
-                  height: spring(getPreviewHeightForResult(result), springOpts),
-                }}
-              >
-                {({ height }) => {
-                  const targetHeight = getPreviewHeightForResult(result);
-                  const snapHeight =
-                    height > targetHeight / 2 ? targetHeight : 0;
-                  const minHeight = preferReducedMotion ? snapHeight : height;
-                  return (
-                    <Visualization
-                      rawSeries={rawSeries}
-                      error={result && result.error}
-                      className={cx("bordered shadowed rounded bg-white", {
-                        p2: result && result.error,
-                      })}
-                      style={{ minHeight }}
-                    />
-                  );
-                }}
-              </Motion>
-            )}
-          </QuestionResultLoader>
-        )}
-      </PreviewRoot>
-    );
-  }
-}
+  return (
+    <Visualization
+      rawSeries={rawSeries}
+      error={result && result.error}
+      className={cx("bordered shadowed rounded bg-white", {
+        p2: result && result.error,
+      })}
+      style={{
+        height: open
+          ? getPreviewHeightForResult(result)
+          : getPreviewHeightForResult(result) / 2,
+        transition: `height ${transitionDuration}ms cubic-bezier(0, 0, 0.2, 1)`,
+      }}
+    />
+  );
+};
 
 function getPreviewHeightForResult(result) {
   const rowCount = result ? result.data.rows.length : 1;

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -37,20 +37,17 @@ const getPreviewQuestion = step => {
     .setSettings({ "table.pivot": false });
 };
 
-const NotebookStepPreview = props => {
-  const { onClose } = props;
-  const [question, setQuestion] = useState(getPreviewQuestion(props.step));
+const NotebookStepPreview = ({ step, onClose }) => {
+  const [question, setQuestion] = useState(getPreviewQuestion(step));
 
   const refresh = () => {
-    setQuestion(getPreviewQuestion(props.step));
+    setQuestion(getPreviewQuestion(step));
   };
 
-  const getIsDirty = () => {
-    const newQuestion = getPreviewQuestion(props.step);
+  const isDirty = useMemo(() => {
+    const newQuestion = getPreviewQuestion(step);
     return !_.isEqual(newQuestion.card(), question.card());
-  };
-
-  const isDirty = getIsDirty();
+  }, [step, question]);
 
   return (
     <PreviewRoot data-testid="preview-root">


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39715

### Description
Removing use of react-motion in Notebook preview in favor of using CSS transitions. Component was changed from Class based component to functional, though that didn't end up being totally necessary. Should be minimal impact to end users

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders
2. Click the preview button and observe the height change animation

### Demo
before: (taken from stats)
![chrome_piXIGVv3zF](https://github.com/metabase/metabase/assets/1328979/673d54e8-67cb-4152-b3d3-55781929b6eb)

After: (artificially added latency to show a loading transition)
![chrome_weQtFqhfZi](https://github.com/metabase/metabase/assets/1328979/25fd8154-7247-410e-afca-e9ef59bbff65)


### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~
