### PR TITLE
reduce unnecessary debug logs

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-debug.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-debug.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import type { EChartsOption } from "echarts";
+import { useEffect } from "react";
 import type { RawSeries } from "metabase-types/api";
 import { isProduction } from "metabase/env";
 
@@ -12,11 +13,13 @@ export function useChartDebug({
   rawSeries: RawSeries;
   option: EChartsOption;
 }) {
-  if (!isQueryBuilder || isProduction) {
-    return;
-  }
-  console.log("-------------- ECHARTS DEBUG INFO START --------------");
-  console.log("rawSeries", rawSeries);
-  console.log("option", option);
-  console.log("-------------- ECHARTS DEBUG INFO END --------------");
+  useEffect(() => {
+    if (!isQueryBuilder || isProduction) {
+      return;
+    }
+    console.log("-------------- ECHARTS DEBUG INFO START --------------");
+    console.log("rawSeries", rawSeries);
+    console.log("option", option);
+    console.log("-------------- ECHARTS DEBUG INFO END --------------");
+  }, [rawSeries, option, isQueryBuilder]);
 }


### PR DESCRIPTION
### Description

Reduces unnecessary logging due to the performance impact. Hovers should not trigger logging of series and the option since they are not being changed