### PR TITLE
Use hiccup syntax for value-type DAG

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -33,7 +33,7 @@
    [metabase.util.i18n :refer [tru]]
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
-   [metabase.util.ordered-hierarchy :as ordered-hierarchy :refer [derive make-hierarchy]]
+   [metabase.util.ordered-hierarchy :as ordered-hierarchy :refer [make-hierarchy]]
    [toucan2.core :as t2])
   (:import
    (java.io File)))
@@ -80,17 +80,14 @@
   "This hierarchy defines a relationship between value types and their specializations.
   We use an [[metabase.util.ordered-hierarchy]] for its topological sorting, which simplify writing efficient and
   consistent implementations for of our type inference, parsing, and relaxation."
-  (-> (make-hierarchy)
-      (derive ::boolean-or-int ::boolean)
-      (derive ::boolean-or-int ::int)
-      (derive ::auto-incrementing-int-pk ::int)
-      (derive ::int ::float)
-      (derive ::date ::datetime)
-      (derive ::boolean ::varchar-255)
-      (derive ::offset-datetime ::varchar-255)
-      (derive ::datetime ::varchar-255)
-      (derive ::float ::varchar-255)
-      (derive ::varchar-255 ::text)))
+  (-> (make-hierarchy
+       [::text
+        [::varchar-255
+         [::boolean ::boolean-or-int]
+         [::float
+          [::int ::boolean-or-int ::auto-incrementing-int-pk]]
+         [::datetime ::date]
+         [::offset-datetime]]])))
 
 (def ^:private abstract->concrete
   "Not all value types correspond to database types. For those that don't, this maps to their concrete ancestor."

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -80,14 +80,14 @@
   "This hierarchy defines a relationship between value types and their specializations.
   We use an [[metabase.util.ordered-hierarchy]] for its topological sorting, which simplify writing efficient and
   consistent implementations for of our type inference, parsing, and relaxation."
-  (-> (make-hierarchy
-       [::text
-        [::varchar-255
-         [::boolean ::boolean-or-int]
-         [::float
-          [::int ::boolean-or-int ::auto-incrementing-int-pk]]
-         [::datetime ::date]
-         [::offset-datetime]]])))
+  (make-hierarchy
+   [::text
+    [::varchar-255
+     [::boolean ::boolean-or-int]
+     [::float
+      [::int ::boolean-or-int ::auto-incrementing-int-pk]]
+     [::datetime ::date]
+     [::offset-datetime]]]))
 
 (def ^:private abstract->concrete
   "Not all value types correspond to database types. For those that don't, this maps to their concrete ancestor."

--- a/src/metabase/util/ordered_hierarchy.clj
+++ b/src/metabase/util/ordered_hierarchy.clj
@@ -5,14 +5,30 @@
    [flatland.ordered.set :refer [ordered-set]]
    [medley.core :as m]))
 
+(declare derive)
+
+(defn- derive-children
+  [h [parent & children]]
+  (reduce (fn [h child]
+            (if (keyword? child)
+              (derive h child parent)
+              (derive-children (derive h (first child) parent)
+                               child)))
+          h
+          children))
+
 (defn make-hierarchy
   "Similar to [[clojure.core/make-hierarchy]], but the returned hierarchy will supports ordered derivations.
 
+  Can take arguments to be treated as roots, defined using hiccup syntax. NOTE: we do not check that they are roots.
+
   !! WARNING !!
   Using [[clojure.core/derive]] with this will corrupt the ordering - you must use the implementation from this ns."
-  []
-  (-> (clojure.core/make-hierarchy)
-      (with-meta {::ordered? true})))
+  ([]
+   (-> (clojure.core/make-hierarchy)
+       (with-meta {::ordered? true})))
+  ([& roots]
+   (reduce derive-children (make-hierarchy) roots)))
 
 (defn ancestors
   "Returns the immediate and indirect parents of tag, as established via derive. Earlier derivations are shown first.

--- a/test/util/ordered_hierarchy_test.clj
+++ b/test/util/ordered_hierarchy_test.clj
@@ -84,3 +84,38 @@
     (is (= ::boolean-or-int (ordered-hierarchy/first-common-ancestor h ::boolean-or-int ::boolean-or-int)))
     (is (= ::boolean (ordered-hierarchy/first-common-ancestor h ::boolean-or-int ::boolean)))
     (is (= ::varchar-255 (ordered-hierarchy/first-common-ancestor h ::boolean ::int)))))
