### PR TITLE
Using CSS transition and  component for QB header

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -15,7 +15,7 @@ export function mantinePopover() {
 const HOVERCARD_ELEMENT = ".emotion-HoverCard-dropdown[role='dialog']:visible";
 
 export function hovercard() {
-  cy.get(HOVERCARD_ELEMENT).should("be.visible");
+  cy.get(HOVERCARD_ELEMENT, { timeout: 6000 }).should("be.visible");
   return cy.get(HOVERCARD_ELEMENT);
 }
 

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -218,7 +218,7 @@ describe("scenarios > visualizations > table", () => {
       cy.get(".cellData").contains(column).realHover();
 
       // Add a delay here because there can be two popovers active for a very short time.
-      cy.wait(200);
+      cy.wait(50);
 
       hovercard().within(() => {
         test();
@@ -241,7 +241,7 @@ describe("scenarios > visualizations > table", () => {
 
     // Make sure new table results loaded with Custom column and Count columns
     cy.get(".cellData").contains(ccName).realHover();
-    cy.wait(200);
+    cy.wait(50);
 
     hovercard().within(() => {
       cy.contains("No special type");

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -218,7 +218,7 @@ describe("scenarios > visualizations > table", () => {
       cy.get(".cellData").contains(column).realHover();
 
       // Add a delay here because there can be two popovers active for a very short time.
-      cy.wait(50);
+      cy.wait(250);
 
       hovercard().within(() => {
         test();
@@ -241,7 +241,7 @@ describe("scenarios > visualizations > table", () => {
 
     // Make sure new table results loaded with Custom column and Count columns
     cy.get(".cellData").contains(ccName).realHover();
-    cy.wait(50);
+    cy.wait(250);
 
     hovercard().within(() => {
       cy.contains("No special type");

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -215,7 +215,7 @@ describe("scenarios > visualizations > table", () => {
         },
       ],
     ].forEach(([column, test]) => {
-      cy.get(".cellData").contains(column).realHover();
+      cy.get(".cellData").contains(column).trigger("mouseover");
 
       // Add a delay here because there can be two popovers active for a very short time.
       cy.wait(250);
@@ -224,7 +224,7 @@ describe("scenarios > visualizations > table", () => {
         test();
       });
 
-      cy.get(".cellData").contains(column).trigger("mouseleave");
+      cy.get(".cellData").contains(column).trigger("mouseout");
     });
 
     summarize();
@@ -233,14 +233,15 @@ describe("scenarios > visualizations > table", () => {
 
     cy.wait("@dataset");
 
-    cy.get(".cellData").contains("Count").realHover();
+    cy.get(".cellData").contains("Count").trigger("mouseover");
     hovercard().within(() => {
       cy.contains("Quantity");
       cy.findByText("No description");
     });
+    cy.get(".cellData").contains("Count").trigger("mouseout");
 
     // Make sure new table results loaded with Custom column and Count columns
-    cy.get(".cellData").contains(ccName).realHover();
+    cy.get(".cellData").contains(ccName).trigger("mouseover");
     cy.wait(250);
 
     hovercard().within(() => {
@@ -252,7 +253,7 @@ describe("scenarios > visualizations > table", () => {
   it("should show the field metadata popover for a foreign key field (metabase#19577)", () => {
     openOrdersTable({ limit: 2 });
 
-    cy.get(".cellData").contains("Product ID").realHover();
+    cy.get(".cellData").contains("Product ID").trigger("mouseover");
 
     hovercard().within(() => {
       cy.contains("Foreign Key");

--- a/frontend/src/metabase/query_builder/components/view/View.jsx
+++ b/frontend/src/metabase/query_builder/components/view/View.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/prop-types */
 import { Component } from "react";
-import { Motion, spring } from "react-motion";
 import { connect } from "react-redux";
 import { t } from "ttag";
 import _ from "underscore";
@@ -11,6 +10,7 @@ import Toaster from "metabase/components/Toaster";
 import { rememberLastUsedDatabase } from "metabase/query_builder/actions";
 import { SIDEBAR_SIZES } from "metabase/query_builder/constants";
 import { TimeseriesChrome } from "metabase/querying";
+import { Transition } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
 import DatasetEditor from "../DatasetEditor";
@@ -42,6 +42,12 @@ import ChartTypeSidebar from "./sidebars/ChartTypeSidebar";
 import { QuestionInfoSidebar } from "./sidebars/QuestionInfoSidebar";
 import { SummarizeSidebar } from "./sidebars/SummarizeSidebar";
 import TimelineSidebar from "./sidebars/TimelineSidebar";
+
+const fadeIn = {
+  in: { opacity: 1 },
+  out: { opacity: 0 },
+  transitionProperty: "opacity",
+};
 
 class View extends Component {
   getLeftSidebar = () => {
@@ -204,22 +210,19 @@ class View extends Component {
     const isNewQuestion = !isNative && Lib.sourceTableOrCardId(query) === null;
 
     return (
-      <Motion
-        defaultStyle={isNewQuestion ? { opacity: 0 } : { opacity: 1 }}
-        style={isNewQuestion ? { opacity: spring(0) } : { opacity: spring(1) }}
-      >
-        {({ opacity }) => (
-          <QueryBuilderViewHeaderContainer>
-            <BorderedViewTitleHeader {...this.props} style={{ opacity }} />
-            {opacity < 1 && (
-              <NewQuestionHeader
-                className="spread"
-                style={{ opacity: 1 - opacity }}
-              />
-            )}
-          </QueryBuilderViewHeaderContainer>
-        )}
-      </Motion>
+      <QueryBuilderViewHeaderContainer>
+        <BorderedViewTitleHeader
+          {...this.props}
+          style={{
+            transition: "opacity 300ms linear",
+            opacity: isNewQuestion ? 0 : 1,
+          }}
+        />
+        {/*This is used so that the New Question Header is unmounted after the animation*/}
+        <Transition mounted={isNewQuestion} transition={fadeIn} duration={300}>
+          {style => <NewQuestionHeader className="spread" style={style} />}
+        </Transition>
+      </QueryBuilderViewHeaderContainer>
     );
   };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39776

### Description
Small change to migrate QB header away from `react-motion`. Essentially before you have picked a data source, we show you one header, and when you've selected one we fade the current header out and a new header in. The transition component will actually take care of unmounting the `NewQuestionHeader` if it's been removed, or not mounting it at all if it was never needed.

### How to verify

1. New question -> Sample Dataset
2. Observe the header as you select a table. You should notice a transition

### Demo
![chrome_5UnlMKR4tw](https://github.com/metabase/metabase/assets/1328979/d1efb9ab-af97-46c0-8ac7-07b7285349d1)

### Checklist
This is purely presentation. there are existing tests that cover whether or not we show "Pick your starting data"
- [ ] ~Tests have been added/updated to cover changes in this PR~
