### PR TITLE
tweak default modal spacing

### DIFF
--- a/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx
@@ -29,6 +29,7 @@ export const getModalOverrides = (): MantineThemeOverride["components"] => ({
   ModalHeader: {
     defaultProps: {
       p: DEFAULT_MODAL_SPACING,
+      pb: "sm",
     },
   },
   ModalBody: {

--- a/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx
@@ -3,6 +3,7 @@ import { t } from "ttag";
 
 // See `zIndex` prop at https://v6.mantine.dev/core/modal/?t=props
 export const DEFAULT_MODAL_Z_INDEX = 200;
+const DEFAULT_MODAL_SPACING = "lg";
 
 export const getModalOverrides = (): MantineThemeOverride["components"] => ({
   Modal: {
@@ -23,6 +24,16 @@ export const getModalOverrides = (): MantineThemeOverride["components"] => ({
       shadow: "md",
       radius: "sm",
       withinPortal: true,
+    },
+  },
+  ModalHeader: {
+    defaultProps: {
+      p: DEFAULT_MODAL_SPACING,
+    },
+  },
+  ModalBody: {
+    defaultProps: {
+      p: DEFAULT_MODAL_SPACING,
     },
   },
   ModalCloseButton: {


### PR DESCRIPTION
Sets an updated default of "lg" for modal spacing.

Note something is wrong with fonts in storybook right now, so ignore that part and just concentrate on the spacing for the purposes of this PR

Old default:
![Screenshot 2024-03-07 at 12 27 57 PM](https://github.com/metabase/metabase/assets/5248953/44949da2-60e5-4b58-b54b-12effc30b8d6)

New default:
![Screenshot 2024-03-07 at 12 27 31 PM](https://github.com/metabase/metabase/assets/5248953/077b79b7-5f44-4bd3-adb1-e8a95b6819fa)
