### PR TITLE
Move search to toplevel in accordionlist

### DIFF
--- a/frontend/src/metabase/admin/datamodel/metadata/components/SemanticTypeAndTargetPicker/SemanticTypeAndTargetPicker.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/SemanticTypeAndTargetPicker/SemanticTypeAndTargetPicker.tsx
@@ -111,6 +111,7 @@ const SemanticTypeAndTargetPicker = ({
         optionSectionFn={getTypeOptionSection}
         placeholder={t`Select a semantic type`}
         searchProp="name"
+        globalSearch
       />
       {showCurrencyTypeSelect && hasSeparator && <FieldSeparator />}
       {showCurrencyTypeSelect && (

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -202,6 +202,7 @@ export function QueryColumnPicker({
         // Compat with E2E tests around MLv1-based components
         // Prefer using a11y role selectors
         itemTestId="dimension-list-item"
+        globalSearch
       />
     </DelayGroup>
   );

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -272,7 +272,7 @@ export default class AccordionList extends Component {
   };
 
   checkSectionHasItemsMatchingSearch = (section, searchFilter) => {
-    return section.items.filter(searchFilter).length > 0;
+    return section.items?.filter(searchFilter).length > 0;
   };
 
   getFirstSelectedItemCursor = () => {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -499,7 +499,7 @@ export default class AccordionList extends Component {
 
     if (globalSearch) {
       const isSearching = searchText.length > 0;
-      const isEmpty = rows.filter(x => x.type === "item").length === 0;
+      const isEmpty = rows.filter(row => row.type === "item").length === 0;
 
       if (isSearching && isEmpty) {
         rows.unshift({

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -498,6 +498,18 @@ export default class AccordionList extends Component {
     }
 
     if (globalSearch) {
+      const isSearching = searchText.length > 0;
+      const isEmpty = rows.filter(x => x.type === "item").length === 0;
+
+      if (isSearching && isEmpty) {
+        rows.unshift({
+          type: "no-results",
+          section: {},
+          sectionIndex: 0,
+          isLastSection: false,
+        });
+      }
+
       rows.unshift({
         type: "search",
         section: {},

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -308,7 +308,7 @@ export default class AccordionList extends Component {
         this.getInitialCursor(),
         this.props.sections,
         this.isSectionExpanded,
-        !this.props.alwaysExpanded,
+        this.canSelectSection,
         this.searchFilter,
       );
 
@@ -325,7 +325,7 @@ export default class AccordionList extends Component {
         this.getInitialCursor(),
         this.props.sections,
         this.isSectionExpanded,
-        !this.props.alwaysExpanded,
+        this.canSelectSection,
         this.searchFilter,
       );
 
@@ -541,6 +541,10 @@ export default class AccordionList extends Component {
     const openSection = this.getOpenSection();
 
     return this.props.alwaysExpanded || openSection === sectionIndex;
+  };
+
+  canSelectSection = sectionIndex => {
+    return !this.props.alwaysExpanded;
   };
 
   // Because of virtualization, focused search input can be removed which does not trigger blur event.

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -409,15 +409,25 @@ export default class AccordionList extends Component {
       ) {
         if (
           !searchable ||
-          !hideEmptySectionsInSearch ||
-          this.checkSectionHasItemsMatchingSearch(section, searchFilter)
+          !(hideEmptySectionsInSearch || globalSearch) ||
+          this.checkSectionHasItemsMatchingSearch(section, searchFilter) ||
+          section.alwaysVisible
         ) {
-          rows.push({
-            type: "header",
-            section,
-            sectionIndex,
-            isLastSection,
-          });
+          if (section.type === "action") {
+            rows.push({
+              type: "action",
+              section,
+              sectionIndex,
+              isLastSection,
+            });
+          } else {
+            rows.push({
+              type: "header",
+              section,
+              sectionIndex,
+              isLastSection,
+            });
+          }
         }
       } else {
         rows.push({

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -418,7 +418,7 @@ export default class AccordionList extends Component {
           !searchable ||
           !(hideEmptySectionsInSearch || globalSearch) ||
           this.checkSectionHasItemsMatchingSearch(section, searchFilter) ||
-          section.alwaysVisible
+          section.type === "action"
         ) {
           if (section.type === "action") {
             rows.push({

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.js
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.js
@@ -83,6 +83,39 @@ describe("AccordionList", () => {
     assertAbsence(["Foo", "Bar", "Baz"]);
   });
 
+  it("should render with the search bar on top if globalSearch is set", () => {
+    render(<AccordionList sections={SECTIONS} globalSearch searchable />);
+    const SEARCH_FIELD = screen.getByPlaceholderText("Find...");
+    const sections = ["Widgets", "Doohickeys"];
+
+    sections.forEach(name => {
+      const SECTION = screen.queryByText(name);
+      expect(SEARCH_FIELD.compareDocumentPosition(SECTION)).toBe(
+        Node.DOCUMENT_POSITION_FOLLOWING,
+      );
+    });
+  });
+
+  it("should render results in all sections when globalSearch is true", () => {
+    render(<AccordionList sections={SECTIONS} globalSearch searchable />);
+    const SEARCH_FIELD = screen.getByPlaceholderText("Find...");
+    fireEvent.change(SEARCH_FIELD, { target: { value: "Ba" } });
+
+    assertPresence(["Bar", "Baz", "Widgets", "Doohickeys"]);
+    assertAbsence(["Foo"]);
+  });
+
+  it("should render section headers with an action", () => {
+    render(
+      <AccordionList
+        sections={[...SECTIONS, { type: "action", name: "Action" }]}
+        searchable
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Action/ })).toBeInTheDocument();
+  });
+
   describe("with the `renderItemWrapper` prop", () => {
     it("should be able to wrap the list items in components like popovers", async () => {
       const renderItemWrapper = (itemContent, item) => {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.js
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.js
@@ -116,6 +116,15 @@ describe("AccordionList", () => {
     expect(screen.getByRole("button", { name: /Action/ })).toBeInTheDocument();
   });
 
+  it("should an empty section when no results are found with globalSearch", () => {
+    render(<AccordionList sections={SECTIONS} searchable globalSearch />);
+
+    const SEARCH_FIELD = screen.getByPlaceholderText("Find...");
+    fireEvent.change(SEARCH_FIELD, { target: { value: "Quu" } });
+
+    expect(screen.getByText("Didn't find any results")).toBeInTheDocument();
+  });
+
   describe("with the `renderItemWrapper` prop", () => {
     it("should be able to wrap the list items in components like popovers", async () => {
       const renderItemWrapper = (itemContent, item) => {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -13,6 +13,7 @@ import { Icon, Box } from "metabase/ui";
 
 import {
   ListCellItem,
+  ListCellHeader,
   FilterContainer,
   Content,
   IconWrapper,
@@ -71,7 +72,7 @@ export const AccordionListCell = ({
       const icon = renderSectionIcon(section);
       const name = section.name;
       content = (
-        <div
+        <ListCellHeader
           data-element-id="list-section-header"
           className={cx(
             ListS.ListSectionHeader,
@@ -125,14 +126,14 @@ export const AccordionListCell = ({
               />
             </span>
           )}
-        </div>
+        </ListCellHeader>
       );
     }
   } else if (type === "action") {
     const icon = renderSectionIcon(section);
     const name = section.name;
     content = (
-      <div
+      <ListCellHeader
         className={cx(
           "List-section-header",
           CS.px2,
@@ -169,7 +170,7 @@ export const AccordionListCell = ({
         <IconWrapper>
           <Icon name="chevronright" size={12} />
         </IconWrapper>
-      </div>
+      </ListCellHeader>
     );
   } else if (type === "header-hidden") {
     content = <div className={CS.my1} />;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -14,6 +14,7 @@ import {
   ListCellItem,
   FilterContainer,
   Content,
+  IconWrapper,
 } from "./AccordionListCell.styled";
 
 export const AccordionListCell = ({
@@ -125,6 +126,49 @@ export const AccordionListCell = ({
         </div>
       );
     }
+  } else if (type === "action") {
+    const icon = renderSectionIcon(section);
+    const name = section.name;
+    content = (
+      <div
+        className={cx(
+          "List-section-header",
+          CS.px2,
+          CS.py2,
+          CS.flex,
+          CS.alignCenter,
+          CS.hoverParent,
+          {
+            "List-section-header--cursor": hasCursor,
+            [CS.cursorPointer]: canToggleSections,
+            [CS.textBrand]: sectionIsExpanded(sectionIndex),
+          },
+        )}
+        role="button"
+        onClick={
+          canToggleSections ? () => toggleSection(sectionIndex) : undefined
+        }
+      >
+        {icon && (
+          <span
+            className={cx(CS.mr1, CS.flex, CS.alignCenter, "List-section-icon")}
+          >
+            {icon}
+          </span>
+        )}
+        {name && (
+          <h3 className={cx("List-section-title", CS.textWrap)}>{name}</h3>
+        )}
+        {showSpinner(section) && (
+          <Box ml="0.5rem">
+            <LoadingSpinner size={16} borderWidth={2} />
+          </Box>
+        )}
+        <IconWrapper>
+          <Icon name="chevronright" size={12} />
+        </IconWrapper>
+      </div>
+    );
   } else if (type === "header-hidden") {
     content = <div className={CS.my1} />;
   } else if (type === "loading") {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -3,6 +3,7 @@
 import cx from "classnames";
 import { t } from "ttag";
 
+import EmptyState from "metabase/components/EmptyState";
 import ListSearchField from "metabase/components/ListSearchField";
 import LoadingSpinner from "metabase/components/LoadingSpinner";
 import ListS from "metabase/css/components/list.module.css";
@@ -15,6 +16,7 @@ import {
   FilterContainer,
   Content,
   IconWrapper,
+  EmptyStateContainer,
 } from "./AccordionListCell.styled";
 
 export const AccordionListCell = ({
@@ -171,6 +173,12 @@ export const AccordionListCell = ({
     );
   } else if (type === "header-hidden") {
     content = <div className={CS.my1} />;
+  } else if (type === "no-results") {
+    content = (
+      <EmptyStateContainer>
+        <EmptyState message={t`Didn't find any results`} icon="search" />
+      </EmptyStateContainer>
+    );
   } else if (type === "loading") {
     content = (
       <div className={cx(CS.m1, CS.flex, CS.layoutCentered)}>
@@ -199,6 +207,7 @@ export const AccordionListCell = ({
     const description = renderItemDescription(item);
     const extra = renderItemExtra(item, isSelected);
     const label = renderItemLabel ? renderItemLabel(item) : name;
+
     content = (
       <ListCellItem
         data-testid={itemTestId}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -74,6 +74,7 @@ export const AccordionListCell = ({
       content = (
         <ListCellHeader
           data-element-id="list-section-header"
+          borderBottom={section.type === "back"}
           className={cx(
             ListS.ListSectionHeader,
             CS.px2,

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -6,9 +6,12 @@ export interface ListCellItemProps {
   isClickable: boolean;
 }
 
-export const ListCellHeader = styled.div`
+export const ListCellHeader = styled.div<{ borderBottom?: boolean }>`
   border: none;
   border-top: 1px solid ${color("bg-medium")};
+
+  border-bottom: ${props => (props.borderBottom ? 1 : 0)}px solid
+    ${color("bg-medium")};
 
   li:first-child & {
     border-top: none;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -27,3 +27,8 @@ export const Content = styled.div<{ isClickable: boolean }>`
     flex-shrink: 1;
   }
 `;
+
+export const IconWrapper = styled.span`
+  margin-left: auto;
+  font-size: 0.875rem;
+`;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -32,3 +32,9 @@ export const IconWrapper = styled.span`
   margin-left: auto;
   font-size: 0.875rem;
 `;
+
+export const EmptyStateContainer = styled.div`
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+`;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -1,10 +1,19 @@
 import styled from "@emotion/styled";
 
-import { alpha } from "metabase/lib/colors";
+import { alpha, color } from "metabase/lib/colors";
 
 export interface ListCellItemProps {
   isClickable: boolean;
 }
+
+export const ListCellHeader = styled.div`
+  border: none;
+  border-top: 1px solid ${color("bg-medium")};
+
+  li:first-child & {
+    border-top: none;
+  }
+`;
 
 export const ListCellItem = styled.div<ListCellItemProps>`
   border-color: ${props => props.isClickable && alpha("accent2", 0.2)};

--- a/frontend/src/metabase/core/components/AccordionList/utils.ts
+++ b/frontend/src/metabase/core/components/AccordionList/utils.ts
@@ -7,7 +7,7 @@ type Section = {
   items: any;
 };
 
-type IsSectionExpandedFn = (sectionIndex: number) => boolean;
+type SectionPredicate = (sectionIndex: number) => boolean;
 type ItemFilterPredicate = (item: any) => boolean;
 
 const areSameCursors = (left: Cursor, right: Cursor) => {
@@ -20,8 +20,8 @@ const areSameCursors = (left: Cursor, right: Cursor) => {
 export const getNextCursor = (
   cursor: Cursor | null,
   sections: Section[],
-  isSectionExpanded: IsSectionExpandedFn,
-  canSelectSection: boolean,
+  isSectionExpanded: SectionPredicate,
+  canSelectSection: SectionPredicate,
   filterFn: ItemFilterPredicate,
   skipInitial: boolean = true,
 ): Cursor => {
@@ -54,7 +54,7 @@ export const getNextCursor = (
     if (
       !skipSectionItem &&
       (!skipInitial || !areSameCursors(cursor, sectionCursor)) &&
-      canSelectSection
+      canSelectSection(sectionIndex)
     ) {
       return sectionCursor;
     }
@@ -91,8 +91,8 @@ export const getNextCursor = (
 export const getPrevCursor = (
   cursor: Cursor | null,
   sections: Section[],
-  isSectionExpanded: IsSectionExpandedFn,
-  canSelectSection: boolean,
+  isSectionExpanded: SectionPredicate,
+  canSelectSection: SectionPredicate,
   filterFn: ItemFilterPredicate,
 ): Cursor => {
   if (!cursor) {
@@ -151,7 +151,7 @@ export const getPrevCursor = (
       continue;
     }
 
-    if (canSelectSection) {
+    if (canSelectSection(sectionIndex)) {
       return sectionCursor;
     }
 

--- a/frontend/src/metabase/core/components/AccordionList/utils.unit.spec.ts
+++ b/frontend/src/metabase/core/components/AccordionList/utils.unit.spec.ts
@@ -2,6 +2,8 @@ import { getPrevCursor, getNextCursor } from "./utils";
 
 const sectionIsExpanded = () => true;
 const sectionIsNotExpanded = () => false;
+const canSelectSection = () => true;
+const cannotSelectSection = () => false;
 const filterAll = () => true;
 const filterEvenIds = (item: any) => item.id % 2 === 0;
 
@@ -33,13 +35,25 @@ const sections = [
 describe("getNextCursor", () => {
   it("returns the first section selected when initial cursor is null and selecting sections allowed", () => {
     expect(
-      getNextCursor(null, sections, sectionIsExpanded, true, filterAll),
+      getNextCursor(
+        null,
+        sections,
+        sectionIsExpanded,
+        canSelectSection,
+        filterAll,
+      ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
   });
 
   it("returns the first item of the first section selected when initial cursor is null and selecting sections is not allowed", () => {
     expect(
-      getNextCursor(null, sections, sectionIsExpanded, false, filterAll),
+      getNextCursor(
+        null,
+        sections,
+        sectionIsExpanded,
+        cannotSelectSection,
+        filterAll,
+      ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
   });
 
@@ -49,7 +63,7 @@ describe("getNextCursor", () => {
         { sectionIndex: 0, itemIndex: null },
         sections,
         sectionIsExpanded,
-        false,
+        canSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
@@ -61,7 +75,7 @@ describe("getNextCursor", () => {
         { sectionIndex: 0, itemIndex: null },
         sections,
         sectionIsNotExpanded,
-        true,
+        canSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: null });
@@ -73,7 +87,7 @@ describe("getNextCursor", () => {
         { sectionIndex: 0, itemIndex: 0 },
         sections,
         sectionIsExpanded,
-        false,
+        cannotSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 1 });
@@ -85,7 +99,7 @@ describe("getNextCursor", () => {
         { sectionIndex: 0, itemIndex: 1 },
         sections,
         sectionIsExpanded,
-        true,
+        canSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: null });
@@ -97,7 +111,7 @@ describe("getNextCursor", () => {
         { sectionIndex: 0, itemIndex: 1 },
         sections,
         sectionIsExpanded,
-        false,
+        cannotSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: 0 });
@@ -109,7 +123,7 @@ describe("getNextCursor", () => {
         { sectionIndex: 1, itemIndex: 1 },
         sections,
         sectionIsExpanded,
-        false,
+        cannotSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: 1 });
@@ -121,7 +135,7 @@ describe("getNextCursor", () => {
         { sectionIndex: 0, itemIndex: 1 },
         sections,
         sectionIsExpanded,
-        false,
+        cannotSelectSection,
         filterEvenIds,
       ),
     ).toStrictEqual({ sectionIndex: 1, itemIndex: 1 });
@@ -131,7 +145,13 @@ describe("getNextCursor", () => {
 describe("getPrevCursor", () => {
   it("returns the first section when initial cursor is null and selecting sections allowed", () => {
     expect(
-      getPrevCursor(null, sections, sectionIsExpanded, true, filterAll),
+      getPrevCursor(
+        null,
+        sections,
+        sectionIsExpanded,
+        canSelectSection,
+        filterAll,
+      ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
   });
 
@@ -141,7 +161,7 @@ describe("getPrevCursor", () => {
         { sectionIndex: 0, itemIndex: 0 },
         sections,
         sectionIsExpanded,
-        true,
+        canSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
@@ -153,7 +173,7 @@ describe("getPrevCursor", () => {
         { sectionIndex: 0, itemIndex: 0 },
         sections,
         sectionIsExpanded,
-        false,
+        cannotSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
@@ -165,7 +185,7 @@ describe("getPrevCursor", () => {
         { sectionIndex: 0, itemIndex: 1 },
         sections,
         sectionIsExpanded,
-        false,
+        cannotSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });
@@ -177,7 +197,7 @@ describe("getPrevCursor", () => {
         { sectionIndex: 1, itemIndex: null },
         sections,
         sectionIsNotExpanded,
-        true,
+        canSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: null });
@@ -189,7 +209,7 @@ describe("getPrevCursor", () => {
         { sectionIndex: 1, itemIndex: null },
         sections,
         sectionIsExpanded,
-        true,
+        canSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 1 });
@@ -201,7 +221,7 @@ describe("getPrevCursor", () => {
         { sectionIndex: 1, itemIndex: 1 },
         sections,
         sectionIsExpanded,
-        false,
+        cannotSelectSection,
         filterEvenIds,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 1 });

--- a/frontend/src/metabase/core/components/AccordionList/utils.unit.spec.ts
+++ b/frontend/src/metabase/core/components/AccordionList/utils.unit.spec.ts
@@ -63,7 +63,7 @@ describe("getNextCursor", () => {
         { sectionIndex: 0, itemIndex: null },
         sections,
         sectionIsExpanded,
-        canSelectSection,
+        cannotSelectSection,
         filterAll,
       ),
     ).toStrictEqual({ sectionIndex: 0, itemIndex: 0 });

--- a/frontend/src/metabase/core/components/Select/Select.tsx
+++ b/frontend/src/metabase/core/components/Select/Select.tsx
@@ -54,6 +54,7 @@ export interface SelectProps<TValue, TOption = SelectOption<TValue>> {
   searchCaseInsensitive?: boolean;
   searchPlaceholder?: string;
   searchFuzzy?: boolean;
+  globalSearch?: boolean;
   hideEmptySectionsInSearch?: boolean;
   width?: number;
 
@@ -315,6 +316,7 @@ class BaseSelect<TValue, TOption = SelectOption<TValue>> extends Component<
           searchCaseInsensitive={searchCaseInsensitive}
           searchFuzzy={searchFuzzy}
           searchPlaceholder={searchPlaceholder}
+          globalSearch={this.props.globalSearch}
           hideEmptySectionsInSearch={hideEmptySectionsInSearch}
           data-testid={testId ? `${testId}-list` : null}
         />

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -84,6 +84,7 @@ const DataSelectorTablePicker = ({
           database: selectedDatabase,
         })),
         loading: tables.length === 0 && isLoading,
+        type: "back",
       },
     ];
 

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -29,16 +29,20 @@ export interface FilterColumnPickerProps {
 
 type Section = {
   key?: string;
+  type: string;
   name: string;
   items: (Lib.ColumnMetadata | Lib.SegmentMetadata)[];
   icon?: IconName;
+  alwaysVisible?: boolean;
 };
 
 const CUSTOM_EXPRESSION_SECTION: Section = {
   key: "custom-expression",
+  type: "action",
   name: t`Custom Expression`,
   items: [],
   icon: "filter",
+  alwaysVisible: true,
 };
 
 export const isSegmentListItem = (
@@ -125,6 +129,7 @@ export function FilterColumnPicker({
         // Prefer using a11y role selectors
         itemTestId="dimension-list-item"
         searchProp={["name", "displayName"]}
+        globalSearch
       />
     </DelayGroup>
   );

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -33,7 +33,6 @@ type Section = {
   name: string;
   items: (Lib.ColumnMetadata | Lib.SegmentMetadata)[];
   icon?: IconName;
-  alwaysVisible?: boolean;
 };
 
 const CUSTOM_EXPRESSION_SECTION: Section = {
@@ -42,7 +41,6 @@ const CUSTOM_EXPRESSION_SECTION: Section = {
   name: t`Custom Expression`,
   items: [],
   icon: "filter",
-  alwaysVisible: true,
 };
 
 export const isSegmentListItem = (


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41085

Moves the search box in the accordion list to the top level.

<img width="369" alt="Screenshot 2024-03-12 at 17 51 17" src="https://github.com/metabase/metabase/assets/1250185/bbb430d8-7e22-4069-9bc6-fd96d5995412">

<img width="357" alt="Screenshot 2024-04-01 at 12 56 52" src="https://github.com/metabase/metabase/assets/1250185/5d9a7512-bce9-4905-a14e-b5357b410b5f">

