### PR TITLE
Column info fixes

### DIFF
--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.styled.tsx
@@ -22,7 +22,7 @@ export const NameAndBucketing = styled.div`
   ${TriggerButton} {
     height: 100%;
     padding: 0;
-    flex-shrink: 2;
+    flex-shrink: 1;
   }
 `;
 

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/TableInfo.tsx
@@ -64,7 +64,7 @@ function useDependentTableMetadata({
   fetchMetadata,
 }: Pick<AllProps, "tableId" | "table" | "fetchForeignKeys" | "fetchMetadata">) {
   const isMissingFields = !table?.numFields();
-  const isMissingFks = _.isEmpty(table?.fks);
+  const isMissingFks = table?.fks === undefined;
   const shouldFetchMetadata = isMissingFields || isMissingFks;
   const [hasFetchedMetadata, setHasFetchedMetadata] = useState(
     !shouldFetchMetadata,

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -21,4 +21,9 @@ export const Content = styled.div<{ isClickable: boolean }>`
   padding: 0.5rem;
   cursor: ${props => (props.isClickable ? "pointer" : "default")};
   min-width: 0;
+
+  .List-item-content {
+    min-width: 0;
+    flex-shrink: 1;
+  }
 `;

--- a/frontend/src/metabase/query_builder/components/dataref/TableInfoLoader.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/TableInfoLoader.tsx
@@ -27,7 +27,7 @@ function useDependentTableMetadata({
   fetchMetadata,
 }: Pick<AllProps, "table" | "fetchForeignKeys" | "fetchMetadata">) {
   const isMissingFields = !table.numFields();
-  const isMissingFks = _.isEmpty(table.fks);
+  const isMissingFks = table.fks === undefined;
   const shouldFetchMetadata = isMissingFields || isMissingFks;
   const [hasFetchedMetadata, setHasFetchedMetadata] = useState(
     !shouldFetchMetadata,

--- a/frontend/src/metabase/selectors/metadata.ts
+++ b/frontend/src/metabase/selectors/metadata.ts
@@ -339,10 +339,8 @@ function hydrateTableFields(table: Table, metadata: Metadata): Field[] {
 function hydrateTableForeignKeys(
   table: Table,
   metadata: Metadata,
-): ForeignKey[] {
-  const fks = table.getPlainObject().fks ?? [];
-
-  return fks.map(fk => {
+): ForeignKey[] | undefined {
+  return table.getPlainObject().fks?.map(fk => {
     const instance = createForeignKey(fk, metadata);
     instance.origin = metadata.field(fk.origin_id) ?? undefined;
     instance.destination = metadata.field(fk.destination_id) ?? undefined;


### PR DESCRIPTION
### Description

Adds some small fixes for the #39296 PR.


### How to verify

1. New Question → Sample Dataset
2. Hover the info icons on the tables and verify that the loading spinner only shows up when there is something to be loaded
3. Select People
4. Add an aggregation: Birth Date: Quarter of Year
5. Add another aggregation and hover the `Birth Date: Quarter of Year` item, the icon should not be overlapping the rest of the text

### Demo

<img width="672" alt="Screenshot 2024-03-07 at 10 41 58" src="https://github.com/metabase/metabase/assets/1250185/a011fab4-0166-48de-ac28-f359ac482c21">
