### PR TITLE
Remove info icon on table

### DIFF
--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -16,7 +16,6 @@ import {
   appBar,
   queryBuilderHeader,
   openNotebook,
-  hovercard,
 } from "e2e/support/helpers";
 
 describe("scenarios > question > saved", () => {
@@ -203,14 +202,6 @@ describe("scenarios > question > saved", () => {
     cy.findByText(/reverted to an earlier version/i);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/This is a question/i).should("not.exist");
-  });
-
-  it("should show table name in header with a table info popover on hover", () => {
-    visitQuestion(ORDERS_QUESTION_ID);
-    cy.findByTestId("question-table-badges").within(() => {
-      cy.findByLabelText("More info").realHover();
-    });
-    hovercard().contains("9 columns");
   });
 
   it("should show collection breadcrumbs for a saved question in the root collection", () => {

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon.unit.spec.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon.unit.spec.tsx
@@ -8,18 +8,22 @@ import { TableInfoIcon } from "./TableInfoIcon";
 
 type SetupOpts = {
   table: Table;
+  showIfEmpty?: boolean;
 };
 
-function setup({ table }: SetupOpts) {
+function setup({ table, showIfEmpty }: SetupOpts) {
   const state = createMockState({
     entities: createMockEntitiesState({
       tables: [table],
     }),
   });
 
-  return renderWithProviders(<TableInfoIcon table={table} />, {
-    storeInitialState: state,
-  });
+  return renderWithProviders(
+    <TableInfoIcon table={table} showIfEmpty={showIfEmpty} />,
+    {
+      storeInitialState: state,
+    },
+  );
 }
 
 describe("TableInfoIcon", () => {
@@ -36,5 +40,17 @@ describe("TableInfoIcon", () => {
     fireEvent.mouseEnter(icon);
 
     expect(screen.getByText(description, { exact: false })).toBeInTheDocument();
+  });
+
+  it("should not show the icon if there is no description", async () => {
+    const table = createMockTable({ description: undefined });
+    setup({ table });
+    expect(screen.queryByLabelText("More info")).not.toBeInTheDocument();
+  });
+
+  it("should show the icon if there is no description, but showIfEmpty is set", async () => {
+    const table = createMockTable({ description: undefined });
+    setup({ table, showIfEmpty: true });
+    expect(screen.getByLabelText("More info")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -7,6 +7,7 @@ import TableInfo from "../TableInfo";
 
 export type TableInfoPopoverProps = Omit<PopoverProps, "content"> &
   Omit<TableInfoProps, "tableId"> & {
+    hideIfEmpty?: boolean;
     table: {
       id: string | number;
       description?: string | null;
@@ -19,11 +20,16 @@ export function TableInfoPopover({
   disabled,
   position,
   table,
+  hideIfEmpty,
   ...rest
 }: TableInfoPopoverProps) {
   const shouldHavePopover = table.description && !isVirtualCardId(table.id);
 
   if (!shouldHavePopover) {
+    if (hideIfEmpty) {
+      return null;
+    }
+
     return <>{children}</>;
   }
 

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoPopover/TableInfoPopover.tsx
@@ -7,7 +7,7 @@ import TableInfo from "../TableInfo";
 
 export type TableInfoPopoverProps = Omit<PopoverProps, "content"> &
   Omit<TableInfoProps, "tableId"> & {
-    hideIfEmpty?: boolean;
+    showIfEmpty?: boolean;
     table: {
       id: string | number;
       description?: string | null;
@@ -20,17 +20,16 @@ export function TableInfoPopover({
   disabled,
   position,
   table,
-  hideIfEmpty,
+  showIfEmpty = false,
   ...rest
 }: TableInfoPopoverProps) {
   const shouldHavePopover = table.description && !isVirtualCardId(table.id);
 
   if (!shouldHavePopover) {
-    if (hideIfEmpty) {
-      return null;
+    if (showIfEmpty) {
+      return <>{children}</>;
     }
-
-    return <>{children}</>;
+    return null;
   }
 
   return (

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -104,7 +104,7 @@ const DataSelectorTablePicker = ({
       table ? <Icon name="table" /> : null;
 
     const renderItemExtra = ({ table }: { table: Table }) =>
-      table && <TableInfoIcon table={table} position="right" />;
+      table && <TableInfoIcon table={table} position="right" showIfEmpty />;
 
     const renderItemWrapper = (content: ReactNode) => (
       <HoverParent>{content}</HoverParent>

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
@@ -260,7 +260,7 @@ function QuestionTableBadges({ tables, subHead, hasLink, isLast }) {
     >
       <span>
         {table.displayName()}
-        <TableInfoIcon table={table} alwaysVisible />
+        <TableInfoIcon table={table} hideIfEmpty />
       </span>
     </HeadBreadcrumbs.Badge>
   ));

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
@@ -260,7 +260,7 @@ function QuestionTableBadges({ tables, subHead, hasLink, isLast }) {
     >
       <span>
         {table.displayName()}
-        <TableInfoIcon table={table} hideIfEmpty />
+        {!subHead && <TableInfoIcon table={table} hideIfEmpty />}
       </span>
     </HeadBreadcrumbs.Badge>
   ));

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.jsx
@@ -260,7 +260,7 @@ function QuestionTableBadges({ tables, subHead, hasLink, isLast }) {
     >
       <span>
         {table.displayName()}
-        {!subHead && <TableInfoIcon table={table} hideIfEmpty />}
+        {!subHead && <TableInfoIcon table={table} />}
       </span>
     </HeadBreadcrumbs.Badge>
   ));

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionDataSource/QuestionDataSource.unit.spec.js
@@ -561,4 +561,14 @@ describe("QuestionDataSource", () => {
       });
     });
   });
+
+  it("should show info icon on an ad-hoc question header", () => {
+    setup({ card: SOURCE_CARD });
+    expect(screen.getByLabelText("More info")).toBeInTheDocument();
+  });
+
+  it("should show info icon on a subheader", () => {
+    setup({ card: SOURCE_CARD, subHead: true });
+    expect(screen.queryByLabelText("More info")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
### Description

Incorporate @mazameli's feedback for the info icon on the table header

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Browse data -> Orders
2. Make sure there is an info icon in the header
3. Save the question
4. Open the saved question and hover the header
5. Make sure the `Orders` link in the subheader does not have the info icon


- [x] Tests have been added/updated to cover changes in this PR
