### PR TITLE
Handle double escape in entityPicker

### DIFF
--- a/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/dashboard.cy.spec.js
@@ -71,12 +71,20 @@ describe("scenarios > dashboard", () => {
       appBar().findByText("New").click();
       popover().findByText("Dashboard").should("be.visible").click();
 
+      cy.log(
+        "pressing escape should only close the entity picker modal, not the new dashboard modal",
+      );
+      modal().findByTestId("collection-picker-button").click();
+      entityPickerModal().findByText("Select a collection");
+      cy.realPress("Escape");
+      modal().findByText("New dashboard").should("be.visible");
+
       cy.log("Create a new dashboard");
       modal().within(() => {
         // Without waiting for this, the test was constantly flaking locally.
         cy.findByText("Our analytics");
 
-        cy.findByLabelText("Name").type(dashboardName);
+        cy.findByPlaceholderText(/name of your dashboard/i).type(dashboardName);
         cy.findByLabelText("Description").type(dashboardDescription, {
           delay: 0,
         });

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo, useEffect } from "react";
+import { useWindowEvent } from "@mantine/hooks";
+import { useState, useMemo } from "react";
 import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
@@ -83,22 +84,16 @@ export function EntityPickerModal<TItem extends TypeWithModel>({
   const hasTabs = tabs.length > 1 || searchQuery;
   const tabModels = useMemo(() => tabs.map(t => t.model), [tabs]);
 
-  useEffect(() => {
-    const handleEscapeModal = (event: KeyboardEvent) => {
+  useWindowEvent(
+    "keydown",
+    event => {
       if (event.key === "Escape") {
         event.stopPropagation();
         onClose();
       }
-    };
-
-    document.addEventListener("keydown", handleEscapeModal, true);
-
-    const cleanup = () => {
-      document.removeEventListener("keydown", handleEscapeModal, true);
-    };
-
-    return cleanup;
-  }, [onClose]);
+    },
+    { capture: true, once: true },
+  );
 
   return (
     <Modal.Root
@@ -106,6 +101,7 @@ export function EntityPickerModal<TItem extends TypeWithModel>({
       onClose={onClose}
       data-testid="entity-picker-modal"
       trapFocus={trapFocus}
+      closeOnEscape={false} // we're doing this manually in useWindowEvent
     >
       <Modal.Overlay />
       <ModalContent h="100%">

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
@@ -82,6 +82,23 @@ export function EntityPickerModal<TItem extends TypeWithModel>({
 
   const hasTabs = tabs.length > 1 || searchQuery;
   const tabModels = useMemo(() => tabs.map(t => t.model), [tabs]);
+
+  useEffect(() => {
+    const handleEscapeModal = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleEscapeModal, true);
+
+    const cleanup = () => {
+      document.removeEventListener("keydown", handleEscapeModal, true);
+    };
+
+    return cleanup;
+  }, [onClose]);
 
   return (
     <Modal.Root


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/39966

### Description

Prevents hitting `escape` in the entitypicker from also closing any other modals that are open at the same time. (Since entitypicker is often used above another modal (like new collection or new dashboard modal)

_caption: note the modals close separately when the user presses `escape` twice_
![DOUBLE ESCAPE WHAT DOES IT MEAN](https://github.com/metabase/metabase/assets/30528226/ddd9a541-d4fa-43d5-a0e5-2a2751674cae)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
