### PR TITLE
Fix multi-schema data selector header styling

### DIFF
--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableList/MetadataTableList.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableList/MetadataTableList.tsx
@@ -193,7 +193,7 @@ const TableBreadcrumbs = ({ schemaId, onBack }: TableBreadcrumbsProps) => {
         <Icon name="chevronleft" size={10} />
         {t`Schemas`}
       </BackIconContainer>
-      <span className="mx1">-</span>
+      <span className="mx1">/</span>
       <span>{getSchemaName(schemaId)}</span>
     </h4>
   );

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.styled.tsx
@@ -27,13 +27,12 @@ export const DataSelectorTablePickerHeaderClickable = styled.span<Props>`
 
 export const DataSelectorTablePickerHeaderDatabaseName = styled.span`
   flex-wrap: wrap;
-  margin-left: ${space(1)};
+  margin-inline-start: ${space(1)};
 `;
 
 export const DataSelectorTablePickerHeaderSchemaName = styled.span`
   color: ${color("text-medium")};
   flex-wrap: wrap;
-  margin-left: ${space(1)};
 `;
 
 export const LinkToDocsContainer = styled.div`
@@ -46,4 +45,10 @@ export const LinkToDocsContainer = styled.div`
 export const NoTablesFound = styled.div`
   padding: ${space(4)};
   text-align: center;
+`;
+
+export const DataSelectorHeaderDivider = styled.span`
+  color: ${color("text-medium")};
+  display: inline-block;
+  margin-inline: ${space(1)};
 `;

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelectorTablePicker/DataSelectorTablePicker.tsx
@@ -26,6 +26,7 @@ import {
   DataSelectorTablePickerHeaderSchemaName as HeaderSchemaName,
   LinkToDocsContainer,
   NoTablesFound,
+  DataSelectorHeaderDivider,
 } from "./DataSelectorTablePicker.styled";
 
 type DataSelectorTablePickerProps = {
@@ -186,10 +187,12 @@ const Header = ({
     </HeaderClickable>
 
     {selectedSchema?.name && schemas.length > 1 && (
-      <HeaderSchemaName>
-        {"- "}
-        <span data-testid="source-schema">{selectedSchema.displayName()}</span>
-      </HeaderSchemaName>
+      <>
+        <DataSelectorHeaderDivider>/</DataSelectorHeaderDivider>
+        <HeaderSchemaName data-testid="source-schema">
+          {selectedSchema.displayName()}
+        </HeaderSchemaName>
+      </>
     )}
   </HeaderContainer>
 );


### PR DESCRIPTION
- Makes spacing equal on both sides of the divider
- Changes the divider from the hyphen to the forward slash

### Before
![image](https://github.com/metabase/metabase/assets/31325167/5e3379d3-f941-4750-a61b-e9d9c02ac128)

### After
![image](https://github.com/metabase/metabase/assets/31325167/4ebd6d68-ede8-4ce4-a577-ddd5d5b8604f)

Fixes #39999 