### PR TITLE
Fix normalized, stacked bar tooltip names

### DIFF
--- a/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/ChartTooltip.tsx
@@ -26,7 +26,12 @@ const ChartTooltip = ({ hovered, settings }: ChartTooltipProps) => {
     }
 
     if (hovered.stackedTooltipModel) {
-      return <StackedDataTooltip {...hovered.stackedTooltipModel} />;
+      return (
+        <StackedDataTooltip
+          {...hovered.stackedTooltipModel}
+          settings={settings}
+        />
+      );
     }
 
     return <KeyValuePairChartTooltip hovered={hovered} settings={settings} />;

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/StackedDataTooltip.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/StackedDataTooltip/StackedDataTooltip.tsx
@@ -1,6 +1,9 @@
 import { useMemo } from "react";
 import { color } from "metabase/lib/colors";
-import type { StackedTooltipModel } from "metabase/visualizations/types";
+import type {
+  ComputedVisualizationSettings,
+  StackedTooltipModel,
+} from "metabase/visualizations/types";
 import { TooltipRow, TooltipTotalRow } from "../TooltipRow";
 import {
   DataPointHeader,
@@ -19,13 +22,16 @@ import {
 
 const MAX_BODY_ROWS = 8;
 
-type StackedDataTooltipProps = StackedTooltipModel;
+type StackedDataTooltipProps = StackedTooltipModel & {
+  settings: ComputedVisualizationSettings;
+};
 
 const StackedDataTooltip = ({
   headerTitle,
   headerRows,
   bodyRows = [],
   grandTotal,
+  settings,
   showTotal,
   showPercentages,
   totalFormatter = (value: unknown) => String(value),
@@ -38,6 +44,10 @@ const StackedDataTooltip = ({
   const rowsTotal = useMemo(
     () => getTotalValue(sortedHeaderRows, sortedBodyRows),
     [sortedHeaderRows, sortedBodyRows],
+  );
+  const isNormalized = useMemo(
+    () => settings["stackable.stack_type"] === "normalized",
+    [settings],
   );
 
   const isShowingTotalSensible =
@@ -74,6 +84,7 @@ const StackedDataTooltip = ({
               percent={
                 showPercentages ? getPercent(rowsTotal, row.value) : undefined
               }
+              isNormalized={isNormalized}
               {...row}
             />
           ))}
@@ -87,6 +98,7 @@ const StackedDataTooltip = ({
                 percent={
                   showPercentages ? getPercent(rowsTotal, row.value) : undefined
                 }
+                isNormalized={isNormalized}
                 {...row}
               />
             ))}

--- a/frontend/src/metabase/visualizations/components/ChartTooltip/TooltipRow/TooltipRow.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartTooltip/TooltipRow/TooltipRow.tsx
@@ -14,6 +14,7 @@ import {
 export interface TooltipRowProps extends TooltipRowModel {
   isHeader?: boolean;
   percent?: number;
+  isNormalized?: boolean;
 }
 
 export const TooltipRow = ({
@@ -22,6 +23,7 @@ export const TooltipRow = ({
   color,
   percent,
   isHeader,
+  isNormalized,
   formatter = (value: unknown) => String(value),
 }: TooltipRowProps) => (
   <TooltipRowRoot isHeader={isHeader}>
@@ -30,7 +32,10 @@ export const TooltipRow = ({
         <ColorIndicator size={isHeader ? 12 : 8} color={color} />
       </ColorIndicatorCell>
     )}
-    <Cell data-testid="row-name">{name}</Cell>
+    <Cell data-testid="row-name">
+      {isNormalized && "% "}
+      {name}
+    </Cell>
     <ValueCell data-testid="row-value">{formatter(value)}</ValueCell>
     {percent != null ? (
       <PercentCell data-testid="row-percent">


### PR DESCRIPTION
- Closes: https://github.com/metabase/metabase/issues/39590

### Before

**Non-normalized Stacking**

![image](https://github.com/metabase/metabase/assets/22608765/0816af3f-88b0-48e7-825a-5e2ba9ceb8bc)

**Normalized Stacking**

![image](https://github.com/metabase/metabase/assets/22608765/8f635e9b-be64-411b-b375-e1fe0f8b4e6b)


### After

**Non-normalized Stacking**

![image](https://github.com/metabase/metabase/assets/22608765/8664c522-c5d2-43a0-b1e9-8b24c9038a94)


**Normalized Stacking**

![image](https://github.com/metabase/metabase/assets/22608765/90cba7ab-cc54-4031-b0d8-1879533379c9)
