### PR TITLE
fix unaggregated dimension tooltip

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -107,10 +107,12 @@ const aggregateColumnValuesForDatum = (
         ? getDatasetKey(column, cardId)
         : getDatasetKey(column, cardId, row[breakoutIndex]);
 
-    datum[seriesKey] =
-      isMetric(column) && !isDimensionColumn // The dimension values should not be aggregated, only metrics
-        ? sumMetric(datum[seriesKey], rowValue)
-        : rowValue;
+    // The dimension values should not be aggregated, only metrics
+    if (isMetric(column) && !isDimensionColumn) {
+      datum[seriesKey] = sumMetric(datum[seriesKey], rowValue);
+    } else if (!(seriesKey in datum)) {
+      datum[seriesKey] = rowValue;
+    }
   });
 };
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39592

### Description

When the dimension column is unaggregated, the old dc.js implementation would show the first datum with that dimension value in the tooltip, however our new echarts implementation would show the last.

This PR fixes the new implementation so it uses the first datum.

### Demo

![Screenshot 2024-03-18 at 3.55.18 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/fd665abb-1aa7-4696-b2f1-6353da834102.png)


![Screenshot 2024-03-18 at 4.01.51 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/0dc113c3-aca6-48b8-b989-df25e61601fb.png)

Before

![Screenshot 2024-03-18 at 3.53.36 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/17cf63b5-aa5e-4f46-8a8f-1a8d9bdf1a77.png)

After