### PR TITLE
Support metric based queries

### DIFF
--- a/frontend/src/metabase/redux/metadata.js
+++ b/frontend/src/metabase/redux/metadata.js
@@ -4,6 +4,7 @@ import _ from "underscore";
 import Databases from "metabase/entities/databases";
 import Fields from "metabase/entities/fields";
 import Metrics from "metabase/entities/metrics";
+import Questions from "metabase/entities/questions";
 import Schemas from "metabase/entities/schemas";
 import Segments from "metabase/entities/segments";
 import Tables from "metabase/entities/tables";
@@ -300,6 +301,8 @@ export const loadMetadataForDependentItems =
     );
     const promises = uniqueDependentItems.flatMap(({ type, id }) => {
       switch (type) {
+        case "card":
+          return [Questions.actions.fetch({ id }, options)];
         case "schema":
           return [Schemas.actions.fetchList({ dbId: id }, options)];
         case "table":

--- a/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
+++ b/modules/drivers/druid/test/metabase/driver/druid/query_processor_test.clj
@@ -9,15 +9,13 @@
    [metabase.db.metadata-queries :as metadata-queries]
    [metabase.driver :as driver]
    [metabase.driver.druid.query-processor :as druid.qp]
-   [metabase.models :refer [Field Metric Table]]
+   [metabase.models :refer [Field Table]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.compile :as qp.compile]
    [metabase.test :as mt]
    [metabase.timeseries-query-processor-test.util :as tqpt]
-   [metabase.util :as u]
    [metabase.util.date-2 :as u.date]
-   [toucan2.core :as t2]
-   [toucan2.tools.with-temp :as t2.with-temp]))
+   [toucan2.core :as t2]))
 
 (defn- str->absolute-dt [s]
   [:absolute-datetime (u.date/parse s "UTC") :default])
@@ -543,7 +541,8 @@
             (druid-query
               {:aggregation [[:distinct [:+ $id $checkins.venue_price]]]}))))))
 
-(deftest metrics-inside-aggregation-clauses-test
+;; TODO TB legacy macro test, delete or port
+#_(deftest metrics-inside-aggregation-clauses-test
   (mt/test-driver :druid
     (testing "check that we can handle METRICS inside expression aggregation clauses"
       (tqpt/with-flattened-dbdef

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -404,7 +404,10 @@
        :where     [:and
                    [:= :collection_id (:id collection)]
                    [:= :archived (boolean archived?)]
-                   [:= :c.type (h2x/literal (if dataset? "model" "question"))]]}
+                   (if dataset?
+                     [:= :c.type (h2x/literal "model")]
+                     [:in :c.type [(h2x/literal "question")
+                                   (h2x/literal "metric")]])]}
       (cond-> dataset?
         (-> (sql.helpers/select :c.table_id :t.is_upload :c.query_type)
             (sql.helpers/left-join [:metabase_table :t] [:= :t.id :c.table_id])))

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -174,7 +174,8 @@
                                  :where    (into [:and
                                                   [:not= :result_metadata nil]
                                                   [:= :archived false]
-                                                  [:= :type (u/qualified-name card-type)]
+                                                  ;; always return metrics for now
+                                                  [:in :type [(u/qualified-name card-type) "metric"]]
                                                   [:in :database_id ids-of-dbs-that-support-source-queries]
                                                   (collection/visible-collection-ids->honeysql-filter-clause
                                                    (collection/permissions-set->visible-collection-ids

--- a/src/metabase/lib/card.cljc
+++ b/src/metabase/lib/card.cljc
@@ -45,6 +45,16 @@
             (lib.metadata.calculation/display-name query stage-number card-metadata :long))
           (fallback-display-name source-card)))))
 
+;; handle single metric sources like cards for now
+(defmethod lib.metadata.calculation/describe-top-level-key-method :sources
+  [query stage-number _k]
+  (let [{:keys [sources]} (lib.util/query-stage query stage-number)
+        metric-id (lib.util/first-metric-id sources)]
+    (when sources
+      (or (when-let [card-metadata (lib.metadata/card query metric-id)]
+            (lib.metadata.calculation/display-name query stage-number card-metadata :long))
+          (i18n/tru "Metric {0}" (pr-str metric-id))))))
+
 (mu/defn ^:private infer-returned-columns :- [:maybe [:sequential ::lib.schema.metadata/column]]
   [metadata-providerable :- lib.metadata/MetadataProviderable
    card-query            :- :map]

--- a/src/metabase/lib/column_group.cljc
+++ b/src/metabase/lib/column_group.cljc
@@ -71,6 +71,8 @@
         (lib.metadata.calculation/display-info query stage-number table))
       (when-let [card (some->> (:source-card stage) (lib.metadata/card query))]
         (lib.metadata.calculation/display-info query stage-number card))
