### PR TITLE
Publish snowplow events on CSV append success / failure

### DIFF
--- a/snowplow/iglu-client-embedded/schemas/com.metabase/csvupload/jsonschema/1-0-0
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/csvupload/jsonschema/1-0-0
@@ -12,7 +12,7 @@
     "event": {
       "description": "Event name",
       "type": "string",
-      "enum": ["csv_upload_successful", "csv_upload_failed"],
+      "enum": ["csv_upload_successful", "csv_upload_failed", "csv_append_successful", "csv_append_failed"],
       "maxLength": 128
     },
     "model_id": {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/csvupload/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/csvupload/jsonschema/1-0-1
@@ -5,7 +5,7 @@
     "vendor": "com.metabase",
     "name": "csvupload",
     "format": "jsonschema",
-    "version": "1-0-0"
+    "version": "1-0-1"
   },
   "type": "object",
   "properties": {

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/csvupload/jsonschema/1-0-1
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/csvupload/jsonschema/1-0-1
@@ -12,7 +12,7 @@
     "event": {
       "description": "Event name",
       "type": "string",
-      "enum": ["csv_upload_successful", "csv_upload_failed"],
+      "enum": ["csv_upload_successful", "csv_upload_failed", "csv_append_successful", "csv_append_failed"],
       "maxLength": 128
     },
     "model_id": {

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -71,6 +71,8 @@
    ::action-executed                ::action
    ::csv-upload-successful          ::csvupload
    ::csv-upload-failed              ::csvupload
+   ::csv-append-successful          ::csvupload
+   ::csv-append-failed              ::csvupload
    ::metabot-feedback-received      ::metabot
    ::embedding-enabled              ::embed_share
    ::embedding-disabled             ::embed_share

--- a/src/metabase/analytics/snowplow.clj
+++ b/src/metabase/analytics/snowplow.clj
@@ -32,7 +32,7 @@
   {::account              "1-0-1"
    ::browse_data          "1-0-0"
    ::invite               "1-0-1"
-   ::csvupload            "1-0-0"
+   ::csvupload            "1-0-1"
    ::dashboard            "1-1-4"
    ::database             "1-0-1"
    ::instance             "1-1-2"

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -705,7 +705,7 @@
 
         {:row-count row-count}))
     (catch Throwable e
-      (snowplow/track-event! ::snowplow/csv-upload-failed api/*current-user-id* (fail-stats file))
+      (snowplow/track-event! ::snowplow/csv-append-failed api/*current-user-id* (fail-stats file))
       (throw e))))
 
 (defn- can-append-error

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -469,6 +469,16 @@
 ;;; |  public interface for creating CSV table
 ;;; +-----------------------------------------
 
+(defn- fail-stats
+  "If a given upload / append / replace fails, this function is used to create the failure event payload for snowplow.
+  It may involve redundantly reading the file, or even failing again if the file is unreadable."
+  [file]
+  (with-open [reader (bom/bom-reader file)]
+    (let [rows (csv/read-csv reader)]
+      {:size-mb     (file-size-mb file)
+       :num-columns (count (first rows))
+       :num-rows    (count (rest rows))})))
+
 (mu/defn create-csv-upload!
   "Main entry point for CSV uploading.
 
@@ -546,17 +556,11 @@
                                            :model-id    (:id card)
                                            :stats       stats}})
 
-        (snowplow/track-event! ::snowplow/csv-upload-successful
-                               api/*current-user-id*
+        (snowplow/track-event! ::snowplow/csv-upload-successful api/*current-user-id*
                                (assoc stats :model-id (:id card)))
         card)
       (catch Throwable e
-        (let [fail-stats (with-open [reader (bom/bom-reader file)]
-                           (let [rows (csv/read-csv reader)]
-                             {:size-mb     (/ (.length file) 1048576.0)
-                              :num-columns (count (first rows))
-                              :num-rows    (count (rest rows))}))]
-          (snowplow/track-event! ::snowplow/csv-upload-failed api/*current-user-id* fail-stats))
+        (snowplow/track-event! ::snowplow/csv-upload-failed api/*current-user-id* (fail-stats file))
         (throw e)))))
 
 ;;; +-----------------------------
@@ -635,67 +639,74 @@
 
 (defn- append-csv!*
   [database table file]
-  (with-open [reader (bom/bom-reader file)]
-    (let [timer              (start-timer)
-          [header & rows]    (without-auto-pk-columns (csv/read-csv reader))
-          driver             (driver.u/database->driver database)
-          normed-name->field (m/index-by (comp normalize-column-name :name)
-                                         (t2/select :model/Field :table_id (:id table) :active true))
-          normed-header      (map normalize-column-name header)
-          create-auto-pk?    (and
-                              (driver/create-auto-pk-with-append-csv? driver)
-                              (not (contains? normed-name->field auto-pk-column-name)))
-          _                  (check-schema (dissoc normed-name->field auto-pk-column-name) header)
-          settings           (upload-parsing/get-settings)
-          old-column-types   (map (comp base-type->upload-type :base_type normed-name->field) normed-header)
-          ;; in the happy, and most common, case all the values will match the existing types
-          ;; for now we just plan for the worst and perform a fairly expensive operation to detect any type changes
-          ;; we can come back and optimize this to an optimistic-with-fallback approach later.
-          detected-types     (column-types-from-rows settings old-column-types rows)
-          new-column-types   (map #(if (matching-or-upgradable? %1 %2) %2 %1) old-column-types detected-types)
-          _                  (when (and (not= old-column-types new-column-types)
-                                        ;; if we cannot coerce all the columns, don't bother coercing any of them
-                                        ;; we will instead throw an error when we try to parse as the old type
-                                        (= detected-types new-column-types))
-                               (let [fields (map normed-name->field normed-header)]
-                                 (->> (changed-field->new-type fields old-column-types detected-types)
-                                      (alter-columns! driver database table))))
-          ;; this will fail if any of our required relaxations were rejected.
-          parsed-rows        (parse-rows settings new-column-types rows)
-          row-count          (count parsed-rows)]
+  (try
+    (with-open [reader (bom/bom-reader file)]
+      (let [timer              (start-timer)
+            [header & rows]    (without-auto-pk-columns (csv/read-csv reader))
+            driver             (driver.u/database->driver database)
+            normed-name->field (m/index-by (comp normalize-column-name :name)
+                                           (t2/select :model/Field :table_id (:id table) :active true))
+            normed-header      (map normalize-column-name header)
+            create-auto-pk?    (and
+                                (driver/create-auto-pk-with-append-csv? driver)
+                                (not (contains? normed-name->field auto-pk-column-name)))
+            _                  (check-schema (dissoc normed-name->field auto-pk-column-name) header)
+            settings           (upload-parsing/get-settings)
+            old-column-types   (map (comp base-type->upload-type :base_type normed-name->field) normed-header)
+            ;; in the happy, and most common, case all the values will match the existing types
+            ;; for now we just plan for the worst and perform a fairly expensive operation to detect any type changes
+            ;; we can come back and optimize this to an optimistic-with-fallback approach later.
+            detected-types     (column-types-from-rows settings old-column-types rows)
+            new-column-types   (map #(if (matching-or-upgradable? %1 %2) %2 %1) old-column-types detected-types)
+            _                  (when (and (not= old-column-types new-column-types)
+                                          ;; if we cannot coerce all the columns, don't bother coercing any of them
+                                          ;; we will instead throw an error when we try to parse as the old type
+                                          (= detected-types new-column-types))
+                                 (let [fields (map normed-name->field normed-header)]
+                                   (->> (changed-field->new-type fields old-column-types detected-types)
+                                        (alter-columns! driver database table))))
+            ;; this will fail if any of our required relaxations were rejected.
+            parsed-rows        (parse-rows settings new-column-types rows)
+            row-count          (count parsed-rows)
+            stats              {:num-rows          row-count
+                                :num-columns       (count new-column-types)
+                                :generated-columns (if create-auto-pk? 1 0)
+                                :size-mb           (file-size-mb file)
+                                :upload-seconds    (since-ms timer)}]
 
-      (try
-        (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)
-        (catch Throwable e
-          (throw (ex-info (ex-message e) {:status-code 422}))))
+        (try
+          (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)
+          (catch Throwable e
+            (throw (ex-info (ex-message e) {:status-code 422}))))
 
-      (when create-auto-pk?
-        (driver/add-columns! driver
-                             (:id database)
-                             (table-identifier table)
-                             {auto-pk-column-keyword (driver/upload-type->database-type driver ::auto-incrementing-int-pk)}
-                             :primary-key [auto-pk-column-keyword]))
+        (when create-auto-pk?
+          (driver/add-columns! driver
+                               (:id database)
+                               (table-identifier table)
+                               {auto-pk-column-keyword (driver/upload-type->database-type driver ::auto-incrementing-int-pk)}
+                               :primary-key [auto-pk-column-keyword]))
 
-      (scan-and-sync-table! database table)
+        (scan-and-sync-table! database table)
 
-      (when create-auto-pk?
-        (let [auto-pk-field (table-id->auto-pk-column (:id table))]
-          (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})))
+        (when create-auto-pk?
+          (let [auto-pk-field (table-id->auto-pk-column (:id table))]
+            (t2/update! :model/Field (:id auto-pk-field) {:display_name (:name auto-pk-field)})))
 
-      (events/publish-event! :event/upload-append
-                             {:user-id  (:id @api/*current-user*)
-                              :model-id (:id table)
-                              :model    :model/Table
-                              :details  {:db-id       (:id database)
-                                         :schema-name (:schema table)
-                                         :table-name  (:name table)
-                                         :stats       {:num-rows          row-count
-                                                       :num-columns       (count new-column-types)
-                                                       :generated-columns (if create-auto-pk? 1 0)
-                                                       :size-mb           (file-size-mb file)
-                                                       :upload-seconds    (since-ms timer)}}})
+        (events/publish-event! :event/upload-append
+                               {:user-id  (:id @api/*current-user*)
+                                :model-id (:id table)
+                                :model    :model/Table
+                                :details  {:db-id       (:id database)
+                                           :schema-name (:schema table)
+                                           :table-name  (:name table)
+                                           :stats       stats}})
 
-      {:row-count row-count})))
+        (snowplow/track-event! ::snowplow/csv-append-successful api/*current-user-id* stats)
+
+        {:row-count row-count}))
+    (catch Throwable e
+      (snowplow/track-event! ::snowplow/csv-upload-failed api/*current-user-id* (fail-stats file))
+      (throw e))))
 
 (defn- can-append-error
   "Returns an ExceptionInfo object if the user cannot upload to the given database and schema. Returns nil otherwise."

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1541,7 +1541,7 @@
              (finally
                (io/delete-file file))))
 
-         (is (= {:data {"size_mb"      5.245208740234375E-5
+         (is (= {:data {"size_mb"     5.245208740234375E-5
                         "num_columns" 2
                         "num_rows"    1
                         "event"       "csv_append_failed"}

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1111,12 +1111,13 @@
     (snowplow-test/with-fake-snowplow-collector
       (with-upload-table!
         [_table (card->table (upload-example-csv!))]
-        (is (=? {:data {"model_id"        pos?
-                        "size_mb"         3.910064697265625E-5
-                        "num_columns"     2
-                        "num_rows"        2
-                        "upload_seconds"  pos?
-                        "event"           "csv_upload_successful"}
+        (is (=? {:data    {"model_id"          pos?
+                           "size_mb"           3.910064697265625E-5
+                           "num_columns"       2
+                           "num_rows"          2
+                           "generated_columns" 1
+                           "upload_seconds"    pos?
+                           "event"             "csv_upload_successful"}
                  :user-id (str (mt/user->id :rasta))}
                 (last (snowplow-test/pop-event-data-and-user-id!))))
         (mt/with-dynamic-redefs [upload/load-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
@@ -1520,11 +1521,12 @@
              file     (csv-file-with csv-rows (mt/random-name))]
          (append-csv! {:file file, :table-id (:id table)})
 
-         (is (=? {:data {"size_mb"         1.811981201171875E-5
-                         "num_columns"     1
-                         "num_rows"        1
-                         "upload_seconds"  pos?
-                         "event"           "csv_append_successful"}
+         (is (=? {:data    {"size_mb"           1.811981201171875E-5
+                            "num_columns"       1
+                            "num_rows"          1
+                            "generated_columns" 0
+                            "upload_seconds"    pos?
+                            "event"             "csv_append_successful"}
                   :user-id (str (mt/user->id :crowberto))}
                  (last (snowplow-test/pop-event-data-and-user-id!))))
 

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -620,7 +620,7 @@
   (testing "Upload a CSV file with a datetime column"
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-mysql-local-infile-on-and-off
-        (with-redefs [driver/db-default-timezone (constantly "Z")
+        (mt/with-dynamic-redefs [driver/db-default-timezone (constantly "Z")
                       upload/current-database    (constantly (mt/db))]
           (let [table-name (mt/random-name)
                 datetime-pairs [["2022-01-01T12:00:00-07"    "2022-01-01T19:00:00Z"]
@@ -1040,10 +1040,10 @@
           _                    (t2/update! :model/Database db-id {:is_on_demand false
                                                                   :is_full_sync false})]
       (try
-        (with-redefs [ ;; do away with the `future` invocation since we don't want race conditions in a test
-                      future-call (fn [thunk]
-                                    (swap! in-future? (constantly true))
-                                    (thunk))]
+        (mt/with-dynamic-redefs [;; do away with the `future` invocation since we don't want race conditions in a test
+                                 future-call (fn [thunk]
+                                               (swap! in-future? (constantly true))
+                                               (thunk))]
           (testing "Happy path with schema, and without table-prefix"
             ;; make sure the schema exists
             (let [sql (format "CREATE SCHEMA IF NOT EXISTS %s;" (sql.tx/qualify-and-quote driver/*driver* schema-name))]
@@ -1119,8 +1119,7 @@
                         "event"           "csv_upload_successful"}
                  :user-id (str (mt/user->id :rasta))}
                 (last (snowplow-test/pop-event-data-and-user-id!))))
-        (with-redefs [upload/load-from-csv! (fn [_ _ _ _]
-                                              (throw (Exception.)))]
+        (mt/with-dynamic-redefs [upload/load-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
           (try (upload-example-csv!)
                (catch Throwable _
                  nil))
@@ -1169,7 +1168,7 @@
               #"^The uploads database does not exist\.$"
               (upload-example-csv! :db-id Integer/MAX_VALUE, :schema-name "public", :table-prefix "uploaded_magic_"))))
       (testing "Uploads must be supported"
-        (with-redefs [driver/database-supports? (constantly false)]
+        (mt/with-dynamic-redefs [driver/database-supports? (constantly false)]
           (is (thrown-with-msg?
                 java.lang.Exception
                 #"^Uploads are not supported on Postgres databases\."
@@ -1314,7 +1313,7 @@
               :data    {:status-code 422}}
              (catch-ex-info (append-csv-with-defaults! :file (csv-file-with [] (mt/random-name)))))))
     (testing "Uploads must be supported"
-      (with-redefs [driver/database-supports? (constantly false)]
+      (mt/with-dynamic-redefs [driver/database-supports? (constantly false)]
         (is (= {:message (format "Uploads are not supported on %s databases." (str/capitalize (name driver/*driver*)))
                 :data    {:status-code 422}}
                (catch-ex-info (append-csv-with-defaults!))))))))
@@ -1390,8 +1389,8 @@
     (with-mysql-local-infile-on-and-off
       (mt/with-report-timezone-id! "UTC"
         (testing "Append should succeed for all possible CSV column types"
-          (with-redefs [driver/db-default-timezone (constantly "Z")
-                        upload/current-database    (constantly (mt/db))]
+          (mt/with-dynamic-redefs [driver/db-default-timezone (constantly "Z")
+                                   upload/current-database    (constantly (mt/db))]
             (with-upload-table!
               [table (create-upload-table!
                       {:col->upload-type (ordered-map/ordered-map
@@ -1511,6 +1510,41 @@
                    (rows-for-table table))))
           (io/delete-file file))))))
 
+(deftest csv-append-snowplow-test
+  ;; Just test with h2 because snowplow should be independent of the driver
+  (mt/test-driver :h2
+    (snowplow-test/with-fake-snowplow-collector
+
+     (with-upload-table! [table (create-upload-table!)]
+       (let [csv-rows ["name" "Luke Skywalker"]
+             file     (csv-file-with csv-rows (mt/random-name))]
+         (append-csv! {:file file, :table-id (:id table)})
+
+         (is (=? {:data {"size_mb"         1.811981201171875E-5
+                         "num_columns"     1
+                         "num_rows"        1
+                         "upload_seconds"  pos?
+                         "event"           "csv_append_successful"}
+                  :user-id (str (mt/user->id :crowberto))}
+                 (last (snowplow-test/pop-event-data-and-user-id!))))
+
+         (io/delete-file file))
+
+       (mt/with-dynamic-redefs [upload/load-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
+         (let [csv-rows ["mispelled_name, unexpected_column" "Duke Cakewalker, r2dj"]
+               file     (csv-file-with csv-rows (mt/random-name))]
+           (try
+             (append-csv! {:file file, :table-id (:id table)})
+             (catch Throwable _)
+             (finally
+               (io/delete-file file))))
+
+         (is (= {:data {"size_mb"      5.245208740234375E-5
+                        "num_columns" 2
+                        "num_rows"    1
+                        "event"       "csv_append_failed"}
+                 :user-id (str (mt/user->id :crowberto))}
+                (last (snowplow-test/pop-event-data-and-user-id!)))))))))
 
 (deftest csv-append-audit-log-test
   ;; Just test with h2 because these events are independent of the driver


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39867

### Description

This takes "heavy inspiration" from the initial upload events to give analytics coverage for appends as well - the only salient difference is that we don't refer back to the original model created when the table was first created.

### How to verify

... I'd actually appreciate a pointer here, I'm not sure how to test all the wiring. 

Could even have missed something, in fact.