### PR TITLE
Do not allow `undefined` when updating a user setting

### DIFF
--- a/frontend/src/metabase/redux/settings.ts
+++ b/frontend/src/metabase/redux/settings.ts
@@ -35,18 +35,13 @@ export const settings = createReducer(
   },
 );
 
-type RequiredUserSettings = {
-  [K in keyof UserSettings]-?: UserSettings[K];
-};
-
-type UserSettingsMap = {
-  [K in keyof RequiredUserSettings]: { key: K; value: RequiredUserSettings[K] };
-}[keyof RequiredUserSettings];
-
 export const UPDATE_USER_SETTING = "metabase/settings/UPDATE_USER_SETTING";
 export const updateUserSetting = createThunkAction(
   UPDATE_USER_SETTING,
-  function (setting: UserSettingsMap) {
+  function <K extends keyof UserSettings>(setting: {
+    key: K;
+    value: Exclude<UserSettings[K], undefined>;
+  }) {
     return async function (dispatch) {
       try {
         await SettingsApi.put(setting);

--- a/frontend/src/metabase/redux/settings.ts
+++ b/frontend/src/metabase/redux/settings.ts
@@ -35,13 +35,18 @@ export const settings = createReducer(
   },
 );
 
+type RequiredUserSettings = {
+  [K in keyof UserSettings]-?: UserSettings[K];
+};
+
+type UserSettingsMap = {
+  [K in keyof RequiredUserSettings]: { key: K; value: RequiredUserSettings[K] };
+}[keyof RequiredUserSettings];
+
 export const UPDATE_USER_SETTING = "metabase/settings/UPDATE_USER_SETTING";
 export const updateUserSetting = createThunkAction(
   UPDATE_USER_SETTING,
-  function <K extends keyof UserSettings>(setting: {
-    key: K;
-    value: UserSettings[K];
-  }) {
+  function (setting: UserSettingsMap) {
     return async function (dispatch) {
       try {
         await SettingsApi.put(setting);


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/metabase/metabase/pull/39734#discussion_r1516072045), we define settings types as potentially undefined but we don't know if they are going to be used when setting/updating (dispatch) or when getting (fetch) a setting.

This PR removes the ability to erroneously update the setting with an `undefined` value. Backend would reject it anyway.
Inspiration for [this pattern](https://github.com/metabase/metabase/pull/39728/commits/712b1278838b59c7108c1883bb04037c071fe584): https://www.totaltypescript.com/tips/derive-a-union-type-from-an-object

Credits to @hypernurb for teaching me about the [mapping modifiers](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html#mapping-modifiers).