+      (when-let [metric (some->> (:sources stage) lib.util/first-metric-id (lib.metadata/card query))]
+        (lib.metadata.calculation/display-info query stage-number metric))
       ;; for multi-stage queries return an empty string (#30108)
       (when (next (:stages query))
         {:display-name ""})

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -170,9 +170,13 @@
      (when-let [card-id (:source-card base-stage)]
        [{:type :table, :id (str "card__" card-id)}
         {:type :card,  :id card-id}])
+     ;; support metric sources for now
      (for [source (:sources base-stage)
-           :when (= (:lib/type source) :source/metric)]
-       {:type :table, :id (str "card__" (:id source))})
+           :when (= (:lib/type source) :source/metric)
+           :let [card-id (:id source)]
+           item [{:type :table, :id (str "card__" card-id)}
+                 {:type :card, :id card-id}]]
+       item)
      (when-let [table-id (:source-table base-stage)]
        [{:type :table, :id table-id}])
      (for [stage (:stages query-or-join)

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -168,7 +168,11 @@
          {:type :field, :id id}))
      ;; cf. frontend/src/metabase-lib/Question.ts and frontend/src/metabase-lib/queries/StructuredQuery.ts
      (when-let [card-id (:source-card base-stage)]
-       [{:type :table, :id (str "card__" card-id)}])
+       [{:type :table, :id (str "card__" card-id)}
+        {:type :card,  :id card-id}])
+     (for [source (:sources base-stage)
+           :when (= (:lib/type source) :source/metric)]
+       {:type :table, :id (str "card__" (:id source))})
      (when-let [table-id (:source-table base-stage)]
        [{:type :table, :id table-id}])
      (for [stage (:stages query-or-join)
@@ -179,11 +183,12 @@
 (def ^:private DependentItem
   [:and
    [:map
-    [:type [:enum :database :schema :table :field]]]
+    [:type [:enum :database :schema :table :card :field]]]
    [:multi {:dispatch :type}
     [:database [:map [:id ::lib.schema.id/database]]]
     [:schema   [:map [:id ::lib.schema.id/database]]]
     [:table    [:map [:id [:or ::lib.schema.id/table :string]]]]
+    [:card     [:map [:id ::lib.schema.id/card]]]
     [:field    [:map [:id ::lib.schema.id/field]]]]])
 
 (mu/defn dependent-metadata :- [:sequential DependentItem]

--- a/src/metabase/lib/fe_util.cljc
+++ b/src/metabase/lib/fe_util.cljc
@@ -3,6 +3,7 @@
    [metabase.lib.common :as lib.common]
    [metabase.lib.field :as lib.field]
    [metabase.lib.filter :as lib.filter]
+   [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.options :as lib.options]
    [metabase.lib.schema :as lib.schema]
@@ -11,6 +12,7 @@
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.schema.temporal-bucketing :as lib.schema.temporal-bucketing]
    [metabase.lib.temporal-bucket :as lib.temporal-bucket]
+   [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
    [metabase.mbql.util :as mbql.u]
    [metabase.shared.formatting.date :as fmt.date]
@@ -151,6 +153,15 @@
       _
       (lib.metadata.calculation/display-name query stage-number filter-clause))))
 
