### PR TITLE
Revert updating FKs during metadata sync (#39679)

### DIFF
--- a/src/metabase/sync/sync_metadata/fks.clj
+++ b/src/metabase/sync/sync_metadata/fks.clj
@@ -50,10 +50,7 @@
                       ;; - fk_target_field_id is NULL and the new target is not NULL
                       ;; - fk_target_field_id is not NULL but the new target is different and not NULL
                       [pk-field-id-query :pk]
-                      [:and
-                       [:or
-                        [:= :f.fk_target_field_id nil]
-                        [:not= :f.fk_target_field_id :pk.id]]]]
+                      [:= :f.fk_target_field_id nil]]
              :set    {:fk_target_field_id :pk.id
                       :semantic_type      "type/FK"}}
             :postgres
@@ -64,9 +61,7 @@
                       :semantic_type      "type/FK"}
              :where  [:and
                       [:= :fk.id :f.id]
-                      [:or
-                       [:= :f.fk_target_field_id nil]
-                       [:not= :f.fk_target_field_id :pk.id]]]}
+                      [:= :f.fk_target_field_id nil]]}
             :h2
             {:update [:metabase_field :f]
              :set    {:fk_target_field_id pk-field-id-query
@@ -74,9 +69,7 @@
              :where  [:and
                       [:= :f.id fk-field-id-query]
                       [:not= pk-field-id-query nil]
-                      [:or
-                       [:= :f.fk_target_field_id nil]
-                       [:not= :f.fk_target_field_id pk-field-id-query]]]})]
+                      [:= :f.fk_target_field_id nil]]})]
     (sql/format q :dialect (mdb.connection/quoting-style (mdb.connection/db-type)))))
 
 (mu/defn ^:private mark-fk!

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -245,7 +245,8 @@
           ;; 3. add back the FK relationship but targeting continent_2
           (jdbc/execute! db-spec "ALTER TABLE country ADD CONSTRAINT country_continent_id_fkey FOREIGN KEY (continent_id) REFERENCES continent_2(id);")
           (sync/sync-database! db {:scan :schema})
-          (testing "initially country's continent_id is targeting continent_2"
+          ;; FIXME: The following test fails. This was fixed (metabase#39679) but regressed to solve a flakey test (metabase#39861)
+          #_(testing "initially country's continent_id is targeting continent_2"
             (is (=? {:fk_target_field_id (mt/id :continent_2 :id)
                      :semantic_type      :type/FK}
                     (get-fk)))))))))


### PR DESCRIPTION
Hopefully fixes this flake https://github.com/metabase/metabase/issues/39861

This reverts the change in behaviour in https://github.com/metabase/metabase/pull/39679, while keeping the rest of the code intact.

So it will reopen https://github.com/metabase/metabase/issues/39685

This is just temporary until I figure out what's going on with the flake.