### PR TITLE
Collection moving with EntityPicker

### DIFF
--- a/e2e/support/helpers/e2e-collection-helpers.js
+++ b/e2e/support/helpers/e2e-collection-helpers.js
@@ -1,4 +1,4 @@
-import { getFullName, modal, popover } from "e2e/support/helpers";
+import { entityPickerModal, getFullName, popover } from "e2e/support/helpers";
 
 /**
  * Clicks the "+" icon on the collection page and selects one of the menu options
@@ -75,13 +75,12 @@ export const moveOpenedCollectionTo = newParent => {
   openCollectionMenu();
   popover().within(() => cy.findByText("Move").click());
 
-  cy.findAllByTestId("item-picker-item").contains(newParent).click();
-
-  modal().within(() => {
+  entityPickerModal().within(() => {
+    cy.findByText(newParent).click();
     cy.button("Move").click();
   });
-  // Make sure modal closed
-  modal().should("not.exist");
+
+  entityPickerModal().should("not.exist");
 };
 
 export function pickEntity({ path, select }) {

--- a/e2e/test/scenarios/collections/permissions.cy.spec.js
+++ b/e2e/test/scenarios/collections/permissions.cy.spec.js
@@ -13,6 +13,7 @@ import {
   modal,
   setTokenFeatures,
   sidebar,
+  entityPickerModal,
 } from "e2e/support/helpers";
 
 import { displaySidebarChildOf } from "./helpers/e2e-collections-sidebar.js";
@@ -104,34 +105,6 @@ describe("collection permissions", () => {
                 it("should let a user move/undo move a dashboard", () => {
                   move("Orders in a dashboard");
                 });
-
-                function move(item) {
-                  cy.visit("/collection/root");
-                  openCollectionItemMenu(item);
-                  popover().within(() => {
-                    cy.findByText("Move").click();
-                  });
-                  cy.get(".Modal").within(() => {
-                    cy.findByText(`Move "${item}"?`);
-                    // Let's move it into a nested collection
-                    cy.findByText("First collection")
-                      .siblings("[data-testid='expand-btn']")
-                      .click();
-                    cy.findByText("Second collection").click();
-                    cy.findByText("Move").click();
-                  });
-                  cy.findByText(item).should("not.exist");
-                  // Make sure item was properly moved to a correct sub-collection
-                  exposeChildrenFor("First collection");
-                  cy.findByText("Second collection").click();
-                  cy.findByText(item);
-                  // Undo the whole thing
-                  cy.findByText(/Moved (question|dashboard)/);
-                  cy.findByText("Undo").click();
-                  cy.findByText(item).should("not.exist");
-                  cy.visit("/collection/root");
-                  cy.findByText(item);
-                }
               });
 
               describe("duplicate", () => {
@@ -142,20 +115,6 @@ describe("collection permissions", () => {
                 it.skip("should be able to duplicate the question (metabase#15255)", () => {
                   duplicate("Orders");
                 });
-
-                function duplicate(item) {
-                  cy.visit("/collection/root");
-                  openCollectionItemMenu(item);
-                  cy.findByText("Duplicate").click();
-                  cy.get(".Modal")
-                    .as("modal")
-                    .within(() => {
-                      clickButton("Duplicate");
-                      cy.findByText("Failed").should("not.exist");
-                    });
-                  cy.get("@modal").should("not.exist");
-                  cy.findByText(`${item} - Duplicate`);
-                }
               });
 
               describe("archive", () => {
@@ -484,4 +443,43 @@ function exposeChildrenFor(collectionName) {
     .find(".Icon-chevronright")
     .eq(0) // there may be more nested icons, but we need the top level one
     .click();
+}
+
+function move(item) {
+  cy.visit("/collection/root");
+  openCollectionItemMenu(item);
+  popover().findByText("Move").click();
+  entityPickerModal().within(() => {
+    cy.findByText(`Move "${item}"?`);
+    // Let's move it into a nested collection
+    cy.findByText("First collection").click();
+    cy.findByText("Second collection").click();
+    cy.button("Move").click();
+  });
+
+  cy.findByText(item).should("not.exist");
+  // Make sure item was properly moved to a correct sub-collection
+  exposeChildrenFor("First collection");
+  cy.findByText("Second collection").click();
+  cy.findByText(item);
+  // Undo the whole thing
+  cy.findByText(/Moved (question|dashboard)/);
+  cy.findByText("Undo").click();
+  cy.findByText(item).should("not.exist");
+  cy.visit("/collection/root");
+  cy.findByText(item);
+}
+
+function duplicate(item) {
+  cy.visit("/collection/root");
+  openCollectionItemMenu(item);
+  cy.findByText("Duplicate").click();
+  cy.get(".Modal")
+    .as("modal")
+    .within(() => {
+      clickButton("Duplicate");
+      cy.findByText("Failed").should("not.exist");
+    });
+  cy.get("@modal").should("not.exist");
+  cy.findByText(`${item} - Duplicate`);
 }

--- a/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard-management.cy.spec.js
@@ -15,6 +15,7 @@ import {
   undoToast,
   openDashboardMenu,
   toggleDashboardInfoSidebar,
+  entityPickerModal,
 } from "e2e/support/helpers";
 
 const PERMISSIONS = {
@@ -223,9 +224,9 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 popover().findByText("Move").click();
                 cy.location("pathname").should("eq", `/dashboard/${id}/move`);
 
-                modal().within(() => {
+                entityPickerModal().within(() => {
                   cy.findByText("First collection").click();
-                  clickButton("Move");
+                  cy.button("Move").click();
                 });
 
                 assertOnRequest("updateDashboard");
@@ -258,7 +259,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 );
                 modal().within(() => {
                   cy.findByRole("heading", { name: "Archive this dashboard?" }); //Without this, there is some race condition and the button click fails
-                  clickButton("Archive");
+                  cy.button("Archive").click();
                   assertOnRequest("updateDashboard");
                 });
 
@@ -269,7 +270,7 @@ describe("managing dashboard from the dashboard's edit menu", () => {
                 );
                 undoToast().within(() => {
                   cy.findByText("Archived dashboard");
-                  clickButton("Undo");
+                  cy.button("Undo").click();
                   assertOnRequest("updateDashboard");
                 });
 
@@ -312,10 +313,6 @@ describe("managing dashboard from the dashboard's edit menu", () => {
     });
   });
 });
-
-function clickButton(name) {
-  cy.findByRole("button", { name }).should("not.be.disabled").click();
-}
 
 function assertOnRequest(xhr_alias) {
   cy.wait("@" + xhr_alias).then(xhr => {

--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -312,8 +312,8 @@ describe("scenarios > dashboard", () => {
         cy.findByTestId("edit-bar").button("Cancel").click();
         openDashboardMenu();
         popover().findByText("Move").click();
-        modal().within(() => {
-          cy.findByRole("heading", { name: myPersonalCollection }).click();
+        entityPickerModal().within(() => {
+          cy.findByText("Bobby Tables's Personal Collection").click();
           cy.button("Move").click();
         });
 
@@ -330,8 +330,8 @@ describe("scenarios > dashboard", () => {
         cy.findByTestId("edit-bar").button("Cancel").click();
         openDashboardMenu();
         popover().findByText("Move").click();
-        modal().within(() => {
-          cy.findByRole("heading", { name: "Our analytics" }).click();
+        entityPickerModal().within(() => {
+          cy.findByText("Our analytics").click();
           cy.button("Move").click();
         });
 

--- a/e2e/test/scenarios/dashboard/reproductions/16559-show-recent-dashboard-revision.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/16559-show-recent-dashboard-revision.cy.spec.js
@@ -1,7 +1,6 @@
 import {
   dashboardHeader,
   editDashboard,
-  modal,
   openQuestionsSidebar,
   popover,
   restore,
@@ -9,6 +8,7 @@ import {
   rightSidebar,
   toggleDashboardInfoSidebar,
   visitDashboard,
+  entityPickerModal,
 } from "e2e/support/helpers";
 
 const dashboardDetails = {
@@ -81,7 +81,7 @@ describe("issue 16559", () => {
     cy.log("Move dashboard to another collection");
     dashboardHeader().icon("ellipsis").click();
     popover().findByText("Move").click();
-    modal().within(() => {
+    entityPickerModal().within(() => {
       cy.findByText("First collection").click();
       cy.button("Move").click();
     });

--- a/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19737-data-picker-not-showing-moved-model.cy.spec.js
@@ -1,12 +1,13 @@
 import {
   restore,
-  modal,
   popover,
   navigationSidebar,
   openNavigationSidebar,
+  entityPickerModal,
 } from "e2e/support/helpers";
 
 const modelName = "Orders Model";
+const personalCollectionName = "Bobby Tables's Personal Collection";
 
 describe("issue 19737", () => {
   beforeEach(() => {
@@ -17,7 +18,7 @@ describe("issue 19737", () => {
   it("should show moved model in the data picker without refreshing (metabase#19737)", () => {
     cy.visit("/collection/root");
 
-    moveModel(modelName, "My personal collection");
+    moveModel(modelName, personalCollectionName);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Moved model");
@@ -64,7 +65,7 @@ describe("issue 19737", () => {
     openNavigationSidebar();
     navigationSidebar().findByText("First collection").click();
 
-    moveModel(modelName, "My personal collection");
+    moveModel(modelName, personalCollectionName);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Moved model");
@@ -84,11 +85,11 @@ describe("issue 19737", () => {
 
 function moveModel(modelName, collectionName) {
   openEllipsisMenuFor(modelName);
-  popover().contains("Move").click();
+  popover().findByText("Move").click();
 
-  modal().within(() => {
+  entityPickerModal().within(() => {
     cy.findByText(collectionName).click();
-    cy.findByText("Move").click();
+    cy.button("Move").click();
   });
 }
 

--- a/e2e/test/scenarios/native/data_ref.cy.spec.js
+++ b/e2e/test/scenarios/native/data_ref.cy.spec.js
@@ -2,6 +2,8 @@ import {
   restore,
   openNativeEditor,
   openQuestionActions,
+  popover,
+  entityPickerModal,
 } from "e2e/support/helpers";
 
 describe("scenarios > native question > data reference sidebar", () => {
@@ -52,11 +54,12 @@ describe("scenarios > native question > data reference sidebar", () => {
     );
     // Move question to personal collection
     openQuestionActions();
-    cy.findByTestId("move-button").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("My personal collection").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Move").click();
+    popover().findByTestId("move-button").click();
+
+    entityPickerModal().within(() => {
+      cy.findByText("Bobby Tables's Personal Collection").click();
+      cy.button("Move").click();
+    });
 
     openNativeEditor();
     cy.icon("reference").click();

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -6,6 +6,7 @@ import {
   visitQuestion,
   startNewNativeQuestion,
   runNativeQuery,
+  entityPickerModal,
 } from "e2e/support/helpers";
 
 import * as SQLFilter from "../native-filters/helpers/e2e-sql-filter-helpers";
@@ -76,8 +77,10 @@ describe("scenarios > question > native subquery", () => {
         cy.visit(`/question/${questionId2}`);
         openQuestionActions();
         cy.findByTestId("move-button").click();
-        cy.findByText("My personal collection").click();
-        cy.findByText("Move").click();
+        entityPickerModal().within(() => {
+          cy.findByText("Bobby Tables's Personal Collection").click();
+          cy.button("Move").click();
+        });
 
         openNativeEditor();
         cy.reload(); // Refresh the state, so previously created questions need to be loaded again.

--- a/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-data-source.cy.spec.ts
@@ -12,6 +12,7 @@ import {
 import type { StructuredQuestionDetails } from "e2e/support/helpers";
 import {
   createQuestion,
+  entityPickerModal,
   isEE,
   isOSS,
   openNotebook,
@@ -330,14 +331,13 @@ describe("scenarios > notebook > data source", () => {
 });
 
 function moveToCollection(collection: string) {
+  cy.intercept("GET", "/api/collection/tree**").as("updateCollectionTree");
+
   openQuestionActions();
   popover().findByTextEnsureVisible("Move").click();
-  cy.findByRole("dialog").within(() => {
-    cy.intercept("GET", "/api/collection/tree**").as("updateCollectionTree");
-    cy.findAllByTestId("item-picker-item")
-      .filter(`:contains(${collection})`)
-      .click();
 
+  entityPickerModal().within(() => {
+    cy.findByText(collection).click();
     cy.button("Move").click();
     cy.wait("@updateCollectionTree");
   });

--- a/e2e/test/scenarios/question/question-management.cy.spec.js
+++ b/e2e/test/scenarios/question/question-management.cy.spec.js
@@ -23,6 +23,7 @@ import {
   expectNoBadSnowplowEvents,
   expectGoodSnowplowEvents,
   modal,
+  entityPickerModal,
 } from "e2e/support/helpers";
 
 const PERMISSIONS = {
@@ -89,11 +90,7 @@ describe(
                       .should("have.attr", "aria-selected", "false");
                   });
 
-                  openQuestionActions();
-                  cy.findByTestId("move-button").click();
-                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                  cy.findByText("My personal collection").click();
-                  clickButton("Move");
+                  moveQuestionTo(/Personal Collection/);
                   assertOnRequest("updateQuestion");
                   // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                   cy.contains("37.65");
@@ -117,22 +114,25 @@ describe(
                 });
 
                 it("should be able to move the question to a collection created on the go", () => {
+                  const NEW_COLLECTION_NAME = "Foo";
+
                   openQuestionActions();
                   cy.findByTestId("move-button").click();
-                  const NEW_COLLECTION = "Foo";
-
-                  modal().within(() => {
-                    cy.findByText("New collection").click();
+                  entityPickerModal().within(() => {
+                    cy.findByText(/Personal Collection/).click();
+                    cy.findByText("Create a new collection").click();
                   });
 
-                  cy.findByTestId("new-collection-modal").then(modal => {
-                    cy.findByPlaceholderText(
-                      "My new fantastic collection",
-                    ).type(NEW_COLLECTION);
-                    cy.findByText("Create").click();
+                  cy.findByTestId("create-collection-on-the-go").within(() => {
+                    cy.findByPlaceholderText("My new collection").type(
+                      NEW_COLLECTION_NAME,
+                    );
+                    cy.button("Create").click();
                   });
 
-                  cy.get("header").findByText(NEW_COLLECTION);
+                  entityPickerModal().button("Move").click();
+
+                  cy.get("header").findByText(NEW_COLLECTION_NAME);
                 });
 
                 it("should be able to move models", () => {
@@ -152,11 +152,7 @@ describe(
                       .should("have.attr", "aria-selected", "false");
                   });
 
-                  openQuestionActions();
-                  cy.findByTestId("move-button").click();
-                  // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-                  cy.findByText("My personal collection").click();
-                  clickButton("Move");
+                  moveQuestionTo(/Personal Collection/);
                   assertOnRequest("updateQuestion");
                   // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
                   cy.contains("37.65");
@@ -243,14 +239,8 @@ describe(
                   cy.reload();
 
                   cy.log("Move the question to a personal collection");
-                  openQuestionActions();
-                  popover().findByText("Move").click();
-                  modal().within(() => {
-                    cy.findByRole("heading", {
-                      name: myPersonalCollection,
-                    }).click();
-                    cy.button("Move").click();
-                  });
+
+                  moveQuestionTo(/Personal Collection/);
 
                   cy.log("assert public collections are not visible");
                   openQuestionActions();
@@ -267,12 +257,7 @@ describe(
                   });
 
                   cy.log("Move the question to the root collection");
-                  openQuestionActions();
-                  popover().findByText("Move").click();
-                  modal().within(() => {
-                    cy.findByRole("heading", { name: "Our analytics" }).click();
-                    cy.button("Move").click();
-                  });
+                  moveQuestionTo("Our analytics");
 
                   cy.log("assert all collections are visible");
                   openQuestionActions();
@@ -500,4 +485,13 @@ function turnIntoModel() {
 
 function findSelectedItem() {
   return cy.findByRole("dialog").findByRole("option", { selected: true });
+}
+
+function moveQuestionTo(newCollectionName) {
+  openQuestionActions();
+  cy.findByTestId("move-button").click();
+  entityPickerModal().within(() => {
+    cy.findByText(newCollectionName).click();
+    cy.button("Move").click();
+  });
 }

--- a/frontend/src/metabase/collections/components/BulkActions.jsx
+++ b/frontend/src/metabase/collections/components/BulkActions.jsx
@@ -6,7 +6,7 @@ import _ from "underscore";
 import CollectionCopyEntityModal from "metabase/collections/components/CollectionCopyEntityModal";
 import { canArchiveItem, canMoveItem } from "metabase/collections/utils";
 import Modal from "metabase/components/Modal";
-import { MoveModal } from "metabase/containers/MoveModal";
+import { BulkMoveModal } from "metabase/containers/MoveModal";
 import { Transition } from "metabase/ui";
 
 import {
@@ -49,7 +49,7 @@ function BulkActions({
       >
         {styles => (
           <BulkActionsToast style={styles} isNavbarOpen={isNavbarOpen}>
-            <ToastCard dark>
+            <ToastCard dark data-testid="toast-card">
               <CardSide>
                 {ngettext(
                   msgid`${selected.length} item selected`,
@@ -88,17 +88,12 @@ function BulkActions({
         </Modal>
       )}
       {!_.isEmpty(selectedItems) && selectedAction === "move" && (
-        <Modal onClose={onCloseModal}>
-          <MoveModal
-            title={
-              selectedItems.length > 1
-                ? t`Move ${selectedItems.length} items?`
-                : t`Move "${selectedItems[0].getName()}"?`
-            }
-            onClose={onCloseModal}
-            onMove={onMove}
-          />
-        </Modal>
+        <BulkMoveModal
+          selectedItems={selectedItems}
+          onClose={onCloseModal}
+          onMove={onMove}
+          initialCollectionId={collection.id}
+        />
       )}
     </>
   );

--- a/frontend/src/metabase/collections/components/BulkActions.styled.tsx
+++ b/frontend/src/metabase/collections/components/BulkActions.styled.tsx
@@ -13,7 +13,7 @@ export const BulkActionsToast = styled.div<{ isNavbarOpen: boolean }>`
   margin-left: ${props =>
     props.isNavbarOpen ? `${parseInt(NAV_SIDEBAR_WIDTH) / 2}px` : "0"};
   margin-bottom: ${space(2)};
-  z-index: 999;
+  z-index: 400; // needed to put this over popovers (z-index: 300)
 `;
 
 export const ToastCard = styled(Card)`

--- a/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
@@ -7,11 +7,18 @@ import { MoveModal } from "metabase/containers/MoveModal";
 import Collections from "metabase/entities/collections";
 import { useDispatch } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
-import type { Collection, CollectionId } from "metabase-types/api";
+import type {
+  Collection,
+  CollectionItem,
+  CollectionId,
+} from "metabase-types/api";
 
 export interface MoveCollectionModalProps {
   collection: Collection;
-  onMove: (source: Collection, destination: Collection) => void;
+  onMove: (
+    source: Collection | CollectionItem,
+    destination: { id: CollectionId },
+  ) => void;
   onClose: () => void;
 }
 
@@ -21,7 +28,7 @@ const MoveCollectionModalView = ({
   onClose,
 }: MoveCollectionModalProps): JSX.Element => {
   const handleMove = useCallback(
-    async (destination: Collection) => {
+    async (destination: { id: CollectionId }) => {
       await onMove(collection, destination);
       onClose();
     },
@@ -31,7 +38,8 @@ const MoveCollectionModalView = ({
   return (
     <MoveModal
       title={t`Move "${collection.name}"?`}
-      initialCollectionId={collection.id}
+      initialCollectionId={collection.parent_id ?? "root"}
+      movingCollectionId={collection.id}
       onMove={handleMove}
       onClose={onClose}
     />

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionItemPickerResolver.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionItemPickerResolver.tsx
@@ -13,6 +13,7 @@ export const CollectionItemPickerResolver = ({
   query,
   isFolder,
   isCurrentLevel,
+  shouldDisableItem,
 }: CollectionItemListProps) => {
   if (!query) {
     return (
@@ -22,6 +23,7 @@ export const CollectionItemPickerResolver = ({
         onClick={onClick}
         isFolder={isFolder}
         isCurrentLevel={isCurrentLevel}
+        shouldDisableItem={shouldDisableItem}
       />
     );
   }
@@ -33,6 +35,7 @@ export const CollectionItemPickerResolver = ({
         selectedItem={selectedItem}
         isFolder={isFolder}
         isCurrentLevel={isCurrentLevel}
+        shouldDisableItem={shouldDisableItem}
         options={options}
       />
     );
@@ -45,6 +48,7 @@ export const CollectionItemPickerResolver = ({
       selectedItem={selectedItem}
       isFolder={isFolder}
       isCurrentLevel={isCurrentLevel}
+      shouldDisableItem={shouldDisableItem}
       options={options}
     />
   );

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
@@ -33,6 +33,7 @@ interface CollectionPickerProps {
   onItemSelect: (item: CollectionPickerItem) => void;
   initialValue?: Partial<CollectionPickerItem>;
   options?: CollectionPickerOptions;
+  shouldDisableItem?: (item: CollectionPickerItem) => boolean;
 }
 
 export const CollectionPickerInner = (
@@ -40,6 +41,7 @@ export const CollectionPickerInner = (
     onItemSelect,
     initialValue,
     options = defaultOptions,
+    shouldDisableItem,
   }: CollectionPickerProps,
   ref: Ref<unknown>,
 ) => {
@@ -125,6 +127,7 @@ export const CollectionPickerInner = (
     <NestedItemPicker
       itemName={t`collection`}
       isFolder={isFolder}
+      shouldDisableItem={shouldDisableItem}
       options={options}
       generateKey={generateKey}
       onFolderSelect={onFolderSelect}

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -18,6 +18,7 @@ interface CollectionPickerModalProps {
   onClose: () => void;
   options?: CollectionPickerOptions;
   value: Pick<CollectionPickerItem, "id" | "model">;
+  shouldDisableItem?: (item: CollectionPickerItem) => boolean;
 }
 
 const canSelectItem = (item: CollectionPickerItem | null): boolean => {
@@ -36,7 +37,9 @@ export const CollectionPickerModal = ({
   onClose,
   value,
   options = defaultOptions,
+  shouldDisableItem,
 }: CollectionPickerModalProps) => {
+  options = { ...defaultOptions, ...options };
   const [selectedItem, setSelectedItem] = useState<CollectionPickerItem | null>(
     null,
   );
@@ -87,6 +90,7 @@ export const CollectionPickerModal = ({
       element: (
         <CollectionPicker
           onItemSelect={handleItemSelect}
+          shouldDisableItem={shouldDisableItem}
           initialValue={value}
           options={options}
           ref={pickerRef}

--- a/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/NewCollectionDialog.tsx
@@ -56,6 +56,7 @@ export const NewCollectionDialog = ({
           padding: "1rem",
         },
       }}
+      zIndex={400} // needs to be above the EntityPickerModal at 400
     >
       <FormProvider
         initialValues={{ name: "" }}

--- a/frontend/src/metabase/common/components/CollectionPicker/components/PersonalCollectionItemList.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/PersonalCollectionItemList.tsx
@@ -34,6 +34,7 @@ export const PersonalCollectionsItemList = ({
       selectedItem={selectedItem}
       isFolder={isFolder}
       isCurrentLevel={isCurrentLevel}
+      shouldDisableItem={shouldDisableItem}
     />
   );
 };

--- a/frontend/src/metabase/common/components/CollectionPicker/components/PersonalCollectionItemList.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/PersonalCollectionItemList.tsx
@@ -11,6 +11,7 @@ export const PersonalCollectionsItemList = ({
   selectedItem,
   isFolder,
   isCurrentLevel,
+  shouldDisableItem,
 }: CollectionItemListProps) => {
   const {
     data: collections,

--- a/frontend/src/metabase/common/components/CollectionPicker/components/RootItemList.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/RootItemList.tsx
@@ -106,6 +106,7 @@ export const RootItemList = ({
       selectedItem={selectedItem}
       isFolder={isFolder}
       isCurrentLevel={isCurrentLevel}
+      shouldDisableItem={shouldDisableItem}
     />
   );
 };

--- a/frontend/src/metabase/common/components/CollectionPicker/components/RootItemList.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/RootItemList.tsx
@@ -29,6 +29,7 @@ export const RootItemList = ({
   options,
   isFolder,
   isCurrentLevel,
+  shouldDisableItem,
 }: CollectionItemListProps) => {
   const isAdmin = useSelector(getUserIsAdmin);
   const currentUser = useSelector(getUser);

--- a/frontend/src/metabase/common/components/CollectionPicker/components/SearchItemList.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/SearchItemList.tsx
@@ -9,6 +9,7 @@ export const SearchItemList = ({
   selectedItem,
   isFolder,
   isCurrentLevel,
+  shouldDisableItem,
 }: CollectionItemListProps) => {
   const { data, error, isLoading } = useSearchListQuery<CollectionPickerItem>({
     query,
@@ -23,6 +24,7 @@ export const SearchItemList = ({
       selectedItem={selectedItem}
       isFolder={isFolder}
       isCurrentLevel={isCurrentLevel}
+      shouldDisableItem={shouldDisableItem}
     />
   );
 };

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
@@ -9,11 +9,15 @@ export const ButtonBar = ({
   onCancel,
   canConfirm,
   actionButtons,
+  confirmButtonText,
+  cancelButtonText,
 }: {
   onConfirm: () => void;
   onCancel: () => void;
   canConfirm?: boolean;
   actionButtons: JSX.Element[];
+  confirmButtonText?: string;
+  cancelButtonText?: string;
 }) => {
   useEffect(() => {
     const handleEnter = (e: KeyboardEvent) => {
@@ -37,14 +41,16 @@ export const ButtonBar = ({
     >
       <Flex gap="md">{actionButtons}</Flex>
       <Flex gap="md">
-        <Button onClick={onCancel}>{t`Cancel`}</Button>
+        <Button onClick={onCancel} type="button">
+          {cancelButtonText ?? t`Cancel`}
+        </Button>
         <Button
           ml={1}
           variant="filled"
           onClick={onConfirm}
           disabled={!canConfirm}
         >
-          {t`Select`}
+          {confirmButtonText ?? t`Select`}
         </Button>
       </Flex>
     </Flex>

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -27,6 +27,8 @@ export type EntityPickerModalOptions = {
   showSearch?: boolean;
   hasConfirmButtons?: boolean;
   allowCreateNew?: boolean;
+  confirmButtonText?: string;
+  cancelButtonText?: string;
 };
 
 export const defaultOptions: EntityPickerModalOptions = {
@@ -99,6 +101,7 @@ export function EntityPickerModal<
       onClose={onClose}
       data-testid="entity-picker-modal"
       trapFocus={trapFocus}
+      zIndex={400} // needed to put this above the BulkActionsToast
       closeOnEscape={false} // we're doing this manually in useWindowEvent
     >
       <Modal.Overlay />
@@ -137,6 +140,8 @@ export function EntityPickerModal<
                 onCancel={onClose}
                 canConfirm={canSelectItem}
                 actionButtons={actionButtons}
+                confirmButtonText={options?.confirmButtonText}
+                cancelButtonText={options?.cancelButtonText}
               />
             )}
           </ErrorBoundary>

--- a/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
@@ -26,7 +26,7 @@ interface ItemListProps<
   selectedItem: Item | null;
   isFolder: (item: Item) => boolean;
   isCurrentLevel: boolean;
-  shouldDisableItem?: (item: TItem) => boolean;
+  shouldDisableItem?: (item: Item) => boolean;
 }
 
 export const ItemList = <
@@ -41,6 +41,7 @@ export const ItemList = <
   selectedItem,
   isFolder,
   isCurrentLevel,
+  shouldDisableItem,
 }: ItemListProps<Id, Model, Item>) => {
   const activeItemIndex = useMemo(() => {
     if (!items) {

--- a/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
@@ -26,6 +26,7 @@ interface ItemListProps<
   selectedItem: Item | null;
   isFolder: (item: Item) => boolean;
   isCurrentLevel: boolean;
+  shouldDisableItem?: (item: TItem) => boolean;
 }
 
 export const ItemList = <
@@ -87,6 +88,7 @@ export const ItemList = <
       {items.map((item: Item) => (
         <div key={`${item.model}-${item.id}`}>
           <NavLink
+            disabled={shouldDisableItem?.(item)}
             rightSection={
               isFolder(item) ? <Icon name="chevronright" size={10} /> : null
             }

--- a/frontend/src/metabase/common/components/EntityPicker/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/LoadingSpinner/LoadingSpinner.tsx
@@ -4,7 +4,7 @@ import { useMount } from "react-use";
 import { Loader, Flex, Text } from "metabase/ui";
 
 export const LoadingSpinner = ({ text }: { text?: string }) => (
-  <Flex align="center" justify="center" h="100%">
+  <Flex align="center" justify="center" h="100%" data-testid="loading-spinner">
     <Loader size="lg" />
     {!!text && <Text color="text-medium">{text}</Text>}
   </Flex>

--- a/frontend/src/metabase/common/components/EntityPicker/components/NestedItemPicker/NestedItemPicker.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/NestedItemPicker/NestedItemPicker.tsx
@@ -29,7 +29,7 @@ export interface NestedItemPickerProps<
   path: PickerState<Item, Query>;
   isFolder: IsFolder<Id, Model, Item>;
   listResolver: ComponentType<ListProps<Id, Model, Item, Query, Options>>;
-  shouldDisableItem: (item: Item) => boolean;
+  shouldDisableItem?: (item: Item) => boolean;
 }
 
 export function NestedItemPicker<

--- a/frontend/src/metabase/common/components/EntityPicker/components/NestedItemPicker/NestedItemPicker.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/NestedItemPicker/NestedItemPicker.tsx
@@ -29,6 +29,7 @@ export interface NestedItemPickerProps<
   path: PickerState<Item, Query>;
   isFolder: IsFolder<Id, Model, Item>;
   listResolver: ComponentType<ListProps<Id, Model, Item, Query, Options>>;
+  shouldDisableItem: (item: Item) => boolean;
 }
 
 export function NestedItemPicker<
@@ -45,6 +46,7 @@ export function NestedItemPicker<
   path,
   isFolder,
   listResolver: ListResolver,
+  shouldDisableItem,
 }: NestedItemPickerProps<Id, Model, Item, Query, Options>) {
   const handleClick = (item: Item) => {
     if (isFolder(item)) {
@@ -75,6 +77,7 @@ export function NestedItemPicker<
                   options={options}
                   onClick={(item: Item) => handleClick(item)}
                   isCurrentLevel={index === path.length - 2}
+                  shouldDisableItem={shouldDisableItem}
                   isFolder={isFolder}
                 />
               </ErrorBoundary>

--- a/frontend/src/metabase/common/components/EntityPicker/types.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/types.ts
@@ -43,4 +43,5 @@ export type ListProps<
   isFolder: IsFolder<Id, Model, Item>;
   isCurrentLevel: boolean;
   options: Options;
+  shouldDisableItem?: (item: Item) => boolean;
 };

--- a/frontend/src/metabase/containers/MoveModal.styled.tsx
+++ b/frontend/src/metabase/containers/MoveModal.styled.tsx
@@ -1,6 +1,0 @@
-import styled from "@emotion/styled";
-
-export const ButtonContainer = styled.div`
-  display: flex;
-  margin-top: 1rem;
-`;

--- a/frontend/src/metabase/containers/MoveModal.tsx
+++ b/frontend/src/metabase/containers/MoveModal.tsx
@@ -1,19 +1,19 @@
-import { useState } from "react";
 import { t } from "ttag";
+import _ from "underscore";
 
-import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
-import ModalContent from "metabase/components/ModalContent";
-import CollectionPicker from "metabase/containers/CollectionPicker";
-import Button from "metabase/core/components/Button";
-import type { Collection, CollectionId } from "metabase-types/api";
-
-import { ButtonContainer } from "./MoveModal.styled";
+import { isItemCollection } from "metabase/collections/utils";
+import {
+  CollectionPickerModal,
+  type CollectionPickerItem,
+} from "metabase/common/components/EntityPicker";
+import type { CollectionId, CollectionItem } from "metabase-types/api";
 
 interface MoveModalProps {
   title: string;
   onClose: () => void;
-  onMove: (collection: any) => void;
-  initialCollectionId?: number | string | null;
+  onMove: (item: { id: CollectionId }) => void;
+  initialCollectionId: CollectionId;
+  movingCollectionId?: CollectionId;
 }
 
 export const MoveModal = ({
@@ -21,49 +21,90 @@ export const MoveModal = ({
   onClose,
   onMove,
   initialCollectionId,
+  movingCollectionId,
 }: MoveModalProps) => {
-  const [selectedCollectionId, setSelectedCollectionId] =
-    useState(initialCollectionId);
-
-  const [creatingCollection, setCreatingCollection] = useState(false);
-  const [openCollectionId, setOpenCollectionId] = useState<CollectionId>();
-
-  if (creatingCollection) {
-    return (
-      <CreateCollectionModal
-        collectionId={openCollectionId}
-        onClose={() => setCreatingCollection(false)}
-        onCreate={(collection: Collection) => {
-          onMove({ id: collection.id });
-        }}
-      />
-    );
-  }
+  // if we are moving a collection, we can't move it into itself or any of its children
+  const shouldDisableItem = movingCollectionId
+    ? (item: CollectionPickerItem) =>
+        Boolean(
+          item.id === movingCollectionId ||
+            item?.location?.split("/").includes(String(movingCollectionId)),
+        )
+    : undefined;
 
   return (
-    <ModalContent title={title} onClose={onClose}>
-      <CollectionPicker
-        initialOpenCollectionId={openCollectionId}
-        onOpenCollectionChange={setOpenCollectionId}
-        value={selectedCollectionId}
-        onChange={setSelectedCollectionId}
-      />
-      <ButtonContainer>
-        <Button light icon="add" onClick={() => setCreatingCollection(true)}>
-          {t`New collection`}
-        </Button>
-        <Button
-          primary
-          className="ml-auto"
-          disabled={
-            selectedCollectionId === undefined ||
-            selectedCollectionId === initialCollectionId
-          }
-          onClick={() => onMove({ id: selectedCollectionId })}
-        >
-          {t`Move`}
-        </Button>
-      </ButtonContainer>
-    </ModalContent>
+    <CollectionPickerModal
+      title={title}
+      value={{
+        id: initialCollectionId,
+        model: "collection",
+      }}
+      onChange={newCollection => onMove({ id: newCollection.id })}
+      options={{
+        showSearch: true,
+        allowCreateNew: true,
+        hasConfirmButtons: true,
+        showRootCollection: true,
+        showPersonalCollections: true,
+        confirmButtonText: t`Move`,
+      }}
+      shouldDisableItem={shouldDisableItem}
+      onClose={onClose}
+    />
+  );
+};
+
+interface BulkMoveModalProps {
+  onClose: () => void;
+  onMove: (item: { id: CollectionId }) => void;
+  selectedItems: CollectionItem[];
+  initialCollectionId: CollectionId;
+}
+
+export const BulkMoveModal = ({
+  onClose,
+  onMove,
+  selectedItems,
+  initialCollectionId,
+}: BulkMoveModalProps) => {
+  const movingCollectionIds = selectedItems
+    .filter((item: CollectionItem) => isItemCollection(item))
+    .map((item: CollectionItem) => String(item.id));
+
+  // if the move set includes collections, we can't move into any of them
+  const shouldDisableItem = movingCollectionIds.length
+    ? (item: CollectionPickerItem) => {
+        const collectionItemFullPath =
+          item?.location?.split("/").map(String).concat(String(item.id)) ?? [];
+        return (
+          _.intersection(collectionItemFullPath, movingCollectionIds).length > 0
+        );
+      }
+    : undefined;
+
+  const title =
+    selectedItems.length > 1
+      ? t`Move ${selectedItems.length} items?`
+      : t`Move "${selectedItems[0].name}"?`;
+
+  return (
+    <CollectionPickerModal
+      title={title}
+      value={{
+        id: initialCollectionId,
+        model: "collection",
+      }}
+      onChange={newCollection => onMove({ id: newCollection.id })}
+      options={{
+        showSearch: true,
+        allowCreateNew: true,
+        hasConfirmButtons: true,
+        showRootCollection: true,
+        showPersonalCollections: true,
+        confirmButtonText: t`Move`,
+      }}
+      shouldDisableItem={shouldDisableItem}
+      onClose={onClose}
+    />
   );
 };

--- a/frontend/src/metabase/containers/MoveModal.tsx
+++ b/frontend/src/metabase/containers/MoveModal.tsx
@@ -5,7 +5,7 @@ import { isItemCollection } from "metabase/collections/utils";
 import {
   CollectionPickerModal,
   type CollectionPickerItem,
-} from "metabase/common/components/EntityPicker";
+} from "metabase/common/components/CollectionPicker";
 import type { CollectionId, CollectionItem } from "metabase-types/api";
 
 interface MoveModalProps {

--- a/frontend/src/metabase/dashboard/components/DashboardMoveModal.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardMoveModal.tsx
@@ -34,7 +34,7 @@ function DashboardMoveModal({
     <MoveModal
       title={t`Move dashboard to…`}
       onClose={onClose}
-      initialCollectionId={dashboard.collection_id}
+      initialCollectionId={dashboard.collection_id ?? "root"}
       onMove={async destination => {
         await setDashboardCollection({ id: dashboard.id }, destination, {
           notify: {

--- a/frontend/src/metabase/dashboard/components/QuestionPickerModal/QuestionPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPickerModal/QuestionPickerModal.unit.spec.tsx
@@ -44,7 +44,6 @@ const COLLECTION_CARD = createMockCollectionItem({
 
 const DASHBOARD = createMockDashboard({
   id: 1,
-  collection_id: null,
   collection: ROOT_COLLECTION,
 });
 

--- a/frontend/src/metabase/hoc/ModalRoute.tsx
+++ b/frontend/src/metabase/hoc/ModalRoute.tsx
@@ -50,6 +50,7 @@ interface WrappedModalRouteProps {
 const ModalWithRoute = (
   ComposedModal: React.ComponentType<ComposedModalProps>,
   modalProps = {},
+  noWrap = false,
 ) => {
   class ModalRouteComponent extends Component<WrappedModalRouteProps> {
     static displayName: string = `ModalWithRoute[${
@@ -64,6 +65,10 @@ const ModalWithRoute = (
     };
 
     render() {
+      if (noWrap) {
+        return <ComposedModal {...this.props} onClose={this.onClose} />;
+      }
+
       return (
         <Modal {...modalProps} onClose={this.onClose}>
           <ComposedModal {...this.props} onClose={this.onClose} />
@@ -84,11 +89,11 @@ interface ModalRouteProps {
 // react-router Route wrapper that handles routed modals
 class _ModalRoute extends Route {
   static createRouteFromReactElement(element: React.ReactElement) {
-    const { modal, modalProps } = element.props;
+    const { modal, modalProps, noWrap } = element.props;
 
     if (modal) {
       element = React.cloneElement(element, {
-        component: ModalWithRoute(modal, modalProps),
+        component: ModalWithRoute(modal, modalProps, noWrap),
       });
 
       // @ts-expect-error - Route.createRouteFromReactElement is not typed

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailHeader/ModelDetailHeader.tsx
@@ -9,7 +9,7 @@ import Link from "metabase/core/components/Link";
 import * as Urls from "metabase/lib/urls";
 import ArchiveModelModal from "metabase/questions/containers/ArchiveQuestionModal";
 import type Question from "metabase-lib/v1/Question";
-import type { Collection } from "metabase-types/api";
+import type { CollectionId } from "metabase-types/api";
 
 import {
   ModelHeader,
@@ -22,7 +22,7 @@ interface Props {
   model: Question;
   hasEditDefinitionLink: boolean;
   onChangeName: (name?: string) => void;
-  onChangeCollection: (collection: Collection) => void;
+  onChangeCollection: ({ id }: { id: CollectionId }) => void;
 }
 
 type HeaderModal = "move" | "archive";
@@ -59,7 +59,7 @@ function ModelDetailHeader({
   const handleCloseModal = useCallback(() => setModal(null), []);
 
   const handleCollectionChange = useCallback(
-    (collection: Collection) => {
+    (collection: { id: CollectionId }) => {
       onChangeCollection(collection);
       handleCloseModal();
     },

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelDetailPage.tsx
@@ -5,7 +5,7 @@ import TabLink from "metabase/core/components/TabLink";
 import * as Urls from "metabase/lib/urls";
 import type Question from "metabase-lib/v1/Question";
 import type Table from "metabase-lib/v1/metadata/Table";
-import type { Collection } from "metabase-types/api";
+import type { CollectionId } from "metabase-types/api";
 
 import ModelActionDetails from "./ModelActionDetails";
 import ModelDetailHeader from "./ModelDetailHeader";
@@ -30,7 +30,7 @@ interface Props {
   supportsNestedQueries: boolean;
   onChangeName: (name?: string) => void;
   onChangeDescription: (description?: string | null) => void;
-  onChangeCollection: (collection: Collection) => void;
+  onChangeCollection: ({ id }: { id: CollectionId }) => void;
 }
 
 function ModelDetailPage({

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.tsx
@@ -21,7 +21,7 @@ import { getSetting } from "metabase/selectors/settings";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type Table from "metabase-lib/v1/metadata/Table";
-import type { Card, Collection, WritebackAction } from "metabase-types/api";
+import type { Card, CollectionId, WritebackAction } from "metabase-types/api";
 import type { State } from "metabase-types/store";
 
 type OwnProps = {
@@ -51,7 +51,7 @@ type DispatchProps = {
   onChangeModel: (card: Card) => void;
   onChangeCollection: (
     card: Card,
-    collection: Collection,
+    collection: { id: CollectionId },
     opts: ToastOpts,
   ) => void;
   onChangeLocation: (location: LocationDescriptor) => void;
@@ -165,7 +165,7 @@ function ModelDetailPage({
   );
 
   const handleCollectionChange = useCallback(
-    (collection: Collection) => {
+    (collection: { id: CollectionId }) => {
       onChangeCollection(model.card() as Card, collection, {
         notify: {
           message: (

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -37,7 +37,6 @@ import type {
   WritebackQueryAction,
 } from "metabase-types/api";
 import {
-  createMockCollection,
   createMockDatabase,
   createMockField,
   createMockImplicitCUDActions,
@@ -62,9 +61,6 @@ import {
 } from "metabase-types/store/mocks";
 
 import ModelDetailPage from "./ModelDetailPage";
-
-console.warn = jest.fn();
-console.error = jest.fn();
 
 // eslint-disable-next-line react/display-name
 jest.mock("metabase/actions/containers/ActionCreator", () => () => (
@@ -179,18 +175,6 @@ function createMockQueryAction(
     }),
   });
 }
-
-const COLLECTION_1 = createMockCollection({
-  id: 5,
-  name: "C1",
-  can_write: true,
-});
-
-const COLLECTION_2 = createMockCollection({
-  id: 10,
-  name: "C2",
-  can_write: true,
-});
 
 type SetupOpts = {
   model: Card;
@@ -366,32 +350,6 @@ describe("ModelDetailPage", () => {
           expect(modelUpdateSpy).toHaveBeenCalledWith(
             { id: model.id() },
             { archived: true },
-            expect.anything(),
-          );
-        });
-      });
-
-      it("can be moved to another collection", async () => {
-        const { model, modelUpdateSpy } = await setup({
-          model: getModel({ collection_id: 1 }),
-          collections: [COLLECTION_1, COLLECTION_2],
-        });
-
-        userEvent.click(getIcon("ellipsis"));
-        userEvent.click(await screen.findByText("Move"));
-
-        expect(screen.getByRole("dialog")).toBeInTheDocument();
-        userEvent.click(await screen.findByText(COLLECTION_2.name));
-        userEvent.click(screen.getByRole("button", { name: "Move" }));
-
-        await waitFor(() =>
-          expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
-        );
-
-        await waitFor(() => {
-          expect(modelUpdateSpy).toHaveBeenCalledWith(
-            { id: model.id() },
-            { collection_id: COLLECTION_2.id },
             expect.anything(),
           );
         });

--- a/frontend/src/metabase/query_builder/components/QueryModals.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryModals.tsx
@@ -26,7 +26,7 @@ import MoveEventModal from "metabase/timelines/questions/containers/MoveEventMod
 import NewEventModal from "metabase/timelines/questions/containers/NewEventModal";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
-import type { Alert, Card, Collection, User } from "metabase-types/api";
+import type { Alert, Card, CollectionId, User } from "metabase-types/api";
 import type {
   QueryBuilderMode,
   QueryBuilderUIControls,
@@ -72,7 +72,7 @@ interface QueryModalsProps {
   onChangeLocation: (location: string) => void;
   setQuestionCollection: (
     { id }: Pick<Card, "id">,
-    collection: Collection,
+    collection: { id: CollectionId },
     opts: Record<string, unknown>,
   ) => void;
 }
@@ -236,31 +236,29 @@ class QueryModals extends Component<QueryModalsProps> {
         );
       case MODAL_TYPES.MOVE:
         return (
-          <Modal onClose={onCloseModal}>
-            <MoveModal
-              title={t`Which collection should this be in?`}
-              initialCollectionId={question.collectionId()}
-              onClose={onCloseModal}
-              onMove={(collection: Collection) => {
-                this.props.setQuestionCollection(
-                  { id: question.id() },
-                  collection,
-                  {
-                    notify: {
-                      message: (
-                        <QuestionMoveToast
-                          collectionId={collection.id || ROOT_COLLECTION.id}
-                          question={question}
-                        />
-                      ),
-                      undo: false,
-                    },
+          <MoveModal
+            title={t`Which collection should this be in?`}
+            initialCollectionId={question.collectionId() ?? "root"}
+            onClose={onCloseModal}
+            onMove={(collection: { id: CollectionId }) => {
+              this.props.setQuestionCollection(
+                { id: question.id() },
+                { id: collection.id },
+                {
+                  notify: {
+                    message: (
+                      <QuestionMoveToast
+                        collectionId={collection.id || ROOT_COLLECTION.id}
+                        question={question}
+                      />
+                    ),
+                    undo: false,
                   },
-                );
-                onCloseModal();
-              }}
-            />
-          </Modal>
+                },
+              );
+              onCloseModal();
+            }}
+          />
         );
       case MODAL_TYPES.ARCHIVE:
         return (

--- a/frontend/src/metabase/routes.jsx
+++ b/frontend/src/metabase/routes.jsx
@@ -145,7 +145,7 @@ export const getRoutes = store => {
           </Route>
 
           <Route path="collection/:slug" component={CollectionLanding}>
-            <ModalRoute path="move" modal={MoveCollectionModal} />
+            <ModalRoute path="move" modal={MoveCollectionModal} noWrap />
             <ModalRoute path="archive" modal={ArchiveCollectionModal} />
             <ModalRoute path="permissions" modal={CollectionPermissionsModal} />
             {getCollectionTimelineRoutes()}
@@ -156,7 +156,11 @@ export const getRoutes = store => {
             title={t`Dashboard`}
             component={DashboardAppConnected}
           >
-            <ModalRoute path="move" modal={DashboardMoveModalConnected} />
+            <ModalRoute
+              path="move"
+              modal={DashboardMoveModalConnected}
+              noWrap
+            />
             <ModalRoute path="copy" modal={DashboardCopyModalConnected} />
             <ModalRoute path="archive" modal={ArchiveDashboardModalConnected} />
           </Route>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37833
Closes https://github.com/metabase/metabase/issues/30117
Closes https://github.com/metabase/metabase/issues/21786

### Description

Allows moving items around in metabase using the new item picker.
- collections (can't be moved inside themselves)
- questions / models
- dashboards

![move](https://github.com/metabase/metabase/assets/30528226/e647a129-201b-417f-ae83-ed4347a5e96c)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
