### PR TITLE
Fix the `dismissed-custom-dashboard-toast` setting case

### DIFF
--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -115,7 +115,7 @@ export const ADMIN_SETTINGS_SECTIONS = {
         postUpdateActions: [
           () =>
             updateSetting({
-              key: "dismissed_custom_dashboard_toast",
+              key: "dismissed-custom-dashboard-toast",
               value: true,
             }),
           refreshCurrentUser,

--- a/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
+++ b/frontend/src/metabase/home/components/CustomHomePageModal/CustomHomePageModal.tsx
@@ -17,7 +17,7 @@ import type { Collection, DashboardId } from "metabase-types/api";
 
 const CUSTOM_HOMEPAGE_SETTING_KEY = "custom-homepage";
 const CUSTOM_HOMEPAGE_DASHBOARD_SETTING_KEY = "custom-homepage-dashboard";
-const CUSTOM_HOMEPAGE_REDIRECT_TOAST_KEY = "dismissed_custom_dashboard_toast";
+const CUSTOM_HOMEPAGE_REDIRECT_TOAST_KEY = "dismissed-custom-dashboard-toast";
 
 interface CustomHomePageModalProps {
   isOpen: boolean;


### PR DESCRIPTION
This setting key is defined using kebab-case.
Not sure how it worked (if it worked) using the snake_case?