### PR TITLE
Upload CSVs: Rename boolean-or-int to boolean-int

### DIFF
--- a/src/metabase/sync/analyze/classifiers/name.clj
+++ b/src/metabase/sync/analyze/classifiers/name.clj
@@ -11,7 +11,7 @@
    [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]))
 
-(def ^:private bool-or-int-type #{:type/Boolean :type/Integer})
+(def ^:private bool-int-type #{:type/Boolean :type/Integer})
 (def ^:private float-type       #{:type/Float})
 (def ^:private int-type         #{:type/Integer})
 (def ^:private int-or-text-type #{:type/Integer :type/Text})
@@ -46,7 +46,7 @@
    [#"^.*_latitude$"               float-type       :type/Latitude]
    [#"^.*_type$"                   int-or-text-type :type/Category]
    [#"^.*_url$"                    text-type        :type/URL]
-   [#"^active$"                    bool-or-int-type :type/Category]
+   [#"^active$"                    bool-int-type    :type/Category]
    [#"^city$"                      text-type        :type/City]
    [#"^country"                    text-type        :type/Country]
    [#"_country$"                   text-type        :type/Country]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -66,13 +66,13 @@
 ;;     |  /     \
 ;;     | /       \
 ;;     |/         \
-;; boolean-or-int  auto-incrementing-int-pk
+;; boolean-int  auto-incrementing-int-pk
 ;;
-;; `boolean-or-int` is a special type with two parents, where we parse it as a boolean if the whole
-;; column's values are of that type. additionally a column cannot have a boolean-or-int type, but
-;; a value can. if there is a column with a boolean-or-int value and an integer value, the column will be int
-;; if there is a column with a boolean-or-int value and a boolean value, the column will be boolean
-;; if there is a column with only boolean-or-int values, the column will be parsed as if it were boolean
+;; `boolean-int` is a special type with two parents, where we parse it as a boolean if the whole
+;; column's values are of that type. additionally a column cannot have a boolean-int type, but
+;; a value can. if there is a column with a boolean-int value and an integer value, the column will be int
+;; if there is a column with a boolean-int value and a boolean value, the column will be boolean
+;; if there is a column with only boolean-int values, the column will be parsed as if it were boolean
 ;;
 ;; </code></pre>
 
@@ -81,8 +81,8 @@
   We use an [[metabase.util.ordered-hierarchy]] for its topological sorting, which simplify writing efficient and
   consistent implementations for of our type inference, parsing, and relaxation."
   (-> (make-hierarchy)
-      (derive ::boolean-or-int ::boolean)
-      (derive ::boolean-or-int ::int)
+      (derive ::boolean-int ::boolean)
+      (derive ::boolean-int ::int)
       (derive ::auto-incrementing-int-pk ::int)
       (derive ::int ::float)
       (derive ::date ::datetime)
@@ -94,7 +94,7 @@
 
 (def ^:private abstract->concrete
   "Not all value types correspond to database types. For those that don't, this maps to their concrete ancestor."
-  {::boolean-or-int ::boolean})
+  {::boolean-int ::boolean})
 
 (def ^:private value-types
   "All type tags which values can be inferred as. An ordered set from most to least specialized."
@@ -167,7 +167,7 @@
 (defn- boolean-string? [s]
   (boolean (re-matches #"(?i)true|t|yes|y|1|false|f|no|n|0" s)))
 
-(defn- boolean-or-int-string? [s]
+(defn- boolean-int-string? [s]
   (contains? #{"0" "1"} s))
 
 (defn- varchar-255? [s]
@@ -190,7 +190,7 @@
 
 (mu/defn ^:private settings->type->check :- type->check-schema
   [{:keys [number-separators] :as _settings}]
-  {::boolean-or-int  boolean-or-int-string?
+  {::boolean-int     boolean-int-string?
    ::boolean         boolean-string?
    ::offset-datetime offset-datetime-string?
    ::date            date-string?

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -32,7 +32,7 @@
 
 (def ^:private bool-type        ::upload/boolean)
 (def ^:private int-type         ::upload/int)
-(def ^:private bool-or-int-type ::upload/boolean-or-int)
+(def ^:private bool-int-type    ::upload/boolean-int)
 (def ^:private float-type       ::upload/float)
 (def ^:private vchar-type       ::upload/varchar-255)
 (def ^:private date-type        ::upload/date)
@@ -143,8 +143,8 @@
            ["9’986’000"  9986000        int-type ".’"]
            ["$0"         0              int-type]
            ["-1"         -1             int-type]
-           ["0"          false          bool-or-int-type]
-           ["1"          true           bool-or-int-type]
+           ["0"          false          bool-int-type]
+           ["1"          true           bool-int-type]
            ["9.986.000"  "9.986.000"    vchar-type ".,"]
            ["3.14"       3.14           float-type]
            ["3.14"       3.14           float-type "."]
@@ -244,7 +244,7 @@
   (doseq [[type-a            type-b           expected]
           [[bool-type        bool-type        bool-type]
            [bool-type        int-type         vchar-type]
-           [bool-type        bool-or-int-type bool-type]
+           [bool-type        bool-int-type    bool-type]
            [bool-type        date-type        vchar-type]
            [bool-type        datetime-type    vchar-type]
            [bool-type        vchar-type       vchar-type]
@@ -255,8 +255,8 @@
            [int-type         datetime-type    vchar-type]
            [int-type         vchar-type       vchar-type]
            [int-type         text-type        text-type]
-           [int-type         bool-or-int-type int-type]
-           [bool-or-int-type bool-or-int-type bool-or-int-type]
+           [int-type         bool-int-type    int-type]
+           [bool-int-type    bool-int-type    bool-int-type]
            [float-type       vchar-type       vchar-type]
            [float-type       text-type        text-type]
            [float-type       date-type        vchar-type]

--- a/test/metabase/util/ordered_hierarchy_test.clj
+++ b/test/metabase/util/ordered_hierarchy_test.clj
@@ -8,8 +8,8 @@
 
 (def ^:private h
   (-> (ordered-hierarchy/make-hierarchy)
-      (ordered-hierarchy/derive ::boolean-or-int ::boolean)
-      (ordered-hierarchy/derive ::boolean-or-int ::int)
+      (ordered-hierarchy/derive ::boolean-int ::boolean)
+      (ordered-hierarchy/derive ::boolean-int ::int)
       (ordered-hierarchy/derive ::auto-incrementing-int-pk ::int)
       (ordered-hierarchy/derive ::int ::float)
       (ordered-hierarchy/derive ::date ::datetime)
@@ -24,14 +24,14 @@
     (is (nil? (parents h ::text)))
     (is (= [::text] (vec (parents h ::varchar-255))))
     (is (= [::float] (vec (parents h ::int))))
-    (is (= [::boolean ::int] (vec (parents h ::boolean-or-int))))))
+    (is (= [::boolean ::int] (vec (parents h ::boolean-int))))))
 
 (deftest ^:parallel children-test
   (testing "Children are listed in reverse order to when they were each derived from this tag"
-    (is (nil? (ordered-hierarchy/children h ::boolean-or-int)))
+    (is (nil? (ordered-hierarchy/children h ::boolean-int)))
     (is (= [::varchar-255] (vec (ordered-hierarchy/children h ::text))))
     (is (= [::int] (vec (ordered-hierarchy/children h ::float))))
-    (is (= [::auto-incrementing-int-pk ::boolean-or-int] (vec (ordered-hierarchy/children h ::int))))))
+    (is (= [::auto-incrementing-int-pk ::boolean-int] (vec (ordered-hierarchy/children h ::int))))))
 
 (deftest ^:parallel ancestors-test
   (testing "Linear ancestors are listed in order"
@@ -46,17 +46,17 @@
             ::float
             ::varchar-255
             ::text]
-           (vec (ancestors h ::boolean-or-int))))))
+           (vec (ancestors h ::boolean-int))))))
 
 (deftest ^:parallel descendants-test
   (testing "Linear descendants are listed in order"
-    (is (nil? (descendants h ::boolean-or-int)))
+    (is (nil? (descendants h ::boolean-int)))
     (is (nil? (descendants h ::date)))
     (is (= [::date] (vec (descendants h ::datetime))))
-    (is (= [::boolean-or-int] (vec (descendants h ::boolean)))))
+    (is (= [::boolean-int] (vec (descendants h ::boolean)))))
 
   (testing "Non-linear descendants are listed in breadth-first order"
-    (is (= [::int ::auto-incrementing-int-pk ::boolean-or-int] (vec (descendants h ::float))))
+    (is (= [::int ::auto-incrementing-int-pk ::boolean-int] (vec (descendants h ::float))))
     (is (= [::varchar-255
             ::offset-datetime
             ::datetime
@@ -65,12 +65,12 @@
             ::int
             ::auto-incrementing-int-pk
             ::boolean
-            ::boolean-or-int]
+            ::boolean-int]
            (vec (descendants h ::text))))))
 
 (deftest ^:parallel tags-test
   (testing "Tags are returned in a topologically sorted order that also preserves insert order"
-    (is (= [::boolean-or-int
+    (is (= [::boolean-int
             ::boolean
             ::auto-incrementing-int-pk
             ::int
@@ -84,7 +84,7 @@
 
 (deftest ^:parallel first-common-ancestor-test
   (testing "The first-common-ancestor is the first tag in the lineage of tag-a that is also in the lineage of tag-b"
-    (is (= ::boolean-or-int (ordered-hierarchy/first-common-ancestor h ::boolean-or-int nil)))
-    (is (= ::boolean-or-int (ordered-hierarchy/first-common-ancestor h ::boolean-or-int ::boolean-or-int)))
-    (is (= ::boolean (ordered-hierarchy/first-common-ancestor h ::boolean-or-int ::boolean)))
+    (is (= ::boolean-int (ordered-hierarchy/first-common-ancestor h ::boolean-int nil)))
+    (is (= ::boolean-int (ordered-hierarchy/first-common-ancestor h ::boolean-int ::boolean-int)))
+    (is (= ::boolean (ordered-hierarchy/first-common-ancestor h ::boolean-int ::boolean)))
     (is (= ::varchar-255 (ordered-hierarchy/first-common-ancestor h ::boolean ::int)))))


### PR DESCRIPTION
This PR comes from a moment of confusion where I forgot whether `boolean-or-int` includes true and false, and I had to check.

The reason for the confusion is the name: `boolean-or-int` could be interpreted to mean "the union of boolean and integer values". But actually the meaning is "the intersection of boolean and integer values".

I had the same confusion when I saw the `float-or-int` type in https://github.com/metabase/metabase/pull/39724.

This PR proposes a new name: `boolean-int`. 

It is more precise, unambiguous, and fits the intuition from English. In English, "true" is definitely not a "boolean integer", but "0" is.