### PR TITLE
docs - load analytics content

### DIFF
--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -898,6 +898,13 @@ Default: `"(&(objectClass=inetOrgPerson)(|(uid={login})(mail={login})))"`
 
 User lookup filter. The placeholder `{login}` will be replaced by the user supplied login.
 
+### `MB_LOAD_ANALYTICS_CONTENT`
+
+Type: Boolean<br>
+Default: True
+
+If you want to exclude the [Metabase analytics](../usage-and-performance-tools/usage-analytics.md) collection, you can set `MB_LOAD_ANALYTICS_CONTENT=false`. Setting this environment variable to false can also come in handy when migrating environments, as it can simplify the migration process.
+
 ### `MB_LOADING_MESSAGE`
 
 Only available on Metabase [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.<br>


### PR DESCRIPTION
Adds docs for `MB_LOAD_ANALYTICS_CONTENT` environment variable.