+
+
+
+(def ^:private polygons
+  (ordered-hierarchy/make-hierarchy
+   [:quadrilateral
+    [:trapezoid :isosceles-trapezoid :right-trapezoid]
+    [:kite [:rhombus :square]]
+    [:parallelogram
+     :rhombus
+     [:rectangle :square]]]
+   [:triangle
+    :scalene-triangle
+    [:isosceles-triangle :equilateral-triangle]
+    [:acute-triangle :equilateral-triangle]
+    :right-angled-triangle
+    :obtuse-triangle]))
+
+(deftest make-hierarchy-test
+  (testing "Hiccup structures are translated into the expected graph structure"
+    (is (= {:trapezoid             [:quadrilateral]
+            :isosceles-trapezoid   [:trapezoid]
+            :right-trapezoid       [:trapezoid]
+            :kite                  [:quadrilateral]
+            :rhombus               [:kite :parallelogram]
+            :square                [:rhombus :rectangle]
+            :parallelogram         [:quadrilateral]
+            :rectangle             [:parallelogram]
+            :scalene-triangle      [:triangle]
+            :isosceles-triangle    [:triangle]
+            :equilateral-triangle  [:isosceles-triangle :acute-triangle]
+            :acute-triangle        [:triangle]
+            :right-angled-triangle [:triangle]
+            :obtuse-triangle       [:triangle]}
+           (update-vals (:parents polygons) vec)))))

--- a/test/util/ordered_hierarchy_test.clj
+++ b/test/util/ordered_hierarchy_test.clj
@@ -85,8 +85,6 @@
     (is (= ::boolean (ordered-hierarchy/first-common-ancestor h ::boolean-or-int ::boolean)))
     (is (= ::varchar-255 (ordered-hierarchy/first-common-ancestor h ::boolean ::int)))))
 
-
-
 (def ^:private polygons
   (ordered-hierarchy/make-hierarchy
    [:quadrilateral
@@ -103,6 +101,28 @@
     :obtuse-triangle]))
 
 (deftest make-hierarchy-test
+  (testing "Hiccup structures have the expected topological order"
+    (is (= [:isosceles-trapezoid
+            :right-trapezoid
+            :trapezoid
+            :square
+            :rhombus
+            :kite
+            :rectangle
+            :parallelogram
+            :quadrilateral
+            ;; it's unfortunate that we would exhaustively test all the quadrilateral types, before checking
+            ;; if it's a triangle (if "hypothetically" we were using the topological order to test a value
+            ;; ... this is a case where a root-to-leaf traversal would make more sense.
+            :scalene-triangle
+            :equilateral-triangle
+            :isosceles-triangle
+            :acute-triangle
+            :right-angled-triangle
+            :obtuse-triangle
+            :triangle]
+           (ordered-hierarchy/sorted-tags polygons))))
+
   (testing "Hiccup structures are translated into the expected graph structure"
     (is (= {:trapezoid             [:quadrilateral]
             :isosceles-trapezoid   [:trapezoid]


### PR DESCRIPTION
### Description

Introduce some sugar - it's good for you.

This change switches from low-level `derive` calls to a data-driven hiccup expression. While these data structures are not trees, if we avoid listing the children of every node whenever it is repeated, it seems like we get something quite readable.[^1]

It's arguably easier to scan the structure this way, objectively, especially when it comes to noting the ordering of the child edges.

A limitation of this representation is that we are no longer able to order the edges from each child to their parents.

[^1]: Another option would be to repeat the children exactly each time, but this could add a lot of bloat. If we're not repeating however, perhaps it's worth adding some indication that that this is a repeated node, and not a leaf.