### PR TITLE
Don't store analytics checksum if audit loading failed

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -249,16 +249,18 @@
     (ia-content->plugins (plugins/plugins-dir))
     (let [[last-checksum current-checksum] (get-last-and-current-checksum)]
       (when (should-load-audit? (load-analytics-content) last-checksum current-checksum)
-        (last-analytics-checksum! current-checksum)
         (log/info (str "Loading Analytics Content from: " (instance-analytics-plugin-dir (plugins/plugins-dir))))
         ;; The EE token might not have :serialization enabled, but audit features should still be able to use it.
         (let [report (log/with-no-logs
                        (serialization.cmd/v2-load-internal! (str (instance-analytics-plugin-dir (plugins/plugins-dir)))
                                                             {:backfill? false}
                                                             :token-check? false))]
+
           (if (not-empty (:errors report))
             (log/info (str "Error Loading Analytics Content: " (pr-str report)))
-            (log/info (str "Loading Analytics Content Complete (" (count (:seen report)) ") entities loaded."))))))
+            (do
+              (log/info (str "Loading Analytics Content Complete (" (count (:seen report)) ") entities loaded."))
+              (last-analytics-checksum! current-checksum))))))
     (when-let [audit-db (t2/select-one :model/Database :is_audit true)]
       (adjust-audit-db-to-host! audit-db))))
 

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -255,7 +255,6 @@
                        (serialization.cmd/v2-load-internal! (str (instance-analytics-plugin-dir (plugins/plugins-dir)))
                                                             {:backfill? false}
                                                             :token-check? false))]
-
           (if (not-empty (:errors report))
             (log/info (str "Error Loading Analytics Content: " (pr-str report)))
             (do

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -5,6 +5,7 @@
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing use-fixtures]]
    [metabase-enterprise.audit-db :as audit-db]
+   [metabase-enterprise.serialization.cmd :as serialization.cmd]
    [metabase-enterprise.serialization.v2.backfill-ids :as serdes.backfill]
    [metabase.core :as mbc]
    [metabase.models.data-permissions :as data-perms]
@@ -140,6 +141,17 @@
         (testing "No exception is thrown when db has 'duplicate' entries."
           (is (= :metabase-enterprise.audit-db/no-op
                  (audit-db/ensure-audit-db-installed!))))))))
+
+(deftest checksum-not-recorded-when-load-fails-test
+  (mt/test-drivers #{:postgres :h2 :mysql}
+    (t2/delete! :model/Database :is_audit true)
+    (testing "If audit content loading throws an exception, the checksum should not be stored"
+      (audit-db/last-analytics-checksum! 0)
+      (with-redefs [serialization.cmd/v2-load-internal! (fn [& _] (throw (Exception. "Audit loading failed")))]
+        (is (thrown-with-msg? Exception
+                              #"Audit loading failed"
+                              (audit-db/ensure-audit-db-installed!)))
+        (is (= 0 (audit-db/last-analytics-checksum)))))))
 
 (deftest should-load-audit?-test
   (testing "load-analytics-content + checksums dont match => load"


### PR DESCRIPTION
We only want to store the checksum if audit loading succeeded. Otherwise we should ensure that it's attempted again next time startup occurs. In particular, this solves an edge case where Metabase is shut down between the checksum being saved and audit content load finishing, and then not loading the content on the next startup.

Context: https://metaboat.slack.com/archives/C04K1LEUPC5/p1710346505855739