### PR TITLE
Fix time-interval-expression-test flake

### DIFF
--- a/test/metabase/query_processor_test/date_bucketing_test.clj
+++ b/test/metabase/query_processor_test/date_bucketing_test.clj
@@ -1035,8 +1035,7 @@
                     {:aggregation [[:count]]
                      :filter      [:time-interval $timestamp :last :week]})))))))))
 
-;; Commenting out for now because this is blocking CI
-#_(deftest ^:parallel time-interval-expression-test
+(deftest ^:parallel time-interval-expression-test
   (mt/test-drivers (mt/normal-drivers-except #{:snowflake :athena})
     (mt/dataset checkins:1-per-day
       (let [metadata-provider (lib.metadata.jvm/application-database-metadata-provider (mt/id))
@@ -1045,11 +1044,11 @@
             timestamp-col (m/find-first (comp #{(mt/id :checkins :timestamp)} :id) (lib/visible-columns query))
             query (-> query
                       (lib/expression "Date" timestamp-col)
-                      (lib/filter (lib/time-interval timestamp-col :current :quarter))
+                      (lib/filter (lib/time-interval timestamp-col :current :week))
                       (as-> $q (lib/filter $q (lib/time-interval
                                                 (m/find-first (comp #{"Date"} :name) (lib/visible-columns $q))
-                                                :current :quarter))))]
-        (is (= 30
+                                                :current :week))))]
+        (is (= 7
                (count (mt/rows (qp/process-query query)))))))))
 
 ;; Make sure that when referencing the same field multiple times with different units we return the one that actually


### PR DESCRIPTION
Updates test to handle the problem encountered in #40238

> 
> time-interval-expression-test has started to fail consistently on master and the 49 branch.
> 
> The test is flawed and only worked by coincidence when the test was added in February.
> 
> It uses checkins:1-per-day, which has this docstring:
> "Dynamically generated dataset with 30 checkins spaced 24 hours apart, from 15 days ago to 14 days in the future."
> 
> And then goes on to test a query that has filters with (lib/time-interval ... :current :quarter).
> 
> The problem is the current quarter, which ends on March 31, is 13 days in the future.
> 
> I've commented out the test for now, and will leave fixing the test to the QPD team.