### PR TITLE
Improve homepage experience for embedding users

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -208,9 +208,7 @@ describe("scenarios > setup", () => {
     });
     cy.location("pathname").should("eq", "/");
 
-    main()
-      .findByText("Get started with Embedding Metabase in your app")
-      .should("not.exist");
+    main().findByText("Embed Metabase in your app").should("not.exist");
   });
 
   // Values in this test are set through MB_USER_DEFAULTS environment variable!
@@ -335,15 +333,7 @@ describe("scenarios > setup", () => {
 
     cy.location("pathname").should("eq", "/");
 
-    main()
-      .findByText("Get started with Embedding Metabase in your app")
-      .should("exist");
-
-    cy.reload();
-
-    main()
-      .findByText("Get started with Embedding Metabase in your app")
-      .should("exist");
+    main().findByText("Embed Metabase in your app").should("exist");
 
     main()
       .findByRole("link", { name: "Learn more" })
@@ -353,17 +343,10 @@ describe("scenarios > setup", () => {
         /https:\/\/www.metabase.com\/docs\/[^\/]*\/embedding\/start\.html\?utm_media=embed-minimal-homepage/,
       );
 
-    cy.icon("close").click();
-
-    main()
-      .findByText("Get started with Embedding Metabase in your app")
-      .should("not.exist");
-
     cy.reload();
 
-    main()
-      .findByText("Get started with Embedding Metabase in your app")
-      .should("not.exist");
+    // should only show up once
+    main().findByText("Embed Metabase in your app").should("not.exist");
   });
 });
 

--- a/frontend/src/metabase/home/components/EmbedMinimalHomepage/EmbedMinimalHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedMinimalHomepage/EmbedMinimalHomepage.tsx
@@ -1,14 +1,13 @@
+import { useEffect } from "react";
 import { jt, t } from "ttag";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
 import Link from "metabase/core/components/Link";
 import { useSelector } from "metabase/lib/redux";
 import { getDocsUrl } from "metabase/selectors/settings";
-import { Button, Card, Flex, Icon, Stack, Text, Title } from "metabase/ui";
+import { Button, Card, Flex, Icon, Text, Title } from "metabase/ui";
 
 import { removeShowEmbedHomepageFlag } from "../../utils";