+(defn- query-dependents-foreign-keys
+  [metadata-providerable columns]
+  (for [column columns
+        :let [fk-target-field-id (:fk-target-field-id column)]
+        :when (and fk-target-field-id (lib.types.isa/foreign-key? column))]
+    (if-let [fk-target-field (lib.metadata/field metadata-providerable fk-target-field-id)]
+      {:type :table, :id (:table-id fk-target-field)}
+      {:type :field, :id fk-target-field-id})))
+
 (defn- query-dependents
   [metadata-providerable query-or-join]
   (let [base-stage (first (:stages query-or-join))
@@ -173,12 +184,18 @@
      ;; support metric sources for now
      (for [source (:sources base-stage)
            :when (= (:lib/type source) :source/metric)
-           :let [card-id (:id source)]
-           item [{:type :table, :id (str "card__" card-id)}
-                 {:type :card, :id card-id}]]
+           :let [card-id (:id source)
+                 metric-metadata (or (lib.metadata/metric metadata-providerable card-id)
+                                     (lib.metadata/card metadata-providerable card-id))
+                 metric-table-id (:table-id metric-metadata)]
+           item (cond-> [{:type :table, :id (str "card__" card-id)}
+                         {:type :card, :id card-id}]
+                  metric-table-id (conj {:type :table, :id metric-table-id}))]
        item)
      (when-let [table-id (:source-table base-stage)]
-       [{:type :table, :id table-id}])
+       (cons {:type :table, :id table-id}
+             (query-dependents-foreign-keys metadata-providerable
+                                            (lib.metadata/fields metadata-providerable table-id))))
      (for [stage (:stages query-or-join)
            join (:joins stage)
            dependent (query-dependents metadata-providerable join)]

--- a/src/metabase/lib/field.cljc
+++ b/src/metabase/lib/field.cljc
@@ -67,6 +67,7 @@
             stage-columns         (or (:metabase.lib.stage/cached-metadata stage)
                                       (get-in stage [:lib/stage-metadata :columns])
                                       (when (or (:source-card  stage)
+                                                (:sources      stage)
                                                 (:source-table stage)
                                                 (:expressions  stage)
                                                 (:fields       stage))

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -24,6 +24,7 @@
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.metadata.protocols :as lib.metadata.protocols]
    [metabase.lib.order-by :as lib.order-by]
+   [metabase.lib.query :as lib.query]
    [metabase.lib.stage :as lib.stage]
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
@@ -121,7 +122,7 @@
 (defn ^:export legacy-query
   "Coerce a CLJS pMBQL query back to (1) a legacy query (2) in vanilla JS."
   [query-map]
-  (-> query-map lib.convert/->legacy-MBQL fix-namespaced-values (clj->js :keyword-fn u/qualified-name)))
+  (-> query-map lib.query/->legacy-MBQL fix-namespaced-values (clj->js :keyword-fn u/qualified-name)))
 
 (defn ^:export append-stage
   "Adds a new blank stage to the end of the pipeline"
@@ -748,7 +749,8 @@
   with \"card__\") of `a-query`. If `a-query` has none of these, nil is returned."
   [a-query]
   (or (lib.util/source-table-id a-query)
-      (some->> (lib.util/source-card-id a-query) (str "card__"))))
+      (some->> (lib.util/source-card-id a-query) (str "card__"))
+      (some->> (lib.util/source-metric-id a-query) (str "card__"))))
 
 (defn ^:export join-strategy
   "Get the strategy (type) of a given join as an opaque JoinStrategy object."

--- a/src/metabase/lib/metadata/calculation.cljc
+++ b/src/metabase/lib/metadata/calculation.cljc
@@ -142,7 +142,7 @@
 
 (def ^:private TopLevelKey
   "In the interest of making this easy to use in JS-land we'll accept either strings or keywords."
-  [:enum :aggregation :breakout :filters :limit :order-by :source-table :source-card :joins])
+  [:enum :aggregation :breakout :filters :limit :order-by :source-table :source-card :sources :joins])
 
 (mu/defn describe-top-level-key :- [:maybe ::lib.schema.common/non-blank-string]
   "'top-level' here means the top level of an individual stage. Generate a human-friendly string describing a specific

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -9,6 +9,7 @@
    [metabase.lib.hierarchy :as lib.hierarchy]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
+   [metabase.lib.ref :as lib.ref]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
    [metabase.lib.schema.id :as lib.schema.id]
@@ -20,7 +21,7 @@
    [metabase.util.malli :as mu]))
 
 (defmethod lib.metadata.calculation/metadata-method :mbql/query
-  [_query _stage-number _query]
+  [_query _stage-number _likely-the-same-query]
   ;; not i18n'ed because this shouldn't be developer-facing.
   (throw (ex-info "You can't calculate a metadata map for a query! Use lib.metadata.calculation/returned-columns-method instead."
                   {})))

--- a/src/metabase/lib/stage.cljc
+++ b/src/metabase/lib/stage.cljc
@@ -5,6 +5,7 @@
    [medley.core :as m]
    [metabase.lib.aggregation :as lib.aggregation]
    [metabase.lib.breakout :as lib.breakout]
