### PR TITLE
[MLv2] Allow any arithmetic sub-clauses in an aggregation

### DIFF
--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -284,7 +284,7 @@ describe("scenarios > question > custom column", () => {
             aggregation: [
               [
                 "aggregation-options",
-                ["*", 1, 1],
+                ["*", ["count"], 1],
                 { name: CE_NAME, "display-name": CE_NAME },
               ],
             ],

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -146,7 +146,7 @@ describe("scenarios > question > filter", () => {
             aggregation: [
               [
                 "aggregation-options",
-                ["+", 1, 1],
+                ["+", ["count"], 1],
                 { name: CE_NAME, "display-name": CE_NAME },
               ],
             ],

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -400,10 +400,10 @@ describe("AggregationPicker", () => {
   });
 
   describe("custom expressions", () => {
-    it("should allow to enter a custom expression", async () => {
+    it("should allow to enter a custom expression containing an aggregation", async () => {
       const { getRecentClauseInfo } = setup();
 
-      const expression = "1 + 1";
+      const expression = "count + 1";
       const expressionName = "My expression";
 
       userEvent.click(screen.getByText("Custom Expression"));

--- a/src/metabase/lib/schema/aggregation.cljc
+++ b/src/metabase/lib/schema/aggregation.cljc
@@ -108,21 +108,23 @@
              :sum-where
              :var
              ;; legacy metric ref
-             :metric
-             ;; arithmetic TODO -- these are only allowed if they have an aggregation as an arg
-             :+
-             :-
-             :/
-             :*]]
+             :metric]]
   (lib.hierarchy/derive tag ::aggregation-clause-tag))
+
+(defn- aggregation-expression?
+  "A clause is a valid aggregation if it is an aggregation clause, or it is an expression that transitively contains
+  a single aggregation clause."
+  [x]
+  (when-let [[tag _opts & args] (and (vector? x) x)]
+    (or (lib.hierarchy/isa? tag ::aggregation-clause-tag)
+        (some aggregation-expression? args))))
 
 (mr/def ::aggregation
   [:and
    [:ref :metabase.lib.schema.mbql-clause/clause]
    [:fn
     {:error/message "Valid aggregation clause"}
-    (fn [[tag :as _clause]]
-      (lib.hierarchy/isa? tag ::aggregation-clause-tag))]])
+    aggregation-expression?]])
 
 (mr/def ::aggregations
   [:sequential {:min 1} [:ref ::aggregation]])

--- a/test/metabase/lib/expression_test.cljc
+++ b/test/metabase/lib/expression_test.cljc
@@ -485,7 +485,8 @@
           (are [mode expr]
                (nil? (lib.expression/diagnose-expression query 0 mode expr c-pos))
             :expression  (get exprs "non-circular-c")
-            :aggregation (get exprs "circular-c")
+            :aggregation (-> (get exprs "circular-c")
+                             (assoc 3 (lib/count)))
             :filter      (assoc (get exprs "circular-c") 0 :=)))
         (testing "circular definition"
           (is (= {:message "Cycle detected: c → x → b → c"}

--- a/test/metabase/lib/schema/aggregation_test.cljc
+++ b/test/metabase/lib/schema/aggregation_test.cljc
@@ -48,3 +48,40 @@
        {:lib/uuid "00000000-0000-0000-0000-000000000000"}
        [:field {:lib/uuid "00000000-0000-0000-0000-000000000000", :base-type :type/Text} 1]
        0.5])))
+
+(deftest ^:parallel arithmetic-expression-test
+  (testing "valid"
+    (are [clause] (not (me/humanize (mc/explain :metabase.lib.schema.aggregation/aggregation clause)))
+         ;; DIY average
+         [:/ {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+           [:sum {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+            [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 1]]
+           [:count {:lib/uuid "00000000-0000-0000-0000-000000000000"}]]
+         ;; Count, but rounded
+         [:round {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+          [:count {:lib/uuid "00000000-0000-0000-0000-000000000000"}]]
+         ;; Estimated monthly count based on month-to-date
+         [:round {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+          [:* {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+           ;; Daily rate
+           [:/ {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+            [:count {:lib/uuid "00000000-0000-0000-0000-000000000000"}]
+            [:get-day {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+             [:now {:lib/uuid "00000000-0000-0000-0000-000000000000"}]]]
+           ;; Times 30 days
+           30]]))
+  (testing "invalid - no aggregation inside"
+    (are [clause] (me/humanize (mc/explain :metabase.lib.schema.aggregation/aggregation clause))
+         [:get-day {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+          [:now {:lib/uuid "00000000-0000-0000-0000-000000000000"}]]
+         [:+ {:lib/uuid "00000000-0000-0000-0000-000000000000"} 7 8]
+         ;; And the big example from above, but with the count swapped for a field.
+         [:round {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+          [:* {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+           ;; Daily rate
+           [:/ {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+            [:field {:lib/uuid "00000000-0000-0000-0000-000000000000"} 12]
+            [:get-day {:lib/uuid "00000000-0000-0000-0000-000000000000"}
+             [:now {:lib/uuid "00000000-0000-0000-0000-000000000000"}]]]
+           ;; Times 30 days
+           30]])))


### PR DESCRIPTION
This issue was previously punted, because the schema for aggregation
clauses allowed the tag to be `:any`. Now it's a short list of permitted
arithmetic expressions, but that list is too short and excludes things
like `:round`.

This change searches for an aggregation clause transitively in the
expression, and so allows any arithmetic expression.

