### PR TITLE
Optimize upload type inference

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -210,7 +210,7 @@
            first))))
 
 (defn- relax-type
-  "Given an existing column type, and a value to insert into it, relax the type until it can parse the value."
+  "Given an existing column type, and a new value, relax the type until it includes the value."
   [type->check current-type value]
   (cond (nil? value) current-type
         (nil? current-type) (value->type type->check value)
@@ -219,25 +219,18 @@
                      (filter #((type->check %) trimmed))
                      first))))
 
-(defn- row->value-types
-  [type->check row]
-  (map (partial value->type type->check) row))
+(defn- type-relaxer
+  "Given a map of {value-type -> predicate}, return a reducing fn which updates our inferred schema using the next row."
+  [type->check]
+  (let [type->value->type (partial relax-type type->check)]
+    (fn [value-types row]
+      ;; It's important to realise this lazy sequence, because otherwise we can build a huge stack and overflow.
+      (vec (u/map-all type->value->type value-types row)))))
 
-(defn- most-specific-common-ancestor
-  "Return the first \"ancestor\" of `base-type` which is also an \"ancestor\" of `new-type`.
-  We use a more relaxed definition of \"ancestor\" here than usual, which includes the tag itself."
-  [base-type new-type]
-  (when (or base-type new-type)
-    (or (ordered-hierarchy/first-common-ancestor h base-type new-type)
-        (throw (IllegalArgumentException. (tru "Could not find a common type for {0} and {1}"
-                                               base-type
-                                               new-type))))))
-
-(defn- coalesce-types
-  "Given two collections of type tags, find the most specific common ancestor for each pair.
-  If one of the collections is longer, we return its existing tags for the remaining length."
-  [types-a types-b]
-  (u/map-all most-specific-common-ancestor types-a types-b))
+(defn- relax-types [settings current-types rows]
+  (let [type->check       (settings->type->check settings)]
+    (->> (reduce (type-relaxer type->check) current-types rows)
+         (map column-type))))
 
 (defn- normalize-column-name
   [raw-name]
@@ -261,11 +254,7 @@
 (mu/defn column-types-from-rows :- [:sequential (into [:enum] column-types)]
   "Returns a sequence of types, given the unparsed rows in the CSV file"
   [settings column-count rows]
-  (let [type->check (settings->type->check settings)]
-    (->> rows
-         (map (partial row->value-types type->check))
-         (reduce coalesce-types (repeat column-count nil))
-         (map column-type))))
+  (relax-types settings (repeat column-count nil) rows))
 
 (defn- detect-schema
   "Consumes the header and rows from a CSV file.
@@ -652,8 +641,7 @@
           ;; in the happy, and most common, case all the values will match the existing types
           ;; for now we just plan for the worst and perform a fairly expensive operation to detect any type changes
           ;; we can come back and optimize this to an optimistic-with-fallback approach later.
-          type->value->type  (partial relax-type (settings->type->check settings))
-          relaxed-types      (map column-type (reduce #(u/map-all type->value->type %1 %2) old-column-types rows))
+          relaxed-types      (relax-types settings old-column-types rows)
           new-column-types   (map #(if (matching-or-upgradable? %1 %2) %2 %1) old-column-types relaxed-types)
           _                  (when (and (not= old-column-types new-column-types)
                                         ;; if we cannot coerce all the columns, don't bother coercing any of them

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -227,7 +227,7 @@
   (let [type->value->type (partial relax-type type->check)]
     (fn [value-types row]
       ;; It's important to realize this lazy sequence, because otherwise we can build a huge stack and overflow.
-      (vec (u/map-all type->value->type value-types row)))))
+      (vec (u/map-all (partial relax-type type->check) value-types row))))
 
 (defn- relax-types [settings current-types rows]
   (let [type->check (settings->type->check settings)]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -215,9 +215,11 @@
   (cond (nil? value) current-type
         (nil? current-type) (value->type type->check value)
         :else (let [trimmed (str/trim value)]
-                (->> (cons current-type (ancestors h current-type))
-                     (filter #((type->check %) trimmed))
-                     first))))
+                (if (str/blank? trimmed)
+                  current-type
+                  (->> (cons current-type (ancestors h current-type))
+                       (filter #((type->check %) trimmed))
+                       first)))))
 
 (defn- type-relaxer
   "Given a map of {value-type -> predicate}, return a reducing fn which updates our inferred schema using the next row."

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -228,7 +228,7 @@
       (vec (u/map-all type->value->type value-types row)))))
 
 (defn- relax-types [settings current-types rows]
-  (let [type->check       (settings->type->check settings)]
+  (let [type->check (settings->type->check settings)]
     (->> (reduce (type-relaxer type->check) current-types rows)
          (map column-type))))
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -226,7 +226,7 @@
   [type->check]
   (let [type->value->type (partial relax-type type->check)]
     (fn [value-types row]
-      ;; It's important to realise this lazy sequence, because otherwise we can build a huge stack and overflow.
+      ;; It's important to realize this lazy sequence, because otherwise we can build a huge stack and overflow.
       (vec (u/map-all type->value->type value-types row)))))
 
 (defn- relax-types [settings current-types rows]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -23,6 +23,7 @@
    [metabase.upload :as upload]
    [metabase.upload.parsing :as upload-parsing]
    [metabase.util :as u]
+   [metabase.util.ordered-hierarchy :as ordered-hierarchy]
    [toucan2.core :as t2])
   (:import
    (java.io File)))
@@ -268,7 +269,7 @@
            [datetime-type    text-type        text-type]
            [offset-dt-type   text-type        text-type]
            [vchar-type       text-type        text-type]]]
-    (is (= expected (#'upload/most-specific-common-ancestor type-a type-b))
+    (is (= expected (#'ordered-hierarchy/first-common-ancestor @#'upload/h type-a type-b))
         (format "%s + %s = %s" (name type-a) (name type-b) (name expected)))))
 
 (defn csv-file-with


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38958

### Description

This change signifantly optimizes how we infer the types of the columns in a CSV upload.

Without this change we relied on sampling the rows of large files to infer the schema, and after removing the sampling we would now spin for a while before throwing a stack overflow.

With this change the reference file from the Slack conversation gets inferred almost instantly.

There are two small tricks:

- Strict evaluation at every step, to avoid building a huge call stack.
- Skip types we've ruled out already, i.e. start from the current type.

Since I'd already started using this optimization for the append flow, this unifies the code nicely.

If we want to eek out a bit more performance here, we could make a `u/mapv-all` function using a vector transient, but even `clojure.core/mapv` uses laziness for more than 1 collection.

### How to verify

1. Upload the CSV file for which we incorrectly inferred the and int column as float before.
2. It loads quickly, and the column has type float, with uncoerced values.
