### PR TITLE
Remove deprecated and unused `searchTypeaheadEnabled` method

### DIFF
--- a/frontend/src/metabase/lib/settings.ts
+++ b/frontend/src/metabase/lib/settings.ts
@@ -207,13 +207,6 @@ class MetabaseSettings {
   }
 
   /**
-   * @deprecated use getSetting(state, "search-typeahead-enabled")
-   */
-  searchTypeaheadEnabled() {
-    return this.get("search-typeahead-enabled");
-  }
-
-  /**
    * @deprecated use getSetting(state, "anon-tracking-enabled")
    */
   trackingEnabled() {


### PR DESCRIPTION
This PR removes a deprecated and unused `searchTypeaheadEnabled` method from the `MetabaseSettings` prototype.

### How to verify?
- All tests should still pass.
- Search for `search-typeahead-enabled` in all files. You should never see `MetabaseSettings.get("search-typeahead-enabled")` or `MetabaseSettings.searchTypeaheadEnabled()`

This setting is fetched properly (using a hook) in https://github.com/metabase/metabase/blob/master/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.tsx