### PR TITLE
fix showing series comparison tooltip on non-stacked charts

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -327,8 +327,8 @@ export const STACKABLE_SETTINGS = {
 
 export const TOOLTIP_SETTINGS = {
   "graph.tooltip_type": {
-    getDefault: (series, settings) => {
-      return settings["stackable.stack_type"] != null
+    getDefault: (_series, settings) => {
+      return settings["stackable.stack_display"] != null
         ? "series_comparison"
         : "default";
     },


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39550

### Description

Fixes showing series comparison tooltip on some line charts when the visualization settings include stacking settings.

### How to verify

- Create a stacked bar chart
- Switch the viz type to Line
- Hover data points, ensure it shows regular key-value tooltip

### Demo

Before
<img width="430" alt="Screenshot 2024-03-15 at 3 00 40 PM" src="https://github.com/metabase/metabase/assets/14301985/51f4e4d5-cd30-4f3d-8204-d356529f267a">

After
<img width="361" alt="Screenshot 2024-03-15 at 3 00 16 PM" src="https://github.com/metabase/metabase/assets/14301985/2ddbec11-4377-4a69-86df-0d5676945b9f">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
