### PR TITLE
[docs] Organize and add undocumented custom expressions

### DIFF
--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -31,7 +31,7 @@ For an introduction to expressions, check out the [overview of custom expression
     - [case](./expressions/case.md)
     - [coalesce](./expressions/coalesce.md)
     - [isnull](./expressions/isnull.md)
-    - [nonnull](#nonnull)
+    - [notnull](#notnull)
 
   - [Math functions](#math-functions)
     - [abs](#abs)
@@ -259,7 +259,7 @@ Syntax: `isnull(column)`
 
 Example: `isnull([Tax])` would return true if no value were present in the column for that row.
 
-Related: [nonnull](#nonnull), [isempty](#isempty)
+Related: [notnull](#notnull), [isempty](#isempty)
 
 ### notnull
 
@@ -269,7 +269,7 @@ Syntax: `notnull(column)`
 
 Example: `notnull([Tax])` would return true if there is a value present in the column for that row.
 
-Related: [isnull](#nonnull), [nonempty](#notempty)
+Related: [isnull](#isnull), [notempty](#notempty)
 
 ## Math functions
 Math functions implement common mathematical operations.
@@ -415,13 +415,13 @@ Related: [startsWith](#startswith), [contains](#contains), [doesNotContain](#doe
 
 ### [isempty](./expressions/isempty.md)
 
-Returns true if a _string column_ contains an empty string or is null. Calling this function on a non-string column will cause an error.
+Returns true if a _string column_ contains an empty string or is null. Calling this function on a non-string column will cause an error. You can use [isnull](#isnull) for non-string columns.
 
 Syntax: `isempty(column)`
 
 Example: `isempty([Feedback])` would return true if `Feedback` was an empty string (`''`) or did not contain a value.
 
-Related: [nonempty](#nonempty), [isnull](#isnull)
+Related: [notempty](#notempty), [isnull](#isnull)
 
 ### ltrim
 
@@ -451,9 +451,9 @@ Example: `lower([Status])`. If the `Status` were "QUIET", the expression would r
 
 Related: [upper](#upper).
 
-### [nonempty](./expressions/isempty.md)
+### notempty
 
-Returns true if a _string column_ contains a value that is not the empty string. Calling this function on a non-string column will cause an error.
+Returns true if a _string column_ contains a value that is not the empty string. Calling this function on a non-string column will cause an error. You can use [notnull](#notnull) on non-string columns.
 
 Syntax: `notempty(column)`
 

--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -30,8 +30,8 @@ For an introduction to expressions, check out the [overview of custom expression
     - [between](#between)
     - [case](./expressions/case.md)
     - [coalesce](./expressions/coalesce.md)
-    - [isempty](./expressions/isempty.md)
     - [isnull](./expressions/isnull.md)
+    - [nonnull](#nonnull)
 
   - [Math functions](#math-functions)
     - [abs](#abs)
@@ -46,14 +46,17 @@ For an introduction to expressions, check out the [overview of custom expression
   - [String functions](#string-functions)
     - [concat](./expressions/concat.md)
     - [contains](#contains)
-    - [endswith](#endswith)
-    - [lefttrim](#lefttrim)
+    - [doesNotContain](#doesnotcontain)
+    - [endsWith](#endswith)
+    - [isempty](./expressions/isempty.md)
+    - [ltrim](#ltrim)
     - [length](#length)
     - [lower](#lower)
+    - [nonempty](#nonempty)
     - [regexextract](./expressions/regexextract.md)
     - [replace](#replace)
-    - [righttrim](#righttrim)
-    - [startswith](#startswith)
+    - [rtrim](#rtrim)
+    - [startsWith](#startswith)
     - [substring](./expressions/substring.md)
     - [trim](#trim)
     - [upper](#upper)
@@ -70,6 +73,7 @@ For an introduction to expressions, check out the [overview of custom expression
     - [month](#month)
     - [now](./expressions/now.md)
     - [quarter](#quarter)
+    - [relativeDateTime](#relativedatetime)
     - [second](#second)
     - [week](#week)
     - [weekday](#weekday)
@@ -78,7 +82,7 @@ For an introduction to expressions, check out the [overview of custom expression
 
 ## Aggregations
 
-Aggregation expressions take into account all values in a field. They can only be used in the **Summarize** section of the notebook editor.
+Aggregation expressions take into account all values in a field. They can only be used in the **Summarize** section of the query builder.
 
 ### Average
 
@@ -247,14 +251,6 @@ Syntax: `coalesce(value1, value2, …)`
 
 Example: `coalesce([Comments], [Notes], "No comments")`. If both the `Comments` and `Notes` columns are null for that row, the expression will return the string "No comments".
 
-### [isempty](./expressions/isempty.md)
-
-Returns true if the column is empty.
-
-Syntax: `isempty(column)`
-
-Example: `isempty([Discount])` would return true if there were no value in the discount field.
-
 ### [isnull](./expressions/isnull.md)
 
 Returns true if the column is null.
@@ -262,6 +258,17 @@ Returns true if the column is null.
 Syntax: `isnull(column)`
 
 Example: `isnull([Tax])` would return true if no value were present in the column for that row.
+
+Related: [nonnull](#nonnull), [isempty](#isempty)
+
+### [nonnull](./expressions/isnull.md)
+
+Returns true if the column contains a value.
+
+Syntax: `nonnull(column)`
+
+Example: `nonnull([Tax])` would return true if there is a value present in the column for that row.
+
 
 ## Math functions
 Math functions implement common mathematical operations.
@@ -359,33 +366,60 @@ Example: `concat([Last Name], ", ", [First Name])` would produce a string of the
 
 ### contains
 
-Checks to see if string1 contains string2 within it.
+Checks to see if `string1` contains `string2` within it. Performs case-sensitive match by default.
+You can pass an optional parameter `"case-insensitive"` to perform a case-insensitive match.
 
-Syntax: `contains(string1, string2)`
+Syntax: `contains(string1, string2)` for case-sensitive match.
+`contains(string1, string2, "case-insensitive") for case-insensitive match.
 
-Example: `contains([Status], "Class")`. If `Status` were "Classified", the expression would return `true`.
+Example: `contains([Status], "Class")`. If `Status` were "Classified", the expression would return `true`. If the `Status` were "**c**lassified", the expression would return `false`, because the case
 
-Related: [regexextract](#regexextract).
+Related: [doesNotContain](#doesnotcontain), [regexextract](#regexextract).
 
-### endswith
+### doesNotContain
 
-Returns true if the end of the text matches the comparison text.
+Checks to see if `string1` contains `string2` within it. Performs case-sensitive match by default.
+You can pass an optional parameter `"case-insensitive"` to perform a case-insensitive match.
 
-Syntax: `endsWith(text, comparison)`
+Syntax: `doesNotContain(string1, string2)` for case-sensitive match.
+`doesNotContain(string1, string2, "case-insensitive")` for case-insensitive match.
 
-`endsWith([Appetite], "hungry")`
+Example: `doesNotContain([Status], "Class")`. If `Status` were "Classified", the expression would return `false`.
 
-Related: [contains](#contains) and [startswith](#startswith).
+Related: (contains)[#contains],  [regexextract](#regexextract).
 
-### lefttrim
+### endsWith
+
+Returns true if the end of the text matches the comparison text. Performs case-sensitive match by default.
+You can pass an optional parameter `"case-insensitive"` to perform a case-insensitive match.
+
+Syntax: `endsWith(text, comparison)` for case-sensitive match.
+ `endsWith(text, comparison, "case-insensitive")` for case-insensitive match.
+
+Example: `endsWith([Appetite], "hungry")`
+
+Related: [startsWith](#startswith), [contains](#contains), [doesNotContain](#doesnotcontain).
+
+
+### [isempty](./expressions/isempty.md)
+
+Returns true if a _string column_ contains an empty string or is null. Calling this function on a non-string column will cause an error.
+
+Syntax: `isempty(column)`
+
+Example: `isempty([Feedback])` would return true if `Feedback` was an empty string (`''`) or did not contain a value.
+
+Related: [nonempty](#nonempty), [isnull](#isnull)
+
+### ltrim
 
 Removes leading whitespace from a string of text.
 
 Syntax: `ltrim(text)`
 
-Example: `ltrim([Comment])`. If the comment were " I'd prefer not to", `ltrim` would return "I'd prefer not to".
+Example: `ltrim([Comment])`. If the comment were `" I'd prefer not to"`, `ltrim` would return `"I'd prefer not to"`.
 
-Related: [trim](#trim) and [righttrim](#righttrim).
+Related: [trim](#trim) and [rtrim](#rtrim).
 
 ### length
 
@@ -393,7 +427,7 @@ Returns the number of characters in text.
 
 Syntax: `length(text)`
 
-Example: `length([Comment])` If the `comment` were "wizard", `length` would return 6 ("wizard" has six characters).
+Example: `length([Comment])`. If the `comment` were "wizard", `length` would return 6 ("wizard" has six characters).
 
 ### lower
 
@@ -405,6 +439,17 @@ Example: `lower([Status])`. If the `Status` were "QUIET", the expression would r
 
 Related: [upper](#upper).
 
+### [nonempty](./expressions/isempty.md)
+
+Returns true if the string column contains a value that isn't the empty string (`''`).
+
+Syntax: `nonempty(column)`
+
+Example: `nonempty([Feedback])` would return true if `Feedback` contains a value that isn't the empty string (`''`). . [Learn more](./expressions/isempty.md) about how Metabase handles empty strings and nulls.
+
+Related: [isempty](#isempty), [nonnull](#nonnull)
+
+
 ### [regexextract](./expressions/regexextract.md)
 
 Extracts matching substrings according to a regular expression.
@@ -415,7 +460,7 @@ Example: `regexextract([Address], "[0-9]+")`.
 
 Databases that don't support `regexextract`: H2, SQL Server, SQLite.
 
-Related: [contains](#contains), [substring](#substring).
+Related: [contains](#contains), [doesNotContain](#doesnotcontain), [substring](#substring).
 
 ### replace
 
@@ -425,7 +470,7 @@ Syntax: `replace(text, find, replace)`.
 
 Example: `replace([Title], "Enormous", "Gigantic")`.
 
-### righttrim
+### rtrim
 
 Removes trailing whitespace from a string of text.
 
@@ -433,17 +478,22 @@ Syntax: `rtrim(text)`
 
 Example: `rtrim([Comment])`. If the comment were "Fear is the mindkiller. ", the expression would return "Fear is the mindkiller."
 
-Related: [trim](#trim) and [lefttrim](#lefttrim).
+Related: [trim](#trim) and [ltrim](#ltrim).
 
-### startswith
+### startsWith
 
-Returns true if the beginning of the text matches the comparison text.
+Returns true if the beginning of the text matches the comparison text. Performs case-sensitive match by default.
+You can pass an optional parameter `"case-insensitive"` to perform a case-insensitive match.
 
-Syntax: `startsWith(text, comparison)`.
+Syntax: `startsWith(text, comparison)` for case-sensitive match.
+ `startsWith(text, comparison, "case-insensitive")` for case-insensitive match.
 
-Example: `startsWith([Course Name], "Computer Science")` would return true for course names that began with "Computer Science", like "Computer Science 101: An introduction".
+Example: `startsWith([Course Name], "Computer Science")` would return true for course names that began with "Computer Science", like "Computer Science 101: An introduction". It would return false for "Computer **s**cience 201: Data structures" because the case of "science" does not match the case in the comparison text.
 
-Related: [endswith](#endswith), [contains](#contains).
+`startsWith([Course Name], "Computer Science", "case-insensitive")`would return true for both "Computer Science 101: An introduction" and "Computer science 201: Data structures".
+
+
+Related: [endsWith](#endsWith), [contains](#contains), [doesNotContain](#doesnotcontain).
 
 ### [substring](./expressions/substring.md)
 
@@ -481,6 +531,8 @@ Shifts a date or timestamp value into a specified time zone.
 Syntax: `convertTimezone(column, target, source)`.
 
 Example: `convertTimezone("2022-12-28T12:00:00", "Canada/Pacific", "Canada/Eastern")` would return the value `2022-12-28T09:00:00`, displayed as `December 28, 2022, 9:00 AM`.
+
+See the [database limitations](./expressions/converttimezone.md#limitations) for `convertTimezone`.
 
 ### [datetimeAdd](./expressions/datetimeadd.md)
 
@@ -566,6 +618,21 @@ Syntax: `quarter([datetime column])`.
 
 Example: `quarter("2021-03-25T12:52:37")` would return `1` for the first quarter.
 
+### relativeDateTime
+
+Gets a timestamp relative to the current time.
+
+Syntax: `relativeDateTime(number, text)`
+
+`number`: Period of interval, where negative values are back in time.
+`text`: Type of interval like `"day"`, `"month"`, `"year"`
+
+`relativeDateTime` can only be used as part of a conditional expression.
+
+Example: `[Orders → Created At] < relativeDateTime(-30, "day")` will filter for orders created over 30 days ago from current date.
+
+Related: [dateTimeAdd](#datetimeadd), [dateTimeSubtract](#datetimesubtract).
+
 ### second
 
 Takes a datetime and returns the number of seconds in the minute (0-59) as an integer.
@@ -573,6 +640,18 @@ Takes a datetime and returns the number of seconds in the minute (0-59) as an in
 Syntax: `second([datetime column)`.
 
 Example: `second("2021-03-25T12:52:37")` would return the integer `37`.
+
+### timeSpan
+
+Gets a time interval of specified length.
+
+Syntax: `timeSpan(number, text)`.
+`number`: Period of interval, where negative values are back in time.
+`text`: Type of interval like `"day"`, `"month"`, `"year"`
+
+Example: `[Orders → Created At] + timeSpan(7, "day")` will return the date 7 days after the `Created At` date.
+
+
 
 ### week
 
@@ -617,11 +696,20 @@ Syntax: `year([datetime column])`.
 
 Example: `year("2021-03-25T12:52:37")` would return the year 2021 as an integer, `2,021`.
 
-## Database limitations
+## Limitations
+
+- [Aggregation expressions](#aggregations)  can only be used in the **Summarize** section of the query builder.
+- Functions that return a boolean value, like [isempty](#isempty) or [contains](#contains), cannot be used to create a custom column. To create a custom column based on one of these functions, you must combine them with another function, like `case`.
+For example, to create a new custom column that contains `true` if `[Title]` contain `'Wallet'`, you can use the custom expression
+```
+case(contains([Title], 'Wallet'), true, false)
+``
+
+### Database limitations
 
 Limitations are noted for each aggregation and function above, and here there are in summary:
 
-**H2**: `Median`, `Percentile` and `regexextract`
+**H2** (including Metabase Sample Database): `Median`, `Percentile`, `convertTimezone` and `regexextract`
 
 **MySQL/MariaDB**: `Median`, `Percentile`.
 

--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -6,7 +6,7 @@ redirect_from:
 
 # List of expressions
 
-For an introduction to expressions, check out [Writing expressions in the notebook editor][expressions].
+For an introduction to expressions, check out the [overview of custom expressions][expressions].
 
 - [Aggregations](#aggregations)
   - [Average](#average)
@@ -24,48 +24,56 @@ For an introduction to expressions, check out [Writing expressions in the notebo
   - [Sum](#sum)
   - [SumIf](./expressions/sumif.md)
   - [Variance](#variance)
-- [Functions](#functions)
-  - [abs](#abs)
-  - [between](#between)
-  - [case](./expressions/case.md)
-  - [ceil](#ceil)
-  - [coalesce](./expressions/coalesce.md)
-  - [concat](./expressions/concat.md)
-  - [contains](#contains)
-  - [convertTimezone](./expressions/converttimezone.md)
-  - [datetimeAdd](./expressions/datetimeadd.md)
-  - [datetimeDiff](./expressions/datetimediff.md)
-  - [datetimeSubtract](./expressions/datetimesubtract.md)
-  - [day](#day)
-  - [endswith](#endswith)
-  - [exp](#exp)
-  - [floor](#floor)
-  - [hour](#hour)
-  - [interval](#interval)
-  - [isempty](./expressions/isempty.md)
-  - [isnull](./expressions/isnull.md)
-  - [lefttrim](#lefttrim)
-  - [length](#length)
-  - [log](#log)
-  - [lower](#lower)
-  - [minute](#minute)
-  - [month](#month)
-  - [now](./expressions/now.md)
-  - [power](#power)
-  - [quarter](#quarter)
-  - [regexextract](./expressions/regexextract.md)
-  - [replace](#replace)
-  - [righttrim](#righttrim)
-  - [round](#round)
-  - [second](#second)
-  - [sqrt](#sqrt)
-  - [startswith](#startswith)
-  - [substring](./expressions/substring.md)
-  - [trim](#trim)
-  - [upper](#upper)
-  - [week](#week)
-  - [weekday](#weekday)
-  - [year](#year)
+
+- Functions
+  - [Logical functions](#logical-functions)
+    - [between](#between)
+    - [case](./expressions/case.md)
+    - [coalesce](./expressions/coalesce.md)
+    - [isempty](./expressions/isempty.md)
+    - [isnull](./expressions/isnull.md)
+
+  - [Math functions](#math-functions)
+    - [abs](#abs)
+    - [ceil](#ceil)
+    - [exp](#exp)
+    - [floor](#floor)
+    - [log](#log)
+    - [power](#power)
+    - [round](#round)
+    - [sqrt](#sqrt)
+
+  - [String functions](#string-functions)
+    - [concat](./expressions/concat.md)
+    - [contains](#contains)
+    - [endswith](#endswith)
+    - [lefttrim](#lefttrim)
+    - [length](#length)
+    - [lower](#lower)
+    - [regexextract](./expressions/regexextract.md)
+    - [replace](#replace)
+    - [righttrim](#righttrim)
+    - [startswith](#startswith)
+    - [substring](./expressions/substring.md)
+    - [trim](#trim)
+    - [upper](#upper)
+
+  - [Date functions](#date-functions)
+    - [convertTimezone](./expressions/converttimezone.md)
+    - [datetimeAdd](./expressions/datetimeadd.md)
+    - [datetimeDiff](./expressions/datetimediff.md)
+    - [datetimeSubtract](./expressions/datetimesubtract.md)
+    - [day](#day)
+    - [hour](#hour)
+    - [interval](#interval)
+    - [minute](#minute)
+    - [month](#month)
+    - [now](./expressions/now.md)
+    - [quarter](#quarter)
+    - [second](#second)
+    - [week](#week)
+    - [weekday](#weekday)
+    - [year](#year)
 - [Database limitations](#database-limitations)
 
 ## Aggregations
@@ -210,13 +218,8 @@ Related: [StandardDeviation](#standarddeviation), [Average](#average).
 
 Function expressions apply to each individual value. They can be used to alter or filter values in a column, or create new, custom columns.
 
-### abs
-
-Returns the absolute (positive) value of the specified column.
-
-Syntax: `abs(column)`
-
-Example: `abs([Debt])`. If `Debt` were -100, `abs(-100)` would return `100`.
+## Logical functions
+Logical functions determine if a condition is satisfied or determine what value to return based on a condition.
 
 ### between
 
@@ -236,6 +239,41 @@ Syntax: `case(condition, output, …)`
 
 Example: `case([Weight] > 200, "Large", [Weight] > 150, "Medium", "Small")` If a `Weight` is 250, the expression would return "Large". In this case, the default value is "Small", so any `Weight` 150 or less would return "Small".
 
+### [coalesce](./expressions/coalesce.md)
+
+Looks at the values in each argument in order and returns the first non-null value for each row.
+
+Syntax: `coalesce(value1, value2, …)`
+
+Example: `coalesce([Comments], [Notes], "No comments")`. If both the `Comments` and `Notes` columns are null for that row, the expression will return the string "No comments".
+
+### [isempty](./expressions/isempty.md)
+
+Returns true if the column is empty.
+
+Syntax: `isempty(column)`
+
+Example: `isempty([Discount])` would return true if there were no value in the discount field.
+
+### [isnull](./expressions/isnull.md)
+
+Returns true if the column is null.
+
+Syntax: `isnull(column)`
+
+Example: `isnull([Tax])` would return true if no value were present in the column for that row.
+
+## Math functions
+Math functions implement common mathematical operations.
+
+### abs
+
+Returns the absolute (positive) value of the specified column.
+
+Syntax: `abs(column)`
+
+Example: `abs([Debt])`. If `Debt` were -100, `abs(-100)` would return `100`.
+
 ### ceil
 
 Rounds a decimal up (ceil as in ceiling).
@@ -246,13 +284,70 @@ Example: `ceil([Price])`. `ceil(2.99)` would return 3.
 
 Related: [floor](#floor), [round](#round).
 
-### [coalesce](./expressions/coalesce.md)
+### exp
 
-Looks at the values in each argument in order and returns the first non-null value for each row.
+Returns [Euler's number](<https://en.wikipedia.org/wiki/E_(mathematical_constant)>), e, raised to the power of the supplied number. (Euler sounds like "Oy-ler").
 
-Syntax: `coalesce(value1, value2, …)`
+Syntax: `exp(column)`.
 
-Example: `coalesce([Comments], [Notes], "No comments")`. If both the `Comments` and `Notes` columns are null for that row, the expression will return the string "No comments".
+Example: `exp([Interest Months])`
+
+Related: [power](#power).
+
+### floor
+
+Rounds a decimal number down.
+
+Syntax: `floor(column)`
+
+Example: `floor([Price])`. If the `Price` were 1.99, the expression would return 1.
+
+Related: [ceil](#ceil), [round](#round).
+
+### log
+
+Returns the base 10 log of the number.
+
+Syntax: `log(column)`.
+
+Example: `log([Value])`.
+
+### power
+
+Raises a number to the power of the exponent value.
+
+Syntax: `power(column, exponent)`.
+
+Example: `power([Length], 2)`. If the length were `3`, the expression would return `9` (3 to the second power is 3\*3).
+
+Databases that don't support `power`: SQLite.
+
+Related: [exp](#exp).
+
+### round
+
+Rounds a decimal number either up or down to the nearest integer value.
+
+Syntax: `round(column)`.
+
+Example: `round([Temperature])`. If the temp were `13.5` degrees centigrade, the expression would return `14`.
+
+Example: `round([Temperature] * 10) / 10`. If the temp were `100.75`, the expression would return `100.8`.
+
+### sqrt
+
+Returns the square root of a value.
+
+Syntax: `sqrt(column)`.
+
+Example: `sqrt([Hypotenuse])`.
+
+Databases that don't support `sqrt`: SQLite.
+
+Related: [Power](#power).
+
+## String functions
+String functions manipulate or validate string data.
 
 ### [concat](./expressions/concat.md)
 
@@ -271,6 +366,113 @@ Syntax: `contains(string1, string2)`
 Example: `contains([Status], "Class")`. If `Status` were "Classified", the expression would return `true`.
 
 Related: [regexextract](#regexextract).
+
+### endswith
+
+Returns true if the end of the text matches the comparison text.
+
+Syntax: `endsWith(text, comparison)`
+
+`endsWith([Appetite], "hungry")`
+
+Related: [contains](#contains) and [startswith](#startswith).
+
+### lefttrim
+
+Removes leading whitespace from a string of text.
+
+Syntax: `ltrim(text)`
+
+Example: `ltrim([Comment])`. If the comment were " I'd prefer not to", `ltrim` would return "I'd prefer not to".
+
+Related: [trim](#trim) and [righttrim](#righttrim).
+
+### length
+
+Returns the number of characters in text.
+
+Syntax: `length(text)`
+
+Example: `length([Comment])` If the `comment` were "wizard", `length` would return 6 ("wizard" has six characters).
+
+### lower
+
+Returns the string of text in all lower case.
+
+Syntax: `lower(text)`.
+
+Example: `lower([Status])`. If the `Status` were "QUIET", the expression would return "quiet".
+
+Related: [upper](#upper).
+
+### [regexextract](./expressions/regexextract.md)
+
+Extracts matching substrings according to a regular expression.
+
+Syntax: `regexextract(text, regular_expression)`.
+
+Example: `regexextract([Address], "[0-9]+")`.
+
+Databases that don't support `regexextract`: H2, SQL Server, SQLite.
+
+Related: [contains](#contains), [substring](#substring).
+
+### replace
+
+Replaces all occurrences of a search text in the input text with the replacement text.
+
+Syntax: `replace(text, find, replace)`.
+
+Example: `replace([Title], "Enormous", "Gigantic")`.
+
+### righttrim
+
+Removes trailing whitespace from a string of text.
+
+Syntax: `rtrim(text)`
+
+Example: `rtrim([Comment])`. If the comment were "Fear is the mindkiller. ", the expression would return "Fear is the mindkiller."
+
+Related: [trim](#trim) and [lefttrim](#lefttrim).
+
+### startswith
+
+Returns true if the beginning of the text matches the comparison text.
+
+Syntax: `startsWith(text, comparison)`.
+
+Example: `startsWith([Course Name], "Computer Science")` would return true for course names that began with "Computer Science", like "Computer Science 101: An introduction".
+
+Related: [endswith](#endswith), [contains](#contains).
+
+### [substring](./expressions/substring.md)
+
+Returns a portion of the supplied text, specified by a starting position and a length.
+
+Syntax: `substring(text, position, length)`
+
+Example: `substring([Title], 1, 10)` returns the first 10 letters of a string (the string index starts at position 1).
+
+Related: [regexextract](#regexextract), [replace](#replace).
+
+### trim
+
+Removes leading and trailing whitespace from a string of text.
+
+Syntax: `trim(text)`
+
+Example: `trim([Comment])` will remove any whitespace characters on either side of a comment.
+
+### upper
+
+Returns the text in all upper case.
+
+Syntax: `upper(text)`.
+
+Example: `upper([Status])`. If status were "hyper", `upper("hyper")` would return "HYPER".
+
+## Date functions
+Date functions manipulate, extract, or create date and time values.
 
 ### [convertTimezone](./expressions/converttimezone.md)
 
@@ -316,36 +518,6 @@ Syntax: `day([datetime column])`.
 
 Example: `day("2021-03-25T12:52:37")` would return the day as an integer, `25`.
 
-### endswith
-
-Returns true if the end of the text matches the comparison text.
-
-Syntax: `endsWith(text, comparison)`
-
-`endsWith([Appetite], "hungry")`
-
-Related: [contains](#contains) and [startswith](#startswith).
-
-### exp
-
-Returns [Euler's number](<https://en.wikipedia.org/wiki/E_(mathematical_constant)>), e, raised to the power of the supplied number. (Euler sounds like "Oy-ler").
-
-Syntax: `exp(column)`.
-
-Example: `exp([Interest Months])`
-
-Related: [power](#power).
-
-### floor
-
-Rounds a decimal number down.
-
-Syntax: `floor(column)`
-
-Example: `floor([Price])`. If the `Price` were 1.99, the expression would return 1.
-
-Related: [ceil](#ceil), [round](#round).
-
 ### hour
 
 Takes a datetime and returns the hour as an integer (0-23).
@@ -363,58 +535,6 @@ Syntax: `interval(column, number, text)`.
 Example: `interval([Created At], -1, "month")`.
 
 Related: [between](#between).
-
-### [isempty](./expressions/isempty.md)
-
-Returns true if the column is empty.
-
-Syntax: `isempty(column)`
-
-Example: `isempty([Discount])` would return true if there were no value in the discount field.
-
-### [isnull](./expressions/isnull.md)
-
-Returns true if the column is null.
-
-Syntax: `isnull(column)`
-
-Example: `isnull([Tax])` would return true if no value were present in the column for that row.
-
-### lefttrim
-
-Removes leading whitespace from a string of text.
-
-Syntax: `ltrim(text)`
-
-Example: `ltrim([Comment])`. If the comment were " I'd prefer not to", `ltrim` would return "I'd prefer not to".
-
-Related: [trim](#trim) and [righttrim](#righttrim).
-
-### length
-
-Returns the number of characters in text.
-
-Syntax: `length(text)`
-
-Example: `length([Comment])` If the `comment` were "wizard", `length` would return 6 ("wizard" has six characters).
-
-### log
-
-Returns the base 10 log of the number.
-
-Syntax: `log(column)`.
-
-Example: `log([Value])`.
-
-### lower
-
-Returns the string of text in all lower case.
-
-Syntax: `lower(text)`.
-
-Example: `lower([Status])`. If the `Status` were "QUIET", the expression would return "quiet".
-
-Related: [upper](#upper).
 
 ### minute
 
@@ -438,18 +558,6 @@ Returns the current date and time using your Metabase [report timezone](../../co
 
 Syntax: `now`.
 
-### power
-
-Raises a number to the power of the exponent value.
-
-Syntax: `power(column, exponent)`.
-
-Example: `power([Length], 2)`. If the length were `3`, the expression would return `9` (3 to the second power is 3\*3).
-
-Databases that don't support `power`: SQLite.
-
-Related: [exp](#exp).
-
 ### quarter
 
 Takes a datetime and returns the number of the quarter in a year (1-4) as an integer.
@@ -458,46 +566,6 @@ Syntax: `quarter([datetime column])`.
 
 Example: `quarter("2021-03-25T12:52:37")` would return `1` for the first quarter.
 
-### [regexextract](./expressions/regexextract.md)
-
-Extracts matching substrings according to a regular expression.
-
-Syntax: `regexextract(text, regular_expression)`.
-
-Example: `regexextract([Address], "[0-9]+")`.
-
-Databases that don't support `regexextract`: H2, SQL Server, SQLite.
-
-Related: [contains](#contains), [substring](#substring).
-
-### replace
-
-Replaces all occurrences of a search text in the input text with the replacement text.
-
-Syntax: `replace(text, find, replace)`.
-
-Example: `replace([Title], "Enormous", "Gigantic")`.
-
-### righttrim
-
-Removes trailing whitespace from a string of text.
-
-Syntax: `rtrim(text)`
-
-Example: `rtrim([Comment])`. If the comment were "Fear is the mindkiller. ", the expression would return "Fear is the mindkiller."
-
-Related: [trim](#trim) and [lefttrim](#lefttrim).
-
-### round
-
-Rounds a decimal number either up or down to the nearest integer value.
-
-Syntax: `round(column)`.
-
-Example: `round([Temperature])`. If the temp were `13.5` degrees centigrade, the expression would return `14`.
-
-Example: `round([Temperature] * 10) / 10`. If the temp were `100.75`, the expression would return `100.8`.
-
 ### second
 
 Takes a datetime and returns the number of seconds in the minute (0-59) as an integer.
@@ -505,54 +573,6 @@ Takes a datetime and returns the number of seconds in the minute (0-59) as an in
 Syntax: `second([datetime column)`.
 
 Example: `second("2021-03-25T12:52:37")` would return the integer `37`.
-
-### sqrt
-
-Returns the square root of a value.
-
-Syntax: `sqrt(column)`.
-
-Example: `sqrt([Hypotenuse])`.
-
-Databases that don't support `sqrt`: SQLite.
-
-Related: [Power](#power).
-
-### startswith
-
-Returns true if the beginning of the text matches the comparison text.
-
-Syntax: `startsWith(text, comparison)`.
-
-Example: `startsWith([Course Name], "Computer Science")` would return true for course names that began with "Computer Science", like "Computer Science 101: An introduction".
-
-Related: [endswith](#endswith), [contains](#contains).
-
-### [substring](./expressions/substring.md)
-
-Returns a portion of the supplied text, specified by a starting position and a length.
-
-Syntax: `substring(text, position, length)`
-
-Example: `substring([Title], 1, 10)` returns the first 10 letters of a string (the string index starts at position 1).
-
-Related: [regexextract](#regexextract), [replace](#replace).
-
-### trim
-
-Removes leading and trailing whitespace from a string of text.
-
-Syntax: `trim(text)`
-
-Example: `trim([Comment])` will remove any whitespace characters on either side of a comment.
-
-### upper
-
-Returns the text in all upper case.
-
-Syntax: `upper(text)`.
-
-Example: `upper([Status])`. If status were "hyper", `upper("hyper")` would return "HYPER".
 
 ### week
 
@@ -580,12 +600,12 @@ Example:
 
 ```
 case(
-  weekday([Created At]) = 1, "Sunday", 
-  weekday([Created At]) = 2, "Monday", 
-  weekday([Created At]) = 3, "Tuesday", 
-  weekday([Created At]) = 4, "Wednesday", 
-  weekday([Created At]) = 5, "Thursday", 
-  weekday([Created At]) = 6, "Friday", 
+  weekday([Created At]) = 1, "Sunday",
+  weekday([Created At]) = 2, "Monday",
+  weekday([Created At]) = 3, "Tuesday",
+  weekday([Created At]) = 4, "Wednesday",
+  weekday([Created At]) = 5, "Thursday",
+  weekday([Created At]) = 6, "Friday",
   weekday([Created At]) = 7, "Saturday")
 ```
 
@@ -615,6 +635,6 @@ Additionally, **Presto** only provides _approximate_ results for `Median` and `P
 
 If you're using or maintaining a third-party database driver, please [refer to the wiki](https://github.com/metabase/metabase/wiki/What's-new-in-0.35.0-for-Metabase-driver-authors) to see how your driver might be impacted.
 
-See [Custom expressions in the notebook editor](https://www.metabase.com/learn/questions/custom-expressions) to learn more.
+Check out our tutorial on [custom expressions in the query builder](https://www.metabase.com/learn/questions/custom-expressions) to learn more.
 
 [expressions]: ./expressions.md

--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -52,7 +52,7 @@ For an introduction to expressions, check out the [overview of custom expression
     - [ltrim](#ltrim)
     - [length](#length)
     - [lower](#lower)
-    - [nonempty](#nonempty)
+    - [notempty](#notempty)
     - [regexextract](./expressions/regexextract.md)
     - [replace](#replace)
     - [rtrim](#rtrim)
@@ -261,15 +261,15 @@ Example: `isnull([Tax])` would return true if no value were present in the colum
 
 Related: [nonnull](#nonnull), [isempty](#isempty)
 
-### [nonnull](./expressions/isnull.md)
+### notnull
 
 Returns true if the column contains a value.
 
-Syntax: `nonnull(column)`
+Syntax: `notnull(column)`
 
-Example: `nonnull([Tax])` would return true if there is a value present in the column for that row.
+Example: `notnull([Tax])` would return true if there is a value present in the column for that row.
 
-Related: [isnull](#nonnull), [nonempty](#nonempty)
+Related: [isnull](#nonnull), [nonempty](#notempty)
 
 ## Math functions
 Math functions implement common mathematical operations.
@@ -455,13 +455,12 @@ Related: [upper](#upper).
 
 Returns true if a _string column_ contains a value that is not the empty string. Calling this function on a non-string column will cause an error.
 
-Syntax: `nonempty(column)`
+Syntax: `notempty(column)`
 
-Example: `nonempty([Feedback])` would return true if `Feedback` contains a value that isn't the empty string (`''`).
+Example: `notempty([Feedback])` would return true if `Feedback` contains a value that isn't the empty string (`''`).
 
-[Learn more](./expressions/isempty.md) about how Metabase handles empty strings and nulls.
 
-Related: [isempty](#isempty), [nonnull](#nonnull)
+Related: [isempty](#isempty), [isnull](#isnull), [notnull](#notnull)
 
 
 ### [regexextract](./expressions/regexextract.md)

--- a/docs/questions/query-builder/expressions-list.md
+++ b/docs/questions/query-builder/expressions-list.md
@@ -269,6 +269,7 @@ Syntax: `nonnull(column)`
 
 Example: `nonnull([Tax])` would return true if there is a value present in the column for that row.
 
+Related: [isnull](#nonnull), [nonempty](#nonempty)
 
 ## Math functions
 Math functions implement common mathematical operations.
@@ -366,34 +367,45 @@ Example: `concat([Last Name], ", ", [First Name])` would produce a string of the
 
 ### contains
 
-Checks to see if `string1` contains `string2` within it. Performs case-sensitive match by default.
+Checks to see if `string1` contains `string2` within it.
+
+Performs case-sensitive match by default.
 You can pass an optional parameter `"case-insensitive"` to perform a case-insensitive match.
 
 Syntax: `contains(string1, string2)` for case-sensitive match.
-`contains(string1, string2, "case-insensitive") for case-insensitive match.
 
-Example: `contains([Status], "Class")`. If `Status` were "Classified", the expression would return `true`. If the `Status` were "**c**lassified", the expression would return `false`, because the case
+`contains(string1, string2, "case-insensitive")` for case-insensitive match.
+
+Example: `contains([Status], "Class")`.
+
+If `Status` were "Classified", the expression would return `true`. If the `Status` were "**c**lassified", the expression would return `false`, because the case does not match.
 
 Related: [doesNotContain](#doesnotcontain), [regexextract](#regexextract).
 
 ### doesNotContain
 
-Checks to see if `string1` contains `string2` within it. Performs case-sensitive match by default.
+Checks to see if `string1` contains `string2` within it.
+
+Performs case-sensitive match by default.
 You can pass an optional parameter `"case-insensitive"` to perform a case-insensitive match.
 
 Syntax: `doesNotContain(string1, string2)` for case-sensitive match.
+
 `doesNotContain(string1, string2, "case-insensitive")` for case-insensitive match.
 
 Example: `doesNotContain([Status], "Class")`. If `Status` were "Classified", the expression would return `false`.
 
-Related: (contains)[#contains],  [regexextract](#regexextract).
+Related: [contains](#contains),  [regexextract](#regexextract).
 
 ### endsWith
 
-Returns true if the end of the text matches the comparison text. Performs case-sensitive match by default.
+Returns true if the end of the text matches the comparison text.
+
+ Performs case-sensitive match by default.
 You can pass an optional parameter `"case-insensitive"` to perform a case-insensitive match.
 
 Syntax: `endsWith(text, comparison)` for case-sensitive match.
+
  `endsWith(text, comparison, "case-insensitive")` for case-insensitive match.
 
 Example: `endsWith([Appetite], "hungry")`
@@ -441,11 +453,13 @@ Related: [upper](#upper).
 
 ### [nonempty](./expressions/isempty.md)
 
-Returns true if the string column contains a value that isn't the empty string (`''`).
+Returns true if a _string column_ contains a value that is not the empty string. Calling this function on a non-string column will cause an error.
 
 Syntax: `nonempty(column)`
 
-Example: `nonempty([Feedback])` would return true if `Feedback` contains a value that isn't the empty string (`''`). . [Learn more](./expressions/isempty.md) about how Metabase handles empty strings and nulls.
+Example: `nonempty([Feedback])` would return true if `Feedback` contains a value that isn't the empty string (`''`).
+
+[Learn more](./expressions/isempty.md) about how Metabase handles empty strings and nulls.
 
 Related: [isempty](#isempty), [nonnull](#nonnull)
 
@@ -486,14 +500,17 @@ Returns true if the beginning of the text matches the comparison text. Performs 
 You can pass an optional parameter `"case-insensitive"` to perform a case-insensitive match.
 
 Syntax: `startsWith(text, comparison)` for case-sensitive match.
+
  `startsWith(text, comparison, "case-insensitive")` for case-insensitive match.
 
-Example: `startsWith([Course Name], "Computer Science")` would return true for course names that began with "Computer Science", like "Computer Science 101: An introduction". It would return false for "Computer **s**cience 201: Data structures" because the case of "science" does not match the case in the comparison text.
+Example: `startsWith([Course Name], "Computer Science")` would return true for course names that began with "Computer Science", like "Computer Science 101: An introduction".
 
-`startsWith([Course Name], "Computer Science", "case-insensitive")`would return true for both "Computer Science 101: An introduction" and "Computer science 201: Data structures".
+ It would return false for "Computer **s**cience 201: Data structures" because the case of "science" does not match the case in the comparison text.
+
+`startsWith([Course Name], "Computer Science", "case-insensitive")` would return true for both "Computer Science 101: An introduction" and "Computer science 201: Data structures".
 
 
-Related: [endsWith](#endsWith), [contains](#contains), [doesNotContain](#doesnotcontain).
+Related: [endsWith](#endswith), [contains](#contains), [doesNotContain](#doesnotcontain).
 
 ### [substring](./expressions/substring.md)
 
@@ -625,19 +642,20 @@ Gets a timestamp relative to the current time.
 Syntax: `relativeDateTime(number, text)`
 
 `number`: Period of interval, where negative values are back in time.
+
 `text`: Type of interval like `"day"`, `"month"`, `"year"`
 
 `relativeDateTime` can only be used as part of a conditional expression.
 
 Example: `[Orders → Created At] < relativeDateTime(-30, "day")` will filter for orders created over 30 days ago from current date.
 
-Related: [dateTimeAdd](#datetimeadd), [dateTimeSubtract](#datetimesubtract).
+Related: [datetimeAdd](#datetimeadd), [datetimeSubtract](#datetimesubtract).
 
 ### second
 
 Takes a datetime and returns the number of seconds in the minute (0-59) as an integer.
 
-Syntax: `second([datetime column)`.
+Syntax: `second([datetime column])`.
 
 Example: `second("2021-03-25T12:52:37")` would return the integer `37`.
 
@@ -646,7 +664,9 @@ Example: `second("2021-03-25T12:52:37")` would return the integer `37`.
 Gets a time interval of specified length.
 
 Syntax: `timeSpan(number, text)`.
+
 `number`: Period of interval, where negative values are back in time.
+
 `text`: Type of interval like `"day"`, `"month"`, `"year"`
 
 Example: `[Orders → Created At] + timeSpan(7, "day")` will return the date 7 days after the `Created At` date.
@@ -700,10 +720,11 @@ Example: `year("2021-03-25T12:52:37")` would return the year 2021 as an integer,
 
 - [Aggregation expressions](#aggregations)  can only be used in the **Summarize** section of the query builder.
 - Functions that return a boolean value, like [isempty](#isempty) or [contains](#contains), cannot be used to create a custom column. To create a custom column based on one of these functions, you must combine them with another function, like `case`.
+
 For example, to create a new custom column that contains `true` if `[Title]` contain `'Wallet'`, you can use the custom expression
 ```
 case(contains([Title], 'Wallet'), true, false)
-``
+```
 
 ### Database limitations
 

--- a/docs/questions/query-builder/expressions.md
+++ b/docs/questions/query-builder/expressions.md
@@ -40,7 +40,7 @@ Use `+`, `-`, `*` (multiply), `/` (divide) on numeric columns with numeric value
 
 For example, you could create a new column that calculates the difference between the total and subtotal of a order: `= [Total] - [Subtotal]`.
 
-To do math on timestamp columns, you can use [Date functions](./expressions-list.md/#date-functions) like [dateDiff](./expressions/datetimediff.md).
+To do math on timestamp columns, you can use [Date functions](expressions-list.md#date-functions) like [dateDiff](./expressions/datetimediff.md).
 
 ## Conditional operators
 

--- a/docs/questions/query-builder/expressions.md
+++ b/docs/questions/query-builder/expressions.md
@@ -16,9 +16,9 @@ To use custom expression, create a __Custom Column__ (where the custom expressio
 
 When using the query builder, you can use expressions to create new:
 
-- **Filters**. The expression `= contains([comment], "Metabase")` would filter for rows where the `comment` field contained the word "Metabase".
-- **Metrics**. Also known as summaries or aggregations. `= share([Total] > 50)` would return the percentage of orders with totals greater than 50 dollars.
 - **Custom columns**. You could use `= [Subtotal] / [Quantity]` to create a new column, which you could name "Item price".
+- **Filters**. The expression `= contains([comment], "Metabase")` would filter for rows where the `comment` field contained the word "Metabase".
+- **Summaries**. Also known as metrics or aggregations. `= Share([Total] > 50)` would return the percentage of orders with totals greater than 50 dollars.
 
 This page covers the basics of expressions. You can check out a [full list of expressions][expression-list] in Metabase, or walk through a tutorial that shows you how you can use [custom expressions in the notebook editor][custom-expressions].
 
@@ -40,7 +40,7 @@ Use `+`, `-`, `*` (multiply), `/` (divide) on numeric columns with numeric value
 
 For example, you could create a new column that calculates the difference between the total and subtotal of a order: `= [Total] - [Subtotal]`.
 
-You can't currently do math on timestamp columns (we're working on adding new date functions soon, so stay tuned).
+To do math on timestamp columns, you can use [Date functions](./expressions-list.md/#date-functions) like [dateDiff](./expressions/datetimediff.md).
 
 ## Conditional operators
 
@@ -52,7 +52,7 @@ For example, you could create a filter for customers from California or Vermont:
 
 You can refer to columns in the current table, or to columns that are linked via a foreign key relationship. Column names should be included inside of square brackets, like this: `[Name of Column]`. Columns in connected tables can be referred to like this: `[ConnectedTableName.Column]`.
 
-## Referencing Segments and metrics
+## Referencing Segments and Metrics
 
 You can refer to saved [Segments or Metrics](../../data-modeling/segments-and-metrics.md) that are present in the currently selected table. You write these out the same as with columns, like this: `[Valid User Sessions]`.
 
@@ -61,7 +61,7 @@ You can refer to saved [Segments or Metrics](../../data-modeling/segments-and-me
 Some things to keep in mind about filter expressions and conditionals:
 
 - Filter expressions are different in that they must return a Boolean value (something that's either true or false). For example, you could write `[Subtotal] + [Tax] < 100`. Metabase would look at each row, add its subtotal and tax, the check if that sum is greater than 100. If it is, the statement evaluates as true, and Metabase will include the row in the result. If instead you were to (incorrectly) write `[Subtotal] + [Tax]`, Metabase wouldn't know what to do, as that expression doesn't evaluate to true or false.
-- You can use functions inside of the conditional portion of the `Countif` and `Sumif` aggregations, like so: `countif( round([Subtotal]) > 100 OR floor([Tax]) < 10 )`.
+- You can use functions inside of the conditional portion of the `CountIf` and `SumIf` aggregations, like so: `CountIf( round([Subtotal]) > 100 OR floor([Tax]) < 10 )`.
 
 ## Working with dates in filter expressions
 
@@ -77,7 +77,7 @@ This expression would return rows where `Created At` is between January 1, 2020 
 
 See a full list of [expressions][expression-list].
 
-For a tutorial on expressions, see [Custom expressions in the notebook editor][custom-expressions].
+For a tutorial on expressions, see [Custom expressions in the query builder][custom-expressions].
 
 [aggregations]: ./expressions-list.md#aggregations
 [custom-expressions]: https://www.metabase.com/learn/questions/custom-expressions

--- a/docs/questions/query-builder/expressions/converttimezone.md
+++ b/docs/questions/query-builder/expressions/converttimezone.md
@@ -121,6 +121,7 @@ Note that the first part of the timestamp is in UTC (same thing as GMT). The tim
 - Presto
 - SparkSQL
 - SQLite
+- Metabase Sample Database
 
 ### Notes on source time zones
 

--- a/docs/questions/query-builder/expressions/isnull.md
+++ b/docs/questions/query-builder/expressions/isnull.md
@@ -6,39 +6,54 @@ title: Isnull
 
 `isnull` checks if a value is a `null`, a special kind of placeholder that's used by a database when something is missing or unknown.
 
-**In Metabase, you must combine `isnull` with another expression that accepts boolean values.** The table below shows you examples of the boolean value that will be passed to your other expression(s).
+## Syntax
 
-| Syntax                                                | Example with a true `null` | Example with an empty string |
-| ----------------------------------------------------- | -------------------------- | ---------------------------- |
-| `isnull(value)`                                       | `isnull(null)`             | `isnull("")`                 |
-| Returns `true` if a value is `null`, false otherwise. | `true`                     | `false`                      |
+```
+isnull(text column)
+```
+
+You can use `isnull` in [custom filters](../expressions.md#filter-expressions-and-conditionals), or as the condition for conditional aggregations [`CountIf`](../expressions/countif.md) and [`SumIf`](../expressions/sumif.md). To create a custom column using `isnull`, you must combine `isnull` with another function that accepts boolean values, like [`case`](./case.md).
 
 ## How Metabase handles nulls
 
-In Metabase tables, `null`s are displayed as blank cells. For example, in the Feedback column below, the blank cells could contain either:
+In Metabase tables, `null`s are displayed as blank cells. Additionally, for string columns, empty strings and strings containing only whitespace characters will be displayed as blank as well.
 
-- `null`: no feedback was submitted, so the customer's thoughts are "unknown".
-- `""`: feedback was submitted and left intentionally blank, so the customer had "no feedback to give".
+The table below shows you examples of the output of `isnull`.
 
-| Customer Feedback  |
-| ------------------ |
-|                    |
-|                    |
-| I like your style. |
+| Metabase shows| Database value      | `isnull(value)`   |
+|---------------| --------------------| ------------------|
+|               | `null`              | `true`            |
+|               | `""` (empty string) | `false`\*         |
+|               | `"   "` (whitespace)| `false`           |
+|     kitten    |`"kitten"`           | `false`           |
+
+\*In Oracle and Vertica databases, empty strings are treated as nulls.
+
+## Creating a boolean custom column
+
+To create a custom column using `isnull`, you must combine `isnull` with another function.
+For example, if you want to create a custom column that contains `true` when the `Discount` column is null, and `false` otherwise, you can use the [`case expression`](./case.md) :
+
+```
+case(isnull([Discount]), true, false)
+```
 
 ## Replacing null values with another value
 
-| Feedback           | `case(isnull([Feedback]), "Unknown feedback.", [Feedback])` |
-| ------------------ | ----------------------------------------------------------- |
-|                    | Unknown feedback.                                           |
-|                    |                                                             |
-| I like your style. | I like your style.                                          |
+Combine `isnull` with the [`case` expression](./case.md) to replace missing information with something more descriptive:
 
-Combine `isnull` with the [`case` expression](./case.md) to replace "unknown" information with something more descriptive.
+For example, you can create a new custom column that will contain `"Unknown feedback"` when the original `[Feedback]` column is null, and the actual feedback value when `[Feedback]` is has a value. The custom expression to do it is:
+```
+case(isnull([Feedback]), "Unknown feedback.", [Feedback])
+```
 
-Let's say that the first row's blank cell is actually a `null`, so `isnull` will return `true`. The `case` statement evaluates `true` to return the first output "Unknown feedback".
 
-The second row's blank cell doesn't have a `null`, but we're not sure what's in it either---it could be an empty string, or even an emoji that blends into your table's background. No matter what the edge case is, `isnull` will return `false`, and `case` will return whatever's in the Feedback column as the default output.
+| Feedback               | `case(isnull([Feedback]), "Unknown feedback.", [Feedback])` |
+| -----------------------| ----------------------------------------------------------- |
+| `null`                 | `"Unknown feedback."`                                       |
+| `""`                   | `""`                                                        |
+| `"I like your style."` | `"I like your style."`                                      |
+
 
 ## Accepted data types
 
@@ -66,15 +81,15 @@ This section covers functions and formulas that can be used interchangeably with
 
 All examples below use the table from the [Replacing null values](#replacing-null-values-with-another-value) example:
 
-| Feedback           | `case(isnull([Feedback]), "Unknown feedback.", [Feedback])` |
-| ------------------ | ----------------------------------------------------------- |
-|                    | Unknown feedback.                                           |
-|                    |                                                             |
-| I like your style. | I like your style.                                          |
+| Feedback               | `case(isnull([Feedback]), "Unknown feedback.", [Feedback])` |
+| -----------------------| ----------------------------------------------------------- |
+| `null`                 | `"Unknown feedback."`                                       |
+| `""`                   | `""`                                                        |
+| `"I like your style."` | `"I like your style."`                                      |
 
 ### SQL
 
-In most cases (unless you're using a NoSQL database), questions created from the [notebook editor][notebook-editor-def] are converted into SQL queries that run against your database or data warehouse.
+In most cases (unless you're using a NoSQL database), questions created from the [query builder][notebook-editor-def] are converted into SQL queries that run against your database or data warehouse.
 
 ```sql
 CASE WHEN Feedback IS NULL THEN "Unknown feedback",
@@ -127,6 +142,6 @@ case(isnull([Feedback]), "Unknown feedback.", [Feedback])
 [custom-expressions-doc]: ../expressions.md
 [custom-expressions-learn]: https://www.metabase.com/learn/questions/custom-expressions
 [data-types]: https://www.metabase.com/learn/databases/data-types-overview#examples-of-data-types
-[notebook-editor-def]: https://www.metabase.com/glossary/notebook_editor
+[notebook-editor-def]: https://www.metabase.com/glossary/query_builder
 [numpy]: https://numpy.org/doc/
 [pandas]: https://pandas.pydata.org/pandas-docs/stable/

--- a/docs/questions/query-builder/expressions/isnull.md
+++ b/docs/questions/query-builder/expressions/isnull.md
@@ -27,7 +27,7 @@ The table below shows you examples of the output of `isnull`.
 |               | `"   "` (whitespace)| `false`           |
 |     kitten    |`"kitten"`           | `false`           |
 
-\*In Oracle and Vertica databases, empty strings are treated as nulls.
+\*In Oracle and Vertica databases, empty strings are treated as nulls instead.
 
 ## Creating a boolean custom column
 


### PR DESCRIPTION
- Organize custom expressions by use case
<img width="142" alt="image" src="https://github.com/metabase/metabase/assets/16640109/906a6ca0-a7b7-4595-9064-b89ca15dcc58">


Diff is a bit hard to look at so here are the expressions that changed:
- document `doesNotContain`, `nonnull`, `nonempty`, `relativeDateTime`, `timeSpan`
- add case sensitivity notes to `startsWith`, `endsWith`, `contains`, `doesNotContain`
- logic of `isempty` and `isnull`
