### PR TITLE
 search display name in filter picker

### DIFF
--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -198,6 +198,7 @@ export function QueryColumnPicker({
         color={color}
         maxHeight={Infinity}
         data-testid={dataTestId}
+        searchProp={["name", "displayName"]}
         // Compat with E2E tests around MLv1-based components
         // Prefer using a11y role selectors
         itemTestId="dimension-list-item"

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 
-import { render, screen, within } from "__support__/ui";
+import { render, screen, within, fireEvent } from "__support__/ui";
 import * as Lib from "metabase-lib";
 import { createQuery, columnFinder } from "metabase-lib/test-helpers";
 
@@ -140,5 +140,18 @@ describe("QueryColumnPicker", () => {
         within(createdAt).queryByLabelText("Temporal bucket"),
       ).not.toBeInTheDocument();
     });
+  });
+
+  it("should allow searching using displayName (#39622)", () => {
+    setup();
+
+    screen.getByText("User").click();
+    fireEvent.change(screen.getByTestId("list-search-field"), {
+      target: { value: "Birth Date" },
+    });
+
+    expect(
+      screen.getByRole("option", { name: "Birth Date" }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -124,6 +124,7 @@ export function FilterColumnPicker({
         // Compat with E2E tests around MLv1-based components
         // Prefer using a11y role selectors
         itemTestId="dimension-list-item"
+        searchProp={["name", "displayName"]}
       />
     </DelayGroup>
   );

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { setupFieldsValuesEndpoints } from "__support__/server-mocks";
-import { renderWithProviders, screen, within } from "__support__/ui";
+import { renderWithProviders, screen, within, fireEvent } from "__support__/ui";
 import type * as Lib from "metabase-lib";
 import { createQuery } from "metabase-lib/test-helpers";
 import { SAMPLE_DB_FIELD_VALUES } from "metabase-types/api/mocks/presets";
@@ -26,13 +26,27 @@ function setup({ query, stageIndex }: SetupOpts) {
 }
 
 describe("FilterModal", () => {
-  const query = createQuery();
-  const stageIndex = 0;
-  setup({ query, stageIndex });
-
-  test("The info icon should exist on each column", async () => {
+  test("The info icon should exist on each column", () => {
+    const query = createQuery();
+    const stageIndex = 0;
+    setup({ query, stageIndex });
     screen.getAllByTestId("dimension-list-item").forEach(function (item) {
       expect(within(item).getByLabelText("More info")).toBeInTheDocument();
     });
+  });
+
+  test("Searching by displayName should works (#39622)", () => {
+    const query = createQuery();
+    const stageIndex = 0;
+    setup({ query, stageIndex });
+
+    screen.getByText("User").click();
+    fireEvent.change(screen.getByTestId("list-search-field"), {
+      target: { value: "Birth Date" },
+    });
+
+    expect(
+      screen.getByRole("option", { name: "Birth Date" }),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39622

### Description

Allows searching by display name in the summarize and filter column pickers.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question → Sample Dataset → Orders
2. Add a filter and unfurl the User section
3. In the search bar type `Birth Date`, you should see one search result
4. Do the same for the summarization breakout

### Demo

<img width="484" alt="Screenshot 2024-03-12 at 16 49 59" src="https://github.com/metabase/metabase/assets/1250185/d0b7c200-2a23-44e9-bb31-133d14d43b73">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
