### PR TITLE
eslint: Disable testing-library/no-unnecessary-act

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,7 +42,14 @@
           "orderImportKind": "asc",
           "caseInsensitive": false
         },
-        "groups": ["builtin", "external", "internal", "parent", "sibling", "index"],
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index"
+        ],
         "warnOnUnassignedImports": false
       }
     ],
@@ -193,7 +200,10 @@
         "*.unit.spec.jsx"
       ],
       "rules": {
-        "jest/valid-title": ["error", { "ignoreTypeOfDescribeName": true }]
+        "jest/valid-title": ["error", { "ignoreTypeOfDescribeName": true }],
+        // In unit tests, you should use `act(() => {})` to invoke things causing state updates
+        // and rerenders to remove lengthy warnings from jest. Disabling the rule allows this.
+        "testing-library/no-unnecessary-act": "off"
       }
     }
   ]

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterPicker.unit.spec.tsx
@@ -403,7 +403,6 @@ describe("FilterPicker", () => {
 
       // The expression editor applies changes on blur,
       // but for some reason it doesn't work without `act`.
-      // eslint-disable-next-line testing-library/no-unnecessary-act
       await act(async () => {
         await userEvent.type(input, text, { delay });
         await userEvent.tab();


### PR DESCRIPTION
## Description

As discussed [on Slack](https://metaboat.slack.com/archives/C505ZNNH4/p1710341080945209), we're removing the rule to allow `act(() => {}` in unit tests.

There's another possible solution to the issue, which I will investigate further so this PR might be not needed. 