### PR TITLE
Remove `user-locale` from settings

### DIFF
--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -218,7 +218,6 @@ export const createMockSettings = (
   "subscription-allowed-domains": null,
   "token-features": createMockTokenFeatures(),
   "token-status": null,
-  "user-locale": null,
   version: createMockVersion(),
   "version-info": createMockVersionInfo(),
   "version-info-last-checked": null,

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -203,7 +203,6 @@ interface InstanceSettings {
   "show-homepage-xrays": boolean;
   "site-uuid": string;
   "subscription-allowed-domains": string | null;
-  "user-locale": string | null;
   "uploads-enabled": boolean;
   "uploads-database-id": number | null;
   "uploads-schema-name": string | null;

--- a/frontend/src/metabase/lib/cron.ts
+++ b/frontend/src/metabase/lib/cron.ts
@@ -60,9 +60,7 @@ export function validateCronExpression(
 export function explainCronExpression(cronExpression: string) {
   return cronstrue.toString(cronExpression, {
     verbose: false,
-    locale:
-      MetabaseSettings.get("user-locale") ||
-      MetabaseSettings.get("site-locale"),
+    locale: MetabaseSettings.get("site-locale"),
     use24HourTimeFormat: has24HourModeSetting(),
   });
 }


### PR DESCRIPTION
`user-locale` doesn't exist anymore in settings.
You can easily verify that by greping the code base for `defsetting user-locale` or simply by observing the `GET /api/session/properties` response.