### PR TITLE
Detect the use of unsupported features in the expression editor

### DIFF
--- a/e2e/test/scenarios/custom-column/cc-data-type.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/cc-data-type.cy.spec.js
@@ -5,7 +5,7 @@ import {
   popover,
   enterCustomColumnDetails,
   filter,
-  openOrdersTable,
+  startNewQuestion,
   visualize,
   getNotebookStep,
 } from "e2e/support/helpers";
@@ -15,6 +15,8 @@ const { ORDERS_ID, PEOPLE_ID, PRODUCTS_ID } = SAMPLE_DATABASE;
 describe("scenarios > question > custom column > data type", () => {
   beforeEach(() => {
     restore();
+    restore("postgres-12");
+
     cy.signInAsAdmin();
   });
 
@@ -38,7 +40,12 @@ describe("scenarios > question > custom column > data type", () => {
   });
 
   it("should understand date functions", () => {
-    openOrdersTable({ mode: "notebook" });
+    startNewQuestion();
+    popover().within(() => {
+      cy.findByText("Raw Data").click();
+      cy.findByText("QA Postgres12").click();
+      cy.findByText("Orders").click();
+    });
 
     addCustomColumns([
       { name: "Year", formula: "year([Created At])" },
@@ -132,11 +139,11 @@ function addCustomColumns(columns) {
     if (index) {
       getNotebookStep("expression").icon("add").click();
     } else {
-      cy.findByText("Custom column").click();
+      cy.findByLabelText("Custom column").click();
     }
 
     enterCustomColumnDetails(column);
-    cy.button("Done").click();
+    cy.button("Done").click({ force: true });
   });
 }
 

--- a/frontend/src/metabase-lib/expressions/diagnostics.ts
+++ b/frontend/src/metabase-lib/expressions/diagnostics.ts
@@ -224,7 +224,13 @@ function prattCompiler({
       adjustOptions,
       useShorthands,
       adjustCase,
-      expr => resolve(expr, startRule, resolveMBQLField, database),
+      expression =>
+        resolve({
+          expression,
+          type: startRule,
+          fn: resolveMBQLField,
+          database,
+        }),
     ],
     getMBQLName,
   });

--- a/frontend/src/metabase-lib/expressions/process.ts
+++ b/frontend/src/metabase-lib/expressions/process.ts
@@ -49,7 +49,9 @@ export function processSource(options: {
   let compileError;
   try {
     const parsed = parse(source);
-    expression = adjustBooleans(resolve(parsed, startRule, resolveMBQLField));
+    expression = adjustBooleans(
+      resolve({ expression: parsed, type: startRule, fn: resolveMBQLField }),
+    );
 
     // query and stageIndex are not available outside of notebook editor (e.g. in Metrics or Segments).
     if (query && typeof stageIndex !== "undefined") {

--- a/frontend/src/metabase-lib/expressions/resolver.js
+++ b/frontend/src/metabase-lib/expressions/resolver.js
@@ -69,18 +69,19 @@ const isCompatible = (a, b) => {
 };
 
 /**
- *
- * @param {import("./pratt").Expr} expression
- * @param {string} type
- * @param {?(kind: string, name: string, node: import("./pratt").Node) => void} fn
- * @param {Database | null} database
+ * @param {{
+ *   expression: import("./pratt").Expr
+ *   type?: string
+ *   fn?: ?(kind: string, name: string, node: import("./pratt").Node) => void
+ *   database?: Database | null
+ * }} options
  */
-export function resolve(
+export function resolve({
   expression,
   type = "expression",
   fn = undefined,
   database = undefined,
-) {
+}) {
   if (Array.isArray(expression)) {
     const [op, ...operands] = expression;
 
@@ -133,13 +134,13 @@ export function resolve(
       }
 
       const resolvedPairs = pairs.map(([tst, val]) => [
-        resolve(tst, "boolean", fn, database),
-        resolve(val, type, fn, database),
+        resolve({ expression: tst, type: "boolean", fn, database }),
+        resolve({ expression: val, type, fn, database }),
       ]);
 
       if (options && "default" in options) {
         const resolvedOptions = {
-          default: resolve(options.default, type, fn, database),
+          default: resolve({ expression: options.default, type, fn, database }),
         };
         return [op, resolvedPairs, resolvedOptions];
       }
@@ -150,7 +151,9 @@ export function resolve(
     if (operandType) {
       return [
         op,
-        ...operands.map(operand => resolve(operand, operandType, fn, database)),
+        ...operands.map(operand =>
+          resolve({ expression: operand, type: operandType, fn, database }),
+        ),
       ];
     }
 
@@ -200,7 +203,7 @@ export function resolve(
         // as-is, optional object for e.g. ends-with, time-interval, etc
         return operand;
       }
-      return resolve(operand, args[i], fn, database);
+      return resolve({ expression: operand, type: args[i], fn, database });
     });
     return [op, ...resolvedOperands];
   } else if (

--- a/frontend/src/metabase-lib/expressions/resolver.js
+++ b/frontend/src/metabase-lib/expressions/resolver.js
@@ -73,8 +73,14 @@ const isCompatible = (a, b) => {
  * @param {import("./pratt").Expr} expression
  * @param {string} type
  * @param {?(kind: string, name: string, node: import("./pratt").Node) => void} fn
+ * @param {Database | null} database
  */
-export function resolve(expression, type = "expression", fn = undefined) {
+export function resolve(
+  expression,
+  type = "expression",
+  fn = undefined,
+  database = undefined,
+) {
   if (Array.isArray(expression)) {
     const [op, ...operands] = expression;
 
@@ -127,13 +133,13 @@ export function resolve(expression, type = "expression", fn = undefined) {
       }
 
       const resolvedPairs = pairs.map(([tst, val]) => [
-        resolve(tst, "boolean", fn),
-        resolve(val, type, fn),
+        resolve(tst, "boolean", fn, database),
+        resolve(val, type, fn, database),
       ]);
 
       if (options && "default" in options) {
         const resolvedOptions = {
-          default: resolve(options.default, type, fn),
+          default: resolve(options.default, type, fn, database),
         };
         return [op, resolvedPairs, resolvedOptions];
       }
@@ -144,7 +150,7 @@ export function resolve(expression, type = "expression", fn = undefined) {
     if (operandType) {
       return [
         op,
-        ...operands.map(operand => resolve(operand, operandType, fn)),
+        ...operands.map(operand => resolve(operand, operandType, fn, database)),
       ];
     }
 
@@ -152,6 +158,11 @@ export function resolve(expression, type = "expression", fn = undefined) {
     if (!clause) {
       throw new ResolverError(t`Unknown function ${op}`, expression.node);
     }
+
+    if (database && !database.hasFeature(clause.requiresFeature)) {
+      throw new ResolverError(t`Unsupported function ${op}`, expression.node);
+    }
+
     const { displayName, args, multiple, hasOptions, validator } = clause;
     if (!isCompatible(type, clause.type)) {
       throw new ResolverError(
@@ -189,7 +200,7 @@ export function resolve(expression, type = "expression", fn = undefined) {
         // as-is, optional object for e.g. ends-with, time-interval, etc
         return operand;
       }
-      return resolve(operand, args[i], fn);
+      return resolve(operand, args[i], fn, database);
     });
     return [op, ...resolvedOperands];
   } else if (

--- a/frontend/src/metabase-lib/expressions/resolver.js
+++ b/frontend/src/metabase-lib/expressions/resolver.js
@@ -162,7 +162,11 @@ export function resolve({
       throw new ResolverError(t`Unknown function ${op}`, expression.node);
     }
 
-    if (database && !database.hasFeature(clause.requiresFeature)) {
+    if (
+      clause.requiresFeature &&
+      database &&
+      !database.hasFeature(clause.requiresFeature)
+    ) {
       throw new ResolverError(t`Unsupported function ${op}`, expression.node);
     }
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -406,6 +406,7 @@ class ExpressionEditorTextfield extends React.Component<
       query,
       stageIndex,
       expressionPosition,
+      metadata,
     } = this.props;
 
     if (!source || source.length === 0) {
@@ -419,6 +420,7 @@ class ExpressionEditorTextfield extends React.Component<
       query,
       stageIndex,
       expressionPosition,
+      metadata,
     });
   }
 

--- a/frontend/test/metabase/lib/expressions/pratt/common.ts
+++ b/frontend/test/metabase/lib/expressions/pratt/common.ts
@@ -31,7 +31,10 @@ export function compile(source: string, type: Type, opts: Opts = {}) {
     }).root,
     {
       passes: opts.resolverPass
-        ? [...passes, expr => resolve(expr, type, mockResolve as any)]
+        ? [
+            ...passes,
+            expression => resolve({ expression, type, fn: mockResolve }),
+          ]
         : passes,
       getMBQLName,
     },
@@ -56,7 +59,7 @@ export function oracle(source: string, type: Type) {
     }
     throw err;
   }
-  return resolve(mbql, type, mockResolve as any);
+  return resolve({ expression: mbql, type, fn: mockResolve });
 }
 
 export function compare(

--- a/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/recursive-parser.unit.spec.js
@@ -3,7 +3,8 @@ import { resolve } from "metabase-lib/expressions/resolver";
 
 describe("metabase-lib/expressions/recursive-parser", () => {
   const mockResolve = (kind, name) => [kind, name];
-  const process = (source, type) => resolve(parse(source), type, mockResolve);
+  const process = (source, type) =>
+    resolve({ expression: parse(source), type, fn: mockResolve });
   const filter = expr => process(expr, "boolean");
 
   // handy references
@@ -185,7 +186,8 @@ describe("metabase-lib/expressions/recursive-parser", () => {
       throw new ReferenceError(`Unknown ["${kind}", "${name}"]`);
     };
     const type = "aggregation";
-    const aggregation = expr => resolve(parse(expr), type, mockResolve);
+    const aggregation = expr =>
+      resolve({ expression: parse(expr), type, fn: mockResolve });
 
     // sanity check first
     expect(aggregation("SUM(A)")).toEqual(["sum", ["dimension", "A"]]);
@@ -203,7 +205,8 @@ describe("metabase-lib/expressions/recursive-parser", () => {
 
   it("should handle aggregation with another function", () => {
     const type = "aggregation";
-    const aggregation = expr => resolve(parse(expr), type, mockResolve);
+    const aggregation = expr =>
+      resolve({ expression: parse(expr), type, fn: mockResolve });
 
     const A = ["dimension", "A"];
     const B = ["dimension", "B"];
@@ -223,7 +226,8 @@ describe("metabase-lib/expressions/recursive-parser", () => {
       throw new ReferenceError(`Unknown ["${kind}", "${name}"]`);
     };
     const type = "aggregation";
-    const aggregation = expr => resolve(parse(expr), type, mockResolve);
+    const aggregation = expr =>
+      resolve({ expression: parse(expr), type, fn: mockResolve });
 
     // sanity check first
     expect(aggregation("SUM(A)")).toEqual(["sum", ["dimension", "A"]]);

--- a/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/resolver.unit.spec.js
@@ -1,4 +1,6 @@
+import { createMockMetadata } from "__support__/metadata";
 import { resolve } from "metabase-lib/expressions/resolver";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
 describe("metabase-lib/expressions/resolve", () => {
   function collect(expr, startRule = "expression") {
@@ -347,5 +349,20 @@ describe("metabase-lib/expressions/resolve", () => {
 
   it("should reject unknown function", () => {
     expect(() => resolve(["foobar", 42])).toThrow();
+  });
+
+  it("should reject unsupported function (metabase#39773)", () => {
+    const database = createMockMetadata({
+      databases: [
+        createSampleDatabase({
+          id: 1,
+          features: ["foreign-keys"],
+        }),
+      ],
+    }).database(1);
+
+    expect(() =>
+      resolve(["percentile", 1, 2], "aggregation", undefined, database),
+    ).toThrow("Unsupported function percentile");
   });
 });

--- a/frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
+++ b/frontend/test/metabase/lib/expressions/typeinferencer.unit.spec.js
@@ -9,7 +9,11 @@ describe("metabase-lib/expressions/typeinferencer", () => {
   function compileAs(source, startRule) {
     let mbql = null;
     try {
-      mbql = resolve(parse(source), startRule, mockResolve);
+      mbql = resolve({
+        expression: parse(source),
+        type: startRule,
+        fn: mockResolve,
+      });
     } catch (e) {}
     return mbql;
   }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39773

### Description

This adds an extra check to the diagnostics to make sure a functions is supported by the database in the custom expression editor.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question → Sample Dataset → Orders (or any database that does not support `percentile-aggregations`)
2. Click "Pick the metric you want to see" → Custom Expression
3. In the expression editor, type `percentile([Discount], 0.9)`
4. Tab out of the expression editor text field
5. An error should show up: `Unsupported function percentile`

### Demo

<img width="514" alt="Screenshot 2024-03-07 at 16 49 50" src="https://github.com/metabase/metabase/assets/1250185/38023375-4ab9-455e-bc0c-16dda51c0dd5">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
