### PR TITLE
Allow new view-data and create-queries permissions to be read and written via permission graph

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
@@ -30,9 +30,7 @@
                                             (when group-id [:= :group_id group-id])
                                             (when-not audit-db? [:not [:= :db_id config/audit-db-id]])]})]
      (reduce (fn [acc {:keys [db_id group_id]}]
-               (-> acc
-                 (assoc-in [group_id db_id] {:data {:schemas :impersonated}})
-                 (assoc-in [group_id db_id] {:view-data :impersonated})))
+               (assoc-in acc [group_id db_id] {:view-data :impersonated}))
              {}
              impersonations))))
 
@@ -57,16 +55,16 @@
     (log/debugf "Group %d %s for Database %d, deleting all Connection Impersonations for this DB"
                 group-id
                 (case changes
-                  :none  "no longer has any perms"
-                  :all   "now has full data perms"
-                  :block "is now BLOCKED from all non-data-perms access")
+                  :unrestricted "now has full data perms"
+                  :blocked      "is now BLOCKED from all non-data-perms access"
+                  "now has granular (sandboxed) data access")
                 database-id)
     (t2/delete! :model/ConnectionImpersonation :group_id group-id :db_id database-id)))
 
 (defn- delete-impersonations-for-group! [{:keys [group-id]} changes]
   (log/debugf "Deleting unneeded Connection Impersonation policies for Group %d. Graph changes: %s" group-id (pr-str changes))
   (doseq [database-id (set (keys changes))]
-    (when-let [data-perm-changes (get-in changes [database-id :data :schemas])]
+    (when-let [data-perm-changes (get-in changes [database-id :view-data])]
       (delete-impersonations-for-group-database!
        {:group-id group-id, :database-id database-id}
        data-perm-changes))))

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
@@ -30,7 +30,9 @@
                                             (when group-id [:= :group_id group-id])
                                             (when-not audit-db? [:not [:= :db_id config/audit-db-id]])]})]
      (reduce (fn [acc {:keys [db_id group_id]}]
-               (assoc-in acc [group_id db_id] {:view-data :impersonated}))
+               (-> acc
+                  (assoc-in [group_id db_id] {:view-data :impersonated})
+                  (assoc-in [group_id db_id] {:data {:schemas :impersonated}})))
              {}
              impersonations))))
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
@@ -30,7 +30,9 @@
                                             (when group-id [:= :group_id group-id])
                                             (when-not audit-db? [:not [:= :db_id config/audit-db-id]])]})]
      (reduce (fn [acc {:keys [db_id group_id]}]
-               (assoc-in acc [group_id db_id] {:data {:schemas :impersonated}}))
+               (-> acc
+                 (assoc-in [group_id db_id] {:data {:schemas :impersonated}})
+                 (assoc-in [group_id db_id] {:view-data :impersonated})))
              {}
              impersonations))))
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
@@ -31,8 +31,8 @@
                                             (when-not audit-db? [:not [:= :db_id config/audit-db-id]])]})]
      (reduce (fn [acc {:keys [db_id group_id]}]
                (-> acc
-                  (assoc-in [group_id db_id] {:view-data :impersonated})
-                  (assoc-in [group_id db_id] {:data {:schemas :impersonated}})))
+                  (assoc-in [group_id db_id :view-data] :impersonated)
+                  (assoc-in [group_id db_id :data] {:schemas :impersonated})))
              {}
              impersonations))))
 

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -80,8 +80,9 @@
 (defn- merge-sandbox-into-graph
   "Merges a single sandboxing policy into the permissions graph. Adjusts permissions at the database or schema level,
   ensuring table-level permissions are set appropriately."
-  [graph group-id table-id db-id schema]
-  (let [db-perm (get-in graph [group-id db-id :view-data])
+  [graph group-id table-id db-id schema perm-location sandbox-value]
+  (let [db-path (concat [group-id db-id] perm-location)
+        db-perm (get-in graph db-path)
         schema-perm (get db-perm schema)
         default-table-perm (if (keyword? db-perm)
                              db-perm
@@ -97,24 +98,24 @@
         ;; Remove the overarching database or schema permission so that we can add the granular table-level permissions
         graph (cond
                 (and tables (keyword? db-perm))
-                (m/dissoc-in graph [group-id db-id :view-data])
+                (m/dissoc-in graph db-path)
 
                 (and tables (keyword? schema-perm))
-                (m/dissoc-in graph [group-id db-id :view-data (or schema "")])
+                (m/dissoc-in graph (concat db-path [(or schema "")]))
 
                 :else
                 graph)
         ;; Apply granular permissions to each table
         granular-graph (if tables
                          (reduce (fn [g {:keys [id schema]}]
-                                   (assoc-in g [group-id db-id :view-data (or schema "") id] default-table-perm))
+                                   (assoc-in g (concat db-path [(or schema "") id]) default-table-perm))
                                  graph
                                  tables)
                          graph)]
     ;; Set `:segmented` (aka sandboxed) permissions for the target table
-    (-> granular-graph
-       (assoc-in [group-id db-id :view-data (or schema "") table-id]
-                 :sandboxed))))
+    (assoc-in granular-graph
+              (concat db-path [(or schema "") table-id])
+              sandbox-value)))
 
 (defenterprise add-sandboxes-to-permissions-graph
   "Augments a provided permissions graph with active sandboxing policies."
@@ -130,7 +131,9 @@
                                       (when-not audit? [:not [:= :t.db_id config/audit-db-id]])]})]
     ;; Incorporate each sandbox policy into the permissions graph.
     (reduce (fn [acc {:keys [group_id table_id db_id schema]}]
-              (merge-sandbox-into-graph acc group_id table_id db_id schema))
+              (-> acc
+                (merge-sandbox-into-graph group_id table_id db_id schema [:data :schemas] {:query :segmented, :read :all})
+                (merge-sandbox-into-graph group_id table_id db_id schema [:view-data] :sandboxed)))
             graph
             sandboxes)))
 

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
@@ -36,48 +36,21 @@
   (log/debugf "Deleting unneeded GTAPs for Group %d for Table %d. Graph changes: %s"
              group-id table-id (pr-str changes))
   (cond
-    (= changes :none)
-    (do
-      (log/debugf "Group %d no longer has any permissions for Table %d, deleting GTAP for this Table if one exists"
-                 group-id table-id)
-      (delete-gtaps-with-condition! group-id [:= :table.id table-id]))
-
-    (= changes :all)
+    (= changes :unrestricted)
     (do
       (log/debugf "Group %d now has full data perms for Table %d, deleting GTAP for this Table if one exists"
                  group-id table-id)
       (delete-gtaps-with-condition! group-id [:= :table.id table-id]))
 
-    :else
-    (let [new-query-perms (get changes :query :none)]
-      (case new-query-perms
-        :none
-        (do
-          (log/debugf "Group %d no longer has any query perms for Table %d; deleting GTAP for this Table if one exists"
-                     group-id table-id)
-          (delete-gtaps-with-condition! group-id [:= :table.id table-id]))
-
-        :all
-        (do
-          (log/debugf "Group %d now has full non-sandboxed query perms for Table %d; deleting GTAP for this Table if one exists"
-                     group-id table-id)
-          (delete-gtaps-with-condition! group-id [:= :table.id table-id]))
-
-        :segmented
-        (log/debugf "Group %d now has full segmented query perms for Table %d. Do not need to delete GTAPs."
-                   group-id table-id)))))
+    (= changes :sandboxed)
+    (log/debugf "Group %d now has full sandboxed query perms for Table %d. Do not need to delete GTAPs."
+               group-id table-id)))
 
 (defn- delete-gtaps-for-group-schema! [{:keys [group-id database-id schema-name], :as context} changes]
   (log/debugf "Deleting unneeded GTAPs for Group %d for Database %d, schema %s. Graph changes: %s"
              group-id database-id (pr-str schema-name) (pr-str changes))
   (cond
-    (= changes :none)
-    (do
-      (log/debugf "Group %d no longer has any permissions for Database %d schema %s, deleting all GTAPs for this schema"
-                  group-id database-id (pr-str schema-name))
-      (delete-gtaps-with-condition! group-id [:and [:= :table.db_id database-id] [:= :table.schema schema-name]]))
-
-    (= changes :all)
+    (= changes :unrestricted)
     (do
       (log/debugf "Group %d changes has full data perms for Database %d schema %s, deleting all GTAPs for this schema"
                   group-id database-id (pr-str schema-name))
@@ -90,14 +63,13 @@
 (defn- delete-gtaps-for-group-database! [{:keys [group-id database-id], :as context} changes]
   (log/debugf "Deleting unneeded GTAPs for Group %d for Database %d. Graph changes: %s"
               group-id database-id (pr-str changes))
-  (if (#{:none :all :block :impersonated} changes)
+  (if (#{:unrestricted :blocked :impersonated} changes)
     (do
       (log/debugf "Group %d %s for Database %d, deleting all GTAPs for this DB"
                   group-id
                   (case changes
-                    :none  "no longer has any perms"
-                    :all   "now has full data perms"
-                    :block "is now BLOCKED from all non-data-perms access"
+                    :unrestricted "now has full data perms"
+                    :blocked      "is now BLOCKED from all non-data-perms access"
                     :impersonated "is now using connection impersonation")
                   database-id)
       (delete-gtaps-with-condition! group-id [:= :table.db_id database-id]))
@@ -109,7 +81,7 @@
 (defn- delete-gtaps-for-group! [{:keys [group-id]} changes]
   (log/debugf "Deleting unneeded GTAPs for Group %d. Graph changes: %s" group-id (pr-str changes))
   (doseq [database-id (set (keys changes))]
-    (when-let [data-perm-changes (get-in changes [database-id :data :schemas])]
+    (when-let [data-perm-changes (get-in changes [database-id :view-data])]
       (delete-gtaps-for-group-database!
        {:group-id group-id, :database-id database-id}
        data-perm-changes))))

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/impersonation_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/api/impersonation_test.clj
@@ -107,8 +107,8 @@
                                                                :attribute "Attribute Name"}]
         ;; Grant full data access to the DB and group
         (let [graph (assoc-in (data-perms.graph/api-graph)
-                              [:groups group-id (mt/id) :data :schemas]
-                              :all)]
+                              [:groups group-id (mt/id) :view-data]
+                              :unrestricted)]
           (mt/user-http-request :crowberto :put 200 "permissions/graph" graph))
         (is (nil? (t2/select-one :model/ConnectionImpersonation :id impersonation-id)))))
 

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -25,17 +25,18 @@
 ;;;; Graph-related stuff
 
 (defn- test-db-perms [group-id]
-  (get-in (data-perms.graph/api-graph) [:groups group-id (mt/id) :data]))
+  (get-in (data-perms.graph/api-graph) [:groups group-id (mt/id) :view-data]))
 
 (defn- api-test-db-perms [group-id]
-  (into {}
-        (map (fn [[k v]]
-               [k (cond-> v (string? v) keyword)]))
-        (get-in (mt/user-http-request :crowberto :get 200 "permissions/graph")
-                [:groups group-id (mt/id) :data])))
+  (not-empty
+   (into {}
+         (map (fn [[k v]]
+                [k (cond-> v (string? v) keyword)]))
+         (get-in (mt/user-http-request :crowberto :get 200 "permissions/graph")
+                 [:groups group-id (mt/id) :view-data]))))
 
 (deftest graph-test
-  (testing "block permissions should come back from"
+  (testing "block permissions are ellided from the graph"
     (doseq [[message perms] {"the graph function"
                              test-db-perms
 
@@ -43,20 +44,18 @@
                              api-test-db-perms}]
       (testing (str message "\n"))
       (mt/with-temp [PermissionsGroup {group-id :id} {}]
-        (data-perms/set-database-permission! group-id (mt/id) :perms/data-access :block)
-        (is (= {:schemas :block}
-               (perms group-id)))))))
+        (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :blocked)
+        (is (nil? (perms group-id)))))))
 
 (defn- grant-block-perms! [group-id]
-  (data-perms.graph/update-data-perms-graph! [group-id (mt/id) :data] {:schemas :block}))
+  (data-perms.graph/update-data-perms-graph! [group-id (mt/id) :view-data] :blocked))
 
 (defn- api-grant-block-perms! [group-id]
   (let [current-graph (data-perms.graph/api-graph)
-        new-graph     (assoc-in current-graph [:groups group-id (mt/id) :data] {:schemas :block})
+        new-graph     (assoc-in current-graph [:groups group-id (mt/id) :view-data] :blocked)
         result        (mt/with-premium-features #{:advanced-permissions}
                         (mt/user-http-request :crowberto :put 200 "permissions/graph" new-graph))]
-    (is (= "block"
-           (get-in result [:groups group-id (mt/id) :data :schemas])))))
+    (is (nil? (get-in result [:groups group-id (mt/id) :view-data])))))
 
 (deftest api-throws-error-if-premium-feature-not-enabled
   (testing "PUT /api/permissions/graph"
@@ -64,10 +63,11 @@
                   ":advanced-permissions premium feature enabled")
       (t2.with-temp/with-temp [PermissionsGroup {group-id :id}]
         (let [current-graph (data-perms.graph/api-graph)
-              new-graph     (assoc-in current-graph [:groups group-id (mt/id) :data] {:schemas :block})
+              new-graph     (assoc-in current-graph [:groups group-id (mt/id) :view-data] :blocked)
               result        (mt/with-premium-features #{} ; disable premium features
                               (mt/user-http-request :crowberto :put 402 "permissions/graph" new-graph))]
-          (is (= "The block permissions functionality is only enabled if you have a premium token with the advanced-permissions feature."
+          (def result result)
+          (is (= "The blocked permissions functionality is only enabled if you have a premium token with the advanced-permissions feature."
                  result)))))))
 
 (deftest update-graph-test
@@ -81,29 +81,27 @@
                                   api-grant-block-perms!}]
       (testing (str description "\n")
         (t2.with-temp/with-temp [PermissionsGroup {group-id :id}]
-          (testing "Group should have no perms upon creation"
-            (is (= nil
+          (testing "Group should have unrestricted view-data perms upon creation"
+            (is (= :unrestricted
                    (test-db-perms group-id))))
           (testing "group has no existing permissions"
             (mt/with-model-cleanup [Permissions]
               (mt/with-restored-data-perms-for-group! group-id
                 (grant! group-id)
-                (is (= {:schemas :block}
-                       (test-db-perms group-id))))))
+                (is (nil? (test-db-perms group-id))))))
           (testing "group has existing data permissions... :block should remove them"
             (mt/with-model-cleanup [Permissions]
               (mt/with-restored-data-perms-for-group! group-id
                 (data-perms/set-database-permission! group-id (mt/id) :perms/data-access :unrestricted)
                 (grant! group-id)
-                (is (= {:schemas :block}
-                       (test-db-perms group-id)))
-                (is (= #{:block}
+                (is (nil? (test-db-perms group-id)))
+                (is (= #{:blocked}
                        (t2/select-fn-set :perm_value
                                          :model/DataPermissions
                                          {:where [:and
                                                   [:= :db_id (mt/id)]
                                                   [:= :group_id group-id]
-                                                  [:= :perm_type (u/qualified-name :perms/data-access)]]})))))))))))
+                                                  [:= :perm_type (u/qualified-name :perms/view-data)]]})))))))))))
 
 (deftest update-graph-delete-sandboxes-test
   (testing "When setting `:block` permissions any GTAP rows for that Group/Database should get deleted."
@@ -113,18 +111,16 @@
                        GroupTableAccessPolicy _ {:table_id (mt/id :venues)
                                                  :group_id group-id}]
           (grant-block-perms! group-id)
-          (is (= {:schemas :block}
-                 (test-db-perms group-id)))
+          (is (nil? (test-db-perms group-id)))
           (is (not (t2/exists? GroupTableAccessPolicy :group_id group-id))))))))
 
 (deftest update-graph-data-perms-should-delete-block-perms-test
  (testing "granting data permissions for a table should delete existing block permissions"
    (mt/with-temp [PermissionsGroup {group-id :id} {}]
-     (data-perms/set-database-permission! group-id (mt/id) :perms/data-access :block)
-     (is (= {:schemas :block}
-            (test-db-perms group-id)))
-     (data-perms/set-table-permission! group-id (mt/id :venues) :perms/data-access :unrestricted)
-     (is (= {:schemas {"PUBLIC" {(mt/id :venues) :all}}}
+     (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :blocked)
+     (is (nil? (test-db-perms group-id)))
+     (data-perms/set-table-permission! group-id (mt/id :venues) :perms/view-data :unrestricted)
+     (is (= {"PUBLIC" {(mt/id :venues) :unrestricted}}
             (test-db-perms group-id))))))
 
 (deftest update-graph-disallow-native-query-perms-test
@@ -133,26 +129,24 @@
       (testing "via the fn"
         (is (thrown-with-msg?
              clojure.lang.ExceptionInfo
-             ;; TODO -- this error message is totally garbage, fix this
              #"Invalid DB permissions: If you have write access for native queries, you must have data access to all schemas."
-             ;; #"DB permissions with a valid combination of values for :native and :schemas"
-             (data-perms.graph/update-data-perms-graph! [group-id (mt/id) :data]
-                                                        {:schemas :block, :native :write}))))
+             (data-perms.graph/update-data-perms-graph! [group-id (mt/id)] {:view-data :blocked
+                                                                            :create-queries :query-builder-and-native}))))
       (testing "via the API"
         (let [current-graph (data-perms.graph/api-graph)
               new-graph     (assoc-in current-graph
-                                      [:groups group-id (mt/id) :data]
-                                      {:schemas :block, :native :write})]
-          (is (=? {:message  #".*Invalid DB permissions: If you have write access for native queries, you must have data access to all schemas.*"}
+                                      [:groups group-id (mt/id)]
+                                      {:view-data :blocked :create-queries :query-builder-and-native})]
+          (is (=? {:message #".*Invalid DB permissions: If you have write access for native queries, you must have data access to all schemas.*"}
                   (mt/with-premium-features #{:advanced-permissions}
                     (mt/user-http-request :crowberto :put 500 "permissions/graph" new-graph)))))))))
 
 (deftest delete-database-delete-block-perms-test
   (testing "If a Database gets DELETED, any block permissions for it should get deleted too."
     (mt/with-temp [Database    {db-id :id} {}]
-      (data-perms/set-database-permission! (u/the-id (perms-group/all-users)) db-id :perms/data-access :block)
+      (data-perms/set-database-permission! (u/the-id (perms-group/all-users)) db-id :perms/view-data :blocked)
       (letfn [(perms-exist? []
-                (t2/exists? :model/DataPermissions :db_id db-id :perm_value :block))]
+                (t2/exists? :model/DataPermissions :db_id db-id :perm_value :blocked))]
         (is (perms-exist?))
         (t2/delete! Database :id db-id)
         (is (not (perms-exist?)))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/permissions_test.clj
@@ -18,50 +18,33 @@
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (defn- db-graph-keypath [group]
-  [:groups (u/the-id group) (mt/id) :data])
+  [:groups (u/the-id group) (mt/id) :view-data])
 
 (defn- venues-perms-graph-keypath [group]
   (concat
    (db-graph-keypath group)
-   [:schemas :PUBLIC (mt/id :venues)]))
+   [:PUBLIC (mt/id :venues)]))
 
 (deftest revoke-perms-delete-gtaps-test
   (testing "PUT /api/permissions/graph"
     (testing "removing sandboxed permissions for a group should delete the associated GTAP (#16190)"
       (doseq [[message {:keys [updated-db-perms expected-perms]}]
-              {"when revoking all permissions for DB"
-               {:updated-db-perms (constantly {:native :none, :schemas :none})
-                :expected-perms   (constantly nil)}
-
-               "when revoking all permissions for schema"
-               {:updated-db-perms (constantly {:native :none, :schemas {:PUBLIC :none}})
-                :expected-perms   (constantly nil)}
-
-               "when revoking all permissions for Table"
-               {:updated-db-perms (fn []
-                                    {:native :none, :schemas {:PUBLIC {(mt/id :venues) :none
-                                                                       (mt/id :users)  :all}}})
-                :expected-perms   (fn []
-                                    {:schemas {:PUBLIC {(mt/id :users) "all"}}})}
-
-               "when changing permissions for DB to unrestricted access"
-               {:updated-db-perms (constantly {:native :none, :schemas :all})
-                :expected-perms   (constantly {:schemas "all"})}
+              {"when changing permissions for DB to unrestricted access"
+               {:updated-db-perms (constantly :unrestricted)
+                :expected-perms   (constantly "unrestricted")}
 
                "when changing permissions for schema to unrestricted access"
-               {:updated-db-perms (constantly {:native :none, :schemas {:PUBLIC :all}})
-                :expected-perms   (constantly {:schemas {:PUBLIC "all"}})}
+               {:updated-db-perms (constantly {:PUBLIC :unrestricted})
+                :expected-perms   (constantly "unrestricted")}
 
-               "when changing permissions for Table to :query [grant full query perms]"
-               {:updated-db-perms (fn []
-                                    {:native :none, :schemas {:PUBLIC {(mt/id :venues) {:query :all}}}})
-                :expected-perms   (fn []
-                                    {:schemas {:PUBLIC {(mt/id :venues) "all"}}})}}]
+               "when changing permissions for table to unrestricted access"
+               {:updated-db-perms (fn [] {:PUBLIC {(mt/id :venues) :unrestricted}})
+                :expected-perms   (fn [] "unrestricted")}}]
         (met/with-gtaps! {:gtaps {:venues {}}}
           (testing message
             (testing "sanity check"
               (testing "perms graph endpoint should return segmented perms for Venues table"
-                (is (= {:read "all" :query "segmented"}
+                (is (= "sandboxed"
                        (get-in (mt/user-http-request :crowberto :get 200 "permissions/graph")
                                (venues-perms-graph-keypath &group)))))
               (testing "GTAP should exist in application DB"
@@ -127,10 +110,7 @@
                                                            :table_id (mt/id :venues)}]
           (let [graph  (mt/user-http-request :crowberto :get 200 "permissions/graph")
                 graph' (assoc-in graph (db-graph-keypath (perms-group/all-users))
-                                 {:schemas
-                                  {"PUBLIC"
-                                   {(mt/id :venues)
-                                    {:read :all, :query :segmented}}}})]
+                                 {"PUBLIC" {(mt/id :venues) "sandboxed"}})]
             (mt/user-http-request :crowberto :put 200 "permissions/graph" graph')
             (testing "GTAP should not have been deleted"
               (is (t2/exists? GroupTableAccessPolicy :group_id (u/the-id (perms-group/all-users)), :table_id (mt/id :venues))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
@@ -132,12 +132,13 @@
       (testing "Sandbox definitions in the DB are automatically added to the permissions graph"
         (mt/with-temp [GroupTableAccessPolicy _gtap {:table_id (mt/id :venues)
                                                      :group_id (u/the-id (perms-group/all-users))}]
-          (is (= {(u/the-id (perms-group/all-users))
-                  {(mt/id)
-                   {:view-data
-                    {"PUBLIC"
-                     {(mt/id :venues) :sandboxed}}}}}
-                 (sandboxes/add-sandboxes-to-permissions-graph {})))))
+          (is (partial=
+               {(u/the-id (perms-group/all-users))
+                {(mt/id)
+                 {:view-data
+                  {"PUBLIC"
+                   {(mt/id :venues) :sandboxed}}}}}
+               (sandboxes/add-sandboxes-to-permissions-graph {})))))
 
       (testing "When perms are set at the DB level, incorporating a sandbox breaks them out to table-level"
         (mt/with-temp [GroupTableAccessPolicy _gtap {:table_id (mt/id :venues)
@@ -145,8 +146,7 @@
           (is (partial=
                {(u/the-id (perms-group/all-users))
                 {(mt/id)
-                 {:data {:schemas :all}
-                  :view-data {"PUBLIC"
+                 {:view-data {"PUBLIC"
                               {(mt/id :venues) :sandboxed}}}}}
                (sandboxes/add-sandboxes-to-permissions-graph
                 {(u/the-id (perms-group/all-users))
@@ -159,11 +159,10 @@
           (is (partial=
                {(u/the-id (perms-group/all-users))
                 {(mt/id)
-                 {:data {:schemas {"PUBLIC" :all}}
-                  :view-data
+                 {:view-data
                   {"PUBLIC"
                    {(mt/id :venues) :sandboxed}}}}}
                (sandboxes/add-sandboxes-to-permissions-graph
                 {(u/the-id (perms-group/all-users))
                  {(mt/id)
-                  {:data {:schemas {"PUBLIC" :all}}}}}))))))))
+                  {:view-data {"PUBLIC" :all}}}}))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
@@ -134,12 +134,9 @@
                                                      :group_id (u/the-id (perms-group/all-users))}]
           (is (= {(u/the-id (perms-group/all-users))
                   {(mt/id)
-                   {:data
-                    {:schemas
-                     {"PUBLIC"
-                      {(mt/id :venues)
-                       {:query :segmented
-                        :read :all}}}}}}}
+                   {:view-data
+                    {"PUBLIC"
+                     {(mt/id :venues) :sandboxed}}}}}
                  (sandboxes/add-sandboxes-to-permissions-graph {})))))
 
       (testing "When perms are set at the DB level, incorporating a sandbox breaks them out to table-level"
@@ -148,12 +145,9 @@
           (is (partial=
                {(u/the-id (perms-group/all-users))
                 {(mt/id)
-                 {:data
-                  {:schemas
-                   {"PUBLIC"
-                    {(mt/id :venues)   {:query :segmented
-                                        :read :all}
-                     (mt/id :products) :all}}}}}}
+                 {:data {:schemas :all}
+                  :view-data {"PUBLIC"
+                              {(mt/id :venues) :sandboxed}}}}}
                (sandboxes/add-sandboxes-to-permissions-graph
                 {(u/the-id (perms-group/all-users))
                  {(mt/id)
@@ -165,12 +159,10 @@
           (is (partial=
                {(u/the-id (perms-group/all-users))
                 {(mt/id)
-                 {:data
-                  {:schemas
-                   {"PUBLIC"
-                    {(mt/id :venues)   {:query :segmented
-                                        :read :all}
-                     (mt/id :products) :all}}}}}}
+                 {:data {:schemas {"PUBLIC" :all}}
+                  :view-data
+                  {"PUBLIC"
+                   {(mt/id :venues) :sandboxed}}}}}
                (sandboxes/add-sandboxes-to-permissions-graph
                 {(u/the-id (perms-group/all-users))
                  {(mt/id)

--- a/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/models/group_table_access_policy_test.clj
@@ -151,7 +151,7 @@
                (sandboxes/add-sandboxes-to-permissions-graph
                 {(u/the-id (perms-group/all-users))
                  {(mt/id)
-                  {:data {:schemas :all}}}})))))
+                  {:view-data :unrestricted}}})))))
 
       (testing "When perms are set at the schema level, incorporating a sandbox breaks them out to table-level"
         (mt/with-temp [GroupTableAccessPolicy _gtap {:table_id (mt/id :venues)
@@ -165,4 +165,4 @@
                (sandboxes/add-sandboxes-to-permissions-graph
                 {(u/the-id (perms-group/all-users))
                  {(mt/id)
-                  {:view-data {"PUBLIC" :all}}}}))))))))
+                  {:view-data :unrestricted}}}))))))))

