### PR TITLE
Add token parameter to JWT SSO

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
+++ b/enterprise/backend/src/metabase_enterprise/sso/integrations/jwt.clj
@@ -76,7 +76,7 @@
                                                      (group-names->ids group-names)
                                                      (all-mapped-group-ids))))))
 
-(defn- get-jwt-data
+(defn- session-data
   [jwt {{redirect :return_to} :params, :as request}]
   (let [redirect-url (or redirect (URLEncoder/encode "/"))]
     (sso-utils/check-sso-redirect redirect-url)
@@ -120,11 +120,11 @@
     (mw.session/set-session-cookies request (response/redirect redirect-url) session (t/zoned-date-time (t/zone-id "GMT")))))
 
 (defmethod sso.i/sso-get :jwt
-  [{{:keys [jwt redirect token] :or {token false}} :params, :as request}]
+  [{{:keys [jwt redirect token] :or {token nil}} :params, :as request}]
   (premium-features/assert-has-feature :sso-jwt (tru "JWT-based authentication"))
   (check-jwt-enabled)
   (if jwt
-    (handle-jwt-authentication  (get-jwt-data jwt request) token request)
+    (handle-jwt-authentication (session-data jwt request) token request)
     (redirect-to-idp (sso-settings/jwt-identity-provider-uri) redirect)))
 
 (defmethod sso.i/sso-post :jwt

--- a/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sso/integrations/jwt_test.clj
@@ -18,6 +18,7 @@
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
    [metabase.util :as u]
+   [metabase.util.malli.schema :as ms]
    [toucan2.core :as t2]))
 
 (use-fixtures :once (fixtures/initialize :test-users))
@@ -335,23 +336,61 @@
           #"Sorry, but you'll need a test account to view this page. Please contact your administrator."
           (#'mt.jwt/fetch-or-create-user! "Test" "User" "test1234@metabase.com" nil)))))))
 
-(deftest get-jwt-token-test
+(deftest jwt-token-test
   (testing "should return a session token when token=true"
     (with-jwt-default-setup
-      (let [jwt-iat-time (buddy-util/now)
-            jwt-exp-time (+ (buddy-util/now) 3600)
-            result       (saml-test/client-full-response :get 200 "/auth/sso"
-                                                         :token true
-                                                         :jwt (jwt/sign {:email
-                                                                         "rasta@metabase.com"
-                                                                         :first_name "Rasta"
-                                                                         :last_name  "Toucan"
-                                                                         :extra      "keypairs"
-                                                                         :are        "also present"
-                                                                         :iat       jwt-iat-time
-                                                                         :exp        jwt-exp-time}
-                                                                        default-jwt-secret))]
-        (let [{:keys [id exp iat]} (-> result :body)]
-          (is (and id exp iat))
-          (is (= jwt-iat-time iat))
-          (is (= jwt-exp-time exp)))))))
+      (mt/with-temporary-setting-values [enable-embedding true]
+        (let [jwt-iat-time (buddy-util/now)
+              jwt-exp-time (+ (buddy-util/now) 3600)
+              jwt-payload  (jwt/sign {:email      "rasta@metabase.com"
+                                      :first_name "Rasta"
+                                      :last_name  "Toucan"
+                                      :extra      "keypairs"
+                                      :are        "also present"
+                                      :iat        jwt-iat-time
+                                      :exp        jwt-exp-time}
+                                     default-jwt-secret)
+              result       (saml-test/client-full-response :get 200 "/auth/sso"
+                                                           :token true
+                                                           :jwt jwt-payload)]
+          (is (=? {:id  (mt/malli=? ms/NonBlankString)
+                   :iat jwt-iat-time
+                   :exp jwt-exp-time}
+                  (:body result)))))))
+
+  (testing "should not return a session token when embedding is disabled"
+    (with-jwt-default-setup
+      (mt/with-temporary-setting-values [enable-embedding false]
+        (let [jwt-iat-time (buddy-util/now)
+              jwt-exp-time (+ (buddy-util/now) 3600)
+              jwt-payload  (jwt/sign {:email      "rasta@metabase.com"
+                                      :first_name "Rasta"
+                                      :last_name  "Toucan"
+                                      :extra      "keypairs"
+                                      :are        "also present"
+                                      :iat        jwt-iat-time
+                                      :exp        jwt-exp-time}
+                                     default-jwt-secret)
+              result       (saml-test/client-full-response :get 400 "/auth/sso"
+                                                           :token true
+                                                           :jwt jwt-payload)]
+          (is result nil)))))
+
+  (testing "should not return a session token when token=false"
+    (with-jwt-default-setup
+      (mt/with-temporary-setting-values [enable-embedding true]
+        (let [jwt-iat-time (buddy-util/now)
+              jwt-exp-time (+ (buddy-util/now) 3600)
+              jwt-payload  (jwt/sign {:email      "rasta@metabase.com"
+                                      :first_name "Rasta"
+                                      :last_name  "Toucan"
+                                      :extra      "keypairs"
+                                      :are        "also present"
+                                      :iat        jwt-iat-time
+                                      :exp        jwt-exp-time}
+                                     default-jwt-secret)
+              result       (saml-test/client-full-response :get 302 "/auth/sso"
+                                                           {:request-options {:redirect-strategy :none}}
+                                                           :return_to default-redirect-uri
+                                                           :jwt jwt-payload)]
+          (is result nil))))))


### PR DESCRIPTION
Adds a `token` parameter to the JWT SSO endpoint.

### Why?

Two reasons, based on our work on the Embedding SDK.

1. Using tokens, we can monitor the expiration and renew the token ahead of its expiration. Right now, we're using cookies in interactive embedding, which can cause an embedded Metabase instance to redirect to a JWT identity provider which will break user flows and possibly lose a user's progress if they're editing or creating something new.

2. [Browsers are moving away from third-party cookies to preserve customer privacy](https://developers.google.com/privacy-sandbox/3pcd). This PR will help us refactor iframes and such in the future to make sure we're using token authentication rather than cookies, and hopefully help us ensure that things won't immediately break when this policy is put into place.

### How to verify

The tests should pass. We'll have some examples from the embedding side in the future. In the meantime, no behavior should change at all.


### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
