### PR TITLE
Publish audit logs for CSV uploads

### DIFF
--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -215,9 +215,5 @@
 (derive :event/upload-append ::upload-event)
 
 (methodical/defmethod events/publish-event! ::upload-event
-  [topic {:keys [user-id model-id] :as event}]
-  (audit-log/record-event! topic
-                           {:user-id user-id
-                            :model-id model-id
-                            :model :model/Card
-                            :details (dissoc event :user-id :model-id)}))
+  [topic event]
+  (audit-log/record-event! topic event))

--- a/src/metabase/events/audit_log.clj
+++ b/src/metabase/events/audit_log.clj
@@ -209,3 +209,15 @@
 (methodical/defmethod events/publish-event! ::api-key-event
   [topic event]
   (audit-log/record-event! topic event))
+
+(derive ::upload-event ::event)
+(derive :event/upload-create ::upload-event)
+(derive :event/upload-append ::upload-event)
+
+(methodical/defmethod events/publish-event! ::upload-event
+  [topic {:keys [user-id model-id] :as event}]
+  (audit-log/record-event! topic
+                           {:user-id user-id
+                            :model-id model-id
+                            :model :model/Card
+                            :details (dissoc event :user-id :model-id)}))

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -129,6 +129,34 @@
                                         [:user-id [:maybe pos-int?]]
                                         [:model [:or :keyword :string]]])}))
 
+;; upload events
+
+(def ^:private upload-schema
+  (mc/schema [:map {:closed true}
+              ;; TODO WIP
+              [:db-id       integer?]
+              [:schema-name string?]
+              [:table-name  string?]
+              [:stats [:map {:closed true}
+                       [:num-rows          nat-int?]
+                       [:num-columns       nat-int?]
+                       [:generated-columns nat-int?]
+                       [:size-mb           float?]]]
+              ;; generic parameters
+              [:user-id  pos-int?]
+              [:model-id pos-int?]
+              ]))
+
+(comment
+ (def upload-event {:db-id 1, :schema-name "PUBLIC", :table-name "test_20240306225715", :stats {:num-rows 3, :num-columns 2, :generated-columns 1, :size-mb 2.384185791015625E-5}})
+ (mc/validate upload-schema upload-event))
+
+(let [default-schema upload-schema]
+  (def ^:private upload-events
+    {:event/upload-create default-schema
+     :event/upload-append default-schema}))
+
+
 (def topic->schema
   "Returns the schema for an event topic."
   (merge dashboard-events-schemas
@@ -140,4 +168,5 @@
          alert-schema
          pulse-schemas
          table-events
-         permission-failure-events))
+         permission-failure-events
+         upload-events))

--- a/src/metabase/events/schema.clj
+++ b/src/metabase/events/schema.clj
@@ -129,34 +129,6 @@
                                         [:user-id [:maybe pos-int?]]
                                         [:model [:or :keyword :string]]])}))
 