--- a/src/metabase/api/permission_graph.clj
+++ b/src/metabase/api/permission_graph.clj
@@ -55,7 +55,7 @@
 
 (def ^:private TablePerms
   [:or
-   [:enum :all :segmented :none :full :limited]
+   [:enum :all :segmented :none :full :limited :unrestricted :query-builder :no]
    [:map
     [:read {:optional true} [:enum :all :none]]
     [:query {:optional true} [:enum :all :none :segmented]]]])
@@ -72,7 +72,20 @@
 
 (def ^:private Schemas
   [:or
-   [:enum :all :segmented :none :block :full :limited :impersonated]
+   [:enum
+    :all
+    :segmented
+    :none
+    :block
+    :blocked
+    :full
+    :limited
+    :impersonated
+    :unrestricted
+    :legacy-no-self-service
+    :query-builder-and-native
+    :query-builder
+    :no]
    SchemaGraph])
 
 (def ^:private DataPerms
@@ -94,8 +107,9 @@
    [:map-of
     Id
     [:map
+     [:view-data {:optional true} Schemas]
+     [:create-queries {:optional true} Schemas]
      [:data {:optional true} "DataPerms"]
-     [:query {:optional true} "DataPerms"]
      [:download {:optional true} "DataPerms"]
      [:data-model {:optional true} "DataPerms"]
      ;; We use :yes and :no instead of booleans for consistency with the application perms graph, and

--- a/src/metabase/api/permission_graph.clj
+++ b/src/metabase/api/permission_graph.clj
@@ -55,7 +55,7 @@
 
 (def ^:private TablePerms
   [:or
-   [:enum :all :segmented :none :full :limited :unrestricted :query-builder :no]
+   [:enum :all :segmented :none :full :limited :unrestricted :sandboxed :query-builder :no]
    [:map
     [:read {:optional true} [:enum :all :none]]
     [:query {:optional true} [:enum :all :none :segmented]]]])
@@ -82,6 +82,7 @@
     :limited
     :impersonated
     :unrestricted
+    :sandboxed
     :legacy-no-self-service
     :query-builder-and-native
     :query-builder
@@ -114,8 +115,7 @@
      [:data-model {:optional true} "DataPerms"]
      ;; We use :yes and :no instead of booleans for consistency with the application perms graph, and
      ;; consistency with the language used on the frontend.
-     [:details {:optional true} [:enum :yes :no]]
-     [:execute {:optional true} [:enum :all :none]]]]])
+     [:details {:optional true} [:enum :yes :no]]]]])
 
 (def StrictDbGraph
   "like db-graph, but if you have write access for native queries, you must have data access to all schemas."
@@ -129,8 +129,7 @@
      [:data-model {:optional true} "StrictDataPerms"]
      ;; We use :yes and :no instead of booleans for consistency with the application perms graph, and
      ;; consistency with the language used on the frontend.
-     [:details {:optional true} [:enum :yes :no]]
-     [:execute {:optional true} [:enum :all :none]]]]])
+     [:details {:optional true} [:enum :yes :no]]]]])
 
 (def DataPermissionsGraph
   "Used to transform, and verify data permissions graph"

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -49,7 +49,7 @@
    :perms/manage-table-metadata {:model :model/Table :values [:yes :no]}
    :perms/create-queries        {:model :model/Table :values [:query-builder-and-native :query-builder :no]}
 
-   :perms/view-data             {:model :model/Database :values [:unrestricted :block]}
+   :perms/view-data             {:model :model/Database :values [:unrestricted :blocked]}
    :perms/native-query-editing  {:model :model/Database :values [:yes :no]}
    :perms/manage-database       {:model :model/Database :values [:yes :no]}})
 
