### PR TITLE
create ui for the full embedding homepage, without any logic

### DIFF
--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.stories.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.stories.tsx
@@ -41,7 +41,7 @@ export const Default: Story = {
       "https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html",
     embeddingDocsUrl:
       "https://www.metabase.com/docs/latest/embedding/start.html",
-    customerFacingAnalyticsDocsUrl:
+    analyticsDocsUrl:
       "https://www.metabase.com/learn/customer-facing-analytics/",
   },
 };

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.stories.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { EmbedHomepageView } from "./EmbedHomepageView";
+
+type Args = Omit<
+  React.ComponentProps<typeof EmbedHomepageView>,
+  "exampleDashboardId"
+> & {
+  hasExampleDashboard: boolean;
+};
+
+const meta: Meta<Args> = {
+  title: "FEATURES/EmbedHomepage",
+  component: EmbedHomepageView,
+  parameters: {
+    controls: {
+      exclude: "exampleDashboardId",
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<Args>;
+
+export const Default: Story = {
+  render: args => {
+    return (
+      <EmbedHomepageView
+        {...args}
+        exampleDashboardId={args.hasExampleDashboard ? 1 : undefined}
+        key={args.plan}
+      />
+    );
+  },
+  args: {
+    embeddingAutoEnabled: true,
+    hasExampleDashboard: true,
+    licenseActiveAtSetup: true,
+    plan: "oss-starter",
+    interactiveEmbeddingQuickstartUrl:
+      "https://www.metabase.com/docs/latest/embedding/interactive-embedding-quick-start-guide.html",
+    embeddingDocsUrl:
+      "https://www.metabase.com/docs/latest/embedding/start.html",
+    customerFacingAnalyticsDocsUrl:
+      "https://www.metabase.com/learn/customer-facing-analytics/",
+  },
+};

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -1,0 +1,42 @@
+import { useSelector } from "metabase/lib/redux";
+import { getDocsUrl } from "metabase/selectors/settings";
+
+import { EmbedHomepageView } from "./EmbedHomepageView";
+
+export const EmbedHomepage = () => {
+  const interactiveEmbeddingQuickStartUrl = useSelector(state =>
+    // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
+    getDocsUrl(state, {
+      page: "embedding/interactive-embedding-quick-start-guide",
+    }),
+  );
+  const embeddingDocsUrl = useSelector(state =>
+    // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
+    getDocsUrl(state, { page: "embedding/start" }),
+  );
+
+  const learnMoreInteractiveEmbedding = useSelector(state =>
+    // eslint-disable-next-line no-unconditional-metabase-links-render -- this is only visible to admins
+    getDocsUrl(state, { page: "embedding/interactive-embedding" }),
+  );
+
+  const learnMoreStaticEmbedding = useSelector(state =>
+    // eslint-disable-next-line no-unconditional-metabase-links-render -- this is only visible to admins
+    getDocsUrl(state, { page: "embedding/static-embedding" }),
+  );
+
+  return (
+    <EmbedHomepageView
+      exampleDashboardId={1}
+      embeddingAutoEnabled={false}
+      licenseActiveAtSetup={true}
+      plan="oss-starter"
+      interactiveEmbeddingQuickstartUrl={interactiveEmbeddingQuickStartUrl}
+      embeddingDocsUrl={embeddingDocsUrl}
+      // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
+      customerFacingAnalyticsDocsUrl="https://www.metabase.com/learn/customer-facing-analytics/"
+      learnMoreInteractiveEmbedUrl={learnMoreInteractiveEmbedding}
+      learnMoreStaticEmbedUrl={learnMoreStaticEmbedding}
+    />
+  );
+};

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -34,7 +34,7 @@ export const EmbedHomepage = () => {
       interactiveEmbeddingQuickstartUrl={interactiveEmbeddingQuickStartUrl}
       embeddingDocsUrl={embeddingDocsUrl}
       // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
-      customerFacingAnalyticsDocsUrl="https://www.metabase.com/learn/customer-facing-analytics/"
+      analyticsDocsUrl="https://www.metabase.com/learn/customer-facing-analytics/"
       learnMoreInteractiveEmbedUrl={learnMoreInteractiveEmbedding}
       learnMoreStaticEmbedUrl={learnMoreStaticEmbedding}
     />

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -59,8 +59,6 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
             fw="bold"
           >{t`Embedding has been automatically enabled for you`}</Text>
           <Text color="text-light" size="sm">
-            {/*// TODO: add link */}
-
             {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
             {jt`Because you expressed interest in embedding Metabase, we took this step for you so that you can more easily try it out. You can turn it off anytime in ${(
               <Link

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -1,0 +1,88 @@
+import { jt, t } from "ttag";
+
+import ExternalLink from "metabase/core/components/ExternalLink";
+import { Card, Group, Stack, Tabs, Text, Title } from "metabase/ui";
+
+import { InteractiveTabContent } from "./InteractiveTabContent";
+import { StaticTabContent } from "./StaticTabContent";
+
+export type EmbedHomepageViewProps = {
+  embeddingAutoEnabled: boolean;
+  exampleDashboardId?: number;
+  licenseActiveAtSetup: boolean;
+  plan: "oss-starter" | "pro-ee";
+  // links
+  interactiveEmbeddingQuickstartUrl: string;
+  embeddingDocsUrl: string;
+  customerFacingAnalyticsDocsUrl: string;
+  learnMoreStaticEmbedUrl: string;
+  learnMoreInteractiveEmbedUrl: string;
+};
+
+export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
+  const {
+    embeddingAutoEnabled,
+    plan,
+    embeddingDocsUrl,
+    customerFacingAnalyticsDocsUrl,
+  } = props;
+  return (
+    <Stack maw={550}>
+      <Group>
+        {/*  eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
+        <Text fw="bold">{t`Get started with Embedding Metabase in your app`}</Text>
+      </Group>
+      <Card px="xl" py="lg">
+        {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
+        <Title order={2} mb="md">{t`Embedding Metabase`}</Title>
+        <Tabs defaultValue={plan === "oss-starter" ? "static" : "interactive"}>
+          <Tabs.List>
+            <Tabs.Tab value="interactive">{t`Interactive`}</Tabs.Tab>
+            <Tabs.Tab value="static">{t`Static`}</Tabs.Tab>
+          </Tabs.List>
+
+          <Tabs.Panel value="interactive" pt="md">
+            <InteractiveTabContent {...props} />
+          </Tabs.Panel>
+
+          <Tabs.Panel value="static" pt="md">
+            <StaticTabContent {...props} />
+          </Tabs.Panel>
+        </Tabs>
+      </Card>
+
+      {embeddingAutoEnabled && (
+        <Card>
+          <Text
+            color="text-dark"
+            fw="bold"
+          >{t`Embedding has been automatically enabled for you`}</Text>
+          <Text color="text-light" size="sm">
+            {/*// TODO: add link */}
+
+            {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
+            {jt`Because you expressed interest in embedding Metabase, we took this step for you so that you can more easily try it out. You can turn it off anytime in admin/settings/embedding-in-other-applications.`}
+          </Text>
+        </Card>
+      )}
+
+      <Card>
+        <Text color="text-dark" fw="bold">{t`Need more information?`}</Text>
+        <Text color="text-light" size="sm">
+          {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
+          {jt`Explore the ${(
+            <ExternalLink
+              key="embeddingDocs"
+              href={embeddingDocsUrl}
+            >{t`embedding documentation`}</ExternalLink>
+          )} and ${(
+            <ExternalLink
+              key="customerFacingAnalyticsDoc"
+              href={customerFacingAnalyticsDocsUrl}
+            >{t`customer-facing analytics articles`}</ExternalLink>
+          )} to learn more about what Metabase offers.`}
+        </Text>
+      </Card>
+    </Stack>
+  );
+};

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -15,18 +15,14 @@ export type EmbedHomepageViewProps = {
   // links
   interactiveEmbeddingQuickstartUrl: string;
   embeddingDocsUrl: string;
-  customerFacingAnalyticsDocsUrl: string;
+  analyticsDocsUrl: string;
   learnMoreStaticEmbedUrl: string;
   learnMoreInteractiveEmbedUrl: string;
 };
 
 export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
-  const {
-    embeddingAutoEnabled,
-    plan,
-    embeddingDocsUrl,
-    customerFacingAnalyticsDocsUrl,
-  } = props;
+  const { embeddingAutoEnabled, plan, embeddingDocsUrl, analyticsDocsUrl } =
+    props;
   return (
     <Stack maw={550}>
       <Group>
@@ -86,7 +82,7 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
           )} and ${(
             <ExternalLink
               key="customer-facing-analytics-docs"
-              href={customerFacingAnalyticsDocsUrl}
+              href={analyticsDocsUrl}
             >{t`customer-facing analytics articles`}</ExternalLink>
           )} to learn more about what Metabase offers.`}
         </Text>

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -1,7 +1,8 @@
+import { Link } from "react-router";
 import { jt, t } from "ttag";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
-import { Card, Group, Stack, Tabs, Text, Title } from "metabase/ui";
+import { Anchor, Card, Group, Stack, Tabs, Text, Title } from "metabase/ui";
 
 import { InteractiveTabContent } from "./InteractiveTabContent";
 import { StaticTabContent } from "./StaticTabContent";
@@ -61,7 +62,16 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
             {/*// TODO: add link */}
 
             {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
-            {jt`Because you expressed interest in embedding Metabase, we took this step for you so that you can more easily try it out. You can turn it off anytime in admin/settings/embedding-in-other-applications.`}
+            {jt`Because you expressed interest in embedding Metabase, we took this step for you so that you can more easily try it out. You can turn it off anytime in ${(
+              <Link
+                to="admin/settings/embedding-in-other-applications"
+                key="link"
+              >
+                <Anchor size="sm">
+                  admin/settings/embedding-in-other-applications
+                </Anchor>
+              </Link>
+            )}.`}
           </Text>
         </Card>
       )}
@@ -72,12 +82,12 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
           {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
           {jt`Explore the ${(
             <ExternalLink
-              key="embeddingDocs"
+              key="embedding-docs"
               href={embeddingDocsUrl}
             >{t`embedding documentation`}</ExternalLink>
           )} and ${(
             <ExternalLink
-              key="customerFacingAnalyticsDoc"
+              key="customer-facing-analytics-docs"
               href={customerFacingAnalyticsDocsUrl}
             >{t`customer-facing analytics articles`}</ExternalLink>
           )} to learn more about what Metabase offers.`}

--- a/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
@@ -32,7 +32,7 @@ export const InteractiveTabContent = (props: EmbedHomepageViewProps) => {
         // TODO: fix this in a better way
         style={{ listStyleType: "decimal" }}
       >
-        {licenseActiveAtSetup === false && (
+        {!licenseActiveAtSetup && (
           <>
             <List.Item>
               <Link to="/admin/settings/license">

--- a/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
@@ -1,0 +1,82 @@
+// eslint-disable-next-line no-restricted-imports
+import { List } from "@mantine/core";
+import { Link } from "react-router";
+import { t, jt } from "ttag";
+
+import ExternalLink from "metabase/core/components/ExternalLink";
+import { Anchor, Button, Icon, Text } from "metabase/ui";
+
+import type { EmbedHomepageViewProps } from "./EmbedHomepageView";
+
+export const InteractiveTabContent = (props: EmbedHomepageViewProps) => {
+  const {
+    embeddingAutoEnabled,
+    interactiveEmbeddingQuickstartUrl,
+    exampleDashboardId,
+    licenseActiveAtSetup,
+    learnMoreInteractiveEmbedUrl,
+  } = props;
+  return (
+    <>
+      <Text
+        mb="md"
+        lh="1.5"
+      >{t`Use interactive embedding to offer multi-tenant, self-service analytics and dashboard creation in their own data sandbox. Pro and Enterprise plans only. `}</Text>
+
+      <Text fw="bold" mb="md">{t`The TL;DR:`}</Text>
+
+      <List
+        type="ordered"
+        mb="lg"
+        size="sm"
+        // TODO: fix this in a better way
+        style={{ listStyleType: "decimal" }}
+      >
+        {licenseActiveAtSetup === false && (
+          <>
+            <List.Item>
+              <Link to="/admin/settings/license">
+                <Anchor size="sm">{t`Activate your commercial license`}</Anchor>
+              </Link>
+            </List.Item>
+          </>
+        )}
+        {embeddingAutoEnabled === false && (
+          <>
+            <List.Item>
+              <Link to="/admin/settings/embedding-in-other-applications">
+                <Anchor size="sm">{t`Enable embedding in the settings`}</Anchor>
+              </Link>
+            </List.Item>
+          </>
+        )}
+        {exampleDashboardId === undefined && (
+          <List.Item>{t`Create a dashboard to be embedded`}</List.Item>
+        )}
+
+        {/* eslint-disable-next-line no-literal-metabase-strings -- this homepage is only visible to admins*/}
+        <List.Item>{t`Implement SSO to sign app users into Metabase`}</List.Item>
+        {/* eslint-disable-next-line no-literal-metabase-strings -- this homepage is only visible to admins*/}
+        <List.Item>{t`Embed Metabase in your app`}</List.Item>
+        <List.Item>{t`Configure collection permissions`}</List.Item>
+        <List.Item>{t`Setup data sandboxing to automatically scope data access based on user attributes`}</List.Item>
+        <List.Item>{t`Hide any features you don't want to expose to your app’s users`}</List.Item>
+        <List.Item>{t`Customize the look and feel of your application to match your brand.`}</List.Item>
+      </List>
+
+      <ExternalLink href={interactiveEmbeddingQuickstartUrl}>
+        <Button
+          variant="filled"
+          mb="sm"
+          leftIcon={<Icon name="sql" />}
+        >{t`Build it with the quick start`}</Button>
+      </ExternalLink>
+      <Text>{jt`${(
+        <ExternalLink
+          key="learn-more"
+          href={learnMoreInteractiveEmbedUrl}
+        >{t`Learn more`}</ExternalLink>
+      )} about interactive embedding`}</Text>
+    </>
+  );
+};

--- a/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/InteractiveTabContent.tsx
@@ -8,14 +8,13 @@ import { Anchor, Button, Icon, Text } from "metabase/ui";
 
 import type { EmbedHomepageViewProps } from "./EmbedHomepageView";
 
-export const InteractiveTabContent = (props: EmbedHomepageViewProps) => {
-  const {
-    embeddingAutoEnabled,
-    interactiveEmbeddingQuickstartUrl,
-    exampleDashboardId,
-    licenseActiveAtSetup,
-    learnMoreInteractiveEmbedUrl,
-  } = props;
+export const InteractiveTabContent = ({
+  embeddingAutoEnabled,
+  interactiveEmbeddingQuickstartUrl,
+  exampleDashboardId,
+  licenseActiveAtSetup,
+  learnMoreInteractiveEmbedUrl,
+}: EmbedHomepageViewProps) => {
   return (
     <>
       <Text

--- a/frontend/src/metabase/home/components/EmbedHomepage/StaticTabContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/StaticTabContent.tsx
@@ -1,0 +1,65 @@
+// eslint-disable-next-line no-restricted-imports
+import { List } from "@mantine/core";
+import { Link } from "react-router";
+import { t, jt } from "ttag";
+
+import ExternalLink from "metabase/core/components/ExternalLink";
+import { Anchor, Button, Icon, Text } from "metabase/ui";
+
+import type { EmbedHomepageViewProps } from "./EmbedHomepageView";
+
+export const StaticTabContent = (props: EmbedHomepageViewProps) => {
+  const { embeddingAutoEnabled, exampleDashboardId, learnMoreStaticEmbedUrl } =
+    props;
+  return (
+    <>
+      <Text
+        mb="md"
+        lh="1.5"
+      >{t`Use static embedding to present data that applies to all of your tenants at once without ad hoc query access to their data. Available in all plans.`}</Text>
+
+      <Text fw="bold" mb="md">{t`The TL;DR:`}</Text>
+
+      <List
+        type="ordered"
+        mb="lg"
+        size="sm"
+        // TODO: fix this in a better way
+        style={{ listStyleType: "decimal" }}
+      >
+        {embeddingAutoEnabled === false && (
+          <List.Item>
+            <Link to="/admin/settings/embedding-in-other-applications">
+              <Anchor size="sm">{t`Enable embedding in the settings`}</Anchor>
+            </Link>
+          </List.Item>
+        )}
+        <List.Item>{jt`${
+          exampleDashboardId !== undefined ? t`Select` : `Create`
+        } a question or dashboard to embed. Then click ${(
+          <strong key="bold">{t`share`}</strong>
+        )}`}</List.Item>
+        <List.Item>{t`Configure the parameters availability (editable, disabled or locked) in your app's code.`}</List.Item>
+        <List.Item>{t`Publish the dashboard or question`}</List.Item>
+        <List.Item>{t`Add code to your app to sign a token for the embed request. Include values for locked parameters if you have any`}</List.Item>
+        <List.Item>{t`Embed the dashboard into your app using an iframe, the URL and the signed token. `}</List.Item>
+      </List>
+
+      {exampleDashboardId && (
+        <Link to={`/dashboard/${exampleDashboardId}`}>
+          <Button
+            variant="filled"
+            mb="sm"
+            leftIcon={<Icon name="dashboard" />}
+          >{t`Embed this example dashboard`}</Button>
+        </Link>
+      )}
+      <Text>{jt`${(
+        <ExternalLink
+          key="learn-more"
+          href={learnMoreStaticEmbedUrl}
+        >{t`Learn more`}</ExternalLink>
+      )} about static embedding`}</Text>
+    </>
+  );
+};

--- a/frontend/src/metabase/home/components/EmbedHomepage/StaticTabContent.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/StaticTabContent.tsx
@@ -8,9 +8,11 @@ import { Anchor, Button, Icon, Text } from "metabase/ui";
 
 import type { EmbedHomepageViewProps } from "./EmbedHomepageView";
 
-export const StaticTabContent = (props: EmbedHomepageViewProps) => {
-  const { embeddingAutoEnabled, exampleDashboardId, learnMoreStaticEmbedUrl } =
-    props;
+export const StaticTabContent = ({
+  embeddingAutoEnabled,
+  exampleDashboardId,
+  learnMoreStaticEmbedUrl,
+}: EmbedHomepageViewProps) => {
   return (
     <>
       <Text

--- a/frontend/src/metabase/home/components/EmbedHomepage/index.ts
+++ b/frontend/src/metabase/home/components/EmbedHomepage/index.ts
@@ -1,0 +1,3 @@
+export { EmbedHomepage } from "./EmbedHomepage";
+export { EmbedHomepageView } from "./EmbedHomepageView";
+export type { EmbedHomepageViewProps } from "./EmbedHomepageView";


### PR DESCRIPTION
Part of  [[Epic] Initial homepage experience for embedding admins](https://github.com/metabase/metabase/issues/40005)

### Description

This only adds the "dumb" UI, all the logic and tests will come in separate PRs

Note that I'm currently importing `List` from `mantine`, I'll open a PR to re-export it from `metabase/ui` (see [slack](https://metaboat.slack.com/archives/C057WD5L0JG/p1710772511289899)) and to also fix the numbers not showing up without the inline style.

### How to verify

- `yarn storybook`
- open http://localhost:6006/?path=/story/features-embedhomepage--default
- play around with the controls

