### PR TITLE
Fix the stale collection information when the source in the data selector changes

### DIFF
--- a/e2e/test/scenarios/question/reproductions/39812-data-selector-virtual-table-collection-change.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/39812-data-selector-virtual-table-collection-change.cy.spec.js
@@ -20,30 +20,16 @@ describe("issue 39812", () => {
   it("moving the model to another collection should immediately be reflected in the data selector (metabase#39812-1)", () => {
     visitModel(ORDERS_MODEL_ID);
     openNotebook();
-    cy.findByTestId("data-step-cell").click();
-    cy.findByLabelText("Our analytics").should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
-    cy.findByLabelText("Orders Model").should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
+
+    openDataSelector();
+    assertSourceCollection("Our analytics");
+    assertDataSource("Orders Model");
+
     moveToCollection("First collection");
 
-    cy.findByTestId("data-step-cell").click();
-    cy.findByLabelText("First collection").should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
-    cy.findByLabelText("Orders Model").should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
+    openDataSelector();
+    assertSourceCollection("First collection");
+    assertDataSource("Orders Model");
   });
 
   it("moving the source question should immediately reflect in the data selector for the nested question that depends on it (metabase#39812-2)", () => {
@@ -66,17 +52,10 @@ describe("issue 39812", () => {
 
     visitQuestion("@nestedQuestionId");
     openNotebook();
-    cy.findByTestId("data-step-cell").click();
-    cy.findByLabelText("Our analytics").should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
-    cy.findByLabelText(sourceQuestionName).should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
+
+    openDataSelector();
+    assertSourceCollection("Our analytics");
+    assertDataSource(sourceQuestionName);
 
     cy.log("Move the source question to another collection");
     visitQuestion(SOURCE_QUESTION_ID);
@@ -87,17 +66,9 @@ describe("issue 39812", () => {
     visitQuestion("@nestedQuestionId");
     openNotebook();
 
-    cy.findByTestId("data-step-cell").click();
-    cy.findByLabelText("First collection").should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
-    cy.findByLabelText(sourceQuestionName).should(
-      "have.attr",
-      "aria-selected",
-      "true",
-    );
+    openDataSelector();
+    assertSourceCollection("First collection");
+    assertDataSource(sourceQuestionName);
   });
 });
 
@@ -113,4 +84,20 @@ function moveToCollection(collection) {
     cy.button("Move").click();
     cy.wait("@updateCollectionTree");
   });
+}
+
+function openDataSelector() {
+  cy.findByTestId("data-step-cell").click();
+}
+
+function assertItemSelected(item) {
+  cy.findByLabelText(item).should("have.attr", "aria-selected", "true");
+}
+
+function assertSourceCollection(collection) {
+  return assertItemSelected(collection);
+}
+
+function assertDataSource(questionOrModel) {
+  return assertItemSelected(questionOrModel);
 }

--- a/e2e/test/scenarios/question/reproductions/39812-data-selector-virtual-table-collection-change.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/39812-data-selector-virtual-table-collection-change.cy.spec.js
@@ -1,10 +1,14 @@
-import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_MODEL_ID,
+  ORDERS_COUNT_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import {
   restore,
   visitModel,
   openNotebook,
   openQuestionActions,
   popover,
+  visitQuestion,
 } from "e2e/support/helpers";
 
 describe("issue 39812", () => {
@@ -13,7 +17,7 @@ describe("issue 39812", () => {
     cy.signInAsAdmin();
   });
 
-  it("moving the source model or a question to another collection should immediately be refreclted in the data selector (metabase#39812)", () => {
+  it("moving the model to another collection should immediately be reflected in the data selector (metabase#39812-1)", () => {
     visitModel(ORDERS_MODEL_ID);
     openNotebook();
     cy.findByTestId("data-step-cell").click();
@@ -36,6 +40,60 @@ describe("issue 39812", () => {
       "true",
     );
     cy.findByLabelText("Orders Model").should(
+      "have.attr",
+      "aria-selected",
+      "true",
+    );
+  });
+
+  it("moving the source question should immediately reflect in the data selector for the nested question that depends on it (metabase#39812-2)", () => {
+    const SOURCE_QUESTION_ID = ORDERS_COUNT_QUESTION_ID;
+    // Rename the source question to make assertions more explicit
+    const sourceQuestionName = "Source Question";
+    cy.request("PUT", `/api/card/${ORDERS_COUNT_QUESTION_ID}`, {
+      name: sourceQuestionName,
+    });
+
+    const nestedQuestionDetails = {
+      name: "Nested Question",
+      query: { "source-table": `card__${SOURCE_QUESTION_ID}` },
+    };
+
+    cy.createQuestion(nestedQuestionDetails, {
+      wrapId: true,
+      idAlias: "nestedQuestionId",
+    });
+
+    visitQuestion("@nestedQuestionId");
+    openNotebook();
+    cy.findByTestId("data-step-cell").click();
+    cy.findByLabelText("Our analytics").should(
+      "have.attr",
+      "aria-selected",
+      "true",
+    );
+    cy.findByLabelText(sourceQuestionName).should(
+      "have.attr",
+      "aria-selected",
+      "true",
+    );
+
+    cy.log("Move the source question to another collection");
+    visitQuestion(SOURCE_QUESTION_ID);
+    openNotebook();
+    moveToCollection("First collection");
+
+    cy.log("Make sure the source change is reflected in a nested question");
+    visitQuestion("@nestedQuestionId");
+    openNotebook();
+
+    cy.findByTestId("data-step-cell").click();
+    cy.findByLabelText("First collection").should(
+      "have.attr",
+      "aria-selected",
+      "true",
+    );
+    cy.findByLabelText(sourceQuestionName).should(
       "have.attr",
       "aria-selected",
       "true",

--- a/e2e/test/scenarios/question/reproductions/39812-data-selector-virtual-table-collection-change.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/39812-data-selector-virtual-table-collection-change.cy.spec.js
@@ -1,0 +1,58 @@
+import { ORDERS_MODEL_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  restore,
+  visitModel,
+  openNotebook,
+  openQuestionActions,
+  popover,
+} from "e2e/support/helpers";
+
+describe("issue 39812", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("moving the source model or a question to another collection should immediately be refreclted in the data selector (metabase#39812)", () => {
+    visitModel(ORDERS_MODEL_ID);
+    openNotebook();
+    cy.findByTestId("data-step-cell").click();
+    cy.findByLabelText("Our analytics").should(
+      "have.attr",
+      "aria-selected",
+      "true",
+    );
+    cy.findByLabelText("Orders Model").should(
+      "have.attr",
+      "aria-selected",
+      "true",
+    );
+    moveToCollection("First collection");
+
+    cy.findByTestId("data-step-cell").click();
+    cy.findByLabelText("First collection").should(
+      "have.attr",
+      "aria-selected",
+      "true",
+    );
+    cy.findByLabelText("Orders Model").should(
+      "have.attr",
+      "aria-selected",
+      "true",
+    );
+  });
+});
+
+function moveToCollection(collection) {
+  openQuestionActions();
+  popover().findByTextEnsureVisible("Move").click();
+  cy.findByRole("dialog").within(() => {
+    cy.intercept("GET", "/api/collection/tree**").as("updateCollectionTree");
+    cy.findAllByTestId("item-picker-item")
+      .filter(`:contains(${collection})`)
+      .click();
+
+    cy.button("Move").click();
+    cy.wait("@updateCollectionTree");
+  });
+}

--- a/e2e/test/scenarios/question/reproductions/39812-data-selector-virtual-table-collection-change.cy.spec.ts
+++ b/e2e/test/scenarios/question/reproductions/39812-data-selector-virtual-table-collection-change.cy.spec.ts
@@ -72,7 +72,7 @@ describe("issue 39812", () => {
   });
 });
 
-function moveToCollection(collection) {
+function moveToCollection(collection: string) {
   openQuestionActions();
   popover().findByTextEnsureVisible("Move").click();
   cy.findByRole("dialog").within(() => {
@@ -90,14 +90,14 @@ function openDataSelector() {
   cy.findByTestId("data-step-cell").click();
 }
 
-function assertItemSelected(item) {
+function assertItemSelected(item: string) {
   cy.findByLabelText(item).should("have.attr", "aria-selected", "true");
 }
 
-function assertSourceCollection(collection) {
+function assertSourceCollection(collection: string) {
   return assertItemSelected(collection);
 }
 
-function assertDataSource(questionOrModel) {
+function assertDataSource(questionOrModel: string) {
   return assertItemSelected(questionOrModel);
 }

--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -105,19 +105,14 @@ export default createEntity({
           previousSchemaContainingTheQuestion.id,
           virtualQuestionId,
         );
-      } else {
-        state = assocIn(state, [virtualSchemaId], {
-          id: virtualSchemaId,
-          name: virtualSchemaName,
-          database: {
-            id: SAVED_QUESTIONS_VIRTUAL_DB_ID,
-            is_saved_questions: true,
-          },
-        });
       }
 
       if (!state[virtualSchemaId]) {
-        return state;
+        state = assocIn(state, [virtualSchemaId], {
+          id: virtualSchemaId,
+          name: virtualSchemaName,
+          database: SAVED_QUESTIONS_VIRTUAL_DB_ID,
+        });
       }
 
       return updateIn(state, [virtualSchemaId, "tables"], tables => {

--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -91,7 +91,6 @@ export default createEntity({
         isDatasets: card.type === "model",
       });
       const virtualSchemaName = getCollectionVirtualSchemaName(card.collection);
-
       const virtualQuestionId = getQuestionVirtualTableId(card.id);
       const previousSchemaContainingTheQuestion =
         getPreviousSchemaContainingTheQuestion(

--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -87,16 +87,16 @@ export default createEntity({
 
     if (type === Questions.actionTypes.UPDATE && !error) {
       const { question: card } = payload;
-      const schemaId = getCollectionVirtualSchemaId(card.collection, {
+      const virtualSchemaId = getCollectionVirtualSchemaId(card.collection, {
         isDatasets: card.type === "model",
       });
-      const schemaName = getCollectionVirtualSchemaName(card.collection);
+      const virtualSchemaName = getCollectionVirtualSchemaName(card.collection);
 
       const virtualQuestionId = getQuestionVirtualTableId(card.id);
       const previousSchemaContainingTheQuestion =
         getPreviousSchemaContainingTheQuestion(
           state,
-          schemaId,
+          virtualSchemaId,
           virtualQuestionId,
         );
 
@@ -107,9 +107,9 @@ export default createEntity({
           virtualQuestionId,
         );
       } else {
-        state = assocIn(state, [schemaId], {
-          id: schemaId,
-          name: schemaName,
+        state = assocIn(state, [virtualSchemaId], {
+          id: virtualSchemaId,
+          name: virtualSchemaName,
           database: {
             id: SAVED_QUESTIONS_VIRTUAL_DB_ID,
             is_saved_questions: true,
@@ -117,11 +117,11 @@ export default createEntity({
         });
       }
 
-      if (!state[schemaId]) {
+      if (!state[virtualSchemaId]) {
         return state;
       }
 
-      return updateIn(state, [schemaId, "tables"], tables => {
+      return updateIn(state, [virtualSchemaId, "tables"], tables => {
         if (!tables) {
           return tables;
         }

--- a/frontend/src/metabase/entities/schemas.unit.spec.js
+++ b/frontend/src/metabase/entities/schemas.unit.spec.js
@@ -3,7 +3,10 @@ import fetchMock from "fetch-mock";
 import { getStore } from "__support__/entities-store";
 import Questions from "metabase/entities/questions";
 import Schemas from "metabase/entities/schemas";
-import { ROOT_COLLECTION_VIRTUAL_SCHEMA } from "metabase-lib/v1/metadata/utils/saved-questions";
+import {
+  ROOT_COLLECTION_VIRTUAL_SCHEMA,
+  SAVED_QUESTIONS_VIRTUAL_DB_ID,
+} from "metabase-lib/v1/metadata/utils/saved-questions";
 
 describe("schema entity", () => {
   let store;
@@ -251,7 +254,7 @@ describe("schema entity", () => {
       });
     });
 
-    it("should not add question ID when it is unarchived if collection schema is not present in store", () => {
+    it("should add question ID when it is unarchived if collection schema is not present in store", () => {
       const nextState = Schemas.reducer(
         {
           [ROOT_COLLECTION_VIRTUAL_SCHEMA]: {
@@ -264,6 +267,11 @@ describe("schema entity", () => {
       expect(nextState).toEqual({
         [ROOT_COLLECTION_VIRTUAL_SCHEMA]: {
           tables: ["card__123"],
+        },
+        [`${SAVED_QUESTIONS_VIRTUAL_DB_ID}:foo`]: {
+          id: `${SAVED_QUESTIONS_VIRTUAL_DB_ID}:foo`,
+          name: "foo",
+          database: SAVED_QUESTIONS_VIRTUAL_DB_ID,
         },
       });
     });

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -28,6 +28,7 @@ import {
   convertSavedQuestionToVirtualTable,
   getQuestionVirtualTableId,
   getCollectionVirtualSchemaId,
+  getCollectionVirtualSchemaName,
 } from "metabase-lib/v1/metadata/utils/saved-questions";
 
 const listTablesForDatabase = async (...args) =>
@@ -171,10 +172,6 @@ const Tables = createEntity({
     if (type === Questions.actionTypes.UPDATE && !error) {
       const card = payload.question;
       const virtualQuestionId = getQuestionVirtualTableId(card.id);
-      const virtualCollectionSchemaId = getCollectionVirtualSchemaId(
-        card.collection,
-        { isDatasets: card.type === "model" },
-      );
 
       if (card.archived && state[virtualQuestionId]) {
         delete state[virtualQuestionId];
@@ -187,15 +184,17 @@ const Tables = createEntity({
           virtualQuestion.display_name !== card.name ||
           virtualQuestion.moderated_status !== card.moderated_status ||
           virtualQuestion.description !== card.description ||
-          virtualQuestion.schema_name !== card.collection.name
+          virtualQuestion.schema_name !== card.collection?.name
         ) {
           state = updateIn(state, [virtualQuestionId], table => ({
             ...table,
             display_name: card.name,
             moderated_status: card.moderated_status,
             description: card.description,
-            schema_name: card.collection.name,
-            schema: `${virtualCollectionSchemaId}:${card.collection.name}`,
+            schema_name: getCollectionVirtualSchemaName(card.collection),
+            schema: getCollectionVirtualSchemaId(card.collection, {
+              isDatasets: card.type === "model",
+            }),
           }));
         }
 

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -173,6 +173,7 @@ const Tables = createEntity({
       const virtualQuestionId = getQuestionVirtualTableId(card.id);
       const virtualCollectionSchemaId = getCollectionVirtualSchemaId(
         card.collection,
+        { isDatasets: card.type === "model" },
       );
 
       if (card.archived && state[virtualQuestionId]) {

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -179,22 +179,28 @@ const Tables = createEntity({
       }
 
       if (state[virtualQuestionId]) {
-        const virtualQuestion = state[virtualQuestionId];
+        const virtualTable = state[virtualQuestionId];
+        const virtualSchemaId = getCollectionVirtualSchemaId(card.collection, {
+          isDatasets: card.type === "model",
+        });
+        const virtualSchemaName = getCollectionVirtualSchemaName(
+          card.collection,
+        );
+
         if (
-          virtualQuestion.display_name !== card.name ||
-          virtualQuestion.moderated_status !== card.moderated_status ||
-          virtualQuestion.description !== card.description ||
-          virtualQuestion.schema_name !== card.collection?.name
+          virtualTable.display_name !== card.name ||
+          virtualTable.moderated_status !== card.moderated_status ||
+          virtualTable.description !== card.description ||
+          virtualTable.schema !== virtualSchemaId ||
+          virtualTable.schema_name !== virtualSchemaName
         ) {
           state = updateIn(state, [virtualQuestionId], table => ({
             ...table,
             display_name: card.name,
             moderated_status: card.moderated_status,
             description: card.description,
-            schema_name: getCollectionVirtualSchemaName(card.collection),
-            schema: getCollectionVirtualSchemaId(card.collection, {
-              isDatasets: card.type === "model",
-            }),
+            schema: virtualSchemaId,
+            schema_name: virtualSchemaName,
           }));
         }
 

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -27,6 +27,7 @@ import { MetabaseApi } from "metabase/services";
 import {
   convertSavedQuestionToVirtualTable,
   getQuestionVirtualTableId,
+  getCollectionVirtualSchemaId,
 } from "metabase-lib/v1/metadata/utils/saved-questions";
 
 const listTablesForDatabase = async (...args) =>
@@ -170,6 +171,9 @@ const Tables = createEntity({
     if (type === Questions.actionTypes.UPDATE && !error) {
       const card = payload.question;
       const virtualQuestionId = getQuestionVirtualTableId(card.id);
+      const virtualCollectionSchemaId = getCollectionVirtualSchemaId(
+        card.collection,
+      );
 
       if (card.archived && state[virtualQuestionId]) {
         delete state[virtualQuestionId];
@@ -181,13 +185,16 @@ const Tables = createEntity({
         if (
           virtualQuestion.display_name !== card.name ||
           virtualQuestion.moderated_status !== card.moderated_status ||
-          virtualQuestion.description !== card.description
+          virtualQuestion.description !== card.description ||
+          virtualQuestion.schema_name !== card.collection.name
         ) {
           state = updateIn(state, [virtualQuestionId], table => ({
             ...table,
             display_name: card.name,
             moderated_status: card.moderated_status,
             description: card.description,
+            schema_name: card.collection.name,
+            schema: `${virtualCollectionSchemaId}:${card.collection.name}`,
           }));
         }
 

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -171,15 +171,15 @@ const Tables = createEntity({
 
     if (type === Questions.actionTypes.UPDATE && !error) {
       const card = payload.question;
-      const virtualQuestionId = getQuestionVirtualTableId(card.id);
+      const virtualTableId = getQuestionVirtualTableId(card.id);
 
-      if (card.archived && state[virtualQuestionId]) {
-        delete state[virtualQuestionId];
+      if (card.archived && state[virtualTableId]) {
+        delete state[virtualTableId];
         return state;
       }
 
-      if (state[virtualQuestionId]) {
-        const virtualTable = state[virtualQuestionId];
+      if (state[virtualTableId]) {
+        const virtualTable = state[virtualTableId];
         const virtualSchemaId = getCollectionVirtualSchemaId(card.collection, {
           isDatasets: card.type === "model",
         });
@@ -194,7 +194,7 @@ const Tables = createEntity({
           virtualTable.schema !== virtualSchemaId ||
           virtualTable.schema_name !== virtualSchemaName
         ) {
-          state = updateIn(state, [virtualQuestionId], table => ({
+          state = updateIn(state, [virtualTableId], table => ({
             ...table,
             display_name: card.name,
             moderated_status: card.moderated_status,
@@ -209,7 +209,7 @@ const Tables = createEntity({
 
       return {
         ...state,
-        [virtualQuestionId]: convertSavedQuestionToVirtualTable(card),
+        [virtualTableId]: convertSavedQuestionToVirtualTable(card),
       };
     }
 


### PR DESCRIPTION
Reproduces #39812 
Fixes #39812 

### Description
Due to the entity framework internals, the card object and the state object can get out of sync in certain cases. One such example was moving the source of a nested question (or a model) to a different collection.

Actually, there were two places where code was out of sync, and this PR fixed/patched both:
1. `schema` on the _Tables_ entity was pointing to the stale schema
    - Fixed at this commit https://github.com/metabase/metabase/pull/40063/commits/db4b44c8f4f34537c48a8c6bbe40fd633bf7b629
2. the virtual schema on the _Schemas_ entity could be missing
    - Fixed at this commit https://github.com/metabase/metabase/pull/40063/commits/ebac2c9c304f8b029d3478e2c05c5ae80f2e2f60

The DataSelector component is obtaining the `collectionName` from the schema. It then passes it down to its children.
```jsx
collectionName={
  selectedTable &&
  selectedTable.schema &&
  getSchemaName(selectedTable.schema.id)
}
```
Source: https://github.com/metabase/metabase/blob/fd6fab2/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx#L992-L996

### How to verify
Either follow the clear reproduction steps from the original issue, or run the E2E reproduction form this branch.

### Checklist
- [x] Tests have been added/updated to cover changes in this PR

### Additional Info
This section aims to explain why we get the collection name from the table schema. What does table have to do with a saved question or a model?

There is a concept at Metabase called a virtual table.
This means that if a source for a saved card is another card (which is true for both the nested questions and saved models), then the `source-table` equals to `card__:source-card-id`.

Following that logic, there is also a virtual schema on a virtual table. In the case of saved questions and saved models, the schema is the collection those questions/models are saved in.