@@ -591,6 +591,9 @@
                                           :group_id   group-id
                                           :perm_value value
                                           :db_id      db-id})
+      (when (= [:perms/view-data :blocked] [perm-type value])
+        (set-database-permission! group-or-id db-or-id :perms/create-queries :no)
+        (set-database-permission! group-or-id db-or-id :perms/download-results :no))
       (when (= [:perms/data-access :block] [perm-type value])
         (set-database-permission! group-or-id db-or-id :perms/native-query-editing :no)
         (set-database-permission! group-or-id db-or-id :perms/download-results :no)))))

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -49,7 +49,7 @@
    :perms/manage-table-metadata {:model :model/Table :values [:yes :no]}
    :perms/create-queries        {:model :model/Table :values [:query-builder-and-native :query-builder :no]}
 
-   :perms/view-data             {:model :model/Database :values [:unrestricted :blocked]}
+   :perms/view-data             {:model :model/Database :values [:unrestricted :legacy-no-self-service :blocked]}
    :perms/native-query-editing  {:model :model/Database :values [:yes :no]}
    :perms/manage-database       {:model :model/Database :values [:yes :no]}})
 

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -44,12 +44,12 @@
 
 (def Permissions
   "Permissions which apply to individual databases or tables"
-  {:perms/data-access           {:model :model/Table :values [:unrestricted :no-self-service :block]}
+  {:perms/view-data             {:model :model/Table :values [:unrestricted :legacy-no-self-service :blocked]}
+   :perms/data-access           {:model :model/Table :values [:unrestricted :no-self-service :block]}
    :perms/download-results      {:model :model/Table :values [:one-million-rows :ten-thousand-rows :no]}
    :perms/manage-table-metadata {:model :model/Table :values [:yes :no]}
    :perms/create-queries        {:model :model/Table :values [:query-builder-and-native :query-builder :no]}
 
-   :perms/view-data             {:model :model/Database :values [:unrestricted :legacy-no-self-service :blocked]}
    :perms/native-query-editing  {:model :model/Database :values [:yes :no]}
    :perms/manage-database       {:model :model/Database :values [:yes :no]}})
 
@@ -556,9 +556,6 @@
 
 (defn- assert-valid-permission
   [{:keys [perm_type perm_value] :as permission}]
-  (when (= perm_value :legacy-no-self-service)
-    (throw (ex-info (tru "Permission value {0} is deprecated and can not be set." :legacy-no-self-service)
-                    permission)))
   (when-not (mc/validate PermissionType perm_type)
     (throw (ex-info (str/join (mu/explain PermissionType perm_type)) permission)))
   (assert-value-matches-perm-type perm_type perm_value))

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -556,6 +556,9 @@
 
 (defn- assert-valid-permission
   [{:keys [perm_type perm_value] :as permission}]
+  (when (= perm_value :legacy-no-self-service)
+    (throw (ex-info (tru "Permission value {0} is deprecated and can not be set." :legacy-no-self-service)
+                    permission)))
   (when-not (mc/validate PermissionType perm_type)
     (throw (ex-info (str/join (mu/explain PermissionType perm_type)) permission)))
   (assert-value-matches-perm-type perm_type perm_value))

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -577,7 +577,7 @@
   "Sets a single permission to a specified value for a given group and database. If a permission value already exists
   for the specified group and object, it will be updated to the new value.
 
-  Block permissions (i.e. :perms/data-access :block) can only be set at the database-level, despite :perms/data-access
+  Block permissions (i.e. :perms/view-data :blocked) can only be set at the database-level, despite :perms/view-data
   being a table-level permission."
   [group-or-id :- TheIdable
    db-or-id    :- TheIdable

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -25,15 +25,21 @@
 
 ;; See also: [[data-perms/Permissions]]
 (def ^:private ->api-keys
-  {:perms/data-access           :data
+  {:perms/view-data             :view-data
+   :perms/create-queries        :create-queries
+   :perms/data-access           :data
    :perms/download-results      :download
    :perms/manage-table-metadata :data-model
-
    :perms/native-query-editing  :native
    :perms/manage-database       :details})
 
 (def ^:private ->api-vals
-  {:perms/data-access           {:unrestricted    :all
+  {:perms/view-data             {:unrestricted :unrestricted
+                                 :blocked      :blocked}
+   :perms/create-queries        {:query-builder-and-native :query-builder-and-native
+                                 :query-builder            :query-builder
+                                 :no                       :no}
+   :perms/data-access           {:unrestricted    :all
                                  :no-self-service nil
                                  :block           :block}
    :perms/download-results      {:one-million-rows  :full
@@ -113,14 +119,15 @@
   [perm-map]
   (let [granular-keys [:perms/native-query-editing :perms/data-access
                        :perms/download-results :perms/manage-table-metadata
-                       ;; remove the new perms for now
                        :perms/view-data :perms/create-queries]]
     (m/deep-merge
      (into {} (keep rename-or-ellide-kv (apply dissoc perm-map granular-keys)))
      (granular-perm-rename perm-map :perms/data-access [:data :schemas])
      (granular-perm-rename perm-map :perms/native-query-editing [:data :native])
      (granular-perm-rename perm-map :perms/download-results [:download :schemas])
-     (granular-perm-rename perm-map :perms/manage-table-metadata [:data-model :schemas]))))
+     (granular-perm-rename perm-map :perms/manage-table-metadata [:data-model :schemas])
+     (granular-perm-rename perm-map :perms/view-data [:view-data])
+     (granular-perm-rename perm-map :perms/create-queries [:create-queries]))))
 
 (defn- rename-perms [graph]
   (update-vals graph
@@ -131,7 +138,9 @@
    {:data {:native :write, :schemas :all},
     :download {:schemas :full},
     :data-model {:schemas :all},
-    :details :yes})
+    :details :yes
+    :view-data :unrestricted
+    :create-queries :query-builder-and-native})
 
 (defn- add-admin-perms-to-permissions-graph
   "These are not stored in the data-permissions table, but the API expects them to be there (for legacy reasons), so here we populate it.
@@ -183,7 +192,6 @@
                   (add-sandboxes-to-permissions-graph opts)
                   (add-impersonations-to-permissions-graph opts)
                   (add-admin-perms-to-permissions-graph opts))})))
