### PR TITLE
Only return helpText for supported features

### DIFF
--- a/frontend/src/metabase-lib/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/expressions/suggest.ts
@@ -82,7 +82,12 @@ export function suggest({
       if (name && database) {
         const helpText = getHelpText(name, database, reportTimezone);
         if (helpText) {
-          return { suggestions, helpText };
+          const clause = MBQL_CLAUSES[helpText?.name];
+          const isSupported =
+            !clause || database?.hasFeature(clause.requiresFeature);
+          if (isSupported) {
+            return { suggestions, helpText };
+          }
         }
       }
     }

--- a/frontend/src/metabase-lib/expressions/suggest.unit.spec.ts
+++ b/frontend/src/metabase-lib/expressions/suggest.unit.spec.ts
@@ -1,5 +1,6 @@
 import _ from "underscore";
 
+import { createMockMetadata } from "__support__/metadata";
 import * as Lib from "metabase-lib";
 import {
   SAMPLE_DATABASE,
@@ -8,6 +9,7 @@ import {
 } from "metabase-lib/test-helpers";
 import type { DatasetQuery, Join } from "metabase-types/api";
 import {
+  createSampleDatabase,
   ORDERS,
   ORDERS_ID,
   REVIEWS,
@@ -276,6 +278,27 @@ describe("metabase/lib/expression/suggest", () => {
           example: "lower([Status])",
           args: expect.objectContaining({ length: 1 }),
         });
+      });
+
+      it("should not provide help text for an unsupported function (metabase#39766)", () => {
+        const metadata = createMockMetadata({
+          databases: [
+            createSampleDatabase({
+              features: ["foreign-keys"],
+            }),
+          ],
+        });
+
+        expect(
+          helpText({
+            source: "percentile",
+            query: createQuery(),
+            metadata,
+            startRule: "expression",
+            stageIndex: -1,
+            getColumnIcon: () => "icon",
+          }),
+        ).toBeUndefined();
       });
 
       it("should provide help text after first argument if there's only one argument", () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/35156

### Description

Avoid showing help text for unsupported functions.

### How to verify

1. New question → Mariadb
2. Select a table
3. Add a custom expression filter
4. In the textbox type: `percentile(`
5. No help text should show

Doing the same for a Postgres database, should show the help text because it supports percentiles.

### Demo

<img width="573" alt="Screenshot 2024-03-07 at 15 48 04" src="https://github.com/metabase/metabase/assets/1250185/dd6af033-63b7-4212-8fd3-73be9d2b7f99">

- [x] Tests have been added/updated to cover changes in this PR
