### PR TITLE
Fix scrolling with filter field values

### DIFF
--- a/frontend/src/metabase/querying/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -134,7 +134,7 @@ function CoordinateValueInput({
 }: CoordinateValueInputProps) {
   if (hasMultipleValues) {
     return (
-      <Box p="md" mah="16rem" style={{ overflow: "auto" }}>
+      <Box p="md" style={{ overflow: "auto" }}>
         <NumberFilterValuePicker
           query={query}
           stageIndex={stageIndex}

--- a/frontend/src/metabase/querying/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.tsx
@@ -134,7 +134,7 @@ function CoordinateValueInput({
 }: CoordinateValueInputProps) {
   if (hasMultipleValues) {
     return (
-      <Box p="md" style={{ overflow: "auto" }}>
+      <Box p="md" mah="25vh" style={{ overflow: "auto" }}>
         <NumberFilterValuePicker
           query={query}
           stageIndex={stageIndex}

--- a/frontend/src/metabase/querying/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -116,7 +116,7 @@ function NumberValueInput({
 }: NumberValueInputProps) {
   if (hasMultipleValues) {
     return (
-      <Box p="md" mah="16rem" style={{ overflow: "auto" }}>
+      <Box p="md" style={{ overflow: "auto" }}>
         <NumberFilterValuePicker
           query={query}
           stageIndex={stageIndex}

--- a/frontend/src/metabase/querying/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.tsx
@@ -116,7 +116,7 @@ function NumberValueInput({
 }: NumberValueInputProps) {
   if (hasMultipleValues) {
     return (
-      <Box p="md" style={{ overflow: "auto" }}>
+      <Box p="md" mah="25vh" style={{ overflow: "auto" }}>
         <NumberFilterValuePicker
           query={query}
           stageIndex={stageIndex}

--- a/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -124,7 +124,7 @@ function StringValueInput({
 }: StringValueInputProps) {
   if (hasMultipleValues) {
     return (
-      <Box p="md" mah="16rem" style={{ overflow: "auto" }}>
+      <Box p="md" mah="25vh" style={{ overflow: "auto" }}>
         <StringFilterValuePicker
           query={query}
           stageIndex={stageIndex}

--- a/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -124,7 +124,7 @@ function StringValueInput({
 }: StringValueInputProps) {
   if (hasMultipleValues) {
     return (
-      <Box p="md" mah="min(25vh, 16rem)" style={{ overflow: "auto" }}>
+      <Box p="md" style={{ overflow: "auto" }}>
         <StringFilterValuePicker
           query={query}
           stageIndex={stageIndex}

--- a/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -124,7 +124,7 @@ function StringValueInput({
 }: StringValueInputProps) {
   if (hasMultipleValues) {
     return (
-      <Box p="md" mah="25vh" style={{ overflow: "auto" }}>
+      <Box p="md" mah="min(25vh, 16rem)" style={{ overflow: "auto" }}>
         <StringFilterValuePicker
           query={query}
           stageIndex={stageIndex}

--- a/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.tsx
@@ -124,7 +124,7 @@ function StringValueInput({
 }: StringValueInputProps) {
   if (hasMultipleValues) {
     return (
-      <Box p="md" style={{ overflow: "auto" }}>
+      <Box p="md" mah="25vh" style={{ overflow: "auto" }}>
         <StringFilterValuePicker
           query={query}
           stageIndex={stageIndex}

--- a/frontend/src/metabase/querying/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
@@ -89,7 +89,7 @@ function CheckboxListPicker({
   };
 
   return (
-    <Stack>
+    <Stack mah="min(25vh, 14rem)">
       <TextInput
         value={searchValue}
         placeholder={placeholder}

--- a/frontend/src/metabase/querying/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/ListValuePicker/ListValuePicker.tsx
@@ -89,7 +89,7 @@ function CheckboxListPicker({
   };
 
   return (
-    <Stack mah="min(25vh, 14rem)">
+    <Stack>
       <TextInput
         value={searchValue}
         placeholder={placeholder}


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/40071

The fix is not ideal but it should fix the issue in real world cases.

Ideally I wanted to make the value dynamic but I cannot make it work with `Popover`.

How to verify:
- New -> Question -> Orders
- Try adding a filter on Orders.Quantity and Product.Category on different screen sizes:

<img width="506" alt="Screenshot 2024-03-13 at 15 50 26" src="https://github.com/metabase/metabase/assets/8542534/be80aeff-67e3-4f03-9854-ded771fcd485">
<img width="460" alt="Screenshot 2024-03-13 at 15 50 35" src="https://github.com/metabase/metabase/assets/8542534/b052045f-0de1-4c75-86f5-ec947e67c2ea">
<img width="426" alt="Screenshot 2024-03-13 at 15 50 55" src="https://github.com/metabase/metabase/assets/8542534/aa92b767-c6bc-426c-8719-ed706af7d07c">
