### PR TITLE
Correctly show a selected table (in the data selector) which comes from a multi-schema database

### DIFF
--- a/e2e/support/test_tables.js
+++ b/e2e/support/test_tables.js
@@ -148,3 +148,39 @@ export const no_pk_table = async dbClient => {
 
   return null;
 };
+
+export const multi_schema = async dbClient => {
+  const schemas = {
+    Domestic: [
+      "Animals",
+      [
+        { name: "Duck", score: 10 },
+        { name: "Horse", score: 20 },
+        { name: "Cow", score: 30 },
+      ],
+    ],
+    Wild: [
+      "Animals",
+      [
+        { name: "Snake", score: 10 },
+        { name: "Lion", score: 20 },
+        { name: "Elephant", score: 30 },
+      ],
+    ],
+  };
+
+  Object.entries(schemas).forEach(async ([schemaName, details]) => {
+    const [table, rows] = details;
+    await dbClient.schema.createSchemaIfNotExists(schemaName);
+    await dbClient.schema.withSchema(schemaName).dropTableIfExists(table);
+
+    await dbClient.schema.withSchema(schemaName).createTable(table, t => {
+      t.string("name");
+      t.integer("score");
+    });
+
+    await dbClient(`${schemaName}.${table}`).insert(rows);
+  });
+
+  return schemas;
+};

