### PR TITLE
Fix unresponsive dashboard header button

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -590,6 +590,8 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
             items={extraButtons}
             triggerIcon="ellipsis"
             tooltip={t`Move, archive, and more...`}
+            // TODO: Try to restore this transition once we upgrade to React 18 and can prioritize this update
+            transitionDuration={0}
           />,
         );
       }


### PR DESCRIPTION
Repeats #39712 for dashboard header's menu button. Could be annoying to wait for some queries to load when you just wanted to Move or Archive a dashboard