### PR TITLE
fix multiple merged timeline events icon is not star

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
@@ -43,11 +43,10 @@ export const getTimelineEventsSeries = (
       );
 
       const color = getColor(isSelected ? "brand" : "text-light");
+      const iconName =
+        events.length === 1 ? (events[0].icon as IconName) : "star";
 
-      const iconSvg = setSvgColor(
-        Icons[events[0].icon as IconName].source,
-        color,
-      );
+      const iconSvg = setSvgColor(Icons[iconName].source, color);
       const dataUri = svgToDataUri(iconSvg);
 
       return {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39572

### Description

When multiple timeline events are grouped their icon should always be "star".

### How to verify

- create a time series questions in a folder with multiple timeline events within the same year
- change the datetime bucket to "year" to make events grouped
- ensure the event group has "star" icon always

### Demo

<img width="323" alt="Screenshot 2024-03-08 at 6 36 56 PM" src="https://github.com/metabase/metabase/assets/14301985/56d2bc82-fe1f-4492-b2ed-3d3378e98d1d">