--- a/e2e/test/scenarios/question/reproductions/39807-multi-schema-table-data-selector.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/39807-multi-schema-table-data-selector.cy.spec.js
@@ -1,0 +1,57 @@
+import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import {
+  resetTestTable,
+  restore,
+  resyncDatabase,
+  startNewQuestion,
+  popover,
+  saveQuestion,
+  visualize,
+  openNotebook,
+} from "e2e/support/helpers";
+
+const dialect = "postgres";
+const TEST_TABLE = "multi_schema";
+
+const dbName = "Writable Postgres12";
+const schemaName = "Wild";
+const tableName = "Animals";
+
+describe("issue 39807", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it(
+    "should properly display a table from a multi-schema database (metabase#39807)",
+    { tags: "@external" },
+    () => {
+      resetTestTable({ type: dialect, table: TEST_TABLE });
+      restore(`${dialect}-writable`);
+
+      cy.signInAsAdmin();
+
+      resyncDatabase({
+        dbId: WRITABLE_DB_ID,
+      });
+
+      startNewQuestion();
+      popover().within(() => {
+        cy.findByText("Raw Data").click();
+        cy.findByText(dbName).click();
+        cy.findByText(schemaName).click();
+        cy.findByText(tableName).click();
+      });
+      visualize();
+      saveQuestion("Beasts");
+
+      openNotebook();
+      cy.findByTestId("data-step-cell").should("contain", tableName).click();
+      popover().within(() => {
+        cy.findByTestId("source-database").should("have.text", dbName);
+        cy.findByTestId("source-schema").should("have.text", schemaName);
+      });
+    },
+  );
+});

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -623,6 +623,8 @@ export class UnconnectedDataSelector extends Component {
       [TABLE_STEP]: () => {
         if (this.state.selectedSchemaId != null) {
           return this.props.fetchSchemaTables(this.state.selectedSchemaId);
+        } else if (this.state.selectedSchema?.id != null) {
+          return this.props.fetchSchemaTables(this.state.selectedSchema?.id);
         }
       },
       [FIELD_STEP]: () => {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -864,9 +864,6 @@ export class UnconnectedDataSelector extends Component {
 
   isSavedEntitySelected = () => isVirtualCardId(this.props.selectedTableId);
 
-  isTableSelected = () =>
-    this.props.selectedTableId && !this.isSavedEntitySelected();
-
   handleSavedEntitySelect = async tableOrCardId => {
     await this.props.fetchFields(tableOrCardId);
     if (this.props.setSourceTableFn) {

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -259,6 +259,9 @@ export class UnconnectedDataSelector extends Component {
     }
     if (selectedTableId != null) {
       setSelectedTable(getTable(selectedTableId));
+      // We need the schema information when we open already saved question (vitual table id),
+      // or already selected table (the actual table id).
+      setSelectedSchema(selectedTable.schema);
     }
     if (selectedFieldId != null) {
       setSelectedField(getField(selectedFieldId));
@@ -458,9 +461,9 @@ export class UnconnectedDataSelector extends Component {
     } else if (
       // If we go from New > Question/Model flow, schemaId will be selected.
       // OTOH, if we're opening already saved question, or already chosen table,
-      // the schema id information is not preserved.
-      // In that case, we can rely on the selected table information.
-      (this.state.selectedSchemaId || this.isTableSelected()) &&
+      // the schema id information is not preserved and we have to access it directly
+      // through the schema object.
+      (this.state.selectedSchemaId || this.state.selectedSchema?.id) &&
       steps.includes(TABLE_STEP)
     ) {
       await this.switchToStep(TABLE_STEP);

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -258,13 +258,7 @@ export class UnconnectedDataSelector extends Component {
       setSelectedSchema(getSchema(selectedSchemaId));
     }
     if (selectedTableId != null) {
-      const table = getTable(selectedTableId);
-      setSelectedTable(table);
-      // We need the schema information when we open already saved simple question
-      // because its source table might come from a multiple-schemas database.
-      this.setState({
-        selectedSchemaId: table?.schema?.id,
-      });
+      setSelectedTable(getTable(selectedTableId));
     }
     if (selectedFieldId != null) {
       setSelectedField(getField(selectedFieldId));
@@ -461,7 +455,12 @@ export class UnconnectedDataSelector extends Component {
       await this.switchToStep(DATABASE_STEP);
     } else if (this.state.selectedTableId && steps.includes(FIELD_STEP)) {
       await this.switchToStep(FIELD_STEP);
-    } else if (this.state.selectedSchemaId && steps.includes(TABLE_STEP)) {
+    } else if (
+      // Schema id is explicitly set when going through the New > Question/Model flow,
+      // whereas we have to obtain it from the state when opening a saved question.
+      (this.state.selectedSchemaId || this.state.selectedSchema?.id) &&
+      steps.includes(TABLE_STEP)
+    ) {
       await this.switchToStep(TABLE_STEP);
     } else if (this.state.selectedDatabaseId && steps.includes(SCHEMA_STEP)) {
       await this.switchToStep(SCHEMA_STEP);

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -258,10 +258,13 @@ export class UnconnectedDataSelector extends Component {
       setSelectedSchema(getSchema(selectedSchemaId));
     }
     if (selectedTableId != null) {
-      setSelectedTable(getTable(selectedTableId));
-      // We need the schema information when we open already saved question (vitual table id),
-      // or already selected table (the actual table id).
-      setSelectedSchema(selectedTable.schema);
+      const table = getTable(selectedTableId);
+      setSelectedTable(table);
+      // We need the schema information when we open already saved simple question
+      // because its source table might come from a multiple-schemas database.
+      this.setState({
+        selectedSchemaId: table?.schema?.id,
+      });
     }
     if (selectedFieldId != null) {
       setSelectedField(getField(selectedFieldId));
@@ -458,14 +461,7 @@ export class UnconnectedDataSelector extends Component {
       await this.switchToStep(DATABASE_STEP);
     } else if (this.state.selectedTableId && steps.includes(FIELD_STEP)) {
       await this.switchToStep(FIELD_STEP);
-    } else if (
-      // If we go from New > Question/Model flow, schemaId will be selected.
-      // OTOH, if we're opening already saved question, or already chosen table,
-      // the schema id information is not preserved and we have to access it directly
-      // through the schema object.
-      (this.state.selectedSchemaId || this.state.selectedSchema?.id) &&
-      steps.includes(TABLE_STEP)
-    ) {
+    } else if (this.state.selectedSchemaId && steps.includes(TABLE_STEP)) {
       await this.switchToStep(TABLE_STEP);
     } else if (this.state.selectedDatabaseId && steps.includes(SCHEMA_STEP)) {
       await this.switchToStep(SCHEMA_STEP);

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -455,7 +455,14 @@ export class UnconnectedDataSelector extends Component {
       await this.switchToStep(DATABASE_STEP);
     } else if (this.state.selectedTableId && steps.includes(FIELD_STEP)) {
       await this.switchToStep(FIELD_STEP);
-    } else if (this.state.selectedSchemaId && steps.includes(TABLE_STEP)) {
+    } else if (
+      // If we go from New > Question/Model flow, schemaId will be selected.
+      // OTOH, if we're opening already saved question, or already chosen table,
+      // the schema id information is not preserved.
+      // In that case, we can rely on the selected table information.
+      (this.state.selectedSchemaId || this.isTableSelected()) &&
+      steps.includes(TABLE_STEP)
+    ) {
       await this.switchToStep(TABLE_STEP);
     } else if (this.state.selectedDatabaseId && steps.includes(SCHEMA_STEP)) {
       await this.switchToStep(SCHEMA_STEP);
@@ -853,6 +860,9 @@ export class UnconnectedDataSelector extends Component {
   }
 
   isSavedEntitySelected = () => isVirtualCardId(this.props.selectedTableId);
+
+  isTableSelected = () =>
+    this.props.selectedTableId && !this.isSavedEntitySelected();
 
   handleSavedEntitySelect = async tableOrCardId => {
     await this.props.fetchFields(tableOrCardId);

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
@@ -145,7 +145,7 @@ describe("DataSelector", () => {
 
     // db and schema are still visible
     expect(screen.getByText("Multi-schema Database")).toBeInTheDocument();
-    expect(screen.getByText("- First Schema")).toBeInTheDocument();
+    expect(screen.getByText("First Schema")).toBeInTheDocument();
 
     // but other schema is hidden
     expect(screen.queryByText("Second Schema")).not.toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -180,11 +180,16 @@ const Header = ({
   <HeaderContainer>
     <HeaderClickable onClick={onBack}>
       {onBack && <Icon name="chevronleft" size={18} />}
-      <HeaderDatabaseName>{selectedDatabase.name}</HeaderDatabaseName>
+      <HeaderDatabaseName data-testid="source-database">
+        {selectedDatabase.name}
+      </HeaderDatabaseName>
     </HeaderClickable>
 
     {selectedSchema?.name && schemas.length > 1 && (
-      <HeaderSchemaName>- {selectedSchema.displayName()}</HeaderSchemaName>
+      <HeaderSchemaName>
+        {"- "}
+        <span data-testid="source-schema">{selectedSchema.displayName()}</span>
+      </HeaderSchemaName>
     )}
   </HeaderContainer>
 );


### PR DESCRIPTION
Similar to #39699, we don't have the necessary information when opening the table from a multi-schema database. And similar to #39699, the information is there when we go through "New > Question/Model" flow. The `DataSelector` component seems to have been built with that one way flow in mind.

This PR is adding this missing piece of information about the schema to the state when we're opening a saved question.

Reproduces and fixes #39807.

## Testing
This PR also introduces a real [multi-schema database](https://github.com/metabase/metabase/pull/39930/commits/7063c0569126ebec31ac040bb6ac1270608857e8) in E2E tests. I had to work around some of the existing implicit contracts in the related helpers. Ideally, we will adjust those helpers to support the multi-schema context in a more natural way.

The biggest downside currently is that the information about the schema names and the table names stays unavailable to the outside world. This can easily be solved with a callback that takes the return value of a `resetTable` Cypress task as an argument. cc @iethree 

Solving that is outside the scope of this PR.