### PR TITLE
setup e2e with token activation

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -388,6 +388,8 @@ describeEE("scenarios > setup (EE)", () => {
 
       cy.findByText("I'll add my data later").click();
 
+      cy.findByText("Activate your commercial license").should("exist");
+
       typeToken(Cypress.env("NO_FEATURES_TOKEN"));
 
       cy.button("Activate").click();
@@ -581,6 +583,7 @@ const fillUserAndContinue = ({
 
 const skipLicenseStepOnEE = () => {
   if (isEE) {
+    cy.findByText("Activate your commercial license").should("exist");
     cy.button("Skip").click();
   }
 };


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/38867

### Description

This adds a e2e that tests that the token used during the setup is actually activating the license after the setup is finished.

Thread about the token: https://metaboat.slack.com/archives/C010ZSXQY87/p1709306366048049?thread_ts=1708606268.785609&cid=C010ZSXQY87

### How to verify

CI should be green


