### PR TITLE
Fix janky db refreshing

### DIFF
--- a/frontend/src/metabase/browse/components/BrowseDatabases.tsx
+++ b/frontend/src/metabase/browse/components/BrowseDatabases.tsx
@@ -19,17 +19,17 @@ export const BrowseDatabases = ({
 }: {
   databasesResult: ReturnType<typeof useDatabaseListQuery>;
 }) => {
-  const { data: databases = [], error, isLoading } = databasesResult;
+  const { data: databases, error, isLoading } = databasesResult;
 
   if (error) {
     return <LoadingAndErrorWrapper error />;
   }
 
-  if (isLoading) {
+  if (!databases && isLoading) {
     return <LoadingAndErrorWrapper loading />;
   }
 
-  return databases.length ? (
+  return databases?.length ? (
     <DatabaseGrid data-testid="database-browser">
       {databases.map(database => (
         <div key={database.id}>


### PR DESCRIPTION
Closes #39732 

### Description

The problem is that when a new database is added, the tables are handled in a background process which updates the data available through `/api/database`. The Browse databases page pulls in data from that endpoint. But when the endpoint has fresh data to provide, the page goes into a loading state for a split second, causing the page to instantly scroll back up to the top, which is annoying.

This PR fixes the problem by showing the loading spinner only when there are no databases already loaded into the page.

[Loom](https://www.loom.com/share/2afbc170b42a414e8b78d5fbbd6904a3?sid=6180d129-61ce-490e-a88e-0daf69eb7224)