+   [metabase.lib.convert :as lib.convert]
    [metabase.lib.expression :as lib.expression]
    [metabase.lib.field :as lib.field]
    [metabase.lib.hierarchy :as lib.hierarchy]
@@ -15,6 +16,7 @@
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.util :as lib.util]
+   [metabase.mbql.normalize :as mbql.normalize]
    [metabase.shared.util.i18n :as i18n]
    [metabase.util :as u]
    [metabase.util.malli :as mu]))
@@ -47,15 +49,16 @@
 
 (mu/defn ^:private existing-stage-metadata :- [:maybe lib.metadata.calculation/ColumnsWithUniqueAliases]
   "Return existing stage metadata attached to a stage if is already present: return it as-is, but only if this is a
-  native stage or a source-Card stage. if it's any other sort of stage then ignore the metadata, it's probably wrong;
-  we can recalculate the correct metadata anyway."
+  native stage or a source-Card or a metric stage. If it's any other sort of stage then ignore the metadata, it's
+  probably wrong; we can recalculate the correct metadata anyway."
   [query        :- ::lib.schema/query
    stage-number :- :int]
-  (let [{stage-type :lib/type, :keys [source-card] :as stage} (lib.util/query-stage query stage-number)]
+  (let [{stage-type :lib/type, :keys [source-card sources] :as stage} (lib.util/query-stage query stage-number)]
     (or (::cached-metadata stage)
         (when-let [metadata (:lib/stage-metadata stage)]
           (when (or (= stage-type :mbql.stage/native)
-                    source-card)
+                    source-card
+                    (lib.util/first-metric-id sources))
             (let [source-type (case stage-type
                                 :mbql.stage/native :source/native
                                 :mbql.stage/mbql   :source/card)]
@@ -160,6 +163,23 @@
     (when-let [card (lib.metadata/card query card-id)]
       (not-empty (lib.metadata.calculation/visible-columns query stage-number card options)))))
 
+(mu/defn ^:private metric-metadata :- [:maybe lib.metadata.calculation/ColumnsWithUniqueAliases]
+  [query          :- ::lib.schema/query
+   _stage-number   :- :int
+   sources        :- [:maybe ::lib.schema/sources]
+   options        :- lib.metadata.calculation/VisibleColumnsOptions]
+  ;; deal with just a single source for now
+  (when-let [{metric-id :id, source-type :lib/type} (first sources)]
+    (when (= source-type :source/metric)
+      (when-let [card (lib.metadata/card query metric-id)]
+        (let [metric-query (-> card :dataset-query mbql.normalize/normalize lib.convert/->pMBQL
+                               (lib.util/update-query-stage -1 dissoc :aggregation :breakout))]
+          (not-empty (lib.metadata.calculation/visible-columns
+                      (assoc metric-query :lib/metadata (:lib/metadata query))
+                      -1
+                      (lib.util/query-stage metric-query -1)
+                      options)))))))
+
 (mu/defn ^:private expressions-metadata :- [:maybe lib.metadata.calculation/ColumnsWithUniqueAliases]
   [query           :- ::lib.schema/query
    stage-number    :- :int
@@ -184,6 +204,8 @@
 ;;; 1c. Metadata associated with a Saved Question, if we have `:source-card` (`:source-table` is a `card__<id>` string
 ;;;     in legacy MBQL), OR
 ;;;
+;;; 1e. Metadata associated with a Metric, if we have `:sources`, OR
+;;;
 ;;; 1d. `:lib/stage-metadata` if this is a `:mbql.stage/native` stage
 ;;;
 ;;; PLUS
@@ -199,13 +221,15 @@
    stage-number                          :- :int
    {:keys [unique-name-fn], :as options} :- lib.metadata.calculation/VisibleColumnsOptions]
   {:pre [(fn? unique-name-fn)]}
-  (mapv
-   #(dissoc % ::lib.join/join-alias ::lib.field/temporal-unit ::lib.field/binning :fk-field-id)
-   (or
-    ;; 1a. columns returned by previous stage
-    (previous-stage-metadata query stage-number unique-name-fn)
-    ;; 1b or 1c
-    (let [{:keys [source-table source-card], :as this-stage} (lib.util/query-stage query stage-number)]
+  (let [{:keys [source-table source-card sources], :as this-stage} (lib.util/query-stage query stage-number)]
+    (mapv
+     #(cond-> %
+        (not (lib.util/first-metric-id sources))
+        (dissoc ::lib.join/join-alias ::lib.field/temporal-unit ::lib.field/binning :fk-field-id))
+     (or
+      ;; 1a. columns returned by previous stage
+      (previous-stage-metadata query stage-number unique-name-fn)
+      ;; 1b or 1c
       (or
        ;; 1b: default visible Fields for the source Table
        (when source-table
@@ -215,6 +239,9 @@
        ;; 1c. Metadata associated with a saved Question
        (when source-card
          (saved-question-metadata query stage-number source-card (assoc options :include-implicitly-joinable? false)))
+       ;; 1e. Metadata associated with a Metric
+       (when sources
+         (metric-metadata query stage-number sources options))
        ;; 1d: `:lib/stage-metadata` for the (presumably native) query
        (for [col (:columns (:lib/stage-metadata this-stage))]
          (assoc col
@@ -289,6 +316,7 @@
 (def ^:private display-name-source-parts
   [:source-table
    :source-card
+   :sources
    :joins])
 
 (def ^:private display-name-other-parts
@@ -321,7 +349,7 @@
   "Does given query stage have any clauses?"
   [query        :- ::lib.schema/query
    stage-number :- :int]
-  (boolean (seq (dissoc (lib.util/query-stage query stage-number) :lib/type :source-table :source-card))))
+  (boolean (seq (dissoc (lib.util/query-stage query stage-number) :lib/type :source-table :source-card :sources))))
 
 (mu/defn append-stage :- ::lib.schema/query
   "Adds a new blank stage to the end of the pipeline"

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -475,6 +475,18 @@
   [query :- :map]
   (= (first-stage-type query) :mbql.stage/native))
 
+(defn first-metric-id
+  "Return the ID of the first metric source in `sources`, if any."
+  [sources]
+  (some #(when (= (:lib/type %) :source/metric)
+           (:id %))
+        sources))
+
+(mu/defn source-metric-id :- [:maybe ::lib.schema.id/metric]
+  "If this query has a metric in `:sources`, return its ID."
+  [query]
+  (-> query :stages first :sources first-metric-id))
+
 (mu/defn unique-name-generator :- [:=>
                                    [:cat ::lib.schema.common/non-blank-string]
                                    ::lib.schema.common/non-blank-string]

--- a/src/metabase/mbql/normalize.cljc
+++ b/src/metabase/mbql/normalize.cljc
@@ -782,6 +782,9 @@
     (not native?) canonicalize-inner-mbql-query
     native?       canonicalize-native-query))
 
+(defn- canonicalize-sources [sources]
+  (mapv #(update % :lib/type keyword) sources))
+
 (defn- non-empty? [x]
   (if (coll? x)
     (seq x)
@@ -795,7 +798,8 @@
     (non-empty? (:breakout     mbql-query)) (update :breakout     canonicalize-breakouts)
     (non-empty? (:fields       mbql-query)) (update :fields       (partial mapv wrap-implicit-field-id))
     (non-empty? (:order-by     mbql-query)) (update :order-by     canonicalize-order-by)
-    (non-empty? (:source-query mbql-query)) (update :source-query canonicalize-source-query)))
+    (non-empty? (:source-query mbql-query)) (update :source-query canonicalize-source-query)
+    (non-empty? (:sources      mbql-query)) (update :sources      canonicalize-sources)))
 
 (def ^:private ^{:arglists '([query])} canonicalize-inner-mbql-query
   (comp canonicalize-mbql-clauses canonicalize-top-level-mbql-clauses))

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -1085,8 +1085,7 @@
 (deftest create-card-with-metric-type
   (mt/with-model-cleanup [:model/Card]
     (testing "can create a metric card"
-      (is (=? {:dataset false
-               :type    "metric"}
+      (is (=? {:type "metric"}
               (mt/user-http-request :crowberto :post 200 "card" (assoc (card-with-name-and-query (mt/random-name))
                                                                        :type "metric")))))))
 
@@ -1207,8 +1206,7 @@
   (testing "can fetch a metric card"
     (mt/with-temp [:model/Card card {:dataset_query (mbql-count-query)
                                      :type "metric"}]
-      (is (=? {:dataset false
-               :type    "metric"}
+      (is (=? {:type "metric"}
               (mt/user-http-request :crowberto :get 200 (str "card/" (u/the-id card))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+

--- a/test/metabase/lib/fe_util_test.cljc
+++ b/test/metabase/lib/fe_util_test.cljc
@@ -168,14 +168,16 @@
   (testing "source card based query"
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
-                      {:type :table,    :id "card__1"}]
+                      {:type :table,    :id "card__1"}
+                      {:type :card,     :id 1}]
                      (lib/dependent-metadata query))
       lib.tu/query-with-source-card
       (lib/append-stage lib.tu/query-with-source-card)))
   (testing "source card based query with result metadata"
     (are [query] (=? [{:type :database, :id (meta/id)}
                       {:type :schema,   :id (meta/id)}
-                      {:type :table,    :id "card__1"}]
+                      {:type :table,    :id "card__1"}
+                      {:type :card,     :id 1}]
                      (lib/dependent-metadata query))
       lib.tu/query-with-source-card-with-result-metadata
       (lib/append-stage lib.tu/query-with-source-card-with-result-metadata)))
@@ -183,7 +185,8 @@
     (let [query (assoc lib.tu/query-with-source-card :lib/metadata lib.tu/metadata-provider-with-model)]
       (are [query] (=? [{:type :database, :id (meta/id)}
                         {:type :schema,   :id (meta/id)}
-                        {:type :table,    :id "card__1"}]
+                        {:type :table,    :id "card__1"}
+                        {:type :card,     :id 1}]
                        (lib/dependent-metadata query))
         query
         (lib/append-stage query)))))

--- a/test/metabase/query_processor_test/case_test.clj
+++ b/test/metabase/query_processor_test/case_test.clj
@@ -1,7 +1,7 @@
 (ns metabase.query-processor-test.case-test
   (:require
    [clojure.test :refer :all]
-   [metabase.models :refer [Metric Segment]]
+   [metabase.models :refer [Segment]]
    [metabase.test :as mt]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
@@ -37,7 +37,8 @@
                                                          :definition {:source-table (mt/id :venues)
                                                                       :filter       [:< [:field (mt/id :venues :price) nil] 4]}}]
         (is (=  179.0  (test-case [:sum [:case [[[:segment segment-id] [:field (mt/id :venues :price) nil]]]]])))))
-    (testing "Can we use case in metric"
+    ;; TODO TB legacy macro test, delete or port
+    #_(testing "Can we use case in metric"
       (t2.with-temp/with-temp [Metric {metric-id :id} {:table_id   (mt/id :venues)
                                                        :definition {:source-table (mt/id :venues)
                                                                     :aggregation  [:sum

--- a/test/metabase/query_processor_test/count_where_test.clj
+++ b/test/metabase/query_processor_test/count_where_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor-test.count-where-test
   (:require
    [clojure.test :refer :all]
-   [metabase.models.metric :refer [Metric]]
    [metabase.models.segment :refer [Segment]]
    [metabase.test :as mt]
    [toucan2.tools.with-temp :as t2.with-temp]))
@@ -85,7 +84,8 @@
                   ffirst
                   long))))))
 
-(deftest metric-test
+;; TODO TB legacy macro test, delete or port
+#_(deftest metric-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (t2.with-temp/with-temp [Metric {metric-id :id} {:table_id   (mt/id :venues)
                                                      :definition {:source-table (mt/id :venues)

--- a/test/metabase/query_processor_test/expression_aggregations_test.clj
+++ b/test/metabase/query_processor_test/expression_aggregations_test.clj
@@ -2,11 +2,8 @@
   "Tests for expression aggregations and for named aggregations."
   (:require
    [clojure.test :refer :all]
-   [metabase.models.metric :refer [Metric]]
    [metabase.query-processor.test-util :as qp.test-util]
-   [metabase.test :as mt]
-   [metabase.util :as u]
-   [toucan2.tools.with-temp :as t2.with-temp]))
+   [metabase.test :as mt]))
 
 (deftest ^:parallel sum-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
@@ -232,7 +229,8 @@
                    {:aggregation [[:aggregation-options [:- [:sum $price] 41] {:name "sum_41"}]]
                     :breakout    [$price]}))))))))
 
-(deftest metrics-test
+;; TODO TB legacy macro test, delete or port
+#_(deftest metrics-test
   (mt/test-drivers (mt/normal-drivers-with-feature :expression-aggregations)
     (testing "check that we can handle Metrics inside expression aggregation clauses"
       (t2.with-temp/with-temp [Metric metric {:table_id   (mt/id :venues)

--- a/test/metabase/query_processor_test/nested_queries_test.clj
+++ b/test/metabase/query_processor_test/nested_queries_test.clj
@@ -1308,7 +1308,8 @@
               (is (= [[543]]
                      (mt/formatted-rows [int] (qp/process-query q2)))))))))))
 
-(deftest ^:parallel nested-query-with-metric-test
+;; TODO TB legacy macro test, delete or port
+#_(deftest ^:parallel nested-query-with-metric-test
   (mt/test-drivers (mt/normal-drivers-with-feature :nested-queries)
     (testing "A nested query with a Metric should work as expected (#12507)"
       (qp.store/with-metadata-provider (lib.tu/mock-metadata-provider

--- a/test/metabase/query_processor_test/share_test.clj
+++ b/test/metabase/query_processor_test/share_test.clj
@@ -3,7 +3,6 @@
   (:require
    [clojure.test :refer :all]
    [metabase.driver :as driver]
-   [metabase.models.metric :refer [Metric]]
    [metabase.models.segment :refer [Segment]]
    [metabase.test :as mt]
    [toucan2.tools.with-temp :as t2.with-temp]))
@@ -58,17 +57,18 @@
                                                                       :filter       [:< [:field (mt/id :venues :price) nil] 4]}}]
         (is (= [[0.94]]
                (mt/formatted-rows [2.0]
-                 (mt/run-mbql-query venues
-                   {:aggregation [[:share [:segment segment-id]]]}))))))
+                                  (mt/run-mbql-query venues
+                                    {:aggregation [[:share [:segment segment-id]]]}))))))
 
