### PR TITLE
[docs] Explicit callouts about data download in embedding

### DIFF
--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -165,11 +165,11 @@ You can preview appearance settings from your question or dashboard's [embedded 
 
 \* Available on [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.
 
-### Download results
+### Allow people to download the results of an embedded question
 
 {% include plans-blockquote.html feature="Downloading results" %}
 
-You can enable or disable downloading results for embedded questions by setting the `hide_download_button` parameter in the embedding URL to `false` or `true`.
+By default, Metabase will include a **Download** button on embedded questions. You can remove the download button by setting `hide_download_button=true` in the embedding URL in the iframe's `src` attribute, see [customizing the appearance of static embeds](#customizing-the-appearance-of-static-embeds).
 
 If the download button is missing when you expected it to be available, check that the URL in the `src` attribute for your iframe has the parameter `hide_download_button=false`.
 

--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -165,15 +165,15 @@ You can preview appearance settings from your question or dashboard's [embedded 
 
 \* Available on [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.
 
-### Data download
+### Download results
 
-{% include plans-blockquote.html feature="Data download" %}
+{% include plans-blockquote.html feature="Downloading results" %}
 
-You can enable or disable data download for embedded questions by setting the `hide_download_button` parameter in the embedding URL to `false` or `true`.
+You can enable or disable downloading results for embedded questions by setting the `hide_download_button` parameter in the embedding URL to `false` or `true`.
 
 If the download button is missing when you expected it to be available, check that the URL in the `src` attribute for your iframe has the parameter `hide_download_button=false`.
 
-> Data download is available only for questions, not dashboards.
+> Downloading results is available only for questions, not dashboards.
 
 
 ## Maximum request size

--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -169,7 +169,7 @@ You can preview appearance settings from your question or dashboard's [embedded 
 
 {% include plans-blockquote.html feature="Downloading results" %}
 
-By default, Metabase will include a **Download** button on embedded questions. You can remove the download button by setting `hide_download_button=true` in the embedding URL in the iframe's `src` attribute, see [customizing the appearance of static embeds](#customizing-the-appearance-of-static-embeds).
+By default, Metabase will include a **Download** button on embedded questions. You can remove the download button by setting `hide_download_button=true` in the embedding URL in the iframe's `src` attribute, see [customizing the appearance of static embeds](./static-embedding.md#customizing-the-appearance-of-static-embeds).
 
 If the download button is missing when you expected it to be available, check that the URL in the `src` attribute for your iframe has the parameter `hide_download_button=false`.
 

--- a/docs/embedding/static-embedding-parameters.md
+++ b/docs/embedding/static-embedding-parameters.md
@@ -165,6 +165,17 @@ You can preview appearance settings from your question or dashboard's [embedded 
 
 \* Available on [Pro](https://www.metabase.com/product/pro) and [Enterprise](https://www.metabase.com/product/enterprise) plans.
 
+### Data download
+
+{% include plans-blockquote.html feature="Data download" %}
+
+You can enable or disable data download for embedded questions by setting the `hide_download_button` parameter in the embedding URL to `false` or `true`.
+
+If the download button is missing when you expected it to be available, check that the URL in the `src` attribute for your iframe has the parameter `hide_download_button=false`.
+
+> Data download is available only for questions, not dashboards.
+
+
 ## Maximum request size
 
 The maximum length of a static embedding URL (including all parameters) is the value of your [`MB_JETTY_REQUEST_HEADER_SIZE`](../configuring-metabase/environment-variables.md#mb_jetty_request_header_size) environment variable. The default is 8192 bytes.


### PR DESCRIPTION
Add an explicit callout to check the iframe URL for data download parameter, as we had multiple questions about this.