### PR TITLE
Diagnostic Modal Updates

### DIFF
--- a/frontend/src/metabase/ErrorBoundary.tsx
+++ b/frontend/src/metabase/ErrorBoundary.tsx
@@ -27,6 +27,7 @@ export default class ErrorBoundary extends Component<
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(error, errorInfo);
     // if we don't provide a specific onError action, the component will display a generic error message
     if (this.props.onError) {
       this.props.onError(errorInfo);

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -15,12 +15,11 @@ import { useToggle } from "metabase/hooks/use-toggle";
 import { capitalize } from "metabase/lib/formatting";
 import {
   Button,
-  Center,
+  Box,
   Icon,
   Loader,
   Text,
   Stack,
-  Box,
   Modal,
   Flex,
 } from "metabase/ui";
@@ -30,7 +29,8 @@ import { useErrorInfo } from "./use-error-info";
 import { downloadObjectAsJson, hasQueryData } from "./utils";
 
 interface ErrorDiagnosticModalProps {
-  errorInfo: ErrorPayload;
+  errorInfo?: ErrorPayload | null;
+  loading: boolean;
   onClose: () => void;
 }
 
@@ -38,8 +38,31 @@ type PayloadSelection = Partial<Record<keyof ErrorPayload, boolean>>;
 
 export const ErrorDiagnosticModal = ({
   errorInfo,
+  loading,
   onClose,
 }: ErrorDiagnosticModalProps) => {
+  if (loading || !errorInfo) {
+    return (
+      <Modal opened onClose={onClose}>
+        <Stack align="center" justify="center" mb="lg">
+          <Text w="bold" color="text-medium" mb="sm">
+            {c(
+              "loading message indicating that we are gathering debugging information to aid in providing technical support",
+            ).t`Gathering diagnostic information...`}
+          </Text>
+          <Loader />
+        </Stack>
+      </Modal>
+    );
+  }
+
+  const canIncludeQueryData = hasQueryData(errorInfo?.entityName);
+
+  const hiddenValues = {
+    url: true,
+    entityName: true,
+  };
+
   const handleSubmit = (values: PayloadSelection) => {
     const selectedKeys = Object.keys(values).filter(
       key => values[key as keyof PayloadSelection],
@@ -51,13 +74,6 @@ export const ErrorDiagnosticModal = ({
       `metabase-diagnostic-info-${new Date().toISOString()}`,
     );
     onClose();
-  };
-
-  const canIncludeQueryData = hasQueryData(errorInfo?.entityName);
-
-  const hiddenValues = {
-    url: true,
-    entityName: true,
   };
 
   return (
@@ -139,22 +155,7 @@ export const ErrorDiagnosticModal = ({
 };
 
 export const ErrorDiagnosticModalTrigger = () => {
-  const { value: errorInfo, loading, error } = useErrorInfo();
-
   const [isModalOpen, setModalOpen] = useState(false);
-
-  if (loading || !errorInfo) {
-    return (
-      <Center>
-        <Loader />
-      </Center>
-    );
-  }
-
-  if (error) {
-    console.error(error);
-    return null;
-  }
 
   return (
     <ErrorBoundary>
@@ -180,17 +181,103 @@ export const ErrorDiagnosticModalTrigger = () => {
           {t`Download diagnostic information`}
         </Button>
       </Stack>
+      <ErrorDiagnosticModalWrapper
+        isModalOpen={isModalOpen}
+        onClose={() => setModalOpen(false)}
+      />
+    </ErrorBoundary>
+  );
+};
+
+export const ErrorDiagnosticModalWrapper = ({
+  isModalOpen,
+  onClose,
+}: {
+  isModalOpen: boolean;
+  onClose: () => void;
+}) => {
+  const {
+    value: errorInfo,
+    loading,
+    error,
+  } = useErrorInfo({ enabled: isModalOpen });
+
+  if (!isModalOpen) {
+    return null;
+  }
+
+  if (error) {
+    console.error(error);
+    return null;
+  }
+
+  return (
+    <ErrorBoundary>
       {isModalOpen && (
         <ErrorDiagnosticModal
+          loading={loading}
           errorInfo={errorInfo}
-          onClose={() => setModalOpen(false)}
+          onClose={onClose}
         />
       )}
     </ErrorBoundary>
   );
 };
 
-export function KeyboardTriggeredErrorModal() {
+// this is an intermediate modal to give a better error explanation for use
+// when an error component is potentially too small to contain text
+export const ErrorExplanationModal = ({
+  isModalOpen,
+  onClose,
+}: {
+  isModalOpen: boolean;
+  onClose: () => void;
+}) => {
+  const [
+    isShowingDiagnosticModal,
+    { turnOn: openDiagnosticModal, turnOff: closeDiagnosticModal },
+  ] = useToggle(false);
+
+  if (isModalOpen && isShowingDiagnosticModal) {
+    return (
+      <ErrorDiagnosticModalWrapper
+        isModalOpen
+        onClose={() => {
+          onClose();
+          closeDiagnosticModal();
+        }}
+      />
+    );
+  }
+
+  return (
+    <Modal
+      title={t`Oops, something went wrong`}
+      opened={isModalOpen}
+      onClose={onClose}
+    >
+      <Text my="md">
+        {t`We've run into an error, try to refresh the page or go back.`}
+      </Text>
+      <Text my="md">
+        {c("indicates an email address to which to send diagnostic information")
+          .jt`If the error persists, you can download diagnostic information to send to
+        ${(
+          <Link key="email" variant="brand" to="mailto:help@metabase.com">
+            {t`help@metabase.com`}
+          </Link>
+        )}`}
+      </Text>
+      <Flex justify="flex-end">
+        <Button variant="filled" onClick={openDiagnosticModal}>
+          {t`Download diagnostic info`}
+        </Button>
+      </Flex>
+    </Modal>
+  );
+};
+
+export const KeyboardTriggeredErrorModal = () => {
   const [
     isShowingDiagnosticModal,
     { turnOn: openDiagnosticModal, turnOff: closeDiagnosticModal },
@@ -223,27 +310,13 @@ export function KeyboardTriggeredErrorModal() {
     return null;
   }
 
-  if (loading || !errorInfo) {
-    return (
-      <Modal opened onClose={closeDiagnosticModal}>
-        <Stack align="center" justify="center" mb="lg">
-          <Text w="bold" color="text-medium" mb="sm">
-            {c(
-              "loading message indicating that we are gathering debugging information to aid in providing technical support",
-            ).t`Gathering diagnostic information...`}
-          </Text>
-          <Loader />
-        </Stack>
-      </Modal>
-    );
-  }
-
   return (
     <ErrorBoundary>
       <ErrorDiagnosticModal
+        loading={loading}
         errorInfo={errorInfo}
         onClose={closeDiagnosticModal}
       />
     </ErrorBoundary>
   );
-}
+};

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
@@ -68,7 +68,11 @@ const defaultErrorPayload: ErrorPayload = {
 
 const setup = (errorInfo: ErrorPayload) => {
   render(
-    <ErrorDiagnosticModal errorInfo={errorInfo} onClose={() => undefined} />,
+    <ErrorDiagnosticModal
+      errorInfo={errorInfo}
+      onClose={() => undefined}
+      loading={false}
+    />,
   );
 };
 

--- a/frontend/src/metabase/components/ErrorPages/ErrorPages.styled.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorPages.styled.tsx
@@ -1,10 +1,19 @@
 import styled from "@emotion/styled";
 
-export const ErrorPageRoot = styled.div`
+import { color } from "metabase/lib/colors";
+
+export const ErrorPageRoot = styled.div<{ bordered?: boolean }>`
   display: flex;
   width: 100%;
   height: 100%;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  ${({ bordered }) => bordered && `border: 1px solid ${color("border")};`}
+  border-radius: 0.5rem;
+  overflow: hidden;
+`;
+
+export const ResponsiveSpan = styled.span`
+  overflow: hidden;
 `;

--- a/frontend/src/metabase/components/ErrorPages/ErrorPages.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorPages.tsx
@@ -4,10 +4,14 @@ import NoResults from "assets/img/no_results.svg";
 import EmptyState from "metabase/components/EmptyState";
 import ErrorDetails from "metabase/components/ErrorDetails/ErrorDetails";
 import type { ErrorDetailsProps } from "metabase/components/ErrorDetails/types";
+import { useToggle } from "metabase/hooks/use-toggle";
 import { color } from "metabase/lib/colors";
-import { Icon } from "metabase/ui";
+import { Button, Icon, Tooltip } from "metabase/ui";
 
-import { ErrorDiagnosticModalTrigger } from "./ErrorDiagnosticModal";
+import {
+  ErrorDiagnosticModalTrigger,
+  ErrorExplanationModal,
+} from "./ErrorDiagnosticModal";
 import { ErrorPageRoot } from "./ErrorPages.styled";
 
 export const GenericError = ({
@@ -74,17 +78,26 @@ export const Archived = ({
 );
 
 export const SmallGenericError = ({
-  message = t`Something's gone wrong`,
+  message = t`Something's gone wrong, click for more information`,
 }: {
   message?: string;
-}) => (
-  <ErrorPageRoot>
-    <Icon
-      name="warning"
-      size={32}
-      color={color("text-light")}
-      tooltip={message}
-    />
-    <ErrorDiagnosticModalTrigger />
-  </ErrorPageRoot>
-);
+}) => {
+  const [isModalOpen, { turnOn: openModal, turnOff: closeModal }] =
+    useToggle(false);
+
+  return (
+    <ErrorPageRoot bordered>
+      <Tooltip label={message}>
+        <Button
+          leftIcon={
+            <Icon name="warning" size={32} color={color("text-light")} />
+          }
+          color="text-light"
+          onClick={openModal}
+          variant="unstyled"
+        />
+      </Tooltip>
+      <ErrorExplanationModal isModalOpen={isModalOpen} onClose={closeModal} />
+    </ErrorPageRoot>
+  );
+};


### PR DESCRIPTION
### Description

Here, we've got a couple updates to the diagnostic modal:

1. **Handle uncaught errors better.** Adding the download button to the uncaught error component was causing certain errors to overflow, and made some pages look really bad. We made this better in a few ways:
	1. went back to just having a small ⚠️ icon that should fit in basically any errored component
	2. added a small border to the error component to make it clear what has errored - this is especially helpful on dashboards.
	3. gave that ⚠️ component an updated tooltip and made it clickable
	4. clicking the ⚠️ now pops up an intermediate generic error explanation modal from which a user can choose to open the error diagnostic modal.
	5. as a side-effect of all this, we no longer trigger API calls to gather diagnostic information unless a user opens the diagnostic modal - this will prevent duplicate information-gathering on pages that have multiple errored components at once.
2. **Better frontend error capturing** I discovered when testing this on stats that the production bundle handles error reporting differently than the hot-reloading dev bundle. 
    1. The biggest issue I discovered was that any error caught by our error boundary were swallowed. By adding a console.error to the error boundary component, we can be sure that our frontend error buffer gets those errors as well.   
    2. I also added some custom error serialization handling to make sure that error objects get properly serialized when downloaded in our diagnostic json.

![Screen Shot 2024-03-14 at 3 22 09 PM](https://github.com/metabase/metabase/assets/30528226/9db2f6c3-6f28-45de-ba83-326c4acb3a9f)
![diagnosticsmodals](https://github.com/metabase/metabase/assets/30528226/4939ae08-876b-4cf4-98e8-85f9195c9faa)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
