### PR TITLE
Graph gymnastics to handle type coercing and promotion

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -6,6 +6,9 @@ title: Driver interface changelog
 
 ## Metabase 0.49.0
 
+- The multimethod `metabase.driver/alter-columns!` has been added. This method is used to alter a table's columns in the
+  database. This is currently only required for drivers that support the `:uploads` feature.
+
 - The multimethod `metabase.driver.sql-jdbc.sync.interface/current-user-table-privileges` has been added.
   JDBC-based drivers can implement this to improve the performance of the default SQL JDBC implementation of
   `metabase.driver/describe-database`. It needs to be implemented if the database supports the `:table-privileges`

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -924,7 +924,7 @@
 (defmulti alter-columns!
   "Alter columns given by `column-definitions` to a table named `table-name`. If the table doesn't exist it will throw an error.
   Currently we do not currently support changing the the primary key."
-  {:added "0.??.0", :arglists '([driver db-id table-name column-definitions])}
+  {:added "0.49.0", :arglists '([driver db-id table-name column-definitions])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -923,7 +923,7 @@
 
 (defmulti alter-columns!
   "Alter columns given by `column-definitions` to a table named `table-name`. If the table doesn't exist it will throw an error.
-  Currently we do not currently support changing the the primary key."
+  Currently we do not currently support changing the the primary key, or take any guidance on how to coerce values."
   {:added "0.49.0", :arglists '([driver db-id table-name column-definitions])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -921,6 +921,13 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
+(defmulti alter-columns!
+  "Alter columns given by `column-definitions` to a table named `table-name`. If the table doesn't exist it will throw an error.
+  Currently we do not currently support changing the the primary key."
+  {:added "0.??.0", :arglists '([driver db-id table-name column-definitions])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
 (defmulti syncable-schemas
   "Returns the set of syncable schemas in the database (as strings)."
   {:added "0.47.0", :arglists '([driver database])}

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -180,7 +180,7 @@
   [driver db-id table-name column-definitions]
   (let [sql (first (sql/format {:alter-table  (keyword table-name)
                                 :alter-column (map (fn [[column-name type-and-constraints]]
-                                                     (vec (cons column-name type-and-constraints)))
+                                                     (vec (cons column-name (cons :type type-and-constraints))))
                                                    column-definitions)}
                                :quoted true
                                :dialect (sql.qp/quote-style driver)))]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -605,7 +605,7 @@
 
 (def ^:private allowed-type-upgrades
   "A mapping of which types a column can be implicitly relaxed to, based on the content of appended values."
-  {::integer #{::float}})
+  {::int #{::float}})
 
 (defn- check-schema
   "Throws an exception if:
@@ -627,20 +627,23 @@
 (defn- matching-or-upgradable? [current-type relaxed-type]
   (or (= current-type relaxed-type)
       (when-let [f (allowed-type-upgrades current-type)]
-        (f relax-type))))
+        (f relaxed-type))))
 
-(defn- changed-field+new-types
+(defn- changed-field->new-type
   "Given some fields and old and new types, filter out fields with unchanged types, then pair with the new types."
   [fields old-types new-types]
   (let [new-if-changed #(when (not= %1 %2) %2)]
     (->> (map new-if-changed old-types new-types)
          (map vector fields)
-         (filter second))))
+         (filter second)
+         (into {}))))
 
-(defn- convert-columns! [_database _table field+new-types]
-  (doseq [[_field new-type] field+new-types]
-    (let [_column-type (column-type new-type)]
-      ::TODO)))
+(defn- alter-columns! [driver database table field->new-type]
+  (driver/alter-columns! driver (:id database) (table-identifier table)
+                         (m/map-kv (fn [field column-type]
+                                     [(keyword (:name field))
+                                      (driver/upload-type->database-type driver column-type)])
+                                   field->new-type)))
 
 (defn- append-csv!*
   [database table file]
@@ -669,8 +672,8 @@
                                         ;; we will instead throw an error when we try to parse as the old type
                                         (= relaxed-types new-column-types))
                                (let [fields (map normed-name->field normed-header)]
-                                 (->> (changed-field+new-types fields old-column-types relaxed-types)
-                                      (convert-columns! database table))))
+                                 (->> (changed-field->new-type fields old-column-types relaxed-types)
+                                      (alter-columns! driver database table))))
           ;; this will fail if any of our required relaxations were rejected.
           parsed-rows        (parse-rows new-column-types rows)]
       (try
@@ -682,7 +685,7 @@
         (driver/add-columns! driver
                              (:id database)
                              (table-identifier table)
-                             {auto-pk-column-keyword (conj (driver/upload-type->database-type driver ::auto-incrementing-int-pk))}
+                             {auto-pk-column-keyword (driver/upload-type->database-type driver ::auto-incrementing-int-pk)}
                              :primary-key [auto-pk-column-keyword]))
       (scan-and-sync-table! database table)
       (when create-auto-pk?

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -209,6 +209,16 @@
            (filter #((type->check %) trimmed))
            first))))
 
+(defn- relax-type
+  "Given an existing column type, and a value to insert into it, relax the type until it can parse the value."
+  [type->check current-type value]
+  (cond (nil? value) current-type
+        (nil? current-type) (value->type type->check value)
+        :else (let [trimmed (str/trim value)]
+                (->> (cons current-type (ancestors h current-type))
+                     (filter #((type->check %) trimmed))
+                     first))))
+
 (defn- row->value-types
   [type->check row]
   (map (partial value->type type->check) row))
@@ -614,13 +624,10 @@
       (let [error-message (extra-and-missing-error-markdown extra missing)]
         (throw (ex-info error-message {:status-code 422}))))))
 
-(defn- matching-or-upgradable? [old-types common-types]
-  (let [pairs (map vector old-types common-types)]
-    (every? (fn [[old common]]
-              (or (= old common)
-                  (when-let [f (allowed-type-upgrades old)]
-                    (f common))))
-            pairs)))
+(defn- matching-or-upgradable? [current-type relaxed-type]
+  (or (= current-type relaxed-type)
+      (when-let [f (allowed-type-upgrades current-type)]
+        (f relax-type))))
 
 (defn- changed-field+new-types
   "Given some fields and old and new types, filter out fields with unchanged types, then pair with the new types."
@@ -649,17 +656,22 @@
           _                  (check-schema (dissoc normed-name->field auto-pk-column-name) header)
           settings           (upload-parsing/get-settings)
           old-column-types   (map (comp base-type->upload-type :base_type normed-name->field) normed-header)
-          row-column-types   (column-types-from-rows settings (count old-column-types) rows)
-          common-types       (map column-type (coalesce-types old-column-types row-column-types))
-          new-column-types   (if (or (= old-column-types common-types)
-                                     ;; if we cannot coerce all the columns, don't bother coercing any of them
-                                     ;; we will instead throw an error when we try to parse as the old type
-                                     (not (matching-or-upgradable? old-column-types common-types)))
-                               old-column-types
-                               (let [fields          (map normed-name->field normed-header)
-                                     field+new-types (changed-field+new-types fields old-column-types common-types)]
-                                 (convert-columns! database table field+new-types)
-                                 common-types))
+          ;; in the happy, and most common, case all the values will match the existing types
+          ;; for now we just plan for the worst and perform a fairly expensive operation to detect any type changes
+          ;; we can come back and optimize this to an optimistic-with-fallback approach later.
+          type->value->type  (partial relax-type (settings->type->check settings))
+          relaxed-types      (->> (sample-rows rows)
+                                  (reduce #(u/map-all type->value->type %1 %2) old-column-types)
+                                  (map column-type))
+          new-column-types   (map #(if (matching-or-upgradable? %1 %2) %2 %1) old-column-types relaxed-types)
+          _                  (when (and (not= old-column-types new-column-types)
+                                        ;; if we cannot coerce all the columns, don't bother coercing any of them
+                                        ;; we will instead throw an error when we try to parse as the old type
+                                        (= relaxed-types new-column-types))
+                               (let [fields (map normed-name->field normed-header)]
+                                 (->> (changed-field+new-types fields old-column-types relaxed-types)
+                                      (convert-columns! database table))))
+          ;; this will fail if any of our required relaxations were rejected.
           parsed-rows        (parse-rows new-column-types rows)]
       (try
         (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -50,22 +50,23 @@
 ;; type for each column. The most-specific possible type for a column is the lowest common
 ;; ancestor of the types for each value in the column.
 ;;
-;;              text
-;;               |
-;;               |
-;;          varchar-255┐
-;;        /     / \    │
-;;       /     /   \   └──────────┬
-;;      /     /     \             │
-;;  boolean float   datetime  offset-datetime
-;;     |     │       │
-;;     │     │       │
-;;     |    int     date
-;;     |   /   \
-;;     |  /     \
-;;     | /       \
-;;     |/         \
-;; boolean-or-int  auto-incrementing-int-pk
+;;               text
+;;                |
+;;                │
+;;            varchar-255────────────┐
+;;             /  |  \               │
+;;            /   │  datetime  offset-datetime
+;;           /    │      \
+;;          /     │      date
+;;         /      │
+;;    boolean   float-───────┐
+;;        |       |     \    │
+;;        │       │    ──\──int
+;;        │       │  /    \  │
+;;        │ explicit-int  float-or-int
+;;        │    |     |
+;;        │    │     │
+;; boolean-or-int   auto-incrementing-int-pk
 ;;
 ;; `boolean-or-int` is a special type with two parents, where we parse it as a boolean if the whole
 ;; column's values are of that type. additionally a column cannot have a boolean-or-int type, but
@@ -83,6 +84,10 @@
       (derive ::boolean-or-int ::boolean)
       (derive ::boolean-or-int ::int)
       (derive ::auto-incrementing-int-pk ::int)
+      (derive ::explicit-int ::int)
+      (derive ::explicit-int ::float-or-int)
+      (derive ::float-or-int ::float)
+      (derive ::float-or-int ::int)
       (derive ::int ::float)
       (derive ::date ::datetime)
       (derive ::boolean ::varchar-255)
@@ -93,7 +98,9 @@
 
 (def ^:private abstract->concrete
   "Not all value types correspond to database types. For those that don't, this maps to their concrete ancestor."
-  {::boolean-or-int ::boolean})
+  {::boolean-or-int ::boolean
+   ::explicit-int   ::int
+   ::float-or-int   ::float})
 
 (def ^:private value-types
   "All type tags which values can be inferred as. An ordered set from most to least specialized."
@@ -135,6 +142,15 @@
         ",." #"\d[\d.]*"
         ", " #"\d[\d \u00A0]*"
         ".’" #"\d[\d’]*"))))
+
+(defn- float-or-int-regex [number-separators]
+  (with-parens
+   (with-currency
+    (case number-separators
+      ("." ".,") #"\d[\d,]*\.0+"
+      ",." #"\d[\d.]*\,[0]+"
+      ", " #"\d[\d \u00A0]*\,[0.]+"
+      ".’" #"\d[\d’]*\.[0.]+"))))
 
 (defn- float-regex [number-separators]
   (with-parens
@@ -189,15 +205,20 @@
 
 (mu/defn ^:private settings->type->check :- type->check-schema
   [{:keys [number-separators] :as _settings}]
-  {::boolean-or-int  boolean-or-int-string?
-   ::boolean         boolean-string?
-   ::offset-datetime offset-datetime-string?
-   ::date            date-string?
-   ::datetime        datetime-string?
-   ::int             (regex-matcher (int-regex number-separators))
-   ::float           (regex-matcher (float-regex number-separators))
-   ::varchar-255     varchar-255?
-   ::text            (constantly true)})
+  (let [explicit-int? (regex-matcher (int-regex number-separators))
+        float-or-int? (regex-matcher (float-or-int-regex number-separators))
+        coerced-int?  #(or (explicit-int? %) (float-or-int? %))]
+    {::boolean-or-int  boolean-or-int-string?
+     ::boolean         boolean-string?
+     ::offset-datetime offset-datetime-string?
+     ::date            date-string?
+     ::datetime        datetime-string?
+     ::explicit-int    explicit-int?
+     ::int             coerced-int?
+     ::float-or-int    float-or-int?
+     ::float           (regex-matcher (float-regex number-separators))
+     ::varchar-255     varchar-255?
+     ::text            (constantly true)}))
 
 (defn- value->type
   "Determine the most specific type that is compatible with the given value.

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -322,18 +322,6 @@
     (str truncated-name-without-time
          (t/format time-format (strictly-monotonic-now)))))
 
-(def ^:private max-sample-rows "Maximum number of values to use for detecting a column's type" 1000)
-
-(defn- sample-rows
-  "Returns an improper subset of the rows no longer than [[max-sample-rows]]. Takes an evenly-distributed sample (not
-  just the first n)."
-  [rows]
-  (take max-sample-rows
-        (take-nth (max 1
-                       (long (/ (count rows)
-                                max-sample-rows)))
-                  rows)))
-
 (defn- column-definitions
   "Returns a map of column-name -> column-definition from a map of column-name -> upload-type."
   [driver col->upload-type]
@@ -401,7 +389,7 @@
   [driver db-id table-name ^File csv-file]
   (with-open [reader (bom/bom-reader csv-file)]
     (let [[header & rows]         (without-auto-pk-columns (csv/read-csv reader))
-          {:keys [extant-columns generated-columns]} (detect-schema header (sample-rows rows))
+          {:keys [extant-columns generated-columns]} (detect-schema header rows)
           cols->upload-type       (merge generated-columns extant-columns)
           col-definitions         (column-definitions driver cols->upload-type)
           csv-col-names           (keys extant-columns)
@@ -663,10 +651,7 @@
           ;; for now we just plan for the worst and perform a fairly expensive operation to detect any type changes
           ;; we can come back and optimize this to an optimistic-with-fallback approach later.
           type->value->type  (partial relax-type (settings->type->check settings))
-          ;; for now we favor correctness over speed, but need to revisit this if we increase the allowed file size
-          relaxed-types      (->> #_(sample-rows rows) rows
-                                  (reduce #(u/map-all type->value->type %1 %2) old-column-types)
-                                  (map column-type))
+          relaxed-types      (map column-type (reduce #(u/map-all type->value->type %1 %2) old-column-types rows))
           new-column-types   (map #(if (matching-or-upgradable? %1 %2) %2 %1) old-column-types relaxed-types)
           _                  (when (and (not= old-column-types new-column-types)
                                         ;; if we cannot coerce all the columns, don't bother coercing any of them

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -347,13 +347,14 @@
 (defn- parse-rows
   "Returns a lazy seq of parsed rows, given a sequence of upload types for each column.
   Empty strings are parsed as nil."
-  [col-upload-types rows]
-  (let [settings (upload-parsing/get-settings)
-        parsers  (map #(upload-parsing/upload-type->parser % settings) col-upload-types)]
-    (for [row rows]
-      (for [[value parser] (u/map-all vector row parsers)]
-        (when-not (str/blank? value)
-          (parser value))))))
+  ([col-upload-types rows]
+   (parse-rows (upload-parsing/get-settings) col-upload-types rows))
+  ([settings col-upload-types rows]
+   (let [parsers (map #(upload-parsing/upload-type->parser % settings) col-upload-types)]
+     (for [row rows]
+       (for [[value parser] (u/map-all vector row parsers)]
+         (when-not (str/blank? value)
+           (parser value)))))))
 
 (defn- remove-indices
   "Removes the elements at the given indices from the collection. Indices is a set."
@@ -592,6 +593,10 @@
        (str/join "\n\n")
        (not-blank)))
 
+(def ^:private allowed-type-upgrades
+  "A mapping of which types a column can be implicitly relaxed to, based on the content of appended values."
+  {::integer #{::float}})
+
 (defn- check-schema
   "Throws an exception if:
     - the CSV file contains duplicate column names
@@ -609,6 +614,27 @@
       (let [error-message (extra-and-missing-error-markdown extra missing)]
         (throw (ex-info error-message {:status-code 422}))))))
 
+(defn- matching-or-upgradable? [old-types common-types]
+  (let [pairs (map vector old-types common-types)]
+    (every? (fn [[old common]]
+              (or (= old common)
+                  (when-let [f (allowed-type-upgrades old)]
+                    (f common))))
+            pairs)))
+
+(defn- changed-field+new-types
+  "Given some fields and old and new types, filter out fields with unchanged types, then pair with the new types."
+  [fields old-types new-types]
+  (let [new-if-changed #(when (not= %1 %2) %2)]
+    (->> (map new-if-changed old-types new-types)
+         (map vector fields)
+         (filter second))))
+
+(defn- convert-columns! [_database _table field+new-types]
+  (doseq [[_field new-type] field+new-types]
+    (let [_column-type (column-type new-type)]
+      ::TODO)))
+
 (defn- append-csv!*
   [database table file]
   (with-open [reader (bom/bom-reader file)]
@@ -621,8 +647,20 @@
                               (driver/create-auto-pk-with-append-csv? driver)
                               (not (contains? normed-name->field auto-pk-column-name)))
           _                  (check-schema (dissoc normed-name->field auto-pk-column-name) header)
-          col-upload-types   (map (comp base-type->upload-type :base_type normed-name->field) normed-header)
-          parsed-rows        (parse-rows col-upload-types rows)]
+          settings           (upload-parsing/get-settings)
+          old-column-types   (map (comp base-type->upload-type :base_type normed-name->field) normed-header)
+          row-column-types   (column-types-from-rows settings (count old-column-types) rows)
+          common-types       (map column-type (coalesce-types old-column-types row-column-types))
+          new-column-types   (if (or (= old-column-types common-types)
+                                     ;; if we cannot coerce all the columns, don't bother coercing any of them
+                                     ;; we will instead throw an error when we try to parse as the old type
+                                     (not (matching-or-upgradable? old-column-types common-types)))
+                               old-column-types
+                               (let [fields (map normed-name->field normed-header)
+                                     field+new-types (changed-field+new-types fields old-column-types common-types)]
+                                 (convert-columns! database table field+new-types)
+                                 common-types))
+          parsed-rows        (parse-rows new-column-types rows)]
       (try
         (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)
         (catch Throwable e

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -45,18 +45,18 @@
 ;;;; | Schema detection |
 ;;;; +------------------+
 
-;; Upload types form a DAG (directed acyclic graph) where each type can be coerced into any
-;; of its ancestors types. We parse each value in the CSV file to the most-specific possible
-;; type for each column. The most-specific possible type for a column is a common ancestor
-;; of the types for each value in the column, found by walking through the graph in a
-;; topological order, following edges from left to right.
+;; Upload value-types form a DAG (directed acyclic graph) where each type can be coerced into any of
+;; its ancestors types. We parse each value in the CSV file to the most-specific possible type for
+;; each column. The most-specific possible type for a column is the closest common ancestor of the
+;; types for each value in the column, found by walking through the graph in topological order,
+;; following edges from left to right - not that this is not guaranteed to be a least common ancestor!
 ;;
 ;; See [[metabase.util.ordered-hierarchy/first-common-ancestor]] for more details.
 ;;
 ;;                 text
 ;;                  |
 ;;                  │
-;;              varchar-255─────────┐
+;;              varchar-255────────┐
 ;;               /  |  \           │
 ;;              /   │  datetime  offset-datetime
 ;;             /    │      \
@@ -79,18 +79,21 @@
 ;; - `explicit-int` is an integer without an explicit decimal point.
 ;; - `float-or-int` is an integer with an explicit decimal point.
 ;;
-;; A column can never have any of these types, they are used purely for type-inference from values.
-;; As we scan through the values in a given column, we resolve to the first common ancestor of the
-;; value types which we have seen so far, and once this scan is completed, if any of these types
-;; are still not a `column-type` we then then use `abstract->concrete` to resolve it. For ease of
-;; reference we structure the graph so that this projection can always be found by travelling up
-;; along the left-most edge until we reach a valid `column-type`.
+;; While a `boolean-or-int` is a genuinely ambiguous value, `explicit-int` and `float-or-int` exist
+;; solely to power the type coercion and promotion behaviour on CSV appending.
 ;;
-;; While a `boolean-or-int` is a genuintely ambiguous value, `explicit-int` and `float-or-int` exist
-;; solely to power the type coercion and type promotion behaviour on CSV appending. If we encounter
-;; a `float-or-int` inside an `int` column, then we can safely cast it down to an integer. If we
-;; encounter a `float` (i.e. there is a non-zero fraction component), then we will need to promote
-;; the column to a `float.`
+;; - If we encounter a `float-or-int` inside an `int` column, then we can safely cast it down to an integer.
+;; - If we encounter a `float` (i.e. there is a non-zero fraction component), then we will need to promote
+;;   the column to a `float.`
+;;
+;; Columns can not have an abstract type, which has no meaning outside of inference and reconciliation.
+;; If we are left with an abstract type after having processed all the values, we need to traverse
+;; further up the graph until we reach a concrete `column-type`. For ease of reference and explicitness
+;; these corresponding values are given in the `abtract->concrete` map. One can figure out these
+;; mappings without looking away from the graph however by simplify following the first edge up from
+;; each node until you reach a concrete node. Structuring the graph this way not only gives us more
+;; value out of a single graphic, it also makes it simpler to prove that our graph meets some
+;; structural guarantess in our tests. It also saves us from some arbitrary visualization choices.
 ;;
 ;; </code></pre>
 
@@ -100,8 +103,8 @@
   consistent implementations for of our type inference, parsing, and relaxation."
   (-> (make-hierarchy)
       (derive ::boolean-or-int ::boolean)
-      (derive ::boolean-or-int ::int)
-      (derive ::auto-incrementing-int-pk ::int)
+      (derive ::boolean-or-int ::explicit-int)
+      (derive ::auto-incrementing-int-pk ::explicit-int)
       (derive ::explicit-int ::int)
       (derive ::explicit-int ::float-or-int)
       (derive ::float-or-int ::float)

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -663,7 +663,8 @@
           ;; for now we just plan for the worst and perform a fairly expensive operation to detect any type changes
           ;; we can come back and optimize this to an optimistic-with-fallback approach later.
           type->value->type  (partial relax-type (settings->type->check settings))
-          relaxed-types      (->> (sample-rows rows)
+          ;; for now we favor correctness over speed, but need to revisit this if we increase the allowed file size
+          relaxed-types      (->> #_(sample-rows rows) rows
                                   (reduce #(u/map-all type->value->type %1 %2) old-column-types)
                                   (map column-type))
           new-column-types   (map #(if (matching-or-upgradable? %1 %2) %2 %1) old-column-types relaxed-types)
@@ -675,7 +676,7 @@
                                  (->> (changed-field->new-type fields old-column-types relaxed-types)
                                       (alter-columns! driver database table))))
           ;; this will fail if any of our required relaxations were rejected.
-          parsed-rows        (parse-rows new-column-types rows)]
+          parsed-rows        (parse-rows settings new-column-types rows)]
       (try
         (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)
         (catch Throwable e

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -656,7 +656,7 @@
                                      ;; we will instead throw an error when we try to parse as the old type
                                      (not (matching-or-upgradable? old-column-types common-types)))
                                old-column-types
-                               (let [fields (map normed-name->field normed-header)
+                               (let [fields          (map normed-name->field normed-header)
                                      field+new-types (changed-field+new-types fields old-column-types common-types)]
                                  (convert-columns! database table field+new-types)
                                  common-types))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1580,6 +1580,35 @@
                         (is (= 1 (count (rows-for-table table)))))
                       (io/delete-file file))))))))))))
 
+(deftest append-type-upgrade-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (with-mysql-local-infile-on-and-off
+     (testing "Append may upgrade integer columns to floats to avoid lossy import BLAH REWORD ME PLZ"
+       ;; for drivers that insert rows in chunks, we change the chunk size to 1 so that we can test that the
+       ;; inserted rows are rolled back
+       (binding [driver/*insert-chunk-rows* 1]
+         (doseq [auto-pk-column? [true false]]
+           (testing (str "\nFor a table that has " (if auto-pk-column? "an" " no") " automatically generated PK already")
+             (doseq [{:keys [basic specialized]}
+                     [{:basic 5 :specialized 1.4}]
+                     :let [upload-type (#'upload/value->type (str basic) (upload-parsing/get-settings))]]
+               (testing (str "\nTry to upload an invalid value for " ())
+                 (with-upload-table!
+                  [table (create-upload-table!
+                          {:col->upload-type (cond-> (ordered-map/ordered-map
+                                                      :test_column upload-type)
+                                               auto-pk-column?
+                                               (assoc upload/auto-pk-column-keyword ::upload/auto-incrementing-int-pk))
+                           :rows             [[(str basic)]]})]
+                  (let [;; The CSV contains 50 basic rows and 1 that is more specialized
+                        csv-rows `["test_column" ~@(repeat 5 (str basic)) ~(str specialized)]
+                        file     (csv-file-with csv-rows (mt/random-name))]
+                    (append-csv! {:file     file
+                                  :table-id (:id table)})
+                    (testing "\nCheck the data was not uploaded into the table"
+                      (is (= 7 (count (rows-for-table table)))))
+                    (io/delete-file file))))))))))))
+
 ;; FIXME: uploading to a varchar-255 column can fail if the text is too long
 ;; We ideally want to change the column type to text if we detect this will happen, but that's difficult
 ;; currently because we don't store the character length of the column. e.g. a varchar(255) column in postgres

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -29,16 +29,18 @@
 
 (set! *warn-on-reflection* true)
 
-(def ^:private bool-type        ::upload/boolean)
-(def ^:private int-type         ::upload/int)
-(def ^:private bool-or-int-type ::upload/boolean-or-int)
-(def ^:private float-type       ::upload/float)
-(def ^:private vchar-type       ::upload/varchar-255)
-(def ^:private date-type        ::upload/date)
-(def ^:private datetime-type    ::upload/datetime)
-(def ^:private offset-dt-type   ::upload/offset-datetime)
-(def ^:private text-type        ::upload/text)
-(def ^:private auto-pk-type     ::upload/auto-incrementing-int-pk)
+(def ^:private bool-type         ::upload/boolean)
+(def ^:private explicit-int-type ::upload/explicit-int)
+(def ^:private int-type          ::upload/int)
+(def ^:private bool-or-int-type  ::upload/boolean-or-int)
+(def ^:private float-type        ::upload/float)
+(def ^:private float-or-int-type ::upload/float-or-int)
+(def ^:private vchar-type        ::upload/varchar-255)
+(def ^:private date-type         ::upload/date)
+(def ^:private datetime-type     ::upload/datetime)
+(def ^:private offset-dt-type    ::upload/offset-datetime)
+(def ^:private text-type         ::upload/text)
+(def ^:private auto-pk-type      ::upload/auto-incrementing-int-pk)
 
 (defn- local-infile-on? []
   (= "ON" (-> (sql-jdbc.conn/db->pooled-connection-spec (mt/db))
@@ -111,37 +113,37 @@
 (deftest type-detection-and-parse-test
   (doseq [[string-value expected-value expected-type seps]
           ;; Number-related
-          [["0.0"        0              float-type "."]
-           ["0.0"        0              float-type ".,"]
-           ["0,0"        0              float-type ",."]
-           ["0,0"        0              float-type ", "]
-           ["0.0"        0              float-type ".’"]
-           ["$2"         2              int-type]
-           ["$ 3"        3              int-type]
-           ["-43€"       -43            int-type]
-           ["(86)"       -86            int-type]
-           ["($86)"      -86            int-type]
-           ["£1000"      1000           int-type]
-           ["£1000"      1000           int-type "."]
-           ["£1000"      1000           int-type ".,"]
-           ["£1000"      1000           int-type ",."]
-           ["£1000"      1000           int-type ", "]
-           ["£1000"      1000           int-type ".’"]
-           ["-¥9"        -9             int-type]
-           ["₹ -13"      -13            int-type]
-           ["₪13"        13             int-type]
-           ["₩-13"       -13            int-type]
-           ["₿42"        42             int-type]
-           ["-99¢"       -99            int-type]
-           ["2"          2              int-type]
-           ["-86"        -86            int-type]
-           ["9,986,000"  9986000        int-type]
-           ["9,986,000"  9986000        int-type "."]
-           ["9,986,000"  9986000        int-type ".,"]
-           ["9.986.000"  9986000        int-type ",."]
-           ["9’986’000"  9986000        int-type ".’"]
-           ["$0"         0              int-type]
-           ["-1"         -1             int-type]
+          [["0.0"        0              float-or-int-type"."]
+           ["0.0"        0              float-or-int-type ".,"]
+           ["0,0"        0              float-or-int-type ",."]
+           ["0,0"        0              float-or-int-type ", "]
+           ["0.0"        0              float-or-int-type ".’"]
+           ["$2"         2              explicit-int-type]
+           ["$ 3"        3              explicit-int-type]
+           ["-43€"       -43            explicit-int-type]
+           ["(86)"       -86            explicit-int-type]
+           ["($86)"      -86            explicit-int-type]
+           ["£1000"      1000           explicit-int-type]
+           ["£1000"      1000           explicit-int-type "."]
+           ["£1000"      1000           explicit-int-type ".,"]
+           ["£1000"      1000           explicit-int-type ",."]
+           ["£1000"      1000           explicit-int-type ", "]
+           ["£1000"      1000           explicit-int-type ".’"]
+           ["-¥9"        -9             explicit-int-type]
+           ["₹ -13"      -13            explicit-int-type]
+           ["₪13"        13             explicit-int-type]
+           ["₩-13"       -13            explicit-int-type]
+           ["₿42"        42             explicit-int-type]
+           ["-99¢"       -99            explicit-int-type]
+           ["2"          2              explicit-int-type]
+           ["-86"        -86            explicit-int-type]
+           ["9,986,000"  9986000        explicit-int-type]
+           ["9,986,000"  9986000        explicit-int-type "."]
+           ["9,986,000"  9986000        explicit-int-type ".,"]
+           ["9.986.000"  9986000        explicit-int-type ",."]
+           ["9’986’000"  9986000        explicit-int-type ".’"]
+           ["$0"         0              explicit-int-type]
+           ["-1"         -1             explicit-int-type]
            ["0"          false          bool-or-int-type]
            ["1"          true           bool-or-int-type]
            ["9.986.000"  "9.986.000"    vchar-type ".,"]
@@ -155,7 +157,7 @@
            [".14"        ".14"          vchar-type ".,"] ;; TODO: this should be a float type
            ["0.14"       0.14           float-type ".,"]
            ["-9986.567"  -9986.567      float-type ".,"]
-           ["$2.0"       2              float-type ".,"]
+           ["$2.0"       2              float-or-int-type ".,"]
            ["$ 3.50"     3.50           float-type ".,"]
            ["-4300.23€"  -4300.23       float-type ".,"]
            ["£1,000.23"  1000.23        float-type]
@@ -232,7 +234,7 @@
           ;; get the type of the column, if it were filled with only that value
           col-type    (first (upload/column-types-from-rows settings 1 [[string-value]]))
           parser      (upload-parsing/upload-type->parser col-type settings)]
-      (testing (format "\"%s\" is a %s" string-value type)
+      (testing (format "\"%s\" is a %s" string-value value-type)
         (is (= expected-type
                value-type)))
       (testing (format "\"%s\" is parsed into %s" string-value expected-value)


### PR DESCRIPTION
### Description

This follows on from the [int to float promotion](https://github.com/metabase/metabase/pull/39493) work, to keep float-to-int coercion working as well.

It turns out to be quite complex, but also served as a nice stress test of the `ordered-hierarchy`, and it was gratifying to see it handle it.

Two things that occur to me are:

1. Perhaps this complexity isn't worth it, and we should just let these `::float-or-int` values force a column promotion.
2. Getting this behavior might have been easier if we relaxed our DAG to a graph, instead of inserting two more abstract nodes to avoid a cycle. I'm not sure how those details would work out, but I have a hunch there's a way. Might just add a whole different kettle of complex lifeforms though.

### How to verify

See that the test suite is passing again - specifically this test:

```clojure
{:upload-type ::upload/int, :uncoerced "2.0", :coerced 2} ;; upload-test/append-type-coercion-test
```