### PR TITLE
Add test for column re-ordering

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -600,7 +600,7 @@
   [fields-by-normed-name header]
   ;; Assumes table-cols are unique when normalized
   (let [normalized-field-names (keys fields-by-normed-name)
-        normalized-header (map normalize-column-name header)
+        normalized-header      (map normalize-column-name header)
         [extra missing _both] (data/diff (set normalized-header) (set normalized-field-names))]
     ;; check for duplicates
     (when (some #(< 1 %) (vals (frequencies normalized-header)))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -596,7 +596,9 @@
 (defn- check-schema
   "Throws an exception if:
     - the CSV file contains duplicate column names
-    - the schema of the CSV file does not match the schema of the table"
+    - the schema of the CSV file does not match the schema of the table
+
+    Note that we do not require the column ordering to be consistent between the header and the table schema."
   [fields-by-normed-name header]
   ;; Assumes table-cols are unique when normalized
   (let [normalized-field-names (keys fields-by-normed-name)

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1592,7 +1592,7 @@
         (let [csv-rows ["shame,name" "Nothing - you can't prove it,Puke Nightstalker"]
               file     (csv-file-with csv-rows (mt/random-name))]
 
-          (testing "The "
+          (testing "The new row is inserted with the values correctly reordered"
             (is (= {:row-count 1} (append-csv! {:file file, :table-id (:id table)})))
             (is (= [[1 "Obi-Wan Kenobi" "No one really knows me"]
                     [2 "Puke Nightstalker" "Nothing - you can't prove it"]]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1216,7 +1216,8 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (defn create-upload-table!
-  "Creates a table and syncs it in the current test database, as if it were uploaded as a CSV upload. `col->upload-type` should be an ordered map of column names (keywords) to upload types.
+  "Creates a table and syncs it in the current test database, as if it were uploaded as a CSV upload.
+  `col->upload-type` should be an ordered map of column names (keywords) to upload types.
   `rows` should be a vector of vectors of values, one for each row.
   Returns the table.
 
@@ -1415,7 +1416,7 @@
                 (io/delete-file file)))))))))
 
 (deftest append-no-rows-test
-  (mt/test-driver (mt/normal-drivers-with-feature :uploads)
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (with-uploads-allowed
       (testing "Append should succeed with a CSV with only the header"
         (let [csv-rows ["name"]]
@@ -1564,7 +1565,7 @@
             (io/delete-file file)))))))
 
 (deftest append-duplicate-header-csv-test
-  (mt/test-driver (mt/normal-drivers-with-feature :uploads)
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (testing "Append should fail if the CSV file contains duplicate column names"
       (with-upload-table! [table (create-upload-table!)]
         (let [csv-rows ["name,name" "Luke Skywalker,Darth Vader"]
@@ -1575,6 +1576,26 @@
                                               :table-id (:id table)}))))
           (testing "Check the data was not uploaded into the table"
             (is (= [[1 "Obi-Wan Kenobi"]]
+                   (rows-for-table table))))
+          (io/delete-file file))))))
+
+(deftest append-reorder-header-csv-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (testing "Append should handle the columns in the CSV file being reordered"
+      (with-upload-table! [table (create-upload-table!
+                                  :col->upload-type (ordered-map/ordered-map
+                                                     upload/auto-pk-column-keyword ::upload/auto-incrementing-int-pk
+                                                     :name ::upload/varchar-255
+                                                     :shame ::upload/varchar-255)
+                                  :rows [["Obi-Wan Kenobi" "No one really knows me"]])]
+
+        (let [csv-rows ["shame,name" "Nothing - you can't prove it,Puke Nightstalker"]
+              file     (csv-file-with csv-rows (mt/random-name))]
+
+          (testing "The "
+            (is (= {:row-count 1} (append-csv! {:file file, :table-id (:id table)})))
+            (is (= [[1 "Obi-Wan Kenobi" "No one really knows me"]
+                    [2 "Puke Nightstalker" "Nothing - you can't prove it"]]
                    (rows-for-table table))))
           (io/delete-file file))))))
 


### PR DESCRIPTION
Refs https://github.com/metabase/metabase/issues/39868

### Description

It turns out that we already supported re-ordering, but this added an explicit test to cover that.

It turns out that a bunch of tests were not actually being run, due to mixing up helpers for running with a single driver or a collection of them, so fixed that too.