-
 
 ;;; ---------------------------------------- Updating permissions -----------------------------------------------------
 
@@ -351,9 +359,48 @@
   [group-id db-id value]
   (data-perms/set-database-permission! group-id db-id :perms/manage-database value))
 
+(defn- update-table-level-create-queries-permissions!
+  [group-id db-id schema new-table-perms]
+  (let [new-table-perms
+        (-> new-table-perms
+            (update-keys (fn [table-id] {:id table-id :db_id db-id :schema schema})))]
+    (data-perms/set-table-permissions! group-id :perms/create-queries new-table-perms)))
+
+(defn- update-schema-level-create-queries-permissions!
+  [group-id db-id schema new-schema-perms]
+  (if (map? new-schema-perms)
+    (update-table-level-create-queries-permissions! group-id db-id schema new-schema-perms)
+    (let [tables (t2/select :model/Table :db_id db-id :schema (not-empty schema))]
+      (when (seq tables)
+        (data-perms/set-table-permissions! group-id :perms/create-queries (zipmap tables (repeat new-schema-perms)))))))
+
+(defn- update-db-level-create-queries-permissions!
+  [group-id db-id new-db-perms]
+  (if (map? new-db-perms)
+    (doseq [[schema new-schema-perms] new-db-perms]
+      (update-schema-level-create-queries-permissions! group-id db-id schema new-schema-perms))
+    (case new-db-perms
+      (data-perms/set-database-permission! group-id db-id :perms/create-queries new-db-perms))))
+
+(defn- update-db-level-view-data-permissions!
+  [group-id db-id new-db-perms]
+  (if (map? new-db-perms)
+    ;; view-data is only set granularly when some tables are sandboxed, but sandboxes are stored in the `sandboxes`
+    ;; table, so we treat the DB as unrestricted in `data_permissions` and apply sandboxing policies separately
+    (data-perms/set-database-permission! group-id db-id :perms/view-data :unrestricted)
+    (case new-db-perms
+      (:unrestricted :impersonated)
+      (data-perms/set-database-permission! group-id db-id :perms/view-data :unrestricted)
+
+      :blocked
+      (do
+        (when-not (premium-features/has-feature? :advanced-permissions)
+          (throw (ee-permissions-exception :blocked)))
+        (data-perms/set-database-permission! group-id db-id :perms/view-data :blocked)))))
+
 (defn check-audit-db-permissions
   "Check that the changes coming in does not attempt to change audit database permission. Admins should
-  change these permissions in application monitoring permissions."
+  change these permissions implicitly via collection permissions."
   [changes]
   (let [changes-ids (->> changes
                          vals
@@ -407,10 +454,12 @@
      (doseq [[db-id db-changes] group-changes
              [perm-type new-perms] db-changes]
        (case perm-type
-         :data       (update-db-level-data-access-permissions! group-id db-id new-perms)
-         :download   (update-db-level-download-permissions! group-id db-id new-perms)
-         :data-model (update-db-level-metadata-permissions! group-id db-id new-perms)
-         :details    (update-details-perms! group-id db-id new-perms)))))
+         :view-data      (update-db-level-view-data-permissions! group-id db-id new-perms)
+         :create-queries (update-db-level-create-queries-permissions! group-id db-id new-perms)
+         :data           (update-db-level-data-access-permissions! group-id db-id new-perms)
+         :download       (update-db-level-download-permissions! group-id db-id new-perms)
+         :data-model     (update-db-level-metadata-permissions! group-id db-id new-perms)
+         :details        (update-details-perms! group-id db-id new-perms)))))
 
   ;; The following arity is provided soley for convenience for tests/REPL usage
   ([ks :- [:vector :any] new-value]

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -34,8 +34,9 @@
    :perms/manage-database       :details})
 
 (def ^:private ->api-vals
-  {:perms/view-data             {:unrestricted :unrestricted
-                                 :blocked      :blocked}
+  {:perms/view-data             {:unrestricted           :unrestricted
+                                 :legacy-no-self-service :legacy-no-self-service
+                                 :blocked                :blocked}
    :perms/create-queries        {:query-builder-and-native :query-builder-and-native
                                  :query-builder            :query-builder
                                  :no                       :no}

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -379,7 +379,7 @@
   (if (map? new-db-perms)
     (doseq [[schema new-schema-perms] new-db-perms]
       (update-schema-level-create-queries-permissions! group-id db-id schema new-schema-perms))
-    (case new-db-perms
+    (when new-db-perms
       (data-perms/set-database-permission! group-id db-id :perms/create-queries new-db-perms))))
 
 (defn- update-db-level-view-data-permissions!

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -362,9 +362,9 @@
 
 (defn- update-table-level-create-queries-permissions!
   [group-id db-id schema new-table-perms]
-  (let [new-table-perms
-        (-> new-table-perms
-            (update-keys (fn [table-id] {:id table-id :db_id db-id :schema schema})))]
+  (let [new-table-perms (update-keys
+                         new-table-perms
+                         (fn [table-id] {:id table-id :db_id db-id :schema schema}))]
     (data-perms/set-table-permissions! group-id :perms/create-queries new-table-perms)))
 
 (defn- update-schema-level-create-queries-permissions!

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -7,12 +7,7 @@
    [metabase.api.permissions :as api.permissions]
    [metabase.api.permissions-test-util :as perm-test-util]
    [metabase.models
-    :refer [Database
-            Permissions
-            PermissionsGroup
-            PermissionsGroupMembership
-            Table
-            User]]
+    :refer [Database PermissionsGroup PermissionsGroupMembership Table User]]
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.data-permissions.graph :as data-perms.graph]
    [metabase.models.permissions-group :as perms-group]
@@ -215,7 +210,8 @@
          (assoc-in (data-perms.graph/api-graph)
                    [:groups (u/the-id group) db-id :data :schemas]
                    :all))
-        (is (= {:data {:schemas :all}}
+        (is (= {:data {:schemas :all}
+                :view-data :unrestricted}
                (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) db-id])))))))
 
 (deftest update-perms-graph-perms-for-new-db-with-no-tables-test
@@ -228,7 +224,8 @@
          (assoc-in (data-perms.graph/api-graph)
                    [:groups (u/the-id group) db-id :data :schemas]
                    :all))