-    (testing "Share inside a Metric"
-      (t2.with-temp/with-temp [Metric {metric-id :id} {:table_id   (mt/id :venues)
-                                                       :definition {:source-table (mt/id :venues)
-                                                                    :aggregation  [:share [:< [:field (mt/id :venues :price) nil] 4]]}}]
-        (is (= [[0.94]]
-               (mt/formatted-rows [2.0]
-                 (mt/run-mbql-query venues
-                   {:aggregation [[:metric metric-id]]}))))))))
+    ;; TODO TB legacy macro test, delete or port
+    #_(testing "Share inside a Metric"
+        (t2.with-temp/with-temp [Metric {metric-id :id} {:table_id   (mt/id :venues)
+                                                         :definition {:source-table (mt/id :venues)
+                                                                      :aggregation  [:share [:< [:field (mt/id :venues :price) nil] 4]]}}]
+          (is (= [[0.94]]
+                 (mt/formatted-rows [2.0]
+                                    (mt/run-mbql-query venues
+                                      {:aggregation [[:metric metric-id]]}))))))))
 
 (deftest ^:parallel expressions-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations :expressions)

--- a/test/metabase/query_processor_test/sum_where_test.clj
+++ b/test/metabase/query_processor_test/sum_where_test.clj
@@ -1,7 +1,6 @@
 (ns metabase.query-processor-test.sum-where-test
   (:require
    [clojure.test :refer :all]
-   [metabase.models.metric :refer [Metric]]
    [metabase.models.segment :refer [Segment]]
    [metabase.test :as mt]
    [toucan2.tools.with-temp :as t2.with-temp]))
