### PR TITLE
fix incorrect tooltip positioning on waterfall charts

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -110,6 +110,7 @@ export const buildEChartsLabelOptions = (
     silent: true,
     show,
     position,
+    opacity: 1,
     fontFamily: renderingContext.fontFamily,
     fontWeight: CHART_STYLE.seriesLabels.weight,
     fontSize: CHART_STYLE.seriesLabels.size,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
@@ -1,8 +1,4 @@
-import type {
-  RegisteredSeriesOption,
-  EChartsOption,
-  SeriesOption,
-} from "echarts";
+import type { EChartsOption, SeriesOption } from "echarts";
 import type { DatasetOption } from "echarts/types/dist/shared";
 import type { LabelLayoutOptionCallback } from "echarts/types/src/util/types";
 import type {
@@ -36,11 +32,6 @@ import { getTimelineEventsSeries } from "../../timeline-events/option";
 import { buildAxes } from "../../option/axis";
 import { getSharedEChartsOptions } from "../../option";
 import { isCategoryAxis } from "../../model/guards";
-
-type WaterfallSeriesOptions =
-  | RegisteredSeriesOption["line"]
-  | RegisteredSeriesOption["bar"]
-  | RegisteredSeriesOption["custom"];
 
 const getLabelLayoutFn = (
   dataset: ChartDataset,
@@ -104,7 +95,7 @@ export const buildEChartsWaterfallSeries = (
   settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
   renderingContext: RenderingContext,
-): WaterfallSeriesOptions[] => {
+) => {
   const { seriesModels, transformedDataset: dataset } = chartModel;
   const [seriesModel] = seriesModels;
   const barWidth = computeWaterfallBarWidth(
@@ -130,7 +121,7 @@ export const buildEChartsWaterfallSeries = (
     ),
   });
 
-  const series: WaterfallSeriesOptions[] = [
+  const series: SeriesOption[] = [
     {
       id: seriesModel.dataKey,
       type: "custom",
@@ -172,13 +163,10 @@ export const buildEChartsWaterfallSeries = (
     },
     {
       id: WATERFALL_LABELS_SERIES_ID,
-      type: "line",
+      type: "scatter",
       z: CHART_STYLE.seriesLabels.zIndex,
       silent: true,
       dimensions: [X_AXIS_DATA_KEY, WATERFALL_VALUE_KEY, WATERFALL_END_KEY],
-      itemStyle: {
-        color: "transparent",
-      },
       symbolSize: 0,
       labelLayout: getLabelLayoutFn(dataset, chartMeasurements, settings),
       encode: {
@@ -236,9 +224,10 @@ export const getWaterfallChartOption = (
     renderingContext,
   );
 
-  const seriesOption = [dataSeriesOptions, timelineEventsSeries].flatMap(
-    option => option ?? [],
-  );
+  const seriesOption: SeriesOption[] = [
+    dataSeriesOptions,
+    timelineEventsSeries,
+  ].flatMap(option => option ?? []);
 
   const echartsDataset = [{ source: chartModel.transformedDataset }];
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39408

### Description

Due to non-working labels on custom series, the waterfall chart rendered line series with a transparent line for data labels. Even though, the `silent` option was `true` ECharts still triggered events on the entire line <path /> element which caused invalid positioning of the tooltip. This PR changes the data labels series to `scatter`

### How to verify

1. Create a waterfall chart
2. Hover the top left corner of waterfall bars
3. Ensure the tooltip is positioned correctly

### Demo

Before
https://github.com/metabase/metabase/assets/14301985/dfe1778a-17eb-4182-b569-8d084f51df67

After
https://github.com/metabase/metabase/assets/14301985/2ff7c441-95b0-419a-a5fb-bb8a2e557ed3

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
