### PR TITLE
Fixes tabs cy spec flake

### DIFF
--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -377,6 +377,7 @@ describe("scenarios > dashboard > tabs", () => {
 
   it("should only fetch cards on the current tab", () => {
     cy.intercept("PUT", "/api/dashboard/*").as("saveDashboardCards");
+    cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
     visitDashboardAndCreateTab({
       dashboardId: ORDERS_DASHBOARD_ID,
@@ -389,6 +390,9 @@ describe("scenarios > dashboard > tabs", () => {
     sidebar().within(() => {
       cy.findByText("Orders, Count").click();
     });
+
+    cy.wait("@cardQuery");
+
     saveDashboard();
 
     cy.wait("@saveDashboardCards").then(({ response }) => {
@@ -415,6 +419,7 @@ describe("scenarios > dashboard > tabs", () => {
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("not.have.been.called");
 
+    // Ensure the card in the first tab is loaded
     getDashboardCard().findByText("User ID");
 
     // Visit second tab and confirm only second card was queried
@@ -422,13 +427,13 @@ describe("scenarios > dashboard > tabs", () => {
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("have.been.calledOnce");
 
+    // Ensure the card in the second tab is loaded
     getDashboardCard().findByText("Count");
+
     // Go back to first tab, expect no additional queries
     goToTab("Tab 1");
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("have.been.calledOnce");
-
-    getDashboardCard().findByText("User ID");
 
     // Go to public dashboard
     cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });

--- a/e2e/test/scenarios/dashboard/tabs.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/tabs.cy.spec.js
@@ -415,15 +415,20 @@ describe("scenarios > dashboard > tabs", () => {
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("not.have.been.called");
 
+    getDashboardCard().findByText("User ID");
+
     // Visit second tab and confirm only second card was queried
     goToTab("Tab 2");
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("have.been.calledOnce");
 
+    getDashboardCard().findByText("Count");
     // Go back to first tab, expect no additional queries
     goToTab("Tab 1");
     cy.get("@firstTabQuery").should("have.been.calledOnce");
     cy.get("@secondTabQuery").should("have.been.calledOnce");
+
+    getDashboardCard().findByText("User ID");
 
     // Go to public dashboard
     cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });


### PR DESCRIPTION
### Description

We cancel cards requests when switching to other tabs if they haven't been loaded. The spec has been updated to wait until cards data is loaded (visible) before changing tabs.

### How to verify

To reproduce the flake on powerful machines put `cy.pause()` on line 411. Once it gets there, enable throttling Fast 3G and resume the spec. It should not flake
