### PR TITLE
[QP] When querying a bare model with parameters, wrap an extra stage

### DIFF
--- a/src/metabase/query_processor/middleware/parameters.clj
+++ b/src/metabase/query_processor/middleware/parameters.clj
@@ -64,10 +64,16 @@
 
 (mu/defn ^:private move-top-level-params-to-inner-query
   "Move any top-level parameters to the same level (i.e., 'inner query') as the query they affect."
-  [{:keys [parameters], query-type :type, :as outer-query} :- [:map [:type [:enum :query :native]]]]
+  [{:keys [info parameters], query-type :type, :as outer-query} :- [:map [:type [:enum :query :native]]]]
   (cond-> (set/rename-keys outer-query {:parameters :user-parameters})
-    (seq parameters)
-    (assoc-in [query-type :parameters] parameters)))
+    ;; TODO: Native models should be within scope of dashboard filters, by applying the filter on an outer stage.
+    ;; That doesn't work, so the logic below requires MBQL queries only to fix the regression.
+    ;; Native models don't actual get filtered even when linked to dashboard filters, but that's not a regression.
+    ;; This can be fixed properly once this middleware is powered by MLv2. See #40011.
+    (and (seq parameters)
+         (:metadata/model-metadata info)
+         (= query-type :query))          (update query-type (fn [inner-query] {:source-query inner-query}))
+    (seq parameters)                     (assoc-in [query-type :parameters] parameters)))
 
 (defn- expand-parameters
   "Expand parameters in the `outer-query`, and if the query is using a native source query, expand params in that as

--- a/test/metabase/query_processor/middleware/parameters_test.clj
+++ b/test/metabase/query_processor/middleware/parameters_test.clj
@@ -23,7 +23,28 @@
           :native          {:query "WOW", :parameters ["My Param"]}
           :user-parameters ["My Param"]}
          (#'parameters/move-top-level-params-to-inner-query
-          {:type :native, :native {:query "WOW"}, :parameters ["My Param"]}))))
+          {:type :native, :native {:query "WOW"}, :parameters ["My Param"]})))
+  (testing "when top-level query is a model"
+    (testing "and there are parameters, wrap it up as a :source-query"
+      (is (= {:type            :query
+              :query           {:source-query {:source-table 5}
+                                :parameters   ["My Param"]}
+              :info            {:metadata/model-metadata []}
+              :user-parameters ["My Param"]}
+             (#'parameters/move-top-level-params-to-inner-query
+               {:type       :query
+                :query      {:source-table 5}
+                :parameters ["My Param"]
+                :info       {:metadata/model-metadata []}}))))
+    (testing "without parameters, leave the model at the top level"
+      (is (= {:type            :query
+              :query           {:source-table 5
+                                :parameters   ["My Param"]}
+              :user-parameters ["My Param"]}
+             (#'parameters/move-top-level-params-to-inner-query
+               {:type       :query
+                :query      {:source-table 5}
+                :parameters ["My Param"]}))))))
 
 (defn- substitute-params [query]
   (letfn [(thunk []


### PR DESCRIPTION
This matches how models are visualized, and how the parameters are
attached to them in the first place - an extra ad-hoc query is wrapped
around the model.

Because of that wrapping, a parameter will be targeting a model's field
by name rather than by ID, but that parameter cannot be applied directly
on the model's last stage.

Fixes #39940.

