### PR TITLE
Make static field values select searchable

### DIFF
--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -17,6 +17,7 @@ import { createMockFieldValues } from "metabase-types/api/mocks";
 import {
   ORDERS,
   PEOPLE,
+  PEOPLE_STATE_VALUES,
   PRODUCT_CATEGORY_VALUES,
   PRODUCTS,
 } from "metabase-types/api/mocks/presets";
@@ -154,6 +155,24 @@ describe("StringFilterValuePicker", () => {
 
       userEvent.click(screen.getByText("Gadget"));
       expect(onChange).toHaveBeenCalledWith(["Gadget"]);
+    });
+
+    it("should allow to search the list of values in compact mode", async () => {
+      const { onChange } = await setupStringPicker({
+        query,
+        stageIndex,
+        column: findColumn("PEOPLE", "STATE"),
+        values: [],
+        compact: true,
+        fieldValues: PEOPLE_STATE_VALUES,
+      });
+
+      userEvent.type(screen.getByPlaceholderText("Search the list"), "CA");
+      expect(screen.getByText("CA")).toBeInTheDocument();
+      expect(screen.queryByText("GA")).not.toBeInTheDocument();
+
+      userEvent.click(screen.getByText("CA"));
+      expect(onChange).toHaveBeenCalledWith(["CA"]);
     });
 
     it("should allow to update selected values", async () => {

--- a/frontend/src/metabase/querying/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
@@ -155,6 +155,7 @@ export function SelectValuePicker({
       value={selectedValues}
       placeholder={placeholder}
       autoFocus={autoFocus}
+      searchable
       aria-label={t`Filter value`}
       onChange={onChange}
     />


### PR DESCRIPTION
Small UX fix. Now in the filter modal you can actually "search the list" of static field values:

<img width="1183" alt="Screenshot 2024-03-13 at 09 13 43" src="https://github.com/metabase/metabase/assets/8542534/ec87bfb9-1bb3-44ae-8a99-10d404b9c0e3">

