### PR TITLE
remove TODOs from metabase.models.setting

### DIFF
--- a/src/metabase/models/setting.clj
+++ b/src/metabase/models/setting.clj
@@ -109,7 +109,6 @@
 ;;; other things we need for `:json` settings
 (comment metabase.server.middleware.json/keep-me)
 
-;; TODO -- a way to SET Database-local values.
 (def ^:dynamic *database-local-values*
   "Database-local Settings values (as a map of Setting name -> already-deserialized value). This comes from the value of
   `Database.settings` in the application DB. When bound, any Setting that *can* be Database-local will have a value
@@ -117,9 +116,7 @@
 
   This is normally bound automatically in Query Processor context
   by [[metabase.query-processor.setup/do-with-database-local-settings]]. You may need to manually bind it in other
-  places where you want to use Database-local values.
-
-  TODO -- we should probably also bind this in sync contexts e.g. functions in [[metabase.sync]]."
+  places where you want to use Database-local values."
   nil)
 
 (def ^:dynamic *user-local-values*
@@ -1308,9 +1305,7 @@
       (not (current-user-can-access-setting? setting))
       (throw (ex-info (tru "You do not have access to the setting {0}" k) setting))
 
-      ;; TODO - Settings set via an env var aren't returned for security purposes. It is an open question whether we
-      ;; should obfuscate them and still show the last two characters like we do for sensitive values that are set via
-      ;; the UI.
+      ;; Settings set via an env var aren't returned for security purposes.
       (or value-is-default? value-is-from-env-var?)
       nil
 


### PR DESCRIPTION
3 TODOs were removed here:

- "a way to SET Database-local values." More like TODONE :haaa:

- "we should probably also bind this [that is, *database-local-values*] in sync contexts e.g. functions in [[metabase.sync]]" I think we don't need to do this. The full set of maybe-database-local settings right now is `aggregated-query-row-limit`, `unaggregated-query-row-limit`, `database-enable-actions`, and `persist-models-enabled`. None of these need to be set when `sync`ing. If at some point we do add a db-local setting that should affect the way syncing works, we will need to do this - but I don't think this TODO will help figure that out.

- "settings sent via an env var aren't returned for security purposes. It is an open question whether we should obfuscate them and still show the last two characters like we do for sensitive values that are set via the UI." I think if it's been this way for 5 years, it no longer qualifies as an "open question." We can reopen if down the road if this is something we want.