### PR TITLE
Comment out failing time-interval-expression-test

### DIFF
--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1035,7 +1035,8 @@
                     {:aggregation [[:count]]
                      :filter      [:time-interval $timestamp :last :week]})))))))))
 
-(deftest ^:parallel time-interval-expression-test
+;; Commenting out for now because this is blocking CI
+#_(deftest ^:parallel time-interval-expression-test
   (mt/test-drivers (mt/normal-drivers-except #{:snowflake :athena})
     (mt/dataset checkins:1-per-day
       (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (mt/id))


### PR DESCRIPTION
`time-interval-expression-test` has started to fail consistently on master and the 49 branch.

The test is flawed and only worked by coincidence when the test was added in February.

It uses `checkins:1-per-day`, which has this docstring:
"Dynamically generated dataset with 30 checkins spaced 24 hours apart, from 15 days ago to 14 days in the future."

And then goes on to test a query that has filters with `(lib/time-interval ... :current :quarter)`.

The problem is the current quarter, which ends on March 31, is 13 days in the future.

I've commented out the test for now, and will leave fixing the test to the QPD team.