### PR TITLE
Fix - Description for calculated columns in model metadata editing page is incorrectly populated with description from other columns

### DIFF
--- a/e2e/test/scenarios/models/reproductions/25884-34349-null-description-in-column-metadata.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions/25884-34349-null-description-in-column-metadata.cy.spec.ts
@@ -3,13 +3,16 @@ import { openQuestionActions, popover, restore } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
-describe("issue 34349", () => {
+const ID_DESCRIPTION =
+  "This is a unique ID for the product. It is also called the “Invoice number” or “Confirmation number” in customer facing emails and screens.";
+
+describe("issues 25884 and 34349", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
   });
 
-  it("should show empty description input for columns without description in metadata (metabase#34349)", () => {
+  it("should show empty description input for columns without description in metadata (metabase#25884, metabase#34349)", () => {
     cy.createQuestion(
       {
         type: "model",
@@ -30,11 +33,13 @@ describe("issue 34349", () => {
 
     openQuestionActions();
     popover().findByText("Edit metadata").click();
-    cy.findByLabelText("Description").should(
-      "have.text",
-      "This is a unique ID for the product. It is also called the “Invoice number” or “Confirmation number” in customer facing emails and screens.",
-    );
+
+    cy.findByLabelText("Description").should("have.text", ID_DESCRIPTION);
+
     cy.findAllByTestId("header-cell").contains("Country").click();
     cy.findByLabelText("Description").should("have.text", "");
+
+    cy.findAllByTestId("header-cell").contains("ID").click();
+    cy.findByLabelText("Description").should("have.text", ID_DESCRIPTION);
   });
 });

--- a/e2e/test/scenarios/models/reproductions/34349-null-description-in-column-metadata.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions/34349-null-description-in-column-metadata.cy.spec.ts
@@ -1,0 +1,40 @@
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import { openQuestionActions, popover, restore } from "e2e/support/helpers";
+
+const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
+
+describe("issue 34349", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should show empty description input for columns without description in metadata (metabase#34349)", () => {
+    cy.createQuestion(
+      {
+        type: "model",
+        query: {
+          "source-table": ORDERS_ID,
+          expressions: {
+            Country: ["substring", "United States", 1, 20],
+          },
+          fields: [
+            ["field", ORDERS.ID, { "base-type": "type/BigInteger" }],
+            ["expression", "Country", { "base-type": "type/Text" }],
+          ],
+          limit: 5, // optimization
+        },
+      },
+      { visitQuestion: true },
+    );
+
+    openQuestionActions();
+    popover().findByText("Edit metadata").click();
+    cy.findByLabelText("Description").should(
+      "have.text",
+      "This is a unique ID for the product. It is also called the “Invoice number” or “Confirmation number” in customer facing emails and screens.",
+    );
+    cy.findAllByTestId("header-cell").contains("Country").click();
+    cy.findByLabelText("Description").should("have.text", "");
+  });
+});

--- a/frontend/src/metabase/components/form/widgets/FormTextAreaWidget/FormTextAreaWidget.jsx
+++ b/frontend/src/metabase/components/form/widgets/FormTextAreaWidget/FormTextAreaWidget.jsx
@@ -23,6 +23,7 @@ const FormTextAreaWidget = ({
       aria-labelledby={`${field.name}-label`}
       tabIndex={tabIndex}
       {...formDomOnlyProps(field)}
+      value={field.value || ""}
     />
     {helperText && (
       <HelpText

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -246,7 +246,6 @@ export const setup = async ({
     setupModelIndexEndpoints(card.id, []);
   }
 
-  // this workaround can be removed when metabase#34523 is fixed
   if (card === null) {
     fetchMock.get("path:/api/model-index", [createMockModelIndex()]);
   }


### PR DESCRIPTION
Fixes #34349
Fixes #25884

Stress test: https://github.com/metabase/metabase/actions/runs/8204344171
