### PR TITLE
Provide more room for the "expected behavior" in bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,7 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     id: expected-behavior
     attributes:
       label: Expected behavior


### PR DESCRIPTION
The "Expected behavior" in a bug report form was initially coded as a regular input field. It's often not enough, so we're changing that to the textarea in this PR.

This should encourage people to write better bug reports.