### PR TITLE
Remove instance settings from error diagnostics

### DIFF
--- a/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
+++ b/e2e/test/scenarios/admin-2/error-reporting.cy.spec.ts
@@ -32,7 +32,7 @@ describe("error reporting modal", () => {
       expect(fileContent).to.have.property("backendErrors");
       expect(fileContent).to.have.property("userLogs");
       expect(fileContent).to.have.property("logs");
-      expect(fileContent).to.have.property("instanceInfo");
+      expect(fileContent).to.have.property("bugReportDetails");
     });
   });
 
@@ -61,7 +61,7 @@ describe("error reporting modal", () => {
       expect(fileContent).to.have.property("backendErrors");
       expect(fileContent).to.have.property("userLogs");
       expect(fileContent).to.have.property("logs");
-      expect(fileContent).to.have.property("instanceInfo");
+      expect(fileContent).to.have.property("bugReportDetails");
       expect(fileContent).to.have.property("entityInfo");
       expect(fileContent).not.to.have.property("queryResults");
     });
@@ -84,7 +84,7 @@ describe("error reporting modal", () => {
       expect(fileContent).to.have.property("backendErrors");
       expect(fileContent).to.have.property("userLogs");
       expect(fileContent).to.have.property("logs");
-      expect(fileContent).to.have.property("instanceInfo");
+      expect(fileContent).to.have.property("bugReportDetails");
       expect(fileContent).to.have.property("entityInfo");
       expect(fileContent).to.have.property("queryResults");
     });
@@ -117,7 +117,7 @@ describe("error reporting modal", () => {
       expect(fileContent).to.have.property("backendErrors");
       expect(fileContent).to.have.property("userLogs");
       expect(fileContent).to.have.property("logs");
-      expect(fileContent).to.have.property("instanceInfo");
+      expect(fileContent).to.have.property("bugReportDetails");
       expect(fileContent).to.have.property("entityInfo");
       expect(fileContent).to.have.property("queryResults");
     });
@@ -144,7 +144,7 @@ describe("error reporting modal", () => {
       expect(fileContent.url).to.include("/dashboard/");
 
       expect(fileContent).to.have.property("frontendErrors");
-      expect(fileContent).to.have.property("instanceInfo");
+      expect(fileContent).to.have.property("bugReportDetails");
       expect(fileContent).to.have.property("entityInfo");
       expect(fileContent).not.to.have.property("logs");
       expect(fileContent).not.to.have.property("userLogs");

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.tsx
@@ -77,7 +77,7 @@ export const ErrorDiagnosticModal = ({
           backendErrors: true,
           userLogs: true,
           logs: true,
-          instanceInfo: true,
+          bugReportDetails: true,
         }}
         onSubmit={handleSubmit}
       >
@@ -115,9 +115,9 @@ export const ErrorDiagnosticModal = ({
               </>
             )}
             <FormCheckbox
-              name="instanceInfo"
+              name="bugReportDetails"
               // eslint-disable-next-line no-literal-metabase-strings -- we're mucking around in the software here
-              label={t`Metabase instance version and settings`}
+              label={t`Metabase instance version information`}
             />
           </Stack>
           <Alert variant="warning">

--- a/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
+++ b/frontend/src/metabase/components/ErrorPages/ErrorDiagnosticModal.unit.spec.tsx
@@ -45,23 +45,18 @@ const defaultErrorPayload: ErrorPayload = {
   localizedEntityName: "Question",
   entityInfo: createMockCard(),
   queryResults: createMockDatasetData({ rows: [[1]] }),
-  instanceInfo: {
-    bugReportDetails: {
-      "application-database": "h2",
-      "application-database-details": {},
-      databases: ["h2"],
-      "hosting-env": "production",
-      "run-mode": "prod",
-      settings: {},
-      version: {
-        date: "2021-08-31",
-        hash: "abcdef",
-        src_hash: "abcdef",
-        tag: "v1.0.0",
-      },
-    },
-    sessionProperties: {
-      settings: "foo",
+  bugReportDetails: {
+    "application-database": "h2",
+    "application-database-details": {},
+    databases: ["h2"],
+    "hosting-env": "production",
+    "run-mode": "prod",
+    settings: {},
+    version: {
+      date: "2021-08-31",
+      hash: "abcdef",
+      src_hash: "abcdef",
+      tag: "v1.0.0",
     },
   },
 };

--- a/frontend/src/metabase/components/ErrorPages/types.ts
+++ b/frontend/src/metabase/components/ErrorPages/types.ts
@@ -23,8 +23,5 @@ export type ErrorPayload = Partial<{
   localizedEntityName: string;
   entityInfo: Card | Dashboard | Collection;
   queryResults: DatasetData;
-  instanceInfo: {
-    bugReportDetails: MetabaseInfo;
-    sessionProperties: any;
-  };
+  bugReportDetails: MetabaseInfo;
 }>;

--- a/frontend/src/metabase/components/ErrorPages/use-error-info.ts
+++ b/frontend/src/metabase/components/ErrorPages/use-error-info.ts
@@ -4,7 +4,7 @@ import { t } from "ttag";
 import { getCurrentUser } from "metabase/admin/datamodel/selectors";
 import { useSelector } from "metabase/lib/redux";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { UtilApi, MetabaseApi, SessionApi } from "metabase/services";
+import { UtilApi, MetabaseApi } from "metabase/services";
 
 import type { ErrorPayload, ReportableEntityName } from "./types";
 import { getEntityDetails, hasQueryData } from "./utils";
@@ -37,8 +37,6 @@ export const useErrorInfo = (
       ? UtilApi.bug_report_details().catch(nullOnCatch)
       : Promise.resolve(null);
 
-    const sessionPropertiesRequest = SessionApi.properties().catch(nullOnCatch);
-
     const logsRequest: any = isAdmin
       ? UtilApi.logs().catch(nullOnCatch)
       : Promise.resolve(null);
@@ -49,12 +47,12 @@ export const useErrorInfo = (
     const settledPromises = await Promise.allSettled([
       entityInfoRequest,
       bugReportDetailsRequest,
-      sessionPropertiesRequest,
       logsRequest,
     ]);
 
-    const [entityInfo, bugReportDetails, sessionProperties, logs] =
-      settledPromises.map((promise: any) => promise.value);
+    const [entityInfo, bugReportDetails, logs] = settledPromises.map(
+      (promise: any) => promise.value,
+    );
 
     const queryResults =
       hasQueryData(entity) &&
@@ -78,8 +76,6 @@ export const useErrorInfo = (
         log?.msg?.includes?.(` userID: ${currentUser.id} `),
     );
 
-    const { engines, ...sessionPropertiesWithoutEngines } = sessionProperties;
-
     const payload: ErrorPayload = {
       url: location,
       entityInfo,
@@ -90,10 +86,7 @@ export const useErrorInfo = (
       frontendErrors,
       backendErrors,
       userLogs,
-      instanceInfo: {
-        sessionProperties: sessionPropertiesWithoutEngines,
-        bugReportDetails,
-      },
+      bugReportDetails,
     };
 
     return payload;


### PR DESCRIPTION
### Description

We were perhaps a little over-inclusive in the information we included in our diagnostic information download. This removes instance settings from that download.

![Screen Shot 2024-03-18 at 8 27 20 AM](https://github.com/metabase/metabase/assets/30528226/6344f310-1758-4e83-a075-049511fa0ca2)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
