### PR TITLE
Remove TODOs and warnings around hard deletes

### DIFF
--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -536,13 +536,10 @@
 
 ;;; ------------------------------------------------- Deleting Cards -------------------------------------------------
 
-;; TODO - Pretty sure this endpoint is not actually used any more, since Cards are supposed to get archived (via PUT
-;;        /api/card/:id) instead of deleted.  Should we remove this?
 (api/defendpoint DELETE "/:id"
-  "Delete a Card. (DEPRECATED -- don't delete a Card anymore -- archive it instead.)"
+  "Hard delete a Card. To soft delete, use `PUT /api/card/:id`"
   [id]
   {id ms/PositiveInt}
-  (log/warn (tru "DELETE /api/card/:id is deprecated. Instead, change its `archived` value via PUT /api/card/:id."))
   (let [card (api/write-check Card id)]
     (t2/delete! Card :id id)
     (events/publish-event! :event/card-delete {:object card :user-id api/*current-user-id*}))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -427,16 +427,12 @@
     (validation/check-embedding-enabled)
     (api/check-superuser)))
 
-;; TODO - We can probably remove this in the near future since it should no longer be needed now that we're going to
-;; be setting `:archived` to `true` via the `PUT` endpoint instead
 (api/defendpoint DELETE "/:id"
-  "Delete a Dashboard.
+  "Hard delete a Dashboard. To soft delete, use `PUT /api/dashboard/:id`
 
   This will remove also any questions/models/segments/metrics that use this database."
   [id]
   {id ms/PositiveInt}
-  (log/warn (str "DELETE /api/dashboard/:id is deprecated. Instead of deleting a Dashboard, you should change its "
-                 "`archived` value via PUT /api/dashboard/:id."))
   (let [dashboard (api/write-check :model/Dashboard id)]
     (t2/delete! :model/Dashboard :id id)
     (events/publish-event! :event/dashboard-delete {:object dashboard :user-id api/*current-user-id*}))


### PR DESCRIPTION
We have some warnings and TODOs in the code for hard-deleting cards and dashboards. 

These are super out-of-date. We've been using these endpoints for years for hard-deleting cards and dashboards from the /archive page. 

In the future we might change the /archive page to also soft-delete, but we'll always need to offer a way to hard delete things for legal requirements.