-        (is (= {:data {:schemas :all}}
+        (is (= {:data {:schemas :all}
+                :view-data :unrestricted}
                (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) db-id])))))))
 
 (deftest update-perms-graph-with-skip-graph-skips-graph-test
@@ -257,16 +254,6 @@
             (is (not (perm-test-util/validate-graph-api-groups (:groups no-returned-g))))
             (is (mc/validate [:map {:closed true}
                               [:revision pos-int?]] no-returned-g))))))))
-
-
-(deftest update-perms-graph-group-has-no-permissions-test
-  (testing "PUT /api/permissions/graph"
-    (testing "permissions when group has no permissions"
-      (t2.with-temp/with-temp [PermissionsGroup group]
-        (mt/user-http-request :crowberto :put 200 "permissions/graph"
-                              (assoc-in (data-perms.graph/api-graph) [:groups (u/the-id group)] nil))
-        (is (empty? (t2/select Permissions :group_id (u/the-id group))))
-        (is (nil? (get-in (data-perms.graph/api-graph) [:groups (u/the-id group)])))))))
 
 (deftest can-revoke-permsissions-via-graph-test
   (testing "PUT /api/permissions/graph"

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -53,7 +53,13 @@
          (is (thrown-with-msg?
               ExceptionInfo
               #"Permission type :perms/native-query-editing cannot be set to :invalid-value"
-              (data-perms/set-database-permission! group-id database-id :perms/native-query-editing :invalid-value))))))))
+              (data-perms/set-database-permission! group-id database-id :perms/native-query-editing :invalid-value))))
+
+       (testing "View data permissions cannot be set to legacy-no-self-service"
+          (is (thrown-with-msg?
+               ExceptionInfo
+               #"Permission value :legacy-no-self-service is deprecated and can not be set."
+               (data-perms/set-database-permission! group-id database-id :perms/view-data :legacy-no-self-service))))))))
 
 (deftest set-table-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}      {}

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -53,13 +53,7 @@
          (is (thrown-with-msg?
               ExceptionInfo
               #"Permission type :perms/native-query-editing cannot be set to :invalid-value"
-              (data-perms/set-database-permission! group-id database-id :perms/native-query-editing :invalid-value))))
-
-       (testing "View data permissions cannot be set to legacy-no-self-service"
-          (is (thrown-with-msg?
-               ExceptionInfo
-               #"Permission value :legacy-no-self-service is deprecated and can not be set."
-               (data-perms/set-database-permission! group-id database-id :perms/view-data :legacy-no-self-service))))))))
+              (data-perms/set-database-permission! group-id database-id :perms/native-query-editing :invalid-value))))))))
 
 (deftest set-table-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}      {}


### PR DESCRIPTION
Adds `view-data` and `create-queries` to the perms graph and allows them to be fetched and set via the normal permissions API. Does _not_ remove the old `data-access` and `native-query-editing` perms yet; we'll do that in a subsequent PR which will also require updating all the tests that were relying on the `:data` key in the graph. But this PR should be enough to unblock the FE work.