### PR TITLE
Fix order of actions in question, dashboard and collection item menus

### DIFF
--- a/frontend/src/metabase/components/EntityItem/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.jsx
@@ -103,72 +103,95 @@ function EntityItemMenu({
   const isXrayShown = isModel && isXrayEnabled;
   const isMetabotShown = isModel && canUseMetabot;
 
-  const actions = useMemo(
-    () =>
-      [
-        onToggleBookmark && {
-          title: isBookmarked ? t`Remove from bookmarks` : t`Bookmark`,
-          icon: "bookmark",
-          action: onToggleBookmark,
-        },
-        onPin && {
-          title: isPinned ? t`Unpin` : t`Pin this`,
-          icon: isPinned ? "unpin" : "pin",
-          action: onPin,
-        },
-        isMetabotShown && {
-          title: t`Ask Metabot`,
-          link: Urls.modelMetabot(item.id),
-          icon: "insight",
-        },
-        isXrayShown && {
-          title: t`X-ray this`,
-          link: Urls.xrayModel(item.id),
-          icon: "bolt",
-        },
-        onTogglePreview && {
-          title: isPreviewed
-            ? t`Don’t show visualization`
-            : t`Show visualization`,
-          icon: isPreviewed ? "eye_crossed_out" : "eye",
-          action: onTogglePreview,
-          tooltip: !isParameterized
-            ? t`Open this question and fill in its variables to see it.`
-            : undefined,
-          disabled: !isParameterized,
-        },
-        onMove && {
-          title: t`Move`,
-          icon: "move",
-          action: onMove,
-        },
-        onCopy && {
-          title: t`Duplicate`,
-          icon: "clone",
-          action: onCopy,
-        },
-        onArchive && {
-          title: t`Archive`,
-          icon: "archive",
-          action: onArchive,
-        },
-      ].filter(action => action),
-    [
-      item.id,
-      isPinned,
-      isXrayShown,
-      isMetabotShown,
-      isPreviewed,
-      isParameterized,
-      isBookmarked,
-      onPin,
-      onMove,
-      onCopy,
-      onArchive,
-      onTogglePreview,
-      onToggleBookmark,
-    ],
-  );
+  const actions = useMemo(() => {
+    const result = [];
+
+    if (onToggleBookmark) {
+      result.push({
+        title: isBookmarked ? t`Remove from bookmarks` : t`Bookmark`,
+        icon: "bookmark",
+        action: onToggleBookmark,
+      });
+    }
+
+    if (onPin) {
+      result.push({
+        title: isPinned ? t`Unpin` : t`Pin this`,
+        icon: isPinned ? "unpin" : "pin",
+        action: onPin,
+      });
+    }
+
+    if (isMetabotShown) {
+      result.push({
+        title: t`Ask Metabot`,
+        link: Urls.modelMetabot(item.id),
+        icon: "insight",
+      });
+    }
+
+    if (isXrayShown) {
+      result.push({
+        title: t`X-ray this`,
+        link: Urls.xrayModel(item.id),
+        icon: "bolt",
+      });
+    }
+
+    if (onTogglePreview) {
+      result.push({
+        title: isPreviewed
+          ? t`Don’t show visualization`
+          : t`Show visualization`,
+        icon: isPreviewed ? "eye_crossed_out" : "eye",
+        action: onTogglePreview,
+        tooltip: !isParameterized
+          ? t`Open this question and fill in its variables to see it.`
+          : undefined,
+        disabled: !isParameterized,
+      });
+    }
+
+    if (onMove) {
+      result.push({
+        title: t`Move`,
+        icon: "move",
+        action: onMove,
+      });
+    }
+
+    if (onCopy) {
+      result.push({
+        title: t`Duplicate`,
+        icon: "clone",
+        action: onCopy,
+      });
+    }
+
+    if (onArchive) {
+      result.push({
+        title: t`Archive`,
+        icon: "archive",
+        action: onArchive,
+      });
+    }
+
+    return result;
+  }, [
+    item.id,
+    isPinned,
+    isXrayShown,
+    isMetabotShown,
+    isPreviewed,
+    isParameterized,
+    isBookmarked,
+    onPin,
+    onMove,
+    onCopy,
+    onArchive,
+    onTogglePreview,
+    onToggleBookmark,
+  ]);
   if (actions.length === 0) {
     return null;
   }

--- a/frontend/src/metabase/components/EntityItem/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.jsx
@@ -106,18 +106,24 @@ function EntityItemMenu({
   const actions = useMemo(() => {
     const result = [];
 
-    if (onToggleBookmark) {
-      result.push({
-        title: isBookmarked ? t`Remove from bookmarks` : t`Bookmark`,
-        icon: "bookmark",
-        action: onToggleBookmark,
-      });
-    }
+    const bookmarkAction = {
+      title: isBookmarked ? t`Remove from bookmarks` : t`Bookmark`,
+      icon: "bookmark",
+      action: onToggleBookmark,
+    };
 
-    if (onPin) {
+    if (isPinned) {
       result.push({
-        title: isPinned ? t`Unpin` : t`Pin this`,
-        icon: isPinned ? "unpin" : "pin",
+        title: t`Unpin`,
+        icon: "unpin",
+        action: onPin,
+      });
+      result.push(bookmarkAction);
+    } else {
+      result.push(bookmarkAction);
+      result.push({
+        title: t`Pin this`,
+        icon: "pin",
         action: onPin,
       });
     }

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/DashboardHeader.tsx
@@ -518,13 +518,6 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
       });
 
       extraButtons.push({
-        title: t`Duplicate`,
-        icon: "clone",
-        link: `${location.pathname}/copy`,
-        event: "Dashboard;Copy",
-      });
-
-      extraButtons.push({
         title:
           Array.isArray(dashboard.tabs) && dashboard.tabs.length > 1
             ? t`Export tab as PDF`
@@ -543,6 +536,17 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
           link: `${location.pathname}/move`,
           event: "Dashboard;Move",
         });
+      }
+
+      extraButtons.push({
+        title: t`Duplicate`,
+        icon: "clone",
+        link: `${location.pathname}/copy`,
+        event: "Dashboard;Copy",
+      });
+
+      if (canEdit) {
+        extraButtons.push(...PLUGIN_DASHBOARD_HEADER.extraButtons(dashboard));
 
         extraButtons.push({
           title: t`Archive`,
@@ -550,8 +554,6 @@ export const DashboardHeader = (props: DashboardHeaderProps) => {
           link: `${location.pathname}/archive`,
           event: "Dashboard;Archive",
         });
-
-        extraButtons.push(...PLUGIN_DASHBOARD_HEADER.extraButtons(dashboard));
       }
     }
 

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
@@ -189,6 +189,19 @@ export const QuestionActions = ({
       action: () => onOpenModal(MODAL_TYPES.MOVE),
       testId: MOVE_TESTID,
     });
+  }
+
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  if (isEditable) {
+    extraButtons.push({
+      title: t`Duplicate`,
+      icon: "clone",
+      action: () => onOpenModal(MODAL_TYPES.CLONE),
+      testId: CLONE_TESTID,
+    });
+  }
+
+  if (canWrite) {
     if (isQuestion) {
       extraButtons.push({
         title: t`Turn into a model`,
@@ -206,15 +219,7 @@ export const QuestionActions = ({
     }
   }
 
-  const { isEditable } = Lib.queryDisplayInfo(question.query());
-  if (isEditable) {
-    extraButtons.push({
-      title: t`Duplicate`,
-      icon: "clone",
-      action: () => onOpenModal(MODAL_TYPES.CLONE),
-      testId: CLONE_TESTID,
-    });
-  }
+  extraButtons.push(...PLUGIN_QUERY_BUILDER_HEADER.extraButtons(question));
 
   if (canWrite) {
     extraButtons.push({
@@ -224,8 +229,6 @@ export const QuestionActions = ({
       testId: ARCHIVE_TESTID,
     });
   }
-
-  extraButtons.push(...PLUGIN_QUERY_BUILDER_HEADER.extraButtons(question));
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 


### PR DESCRIPTION
Followup on #39755

Desired order from an internal thread: https://metaboat.slack.com/archives/C02H619CJ8K/p1709817314095929

**Pinned collection item**

- unpin
- bookmark
- move
- duplicate
- archive

**Unpinned collection item**

- bookmark
- pin
- move
- duplicate
- archive

**Dashboards**

- enter full screen
- export as pdf
- move
- duplicate
- usage insights
- archive

**Questions**

- add to dashboard
- move
- duplicate
- turn into model
- usage insights
- archive

### Demos

![dashboard-after](https://github.com/metabase/metabase/assets/17258145/d4796a2d-3c83-4bd0-9b88-849407e8b4b8)

![question-after](https://github.com/metabase/metabase/assets/17258145/b6605e71-6b99-401d-9279-0520ea9d1ede)

![CleanShot 2024-03-07 at 16 12 43@2x](https://github.com/metabase/metabase/assets/17258145/51e5f692-6cad-4056-864e-7b5a58ded2d9)

![CleanShot 2024-03-07 at 16 12 34@2x](https://github.com/metabase/metabase/assets/17258145/aec77015-2ade-4714-8546-4a569b95e9c7)
