### PR TITLE
Hide y-axis split lines when setting["graph.y_axis.axis_enabled"] is set to false

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -341,14 +341,15 @@ export const buildMetricAxis = (
       axisModel.label,
       shouldFlipAxisName ? -90 : undefined,
     ),
-    splitLine: hasSplitLine
-      ? {
-          lineStyle: {
-            type: 5,
-            color: renderingContext.getColor("border"),
-          },
-        }
-      : undefined,
+    splitLine:
+      hasSplitLine && !!settings["graph.y_axis.axis_enabled"]
+        ? {
+            lineStyle: {
+              type: 5,
+              color: renderingContext.getColor("border"),
+            },
+          }
+        : undefined,
     position,
     axisLine: {
       show: false,


### PR DESCRIPTION
- Closes: https://github.com/metabase/metabase/issues/39574

**Before**

![image](https://github.com/metabase/metabase/assets/22608765/5187b4f9-6711-491b-bcd7-726b3ec63412)


**After**

![image](https://github.com/metabase/metabase/assets/22608765/f224db49-9d41-49a8-b60a-9b8f8a0f681c)