@@ -93,7 +92,8 @@
                   ffirst
                   double))))))
 
-(deftest metric-test
+;; TODO TB legacy macro test, delete or port
+#_(deftest metric-test
   (mt/test-drivers (mt/normal-drivers-with-feature :basic-aggregations)
     (t2.with-temp/with-temp [Metric {metric-id :id} {:table_id   (mt/id :venues)
                                                      :definition {:source-table (mt/id :venues)


### PR DESCRIPTION
Part of #38724.

The PR allows creating ad-hoc queries based on metrics.

<img width="615" alt="image" src="https://github.com/metabase/metabase/assets/103100869/5bc96064-1599-45d9-a5cd-db2fbe80255d">

```clojure
{:lib/type :mbql/query,
 :stages
 [{:lib/type :mbql.stage/mbql,
   :aggregation [[:metric #:lib{:uuid "32fb5904-efcb-4ce1-8255-e44ddb95db57"} 90]],
   :filters
   [[:=
     #:lib{:uuid "b1467ea2-c6fc-4478-a876-0dea97fb2390"}
     [:field {:base-type :type/Text, :source-field 37, :lib/uuid "378c9312-ddae-43bd-b84a-d5c30761095e"} 64]
     "Widget"]],
   :sources [{:lib/type :source/metric, :id 90}]}],
 :database 1}
```