-;; upload events
-
-(def ^:private upload-schema
-  (mc/schema [:map {:closed true}
-              ;; TODO WIP
-              [:db-id       integer?]
-              [:schema-name string?]
-              [:table-name  string?]
-              [:stats [:map {:closed true}
-                       [:num-rows          nat-int?]
-                       [:num-columns       nat-int?]
-                       [:generated-columns nat-int?]
-                       [:size-mb           float?]]]
-              ;; generic parameters
-              [:user-id  pos-int?]
-              [:model-id pos-int?]
-              ]))
-
-(comment
- (def upload-event {:db-id 1, :schema-name "PUBLIC", :table-name "test_20240306225715", :stats {:num-rows 3, :num-columns 2, :generated-columns 1, :size-mb 2.384185791015625E-5}})
- (mc/validate upload-schema upload-event))
-
-(let [default-schema upload-schema]
-  (def ^:private upload-events
-    {:event/upload-create default-schema
-     :event/upload-append default-schema}))
-
-
 (def topic->schema
   "Returns the schema for an event topic."
   (merge dashboard-events-schemas
@@ -168,5 +140,4 @@
          alert-schema
          pulse-schemas
          table-events
-         permission-failure-events
-         upload-events))
+         permission-failure-events))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -692,8 +692,9 @@
                                          :table-name  (:name table)
                                          :stats       {:num-rows          row-count
                                                        :num-columns       (count new-column-types)
-                                                       :generated-columns (- (count new-column-types)
-                                                                             (count old-column-types))
+                                                       :generated-columns (+ (- (count new-column-types)
+                                                                                (count old-column-types))
+                                                                             (if create-auto-pk? 1 0))
                                                        :size-mb           (file-size-mb file)
                                                        :upload-seconds    (check-timer-ms timer)}}})
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -692,9 +692,7 @@
                                          :table-name  (:name table)
                                          :stats       {:num-rows          row-count
                                                        :num-columns       (count new-column-types)
-                                                       :generated-columns (+ (- (count new-column-types)
-                                                                                (count old-column-types))
-                                                                             (if create-auto-pk? 1 0))
+                                                       :generated-columns (if create-auto-pk? 1 0)
                                                        :size-mb           (file-size-mb file)
                                                        :upload-seconds    (since-ms timer)}}})
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -13,6 +13,7 @@
    [metabase.driver :as driver]
    [metabase.driver.sync :as driver.s]
    [metabase.driver.util :as driver.u]
+   [metabase.events :as events]
    [metabase.lib.core :as lib]
    [metabase.mbql.util :as mbql.u]
    [metabase.models :refer [Database]]
@@ -531,6 +532,16 @@
                                @api/*current-user*)
             upload-seconds    (/ (- (System/currentTimeMillis) start-time)
                                  1000.0)]
+
+        (events/publish-event! :event/upload-create
+                               {:user-id (:id @api/*current-user*)
+                                :model-id (:id card)
+                                ;; details
+                                :db-id db-id
+                                :schema-name schema-name
+                                :table-name table-name
+                                :stats stats})
+
         (snowplow/track-event! ::snowplow/csv-upload-successful
                                api/*current-user-id*
                                (merge

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -466,7 +466,7 @@
 
 (defn- start-timer [] (System/nanoTime))
 
-(defn- check-timer-ms [timer] (/ (- (System/nanoTime) timer) 1e6))
+(defn- since-ms [timer] (/ (- (System/nanoTime) timer) 1e6))
 
 ;;; +-----------------------------------------
 ;;; |  public interface for creating CSV table
@@ -536,7 +536,7 @@
                                 :name                   (humanization/name->human-readable-name filename-prefix)
                                 :visualization_settings {}}
                                @api/*current-user*)
-            upload-seconds    (/ (check-timer-ms timer) 1e3)
+            upload-seconds    (/ (since-ms timer) 1e3)
             stats             (assoc stats :upload-seconds upload-seconds)]
 
         (events/publish-event! :event/upload-create
@@ -696,7 +696,7 @@
                                                                                 (count old-column-types))
                                                                              (if create-auto-pk? 1 0))
                                                        :size-mb           (file-size-mb file)
-                                                       :upload-seconds    (check-timer-ms timer)}}})
+                                                       :upload-seconds    (since-ms timer)}}})
 
       {:row-count row-count})))
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -534,13 +534,12 @@
                                  1000.0)]
 
         (events/publish-event! :event/upload-create
-                               {:user-id (:id @api/*current-user*)
+                               {:user-id  (:id @api/*current-user*)
                                 :model-id (:id card)
-                                ;; details
-                                :db-id db-id
-                                :schema-name schema-name
-                                :table-name table-name
-                                :stats stats})
+                                :details  {:db-id       db-id
+                                           :schema-name schema-name
+                                           :table-name  table-name
+                                           :stats       stats}})
 
         (snowplow/track-event! ::snowplow/csv-upload-successful
                                api/*current-user-id*
@@ -661,7 +660,6 @@
       (try
         (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)
         (catch Throwable e
-
           (throw (ex-info (ex-message e) {:status-code 422}))))
       (when create-auto-pk?
         (driver/add-columns! driver


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39818

### Description

This adds new audit log events for when we create and append to upload tables.

It publishes a similar payload to our snowplow events.
