### PR TITLE
Fix png download in safari in embedding

### DIFF
--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -32,11 +32,12 @@ export const saveChartImage = async (selector: string, fileName: string) => {
     if (blob) {
       const link = document.createElement("a");
       const url = URL.createObjectURL(blob);
-      link.href = url;
+      link.rel = "noopener";
       link.download = fileName;
+      link.href = url;
       link.click();
       link.remove();
-      URL.revokeObjectURL(url);
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
     }
   });
 };

--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -28,14 +28,15 @@ export const saveChartImage = async (selector: string, fileName: string) => {
 
   node.classList.remove(SAVING_DOM_IMAGE_CLASS);
 
-  const link = document.createElement("a");
-
-  link.setAttribute("download", fileName);
-  link.setAttribute(
-    "href",
-    canvas.toDataURL("image/png").replace("image/png", "image/octet-stream"),
-  );
-
-  link.click();
-  link.remove();
+  canvas.toBlob(blob => {
+    if (blob) {
+      const link = document.createElement("a");
+      const url = URL.createObjectURL(blob);
+      link.href = url;
+      link.download = fileName;
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    }
+  });
 };


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/40095

Data URLs do not work with strict CSP in embedding. Object URLs do and they are used for pdf export. Let's do PNG export as we do PDF export.