### PR TITLE
Don't include blank actions in the entitymenu

### DIFF
--- a/frontend/src/metabase/components/EntityItem/EntityItem.jsx
+++ b/frontend/src/metabase/components/EntityItem/EntityItem.jsx
@@ -106,26 +106,36 @@ function EntityItemMenu({
   const actions = useMemo(() => {
     const result = [];
 
-    const bookmarkAction = {
-      title: isBookmarked ? t`Remove from bookmarks` : t`Bookmark`,
-      icon: "bookmark",
-      action: onToggleBookmark,
-    };
+    const bookmarkAction = onToggleBookmark
+      ? {
+          title: isBookmarked ? t`Remove from bookmarks` : t`Bookmark`,
+          icon: "bookmark",
+          action: onToggleBookmark,
+        }
+      : null;
 
     if (isPinned) {
-      result.push({
-        title: t`Unpin`,
-        icon: "unpin",
-        action: onPin,
-      });
-      result.push(bookmarkAction);
+      if (onPin) {
+        result.push({
+          title: t`Unpin`,
+          icon: "unpin",
+          action: onPin,
+        });
+      }
+      if (bookmarkAction) {
+        result.push(bookmarkAction);
+      }
     } else {
-      result.push(bookmarkAction);
-      result.push({
-        title: t`Pin this`,
-        icon: "pin",
-        action: onPin,
-      });
+      if (bookmarkAction) {
+        result.push(bookmarkAction);
+      }
+      if (onPin) {
+        result.push({
+          title: t`Pin this`,
+          icon: "pin",
+          action: onPin,
+        });
+      }
     }
 
     if (isMetabotShown) {


### PR DESCRIPTION
This PR removes the blank entity menus from tables and schemas

The blank menus looked like this:
![image](https://github.com/metabase/metabase/assets/130925/18852b30-ab8c-4a78-bbdb-316bc18b51c2)

The PR fixes a problem introduced in https://github.com/metabase/metabase/pull/39782
