### PR TITLE
Clean up type inference interface

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -230,8 +230,7 @@
 
 (defn- relax-types [settings current-types rows]
   (let [type->check (settings->type->check settings)]
-    (->> (reduce (type-relaxer type->check) current-types rows)
-         (map column-type))))
+    (reduce (type-relaxer type->check) current-types rows)))
 
 (defn- normalize-column-name
   [raw-name]
@@ -253,9 +252,9 @@
                  (t2/select :model/Field :table_id table-id :active true))))
 
 (mu/defn column-types-from-rows :- [:sequential (into [:enum] column-types)]
-  "Returns a sequence of types, given the unparsed rows in the CSV file"
-  [settings column-count rows]
-  (relax-types settings (repeat column-count nil) rows))
+  "Given the types of the existing columns (if there are any), and rows to be added, infer the best supporting types."
+  [settings existing-current-types rows]
+  (map column-type (relax-types settings existing-current-types rows)))
 
 (defn- detect-schema
   "Consumes the header and rows from a CSV file.
@@ -271,7 +270,8 @@
   (let [normalized-header   (map normalize-column-name header)
         unique-header       (map keyword (mbql.u/uniquify-names normalized-header))
         column-count        (count normalized-header)
-        col-name+type-pairs (->> (column-types-from-rows settings column-count rows)
+        initial-types       (repeat column-count nil)
+        col-name+type-pairs (->> (column-types-from-rows settings initial-types rows)
                                  (map vector unique-header))]
     {:extant-columns    (ordered-map/ordered-map col-name+type-pairs)
      :generated-columns (ordered-map/ordered-map auto-pk-column-keyword ::auto-incrementing-int-pk)}))
@@ -636,14 +636,14 @@
           ;; in the happy, and most common, case all the values will match the existing types
           ;; for now we just plan for the worst and perform a fairly expensive operation to detect any type changes
           ;; we can come back and optimize this to an optimistic-with-fallback approach later.
-          relaxed-types      (relax-types settings old-column-types rows)
-          new-column-types   (map #(if (matching-or-upgradable? %1 %2) %2 %1) old-column-types relaxed-types)
+          detected-types     (column-types-from-rows settings old-column-types rows)
+          new-column-types   (map #(if (matching-or-upgradable? %1 %2) %2 %1) old-column-types detected-types)
           _                  (when (and (not= old-column-types new-column-types)
                                         ;; if we cannot coerce all the columns, don't bother coercing any of them
                                         ;; we will instead throw an error when we try to parse as the old type
-                                        (= relaxed-types new-column-types))
+                                        (= detected-types new-column-types))
                                (let [fields (map normed-name->field normed-header)]
-                                 (->> (changed-field->new-type fields old-column-types relaxed-types)
+                                 (->> (changed-field->new-type fields old-column-types detected-types)
                                       (alter-columns! driver database table))))
           ;; this will fail if any of our required relaxations were rejected.
           parsed-rows        (parse-rows settings new-column-types rows)]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -231,7 +231,7 @@
           type->check (#'upload/settings->type->check settings)
           value-type  (#'upload/value->type type->check string-value)
           ;; get the type of the column, if it were filled with only that value
-          col-type    (first (upload/column-types-from-rows settings 1 [[string-value]]))
+          col-type    (first (upload/column-types-from-rows settings nil [[string-value]]))
           parser      (upload-parsing/upload-type->parser col-type settings)]
       (testing (format "\"%s\" is a %s" string-value type)
         (is (= expected-type


### PR DESCRIPTION
### Description

This is a small tweak to address [this comment](https://github.com/metabase/metabase/pull/39741#discussion_r1516151874).

We reorganise some helper methods, rename things, and ensure that both the Create and Append paths use a typed interface.
