### PR TITLE
Backport fix to check base-type in isa if effective-type is missing

### DIFF
--- a/src/metabase/lib/types/isa.cljc
+++ b/src/metabase/lib/types/isa.cljc
@@ -20,7 +20,11 @@
   "Returns if `column` is of category `category`.
   The possible categories are the keys in [[metabase.lib.types.constants/type-hierarchies]]."
   [category column]
-  (let [type-definition (lib.types.constants/type-hierarchies category)]
+  (let [type-definition (lib.types.constants/type-hierarchies category)
+        column          (cond-> column
+                          (and (map? column)
+                               (not (:effective-type column)))
+                          (assoc :effective-type (:base-type column)))]
     (cond
       (nil? column) false
 


### PR DESCRIPTION
Fixes #35640

Pulls snippet from a66db9e here https://github.com/metabase/metabase/blame/ed7e147b7cdace92b6f84e35523558927d1f5821/src/metabase/lib/types/isa.cljc#L24-L27
