### PR TITLE
Disclosure triangle and Fullpage modal transitions

### DIFF
--- a/frontend/src/metabase/components/DisclosureTriangle/DisclosureTriangle.jsx
+++ b/frontend/src/metabase/components/DisclosureTriangle/DisclosureTriangle.jsx
@@ -1,25 +1,15 @@
 /* eslint-disable react/prop-types */
-import { Motion, spring, presets } from "react-motion";
-
 import { Icon } from "metabase/ui";
 
 const DisclosureTriangle = ({ open, className }) => (
-  <Motion
-    defaultStyle={{ deg: 0 }}
+  <Icon
+    className={className}
+    name="expand_arrow"
     style={{
-      deg: open ? spring(0, presets.gentle) : spring(-90, presets.gentle),
+      transition: "transform 300ms ease-out",
+      transform: `rotate(${open ? 0 : -90}deg)`,
     }}
-  >
-    {motionStyle => (
-      <Icon
-        className={className}
-        name="expand_arrow"
-        style={{
-          transform: `rotate(${motionStyle.deg}deg)`,
-        }}
-      />
-    )}
-  </Motion>
+  />
 );
 
 export default DisclosureTriangle;

--- a/frontend/src/metabase/components/Modal/FullPageModal.tsx
+++ b/frontend/src/metabase/components/Modal/FullPageModal.tsx
@@ -99,11 +99,7 @@ export class FullPageModal extends Component<
                 handleDismissal={this.handleDismissal}
                 closeOnClickOutside={this.props.closeOnClickOutside}
               >
-                <div
-                  className="full-height relative scroll-y"
-                  // style={motionStyle}
-                  style={styles}
-                >
+                <div className="full-height relative scroll-y" style={styles}>
                   {getModalContent({
                     ...this.props,
                     fullPageModal: true,

--- a/frontend/src/metabase/components/Modal/FullPageModal.tsx
+++ b/frontend/src/metabase/components/Modal/FullPageModal.tsx
@@ -1,11 +1,11 @@
 import { Component } from "react";
-import { Motion, spring } from "react-motion";
 
 import { MaybeOnClickOutsideWrapper } from "metabase/components/Modal/MaybeOnClickOutsideWrapper";
 import type { BaseModalProps } from "metabase/components/Modal/utils";
 import { getModalContent } from "metabase/components/Modal/utils";
 import SandboxedPortal from "metabase/components/SandboxedPortal";
 import { getScrollX, getScrollY } from "metabase/lib/dom";
+import { Transition } from "metabase/ui";
 
 export type FullPageModalProps = BaseModalProps & {
   isOpen: boolean;
@@ -17,6 +17,12 @@ type FullPageModalState = {
   isOpen: boolean;
 };
 
+const slideIn = {
+  in: { opacity: 1, top: 0 },
+  out: { opacity: 0, top: 20 },
+  common: { transformOrigin: "top" },
+  transitionProperty: "top, opacity",
+};
 export class FullPageModal extends Component<
   FullPageModalProps,
   FullPageModalState
@@ -28,7 +34,7 @@ export class FullPageModal extends Component<
   constructor(props: FullPageModalProps) {
     super(props);
     this.state = {
-      isOpen: true,
+      isOpen: false,
     };
 
     this._modalElement = document.createElement("div");
@@ -52,6 +58,9 @@ export class FullPageModal extends Component<
 
   componentDidMount() {
     this.setTopOfModalToBottomOfNav();
+    this.setState({
+      isOpen: true,
+    });
   }
 
   componentDidUpdate() {
@@ -78,15 +87,8 @@ export class FullPageModal extends Component<
   render() {
     const open = this.state.isOpen;
     return (
-      <Motion
-        defaultStyle={{ opacity: 0, top: 20 }}
-        style={
-          open
-            ? { opacity: spring(1), top: spring(0) }
-            : { opacity: spring(0), top: spring(20) }
-        }
-      >
-        {motionStyle => (
+      <Transition mounted={open} transition={slideIn} duration={300}>
+        {styles => (
           <SandboxedPortal container={this._modalElement}>
             <div className="Modal--full">
               {/* Using an OnClickOutsideWrapper is weird since this modal
@@ -99,7 +101,8 @@ export class FullPageModal extends Component<
               >
                 <div
                   className="full-height relative scroll-y"
-                  style={motionStyle}
+                  // style={motionStyle}
+                  style={styles}
                 >
                   {getModalContent({
                     ...this.props,
@@ -112,7 +115,7 @@ export class FullPageModal extends Component<
             </div>
           </SandboxedPortal>
         )}
-      </Motion>
+      </Transition>
     );
   }
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39764
Closes https://github.com/metabase/metabase/issues/39772

### Description
Grouping a couple of these because they're both quite small. Adjusting the `<DisclosureTriangle />` to be powered by CSS animations, and the `<FullPageModal/>` to use mantine transitions. Both are simple adjustments that remove the need for the `react-motion` package. The only change that may require a look is how the opened state is now handled in FullPageModal. We need to mount the `Transition` component with the "out" styles before changing them if we want them to animate in. Because of how the modals are mounted and unmounted, this is handled by setting the state to false in the constructor, then setting it to true in `componentDidMount`

### How to verify
Disclosure Triangles can be found in the JWT, SAML, and LDAP auth forms.
The only instance of a full page modal being used that I could find was creating alerts for Questions (in the future, this could probably be migrated to a Mantine modal with fullPage set to true)

### Demo
Fullpage Modal:
![chrome_DcgbwIJKRa](https://github.com/metabase/metabase/assets/1328979/153daf5a-22ee-4c9c-b1d5-57bbc65cc253)

Disclosure Triangle:
![chrome_RTTPFMwMQS](https://github.com/metabase/metabase/assets/1328979/2d6314b2-b247-4e8c-9151-4f5bb8f11d15)



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
