### PR TITLE
do not blur timeline events when series hovered

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/timeline-events/option.ts
@@ -51,6 +51,7 @@ export const getTimelineEventsSeries = (
       const dataUri = svgToDataUri(iconSvg);
 
       return {
+        z: CHART_STYLE.timelineEvents.zIndex,
         name: "timeline-event",
         xAxis: date,
         symbolSize: 16,
@@ -79,6 +80,17 @@ export const getTimelineEventsSeries = (
     data: [],
     z: CHART_STYLE.timelineEvents.zIndex,
     markLine: {
+      blur: {
+        label: {
+          opacity: 1,
+        },
+        itemStyle: {
+          opacity: 1,
+        },
+        lineStyle: {
+          opacity: 1,
+        },
+      },
       symbol: "none",
       lineStyle: {
         type: "solid",


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39565

### Description

Do not blur timeline events lines and icons when other series are hovered

### How to verify

Open a chart with timeline events, hover series, ensure timeline events are not blurred
