### PR TITLE
Fix invisible chart legend dots when printing

### DIFF
--- a/frontend/src/metabase/visualizations/components/legend/LegendItem.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendItem.styled.tsx
@@ -34,6 +34,7 @@ export const LegendItemDot = styled.div`
   height: 0.75rem;
   border-radius: 50%;
   background-color: ${({ color }) => color};
+  color-adjust: exact;
 `;
 
 export const LegendItemTitle = styled.div`


### PR DESCRIPTION
Fixes #6963

### To verify

1. Open a dashboard with a chart that has a legend
2. Press `CMD + P` to print
3. Ensure you can see legend dots in the final PDF

### Demo

**Before**
![CleanShot 2024-03-07 at 11 58 55@2x](https://github.com/metabase/metabase/assets/17258145/960a4805-bdaa-4d49-bca5-8760ab85be6d)

**After**
![CleanShot 2024-03-07 at 11 59 35@2x](https://github.com/metabase/metabase/assets/17258145/19f5097f-dc03-4f2f-9e4d-c21a136444e5)