-
-import { NumberedList } from "./EmbedMinimalHomepage.styled";
 
 type EmbedMinimalHomepageProps = {
   onDismiss: () => void;
@@ -27,54 +26,42 @@ export const EmbedMinimalHomepage = ({
     onDismiss();
   };
 
+  useEffect(() => {
+    // this card is only visible once
+    removeShowEmbedHomepageFlag();
+  }, []);
+
   return (
-    <Stack>
-      <Text
-        fw="bold"
-        color="text-dark"
-        // eslint-disable-next-line no-literal-metabase-strings -- this is only visible to admins
-      >{t`Get started with Embedding Metabase in your app`}</Text>
-      <Card px={40} py={32} maw={570}>
-        <Stack spacing="lg">
-          <Flex justify="space-between">
-            <Title size="h4">{t`As you expressed interest in Embedding, follow these steps to start`}</Title>
+    <Card px={40} py={32} maw={320}>
+      <Flex justify="space-between">
+        {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
+        <Title size="h4">{t`Embed Metabase in your app`}</Title>
 
-            <Button
-              variant="white"
-              size="small"
-              color="text-dark"
-              p={0}
-              onClick={dismiss}
-            >
-              <Icon name="close" />
-            </Button>
-          </Flex>
+        <Button
+          variant="white"
+          size="small"
+          color="text-dark"
+          p={0}
+          onClick={dismiss}
+        >
+          <Icon name="close" />
+        </Button>
+      </Flex>
 
-          <NumberedList>
-            <li>{t`Enable and configure embedding in settings`}</li>
-            <li>
-              {t`Select or create a dashboard or question to do a static embed`}
-            </li>
-            <li>{t`Follow the quickstart to do an interactive embed`}</li>
-          </NumberedList>
-
-          <Stack spacing="sm">
-            <Link to="/admin/settings/embedding-in-other-applications">
-              <Button
-                variant="filled"
-                leftIcon={<Icon name="gear" />}
-              >{t`Get started`}</Button>
-            </Link>
-
-            <Text>{jt`${(
-              <ExternalLink
-                href={learnMoreBaseUrl + "?utm_media=embed-minimal-homepage"}
-                key="link"
-              >{t`Learn more`}</ExternalLink>
-            )} about embedding`}</Text>
-          </Stack>
-        </Stack>
-      </Card>
-    </Stack>
+      <Text>{jt`${(
+        <ExternalLink
+          href={learnMoreBaseUrl + "?utm_media=embed-minimal-homepage"}
+          key="link"
+        >{t`Learn more`}</ExternalLink>
+      )} about embedding`}</Text>
+      <Link to="/admin/settings/embedding-in-other-applications">
+        <Button
+          size={"sm"}
+          variant="filled"
+          mt="lg"
+          w="100%"
+        >{t`Go to embedding settings`}</Button>
+      </Link>
+    </Card>
   );
 };

--- a/frontend/src/metabase/home/components/EmbedMinimalHomepage/EmbedMinimalHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedMinimalHomepage/EmbedMinimalHomepage.tsx
@@ -5,6 +5,7 @@ import ExternalLink from "metabase/core/components/ExternalLink";
 import Link from "metabase/core/components/Link";
 import { useSelector } from "metabase/lib/redux";
 import { getDocsUrl } from "metabase/selectors/settings";
+import { getUserIsAdmin } from "metabase/selectors/user";
 import { Button, Card, Flex, Icon, Text, Title } from "metabase/ui";
 
 import { removeShowEmbedHomepageFlag } from "../../utils";
@@ -16,6 +17,7 @@ type EmbedMinimalHomepageProps = {
 export const EmbedMinimalHomepage = ({
   onDismiss,
 }: EmbedMinimalHomepageProps) => {
+  const isAdmin = useSelector(getUserIsAdmin);
   const learnMoreBaseUrl = useSelector(state =>
     // eslint-disable-next-line no-unconditional-metabase-links-render -- this is only visible to admins
     getDocsUrl(state, { page: "embedding/start" }),
@@ -30,6 +32,10 @@ export const EmbedMinimalHomepage = ({
     // this card is only visible once
     removeShowEmbedHomepageFlag();
   }, []);
+
+  if (!isAdmin) {
+    return null;
+  }
 
   return (
     <Card px={40} py={32} maw={320}>

--- a/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
+++ b/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useUpdate } from "react-use";
 
 import {
@@ -9,6 +10,7 @@ import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { useSelector } from "metabase/lib/redux";
 import { isSyncCompleted } from "metabase/lib/syncing";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
+import { Box } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { PopularItem, RecentItem, User } from "metabase-types/api";
 
@@ -31,6 +33,7 @@ export const HomeContent = (): JSX.Element | null => {
   const { data: popularItems, error: popularItemsError } =
     usePopularItemListQuery({ reload: true });
   const error = databasesError || recentItemsError || popularItemsError;
+  const showEmbedHomepage = useMemo(() => shouldShowEmbedHomepage(), []);
 
   if (error) {
     return <LoadingAndErrorWrapper error={error} />;
@@ -38,10 +41,6 @@ export const HomeContent = (): JSX.Element | null => {
 
   if (!user || isLoading(user, databases, recentItems, popularItems)) {
     return <LoadingAndErrorWrapper loading />;
-  }
-
-  if (isAdmin && shouldShowEmbedHomepage()) {
-    return <EmbedMinimalHomepage onDismiss={update} />;
   }
 
   if (isPopularSection(user, recentItems, popularItems)) {
@@ -53,7 +52,16 @@ export const HomeContent = (): JSX.Element | null => {
   }
 
   if (isXraySection(databases, isXrayEnabled)) {
-    return <HomeXraySection />;
+    return (
+      <>
+        <HomeXraySection />
+        {isAdmin && showEmbedHomepage && (
+          <Box mt={64}>
+            <EmbedMinimalHomepage onDismiss={update} />
+          </Box>
+        )}
+      </>
+    );
   }
 
   return null;

--- a/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
+++ b/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
@@ -8,7 +8,7 @@ import {
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { useSelector } from "metabase/lib/redux";
 import { isSyncCompleted } from "metabase/lib/syncing";
-import { getUser, getUserIsAdmin } from "metabase/selectors/user";
+import { getUser } from "metabase/selectors/user";
 import { Box } from "metabase/ui";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { PopularItem, RecentItem, User } from "metabase-types/api";
@@ -22,7 +22,6 @@ import { HomeXraySection } from "../HomeXraySection";
 
 export const HomeContent = (): JSX.Element | null => {
   const user = useSelector(getUser);
-  const isAdmin = useSelector(getUserIsAdmin);
   const isXrayEnabled = useSelector(getIsXrayEnabled);
   const { data: databases, error: databasesError } = useDatabaseListQuery();
   const { data: recentItems, error: recentItemsError } = useRecentItemListQuery(
@@ -55,7 +54,7 @@ export const HomeContent = (): JSX.Element | null => {
     return (
       <>
         <HomeXraySection />
-        {isAdmin && showEmbedHomepage && (
+        {showEmbedHomepage && (
           <Box mt={64}>
             <EmbedMinimalHomepage
               onDismiss={() => setShowEmbedHomepage(false)}
@@ -66,7 +65,9 @@ export const HomeContent = (): JSX.Element | null => {
     );
   }
 
-  return null;
+  return showEmbedHomepage ? (
+    <EmbedMinimalHomepage onDismiss={() => setShowEmbedHomepage(false)} />
+  ) : null;
 };
 
 const isLoading = (

--- a/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
+++ b/frontend/src/metabase/home/components/HomeContent/HomeContent.tsx
@@ -1,5 +1,4 @@
-import { useMemo } from "react";
-import { useUpdate } from "react-use";
+import { useState } from "react";
 
 import {
   useDatabaseListQuery,
@@ -22,7 +21,6 @@ import { HomeRecentSection } from "../HomeRecentSection";
 import { HomeXraySection } from "../HomeXraySection";
 
 export const HomeContent = (): JSX.Element | null => {
-  const update = useUpdate();
   const user = useSelector(getUser);
   const isAdmin = useSelector(getUserIsAdmin);
   const isXrayEnabled = useSelector(getIsXrayEnabled);
@@ -33,7 +31,9 @@ export const HomeContent = (): JSX.Element | null => {
   const { data: popularItems, error: popularItemsError } =
     usePopularItemListQuery({ reload: true });
   const error = databasesError || recentItemsError || popularItemsError;
-  const showEmbedHomepage = useMemo(() => shouldShowEmbedHomepage(), []);
+  const [showEmbedHomepage, setShowEmbedHomepage] = useState(() =>
+    shouldShowEmbedHomepage(),
+  );
 
   if (error) {
     return <LoadingAndErrorWrapper error={error} />;
@@ -57,7 +57,9 @@ export const HomeContent = (): JSX.Element | null => {
         <HomeXraySection />
         {isAdmin && showEmbedHomepage && (
           <Box mt={64}>
-            <EmbedMinimalHomepage onDismiss={update} />
+            <EmbedMinimalHomepage
+              onDismiss={() => setShowEmbedHomepage(false)}
+            />
           </Box>
         )}
       </>

--- a/frontend/src/metabase/home/components/HomeContent/HomeContent.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/HomeContent/HomeContent.unit.spec.tsx
@@ -187,10 +187,11 @@ describe("HomeContent", () => {
       await setup({
         user: createMockUser({ is_superuser: true }),
         hasEmbeddingHomepageFlag: true,
+        databases: [createMockDatabase()],
       });
 
       expect(
-        screen.getByText("Get started with Embedding Metabase in your app"),
+        screen.getByText("Embed Metabase in your app"),
       ).toBeInTheDocument();
     });
 
@@ -198,10 +199,11 @@ describe("HomeContent", () => {
       await setup({
         user: createMockUser({ is_superuser: false }),
         hasEmbeddingHomepageFlag: true,
+        databases: [createMockDatabase()],
       });
 
       expect(
-        screen.queryByText("Get started with Embedding Metabase in your app"),
+        screen.queryByText("Embed Metabase in your app"),
       ).not.toBeInTheDocument();
     });
 
@@ -209,12 +211,13 @@ describe("HomeContent", () => {
       await setup({
         user: createMockUser({ is_superuser: true }),
         hasEmbeddingHomepageFlag: true,
+        databases: [createMockDatabase()],
       });
 
       screen.getByRole("button", { name: "close icon" }).click();
 
       expect(
-        screen.queryByText("Get started with Embedding Metabase in your app"),
+        screen.queryByText("Embed Metabase in your app"),
       ).not.toBeInTheDocument();
 
       expect(localStorage.getItem("showEmbedHomepage")).toBeNull();
@@ -224,20 +227,22 @@ describe("HomeContent", () => {
       await setup({
         user: createMockUser({ is_superuser: false }),
         hasEmbeddingHomepageFlag: true,
+        databases: [createMockDatabase()],
       });
 
       expect(
-        screen.queryByText("Get started with Embedding Metabase in your app"),
+        screen.queryByText("Embed Metabase in your app"),
       ).not.toBeInTheDocument();
     });
 
     it("should not show it if the localStorage flag is not set", async () => {
       await setup({
         user: createMockUser({ is_superuser: true }),
+        databases: [createMockDatabase()],
       });
 
       expect(
-        screen.queryByText("Get started with Embedding Metabase in your app"),
+        screen.queryByText("Embed Metabase in your app"),
       ).not.toBeInTheDocument();
     });
   });


### PR DESCRIPTION
Relate to Epic https://github.com/metabase/metabase/issues/40005

### Description

This implements [this design](https://www.figma.com/file/UFay4YjWyUMyl23T1cXzeC/Meet-first-time-embedders-at-the-door-with-a-dashboard?type=design&node-id=1821-22598&mode=design&t=nl2XxAXnoO36aNk5-4) as suggested [here](https://metaboat.slack.com/archives/C063Q3F1HPF/p1709288042496439?thread_ts=1709224918.522439&cid=C063Q3F1HPF).

I show the card together with xrays, the card will only be shown once at the first load and I can't think of a reason why the first time we load the homepage xrays shouldn't be what we show.

Note: even though it's now technically just a card and not a homepage, I still left the name as is, as next week I'll work on making it a homepage again (milestone v50).

### How to verify

Do the setup and select that you're interested in embedding.

You should see the card as in the screenshot above, if you refresh or dismiss it, it should go away.

### Demo
<img width="1844" alt="image" src="https://github.com/metabase/metabase/assets/1914270/5f0f43b7-fe01-443b-a8a0-bdddbd2fac9a">


If you want to re-enable the card for testing you can paste `localStorage.setItem("showEmbedHomepage", "true")` in the browser console and reload the page.
