### PR TITLE
Forward-port changes from 49 backport: Faster sync-fks for redshift (#38970)

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -4,10 +4,10 @@ title: Driver interface changelog
 
 # Driver Interface Changelog
 
-## Metabase 0.50.0
+## Metabase 0.49.0
 
 - The multimethod `metabase.driver/describe-table-fks` has been deprecated in favor of `metabase.driver/describe-fks`.
-  `metabase.driver/describe-table-fks` will be removed in 0.53.0.
+  `metabase.driver/describe-table-fks` will be removed in 0.52.0.
 
 - The multimethod `metabase.driver/describe-fks` has been added. The method needs to be implemented if the database
   supports the `:foreign-keys` and `:describe-fks` features. It replaces the `metabase.driver/describe-table-fks`
@@ -15,8 +15,6 @@ title: Driver interface changelog
 
 - The multimethod `metabase.driver.sql-jdbc.sync.describe-table/describe-fks-sql` has been added. The method needs
   to be implemented if you want to use the default JDBC implementation of `metabase.driver/describe-fks`.
-
-## Metabase 0.49.0
 
 - The multimethod `metabase.driver/alter-columns!` has been added. This method is used to alter a table's columns in the
   database. This is currently only required for drivers that support the `:uploads` feature, and has a default

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -341,7 +341,7 @@
 (defmulti describe-table-fks
   "Return information about the foreign keys in a `table`. Required for drivers that support `:foreign-keys` but not
   `:describe-fks`. Results should match the [[metabase.sync.interface/FKMetadata]] schema."
-  {:added "0.32.0" :deprecated "0.50.0" :arglists '([driver database table])}
+  {:added "0.32.0" :deprecated "0.49.0" :arglists '([driver database table])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -358,7 +358,7 @@
   Results are ordered by `fk-table-schema` and `fk-table-name` in ascending order.
 
   Required for drivers that support `:describe-fks`."
-  {:added "0.50.0" :arglists '([driver database & {:keys [schema-names table-names]}])}
+  {:added "0.49.0" :arglists '([driver database & {:keys [schema-names table-names]}])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 

--- a/src/metabase/driver/sql_jdbc/sync/describe_table.clj
+++ b/src/metabase/driver/sql_jdbc/sync/describe_table.clj
@@ -275,7 +275,7 @@
 (defmulti describe-fks-sql
  "Returns a SQL query ([sql & params]) for use in the default JDBC implementation of [[metabase.driver/describe-fks]],
  i.e. [[describe-fks]]."
- {:added    "0.50.0"
+ {:added    "0.49.0"
   :arglists '([driver & {:keys [schema-names table-names]}])}
  driver/dispatch-on-initialized-driver
  :hierarchy #'driver/hierarchy)


### PR DESCRIPTION
#38970 made it into 49, so this forward ports the changes I made there to the driver changelog.