### PR TITLE
[docs] Clarifications about dashboard subscriptions

### DIFF
--- a/docs/configuring-metabase/email.md
+++ b/docs/configuring-metabase/email.md
@@ -104,7 +104,7 @@ You can also set this property using the environment variable [`MB_SUBSCRIPTION_
 
 ## Suggest recipients on dashboard subscriptions and alerts
 
-{% include plans-blockquote.html feature="Approved domains for notifications" %}
+{% include plans-blockquote.html feature="Configuring suggested recipients" %}
 
 Control which recipients people can see when they create a new [dashboard subscription](../dashboards/subscriptions.md) or [alert](../questions/sharing/alerts.md). For example, you may want to restrict people to viewing potential recipients that belong to the same [groups](../people-and-groups/managing.md#groups) they are a member of.
 

--- a/docs/configuring-metabase/environment-variables.md
+++ b/docs/configuring-metabase/environment-variables.md
@@ -199,7 +199,7 @@ Maximum number of async Jetty threads. If not set, then [MB_JETTY_MAXTHREADS](#m
 Type: integer<br>
 Default: `20`<br>
 
-Limits the number of rows Metabase will include in tables sent as attachments with dashboard subscriptions and alerts. Range: 1-100.
+Limits the number of rows Metabase will display in tables sent with dashboard subscriptions and alerts. Range: 1-100. To limit the total number of rows included in the file attachment for an email dashboard subscription, use [MB_UNAGGREGATED_QUERY_ROW_LIMIT](#mb_unaggregated_query_row_limit).
 
 ### `MB_AUDIT_MAX_RETENTION_DAYS`
 

--- a/docs/dashboards/subscriptions.md
+++ b/docs/dashboards/subscriptions.md
@@ -29,11 +29,11 @@ Let's say we want to email a dashboard. We'll click on the **Email it** option i
 
 For emails, we can:
 
-- **Add subscribers**. Add email addresses to register subscribers. On Metabase [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise), Admins can limit email recipients to [approved domains for notifications](../configuring-metabase/email.md#approved-domains-for-notifications) and [configure which recipients Metabase suggests](../configuring-metabase/email.md#suggest-recipients-on-dashboard-subscriptions-and-alerts).
+- **Add subscribers**. Add email addresses to register subscribers. On Metabase [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise), admins can limit email recipients to [approved domains for notifications](../configuring-metabase/email.md#approved-domains-for-notifications) and [configure which recipients Metabase suggests](../configuring-metabase/email.md#suggest-recipients-on-dashboard-subscriptions-and-alerts).
 - **Determine frequency and timing**. Tell Metabase how often it should send the dashboard (daily, weekly, or monthly), and what time of day to send the dashboard.
 - **Send email now** sends an email to all subscribers.
 - **Skip updates without results**. If there are no results, we can tell Metabase to skip sending the email.
-- **Attach results**. Tell Metabase if it should attach results to the email as a file, in addition to displaying the table in the email body. You can choose between CSV and XLSX file formats. The attached file will include up to 2000 rows by default, but you can adjust this row limit by setting the environment variable [MB_UNAGGREGATED_QUERY_ROW_LIMIT](../configuring-metabase/environment-variables.md#mb_unaggregated_query_row_limit).
+- **Attach results**. Tell Metabase if it should attach results to the email as a file, in addition to displaying the table in the email body. You can choose between CSV and XLSX file formats. The attached file will include up to 2000 rows by default. If you're self-hosting Metabase, you can adjust this row limit by setting the environment variable [MB_UNAGGREGATED_QUERY_ROW_LIMIT](../configuring-metabase/environment-variables.md#mb_unaggregated_query_row_limit).
 
 If you've added filters to your dashboard and set default values for those filters, Metabase will apply those default values to your subscriptions, filtering the results of all questions that are connected to those filters when the subscriptions are sent. To learn more, check out [dashboard filters](./filters.md).
 

--- a/docs/dashboards/subscriptions.md
+++ b/docs/dashboards/subscriptions.md
@@ -7,7 +7,7 @@ redirect_from:
 
 # Dashboard subscriptions
 
-Dashboard subscriptions allow you to send the results of questions on a dashboard to people via email or Slack - even to people who lack an account in your Metabase. 
+Dashboard subscriptions allow you to send the results of questions on a dashboard to people via email or Slack - even to people who lack an account in your Metabase.
 
 If your Metabase has email or Slack set up, all you need to do is create a dashboard, add subscribers to it, and tell Metabase how often you'd like the send out an update. You can set up as many subscriptions to a dashboard as you like, and if you make any changes to the dashboard, Metabase will update the subscriptions the next time they're delivered.
 
@@ -29,17 +29,19 @@ Let's say we want to email a dashboard. We'll click on the **Email it** option i
 
 For emails, we can:
 
-- **Add subscribers**. Add email addresses to register subscribers.
+- **Add subscribers**. Add email addresses to register subscribers. On Metabase [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise), Admins can limit email recipients to [approved domains for notifications](../configuring-metabase/email.md#approved-domains-for-notifications) and [configure which recipients Metabase suggests](../configuring-metabase/email.md#suggest-recipients-on-dashboard-subscriptions-and-alerts).
 - **Determine frequency and timing**. Tell Metabase how often it should send the dashboard (daily, weekly, or monthly), and what time of day to send the dashboard.
 - **Send email now** sends an email to all subscribers.
 - **Skip updates without results**. If there are no results, we can tell Metabase to skip sending the email.
-- **Attach results**. Tell Metabase if it should also attach results to the email (which will include up to 2000 rows of data). You can choose between CSV and XLSX file formats.
+- **Attach results**. Tell Metabase if it should attach results to the email as a file, in addition to displaying the table in the email body. You can choose between CSV and XLSX file formats. The attached file will include up to 2000 rows by default, but you can adjust this row limit by setting the environment variable [MB_UNAGGREGATED_QUERY_ROW_LIMIT](../configuring-metabase/environment-variables.md#mb_unaggregated_query_row_limit).
 
 If you've added filters to your dashboard and set default values for those filters, Metabase will apply those default values to your subscriptions, filtering the results of all questions that are connected to those filters when the subscriptions are sent. To learn more, check out [dashboard filters](./filters.md).
 
 ## Slack subscription options
 
 For Slack subscriptions, you can set up a subscription for a channel (like #general), or for a single person via their Slack username.
+
+> Note that Slack username can be different from Slack display name.
 
 ![slack subscription options](./images/slack-subscription-options.png)
 


### PR DESCRIPTION
- Note that the list of recipients can be configured
- Note that the row limit can be configured
- Clarify which of the subscription row limit -related  env variables is responsible for what
- Fix wrong reference in blockquote 
- Clarify that Slack username is probably not what you think 
(I wonder if we should talk about this even more? This is actually the username that's configured in workplace setting, and Slack interface says that the concept of username only exists for technical reasons)
