### PR TITLE
fix combined cards drills

### DIFF
--- a/frontend/src/metabase-lib/types.ts
+++ b/frontend/src/metabase-lib/types.ts
@@ -1,4 +1,5 @@
 import type {
+  CardId,
   DatasetColumn,
   FieldId,
   FieldValuesType,
@@ -240,26 +241,27 @@ export type FilterOperatorName =
   | ExcludeDateFilterOperatorName
   | CoordinateFilterOperatorName;
 
-export type StringFilterOperatorName = typeof STRING_FILTER_OPERATORS[number];
+export type StringFilterOperatorName = (typeof STRING_FILTER_OPERATORS)[number];
 
-export type NumberFilterOperatorName = typeof NUMBER_FILTER_OPERATORS[number];
+export type NumberFilterOperatorName = (typeof NUMBER_FILTER_OPERATORS)[number];
 
 export type CoordinateFilterOperatorName =
-  typeof COORDINATE_FILTER_OPERATORS[number];
+  (typeof COORDINATE_FILTER_OPERATORS)[number];
 
-export type BooleanFilterOperatorName = typeof BOOLEAN_FILTER_OPERATORS[number];
+export type BooleanFilterOperatorName =
+  (typeof BOOLEAN_FILTER_OPERATORS)[number];
 
 export type SpecificDateFilterOperatorName =
-  typeof SPECIFIC_DATE_FILTER_OPERATORS[number];
+  (typeof SPECIFIC_DATE_FILTER_OPERATORS)[number];
 
 export type ExcludeDateFilterOperatorName =
-  typeof EXCLUDE_DATE_FILTER_OPERATORS[number];
+  (typeof EXCLUDE_DATE_FILTER_OPERATORS)[number];
 
-export type TimeFilterOperatorName = typeof TIME_FILTER_OPERATORS[number];
+export type TimeFilterOperatorName = (typeof TIME_FILTER_OPERATORS)[number];
 
-export type RelativeDateBucketName = typeof RELATIVE_DATE_BUCKETS[number];
+export type RelativeDateBucketName = (typeof RELATIVE_DATE_BUCKETS)[number];
 
-export type ExcludeDateBucketName = typeof EXCLUDE_DATE_BUCKETS[number];
+export type ExcludeDateBucketName = (typeof EXCLUDE_DATE_BUCKETS)[number];
 
 export type FilterOperatorDisplayInfo = {
   shortName: FilterOperatorName;
@@ -491,6 +493,7 @@ export interface ClickObject {
   event?: MouseEvent;
   element?: Element;
   seriesIndex?: number;
+  cardId?: CardId;
   settings?: Record<string, unknown>;
   origin?: {
     row: RowValue;

--- a/frontend/src/metabase/visualizations/components/ChartCaption.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.tsx
@@ -36,7 +36,6 @@ const ChartCaption = ({
   const handleSelectTitle = useCallback(() => {
     onChangeCardAndRun({
       nextCard: card,
-      seriesIndex: 0,
     });
   }, [card, onChangeCardAndRun]);
 

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/KeyValuePairChartTooltip/KeyValuePairChartTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/KeyValuePairChartTooltip/KeyValuePairChartTooltip.tsx
@@ -8,6 +8,7 @@ import type {
   HoveredObject,
   RemappingHydratedDatasetColumn,
 } from "metabase/visualizations/types";
+import type { DatasetColumn } from "metabase-types/api";
 import { formatValueForTooltip } from "../utils";
 import { TooltipTableCell } from "./KeyValuePairChartTooltip.styled";
 
@@ -42,7 +43,7 @@ const KeyValuePairChartTooltip = ({
 export interface TooltipRowProps {
   name?: string;
   value?: any;
-  column?: RemappingHydratedDatasetColumn;
+  column: RemappingHydratedDatasetColumn | DatasetColumn | null;
   settings: ComputedVisualizationSettings;
 }
 

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/utils.ts
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/utils.ts
@@ -1,3 +1,4 @@
+import type { DatasetColumn } from "metabase-types/api";
 import { formatValue } from "metabase/lib/formatting";
 import type {
   ComputedVisualizationSettings,
@@ -10,7 +11,7 @@ export const formatValueForTooltip = ({
   settings,
 }: {
   value?: unknown;
-  column?: RemappingHydratedDatasetColumn;
+  column?: RemappingHydratedDatasetColumn | DatasetColumn | null;
   settings?: ComputedVisualizationSettings;
 }) =>
   formatValue(value, {

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -233,10 +233,13 @@ class Visualization extends PureComponent {
       metadata,
       isRawTable,
       getExtraDataForClick = () => ({}),
+      rawSeries,
     } = this.props;
 
-    const seriesIndex = clicked.seriesIndex || 0;
-    const card = this.state.series[seriesIndex].card;
+    const card =
+      rawSeries.find(series => series.card.id === clicked.cardId)?.card ??
+      rawSeries[0].card;
+
     const question = this._getQuestionForCardCached(metadata, card);
     const mode = this.getMode(this.props.mode, question);
 
@@ -304,11 +307,12 @@ class Visualization extends PureComponent {
   };
 
   // Add the underlying card of current series to onChangeCardAndRun if available
-  handleOnChangeCardAndRun = ({ nextCard, seriesIndex, objectId }) => {
-    const { series, clicked } = this.state;
+  handleOnChangeCardAndRun = ({ nextCard, objectId }) => {
+    const { rawSeries } = this.props;
 
-    const index = seriesIndex || (clicked && clicked.seriesIndex) || 0;
-    const previousCard = series && series[index] && series[index].card;
+    const previousCard =
+      rawSeries.find(series => series.card.id === nextCard?.id)?.card ??
+      rawSeries[0].card;
 
     this.props.onChangeCardAndRun({ nextCard, previousCard, objectId });
   };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -58,6 +58,7 @@ export const getCardsSeriesModels = (
       cardDataset,
       cardColumns,
       hasMultipleCards,
+      index === 0,
       settings,
       renderingContext,
     );

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/series.ts
@@ -27,12 +27,17 @@ import { NULL_DISPLAY_VALUE } from "metabase/lib/constants";
 export const getSeriesVizSettingsKey = (
   column: DatasetColumn,
   hasMultipleCards: boolean,
+  isFirstCard: boolean,
   metricsCount: number,
   breakoutName: string | null,
   cardName?: string,
 ): VizSettingsKey => {
   const isBreakoutSeries = breakoutName != null;
   const isSingleMetricCard = metricsCount === 1 && !isBreakoutSeries;
+
+  if (isFirstCard && !isBreakoutSeries) {
+    return column.name;
+  }
 
   // When multiple cards are combined and one of them is a single metric card without a breakout,
   // the default series name is the card name.
@@ -100,6 +105,7 @@ export const getCardSeriesModels = (
   { card, data }: SingleSeries,
   columns: CartesianChartColumns,
   hasMultipleCards: boolean,
+  isFirstCard: boolean,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
 ): SeriesModel[] => {
@@ -114,6 +120,7 @@ export const getCardSeriesModels = (
       const vizSettingsKey = getSeriesVizSettingsKey(
         metric.column,
         hasMultipleCards,
+        isFirstCard,
         columns.metrics.length,
         null,
         card.name,
@@ -167,6 +174,7 @@ export const getCardSeriesModels = (
     const vizSettingsKey = getSeriesVizSettingsKey(
       metric.column,
       hasMultipleCards,
+      isFirstCard,
       1,
       formattedBreakoutValue,
       card.name,

--- a/frontend/src/metabase/visualizations/types/hover.ts
+++ b/frontend/src/metabase/visualizations/types/hover.ts
@@ -1,11 +1,10 @@
 import type { TimelineEvent } from "metabase-types/api";
+import type { ClickObjectDataRow } from "metabase-lib";
 import type { RemappingHydratedDatasetColumn } from "./columns";
 import type { ComputedVisualizationSettings } from "./visualization";
 
-export interface DataPoint {
+export interface DataPoint extends ClickObjectDataRow {
   key: string;
-  col?: RemappingHydratedDatasetColumn;
-  value?: unknown;
 }
 
 export interface HoveredDimension {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -14,7 +14,7 @@ import type {
 } from "metabase-types/api";
 import { isNotNull } from "metabase/lib/types";
 import { getObjectKeys } from "metabase/lib/objects";
-import type { ClickObjectDimension } from "metabase-lib";
+import type { ClickObject, ClickObjectDimension } from "metabase-lib";
 import type {
   ComputedVisualizationSettings,
   DataPoint,
@@ -314,7 +314,7 @@ export const getSeriesClickData = (
   chartModel: BaseCartesianChartModel,
   settings: ComputedVisualizationSettings,
   event: EChartsSeriesMouseEvent,
-) => {
+): ClickObject | undefined => {
   const { seriesId, dataIndex } = event;
   const seriesIndex = findSeriesModelIndexById(chartModel, seriesId);
   const seriesModel = chartModel.seriesModels[seriesIndex];
@@ -334,6 +334,7 @@ export const getSeriesClickData = (
   );
 
   return {
+    cardId: seriesModel.cardId,
     event: event.event.event,
     value: datum[seriesModel.dataKey],
     column: seriesModel.column,

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/funnel-bar-transform.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/funnel-bar-transform.ts
@@ -28,6 +28,7 @@ export const funnelToBarTransform: TransformSeries = (
         }),
         display: "bar",
         visualization_settings: {
+          "card.title": card.name,
           "graph.tooltip_type": "default",
           "stackable.stack_type": "stacked" as const,
           "graph.dimensions": [settings["funnel.dimension"]],

--- a/frontend/src/metabase/visualizations/visualizations/Funnel/funnel-bar-transform.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Funnel/funnel-bar-transform.ts
@@ -19,26 +19,33 @@ export const funnelToBarTransform: TransformSeries = (
   );
 
   return rows.map((row, index) => {
+    const name = renderingContext.formatValue(row[dimensionIndex], {
+      column: cols[dimensionIndex],
+    });
     return {
       card: {
         ...card,
         id: index,
-        name: renderingContext.formatValue(row[dimensionIndex], {
-          column: cols[dimensionIndex],
-        }),
+        name,
         display: "bar",
         visualization_settings: {
           "card.title": card.name,
           "graph.tooltip_type": "default",
           "stackable.stack_type": "stacked" as const,
           "graph.dimensions": [settings["funnel.dimension"]],
-          "graph.metrics": [settings["funnel.metric"]],
+          "graph.metrics": [name],
           "graph.y_axis.auto_split": false,
         },
       },
       data: {
         rows: [[row[dimensionIndex], row[metricIndex]]],
-        cols: [cols[dimensionIndex], cols[metricIndex]],
+        cols: [
+          cols[dimensionIndex],
+          {
+            ...cols[metricIndex],
+            name,
+          },
+        ],
         rows_truncated: 0,
         results_metadata: { columns: [] },
       },

--- a/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/RowChart.tsx
@@ -191,7 +191,6 @@ const RowChartVisualization = ({
     if (onChangeCardAndRun) {
       onChangeCardAndRun({
         nextCard: card,
-        seriesIndex: 0,
       });
     }
   };

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/scalars-bar-transform.ts
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/scalars-bar-transform.ts
@@ -21,7 +21,7 @@ export const scalarToBarTransform: TransformSeries = rawSeries => {
           name: "name",
           source: "query-transform",
         },
-        { ...data.cols[metricColumnIndex] },
+        { ...data.cols[metricColumnIndex], name: card.name },
       ],
       rows: [[card.name, data.rows[0][metricColumnIndex]]],
     };
@@ -34,7 +34,7 @@ export const scalarToBarTransform: TransformSeries = rawSeries => {
         "graph.x_axis.labels_enabled": false,
         "stackable.stack_type": "stacked",
         "graph.dimensions": [transformedDataset.cols[0].name],
-        "graph.metrics": [transformedDataset.cols[1].name],
+        "graph.metrics": [card.name],
       },
     };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39742
Closes https://github.com/metabase/metabase/issues/39610

### Description

Fixes combined cards drills on the combo chart. The root cause of missing series on combined cards is wrong viz settings key computation. There is a special case for the first card without a breakout: the series key is the raw column name without the card name prefix.

### How to verify

Combine the following variants on a dashcard, the order of combining matters:
1) Multiple metrics card + Breakout card
2) Breakout card + Multiple metrics card

- Ensure all series rendered in the first place
- Ensure drills open the right card and apply correct filter

### Demo

Before
<img width="845" alt="Screenshot 2024-03-08 at 9 35 30 PM" src="https://github.com/metabase/metabase/assets/14301985/58417622-0f07-4a19-acb8-53a275cabfda">

After
<img width="853" alt="Screenshot 2024-03-08 at 9 35 02 PM" src="https://github.com/metabase/metabase/assets/14301985/c6490759-e6b6-4c6d-a876-1c1e1eddad49">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
