### PR TITLE
Fix failing sql-filters-source e2e test

### DIFF
--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -361,7 +361,7 @@ describeEE("scenarios > filters > sql filters > values source", () => {
   it("should sandbox parameter values in questions", () => {
     cy.updatePermissionsGraph({
       [COLLECTION_GROUP]: {
-        [SAMPLE_DB_ID]: { data: { schemas: "all", native: "write" } },
+        [SAMPLE_DB_ID]: { data: { schemas: "all" } },
       },
     });
 

--- a/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters-source.cy.spec.js
@@ -389,15 +389,6 @@ describeEE("scenarios > filters > sql filters > values source", () => {
     checkFilterValueNotInList("Gadget");
     checkFilterValueNotInList("Doohickey");
     FieldFilter.selectFilterValueFromList("Gizmo");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Open Editor").click();
-    cy.icon("variable").click();
-    FieldFilter.openEntryForm(true);
-    cy.wait("@parameterValues");
-    checkFilterValueNotInList("Gadget");
-    checkFilterValueNotInList("Doohickey");
-    FieldFilter.selectFilterValueFromList("Gizmo");
   });
 });
 


### PR DESCRIPTION
Fixes a failing e2e test on the permissions feature branch.

This test was a little odd since it was requiring a user to have native query editing access _and_ be sandboxed. This isn't actually a valid permission state, since you need full non-sandboxed data access permissions if you have native access. So I think we're OK to remove the part of this test that was relying on that.