### PR TITLE
Upgrade @testing-library/user-event to v14

### DIFF
--- a/docs/developers-guide/frontend.md
+++ b/docs/developers-guide/frontend.md
@@ -476,9 +476,9 @@ describe("CollectionHeader", () => {
       collection,
     });
 
-    userEvent.clear(screen.getByDisplayValue("Old name"));
-    userEvent.type(screen.getByPlaceholderText("Add title"), "New title");
-    userEvent.tab();
+    await userEvent.clear(screen.getByDisplayValue("Old name"));
+    await userEvent.type(screen.getByPlaceholderText("Add title"), "New title");
+    await userEvent.tab();
 
     expect(onUpdateCollection).toHaveBeenCalledWith({
       ...collection,

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.unit.spec.tsx
@@ -134,7 +134,7 @@ describe("impersonation modal", () => {
   it("should not update impersonation if it has not changed", async () => {
     const store = await setup({ userAttributes: ["foo"] });
 
-    userEvent.click(screen.getByText(/save/i));
+    await userEvent.click(screen.getByText(/save/i));
 
     expect(
       getImpersonations(store.getState() as AdvancedPermissionsStoreState),
@@ -144,11 +144,11 @@ describe("impersonation modal", () => {
   it("should create impersonation", async () => {
     const store = await setup({ hasImpersonation: false });
 
-    userEvent.click(await screen.findByText(/pick a user attribute/i));
-    userEvent.click(await screen.findByText("foo"));
+    await userEvent.click(await screen.findByText(/pick a user attribute/i));
+    await userEvent.click(await screen.findByText("foo"));
 
     expect(await screen.findByRole("button", { name: /save/i })).toBeEnabled();
-    userEvent.click(await screen.findByRole("button", { name: /save/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /save/i }));
 
     await waitFor(() => {
       expect(
@@ -166,11 +166,11 @@ describe("impersonation modal", () => {
   it("should update impersonation", async () => {
     const store = await setup();
 
-    userEvent.click(await screen.findByText(selectedAttribute));
-    userEvent.click(await screen.findByText("bar"));
+    await userEvent.click(await screen.findByText(selectedAttribute));
+    await userEvent.click(await screen.findByText("bar"));
 
     expect(await screen.findByRole("button", { name: /save/i })).toBeEnabled();
-    userEvent.click(await screen.findByRole("button", { name: /save/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /save/i }));
 
     await waitFor(() => {
       expect(

--- a/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/auth/components/SettingsJWTForm/SettingsJWTForm.unit.spec.tsx
@@ -153,33 +153,33 @@ describe("SettingsJWTForm", () => {
       "jwt-group-sync": true,
     };
 
-    userEvent.click(screen.getByLabelText(/User Provisioning/));
-    userEvent.type(
+    await userEvent.click(screen.getByLabelText(/User Provisioning/));
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /JWT Identity Provider URI/ }),
       ATTRS["jwt-identity-provider-uri"],
     );
-    userEvent.type(
+    await userEvent.type(
       await screen.findByRole("textbox", {
         name: /String used by the JWT signing key/,
       }),
       ATTRS["jwt-shared-secret"],
     );
-    userEvent.type(
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /Email attribute/ }),
       ATTRS["jwt-attribute-email"],
     );
-    userEvent.type(
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /First name attribute/ }),
       ATTRS["jwt-attribute-firstname"],
     );
-    userEvent.type(
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /Last name attribute/ }),
       ATTRS["jwt-attribute-lastname"],
     );
     const groupSchema = await screen.findByTestId("jwt-group-schema");
-    userEvent.click(within(groupSchema).getByRole("checkbox")); // checkbox for "jwt-group-sync"
+    await userEvent.click(within(groupSchema).getByRole("checkbox")); // checkbox for "jwt-group-sync"
 
-    userEvent.click(await screen.findByRole("button", { name: /Save/ }));
+    await userEvent.click(await screen.findByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(ATTRS);

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTTLField/CacheTTLField.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/CacheTTLField/CacheTTLField.unit.spec.js
@@ -43,20 +43,20 @@ describe("CacheTTLField", () => {
     expect(screen.getByText("Cache results for")).toBeInTheDocument();
   });
 
-  it("calls onChange correctly", () => {
+  it("calls onChange correctly", async () => {
     const { field, onChange } = setup({ value: 4 });
 
-    userEvent.clear(field);
-    userEvent.type(field, "14");
+    await userEvent.clear(field);
+    await userEvent.type(field, "14");
     field.blur();
 
     expect(onChange).toHaveBeenLastCalledWith(14);
   });
 
-  it("calls onChange with null value if input is cleared", () => {
+  it("calls onChange with null value if input is cleared", async () => {
     const { field, onChange } = setup({ value: 4 });
 
-    userEvent.clear(field);
+    await userEvent.clear(field);
     field.blur();
 
     expect(onChange).toHaveBeenLastCalledWith(null);

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTTLField/DatabaseCacheTTLField.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/DatabaseCacheTTLField/DatabaseCacheTTLField.unit.spec.js
@@ -11,14 +11,14 @@ function setup({ value = null } = {}) {
   return { onChange };
 }
 
-function selectMode(nextMode) {
+async function selectMode(nextMode) {
   const currentModeLabel =
     nextMode === "custom" ? "Use instance default (TTL)" : "Custom";
   const nextModeLabel =
     nextMode === "instance-default" ? "Use instance default (TTL)" : "Custom";
 
-  userEvent.click(screen.getByText(currentModeLabel));
-  userEvent.click(screen.getByText(nextModeLabel));
+  await userEvent.click(screen.getByText(currentModeLabel));
+  await userEvent.click(screen.getByText(nextModeLabel));
 }
 
 describe("DatabaseCacheTTLField", () => {
@@ -36,16 +36,16 @@ describe("DatabaseCacheTTLField", () => {
 
   it("sets 24 hours as a default TTL custom value", async () => {
     const { onChange } = setup();
-    selectMode("custom");
+    await selectMode("custom");
     await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(24));
   });
 
-  it("can select and fill custom cache TTL value", () => {
+  it("can select and fill custom cache TTL value", async () => {
     const { onChange } = setup();
 
-    selectMode("custom");
+    await selectMode("custom");
     const input = screen.getByPlaceholderText("24");
-    userEvent.type(input, "{selectall}{backspace}14");
+    await userEvent.type(input, "{selectall}{backspace}14");
     input.blur();
 
     expect(onChange).toHaveBeenLastCalledWith(14);
@@ -62,7 +62,7 @@ describe("DatabaseCacheTTLField", () => {
 
   it("can reset cache_ttl to instance default", async () => {
     const { onChange } = setup({ value: 48 });
-    selectMode("instance-default");
+    await selectMode("instance-default");
     await waitFor(() => expect(onChange).toHaveBeenLastCalledWith(null));
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheTTLField/QuestionCacheTTLField.unit.spec.js
+++ b/enterprise/frontend/src/metabase-enterprise/caching/components/QuestionCacheTTLField/QuestionCacheTTLField.unit.spec.js
@@ -47,18 +47,18 @@ function setup({
 
 const DEFAULT_MODE_REGEXP = /Use default \([.0-9]+ hours\)/;
 
-function selectMode(nextMode) {
+async function selectMode(nextMode) {
   const currentModeLabel =
     nextMode === "custom" ? DEFAULT_MODE_REGEXP : "Custom";
   const nextModeLabel = nextMode === "default" ? DEFAULT_MODE_REGEXP : "Custom";
 
-  userEvent.click(screen.getByText(currentModeLabel));
-  userEvent.click(screen.getByText(nextModeLabel));
+  await userEvent.click(screen.getByText(currentModeLabel));
+  await userEvent.click(screen.getByText(nextModeLabel));
 }
 
-function fillValue(input, value) {
-  userEvent.clear(input);
-  userEvent.type(input, String(value));
+async function fillValue(input, value) {
+  await userEvent.clear(input);
+  await userEvent.type(input, String(value));
   input.blur();
 }
 
@@ -100,9 +100,9 @@ describe("QuestionCacheTTLField", () => {
     expect(screen.getByLabelText(expectedLabel)).toBeInTheDocument();
   });
 
-  it("calls onChange correctly when filling the input", () => {
+  it("calls onChange correctly when filling the input", async () => {
     const { onChange } = setup();
-    fillValue(screen.getByLabelText("Label"), 48);
+    await fillValue(screen.getByLabelText("Label"), 48);
     expect(onChange).toHaveBeenLastCalledWith(48);
   });
 
@@ -113,25 +113,25 @@ describe("QuestionCacheTTLField", () => {
     expect(screen.queryByLabelText("Custom")).not.toBeChecked();
   });
 
-  it("allows to overwrite default caching with custom value", () => {
+  it("allows to overwrite default caching with custom value", async () => {
     const { onChange } = setup({ databaseCacheTTL: 32 });
 
-    selectMode("custom");
-    fillValue(screen.getByLabelText("Label"), 24);
+    await selectMode("custom");
+    await fillValue(screen.getByLabelText("Label"), 24);
 
     expect(onChange).toHaveBeenLastCalledWith(24);
   });
 
-  it("offers to switch to default caching instead of a custom TTL", () => {
+  it("offers to switch to default caching instead of a custom TTL", async () => {
     setup({ value: 24, databaseCacheTTL: 32 });
 
     expect(screen.queryByLabelText("Use default (32 hours)")).not.toBeChecked();
     expect(screen.queryByLabelText("Custom")).toBeChecked();
   });
 
-  it("allows to switch to default caching instead of a custom TTL", () => {
+  it("allows to switch to default caching instead of a custom TTL", async () => {
     const { onChange } = setup({ value: 24, databaseCacheTTL: 32 });
-    selectMode("default");
+    await selectMode("default");
     expect(onChange).toHaveBeenLastCalledWith(null);
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionAuthorityLevelIcon.unit.spec.tsx
@@ -49,31 +49,31 @@ describe("CollectionAuthorityLevelIcon", () => {
       expect(queryOfficialIcon()).toBeInTheDocument();
     });
 
-    it(`displays a tooltip by default`, () => {
+    it(`displays a tooltip by default`, async () => {
       renderOfficialCollection();
-      userEvent.hover(queryOfficialIcon());
+      await userEvent.hover(queryOfficialIcon());
       expect(screen.getByRole("tooltip")).toHaveTextContent(
         "Official collection",
       );
     });
 
-    it(`can display different tooltip`, () => {
+    it(`can display different tooltip`, async () => {
       renderOfficialCollection({ tooltip: "belonging" });
-      userEvent.hover(queryOfficialIcon());
+      await userEvent.hover(queryOfficialIcon());
       expect(screen.getByRole("tooltip")).toHaveTextContent(
         "Belongs to an Official collection",
       );
     });
 
-    it(`can display custom tooltip text`, () => {
+    it(`can display custom tooltip text`, async () => {
       renderOfficialCollection({ tooltip: "Hello" });
-      userEvent.hover(queryOfficialIcon());
+      await userEvent.hover(queryOfficialIcon());
       expect(screen.getByRole("tooltip")).toHaveTextContent("Hello");
     });
 
-    it(`can hide tooltip`, () => {
+    it(`can hide tooltip`, async () => {
       renderOfficialCollection({ tooltip: null });
-      userEvent.hover(queryOfficialIcon());
+      await userEvent.hover(queryOfficialIcon());
       expect(screen.queryByLabelText("tooltip")).not.toBeInTheDocument();
     });
   });

--- a/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionInstanceAnalyticsIcon.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/collections/components/CollectionInstanceAnalyticsIcon.unit.spec.tsx
@@ -52,12 +52,12 @@ describe("CollectionInstanceAnalyticsIcon", () => {
     }
 
     ["collection", "dashboard", "model", "question"].forEach(entity => {
-      it(`displays the correct tooltip for ${entity}`, () => {
+      it(`displays the correct tooltip for ${entity}`, async () => {
         renderInstanceAnalyticsCollection({
           entity: entity,
         });
         expect(queryOfficialIcon()).toBeInTheDocument();
-        userEvent.hover(queryOfficialIcon());
+        await userEvent.hover(queryOfficialIcon());
         expect(screen.getByRole("tooltip")).toHaveTextContent(
           `This is a read-only Metabase Analytics ${entity}`,
         );

--- a/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/license/components/LicenseAndBillingSettings/LicenseAndBillingSettings.unit.spec.tsx
@@ -313,8 +313,8 @@ describe("LicenseAndBilling", () => {
       ),
     ).toBeInTheDocument();
 
-    userEvent.type(screen.getByTestId("license-input"), "invalid");
-    userEvent.click(screen.getByTestId("activate-button"));
+    await userEvent.type(screen.getByTestId("license-input"), "invalid");
+    await userEvent.click(screen.getByTestId("activate-button"));
 
     expect(
       await screen.findByText(
@@ -334,7 +334,7 @@ describe("LicenseAndBilling", () => {
       ),
     ).toBeInTheDocument();
 
-    userEvent.type(screen.getByTestId("license-input"), "valid");
-    userEvent.click(screen.getByTestId("activate-button"));
+    await userEvent.type(screen.getByTestId("license-input"), "valid");
+    await userEvent.click(screen.getByTestId("activate-button"));
   });
 });

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.unit.spec.tsx
@@ -27,7 +27,7 @@ describe("ModerationReviewIcon", () => {
     expect(screen.getByLabelText("verified icon")).toBeInTheDocument();
   });
 
-  it("should show a tooltip on hover when moderator is loaded", () => {
+  it("should show a tooltip on hover when moderator is loaded", async () => {
     const props = getProps({
       review: createMockModerationReview({
         moderator_id: 1,
@@ -38,7 +38,7 @@ describe("ModerationReviewIcon", () => {
     });
 
     render(<ModerationReviewIcon {...props} />);
-    userEvent.hover(screen.getByLabelText("verified icon"));
+    await userEvent.hover(screen.getByLabelText("verified icon"));
 
     expect(screen.getByText("You verified this")).toBeInTheDocument();
     expect(screen.getByText("a year ago")).toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/moderation/components/ModerationReviewIcon/ModerationReviewIcon.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 
 import {
   createMockModerationReview,
@@ -8,6 +8,10 @@ import {
 
 import type { ModerationReviewIconProps } from "./ModerationReviewIcon";
 import ModerationReviewIcon from "./ModerationReviewIcon";
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 describe("ModerationReviewIcon", () => {
   beforeEach(() => {

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/components/EditSandboxingModal/EditSandboxingModal.unit.spec.tsx
@@ -97,13 +97,13 @@ describe("EditSandboxingModal", () => {
 
         expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
 
-        userEvent.click(screen.getByText("Pick a column"));
-        userEvent.click(await screen.findByText("ID"));
+        await userEvent.click(screen.getByText("Pick a column"));
+        await userEvent.click(await screen.findByText("ID"));
 
-        userEvent.click(screen.getByText("Pick a user attribute"));
-        userEvent.click(await screen.findByText("foo"));
+        await userEvent.click(screen.getByText("Pick a user attribute"));
+        await userEvent.click(await screen.findByText("foo"));
 
-        userEvent.click(screen.getByText("Save"));
+        await userEvent.click(screen.getByText("Save"));
 
         await waitFor(() =>
           expect(onSave).toHaveBeenCalledWith({
@@ -129,15 +129,15 @@ describe("EditSandboxingModal", () => {
 
         expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByText(
             "Use a saved question to create a custom view for this table",
           ),
         );
 
-        userEvent.click(await screen.findByText("sandbox question"));
+        await userEvent.click(await screen.findByText("sandbox question"));
 
-        userEvent.click(screen.getByText("Save"));
+        await userEvent.click(screen.getByText("Save"));
 
         await waitFor(() => {
           expect(screen.queryByText("Saving...")).not.toBeInTheDocument();
@@ -175,15 +175,15 @@ describe("EditSandboxingModal", () => {
 
       expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByText(
           "Use a saved question to create a custom view for this table",
         ),
       );
 
-      userEvent.click(await screen.findByText("sandbox question"));
+      await userEvent.click(await screen.findByText("sandbox question"));
 
-      userEvent.click(screen.getByText("Save"));
+      await userEvent.click(screen.getByText("Save"));
 
       await waitFor(() => {
         expect(screen.queryByText("Saving...")).not.toBeInTheDocument();

--- a/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/snippets/components/SnippetCollectionFormModal.unit.spec.tsx
@@ -119,7 +119,7 @@ describe("SnippetCollectionFormModal", () => {
     it("can submit when name is filled in", async () => {
       await setup();
 
-      userEvent.type(screen.getByLabelText(LABEL.NAME), "My folder");
+      await userEvent.type(screen.getByLabelText(LABEL.NAME), "My folder");
 
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "Create" })).toBeEnabled();
@@ -135,7 +135,7 @@ describe("SnippetCollectionFormModal", () => {
 
     it("calls onClose when cancel button is clicked", async () => {
       const { onClose } = await setup();
-      userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
       await waitFor(() => {
         expect(onClose).toHaveBeenCalledTimes(1);
       });
@@ -179,7 +179,7 @@ describe("SnippetCollectionFormModal", () => {
 
     it("can't submit if name is empty", async () => {
       await setupEditing();
-      userEvent.clear(screen.getByLabelText(LABEL.NAME));
+      await userEvent.clear(screen.getByLabelText(LABEL.NAME));
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "Update" })).toBeDisabled();
       });
@@ -187,7 +187,7 @@ describe("SnippetCollectionFormModal", () => {
 
     it("can submit when have changes", async () => {
       await setupEditing();
-      userEvent.type(screen.getByLabelText(LABEL.NAME), "My folder");
+      await userEvent.type(screen.getByLabelText(LABEL.NAME), "My folder");
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "Update" })).toBeEnabled();
       });
@@ -202,7 +202,7 @@ describe("SnippetCollectionFormModal", () => {
 
     it("calls onClose when cancel button is clicked", async () => {
       const { onClose } = await setupEditing();
-      userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
       await waitFor(() => {
         expect(onClose).toHaveBeenCalledTimes(1);
       });

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorSettings/ColorSettings.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ColorSettings/ColorSettings.unit.spec.tsx
@@ -11,7 +11,7 @@ describe("ColorSettings", () => {
     accent1: color("text-medium"),
   };
 
-  it("should update brand colors", () => {
+  it("should update brand colors", async () => {
     const onChange = jest.fn();
 
     render(
@@ -23,8 +23,8 @@ describe("ColorSettings", () => {
     );
 
     const input = screen.getByPlaceholderText(color("summarize"));
-    userEvent.clear(input);
-    userEvent.type(input, color("error"));
+    await userEvent.clear(input);
+    await userEvent.type(input, color("error"));
 
     expect(onChange).toHaveBeenLastCalledWith({
       brand: color("success"),
@@ -33,7 +33,7 @@ describe("ColorSettings", () => {
     });
   });
 
-  it("should update chart colors", () => {
+  it("should update chart colors", async () => {
     const onChange = jest.fn();
 
     render(
@@ -45,8 +45,8 @@ describe("ColorSettings", () => {
     );
 
     const input = screen.getByDisplayValue(color("text-medium"));
-    userEvent.clear(input);
-    userEvent.type(input, color("text-light"));
+    await userEvent.clear(input);
+    await userEvent.type(input, color("text-light"));
 
     expect(onChange).toHaveBeenLastCalledWith({
       brand: color("success"),
@@ -54,7 +54,7 @@ describe("ColorSettings", () => {
     });
   });
 
-  it("should reset chart colors", () => {
+  it("should reset chart colors", async () => {
     const onChange = jest.fn();
 
     render(
@@ -65,15 +65,15 @@ describe("ColorSettings", () => {
       />,
     );
 
-    userEvent.click(screen.getByText("Reset to default colors"));
-    userEvent.click(screen.getByText("Reset"));
+    await userEvent.click(screen.getByText("Reset to default colors"));
+    await userEvent.click(screen.getByText("Reset"));
 
     expect(onChange).toHaveBeenLastCalledWith({
       brand: color("success"),
     });
   });
 
-  it("should generate chart colors", () => {
+  it("should generate chart colors", async () => {
     const onChange = jest.fn();
 
     render(
@@ -84,7 +84,7 @@ describe("ColorSettings", () => {
       />,
     );
 
-    userEvent.click(screen.getByText("Generate chart colors"));
+    await userEvent.click(screen.getByText("Generate chart colors"));
 
     expect(onChange).toHaveBeenLastCalledWith({
       brand: color("success"),

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontFilesWidget/FontFilesWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontFilesWidget/FontFilesWidget.unit.spec.tsx
@@ -6,7 +6,7 @@ import { createMockFontFile } from "metabase-types/api/mocks";
 import FontFilesWidget from "./FontFilesWidget";
 
 describe("FontFilesWidget", () => {
-  it("should add a font file with a query string in the URL", () => {
+  it("should add a font file with a query string in the URL", async () => {
     const file = createMockFontFile({
       src: "https://metabase.test/regular.ttf?raw=true",
       fontWeight: 400,
@@ -18,13 +18,13 @@ describe("FontFilesWidget", () => {
     render(<FontFilesWidget setting={setting} onChange={onChange} />);
 
     const input = screen.getByLabelText("Regular");
-    userEvent.type(input, file.src);
-    userEvent.tab();
+    await userEvent.type(input, file.src);
+    await userEvent.tab();
 
     expect(onChange).toHaveBeenCalledWith([file]);
   });
 
-  it("should add a font file with an invalid URL", () => {
+  it("should add a font file with an invalid URL", async () => {
     const file = createMockFontFile({
       src: "invalid",
       fontWeight: 400,
@@ -36,13 +36,13 @@ describe("FontFilesWidget", () => {
     render(<FontFilesWidget setting={setting} onChange={onChange} />);
 
     const input = screen.getByLabelText("Regular");
-    userEvent.type(input, file.src);
-    userEvent.tab();
+    await userEvent.type(input, file.src);
+    await userEvent.tab();
 
     expect(onChange).toHaveBeenCalledWith([file]);
   });
 
-  it("should remove a font file", () => {
+  it("should remove a font file", async () => {
     const files = [
       createMockFontFile({
         src: "https://metabase.test/regular.ttf?raw=true",
@@ -61,8 +61,8 @@ describe("FontFilesWidget", () => {
     render(<FontFilesWidget setting={setting} onChange={onChange} />);
 
     const input = screen.getByLabelText("Regular");
-    userEvent.clear(input);
-    userEvent.tab();
+    await userEvent.clear(input);
+    await userEvent.tab();
 
     expect(onChange).toHaveBeenCalledWith([files[1]]);
   });

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/FontWidget/FontWidget.unit.spec.tsx
@@ -8,18 +8,18 @@ import type { FontSetting, FontSettingValues } from "./types";
 const FONT_FILES_KEY = "application-font-files";
 
 describe("FontWidget", () => {
-  it("should set a built-in font from a built-in font", () => {
+  it("should set a built-in font from a built-in font", async () => {
     const props = getProps();
 
     render(<FontWidget {...props} />);
-    clickSelect("Lato");
-    userEvent.click(screen.getByText("Lora"));
+    await clickSelect("Lato");
+    await userEvent.click(screen.getByText("Lora"));
 
     expect(props.onChange).toHaveBeenCalledWith("Lora");
     expect(props.onChangeSetting).toHaveBeenCalledWith(FONT_FILES_KEY, null);
   });
 
-  it("should set a custom font from a built-in font", () => {
+  it("should set a custom font from a built-in font", async () => {
     const props = getProps({
       setting: getSetting({
         value: "Lora",
@@ -27,14 +27,14 @@ describe("FontWidget", () => {
     });
 
     render(<FontWidget {...props} />);
-    clickSelect("Lora");
-    userEvent.click(screen.getByText("Custom…"));
+    await clickSelect("Lora");
+    await userEvent.click(screen.getByText("Custom…"));
 
     expect(props.onChange).toHaveBeenCalledWith("Lato");
     expect(props.onChangeSetting).toHaveBeenCalledWith(FONT_FILES_KEY, []);
   });
 
-  it("should set a built-in font from a custom font", () => {
+  it("should set a built-in font from a custom font", async () => {
     const props = getProps({
       settingValues: getSettingValues({
         "application-font-files": [],
@@ -42,8 +42,8 @@ describe("FontWidget", () => {
     });
 
     render(<FontWidget {...props} />);
-    clickSelect("Custom…");
-    userEvent.click(screen.getByText("Lora"));
+    await clickSelect("Custom…");
+    await userEvent.click(screen.getByText("Lora"));
 
     expect(props.onChange).toHaveBeenCalledWith("Lora");
     expect(props.onChangeSetting).toHaveBeenCalledWith(FONT_FILES_KEY, null);
@@ -73,8 +73,8 @@ const getSettingValues = (
   ...opts,
 });
 
-function clickSelect(text: string) {
+async function clickSelect(text: string) {
   const input = screen.getByRole("searchbox");
   expect(input).toHaveValue(text);
-  userEvent.click(input);
+  await userEvent.click(input);
 }

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LighthouseToggleWidget/LighthouseToggleWidget.unit.spec.tsx
@@ -7,22 +7,22 @@ import type { LighthouseSetting } from "./types";
 const TOGGLE_LABEL = "Show this on the home and login pages";
 
 describe("LighthouseToggleWidget", () => {
-  it("should disable the illustration", () => {
+  it("should disable the illustration", async () => {
     const setting = getSetting();
     const onChange = jest.fn();
 
     render(<LighthouseToggleWidget setting={setting} onChange={onChange} />);
-    userEvent.click(screen.getByText(TOGGLE_LABEL));
+    await userEvent.click(screen.getByText(TOGGLE_LABEL));
 
     expect(onChange).toHaveBeenCalledWith(false);
   });
 
-  it("should enable the illustration", () => {
+  it("should enable the illustration", async () => {
     const setting = getSetting({ value: false });
     const onChange = jest.fn();
 
     render(<LighthouseToggleWidget setting={setting} onChange={onChange} />);
-    userEvent.click(screen.getByText(TOGGLE_LABEL));
+    await userEvent.click(screen.getByText(TOGGLE_LABEL));
 
     expect(onChange).toHaveBeenCalledWith(true);
   });

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.unit.spec.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/MetabotToggleWidget/MetabotToggleWidget.unit.spec.tsx
@@ -19,18 +19,18 @@ const setup = ({ value = null }: SetupOpts = {}) => {
 };
 
 describe("MetabotToggleWidget", () => {
-  it("should disable Metabot", () => {
+  it("should disable Metabot", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByText(TOGGLE_LABEL));
+    await userEvent.click(screen.getByText(TOGGLE_LABEL));
 
     expect(onChange).toHaveBeenCalledWith(false);
   });
 
-  it("should enable Metabot", () => {
+  it("should enable Metabot", async () => {
     const { onChange } = setup({ value: false });
 
-    userEvent.click(screen.getByText(TOGGLE_LABEL));
+    await userEvent.click(screen.getByText(TOGGLE_LABEL));
 
     expect(onChange).toHaveBeenCalledWith(true);
   });

--- a/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.unit.spec.tsx
+++ b/frontend/src/metabase/account/profile/components/UserProfileForm/UserProfileForm.unit.spec.tsx
@@ -13,9 +13,9 @@ describe("UserProfileForm", () => {
     });
 
     render(<UserProfileForm {...props} />);
-    userEvent.clear(screen.getByLabelText("First name"));
-    userEvent.type(screen.getByLabelText("First name"), "New name");
-    userEvent.click(screen.getByText("Update"));
+    await userEvent.clear(screen.getByLabelText("First name"));
+    await userEvent.type(screen.getByLabelText("First name"), "New name");
+    await userEvent.click(screen.getByText("Update"));
 
     expect(await screen.findByText("Success")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionForm/ActionForm.unit.spec.tsx
@@ -249,9 +249,9 @@ describe("Actions > ActionForm", () => {
         },
       });
 
-      userEvent.type(screen.getByLabelText(/text input/i), "Murloc");
-      userEvent.type(screen.getByLabelText(/number input/i), "12345");
-      userEvent.click(screen.getByRole("button", { name: action.name }));
+      await userEvent.type(screen.getByLabelText(/text input/i), "Murloc");
+      await userEvent.type(screen.getByLabelText(/number input/i), "12345");
+      await userEvent.click(screen.getByRole("button", { name: action.name }));
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -290,9 +290,9 @@ describe("Actions > ActionForm", () => {
         },
       });
 
-      userEvent.type(screen.getByLabelText(/text input/i), "Murloc");
-      userEvent.type(screen.getByLabelText(/number input/i), "12345");
-      userEvent.click(screen.getByRole("button", { name: action.name }));
+      await userEvent.type(screen.getByLabelText(/text input/i), "Murloc");
+      await userEvent.type(screen.getByLabelText(/number input/i), "12345");
+      await userEvent.click(screen.getByRole("button", { name: action.name }));
 
       expect(await screen.findByText(message)).toBeInTheDocument();
       expect(
@@ -327,9 +327,9 @@ describe("Actions > ActionForm", () => {
         },
       });
 
-      userEvent.type(await screen.findByLabelText(/foo input/i), "baz");
-      userEvent.type(await screen.findByLabelText(/bar input/i), "baz");
-      userEvent.click(screen.getByRole("button", { name: action.name }));
+      await userEvent.type(await screen.findByLabelText(/foo input/i), "baz");
+      await userEvent.type(await screen.findByLabelText(/bar input/i), "baz");
+      await userEvent.click(screen.getByRole("button", { name: action.name }));
 
       await waitFor(() => expect(onSubmit).toHaveBeenCalled());
       expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
@@ -360,15 +360,15 @@ describe("Actions > ActionForm", () => {
         },
       });
 
-      userEvent.click(await screen.findByLabelText(/foo input/i)); // leave empty
-      userEvent.type(await screen.findByLabelText(/bar input/i), "baz");
+      await userEvent.click(await screen.findByLabelText(/foo input/i)); // leave empty
+      await userEvent.type(await screen.findByLabelText(/bar input/i), "baz");
       await waitFor(() =>
         expect(
           screen.getByRole("button", { name: action.name }),
         ).toBeDisabled(),
       );
 
-      userEvent.click(screen.getByRole("button", { name: action.name }));
+      await userEvent.click(screen.getByRole("button", { name: action.name }));
 
       expect(await screen.findByText(/required/i)).toBeInTheDocument();
       expect(onSubmit).not.toHaveBeenCalled();
@@ -401,12 +401,12 @@ describe("Actions > ActionForm", () => {
 
       expect(screen.getByRole("button", { name: action.name })).toBeDisabled();
 
-      userEvent.type(screen.getByLabelText(/foo input/i), "baz");
+      await userEvent.type(screen.getByLabelText(/foo input/i), "baz");
       await waitFor(() => {
         expect(screen.getByRole("button", { name: action.name })).toBeEnabled();
       });
 
-      userEvent.click(screen.getByRole("button", { name: action.name }));
+      await userEvent.click(screen.getByRole("button", { name: action.name }));
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalled();
       });
@@ -439,7 +439,7 @@ describe("Actions > ActionForm", () => {
 
       expect(screen.getByRole("button", { name: action.name })).toBeEnabled();
 
-      userEvent.click(screen.getByRole("button", { name: action.name }));
+      await userEvent.click(screen.getByRole("button", { name: action.name }));
 
       await waitFor(() => expect(onSubmit).toHaveBeenCalled());
     });
@@ -456,7 +456,7 @@ describe("Actions > ActionForm", () => {
       });
 
       const input = await screen.findByLabelText(/form field name/i);
-      userEvent.type(input, "baz");
+      await userEvent.type(input, "baz");
 
       await waitFor(() => expect(input).not.toHaveValue());
     });
@@ -486,9 +486,9 @@ describe("Actions > ActionForm", () => {
         },
       });
 
-      userEvent.type(await screen.findByLabelText(/foo input/i), "baz");
-      userEvent.type(await screen.findByLabelText(/bar input/i), "baz");
-      userEvent.click(screen.getByRole("button", { name: action.name }));
+      await userEvent.type(await screen.findByLabelText(/foo input/i), "baz");
+      await userEvent.type(await screen.findByLabelText(/bar input/i), "baz");
+      await userEvent.click(screen.getByRole("button", { name: action.name }));
 
       await waitFor(() => expect(onSubmit).toHaveBeenCalled());
       expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
@@ -521,7 +521,7 @@ describe("Actions > ActionForm", () => {
         },
       });
 
-      userEvent.click(screen.getByRole("button", { name: action.name }));
+      await userEvent.click(screen.getByRole("button", { name: action.name }));
 
       await waitFor(() => expect(onSubmit).toHaveBeenCalled());
       expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
@@ -559,10 +559,10 @@ describe("Actions > ActionForm", () => {
         },
       });
 
-      userEvent.type(await screen.findByLabelText(/foo input/i), "1");
-      userEvent.type(await screen.findByLabelText(/bar input/i), "1");
-      userEvent.type(await screen.findByLabelText(/baz input/i), "1");
-      userEvent.click(screen.getByRole("button", { name: action.name }));
+      await userEvent.type(await screen.findByLabelText(/foo input/i), "1");
+      await userEvent.type(await screen.findByLabelText(/bar input/i), "1");
+      await userEvent.type(await screen.findByLabelText(/baz input/i), "1");
+      await userEvent.click(screen.getByRole("button", { name: action.name }));
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -602,7 +602,9 @@ describe("Actions > ActionForm", () => {
         fireEvent.change(screen.getByLabelText(/input/i), {
           target: { value: "" },
         });
-        userEvent.click(screen.getByRole("button", { name: action.name }));
+        await userEvent.click(
+          screen.getByRole("button", { name: action.name }),
+        );
 
         await waitFor(() => {
           expect(onSubmit).toHaveBeenCalledWith(
@@ -634,8 +636,8 @@ describe("Actions > ActionForm", () => {
         },
       });
 
-      userEvent.clear(screen.getByLabelText(/input/i));
-      userEvent.click(screen.getByRole("button", { name: action.name }));
+      await userEvent.clear(screen.getByLabelText(/input/i));
+      await userEvent.click(screen.getByRole("button", { name: action.name }));
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(

--- a/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/Action.unit.spec.tsx
@@ -210,7 +210,7 @@ describe("Actions > ActionViz > Action", () => {
     it("clicking an action button with parameters should open a modal action form", async () => {
       await setup();
 
-      userEvent.click(screen.getByRole("button"));
+      await userEvent.click(screen.getByRole("button"));
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByTestId("action-form")).toBeInTheDocument();
       expect(screen.getByLabelText("Parameter 1")).toBeInTheDocument();
@@ -227,7 +227,7 @@ describe("Actions > ActionViz > Action", () => {
         }),
       });
 
-      userEvent.click(screen.getByRole("button"));
+      await userEvent.click(screen.getByRole("button"));
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByTestId("action-form")).toBeInTheDocument();
       expect(screen.queryByLabelText(/^Parameter/)).not.toBeInTheDocument();
@@ -236,16 +236,16 @@ describe("Actions > ActionViz > Action", () => {
     it("the modal should have the action name as a title", async () => {
       await setup();
 
-      userEvent.click(screen.getByRole("button"));
+      await userEvent.click(screen.getByRole("button"));
       expect(screen.getByRole("dialog")).toHaveTextContent("My Awesome Action");
     });
 
     it("clicking the cancel button on the form should close the modal", async () => {
       await setup();
 
-      userEvent.click(screen.getByRole("button"));
+      await userEvent.click(screen.getByRole("button"));
       expect(screen.getByRole("dialog")).toHaveTextContent("My Awesome Action");
-      userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
@@ -289,10 +289,10 @@ describe("Actions > ActionViz > Action", () => {
         parameterValues: { "dash-param-1": "44" },
       });
 
-      userEvent.click(screen.getByRole("button", { name: "Click me" }));
+      await userEvent.click(screen.getByRole("button", { name: "Click me" }));
       expect(screen.getByRole("dialog")).toBeInTheDocument();
       expect(screen.getByTestId("action-form")).toBeInTheDocument();
-      userEvent.click(
+      await userEvent.click(
         within(screen.getByRole("dialog")).getByRole("button", {
           name: action.name,
         }),
@@ -321,7 +321,7 @@ describe("Actions > ActionViz > Action", () => {
         }),
       });
 
-      userEvent.click(screen.getByText("Click me"));
+      await userEvent.click(screen.getByText("Click me"));
 
       expect(queryIcon("pencil")).not.toBeInTheDocument();
     });
@@ -334,7 +334,7 @@ describe("Actions > ActionViz > Action", () => {
 
       await setup({ database: readOnlyDB });
 
-      userEvent.click(screen.getByText("Click me"));
+      await userEvent.click(screen.getByText("Click me"));
 
       expect(queryIcon("pencil")).not.toBeInTheDocument();
     });
@@ -342,12 +342,12 @@ describe("Actions > ActionViz > Action", () => {
     it("should allow to edit underlying action if a user has edit permissions", async () => {
       await setup();
 
-      userEvent.click(screen.getByText("Click me"));
+      await userEvent.click(screen.getByText("Click me"));
 
       const editActionEl = getIcon("pencil");
       expect(editActionEl).toBeInTheDocument();
 
-      userEvent.click(editActionEl);
+      await userEvent.click(editActionEl);
 
       const editorModal = await screen.findByTestId("action-editor-modal");
 
@@ -358,7 +358,7 @@ describe("Actions > ActionViz > Action", () => {
 
       expect(within(editorModal).getByText("Update")).toBeInTheDocument();
 
-      userEvent.click(cancelEditButton);
+      await userEvent.click(cancelEditButton);
 
       expect(
         screen.getByTestId("action-parameters-input-modal"),
@@ -382,9 +382,9 @@ describe("Actions > ActionViz > Action", () => {
         },
       );
 
-      userEvent.click(screen.getByText("Click me"));
+      await userEvent.click(screen.getByText("Click me"));
 
-      userEvent.click(getIcon("pencil"));
+      await userEvent.click(getIcon("pencil"));
 
       // wait for action edit form to be loaded
       const editorModal = await screen.findByTestId("action-editor-modal");
@@ -393,10 +393,10 @@ describe("Actions > ActionViz > Action", () => {
       const actionTitleField = await within(editorModal).findByTestId(
         "editable-text",
       );
-      userEvent.type(actionTitleField, updatedTitle);
-      userEvent.tab(); // blur field
+      await userEvent.type(actionTitleField, updatedTitle);
+      await userEvent.tab(); // blur field
 
-      userEvent.click(within(editorModal).getByText("Update"));
+      await userEvent.click(within(editorModal).getByText("Update"));
 
       expect(fetchMock.called(`path:/api/action/${ACTION.id}`)).toBe(true);
 
@@ -462,17 +462,17 @@ describe("Actions > ActionViz > Action", () => {
 
       await setup({ settings: formSettings });
 
-      userEvent.type(screen.getByLabelText("Parameter 1"), "foo");
+      await userEvent.type(screen.getByLabelText("Parameter 1"), "foo");
       await waitFor(() =>
         expect(screen.getByLabelText("Parameter 1")).toHaveValue("foo"),
       );
 
-      userEvent.type(screen.getByLabelText("Parameter 2"), "5");
+      await userEvent.type(screen.getByLabelText("Parameter 2"), "5");
       await waitFor(() =>
         expect(screen.getByLabelText("Parameter 2")).toHaveValue(5),
       );
 
-      userEvent.click(screen.getByRole("button", { name: ACTION.name }));
+      await userEvent.click(screen.getByRole("button", { name: ACTION.name }));
 
       await waitFor(async () => {
         const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
@@ -494,12 +494,12 @@ describe("Actions > ActionViz > Action", () => {
         parameterValues: { "dash-param-2": "5" },
       });
 
-      userEvent.type(screen.getByLabelText("Parameter 1"), "foo");
+      await userEvent.type(screen.getByLabelText("Parameter 1"), "foo");
       await waitFor(() =>
         expect(screen.getByLabelText("Parameter 1")).toHaveValue("foo"),
       );
 
-      userEvent.click(screen.getByRole("button", { name: ACTION.name }));
+      await userEvent.click(screen.getByRole("button", { name: ACTION.name }));
 
       await waitFor(async () => {
         const call = fetchMock.lastCall(ACTION_EXEC_MOCK_PATH);
@@ -529,7 +529,7 @@ describe("Actions > ActionViz > Action", () => {
         parameterValues: { "dash-param-1": "foo" },
       });
 
-      userEvent.click(screen.getByRole("button"));
+      await userEvent.click(screen.getByRole("button"));
       expect(screen.getByRole("dialog")).toHaveTextContent(/cannot be undone/i);
       expect(
         screen.getByRole("button", { name: "Delete" }),

--- a/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionDashcardSettings.unit.spec.tsx
@@ -161,7 +161,7 @@ describe("ActionViz > ActionDashcardSettings", () => {
           `parameter-form-section-${actionParameter1.id}`,
         );
 
-        userEvent.click(within(formSection).getByTestId("select-button"));
+        await userEvent.click(within(formSection).getByTestId("select-button"));
 
         const popover = await screen.findByRole("grid");
 
@@ -211,7 +211,7 @@ describe("ActionViz > ActionDashcardSettings", () => {
           `parameter-form-section-${actionParameter1.id}`,
         );
 
-        userEvent.click(within(formSection).getByTestId("select-button"));
+        await userEvent.click(within(formSection).getByTestId("select-button"));
 
         const popover = await screen.findByRole("grid");
 
@@ -270,7 +270,7 @@ describe("ActionViz > ActionDashcardSettings", () => {
         `parameter-form-section-${actionParameter1.id}`,
       );
 
-      userEvent.click(within(formSection).getByTestId("select-button"));
+      await userEvent.click(within(formSection).getByTestId("select-button"));
 
       const popover = await screen.findByRole("grid");
 
@@ -311,7 +311,7 @@ describe("ActionViz > ActionDashcardSettings", () => {
           `parameter-form-section-${actionParameter1.id}`,
         );
 
-        userEvent.click(within(formSection).getByTestId("select-button"));
+        await userEvent.click(within(formSection).getByTestId("select-button"));
 
         const popover = await screen.findByRole("grid");
 
@@ -347,7 +347,7 @@ describe("ActionViz > ActionDashcardSettings", () => {
           `parameter-form-section-${actionParameter1.id}`,
         );
 
-        userEvent.click(within(formSection).getByTestId("select-button"));
+        await userEvent.click(within(formSection).getByTestId("select-button"));
 
         const popover = await screen.findByRole("grid");
 
@@ -437,7 +437,7 @@ describe("ActionViz > ActionDashcardSettings", () => {
 
     expect(screen.queryByText("Action Uno")).not.toBeInTheDocument();
 
-    userEvent.click(modelExpander);
+    await userEvent.click(modelExpander);
 
     await screen.findByText("Action Uno");
     expect(screen.getByText("Action Uno")).toBeInTheDocument();
@@ -487,10 +487,10 @@ describe("ActionViz > ActionDashcardSettings", () => {
     ).toBeInTheDocument();
   });
 
-  it("can close the modal with the done button", () => {
+  it("can close the modal with the done button", async () => {
     const { closeSpy } = setup();
 
-    userEvent.click(screen.getByRole("button", { name: "Done" }));
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/components/ActionViz/ActionVizForm.unit.spec.tsx
@@ -94,7 +94,7 @@ describe("Actions > ActionVizForm", () => {
       mappedParameters: [idParameter],
     });
 
-    userEvent.click(screen.getByText("Click me"));
+    await userEvent.click(screen.getByText("Click me"));
 
     await waitFor(async () => {
       expect(screen.getByLabelText("Parameter 1")).toHaveValue("uno");
@@ -112,7 +112,7 @@ describe("Actions > ActionVizForm", () => {
       dashcardParamValues: {},
     });
 
-    userEvent.click(screen.getByText("Click me"));
+    await userEvent.click(screen.getByText("Click me"));
 
     expect(screen.getByText(/Choose a record to update/i)).toBeInTheDocument();
   });

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FieldSettingsPopover.unit.spec.tsx
@@ -40,8 +40,8 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
   it("should allow to change the input type", async () => {
     const { settings, onChange } = setup();
 
-    userEvent.click(screen.getByLabelText("Field settings"));
-    userEvent.click(await screen.findByText("Dropdown"));
+    await userEvent.click(screen.getByLabelText("Field settings"));
+    await userEvent.click(await screen.findByText("Dropdown"));
 
     expect(onChange).toHaveBeenCalledWith({
       ...settings,
@@ -52,8 +52,8 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
   it("should allow to change the placeholder", async () => {
     const { settings, onChange } = setup();
 
-    userEvent.click(screen.getByLabelText("Field settings"));
-    userEvent.type(await screen.findByLabelText("Placeholder text"), "$");
+    await userEvent.click(screen.getByLabelText("Field settings"));
+    await userEvent.type(await screen.findByLabelText("Placeholder text"), "$");
 
     expect(onChange).toHaveBeenLastCalledWith({
       ...settings,
@@ -68,7 +68,7 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
       });
       setup({ settings });
 
-      userEvent.click(screen.getByLabelText("Field settings"));
+      await userEvent.click(screen.getByLabelText("Field settings"));
       await screen.findByLabelText("Default value");
 
       expect(screen.getAllByTestId("divider").length).toBe(2);
@@ -82,7 +82,7 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
       });
       setup({ settings });
 
-      userEvent.click(screen.getByLabelText("Field settings"));
+      await userEvent.click(screen.getByLabelText("Field settings"));
       await screen.findByLabelText("Default value");
 
       expect(screen.getAllByTestId("divider").length).toBe(1);
@@ -96,15 +96,15 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
     });
     const { onChange } = setup({ settings });
 
-    userEvent.click(screen.getByLabelText("Field settings"));
-    userEvent.click(await screen.findByLabelText("Required"));
+    await userEvent.click(screen.getByLabelText("Field settings"));
+    await userEvent.click(await screen.findByLabelText("Required"));
     expect(onChange).toHaveBeenLastCalledWith({
       ...settings,
       required: false,
     });
     expect(screen.queryByLabelText("Default value")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText("Required"));
+    await userEvent.click(screen.getByLabelText("Required"));
     expect(onChange).toHaveBeenLastCalledWith({
       ...settings,
       required: true,
@@ -118,11 +118,11 @@ describe("actions > FormCreator > FieldSettingsPopover", () => {
       required: true,
     });
     const { onChange } = setup({ settings });
-    userEvent.click(screen.getByLabelText("Field settings"));
+    await userEvent.click(screen.getByLabelText("Field settings"));
 
     const input = await screen.findByLabelText("Default value");
-    userEvent.clear(input);
-    userEvent.type(input, "10");
+    await userEvent.clear(input);
+    await userEvent.type(input, "10");
 
     expect(onChange).toHaveBeenLastCalledWith({
       ...settings,

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormCreator.unit.spec.tsx
@@ -79,7 +79,7 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
     expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
-  it("can change a string field to a numeric field", () => {
+  it("can change a string field to a numeric field", async () => {
     const formSettings: ActionFormSettings = {
       type: "form",
       fields: {
@@ -91,7 +91,7 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
       formSettings,
     });
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("radio", {
         name: /number/i,
       }),
@@ -122,8 +122,8 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
     });
 
     // click the settings cog then the number input type
-    userEvent.click(screen.getByLabelText("Field settings"));
-    userEvent.click(await screen.findByText("Long text"));
+    await userEvent.click(screen.getByLabelText("Field settings"));
+    await userEvent.click(await screen.findByText("Long text"));
 
     expect(onChange).toHaveBeenCalledWith({
       ...formSettings,
@@ -136,7 +136,7 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
     });
   });
 
-  it("can change a numeric field to a date field", () => {
+  it("can change a numeric field to a date field", async () => {
     const formSettings: ActionFormSettings = {
       type: "form",
       fields: {
@@ -149,7 +149,7 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
       formSettings,
     });
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("radio", {
         name: /date/i,
       }),
@@ -178,7 +178,7 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
       formSettings,
     });
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("radio", {
         name: /number/i,
       }),
@@ -207,8 +207,8 @@ describe("actions > containers > ActionCreator > FormCreator", () => {
       formSettings,
     });
 
-    userEvent.click(screen.getByLabelText("Field settings"));
-    userEvent.click(await screen.findByRole("switch"));
+    await userEvent.click(screen.getByLabelText("Field settings"));
+    await userEvent.click(await screen.findByRole("switch"));
 
     expect(onChange).toHaveBeenCalledWith({
       ...formSettings,

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormFieldEditor/FormFieldEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/FormFieldEditor/FormFieldEditor.unit.spec.tsx
@@ -68,10 +68,10 @@ describe("FormFieldEditor", () => {
     expect(getIcon("grabber")).toBeInTheDocument();
   });
 
-  it("handles field type change", () => {
+  it("handles field type change", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByText("Date"));
+    await userEvent.click(screen.getByText("Date"));
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith({
@@ -80,7 +80,7 @@ describe("FormFieldEditor", () => {
       inputType: "date",
     });
 
-    userEvent.click(screen.getByText("Number"));
+    await userEvent.click(screen.getByText("Number"));
 
     expect(onChange).toHaveBeenLastCalledWith({
       ...getDefaultFieldSettings(),
@@ -110,11 +110,13 @@ describe("FormFieldEditor", () => {
 
     it("keeps value options when switching between input types", async () => {
       const { onChange } = setup({ fieldSettings: TEST_STRING_FIELD_SETTINGS });
-      userEvent.click(screen.getByLabelText("Field settings"));
-      userEvent.unhover(screen.getByLabelText("Field settings"));
+      await userEvent.click(screen.getByLabelText("Field settings"));
+      await userEvent.unhover(screen.getByLabelText("Field settings"));
       const popover = await screen.findByRole("tooltip");
 
-      userEvent.click(within(popover).getByRole("radio", { name: "Text" }));
+      await userEvent.click(
+        within(popover).getByRole("radio", { name: "Text" }),
+      );
       await waitFor(() =>
         expect(onChange).toHaveBeenLastCalledWith({
           ...TEST_STRING_FIELD_SETTINGS,
@@ -122,7 +124,7 @@ describe("FormFieldEditor", () => {
         }),
       );
 
-      userEvent.click(
+      await userEvent.click(
         within(popover).getByRole("radio", { name: "Inline select" }),
       );
       await waitFor(() =>
@@ -136,7 +138,7 @@ describe("FormFieldEditor", () => {
     it("handles value options when switching between field types", async () => {
       const { onChange } = setup({ fieldSettings: TEST_STRING_FIELD_SETTINGS });
 
-      userEvent.click(screen.getByText("Number"));
+      await userEvent.click(screen.getByText("Number"));
       await waitFor(() =>
         expect(onChange).toHaveBeenLastCalledWith({
           ...TEST_STRING_FIELD_SETTINGS,
@@ -145,7 +147,7 @@ describe("FormFieldEditor", () => {
         }),
       );
 
-      userEvent.click(screen.getByText("Date"));
+      await userEvent.click(screen.getByText("Date"));
       await waitFor(() =>
         expect(onChange).toHaveBeenLastCalledWith({
           ...TEST_STRING_FIELD_SETTINGS,
@@ -167,11 +169,11 @@ describe("FormFieldEditor", () => {
 
       const { onChange } = setup({ fieldSettings });
 
-      userEvent.click(screen.getByLabelText("Field settings"));
-      userEvent.unhover(screen.getByLabelText("Field settings"));
+      await userEvent.click(screen.getByLabelText("Field settings"));
+      await userEvent.unhover(screen.getByLabelText("Field settings"));
       expect(await screen.findByRole("tooltip")).toBeInTheDocument();
 
-      userEvent.click(screen.getByRole("radio", { name: "Long text" }));
+      await userEvent.click(screen.getByRole("radio", { name: "Long text" }));
 
       expect(onChange).toHaveBeenLastCalledWith({
         ...fieldSettings,
@@ -189,11 +191,11 @@ describe("FormFieldEditor", () => {
       });
 
       const { onChange } = setup({ fieldSettings });
-      userEvent.click(screen.getByLabelText("Field settings"));
-      userEvent.unhover(screen.getByLabelText("Field settings"));
+      await userEvent.click(screen.getByLabelText("Field settings"));
+      await userEvent.unhover(screen.getByLabelText("Field settings"));
       expect(await screen.findByRole("tooltip")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText("Number"));
+      await userEvent.click(screen.getByText("Number"));
       expect(onChange).toHaveBeenLastCalledWith({
         ...fieldSettings,
         fieldType: "number",
@@ -201,7 +203,7 @@ describe("FormFieldEditor", () => {
         defaultValue: 123,
       });
 
-      userEvent.click(screen.getByText("Date"));
+      await userEvent.click(screen.getByText("Date"));
       expect(onChange).toHaveBeenLastCalledWith({
         ...fieldSettings,
         fieldType: "date",

--- a/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/FormCreator/OptionEditor.unit.spec.tsx
@@ -28,8 +28,8 @@ async function baseSetup({
 
   render(<UncontrolledOptionEditor />);
 
-  userEvent.click(getIcon("list"));
-  userEvent.unhover(getIcon("list"));
+  await userEvent.click(getIcon("list"));
+  await userEvent.unhover(getIcon("list"));
   await screen.findByRole("tooltip");
 
   const input = screen.getByPlaceholderText("Enter one option per line");
@@ -66,8 +66,8 @@ describe("OptionEditor", () => {
     it("should handle changes correctly", async () => {
       const { input, saveButton, onChange } = await setup({ options: [] });
 
-      userEvent.type(input, options.join("\n"));
-      userEvent.click(saveButton);
+      await userEvent.type(input, options.join("\n"));
+      await userEvent.click(saveButton);
 
       expect(input).toHaveValue(options.join("\n"));
       expect(saveButton).toBeDisabled();
@@ -77,8 +77,8 @@ describe("OptionEditor", () => {
     it("should close popover on save", async () => {
       const { input, saveButton } = await setup({ options: [] });
 
-      userEvent.type(input, options.join("\n"));
-      userEvent.click(saveButton);
+      await userEvent.type(input, options.join("\n"));
+      await userEvent.click(saveButton);
 
       expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     });
@@ -90,20 +90,20 @@ describe("OptionEditor", () => {
         fieldType: "number",
       });
 
-      userEvent.type(input, "foo\nbar");
-      userEvent.click(saveButton);
+      await userEvent.type(input, "foo\nbar");
+      await userEvent.click(saveButton);
 
       expect(screen.getByText("Invalid number format")).toBeInTheDocument();
       expect(saveButton).toBeDisabled();
       expect(onChange).not.toHaveBeenCalled();
 
-      userEvent.clear(input);
+      await userEvent.clear(input);
       expect(
         screen.queryByText("Invalid number format"),
       ).not.toBeInTheDocument();
 
-      userEvent.type(input, "1\n2");
-      userEvent.click(saveButton);
+      await userEvent.type(input, "1\n2");
+      await userEvent.click(saveButton);
 
       expect(onChange).toHaveBeenCalledWith([1, 2]);
     });
@@ -114,8 +114,8 @@ describe("OptionEditor", () => {
         options: [],
       });
 
-      userEvent.type(input, "1\n2\n\n2\n\n1\n\n");
-      userEvent.click(saveButton);
+      await userEvent.type(input, "1\n2\n\n2\n\n1\n\n");
+      await userEvent.click(saveButton);
 
       expect(onChange).toHaveBeenCalledWith([1, 2]);
     });
@@ -127,8 +127,8 @@ describe("OptionEditor", () => {
           options: [],
         });
 
-        userEvent.type(input, "1\n2\n\n2\n\n1\n\n");
-        userEvent.click(saveButton);
+        await userEvent.type(input, "1\n2\n\n2\n\n1\n\n");
+        await userEvent.click(saveButton);
 
         expect(onChange).toHaveBeenCalledWith(["1", "2"]);
       });

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Common.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Common.unit.spec.tsx
@@ -40,11 +40,11 @@ describe("ActionCreator > Common", () => {
       it("should be able to set success message", async () => {
         await setup();
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByRole("button", { name: "Action settings" }),
         );
 
-        userEvent.type(
+        await userEvent.type(
           screen.getByRole("textbox", { name: "Success message" }),
           `Thanks!`,
         );
@@ -62,16 +62,16 @@ describe("ActionCreator > Common", () => {
           canWrite: true,
         });
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByRole("button", { name: "Action settings" }),
         );
 
-        userEvent.type(
+        await userEvent.type(
           screen.getByRole("textbox", { name: "Success message" }),
           `Thanks!`,
         );
 
-        userEvent.tab();
+        await userEvent.tab();
 
         expect(
           screen.getByRole("textbox", { name: "Success message" }),
@@ -110,7 +110,7 @@ describe("ActionCreator > Common", () => {
         expect(input).toBeEnabled();
         expect(checkbox).toBeChecked();
 
-        userEvent.click(checkbox);
+        await userEvent.click(checkbox);
 
         expect(checkbox).not.toBeChecked();
         expect(input).toBeDisabled();
@@ -127,7 +127,7 @@ describe("ActionCreator > Common", () => {
       it("should not allow editing success message", async () => {
         await setup({ canWrite: false });
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByRole("button", { name: "Action settings" }),
         );
 

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
@@ -35,7 +35,7 @@ describe("ActionCreator > Query Actions", () => {
 
     it("should show clickable data reference icon", async () => {
       await setup();
-      userEvent.click(getIcon("reference"));
+      await userEvent.click(getIcon("reference"));
 
       expect(screen.getAllByText("Data Reference")).toHaveLength(2);
       expect(
@@ -56,12 +56,10 @@ describe("ActionCreator > Query Actions", () => {
 
         // put query into textbox
         const view = screen.getByTestId("mock-native-query-editor");
-        userEvent.paste(
-          within(view).getByRole("textbox"),
-          "select * from orders where {{paramNane}}",
-        );
+        within(view).getByRole("textbox").click();
+        await userEvent.paste("select * from orders where {{paramNane}}");
 
-        userEvent.click(screen.getByRole("button", { name: "Save" }));
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
         // form is rendered
         expect(
@@ -82,12 +80,10 @@ describe("ActionCreator > Query Actions", () => {
 
         // put query into textbox
         const view = screen.getByTestId("mock-native-query-editor");
-        userEvent.paste(
-          within(view).getByRole("textbox"),
-          "select * from orders where {{paramNane}}",
-        );
+        within(view).getByRole("textbox").click();
+        await userEvent.paste("select * from orders where {{paramNane}}");
 
-        userEvent.click(screen.getByRole("button", { name: "Save" }));
+        await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
         // form is rendered
         expect(

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-QueryActions.unit.spec.ts
@@ -56,14 +56,14 @@ describe("ActionCreator > Query Actions", () => {
 
         // put query into textbox
         const view = screen.getByTestId("mock-native-query-editor");
-        within(view).getByRole("textbox").click();
+        await userEvent.click(within(view).getByRole("textbox"));
         await userEvent.paste("select * from orders where {{paramNane}}");
 
         await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
         // form is rendered
         expect(
-          screen.getByPlaceholderText("My new fantastic action"),
+          await screen.findByPlaceholderText("My new fantastic action"),
         ).toBeInTheDocument();
         expect(screen.getByTestId("select-button-content")).toHaveTextContent(
           "Select a model",
@@ -80,7 +80,7 @@ describe("ActionCreator > Query Actions", () => {
 
         // put query into textbox
         const view = screen.getByTestId("mock-native-query-editor");
-        within(view).getByRole("textbox").click();
+        await userEvent.click(within(view).getByRole("textbox"));
         await userEvent.paste("select * from orders where {{paramNane}}");
 
         await userEvent.click(screen.getByRole("button", { name: "Save" }));

--- a/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Sharing.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreator/tests/ActionCreator-Sharing.unit.spec.tsx
@@ -111,7 +111,7 @@ describe("ActionCreator > Sharing", () => {
           isPublicSharingEnabled: false,
         });
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByRole("button", { name: "Action settings" }),
         );
         expect(
@@ -127,7 +127,7 @@ describe("ActionCreator > Sharing", () => {
           isPublicSharingEnabled: true,
         });
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByRole("button", { name: "Action settings" }),
         );
         expect(

--- a/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionCreatorModal/ActionCreatorModal.unit.spec.tsx
@@ -147,8 +147,8 @@ describe("actions > containers > ActionCreatorModal", () => {
         expect(screen.getByTestId("action-creator")).toBeInTheDocument();
       });
 
-      userEvent.type(screen.getByDisplayValue("New Action"), "a change");
-      userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
+      await userEvent.type(screen.getByDisplayValue("New Action"), "a change");
+      await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
       history.goBack();
 
@@ -168,9 +168,9 @@ describe("actions > containers > ActionCreatorModal", () => {
 
       const query = "select 1;";
 
-      userEvent.type(screen.getByDisplayValue("New Action"), "a change");
-      userEvent.type(screen.queryAllByRole("textbox")[1], query);
-      userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
+      await userEvent.type(screen.getByDisplayValue("New Action"), "a change");
+      await userEvent.type(screen.queryAllByRole("textbox")[1], query);
+      await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
       fetchMock.post("path:/api/action", {
         name: "New Actiona change",
@@ -195,8 +195,8 @@ describe("actions > containers > ActionCreatorModal", () => {
         },
       });
 
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
-      userEvent.click(screen.getByRole("button", { name: "Create" }));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByRole("button", { name: "Create" }));
 
       await waitFor(() => {
         expect(history.getCurrentLocation().pathname).toBe(initialRoute);
@@ -222,10 +222,10 @@ describe("actions > containers > ActionCreatorModal", () => {
       });
 
       const input = screen.getByDisplayValue(action.name);
-      userEvent.type(input, "12");
-      userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
-      userEvent.type(input, "{backspace}{backspace}");
-      userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
+      await userEvent.type(input, "12");
+      await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
+      await userEvent.type(input, "{backspace}{backspace}");
+      await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
       history.goBack();
 
@@ -246,8 +246,8 @@ describe("actions > containers > ActionCreatorModal", () => {
         expect(screen.getByTestId("action-creator")).toBeInTheDocument();
       });
 
-      userEvent.type(screen.getByDisplayValue(action.name), "a change");
-      userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
+      await userEvent.type(screen.getByDisplayValue(action.name), "a change");
+      await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
       history.goBack();
 
@@ -267,8 +267,8 @@ describe("actions > containers > ActionCreatorModal", () => {
         expect(screen.getByTestId("action-creator")).toBeInTheDocument();
       });
 
-      userEvent.type(screen.getByDisplayValue(action.name), "a change");
-      userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
+      await userEvent.type(screen.getByDisplayValue(action.name), "a change");
+      await userEvent.tab(); // need to click away from the input to re-compute the isDirty flag
 
       fetchMock.put(
         `path:/api/action/${action.id}`,
@@ -279,7 +279,7 @@ describe("actions > containers > ActionCreatorModal", () => {
         { overwriteRoutes: true },
       );
 
-      userEvent.click(screen.getByRole("button", { name: "Update" }));
+      await userEvent.click(screen.getByRole("button", { name: "Update" }));
 
       await waitFor(() => {
         expect(history.getCurrentLocation().pathname).toBe(initialRoute);

--- a/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.unit.spec.tsx
+++ b/frontend/src/metabase/actions/containers/ActionParametersInputForm/ActionParametersInputForm.unit.spec.tsx
@@ -88,7 +88,7 @@ describe("Actions > ActionParametersInputForm", () => {
   it("should call onCancel when clicking the cancel button", async () => {
     const cancelSpy = jest.fn();
     await setup({ onCancel: cancelSpy });
-    userEvent.click(screen.getByText("Cancel"));
+    await userEvent.click(screen.getByText("Cancel"));
     expect(cancelSpy).toHaveBeenCalled();
   });
 
@@ -98,17 +98,17 @@ describe("Actions > ActionParametersInputForm", () => {
       onSubmit: submitSpy,
     });
 
-    userEvent.type(screen.getByLabelText("Parameter 1"), "uno");
+    await userEvent.type(screen.getByLabelText("Parameter 1"), "uno");
     await waitFor(() =>
       expect(screen.getByLabelText("Parameter 1")).toHaveValue("uno"),
     );
 
-    userEvent.type(screen.getByLabelText("Parameter 2"), "dos");
+    await userEvent.type(screen.getByLabelText("Parameter 2"), "dos");
     await waitFor(() =>
       expect(screen.getByLabelText("Parameter 2")).toHaveValue("dos"),
     );
 
-    userEvent.click(screen.getByText(mockAction.name));
+    await userEvent.click(screen.getByText(mockAction.name));
 
     await waitFor(() => {
       expect(submitSpy).toHaveBeenCalledWith({
@@ -210,11 +210,11 @@ describe("Actions > ActionParametersInputForm", () => {
       const editActionTrigger = getIcon("pencil");
       expect(editActionTrigger).toBeInTheDocument();
 
-      userEvent.hover(editActionTrigger);
+      await userEvent.hover(editActionTrigger);
 
       expect(screen.getByText("Edit this action")).toBeInTheDocument();
 
-      userEvent.click(editActionTrigger);
+      await userEvent.click(editActionTrigger);
 
       expect(onEditMock).toHaveBeenCalledTimes(1);
     });

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/ModelActionsSection/ModelActionsSection.unit.spec.tsx
@@ -49,12 +49,12 @@ describe("ModelActionsSection", () => {
 
     expect(toggle).not.toBeChecked();
 
-    userEvent.click(toggle);
+    await userEvent.click(toggle);
 
     await waitFor(() => expect(toggle).toBeChecked());
     expect(onToggleModelActionsEnabled).toHaveBeenLastCalledWith(true);
 
-    userEvent.click(toggle);
+    await userEvent.click(toggle);
 
     await waitFor(() => expect(toggle).not.toBeChecked());
     expect(onToggleModelActionsEnabled).toHaveBeenLastCalledWith(false);
@@ -71,11 +71,11 @@ describe("ModelActionsSection", () => {
       onToggleModelActionsEnabled,
     });
 
-    userEvent.click(toggle);
+    await userEvent.click(toggle);
     await waitFor(() => expect(toggle).not.toBeChecked());
     expect(screen.getByText(errorMessage)).toBeInTheDocument();
 
-    userEvent.click(toggle);
+    await userEvent.click(toggle);
     await waitFor(() => expect(toggle).toBeChecked());
     expect(screen.queryByText(errorMessage)).not.toBeInTheDocument();
     expect(onToggleModelActionsEnabled).toHaveBeenLastCalledWith(true);

--- a/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DatabaseEditApp/Sidebar/Sidebar.unit.spec.tsx
@@ -81,15 +81,15 @@ function setup({
 }
 
 describe("DatabaseEditApp/Sidebar", () => {
-  it("syncs database schema", () => {
+  it("syncs database schema", async () => {
     const { database, syncDatabaseSchema } = setup();
-    userEvent.click(screen.getByText(/Sync database schema now/i));
+    await userEvent.click(screen.getByText(/Sync database schema now/i));
     expect(syncDatabaseSchema).toHaveBeenCalledWith(database.id);
   });
 
   it("re-scans database field values", async () => {
     const { database } = setup();
-    userEvent.click(screen.getByText(/Re-scan field values now/i));
+    await userEvent.click(screen.getByText(/Re-scan field values now/i));
     await waitFor(() => {
       expect(
         fetchMock.called(`path:/api/database/${database.id}/rescan_values`),
@@ -119,11 +119,13 @@ describe("DatabaseEditApp/Sidebar", () => {
         ).toBeInTheDocument();
       });
 
-      it(`can be dismissed for a database with "${initial_sync_status}" sync status (#20863)`, () => {
+      it(`can be dismissed for a database with "${initial_sync_status}" sync status (#20863)`, async () => {
         const database = createMockDatabase({ initial_sync_status });
         const { dismissSyncSpinner } = setup({ database });
 
-        userEvent.click(screen.getByText(/Dismiss sync spinner manually/i));
+        await userEvent.click(
+          screen.getByText(/Dismiss sync spinner manually/i),
+        );
 
         expect(dismissSyncSpinner).toHaveBeenCalledWith(database.id);
       });
@@ -134,8 +136,10 @@ describe("DatabaseEditApp/Sidebar", () => {
     it("discards field values", async () => {
       const { database } = setup();
 
-      userEvent.click(screen.getByText(/Discard saved field values/i));
-      userEvent.click(within(getModal()).getByRole("button", { name: "Yes" }));
+      await userEvent.click(screen.getByText(/Discard saved field values/i));
+      await userEvent.click(
+        within(getModal()).getByRole("button", { name: "Yes" }),
+      );
 
       await waitFor(() => {
         expect(
@@ -147,8 +151,8 @@ describe("DatabaseEditApp/Sidebar", () => {
     it("allows to cancel confirmation modal", async () => {
       const { database } = setup();
 
-      userEvent.click(screen.getByText(/Discard saved field values/i));
-      userEvent.click(
+      await userEvent.click(screen.getByText(/Discard saved field values/i));
+      await userEvent.click(
         within(getModal()).getByRole("button", { name: "Cancel" }),
       );
 
@@ -209,10 +213,10 @@ describe("DatabaseEditApp/Sidebar", () => {
       expect(screen.queryByText(/Model actions/i)).not.toBeInTheDocument();
     });
 
-    it("enables actions", () => {
+    it("enables actions", async () => {
       const { database, updateDatabase } = setup();
 
-      userEvent.click(screen.getByLabelText(/Model actions/i));
+      await userEvent.click(screen.getByLabelText(/Model actions/i));
 
       expect(updateDatabase).toHaveBeenCalledWith({
         id: database.id,
@@ -220,13 +224,13 @@ describe("DatabaseEditApp/Sidebar", () => {
       });
     });
 
-    it("disables actions", () => {
+    it("disables actions", async () => {
       const database = createMockDatabase({
         settings: { "database-enable-actions": true },
       });
       const { updateDatabase } = setup({ database });
 
-      userEvent.click(screen.getByLabelText(/Model actions/i));
+      await userEvent.click(screen.getByLabelText(/Model actions/i));
 
       expect(updateDatabase).toHaveBeenCalledWith({
         id: database.id,
@@ -295,12 +299,17 @@ describe("DatabaseEditApp/Sidebar", () => {
 
     it("removes database", async () => {
       const { database, deleteDatabase } = setup({ isAdmin: true });
-      userEvent.click(screen.getByText(/Remove this database/i));
+      await userEvent.click(screen.getByText(/Remove this database/i));
       const modal = getModal();
 
       // Fill in database name to confirm deletion
-      userEvent.type(await within(modal).findByRole("textbox"), database.name);
-      userEvent.click(within(modal).getByRole("button", { name: "Delete" }));
+      await userEvent.type(
+        await within(modal).findByRole("textbox"),
+        database.name,
+      );
+      await userEvent.click(
+        within(modal).getByRole("button", { name: "Delete" }),
+      );
       await waitFor(() => {
         expect(getModal()).not.toBeInTheDocument();
       });
@@ -311,11 +320,11 @@ describe("DatabaseEditApp/Sidebar", () => {
 
     it("allows to dismiss confirmation modal", async () => {
       const { database, deleteDatabase } = setup({ isAdmin: true });
-      userEvent.click(screen.getByText(/Remove this database/i));
+      await userEvent.click(screen.getByText(/Remove this database/i));
       const modal = getModal();
 
       within(modal).getByText(`Delete the ${database.name} database?`);
-      userEvent.click(
+      await userEvent.click(
         await within(modal).findByRole("button", { name: "Cancel" }),
       );
 

--- a/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/components/DeleteDatabaseModel/DeleteDatabaseModal.unit.spec.tsx
@@ -55,14 +55,14 @@ describe("DeleteDatabaseModal", () => {
 
     expect(deleteButton).toBeDisabled();
 
-    userEvent.type(
+    await userEvent.type(
       screen.getByTestId("database-name-confirmation-input"),
       "database name",
     );
 
     expect(deleteButton).toBeEnabled();
 
-    userEvent.click(deleteButton);
+    await userEvent.click(deleteButton);
 
     expect(onDelete).toHaveBeenCalledWith(database);
   });
@@ -76,21 +76,21 @@ describe("DeleteDatabaseModal", () => {
 
     expect(deleteButton).toBeDisabled();
 
-    userEvent.click(screen.getByText("Delete 10 saved questions"));
-    userEvent.click(screen.getByText("Delete 20 models"));
-    userEvent.click(screen.getByText("Delete 30 metrics"));
-    userEvent.click(screen.getByText("Delete 40 segments"));
+    await userEvent.click(screen.getByText("Delete 10 saved questions"));
+    await userEvent.click(screen.getByText("Delete 20 models"));
+    await userEvent.click(screen.getByText("Delete 30 metrics"));
+    await userEvent.click(screen.getByText("Delete 40 segments"));
 
     expect(deleteButton).toBeDisabled();
 
-    userEvent.type(
+    await userEvent.type(
       screen.getByTestId("database-name-confirmation-input"),
       "database name",
     );
 
     expect(deleteButton).toBeEnabled();
 
-    userEvent.click(deleteButton);
+    await userEvent.click(deleteButton);
 
     expect(onDelete).toHaveBeenCalledWith(database);
   });
@@ -104,12 +104,12 @@ describe("DeleteDatabaseModal", () => {
     });
 
     const deleteButton = screen.getByRole("button", { name: "Delete" });
-    userEvent.type(
+    await userEvent.type(
       screen.getByTestId("database-name-confirmation-input"),
       "database name",
     );
 
-    userEvent.click(deleteButton);
+    await userEvent.click(deleteButton);
 
     expect(screen.getByText("Something went wrong")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/databases/containers/DatabaseEditApp.unit.spec.tsx
@@ -111,7 +111,7 @@ describe("DatabaseEditApp", () => {
       expect(saveButton).toBeDisabled();
 
       const connectionField = await screen.findByLabelText("Connection String");
-      userEvent.type(connectionField, "Test Connection");
+      await userEvent.type(connectionField, "Test Connection");
 
       await waitFor(() => {
         expect(saveButton).toBeEnabled();
@@ -123,7 +123,7 @@ describe("DatabaseEditApp", () => {
 
       const displayNameInput = await screen.findByLabelText("Display name");
 
-      userEvent.type(displayNameInput, "Test database");
+      await userEvent.type(displayNameInput, "Test database");
       const mockEvent = await waitFor(() => {
         return callMockEvent(mockEventListener, "beforeunload");
       });
@@ -147,8 +147,8 @@ describe("DatabaseEditApp", () => {
       await waitForLoaderToBeRemoved();
 
       const displayNameInput = await screen.findByLabelText("Display name");
-      userEvent.type(displayNameInput, "ab");
-      userEvent.type(displayNameInput, "{backspace}{backspace}");
+      await userEvent.type(displayNameInput, "ab");
+      await userEvent.type(displayNameInput, "{backspace}{backspace}");
 
       history.goBack();
 
@@ -165,7 +165,7 @@ describe("DatabaseEditApp", () => {
       await waitForLoaderToBeRemoved();
 
       const displayNameInput = await screen.findByLabelText("Display name");
-      userEvent.type(displayNameInput, "Test database");
+      await userEvent.type(displayNameInput, "Test database");
 
       history.goBack();
 
@@ -180,16 +180,16 @@ describe("DatabaseEditApp", () => {
       await waitForLoaderToBeRemoved();
 
       const displayNameInput = await screen.findByLabelText("Display name");
-      userEvent.type(displayNameInput, "Test database");
+      await userEvent.type(displayNameInput, "Test database");
       const connectionStringInput = await screen.findByLabelText(
         "Connection String",
       );
-      userEvent.type(
+      await userEvent.type(
         connectionStringInput,
         "file:/sample-database.db;USER=GUEST;PASSWORD=guest",
       );
 
-      userEvent.click(await screen.findByText("Save"));
+      await userEvent.click(await screen.findByText("Save"));
 
       await waitFor(() => {
         expect(history.getCurrentLocation().pathname).toEqual(

--- a/frontend/src/metabase/admin/datamodel/components/FilterPopover/FilterPopover.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/FilterPopover/FilterPopover.unit.spec.tsx
@@ -98,16 +98,16 @@ describe("FilterPopover", () => {
       it.skip("should let the user toggle an option", async () => {
         setup({ filter: RELATIVE_DAY_FILTER });
         const ellipsis = screen.getByLabelText("ellipsis icon");
-        userEvent.click(ellipsis);
+        await userEvent.click(ellipsis);
         const includeToday = await screen.findByText("Include today");
-        userEvent.click(includeToday);
+        await userEvent.click(includeToday);
       });
 
       // eslint-disable-next-line jest/no-disabled-tests
       it.skip("should let the user toggle a date filter type", async () => {
         setup({ filter: RELATIVE_DAY_FILTER });
         const back = screen.getByLabelText("chevronleft icon");
-        userEvent.click(back);
+        await userEvent.click(back);
         expect(
           await screen.findByTestId("date-picker-shortcuts"),
         ).toBeInTheDocument();
@@ -116,8 +116,8 @@ describe("FilterPopover", () => {
       // eslint-disable-next-line jest/no-disabled-tests
       it.skip("should let the user toggle a text filter type", async () => {
         setup({ filter: STRING_CONTAINS_FILTER });
-        userEvent.click(await screen.findByText("Contains"));
-        userEvent.click(await screen.findByText("Is"));
+        await userEvent.click(await screen.findByText("Contains"));
+        await userEvent.click(await screen.findByText("Is"));
 
         expect(
           await screen.findByTestId("date-picker-shortcuts"),

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -178,7 +178,7 @@ describe("DatePicker", () => {
       it(`shows a ${type} date picker when the user clicks ${type} on the shortcut screen`, async () => {
         render(<DatePickerStateWrapper filter={filter} />);
 
-        userEvent.click(screen.getByText(new RegExp(type, "i")));
+        await userEvent.click(screen.getByText(new RegExp(type, "i")));
 
         expect(
           (await screen.findAllByTestId(`${type}-date-picker`)).length,
@@ -228,7 +228,7 @@ describe("DatePicker", () => {
             <DatePickerStateWrapper filter={filter} onCommit={commitSpy} />,
           );
 
-          userEvent.click(screen.getByText(new RegExp(label, "i")));
+          await userEvent.click(screen.getByText(new RegExp(label, "i")));
           expect(commitSpy).toHaveBeenCalledWith(expectedFilter);
         });
       });
@@ -248,12 +248,12 @@ describe("DatePicker", () => {
           render(
             <DatePickerStateWrapper filter={filter} onChange={changeSpy} />,
           );
-          userEvent.click(screen.getByText(/specific dates/i));
-          userEvent.click(screen.getByText("On"));
+          await userEvent.click(screen.getByText(/specific dates/i));
+          await userEvent.click(screen.getByText("On"));
           await screen.findByTestId(`specific-date-picker`);
-          userEvent.click(screen.getByText(new RegExp(description, "i")));
+          await userEvent.click(screen.getByText(new RegExp(description, "i")));
           const dateField = screen.getByText("21");
-          userEvent.click(dateField);
+          await userEvent.click(dateField);
 
           expect(changeSpy).toHaveBeenLastCalledWith([
             operator,
@@ -268,14 +268,14 @@ describe("DatePicker", () => {
 
         render(<DatePickerStateWrapper filter={filter} onChange={changeSpy} />);
 
-        userEvent.click(await screen.findByText(/specific/i));
-        userEvent.click(await screen.findByText(/between/i));
+        await userEvent.click(await screen.findByText(/specific/i));
+        await userEvent.click(await screen.findByText(/between/i));
 
         const dateField1 = screen.getByText("17");
         const dateField2 = screen.getByText("19");
 
-        userEvent.click(dateField1); // begin range, clears end range
-        userEvent.click(dateField2); // end range
+        await userEvent.click(dateField1); // begin range, clears end range
+        await userEvent.click(dateField2); // end range
 
         expect(changeSpy).toHaveBeenLastCalledWith([
           "between",
@@ -287,13 +287,13 @@ describe("DatePicker", () => {
 
       it("can navigate between months on the calendar using arrows", async () => {
         render(<DatePickerStateWrapper filter={filter} />);
-        userEvent.click(screen.getByText(/specific/i));
-        userEvent.click(screen.getByText("On"));
+        await userEvent.click(screen.getByText(/specific/i));
+        await userEvent.click(screen.getByText("On"));
 
         expect(await screen.findByText("May 2020")).toBeInTheDocument();
-        userEvent.click(screen.getByLabelText(/chevronright/i));
+        await userEvent.click(screen.getByLabelText(/chevronright/i));
         expect(await screen.findByText("June 2020")).toBeInTheDocument();
-        userEvent.click(screen.getByLabelText(/chevronright/i));
+        await userEvent.click(screen.getByLabelText(/chevronright/i));
         expect(await screen.findByText("July 2020")).toBeInTheDocument();
       });
     });
@@ -318,19 +318,21 @@ describe("DatePicker", () => {
             render(
               <DatePickerStateWrapper filter={filter} onChange={changeSpy} />,
             );
-            userEvent.click(screen.getByText(/relative dates/i));
-            userEvent.click(screen.getByText(new RegExp(direction, "i")));
+            await userEvent.click(screen.getByText(/relative dates/i));
+            await userEvent.click(screen.getByText(new RegExp(direction, "i")));
 
             const valueInput = await screen.findByTestId(
               "relative-datetime-value",
             );
-            userEvent.clear(valueInput);
-            userEvent.type(valueInput, String(relativeTimeValue));
+            await userEvent.clear(valueInput);
+            await userEvent.type(valueInput, String(relativeTimeValue));
 
-            userEvent.click(
+            await userEvent.click(
               await screen.findByTestId("relative-datetime-unit"),
             );
-            userEvent.click(await screen.findByText(new RegExp(unit, "i")));
+            await userEvent.click(
+              await screen.findByText(new RegExp(unit, "i")),
+            );
 
             expect(changeSpy).toHaveBeenLastCalledWith([
               "time-interval",
@@ -354,9 +356,9 @@ describe("DatePicker", () => {
           render(
             <DatePickerStateWrapper filter={filter} onCommit={commitSpy} />,
           );
-          userEvent.click(screen.getByText(/relative dates/i));
-          userEvent.click(screen.getByText(/current/i));
-          userEvent.click(screen.getByText(new RegExp(unit, "i")));
+          await userEvent.click(screen.getByText(/relative dates/i));
+          await userEvent.click(screen.getByText(/current/i));
+          await userEvent.click(screen.getByText(new RegExp(unit, "i")));
 
           expect(commitSpy).toHaveBeenLastCalledWith([
             "time-interval",
@@ -376,8 +378,8 @@ describe("DatePicker", () => {
           <DatePickerStateWrapper filter={filter} onChange={onChangeMock} />,
         );
 
-        userEvent.click(screen.getByText("Exclude..."));
-        userEvent.click(screen.getByText("Hours of the day..."));
+        await userEvent.click(screen.getByText("Exclude..."));
+        await userEvent.click(screen.getByText("Hours of the day..."));
 
         const midnightCheckbox = screen.getByRole("checkbox", {
           name: /12 AM/i,
@@ -385,7 +387,7 @@ describe("DatePicker", () => {
 
         expect(midnightCheckbox).toBeChecked();
 
-        userEvent.click(midnightCheckbox);
+        await userEvent.click(midnightCheckbox);
 
         expect(onChangeMock).toHaveBeenCalledWith([
           "!=",

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/DatePicker.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
 import { createMockMetadata } from "__support__/metadata";
@@ -12,6 +12,10 @@ import {
 } from "metabase-types/api/mocks/presets";
 
 import DatePicker from "./DatePicker";
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 const metadata = createMockMetadata({
   databases: [createSampleDatabase()],

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RangeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RangeDatePicker.unit.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 import { useState } from "react";
 
 import { BetweenPicker } from "./RangeDatePicker";
@@ -12,6 +12,10 @@ const TestBetweenPicker = ({ initialFilter }: TestBetweenPickerProps) => {
   const [filter, setFilter] = useState(initialFilter);
   return <BetweenPicker filter={filter} onFilterChange={setFilter} />;
 };
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 describe("BetweenPicker", () => {
   const field = ["field", 10, null];

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RangeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RangeDatePicker.unit.spec.tsx
@@ -25,29 +25,29 @@ describe("BetweenPicker", () => {
     jest.useRealTimers();
   });
 
-  it("should change the filter by calendar", () => {
+  it("should change the filter by calendar", async () => {
     const initialFilter = ["between", field, "2022-08-10", "2022-08-29"];
 
     render(<TestBetweenPicker initialFilter={initialFilter} />);
-    userEvent.click(screen.getByText("12"));
-    userEvent.click(screen.getByText("20"));
+    await userEvent.click(screen.getByText("12"));
+    await userEvent.click(screen.getByText("20"));
 
     expect(screen.getByDisplayValue("08/12/2022")).toBeInTheDocument();
     expect(screen.getByDisplayValue("08/20/2022")).toBeInTheDocument();
   });
 
-  it("should change the filter by keyboard and calendar", () => {
+  it("should change the filter by keyboard and calendar", async () => {
     const initialFilter = ["between", field, "2022-08-10", "2022-08-29"];
 
     render(<TestBetweenPicker initialFilter={initialFilter} />);
 
     const startDateInput = screen.getByDisplayValue("08/10/2022");
-    userEvent.clear(startDateInput);
-    userEvent.type(startDateInput, "07/25/2022");
-    userEvent.tab();
+    await userEvent.clear(startDateInput);
+    await userEvent.type(startDateInput, "07/25/2022");
+    await userEvent.tab();
 
     const endDateInput = screen.getByDisplayValue("08/29/2022");
-    userEvent.click(screen.getByText("20"));
+    await userEvent.click(screen.getByText("20"));
 
     expect(startDateInput).toHaveValue("07/25/2022");
     expect(endDateInput).toHaveValue("08/20/2022");

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DatePicker/RelativeDatePicker.unit.spec.tsx
@@ -6,54 +6,54 @@ import Filter from "metabase-lib/v1/queries/structured/Filter";
 import { PastPicker, NextPicker } from "./RelativeDatePicker";
 
 describe("PastPicker", () => {
-  it("should change a filter", () => {
+  it("should change a filter", async () => {
     const filter = new Filter(["time-interval", null, -10, "month"]);
     const onFilterChange = jest.fn();
 
     render(<PastPicker filter={filter} onFilterChange={onFilterChange} />);
-    typeByDisplayValue("10", "20");
+    await typeByDisplayValue("10", "20");
 
     const expectedFilter = ["time-interval", null, -20, "month"];
     expect(onFilterChange).toHaveBeenCalledWith(expectedFilter);
   });
 
-  it("should not allow to enter an empty time interval", () => {
+  it("should not allow to enter an empty time interval", async () => {
     const filter = new Filter(["time-interval", null, -10, "month"]);
     const onFilterChange = jest.fn();
 
     render(<PastPicker filter={filter} onFilterChange={onFilterChange} />);
-    typeByDisplayValue("10", "0");
+    await typeByDisplayValue("10", "0");
 
     expect(onFilterChange).toHaveBeenCalledWith(filter);
   });
 });
 
 describe("NextPicker", () => {
-  it("should change a filter", () => {
+  it("should change a filter", async () => {
     const filter = new Filter(["time-interval", null, 10, "month"]);
     const onFilterChange = jest.fn();
 
     render(<NextPicker filter={filter} onFilterChange={onFilterChange} />);
-    typeByDisplayValue("10", "20");
+    await typeByDisplayValue("10", "20");
 
     const expectedFilter = ["time-interval", null, 20, "month"];
     expect(onFilterChange).toHaveBeenCalledWith(expectedFilter);
   });
 
-  it("should not allow to enter an empty time interval", () => {
+  it("should not allow to enter an empty time interval", async () => {
     const filter = new Filter(["time-interval", null, 10, "month"]);
     const onFilterChange = jest.fn();
 
     render(<NextPicker filter={filter} onFilterChange={onFilterChange} />);
-    typeByDisplayValue("10", "0");
+    await typeByDisplayValue("10", "0");
 
     expect(onFilterChange).toHaveBeenCalledWith(filter);
   });
 });
 
-const typeByDisplayValue = (label: string, value: string) => {
+const typeByDisplayValue = async (label: string, value: string) => {
   const input = screen.getByDisplayValue(label);
-  userEvent.clear(input);
-  userEvent.type(input, value);
-  userEvent.tab();
+  await userEvent.clear(input);
+  await userEvent.type(input, value);
+  await userEvent.tab();
 };

--- a/frontend/src/metabase/admin/datamodel/components/filters/pickers/DefaultPicker/DefaultPicker.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/components/filters/pickers/DefaultPicker/DefaultPicker.unit.spec.tsx
@@ -143,7 +143,7 @@ describe("Filters > DefaultPicker", () => {
 
     const input = screen.getByRole("textbox");
 
-    userEvent.type(input, "Fancy Sandals");
+    await userEvent.type(input, "Fancy Sandals");
 
     expect(setValuesSpy).toHaveBeenLastCalledWith([
       "Ugly Shoes",
@@ -157,7 +157,7 @@ describe("Filters > DefaultPicker", () => {
 
     const input = screen.getByRole("textbox");
 
-    userEvent.type(input, "25");
+    await userEvent.type(input, "25");
     // index, value
     expect(setValueSpy).toHaveBeenLastCalledWith(0, 125);
   });
@@ -172,7 +172,7 @@ describe("Filters > DefaultPicker", () => {
 
     const input = screen.getAllByRole("textbox")[0];
 
-    userEvent.type(input, "1{enter}");
+    await userEvent.type(input, "1{enter}");
 
     expect(onCommitSpy).toHaveBeenCalled();
   });

--- a/frontend/src/metabase/admin/datamodel/containers/MetricApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/MetricApp.unit.spec.tsx
@@ -63,7 +63,7 @@ describe("MetricApp", () => {
   it("should have beforeunload event when user makes edits to a metric", async () => {
     const { mockEventListener } = setup();
 
-    userEvent.type(screen.getByLabelText("Name Your Metric"), "Name");
+    await userEvent.type(screen.getByLabelText("Name Your Metric"), "Name");
 
     const mockEvent = await waitFor(() => {
       return callMockEvent(mockEventListener, "beforeunload");
@@ -91,12 +91,12 @@ describe("MetricApp", () => {
     expect(screen.queryByTestId("leave-confirmation")).not.toBeInTheDocument();
   });
 
-  it("shows custom warning modal when leaving with unsaved changes via SPA navigation", () => {
+  it("shows custom warning modal when leaving with unsaved changes via SPA navigation", async () => {
     const { history } = setup({ initialRoute: "/" });
 
     history.push(FORM_URL);
 
-    userEvent.type(screen.getByLabelText("Name Your Metric"), "Name");
+    await userEvent.type(screen.getByLabelText("Name Your Metric"), "Name");
 
     history.goBack();
 
@@ -106,20 +106,22 @@ describe("MetricApp", () => {
   it("does not show custom warning modal when saving changes", async () => {
     const { history } = setup();
 
-    userEvent.click(screen.getByText("Select a table"));
+    await userEvent.click(screen.getByText("Select a table"));
 
     await waitForLoaderToBeRemoved();
 
-    userEvent.click(screen.getByText("Orders"));
+    await userEvent.click(screen.getByText("Orders"));
 
     await waitForLoaderToBeRemoved();
 
-    userEvent.click(screen.getByText("Add filters to narrow your answer"));
-    userEvent.click(screen.getByText("ID"));
-    userEvent.type(screen.getByPlaceholderText("Enter an ID"), "1");
-    userEvent.click(screen.getByText("Add filter"));
-    userEvent.type(screen.getByLabelText("Name Your Metric"), "Name");
-    userEvent.type(
+    await userEvent.click(
+      screen.getByText("Add filters to narrow your answer"),
+    );
+    await userEvent.click(screen.getByText("ID"));
+    await userEvent.type(screen.getByPlaceholderText("Enter an ID"), "1");
+    await userEvent.click(screen.getByText("Add filter"));
+    await userEvent.type(screen.getByLabelText("Name Your Metric"), "Name");
+    await userEvent.type(
       screen.getByLabelText("Describe Your Metric"),
       "Description",
     );
@@ -128,7 +130,7 @@ describe("MetricApp", () => {
       expect(screen.getByText("Save changes")).toBeEnabled();
     });
 
-    userEvent.click(screen.getByText("Save changes"));
+    await userEvent.click(screen.getByText("Save changes"));
 
     await waitFor(() => {
       expect(history.getCurrentLocation().pathname).toBe(METRICS_URL);

--- a/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/containers/SegmentApp.unit.spec.tsx
@@ -63,7 +63,7 @@ describe("SegmentApp", () => {
   it("should have beforeunload event when user makes edits to a segment", async () => {
     const { mockEventListener } = setup();
 
-    userEvent.type(screen.getByLabelText("Name Your Segment"), "Name");
+    await userEvent.type(screen.getByLabelText("Name Your Segment"), "Name");
 
     const mockEvent = await waitFor(() => {
       return callMockEvent(mockEventListener, "beforeunload");
@@ -91,12 +91,12 @@ describe("SegmentApp", () => {
     expect(screen.queryByTestId("leave-confirmation")).not.toBeInTheDocument();
   });
 
-  it("shows custom warning modal when leaving with unsaved changes via SPA navigation", () => {
+  it("shows custom warning modal when leaving with unsaved changes via SPA navigation", async () => {
     const { history } = setup({ initialRoute: "/" });
 
     history.push(FORM_URL);
 
-    userEvent.type(screen.getByLabelText("Name Your Segment"), "Name");
+    await userEvent.type(screen.getByLabelText("Name Your Segment"), "Name");
 
     history.goBack();
 
@@ -106,20 +106,22 @@ describe("SegmentApp", () => {
   it("does not show custom warning modal when saving changes", async () => {
     const { history } = setup();
 
-    userEvent.click(screen.getByText("Select a table"));
+    await userEvent.click(screen.getByText("Select a table"));
 
     await waitForLoaderToBeRemoved();
 
-    userEvent.click(screen.getByText("Orders"));
+    await userEvent.click(screen.getByText("Orders"));
 
     await waitForLoaderToBeRemoved();
 
-    userEvent.click(screen.getByText("Add filters to narrow your answer"));
-    userEvent.click(screen.getByText("ID"));
-    userEvent.type(screen.getByPlaceholderText("Enter an ID"), "1");
-    userEvent.click(screen.getByText("Add filter"));
-    userEvent.type(screen.getByLabelText("Name Your Segment"), "Name");
-    userEvent.type(
+    await userEvent.click(
+      screen.getByText("Add filters to narrow your answer"),
+    );
+    await userEvent.click(screen.getByText("ID"));
+    await userEvent.type(screen.getByPlaceholderText("Enter an ID"), "1");
+    await userEvent.click(screen.getByText("Add filter"));
+    await userEvent.type(screen.getByLabelText("Name Your Segment"), "Name");
+    await userEvent.type(
       screen.getByLabelText("Describe Your Segment"),
       "Description",
     );
@@ -128,7 +130,7 @@ describe("SegmentApp", () => {
       expect(screen.getByText("Save changes")).toBeEnabled();
     });
 
-    userEvent.click(screen.getByText("Save changes"));
+    await userEvent.click(screen.getByText("Save changes"));
 
     await waitFor(() => {
       expect(history.getCurrentLocation().pathname).toBe(SEGMENTS_URL);

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataEditor/MetadataEditor.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataEditor/MetadataEditor.unit.spec.tsx
@@ -171,7 +171,10 @@ describe("MetadataEditor", () => {
       await setup();
 
       const searchValue = ORDERS_TABLE.name.substring(0, 3);
-      userEvent.type(screen.getByPlaceholderText("Find a table"), searchValue);
+      await userEvent.type(
+        screen.getByPlaceholderText("Find a table"),
+        searchValue,
+      );
 
       expect(screen.getByText(ORDERS_TABLE.display_name)).toBeInTheDocument();
       expect(
@@ -182,11 +185,11 @@ describe("MetadataEditor", () => {
     it("should not allow to enter an empty table name", async () => {
       await setup();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
-      userEvent.clear(
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.clear(
         await screen.findByDisplayValue(ORDERS_TABLE.display_name),
       );
-      userEvent.tab();
+      await userEvent.tab();
 
       expect(
         screen.getByDisplayValue(ORDERS_TABLE.display_name),
@@ -196,11 +199,11 @@ describe("MetadataEditor", () => {
     it("should not allow to enter an empty field name", async () => {
       await setup();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
-      userEvent.clear(
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.clear(
         await screen.findByDisplayValue(ORDERS_ID_FIELD.display_name),
       );
-      userEvent.tab();
+      await userEvent.tab();
 
       expect(
         screen.getByDisplayValue(ORDERS_ID_FIELD.display_name),
@@ -210,7 +213,7 @@ describe("MetadataEditor", () => {
     it("should allow to switch between metadata and original schema", async () => {
       await setup();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
       expect(
         await screen.findByDisplayValue(ORDERS_TABLE.display_name),
       ).toBeInTheDocument();
@@ -218,7 +221,9 @@ describe("MetadataEditor", () => {
         screen.getByDisplayValue(ORDERS_ID_FIELD.display_name),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByRole("radio", { name: "Original schema" }));
+      await userEvent.click(
+        screen.getByRole("radio", { name: "Original schema" }),
+      );
       expect(screen.getByText(ORDERS_TABLE.name)).toBeInTheDocument();
       expect(screen.getByText(ORDERS_ID_FIELD.name)).toBeInTheDocument();
     });
@@ -228,7 +233,7 @@ describe("MetadataEditor", () => {
       expect(await screen.findByText("1 Queryable Table")).toBeInTheDocument();
       expect(screen.getByText("1 Hidden Table")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(PRODUCTS_TABLE.display_name));
+      await userEvent.click(screen.getByText(PRODUCTS_TABLE.display_name));
       expect(
         await screen.findByDisplayValue(PRODUCTS_TABLE.display_name),
       ).toBeInTheDocument();
@@ -249,7 +254,7 @@ describe("MetadataEditor", () => {
       expect(await screen.findByText("1 Queryable Table")).toBeInTheDocument();
       expect(screen.getByText("1 Hidden Table")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
       expect(
         await screen.findByDisplayValue(ORDERS_TABLE.display_name),
       ).toBeInTheDocument();
@@ -291,8 +296,8 @@ describe("MetadataEditor", () => {
     it("should display sort options", async () => {
       await setup();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
-      userEvent.click(await screen.findByLabelText("Sort"));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(await screen.findByLabelText("Sort"));
 
       expect(await screen.findByText("Database")).toBeInTheDocument();
       expect(screen.getByText("Alphabetical")).toBeInTheDocument();
@@ -302,12 +307,12 @@ describe("MetadataEditor", () => {
 
     it("should display field visibility options", async () => {
       await setup();
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
 
       const section = within(
         await screen.findByLabelText(ORDERS_ID_FIELD.name),
       );
-      userEvent.click(section.getByText("Everywhere"));
+      await userEvent.click(section.getByText("Everywhere"));
 
       expect(
         await screen.findByText("Only in detail views"),
@@ -317,39 +322,39 @@ describe("MetadataEditor", () => {
 
     it("should allow to search for field semantic types", async () => {
       await setup();
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
 
       const section = within(
         await screen.findByLabelText(ORDERS_ID_FIELD.name),
       );
-      userEvent.click(section.getByText("Entity Key"));
+      await userEvent.click(section.getByText("Entity Key"));
       expect(await screen.findByText("Entity Name")).toBeInTheDocument();
 
-      userEvent.type(screen.getByPlaceholderText("Find..."), "Pri");
+      await userEvent.type(screen.getByPlaceholderText("Find..."), "Pri");
       expect(screen.getByText("Price")).toBeInTheDocument();
       expect(screen.queryByText("Score")).not.toBeInTheDocument();
     });
 
     it("should show the foreign key target for foreign keys", async () => {
       await setup();
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
 
       const section = within(
         await screen.findByLabelText(ORDERS_PRODUCT_ID_FIELD.name),
       );
-      userEvent.click(section.getByText("Products → ID"));
+      await userEvent.click(section.getByText("Products → ID"));
 
       const popover = within(await screen.findByTestId("popover"));
       expect(popover.getByText("Products → ID")).toBeInTheDocument();
       expect(popover.queryByText("Orders → ID")).not.toBeInTheDocument();
 
-      userEvent.type(popover.getByPlaceholderText("Find..."), "Products");
+      await userEvent.type(popover.getByPlaceholderText("Find..."), "Products");
       expect(popover.getByText("Products → ID")).toBeInTheDocument();
     });
 
     it("should show an access denied error if the foreign key field has an inaccessible target", async () => {
       await setup();
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
 
       const section = within(
         await screen.findByLabelText(ORDERS_USER_ID_FIELD.name),
@@ -360,7 +365,7 @@ describe("MetadataEditor", () => {
     it("should not show the foreign key target for non-foreign keys", async () => {
       await setup();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
       const section = within(
         await screen.findByLabelText(ORDERS_ID_FIELD.name),
       );
@@ -370,18 +375,18 @@ describe("MetadataEditor", () => {
 
     it("should show currency settings for currency fields", async () => {
       await setup();
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
 
       const section = within(
         await screen.findByLabelText(ORDERS_DISCOUNT_FIELD.name),
       );
-      userEvent.click(section.getByText("US Dollar"));
+      await userEvent.click(section.getByText("US Dollar"));
 
       const popover = within(await screen.findByTestId("popover"));
       expect(popover.getByText("Canadian Dollar")).toBeInTheDocument();
       expect(popover.getByText("Euro")).toBeInTheDocument();
 
-      userEvent.type(popover.getByPlaceholderText("Find..."), "Dollar");
+      await userEvent.type(popover.getByPlaceholderText("Find..."), "Dollar");
       expect(popover.getByText("US Dollar")).toBeInTheDocument();
       expect(popover.getByText("Canadian Dollar")).toBeInTheDocument();
       expect(popover.queryByText("Euro")).not.toBeInTheDocument();
@@ -389,7 +394,7 @@ describe("MetadataEditor", () => {
 
     it("should not show currency settings for non-currency fields", async () => {
       await setup();
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
 
       const section = within(
         await screen.findByLabelText(ORDERS_ID_FIELD.name),
@@ -418,7 +423,10 @@ describe("MetadataEditor", () => {
       await setup({ databases: [SAMPLE_DB_MULTI_SCHEMA] });
 
       const searchValue = PEOPLE_TABLE_MULTI_SCHEMA.schema.substring(0, 3);
-      userEvent.type(screen.getByPlaceholderText("Find a schema"), searchValue);
+      await userEvent.type(
+        screen.getByPlaceholderText("Find a schema"),
+        searchValue,
+      );
 
       expect(
         screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema),
@@ -431,7 +439,7 @@ describe("MetadataEditor", () => {
     it("should allow to search for a table", async () => {
       await setup({ databases: [SAMPLE_DB_MULTI_SCHEMA] });
 
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
+      await userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
       expect(
         await screen.findByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name),
       ).toBeInTheDocument();
@@ -439,7 +447,7 @@ describe("MetadataEditor", () => {
         screen.queryByText(REVIEWS_TABLE_MULTI_SCHEMA.display_name),
       ).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByText("Schemas"));
+      await userEvent.click(screen.getByText("Schemas"));
       expect(
         screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema),
       ).toBeInTheDocument();
@@ -456,9 +464,9 @@ describe("MetadataEditor", () => {
         await screen.findByText(ORDERS_TABLE.display_name),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(SAMPLE_DB.name));
-      userEvent.click(screen.getByText(SAMPLE_DB_MULTI_SCHEMA.name));
-      userEvent.click(
+      await userEvent.click(screen.getByText(SAMPLE_DB.name));
+      await userEvent.click(screen.getByText(SAMPLE_DB_MULTI_SCHEMA.name));
+      await userEvent.click(
         await screen.findByText(PEOPLE_TABLE_MULTI_SCHEMA.schema),
       );
       expect(
@@ -480,7 +488,7 @@ describe("MetadataEditor", () => {
   describe("databases with json fields", () => {
     it("should display unfolded json fields", async () => {
       await setup({ databases: [JSON_DB] });
-      userEvent.click(screen.getByText(JSON_TABLE.display_name));
+      await userEvent.click(screen.getByText(JSON_TABLE.display_name));
       expect(
         await screen.findByDisplayValue(JSON_TABLE.display_name),
       ).toBeInTheDocument();
@@ -501,7 +509,7 @@ describe("MetadataEditor", () => {
       const { history } = await setup({ initialRoute: "notAdmin" });
 
       expect(screen.getByText("Link to Datamodel")).toBeInTheDocument();
-      userEvent.click(screen.getByText("Link to Datamodel"));
+      await userEvent.click(screen.getByText("Link to Datamodel"));
 
       await waitForLoaderToBeRemoved();
       expect(screen.getByText("Sample Database")).toBeInTheDocument();

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataEditor/MetadataEditor.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataEditor/MetadataEditor.unit.spec.tsx
@@ -281,11 +281,13 @@ describe("MetadataEditor", () => {
           "Select any table to see its schema and add or edit metadata.",
         ),
       ).toBeInTheDocument();
-      expect(() =>
-        userEvent.click(
-          screen.getByText(ORDERS_TABLE_INITIAL_SYNC_INCOMPLETE.display_name),
-        ),
-      ).toThrow();
+
+      // This click should not cause a change, as the table should be disabled
+      await userEvent.click(
+        screen.getByText(ORDERS_TABLE_INITIAL_SYNC_INCOMPLETE.display_name),
+        { pointerEventsCheck: 0 }, //This is needed due to pointer events: none on the element
+      );
+
       expect(
         await screen.findByText(
           "Select any table to see its schema and add or edit metadata.",

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataEditor/MetadataEditor.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataEditor/MetadataEditor.unit.spec.tsx
@@ -283,10 +283,11 @@ describe("MetadataEditor", () => {
       ).toBeInTheDocument();
 
       // This click should not cause a change, as the table should be disabled
-      await userEvent.click(
-        screen.getByText(ORDERS_TABLE_INITIAL_SYNC_INCOMPLETE.display_name),
-        { pointerEventsCheck: 0 }, //This is needed due to pointer events: none on the element
-      );
+      await expect(
+        userEvent.click(
+          screen.getByText(ORDERS_TABLE_INITIAL_SYNC_INCOMPLETE.display_name),
+        ),
+      ).rejects.toThrow(/pointer-events: none/);
 
       expect(
         await screen.findByText(

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataFieldSettings/MetadataFieldSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataFieldSettings/MetadataFieldSettings.unit.spec.tsx
@@ -155,15 +155,15 @@ describe("MetadataFieldSettings", () => {
       await setup();
       expect(screen.queryByText(ORDERS_TABLE.schema)).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
       await waitForLoaderToBeRemoved();
-      userEvent.click(fieldLink(ORDERS_ID_FIELD));
+      await userEvent.click(fieldLink(ORDERS_ID_FIELD));
       await waitForLoaderToBeRemoved();
       expect(screen.getByText("General")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(SAMPLE_DB.name));
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
-      userEvent.click(fieldLink(ORDERS_ID_FIELD));
+      await userEvent.click(screen.getByText(SAMPLE_DB.name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(fieldLink(ORDERS_ID_FIELD));
       await waitForLoaderToBeRemoved();
       expect(screen.getByText("General")).toBeInTheDocument();
     });
@@ -175,22 +175,28 @@ describe("MetadataFieldSettings", () => {
         field: PEOPLE_ID_FIELD,
       });
 
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name));
+      await userEvent.click(
+        screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name),
+      );
       await waitForLoaderToBeRemoved();
-      userEvent.click(fieldLink(PEOPLE_ID_FIELD));
-      await waitForLoaderToBeRemoved();
-      expect(screen.getByText("General")).toBeInTheDocument();
-
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name));
-      userEvent.click(fieldLink(PEOPLE_ID_FIELD));
+      await userEvent.click(fieldLink(PEOPLE_ID_FIELD));
       await waitForLoaderToBeRemoved();
       expect(screen.getByText("General")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(SAMPLE_DB_MULTI_SCHEMA.name));
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name));
-      userEvent.click(fieldLink(PEOPLE_ID_FIELD));
+      await userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
+      await userEvent.click(
+        screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name),
+      );
+      await userEvent.click(fieldLink(PEOPLE_ID_FIELD));
+      await waitForLoaderToBeRemoved();
+      expect(screen.getByText("General")).toBeInTheDocument();
+
+      await userEvent.click(screen.getByText(SAMPLE_DB_MULTI_SCHEMA.name));
+      await userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
+      await userEvent.click(
+        screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name),
+      );
+      await userEvent.click(fieldLink(PEOPLE_ID_FIELD));
       await waitForLoaderToBeRemoved();
       expect(screen.getByText("General")).toBeInTheDocument();
     });
@@ -200,8 +206,10 @@ describe("MetadataFieldSettings", () => {
     it("should not allow to enter an empty field name", async () => {
       await setup();
 
-      userEvent.clear(screen.getByDisplayValue(ORDERS_ID_FIELD.display_name));
-      userEvent.tab();
+      await userEvent.clear(
+        screen.getByDisplayValue(ORDERS_ID_FIELD.display_name),
+      );
+      await userEvent.tab();
 
       expect(
         screen.getByDisplayValue(ORDERS_ID_FIELD.display_name),
@@ -224,8 +232,8 @@ describe("MetadataFieldSettings", () => {
         screen.getByText("Cast to a specific data type"),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByText("Don't cast"));
-      userEvent.type(screen.getByPlaceholderText("Find..."), "Micro");
+      await userEvent.click(screen.getByText("Don't cast"));
+      await userEvent.type(screen.getByPlaceholderText("Find..."), "Micro");
       expect(
         screen.getByText("Coercion/UNIXMicroSeconds->DateTime"),
       ).toBeInTheDocument();
@@ -263,7 +271,7 @@ describe("MetadataFieldSettings", () => {
     it("should allow to rescan field values", async () => {
       await setup();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole("button", { name: "Re-scan this field" }),
       );
 
@@ -276,7 +284,7 @@ describe("MetadataFieldSettings", () => {
     it("should allow to discard field values", async () => {
       await setup();
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole("button", {
           name: "Discard cached field values",
         }),

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableSettings/MetadataTableSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableSettings/MetadataTableSettings.unit.spec.tsx
@@ -76,18 +76,24 @@ describe("MetadataTableSettings", () => {
     it("should allow to navigate to and from table settings in a no-schema database", async () => {
       await setup({ databases: [SAMPLE_DB_NO_SCHEMA] });
 
-      userEvent.click(screen.getByText(ORDERS_TABLE_NO_SCHEMA.display_name));
-      userEvent.click(screen.getByLabelText("Settings"));
+      await userEvent.click(
+        screen.getByText(ORDERS_TABLE_NO_SCHEMA.display_name),
+      );
+      await userEvent.click(screen.getByLabelText("Settings"));
       expect(await screen.findByText("Settings")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(SAMPLE_DB_NO_SCHEMA.name));
+      await userEvent.click(screen.getByText(SAMPLE_DB_NO_SCHEMA.name));
       expect(await screen.findByText("1 Queryable Table")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE_NO_SCHEMA.display_name));
-      userEvent.click(screen.getByLabelText("Settings"));
+      await userEvent.click(
+        screen.getByText(ORDERS_TABLE_NO_SCHEMA.display_name),
+      );
+      await userEvent.click(screen.getByLabelText("Settings"));
       expect(await screen.findByText("Settings")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE_NO_SCHEMA.display_name));
+      await userEvent.click(
+        screen.getByText(ORDERS_TABLE_NO_SCHEMA.display_name),
+      );
       expect(
         await screen.findByDisplayValue(ORDERS_TABLE_NO_SCHEMA.display_name),
       ).toBeInTheDocument();
@@ -96,18 +102,18 @@ describe("MetadataTableSettings", () => {
     it("should allow to navigate to and from table settings in a single-schema database", async () => {
       await setup();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
-      userEvent.click(screen.getByLabelText("Settings"));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByLabelText("Settings"));
       expect(await screen.findByText("Settings")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(SAMPLE_DB.name));
+      await userEvent.click(screen.getByText(SAMPLE_DB.name));
       expect(await screen.findByText("1 Queryable Table")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
-      userEvent.click(screen.getByLabelText("Settings"));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByLabelText("Settings"));
       expect(await screen.findByText("Settings")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
       expect(
         await screen.findByDisplayValue(ORDERS_TABLE.display_name),
       ).toBeInTheDocument();
@@ -116,31 +122,35 @@ describe("MetadataTableSettings", () => {
     it("should allow to navigate to and from table settings in a multi-schema database", async () => {
       await setup({ databases: [SAMPLE_DB_MULTI_SCHEMA] });
 
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
-      userEvent.click(
+      await userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
+      await userEvent.click(
         await screen.findByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name),
       );
-      userEvent.click(screen.getByLabelText("Settings"));
+      await userEvent.click(screen.getByLabelText("Settings"));
       expect(await screen.findByText("Settings")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(SAMPLE_DB_MULTI_SCHEMA.name));
+      await userEvent.click(screen.getByText(SAMPLE_DB_MULTI_SCHEMA.name));
       expect(await screen.findByText("2 schemas")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name));
-      userEvent.click(screen.getByLabelText("Settings"));
+      await userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
+      await userEvent.click(
+        screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name),
+      );
+      await userEvent.click(screen.getByLabelText("Settings"));
       expect(await screen.findByText("Settings")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
+      await userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.schema));
       expect(await screen.findByText("1 Queryable Table")).toBeInTheDocument();
 
-      userEvent.click(
+      await userEvent.click(
         await screen.findByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name),
       );
-      userEvent.click(screen.getByLabelText("Settings"));
+      await userEvent.click(screen.getByLabelText("Settings"));
       expect(await screen.findByText("Settings")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name));
+      await userEvent.click(
+        screen.getByText(PEOPLE_TABLE_MULTI_SCHEMA.display_name),
+      );
       expect(
         await screen.findByDisplayValue(PEOPLE_TABLE_MULTI_SCHEMA.display_name),
       ).toBeInTheDocument();
@@ -151,9 +161,9 @@ describe("MetadataTableSettings", () => {
     it("should allow to rescan field values", async () => {
       await setup();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
-      userEvent.click(screen.getByLabelText("Settings"));
-      userEvent.click(
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByLabelText("Settings"));
+      await userEvent.click(
         await screen.findByRole("button", { name: "Re-scan this table" }),
       );
 
@@ -166,9 +176,9 @@ describe("MetadataTableSettings", () => {
     it("should allow to discard field values", async () => {
       await setup();
 
-      userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
-      userEvent.click(screen.getByLabelText("Settings"));
-      userEvent.click(
+      await userEvent.click(screen.getByText(ORDERS_TABLE.display_name));
+      await userEvent.click(screen.getByLabelText("Settings"));
+      await userEvent.click(
         await screen.findByRole("button", {
           name: "Discard cached field values",
         }),

--- a/frontend/src/metabase/admin/people/forms/UserForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/people/forms/UserForm.unit.spec.tsx
@@ -86,14 +86,14 @@ describe("UserForm", () => {
     it("should allow you to add groups", async () => {
       const { onSubmit } = setup();
 
-      userEvent.click(await screen.findByText("foo"));
-      userEvent.click(await screen.findByText("Administrators"));
+      await userEvent.click(await screen.findByText("foo"));
+      await userEvent.click(await screen.findByText("Administrators"));
 
       expect(
         await screen.findByRole("generic", { name: "group-summary" }),
       ).toHaveTextContent("Admin and 1 other group");
 
-      userEvent.click(await screen.findByText("bar"));
+      await userEvent.click(await screen.findByText("bar"));
 
       expect(
         await screen.findByRole("generic", { name: "group-summary" }),
@@ -103,7 +103,9 @@ describe("UserForm", () => {
         await screen.findByRole("button", { name: "Update" }),
       ).toBeEnabled();
 
-      userEvent.click(await screen.findByRole("button", { name: "Update" }));
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Update" }),
+      );
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -136,14 +138,18 @@ describe("UserForm", () => {
     it("should allow you to remove a group", async () => {
       const { onSubmit } = setup();
 
-      userEvent.click(await screen.findByText("foo"));
-      userEvent.click(await screen.findByRole("listitem", { name: "foo" }));
+      await userEvent.click(await screen.findByText("foo"));
+      await userEvent.click(
+        await screen.findByRole("listitem", { name: "foo" }),
+      );
 
       expect(
         await screen.findByRole("generic", { name: "group-summary" }),
       ).toHaveTextContent("Default");
 
-      userEvent.click(await screen.findByRole("button", { name: "Update" }));
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Update" }),
+      );
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -186,15 +192,24 @@ describe("UserForm", () => {
         initialValues: eeUser,
       });
 
-      userEvent.click(await screen.findByText("Add an attribute"));
+      await userEvent.click(await screen.findByText("Add an attribute"));
 
-      userEvent.type((await screen.findAllByPlaceholderText("Key"))[1], "exp");
-      userEvent.type(
-        (await screen.findAllByPlaceholderText("Value"))[1],
+      await userEvent.type(
+        (
+          await screen.findAllByPlaceholderText("Key")
+        )[1],
+        "exp",
+      );
+      await userEvent.type(
+        (
+          await screen.findAllByPlaceholderText("Value")
+        )[1],
         "1234",
       );
 
-      userEvent.click(await screen.findByRole("button", { name: "Update" }));
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Update" }),
+      );
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -216,9 +231,11 @@ describe("UserForm", () => {
         initialValues: eeUser,
       });
 
-      userEvent.click(await screen.findByTestId("remove-mapping"));
+      await userEvent.click(await screen.findByTestId("remove-mapping"));
 
-      userEvent.click(await screen.findByRole("button", { name: "Update" }));
+      await userEvent.click(
+        await screen.findByRole("button", { name: "Update" }),
+      );
 
       await waitFor(() => {
         expect(onSubmit).toHaveBeenCalledWith(
@@ -237,9 +254,14 @@ describe("UserForm", () => {
         initialValues: eeUser,
       });
 
-      userEvent.click(await screen.findByText("Add an attribute"));
+      await userEvent.click(await screen.findByText("Add an attribute"));
 
-      userEvent.type((await screen.findAllByPlaceholderText("Key"))[1], "1");
+      await userEvent.type(
+        (
+          await screen.findAllByPlaceholderText("Key")
+        )[1],
+        "1",
+      );
 
       expect((await screen.findAllByPlaceholderText("Key"))[1]).toHaveValue(
         "1",
@@ -252,7 +274,7 @@ describe("UserForm", () => {
         initialValues: eeUser,
       });
 
-      userEvent.click(await screen.findByText("Add an attribute"));
+      await userEvent.click(await screen.findByText("Add an attribute"));
 
       // We need a delay in typing into the form so that the error
       // state is handled apropriately. Formik clears errors when you call

--- a/frontend/src/metabase/admin/permissions/components/ToolbarUpsell/ToolbarUpsell.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/components/ToolbarUpsell/ToolbarUpsell.unit.spec.tsx
@@ -9,10 +9,10 @@ const setup = () => {
 };
 
 describe("ToolbarUpsell", () => {
-  it("should add utm_media to the upgrade link", () => {
+  it("should add utm_media to the upgrade link", async () => {
     setup();
 
-    userEvent.click(screen.getByText("Get more control"));
+    await userEvent.click(screen.getByText("Get more control"));
 
     expect(
       screen.getByRole("link", { name: "Upgrade to Pro or Enterprise" }),

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
@@ -83,7 +83,7 @@ describe("Admin > CollectionPermissionsPage", () => {
       await userEvent.click(await screen.findByText("Yes"));
 
       expect(
-        await screen.findByText("You've made changes to permissions."),
+        screen.queryByText("You've made changes to permissions."),
       ).not.toBeInTheDocument();
 
       expect(await screen.findByText("Curate")).toBeInTheDocument();
@@ -140,7 +140,7 @@ describe("Admin > CollectionPermissionsPage", () => {
       await userEvent.click(await screen.findByText("Yes"));
 
       expect(
-        await screen.findByText("You've made changes to permissions."),
+        screen.queryByText("You've made changes to permissions."),
       ).not.toBeInTheDocument();
 
       expect(await screen.findAllByText("Curate")).toHaveLength(3);

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/common.unit.spec.tsx
@@ -24,7 +24,7 @@ describe("Admin > CollectionPermissionsPage", () => {
 
       const collection1 = await screen.findByText("Collection One");
       expect(screen.queryByText("Nested One")).not.toBeInTheDocument();
-      userEvent.click(collection1);
+      await userEvent.click(collection1);
       expect(await screen.findByText("Nested One")).toBeInTheDocument();
     });
 
@@ -42,8 +42,8 @@ describe("Admin > CollectionPermissionsPage", () => {
         await screen.findByText("Select a collection to see its permissions"),
       ).toBeVisible();
 
-      userEvent.click(await screen.findByText("Collection One"));
-      userEvent.click(await screen.findByText("Nested One"));
+      await userEvent.click(await screen.findByText("Collection One"));
+      await userEvent.click(await screen.findByText("Nested One"));
 
       expect(
         await screen.findByText("Permissions for Nested One"),
@@ -65,22 +65,22 @@ describe("Admin > CollectionPermissionsPage", () => {
         await screen.findByText("Select a collection to see its permissions"),
       ).toBeVisible();
 
-      userEvent.click(await screen.findByText("Collection One"));
-      userEvent.click(await screen.findByText("Nested One"));
+      await userEvent.click(await screen.findByText("Collection One"));
+      await userEvent.click(await screen.findByText("Nested One"));
 
       // change Other users from no access to view
-      userEvent.click(await screen.findByText("No access"));
+      await userEvent.click(await screen.findByText("No access"));
       const listbox = await screen.findByRole("listbox");
-      userEvent.click(within(listbox).getByText("View"));
+      await userEvent.click(within(listbox).getByText("View"));
 
       expect(
         await screen.findByText("You've made changes to permissions."),
       ).toBeInTheDocument();
 
-      userEvent.click(await screen.findByText("Save changes"));
+      await userEvent.click(await screen.findByText("Save changes"));
 
       // are you sure you want to save?
-      userEvent.click(await screen.findByText("Yes"));
+      await userEvent.click(await screen.findByText("Yes"));
 
       expect(
         await screen.findByText("You've made changes to permissions."),
@@ -115,7 +115,7 @@ describe("Admin > CollectionPermissionsPage", () => {
         await screen.findByText("Select a collection to see its permissions"),
       ).toBeVisible();
 
-      userEvent.click(await screen.findByText("Collection One"));
+      await userEvent.click(await screen.findByText("Collection One"));
 
       // change other users from read to curate on collection one
       // should also change permissions on nested one from no access to curate
@@ -124,20 +124,20 @@ describe("Admin > CollectionPermissionsPage", () => {
         .then(rows => rows[3]);
 
       expect(within(otherUsersRow).getByText("Other Users")).toBeVisible();
-      userEvent.click(within(otherUsersRow).getByText("View"));
+      await userEvent.click(within(otherUsersRow).getByText("View"));
 
       const popover = await screen.findByTestId("popover");
-      userEvent.click(within(popover).getByRole("switch")); // propagate switch
-      userEvent.click(within(popover).getByText("Curate"));
+      await userEvent.click(within(popover).getByRole("switch")); // propagate switch
+      await userEvent.click(within(popover).getByText("Curate"));
 
       expect(
         await screen.findByText("You've made changes to permissions."),
       ).toBeInTheDocument();
 
-      userEvent.click(await screen.findByText("Save changes"));
+      await userEvent.click(await screen.findByText("Save changes"));
 
       // are you sure you want to save?
-      userEvent.click(await screen.findByText("Yes"));
+      await userEvent.click(await screen.findByText("Yes"));
 
       expect(
         await screen.findByText("You've made changes to permissions."),
@@ -168,8 +168,8 @@ describe("Admin > CollectionPermissionsPage", () => {
     it("should show toggle to change sub-collection permissions if the collection has sub-collections", async () => {
       await setup();
 
-      userEvent.click(await screen.findByText("Collection One"));
-      userEvent.click(await screen.findByText("View"));
+      await userEvent.click(await screen.findByText("Collection One"));
+      await userEvent.click(await screen.findByText("View"));
 
       expect(
         await screen.findByText("Also change sub-collections"),
@@ -179,9 +179,9 @@ describe("Admin > CollectionPermissionsPage", () => {
     it("should not show toggle to change sub-collection permissions if the collection does not have sub-collections", async () => {
       await setup();
 
-      userEvent.click(await screen.findByText("Collection One"));
-      userEvent.click(await screen.findByText("Nested One"));
-      userEvent.click(await screen.findByText("View"));
+      await userEvent.click(await screen.findByText("Collection One"));
+      await userEvent.click(await screen.findByText("Nested One"));
+      await userEvent.click(await screen.findByText("View"));
 
       expect(
         screen.queryByText("Also change sub-collections"),

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
@@ -95,7 +95,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       await userEvent.click(await screen.findByText("Yes"));
 
       expect(
-        await screen.findByText("You've made changes to permissions."),
+        screen.queryByText("You've made changes to permissions."),
       ).not.toBeInTheDocument();
 
       expect(await screen.findAllByText("View")).toHaveLength(2);

--- a/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/pages/CollectionPermissionsPage/tests/enterprise.unit.spec.tsx
@@ -43,7 +43,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       expect(await screen.findByText("Instance Analytics")).toBeInTheDocument();
       expect(await screen.findAllByText("View")).toHaveLength(3);
 
-      userEvent.click(
+      await userEvent.click(
         await screen.findAllByText("View").then(dropdowns => dropdowns[2]),
       );
 
@@ -62,7 +62,7 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       expect(await screen.findByText("Instance Analytics")).toBeInTheDocument();
       expect(await screen.findAllByText("View")).toHaveLength(3);
 
-      userEvent.hover(
+      await userEvent.hover(
         await screen.findAllByText("View").then(dropdowns => dropdowns[1]),
       );
 
@@ -80,19 +80,19 @@ describe("Admin > CollectionPermissionsPage (enterprise)", () => {
       });
 
       // change all users users view to no access
-      userEvent.click(
+      await userEvent.click(
         await screen.findAllByText("View").then(dropdowns => dropdowns[0]),
       );
-      userEvent.click(await screen.findByText("No access"));
+      await userEvent.click(await screen.findByText("No access"));
 
       expect(
         await screen.findByText("You've made changes to permissions."),
       ).toBeInTheDocument();
 
-      userEvent.click(await screen.findByText("Save changes"));
+      await userEvent.click(await screen.findByText("Save changes"));
 
       // are you sure you want to save?
-      userEvent.click(await screen.findByText("Yes"));
+      await userEvent.click(await screen.findByText("Yes"));
 
       expect(
         await screen.findByText("You've made changes to permissions."),

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/common.unit.spec.tsx
@@ -16,8 +16,8 @@ describe("SettingsEditor", () => {
         settingValues: createMockSettings({ "enable-embedding": true }),
       });
 
-      userEvent.click(screen.getByText("Embedding"));
-      userEvent.click(screen.getByText("Interactive embedding"));
+      await userEvent.click(screen.getByText("Embedding"));
+      await userEvent.click(screen.getByText("Interactive embedding"));
       expect(screen.queryByText("Authorized origins")).not.toBeInTheDocument();
       expect(
         screen.queryByText("SameSite cookie setting"),

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding.unit.spec.tsx
@@ -34,8 +34,8 @@ describe("SettingsEditor", () => {
       }),
     });
 
-    userEvent.click(screen.getByText("Embedding"));
-    goToInteractiveEmbeddingSettings();
+    await userEvent.click(screen.getByText("Embedding"));
+    await goToInteractiveEmbeddingSettings();
     expect(screen.getByText("Interactive embedding")).toBeInTheDocument();
 
     expect(screen.getByText("Authorized origins")).toBeInTheDocument();
@@ -61,8 +61,8 @@ describe("SettingsEditor", () => {
         }),
       });
 
-      userEvent.click(screen.getByText("Embedding"));
-      goToInteractiveEmbeddingSettings();
+      await userEvent.click(screen.getByText("Embedding"));
+      await goToInteractiveEmbeddingSettings();
 
       expect(screen.getByTestId("authorized-origins-note")).toBeInTheDocument();
     });
@@ -81,8 +81,8 @@ describe("SettingsEditor", () => {
         }),
       });
 
-      userEvent.click(screen.getByText("Embedding"));
-      goToInteractiveEmbeddingSettings();
+      await userEvent.click(screen.getByText("Embedding"));
+      await goToInteractiveEmbeddingSettings();
 
       expect(
         screen.queryByTestId("authorized-origins-note"),
@@ -103,8 +103,8 @@ describe("SettingsEditor", () => {
         }),
       });
 
-      userEvent.click(screen.getByText("Embedding"));
-      goToInteractiveEmbeddingSettings();
+      await userEvent.click(screen.getByText("Embedding"));
+      await goToInteractiveEmbeddingSettings();
 
       expect(
         screen.queryByTestId("authorized-origins-note"),
@@ -113,6 +113,6 @@ describe("SettingsEditor", () => {
   });
 });
 
-const goToInteractiveEmbeddingSettings = () => {
-  userEvent.click(screen.getByText("Configure"));
+const goToInteractiveEmbeddingSettings = async () => {
+  await userEvent.click(screen.getByText("Configure"));
 };

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
@@ -105,7 +105,7 @@ describe("[OSS] embedding settings", () => {
         settingValues: { "enable-embedding": true },
       });
 
-      goToStaticEmbeddingSettings();
+      await goToStaticEmbeddingSettings();
 
       const location = history.getCurrentLocation();
       expect(location.pathname).toEqual(staticEmbeddingSettingsUrl);

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/common.embedding.unit.spec.tsx
@@ -4,7 +4,6 @@ import {
   goToStaticEmbeddingSettings,
   setupEmbedding,
   getQuickStartLink,
-  goToInteractiveEmbeddingSettings,
   staticEmbeddingSettingsUrl,
   embeddingSettingsUrl,
   interactiveEmbeddingSettingsUrl,
@@ -18,9 +17,7 @@ describe("[OSS] embedding settings", () => {
           settingValues: { "enable-embedding": false },
         });
 
-        expect(() => {
-          goToStaticEmbeddingSettings();
-        }).toThrow();
+        expect(screen.getByRole("button", { name: "Manage" })).toBeDisabled();
 
         history.push(staticEmbeddingSettingsUrl);
 
@@ -116,7 +113,12 @@ describe("[OSS] embedding settings", () => {
         settingValues: { "enable-embedding": true },
       });
 
-      expect(() => goToInteractiveEmbeddingSettings()).toThrow();
+      expect(
+        screen.queryByRole("button", { name: "Configure" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: "Learn More" }),
+      ).toBeInTheDocument();
 
       history.push(interactiveEmbeddingSettingsUrl);
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
@@ -114,7 +114,7 @@ describe("[EE, no token] embedding settings", () => {
         settingValues: { "enable-embedding": true },
       });
 
-      goToStaticEmbeddingSettings();
+      await goToStaticEmbeddingSettings();
 
       const location = history.getCurrentLocation();
       expect(location.pathname).toEqual(staticEmbeddingSettingsUrl);

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/enterprise.embedding.unit.spec.tsx
@@ -5,7 +5,6 @@ import {
   goToStaticEmbeddingSettings,
   setupEmbedding,
   getQuickStartLink,
-  goToInteractiveEmbeddingSettings,
   staticEmbeddingSettingsUrl,
   embeddingSettingsUrl,
   interactiveEmbeddingSettingsUrl,
@@ -27,9 +26,7 @@ describe("[EE, no token] embedding settings", () => {
           settingValues: { "enable-embedding": false },
         });
 
-        expect(() => {
-          goToStaticEmbeddingSettings();
-        }).toThrow();
+        expect(screen.getByRole("button", { name: "Manage" })).toBeDisabled();
 
         history.push(staticEmbeddingSettingsUrl);
 
@@ -125,7 +122,13 @@ describe("[EE, no token] embedding settings", () => {
         settingValues: { "enable-embedding": true },
       });
 
-      expect(() => goToInteractiveEmbeddingSettings()).toThrow();
+      expect(
+        screen.queryByRole("button", { name: "Configure" }),
+      ).not.toBeInTheDocument();
+
+      expect(
+        screen.getByRole("link", { name: "Learn More" }),
+      ).toBeInTheDocument();
 
       history.push(interactiveEmbeddingSettingsUrl);
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -27,9 +27,9 @@ describe("[EE, with token] embedding settings", () => {
           settingValues: { "enable-embedding": false },
         });
 
-        expect(() => {
-          goToStaticEmbeddingSettings();
-        }).toThrow();
+        expect(
+          await screen.findByRole("button", { name: "Manage" }),
+        ).toBeDisabled();
 
         history.push(staticEmbeddingSettingsUrl);
 
@@ -55,9 +55,9 @@ describe("[EE, with token] embedding settings", () => {
           settingValues: { "enable-embedding": false },
         });
 
-        expect(() => {
-          goToInteractiveEmbeddingSettings();
-        }).toThrow();
+        expect(
+          await screen.findByRole("button", { name: "Configure" }),
+        ).toBeDisabled();
 
         history.push(interactiveEmbeddingSettingsUrl);
 

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/premium.embedding.unit.spec.tsx
@@ -87,7 +87,7 @@ describe("[EE, with token] embedding settings", () => {
         settingValues: { "enable-embedding": true },
       });
 
-      goToStaticEmbeddingSettings();
+      await goToStaticEmbeddingSettings();
 
       const location = history.getCurrentLocation();
       expect(location.pathname).toEqual(staticEmbeddingSettingsUrl);
@@ -98,7 +98,7 @@ describe("[EE, with token] embedding settings", () => {
         settingValues: { "enable-embedding": true },
       });
 
-      goToInteractiveEmbeddingSettings();
+      await goToInteractiveEmbeddingSettings();
 
       const location = history.getCurrentLocation();
       expect(location.pathname).toEqual(interactiveEmbeddingSettingsUrl);

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/setup.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/embedding/setup.tsx
@@ -33,17 +33,17 @@ export const setupEmbedding = async ({
   fetchMock.get("path:/api/dashboard/embeddable", []);
   fetchMock.get("path:/api/card/embeddable", []);
 
-  userEvent.click(screen.getByText("Embedding"));
+  await userEvent.click(screen.getByText("Embedding"));
 
   return { ...returnedValue, history: checkNotNull(returnedValue.history) };
 };
 
-export const goToStaticEmbeddingSettings = () => {
-  userEvent.click(screen.getByText("Manage"));
+export const goToStaticEmbeddingSettings = async () => {
+  await userEvent.click(screen.getByText("Manage"));
 };
 
-export const goToInteractiveEmbeddingSettings = () => {
-  userEvent.click(screen.getByText("Configure"));
+export const goToInteractiveEmbeddingSettings = async () => {
+  await userEvent.click(screen.getByText("Configure"));
 };
 
 export const getQuickStartLink = () => {

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/enterprise.unit.spec.tsx
@@ -26,8 +26,8 @@ describe("SettingsEditor", () => {
       settingValues: createMockSettings({ "enable-embedding": true }),
     });
 
-    userEvent.click(screen.getByText("Embedding"));
-    userEvent.click(screen.getByText("Interactive embedding"));
+    await userEvent.click(screen.getByText("Embedding"));
+    await userEvent.click(screen.getByText("Interactive embedding"));
     expect(screen.queryByText("Authorized origins")).not.toBeInTheDocument();
     expect(
       screen.queryByText("SameSite cookie setting"),
@@ -46,7 +46,7 @@ describe("SettingsEditor", () => {
       }),
     });
 
-    userEvent.click(screen.getByText("Authentication"));
+    await userEvent.click(screen.getByText("Authentication"));
     expect(screen.getByText("Sign in with Google")).toBeInTheDocument();
     expect(
       screen.queryByText("Enable Password Authentication"),

--- a/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/password-login.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/app/components/SettingsEditor/tests/password-login.unit.spec.tsx
@@ -34,7 +34,7 @@ describe("SettingsEditor", () => {
       }),
     });
 
-    userEvent.click(screen.getByText("Authentication"));
+    await userEvent.click(screen.getByText("Authentication"));
     expect(screen.getByText("Sign in with Google")).toBeInTheDocument();
     expect(
       screen.getByText("Enable Password Authentication"),

--- a/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/AuthCard/AuthCard.unit.spec.tsx
@@ -25,9 +25,9 @@ describe("AuthCard", () => {
     });
 
     render(<AuthCard {...props} />);
-    userEvent.click(screen.getByLabelText("ellipsis icon"));
+    await userEvent.click(screen.getByLabelText("ellipsis icon"));
     await screen.findByRole("dialog");
-    userEvent.click(screen.getByText("Pause"));
+    await userEvent.click(screen.getByText("Pause"));
 
     expect(props.onChange).toHaveBeenCalledWith(false);
   });
@@ -39,9 +39,9 @@ describe("AuthCard", () => {
     });
 
     render(<AuthCard {...props} />);
-    userEvent.click(screen.getByLabelText("ellipsis icon"));
+    await userEvent.click(screen.getByLabelText("ellipsis icon"));
     await screen.findByRole("dialog");
-    userEvent.click(screen.getByText("Resume"));
+    await userEvent.click(screen.getByText("Resume"));
 
     expect(props.onChange).toHaveBeenCalledWith(true);
   });
@@ -53,10 +53,10 @@ describe("AuthCard", () => {
     });
 
     render(<AuthCard {...props} />);
-    userEvent.click(screen.getByLabelText("ellipsis icon"));
+    await userEvent.click(screen.getByLabelText("ellipsis icon"));
     await screen.findByRole("dialog");
-    userEvent.click(screen.getByText("Deactivate"));
-    userEvent.click(screen.getByRole("button", { name: "Deactivate" }));
+    await userEvent.click(screen.getByText("Deactivate"));
+    await userEvent.click(screen.getByRole("button", { name: "Deactivate" }));
 
     expect(props.onDeactivate).toHaveBeenCalled();
   });

--- a/frontend/src/metabase/admin/settings/auth/components/GoogleAuthForm/GoogleAuthForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/auth/components/GoogleAuthForm/GoogleAuthForm.unit.spec.tsx
@@ -11,7 +11,7 @@ describe("GoogleAuthForm", () => {
     const props = getProps();
 
     render(<GoogleAuthForm {...props} />);
-    userEvent.type(screen.getByLabelText("Client ID"), "id.test");
+    await userEvent.type(screen.getByLabelText("Client ID"), "id.test");
     await waitFor(() => expect(screen.getByText(/Save/)).toBeEnabled());
     screen.getByText("Save and enable").click();
 
@@ -27,7 +27,7 @@ describe("GoogleAuthForm", () => {
     });
   });
 
-  it("should not submit the form without required fields", () => {
+  it("should not submit the form without required fields", async () => {
     const props = getProps({
       isEnabled: true,
       elements: [
@@ -39,7 +39,7 @@ describe("GoogleAuthForm", () => {
     });
 
     render(<GoogleAuthForm {...props} />);
-    userEvent.type(screen.getByLabelText("Domain"), "domain.test");
+    await userEvent.type(screen.getByLabelText("Domain"), "domain.test");
 
     expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
   });
@@ -56,7 +56,7 @@ describe("GoogleAuthForm", () => {
     });
 
     render(<GoogleAuthForm {...props} />);
-    userEvent.type(screen.getByLabelText("Domain"), "domain.test");
+    await userEvent.type(screen.getByLabelText("Domain"), "domain.test");
     screen.getByText("Save changes").click();
 
     await waitFor(() => {

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.unit.spec.tsx
@@ -87,15 +87,15 @@ describe("ManageApiKeys", () => {
   });
   it("should create a new API key", async () => {
     await setup();
-    userEvent.click(screen.getByText("Create API Key"));
+    await userEvent.click(screen.getByText("Create API Key"));
     expect(await screen.findByText("Create a new API Key")).toBeInTheDocument();
-    userEvent.type(screen.getByLabelText(/Key name/), "New key");
-    userEvent.click(await screen.findByLabelText(/which group/i));
-    userEvent.click(await screen.findByText("flamingos"));
+    await userEvent.type(screen.getByLabelText(/Key name/), "New key");
+    await userEvent.click(await screen.findByLabelText(/which group/i));
+    await userEvent.click(await screen.findByText("flamingos"));
 
     const createButton = screen.getByRole("button", { name: "Create" });
     await waitFor(() => expect(createButton).toBeEnabled());
-    userEvent.click(createButton);
+    await userEvent.click(createButton);
 
     expect(
       await screen.findByText("Copy and save the API key"),
@@ -106,7 +106,7 @@ describe("ManageApiKeys", () => {
         ?.request?.json(),
     ).toEqual({ name: "New key", group_id: 5 });
 
-    userEvent.click(screen.getByRole("button", { name: "Done" }));
+    await userEvent.click(screen.getByRole("button", { name: "Done" }));
 
     await waitFor(() =>
       expect(
@@ -119,7 +119,7 @@ describe("ManageApiKeys", () => {
     const REGEN_URL = "path:/api/api-key/1/regenerate";
     fetchMock.put(REGEN_URL, 200);
 
-    userEvent.click(
+    await userEvent.click(
       within(
         await screen.findByRole("row", {
           name: /development api key/i,
@@ -127,8 +127,12 @@ describe("ManageApiKeys", () => {
       ).getByRole("img", { name: /pencil/i }),
     );
     await screen.findByText("Edit API Key");
-    userEvent.click(screen.getByRole("button", { name: "Regenerate API Key" }));
-    userEvent.click(await screen.findByRole("button", { name: "Regenerate" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Regenerate API Key" }),
+    );
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Regenerate" }),
+    );
 
     await screen.findByText("Copy and save the API key");
     expect(
@@ -145,7 +149,7 @@ describe("ManageApiKeys", () => {
     const EDIT_URL = "path:/api/api-key/1";
     fetchMock.put(EDIT_URL, 200);
 
-    userEvent.click(
+    await userEvent.click(
       within(
         await screen.findByRole("row", {
           name: /development api key/i,
@@ -155,14 +159,14 @@ describe("ManageApiKeys", () => {
     await screen.findByText("Edit API Key");
 
     const group = await screen.findByLabelText(/which group/i);
-    userEvent.click(group);
-    userEvent.click(await screen.findByText("flamingos"));
+    await userEvent.click(group);
+    await userEvent.click(await screen.findByText("flamingos"));
 
     const keyName = screen.getByLabelText("Key name");
-    userEvent.clear(keyName);
-    userEvent.type(keyName, "My Key");
+    await userEvent.clear(keyName);
+    await userEvent.type(keyName, "My Key");
 
-    userEvent.click(screen.getByRole("button", { name: "Save" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
     await waitFor(async () => {
       expect(
         await fetchMock.lastCall(EDIT_URL, { method: "PUT" })?.request?.json(),
@@ -179,14 +183,14 @@ describe("ManageApiKeys", () => {
     const DELETE_URL = "path:/api/api-key/1";
     fetchMock.delete(DELETE_URL, 200);
 
-    userEvent.click(
+    await userEvent.click(
       within(
         await screen.findByRole("row", {
           name: /development api key/i,
         }),
       ).getByRole("img", { name: /trash/i }),
     );
-    userEvent.click(
+    await userEvent.click(
       await screen.findByRole("button", { name: "Delete API Key" }),
     );
     await waitFor(() => {

--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.unit.spec.tsx
@@ -254,7 +254,6 @@ describe("SettingsLdapForm", () => {
       "ldap-sync-admin-group": true,
     };
 
-    await userEvent.click(screen.getByLabelText(/User Provisioning/));
     await userEvent.type(
       await screen.findByRole("textbox", { name: /LDAP Host/ }),
       ATTRS["ldap-host"],

--- a/frontend/src/metabase/admin/settings/components/SettingsLdapForm.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsLdapForm.unit.spec.tsx
@@ -254,54 +254,58 @@ describe("SettingsLdapForm", () => {
       "ldap-sync-admin-group": true,
     };
 
-    userEvent.type(
+    await userEvent.click(screen.getByLabelText(/User Provisioning/));
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /LDAP Host/ }),
       ATTRS["ldap-host"],
     );
-    userEvent.type(
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /LDAP Port/ }),
       ATTRS["ldap-port"],
     );
-    userEvent.click(screen.getByRole("radio", { name: /SSL/ }));
-    userEvent.type(
+    await userEvent.click(screen.getByRole("radio", { name: /SSL/ }));
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /Username or DN/ }),
       ATTRS["ldap-bind-dn"],
     );
-    userEvent.type(screen.getByLabelText(/Password/), ATTRS["ldap-password"]);
-    userEvent.type(
+    await userEvent.type(
+      screen.getByLabelText(/Password/),
+      ATTRS["ldap-password"],
+    );
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /User search base/ }),
       ATTRS["ldap-user-base"],
     );
-    userEvent.type(
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /User filter/ }),
       ATTRS["ldap-user-filter"],
     );
-    userEvent.type(
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /Email attribute/ }),
       ATTRS["ldap-attribute-email"],
     );
-    userEvent.type(
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /First name attribute/ }),
       ATTRS["ldap-attribute-firstname"],
     );
-    userEvent.type(
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /Last name attribute/ }),
       ATTRS["ldap-attribute-lastname"],
     );
-    userEvent.click(screen.getByTestId("group-sync-switch")); // checkbox for "ldap-group-sync"
-    userEvent.type(
+    await userEvent.click(screen.getByTestId("group-sync-switch")); // checkbox for "ldap-group-sync"
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /Group search base/ }),
       ATTRS["ldap-group-base"],
     );
-    userEvent.type(
+    await userEvent.type(
       await screen.findByRole("textbox", { name: /Group membership filter/ }),
       ATTRS["ldap-group-membership-filter"],
     );
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("checkbox", { name: /Sync Administrator group/ }),
     );
 
-    userEvent.click(await screen.findByRole("button", { name: /Save/ }));
+    await userEvent.click(await screen.findByRole("button", { name: /Save/ }));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(ATTRS);

--- a/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/UploadSettings/UploadSettings.unit.spec.tsx
@@ -115,7 +115,7 @@ describe("Admin > Settings > UploadSetting", () => {
 
   it("should populate a dropdown of actions-enabled DBs", async () => {
     setup();
-    userEvent.click(await screen.findByText("Select a database"));
+    await userEvent.click(await screen.findByText("Select a database"));
 
     expect(await screen.findByText("Db Uno")).toBeInTheDocument();
     expect(await screen.findByText("Db Dos")).toBeInTheDocument();
@@ -125,13 +125,13 @@ describe("Admin > Settings > UploadSetting", () => {
 
   it("should populate a dropdown of schema for schema-enabled DBs", async () => {
     setup();
-    userEvent.click(await screen.findByText("Select a database"));
+    await userEvent.click(await screen.findByText("Select a database"));
 
     const dbItem = await screen.findByText("Db Uno");
-    userEvent.click(dbItem);
+    await userEvent.click(dbItem);
 
     const schemaDropdown = await screen.findByText("Select a schema");
-    userEvent.click(schemaDropdown);
+    await userEvent.click(schemaDropdown);
 
     expect(await screen.findByText("public")).toBeInTheDocument();
     expect(await screen.findByText("uploads")).toBeInTheDocument();
@@ -140,19 +140,19 @@ describe("Admin > Settings > UploadSetting", () => {
 
   it("should be able to submit a db + schema combination selection", async () => {
     const { updateSpy } = setup();
-    userEvent.click(await screen.findByText("Select a database"));
+    await userEvent.click(await screen.findByText("Select a database"));
 
     const dbItem = await screen.findByText("Db Uno");
-    userEvent.click(dbItem);
+    await userEvent.click(dbItem);
 
     const schemaDropdown = await screen.findByText("Select a schema");
-    userEvent.click(schemaDropdown);
+    await userEvent.click(schemaDropdown);
 
     const schemaItem = await screen.findByText("uploads");
 
-    userEvent.click(schemaItem);
+    await userEvent.click(schemaItem);
 
-    userEvent.click(
+    await userEvent.click(
       await screen.findByRole("button", { name: "Enable uploads" }),
     );
 
@@ -166,17 +166,17 @@ describe("Admin > Settings > UploadSetting", () => {
 
   it("should be able to submit a table prefix for databases without schema", async () => {
     const { updateSpy } = setup();
-    userEvent.click(await screen.findByText("Select a database"));
+    await userEvent.click(await screen.findByText("Select a database"));
 
     const dbItem = await screen.findByText("Db Dos");
-    userEvent.click(dbItem);
+    await userEvent.click(dbItem);
 
     const prefixInput = await screen.findByPlaceholderText("upload_");
 
-    userEvent.clear(prefixInput);
-    userEvent.type(prefixInput, "my_prefix_");
+    await userEvent.clear(prefixInput);
+    await userEvent.type(prefixInput, "my_prefix_");
 
-    userEvent.click(
+    await userEvent.click(
       await screen.findByRole("button", { name: "Enable uploads" }),
     );
 
@@ -190,22 +190,22 @@ describe("Admin > Settings > UploadSetting", () => {
 
   it("should be able to submit a table prefix for databases with schema", async () => {
     const { updateSpy } = setup();
-    userEvent.click(await screen.findByText("Select a database"));
+    await userEvent.click(await screen.findByText("Select a database"));
 
     const dbItem = await screen.findByText("Db Uno");
-    userEvent.click(dbItem);
+    await userEvent.click(dbItem);
 
     const schemaDropdown = await screen.findByText("Select a schema");
-    userEvent.click(schemaDropdown);
+    await userEvent.click(schemaDropdown);
 
     const schemaItem = await screen.findByText("uploads");
-    userEvent.click(schemaItem);
+    await userEvent.click(schemaItem);
 
     const prefixInput = await screen.findByPlaceholderText("upload_");
-    userEvent.clear(prefixInput);
-    userEvent.type(prefixInput, "my_prefix_");
+    await userEvent.clear(prefixInput);
+    await userEvent.type(prefixInput, "my_prefix_");
 
-    userEvent.click(
+    await userEvent.click(
       await screen.findByRole("button", { name: "Enable uploads" }),
     );
 
@@ -219,17 +219,17 @@ describe("Admin > Settings > UploadSetting", () => {
 
   it("should call update methods on saveStatusRef", async () => {
     const { savingSpy, savedSpy } = setup();
-    userEvent.click(await screen.findByText("Select a database"));
+    await userEvent.click(await screen.findByText("Select a database"));
 
     const dbItem = await screen.findByText("Db Dos");
-    userEvent.click(dbItem);
+    await userEvent.click(dbItem);
 
     const prefixInput = await screen.findByPlaceholderText("upload_");
 
-    userEvent.clear(prefixInput);
-    userEvent.type(prefixInput, "my_prefix_");
+    await userEvent.clear(prefixInput);
+    await userEvent.type(prefixInput, "my_prefix_");
 
-    userEvent.click(
+    await userEvent.click(
       await screen.findByRole("button", { name: "Enable uploads" }),
     );
 
@@ -240,12 +240,12 @@ describe("Admin > Settings > UploadSetting", () => {
   it("should show an error if enabling fails", async () => {
     const { updateSpy } = setup();
     updateSpy.mockImplementation(() => Promise.reject(new Error("Oh no!")));
-    userEvent.click(await screen.findByText("Select a database"));
+    await userEvent.click(await screen.findByText("Select a database"));
 
     const dbItem = await screen.findByText("Db Dos");
-    userEvent.click(dbItem);
+    await userEvent.click(dbItem);
 
-    userEvent.click(
+    await userEvent.click(
       await screen.findByRole("button", { name: "Enable uploads" }),
     );
 
@@ -268,7 +268,7 @@ describe("Admin > Settings > UploadSetting", () => {
         uploads_table_prefix: null,
       },
     });
-    userEvent.click(
+    await userEvent.click(
       await screen.findByRole("button", { name: "Disable uploads" }),
     );
 
@@ -290,7 +290,7 @@ describe("Admin > Settings > UploadSetting", () => {
       },
     });
     updateSpy.mockImplementation(() => Promise.reject(new Error("Oh no!")));
-    userEvent.click(
+    await userEvent.click(
       await screen.findByRole("button", { name: "Disable uploads" }),
     );
 
@@ -362,10 +362,10 @@ describe("Admin > Settings > UploadSetting", () => {
         uploads_table_prefix: null,
       },
     });
-    userEvent.click(await screen.findByText("Db Dos"));
+    await userEvent.click(await screen.findByText("Db Dos"));
 
     const dbItem = await screen.findByText("Db Uno");
-    userEvent.click(dbItem);
+    await userEvent.click(dbItem);
 
     expect(
       screen.queryByRole("button", { name: "Enable uploads" }),
@@ -377,12 +377,12 @@ describe("Admin > Settings > UploadSetting", () => {
     expect(updateButton).toBeDisabled(); // because no schema is selected
 
     const schemaDropdown = await screen.findByText("Select a schema");
-    userEvent.click(schemaDropdown);
+    await userEvent.click(schemaDropdown);
 
     const schemaItem = await screen.findByText("uploads");
-    userEvent.click(schemaItem);
+    await userEvent.click(schemaItem);
 
-    userEvent.click(
+    await userEvent.click(
       await screen.findByRole("button", { name: "Update settings" }),
     );
 
@@ -404,10 +404,10 @@ describe("Admin > Settings > UploadSetting", () => {
 
     it("should show disabled enable button when no schema is selected", async () => {
       setup();
-      userEvent.click(await screen.findByText("Select a database"));
+      await userEvent.click(await screen.findByText("Select a database"));
 
       const dbItem = await screen.findByText("Db Uno");
-      userEvent.click(dbItem);
+      await userEvent.click(dbItem);
 
       expect(
         await screen.findByRole("button", { name: "Enable uploads" }),
@@ -430,10 +430,10 @@ describe("Admin > Settings > UploadSetting", () => {
 
     it("should enable the enable button when a schemaless db is selected", async () => {
       setup();
-      userEvent.click(await screen.findByText("Select a database"));
+      await userEvent.click(await screen.findByText("Select a database"));
 
       const dbItem = await screen.findByText("Db Dos");
-      userEvent.click(dbItem);
+      await userEvent.click(dbItem);
 
       expect(
         await screen.findByRole("button", { name: "Enable uploads" }),
@@ -449,10 +449,10 @@ describe("Admin > Settings > UploadSetting", () => {
           uploads_table_prefix: null,
         },
       });
-      userEvent.click(await screen.findByText("Db Dos"));
+      await userEvent.click(await screen.findByText("Db Dos"));
 
       const dbItem = await screen.findByText("Db Uno");
-      userEvent.click(dbItem);
+      await userEvent.click(dbItem);
 
       expect(
         screen.queryByRole("button", { name: "Enable uploads" }),
@@ -467,10 +467,10 @@ describe("Admin > Settings > UploadSetting", () => {
       expect(updateButton).toBeDisabled(); // because no schema is selected
 
       const schemaDropdown = await screen.findByText("Select a schema");
-      userEvent.click(schemaDropdown);
+      await userEvent.click(schemaDropdown);
 
       const schemaItem = await screen.findByText("uploads");
-      userEvent.click(schemaItem);
+      await userEvent.click(schemaItem);
 
       expect(updateButton).toBeEnabled(); // now that a schema is selected
     });
@@ -486,8 +486,8 @@ describe("Admin > Settings > UploadSetting", () => {
       });
 
       const prefixInput = await screen.findByPlaceholderText("upload_");
-      userEvent.clear(prefixInput);
-      userEvent.type(prefixInput, "my_prefix_");
+      await userEvent.clear(prefixInput);
+      await userEvent.type(prefixInput, "my_prefix_");
 
       expect(
         await screen.findByRole("button", { name: "Update settings" }),
@@ -508,13 +508,13 @@ describe("Admin > Settings > UploadSetting", () => {
       );
 
       const prefixInput = await screen.findByPlaceholderText("upload_");
-      userEvent.clear(prefixInput);
-      userEvent.type(prefixInput, "my_prefix_");
+      await userEvent.clear(prefixInput);
+      await userEvent.type(prefixInput, "my_prefix_");
 
       const updateButton = await screen.findByRole("button", {
         name: "Update settings",
       });
-      userEvent.click(updateButton);
+      await userEvent.click(updateButton);
       expect(await screen.findByTestId("loading-spinner")).toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: "Update settings" }),
@@ -535,20 +535,20 @@ describe("Admin > Settings > UploadSetting", () => {
       );
 
       const prefixInput = await screen.findByPlaceholderText("upload_");
-      userEvent.clear(prefixInput);
-      userEvent.type(prefixInput, "my_prefix_");
+      await userEvent.clear(prefixInput);
+      await userEvent.type(prefixInput, "my_prefix_");
 
       const updateButton = await screen.findByRole("button", {
         name: "Update settings",
       });
-      userEvent.click(updateButton);
+      await userEvent.click(updateButton);
       expect(await screen.findByTestId("loading-spinner")).toBeInTheDocument();
       expect(
         screen.queryByRole("button", { name: "Update settings" }),
       ).not.toBeInTheDocument();
 
-      userEvent.clear(prefixInput);
-      userEvent.type(prefixInput, "_2");
+      await userEvent.clear(prefixInput);
+      await userEvent.type(prefixInput, "_2");
       expect(
         screen.getByRole("button", { name: "Update settings" }),
       ).toBeInTheDocument();
@@ -557,9 +557,9 @@ describe("Admin > Settings > UploadSetting", () => {
 
   it("should show a warning for h2 databases", async () => {
     setup();
-    userEvent.click(await screen.findByText("Select a database"));
+    await userEvent.click(await screen.findByText("Select a database"));
 
-    userEvent.click(await screen.findByText("Db Cinco")); // h2
+    await userEvent.click(await screen.findByText("Db Cinco")); // h2
 
     expect(
       screen.getByText(/uploads to the Sample Database are for testing only/i),

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/DeleteGroupMappingModal/DeleteGroupMappingModal.unit.spec.tsx
@@ -60,16 +60,16 @@ describe("DeleteGroupMappingModal", () => {
     ).toBeChecked();
   });
 
-  it("confirms when clearing members", () => {
+  it("confirms when clearing members", async () => {
     setup();
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByLabelText(
         "Also remove all group members (except from Admin)",
       ),
     );
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("button", { name: "Remove mapping and members" }),
     );
 
@@ -80,12 +80,12 @@ describe("DeleteGroupMappingModal", () => {
     );
   });
 
-  it("confirms when deleting groups", () => {
+  it("confirms when deleting groups", async () => {
     setup();
 
-    userEvent.click(screen.getByLabelText("Also delete the group"));
+    await userEvent.click(screen.getByLabelText("Also delete the group"));
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("button", { name: "Remove mapping and delete group" }),
     );
 

--- a/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/GroupMappingsWidget.unit.spec.jsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/GroupMappingsWidget/GroupMappingsWidget.unit.spec.jsx
@@ -46,10 +46,10 @@ describe("GroupMappingsWidget", () => {
       expect(await screen.findByText("Admin")).toBeInTheDocument();
 
       // Click on button to delete mapping
-      userEvent.click(await screen.findByLabelText("close icon"));
+      await userEvent.click(await screen.findByLabelText("close icon"));
 
       // Confirm remove
-      userEvent.click(screen.getByText("Yes"));
+      await userEvent.click(screen.getByText("Yes"));
 
       await waitFor(() => {
         expect(updateSettingSpy).toHaveBeenCalledTimes(1);
@@ -75,10 +75,12 @@ describe("GroupMappingsWidget", () => {
       expect(await screen.findByText("2 other groups")).toBeInTheDocument();
 
       // Click on button to delete mapping
-      userEvent.click(await screen.findByLabelText("close icon"));
+      await userEvent.click(await screen.findByLabelText("close icon"));
 
-      userEvent.click(screen.getByLabelText(/Also remove all group members/i));
-      userEvent.click(
+      await userEvent.click(
+        screen.getByLabelText(/Also remove all group members/i),
+      );
+      await userEvent.click(
         await screen.findByRole("button", {
           name: "Remove mapping and members",
         }),
@@ -98,10 +100,10 @@ describe("GroupMappingsWidget", () => {
       expect(await screen.findByText("2 other groups")).toBeInTheDocument();
 
       // Click on button to delete mapping
-      userEvent.click(await screen.findByLabelText("close icon"));
+      await userEvent.click(await screen.findByLabelText("close icon"));
 
-      userEvent.click(screen.getByLabelText(/Also delete the groups/i));
-      userEvent.click(
+      await userEvent.click(screen.getByLabelText(/Also delete the groups/i));
+      await userEvent.click(
         await screen.findByRole("button", {
           name: "Remove mapping and delete groups",
         }),

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingInput/SettingInput.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingInput/SettingInput.unit.spec.tsx
@@ -36,7 +36,7 @@ function setup({ setting, value, type, normalize }: SetupOpts) {
 }
 
 describe("SettingInput", () => {
-  it("when type=number should allow decimal values", () => {
+  it("when type=number should allow decimal values", async () => {
     const setting = {
       key: "test",
       value: "100",
@@ -45,8 +45,8 @@ describe("SettingInput", () => {
     };
     const { onChange } = setup({ setting, value: 100, type: "number" });
 
-    userEvent.type(screen.getByPlaceholderText("numeric value"), ".25");
-    userEvent.tab(); // blur
+    await userEvent.type(screen.getByPlaceholderText("numeric value"), ".25");
+    await userEvent.tab(); // blur
 
     expect(onChange).toHaveBeenCalledWith(100.25);
   });
@@ -74,34 +74,34 @@ describe("SettingInput", () => {
       expect(screen.getByDisplayValue(value)).toBeInTheDocument();
     });
 
-    it("should call onChange without leading or trailing spaces string", () => {
+    it("should call onChange without leading or trailing spaces string", async () => {
       const value = "/";
       const { onChange } = setup({ setting, value, type: "text", normalize });
 
       const input = screen.getByDisplayValue(value);
-      userEvent.clear(input);
-      userEvent.type(input, "  /  ");
+      await userEvent.clear(input);
+      await userEvent.type(input, "  /  ");
       input.blur();
       expect(onChange).toHaveBeenCalledWith("/");
     });
 
-    it("should call onChange with null", () => {
+    it("should call onChange with null", async () => {
       const value = "/";
       const { onChange } = setup({ setting, value, type: "text", normalize });
 
       const input = screen.getByDisplayValue(value);
-      userEvent.clear(input);
+      await userEvent.clear(input);
       input.blur();
       expect(onChange).toHaveBeenCalledWith(null);
     });
 
-    it("should call onChange with number", () => {
+    it("should call onChange with number", async () => {
       const value = "1";
       const { onChange } = setup({ setting, value, type: "number", normalize });
 
       const input = screen.getByDisplayValue(value);
-      userEvent.clear(input);
-      userEvent.type(input, "2");
+      await userEvent.clear(input);
+      await userEvent.type(input, "2");
       input.blur();
       expect(onChange).toHaveBeenCalledWith(2);
     });

--- a/frontend/src/metabase/admin/settings/components/widgets/SettingTextInput/SettingTextInput.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/components/widgets/SettingTextInput/SettingTextInput.unit.spec.tsx
@@ -59,23 +59,23 @@ describe("SettingTextInput (metabase/ui)", () => {
       expect(screen.getByDisplayValue(value)).toBeInTheDocument();
     });
 
-    it("should call onChange without leading or trailing spaces string", () => {
+    it("should call onChange without leading or trailing spaces string", async () => {
       const value = "/";
       const { onChange } = setup({ setting, value, type: "text", normalize });
 
       const input = screen.getByDisplayValue(value);
-      userEvent.clear(input);
-      userEvent.type(input, "  /  ");
+      await userEvent.clear(input);
+      await userEvent.type(input, "  /  ");
       input.blur();
       expect(onChange).toHaveBeenCalledWith("/");
     });
 
-    it("should call onChange with null", () => {
+    it("should call onChange with null", async () => {
       const value = "/";
       const { onChange } = setup({ setting, value, type: "text", normalize });
 
       const input = screen.getByDisplayValue(value);
-      userEvent.clear(input);
+      await userEvent.clear(input);
       input.blur();
       expect(onChange).toHaveBeenCalledWith(null);
     });

--- a/frontend/src/metabase/admin/settings/setup/components/SetupCheckList/SetupCheckList.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/setup/components/SetupCheckList/SetupCheckList.unit.spec.tsx
@@ -62,7 +62,7 @@ describe("SetupCheckList", () => {
     const link = screen.getByRole("link", { name: ADD_DB_TASK.title });
     expect(link).not.toHaveAttribute("target");
 
-    userEvent.click(link);
+    await userEvent.click(link);
     expect(history?.getCurrentLocation().pathname).toBe(ADD_DB_TASK.link);
   });
 

--- a/frontend/src/metabase/admin/settings/slack/components/SlackDeleteModal/SlackDeleteModal.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackDeleteModal/SlackDeleteModal.unit.spec.tsx
@@ -9,18 +9,18 @@ describe("SlackDeleteModal", () => {
     const onClose = jest.fn();
 
     render(<SlackDeleteModal onDelete={onDelete} onClose={onClose} />);
-    userEvent.click(screen.getByText("Delete"));
+    await userEvent.click(screen.getByText("Delete"));
 
     await waitFor(() => expect(onDelete).toHaveBeenCalled());
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("should close the modal on cancel", () => {
+  it("should close the modal on cancel", async () => {
     const onDelete = jest.fn();
     const onClose = jest.fn();
 
     render(<SlackDeleteModal onDelete={onDelete} onClose={onClose} />);
-    userEvent.click(screen.getByText("Cancel"));
+    await userEvent.click(screen.getByText("Cancel"));
 
     expect(onDelete).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();

--- a/frontend/src/metabase/admin/settings/slack/components/SlackSetup/SlackSetup.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackSetup/SlackSetup.unit.spec.tsx
@@ -6,16 +6,16 @@ import SlackSetup from "./SlackSetup";
 const FormMock = () => <div />;
 
 describe("SlackSetup", () => {
-  it("should toggle setup sections", () => {
+  it("should toggle setup sections", async () => {
     render(<SlackSetup Form={FormMock} />);
     expect(screen.getByText("Install to workspace")).toBeInTheDocument();
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByText("1. Click the button below and create your Slack App"),
     );
     expect(screen.queryByText("Install to workspace")).not.toBeInTheDocument();
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByText("1. Click the button below and create your Slack App"),
     );
     expect(screen.getByText("Install to workspace")).toBeInTheDocument();

--- a/frontend/src/metabase/admin/settings/slack/components/SlackStatus/SlackStatus.unit.spec.tsx
+++ b/frontend/src/metabase/admin/settings/slack/components/SlackStatus/SlackStatus.unit.spec.tsx
@@ -26,8 +26,8 @@ describe("SlackStatus", () => {
     const onDelete = jest.fn();
 
     render(<SlackStatus Form={FormMock} isValid={true} onDelete={onDelete} />);
-    userEvent.click(screen.getByText("Delete Slack App"));
-    userEvent.click(screen.getByText("Delete"));
+    await userEvent.click(screen.getByText("Delete Slack App"));
+    await userEvent.click(screen.getByText("Delete"));
 
     await waitFor(() => expect(onDelete).toHaveBeenCalled());
   });

--- a/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/ForgotPassword/ForgotPassword.unit.spec.tsx
@@ -46,12 +46,12 @@ describe("ForgotPassword", () => {
 
   it("should show a success message when the form is submitted", async () => {
     setup({ isEmailConfigured: true });
-    userEvent.type(screen.getByLabelText("Email address"), TEST_EMAIL);
+    await userEvent.type(screen.getByLabelText("Email address"), TEST_EMAIL);
     await waitFor(() => {
       expect(screen.getByText("Send password reset email")).toBeEnabled();
     });
 
-    userEvent.click(screen.getByText("Send password reset email"));
+    await userEvent.click(screen.getByText("Send password reset email"));
     expect(await screen.findByText(/Check your email/)).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/PasswordPanel/PasswordPanel.unit.spec.tsx
@@ -51,14 +51,14 @@ describe("PasswordPanel", () => {
   it("should login successfully", async () => {
     setup();
 
-    userEvent.type(screen.getByLabelText("Email address"), TEST_EMAIL);
-    userEvent.type(screen.getByLabelText("Password"), TEST_PASSWORD);
+    await userEvent.type(screen.getByLabelText("Email address"), TEST_EMAIL);
+    await userEvent.type(screen.getByLabelText("Password"), TEST_PASSWORD);
 
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Sign in" })).toBeEnabled();
     });
 
-    userEvent.click(screen.getByRole("button", { name: "Sign in" }));
+    await userEvent.click(screen.getByRole("button", { name: "Sign in" }));
 
     await waitFor(() => {
       expect(fetchMock.done("path:/api/session")).toBe(true);

--- a/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.unit.spec.tsx
+++ b/frontend/src/metabase/auth/components/ResetPassword/ResetPassword.unit.spec.tsx
@@ -55,13 +55,16 @@ describe("ResetPassword", () => {
     setup({ isTokenValid: true });
     expect(await screen.findByText("New password")).toBeInTheDocument();
 
-    userEvent.type(screen.getByLabelText("Create a password"), "test");
-    userEvent.type(screen.getByLabelText("Confirm your password"), "test");
+    await userEvent.type(screen.getByLabelText("Create a password"), "test");
+    await userEvent.type(
+      screen.getByLabelText("Confirm your password"),
+      "test",
+    );
     await waitFor(() => {
       expect(screen.getByText("Save new password")).toBeEnabled();
     });
 
-    userEvent.click(screen.getByText("Save new password"));
+    await userEvent.click(screen.getByText("Save new password"));
     expect(await screen.findByText("Home")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
@@ -237,12 +237,12 @@ describe("BrowseModels", () => {
 
   it("can collapse collections to hide models within them", async () => {
     renderBrowseModels(10);
-    userEvent.click(await screen.findByLabelText("collapse Alpha"));
+    await userEvent.click(await screen.findByLabelText("collapse Alpha"));
     expect(screen.queryByText("Model 0")).not.toBeInTheDocument();
     expect(screen.queryByText("Model 1")).not.toBeInTheDocument();
     expect(screen.queryByText("Model 2")).not.toBeInTheDocument();
 
-    userEvent.click(await screen.findByLabelText("collapse Beta"));
+    await userEvent.click(await screen.findByLabelText("collapse Beta"));
     expect(screen.queryByText("Model 3")).not.toBeInTheDocument();
     expect(screen.queryByText("Model 4")).not.toBeInTheDocument();
     expect(screen.queryByText("Model 5")).not.toBeInTheDocument();
@@ -250,9 +250,9 @@ describe("BrowseModels", () => {
 
   it("can expand a collection to see models within it", async () => {
     renderBrowseModels(10);
-    userEvent.click(await screen.findByLabelText("collapse Alpha"));
+    await userEvent.click(await screen.findByLabelText("collapse Alpha"));
     expect(screen.queryByText("Model 0")).not.toBeInTheDocument();
-    userEvent.click(await screen.findByLabelText("expand Alpha"));
+    await userEvent.click(await screen.findByLabelText("expand Alpha"));
     expect(await screen.findByText("Model 0")).toBeInTheDocument();
   });
 
@@ -276,32 +276,32 @@ describe("BrowseModels", () => {
     renderBrowseModels(9999);
     await screen.findByText("6 of 100");
     expect(screen.queryByText("Model 350")).not.toBeInTheDocument();
-    userEvent.click(await screen.findByText("Show all"));
+    await userEvent.click(await screen.findByText("Show all"));
     assertThatModelsExist(300, 399);
   });
 
   it("can show less than all models by clicking 'Show less'", async () => {
     renderBrowseModels(9999);
     expect(screen.queryByText("Model 399")).not.toBeInTheDocument();
-    userEvent.click(await screen.findByText("Show all"));
+    await userEvent.click(await screen.findByText("Show all"));
     await screen.findByText("Model 301");
     expect(screen.getByText("Model 399")).toBeInTheDocument();
-    userEvent.click(await screen.findByText("Show less"));
+    await userEvent.click(await screen.findByText("Show less"));
     await screen.findByText("Model 301");
     expect(screen.queryByText("Model 399")).not.toBeInTheDocument();
   });
 
   it("persists show-all state when expanding and collapsing collections", async () => {
     renderBrowseModels(9999);
-    userEvent.click(screen.getByText("Show all"));
+    await userEvent.click(screen.getByText("Show all"));
     expect(await screen.findByText("Model 301")).toBeInTheDocument();
     expect(screen.getByText("Model 399")).toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText("collapse Grande"));
+    await userEvent.click(screen.getByLabelText("collapse Grande"));
     expect(screen.queryByText("Model 301")).not.toBeInTheDocument();
     expect(screen.queryByText("Model 399")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText("expand Grande"));
+    await userEvent.click(screen.getByLabelText("expand Grande"));
     expect(await screen.findByText("Model 301")).toBeInTheDocument();
     expect(screen.getByText("Model 399")).toBeInTheDocument();
   });
@@ -309,7 +309,7 @@ describe("BrowseModels", () => {
   describe("local storage", () => {
     it("persists the expanded state of collections in local storage", async () => {
       renderBrowseModels(10);
-      userEvent.click(await screen.findByLabelText("collapse Alpha"));
+      await userEvent.click(await screen.findByLabelText("collapse Alpha"));
       expect(screen.queryByText("Model 0")).not.toBeInTheDocument();
       expect(localStorage.getItem(BROWSE_MODELS_LOCALSTORAGE_KEY)).toEqual(
         JSON.stringify({ 99: { expanded: false, showAll: false } }),
@@ -327,7 +327,7 @@ describe("BrowseModels", () => {
 
     it("persists the 'show all' state of collections in local storage", async () => {
       renderBrowseModels(9999);
-      userEvent.click(await screen.findByText("Show all"));
+      await userEvent.click(await screen.findByText("Show all"));
       await screen.findByText("Model 399");
       expect(localStorage.getItem(BROWSE_MODELS_LOCALSTORAGE_KEY)).toEqual(
         JSON.stringify({ 7: { expanded: true, showAll: true } }),
@@ -348,7 +348,7 @@ describe("BrowseModels", () => {
       localStorage.setItem(BROWSE_MODELS_LOCALSTORAGE_KEY, "{invalid json[[[}");
       renderBrowseModels(10);
       expect(await screen.findByText("Model 0")).toBeInTheDocument();
-      userEvent.click(await screen.findByLabelText("collapse Alpha"));
+      await userEvent.click(await screen.findByLabelText("collapse Alpha"));
       expect(screen.queryByText("Model 0")).not.toBeInTheDocument();
       // ignores invalid data and persists the new state
       expect(localStorage.getItem(BROWSE_MODELS_LOCALSTORAGE_KEY)).toEqual(

--- a/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/ActionMenu/ActionMenu.unit.spec.tsx
@@ -72,8 +72,10 @@ describe("ActionMenu", () => {
 
       setup({ item });
 
-      userEvent.click(getIcon("ellipsis"));
-      userEvent.click(await screen.findByText("Don’t show visualization"));
+      await userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(
+        await screen.findByText("Don’t show visualization"),
+      );
 
       expect(item.setCollectionPreview).toHaveBeenCalledWith(false);
     });
@@ -88,13 +90,13 @@ describe("ActionMenu", () => {
 
       setup({ item });
 
-      userEvent.click(getIcon("ellipsis"));
-      userEvent.click(await screen.findByText("Show visualization"));
+      await userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(await screen.findByText("Show visualization"));
 
       expect(item.setCollectionPreview).toHaveBeenCalledWith(true);
     });
 
-    it("should not show an option to hide preview for a pinned model", () => {
+    it("should not show an option to hide preview for a pinned model", async () => {
       setup({
         item: createMockCollectionItem({
           model: "dataset",
@@ -103,7 +105,7 @@ describe("ActionMenu", () => {
         }),
       });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
 
       expect(
         screen.queryByText("Don’t show visualization"),
@@ -123,16 +125,16 @@ describe("ActionMenu", () => {
 
       const { onMove } = setup({ item });
 
-      userEvent.click(getIcon("ellipsis"));
-      userEvent.click(await screen.findByText("Move"));
+      await userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(await screen.findByText("Move"));
       expect(onMove).toHaveBeenCalledWith([item]);
 
-      userEvent.click(getIcon("ellipsis"));
-      userEvent.click(await screen.findByText("Archive"));
+      await userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(await screen.findByText("Archive"));
       expect(item.setArchived).toHaveBeenCalledWith(true);
     });
 
-    it("should not allow to move and archive personal collections", () => {
+    it("should not allow to move and archive personal collections", async () => {
       const item = createMockCollectionItem({
         name: "My personal collection",
         model: "collection",
@@ -144,12 +146,12 @@ describe("ActionMenu", () => {
 
       setup({ item });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(screen.queryByText("Move")).not.toBeInTheDocument();
       expect(screen.queryByText("Archive")).not.toBeInTheDocument();
     });
 
-    it("should not allow to move and archive read only collections", () => {
+    it("should not allow to move and archive read only collections", async () => {
       const item = createMockCollectionItem({
         name: "My Read Only collection",
         model: "collection",
@@ -160,7 +162,7 @@ describe("ActionMenu", () => {
 
       setup({ item });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(screen.queryByText("Move")).not.toBeInTheDocument();
       expect(screen.queryByText("Archive")).not.toBeInTheDocument();
     });
@@ -175,11 +177,11 @@ describe("ActionMenu", () => {
 
       setup({ item, isXrayEnabled: true });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(await screen.findByText("X-ray this")).toBeInTheDocument();
     });
 
-    it("should not allow to x-ray a model when xrays are not enabled", () => {
+    it("should not allow to x-ray a model when xrays are not enabled", async () => {
       const item = createMockCollectionItem({
         id: 1,
         model: "dataset",
@@ -187,11 +189,11 @@ describe("ActionMenu", () => {
 
       setup({ item, isXrayEnabled: false });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(screen.queryByText("X-ray this")).not.toBeInTheDocument();
     });
 
-    it("should not allow to x-ray a question when xrays are enabled", () => {
+    it("should not allow to x-ray a question when xrays are enabled", async () => {
       const item = createMockCollectionItem({
         id: 1,
         model: "card",
@@ -199,11 +201,11 @@ describe("ActionMenu", () => {
 
       setup({ item, isXrayEnabled: true });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(screen.queryByText("X-ray this")).not.toBeInTheDocument();
     });
 
-    it("should not allow to x-ray non-models", () => {
+    it("should not allow to x-ray non-models", async () => {
       const item = createMockCollectionItem({
         id: 1,
         model: "dashboard",
@@ -211,7 +213,7 @@ describe("ActionMenu", () => {
 
       setup({ item, isXrayEnabled: true });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(screen.queryByText("X-ray this")).not.toBeInTheDocument();
     });
   });
@@ -244,49 +246,49 @@ describe("ActionMenu", () => {
         native_permissions: "write",
       });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(await screen.findByText("Ask Metabot")).toBeInTheDocument();
     });
 
-    it("should not allow to ask metabot when it is not enabled but there is native write access", () => {
+    it("should not allow to ask metabot when it is not enabled but there is native write access", async () => {
       setupMetabot(false, {
         native_permissions: "write",
       });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(screen.queryByText("Ask Metabot")).not.toBeInTheDocument();
     });
 
-    it("should not allow to ask metabot when it is enabled but there is no native write access", () => {
+    it("should not allow to ask metabot when it is enabled but there is no native write access", async () => {
       setupMetabot(true, {
         native_permissions: "none",
       });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(screen.queryByText("Ask Metabot")).not.toBeInTheDocument();
     });
 
-    it("should not allow to ask metabot for non-sql databases", () => {
+    it("should not allow to ask metabot for non-sql databases", async () => {
       setupMetabot(true, {
         engine: "mongo",
         native_permissions: "write",
       });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(screen.queryByText("Ask Metabot")).not.toBeInTheDocument();
     });
 
-    it("should not allow to ask metabot for sql databases without nested-queries support", () => {
+    it("should not allow to ask metabot for sql databases without nested-queries support", async () => {
       setupMetabot(true, {
         native_permissions: "write",
         features: [],
       });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(screen.queryByText("Ask Metabot")).not.toBeInTheDocument();
     });
 
-    it("should not allow to ask metabot when it is enabled but there is no data access", () => {
+    it("should not allow to ask metabot when it is enabled but there is no data access", async () => {
       const item = createMockCollectionItem({
         id: 1,
         model: "dataset",
@@ -299,7 +301,7 @@ describe("ActionMenu", () => {
         isMetabotEnabled: true,
       });
 
-      userEvent.click(getIcon("ellipsis"));
+      await userEvent.click(getIcon("ellipsis"));
       expect(screen.queryByText("Ask Metabot")).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/collections/components/BaseItemsTable.unit.spec.js
+++ b/frontend/src/metabase/collections/components/BaseItemsTable.unit.spec.js
@@ -64,11 +64,11 @@ describe("Collections BaseItemsTable", () => {
     expect(screen.getByText(lastEditedAt)).toBeInTheDocument();
   });
 
-  it("displays last edit time on hover", () => {
+  it("displays last edit time on hover", async () => {
     setup();
     const lastEditedAt = moment(timestamp).format("MMMM DD, YYYY");
 
-    userEvent.hover(screen.getByText(lastEditedAt));
+    await userEvent.hover(screen.getByText(lastEditedAt));
 
     expect(screen.getByRole("tooltip")).toHaveTextContent(
       moment(timestamp).format(`${DEFAULT_DATE_STYLE}, ${DEFAULT_TIME_STYLE}`),
@@ -80,7 +80,7 @@ describe("Collections BaseItemsTable", () => {
     expect(screen.queryByTestId("model-detail-link")).not.toBeInTheDocument();
   });
 
-  it("allows user with write permission to select all items", () => {
+  it("allows user with write permission to select all items", async () => {
     const onSelectAll = jest.fn();
     setup({
       hasUnselected: true,
@@ -88,12 +88,12 @@ describe("Collections BaseItemsTable", () => {
       collection: { can_write: true },
     });
 
-    userEvent.click(screen.getByLabelText("Select all items"));
+    await userEvent.click(screen.getByLabelText("Select all items"));
 
     expect(onSelectAll).toHaveBeenCalled();
   });
 
-  it("allows user with write permission to deselect all items", () => {
+  it("allows user with write permission to deselect all items", async () => {
     const onSelectNone = jest.fn();
     setup({
       hasUnselected: false,
@@ -101,7 +101,7 @@ describe("Collections BaseItemsTable", () => {
       collection: { can_write: true },
     });
 
-    userEvent.click(screen.getByLabelText("Select all items"));
+    await userEvent.click(screen.getByLabelText("Select all items"));
 
     expect(onSelectNone).toHaveBeenCalled();
   });
@@ -116,14 +116,14 @@ describe("Collections BaseItemsTable", () => {
   });
 
   describe("description", () => {
-    it("shows description on hover", () => {
+    it("shows description on hover", async () => {
       const DESCRIPTION = "My collection";
       const ITEM = getCollectionItem({ description: DESCRIPTION });
 
       setup({ items: [ITEM] });
 
       const icon = getIcon("info");
-      userEvent.hover(icon);
+      await userEvent.hover(icon);
 
       const tooltip = screen.getByRole("tooltip");
 
@@ -131,14 +131,14 @@ describe("Collections BaseItemsTable", () => {
       expect(tooltip).toHaveTextContent(DESCRIPTION);
     });
 
-    it("shows markdown in description on hover", () => {
+    it("shows markdown in description on hover", async () => {
       const DESCRIPTION = "**important** text";
       const ITEM = getCollectionItem({ description: DESCRIPTION });
 
       setup({ items: [ITEM] });
 
       const icon = getIcon("info");
-      userEvent.hover(icon);
+      await userEvent.hover(icon);
 
       const tooltip = screen.getByRole("tooltip");
 

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/common.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent, { specialChars } from "@testing-library/user-event";
+import userEvent from "@testing-library/user-event";
 
 import { getIcon, screen } from "__support__/ui";
 import type { CollectionId } from "metabase-types/api";
@@ -7,7 +7,7 @@ import { setup } from "./setup";
 
 describe("CollectionHeader", () => {
   describe("collection name", () => {
-    it("should be able to edit name with write access", () => {
+    it("should be able to edit name with write access", async () => {
       const collection = {
         name: "Name",
         can_write: true,
@@ -18,8 +18,8 @@ describe("CollectionHeader", () => {
       });
 
       const input = screen.getByDisplayValue("Name");
-      userEvent.clear(input);
-      userEvent.type(input, `New name${specialChars.enter}`);
+      await userEvent.clear(input);
+      await userEvent.type(input, `New name{Enter}`);
 
       expect(onUpdateCollection).toHaveBeenCalledWith(myCollection, {
         name: "New name",
@@ -66,7 +66,7 @@ describe("CollectionHeader", () => {
   });
 
   describe("collection description", () => {
-    it("should be able to edit description with write access", () => {
+    it("should be able to edit description with write access", async () => {
       const collection = {
         description: "Description",
         can_write: true,
@@ -78,19 +78,19 @@ describe("CollectionHeader", () => {
 
       // show input
       const editableText = screen.getByText("Description");
-      userEvent.click(editableText);
+      await userEvent.click(editableText);
 
       const input = screen.getByDisplayValue("Description");
-      userEvent.clear(input);
-      userEvent.type(input, "New description");
-      userEvent.tab();
+      await userEvent.clear(input);
+      await userEvent.type(input, "New description");
+      await userEvent.tab();
 
       expect(onUpdateCollection).toHaveBeenCalledWith(myCollection, {
         description: "New description",
       });
     });
 
-    it("should be able to add description with write access", () => {
+    it("should be able to add description with write access", async () => {
       const collection = {
         description: null,
         can_write: true,
@@ -101,8 +101,8 @@ describe("CollectionHeader", () => {
       });
 
       const input = screen.getByPlaceholderText("Add description");
-      userEvent.type(input, "New description");
-      userEvent.tab();
+      await userEvent.type(input, "New description");
+      await userEvent.tab();
 
       expect(onUpdateCollection).toHaveBeenCalledWith(myCollection, {
         description: "New description",
@@ -121,7 +121,7 @@ describe("CollectionHeader", () => {
       expect(input).not.toBeInTheDocument();
     });
 
-    it("should be able to view the description without write access", () => {
+    it("should be able to view the description without write access", async () => {
       const collection = {
         description: "Description",
         can_write: false,
@@ -131,7 +131,7 @@ describe("CollectionHeader", () => {
 
       // show input
       const editableText = screen.getByText("Description");
-      userEvent.click(editableText);
+      await userEvent.click(editableText);
 
       const input = screen.getByDisplayValue("Description");
       expect(input).toBeInTheDocument();
@@ -148,7 +148,7 @@ describe("CollectionHeader", () => {
   });
 
   describe("collection bookmark", () => {
-    it("should be able to bookmark a collection", () => {
+    it("should be able to bookmark a collection", async () => {
       const collection = {
         can_write: false,
       };
@@ -157,12 +157,12 @@ describe("CollectionHeader", () => {
         collection,
         isBookmarked: false,
       });
-      userEvent.click(screen.getByLabelText("bookmark icon"));
+      await userEvent.click(screen.getByLabelText("bookmark icon"));
 
       expect(onCreateBookmark).toHaveBeenCalledWith(myCollection);
     });
 
-    it("should be able to remove a collection from bookmarks", () => {
+    it("should be able to remove a collection from bookmarks", async () => {
       const collection = {
         can_write: false,
       };
@@ -171,7 +171,7 @@ describe("CollectionHeader", () => {
         collection,
         isBookmarked: true,
       });
-      userEvent.click(screen.getByLabelText("bookmark_filled icon"));
+      await userEvent.click(screen.getByLabelText("bookmark_filled icon"));
 
       expect(onDeleteBookmark).toHaveBeenCalledWith(myCollection);
     });
@@ -182,7 +182,7 @@ describe("CollectionHeader", () => {
       const collection = { can_write: true };
       setup({ collection });
 
-      userEvent.click(screen.getByLabelText("ellipsis icon"));
+      await userEvent.click(screen.getByLabelText("ellipsis icon"));
       expect(await screen.findByText("Move")).toBeInTheDocument();
       expect(screen.getByText("Archive")).toBeInTheDocument();
     });
@@ -229,7 +229,7 @@ describe("CollectionHeader", () => {
         canUpload: true,
         isAdmin: false,
       });
-      userEvent.click(screen.getByLabelText("Upload data"));
+      await userEvent.click(screen.getByLabelText("Upload data"));
 
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
       expect(screen.getByText("Uploads CSVs to Metabase")).toBeInTheDocument();
@@ -242,7 +242,7 @@ describe("CollectionHeader", () => {
         canUpload: true,
         isAdmin: true,
       });
-      userEvent.click(screen.getByLabelText("Upload data"));
+      await userEvent.click(screen.getByLabelText("Upload data"));
 
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
       expect(screen.getByText("Enable in settings")).toBeInTheDocument();
@@ -256,7 +256,7 @@ describe("CollectionHeader", () => {
         canUpload: true,
         isAdmin: false,
       });
-      userEvent.click(screen.getByLabelText("Upload data"));
+      await userEvent.click(screen.getByLabelText("Upload data"));
 
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
       expect(screen.getByText(/ask your admin to enable/i)).toBeInTheDocument();
@@ -269,10 +269,10 @@ describe("CollectionHeader", () => {
         canUpload: true,
         isAdmin: true,
       });
-      userEvent.click(screen.getByLabelText("Upload data"));
+      await userEvent.click(screen.getByLabelText("Upload data"));
 
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
-      userEvent.click(getIcon("close"));
+      await userEvent.click(getIcon("close"));
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
 
@@ -283,10 +283,10 @@ describe("CollectionHeader", () => {
         canUpload: true,
         isAdmin: false,
       });
-      userEvent.click(screen.getByLabelText("Upload data"));
+      await userEvent.click(screen.getByLabelText("Upload data"));
 
       expect(await screen.findByRole("dialog")).toBeInTheDocument();
-      userEvent.click(screen.getByText("Got it"));
+      await userEvent.click(screen.getByText("Got it"));
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionHeader/tests/enterprise.unit.spec.tsx
@@ -76,7 +76,7 @@ describe("instance analytics custom reports collection", () => {
 
   it("should not show move button", async () => {
     setup(defaultOptions);
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     await screen.findByRole("dialog");
 
     expect(getIcon("lock")).toBeInTheDocument();
@@ -86,7 +86,7 @@ describe("instance analytics custom reports collection", () => {
 
   it("should not show archive button", async () => {
     setup(defaultOptions);
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     await screen.findByRole("dialog");
 
     expect(getIcon("lock")).toBeInTheDocument();
@@ -109,7 +109,7 @@ describe("Official Collections Header", () => {
 
   it("should allow admin users to designate official collections", async () => {
     setup(officialCollectionOptions);
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(
       await screen.findByText("Make collection official"),
     ).toBeInTheDocument();
@@ -121,7 +121,7 @@ describe("Official Collections Header", () => {
       ...officialCollectionOptions,
       isAdmin: false,
     });
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(
       screen.queryByText("Make collection official"),
     ).not.toBeInTheDocument();
@@ -136,7 +136,7 @@ describe("Official Collections Header", () => {
         can_write: false,
       },
     });
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(
       screen.queryByText("Make collection official"),
     ).not.toBeInTheDocument();

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/common.unit.spec.tsx
@@ -14,11 +14,11 @@ describe("CollectionMenu", () => {
       isAdmin: true,
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(await screen.findByText("Edit permissions")).toBeInTheDocument();
   });
 
-  it("should not be able to edit collection permissions without admin access", () => {
+  it("should not be able to edit collection permissions without admin access", async () => {
     setup({
       collection: createMockCollection({
         can_write: true,
@@ -26,7 +26,7 @@ describe("CollectionMenu", () => {
       isAdmin: false,
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(screen.queryByText("Edit permissions")).not.toBeInTheDocument();
   });
 
@@ -42,7 +42,7 @@ describe("CollectionMenu", () => {
     expect(queryIcon("ellipsis")).not.toBeInTheDocument();
   });
 
-  it("should not be able to edit permissions for personal subcollections", () => {
+  it("should not be able to edit permissions for personal subcollections", async () => {
     setup({
       collection: createMockCollection({
         can_write: true,
@@ -51,7 +51,7 @@ describe("CollectionMenu", () => {
       isPersonalCollectionChild: true,
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(screen.queryByText("Edit permissions")).not.toBeInTheDocument();
   });
 
@@ -62,7 +62,7 @@ describe("CollectionMenu", () => {
       }),
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(await screen.findByText("Move")).toBeInTheDocument();
     expect(screen.getByText("Archive")).toBeInTheDocument();
   });
@@ -100,7 +100,7 @@ describe("CollectionMenu", () => {
     expect(queryIcon("ellipsis")).not.toBeInTheDocument();
   });
 
-  it("should not be able to make the collection official", () => {
+  it("should not be able to make the collection official", async () => {
     setup({
       collection: createMockCollection({
         can_write: true,
@@ -108,7 +108,7 @@ describe("CollectionMenu", () => {
       isAdmin: true,
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(
       screen.queryByText("Make collection official"),
     ).not.toBeInTheDocument();

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/enterprise.unit.spec.tsx
@@ -11,7 +11,7 @@ const setupEnterprise = (opts?: SetupOpts) => {
 };
 
 describe("CollectionMenu", () => {
-  it("should not be able to make the collection official", () => {
+  it("should not be able to make the collection official", async () => {
     setupEnterprise({
       collection: createMockCollection({
         can_write: true,
@@ -19,7 +19,7 @@ describe("CollectionMenu", () => {
       isAdmin: true,
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(
       screen.queryByText("Make collection official"),
     ).not.toBeInTheDocument();

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
@@ -27,8 +27,8 @@ describe("CollectionMenu", () => {
       isAdmin: true,
     });
 
-    userEvent.click(getIcon("ellipsis"));
-    userEvent.click(await screen.findByText("Make collection official"));
+    await userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(await screen.findByText("Make collection official"));
     expect(onUpdateCollection).toHaveBeenCalledWith(collection, {
       authority_level: "official",
     });
@@ -44,14 +44,14 @@ describe("CollectionMenu", () => {
       isAdmin: true,
     });
 
-    userEvent.click(getIcon("ellipsis"));
-    userEvent.click(await screen.findByText("Remove Official badge"));
+    await userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(await screen.findByText("Remove Official badge"));
     expect(onUpdateCollection).toHaveBeenCalledWith(collection, {
       authority_level: null,
     });
   });
 
-  it("should not be able to make the collection official if not an admin", () => {
+  it("should not be able to make the collection official if not an admin", async () => {
     const collection = createMockCollection({
       can_write: true,
     });
@@ -60,13 +60,13 @@ describe("CollectionMenu", () => {
       isAdmin: false,
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(
       screen.queryByText("Make collection official"),
     ).not.toBeInTheDocument();
   });
 
-  it("should not be able to make the collection official if it's the root collection", () => {
+  it("should not be able to make the collection official if it's the root collection", async () => {
     const collection = createMockCollection({
       id: "root",
       can_write: true,
@@ -76,7 +76,7 @@ describe("CollectionMenu", () => {
       isAdmin: true,
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(
       screen.queryByText("Make collection official"),
     ).not.toBeInTheDocument();
@@ -92,13 +92,13 @@ describe("CollectionMenu", () => {
       isAdmin: true,
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(
       await screen.findByText("Make collection official"),
     ).toBeInTheDocument();
   });
 
-  it("should not be able to make the collection official if it's a personal collection child", () => {
+  it("should not be able to make the collection official if it's a personal collection child", async () => {
     const collection = createMockCollection({
       can_write: true,
     });
@@ -108,7 +108,7 @@ describe("CollectionMenu", () => {
       isPersonalCollectionChild: true,
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(
       screen.queryByText("Make collection official"),
     ).not.toBeInTheDocument();

--- a/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CollectionMenu/tests/premium.unit.spec.tsx
@@ -98,7 +98,7 @@ describe("CollectionMenu", () => {
     ).toBeInTheDocument();
   });
 
-  it("should not be able to make the collection official if it's a personal collection child", async () => {
+  it("should be able to make the collection official if even it's a personal collection child", async () => {
     const collection = createMockCollection({
       can_write: true,
     });
@@ -109,8 +109,6 @@ describe("CollectionMenu", () => {
     });
 
     await userEvent.click(getIcon("ellipsis"));
-    expect(
-      screen.queryByText("Make collection official"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText("Make collection official")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/collections/components/CreateCollectionForm/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/collections/components/CreateCollectionForm/tests/common.unit.spec.tsx
@@ -26,9 +26,9 @@ describe("CreateCollectionForm", () => {
     expect(screen.getByRole("button", { name: "Create" })).toBeDisabled();
   });
 
-  it("calls onCancel when cancel button is clicked", () => {
+  it("calls onCancel when cancel button is clicked", async () => {
     const { onCancel } = setup();
-    userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
+++ b/frontend/src/metabase/collections/components/PinnedItemCard/PinnedItemCard.unit.spec.js
@@ -102,7 +102,7 @@ describe("PinnedItemCard", () => {
 
   it("should show an action menu when user clicks on the menu icon in the card", async () => {
     setup();
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     expect(await screen.findByText("Unpin")).toBeInTheDocument();
   });
 
@@ -159,10 +159,10 @@ describe("PinnedItemCard", () => {
       expect(screen.getByText(MARKDOWN_AS_TEXT)).toBeInTheDocument();
     });
 
-    it("should show description tooltip with markdown formatting on hover", () => {
+    it("should show description tooltip with markdown formatting on hover", async () => {
       setup({ item: getCollectionItem({ description: MARKDOWN }) });
 
-      userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
+      await userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
 
       expect(screen.getByRole("tooltip")).toHaveTextContent(MARKDOWN_AS_TEXT);
     });

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import { createMockMetadata } from "__support__/metadata";
 import { createMockEntitiesState } from "__support__/store";
-import { renderWithProviders, screen, within } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import {
@@ -232,20 +232,6 @@ describe("AggregationPicker", () => {
       });
     });
 
-    it("should show operator descriptions", async () => {
-      setup();
-
-      const sumOfOption = screen.getByRole("option", { name: "Sum of ..." });
-      const infoIcon = within(sumOfOption).getByRole("img", {
-        name: "question icon",
-      });
-      await userEvent.hover(infoIcon);
-
-      expect(screen.getByRole("tooltip")).toHaveTextContent(
-        "Sum of all the values of a column",
-      );
-    });
-
     it("should apply a column-less operator", async () => {
       const { getRecentClauseInfo } = setup();
 
@@ -372,24 +358,6 @@ describe("AggregationPicker", () => {
         metadata: createMetadata({ metrics: [TEST_METRIC] }),
       });
       expect(screen.queryByText(PRODUCT_METRIC.name)).not.toBeInTheDocument();
-    });
-
-    it("should show a description for each metric", async () => {
-      await setupMetrics({
-        metadata: createMetadata({ metrics: [TEST_METRIC] }),
-      });
-
-      const metricOption = screen.getByRole("option", {
-        name: TEST_METRIC.name,
-      });
-      const infoIcon = within(metricOption).getByRole("img", {
-        name: "question icon",
-      });
-      await userEvent.hover(infoIcon);
-
-      expect(screen.getByRole("tooltip")).toHaveTextContent(
-        TEST_METRIC.description,
-      );
     });
 
     it("should allow picking a metric", async () => {

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import { createMockMetadata } from "__support__/metadata";
 import { createMockEntitiesState } from "__support__/store";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, within } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import {
@@ -195,7 +195,7 @@ function setup({
 }
 
 describe("AggregationPicker", () => {
-  it("should allow switching between aggregation approaches", () => {
+  it("should allow switching between aggregation approaches", async () => {
     const metadata = createMetadata({ metrics: [TEST_METRIC] });
     const { getRecentClauseInfo } = setup({
       query: createQueryWithCountAggregation({ metadata }),
@@ -203,8 +203,8 @@ describe("AggregationPicker", () => {
     });
     const metric = checkNotNull(metadata.metric(TEST_METRIC.id));
 
-    userEvent.click(screen.getByText("Common Metrics"));
-    userEvent.click(screen.getByText(TEST_METRIC.name));
+    await userEvent.click(screen.getByText("Common Metrics"));
+    await userEvent.click(screen.getByText(TEST_METRIC.name));
 
     expect(getRecentClauseInfo()).toMatchObject({
       displayName: metric.displayName(),
@@ -232,10 +232,24 @@ describe("AggregationPicker", () => {
       });
     });
 
-    it("should apply a column-less operator", () => {
+    it("should show operator descriptions", async () => {
+      setup();
+
+      const sumOfOption = screen.getByRole("option", { name: "Sum of ..." });
+      const infoIcon = within(sumOfOption).getByRole("img", {
+        name: "question icon",
+      });
+      await userEvent.hover(infoIcon);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "Sum of all the values of a column",
+      );
+    });
+
+    it("should apply a column-less operator", async () => {
       const { getRecentClauseInfo } = setup();
 
-      userEvent.click(screen.getByText("Count of rows"));
+      await userEvent.click(screen.getByText("Count of rows"));
 
       expect(getRecentClauseInfo()).toMatchObject({
         name: "count",
@@ -243,11 +257,11 @@ describe("AggregationPicker", () => {
       });
     });
 
-    it("should apply an operator requiring columns", () => {
+    it("should apply an operator requiring columns", async () => {
       const { getRecentClauseInfo } = setup();
 
-      userEvent.click(screen.getByText("Average of ..."));
-      userEvent.click(screen.getByText("Quantity"));
+      await userEvent.click(screen.getByText("Average of ..."));
+      await userEvent.click(screen.getByText("Quantity"));
 
       expect(getRecentClauseInfo()).toMatchObject({
         name: "avg",
@@ -255,12 +269,12 @@ describe("AggregationPicker", () => {
       });
     });
 
-    it("should allow picking a foreign column", () => {
+    it("should allow picking a foreign column", async () => {
       const { getRecentClauseInfo } = setup();
 
-      userEvent.click(screen.getByText("Average of ..."));
-      userEvent.click(screen.getByText("Product"));
-      userEvent.click(screen.getByText("Rating"));
+      await userEvent.click(screen.getByText("Average of ..."));
+      await userEvent.click(screen.getByText("Product"));
+      await userEvent.click(screen.getByText("Rating"));
 
       expect(getRecentClauseInfo()).toMatchObject({
         name: "avg",
@@ -292,24 +306,24 @@ describe("AggregationPicker", () => {
       );
     });
 
-    it("shouldn't list columns for column-less operators", () => {
+    it("shouldn't list columns for column-less operators", async () => {
       setup();
 
-      userEvent.click(screen.getByText("Count of rows"));
+      await userEvent.click(screen.getByText("Count of rows"));
 
       expect(screen.queryByText("Quantity")).not.toBeInTheDocument();
       // check that we're still in the same step
       expect(screen.getByText("Average of ...")).toBeInTheDocument();
     });
 
-    it("should allow to change an operator for existing aggregation", () => {
+    it("should allow to change an operator for existing aggregation", async () => {
       const { getRecentClauseInfo } = setup({
         query: createQueryWithMaxAggregation(),
       });
 
-      userEvent.click(screen.getByText("Maximum of ...")); // go back
-      userEvent.click(screen.getByText("Average of ..."));
-      userEvent.click(screen.getByText("Quantity"));
+      await userEvent.click(screen.getByText("Maximum of ...")); // go back
+      await userEvent.click(screen.getByText("Average of ..."));
+      await userEvent.click(screen.getByText("Quantity"));
 
       expect(getRecentClauseInfo()).toMatchObject({
         name: "avg",
@@ -317,12 +331,12 @@ describe("AggregationPicker", () => {
       });
     });
 
-    it("should allow to change a column for existing aggregation", () => {
+    it("should allow to change a column for existing aggregation", async () => {
       const { getRecentClauseInfo } = setup({
         query: createQueryWithMaxAggregation(),
       });
 
-      userEvent.click(screen.getByText("Discount"));
+      await userEvent.click(screen.getByText("Discount"));
 
       expect(getRecentClauseInfo()).toMatchObject({
         name: "max",
@@ -332,11 +346,11 @@ describe("AggregationPicker", () => {
   });
 
   describe("metrics", () => {
-    function setupMetrics(opts: SetupOpts = {}) {
+    async function setupMetrics(opts: SetupOpts = {}) {
       const result = setup(opts);
 
       // Expand the metrics section
-      userEvent.click(screen.getByText("Common Metrics"));
+      await userEvent.click(screen.getByText("Common Metrics"));
 
       return result;
     }
@@ -346,22 +360,44 @@ describe("AggregationPicker", () => {
       expect(screen.queryByText("Common Metrics")).not.toBeInTheDocument();
     });
 
-    it("should list metrics for the query table", () => {
-      setupMetrics({ metadata: createMetadata({ metrics: [TEST_METRIC] }) });
+    it("should list metrics for the query table", async () => {
+      await setupMetrics({
+        metadata: createMetadata({ metrics: [TEST_METRIC] }),
+      });
       expect(screen.getByText(TEST_METRIC.name)).toBeInTheDocument();
     });
 
-    it("shouldn't list metrics for other tables", () => {
-      setupMetrics({ metadata: createMetadata({ metrics: [TEST_METRIC] }) });
+    it("shouldn't list metrics for other tables", async () => {
+      await setupMetrics({
+        metadata: createMetadata({ metrics: [TEST_METRIC] }),
+      });
       expect(screen.queryByText(PRODUCT_METRIC.name)).not.toBeInTheDocument();
     });
 
-    it("should allow picking a metric", () => {
+    it("should show a description for each metric", async () => {
+      await setupMetrics({
+        metadata: createMetadata({ metrics: [TEST_METRIC] }),
+      });
+
+      const metricOption = screen.getByRole("option", {
+        name: TEST_METRIC.name,
+      });
+      const infoIcon = within(metricOption).getByRole("img", {
+        name: "question icon",
+      });
+      await userEvent.hover(infoIcon);
+
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        TEST_METRIC.description,
+      );
+    });
+
+    it("should allow picking a metric", async () => {
       const metadata = createMetadata({ metrics: [TEST_METRIC] });
-      const { getRecentClauseInfo } = setupMetrics({ metadata });
+      const { getRecentClauseInfo } = await setupMetrics({ metadata });
       const metric = checkNotNull(metadata.metric(TEST_METRIC.id));
 
-      userEvent.click(screen.getByText(TEST_METRIC.name));
+      await userEvent.click(screen.getByText(TEST_METRIC.name));
 
       expect(getRecentClauseInfo()).toMatchObject({
         displayName: metric.displayName(),
@@ -376,10 +412,10 @@ describe("AggregationPicker", () => {
       const expression = "count + 1";
       const expressionName = "My expression";
 
-      userEvent.click(screen.getByText("Custom Expression"));
-      userEvent.type(screen.getByLabelText("Expression"), expression);
-      userEvent.type(screen.getByLabelText("Name"), expressionName);
-      userEvent.click(screen.getByRole("button", { name: "Done" }));
+      await userEvent.click(screen.getByText("Custom Expression"));
+      await userEvent.type(screen.getByLabelText("Expression"), expression);
+      await userEvent.type(screen.getByLabelText("Name"), expressionName);
+      await userEvent.click(screen.getByRole("button", { name: "Done" }));
       expect(getRecentClauseInfo().displayName).toBe(expressionName);
     });
 

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/EntityPickerModal.unit.spec.tsx
@@ -121,7 +121,7 @@ describe("EntityPickerModal", () => {
       await within(tabList).findByRole("tab", { name: /All the bar/ }),
     ).toBeInTheDocument();
 
-    userEvent.click(
+    await userEvent.click(
       await within(tabList).findByRole("tab", { name: /All the bar/ }),
     );
 
@@ -158,7 +158,7 @@ describe("EntityPickerModal", () => {
       onConfirm,
     });
 
-    userEvent.type(await screen.findByPlaceholderText("Search…"), "My ", {
+    await userEvent.type(await screen.findByPlaceholderText("Search…"), "My ", {
       delay: 50,
     });
 
@@ -169,7 +169,7 @@ describe("EntityPickerModal", () => {
 
     expect(await screen.findAllByTestId("search-result-item")).toHaveLength(2);
 
-    userEvent.click(await screen.findByText("Search Result 1"));
+    await userEvent.click(await screen.findByText("Search Result 1"));
 
     expect(onItemSelect).toHaveBeenCalledTimes(1);
   });
@@ -188,7 +188,9 @@ describe("EntityPickerModal", () => {
     expect(
       await screen.findByRole("button", { name: "Click Me" }),
     ).toBeInTheDocument();
-    userEvent.click(await screen.findByRole("button", { name: "Click Me" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Click Me" }),
+    );
 
     expect(actionFn).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/BucketPickerPopover/BucketPickerPopover.unit.spec.tsx
@@ -33,7 +33,7 @@ function setup({ column }: { column: Lib.ColumnMetadata }) {
 
 async function setupBinningPicker({ column }: { column: Lib.ColumnMetadata }) {
   setup({ column });
-  userEvent.click(screen.getByLabelText("Binning strategy"));
+  await userEvent.click(screen.getByLabelText("Binning strategy"));
   await screen.findByText("Don't bin");
 }
 
@@ -43,7 +43,7 @@ async function setupTemporalBucketPicker({
   column: Lib.ColumnMetadata;
 }) {
   setup({ column });
-  userEvent.click(screen.getByLabelText("Temporal bucket"));
+  await userEvent.click(screen.getByLabelText("Temporal bucket"));
   await screen.findByText("Year");
 }
 
@@ -62,7 +62,7 @@ describe("BucketPickerPopover", () => {
     expect(screen.queryByText("Day of month")).not.toBeInTheDocument();
     expect(screen.queryByText("Month of year")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByRole("button", { name: "More…" }));
+    await userEvent.click(screen.getByRole("button", { name: "More…" }));
 
     expect(screen.getAllByRole("menuitem")).toHaveLength(
       [...buckets, "Don't bin"].length,
@@ -94,13 +94,13 @@ describe("BucketPickerPopover", () => {
   it("should collapse after popover is closed", async () => {
     await setupTemporalBucketPicker({ column: dateColumn });
 
-    userEvent.click(screen.getByRole("button", { name: "More…" }));
+    await userEvent.click(screen.getByRole("button", { name: "More…" }));
     // Clicking outside the popover should close it
-    userEvent.click(screen.getByTestId("container"));
+    await userEvent.click(screen.getByTestId("container"));
 
     await waitFor(() => expect(screen.getByText("Month")).not.toBeVisible());
 
-    userEvent.click(screen.getByLabelText("Temporal bucket"));
+    await userEvent.click(screen.getByLabelText("Temporal bucket"));
     await screen.findByText("Month");
 
     expect(screen.getAllByRole("menuitem")).toHaveLength(
@@ -115,11 +115,11 @@ describe("BucketPickerPopover", () => {
     await setupTemporalBucketPicker({ column });
 
     // Clicking outside the popover should close it
-    userEvent.click(screen.getByTestId("container"));
+    await userEvent.click(screen.getByTestId("container"));
 
     await waitFor(() => expect(screen.getByText("Month")).not.toBeVisible());
 
-    userEvent.click(screen.getByLabelText("Temporal bucket"));
+    await userEvent.click(screen.getByLabelText("Temporal bucket"));
     await screen.findByText("Month");
 
     expect(screen.getAllByRole("menuitem")).toHaveLength(

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.unit.spec.tsx
@@ -73,10 +73,10 @@ describe("QueryColumnPicker", () => {
     expect(screen.getByRole("option", { name: "Tax" })).toBeInTheDocument();
   });
 
-  it("should display column from foreign tables", () => {
+  it("should display column from foreign tables", async () => {
     setup();
 
-    userEvent.click(screen.getByText("Product"));
+    await userEvent.click(screen.getByText("Product"));
 
     expect(screen.getByRole("option", { name: "ID" })).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "Price" })).toBeInTheDocument();
@@ -85,10 +85,10 @@ describe("QueryColumnPicker", () => {
     ).toBeInTheDocument();
   });
 
-  it("should allow picking a column", () => {
+  it("should allow picking a column", async () => {
     const { sampleColumn, sampleColumnInfo, onSelect, onClose } = setup();
 
-    userEvent.click(screen.getByText(sampleColumnInfo.displayName));
+    await userEvent.click(screen.getByText(sampleColumnInfo.displayName));
 
     expect(onSelect).toHaveBeenCalledWith(sampleColumn);
     expect(onClose).toHaveBeenCalled();

--- a/frontend/src/metabase/common/hooks/entity-framework/use-entity-list-query/use-entity-list-query.unit.spec.tsx
+++ b/frontend/src/metabase/common/hooks/entity-framework/use-entity-list-query/use-entity-list-query.unit.spec.tsx
@@ -158,7 +158,7 @@ describe("useEntityListQuery", () => {
     setup();
 
     await waitForLoaderToBeRemoved();
-    userEvent.click(screen.getByText("Invalidate databases"));
+    await userEvent.click(screen.getByText("Invalidate databases"));
 
     await waitFor(() => {
       expect(fetchMock.calls("path:/api/database")).toHaveLength(2);
@@ -170,7 +170,7 @@ describe("useEntityListQuery", () => {
     setup();
 
     await waitForLoaderToBeRemoved();
-    userEvent.click(screen.getByText("Invalidate tables"));
+    await userEvent.click(screen.getByText("Invalidate tables"));
 
     await waitFor(() => {
       expect(fetchMock.calls("path:/api/table")).toHaveLength(2);

--- a/frontend/src/metabase/components/Calendar/Calendar.unit.spec.tsx
+++ b/frontend/src/metabase/components/Calendar/Calendar.unit.spec.tsx
@@ -14,7 +14,7 @@ describe("Calendar", () => {
     mockDate.reset();
   });
 
-  it("should switch months correctly", () => {
+  it("should switch months correctly", async () => {
     mockDate.set("2018-01-12T12:00:00Z", 0);
     setup({ selected: moment("2018-01-01") });
 
@@ -23,11 +23,11 @@ describe("Calendar", () => {
 
     expect(screen.getByText("January 2018")).toBeInTheDocument();
 
-    userEvent.click(PREVIOUS);
+    await userEvent.click(PREVIOUS);
     expect(screen.getByText("December 2017")).toBeInTheDocument();
 
-    userEvent.click(NEXT);
-    userEvent.click(NEXT);
+    await userEvent.click(NEXT);
+    await userEvent.click(NEXT);
     expect(screen.getByText("February 2018")).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/components/ClampedText/ClampedText.unit.spec.js
+++ b/frontend/src/metabase/components/ClampedText/ClampedText.unit.spec.js
@@ -27,8 +27,8 @@ describe("ClampedText", () => {
 
     it("should show a toggle for showing expanded or clamped text", async () => {
       render(<ClampedText visibleLines={1} text={TEXT} />);
-      userEvent.click(screen.getByText("See more"));
-      userEvent.click(screen.getByText("See less"));
+      await userEvent.click(screen.getByText("See more"));
+      await userEvent.click(screen.getByText("See less"));
       expect(screen.getByText("See more")).toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/components/ErrorDetails/ErrorDetails.unit.spec.tsx
+++ b/frontend/src/metabase/components/ErrorDetails/ErrorDetails.unit.spec.tsx
@@ -10,14 +10,14 @@ const setup = (propOverrides?: object) => {
 describe("ErrorDetails", () => {
   it("should render string errors", async () => {
     setup({ details: "Oh no!" });
-    userEvent.click(screen.getByText("Show error details"));
+    await userEvent.click(screen.getByText("Show error details"));
 
     expect(await screen.findByText("Oh no!")).toBeVisible();
   });
 
   it("should render message property errors", async () => {
     setup({ details: { message: "Oh no!" } });
-    userEvent.click(screen.getByText("Show error details"));
+    await userEvent.click(screen.getByText("Show error details"));
 
     expect(await screen.findByText("Oh no!")).toBeVisible();
   });
@@ -26,7 +26,7 @@ describe("ErrorDetails", () => {
     setup({ details: { message: "Oh no!" } });
     expect(screen.queryByText("Oh no!")).not.toBeVisible();
 
-    userEvent.click(screen.getByText("Show error details"));
+    await userEvent.click(screen.getByText("Show error details"));
 
     expect(await screen.findByText("Oh no!")).toBeVisible();
   });

--- a/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
+++ b/frontend/src/metabase/components/FieldValuesWidget/FieldValuesWidget.unit.spec.tsx
@@ -286,7 +286,7 @@ describe("FieldValuesWidget", () => {
         searchValue,
       });
 
-      userEvent.type(
+      await userEvent.type(
         screen.getByPlaceholderText(`Search by ${displayName}`),
         searchValue,
       );
@@ -308,7 +308,7 @@ describe("FieldValuesWidget", () => {
         searchValue,
       });
 
-      userEvent.type(screen.getByPlaceholderText("Search"), searchValue);
+      await userEvent.type(screen.getByPlaceholderText("Search"), searchValue);
 
       expect(await screen.findByText(`No matching result`)).toBeInTheDocument();
     });

--- a/frontend/src/metabase/components/InputBlurChange/InputBlurChange.unit.spec.tsx
+++ b/frontend/src/metabase/components/InputBlurChange/InputBlurChange.unit.spec.tsx
@@ -10,7 +10,7 @@ describe("InputBlurChange", () => {
     jest.clearAllMocks();
   });
 
-  it('should trigger "onBlurChange" on input blur', () => {
+  it('should trigger "onBlurChange" on input blur', async () => {
     const {
       props: { placeholder },
       mocks: { onBlurChange },
@@ -23,20 +23,20 @@ describe("InputBlurChange", () => {
     // should not be triggered if value hasn't changed
     expect(onBlurChange).toHaveBeenCalledTimes(0);
 
-    userEvent.type(inputEl, "test");
+    await userEvent.type(inputEl, "test");
     inputEl.blur();
 
     expect(onBlurChange).toHaveBeenCalledTimes(1);
     expect(onBlurChange.mock.results[0].value).toBe("test");
   });
 
-  it('should trigger "onBlurChange" on component unmount', () => {
+  it('should trigger "onBlurChange" on component unmount', async () => {
     const {
       props: { placeholder },
       mocks: { onBlurChange },
     } = setup();
 
-    userEvent.type(screen.getByPlaceholderText(placeholder), "test");
+    await userEvent.type(screen.getByPlaceholderText(placeholder), "test");
 
     cleanup();
 
@@ -44,12 +44,12 @@ describe("InputBlurChange", () => {
     expect(onBlurChange.mock.results[0].value).toBe("test");
   });
 
-  it("should set `internalValue` to the normalized value even if the normalized value is the same as the previous one", () => {
+  it("should set `internalValue` to the normalized value even if the normalized value is the same as the previous one", async () => {
     const value = "/";
     setup({ value, normalize: value => (value as string).trim() });
     const input = screen.getByDisplayValue(value) as HTMLInputElement;
-    userEvent.clear(input);
-    userEvent.type(input, "           /         ");
+    await userEvent.clear(input);
+    await userEvent.type(input, "           /         ");
 
     const normalizedValue = "/";
     expect(input.value).toEqual(normalizedValue);

--- a/frontend/src/metabase/components/Modal/WindowModal.unit.spec.tsx
+++ b/frontend/src/metabase/components/Modal/WindowModal.unit.spec.tsx
@@ -29,17 +29,17 @@ const setup = () => {
 };
 
 describe("WindowModal", () => {
-  it("should render modal content when the modal is opened", () => {
+  it("should render modal content when the modal is opened", async () => {
     setup();
-    userEvent.click(screen.getByTestId("modal-toggle"));
+    await userEvent.click(screen.getByTestId("modal-toggle"));
     expect(screen.getByText(WINDOW_MODAL_CONTENT)).toBeInTheDocument();
   });
 
   it("should not render modal content if the modal has been closed", async () => {
     setup();
-    userEvent.click(screen.getByTestId("modal-toggle"));
+    await userEvent.click(screen.getByTestId("modal-toggle"));
     expect(screen.getByText(WINDOW_MODAL_CONTENT)).toBeInTheDocument();
-    userEvent.click(screen.getByTestId("modal-toggle"));
+    await userEvent.click(screen.getByTestId("modal-toggle"));
 
     await waitFor(() =>
       expect(screen.queryByText(WINDOW_MODAL_CONTENT)).not.toBeInTheDocument(),
@@ -48,15 +48,15 @@ describe("WindowModal", () => {
 
   it("should only allow keyboard navigation on elements inside the modal", async () => {
     setup();
-    userEvent.click(screen.getByTestId("modal-toggle"));
+    await userEvent.click(screen.getByTestId("modal-toggle"));
     await screen.findByText(WINDOW_MODAL_CONTENT);
 
     // first tab to establish that the focus is on the modal button
-    userEvent.tab();
+    await userEvent.tab();
     expect(screen.getByTestId("modal-button")).toHaveFocus();
 
     // second tab to make sure that focus doesn't leave the modal or the button.
-    userEvent.tab();
+    await userEvent.tab();
     expect(screen.getByTestId("modal-button")).toHaveFocus();
   });
 });

--- a/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/components/ModalContent/ModalContent.unit.spec.tsx
@@ -8,7 +8,7 @@ import ModalContent from "./ModalContent";
 import { ModalContentActionIcon } from "./ModalContent.styled";
 
 describe("ModalContent", () => {
-  it("should render header action buttons", () => {
+  it("should render header action buttons", async () => {
     const headerActions = [
       {
         icon: "pencil" as const,
@@ -30,17 +30,17 @@ describe("ModalContent", () => {
 
     setup({ headerActions: headerActionsEl });
 
-    headerActions.forEach(({ icon, onClick }) => {
+    for (const { icon, onClick } of headerActions) {
       const iconEl = getIcon(icon);
       expect(iconEl).toBeInTheDocument();
 
-      userEvent.click(iconEl);
+      await userEvent.click(iconEl);
 
       expect(onClick).toHaveBeenCalledTimes(1);
-    });
+    }
   });
 
-  it("should render back button if onBack props is passed", () => {
+  it("should render back button if onBack props is passed", async () => {
     const onBack = jest.fn();
 
     setup({ onBack });
@@ -48,7 +48,7 @@ describe("ModalContent", () => {
     const backButton = screen.getByLabelText("chevronleft icon");
     expect(backButton).toBeInTheDocument();
 
-    userEvent.click(backButton);
+    await userEvent.click(backButton);
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/metabase/components/Popover/TippyPopover.unit.spec.js
+++ b/frontend/src/metabase/components/Popover/TippyPopover.unit.spec.js
@@ -38,7 +38,7 @@ function setup({
 describe("Popover", () => {
   it("should be visible on hover of child target element", async () => {
     setup();
-    userEvent.hover(screen.getByText("child target element"));
+    await userEvent.hover(screen.getByText("child target element"));
     expect(await screen.findByText("popover content")).toBeVisible();
   });
 
@@ -55,7 +55,7 @@ describe("Popover", () => {
       const contentFn = jest.fn();
       setup({ contentFn });
       expect(contentFn).not.toHaveBeenCalled();
-      userEvent.hover(screen.getByText("child target element"));
+      await userEvent.hover(screen.getByText("child target element"));
 
       await screen.findByText("popover content");
       expect(contentFn).toHaveBeenCalled();

--- a/frontend/src/metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger.unit.spec.tsx
+++ b/frontend/src/metabase/components/PopoverWithTrigger/ControlledPopoverWithTrigger.unit.spec.tsx
@@ -64,9 +64,9 @@ describe("ControlledPopoverWithTrigger", () => {
       );
     });
 
-    it("should be clickable via the onClick prop the function receives as an argument", () => {
+    it("should be clickable via the onClick prop the function receives as an argument", async () => {
       const { onOpen } = setup({ visible: false, renderTrigger });
-      userEvent.click(screen.getByText("custom trigger"));
+      await userEvent.click(screen.getByText("custom trigger"));
       expect(onOpen).toHaveBeenCalled();
     });
   });
@@ -78,9 +78,9 @@ describe("ControlledPopoverWithTrigger", () => {
       expect(screen.getByRole("button")).toHaveTextContent("trigger content");
     });
 
-    it("should be clickable and trigger the onOpen prop of the component", () => {
+    it("should be clickable and trigger the onOpen prop of the component", async () => {
       const { onOpen } = setup({ visible: false });
-      userEvent.click(screen.getByText("trigger content"));
+      await userEvent.click(screen.getByText("trigger content"));
       expect(onOpen).toHaveBeenCalled();
     });
   });
@@ -103,15 +103,17 @@ describe("ControlledPopoverWithTrigger", () => {
       expect(await screen.findByText("popover content")).toBeVisible();
     });
 
-    it("should be able to trigger an onClose event via an outside click", () => {
+    it("should be able to trigger an onClose event via an outside click", async () => {
       const { onClose } = setup({ visible: true });
-      userEvent.click(screen.getByText("something outside of the popover"));
+      await userEvent.click(
+        screen.getByText("something outside of the popover"),
+      );
       expect(onClose).toHaveBeenCalled();
     });
 
-    it("should be able to trigger an onClose event via an Esc press", () => {
+    it("should be able to trigger an onClose event via an Esc press", async () => {
       const { onClose } = setup({ visible: true });
-      userEvent.type(document.body, "{Escape}");
+      await userEvent.type(document.body, "{Escape}");
       expect(onClose).toHaveBeenCalled();
     });
   });
@@ -123,15 +125,15 @@ describe("ControlledPopoverWithTrigger", () => {
 
     it("should pass the onClose prop to the popoverContent fn", async () => {
       const { onClose } = setup({ visible: true, popoverContent });
-      userEvent.click(await screen.findByText("popover content"));
+      await userEvent.click(await screen.findByText("popover content"));
       expect(onClose).toHaveBeenCalled();
     });
   });
 
   describe("disabled true, visible false", () => {
-    it("should prevent the triggering of the onOpen fn", () => {
+    it("should prevent the triggering of the onOpen fn", async () => {
       const { onOpen } = setup({ disabled: true, visible: false });
-      userEvent.click(screen.getByText("trigger content"));
+      await userEvent.click(screen.getByText("trigger content"));
       expect(onOpen).not.toHaveBeenCalled();
     });
   });

--- a/frontend/src/metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger.unit.spec.tsx
+++ b/frontend/src/metabase/components/PopoverWithTrigger/TippyPopoverWithTrigger.unit.spec.tsx
@@ -22,25 +22,25 @@ describe("TippyPopoverWithTrigger", () => {
 
   it("should show the popover when user clicks the trigger", async () => {
     setup();
-    userEvent.click(screen.getByText("trigger content"));
+    await userEvent.click(screen.getByText("trigger content"));
     expect(await screen.findByText("popover content")).toBeVisible();
   });
 
   it("should hide the popover if the user clicks outside of the popover", async () => {
     setup();
-    userEvent.click(screen.getByText("trigger content"));
+    await userEvent.click(screen.getByText("trigger content"));
     expect(await screen.findByText("popover content")).toBeVisible();
 
-    userEvent.click(screen.getByText("something outside of the popover"));
+    await userEvent.click(screen.getByText("something outside of the popover"));
     expect(await screen.findByText("popover content")).not.toBeVisible();
   });
 
   it("should hide the popover if the user presses the escape key while the popover is open", async () => {
     setup();
-    userEvent.click(screen.getByText("trigger content"));
+    await userEvent.click(screen.getByText("trigger content"));
     expect(await screen.findByText("popover content")).toBeVisible();
 
-    userEvent.type(document.body, "{Escape}");
+    await userEvent.type(document.body, "{Escape}");
     expect(await screen.findByText("popover content")).not.toBeVisible();
   });
 });

--- a/frontend/src/metabase/components/SelectList/SelectList.unit.spec.tsx
+++ b/frontend/src/metabase/components/SelectList/SelectList.unit.spec.tsx
@@ -39,7 +39,7 @@ describe("Components > SelectList", () => {
     );
   });
 
-  it("allows the user to select an item on click", () => {
+  it("allows the user to select an item on click", async () => {
     const selectSpy = jest.fn();
 
     render(
@@ -54,7 +54,7 @@ describe("Components > SelectList", () => {
       </SelectList>,
     );
 
-    userEvent.click(screen.getByText("Item 2"));
+    await userEvent.click(screen.getByText("Item 2"));
 
     expect(selectSpy).toHaveBeenCalledWith("2", expect.anything());
   });

--- a/frontend/src/metabase/components/TokenField/TokenField.tsx
+++ b/frontend/src/metabase/components/TokenField/TokenField.tsx
@@ -17,6 +17,8 @@ import {
   KEYCODE_DOWN,
   KEYCODE_BACKSPACE,
   KEY_COMMA,
+  KEY_ENTER,
+  KEY_BACKSPACE,
 } from "metabase/lib/keyboard";
 import { Icon } from "metabase/ui";
 
@@ -310,7 +312,8 @@ class _TokenField extends Component<TokenFieldProps, TokenFieldState> {
       // ",". Similarly, if you want to type "<" on the US keyboard layout, you
       // need to look at `key` to distinguish it from ",".
       key === KEY_COMMA ||
-      keyCode === KEYCODE_ENTER
+      keyCode === KEYCODE_ENTER ||
+      key === KEY_ENTER
     ) {
       if (this.addSelectedOption(event)) {
         event.preventDefault();
@@ -338,7 +341,7 @@ class _TokenField extends Component<TokenFieldProps, TokenFieldState> {
           selectedOptionValue: this._value(filteredOptions[index + 1]),
         });
       }
-    } else if (keyCode === KEYCODE_BACKSPACE) {
+    } else if (keyCode === KEYCODE_BACKSPACE || key === KEY_BACKSPACE) {
       // backspace
       const { value } = this.props;
       if (!this.state.inputValue && value.length > 0) {

--- a/frontend/src/metabase/components/TokenField/TokenField.unit.spec.js
+++ b/frontend/src/metabase/components/TokenField/TokenField.unit.spec.js
@@ -170,7 +170,7 @@ describe("TokenField", () => {
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
-  it("should add freeform value if parseFreeformValue is provided", () => {
+  it("should add freeform value if parseFreeformValue is provided", async () => {
     render(
       <TokenFieldWithStateAndDefaults
         value={[]}
@@ -178,7 +178,7 @@ describe("TokenField", () => {
         parseFreeformValue={value => value}
       />,
     );
-    userEvent.type(input(), "yep");
+    await userEvent.type(input(), "yep");
     expect(input().value).toEqual("yep");
 
     type("yep");
@@ -264,11 +264,11 @@ describe("TokenField", () => {
     });
 
     // This is messy and tricky to test with RTL
-    it("should not commit empty freeform value", () => {
+    it("should not commit empty freeform value", async () => {
       setup();
 
       type("Doohickey");
-      userEvent.clear(input());
+      await userEvent.clear(input());
       type("");
       input().blur();
       expect(values()).toHaveTextContent("");
@@ -420,7 +420,7 @@ describe("TokenField", () => {
   });
 
   describe("with multi=false", () => {
-    it("should not prevent blurring on tab", () => {
+    it("should not prevent blurring on tab", async () => {
       render(
         <TokenFieldWithStateAndDefaults
           options={DEFAULT_OPTIONS}
@@ -431,7 +431,7 @@ describe("TokenField", () => {
       );
       type("asdf");
       input().focus();
-      userEvent.tab();
+      await userEvent.tab();
       expect(input()).not.toHaveFocus();
     });
 

--- a/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/AddToDashSelectDashModal/AddToDashSelectDashModal.unit.spec.tsx
@@ -260,7 +260,7 @@ describe("AddToDashSelectDashModal", () => {
         name: "Create a new dashboard",
       });
 
-      userEvent.click(createNewDashboard);
+      await userEvent.click(createNewDashboard);
 
       // opened CreateDashboardModal
       expect(
@@ -448,7 +448,7 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           it('should render "Create a new dashboard" option when opening public subcollections', async () => {
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: COLLECTION.name,
               }),
@@ -460,7 +460,7 @@ describe("AddToDashSelectDashModal", () => {
               }),
             ).toBeInTheDocument();
 
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: SUBCOLLECTION.name,
               }),
@@ -474,7 +474,7 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_COLLECTION.name,
               }),
@@ -486,7 +486,7 @@ describe("AddToDashSelectDashModal", () => {
               }),
             ).toBeInTheDocument();
 
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_SUBCOLLECTION.name,
               }),
@@ -500,15 +500,15 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           describe('when "Create a new dashboard" option is clicked', () => {
-            beforeEach(() => {
+            beforeEach(async () => {
               // Open "Create a new dashboard" modal
-              userEvent.click(
+              await userEvent.click(
                 screen.getByRole("heading", {
                   name: "Create a new dashboard",
                 }),
               );
 
-              userEvent.click(screen.getByLabelText(/Which collection/));
+              await userEvent.click(screen.getByLabelText(/Which collection/));
             });
 
             it("should render all collections", async () => {
@@ -551,7 +551,7 @@ describe("AddToDashSelectDashModal", () => {
               beforeEach(async () => {
                 const popover = screen.getByTestId("entity-picker-modal");
 
-                userEvent.click(
+                await userEvent.click(
                   await within(popover).findByText(/new collection/),
                 );
               });
@@ -604,7 +604,7 @@ describe("AddToDashSelectDashModal", () => {
               dashboard: dashboardInPublicSubcollection,
             });
 
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: COLLECTION.name,
               }),
@@ -629,7 +629,7 @@ describe("AddToDashSelectDashModal", () => {
               dashboard: dashboardInPersonalCollection,
             });
 
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_COLLECTION.name,
               }),
@@ -654,12 +654,12 @@ describe("AddToDashSelectDashModal", () => {
               dashboard: dashboardInPersonalSubcollection,
             });
 
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_COLLECTION.name,
               }),
             );
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_SUBCOLLECTION.name,
               }),
@@ -708,8 +708,8 @@ describe("AddToDashSelectDashModal", () => {
             ).not.toBeInTheDocument();
           });
 
-          it('should render "Create a new dashboard" option when opening personal subcollections', () => {
-            userEvent.click(
+          it('should render "Create a new dashboard" option when opening personal subcollections', async () => {
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_COLLECTION.name,
               }),
@@ -721,7 +721,7 @@ describe("AddToDashSelectDashModal", () => {
               }),
             ).toBeInTheDocument();
 
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_SUBCOLLECTION.name,
               }),
@@ -735,14 +735,14 @@ describe("AddToDashSelectDashModal", () => {
           });
 
           describe('when "Create a new dashboard" option is clicked when opening personal collections', () => {
-            beforeEach(() => {
+            beforeEach(async () => {
               // "Create a new dashboard" option only renders when opening personal collections
-              userEvent.click(
+              await userEvent.click(
                 screen.getByRole("heading", {
                   name: PERSONAL_COLLECTION.name,
                 }),
               );
-              userEvent.click(
+              await userEvent.click(
                 screen.getByRole("heading", {
                   name: "Create a new dashboard",
                 }),
@@ -753,7 +753,9 @@ describe("AddToDashSelectDashModal", () => {
               expect(
                 screen.getByRole("heading", { name: "New dashboard" }),
               ).toBeInTheDocument();
-              userEvent.click(await screen.findByLabelText(/Which collection/));
+              await userEvent.click(
+                await screen.findByLabelText(/Which collection/),
+              );
 
               const popover = await screen.findByTestId("entity-picker-modal");
 
@@ -828,7 +830,7 @@ describe("AddToDashSelectDashModal", () => {
               dashboard: dashboardInPersonalCollection,
             });
 
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_COLLECTION.name,
               }),
@@ -854,13 +856,13 @@ describe("AddToDashSelectDashModal", () => {
               dashboard: dashboardInPersonalSubcollection,
             });
 
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_COLLECTION.name,
               }),
             );
 
-            userEvent.click(
+            await userEvent.click(
               screen.getByRole("heading", {
                 name: PERSONAL_SUBCOLLECTION.name,
               }),
@@ -884,9 +886,9 @@ describe("AddToDashSelectDashModal", () => {
             searchResults: [DASHBOARD_RESULT_IN_PUBLIC_COLLECTION],
           });
 
-          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          await userEvent.click(screen.getByRole("button", { name: "Search" }));
           const typedText = "dashboard";
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Search"),
             `${typedText}{enter}`,
           );
@@ -912,9 +914,9 @@ describe("AddToDashSelectDashModal", () => {
             searchResults: [DASHBOARD_RESULT_IN_PUBLIC_COLLECTION],
           });
 
-          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          await userEvent.click(screen.getByRole("button", { name: "Search" }));
           const typedText = "dashboard";
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Search"),
             `${typedText}{enter}`,
           );
@@ -943,9 +945,9 @@ describe("AddToDashSelectDashModal", () => {
             ],
           });
 
-          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          await userEvent.click(screen.getByRole("button", { name: "Search" }));
           const typedText = "dashboard";
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Search"),
             `${typedText}{enter}`,
           );

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Models.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Models.unit.spec.ts
@@ -32,7 +32,7 @@ describe("DataPicker — picking models", () => {
   it("opens the picker", async () => {
     await setup();
 
-    userEvent.click(screen.getByText(/Models/i));
+    await userEvent.click(screen.getByText(/Models/i));
 
     expect(await screen.findByText(ROOT_COLLECTION.name)).toBeInTheDocument();
     expect(await screen.findByText(SAMPLE_MODEL.name)).toBeInTheDocument();
@@ -43,8 +43,8 @@ describe("DataPicker — picking models", () => {
   it("has empty state", async () => {
     await setup();
 
-    userEvent.click(screen.getByText(/Saved Questions/i));
-    userEvent.click(await screen.findByText(EMPTY_COLLECTION.name));
+    await userEvent.click(screen.getByText(/Saved Questions/i));
+    await userEvent.click(await screen.findByText(EMPTY_COLLECTION.name));
 
     expect(screen.getByText(/Nothing here/i)).toBeInTheDocument();
   });
@@ -78,9 +78,9 @@ describe("DataPicker — picking models", () => {
   it("allows to pick a single model", async () => {
     const { onChange } = await setup();
 
-    userEvent.click(screen.getByText(/Models/i));
-    userEvent.click(await screen.findByText(SAMPLE_MODEL.name));
-    userEvent.click(screen.getByText(SAMPLE_MODEL_2.name));
+    await userEvent.click(screen.getByText(/Models/i));
+    await userEvent.click(await screen.findByText(SAMPLE_MODEL.name));
+    await userEvent.click(screen.getByText(SAMPLE_MODEL_2.name));
 
     const selectedItem = screen.getByRole("menuitem", {
       name: SAMPLE_MODEL_2.name,
@@ -98,11 +98,11 @@ describe("DataPicker — picking models", () => {
   it("allows to pick multiple models", async () => {
     const { onChange } = await setup({ isMultiSelect: true });
 
-    userEvent.click(screen.getByText(/Models/i));
-    userEvent.click(await screen.findByText(SAMPLE_MODEL.name));
-    userEvent.click(screen.getByText(SAMPLE_MODEL_2.name));
-    userEvent.click(screen.getByText(SAMPLE_MODEL_3.name));
-    userEvent.click(screen.getByText(SAMPLE_MODEL.name));
+    await userEvent.click(screen.getByText(/Models/i));
+    await userEvent.click(await screen.findByText(SAMPLE_MODEL.name));
+    await userEvent.click(screen.getByText(SAMPLE_MODEL_2.name));
+    await userEvent.click(screen.getByText(SAMPLE_MODEL_3.name));
+    await userEvent.click(screen.getByText(SAMPLE_MODEL.name));
 
     expect(onChange).toHaveBeenLastCalledWith({
       type: "models",
@@ -118,9 +118,9 @@ describe("DataPicker — picking models", () => {
   it("allows to return to the data type picker", async () => {
     await setup();
 
-    userEvent.click(screen.getByText(/Models/i));
+    await userEvent.click(screen.getByText(/Models/i));
     await waitForLoaderToBeRemoved();
-    userEvent.click(screen.getByRole("button", { name: /Back/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Back/i }));
 
     expect(screen.getByText(/Models/i)).toBeInTheDocument();
     expect(screen.getByText(/Raw Data/i)).toBeInTheDocument();
@@ -135,9 +135,9 @@ describe("DataPicker — picking models", () => {
   it("resets selection on collection change", async () => {
     const { onChange } = await setup();
 
-    userEvent.click(screen.getByText(/Models/i));
-    userEvent.click(await screen.findByText(SAMPLE_MODEL.name));
-    userEvent.click(screen.getByText(SAMPLE_COLLECTION.name));
+    await userEvent.click(screen.getByText(/Models/i));
+    await userEvent.click(await screen.findByText(SAMPLE_MODEL.name));
+    await userEvent.click(screen.getByText(SAMPLE_COLLECTION.name));
 
     expect(onChange).toHaveBeenLastCalledWith({
       type: "models",
@@ -153,9 +153,9 @@ describe("DataPicker — picking models", () => {
   it("resets selection when going back to data type picker", async () => {
     const { onChange } = await setup();
 
-    userEvent.click(screen.getByText(/Models/i));
-    userEvent.click(await screen.findByText(SAMPLE_MODEL.name));
-    userEvent.click(screen.getByRole("button", { name: /Back/i }));
+    await userEvent.click(screen.getByText(/Models/i));
+    await userEvent.click(await screen.findByText(SAMPLE_MODEL.name));
+    await userEvent.click(screen.getByRole("button", { name: /Back/i }));
 
     expect(onChange).toHaveBeenLastCalledWith({
       type: undefined,
@@ -195,11 +195,11 @@ describe("DataPicker — picking models", () => {
       },
     });
 
-    userEvent.type(screen.getByRole("textbox"), SAMPLE_MODEL.name);
+    await userEvent.type(screen.getByRole("textbox"), SAMPLE_MODEL.name);
     expect(await screen.findByText(SAMPLE_MODEL.name)).toBeInTheDocument();
     expect(screen.queryByText(SAMPLE_QUESTION.name)).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByText(SAMPLE_MODEL.name));
+    await userEvent.click(screen.getByText(SAMPLE_MODEL.name));
     expect(onChange).toHaveBeenLastCalledWith({
       type: "models",
       databaseId: SAVED_QUESTIONS_VIRTUAL_DB_ID,
@@ -222,11 +222,11 @@ describe("DataPicker — picking models", () => {
       },
     });
 
-    userEvent.type(screen.getByRole("textbox"), "Sample");
+    await userEvent.type(screen.getByRole("textbox"), "Sample");
     expect(await screen.findByText(SAMPLE_MODEL.name)).toBeInTheDocument();
     expect(screen.getByText(SAMPLE_QUESTION.name)).toBeInTheDocument();
 
-    userEvent.click(screen.getByText(SAMPLE_MODEL.name));
+    await userEvent.click(screen.getByText(SAMPLE_MODEL.name));
     expect(onChange).toHaveBeenLastCalledWith({
       type: "models",
       databaseId: SAVED_QUESTIONS_VIRTUAL_DB_ID,

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Questions.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-Questions.unit.spec.ts
@@ -29,7 +29,7 @@ describe("DataPicker — picking questions", () => {
   it("opens the picker", async () => {
     await setup();
 
-    userEvent.click(screen.getByText(/Saved Questions/i));
+    await userEvent.click(screen.getByText(/Saved Questions/i));
 
     expect(await screen.findByText(SAMPLE_QUESTION.name)).toBeInTheDocument();
     expect(screen.getByText(ROOT_COLLECTION.name)).toBeInTheDocument();
@@ -40,8 +40,8 @@ describe("DataPicker — picking questions", () => {
   it("has empty state", async () => {
     await setup();
 
-    userEvent.click(screen.getByText(/Saved Questions/i));
-    userEvent.click(await screen.findByText(EMPTY_COLLECTION.name));
+    await userEvent.click(screen.getByText(/Saved Questions/i));
+    await userEvent.click(await screen.findByText(EMPTY_COLLECTION.name));
 
     expect(screen.getByText(/Nothing here/i)).toBeInTheDocument();
   });
@@ -76,9 +76,9 @@ describe("DataPicker — picking questions", () => {
   it("allows to pick a single question", async () => {
     const { onChange } = await setup();
 
-    userEvent.click(screen.getByText(/Saved Questions/i));
-    userEvent.click(await screen.findByText(SAMPLE_QUESTION.name));
-    userEvent.click(screen.getByText(SAMPLE_QUESTION_2.name));
+    await userEvent.click(screen.getByText(/Saved Questions/i));
+    await userEvent.click(await screen.findByText(SAMPLE_QUESTION.name));
+    await userEvent.click(screen.getByText(SAMPLE_QUESTION_2.name));
 
     const selectedItem = screen.getByRole("menuitem", {
       name: SAMPLE_QUESTION_2.name,
@@ -96,11 +96,11 @@ describe("DataPicker — picking questions", () => {
   it("allows to pick multiple questions", async () => {
     const { onChange } = await setup({ isMultiSelect: true });
 
-    userEvent.click(screen.getByText(/Saved Questions/i));
-    userEvent.click(await screen.findByText(SAMPLE_QUESTION.name));
-    userEvent.click(screen.getByText(SAMPLE_QUESTION_2.name));
-    userEvent.click(screen.getByText(SAMPLE_QUESTION_3.name));
-    userEvent.click(screen.getByText(SAMPLE_QUESTION.name));
+    await userEvent.click(screen.getByText(/Saved Questions/i));
+    await userEvent.click(await screen.findByText(SAMPLE_QUESTION.name));
+    await userEvent.click(screen.getByText(SAMPLE_QUESTION_2.name));
+    await userEvent.click(screen.getByText(SAMPLE_QUESTION_3.name));
+    await userEvent.click(screen.getByText(SAMPLE_QUESTION.name));
 
     expect(onChange).toHaveBeenLastCalledWith({
       type: "questions",
@@ -116,9 +116,9 @@ describe("DataPicker — picking questions", () => {
   it("allows to return to the data type picker", async () => {
     await setup();
 
-    userEvent.click(screen.getByText(/Saved Questions/i));
+    await userEvent.click(screen.getByText(/Saved Questions/i));
     await waitForLoaderToBeRemoved();
-    userEvent.click(screen.getByRole("button", { name: /Back/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Back/i }));
 
     expect(screen.getByText(/Models/i)).toBeInTheDocument();
     expect(screen.getByText(/Raw Data/i)).toBeInTheDocument();
@@ -133,9 +133,9 @@ describe("DataPicker — picking questions", () => {
   it("resets selection on collection change", async () => {
     const { onChange } = await setup();
 
-    userEvent.click(screen.getByText(/Saved Questions/i));
+    await userEvent.click(screen.getByText(/Saved Questions/i));
     await waitForLoaderToBeRemoved();
-    userEvent.click(screen.getByText(SAMPLE_COLLECTION.name));
+    await userEvent.click(screen.getByText(SAMPLE_COLLECTION.name));
 
     expect(onChange).toHaveBeenLastCalledWith({
       type: "questions",
@@ -149,10 +149,10 @@ describe("DataPicker — picking questions", () => {
   it("resets selection when going back to data type picker", async () => {
     const { onChange } = await setup();
 
-    userEvent.click(screen.getByText(/Saved Questions/i));
+    await userEvent.click(screen.getByText(/Saved Questions/i));
     const tableListItem = await screen.findByText(SAMPLE_QUESTION.name);
-    userEvent.click(tableListItem);
-    userEvent.click(screen.getByRole("button", { name: /Back/i }));
+    await userEvent.click(tableListItem);
+    await userEvent.click(screen.getByRole("button", { name: /Back/i }));
 
     expect(onChange).toHaveBeenLastCalledWith({
       type: undefined,
@@ -170,11 +170,11 @@ describe("DataPicker — picking questions", () => {
       },
     });
 
-    userEvent.type(screen.getByRole("textbox"), SAMPLE_QUESTION.name);
+    await userEvent.type(screen.getByRole("textbox"), SAMPLE_QUESTION.name);
     expect(await screen.findByText(SAMPLE_QUESTION.name)).toBeInTheDocument();
     expect(screen.queryByText(SAMPLE_MODEL.name)).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByText(SAMPLE_QUESTION.name));
+    await userEvent.click(screen.getByText(SAMPLE_QUESTION.name));
     expect(onChange).toHaveBeenLastCalledWith({
       type: "questions",
       databaseId: SAVED_QUESTIONS_VIRTUAL_DB_ID,
@@ -197,11 +197,11 @@ describe("DataPicker — picking questions", () => {
       },
     });
 
-    userEvent.type(screen.getByRole("textbox"), "Sample");
+    await userEvent.type(screen.getByRole("textbox"), "Sample");
     expect(await screen.findByText(SAMPLE_QUESTION.name)).toBeInTheDocument();
     expect(screen.getByText(SAMPLE_MODEL.name)).toBeInTheDocument();
 
-    userEvent.click(screen.getByText(SAMPLE_QUESTION.name));
+    await userEvent.click(screen.getByText(SAMPLE_QUESTION.name));
     expect(onChange).toHaveBeenLastCalledWith({
       type: "questions",
       databaseId: SAVED_QUESTIONS_VIRTUAL_DB_ID,

--- a/frontend/src/metabase/containers/DataPicker/tests/DataPicker-RawData.unit.spec.ts
+++ b/frontend/src/metabase/containers/DataPicker/tests/DataPicker-RawData.unit.spec.ts
@@ -22,7 +22,7 @@ describe("DataPicker — picking raw data", () => {
   it("opens the picker", async () => {
     await setup();
 
-    userEvent.click(screen.getByText(/Raw Data/i));
+    await userEvent.click(screen.getByText(/Raw Data/i));
     await waitForLoaderToBeRemoved();
 
     expect(screen.getByText(SAMPLE_DATABASE.name)).toBeInTheDocument();
@@ -36,24 +36,24 @@ describe("DataPicker — picking raw data", () => {
   it("has empty state", async () => {
     await setup({ hasEmptyDatabase: true });
 
-    userEvent.click(screen.getByText(/Raw Data/i));
-    userEvent.click(screen.getByText(EMPTY_DATABASE.name));
+    await userEvent.click(screen.getByText(/Raw Data/i));
+    await userEvent.click(screen.getByText(EMPTY_DATABASE.name));
 
     expect(await screen.findByText(/Nothing here/i)).toBeInTheDocument();
   });
 
   it("doesn't show saved questions database", async () => {
     await setup();
-    userEvent.click(screen.getByText("Raw Data"));
+    await userEvent.click(screen.getByText("Raw Data"));
     expect(screen.queryByText(/Saved Questions/i)).not.toBeInTheDocument();
   });
 
   it("allows to pick multiple tables", async () => {
     const { onChange } = await setup({ isMultiSelect: true });
 
-    userEvent.click(screen.getByText(/Raw Data/i));
-    userEvent.click(await screen.findByText(SAMPLE_TABLE.display_name));
-    userEvent.click(screen.getByText(SAMPLE_TABLE_2.display_name));
+    await userEvent.click(screen.getByText(/Raw Data/i));
+    await userEvent.click(await screen.findByText(SAMPLE_TABLE.display_name));
+    await userEvent.click(screen.getByText(SAMPLE_TABLE_2.display_name));
 
     expect(onChange).toHaveBeenLastCalledWith({
       type: "raw-data",
@@ -66,9 +66,9 @@ describe("DataPicker — picking raw data", () => {
   it("allows to return to the data type picker", async () => {
     await setup();
 
-    userEvent.click(screen.getByText(/Raw Data/i));
+    await userEvent.click(screen.getByText(/Raw Data/i));
     await waitForLoaderToBeRemoved();
-    userEvent.click(screen.getByRole("button", { name: /Back/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Back/i }));
 
     expect(screen.getByText(/Models/i)).toBeInTheDocument();
     expect(screen.getByText(/Raw Data/i)).toBeInTheDocument();
@@ -86,9 +86,9 @@ describe("DataPicker — picking raw data", () => {
   it("allows to pick a single table", async () => {
     const { onChange } = await setup();
 
-    userEvent.click(screen.getByText(/Raw Data/i));
-    userEvent.click(await screen.findByText(SAMPLE_TABLE.display_name));
-    userEvent.click(screen.getByText(SAMPLE_TABLE_2.display_name));
+    await userEvent.click(screen.getByText(/Raw Data/i));
+    await userEvent.click(await screen.findByText(SAMPLE_TABLE.display_name));
+    await userEvent.click(screen.getByText(SAMPLE_TABLE_2.display_name));
 
     const selectedItem = screen.getByRole("menuitem", {
       name: SAMPLE_TABLE_2.display_name,
@@ -165,11 +165,11 @@ describe("DataPicker — picking raw data", () => {
 
       const { onChange } = await setup({ hasMultiSchemaDatabase: true });
 
-      userEvent.click(screen.getByText(/Raw Data/i));
-      userEvent.click(screen.getByText(MULTI_SCHEMA_DATABASE.name));
-      userEvent.click(await screen.findByText(schema1));
-      userEvent.click(await screen.findByText(schema1Table.display_name));
-      userEvent.click(await screen.findByText(schema2));
+      await userEvent.click(screen.getByText(/Raw Data/i));
+      await userEvent.click(screen.getByText(MULTI_SCHEMA_DATABASE.name));
+      await userEvent.click(await screen.findByText(schema1));
+      await userEvent.click(await screen.findByText(schema1Table.display_name));
+      await userEvent.click(await screen.findByText(schema2));
 
       expect(onChange).toHaveBeenLastCalledWith({
         type: "raw-data",
@@ -184,10 +184,10 @@ describe("DataPicker — picking raw data", () => {
     it("resets selected tables on database change", async () => {
       const { onChange } = await setup({ hasMultiSchemaDatabase: true });
 
-      userEvent.click(screen.getByText(/Raw Data/i));
-      userEvent.click(screen.getByText(SAMPLE_DATABASE.name));
-      userEvent.click(await screen.findByText(SAMPLE_TABLE.display_name));
-      userEvent.click(screen.getByText(MULTI_SCHEMA_DATABASE.name));
+      await userEvent.click(screen.getByText(/Raw Data/i));
+      await userEvent.click(screen.getByText(SAMPLE_DATABASE.name));
+      await userEvent.click(await screen.findByText(SAMPLE_TABLE.display_name));
+      await userEvent.click(screen.getByText(MULTI_SCHEMA_DATABASE.name));
 
       expect(onChange).toHaveBeenLastCalledWith({
         type: "raw-data",
@@ -201,9 +201,9 @@ describe("DataPicker — picking raw data", () => {
   it("resets selection when going back to data type picker", async () => {
     const { onChange } = await setup();
 
-    userEvent.click(screen.getByText(/Raw Data/i));
-    userEvent.click(await screen.findByText(SAMPLE_TABLE.display_name));
-    userEvent.click(screen.getByRole("button", { name: /Back/i }));
+    await userEvent.click(screen.getByText(/Raw Data/i));
+    await userEvent.click(await screen.findByText(SAMPLE_TABLE.display_name));
+    await userEvent.click(screen.getByRole("button", { name: /Back/i }));
 
     expect(onChange).toHaveBeenLastCalledWith({
       type: undefined,

--- a/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
+++ b/frontend/src/metabase/containers/ItemPicker/ItemPicker.unit.spec.js
@@ -193,7 +193,7 @@ describe("ItemPicker", () => {
     await openCollectionWait(COLLECTION.REGULAR.name);
     let header = within(getItemPickerHeader());
 
-    userEvent.click(header.getByText(/Our analytics/i));
+    await userEvent.click(header.getByText(/Our analytics/i));
 
     header = within(getItemPickerHeader());
     const list = within(getItemPickerList());
@@ -210,7 +210,7 @@ describe("ItemPicker", () => {
   it("calls onChange when selecting an item", async () => {
     const { onChange } = await setup();
 
-    userEvent.click(screen.getByText(DASHBOARD.REGULAR.name));
+    await userEvent.click(screen.getByText(DASHBOARD.REGULAR.name));
 
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining(DASHBOARD.REGULAR),
@@ -220,7 +220,7 @@ describe("ItemPicker", () => {
 
   it("doesn't call onChange if it's not a collection picker", async () => {
     const { onChange } = await setup();
-    userEvent.click(screen.getByText(COLLECTION.REGULAR.name));
+    await userEvent.click(screen.getByText(COLLECTION.REGULAR.name));
     expect(onChange).not.toHaveBeenCalled();
   });
 
@@ -229,7 +229,7 @@ describe("ItemPicker", () => {
       collections: [...Object.values(COLLECTION), COLLECTION_OTHER_USERS],
     });
 
-    userEvent.click(screen.getByText(/All personal collections/i));
+    await userEvent.click(screen.getByText(/All personal collections/i));
 
     const list = within(getItemPickerList());
     expect(list.getByText(COLLECTION_OTHER_USERS.name)).toBeInTheDocument();
@@ -321,8 +321,8 @@ describe("ItemPicker", () => {
     it("should show search results", async () => {
       await setup();
 
-      userEvent.click(screen.getByRole("img", { name: /search/ }));
-      userEvent.type(screen.getByPlaceholderText("Search"), "das{enter}");
+      await userEvent.click(screen.getByRole("img", { name: /search/ }));
+      await userEvent.type(screen.getByPlaceholderText("Search"), "das{enter}");
 
       expect(
         await screen.findByText(/^regular dashboard$/i),
@@ -337,8 +337,8 @@ describe("ItemPicker", () => {
           !isPersonalCollectionOrChild(collection, allCollections),
       });
 
-      userEvent.click(screen.getByRole("img", { name: /search/ }));
-      userEvent.type(screen.getByPlaceholderText("Search"), "das{enter}");
+      await userEvent.click(screen.getByRole("img", { name: /search/ }));
+      await userEvent.type(screen.getByPlaceholderText("Search"), "das{enter}");
 
       expect(
         await screen.findByText(/^regular dashboard$/i),

--- a/frontend/src/metabase/containers/ItemPicker/test-utils.js
+++ b/frontend/src/metabase/containers/ItemPicker/test-utils.js
@@ -16,12 +16,12 @@ export function queryListItem(itemName) {
     .closest("[data-testid=item-picker-item]");
 }
 
-export function openCollection(itemName) {
+export async function openCollection(itemName) {
   const collectionNode = within(queryListItem(itemName));
-  userEvent.click(collectionNode.getByLabelText("chevronright icon"));
+  await userEvent.click(collectionNode.getByLabelText("chevronright icon"));
 }
 
 export async function openCollectionWait(itemName) {
-  openCollection(itemName);
+  await openCollection(itemName);
   await waitForLoaderToBeRemoved();
 }

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -91,7 +91,7 @@ describe("NewItemMenu", () => {
   describe("New Collection", () => {
     it("should open new collection modal on click", async () => {
       setup();
-      userEvent.click(await screen.findByText("Collection"));
+      await userEvent.click(await screen.findByText("Collection"));
       const modal = await screen.findByRole("dialog", {
         name: /new collection/i,
       });
@@ -102,7 +102,7 @@ describe("NewItemMenu", () => {
   describe("New Dashboard", () => {
     it("should open new dashboard modal on click", async () => {
       setup();
-      userEvent.click(await screen.findByText("Dashboard"));
+      await userEvent.click(await screen.findByText("Dashboard"));
       const modal = await screen.findByRole("dialog");
       expect(modal).toHaveTextContent("New dashboard");
     });

--- a/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
+++ b/frontend/src/metabase/containers/NewItemMenu/NewItemMenu.unit.spec.tsx
@@ -52,7 +52,7 @@ const DB_WITHOUT_WRITE_ACCESS = createMockDatabase({
 
 const COLLECTION = createMockCollection();
 
-function setup({
+async function setup({
   databases = [SAMPLE_DATABASE, DB_WITH_ACTIONS],
   hasModels = true,
 }: SetupOpts = {}) {
@@ -84,7 +84,7 @@ function setup({
       <NewModals />
     </>,
   );
-  userEvent.click(screen.getByText("New"));
+  await userEvent.click(screen.getByText("New"));
 }
 
 describe("NewItemMenu", () => {
@@ -110,26 +110,26 @@ describe("NewItemMenu", () => {
 
   describe("New Action", () => {
     it("should open action editor on click", async () => {
-      setup();
+      await setup();
 
-      userEvent.click(await screen.findByText("Action"));
+      await userEvent.click(await screen.findByText("Action"));
       const modal = screen.getByRole("dialog");
 
       expect(modal).toBeVisible();
     });
 
-    it("should not be visible if there are no databases with actions enabled", () => {
-      setup({ databases: [SAMPLE_DATABASE] });
+    it("should not be visible if there are no databases with actions enabled", async () => {
+      await setup({ databases: [SAMPLE_DATABASE] });
       expect(screen.queryByText("Action")).not.toBeInTheDocument();
     });
 
-    it("should not be visible if user has no models", () => {
-      setup({ hasModels: false });
+    it("should not be visible if user has no models", async () => {
+      await setup({ hasModels: false });
       expect(screen.queryByText("Action")).not.toBeInTheDocument();
     });
 
-    it("should not be visible if user has no write data access", () => {
-      setup({ databases: [DB_WITHOUT_WRITE_ACCESS] });
+    it("should not be visible if user has no write data access", async () => {
+      await setup({ databases: [DB_WITHOUT_WRITE_ACCESS] });
       expect(screen.queryByText("Action")).not.toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -162,7 +162,7 @@ function getDirtyQuestion(originalQuestion: Question) {
     .markDirty();
 }
 
-function fillForm({
+async function fillForm({
   name,
   description,
 }: {
@@ -171,13 +171,13 @@ function fillForm({
 }) {
   if (name) {
     const input = screen.getByLabelText("Name");
-    userEvent.clear(input);
-    userEvent.type(input, name);
+    await userEvent.clear(input);
+    await userEvent.type(input, name);
   }
   if (description) {
     const input = screen.getByLabelText("Description");
-    userEvent.clear(input);
-    userEvent.type(input, description);
+    await userEvent.clear(input);
+    await userEvent.type(input, description);
   }
 }
 
@@ -224,7 +224,7 @@ describe("SaveQuestionModal", () => {
       const question = getQuestion();
       const { onCreateMock } = await setup(question);
 
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(onCreateMock).toHaveBeenCalledTimes(1);
@@ -244,11 +244,11 @@ describe("SaveQuestionModal", () => {
       const question = getQuestion();
       const { onCreateMock } = await setup(question);
 
-      fillForm({
+      await fillForm({
         name: "My favorite orders",
         description: "So many of them",
       });
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(onCreateMock).toHaveBeenCalledTimes(1);
@@ -268,11 +268,11 @@ describe("SaveQuestionModal", () => {
       const question = getQuestion();
       const { onCreateMock } = await setup(question);
 
-      fillForm({
+      await fillForm({
         name: "    My favorite orders ",
         description: "  So many of them   ",
       });
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(onCreateMock).toHaveBeenCalledTimes(1);
@@ -294,8 +294,8 @@ describe("SaveQuestionModal", () => {
       });
       const { onCreateMock } = await setup(question);
 
-      fillForm({ name: "foo", description: "bar" });
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await fillForm({ name: "foo", description: "bar" });
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(onCreateMock).toHaveBeenCalledTimes(1);
@@ -315,7 +315,7 @@ describe("SaveQuestionModal", () => {
       const question = getQuestion();
       const { onSaveMock } = await setup(question);
 
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       expect(onSaveMock).not.toHaveBeenCalled();
     });
@@ -352,7 +352,7 @@ describe("SaveQuestionModal", () => {
       const dirtyQuestion = getDirtyQuestion(originalQuestion);
       await setup(dirtyQuestion, originalQuestion);
 
-      userEvent.click(screen.getByText("Save as new question"));
+      await userEvent.click(screen.getByText("Save as new question"));
 
       expect(screen.getByLabelText("Name")).toHaveValue(
         EXPECTED_DIRTY_SUGGESTED_NAME,
@@ -368,8 +368,8 @@ describe("SaveQuestionModal", () => {
       const dirtyQuestion = getDirtyQuestion(originalQuestion);
       const { onCreateMock } = await setup(dirtyQuestion, originalQuestion);
 
-      userEvent.click(screen.getByText("Save as new question"));
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByText("Save as new question"));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(onCreateMock).toHaveBeenCalledTimes(1);
@@ -390,9 +390,9 @@ describe("SaveQuestionModal", () => {
       const dirtyQuestion = getDirtyQuestion(originalQuestion);
       const { onCreateMock } = await setup(dirtyQuestion, originalQuestion);
 
-      userEvent.click(screen.getByText("Save as new question"));
-      fillForm({ name: "My Q", description: "Sample" });
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByText("Save as new question"));
+      await fillForm({ name: "My Q", description: "Sample" });
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(onCreateMock).toHaveBeenCalledTimes(1);
@@ -412,9 +412,9 @@ describe("SaveQuestionModal", () => {
       const originalQuestion = getQuestion({ isSaved: true });
       await setup(getDirtyQuestion(originalQuestion), originalQuestion);
 
-      userEvent.click(screen.getByText("Save as new question"));
-      userEvent.clear(screen.getByLabelText("Name"));
-      userEvent.clear(screen.getByLabelText("Description"));
+      await userEvent.click(screen.getByText("Save as new question"));
+      await userEvent.clear(screen.getByLabelText("Name"));
+      await userEvent.clear(screen.getByLabelText("Description"));
 
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
@@ -439,8 +439,8 @@ describe("SaveQuestionModal", () => {
       );
 
       const inputEl = screen.getByLabelText("Name");
-      userEvent.click(inputEl);
-      userEvent.tab();
+      await userEvent.click(inputEl);
+      await userEvent.tab();
 
       expect(
         screen.getByText(getBrokenUpTextMatcher("Name: required"), {
@@ -453,9 +453,9 @@ describe("SaveQuestionModal", () => {
       await setup(getQuestion());
 
       const inputEl = screen.getByLabelText("Name");
-      userEvent.click(inputEl);
-      userEvent.clear(inputEl); // remove autogenerated name
-      userEvent.tab();
+      await userEvent.click(inputEl);
+      await userEvent.clear(inputEl); // remove autogenerated name
+      await userEvent.tab();
 
       await waitFor(() => {
         expect(
@@ -486,7 +486,7 @@ describe("SaveQuestionModal", () => {
       const dirtyQuestion = getDirtyQuestion(originalQuestion);
       const { onSaveMock } = await setup(dirtyQuestion, originalQuestion);
 
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(onSaveMock).toHaveBeenCalledTimes(1);
@@ -507,9 +507,11 @@ describe("SaveQuestionModal", () => {
       const dirtyQuestion = getDirtyQuestion(originalQuestion);
       const { onSaveMock } = await setup(dirtyQuestion, originalQuestion);
 
-      userEvent.click(screen.getByText("Save as new question"));
-      userEvent.click(screen.getByText(/Replace original question, ".*"/));
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByText("Save as new question"));
+      await userEvent.click(
+        screen.getByText(/Replace original question, ".*"/),
+      );
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(onSaveMock).toHaveBeenCalledTimes(1);
@@ -533,7 +535,7 @@ describe("SaveQuestionModal", () => {
       const dirtyQuestion = getDirtyQuestion(originalQuestion);
       const { onSaveMock } = await setup(dirtyQuestion, originalQuestion);
 
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(onSaveMock).toHaveBeenCalledTimes(1);
@@ -552,8 +554,8 @@ describe("SaveQuestionModal", () => {
     it("shouldn't allow to save a question if form is invalid", async () => {
       await setup(getQuestion());
 
-      userEvent.clear(screen.getByLabelText("Name"));
-      userEvent.clear(screen.getByLabelText("Description"));
+      await userEvent.clear(screen.getByLabelText("Name"));
+      await userEvent.clear(screen.getByLabelText("Description"));
 
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
@@ -565,7 +567,7 @@ describe("SaveQuestionModal", () => {
       const dirtyQuestion = getDirtyQuestion(originalQuestion);
       const { onCreateMock } = await setup(dirtyQuestion, originalQuestion);
 
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       await waitFor(() => {
         expect(onCreateMock).not.toHaveBeenCalled();
@@ -576,13 +578,15 @@ describe("SaveQuestionModal", () => {
       const originalQuestion = getQuestion({ isSaved: true });
       await setup(getDirtyQuestion(originalQuestion), originalQuestion);
 
-      userEvent.click(screen.getByText("Save as new question"));
-      fillForm({
+      await userEvent.click(screen.getByText("Save as new question"));
+      await fillForm({
         name: "Should not be erased",
         description: "This should not be erased too",
       });
-      userEvent.click(screen.getByText(/Replace original question, ".*"/));
-      userEvent.click(screen.getByText("Save as new question"));
+      await userEvent.click(
+        screen.getByText(/Replace original question, ".*"/),
+      );
+      await userEvent.click(screen.getByText("Save as new question"));
 
       await waitFor(() => {
         expect(screen.getByLabelText("Name")).toHaveValue(
@@ -598,9 +602,11 @@ describe("SaveQuestionModal", () => {
       const originalQuestion = getQuestion({ isSaved: true });
       await setup(getDirtyQuestion(originalQuestion), originalQuestion);
 
-      userEvent.click(screen.getByText("Save as new question"));
-      userEvent.clear(screen.getByLabelText("Name"));
-      userEvent.click(screen.getByText(/Replace original question, ".*"/));
+      await userEvent.click(screen.getByText("Save as new question"));
+      await userEvent.clear(screen.getByLabelText("Name"));
+      await userEvent.click(
+        screen.getByText(/Replace original question, ".*"/),
+      );
 
       expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
     });
@@ -625,13 +631,13 @@ describe("SaveQuestionModal", () => {
 
   it("should call onClose when Cancel button is clicked", async () => {
     const { onCloseMock } = await setup(getQuestion());
-    userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onCloseMock).toHaveBeenCalledTimes(1);
   });
 
   it("should call onClose when close icon is clicked", async () => {
     const { onCloseMock } = await setup(getQuestion());
-    userEvent.click(screen.getByLabelText("Close"));
+    await userEvent.click(screen.getByLabelText("Close"));
     expect(onCloseMock).toHaveBeenCalledTimes(1);
   });
 
@@ -733,17 +739,17 @@ describe("SaveQuestionModal", () => {
 
     it("should have a new collection button in the collection picker", async () => {
       await setup(getQuestion());
-      userEvent.click(collDropdown());
+      await userEvent.click(collDropdown());
       await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
     });
     it("should open new collection modal and return to dashboard modal when clicking close", async () => {
       await setup(getQuestion());
-      userEvent.click(collDropdown());
+      await userEvent.click(collDropdown());
       await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
-      userEvent.click(newCollBtn());
+      await userEvent.click(newCollBtn());
       await screen.findByText("Give it a name");
-      userEvent.click(cancelBtn());
-      userEvent.click(cancelBtn());
+      await userEvent.click(cancelBtn());
+      await userEvent.click(cancelBtn());
       await waitFor(() => expect(questionModalTitle()).toBeInTheDocument());
     });
     describe("new collection location", () => {
@@ -757,20 +763,20 @@ describe("SaveQuestionModal", () => {
         setupCollectionByIdEndpoint({ collections: [COLLECTION.PARENT] });
       });
       it("should create collection inside nested folder", async () => {
-        userEvent.click(collDropdown());
+        await userEvent.click(collDropdown());
         await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
-        userEvent.click(
+        await userEvent.click(
           await screen.findByRole("button", {
             name: new RegExp(COLLECTION.PARENT.name),
           }),
         );
-        userEvent.click(newCollBtn());
+        await userEvent.click(newCollBtn());
         await screen.findByText("Give it a name");
       });
       it("should create collection inside root folder", async () => {
-        userEvent.click(collDropdown());
+        await userEvent.click(collDropdown());
         await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
-        userEvent.click(newCollBtn());
+        await userEvent.click(newCollBtn());
         await waitFor(async () =>
           expect(
             await screen.findByRole("heading", {

--- a/frontend/src/metabase/containers/UserCollectionList.unit.spec.tsx
+++ b/frontend/src/metabase/containers/UserCollectionList.unit.spec.tsx
@@ -34,7 +34,7 @@ describe("UserCollectionList", () => {
     expect(await screen.findByText("1 - 27")).toBeInTheDocument();
 
     expect(await screen.findByTestId("previous-page-btn")).toBeDisabled();
-    userEvent.click(await screen.findByTestId("next-page-btn"));
+    await userEvent.click(await screen.findByTestId("next-page-btn"));
 
     expect(await screen.findByText("28 - 54")).toBeInTheDocument();
 

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.js
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.unit.spec.js
@@ -100,7 +100,7 @@ describe("AccordionList", () => {
         />,
       );
 
-      userEvent.hover(screen.getByText("Foo"));
+      await userEvent.hover(screen.getByText("Foo"));
       expect(await screen.findByText("popover")).toBeVisible();
     });
   });

--- a/frontend/src/metabase/core/components/AutocompleteInput/AutocompleteInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/AutocompleteInput/AutocompleteInput.unit.spec.tsx
@@ -38,7 +38,7 @@ describe("AutocompleteInput", () => {
       value: "or",
     });
 
-    userEvent.click(input);
+    await userEvent.click(input);
 
     const options = await getOptions();
     expect(options).toHaveLength(1);
@@ -53,11 +53,11 @@ describe("AutocompleteInput", () => {
       onChange,
     });
 
-    userEvent.click(input);
+    await userEvent.click(input);
 
     const options = await getOptions();
 
-    userEvent.click(options[0]);
+    await userEvent.click(options[0]);
 
     expect(onChange).toHaveBeenCalledWith("Orange");
   });
@@ -78,7 +78,7 @@ describe("AutocompleteInput", () => {
       filterOptions,
     });
 
-    userEvent.click(input);
+    await userEvent.click(input);
 
     const options = await getOptions();
     expect(options).toHaveLength(2);
@@ -97,11 +97,11 @@ describe("AutocompleteInput", () => {
       onOptionSelect,
     });
 
-    userEvent.click(input);
+    await userEvent.click(input);
 
     const options = await getOptions();
 
-    userEvent.click(options[0]);
+    await userEvent.click(options[0]);
 
     expect(onOptionSelect).toHaveBeenCalledWith("Orange");
     expect(onChange).not.toHaveBeenCalled();

--- a/frontend/src/metabase/core/components/Button/Button.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/Button/Button.unit.spec.tsx
@@ -18,9 +18,9 @@ describe("Button", () => {
     expect(screen.getByRole("img", { name: "star icon" })).toBeInTheDocument();
   });
 
-  it("should receive focus on tab", () => {
+  it("should receive focus on tab", async () => {
     render(<Button>{title}</Button>);
-    userEvent.tab();
+    await userEvent.tab();
 
     expect(screen.getByRole("button")).toHaveFocus();
   });

--- a/frontend/src/metabase/core/components/ButtonGroup/ButtonGroup.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ButtonGroup/ButtonGroup.unit.spec.tsx
@@ -18,7 +18,7 @@ describe("ButtonGroup", () => {
     expect(screen.getByRole("button", { name: "Two" })).toBeInTheDocument();
   });
 
-  it("should receive focus on tab", () => {
+  it("should receive focus on tab", async () => {
     render(
       <ButtonGroup>
         <Button>One</Button>
@@ -26,10 +26,10 @@ describe("ButtonGroup", () => {
       </ButtonGroup>,
     );
 
-    userEvent.tab();
+    await userEvent.tab();
     expect(screen.getByRole("button", { name: "One" })).toHaveFocus();
 
-    userEvent.tab();
+    await userEvent.tab();
     expect(screen.getByRole("button", { name: "Two" })).toHaveFocus();
   });
 });

--- a/frontend/src/metabase/core/components/CheckBox/CheckBox.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/CheckBox/CheckBox.unit.spec.tsx
@@ -1,51 +1,51 @@
 import { render, screen } from "@testing-library/react";
-import userEvent, { specialChars } from "@testing-library/user-event";
+import userEvent from "@testing-library/user-event";
 
 import CheckBox from "./CheckBox";
 
 describe("CheckBox", () => {
-  it("should receive focus on tab", () => {
+  it("should receive focus on tab", async () => {
     const onChange = jest.fn();
 
     render(<CheckBox checked={false} onChange={onChange} />);
 
     const checkbox = screen.getByRole("checkbox");
-    userEvent.tab();
+    await userEvent.tab();
 
     expect(checkbox).toHaveFocus();
   });
 
-  it("should change on enter", () => {
+  it("should change on enter", async () => {
     const onChange = jest.fn();
 
     render(<CheckBox checked={false} onChange={onChange} />);
 
     const checkbox = screen.getByRole("checkbox");
-    userEvent.tab();
-    userEvent.type(checkbox, specialChars.enter);
+    await userEvent.tab();
+    await userEvent.type(checkbox, "{Enter}");
 
     expect(onChange).toHaveBeenCalled();
   });
 
-  it("should change on space", () => {
+  it("should change on space", async () => {
     const onChange = jest.fn();
 
     render(<CheckBox checked={false} onChange={onChange} />);
 
     const checkbox = screen.getByRole("checkbox");
-    userEvent.tab();
-    userEvent.type(checkbox, specialChars.space);
+    await userEvent.tab();
+    await userEvent.type(checkbox, "Space");
 
     expect(onChange).toHaveBeenCalled();
   });
 
-  it("should change on click", () => {
+  it("should change on click", async () => {
     const onChange = jest.fn();
 
     render(<CheckBox checked={false} onChange={onChange} />);
 
     const checkbox = screen.getByRole("checkbox");
-    userEvent.click(checkbox);
+    await userEvent.click(checkbox);
 
     expect(checkbox).toHaveFocus();
     expect(onChange).toHaveBeenCalled();

--- a/frontend/src/metabase/core/components/ColorPicker/ColorPicker.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorPicker/ColorPicker.unit.spec.tsx
@@ -13,26 +13,26 @@ const TestColorPicker = () => {
 };
 
 describe("ColorPicker", () => {
-  it("should input a color inline", () => {
+  it("should input a color inline", async () => {
     render(<TestColorPicker />);
 
     const color = Color.rgb(0, 0, 0);
     const input = screen.getByRole("textbox");
-    userEvent.clear(input);
-    userEvent.type(input, color.hex());
+    await userEvent.clear(input);
+    await userEvent.type(input, color.hex());
 
     expect(screen.getByLabelText(color.hex())).toBeInTheDocument();
   });
 
   it("should input a color in a popover", async () => {
     render(<TestColorPicker />);
-    userEvent.click(screen.getByLabelText("white"));
+    await userEvent.click(screen.getByLabelText("white"));
 
     const color = Color.rgb(0, 0, 0);
     const tooltip = await screen.findByRole("tooltip");
     const input = within(tooltip).getByRole("textbox");
-    userEvent.clear(input);
-    userEvent.type(input, color.hex());
+    await userEvent.clear(input);
+    await userEvent.type(input, color.hex());
 
     expect(screen.getByLabelText(color.hex())).toBeInTheDocument();
   });

--- a/frontend/src/metabase/core/components/ColorSelector/ColorSelector.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ColorSelector/ColorSelector.unit.spec.tsx
@@ -15,9 +15,9 @@ describe("ColorSelector", () => {
       />,
     );
 
-    userEvent.click(screen.getByLabelText("white"));
+    await userEvent.click(screen.getByLabelText("white"));
     const tooltip = await screen.findByRole("tooltip");
-    userEvent.click(within(tooltip).getByLabelText("blue"));
+    await userEvent.click(within(tooltip).getByLabelText("blue"));
 
     expect(onChange).toHaveBeenCalledWith("blue");
   });

--- a/frontend/src/metabase/core/components/DateInput/DateInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/DateInput/DateInput.unit.spec.tsx
@@ -22,42 +22,42 @@ const DateInputTest = ({ onChange, ...props }: DateInputProps) => {
 };
 
 describe("DateInput", () => {
-  it("should set date", () => {
+  it("should set date", async () => {
     const onChange = jest.fn();
 
     render(<DateInputTest onChange={onChange} />);
-    userEvent.type(screen.getByRole("textbox"), "10/20/21");
+    await userEvent.type(screen.getByRole("textbox"), "10/20/21");
 
     const expected = moment("10/20/21", ["MM/DD/YYYY"]);
     expect(onChange).toHaveBeenLastCalledWith(expected);
   });
 
-  it("should set date with time with 12-hour clock", () => {
+  it("should set date with time with 12-hour clock", async () => {
     const onChange = jest.fn();
 
     render(<DateInputTest hasTime onChange={onChange} />);
-    userEvent.type(screen.getByRole("textbox"), "10/20/21 9:15 PM");
+    await userEvent.type(screen.getByRole("textbox"), "10/20/21 9:15 PM");
 
     const expected = moment("10/20/21 9:15 PM", ["MM/DD/YYYY, h:mm A"]);
     expect(onChange).toHaveBeenLastCalledWith(expected);
   });
 
-  it("should set date with time with 24-hour clock", () => {
+  it("should set date with time with 24-hour clock", async () => {
     const onChange = jest.fn();
 
     render(<DateInputTest hasTime onChange={onChange} />);
-    userEvent.type(screen.getByRole("textbox"), "10/20/21 9:15");
+    await userEvent.type(screen.getByRole("textbox"), "10/20/21 9:15");
 
     const expected = moment("10/20/21 9:15", ["MM/DD/YYYY, HH:mm"]);
     expect(onChange).toHaveBeenLastCalledWith(expected);
   });
 
-  it("should clear date", () => {
+  it("should clear date", async () => {
     const onChange = jest.fn();
 
     render(<DateInputTest onChange={onChange} />);
-    userEvent.type(screen.getByRole("textbox"), "10/20/21");
-    userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.type(screen.getByRole("textbox"), "10/20/21");
+    await userEvent.clear(screen.getByRole("textbox"));
 
     expect(onChange).toHaveBeenLastCalledWith(undefined);
   });

--- a/frontend/src/metabase/core/components/EditableText/EditableText.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/EditableText/EditableText.unit.spec.tsx
@@ -28,13 +28,13 @@ describe("EditableText", () => {
     expect(screen.getByText("Description")).toBeInTheDocument();
   });
 
-  it("should render input after a click", () => {
+  it("should render input after a click", async () => {
     setup({
       initialValue: "Description",
       isMarkdown: true,
     });
 
-    userEvent.click(screen.getByText("Description"));
+    await userEvent.click(screen.getByText("Description"));
 
     expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
@@ -45,7 +45,7 @@ describe("EditableText", () => {
       isMarkdown: true,
     });
 
-    userEvent.click(screen.getByText("Description"));
+    await userEvent.click(screen.getByText("Description"));
 
     await waitFor(() => {
       expect(screen.getByRole("textbox")).toHaveFocus();
@@ -58,25 +58,25 @@ describe("EditableText", () => {
       isMarkdown: true,
     });
 
-    userEvent.click(screen.getByTestId("editable-text"));
+    await userEvent.click(screen.getByTestId("editable-text"));
 
     await waitFor(() => {
       expect(screen.getByRole("textbox")).toHaveFocus();
     });
 
-    userEvent.tab();
+    await userEvent.tab();
 
     expect(screen.getByTestId("editable-text")).toHaveTextContent("bold link");
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
-  it("should not render input if click happened on the link", () => {
+  it("should not render input if click happened on the link", async () => {
     setup({
       initialValue: "**bold** [link](https://metabase.com)",
       isMarkdown: true,
     });
 
-    userEvent.click(screen.getByRole("link"));
+    await userEvent.click(screen.getByRole("link"));
 
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
     expect(screen.getByTestId("editable-text")).toHaveTextContent("bold link");

--- a/frontend/src/metabase/core/components/ExternalLink/ExternalLink.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/ExternalLink/ExternalLink.unit.spec.tsx
@@ -4,9 +4,9 @@ import userEvent from "@testing-library/user-event";
 import ExternalLink from "./ExternalLink";
 
 describe("ExternalLink", () => {
-  it("should receive focus on tab", () => {
+  it("should receive focus on tab", async () => {
     render(<ExternalLink href="/">Link</ExternalLink>);
-    userEvent.tab();
+    await userEvent.tab();
 
     expect(screen.getByRole("link")).toHaveFocus();
   });

--- a/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormCheckBox/FormCheckBox.unit.spec.tsx
@@ -45,8 +45,8 @@ describe("FormCheckBox", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormCheckBox onSubmit={onSubmit} />);
-    userEvent.click(screen.getByRole("checkbox"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByRole("checkbox"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       const values = { value: true };
@@ -66,8 +66,8 @@ describe("FormCheckBox", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormCheckBox initialValue={true} onSubmit={onSubmit} />);
-    userEvent.click(screen.getByRole("checkbox"));
-    userEvent.tab();
+    await userEvent.click(screen.getByRole("checkbox"));
+    await userEvent.tab();
 
     expect(await screen.findByText(": error")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/core/components/FormDateInput/FormDateInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormDateInput/FormDateInput.unit.spec.tsx
@@ -45,8 +45,8 @@ describe("FormDateInput", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormDateInput onSubmit={onSubmit} />);
-    userEvent.type(screen.getByRole("textbox"), "10/20/22");
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.type(screen.getByRole("textbox"), "10/20/22");
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       const value = expect.stringMatching(/2022-10-20T00:00:00.000/);
@@ -66,8 +66,8 @@ describe("FormDateInput", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormDateInput onSubmit={onSubmit} />);
-    userEvent.clear(screen.getByRole("textbox"));
-    userEvent.tab();
+    await userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.tab();
 
     expect(await screen.findByText(": error")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormInput/FormInput.unit.spec.tsx
@@ -54,8 +54,8 @@ describe("FormInput", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormInput onSubmit={onSubmit} />);
-    userEvent.type(screen.getByRole("textbox"), "Text");
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.type(screen.getByRole("textbox"), "Text");
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       const values = { value: "Text" };
@@ -75,8 +75,8 @@ describe("FormInput", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormInput initialValue="Text" onSubmit={onSubmit} />);
-    userEvent.clear(screen.getByRole("textbox"));
-    userEvent.tab();
+    await userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.tab();
 
     expect(await screen.findByText(": error")).toBeInTheDocument();
   });
@@ -115,7 +115,7 @@ describe("FormInput", () => {
     expect(screen.getByLabelText("Label")).toBeInTheDocument();
   });
 
-  it("should have info tooltip", () => {
+  it("should have info tooltip", async () => {
     const onSubmit = jest.fn();
     const infoTooltipText = "info tooltip text";
 
@@ -128,7 +128,7 @@ describe("FormInput", () => {
       />,
     );
 
-    userEvent.hover(screen.getByLabelText("info icon"));
+    await userEvent.hover(screen.getByLabelText("info icon"));
     expect(screen.getByText(infoTooltipText)).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormNumericInput/FormNumericInput.unit.spec.tsx
@@ -45,8 +45,8 @@ describe("FormNumericInput", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormNumericInput onSubmit={onSubmit} />);
-    userEvent.type(screen.getByRole("textbox"), "10");
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.type(screen.getByRole("textbox"), "10");
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       const values = { value: 10 };
@@ -66,8 +66,8 @@ describe("FormNumericInput", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormNumericInput initialValue={10} onSubmit={onSubmit} />);
-    userEvent.clear(screen.getByRole("textbox"));
-    userEvent.tab();
+    await userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.tab();
 
     expect(await screen.findByText(": error")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormRadio/FormRadio.unit.spec.tsx
@@ -48,8 +48,8 @@ describe("FormRadio", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormRadio onSubmit={onSubmit} />);
-    userEvent.click(screen.getByRole("radio", { name: "Line" }));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByRole("radio", { name: "Line" }));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       const values = { value: "line" };
@@ -61,8 +61,8 @@ describe("FormRadio", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormRadio initialValue="line" onSubmit={onSubmit} />);
-    userEvent.click(screen.getByRole("radio", { name: "Bar" }));
-    userEvent.tab();
+    await userEvent.click(screen.getByRole("radio", { name: "Bar" }));
+    await userEvent.tab();
 
     expect(await screen.findByText(": error")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/core/components/FormSelect/FormSelect.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormSelect/FormSelect.unit.spec.tsx
@@ -53,9 +53,9 @@ describe("FormSelect", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormSelect onSubmit={onSubmit} />);
-    userEvent.click(screen.getByText("Choose"));
-    userEvent.click(screen.getByText("Line"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByText("Choose"));
+    await userEvent.click(screen.getByText("Line"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       const values = { value: "line" };
@@ -75,9 +75,9 @@ describe("FormSelect", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormSelect initialValue="line" onSubmit={onSubmit} />);
-    userEvent.click(screen.getByText("Line"));
-    userEvent.click(screen.getByText("Bar"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByText("Line"));
+    await userEvent.click(screen.getByText("Bar"));
+    await userEvent.click(screen.getByText("Submit"));
 
     expect(await screen.findByText(": error")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/FormToggle/FormToggle.unit.spec.tsx
@@ -45,8 +45,8 @@ describe("FormToggle", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormToggle onSubmit={onSubmit} />);
-    userEvent.click(screen.getByRole("switch"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByRole("switch"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       const values = { value: true };
@@ -66,8 +66,8 @@ describe("FormToggle", () => {
     const onSubmit = jest.fn();
 
     render(<TestFormToggle initialValue={true} onSubmit={onSubmit} />);
-    userEvent.click(screen.getByRole("switch"));
-    userEvent.tab();
+    await userEvent.click(screen.getByRole("switch"));
+    await userEvent.tab();
 
     expect(await screen.findByText(": error")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/core/components/Input/Input.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/Input/Input.unit.spec.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import Input from "./Input";
 
 describe("Input", () => {
-  it("should render icon tooltips when hover them", () => {
+  it("should render icon tooltips when hover them", async () => {
     render(
       <Input
         leftIconTooltip="left tooltip"
@@ -15,11 +15,11 @@ describe("Input", () => {
     );
 
     const leftIcon = screen.getByTestId("input-left-icon-button");
-    userEvent.hover(leftIcon);
+    await userEvent.hover(leftIcon);
     expect(screen.getByText("left tooltip")).toBeInTheDocument();
 
     const rightIcon = screen.getByTestId("input-right-icon-button");
-    userEvent.hover(rightIcon);
+    await userEvent.hover(rightIcon);
     expect(screen.getByText("right tooltip")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/MarkdownPreview/MarkdownPreview.unit.spec.tsx
@@ -35,10 +35,10 @@ describe("MarkdownPreview", () => {
     expect(screen.getByText(MARKDOWN_AS_TEXT)).toBeInTheDocument();
   });
 
-  it("should not show tooltip with markdown formatting on hover when text is not truncated", () => {
+  it("should not show tooltip with markdown formatting on hover when text is not truncated", async () => {
     setup();
 
-    userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
+    await userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
@@ -66,10 +66,10 @@ describe("MarkdownPreview", () => {
       }
     });
 
-    it("should show tooltip with markdown formatting on hover when text is truncated", () => {
+    it("should show tooltip with markdown formatting on hover when text is truncated", async () => {
       setup();
 
-      userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
+      await userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
 
       const tooltip = screen.getByRole("tooltip");
       expect(tooltip).not.toHaveTextContent(MARKDOWN);

--- a/frontend/src/metabase/core/components/NumericInput/NumericInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/NumericInput/NumericInput.unit.spec.tsx
@@ -20,21 +20,21 @@ const NumericInputTest = ({ onChange, ...props }: NumericInputProps) => {
 };
 
 describe("NumericInput", () => {
-  it("should set number", () => {
+  it("should set number", async () => {
     const onChange = jest.fn();
 
     render(<NumericInputTest onChange={onChange} />);
-    userEvent.type(screen.getByRole("textbox"), "123");
+    await userEvent.type(screen.getByRole("textbox"), "123");
 
     expect(onChange).toHaveBeenLastCalledWith(123);
   });
 
-  it("should clear number", () => {
+  it("should clear number", async () => {
     const onChange = jest.fn();
 
     render(<NumericInputTest onChange={onChange} />);
-    userEvent.type(screen.getByRole("textbox"), "123");
-    userEvent.clear(screen.getByRole("textbox"));
+    await userEvent.type(screen.getByRole("textbox"), "123");
+    await userEvent.clear(screen.getByRole("textbox"));
 
     expect(onChange).toHaveBeenLastCalledWith(undefined);
   });

--- a/frontend/src/metabase/core/components/Radio/Radio.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/Radio/Radio.unit.spec.tsx
@@ -10,9 +10,9 @@ describe("Radio", () => {
     { name: "Bar", value: "B" },
   ];
 
-  it("should receive focus on tab", () => {
+  it("should receive focus on tab", async () => {
     render(<Radio options={options} />);
-    userEvent.tab();
+    await userEvent.tab();
 
     expect(screen.getByLabelText("Line")).toHaveFocus();
   });

--- a/frontend/src/metabase/core/components/SelectButton/SelectButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/SelectButton/SelectButton.unit.spec.tsx
@@ -12,16 +12,16 @@ describe("SelectButton", () => {
     expect(screen.getByRole("button")).toHaveTextContent(title);
   });
 
-  it("should receive focus on tab", () => {
+  it("should receive focus on tab", async () => {
     render(<SelectButton>{title}</SelectButton>);
-    userEvent.tab();
+    await userEvent.tab();
 
     expect(screen.getByRole("button")).toHaveFocus();
   });
 
-  it("should not receive focus on tab when disabled", () => {
+  it("should not receive focus on tab when disabled", async () => {
     render(<SelectButton disabled>{title}</SelectButton>);
-    userEvent.tab();
+    await userEvent.tab();
 
     expect(screen.getByRole("button")).not.toHaveFocus();
   });
@@ -41,7 +41,7 @@ describe("SelectButton", () => {
       expect(screen.queryByLabelText("close icon")).not.toBeInTheDocument();
     });
 
-    it("should call onClear when close icon is clicked", () => {
+    it("should call onClear when close icon is clicked", async () => {
       const onClear = jest.fn();
       render(
         <SelectButton hasValue onClear={onClear}>
@@ -49,12 +49,12 @@ describe("SelectButton", () => {
         </SelectButton>,
       );
 
-      userEvent.click(screen.getByLabelText("close icon"));
+      await userEvent.click(screen.getByLabelText("close icon"));
 
       expect(onClear).toHaveBeenCalledTimes(1);
     });
 
-    it("should not call usual onClick when close icon is clicked", () => {
+    it("should not call usual onClick when close icon is clicked", async () => {
       const onClick = jest.fn();
       render(
         <SelectButton hasValue onClick={onClick} onClear={jest.fn()}>
@@ -62,7 +62,7 @@ describe("SelectButton", () => {
         </SelectButton>,
       );
 
-      userEvent.click(screen.getByLabelText("close icon"));
+      await userEvent.click(screen.getByLabelText("close icon"));
 
       expect(onClick).not.toHaveBeenCalled();
     });

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -33,7 +33,7 @@ describe("TabButton", () => {
   it("should open the menu upon clicking the chevron", async () => {
     setup();
 
-    userEvent.click(getIcon("chevrondown"));
+    await userEvent.click(getIcon("chevrondown"));
 
     expect(
       await screen.findByRole("option", { name: "first item" }),
@@ -43,7 +43,7 @@ describe("TabButton", () => {
   it("should call the action function upon clicking an item in the menu", async () => {
     const { action, value } = setup();
 
-    userEvent.click(getIcon("chevrondown"));
+    await userEvent.click(getIcon("chevrondown"));
     (await screen.findByRole("option", { name: "first item" })).click();
 
     expect(action).toHaveBeenCalledWith(value);
@@ -52,7 +52,7 @@ describe("TabButton", () => {
   it("should not open the menu when disabled", async () => {
     setup({ disabled: true });
 
-    userEvent.click(getIcon("chevrondown"));
+    await userEvent.click(getIcon("chevrondown"));
 
     expect(
       screen.queryByRole("option", { name: "first item" }),
@@ -62,12 +62,12 @@ describe("TabButton", () => {
   it("should call the onRename function when renaming and update its own label", async () => {
     const { onRename } = setup();
 
-    userEvent.click(getIcon("chevrondown"));
+    await userEvent.click(getIcon("chevrondown"));
     (await renameOption()).click();
 
     const newLabel = "A new label";
     const inputEl = screen.getByRole("textbox");
-    userEvent.type(inputEl, newLabel);
+    await userEvent.type(inputEl, newLabel);
     fireEvent.keyPress(inputEl, { key: "Enter", charCode: 13 });
 
     expect(onRename).toHaveBeenCalledWith(newLabel);
@@ -77,11 +77,11 @@ describe("TabButton", () => {
   it("should allow the user to rename via double click", async () => {
     const { onRename } = setup();
 
-    userEvent.dblClick(screen.getByTestId(INPUT_WRAPPER_TEST_ID));
+    await userEvent.dblClick(screen.getByTestId(INPUT_WRAPPER_TEST_ID));
 
     const newLabel = "A new label";
     const inputEl = screen.getByRole("textbox");
-    userEvent.type(inputEl, newLabel);
+    await userEvent.type(inputEl, newLabel);
     fireEvent.keyPress(inputEl, { key: "Enter", charCode: 13 });
 
     expect(onRename).toHaveBeenCalledWith(newLabel);
@@ -91,15 +91,15 @@ describe("TabButton", () => {
   it("should limit the length to 75 chars", async () => {
     const { onRename } = setup();
 
-    userEvent.click(getIcon("chevrondown"));
+    await userEvent.click(getIcon("chevrondown"));
     (await renameOption()).click();
 
     const newLabel = "a".repeat(100);
     const expectedLabel = newLabel.slice(0, 75);
 
     const inputEl = screen.getByRole("textbox");
-    userEvent.type(inputEl, newLabel);
-    userEvent.type(inputEl, "{enter}");
+    await userEvent.type(inputEl, newLabel);
+    await userEvent.type(inputEl, "{enter}");
 
     expect(onRename).toHaveBeenCalledWith(expectedLabel);
     expect(await screen.findByDisplayValue(expectedLabel)).toBeInTheDocument();

--- a/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabButton/TabButton.unit.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { getIcon } from "__support__/ui";
@@ -67,8 +67,8 @@ describe("TabButton", () => {
 
     const newLabel = "A new label";
     const inputEl = screen.getByRole("textbox");
-    await userEvent.type(inputEl, newLabel);
-    fireEvent.keyPress(inputEl, { key: "Enter", charCode: 13 });
+    await userEvent.clear(inputEl);
+    await userEvent.type(inputEl, `${newLabel}{enter}`);
 
     expect(onRename).toHaveBeenCalledWith(newLabel);
     expect(await screen.findByDisplayValue(newLabel)).toBeInTheDocument();
@@ -81,8 +81,8 @@ describe("TabButton", () => {
 
     const newLabel = "A new label";
     const inputEl = screen.getByRole("textbox");
-    await userEvent.type(inputEl, newLabel);
-    fireEvent.keyPress(inputEl, { key: "Enter", charCode: 13 });
+    await userEvent.clear(inputEl);
+    await userEvent.type(inputEl, `${newLabel}{enter}`);
 
     expect(onRename).toHaveBeenCalledWith(newLabel);
     expect(await screen.findByDisplayValue(newLabel)).toBeInTheDocument();
@@ -98,8 +98,8 @@ describe("TabButton", () => {
     const expectedLabel = newLabel.slice(0, 75);
 
     const inputEl = screen.getByRole("textbox");
-    await userEvent.type(inputEl, newLabel);
-    await userEvent.type(inputEl, "{enter}");
+    await userEvent.clear(inputEl);
+    await userEvent.type(inputEl, `${newLabel}{enter}`);
 
     expect(onRename).toHaveBeenCalledWith(expectedLabel);
     expect(await screen.findByDisplayValue(expectedLabel)).toBeInTheDocument();

--- a/frontend/src/metabase/core/components/TabContent/TabContent.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabContent/TabContent.unit.spec.tsx
@@ -24,12 +24,12 @@ const TestTabContent = () => {
 };
 
 describe("TabContent", () => {
-  it("should navigate between tabs", () => {
+  it("should navigate between tabs", async () => {
     render(<TestTabContent />);
     expect(screen.getByText("Panel 1")).toBeInTheDocument();
     expect(screen.queryByText("Panel 2")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByRole("tab", { name: "Tab 2" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Tab 2" }));
     expect(screen.queryByText("Panel 1")).not.toBeInTheDocument();
     expect(screen.getByText("Panel 2")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/core/components/TabList/TabList.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabList/TabList.unit.spec.tsx
@@ -18,7 +18,7 @@ const TestTabList = () => {
 };
 
 describe("TabList", () => {
-  it("should navigate between tabs", () => {
+  it("should navigate between tabs", async () => {
     render(<TestTabList />);
 
     const option1 = screen.getByRole("tab", { name: "Tab 1" });
@@ -26,7 +26,7 @@ describe("TabList", () => {
     expect(option1).toHaveAttribute("aria-selected", "true");
     expect(option2).toHaveAttribute("aria-selected", "false");
 
-    userEvent.click(option2);
+    await userEvent.click(option2);
     expect(option1).toHaveAttribute("aria-selected", "false");
     expect(option2).toHaveAttribute("aria-selected", "true");
   });

--- a/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TabRow/TabRow.unit.spec.tsx
@@ -18,7 +18,7 @@ const TestTabRow = () => {
 };
 
 describe("TabRow", () => {
-  it("should navigate between tabs", () => {
+  it("should navigate between tabs", async () => {
     render(<TestTabRow />);
 
     const option1 = screen.getByRole("tab", { name: "Tab 1" });
@@ -26,7 +26,7 @@ describe("TabRow", () => {
     expect(option1).toHaveAttribute("aria-selected", "true");
     expect(option2).toHaveAttribute("aria-selected", "false");
 
-    userEvent.click(option2);
+    await userEvent.click(option2);
     expect(option1).toHaveAttribute("aria-selected", "false");
     expect(option2).toHaveAttribute("aria-selected", "true");
   });

--- a/frontend/src/metabase/core/components/TimeInput/TimeInput.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/TimeInput/TimeInput.unit.spec.tsx
@@ -22,15 +22,15 @@ const TestTimeInput = ({ onChange, ...props }: TimeInputProps) => {
 };
 
 describe("TimeInput", () => {
-  it("should set time in 12-hour clock", () => {
+  it("should set time in 12-hour clock", async () => {
     const value = moment({ hours: 0, minutes: 0 });
     const onChange = jest.fn();
 
     render(<TestTimeInput value={value} onChange={onChange} />);
-    userEvent.clear(screen.getByLabelText("Hours"));
-    userEvent.type(screen.getByLabelText("Hours"), "5");
-    userEvent.clear(screen.getByLabelText("Minutes"));
-    userEvent.type(screen.getByLabelText("Minutes"), "20");
+    await userEvent.clear(screen.getByLabelText("Hours"));
+    await userEvent.type(screen.getByLabelText("Hours"), "5");
+    await userEvent.clear(screen.getByLabelText("Minutes"));
+    await userEvent.type(screen.getByLabelText("Minutes"), "20");
 
     const expected = value.clone();
     expected.hours(5);
@@ -38,17 +38,17 @@ describe("TimeInput", () => {
     expect(onChange).toHaveBeenLastCalledWith(expected);
   });
 
-  it("should set time in 24-hour clock", () => {
+  it("should set time in 24-hour clock", async () => {
     const value = moment({ hours: 0, minutes: 0 });
     const onChange = jest.fn();
 
     render(
       <TestTimeInput value={value} timeFormat="HH:mm" onChange={onChange} />,
     );
-    userEvent.clear(screen.getByLabelText("Hours"));
-    userEvent.type(screen.getByLabelText("Hours"), "15");
-    userEvent.clear(screen.getByLabelText("Minutes"));
-    userEvent.type(screen.getByLabelText("Minutes"), "10");
+    await userEvent.clear(screen.getByLabelText("Hours"));
+    await userEvent.type(screen.getByLabelText("Hours"), "15");
+    await userEvent.clear(screen.getByLabelText("Minutes"));
+    await userEvent.type(screen.getByLabelText("Minutes"), "10");
 
     const expected = value.clone();
     expected.hours(15);
@@ -56,40 +56,40 @@ describe("TimeInput", () => {
     expect(onChange).toHaveBeenLastCalledWith(expected);
   });
 
-  it("should change meridiem to am", () => {
+  it("should change meridiem to am", async () => {
     const value = moment({ hours: 12, minutes: 20 });
     const onChange = jest.fn();
 
     render(<TestTimeInput value={value} onChange={onChange} />);
-    userEvent.click(screen.getByText("AM"));
+    await userEvent.click(screen.getByText("AM"));
 
     const expected = value.clone();
     expected.hours(0);
     expect(onChange).toHaveBeenCalledWith(expected);
   });
 
-  it("should change meridiem to pm", () => {
+  it("should change meridiem to pm", async () => {
     const value = moment({ hours: 10, minutes: 20 });
     const onChange = jest.fn();
 
     render(<TestTimeInput value={value} onChange={onChange} />);
-    userEvent.click(screen.getByText("PM"));
+    await userEvent.click(screen.getByText("PM"));
 
     const expected = value.clone();
     expected.hours(22);
     expect(onChange).toHaveBeenCalledWith(expected);
   });
 
-  it("should clear time", () => {
+  it("should clear time", async () => {
     const value = moment({ hours: 2, minutes: 10 });
     const onClear = jest.fn();
 
     render(<TestTimeInput value={value} onClear={onClear} />);
-    userEvent.clear(screen.getByLabelText("Hours"));
-    userEvent.type(screen.getByLabelText("Hours"), "5");
-    userEvent.clear(screen.getByLabelText("Minutes"));
-    userEvent.type(screen.getByLabelText("Minutes"), "20");
-    userEvent.click(screen.getByLabelText("Remove time"));
+    await userEvent.clear(screen.getByLabelText("Hours"));
+    await userEvent.type(screen.getByLabelText("Hours"), "5");
+    await userEvent.clear(screen.getByLabelText("Minutes"));
+    await userEvent.type(screen.getByLabelText("Minutes"), "20");
+    await userEvent.click(screen.getByLabelText("Remove time"));
 
     const expected = value.clone();
     expected.hours(0);

--- a/frontend/src/metabase/core/components/Toggle/Toggle.unit.spec.tsx
+++ b/frontend/src/metabase/core/components/Toggle/Toggle.unit.spec.tsx
@@ -1,51 +1,51 @@
 import { render, screen } from "@testing-library/react";
-import userEvent, { specialChars } from "@testing-library/user-event";
+import userEvent from "@testing-library/user-event";
 
 import Toggle from "./Toggle";
 
 describe("Toggle", () => {
-  it("should receive focus on tab", () => {
+  it("should receive focus on tab", async () => {
     const onChange = jest.fn();
 
     render(<Toggle value={false} onChange={onChange} />);
 
     const checkbox = screen.getByRole("switch");
-    userEvent.tab();
+    await userEvent.tab();
 
     expect(checkbox).toHaveFocus();
   });
 
-  it("should toggle on enter", () => {
+  it("should toggle on enter", async () => {
     const onChange = jest.fn();
 
     render(<Toggle value={false} onChange={onChange} />);
 
     const checkbox = screen.getByRole("switch");
-    userEvent.tab();
-    userEvent.type(checkbox, specialChars.enter);
+    await userEvent.tab();
+    await userEvent.type(checkbox, "{Enter}");
 
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
-  it("should toggle on space", () => {
+  it("should toggle on space", async () => {
     const onChange = jest.fn();
 
     render(<Toggle value={false} onChange={onChange} />);
 
     const checkbox = screen.getByRole("switch");
-    userEvent.tab();
-    userEvent.type(checkbox, specialChars.space);
+    await userEvent.tab();
+    await userEvent.type(checkbox, "{Space}");
 
     expect(onChange).toHaveBeenCalledWith(true);
   });
 
-  it("should toggle on click", () => {
+  it("should toggle on click", async () => {
     const onChange = jest.fn();
 
     render(<Toggle value={false} onChange={onChange} />);
 
     const checkbox = screen.getByRole("switch");
-    userEvent.click(checkbox);
+    await userEvent.click(checkbox);
 
     expect(checkbox).toHaveFocus();
     expect(onChange).toHaveBeenCalledWith(true);

--- a/frontend/src/metabase/core/components/Tooltip/Tooltip.unit.spec.js
+++ b/frontend/src/metabase/core/components/Tooltip/Tooltip.unit.spec.js
@@ -27,17 +27,17 @@ function setup({
 }
 
 describe("Tooltip", () => {
-  it("should be visible on hover of child target element", () => {
+  it("should be visible on hover of child target element", async () => {
     setup();
-    userEvent.hover(screen.getByText("child target element"));
+    await userEvent.hover(screen.getByText("child target element"));
     expect(screen.getByText("tooltip content")).toBeInTheDocument();
   });
 
   describe("isOpen", () => {
-    it("should override hover behavior", () => {
+    it("should override hover behavior", async () => {
       setup({ isOpen: false });
 
-      userEvent.hover(screen.getByText("child target element"));
+      await userEvent.hover(screen.getByText("child target element"));
       expect(screen.queryByText("tooltip content")).not.toBeInTheDocument();
     });
 
@@ -48,31 +48,31 @@ describe("Tooltip", () => {
   });
 
   describe("isEnabled", () => {
-    it("should override hover behavior when false", () => {
+    it("should override hover behavior when false", async () => {
       setup({ isEnabled: false });
 
-      userEvent.hover(screen.getByText("child target element"));
+      await userEvent.hover(screen.getByText("child target element"));
       expect(screen.queryByText("tooltip content")).not.toBeInTheDocument();
     });
 
-    it("should not override hover behavior when true", () => {
+    it("should not override hover behavior when true", async () => {
       setup({ isEnabled: true });
 
-      userEvent.hover(screen.getByText("child target element"));
+      await userEvent.hover(screen.getByText("child target element"));
       expect(screen.getByText("tooltip content")).toBeInTheDocument();
     });
 
-    it("should override isOpen when false", () => {
+    it("should override isOpen when false", async () => {
       setup({ isEnabled: false, isOpen: true });
 
-      userEvent.hover(screen.getByText("child target element"));
+      await userEvent.hover(screen.getByText("child target element"));
       expect(screen.queryByText("tooltip content")).not.toBeInTheDocument();
     });
 
-    it("should not override isOpen when true", () => {
+    it("should not override isOpen when true", async () => {
       setup({ isEnabled: true, isOpen: true });
 
-      userEvent.hover(screen.getByText("child target element"));
+      await userEvent.hover(screen.getByText("child target element"));
       expect(screen.getByText("tooltip content")).toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ActionSidebar/ActionSidebar.unit.spec.tsx
@@ -68,10 +68,10 @@ const setup = (
 };
 
 const navigateToActionCreatorModal = async () => {
-  userEvent.click(screen.getByText("Pick an action"));
+  await userEvent.click(screen.getByText("Pick an action"));
   await waitForLoaderToBeRemoved();
-  userEvent.click(screen.getByText(collectionItem.name));
-  userEvent.click(screen.getByText("Create new action"));
+  await userEvent.click(screen.getByText(collectionItem.name));
+  await userEvent.click(screen.getByText("Create new action"));
   await waitForLoaderToBeRemoved();
 };
 
@@ -92,8 +92,8 @@ describe("Dashboard > ActionSidebar", () => {
     expect(textInput).toHaveValue(
       actionDashcard.visualization_settings["button.label"] as string,
     );
-    userEvent.clear(textInput);
-    userEvent.type(textInput, "xyz");
+    await userEvent.clear(textInput);
+    await userEvent.type(textInput, "xyz");
 
     await waitFor(() =>
       expect(vizUpdateSpy).toHaveBeenLastCalledWith({ "button.label": "xyz" }),
@@ -106,8 +106,8 @@ describe("Dashboard > ActionSidebar", () => {
     const dropdown = screen.getByLabelText("Button variant");
 
     expect(screen.getByText("Primary")).toBeInTheDocument();
-    userEvent.click(dropdown);
-    userEvent.click(screen.getByText("Danger"));
+    await userEvent.click(dropdown);
+    await userEvent.click(screen.getByText("Danger"));
 
     await waitFor(() =>
       expect(vizUpdateSpy).toHaveBeenLastCalledWith({
@@ -120,7 +120,7 @@ describe("Dashboard > ActionSidebar", () => {
     const { closeSpy } = setup();
 
     const closeButton = screen.getByRole("button", { name: "Close" });
-    userEvent.click(closeButton);
+    await userEvent.click(closeButton);
 
     await waitFor(() => expect(closeSpy).toHaveBeenCalledTimes(1));
   });
@@ -136,7 +136,7 @@ describe("Dashboard > ActionSidebar", () => {
       setup();
       await navigateToActionCreatorModal();
 
-      userEvent.click(document.body);
+      await userEvent.click(document.body);
 
       const mockNativeQueryEditor = screen.getByTestId(
         "mock-native-query-editor",
@@ -151,7 +151,7 @@ describe("Dashboard > ActionSidebar", () => {
 
       const cancelButton = screen.getByRole("button", { name: "Cancel" });
 
-      userEvent.click(cancelButton);
+      await userEvent.click(cancelButton);
 
       expect(
         screen.queryByTestId("mock-native-query-editor"),

--- a/frontend/src/metabase/dashboard/components/AddCardSidebar/AddCardSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/AddCardSidebar/AddCardSidebar.unit.spec.tsx
@@ -186,7 +186,7 @@ describe("AddCardSideBar", () => {
       });
 
       const typedText = "dashboard";
-      userEvent.type(screen.getByPlaceholderText("Search…"), typedText);
+      await userEvent.type(screen.getByPlaceholderText("Search…"), typedText);
       const baseQuery = {
         models: ["card", "dataset"],
         offset: 0,
@@ -258,7 +258,7 @@ describe("AddCardSideBar", () => {
       });
 
       const typedText = "dashboard";
-      userEvent.type(screen.getByPlaceholderText("Search…"), typedText);
+      await userEvent.type(screen.getByPlaceholderText("Search…"), typedText);
       const baseQuery = {
         models: ["card", "dataset"],
         offset: 0,
@@ -349,7 +349,7 @@ describe("AddCardSideBar", () => {
       });
 
       const typedText = "dashboard";
-      userEvent.type(screen.getByPlaceholderText("Search…"), typedText);
+      await userEvent.type(screen.getByPlaceholderText("Search…"), typedText);
       const baseQuery = {
         models: ["card", "dataset"],
         offset: 0,

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/AddSeriesModal.unit.spec.tsx
@@ -145,7 +145,7 @@ describe("AddSeriesModal", () => {
 
     const firstSeriesLegendItem = screen.getAllByTestId("legend-item")[1];
 
-    userEvent.click(
+    await userEvent.click(
       within(firstSeriesLegendItem).getByRole("img", { name: "close icon" }),
     );
 
@@ -163,7 +163,7 @@ describe("AddSeriesModal", () => {
 
     const secondSeriesLegendItem = screen.getAllByTestId("legend-item")[2];
 
-    userEvent.click(
+    await userEvent.click(
       within(secondSeriesLegendItem).getByRole("img", { name: "close icon" }),
     );
 
@@ -181,7 +181,7 @@ describe("AddSeriesModal", () => {
 
     const firstSeriesLegendItem = screen.getAllByTestId("legend-item")[1];
 
-    userEvent.click(
+    await userEvent.click(
       within(firstSeriesLegendItem).getByRole("img", { name: "close icon" }),
     );
 
@@ -189,7 +189,7 @@ describe("AddSeriesModal", () => {
 
     const secondSeriesLegendItem = screen.getAllByTestId("legend-item")[1];
 
-    userEvent.click(
+    await userEvent.click(
       within(secondSeriesLegendItem).getByRole("img", { name: "close icon" }),
     );
 

--- a/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/AddSeriesModal/QuestionList.unit.spec.tsx
@@ -67,7 +67,7 @@ describe("QuestionList", () => {
       last_cursor: _.last(compatibleCardsFirstPage)?.id,
     });
 
-    userEvent.click(
+    await userEvent.click(
       await screen.findByRole("button", {
         name: /load more/i,
       }),
@@ -75,7 +75,7 @@ describe("QuestionList", () => {
 
     const secondPageItem = await screen.findByText("compatible card 50 page 2");
 
-    userEvent.click(secondPageItem);
+    await userEvent.click(secondPageItem);
     expect(onSelect).toHaveBeenCalledWith(compatibleCardsSecondPage[0], true);
   });
 
@@ -107,7 +107,7 @@ describe("QuestionList", () => {
       },
     );
 
-    userEvent.type(
+    await userEvent.type(
       screen.getByPlaceholderText("Search for a question"),
       "search text",
     );

--- a/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/ClickBehaviorSidebar/LinkOptions/LinkedEntityPicker/LinkedEntityPicker.unit.spec.tsx
@@ -146,9 +146,9 @@ describe("LinkedEntityPicker", () => {
             dashboard: dashboardInPublicCollection,
             searchResults: [dashboardSearchResult],
           });
-          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          await userEvent.click(screen.getByRole("button", { name: "Search" }));
           const typedText = "dashboard";
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Search"),
             `${typedText}{enter}`,
           );
@@ -201,9 +201,9 @@ describe("LinkedEntityPicker", () => {
             dashboard: dashboardInPersonalCollection,
             searchResults: [dashboardSearchResult],
           });
-          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          await userEvent.click(screen.getByRole("button", { name: "Search" }));
           const typedText = "dashboard";
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Search"),
             `${typedText}{enter}`,
           );
@@ -272,9 +272,9 @@ describe("LinkedEntityPicker", () => {
             dashboard: dashboardInPublicCollection,
             searchResults: [questionSearchResult],
           });
-          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          await userEvent.click(screen.getByRole("button", { name: "Search" }));
           const typedText = "question";
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Search"),
             `${typedText}{enter}`,
           );
@@ -332,9 +332,9 @@ describe("LinkedEntityPicker", () => {
             dashboard: dashboardInPersonalCollection,
             searchResults: [questionSearchResult],
           });
-          userEvent.click(screen.getByRole("button", { name: "Search" }));
+          await userEvent.click(screen.getByRole("button", { name: "Search" }));
           const typedText = "question";
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Search"),
             `${typedText}{enter}`,
           );

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardTabMenu/DashCardTabMenu.unit.spec.tsx
@@ -85,7 +85,7 @@ describe("DashCardTabMenu", () => {
     it("should show tabs other than the current one as options when hovering the button", async () => {
       setup({});
 
-      userEvent.hover(getIconButton());
+      await userEvent.hover(getIconButton());
 
       const menu = await waitFor(() => screen.findByRole("menu"));
 

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardMenu/DashCardMenu.unit.spec.tsx
@@ -112,8 +112,8 @@ describe("DashCardMenu", () => {
   it("should display a link to the notebook editor", async () => {
     const { history } = setup();
 
-    userEvent.click(getIcon("ellipsis"));
-    userEvent.click(await screen.findByText("Edit question"));
+    await userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(await screen.findByText("Edit question"));
 
     const pathname = history?.getCurrentLocation().pathname;
     expect(pathname).toBe(`/question/${TEST_CARD_SLUG}/notebook`);
@@ -122,8 +122,8 @@ describe("DashCardMenu", () => {
   it("should display a link to the query builder for native questions", async () => {
     const { history } = setup({ card: TEST_CARD_NATIVE });
 
-    userEvent.click(getIcon("ellipsis"));
-    userEvent.click(await screen.findByText("Edit question"));
+    await userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(await screen.findByText("Edit question"));
 
     const pathname = history?.getCurrentLocation().pathname;
     expect(pathname).toBe(`/question/${TEST_CARD_SLUG}`);
@@ -132,7 +132,7 @@ describe("DashCardMenu", () => {
   it("should not display a link to the notebook editor if the user does not have the data permission", async () => {
     setup({ card: TEST_CARD_NO_DATA_ACCESS });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
 
     expect(await screen.findByText("Download results")).toBeInTheDocument();
     expect(screen.queryByText("Edit question")).not.toBeInTheDocument();
@@ -141,7 +141,7 @@ describe("DashCardMenu", () => {
   it("should not display a link to the notebook editor if the user does not have the collection write permission (metabase#35077)", async () => {
     setup({ card: TEST_CARD_NO_COLLECTION_WRITE_ACCESS });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
 
     expect(await screen.findByText("Download results")).toBeInTheDocument();
     expect(screen.queryByText("Edit question")).not.toBeInTheDocument();
@@ -150,8 +150,8 @@ describe("DashCardMenu", () => {
   it("should display query export options", async () => {
     setup();
 
-    userEvent.click(getIcon("ellipsis"));
-    userEvent.click(await screen.findByText("Download results"));
+    await userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(await screen.findByText("Download results"));
 
     expect(screen.getByText("Download full results")).toBeInTheDocument();
   });
@@ -159,7 +159,7 @@ describe("DashCardMenu", () => {
   it("should not display query export options when there is a query error", async () => {
     setup({ result: TEST_RESULT_ERROR });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
 
     expect(await screen.findByText("Edit question")).toBeInTheDocument();
     expect(screen.queryByText("Download results")).not.toBeInTheDocument();

--- a/frontend/src/metabase/dashboard/components/DashboardEmbedAction/DashboardEmbedAction.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardEmbedAction/DashboardEmbedAction.unit.spec.tsx
@@ -75,7 +75,7 @@ describe("DashboardEmbedAction", () => {
           publicLinksEnabled: true,
           embeddingEnabled: false,
         });
-        userEvent.click(screen.getByLabelText("share icon"));
+        await userEvent.click(screen.getByLabelText("share icon"));
         expect(
           await screen.findByTestId("embed-header-menu"),
         ).toBeInTheDocument();
@@ -85,13 +85,13 @@ describe("DashboardEmbedAction", () => {
 
       it("should have a `Sharing` tooltip if public sharing is enabled", async () => {
         setup({ isAdmin: true, publicLinksEnabled: true });
-        userEvent.hover(screen.getByLabelText("share icon"));
+        await userEvent.hover(screen.getByLabelText("share icon"));
         expect(await screen.findByText("Sharing")).toBeInTheDocument();
       });
 
-      it("should have an `Embedding` tooltip if public sharing is disabled", () => {
+      it("should have an `Embedding` tooltip if public sharing is disabled", async () => {
         setup({ isAdmin: true, publicLinksEnabled: false });
-        userEvent.hover(screen.getByLabelText("share icon"));
+        await userEvent.hover(screen.getByLabelText("share icon"));
         expect(screen.getByText("Embedding")).toBeInTheDocument();
       });
     });
@@ -103,7 +103,7 @@ describe("DashboardEmbedAction", () => {
           isAdmin: false,
         });
 
-        userEvent.hover(screen.getByLabelText("share icon"));
+        await userEvent.hover(screen.getByLabelText("share icon"));
         expect(
           await screen.findByText("Public links are disabled"),
         ).toBeInTheDocument();
@@ -116,7 +116,7 @@ describe("DashboardEmbedAction", () => {
           publicLinksEnabled: true,
         });
 
-        userEvent.hover(screen.getByLabelText("share icon"));
+        await userEvent.hover(screen.getByLabelText("share icon"));
         expect(
           await screen.findByText("Ask your admin to create a public link"),
         ).toBeInTheDocument();
@@ -136,7 +136,7 @@ describe("DashboardEmbedAction", () => {
   describe("when the popover or modal should be rendered", () => {
     it("should render the popover when public sharing is enabled", async () => {
       setup({ publicLinksEnabled: true, isAdmin: true });
-      userEvent.click(screen.getByLabelText("share icon"));
+      await userEvent.click(screen.getByLabelText("share icon"));
       expect(
         await screen.findByTestId("embed-header-menu"),
       ).toBeInTheDocument();
@@ -145,14 +145,16 @@ describe("DashboardEmbedAction", () => {
     it("should render the embedding modal and disabled public sharing item when public sharing is disabled", async () => {
       setup({ publicLinksEnabled: false, isAdmin: true });
 
-      userEvent.click(screen.getByLabelText("share icon"));
+      await userEvent.click(screen.getByLabelText("share icon"));
 
       expect(
         await screen.findByText("Public links are off"),
       ).toBeInTheDocument();
       expect(screen.getByText("Enable them in settings")).toBeInTheDocument();
 
-      userEvent.click(await screen.findByTestId("embed-menu-embed-modal-item"));
+      await userEvent.click(
+        await screen.findByTestId("embed-menu-embed-modal-item"),
+      );
 
       expect(
         await screen.findByTestId("dashboard-sharing-embedding-modal"),
@@ -161,14 +163,16 @@ describe("DashboardEmbedAction", () => {
 
     it("should not render the embedding modal when the modal is closed", async () => {
       setup({ publicLinksEnabled: false, isAdmin: true });
-      userEvent.click(await screen.findByLabelText("share icon"));
-      userEvent.click(await screen.findByTestId("embed-menu-embed-modal-item"));
+      await userEvent.click(await screen.findByLabelText("share icon"));
+      await userEvent.click(
+        await screen.findByTestId("embed-menu-embed-modal-item"),
+      );
 
       expect(
         await screen.findByTestId("dashboard-sharing-embedding-modal"),
       ).toBeInTheDocument();
 
-      userEvent.click(await screen.findByTestId("close-embedding-modal"));
+      await userEvent.click(await screen.findByTestId("close-embedding-modal"));
 
       expect(
         screen.queryByTestId("dashboard-sharing-embedding-modal"),
@@ -184,7 +188,7 @@ describe("DashboardEmbedAction", () => {
           publicLinksEnabled: true,
           isAdmin: true,
         });
-        userEvent.click(screen.getByLabelText("share icon"));
+        await userEvent.click(screen.getByLabelText("share icon"));
         expect(
           await screen.findByText("Create a public link"),
         ).toBeInTheDocument();
@@ -198,7 +202,7 @@ describe("DashboardEmbedAction", () => {
           isAdmin: true,
         });
 
-        userEvent.click(screen.getByLabelText("share icon"));
+        await userEvent.click(screen.getByLabelText("share icon"));
 
         expect(await screen.findByText("Public link")).toBeInTheDocument();
         expect(await screen.findByText("Embed")).toBeInTheDocument();

--- a/frontend/src/metabase/dashboard/components/DashboardHeader/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardHeader/tests/common.unit.spec.tsx
@@ -13,7 +13,7 @@ describe("DashboardHeader", () => {
       dashboard: TEST_DASHBOARD,
     });
 
-    userEvent.click(screen.getByLabelText("dashboard-menu-button"));
+    await userEvent.click(screen.getByLabelText("dashboard-menu-button"));
     await screen.findByRole("dialog");
 
     const exportPdfButton = within(
@@ -27,7 +27,7 @@ describe("DashboardHeader", () => {
       dashboard: TEST_DASHBOARD_WITH_TABS,
     });
 
-    userEvent.click(screen.getByLabelText("dashboard-menu-button"));
+    await userEvent.click(screen.getByLabelText("dashboard-menu-button"));
     await screen.findByRole("dialog");
 
     const exportPdfButton = within(

--- a/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardInfoSidebar/DashboardInfoSidebar.unit.spec.tsx
@@ -35,15 +35,15 @@ describe("DashboardInfoSidebar", () => {
     expect(screen.getByText("About")).toBeInTheDocument();
   });
 
-  it("should allow to set description", () => {
+  it("should allow to set description", async () => {
     const { setDashboardAttribute } = setup();
 
-    userEvent.click(screen.getByTestId("editable-text"));
-    userEvent.type(
+    await userEvent.click(screen.getByTestId("editable-text"));
+    await userEvent.type(
       screen.getByPlaceholderText("Add description"),
       "some description",
     );
-    userEvent.tab();
+    await userEvent.tab();
 
     expect(setDashboardAttribute).toHaveBeenCalledWith(
       "description",
@@ -51,14 +51,14 @@ describe("DashboardInfoSidebar", () => {
     );
   });
 
-  it("should allow to clear description", () => {
+  it("should allow to clear description", async () => {
     const { setDashboardAttribute } = setup({
       dashboard: createMockDashboard({ description: "some description" }),
     });
 
-    userEvent.click(screen.getByTestId("editable-text"));
-    userEvent.clear(screen.getByPlaceholderText("Add description"));
-    userEvent.tab();
+    await userEvent.click(screen.getByTestId("editable-text"));
+    await userEvent.clear(screen.getByPlaceholderText("Add description"));
+    await userEvent.tab();
 
     expect(setDashboardAttribute).toHaveBeenCalledWith("description", "");
   });

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -114,7 +114,9 @@ async function selectTabMenuItem(
     hidden: true,
   });
   await userEvent.click(dropdownIcons[num - 1]);
-  (await screen.findByRole("option", { name, hidden: true })).click();
+  await userEvent.click(
+    await screen.findByRole("option", { name, hidden: true }),
+  );
 }
 
 async function deleteTab(num: number) {
@@ -128,6 +130,7 @@ async function renameTab(num: number, name: string) {
     name: `Tab ${num}`,
     hidden: true,
   });
+  await userEvent.clear(inputEl);
   await userEvent.type(inputEl, `${name}{enter}`);
 }
 
@@ -369,6 +372,7 @@ describe("DashboardTabs", () => {
           name: "Tab 1",
           hidden: true,
         });
+        await userEvent.clear(inputEl);
         await userEvent.type(inputEl, `${name}{enter}`);
 
         expect(queryTab(name)).toBeInTheDocument();

--- a/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardTabs/DashboardTabs.unit.spec.tsx
@@ -86,14 +86,14 @@ function queryTab(numOrName: number | string) {
   return screen.queryByRole("tab", { name, hidden: true });
 }
 
-function selectTab(num: number) {
+async function selectTab(num: number) {
   const selectedTab = queryTab(num) as HTMLElement;
-  userEvent.click(selectedTab);
+  await userEvent.click(selectedTab);
   return selectedTab;
 }
 
-function createNewTab() {
-  userEvent.click(screen.getByLabelText("Create new tab"));
+async function createNewTab() {
+  await userEvent.click(screen.getByLabelText("Create new tab"));
 }
 
 async function openTabMenu(num: number) {
@@ -101,7 +101,7 @@ async function openTabMenu(num: number) {
     name: "chevrondown icon",
     hidden: true,
   });
-  userEvent.click(dropdownIcons[num - 1]);
+  await userEvent.click(dropdownIcons[num - 1]);
   await screen.findByRole("option");
 }
 
@@ -113,7 +113,7 @@ async function selectTabMenuItem(
     name: "chevrondown icon",
     hidden: true,
   });
-  userEvent.click(dropdownIcons[num - 1]);
+  await userEvent.click(dropdownIcons[num - 1]);
   (await screen.findByRole("option", { name, hidden: true })).click();
 }
 
@@ -128,7 +128,7 @@ async function renameTab(num: number, name: string) {
     name: `Tab ${num}`,
     hidden: true,
   });
-  userEvent.type(inputEl, `${name}{enter}`);
+  await userEvent.type(inputEl, `${name}{enter}`);
 }
 
 async function duplicateTab(num: number) {
@@ -189,7 +189,7 @@ describe("DashboardTabs", () => {
           slug: getSlug({ tabId: 2, name: "Tab 2" }),
         });
 
-        expect(selectTab(2)).toHaveAttribute("aria-selected", "true");
+        expect(await selectTab(2)).toHaveAttribute("aria-selected", "true");
         expect(queryTab(1)).toHaveAttribute("aria-selected", "false");
         expect(queryTab(3)).toHaveAttribute("aria-selected", "false");
 
@@ -212,7 +212,7 @@ describe("DashboardTabs", () => {
       it("should allow you to click to select tabs", async () => {
         setup({ isEditing: false });
 
-        expect(selectTab(2)).toHaveAttribute("aria-selected", "true");
+        expect(await selectTab(2)).toHaveAttribute("aria-selected", "true");
         expect(queryTab(1)).toHaveAttribute("aria-selected", "false");
         expect(queryTab(3)).toHaveAttribute("aria-selected", "false");
 
@@ -249,7 +249,7 @@ describe("DashboardTabs", () => {
     it("should allow you to click to select tabs", async () => {
       setup();
 
-      expect(selectTab(2)).toHaveAttribute("aria-selected", "true");
+      expect(await selectTab(2)).toHaveAttribute("aria-selected", "true");
       expect(queryTab(1)).toHaveAttribute("aria-selected", "false");
       expect(queryTab(3)).toHaveAttribute("aria-selected", "false");
 
@@ -257,9 +257,9 @@ describe("DashboardTabs", () => {
     });
 
     describe("when adding tabs", () => {
-      it("should add two tabs, assign cards to the first, and select the second when adding a tab for the first time", () => {
+      it("should add two tabs, assign cards to the first, and select the second when adding a tab for the first time", async () => {
         const { getDashcards } = setup({ tabs: [] });
-        createNewTab();
+        await createNewTab();
         const firstNewTab = queryTab(1);
         const secondNewTab = queryTab(2);
 
@@ -274,9 +274,9 @@ describe("DashboardTabs", () => {
         expect(dashcards[1].dashboard_tab_id).toEqual(-1);
       });
 
-      it("should add add one tab, not reassign cards, and select the tab when adding an additional tab", () => {
+      it("should add add one tab, not reassign cards, and select the tab when adding an additional tab", async () => {
         const { getDashcards } = setup();
-        createNewTab();
+        await createNewTab();
         const newTab = queryTab(4);
 
         expect(newTab).toBeVisible();
@@ -306,7 +306,7 @@ describe("DashboardTabs", () => {
 
       it("should select the tab to the left if the selected tab was deleted", async () => {
         setup();
-        selectTab(2);
+        await selectTab(2);
         await deleteTab(2);
 
         expect(queryTab(1)).toHaveAttribute("aria-selected", "true");
@@ -315,7 +315,7 @@ describe("DashboardTabs", () => {
 
       it("should select the tab to the right if the selected tab was deleted and was the first tab", async () => {
         setup();
-        selectTab(1);
+        await selectTab(1);
         await deleteTab(1);
 
         expect(queryTab(2)).toHaveAttribute("aria-selected", "true");
@@ -339,8 +339,8 @@ describe("DashboardTabs", () => {
 
       it("should correctly update selected tab id when deleting tabs (#30923)", async () => {
         setup({ tabs: [] });
-        createNewTab();
-        createNewTab();
+        await createNewTab();
+        await createNewTab();
 
         await deleteTab(2);
         await deleteTab(2);
@@ -363,13 +363,13 @@ describe("DashboardTabs", () => {
         setup();
         const name = "Another cool new name";
         const inputWrapperEl = screen.getAllByTestId(INPUT_WRAPPER_TEST_ID)[0];
-        userEvent.dblClick(inputWrapperEl);
+        await userEvent.dblClick(inputWrapperEl);
 
         const inputEl = screen.getByRole("textbox", {
           name: "Tab 1",
           hidden: true,
         });
-        userEvent.type(inputEl, `${name}{enter}`);
+        await userEvent.type(inputEl, `${name}{enter}`);
 
         expect(queryTab(name)).toBeInTheDocument();
         expect(await findSlug({ tabId: 1, name })).toBeInTheDocument();
@@ -403,10 +403,10 @@ describe("DashboardTabs", () => {
   });
 
   describe("when navigating away from dashboard", () => {
-    it("should preserve selected tab id", () => {
+    it("should preserve selected tab id", async () => {
       setup();
 
-      selectTab(2);
+      await selectTab(2);
       expect(screen.getByText("Selected tab id is 2")).toBeInTheDocument();
 
       screen.getByText("Navigate away").click();

--- a/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/EmbedMenu/AdminEmbedMenu.unit.spec.tsx
@@ -49,15 +49,15 @@ const setup = ({
 
 describe("AdminEmbedMenu", () => {
   describe("when public sharing enabled, public link exists, embedding enabled", () => {
-    it("should have a `Sharing` tooltip", () => {
+    it("should have a `Sharing` tooltip", async () => {
       setup();
-      userEvent.hover(screen.getByTestId("resource-embed-button"));
+      await userEvent.hover(screen.getByTestId("resource-embed-button"));
       expect(screen.getByRole("tooltip")).toHaveTextContent("Sharing");
     });
 
     it("should show `Public link` and `Embed` options", async () => {
       setup();
-      userEvent.click(screen.getByTestId("resource-embed-button"));
+      await userEvent.click(screen.getByTestId("resource-embed-button"));
 
       expect(
         await screen.findByTestId("embed-header-menu"),
@@ -72,13 +72,13 @@ describe("AdminEmbedMenu", () => {
 
     it("should open the public link popover when `Public link` is clicked", async () => {
       setup();
-      userEvent.click(screen.getByTestId("resource-embed-button"));
+      await userEvent.click(screen.getByTestId("resource-embed-button"));
 
       expect(
         await screen.findByTestId("embed-header-menu"),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByText("Public link"));
+      await userEvent.click(screen.getByText("Public link"));
 
       expect(
         await screen.findByTestId("public-link-popover-content"),
@@ -101,13 +101,13 @@ describe("AdminEmbedMenu", () => {
 
     it("should open the embed modal when `Embed` is clicked", async () => {
       const { onModalOpen } = setup();
-      userEvent.click(screen.getByTestId("resource-embed-button"));
+      await userEvent.click(screen.getByTestId("resource-embed-button"));
 
       expect(
         await screen.findByTestId("embed-header-menu"),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByText("Embed"));
+      await userEvent.click(screen.getByText("Embed"));
 
       expect(onModalOpen).toHaveBeenCalled();
     });
@@ -118,13 +118,13 @@ describe("AdminEmbedMenu", () => {
       setup({ hasPublicLink: false });
     });
 
-    it("should have a `Sharing` tooltip", () => {
-      userEvent.hover(screen.getByTestId("resource-embed-button"));
+    it("should have a `Sharing` tooltip", async () => {
+      await userEvent.hover(screen.getByTestId("resource-embed-button"));
       expect(screen.getByRole("tooltip")).toHaveTextContent("Sharing");
     });
 
     it("should show `Create a public link` and `Embed` options", async () => {
-      userEvent.click(screen.getByTestId("resource-embed-button"));
+      await userEvent.click(screen.getByTestId("resource-embed-button"));
 
       expect(
         await screen.findByTestId("embed-header-menu"),
@@ -143,13 +143,13 @@ describe("AdminEmbedMenu", () => {
       setup({ isEmbeddingEnabled: false });
     });
 
-    it("should have a `Sharing` tooltip", () => {
-      userEvent.hover(screen.getByTestId("resource-embed-button"));
+    it("should have a `Sharing` tooltip", async () => {
+      await userEvent.hover(screen.getByTestId("resource-embed-button"));
       expect(screen.getByRole("tooltip")).toHaveTextContent("Sharing");
     });
 
     it("should show `Public link` and `Embed` options", async () => {
-      userEvent.click(screen.getByTestId("resource-embed-button"));
+      await userEvent.click(screen.getByTestId("resource-embed-button"));
 
       expect(
         await screen.findByTestId("embed-header-menu"),
@@ -169,13 +169,13 @@ describe("AdminEmbedMenu", () => {
       setup({ hasPublicLink: false, isEmbeddingEnabled: false });
     });
 
-    it("should have a `Sharing` tooltip", () => {
-      userEvent.hover(screen.getByTestId("resource-embed-button"));
+    it("should have a `Sharing` tooltip", async () => {
+      await userEvent.hover(screen.getByTestId("resource-embed-button"));
       expect(screen.getByRole("tooltip")).toHaveTextContent("Sharing");
     });
 
     it("should show `Public link` and `Embed` options", async () => {
-      userEvent.click(screen.getByTestId("resource-embed-button"));
+      await userEvent.click(screen.getByTestId("resource-embed-button"));
 
       expect(
         await screen.findByTestId("embed-header-menu"),
@@ -195,13 +195,13 @@ describe("AdminEmbedMenu", () => {
       setup({ isPublicSharingEnabled: false });
     });
 
-    it("should have an `Embedding` tooltip", () => {
-      userEvent.hover(screen.getByTestId("resource-embed-button"));
+    it("should have an `Embedding` tooltip", async () => {
+      await userEvent.hover(screen.getByTestId("resource-embed-button"));
       expect(screen.getByRole("tooltip")).toHaveTextContent("Embedding");
     });
 
     it("should show `Public link` and `Embed` options", async () => {
-      userEvent.click(screen.getByTestId("resource-embed-button"));
+      await userEvent.click(screen.getByTestId("resource-embed-button"));
 
       expect(
         await screen.findByTestId("embed-header-menu"),
@@ -221,13 +221,13 @@ describe("AdminEmbedMenu", () => {
       setup({ isPublicSharingEnabled: false, isEmbeddingEnabled: false });
     });
 
-    it("should have an `Embedding` tooltip", () => {
-      userEvent.hover(screen.getByTestId("resource-embed-button"));
+    it("should have an `Embedding` tooltip", async () => {
+      await userEvent.hover(screen.getByTestId("resource-embed-button"));
       expect(screen.getByRole("tooltip")).toHaveTextContent("Embedding");
     });
 
     it("should show `Public link` and `Embed` options", async () => {
-      userEvent.click(screen.getByTestId("resource-embed-button"));
+      await userEvent.click(screen.getByTestId("resource-embed-button"));
 
       expect(
         await screen.findByTestId("embed-header-menu"),

--- a/frontend/src/metabase/dashboard/components/EmbedMenu/NonAdminEmbedMenu.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/EmbedMenu/NonAdminEmbedMenu.unit.spec.tsx
@@ -47,13 +47,13 @@ describe("NonAdminEmbedMenu", () => {
       setup();
     });
 
-    it("should render a button with a `Sharing` tooltip", () => {
-      userEvent.hover(screen.getByLabelText("share icon"));
+    it("should render a button with a `Sharing` tooltip", async () => {
+      await userEvent.hover(screen.getByLabelText("share icon"));
       expect(screen.getByText("Sharing")).toBeInTheDocument();
     });
 
     it("should render the public link dropdown when clicked", async () => {
-      userEvent.click(screen.getByLabelText("share icon"));
+      await userEvent.click(screen.getByLabelText("share icon"));
 
       expect(
         await screen.findByTestId("public-link-popover-content"),
@@ -79,8 +79,8 @@ describe("NonAdminEmbedMenu", () => {
       setup({ hasPublicLink: false });
     });
 
-    it("should render a disabled button with a `Ask your admin to create a public link` tooltip", () => {
-      userEvent.hover(screen.getByLabelText("share icon"));
+    it("should render a disabled button with a `Ask your admin to create a public link` tooltip", async () => {
+      await userEvent.hover(screen.getByLabelText("share icon"));
       expect(
         screen.getByText("Ask your admin to create a public link"),
       ).toBeInTheDocument();
@@ -92,8 +92,8 @@ describe("NonAdminEmbedMenu", () => {
       setup({ isPublicSharingEnabled: false });
     });
 
-    it("should render a disabled button with a `Public links are disabled` tooltip", () => {
-      userEvent.hover(screen.getByLabelText("share icon"));
+    it("should render a disabled button with a `Public links are disabled` tooltip", async () => {
+      await userEvent.hover(screen.getByLabelText("share icon"));
       expect(screen.getByText("Public links are disabled")).toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/DashboardPublicLinkPopover.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/DashboardPublicLinkPopover.unit.spec.tsx
@@ -92,7 +92,7 @@ describe("DashboardPublicLinkPopover", () => {
 
   it("should call the Dashboard public link API when deleting link", async () => {
     setup({ hasPublicLink: true });
-    userEvent.click(screen.getByText("Remove public link"));
+    await userEvent.click(screen.getByText("Remove public link"));
     expect(
       fetchMock.calls(`path:/api/dashboard/${TEST_DASHBOARD_ID}/public_link`, {
         method: "DELETE",

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/PublicLinkPopover.unit.spec.tsx
@@ -123,7 +123,7 @@ describe("PublicLinkPopover", () => {
         isAdmin: true,
       });
 
-      userEvent.hover(screen.getByText("Remove public link"));
+      await userEvent.hover(screen.getByText("Remove public link"));
 
       expect(
         await screen.findByText(
@@ -155,7 +155,7 @@ describe("PublicLinkPopover", () => {
     it("should call createPublicLink when uuid is null and the popover is opened", async () => {
       const { createPublicLink } = setup({ hasUUID: false, isOpen: false });
 
-      userEvent.click(screen.getByTestId("target"));
+      await userEvent.click(screen.getByTestId("target"));
 
       expect(
         await screen.findByTestId("public-link-popover-content"),
@@ -167,7 +167,7 @@ describe("PublicLinkPopover", () => {
     it("should not call createPublicLink when uuid is not null and the popover is opened", async () => {
       const { createPublicLink } = setup({ hasUUID: true, isOpen: false });
 
-      userEvent.click(screen.getByTestId("target"));
+      await userEvent.click(screen.getByTestId("target"));
 
       expect(createPublicLink).not.toHaveBeenCalled();
       expect(
@@ -177,14 +177,14 @@ describe("PublicLinkPopover", () => {
   });
 
   describe("when deleting public links", () => {
-    it("should call deletePublicLink and onClose when `Remove public link` is clicked", () => {
+    it("should call deletePublicLink and onClose when `Remove public link` is clicked", async () => {
       const { deletePublicLink, onClose } = setup({
         hasUUID: true,
         isOpen: true,
         isAdmin: true,
       });
 
-      userEvent.click(screen.getByText("Remove public link"));
+      await userEvent.click(screen.getByText("Remove public link"));
 
       expect(deletePublicLink).toHaveBeenCalledTimes(1);
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -199,7 +199,7 @@ describe("PublicLinkPopover", () => {
         await screen.findByDisplayValue("sample-public-link"),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByLabelText("copy icon"));
+      await userEvent.click(screen.getByLabelText("copy icon"));
 
       expect(await screen.findByText("Copied!")).toBeInTheDocument();
     });
@@ -211,7 +211,7 @@ describe("PublicLinkPopover", () => {
         await screen.findByDisplayValue("sample-public-link"),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByLabelText("copy icon"));
+      await userEvent.click(screen.getByLabelText("copy icon"));
 
       expect(await screen.findByText("Copied!")).toBeInTheDocument();
     });
@@ -229,7 +229,7 @@ describe("PublicLinkPopover", () => {
         await screen.findByDisplayValue("sample-public-link"),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByText("csv"));
+      await userEvent.click(screen.getByText("csv"));
       expect(
         screen.getByDisplayValue("sample-public-link.csv"),
       ).toBeInTheDocument();
@@ -246,12 +246,12 @@ describe("PublicLinkPopover", () => {
         await screen.findByDisplayValue("sample-public-link"),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByText("csv"));
+      await userEvent.click(screen.getByText("csv"));
       expect(
         screen.getByDisplayValue("sample-public-link.csv"),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByText("csv"));
+      await userEvent.click(screen.getByText("csv"));
 
       expect(
         await screen.findByDisplayValue("sample-public-link"),

--- a/frontend/src/metabase/dashboard/components/PublicLinkPopover/QuestionPublicLinkPopover.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/PublicLinkPopover/QuestionPublicLinkPopover.unit.spec.tsx
@@ -106,7 +106,7 @@ describe("QuestionPublicLinkPopover", () => {
 
   it("should call the Card public link API when deleting link", async () => {
     setup({ hasPublicLink: true });
-    userEvent.click(screen.getByText("Remove public link"));
+    await userEvent.click(screen.getByText("Remove public link"));
     expect(
       fetchMock.calls(`path:/api/card/${TEST_CARD_ID}/public_link`, {
         method: "DELETE",

--- a/frontend/src/metabase/dashboard/components/QuestionPickerModal/QuestionPickerModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/components/QuestionPickerModal/QuestionPickerModal.unit.spec.tsx
@@ -97,7 +97,7 @@ describe("QuestionPickerModal", () => {
   it("should select a question from the root collection", async () => {
     const { onSelect, onClose } = await setup();
 
-    userEvent.click(screen.getByText(ROOT_CARD.name));
+    await userEvent.click(screen.getByText(ROOT_CARD.name));
 
     expect(onSelect).toHaveBeenCalledWith(ROOT_CARD.id);
     expect(onClose).toHaveBeenCalled();
@@ -106,8 +106,8 @@ describe("QuestionPickerModal", () => {
   it("should select a question from a nested collection", async () => {
     const { onSelect, onClose } = await setup();
 
-    userEvent.click(screen.getByText(COLLECTION.name));
-    userEvent.click(await screen.findByText(COLLECTION_CARD.name));
+    await userEvent.click(screen.getByText(COLLECTION.name));
+    await userEvent.click(await screen.findByText(COLLECTION_CARD.name));
 
     expect(onSelect).toHaveBeenCalledWith(COLLECTION_CARD.id);
     expect(onClose).toHaveBeenCalled();
@@ -117,7 +117,7 @@ describe("QuestionPickerModal", () => {
     const { onSelect, onClose } = await setup();
     expect(screen.getByText(ROOT_CARD.name)).toBeInTheDocument();
 
-    userEvent.type(screen.getByPlaceholderText(/Search/), "Popular");
+    await userEvent.type(screen.getByPlaceholderText(/Search/), "Popular");
     act(() => jest.runAllTimers());
 
     expect(await screen.findByText(COLLECTION_CARD.name)).toBeInTheDocument();
@@ -125,7 +125,7 @@ describe("QuestionPickerModal", () => {
     expect(screen.queryByText(ROOT_COLLECTION.name)).not.toBeInTheDocument();
     expect(screen.queryByText(COLLECTION.name)).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByText(COLLECTION_CARD.name));
+    await userEvent.click(screen.getByText(COLLECTION_CARD.name));
 
     expect(onSelect).toHaveBeenCalledWith(COLLECTION_CARD.id);
     expect(onClose).toHaveBeenCalled();
@@ -135,7 +135,7 @@ describe("QuestionPickerModal", () => {
     await setup();
     expect(screen.getByText(ROOT_CARD.name)).toBeInTheDocument();
 
-    userEvent.type(screen.getByPlaceholderText(/Search/), "No match");
+    await userEvent.type(screen.getByPlaceholderText(/Search/), "No match");
     act(() => jest.runAllTimers());
 
     expect(await screen.findByText("Nothing here")).toBeInTheDocument();
@@ -148,7 +148,7 @@ describe("QuestionPickerModal", () => {
   it("should close", async () => {
     const { onSelect, onClose } = await setup();
 
-    userEvent.click(screen.getByLabelText("Close"));
+    await userEvent.click(screen.getByLabelText("Close"));
 
     expect(onClose).toHaveBeenCalled();
     expect(onSelect).not.toHaveBeenCalled();

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -123,7 +123,9 @@ describe("CreateDashboardModal", () => {
 
   it("calls onClose when Cancel button is clicked", async () => {
     const { onClose } = setup();
-    userEvent.click(screen.getByRole("button", { name: "Cancel" }) as Element);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Cancel" }) as Element,
+    );
     await waitFor(() => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
@@ -168,7 +170,7 @@ describe("CreateDashboardModal", () => {
 
     it("should have a new collection button in the collection picker", async () => {
       setup();
-      userEvent.click(collDropdown());
+      await userEvent.click(collDropdown());
       await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
     });
     it("should open new collection modal and return to dashboard modal when clicking close", async () => {
@@ -177,16 +179,16 @@ describe("CreateDashboardModal", () => {
       await waitFor(async () =>
         expect(await dashModalTitle()).toBeInTheDocument(),
       );
-      userEvent.type(nameField(), name);
-      userEvent.click(collDropdown());
+      await userEvent.type(nameField(), name);
+      await userEvent.click(collDropdown());
       await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
       // Open New Collection Dialog
-      userEvent.click(newCollBtn());
+      await userEvent.click(newCollBtn());
       await screen.findByText("Give it a name");
       // Close New Collection Dialog
-      userEvent.click(cancelBtn());
+      await userEvent.click(cancelBtn());
       // Close Collection Picker
-      userEvent.click(cancelBtn());
+      await userEvent.click(cancelBtn());
 
       await waitFor(() => expect(dashModalTitle()).toBeInTheDocument());
       expect(nameField()).toHaveValue(name);
@@ -194,27 +196,27 @@ describe("CreateDashboardModal", () => {
     it("should create collection inside nested folder", async () => {
       setup();
       const name = "my dashboard";
-      userEvent.type(nameField(), name);
+      await userEvent.type(nameField(), name);
       //Open Collection Picker
-      userEvent.click(collDropdown());
+      await userEvent.click(collDropdown());
       await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
       //Select Parent Collection
-      userEvent.click(
+      await userEvent.click(
         await screen.findByRole("button", {
           name: new RegExp(COLLECTION.PARENT.name),
         }),
       );
       //Open Create Collection Dialog
-      userEvent.click(newCollBtn());
+      await userEvent.click(newCollBtn());
       await screen.findByText("Give it a name");
     });
     it("should create collection inside root folder", async () => {
       setup();
       const name = "my dashboard";
-      userEvent.type(nameField(), name);
-      userEvent.click(collDropdown());
+      await userEvent.type(nameField(), name);
+      await userEvent.click(collDropdown());
       await waitFor(() => expect(newCollBtn()).toBeInTheDocument());
-      userEvent.click(newCollBtn());
+      await userEvent.click(newCollBtn());
       await screen.findByTestId("create-collection-on-the-go"),
         await screen.findByText("Give it a name");
     });

--- a/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/DashboardApp/DashboardApp.unit.spec.tsx
@@ -127,11 +127,11 @@ describe("DashboardApp", () => {
     it("should have a beforeunload event when the user tries to leave a dirty dashboard", async function () {
       const { mockEventListener } = await setup();
 
-      userEvent.click(screen.getByLabelText("Edit dashboard"));
-      userEvent.click(screen.getByTestId("dashboard-name-heading"));
-      userEvent.type(screen.getByTestId("dashboard-name-heading"), "a");
+      await userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(screen.getByTestId("dashboard-name-heading"));
+      await userEvent.type(screen.getByTestId("dashboard-name-heading"), "a");
       // need to click away from the input to trigger the isDirty flag
-      userEvent.tab();
+      await userEvent.tab();
 
       const mockEvent = callMockEvent(mockEventListener, "beforeunload");
 
@@ -142,7 +142,7 @@ describe("DashboardApp", () => {
     it("should not have a beforeunload event when the dashboard is unedited", async function () {
       const { mockEventListener } = await setup();
 
-      userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(screen.getByLabelText("Edit dashboard"));
 
       const mockEvent = callMockEvent(mockEventListener, "beforeunload");
       expect(mockEvent.preventDefault).not.toHaveBeenCalled();
@@ -157,7 +157,7 @@ describe("DashboardApp", () => {
 
       await waitForLoaderToBeRemoved();
 
-      userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(screen.getByLabelText("Edit dashboard"));
 
       history.goBack();
 
@@ -174,10 +174,10 @@ describe("DashboardApp", () => {
 
       await waitForLoaderToBeRemoved();
 
-      userEvent.click(screen.getByLabelText("Edit dashboard"));
-      userEvent.click(screen.getByTestId("dashboard-name-heading"));
-      userEvent.type(screen.getByTestId("dashboard-name-heading"), "a");
-      userEvent.tab(); // need to click away from the input to trigger the isDirty flag
+      await userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(screen.getByTestId("dashboard-name-heading"));
+      await userEvent.type(screen.getByTestId("dashboard-name-heading"), "a");
+      await userEvent.tab(); // need to click away from the input to trigger the isDirty flag
 
       history.goBack();
 
@@ -187,9 +187,9 @@ describe("DashboardApp", () => {
     it("does not show custom warning modal when leaving with no changes via Cancel button", async () => {
       await setup();
 
-      userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(screen.getByLabelText("Edit dashboard"));
 
-      userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -199,12 +199,12 @@ describe("DashboardApp", () => {
     it("shows custom warning modal when leaving with unsaved changes via Cancel button", async () => {
       await setup();
 
-      userEvent.click(screen.getByLabelText("Edit dashboard"));
-      userEvent.click(screen.getByTestId("dashboard-name-heading"));
-      userEvent.type(screen.getByTestId("dashboard-name-heading"), "a");
-      userEvent.tab(); // need to click away from the input to trigger the isDirty flag
+      await userEvent.click(screen.getByLabelText("Edit dashboard"));
+      await userEvent.click(screen.getByTestId("dashboard-name-heading"));
+      await userEvent.type(screen.getByTestId("dashboard-name-heading"), "a");
+      await userEvent.tab(); // need to click away from the input to trigger the isDirty flag
 
-      userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });

--- a/frontend/src/metabase/databases/components/DatabaseForm/tests/cache-granular-controls.unit.spec.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/tests/cache-granular-controls.unit.spec.tsx
@@ -23,22 +23,22 @@ const setupGranularCacheControls = (opts: SetupOpts) => {
 };
 
 describe("DatabaseForm", () => {
-  it("should show caching controls in advanced options when caching is enabled", () => {
+  it("should show caching controls in advanced options when caching is enabled", async () => {
     setupGranularCacheControls({ isCachingEnabled: true });
     expect(screen.getByText("Display name")).toBeInTheDocument();
     expect(
       screen.queryByText("Default result cache duration"),
     ).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Show advanced options"));
+    await userEvent.click(screen.getByText("Show advanced options"));
     expect(
       screen.getByText("Default result cache duration"),
     ).toBeInTheDocument();
   });
 
-  it("should not allow to configure cache ttl when query caching is not enabled", () => {
+  it("should not allow to configure cache ttl when query caching is not enabled", async () => {
     setupGranularCacheControls({ isCachingEnabled: false });
-    userEvent.click(screen.getByText("Show advanced options"));
+    await userEvent.click(screen.getByText("Show advanced options"));
     expect(
       screen.getByText("Choose when syncs and scans happen"),
     ).toBeInTheDocument();
@@ -50,20 +50,23 @@ describe("DatabaseForm", () => {
   it("should allow to submit the form with the cache ttl value", async () => {
     const { onSubmit } = setupGranularCacheControls({ isCachingEnabled: true });
 
-    userEvent.type(screen.getByLabelText("Display name"), "H2");
-    userEvent.type(screen.getByLabelText("Connection String"), "file:/db");
-    userEvent.click(screen.getByText("Show advanced options"));
-    userEvent.click(screen.getByText("Use instance default (TTL)"));
-    userEvent.click(screen.getByText("Custom"));
+    await userEvent.type(screen.getByLabelText("Display name"), "H2");
+    await userEvent.type(
+      screen.getByLabelText("Connection String"),
+      "file:/db",
+    );
+    await userEvent.click(screen.getByText("Show advanced options"));
+    await userEvent.click(screen.getByText("Use instance default (TTL)"));
+    await userEvent.click(screen.getByText("Custom"));
 
     const cacheInput = screen.getByPlaceholderText("24");
-    userEvent.clear(cacheInput);
-    userEvent.type(cacheInput, "10");
+    await userEvent.clear(cacheInput);
+    await userEvent.type(cacheInput, "10");
 
     const saveButton = screen.getByRole("button", { name: "Save" });
     await waitFor(() => expect(saveButton).toBeEnabled());
 
-    userEvent.click(saveButton);
+    await userEvent.click(saveButton);
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/frontend/src/metabase/databases/components/DatabaseForm/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/tests/common.unit.spec.tsx
@@ -10,8 +10,11 @@ describe("DatabaseForm", () => {
 
     const expectedDatabaseName = "My H2 Database";
     const expectedConnectionString = "file:/somewhere";
-    userEvent.type(screen.getByLabelText("Display name"), expectedDatabaseName);
-    userEvent.type(
+    await userEvent.type(
+      screen.getByLabelText("Display name"),
+      expectedDatabaseName,
+    );
+    await userEvent.type(
       screen.getByLabelText("Connection String"),
       expectedConnectionString,
     );
@@ -19,7 +22,7 @@ describe("DatabaseForm", () => {
     const saveButton = screen.getByRole("button", { name: "Save" });
     await waitFor(() => expect(saveButton).toBeEnabled());
 
-    userEvent.click(saveButton);
+    await userEvent.click(saveButton);
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({
         ...EXPECTED_DEFAULT_SCHEMA,
@@ -33,9 +36,9 @@ describe("DatabaseForm", () => {
     });
   });
 
-  it("should not allow to configure cache ttl", () => {
+  it("should not allow to configure cache ttl", async () => {
     setup({ isCachingEnabled: true });
-    userEvent.click(screen.getByText("Show advanced options"));
+    await userEvent.click(screen.getByText("Show advanced options"));
     expect(
       screen.getByText("Choose when syncs and scans happen"),
     ).toBeInTheDocument();

--- a/frontend/src/metabase/databases/components/DatabaseForm/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseForm/tests/enterprise.unit.spec.tsx
@@ -13,9 +13,9 @@ const setupEnterprise = (opts?: SetupOpts) => {
 };
 
 describe("DatabaseForm", () => {
-  it("should not allow to configure cache ttl", () => {
+  it("should not allow to configure cache ttl", async () => {
     setupEnterprise({ isCachingEnabled: true });
-    userEvent.click(screen.getByText("Show advanced options"));
+    await userEvent.click(screen.getByText("Show advanced options"));
     expect(
       screen.getByText("Choose when syncs and scans happen"),
     ).toBeInTheDocument();

--- a/frontend/src/metabase/databases/components/DatabaseSyncModal/DatabaseSyncModal.unit.spec.tsx
+++ b/frontend/src/metabase/databases/components/DatabaseSyncModal/DatabaseSyncModal.unit.spec.tsx
@@ -10,11 +10,11 @@ describe("DatabaseSyncModal", () => {
     expect(screen.getByText("Explore sample data")).toBeInTheDocument();
   });
 
-  it("should render with no sample database", () => {
+  it("should render with no sample database", async () => {
     const onClose = jest.fn();
 
     render(<DatabaseSyncModal onClose={onClose} />);
-    userEvent.click(screen.getByText("Got it"));
+    await userEvent.click(screen.getByText("Got it"));
 
     expect(onClose).toHaveBeenCalled();
   });

--- a/frontend/src/metabase/forms/components/FormCheckbox/FormCheckbox.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormCheckbox/FormCheckbox.unit.spec.tsx
@@ -54,8 +54,8 @@ describe("FormCheckbox", () => {
   it("should submit values when the checkbox is checked", async () => {
     const { onSubmit } = setup();
 
-    userEvent.click(screen.getByLabelText("Remember me"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByLabelText("Remember me"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -69,8 +69,8 @@ describe("FormCheckbox", () => {
     const { onSubmit } = setup({
       initialValues: { remember: true },
     });
-    userEvent.click(screen.getByLabelText("Remember me"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByLabelText("Remember me"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -87,8 +87,8 @@ describe("FormCheckbox", () => {
     setup({ initialValues: validationSchema.getDefault(), validationSchema });
     expect(screen.queryByText("Must be checked")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText("Remember me"));
-    userEvent.tab();
+    await userEvent.click(screen.getByLabelText("Remember me"));
+    await userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText("Must be checked")).toBeInTheDocument();
     });

--- a/frontend/src/metabase/forms/components/FormCheckboxGroup/FormCheckboxGroup.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormCheckboxGroup/FormCheckboxGroup.unit.spec.tsx
@@ -59,8 +59,8 @@ describe("FormCheckboxGroup", () => {
   it("should submit a non-empty value", async () => {
     const { onSubmit } = setup();
 
-    userEvent.click(screen.getByLabelText("Name"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByLabelText("Name"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -82,9 +82,9 @@ describe("FormCheckboxGroup", () => {
     });
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText("Name"));
-    userEvent.click(screen.getByLabelText("Name"));
-    userEvent.tab();
+    await userEvent.click(screen.getByLabelText("Name"));
+    await userEvent.click(screen.getByLabelText("Name"));
+    await userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText("Required")).toBeInTheDocument();
     });

--- a/frontend/src/metabase/forms/components/FormErrorMessage/FormErrorMessage.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormErrorMessage/FormErrorMessage.unit.spec.tsx
@@ -35,14 +35,14 @@ describe("FormErrorMessage", () => {
   it("should show the default error message", async () => {
     const { onSubmit } = setup();
     onSubmit.mockRejectedValue(new Error());
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByText("Submit"));
     expect(await screen.findByText("An error occurred")).toBeInTheDocument();
   });
 
   it("should show a custom error message", async () => {
     const { onSubmit } = setup();
     onSubmit.mockRejectedValue(new Error("Wrong host or port"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByText("Submit"));
     expect(await screen.findByText("Wrong host or port")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/forms/components/FormNumberInput/FormNumberInput.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormNumberInput/FormNumberInput.unit.spec.tsx
@@ -56,8 +56,8 @@ describe("FormNumberInput", () => {
   it("should submit a non-empty value", async () => {
     const { onSubmit } = setup();
 
-    userEvent.type(screen.getByLabelText("Goal"), "20");
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.type(screen.getByLabelText("Goal"), "20");
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({ goal: 20 }, expect.anything());
@@ -69,8 +69,8 @@ describe("FormNumberInput", () => {
       initialValues: { goal: 20 },
     });
 
-    userEvent.clear(screen.getByLabelText("Goal"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.clear(screen.getByLabelText("Goal"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -86,8 +86,8 @@ describe("FormNumberInput", () => {
       nullable: true,
     });
 
-    userEvent.clear(screen.getByLabelText("Goal"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.clear(screen.getByLabelText("Goal"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({ goal: null }, expect.anything());
@@ -101,9 +101,9 @@ describe("FormNumberInput", () => {
     setup({ initialValues: validationSchema.getDefault(), validationSchema });
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
 
-    userEvent.type(screen.getByLabelText("Goal"), "20");
-    userEvent.clear(screen.getByLabelText("Goal"));
-    userEvent.tab();
+    await userEvent.type(screen.getByLabelText("Goal"), "20");
+    await userEvent.clear(screen.getByLabelText("Goal"));
+    await userEvent.tab();
 
     await waitFor(() => {
       expect(screen.getByText("Required")).toBeInTheDocument();
@@ -124,9 +124,9 @@ describe("FormNumberInput", () => {
     });
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
 
-    userEvent.type(screen.getByLabelText("Goal"), "20");
-    userEvent.clear(screen.getByLabelText("Goal"));
-    userEvent.tab();
+    await userEvent.type(screen.getByLabelText("Goal"), "20");
+    await userEvent.clear(screen.getByLabelText("Goal"));
+    await userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText("Required")).toBeInTheDocument();
     });

--- a/frontend/src/metabase/forms/components/FormRadioGroup/FormRadioGroup.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormRadioGroup/FormRadioGroup.unit.spec.tsx
@@ -8,7 +8,6 @@ import {
   FormRadioGroup,
   FormProvider,
   FormSubmitButton,
-  requiredErrorMessage,
 } from "metabase/forms";
 import { Radio } from "metabase/ui";
 
@@ -73,20 +72,25 @@ describe("FormRadioGroup", () => {
   });
 
   it("should show validation errors", async () => {
+    // This is test used to test setting and unsetting the radio value, but userEvents 14
+    // cause this to not work (we weren't able to unselect the radio). To simulate, we have
+    // repaced the logic with a nonsense validation object to error after setting the value
     const validationSchema = Yup.object({
-      column: Yup.string().required(requiredErrorMessage),
+      column: Yup.string().email("This should error"),
     });
     setup({
       initialValues: validationSchema.getDefault(),
       validationSchema: validationSchema,
     });
-    expect(screen.queryByText("Required")).not.toBeInTheDocument();
+    expect(screen.queryByText("This should error")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Submit"));
 
     await userEvent.click(screen.getByLabelText("Name"));
-    await userEvent.click(screen.getByLabelText("Name"));
     await userEvent.tab();
+
     await waitFor(() => {
-      expect(screen.getByText("Required")).toBeInTheDocument();
+      expect(screen.getByText("This should error")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/forms/components/FormRadioGroup/FormRadioGroup.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormRadioGroup/FormRadioGroup.unit.spec.tsx
@@ -59,8 +59,8 @@ describe("FormRadioGroup", () => {
   it("should submit a non-empty value", async () => {
     const { onSubmit } = setup();
 
-    userEvent.click(screen.getByLabelText("Name"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByLabelText("Name"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -82,9 +82,9 @@ describe("FormRadioGroup", () => {
     });
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText("Name"));
-    userEvent.click(screen.getByLabelText("Name"));
-    userEvent.tab();
+    await userEvent.click(screen.getByLabelText("Name"));
+    await userEvent.click(screen.getByLabelText("Name"));
+    await userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText("Required")).toBeInTheDocument();
     });

--- a/frontend/src/metabase/forms/components/FormSelect/FormSelect.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormSelect/FormSelect.unit.spec.tsx
@@ -71,9 +71,9 @@ describe("FormSelect", () => {
   it("should submit a non-empty value", async () => {
     const { onSubmit } = setup();
 
-    userEvent.click(screen.getByLabelText("Display"));
-    userEvent.click(screen.getByText("Line"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByLabelText("Display"));
+    await userEvent.click(screen.getByText("Line"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -88,8 +88,8 @@ describe("FormSelect", () => {
       initialValues: { display: "line" },
     });
 
-    userEvent.click(screen.getByLabelText("Clear"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByLabelText("Clear"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -105,8 +105,8 @@ describe("FormSelect", () => {
       nullable: true,
     });
 
-    userEvent.click(screen.getByLabelText("Clear"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByLabelText("Clear"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -124,10 +124,10 @@ describe("FormSelect", () => {
     setup({ initialValues: validationSchema.getDefault(), validationSchema });
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByPlaceholderText("No display type"));
-    userEvent.click(screen.getByText("Line"));
-    userEvent.click(screen.getByLabelText("Clear"));
-    userEvent.tab();
+    await userEvent.click(screen.getByPlaceholderText("No display type"));
+    await userEvent.click(screen.getByText("Line"));
+    await userEvent.click(screen.getByLabelText("Clear"));
+    await userEvent.tab();
 
     await waitFor(() => {
       expect(screen.getByText("Required")).toBeInTheDocument();
@@ -148,10 +148,10 @@ describe("FormSelect", () => {
     });
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByPlaceholderText("No display type"));
-    userEvent.click(screen.getByText("Line"));
-    userEvent.click(screen.getByLabelText("Clear"));
-    userEvent.tab();
+    await userEvent.click(screen.getByPlaceholderText("No display type"));
+    await userEvent.click(screen.getByText("Line"));
+    await userEvent.click(screen.getByLabelText("Clear"));
+    await userEvent.tab();
 
     await waitFor(() => {
       expect(screen.getByText("Required")).toBeInTheDocument();

--- a/frontend/src/metabase/forms/components/FormSubmitButton/FormSubmitButton.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormSubmitButton/FormSubmitButton.unit.spec.tsx
@@ -46,28 +46,28 @@ describe("FormSubmitButton", () => {
   it("should show the default success message", async () => {
     const { onSubmit } = setup();
     onSubmit.mockResolvedValue(true);
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByText("Submit"));
     expect(await screen.findByText("Success")).toBeInTheDocument();
   });
 
   it("should show a custom success message", async () => {
     const { onSubmit } = setup({ label: "Save", successLabel: "Saved" });
     onSubmit.mockResolvedValue(true);
-    userEvent.click(screen.getByText("Save"));
+    await userEvent.click(screen.getByText("Save"));
     expect(await screen.findByText("Saved")).toBeInTheDocument();
   });
 
   it("should show the default error message", async () => {
     const { onSubmit } = setup();
     onSubmit.mockRejectedValue(new Error("An error occurred"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByText("Submit"));
     expect(await screen.findByText("Failed")).toBeInTheDocument();
   });
 
   it("should show a custom error message", async () => {
     const { onSubmit } = setup({ failedLabel: "Error" });
     onSubmit.mockRejectedValue(new Error("An error occurred"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByText("Submit"));
     expect(await screen.findByText("Error")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/forms/components/FormSwitch/FormSwitch.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormSwitch/FormSwitch.unit.spec.tsx
@@ -50,8 +50,8 @@ describe("FormSwitch", () => {
   it("should submit a true value", async () => {
     const { onSubmit } = setup({ initialValues: {} });
 
-    userEvent.click(screen.getByLabelText("Agree?"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByLabelText("Agree?"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({ agree: true }, expect.anything());
@@ -61,9 +61,9 @@ describe("FormSwitch", () => {
   it("should submit a false value", async () => {
     const { onSubmit } = setup({ initialValues: {} });
 
-    userEvent.click(screen.getByLabelText("Agree?"));
-    userEvent.click(screen.getByLabelText("Agree?"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByLabelText("Agree?"));
+    await userEvent.click(screen.getByLabelText("Agree?"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -76,7 +76,7 @@ describe("FormSwitch", () => {
   it("should submit an empty value", async () => {
     const { onSubmit } = setup({ initialValues: {} });
 
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({}, expect.anything());

--- a/frontend/src/metabase/forms/components/FormTextInput/FormTextInput.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormTextInput/FormTextInput.unit.spec.tsx
@@ -82,8 +82,8 @@ describe("FormTextInput", () => {
   it("should submit a non-empty value", async () => {
     const { onSubmit } = setup();
 
-    userEvent.type(screen.getByLabelText("Name"), "Test");
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.type(screen.getByLabelText("Name"), "Test");
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -98,8 +98,8 @@ describe("FormTextInput", () => {
       initialValues: { name: "Test" },
     });
 
-    userEvent.clear(screen.getByLabelText("Name"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -115,8 +115,8 @@ describe("FormTextInput", () => {
       nullable: true,
     });
 
-    userEvent.clear(screen.getByLabelText("Name"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({ name: null }, expect.anything());
@@ -130,9 +130,9 @@ describe("FormTextInput", () => {
     setup({ initialValues: validationSchema.getDefault(), validationSchema });
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
 
-    userEvent.type(screen.getByLabelText("Name"), "Test");
-    userEvent.clear(screen.getByLabelText("Name"));
-    userEvent.tab();
+    await userEvent.type(screen.getByLabelText("Name"), "Test");
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.tab();
 
     await waitFor(() => {
       expect(screen.getByText("Required")).toBeInTheDocument();
@@ -149,9 +149,9 @@ describe("FormTextInput", () => {
     setup({ initialValues: validationSchema.getDefault(), validationSchema });
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
 
-    userEvent.type(screen.getByLabelText("Name"), "Test");
-    userEvent.clear(screen.getByLabelText("Name"));
-    userEvent.tab();
+    await userEvent.type(screen.getByLabelText("Name"), "Test");
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText("Required")).toBeInTheDocument();
     });

--- a/frontend/src/metabase/forms/components/FormTextarea/FormTextarea.unit.spec.tsx
+++ b/frontend/src/metabase/forms/components/FormTextarea/FormTextarea.unit.spec.tsx
@@ -56,8 +56,8 @@ describe("FormTextarea", () => {
   it("should submit a non-empty value", async () => {
     const { onSubmit } = setup();
 
-    userEvent.type(screen.getByLabelText("Name"), "Test");
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.type(screen.getByLabelText("Name"), "Test");
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -72,8 +72,8 @@ describe("FormTextarea", () => {
       initialValues: { name: "Test" },
     });
 
-    userEvent.clear(screen.getByLabelText("Name"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith(
@@ -89,8 +89,8 @@ describe("FormTextarea", () => {
       nullable: true,
     });
 
-    userEvent.clear(screen.getByLabelText("Name"));
-    userEvent.click(screen.getByText("Submit"));
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.click(screen.getByText("Submit"));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({ name: null }, expect.anything());
@@ -104,9 +104,9 @@ describe("FormTextarea", () => {
     setup({ initialValues: validationSchema.getDefault(), validationSchema });
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
 
-    userEvent.type(screen.getByLabelText("Name"), "Test");
-    userEvent.clear(screen.getByLabelText("Name"));
-    userEvent.tab();
+    await userEvent.type(screen.getByLabelText("Name"), "Test");
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.tab();
 
     await waitFor(() => {
       expect(screen.getByText("Required")).toBeInTheDocument();
@@ -123,9 +123,9 @@ describe("FormTextarea", () => {
     setup({ initialValues: validationSchema.getDefault(), validationSchema });
     expect(screen.queryByText("Required")).not.toBeInTheDocument();
 
-    userEvent.type(screen.getByLabelText("Name"), "Test");
-    userEvent.clear(screen.getByLabelText("Name"));
-    userEvent.tab();
+    await userEvent.type(screen.getByLabelText("Name"), "Test");
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.tab();
     await waitFor(() => {
       expect(screen.getByText("Required")).toBeInTheDocument();
     });

--- a/frontend/src/metabase/hooks/use-callback-effect/use-callback-effect.unit.spec.tsx
+++ b/frontend/src/metabase/hooks/use-callback-effect/use-callback-effect.unit.spec.tsx
@@ -36,7 +36,7 @@ describe("useCallbackEffect", () => {
 
     render(<TestComponent callback={callback} />);
 
-    userEvent.click(screen.getByRole("button", { name: "Schedule" }));
+    await userEvent.click(screen.getByRole("button", { name: "Schedule" }));
 
     expect(screen.getByText("Status: scheduled")).toBeInTheDocument();
     expect(callback).not.toHaveBeenCalled();

--- a/frontend/src/metabase/hooks/use-callback-effect/use-callback-effect.unit.spec.tsx
+++ b/frontend/src/metabase/hooks/use-callback-effect/use-callback-effect.unit.spec.tsx
@@ -36,18 +36,16 @@ describe("useCallbackEffect", () => {
 
     render(<TestComponent callback={callback} />);
 
-    await userEvent.click(screen.getByRole("button", { name: "Schedule" }));
+    userEvent.click(screen.getByRole("button", { name: "Schedule" }));
 
-    expect(screen.getByText("Status: scheduled")).toBeInTheDocument();
     expect(callback).not.toHaveBeenCalled();
+    await screen.findByText("Status: scheduled");
 
     await waitFor(() => {
       expect(callback).toHaveBeenCalledTimes(1);
     });
 
-    await waitFor(() => {
-      expect(screen.getByText("Status: not scheduled")).toBeInTheDocument();
-    });
+    expect(screen.getByText("Status: not scheduled")).toBeInTheDocument();
 
     expect(callback).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/metabase/lib/keyboard.js
+++ b/frontend/src/metabase/lib/keyboard.js
@@ -14,3 +14,4 @@ export const KEYCODE_FORWARD_SLASH = 191;
 
 export const KEY_ESCAPE = "Escape";
 export const KEY_ENTER = "Enter";
+export const KEY_BACKSPACE = "Backspace";

--- a/frontend/src/metabase/metabot/components/Metabot/Metabot.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/Metabot/Metabot.unit.spec.tsx
@@ -142,7 +142,7 @@ describe("Metabot", () => {
       setupMetabotDatabaseEndpoints();
       setup({ entityType: "database" });
 
-      enterPromptAndGetResults("Ask something…");
+      await enterPromptAndGetResults("Ask something…");
 
       expect(await screen.findByText("Here you go!")).toBeInTheDocument();
       expect(await screen.findByText(RESULT_VALUE)).toBeInTheDocument();
@@ -153,7 +153,7 @@ describe("Metabot", () => {
       setupMetabotDatabaseEndpoints(false);
       setup({ entityType: "database" });
 
-      enterPromptAndGetResults("Ask something…");
+      await enterPromptAndGetResults("Ask something…");
 
       expect(await screen.findByText(API_ERROR)).toBeInTheDocument();
       expect(screen.queryByText("How did I do?")).not.toBeInTheDocument();
@@ -165,7 +165,7 @@ describe("Metabot", () => {
       setupMetabotModelEndpoints();
       setup({ entityType: "model", model: MODEL });
 
-      enterPromptAndGetResults(
+      await enterPromptAndGetResults(
         "Ask something like, how many Q1 have we had over time?",
       );
       expect(await screen.findByText("Here you go!")).toBeInTheDocument();
@@ -177,7 +177,7 @@ describe("Metabot", () => {
       setupMetabotModelEndpoints(false);
       setup({ entityType: "model", model: MODEL });
 
-      enterPromptAndGetResults(
+      await enterPromptAndGetResults(
         "Ask something like, how many Q1 have we had over time?",
       );
       expect(await screen.findByText(API_ERROR)).toBeInTheDocument();
@@ -186,7 +186,9 @@ describe("Metabot", () => {
       // The error state get cleared
       setupMetabotModelEndpoints(true);
 
-      userEvent.click(screen.getByRole("button", { name: /get answer/i }));
+      await userEvent.click(
+        screen.getByRole("button", { name: /get answer/i }),
+      );
       expect(await screen.findByText("Here you go!")).toBeInTheDocument();
       expect(await screen.findByText(RESULT_VALUE)).toBeInTheDocument();
     });
@@ -200,24 +202,24 @@ describe("Metabot", () => {
     setupMetabotModelEndpoints();
     setup({ entityType, model: MODEL });
 
-    enterPromptAndGetResults(
+    await enterPromptAndGetResults(
       "Ask something like, how many Q1 have we had over time?",
     );
 
     expect(await screen.findByText("How did I do?")).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("This is great!"));
+    await userEvent.click(screen.getByText("This is great!"));
 
     expect(await screen.findByText("Glad to hear it!")).toBeInTheDocument();
   });
 });
 
-function enterPromptAndGetResults(inputPlaceholder: string) {
+async function enterPromptAndGetResults(inputPlaceholder: string) {
   // Empty state
   screen.getByRole("img", { name: /insight icon/i });
 
-  userEvent.type(screen.getByPlaceholderText(inputPlaceholder), PROMPT);
-  userEvent.click(screen.getByRole("button", { name: /get answer/i }));
+  await userEvent.type(screen.getByPlaceholderText(inputPlaceholder), PROMPT);
+  await userEvent.click(screen.getByRole("button", { name: /get answer/i }));
 
   expect(screen.getByText("Doing science...")).toBeInTheDocument();
 }

--- a/frontend/src/metabase/metabot/components/Metabot/Metabot.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/Metabot/Metabot.unit.spec.tsx
@@ -220,6 +220,4 @@ async function enterPromptAndGetResults(inputPlaceholder: string) {
 
   await userEvent.type(screen.getByPlaceholderText(inputPlaceholder), PROMPT);
   await userEvent.click(screen.getByRole("button", { name: /get answer/i }));
-
-  expect(screen.getByText("Doing science...")).toBeInTheDocument();
 }

--- a/frontend/src/metabase/metabot/components/MetabotWidget/MetabotWidget.unit.spec.tsx
+++ b/frontend/src/metabase/metabot/components/MetabotWidget/MetabotWidget.unit.spec.tsx
@@ -99,8 +99,11 @@ describe("MetabotWidget", () => {
   it("should redirect to the database metabot page with the prompt", async () => {
     const { history } = await setup();
 
-    userEvent.type(screen.getByPlaceholderText(TEST_MODEL_PLACEHOLDER), "How");
-    userEvent.click(screen.getByRole("button", { name: "Get Answer" }));
+    await userEvent.type(
+      screen.getByPlaceholderText(TEST_MODEL_PLACEHOLDER),
+      "How",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Get Answer" }));
 
     const location = history?.getCurrentLocation();
     expect(location?.pathname).toBe(`/metabot/database/${TEST_DATABASE.id}`);
@@ -111,10 +114,13 @@ describe("MetabotWidget", () => {
       databases: [TEST_DATABASE, TEST_DATABASE_2],
     });
 
-    userEvent.click(screen.getByText(TEST_DATABASE.name));
-    userEvent.click(screen.getByText(TEST_DATABASE_2.name));
-    userEvent.type(screen.getByPlaceholderText(TEST_MODEL_PLACEHOLDER), "How");
-    userEvent.click(screen.getByRole("button", { name: "Get Answer" }));
+    await userEvent.click(screen.getByText(TEST_DATABASE.name));
+    await userEvent.click(screen.getByText(TEST_DATABASE_2.name));
+    await userEvent.type(
+      screen.getByPlaceholderText(TEST_MODEL_PLACEHOLDER),
+      "How",
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Get Answer" }));
 
     const location = history?.getCurrentLocation();
     expect(location?.pathname).toBe(`/metabot/database/${TEST_DATABASE_2.id}`);
@@ -156,7 +162,7 @@ describe("MetabotWidget", () => {
       ],
     });
 
-    userEvent.click(screen.getByText(TEST_DATABASE.name));
+    await userEvent.click(screen.getByText(TEST_DATABASE.name));
     expect(screen.queryByText(mongoDbName)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.unit.spec.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelActionDetails/ModelActionDetails.unit.spec.tsx
@@ -58,7 +58,7 @@ describe("ModelActionDetails", () => {
   it("should not leave ActionCreatorModal when clicking outside modal", async () => {
     await setup({});
 
-    userEvent.click(document.body);
+    await userEvent.click(document.body);
 
     const mockQueryEditor = await screen.findByTestId(
       "mock-native-query-editor",

--- a/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
+++ b/frontend/src/metabase/models/containers/ModelDetailPage/ModelDetailPage.unit.spec.tsx
@@ -273,10 +273,10 @@ async function setupActions({
   });
 }
 
-function openActionMenu(action: WritebackAction) {
+async function openActionMenu(action: WritebackAction) {
   const listItem = screen.getByRole("listitem", { name: action.name });
   const menuButton = within(listItem).getByLabelText("ellipsis icon");
-  userEvent.click(menuButton);
+  await userEvent.click(menuButton);
 }
 
 describe("ModelDetailPage", () => {
@@ -307,8 +307,8 @@ describe("ModelDetailPage", () => {
         const { model, modelUpdateSpy } = await setup({ model: getModel() });
 
         const input = screen.getByDisplayValue(model.displayName() as string);
-        userEvent.clear(input);
-        userEvent.type(input, "New model name");
+        await userEvent.clear(input);
+        await userEvent.type(input, "New model name");
         fireEvent.blur(input);
 
         await waitFor(() => {
@@ -323,7 +323,7 @@ describe("ModelDetailPage", () => {
         const { model, modelUpdateSpy } = await setup({ model: getModel() });
 
         const input = screen.getByPlaceholderText("Add description");
-        userEvent.type(input, "Foo bar");
+        await userEvent.type(input, "Foo bar");
         fireEvent.blur(input);
 
         await waitFor(() => {
@@ -340,11 +340,11 @@ describe("ModelDetailPage", () => {
       it("can be archived", async () => {
         const { model, modelUpdateSpy } = await setup({ model: getModel() });
 
-        userEvent.click(getIcon("ellipsis"));
-        userEvent.click(await screen.findByText("Archive"));
+        await userEvent.click(getIcon("ellipsis"));
+        await userEvent.click(await screen.findByText("Archive"));
 
         expect(screen.getByRole("dialog")).toBeInTheDocument();
-        userEvent.click(screen.getByRole("button", { name: "Archive" }));
+        await userEvent.click(screen.getByRole("button", { name: "Archive" }));
 
         await waitFor(() => {
           expect(modelUpdateSpy).toHaveBeenCalledWith(
@@ -425,7 +425,7 @@ describe("ModelDetailPage", () => {
         const { model } = await setup({ model: getModel(), tab: "schema" });
         const fields = model.getResultMetadata();
 
-        userEvent.click(screen.getByText("Schema"));
+        await userEvent.click(screen.getByText("Schema"));
 
         expect(fields.length).toBeGreaterThan(0);
         expect(screen.getByText(`${fields.length} fields`)).toBeInTheDocument();
@@ -512,7 +512,7 @@ describe("ModelDetailPage", () => {
 
       it("allows to create a new query action from the empty state", async () => {
         await setupActions({ model: getModel(), actions: [] });
-        userEvent.click(screen.getByRole("link", { name: "New action" }));
+        await userEvent.click(screen.getByRole("link", { name: "New action" }));
         expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
       });
 
@@ -567,7 +567,7 @@ describe("ModelDetailPage", () => {
           actions: [createMockQueryAction({ model_id: model.id })],
         });
 
-        userEvent.click(screen.getByRole("link", { name: "New action" }));
+        await userEvent.click(screen.getByRole("link", { name: "New action" }));
 
         expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
       });
@@ -577,7 +577,7 @@ describe("ModelDetailPage", () => {
         const action = createMockQueryAction({ model_id: model.id });
         await setupActions({ model, actions: [action] });
 
-        userEvent.click(screen.getByRole("link", { name: action.name }));
+        await userEvent.click(screen.getByRole("link", { name: action.name }));
 
         expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
       });
@@ -587,8 +587,8 @@ describe("ModelDetailPage", () => {
         const action = createMockQueryAction({ model_id: model.id });
         await setupActions({ model, actions: [action] });
 
-        openActionMenu(action);
-        userEvent.click(await screen.findByText("Edit"));
+        await openActionMenu(action);
+        await userEvent.click(await screen.findByText("Edit"));
 
         expect(await screen.findByTestId("mock-action-editor")).toBeVisible();
       });
@@ -600,11 +600,13 @@ describe("ModelDetailPage", () => {
         await setupActions({ model, actions: [action] });
 
         const listItem = screen.getByRole("listitem", { name: action.name });
-        userEvent.click(within(listItem).getByLabelText("ellipsis icon"));
-        userEvent.click(await screen.findByText("Archive"));
+        await userEvent.click(within(listItem).getByLabelText("ellipsis icon"));
+        await userEvent.click(await screen.findByText("Archive"));
 
         const modal = screen.getByRole("dialog");
-        userEvent.click(within(modal).getByRole("button", { name: "Archive" }));
+        await userEvent.click(
+          within(modal).getByRole("button", { name: "Archive" }),
+        );
 
         await waitFor(() =>
           expect(screen.queryByRole("dialog")).not.toBeInTheDocument(),
@@ -622,7 +624,7 @@ describe("ModelDetailPage", () => {
         });
         await setupActions({ model, actions: [action] });
 
-        openActionMenu(action);
+        await openActionMenu(action);
 
         expect(screen.queryByText("Archive")).not.toBeInTheDocument();
       });
@@ -633,9 +635,9 @@ describe("ModelDetailPage", () => {
         const actions = createMockImplicitCUDActions(model.id);
         await setupActions({ model, actions });
 
-        userEvent.click(screen.getByLabelText("Actions menu"));
-        userEvent.click(await screen.findByText("Disable basic actions"));
-        userEvent.click(screen.getByRole("button", { name: "Disable" }));
+        await userEvent.click(screen.getByLabelText("Actions menu"));
+        await userEvent.click(await screen.findByText("Disable basic actions"));
+        await userEvent.click(screen.getByRole("button", { name: "Disable" }));
 
         actions.forEach(action => {
           expect(deleteActionSpy).toHaveBeenCalledWith({ id: action.id });
@@ -672,7 +674,7 @@ describe("ModelDetailPage", () => {
 
       it("doesn't show a link to the metadata editor", async () => {
         await setup({ model: modelCard });
-        userEvent.click(screen.getByText("Schema"));
+        await userEvent.click(screen.getByText("Schema"));
         expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
       });
 
@@ -689,7 +691,7 @@ describe("ModelDetailPage", () => {
         const action = createMockQueryAction({ model_id: modelCard.id });
         await setupActions({ model: modelCard, actions: [action] });
 
-        openActionMenu(action);
+        await openActionMenu(action);
 
         expect(await screen.findByText("View")).toBeInTheDocument();
       });
@@ -698,7 +700,7 @@ describe("ModelDetailPage", () => {
         const action = createMockQueryAction({ model_id: modelCard.id });
         await setupActions({ model: modelCard, actions: [action] });
 
-        openActionMenu(action);
+        await openActionMenu(action);
 
         expect(screen.queryByText("Archive")).not.toBeInTheDocument();
       });
@@ -804,8 +806,8 @@ describe("ModelDetailPage", () => {
       const action = createMockQueryAction({ model_id: modelCard.id });
       await setupActions({ model: modelCard, actions: [action] });
 
-      userEvent.click(screen.getByLabelText("Actions menu"));
-      userEvent.click(await screen.findByText("Create basic actions"));
+      await userEvent.click(screen.getByLabelText("Actions menu"));
+      await userEvent.click(await screen.findByText("Create basic actions"));
 
       await waitFor(() => {
         expect(createActionSpy).toHaveBeenCalledWith({
@@ -833,7 +835,7 @@ describe("ModelDetailPage", () => {
       const createActionSpy = jest.spyOn(ActionsApi, "create");
       await setupActions({ model: modelCard, actions: [] });
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole("button", { name: /Create basic action/i }),
       );
 
@@ -865,7 +867,7 @@ describe("ModelDetailPage", () => {
         actions: createMockImplicitCUDActions(modelCard.id),
       });
 
-      userEvent.click(screen.getByLabelText("Actions menu"));
+      await userEvent.click(screen.getByLabelText("Actions menu"));
 
       expect(
         screen.queryByText(/Create basic action/i),
@@ -875,7 +877,7 @@ describe("ModelDetailPage", () => {
     it("doesn't allow to disable implicit actions if they don't exist", async () => {
       await setupActions({ model: modelCard, actions: [] });
 
-      userEvent.click(screen.getByLabelText("Actions menu"));
+      await userEvent.click(screen.getByLabelText("Actions menu"));
 
       expect(
         screen.queryByText("Disable basic actions"),
@@ -935,21 +937,21 @@ describe("ModelDetailPage", () => {
         "true",
       );
 
-      userEvent.click(screen.getByText("Schema"));
+      await userEvent.click(screen.getByText("Schema"));
       expect(history?.getCurrentLocation().pathname).toBe(`${baseUrl}/schema`);
       expect(screen.getByRole("tab", { name: "Schema" })).toHaveAttribute(
         "aria-selected",
         "true",
       );
 
-      userEvent.click(screen.getByText("Actions"));
+      await userEvent.click(screen.getByText("Actions"));
       expect(history?.getCurrentLocation().pathname).toBe(`${baseUrl}/actions`);
       expect(screen.getByRole("tab", { name: "Actions" })).toHaveAttribute(
         "aria-selected",
         "true",
       );
 
-      userEvent.click(screen.getByText("Used by"));
+      await userEvent.click(screen.getByText("Used by"));
       expect(history?.getCurrentLocation().pathname).toBe(`${baseUrl}/usage`);
       expect(screen.getByRole("tab", { name: "Used by" })).toHaveAttribute(
         "aria-selected",

--- a/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/ProfileLink/ProfileLink.unit.spec.tsx
@@ -192,6 +192,6 @@ describe("ProfileLink", () => {
 });
 
 const openMenu = async () => {
-  userEvent.click(screen.getByRole("img", { name: /gear/i }));
+  await userEvent.click(screen.getByRole("img", { name: /gear/i }));
   await screen.findByRole("dialog");
 };

--- a/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchBar/SearchBar.unit.spec.tsx
@@ -90,7 +90,7 @@ describe("SearchBar", () => {
     it("should change URL when user types a query and hits `Enter`", async () => {
       const { history } = setup();
 
-      userEvent.type(getSearchBar(), "BC{enter}");
+      await userEvent.type(getSearchBar(), "BC{enter}");
 
       const location = history.getCurrentLocation();
       expect(location.pathname).toEqual("search");
@@ -100,7 +100,7 @@ describe("SearchBar", () => {
     it("should render 'No Results Found' when the query has no results", async () => {
       setup({ searchResultItems: [] });
       const searchBar = getSearchBar();
-      userEvent.type(searchBar, "XXXXX");
+      await userEvent.type(searchBar, "XXXXX");
       await waitForLoaderToBeRemoved();
 
       expect(screen.getByText("Didn't find anything")).toBeInTheDocument();
@@ -110,13 +110,13 @@ describe("SearchBar", () => {
   describe("focusing on search bar", () => {
     it("should render `Recent Searches` list when clicking the search bar", async () => {
       setup();
-      userEvent.click(getSearchBar());
+      await userEvent.click(getSearchBar());
       expect(await screen.findByText("Recents ABC")).toBeInTheDocument();
     });
 
     it("should render `Nothing here` and a folder icon if there are no recently viewed items", async () => {
       setup({ recentViewsItems: [] });
-      userEvent.click(getSearchBar());
+      await userEvent.click(getSearchBar());
       expect(await screen.findByText("Nothing here")).toBeInTheDocument();
     });
   });
@@ -124,8 +124,8 @@ describe("SearchBar", () => {
   describe("keyboard navigation", () => {
     it("should allow navigation through the search results with the keyboard", async () => {
       setup();
-      userEvent.click(getSearchBar());
-      userEvent.type(getSearchBar(), "BC");
+      await userEvent.click(getSearchBar());
+      await userEvent.type(getSearchBar(), "BC");
 
       // wait for dropdown to open
       await waitForLoaderToBeRemoved();
@@ -143,7 +143,7 @@ describe("SearchBar", () => {
       // There are two search results, each with a link to `Our analytics`,
       // so we want to navigate to the search result, then the collection link.
       for (const cardName of ["Card ABC", "Card BCD"]) {
-        userEvent.tab();
+        await userEvent.tab();
 
         const filteredElement = resultItems.find(element =>
           element.textContent?.includes(cardName),
@@ -152,7 +152,7 @@ describe("SearchBar", () => {
         expect(filteredElement).not.toBeUndefined();
         expect(screen.getByText(cardName)).toHaveFocus();
 
-        userEvent.tab();
+        await userEvent.tab();
 
         expect(
           within(filteredElement as HTMLElement).getByText("Our analytics"),
@@ -180,13 +180,13 @@ describe("SearchBar", () => {
   });
 
   describe("persisting search filters", () => {
-    it("should keep URL search filters when changing the text query", () => {
+    it("should keep URL search filters when changing the text query", async () => {
       const { history } = setup({
         initialRoute: "/search?q=foo&type=card",
       });
 
-      userEvent.clear(getSearchBar());
-      userEvent.type(getSearchBar(), "bar{enter}");
+      await userEvent.clear(getSearchBar());
+      await userEvent.type(getSearchBar(), "bar{enter}");
 
       const location = history.getCurrentLocation();
 
@@ -194,13 +194,13 @@ describe("SearchBar", () => {
       expect(location.search).toEqual("?q=bar&type=card");
     });
 
-    it("should not keep URL search filters when not in the search app", () => {
+    it("should not keep URL search filters when not in the search app", async () => {
       const { history } = setup({
         initialRoute: "/collection/root?q=foo&type=card&type=dashboard",
       });
 
-      userEvent.clear(getSearchBar());
-      userEvent.type(getSearchBar(), "bar{enter}");
+      await userEvent.clear(getSearchBar());
+      await userEvent.type(getSearchBar(), "bar{enter}");
 
       const location = history.getCurrentLocation();
 

--- a/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResults/SearchResults.unit.spec.tsx
@@ -109,7 +109,7 @@ describe("SearchResults", () => {
     await setup();
 
     for (const { name } of TEST_SEARCH_RESULTS) {
-      userEvent.keyboard("{arrowdown}");
+      await userEvent.keyboard("{arrowdown}");
 
       const resultItems = await screen.findAllByTestId("search-result-item");
 
@@ -125,7 +125,7 @@ describe("SearchResults", () => {
       forceEntitySelect: true,
     });
 
-    userEvent.click(screen.getByText(TEST_SEARCH_RESULTS[0].name));
+    await userEvent.click(screen.getByText(TEST_SEARCH_RESULTS[0].name));
 
     expect(onEntitySelect).toHaveBeenCalled();
     expect(onEntitySelect.mock.lastCall[0].name).toEqual(
@@ -142,7 +142,7 @@ describe("SearchResults", () => {
       forceEntitySelect: false,
     });
 
-    userEvent.click(screen.getByText(TEST_SEARCH_RESULTS[0].name));
+    await userEvent.click(screen.getByText(TEST_SEARCH_RESULTS[0].name));
 
     expect(onEntitySelect).not.toHaveBeenCalled();
     expect(history.getCurrentLocation().pathname).toEqual("/question/1-test-0");
@@ -159,7 +159,7 @@ describe("SearchResults", () => {
     const { history, onEntitySelect } = await setup({
       searchResults: [indexedEntityResult],
     });
-    userEvent.click(screen.getByText(indexedEntityResult.name));
+    await userEvent.click(screen.getByText(indexedEntityResult.name));
 
     expect(onEntitySelect).toHaveBeenCalled();
     expect(onEntitySelect.mock.lastCall[0].name).toEqual(

--- a/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.unit.spec.tsx
+++ b/frontend/src/metabase/nav/components/search/SearchResultsDropdown/SearchResultsDropdown.unit.spec.tsx
@@ -90,7 +90,7 @@ describe("SearchResultsDropdown", () => {
 
     expect(searchItem).toHaveTextContent("Test 1");
 
-    userEvent.click(searchItem);
+    await userEvent.click(searchItem);
 
     expect(history.getCurrentLocation().pathname).toEqual("/question/1-test-1");
   });
@@ -98,7 +98,7 @@ describe("SearchResultsDropdown", () => {
   it("should call goToSearchApp when the footer is clicked", async () => {
     const { goToSearchApp } = await setup();
     const footer = await screen.findByTestId("search-dropdown-footer");
-    userEvent.click(footer);
+    await userEvent.click(footer);
     expect(goToSearchApp).toHaveBeenCalled();
   });
 
@@ -107,7 +107,7 @@ describe("SearchResultsDropdown", () => {
       searchText: "Indexed record",
     });
     const searchItem = screen.getByText("Indexed record");
-    userEvent.click(searchItem);
+    await userEvent.click(searchItem);
     expect(onSearchItemSelect).toHaveBeenCalled();
   });
 

--- a/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
+++ b/frontend/src/metabase/nav/containers/AppBar/AppBar.unit.spec.tsx
@@ -91,7 +91,7 @@ describe("AppBar", () => {
         }
 
         expect(history.getCurrentLocation().pathname).toBe("/question/1");
-        userEvent.click(screen.getByTestId("main-logo"));
+        await userEvent.click(screen.getByTestId("main-logo"));
         expect(history.getCurrentLocation().pathname).toBe("/");
       });
     });
@@ -158,7 +158,7 @@ describe("AppBar", () => {
         }
 
         expect(history.getCurrentLocation().pathname).toBe("/question/1");
-        userEvent.click(screen.getByTestId("main-logo"));
+        await userEvent.click(screen.getByTestId("main-logo"));
         expect(history.getCurrentLocation().pathname).toBe("/");
       });
     });

--- a/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterLinkedFilters/ParameterLinkedFilters.unit.spec.tsx
@@ -29,7 +29,7 @@ const setup = ({ parameter, otherParameters }: SetupOpts) => {
 };
 
 describe("ParameterLinkedFilters", () => {
-  it("should toggle filtering parameters", () => {
+  it("should toggle filtering parameters", async () => {
     const { onChangeFilteringParameters } = setup({
       parameter: createMockUiParameter({
         id: "p1",
@@ -43,7 +43,7 @@ describe("ParameterLinkedFilters", () => {
       ],
     });
 
-    userEvent.click(screen.getByRole("switch"));
+    await userEvent.click(screen.getByRole("switch"));
 
     expect(onChangeFilteringParameters).toHaveBeenCalledWith(["p2"]);
   });

--- a/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSettings/ParameterSettings.unit.spec.tsx
@@ -10,15 +10,15 @@ interface SetupOpts {
   parameter?: UiParameter;
 }
 
-function fillValue(input: HTMLElement, value: string) {
-  userEvent.clear(input);
+async function fillValue(input: HTMLElement, value: string) {
+  await userEvent.clear(input);
   if (value.length) {
-    userEvent.type(input, value);
+    await userEvent.type(input, value);
   }
 }
 
 describe("ParameterSidebar", () => {
-  it("should allow to change source settings for string parameters", () => {
+  it("should allow to change source settings for string parameters", async () => {
     const { onChangeQueryType } = setup({
       parameter: createMockUiParameter({
         type: "string/=",
@@ -26,12 +26,12 @@ describe("ParameterSidebar", () => {
       }),
     });
 
-    userEvent.click(screen.getByRole("radio", { name: "Search box" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Search box" }));
 
     expect(onChangeQueryType).toHaveBeenCalledWith("search");
   });
 
-  it("should not update the label if the input is blank", () => {
+  it("should not update the label if the input is blank", async () => {
     const { onChangeName } = setup({
       parameter: createMockUiParameter({
         name: "foo",
@@ -41,7 +41,7 @@ describe("ParameterSidebar", () => {
     });
     const labelInput = screen.getByLabelText("Label");
     expect(labelInput).toHaveValue("foo");
-    fillValue(labelInput, "");
+    await fillValue(labelInput, "");
     // expect there to be an error message with the text "Required"
     expect(screen.getByText(/required/i)).toBeInTheDocument();
     labelInput.blur();
@@ -52,13 +52,13 @@ describe("ParameterSidebar", () => {
     expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
 
     // sanity check with a non-blank value
-    fillValue(labelInput, "bar");
+    await fillValue(labelInput, "bar");
     labelInput.blur();
     expect(onChangeName).toHaveBeenCalledWith("bar");
     expect(labelInput).toHaveValue("bar");
   });
 
-  it("should not update the label if the input is any variation of the word 'tab'", () => {
+  it("should not update the label if the input is any variation of the word 'tab'", async () => {
     const { onChangeName } = setup({
       parameter: createMockUiParameter({
         name: "foo",
@@ -68,7 +68,7 @@ describe("ParameterSidebar", () => {
     });
     const labelInput = screen.getByLabelText("Label");
     expect(labelInput).toHaveValue("foo");
-    fillValue(labelInput, "tAb");
+    await fillValue(labelInput, "tAb");
     // expect there to be an error message with the text "reserved"
     expect(screen.getByText(/reserved/i)).toBeInTheDocument();
     labelInput.blur();
@@ -79,13 +79,13 @@ describe("ParameterSidebar", () => {
     expect(screen.queryByText(/reserved/i)).not.toBeInTheDocument();
 
     // sanity check with a non-blank value
-    fillValue(labelInput, "bar");
+    await fillValue(labelInput, "bar");
     labelInput.blur();
     expect(onChangeName).toHaveBeenCalledWith("bar");
     expect(labelInput).toHaveValue("bar");
   });
 
-  it("should allow to change source settings for location parameters", () => {
+  it("should allow to change source settings for location parameters", async () => {
     const { onChangeQueryType } = setup({
       parameter: createMockUiParameter({
         type: "string/=",
@@ -93,7 +93,7 @@ describe("ParameterSidebar", () => {
       }),
     });
 
-    userEvent.click(screen.getByRole("radio", { name: "Input box" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Input box" }));
 
     expect(onChangeQueryType).toHaveBeenCalledWith("none");
   });

--- a/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterSidebar/ParameterSidebar.unit.spec.tsx
@@ -18,7 +18,7 @@ const setup = ({
   nextParameter,
   otherParameters,
 }: SetupOpts): {
-  clickNextParameterButton: () => void;
+  clickNextParameterButton: () => Promise<void>;
 } => {
   const NEXT_PARAMETER_BUTTON_ID = "parameter-sidebar-test-change";
 
@@ -75,13 +75,13 @@ const setup = ({
   };
 };
 
-function fillValue(input: HTMLElement, value: string) {
-  userEvent.clear(input);
-  userEvent.type(input, value);
+async function fillValue(input: HTMLElement, value: string) {
+  await userEvent.clear(input);
+  await userEvent.type(input, value);
 }
 
 describe("ParameterSidebar", () => {
-  it("should not update the label if the slug is duplicated with another parameter", () => {
+  it("should not update the label if the slug is duplicated with another parameter", async () => {
     setup({
       initialParameter: createMockUiParameter({
         id: "id2",
@@ -97,9 +97,9 @@ describe("ParameterSidebar", () => {
       ],
     });
 
-    userEvent.click(screen.getByRole("radio", { name: "Settings" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Settings" }));
     const labelInput = screen.getByLabelText("Label");
-    fillValue(labelInput, "Baz");
+    await fillValue(labelInput, "Baz");
     // expect there to be an error message with the text "This label is already in use"
     const error = /this label is already in use/i;
     expect(screen.getByText(error)).toBeInTheDocument();
@@ -110,12 +110,12 @@ describe("ParameterSidebar", () => {
     expect(screen.queryByText(error)).not.toBeInTheDocument();
 
     // sanity check with another value
-    fillValue(labelInput, "Bar");
+    await fillValue(labelInput, "Bar");
     labelInput.blur();
     expect(labelInput).toHaveValue("Bar");
   });
 
-  it("if the parameter updates, the label should update (metabase#34611)", () => {
+  it("if the parameter updates, the label should update (metabase#34611)", async () => {
     const initialParameter = createMockUiParameter({
       id: "id1",
       name: "Foo",
@@ -134,7 +134,7 @@ describe("ParameterSidebar", () => {
 
     const labelInput = screen.getByLabelText("Label");
     expect(labelInput).toHaveValue("Foo");
-    clickNextParameterButton();
+    await clickNextParameterButton();
     expect(labelInput).toHaveValue("Bar");
   });
 });

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ListPicker/ListPicker.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ListPicker/ListPicker.unit.spec.tsx
@@ -51,19 +51,19 @@ function setup(value: string, values: string[], searchDebounceMs?: number) {
 }
 
 describe("ListPicker", () => {
-  it("onSearchChange fires only once per input char", () => {
+  it("onSearchChange fires only once per input char", async () => {
     const { onSearchChange } = setup("", VALUES.slice());
 
     const select = screen.getByPlaceholderText("Pick values");
     expect(onSearchChange).toHaveBeenCalledTimes(1);
     expect(onSearchChange).toHaveBeenCalledWith("");
 
-    userEvent.click(select);
-    userEvent.type(select, "A");
+    await userEvent.click(select);
+    await userEvent.type(select, "A");
     expect(onSearchChange).toHaveBeenCalledTimes(2);
     expect(onSearchChange).toHaveBeenCalledWith("A");
 
-    userEvent.type(select, "B");
+    await userEvent.type(select, "B");
     expect(onSearchChange).toHaveBeenCalledTimes(3);
     expect(onSearchChange).toHaveBeenCalledWith("AB");
   });
@@ -72,12 +72,12 @@ describe("ListPicker", () => {
     const { onSearchChange } = setup("", VALUES.slice(), 100);
     const select = screen.getByPlaceholderText("Pick values");
 
-    userEvent.click(select);
-    userEvent.type(select, "H");
-    userEvent.type(select, "e");
-    userEvent.type(select, "l");
-    userEvent.type(select, "l");
-    userEvent.type(select, "o");
+    await userEvent.click(select);
+    await userEvent.type(select, "H");
+    await userEvent.type(select, "e");
+    await userEvent.type(select, "l");
+    await userEvent.type(select, "l");
+    await userEvent.type(select, "o");
 
     await waitFor(() => expect(onSearchChange).toHaveBeenCalledTimes(1));
     expect(onSearchChange).toHaveBeenCalledWith("Hello");
@@ -87,10 +87,10 @@ describe("ListPicker", () => {
     const { onSearchChange, unmount } = setup("", VALUES.slice(), 100);
     const select = screen.getByPlaceholderText("Pick values");
 
-    userEvent.click(select);
-    userEvent.type(select, "B");
-    userEvent.type(select, "y");
-    userEvent.type(select, "e");
+    await userEvent.click(select);
+    await userEvent.type(select, "B");
+    await userEvent.type(select, "y");
+    await userEvent.type(select, "e");
     unmount();
 
     // Careful, this won't catch calling it after the component was unmounted

--- a/frontend/src/metabase/parameters/components/ParameterValuePicker/ListPickerConnected/ListPickerConnected.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterValuePicker/ListPickerConnected/ListPickerConnected.unit.spec.tsx
@@ -169,13 +169,15 @@ function setup({
 
 describe("ListPickerConnected", () => {
   describe("static value list", () => {
-    it("without values", () => {
+    it("without values", async () => {
       const { onChangeMock, fetchValuesMock } = setup({
         value: null,
         parameter: getStaticListParam([]),
       });
 
-      userEvent.click(screen.getByPlaceholderText("Select a default value…"));
+      await userEvent.click(
+        screen.getByPlaceholderText("Select a default value…"),
+      );
       expect(screen.getByText("No matching result")).toBeVisible();
 
       expect(onChangeMock).toHaveBeenCalledTimes(0);
@@ -190,19 +192,21 @@ describe("ListPickerConnected", () => {
 
       // there's a hidden input with the same value that you can't click
       const input = screen.getByRole("searchbox");
-      userEvent.click(input);
+      await userEvent.click(input);
       STATIC_VALUES.forEach(value =>
         expect(screen.getByText(value)).toBeVisible(),
       );
 
-      act(() => userEvent.click(screen.getByText("1 Joseph Drive")));
+      await act(
+        async () => await userEvent.click(screen.getByText("1 Joseph Drive")),
+      );
 
       expect(onChangeMock).toHaveBeenCalledTimes(1);
       expect(onChangeMock).toHaveBeenCalledWith("1 Joseph Drive");
       expect(fetchValuesMock).toHaveBeenCalledTimes(0);
     });
 
-    it("filters on search", () => {
+    it("filters on search", async () => {
       setup({
         value: null,
         parameter: getStaticListParam(STATIC_VALUES, "search"),
@@ -210,8 +214,8 @@ describe("ListPickerConnected", () => {
 
       const select = screen.getByPlaceholderText("Start typing to filter…");
 
-      userEvent.click(select);
-      userEvent.type(select, "Road");
+      await userEvent.click(select);
+      await userEvent.type(select, "Road");
 
       STATIC_VALUES.filter(value => value.includes("Road")).forEach(value => {
         const listItem = screen.queryByText(value);
@@ -224,36 +228,48 @@ describe("ListPickerConnected", () => {
       });
     });
 
-    it("clears value when clicked on close", () => {
+    it("clears value when clicked on close", async () => {
       const { onChangeMock } = setup({
         value: "1-1245 Lee Road 146",
         parameter: getStaticListParam(),
       });
 
-      userEvent.click(screen.getByLabelText("close icon"));
+      await userEvent.click(screen.getByLabelText("close icon"));
       expect(onChangeMock).toHaveBeenCalledTimes(1);
       expect(onChangeMock).toHaveBeenCalledWith(null);
       onChangeMock.mockClear();
 
-      act(() =>
-        userEvent.click(screen.getByPlaceholderText("Select a default value…")),
+      await act(
+        async () =>
+          await userEvent.click(
+            screen.getByPlaceholderText("Select a default value…"),
+          ),
       );
-      act(() => userEvent.click(screen.getByText("1-7 County Road 462")));
+      await act(
+        async () =>
+          await userEvent.click(screen.getByText("1-7 County Road 462")),
+      );
 
       expect(onChangeMock).toHaveBeenCalledTimes(1);
       expect(onChangeMock).toHaveBeenCalledWith("1-7 County Road 462");
     });
 
-    it("resets and keeps working when re-rendering with another parameter", () => {
+    it("resets and keeps working when re-rendering with another parameter", async () => {
       const render1 = setup({
         value: null,
         parameter: getStaticListParam(),
       });
 
-      act(() =>
-        userEvent.click(screen.getByPlaceholderText("Select a default value…")),
+      await act(
+        async () =>
+          await userEvent.click(
+            screen.getByPlaceholderText("Select a default value…"),
+          ),
       );
-      act(() => userEvent.click(screen.getByText("1-7 County Road 462")));
+      await act(
+        async () =>
+          await userEvent.click(screen.getByText("1-7 County Road 462")),
+      );
 
       render1.onChangeMock.mockClear();
 
@@ -261,7 +277,9 @@ describe("ListPickerConnected", () => {
       expect(render1.onChangeMock).toHaveBeenCalledTimes(1);
       expect(render1.onChangeMock).toHaveBeenCalledWith(null);
 
-      userEvent.click(screen.getByPlaceholderText("Select a default value…"));
+      await userEvent.click(
+        screen.getByPlaceholderText("Select a default value…"),
+      );
       OTHER_VALUES.forEach(value => {
         expect(screen.getByText(value)).toBeVisible();
       });
@@ -273,18 +291,24 @@ describe("ListPickerConnected", () => {
         parameter: getAnotherStaticListParam(),
       });
 
-      act(() =>
-        userEvent.click(screen.getByPlaceholderText("Select a default value…")),
+      await act(
+        async () =>
+          await userEvent.click(
+            screen.getByPlaceholderText("Select a default value…"),
+          ),
       );
       OTHER_VALUES.forEach(value => {
         expect(screen.getByText(value)).toBeVisible();
       });
-      act(() => userEvent.click(screen.getByText("AL")));
+      await act(async () => await userEvent.click(screen.getByText("AL")));
 
-      act(() =>
-        userEvent.click(screen.getByPlaceholderText("Select a default value…")),
+      await act(
+        async () =>
+          await userEvent.click(
+            screen.getByPlaceholderText("Select a default value…"),
+          ),
       );
-      act(() => userEvent.click(screen.getByText("CA")));
+      await act(async () => await userEvent.click(screen.getByText("CA")));
       expect(render2.onChangeMock).toHaveBeenCalledTimes(2);
       expect(render2.onChangeMock).toHaveBeenCalledWith("AL");
       expect(render2.onChangeMock).toHaveBeenCalledWith("CA");
@@ -293,7 +317,9 @@ describe("ListPickerConnected", () => {
       render2.rerender(null, getAnotherStaticListParam());
       expect(render2.onChangeMock).toHaveBeenCalledTimes(0);
 
-      userEvent.click(screen.getByPlaceholderText("Select a default value…"));
+      await userEvent.click(
+        screen.getByPlaceholderText("Select a default value…"),
+      );
       OTHER_VALUES.forEach(value => {
         expect(screen.getByText(value)).toBeVisible();
       });
@@ -397,7 +423,7 @@ async function checkFetch(mock: jest.Mock, callValue: string, value: string) {
 }
 
 async function clickCheckChange(mock: jest.Mock, calls: number, value: string) {
-  act(() => userEvent.click(screen.getByText(value)));
+  await act(async () => await userEvent.click(screen.getByText(value)));
   await waitFor(() => expect(mock).toHaveBeenCalledWith(value));
   await waitFor(() => expect(mock).toHaveBeenCalledTimes(calls));
 }

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.unit.spec.tsx
@@ -1,5 +1,7 @@
 import { screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import userEvent, {
+  PointerEventsCheckLevel,
+} from "@testing-library/user-event";
 
 import { renderWithProviders } from "__support__/ui";
 import Field from "metabase-lib/v1/metadata/Field";
@@ -38,38 +40,39 @@ describe("ParameterWidget", () => {
     expect(screen.getByText("Text contains")).toBeInTheDocument();
   });
 
-  it("should be able to set parameter value", () => {
+  it("should be able to set parameter value", async () => {
     const { setValue } = setup();
 
-    userEvent.click(screen.getByText("Text contains"));
-    userEvent.type(screen.getByPlaceholderText("Enter some text"), "Gadget");
+    await userEvent.click(screen.getByText("Text contains"));
+    await userEvent.type(
+      screen.getByPlaceholderText("Enter some text"),
+      "Gadget",
+    );
 
-    userEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    await userEvent.click(screen.getByRole("button", { name: "Add filter" }));
     expect(setValue).toHaveBeenCalledWith(["Gadget"]);
   });
 
-  it("should not be able to submit empty value (metabase#15462)", () => {
+  it("should not be able to submit empty value (metabase#15462)", async () => {
     const { setValue } = setup();
 
-    userEvent.click(screen.getByText("Text contains"));
+    await userEvent.click(screen.getByText("Text contains"));
 
     const text = "Gadget";
     const textInput = screen.getByPlaceholderText("Enter some text");
-    userEvent.type(textInput, text);
+    await userEvent.type(textInput, text);
     expect(screen.getByRole("button", { name: "Add filter" })).toBeEnabled();
 
-    userEvent.type(textInput, "{backspace}".repeat(text.length));
+    await userEvent.type(textInput, "{backspace}".repeat(text.length));
     expect(screen.getByRole("button", { name: "Add filter" })).toBeDisabled();
 
-    userEvent.click(
-      screen.getByRole("button", { name: "Add filter" }),
-      undefined,
-      { skipPointerEventsCheck: true },
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Add filter" }), {
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
     expect(setValue).not.toHaveBeenCalled();
   });
 
-  it("should not be able to submit empty value when parameter has connected field (metabase#15462)", () => {
+  it("should not be able to submit empty value when parameter has connected field (metabase#15462)", async () => {
     const field = new Field(
       createMockField({
         id: 1,
@@ -80,21 +83,19 @@ describe("ParameterWidget", () => {
     );
     const { setValue } = setup({ connectedField: field });
 
-    userEvent.click(screen.getByText("Text contains"));
+    await userEvent.click(screen.getByText("Text contains"));
 
     const text = "Gadget";
     const textInput = screen.getByPlaceholderText("Enter some text");
-    userEvent.type(textInput, text);
+    await userEvent.type(textInput, text);
     expect(screen.getByRole("button", { name: "Add filter" })).toBeEnabled();
 
-    userEvent.type(textInput, "{backspace}".repeat(text.length));
+    await userEvent.type(textInput, "{backspace}".repeat(text.length));
     expect(screen.getByRole("button", { name: "Add filter" })).toBeDisabled();
 
-    userEvent.click(
-      screen.getByRole("button", { name: "Add filter" }),
-      undefined,
-      { skipPointerEventsCheck: true },
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Add filter" }), {
+      pointerEventsCheck: PointerEventsCheckLevel.Never,
+    });
     expect(setValue).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceModal.unit.spec.tsx
@@ -127,7 +127,7 @@ describe("ValuesSourceModal", () => {
       });
       expect(screen.getByRole("textbox")).toHaveValue("C\nD");
 
-      userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
+      await userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
       expect(screen.getByRole("radio", { name: "Custom list" })).toBeChecked();
       expect(screen.getByRole("textbox")).toHaveValue("C\nD");
     });
@@ -148,7 +148,7 @@ describe("ValuesSourceModal", () => {
         screen.getByText(/We don’t have any cached values/),
       ).toBeInTheDocument();
 
-      userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
+      await userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
       expect(screen.getByRole("radio", { name: "Custom list" })).toBeChecked();
       expect(screen.getByRole("textbox")).toHaveValue("A\nB");
     });
@@ -206,13 +206,15 @@ describe("ValuesSourceModal", () => {
         ],
       });
 
-      userEvent.click(screen.getByRole("button", { name: /Pick a column/ }));
+      await userEvent.click(
+        screen.getByRole("button", { name: /Pick a column/ }),
+      );
       expect(
         screen.queryByRole("heading", { name: "ID" }),
       ).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByRole("heading", { name: "Category" }));
-      userEvent.click(screen.getByRole("button", { name: "Done" }));
+      await userEvent.click(screen.getByRole("heading", { name: "Category" }));
+      await userEvent.click(screen.getByRole("button", { name: "Done" }));
       expect(onSubmit).toHaveBeenCalledWith("card", {
         card_id: 1,
         value_field: ["field", 2, null],
@@ -277,10 +279,10 @@ describe("ValuesSourceModal", () => {
         hasCollectionAccess: false,
       });
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole("radio", { name: "From another model or question" }),
       );
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole("button", { name: /Pick a model or question…/ }),
       );
 
@@ -349,7 +351,7 @@ describe("ValuesSourceModal", () => {
       });
       expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
 
-      userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
+      await userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
       expect(screen.getByRole("radio", { name: "Custom list" })).toBeChecked();
       expect(screen.getByRole("textbox")).toHaveValue("A\nB\nC");
     });
@@ -359,9 +361,9 @@ describe("ValuesSourceModal", () => {
     it("should set static list values", async () => {
       const { onSubmit } = await setup();
 
-      userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
-      userEvent.type(screen.getByRole("textbox"), "Gadget\nWidget");
-      userEvent.click(screen.getByRole("button", { name: "Done" }));
+      await userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
+      await userEvent.type(screen.getByRole("textbox"), "Gadget\nWidget");
+      await userEvent.click(screen.getByRole("button", { name: "Done" }));
 
       expect(onSubmit).toHaveBeenCalledWith("static-list", {
         values: ["Gadget", "Widget"],
@@ -379,10 +381,10 @@ describe("ValuesSourceModal", () => {
         }),
       });
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByRole("radio", { name: "From connected fields" }),
       );
-      userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
+      await userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
 
       expect(screen.getByRole("textbox")).toHaveValue("Gadget\nWidget");
     });

--- a/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceSettings/ValuesSourceSettings.unit.spec.tsx
@@ -33,38 +33,43 @@ describe("ValuesSourceSettings", () => {
     ["string/=", "search"],
     ["category", "list"],
     ["category", "search"],
-  ])("should allow changing values settings for %s, %s", (type, queryType) => {
-    const { onChangeSourceSettings } = setup({
-      parameter: createMockParameter({
-        type,
-        values_query_type: queryType,
-      }),
-    });
+  ])(
+    "should allow changing values settings for %s, %s",
+    async (type, queryType) => {
+      const { onChangeSourceSettings } = setup({
+        parameter: createMockParameter({
+          type,
+          values_query_type: queryType,
+        }),
+      });
 
-    userEvent.click(screen.getByRole("button", { name: "Edit" }));
-    userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
-    userEvent.type(screen.getByRole("textbox"), "A");
-    userEvent.click(screen.getByRole("button", { name: "Done" }));
+      await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+      await userEvent.click(screen.getByRole("radio", { name: "Custom list" }));
+      await userEvent.type(screen.getByRole("textbox"), "A");
+      await userEvent.click(screen.getByRole("button", { name: "Done" }));
 
-    expect(onChangeSourceSettings).toHaveBeenCalledWith("static-list", {
-      values: ["A"],
-    });
-  });
+      expect(onChangeSourceSettings).toHaveBeenCalledWith("static-list", {
+        values: ["A"],
+      });
+    },
+  );
 
-  it("editing the values source should be disabled when the filter has linked filters", () => {
+  it("editing the values source should be disabled when the filter has linked filters", async () => {
     setup({
       parameter: createMockParameter({
         filteringParameters: ["2"],
       }),
     });
 
-    userEvent.click(screen.getByRole("radio", { name: "Dropdown list" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Dropdown list" }));
     expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
-    userEvent.click(screen.getByRole("radio", { name: "Search box" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Search box" }));
     expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
 
     // hovering over the button shows the tooltip"
-    userEvent.hover(screen.getByTestId("values-source-settings-edit-btn"));
+    await userEvent.hover(
+      screen.getByTestId("values-source-settings-edit-btn"),
+    );
     expect(
       screen.getByText(
         "You can’t customize selectable values for this filter because it is linked to another one.",
@@ -72,20 +77,22 @@ describe("ValuesSourceSettings", () => {
     ).toBeInTheDocument();
   });
 
-  it("Editing the values source should be enabled when the filter has no linked filters", () => {
+  it("Editing the values source should be enabled when the filter has no linked filters", async () => {
     setup({
       parameter: createMockParameter({
         filteringParameters: [],
       }),
     });
 
-    userEvent.click(screen.getByRole("radio", { name: "Dropdown list" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Dropdown list" }));
     expect(screen.getByRole("button", { name: "Edit" })).toBeEnabled();
-    userEvent.click(screen.getByRole("radio", { name: "Search box" }));
+    await userEvent.click(screen.getByRole("radio", { name: "Search box" }));
     expect(screen.getByRole("button", { name: "Edit" })).toBeEnabled();
 
     // hovering over the button doesn't show the tooltip
-    userEvent.hover(screen.getByTestId("values-source-settings-edit-btn"));
+    await userEvent.hover(
+      screen.getByTestId("values-source-settings-edit-btn"),
+    );
     expect(
       screen.queryByText(
         "You can’t customize selectable values for this filter because it is linked to another one.",

--- a/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/NumberInputWidget/NumberInputWidget.unit.spec.tsx
@@ -42,7 +42,7 @@ describe("NumberInputWidget", () => {
       expect(textbox).toHaveAttribute("placeholder", "Enter a number");
     });
 
-    it("should render a disabled update button, until the value is changed", () => {
+    it("should render a disabled update button, until the value is changed", async () => {
       render(
         <NumberInputWidget
           value={[123]}
@@ -55,11 +55,11 @@ describe("NumberInputWidget", () => {
       expect(button).toBeInTheDocument();
       expect(button).toBeDisabled();
 
-      userEvent.type(screen.getByRole("textbox"), "456");
+      await userEvent.type(screen.getByRole("textbox"), "456");
       expect(button).toBeEnabled();
     });
 
-    it("should let you update the input with a new value", () => {
+    it("should let you update the input with a new value", async () => {
       render(
         <NumberInputWidget
           value={[123]}
@@ -69,14 +69,14 @@ describe("NumberInputWidget", () => {
       );
 
       const textbox = screen.getByRole("textbox");
-      userEvent.clear(textbox);
-      userEvent.type(textbox, "456");
+      await userEvent.clear(textbox);
+      await userEvent.type(textbox, "456");
       const button = screen.getByRole("button", { name: "Update filter" });
-      userEvent.click(button);
+      await userEvent.click(button);
       expect(mockSetValue).toHaveBeenCalledWith([456]);
     });
 
-    it("should let you update the input with an undefined value", () => {
+    it("should let you update the input with an undefined value", async () => {
       render(
         <NumberInputWidget
           value={[1]}
@@ -87,8 +87,8 @@ describe("NumberInputWidget", () => {
 
       const textbox = screen.getByRole("textbox");
       const button = screen.getByRole("button", { name: "Update filter" });
-      userEvent.type(textbox, "{backspace}");
-      userEvent.click(button);
+      await userEvent.type(textbox, "{backspace}");
+      await userEvent.click(button);
       expect(mockSetValue).toHaveBeenCalledWith(undefined);
     });
   });
@@ -112,7 +112,7 @@ describe("NumberInputWidget", () => {
       expect(textbox2).toHaveValue("456");
     });
 
-    it("should be invalid when one of the inputs is empty", () => {
+    it("should be invalid when one of the inputs is empty", async () => {
       render(
         <NumberInputWidget
           arity={2}
@@ -123,12 +123,12 @@ describe("NumberInputWidget", () => {
       );
 
       const [textbox1] = screen.getAllByRole("textbox");
-      userEvent.clear(textbox1);
+      await userEvent.clear(textbox1);
       const button = screen.getByRole("button", { name: "Update filter" });
       expect(button).toBeDisabled();
     });
 
-    it("should be settable", () => {
+    it("should be settable", async () => {
       render(
         <NumberInputWidget
           arity={2}
@@ -139,16 +139,16 @@ describe("NumberInputWidget", () => {
       );
 
       const [textbox1, textbox2] = screen.getAllByRole("textbox");
-      userEvent.type(textbox1, "1");
-      userEvent.type(textbox2, "2");
+      await userEvent.type(textbox1, "1");
+      await userEvent.type(textbox2, "2");
 
       const button = screen.getByRole("button", { name: "Add filter" });
-      userEvent.click(button);
+      await userEvent.click(button);
 
       expect(mockSetValue).toHaveBeenCalledWith([1, 2]);
     });
 
-    it("should be clearable by emptying all inputs", () => {
+    it("should be clearable by emptying all inputs", async () => {
       render(
         <NumberInputWidget
           arity={2}
@@ -159,11 +159,11 @@ describe("NumberInputWidget", () => {
       );
 
       const [textbox1, textbox2] = screen.getAllByRole("textbox");
-      userEvent.clear(textbox1);
-      userEvent.clear(textbox2);
+      await userEvent.clear(textbox1);
+      await userEvent.clear(textbox2);
 
       const button = screen.getByRole("button", { name: "Update filter" });
-      userEvent.click(button);
+      await userEvent.click(button);
 
       expect(mockSetValue).toHaveBeenCalledWith(undefined);
     });
@@ -184,7 +184,7 @@ describe("NumberInputWidget", () => {
       expect(values).toHaveTextContent("1234");
     });
 
-    it("should correctly parse number inputs", () => {
+    it("should correctly parse number inputs", async () => {
       render(
         <NumberInputWidget
           arity="n"
@@ -195,17 +195,17 @@ describe("NumberInputWidget", () => {
       );
 
       const input = screen.getByRole("textbox");
-      userEvent.type(input, "foo{enter}123abc{enter}456{enter}");
+      await userEvent.type(input, "foo{enter}123abc{enter}456{enter}");
 
       const values = screen.getAllByRole("list")[0];
       expect(values).toHaveTextContent("123456");
 
       const button = screen.getByRole("button", { name: "Add filter" });
-      userEvent.click(button);
+      await userEvent.click(button);
       expect(mockSetValue).toHaveBeenCalledWith([123, 456]);
     });
 
-    it("should be unsettable", () => {
+    it("should be unsettable", async () => {
       render(
         <NumberInputWidget
           arity="n"
@@ -216,11 +216,11 @@ describe("NumberInputWidget", () => {
       );
 
       const input = screen.getByRole("textbox");
-      userEvent.type(input, "{backspace}{backspace}");
+      await userEvent.type(input, "{backspace}{backspace}");
 
       const button = screen.getByRole("button", { name: "Update filter" });
 
-      userEvent.click(button);
+      await userEvent.click(button);
       expect(mockSetValue).toHaveBeenCalledWith(undefined);
     });
   });

--- a/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.unit.spec.tsx
+++ b/frontend/src/metabase/parameters/components/widgets/StringInputWidget/StringInputWidget.unit.spec.tsx
@@ -42,7 +42,7 @@ describe("StringInputWidget", () => {
       expect(textbox).toHaveAttribute("placeholder", "Enter some text");
     });
 
-    it("should render a disabled update button, until the value is changed", () => {
+    it("should render a disabled update button, until the value is changed", async () => {
       render(
         <StringInputWidget
           value={["foo"]}
@@ -55,11 +55,11 @@ describe("StringInputWidget", () => {
       expect(button).toBeInTheDocument();
       expect(button).toBeDisabled();
 
-      userEvent.type(screen.getByRole("textbox"), "bar");
+      await userEvent.type(screen.getByRole("textbox"), "bar");
       expect(button).toBeEnabled();
     });
 
-    it("should let you update the input with a new value", () => {
+    it("should let you update the input with a new value", async () => {
       render(
         <StringInputWidget
           value={["foo"]}
@@ -69,13 +69,13 @@ describe("StringInputWidget", () => {
       );
 
       const textbox = screen.getByRole("textbox");
-      userEvent.type(textbox, "{backspace}{backspace}{backspace}bar");
+      await userEvent.type(textbox, "{backspace}{backspace}{backspace}bar");
       const button = screen.getByRole("button", { name: "Update filter" });
-      userEvent.click(button);
+      await userEvent.click(button);
       expect(mockSetValue).toHaveBeenCalledWith(["bar"]);
     });
 
-    it("should let you update the input with an undefined value", () => {
+    it("should let you update the input with an undefined value", async () => {
       render(
         <StringInputWidget
           value={["a"]}
@@ -86,8 +86,8 @@ describe("StringInputWidget", () => {
 
       const textbox = screen.getByRole("textbox");
       const button = screen.getByRole("button", { name: "Update filter" });
-      userEvent.type(textbox, "{backspace}{enter}");
-      userEvent.click(button);
+      await userEvent.type(textbox, "{backspace}{enter}");
+      await userEvent.click(button);
       expect(mockSetValue).toHaveBeenCalledWith(undefined);
     });
   });
@@ -107,7 +107,7 @@ describe("StringInputWidget", () => {
       expect(values).toHaveTextContent("foobar");
     });
 
-    it("should correctly parse number inputs", () => {
+    it("should correctly parse number inputs", async () => {
       render(
         <StringInputWidget
           arity="n"
@@ -118,17 +118,17 @@ describe("StringInputWidget", () => {
       );
 
       const input = screen.getByRole("textbox");
-      userEvent.type(input, "foo{enter}bar{enter}baz{enter}");
+      await userEvent.type(input, "foo{enter}bar{enter}baz{enter}");
 
       const values = screen.getAllByRole("list")[0];
       expect(values).toHaveTextContent("foobarbaz");
 
       const button = screen.getByRole("button", { name: "Add filter" });
-      userEvent.click(button);
+      await userEvent.click(button);
       expect(mockSetValue).toHaveBeenCalledWith(["foo", "bar", "baz"]);
     });
 
-    it("should be unsettable", () => {
+    it("should be unsettable", async () => {
       render(
         <StringInputWidget
           arity="n"
@@ -139,11 +139,11 @@ describe("StringInputWidget", () => {
       );
 
       const input = screen.getByRole("textbox");
-      userEvent.type(input, "{backspace}{backspace}");
+      await userEvent.type(input, "{backspace}{backspace}");
 
       const button = screen.getByRole("button", { name: "Update filter" });
 
-      userEvent.click(button);
+      await userEvent.click(button);
       expect(mockSetValue).toHaveBeenCalledWith(undefined);
     });
   });

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.unit.spec.tsx
@@ -68,20 +68,20 @@ describe("EmbedModal", () => {
     );
   });
 
-  it("should go to the legalese step when `Next` is clicked", () => {
+  it("should go to the legalese step when `Next` is clicked", async () => {
     setup();
 
-    userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByText("Next"));
 
     expect(screen.getByTestId("test-embed-step")).toHaveTextContent("legalese");
   });
 
-  it("should go to the legalese step then the static embedding step if the user has not accepted the embedding terms", () => {
+  it("should go to the legalese step then the static embedding step if the user has not accepted the embedding terms", async () => {
     setup({ showStaticEmbedTerms: true });
-    userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByText("Next"));
     expect(screen.getByTestId("test-embed-step")).toHaveTextContent("legalese");
 
-    userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByText("Next"));
     expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
       "application",
     );
@@ -90,7 +90,7 @@ describe("EmbedModal", () => {
   it("should immediately go to the static embedding step if the user has accepted the terms", async () => {
     setup({ showStaticEmbedTerms: false });
 
-    userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByText("Next"));
     expect(
       within(screen.getByTestId("modal-header")).getByText("Static embedding"),
     ).toBeInTheDocument();
@@ -99,21 +99,21 @@ describe("EmbedModal", () => {
     );
   });
 
-  it("returns to the initial embed modal landing when the user clicks the modal title", () => {
+  it("returns to the initial embed modal landing when the user clicks the modal title", async () => {
     setup();
 
-    userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByText("Next"));
     expect(screen.getByTestId("test-embed-step")).toHaveTextContent("legalese");
 
-    userEvent.click(screen.getByText("Static embedding"));
+    await userEvent.click(screen.getByText("Static embedding"));
     expect(screen.getByTestId("test-embed-step")).toHaveTextContent(
       "Embed Landing",
     );
   });
 
-  it("calls onClose when the modal is closed", () => {
+  it("calls onClose when the modal is closed", async () => {
     const { onClose } = setup();
-    userEvent.click(screen.getByLabelText("close icon"));
+    await userEvent.click(screen.getByLabelText("close icon"));
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModalContent/EmbedModalContent.unit.spec.tsx
@@ -18,12 +18,12 @@ describe("EmbedModalContent", () => {
       expect(screen.getByText("Public embed")).toBeInTheDocument();
     });
 
-    it("should switch to StaticEmbedSetupPane", () => {
+    it("should switch to StaticEmbedSetupPane", async () => {
       const { goToNextStep } = setup();
 
       expect(goToNextStep).toHaveBeenCalledTimes(0);
 
-      userEvent.click(screen.getByText("Set this up"));
+      await userEvent.click(screen.getByText("Set this up"));
 
       expect(goToNextStep).toHaveBeenCalledTimes(1);
     });

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/InteractiveEmbeddingCTA/InteractiveEmbeddingCTA.unit.spec.tsx
@@ -29,7 +29,7 @@ const setup = ({ isPaidPlan }: { isPaidPlan: boolean }) => {
   };
 };
 describe("InteractiveEmbeddingCTA", () => {
-  it("renders correctly for paid plan", () => {
+  it("renders correctly for paid plan", async () => {
     const { history } = setup({ isPaidPlan: true });
 
     expect(screen.getByText("Interactive Embedding")).toBeInTheDocument();
@@ -40,7 +40,7 @@ describe("InteractiveEmbeddingCTA", () => {
       ),
     ).toBeInTheDocument();
 
-    userEvent.click(screen.getByTestId("interactive-embedding-cta"));
+    await userEvent.click(screen.getByTestId("interactive-embedding-cta"));
 
     expect(history.getCurrentLocation().pathname).toEqual(
       "/admin/settings/embedding-in-other-applications/full-app",

--- a/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/SelectEmbedTypePane/SelectEmbedTypePane.unit.spec.tsx
@@ -78,10 +78,12 @@ describe("SelectEmbedTypePane", () => {
         ).toBeInTheDocument();
       });
 
-      it("should call `goToNextStep` with `application` when `Edit settings` is clicked", () => {
+      it("should call `goToNextStep` with `application` when `Edit settings` is clicked", async () => {
         const { goToNextStep } = setup({ isResourcePublished: true });
 
-        userEvent.click(screen.getByRole("button", { name: "Edit settings" }));
+        await userEvent.click(
+          screen.getByRole("button", { name: "Edit settings" }),
+        );
 
         expect(goToNextStep).toHaveBeenCalled();
       });
@@ -96,10 +98,12 @@ describe("SelectEmbedTypePane", () => {
         ).toBeInTheDocument();
       });
 
-      it("should call `goToNextStep` with `application` when `Set this up` is clicked", () => {
+      it("should call `goToNextStep` with `application` when `Set this up` is clicked", async () => {
         const { goToNextStep } = setup({ isResourcePublished: false });
 
-        userEvent.click(screen.getByRole("button", { name: "Set this up" }));
+        await userEvent.click(
+          screen.getByRole("button", { name: "Set this up" }),
+        );
 
         expect(goToNextStep).toHaveBeenCalled();
       });
@@ -125,12 +129,12 @@ describe("SelectEmbedTypePane", () => {
         expect(embedLinkButton).toBeDisabled();
       });
 
-      it("should redirect to settings when public sharing is disabled and `Settings` is clicked", () => {
+      it("should redirect to settings when public sharing is disabled and `Settings` is clicked", async () => {
         const { history } = setup({
           isPublicSharingEnabled: false,
         });
 
-        userEvent.click(screen.getByTestId("sharing-pane-settings-link"));
+        await userEvent.click(screen.getByTestId("sharing-pane-settings-link"));
 
         expect(history.getCurrentLocation().pathname).toEqual(
           "/admin/settings/public-sharing",
@@ -139,7 +143,7 @@ describe("SelectEmbedTypePane", () => {
     });
 
     describe("when a public link exists", () => {
-      it("should render iframe link, copy button, `Copy snippet` description, and `Affects public url and link` tooltip", () => {
+      it("should render iframe link, copy button, `Copy snippet` description, and `Affects public url and link` tooltip", async () => {
         setup({ hasPublicLink: true, isPublicSharingEnabled: true });
 
         expect(
@@ -155,7 +159,7 @@ describe("SelectEmbedTypePane", () => {
         expect(screen.getByTestId("copy-button")).toBeInTheDocument();
         expect(screen.getByText("Remove public URL")).toBeInTheDocument();
 
-        userEvent.hover(screen.getByText("Remove public URL"));
+        await userEvent.hover(screen.getByText("Remove public URL"));
         expect(
           screen.getByText(
             "Affects both embed URL and public link for this dashboard",
@@ -163,13 +167,13 @@ describe("SelectEmbedTypePane", () => {
         ).toBeInTheDocument();
       });
 
-      it("should call `onDeletePublicLink` when `Remove public URL` is clicked", () => {
+      it("should call `onDeletePublicLink` when `Remove public URL` is clicked", async () => {
         const { onDeletePublicLink } = setup({
           hasPublicLink: true,
           isPublicSharingEnabled: true,
         });
 
-        userEvent.click(screen.getByText("Remove public URL"));
+        await userEvent.click(screen.getByText("Remove public URL"));
 
         expect(onDeletePublicLink).toHaveBeenCalled();
       });
@@ -188,10 +192,10 @@ describe("SelectEmbedTypePane", () => {
         expect(screen.getByText("Get an embed link")).toBeInTheDocument();
       });
 
-      it("should call `onCreatePublicLink` when `Get an embed link` is clicked", () => {
+      it("should call `onCreatePublicLink` when `Get an embed link` is clicked", async () => {
         const { onCreatePublicLink } = setup({ isPublicSharingEnabled: true });
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByRole("button", { name: "Get an embed link" }),
         );
 

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
@@ -23,8 +23,8 @@ describe("Static Embed Setup phase", () => {
     },
   ])("$resourceType", ({ resourceType }) => {
     describe("EmbedModalContentStatusBar", () => {
-      it(`should render actions banner for non-published ${resourceType}`, () => {
-        const { onUpdateEnableEmbedding } = setup({
+      it(`should render actions banner for non-published ${resourceType}`, async () => {
+        const { onUpdateEnableEmbedding } = await setup({
           props: {
             resourceType,
           },
@@ -41,13 +41,13 @@ describe("Static Embed Setup phase", () => {
         });
         expect(button).toBeVisible();
 
-        userEvent.click(button);
+        await userEvent.click(button);
 
         expect(onUpdateEnableEmbedding).toHaveBeenLastCalledWith(true);
       });
 
-      it(`should render actions banner for published ${resourceType}`, () => {
-        const { onUpdateEnableEmbedding } = setup({
+      it(`should render actions banner for published ${resourceType}`, async () => {
+        const { onUpdateEnableEmbedding } = await setup({
           props: {
             resource: getMockResource(resourceType, true),
             resourceType,
@@ -65,7 +65,7 @@ describe("Static Embed Setup phase", () => {
         });
         expect(button).toBeVisible();
 
-        userEvent.click(button);
+        await userEvent.click(button);
 
         expect(onUpdateEnableEmbedding).toHaveBeenLastCalledWith(false);
       });
@@ -164,7 +164,7 @@ describe("Static Embed Setup phase", () => {
         );
       });
 
-      it("should render preview iframe in Preview mode", () => {
+      it("should render preview iframe in Preview mode", async () => {
         setup({
           props: {
             resourceType,
@@ -173,7 +173,7 @@ describe("Static Embed Setup phase", () => {
           activeTab: "Parameters",
         });
 
-        userEvent.click(screen.getByText("Preview"));
+        await userEvent.click(screen.getByText("Preview"));
 
         expect(screen.getByTestId("embed-preview-iframe")).toBeVisible();
       });
@@ -276,7 +276,7 @@ describe("Static Embed Setup phase", () => {
         });
 
         it("should update a card with only valid parameters", async () => {
-          const { onUpdateEmbeddingParams } = setup({
+          const { onUpdateEmbeddingParams } = await setup({
             props: {
               resource: {
                 ...createMockDashboard(),
@@ -302,11 +302,11 @@ describe("Static Embed Setup phase", () => {
             "Disabled",
           );
 
-          userEvent.click(screen.getByLabelText("My param"));
+          await userEvent.click(screen.getByLabelText("My param"));
 
-          userEvent.click(screen.getByText("Locked"));
+          await userEvent.click(screen.getByText("Locked"));
 
-          userEvent.click(
+          await userEvent.click(
             screen.getByRole("button", { name: "Publish changes" }),
           );
 
@@ -317,7 +317,7 @@ describe("Static Embed Setup phase", () => {
           );
         });
 
-        it("should highlight changed code on parameters change", () => {
+        it("should highlight changed code on parameters change", async () => {
           setup({
             props: {
               resourceType,
@@ -327,9 +327,11 @@ describe("Static Embed Setup phase", () => {
             activeTab: "Parameters",
           });
 
-          userEvent.click(screen.getByLabelText(DATE_PARAMETER_MOCK.name));
+          await userEvent.click(
+            screen.getByLabelText(DATE_PARAMETER_MOCK.name),
+          );
 
-          userEvent.click(screen.getByText("Locked"));
+          await userEvent.click(screen.getByText("Locked"));
 
           expect(
             screen.getByText(
@@ -342,7 +344,7 @@ describe("Static Embed Setup phase", () => {
           );
         });
 
-        it("should highlight changed code on locked parameter value change", () => {
+        it("should highlight changed code on locked parameter value change", async () => {
           setup({
             props: {
               resourceType,
@@ -357,15 +359,15 @@ describe("Static Embed Setup phase", () => {
             activeTab: "Parameters",
           });
 
-          userEvent.click(
+          await userEvent.click(
             within(
               screen.getByLabelText("Previewing locked parameters"),
             ).getByRole("button", { name: DATE_PARAMETER_MOCK.name }),
           );
 
-          userEvent.click(screen.getByText("February"));
+          await userEvent.click(screen.getByText("February"));
 
-          userEvent.click(screen.getByText("Code"));
+          await userEvent.click(screen.getByText("Code"));
 
           expect(
             screen.getByTestId("text-editor-mock-highlighted-code"),
@@ -418,7 +420,7 @@ describe("Static Embed Setup phase", () => {
         );
       });
 
-      it("should render preview iframe in Preview mode", () => {
+      it("should render preview iframe in Preview mode", async () => {
         setup({
           props: {
             resourceType,
@@ -426,12 +428,12 @@ describe("Static Embed Setup phase", () => {
           activeTab: "Appearance",
         });
 
-        userEvent.click(screen.getByText("Preview"));
+        await userEvent.click(screen.getByText("Preview"));
 
         expect(screen.getByTestId("embed-preview-iframe")).toBeVisible();
       });
 
-      it("should highlight changed code on settings change", () => {
+      it("should highlight changed code on settings change", async () => {
         setup({
           props: {
             resourceType,
@@ -439,7 +441,7 @@ describe("Static Embed Setup phase", () => {
           activeTab: "Appearance",
         });
 
-        userEvent.click(screen.getByText("Transparent"));
+        await userEvent.click(screen.getByText("Transparent"));
 
         expect(
           screen.getByText("Here’s the code you’ll need to alter:"),
@@ -449,7 +451,7 @@ describe("Static Embed Setup phase", () => {
           `"#theme=transparent&bordered=true&titled=true"`,
         );
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByText(
             resourceType === "dashboard" ? "Dashboard title" : "Question title",
           ),
@@ -518,15 +520,15 @@ describe("Static Embed Setup phase", () => {
     });
   });
 
-  it("should preserve selected preview mode selection on tabs navigation", () => {
+  it("should preserve selected preview mode selection on tabs navigation", async () => {
     setup({
       props: {},
       activeTab: "Parameters",
     });
 
-    userEvent.click(screen.getByText("Preview"));
+    await userEvent.click(screen.getByText("Preview"));
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("tab", {
         name: "Appearance",
       }),
@@ -538,7 +540,7 @@ describe("Static Embed Setup phase", () => {
 
     expect(screen.getByLabelText("Preview")).toBeChecked();
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("tab", {
         name: "Parameters",
       }),
@@ -563,7 +565,7 @@ describe("Static Embed Setup phase", () => {
       newLanguage: "Python",
     });
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("tab", {
         name: "Parameters",
       }),
@@ -573,7 +575,7 @@ describe("Static Embed Setup phase", () => {
       "Python",
     );
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("tab", {
         name: "Appearance",
       }),
@@ -593,9 +595,9 @@ describe("Static Embed Setup phase", () => {
       activeTab: "Parameters",
     });
 
-    userEvent.click(screen.getByLabelText(DATE_PARAMETER_MOCK.name));
+    await userEvent.click(screen.getByLabelText(DATE_PARAMETER_MOCK.name));
 
-    userEvent.click(screen.getByText("Locked"));
+    await userEvent.click(screen.getByText("Locked"));
 
     const parametersChangedCode = `params: { "${DATE_PARAMETER_MOCK.slug}": null }`;
 
@@ -603,7 +605,7 @@ describe("Static Embed Setup phase", () => {
       screen.getByTestId("text-editor-mock-highlighted-code"),
     ).toHaveTextContent(parametersChangedCode);
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("tab", {
         name: "Appearance",
       }),
@@ -613,7 +615,7 @@ describe("Static Embed Setup phase", () => {
       screen.getByTestId("text-editor-mock-highlighted-code"),
     ).toHaveTextContent(`params: { "${DATE_PARAMETER_MOCK.slug}": null }`);
 
-    userEvent.click(screen.getByText("Transparent"));
+    await userEvent.click(screen.getByText("Transparent"));
 
     const appearanceChangedCode = `"#theme=transparent&bordered=true&titled=true"`;
 
@@ -621,7 +623,7 @@ describe("Static Embed Setup phase", () => {
       screen.getByTestId("text-editor-mock-highlighted-code"),
     ).toHaveTextContent(`${parametersChangedCode},${appearanceChangedCode}`);
 
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("tab", {
         name: "Overview",
       }),
@@ -667,11 +669,11 @@ describe("Static Embed Setup phase", () => {
       "Configuring parameters",
     );
 
-    userEvent.click(
+    await userEvent.click(
       within(parametersTypeSection).getByLabelText("My other param"),
     );
 
-    userEvent.click(
+    await userEvent.click(
       within(await screen.findByRole("grid")).getByText("Locked"),
     );
 
@@ -681,11 +683,11 @@ describe("Static Embed Setup phase", () => {
       }),
     ).toBeVisible();
 
-    userEvent.click(
+    await userEvent.click(
       within(parametersTypeSection).getByLabelText("My other param"),
     );
 
-    userEvent.click(
+    await userEvent.click(
       within(await screen.findByRole("grid")).getByText("Disabled"),
     );
 
@@ -704,9 +706,9 @@ async function selectServerCodeLanguage({
   currentLanguage?: string;
   newLanguage: string;
 }) {
-  userEvent.click(screen.getByText(currentLanguage));
+  await userEvent.click(screen.getByText(currentLanguage));
 
-  userEvent.click(
+  await userEvent.click(
     within(await screen.findByRole("grid")).getByText(newLanguage),
   );
 }

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/common.unit.spec.tsx
@@ -72,8 +72,8 @@ describe("Static Embed Setup phase", () => {
     });
 
     describe("Overview tab", () => {
-      it("should render content", () => {
-        setup({
+      it("should render content", async () => {
+        await setup({
           props: {
             resourceType,
           },
@@ -111,8 +111,8 @@ describe("Static Embed Setup phase", () => {
       });
 
       if (resourceType === "dashboard") {
-        it("should render dashboard-specific content", () => {
-          setup({
+        it("should render dashboard-specific content", async () => {
+          await setup({
             props: {
               resourceType,
             },
@@ -128,7 +128,7 @@ describe("Static Embed Setup phase", () => {
       }
 
       it("should select proper client code language on server code option change", async () => {
-        setup({
+        await setup({
           props: {
             resourceType,
           },
@@ -148,8 +148,8 @@ describe("Static Embed Setup phase", () => {
     });
 
     describe("Parameters tab", () => {
-      it("should render Code preview mode by default", () => {
-        setup({
+      it("should render Code preview mode by default", async () => {
+        await setup({
           props: {
             resourceType,
             resource: getMockResource(resourceType),
@@ -165,7 +165,7 @@ describe("Static Embed Setup phase", () => {
       });
 
       it("should render preview iframe in Preview mode", async () => {
-        setup({
+        await setup({
           props: {
             resourceType,
             resource: getMockResource(resourceType),
@@ -178,8 +178,8 @@ describe("Static Embed Setup phase", () => {
         expect(screen.getByTestId("embed-preview-iframe")).toBeVisible();
       });
 
-      it("should render message if there are no parameters", () => {
-        setup({
+      it("should render message if there are no parameters", async () => {
+        await setup({
           props: {
             resourceType,
             resource: getMockResource(resourceType),
@@ -195,8 +195,8 @@ describe("Static Embed Setup phase", () => {
       });
 
       if (resourceType === "dashboard") {
-        it("should render unsaved parameters", () => {
-          setup({
+        it("should render unsaved parameters", async () => {
+          await setup({
             props: {
               resourceParameters: [
                 {
@@ -216,8 +216,8 @@ describe("Static Embed Setup phase", () => {
           );
         });
 
-        it("should render saved parameters", () => {
-          setup({
+        it("should render saved parameters", async () => {
+          await setup({
             props: {
               resource: {
                 ...createMockDashboard(),
@@ -248,8 +248,8 @@ describe("Static Embed Setup phase", () => {
           ).toHaveTextContent("Locked");
         });
 
-        it("should only render valid parameters", () => {
-          setup({
+        it("should only render valid parameters", async () => {
+          await setup({
             props: {
               resource: {
                 ...createMockDashboard(),
@@ -318,7 +318,7 @@ describe("Static Embed Setup phase", () => {
         });
 
         it("should highlight changed code on parameters change", async () => {
-          setup({
+          await setup({
             props: {
               resourceType,
               resource: getMockResource(resourceType),
@@ -345,7 +345,7 @@ describe("Static Embed Setup phase", () => {
         });
 
         it("should highlight changed code on locked parameter value change", async () => {
-          setup({
+          await setup({
             props: {
               resourceType,
               resource: {
@@ -381,8 +381,8 @@ describe("Static Embed Setup phase", () => {
     });
 
     describe("Appearance tab", () => {
-      it("should render link to documentation", () => {
-        setup({
+      it("should render link to documentation", async () => {
+        await setup({
           props: {
             resourceType,
           },
@@ -403,9 +403,9 @@ describe("Static Embed Setup phase", () => {
         );
       });
 
-      it("should render Code mode by default", () => {
+      it("should render Code mode by default", async () => {
         const resource = getMockResource(resourceType);
-        setup({
+        await setup({
           props: {
             resourceType,
             resource,
@@ -421,7 +421,7 @@ describe("Static Embed Setup phase", () => {
       });
 
       it("should render preview iframe in Preview mode", async () => {
-        setup({
+        await setup({
           props: {
             resourceType,
           },
@@ -434,7 +434,7 @@ describe("Static Embed Setup phase", () => {
       });
 
       it("should highlight changed code on settings change", async () => {
-        setup({
+        await setup({
           props: {
             resourceType,
           },
@@ -462,8 +462,8 @@ describe("Static Embed Setup phase", () => {
         );
       });
 
-      it("should not render Font selector", () => {
-        setup({
+      it("should not render Font selector", async () => {
+        await setup({
           props: {
             resourceType,
           },
@@ -488,8 +488,8 @@ describe("Static Embed Setup phase", () => {
         );
       });
 
-      it('should render "Powered by Metabase" banner caption', () => {
-        setup({
+      it('should render "Powered by Metabase" banner caption', async () => {
+        await setup({
           props: {},
           activeTab: "Appearance",
         });
@@ -521,7 +521,7 @@ describe("Static Embed Setup phase", () => {
   });
 
   it("should preserve selected preview mode selection on tabs navigation", async () => {
-    setup({
+    await setup({
       props: {},
       activeTab: "Parameters",
     });
@@ -556,7 +556,7 @@ describe("Static Embed Setup phase", () => {
   });
 
   it("should preserve selected code language selection on tabs navigation", async () => {
-    setup({
+    await setup({
       props: {},
       activeTab: "Overview",
     });
@@ -587,7 +587,7 @@ describe("Static Embed Setup phase", () => {
   });
 
   it("should preserve highlighted code on tabs navigation", async () => {
-    setup({
+    await setup({
       props: {
         resource: createMockDashboard(),
         resourceParameters: [DATE_PARAMETER_MOCK],
@@ -637,7 +637,7 @@ describe("Static Embed Setup phase", () => {
   });
 
   it("should not display changes after parameters reset to initial values", async () => {
-    setup({
+    await setup({
       props: {
         resource: {
           ...createMockDashboard({

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/enterprise.unit.spec.tsx
@@ -14,8 +14,8 @@ describe("Static Embed Setup phase - EE, no token", () => {
     },
   ])("$resourceType", ({ resourceType }) => {
     describe("Appearance tab", () => {
-      it("should not render Font selector", () => {
-        setup({
+      it("should not render Font selector", async () => {
+        await setup({
           props: {
             resourceType,
           },
@@ -30,8 +30,8 @@ describe("Static Embed Setup phase - EE, no token", () => {
         ).toBeVisible();
       });
 
-      it('should render "Powered by Metabase" banner caption', () => {
-        setup({
+      it('should render "Powered by Metabase" banner caption', async () => {
+        await setup({
           props: {},
           activeTab: "Appearance",
           hasEnterprisePlugins: true,

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/premium.unit.spec.tsx
@@ -15,8 +15,8 @@ describe("Static Embed Setup phase - EE, with token", () => {
     },
   ])("$resourceType", ({ resourceType }) => {
     describe("Overview tab", () => {
-      it("should render content", () => {
-        setup({
+      it("should render content", async () => {
+        await setup({
           props: {
             resourceType,
           },
@@ -40,7 +40,7 @@ describe("Static Embed Setup phase - EE, with token", () => {
 
     describe("Appearance tab", () => {
       it("should render Font selector", async () => {
-        setup({
+        await setup({
           props: {
             resourceType,
           },
@@ -52,7 +52,7 @@ describe("Static Embed Setup phase - EE, with token", () => {
         const fontSelect = screen.getByLabelText("Font");
         expect(fontSelect).toBeVisible();
 
-        userEvent.click(fontSelect);
+        await userEvent.click(fontSelect);
 
         const popover = await screen.findByRole("grid");
 
@@ -60,7 +60,7 @@ describe("Static Embed Setup phase - EE, with token", () => {
           expect(within(popover).getByText(fontName)).toBeVisible();
         });
 
-        userEvent.click(within(popover).getByText(FONTS_MOCK_VALUES[0]));
+        await userEvent.click(within(popover).getByText(FONTS_MOCK_VALUES[0]));
 
         expect(screen.getByTestId("text-editor-mock")).toHaveTextContent(
           `font=${encodeURIComponent(FONTS_MOCK_VALUES[0])}`,
@@ -68,7 +68,7 @@ describe("Static Embed Setup phase - EE, with token", () => {
       });
 
       it('should not render "Powered by Metabase" banner caption', async () => {
-        setup({
+        await setup({
           props: {
             resourceType,
           },
@@ -82,8 +82,8 @@ describe("Static Embed Setup phase - EE, with token", () => {
         ).not.toBeInTheDocument();
       });
 
-      it("should render link to documentation", () => {
-        setup({
+      it("should render link to documentation", async () => {
+        await setup({
           props: {
             resourceType,
           },
@@ -107,8 +107,8 @@ describe("Static Embed Setup phase - EE, with token", () => {
       });
 
       if (resourceType === "question") {
-        it('should render "Download data" control', () => {
-          setup({
+        it('should render "Download data" control', async () => {
+          await setup({
             props: {
               resourceType,
               resource: getMockResource(resourceType, true),
@@ -121,7 +121,7 @@ describe("Static Embed Setup phase - EE, with token", () => {
           expect(screen.getByText("Download data")).toBeVisible();
           expect(screen.getByLabelText("Download data")).toBeChecked();
 
-          userEvent.click(screen.getByLabelText("Download data"));
+          await userEvent.click(screen.getByLabelText("Download data"));
 
           expect(screen.getByTestId("text-editor-mock")).toHaveTextContent(
             `hide_download_button=true`,

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/setup.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/setup.tsx
@@ -49,7 +49,7 @@ export interface SetupOpts {
   hasEnterprisePlugins?: boolean;
 }
 
-export function setup(
+export async function setup(
   {
     props: {
       resourceType = "dashboard",
@@ -99,7 +99,7 @@ export function setup(
   );
 
   if (activeTab && activeTab !== "Overview") {
-    userEvent.click(
+    await userEvent.click(
       screen.getByRole("tab", {
         name: activeTab,
       }),

--- a/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/setup.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/StaticEmbedSetupPane/tests/setup.tsx
@@ -100,7 +100,7 @@ export async function setup(
 
   if (activeTab && activeTab !== "Overview") {
     await userEvent.click(
-      screen.getByRole("tab", {
+      await screen.findByRole("tab", {
         name: activeTab,
       }),
     );

--- a/frontend/src/metabase/public/components/ResourceEmbedButton/ResourceEmbedButton.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/ResourceEmbedButton/ResourceEmbedButton.unit.spec.tsx
@@ -36,35 +36,35 @@ const setup = ({
 };
 
 describe("ResourceEmbedButton", () => {
-  it('should render "Sharing" label when public sharing is enabled', () => {
+  it('should render "Sharing" label when public sharing is enabled', async () => {
     setup({ isPublicSharingEnabled: true });
-    userEvent.hover(screen.getByLabelText("share icon"));
+    await userEvent.hover(screen.getByLabelText("share icon"));
     expect(screen.getByText("Sharing")).toBeInTheDocument();
   });
 
-  it('should render "Embedding" label when public sharing is disabled', () => {
+  it('should render "Embedding" label when public sharing is disabled', async () => {
     setup({ isPublicSharingEnabled: false });
-    userEvent.hover(screen.getByLabelText("share icon"));
+    await userEvent.hover(screen.getByLabelText("share icon"));
     expect(screen.getByText("Embedding")).toBeInTheDocument();
   });
 
-  it("should display the tooltip text when a tooltip is passed", () => {
+  it("should display the tooltip text when a tooltip is passed", async () => {
     setup({ tooltip: "test tooltip" });
-    userEvent.hover(screen.getByLabelText("share icon"));
+    await userEvent.hover(screen.getByLabelText("share icon"));
     expect(screen.getByText("test tooltip")).toBeInTheDocument();
   });
 
-  it("should be disabled when disabled=true", () => {
+  it("should be disabled when disabled=true", async () => {
     const { onClick } = setup({ disabled: true });
-    userEvent.click(screen.getByTestId("resource-embed-button"));
+    await userEvent.click(screen.getByTestId("resource-embed-button"));
 
     expect(screen.getByTestId("resource-embed-button")).toBeDisabled();
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  it("should call onClick when the button is clicked", () => {
+  it("should call onClick when the button is clicked", async () => {
     const { onClick } = setup();
-    userEvent.click(screen.getByTestId("resource-embed-button"));
+    await userEvent.click(screen.getByTestId("resource-embed-button"));
     expect(onClick).toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.unit.spec.tsx
@@ -58,7 +58,7 @@ describe("LegaleseStep", () => {
     );
 
     const { goToNextStep } = setup();
-    userEvent.click(screen.getByText("Agree and continue"));
+    await userEvent.click(screen.getByText("Agree and continue"));
 
     expect(settingPutCalls.calls().length).toBe(1);
     expect(await settingPutCalls.lastCall()?.request?.json()).toEqual({

--- a/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.unit.spec.tsx
+++ b/frontend/src/metabase/public/components/widgets/LegaleseStep/LegaleseStep.unit.spec.tsx
@@ -52,16 +52,17 @@ describe("LegaleseStep", () => {
   });
 
   it("calls goToNextStep and updates setting on clicking 'Agree and continue'", async () => {
-    const settingPutCalls = fetchMock.put(
-      "path:/api/setting/show-static-embed-terms",
-      {},
-    );
+    fetchMock.put("path:/api/setting/show-static-embed-terms", 204);
 
     const { goToNextStep } = setup();
     await userEvent.click(screen.getByText("Agree and continue"));
 
-    expect(settingPutCalls.calls().length).toBe(1);
-    expect(await settingPutCalls.lastCall()?.request?.json()).toEqual({
+    const settingPutCalls = fetchMock.calls(
+      "path:/api/setting/show-static-embed-terms",
+    );
+
+    expect(settingPutCalls.length).toBe(1);
+    expect(await settingPutCalls[0]?.request?.json()).toEqual({
       value: false,
     });
     expect(goToNextStep).toHaveBeenCalled();

--- a/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicAction/PublicAction.unit.spec.tsx
@@ -121,12 +121,12 @@ describe("PublicAction", () => {
     };
     await setup({ action });
 
-    userEvent.type(screen.getByLabelText("Size"), "42");
+    await userEvent.type(screen.getByLabelText("Size"), "42");
     expect(
       screen.getByRole("button", { name: TEST_ACTION.name }),
     ).toBeDisabled();
 
-    userEvent.type(screen.getByLabelText("Color"), "metablue");
+    await userEvent.type(screen.getByLabelText("Color"), "metablue");
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: TEST_ACTION.name }),
@@ -144,9 +144,11 @@ describe("PublicAction", () => {
       },
     });
 
-    userEvent.type(screen.getByLabelText("Size"), "42");
-    userEvent.type(screen.getByLabelText("Color"), "metablue");
-    userEvent.click(screen.getByRole("button", { name: TEST_ACTION.name }));
+    await userEvent.type(screen.getByLabelText("Size"), "42");
+    await userEvent.type(screen.getByLabelText("Color"), "metablue");
+    await userEvent.click(
+      screen.getByRole("button", { name: TEST_ACTION.name }),
+    );
 
     await waitFor(() => {
       expect(
@@ -158,9 +160,11 @@ describe("PublicAction", () => {
   it("shows a message on successful submit", async () => {
     await setup();
 
-    userEvent.type(screen.getByLabelText("Size"), "42");
-    userEvent.type(screen.getByLabelText("Color"), "metablue");
-    userEvent.click(screen.getByRole("button", { name: TEST_ACTION.name }));
+    await userEvent.type(screen.getByLabelText("Size"), "42");
+    await userEvent.type(screen.getByLabelText("Color"), "metablue");
+    await userEvent.click(
+      screen.getByRole("button", { name: TEST_ACTION.name }),
+    );
 
     expect(
       await screen.findByText(`${TEST_ACTION.name} ran successfully`),
@@ -172,9 +176,11 @@ describe("PublicAction", () => {
   it("shows error if can't fetch action", async () => {
     await setup({ shouldExecutionFail: true });
 
-    userEvent.type(screen.getByLabelText("Size"), "42");
-    userEvent.type(screen.getByLabelText("Color"), "metablue");
-    userEvent.click(screen.getByRole("button", { name: TEST_ACTION.name }));
+    await userEvent.type(screen.getByLabelText("Size"), "42");
+    await userEvent.type(screen.getByLabelText("Color"), "metablue");
+    await userEvent.click(
+      screen.getByRole("button", { name: TEST_ACTION.name }),
+    );
 
     expect(await screen.findByText("Something's off")).toBeInTheDocument();
   });
@@ -194,7 +200,9 @@ describe("PublicAction", () => {
     expect(
       screen.getByRole("heading", { name: TEST_ACTION.name }),
     ).toBeInTheDocument();
-    userEvent.click(screen.getByRole("button", { name: TEST_ACTION.name }));
+    await userEvent.click(
+      screen.getByRole("button", { name: TEST_ACTION.name }),
+    );
     await waitFor(() =>
       expect(
         fetchMock.done(`path:/api/public/action/${TEST_PUBLIC_ID}/execute`),

--- a/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicApp/PublicApp.unit.spec.tsx
@@ -60,9 +60,9 @@ describe("PublicApp", () => {
     expect(screen.queryByText("My Description")).not.toBeInTheDocument();
   });
 
-  it("renders description", () => {
+  it("renders description", async () => {
     setup({ name: "My Title", description: "My Description" });
-    userEvent.hover(getIcon("info"));
+    await userEvent.hover(getIcon("info"));
     expect(screen.getByText("My Description")).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/QueryDownloadWidget/QueryDownloadWidget.unit.spec.tsx
@@ -53,8 +53,8 @@ describe("QueryDownloadWidget", () => {
   it("should display query export options", async () => {
     setup();
 
-    userEvent.click(getIcon("download"));
-    userEvent.unhover(getIcon("download"));
+    await userEvent.click(getIcon("download"));
+    await userEvent.unhover(getIcon("download"));
 
     expect(
       await screen.findByText("Download full results"),

--- a/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/SavedQuestionHeaderButton/SavedQuestionHeaderButton.unit.spec.js
@@ -39,11 +39,11 @@ describe("SavedQuestionHeaderButton", () => {
     expect(screen.getByText("foo")).toBeInTheDocument();
   });
 
-  it("calls onSave on input blur", () => {
+  it("calls onSave on input blur", async () => {
     const { onSave } = setup({ question });
 
     const title = screen.getByTestId("saved-question-header-title");
-    userEvent.type(title, "1");
+    await userEvent.type(title, "1");
     title.blur();
 
     expect(onSave).toHaveBeenCalled();

--- a/frontend/src/metabase/query_builder/components/Warnings.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/Warnings.unit.spec.js
@@ -9,16 +9,16 @@ describe("Warnings", () => {
     expect(screen.getByLabelText("warning icon")).toBeInTheDocument();
   });
 
-  it("should render a warning message tooltip on hover", () => {
+  it("should render a warning message tooltip on hover", async () => {
     render(<Warnings warnings={["test warning message"]} />);
-    userEvent.hover(screen.getByLabelText("warning icon"));
+    await userEvent.hover(screen.getByLabelText("warning icon"));
     expect(screen.getByText("test warning message")).toBeInTheDocument();
   });
 
-  it("should render multiple warnings", () => {
+  it("should render multiple warnings", async () => {
     const warningMessages = ["foo", "bar", "baz"];
     render(<Warnings warnings={warningMessages} />);
-    userEvent.hover(screen.getByLabelText("warning icon"));
+    await userEvent.hover(screen.getByLabelText("warning icon"));
 
     warningMessages.forEach(message => {
       expect(screen.getByText(message)).toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/dataref/DatabaseTablesPane.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/DatabaseTablesPane.tsx
@@ -104,7 +104,11 @@ export const DatabaseTablesPane = ({
                   onClick={() => onItemClick("table", table)}
                 >
                   <NodeListItemIcon name="table" />
-                  <NodeListItemName>{table.table_name}</NodeListItemName>
+                  <NodeListItemName
+                    data-disabled={table.initial_sync_status !== "complete"}
+                  >
+                    {table.table_name}
+                  </NodeListItemName>
                 </NodeListItemLink>
               </li>
             ))}

--- a/frontend/src/metabase/query_builder/components/dataref/DatabaseTablesPane.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/DatabaseTablesPane.unit.spec.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import { createMockMetadata } from "__support__/metadata";
 import { renderWithProviders, screen } from "__support__/ui";
 import { getNextId } from "__support__/utils";
@@ -104,16 +102,12 @@ describe("DatabaseTablesPane", () => {
  * Clicking the element allows us to detect interactiveness (being enabled/disabled) with certainty.
  */
 function expectToBeDisabled(element: Element) {
-  expect(() => {
-    userEvent.click(element);
-  }).toThrow();
+  expect(element).toHaveAttribute("data-disabled", "true");
 }
 
 /**
  * @see expectToBeDisabled
  */
 function expectToBeEnabled(element: Element) {
-  expect(() => {
-    userEvent.click(element);
-  }).not.toThrow();
+  expect(element).toHaveAttribute("data-disabled", "false");
 }

--- a/frontend/src/metabase/query_builder/components/dataref/DatabaseTablesPane.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/dataref/DatabaseTablesPane.unit.spec.tsx
@@ -1,3 +1,5 @@
+import userEvent from "@testing-library/user-event";
+
 import { createMockMetadata } from "__support__/metadata";
 import { renderWithProviders, screen } from "__support__/ui";
 import { getNextId } from "__support__/utils";
@@ -52,7 +54,7 @@ const setup = (options?: Partial<DatabaseTablesPaneProps>) => {
 };
 
 describe("DatabaseTablesPane", () => {
-  it("should show tables with initial_sync_status='incomplete' as non-interactive (disabled)", () => {
+  it("should show tables with initial_sync_status='incomplete' as non-interactive (disabled)", async () => {
     setup({
       searchResults: [incompleteTableSearchResult],
     });
@@ -62,10 +64,10 @@ describe("DatabaseTablesPane", () => {
     );
 
     expect(textElement).toBeInTheDocument();
-    expectToBeDisabled(textElement);
+    await expectToBeDisabled(textElement);
   });
 
-  it("should show tables with initial_sync_status='aborted' as non-interactive (disabled)", () => {
+  it("should show tables with initial_sync_status='aborted' as non-interactive (disabled)", async () => {
     setup({
       searchResults: [abortedTableSearchResult],
     });
@@ -75,10 +77,10 @@ describe("DatabaseTablesPane", () => {
     );
 
     expect(textElement).toBeInTheDocument();
-    expectToBeDisabled(textElement);
+    await expectToBeDisabled(textElement);
   });
 
-  it("should show tables with initial_sync_status='complete' as interactive (enabled)", () => {
+  it("should show tables with initial_sync_status='complete' as interactive (enabled)", async () => {
     setup({
       searchResults: [completeTableSearchResult],
     });
@@ -88,7 +90,7 @@ describe("DatabaseTablesPane", () => {
     );
 
     expect(textElement).toBeInTheDocument();
-    expectToBeEnabled(textElement);
+    await expectToBeEnabled(textElement);
   });
 });
 
@@ -101,13 +103,15 @@ describe("DatabaseTablesPane", () => {
  *
  * Clicking the element allows us to detect interactiveness (being enabled/disabled) with certainty.
  */
-function expectToBeDisabled(element: Element) {
-  expect(element).toHaveAttribute("data-disabled", "true");
+async function expectToBeDisabled(element: Element) {
+  await expect(userEvent.click(element)).rejects.toThrow(
+    /pointer-events: none/,
+  );
 }
 
 /**
  * @see expectToBeDisabled
  */
-function expectToBeEnabled(element: Element) {
-  expect(element).toHaveAttribute("data-disabled", "false");
+async function expectToBeEnabled(element: Element) {
+  await expect(userEvent.click(element)).resolves.not.toThrow();
 }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -24,7 +24,7 @@ describe("ExpressionWidget", () => {
     expect(screen.queryByText("Name")).not.toBeInTheDocument();
   });
 
-  it("should render help icon with tooltip which opens documentation page", () => {
+  it("should render help icon with tooltip which opens documentation page", async () => {
     setup();
 
     const icon = getIcon("info");
@@ -40,7 +40,7 @@ describe("ExpressionWidget", () => {
       "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
     );
 
-    userEvent.hover(link);
+    await userEvent.hover(link);
 
     expect(
       screen.getByText(
@@ -49,7 +49,7 @@ describe("ExpressionWidget", () => {
     ).toBeInTheDocument();
   });
 
-  it("should trigger onChangeExpression if expression is valid", () => {
+  it("should trigger onChangeExpression if expression is valid", async () => {
     const { onChangeExpression } = setup();
 
     const doneButton = screen.getByRole("button", { name: "Done" });
@@ -58,18 +58,18 @@ describe("ExpressionWidget", () => {
     const expressionInput = screen.getByRole("textbox");
     expect(expressionInput).toHaveClass("ace_text-input");
 
-    userEvent.type(expressionInput, "1 + 1");
-    userEvent.tab();
+    await userEvent.type(expressionInput, "1 + 1");
+    await userEvent.tab();
 
     expect(doneButton).toBeEnabled();
 
-    userEvent.click(doneButton);
+    await userEvent.click(doneButton);
 
     expect(onChangeExpression).toHaveBeenCalledTimes(1);
     expect(onChangeExpression).toHaveBeenCalledWith("", ["+", 1, 1]);
   });
 
-  it("should trigger onChangeClause if expression is valid", () => {
+  it("should trigger onChangeClause if expression is valid", async () => {
     const { getRecentExpressionClauseInfo, onChangeClause } = setup();
 
     const doneButton = screen.getByRole("button", { name: "Done" });
@@ -78,19 +78,19 @@ describe("ExpressionWidget", () => {
     const expressionInput = screen.getByRole("textbox");
     expect(expressionInput).toHaveClass("ace_text-input");
 
-    userEvent.type(expressionInput, "1 + 1");
-    userEvent.tab();
+    await userEvent.type(expressionInput, "1 + 1");
+    await userEvent.tab();
 
     expect(doneButton).toBeEnabled();
 
-    userEvent.click(doneButton);
+    await userEvent.click(doneButton);
 
     expect(onChangeClause).toHaveBeenCalledTimes(1);
     expect(onChangeClause).toHaveBeenCalledWith("", expect.anything());
     expect(getRecentExpressionClauseInfo().displayName).toBe("1 + 1");
   });
 
-  it(`should render interactive header if it is passed`, () => {
+  it(`should render interactive header if it is passed`, async () => {
     const mockTitle = "Some Title";
     const onClose = jest.fn();
     setup({
@@ -101,7 +101,7 @@ describe("ExpressionWidget", () => {
     const titleEl = screen.getByText(mockTitle);
     expect(titleEl).toBeInTheDocument();
 
-    userEvent.click(titleEl);
+    await userEvent.click(titleEl);
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -113,7 +113,7 @@ describe("ExpressionWidget", () => {
       expect(screen.getByText("Name")).toBeInTheDocument();
     });
 
-    it("should validate name value", () => {
+    it("should validate name value", async () => {
       const expression: Expression = ["+", 1, 1];
       const {
         getRecentExpressionClauseInfo,
@@ -131,7 +131,7 @@ describe("ExpressionWidget", () => {
 
       expect(doneButton).toBeDisabled();
 
-      userEvent.type(screen.getByDisplayValue("1 + 1"), "{enter}");
+      await userEvent.type(screen.getByDisplayValue("1 + 1"), "{enter}");
 
       // enter in expression editor should not trigger "onChangeClause" or "onChangeExpression"
       // as popover is not valid with empty "name"
@@ -139,27 +139,27 @@ describe("ExpressionWidget", () => {
       expect(onChangeExpression).toHaveBeenCalledTimes(0);
 
       // The name must not be empty
-      userEvent.type(expressionNameInput, "");
+      await userEvent.type(expressionNameInput, "");
       expect(doneButton).toBeDisabled();
 
       // The name must not consist of spaces or tabs only.
-      userEvent.type(expressionNameInput, " ");
+      await userEvent.type(expressionNameInput, " ");
       expect(doneButton).toBeDisabled();
-      userEvent.type(expressionNameInput, "\t");
+      await userEvent.type(expressionNameInput, "\t");
       expect(doneButton).toBeDisabled();
-      userEvent.type(expressionNameInput, "  \t\t");
+      await userEvent.type(expressionNameInput, "  \t\t");
       expect(doneButton).toBeDisabled();
 
-      userEvent.clear(expressionNameInput);
+      await userEvent.clear(expressionNameInput);
 
-      userEvent.type(
+      await userEvent.type(
         expressionNameInput,
         "Some n_am!e 2q$w&YzT(6i~#sLXv7+HjP}Ku1|9c*RlF@4o5N=e8;G*-bZ3/U0:Qa'V,t(W-_D",
       );
 
       expect(doneButton).toBeEnabled();
 
-      userEvent.click(doneButton);
+      await userEvent.click(doneButton);
 
       expect(onChangeExpression).toHaveBeenCalledTimes(1);
       expect(onChangeExpression).toHaveBeenCalledWith(

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.unit.spec.tsx
@@ -139,7 +139,7 @@ describe("ExpressionWidget", () => {
       expect(onChangeExpression).toHaveBeenCalledTimes(0);
 
       // The name must not be empty
-      await userEvent.type(expressionNameInput, "");
+      await userEvent.clear(expressionNameInput);
       expect(doneButton).toBeDisabled();
 
       // The name must not consist of spaces or tabs only.

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/common.unit.spec.ts
@@ -5,7 +5,7 @@ import { screen } from "__support__/ui";
 import { setup } from "./setup";
 
 describe("ExpressionWidgetInfo (OSS)", () => {
-  it("should show a help link when `show-metabase-links: true`", () => {
+  it("should show a help link when `show-metabase-links: true`", async () => {
     setup({ showMetabaseLinks: true });
 
     expect(
@@ -14,7 +14,7 @@ describe("ExpressionWidgetInfo (OSS)", () => {
       "href",
       "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
     );
-    userEvent.hover(screen.getByLabelText("info icon"));
+    await userEvent.hover(screen.getByLabelText("info icon"));
     expect(
       screen.getByText(
         "You can reference columns here in functions or equations, like: floor([Price] - [Discount]). Click for documentation.",
@@ -22,7 +22,7 @@ describe("ExpressionWidgetInfo (OSS)", () => {
     ).toBeInTheDocument();
   });
 
-  it("should show a help link when `show-metabase-links: false`", () => {
+  it("should show a help link when `show-metabase-links: false`", async () => {
     setup({ showMetabaseLinks: false });
 
     expect(
@@ -31,7 +31,7 @@ describe("ExpressionWidgetInfo (OSS)", () => {
       "href",
       "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
     );
-    userEvent.hover(screen.getByLabelText("info icon"));
+    await userEvent.hover(screen.getByLabelText("info icon"));
     expect(
       screen.getByText(
         "You can reference columns here in functions or equations, like: floor([Price] - [Discount]). Click for documentation.",

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/enterprise.unit.spec.ts
@@ -10,7 +10,7 @@ function setup(opts: SetupOpts) {
 }
 
 describe("ExpressionWidgetInfo (EE without token)", () => {
-  it("should show a help link when `show-metabase-links: true`", () => {
+  it("should show a help link when `show-metabase-links: true`", async () => {
     setup({ showMetabaseLinks: true });
 
     expect(
@@ -19,7 +19,7 @@ describe("ExpressionWidgetInfo (EE without token)", () => {
       "href",
       "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
     );
-    userEvent.hover(screen.getByLabelText("info icon"));
+    await userEvent.hover(screen.getByLabelText("info icon"));
     expect(
       screen.getByText(
         "You can reference columns here in functions or equations, like: floor([Price] - [Discount]). Click for documentation.",
@@ -27,7 +27,7 @@ describe("ExpressionWidgetInfo (EE without token)", () => {
     ).toBeInTheDocument();
   });
 
-  it("should show a help link when `show-metabase-links: false`", () => {
+  it("should show a help link when `show-metabase-links: false`", async () => {
     setup({ showMetabaseLinks: false });
 
     expect(
@@ -36,7 +36,7 @@ describe("ExpressionWidgetInfo (EE without token)", () => {
       "href",
       "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
     );
-    userEvent.hover(screen.getByLabelText("info icon"));
+    await userEvent.hover(screen.getByLabelText("info icon"));
     expect(
       screen.getByText(
         "You can reference columns here in functions or equations, like: floor([Price] - [Discount]). Click for documentation.",

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidgetInfo/tests/premium.unit.spec.ts
@@ -14,7 +14,7 @@ function setup(opts: SetupOpts) {
 }
 
 describe("ExpressionWidgetInfo (EE with token)", () => {
-  it("should show a help link when `show-metabase-links: true`", () => {
+  it("should show a help link when `show-metabase-links: true`", async () => {
     setup({ showMetabaseLinks: true });
 
     expect(
@@ -23,7 +23,7 @@ describe("ExpressionWidgetInfo (EE with token)", () => {
       "href",
       "https://www.metabase.com/docs/latest/questions/query-builder/expressions.html",
     );
-    userEvent.hover(screen.getByLabelText("info icon"));
+    await userEvent.hover(screen.getByLabelText("info icon"));
     expect(
       screen.getByText(
         "You can reference columns here in functions or equations, like: floor([Price] - [Discount]). Click for documentation.",
@@ -31,13 +31,13 @@ describe("ExpressionWidgetInfo (EE with token)", () => {
     ).toBeInTheDocument();
   });
 
-  it("should not show a help link when `show-metabase-links: false`", () => {
+  it("should not show a help link when `show-metabase-links: false`", async () => {
     setup({ showMetabaseLinks: false });
 
     expect(
       screen.queryByRole("link", { name: "Open expressions documentation" }),
     ).not.toBeInTheDocument();
-    userEvent.hover(screen.getByLabelText("info icon"));
+    await userEvent.hover(screen.getByLabelText("info icon"));
     expect(
       screen.getByText(
         "You can reference columns here in functions or equations, like: floor([Price] - [Discount]).",

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
@@ -79,14 +79,14 @@ describe("NotebookStep", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("sets the row limit only on blur", () => {
+  it("sets the row limit only on blur", async () => {
     const step = createMockNotebookStep({ type: "limit" });
     const { updateQuery } = setup({ step });
 
     const input = screen.getByPlaceholderText("Enter a limit");
-    userEvent.type(input, "38");
-    userEvent.type(input, "clear");
-    userEvent.type(input, "42");
+    await userEvent.type(input, "38");
+    await userEvent.type(input, "clear");
+    await userEvent.type(input, "42");
     input.blur();
 
     expect(updateQuery).toHaveBeenCalledTimes(1);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/AggregateStep/AggregateStep.unit.spec.tsx
@@ -85,12 +85,12 @@ describe("AggregateStep", () => {
     expect(screen.getByText("Average of Product → Rating")).toBeInTheDocument();
   });
 
-  it("should add an aggregation with a basic operator", () => {
+  it("should add an aggregation with a basic operator", async () => {
     const { getRecentAggregationClause } = setup();
 
-    userEvent.click(screen.getByText("Pick the metric you want to see"));
-    userEvent.click(screen.getByText("Average of ..."));
-    userEvent.click(screen.getByText("Quantity"));
+    await userEvent.click(screen.getByText("Pick the metric you want to see"));
+    await userEvent.click(screen.getByText("Average of ..."));
+    await userEvent.click(screen.getByText("Quantity"));
 
     const clause = getRecentAggregationClause();
     expect(clause).toEqual(
@@ -101,14 +101,14 @@ describe("AggregateStep", () => {
     );
   });
 
-  it("should change an aggregation operator", () => {
+  it("should change an aggregation operator", async () => {
     const { getNextQuery, getRecentAggregationClause } = setup(
       createMockNotebookStep({ query: createAggregatedQuery() }),
     );
 
-    userEvent.click(screen.getByText("Average of Quantity"));
-    userEvent.click(screen.getByText("Average of ...")); // go back to operator selection
-    userEvent.click(screen.getByText("Count of rows"));
+    await userEvent.click(screen.getByText("Average of Quantity"));
+    await userEvent.click(screen.getByText("Average of ...")); // go back to operator selection
+    await userEvent.click(screen.getByText("Count of rows"));
 
     const nextQuery = getNextQuery();
     const clause = getRecentAggregationClause();
@@ -121,13 +121,13 @@ describe("AggregateStep", () => {
     );
   });
 
-  it("should change an aggregation column", () => {
+  it("should change an aggregation column", async () => {
     const { getNextQuery, getRecentAggregationClause } = setup(
       createMockNotebookStep({ query: createAggregatedQuery() }),
     );
 
-    userEvent.click(screen.getByText("Average of Quantity"));
-    userEvent.click(screen.getByText("Total"));
+    await userEvent.click(screen.getByText("Average of Quantity"));
+    await userEvent.click(screen.getByText("Total"));
 
     const nextQuery = getNextQuery();
     const clause = getRecentAggregationClause();
@@ -140,12 +140,12 @@ describe("AggregateStep", () => {
     );
   });
 
-  it("should remove an aggregation", () => {
+  it("should remove an aggregation", async () => {
     const { getNextQuery } = setup(
       createMockNotebookStep({ query: createAggregatedQuery() }),
     );
 
-    userEvent.click(getIcon("close"));
+    await userEvent.click(getIcon("close"));
 
     const nextQuery = getNextQuery();
     expect(Lib.aggregations(nextQuery, 0)).toHaveLength(0);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/BreakoutStep/BreakoutStep.unit.spec.tsx
@@ -97,18 +97,18 @@ describe("BreakoutStep", () => {
     const columnName = columnInfo.displayName;
     setup(createMockNotebookStep({ query }));
 
-    userEvent.click(screen.getByText(columnName));
+    await userEvent.click(screen.getByText(columnName));
 
     const listItem = await screen.findByRole("option", { name: columnName });
     expect(listItem).toBeInTheDocument();
     expect(listItem).toHaveAttribute("aria-selected", "true");
   });
 
-  it("shouldn't show already used columns when adding a new breakout", () => {
+  it("shouldn't show already used columns when adding a new breakout", async () => {
     const { query, columnInfo } = createQueryWithBreakout();
     setup(createMockNotebookStep({ query }));
 
-    userEvent.click(getIcon("add"));
+    await userEvent.click(getIcon("add"));
 
     expect(
       screen.queryByRole("option", { name: columnInfo.displayName }),
@@ -118,8 +118,8 @@ describe("BreakoutStep", () => {
   it("should add a breakout", async () => {
     const { getRecentBreakoutClause } = setup();
 
-    userEvent.click(screen.getByText("Pick a column to group by"));
-    userEvent.click(await screen.findByText("Created At"));
+    await userEvent.click(screen.getByText("Pick a column to group by"));
+    await userEvent.click(await screen.findByText("Created At"));
 
     const breakout = getRecentBreakoutClause();
     expect(breakout.displayName).toBe("Created At: Month");
@@ -131,18 +131,18 @@ describe("BreakoutStep", () => {
       createMockNotebookStep({ query }),
     );
 
-    userEvent.click(screen.getByText(columnInfo.displayName));
-    userEvent.click(await screen.findByText("Discount"));
+    await userEvent.click(screen.getByText(columnInfo.displayName));
+    await userEvent.click(await screen.findByText("Discount"));
 
     const breakout = getRecentBreakoutClause();
     expect(breakout.displayName).toBe("Discount: Auto binned");
   });
 
-  it("should remove a breakout", () => {
+  it("should remove a breakout", async () => {
     const { query } = createQueryWithBreakout();
     const { getNextQuery } = setup(createMockNotebookStep({ query }));
 
-    userEvent.click(getIcon("close"));
+    await userEvent.click(getIcon("close"));
 
     const nextQuery = getNextQuery();
     expect(Lib.breakouts(nextQuery, 0)).toHaveLength(0);
@@ -152,12 +152,12 @@ describe("BreakoutStep", () => {
     it("should apply default binning strategy", async () => {
       const { getRecentBreakoutClause } = setup();
 
-      userEvent.click(screen.getByText("Pick a column to group by"));
+      await userEvent.click(screen.getByText("Pick a column to group by"));
       const option = await screen.findByRole("option", { name: "Total" });
 
       expect(within(option).getByText("Auto bin")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText("Total"));
+      await userEvent.click(screen.getByText("Total"));
 
       const breakout = getRecentBreakoutClause();
       expect(breakout.displayName).toBe("Total: Auto binned");
@@ -166,10 +166,12 @@ describe("BreakoutStep", () => {
     it("should apply selected binning strategy", async () => {
       const { getRecentBreakoutClause } = setup();
 
-      userEvent.click(screen.getByText("Pick a column to group by"));
+      await userEvent.click(screen.getByText("Pick a column to group by"));
       const option = await screen.findByRole("option", { name: "Total" });
-      userEvent.click(within(option).getByLabelText("Binning strategy"));
-      userEvent.click(await screen.findByRole("menuitem", { name: "10 bins" }));
+      await userEvent.click(within(option).getByLabelText("Binning strategy"));
+      await userEvent.click(
+        await screen.findByRole("menuitem", { name: "10 bins" }),
+      );
 
       const breakout = getRecentBreakoutClause();
       expect(breakout.displayName).toBe("Total: 10 bins");
@@ -179,9 +181,9 @@ describe("BreakoutStep", () => {
       const { query } = createQueryWithBinning();
       setup(createMockNotebookStep({ query }));
 
-      userEvent.click(screen.getByText("Tax: 10 bins"));
+      await userEvent.click(screen.getByText("Tax: 10 bins"));
       const option = await screen.findByRole("option", { name: "Tax" });
-      userEvent.click(within(option).getByLabelText("Binning strategy"));
+      await userEvent.click(within(option).getByLabelText("Binning strategy"));
 
       expect(
         await screen.findByRole("menuitem", { name: "10 bins" }),
@@ -192,8 +194,8 @@ describe("BreakoutStep", () => {
       const { query } = createQueryWithBinning();
       const { updateQuery } = setup(createMockNotebookStep({ query }));
 
-      userEvent.click(screen.getByText("Tax: 10 bins"));
-      userEvent.click(await screen.findByText("Tax"));
+      await userEvent.click(screen.getByText("Tax: 10 bins"));
+      await userEvent.click(await screen.findByText("Tax"));
 
       expect(updateQuery).not.toHaveBeenCalled();
     });
@@ -202,14 +204,14 @@ describe("BreakoutStep", () => {
       const { query, columnInfo } = createQueryWithBinning("Don't bin");
       setup(createMockNotebookStep({ query }));
 
-      userEvent.click(screen.getByText(columnInfo.displayName));
+      await userEvent.click(screen.getByText(columnInfo.displayName));
       const option = await screen.findByRole("option", {
         name: columnInfo.displayName,
       });
 
       expect(within(option).getByText("Unbinned")).toBeInTheDocument();
 
-      userEvent.click(within(option).getByLabelText("Binning strategy"));
+      await userEvent.click(within(option).getByLabelText("Binning strategy"));
       expect(
         await screen.findByRole("menuitem", { name: "Don't bin" }),
       ).toHaveAttribute("aria-selected", "true");
@@ -218,8 +220,8 @@ describe("BreakoutStep", () => {
     it("should apply default temporal bucket", async () => {
       const { getRecentBreakoutClause } = setup();
 
-      userEvent.click(screen.getByText("Pick a column to group by"));
-      userEvent.click(await screen.findByText("Created At"));
+      await userEvent.click(screen.getByText("Pick a column to group by"));
+      await userEvent.click(await screen.findByText("Created At"));
 
       const breakout = getRecentBreakoutClause();
       expect(breakout.displayName).toBe("Created At: Month");
@@ -228,9 +230,9 @@ describe("BreakoutStep", () => {
     it("should apply selected temporal bucket", async () => {
       const { getRecentBreakoutClause } = setup();
 
-      userEvent.click(screen.getByText("Pick a column to group by"));
+      await userEvent.click(screen.getByText("Pick a column to group by"));
       const option = await screen.findByRole("option", { name: "Created At" });
-      userEvent.click(within(option).getByLabelText("Temporal bucket"));
+      await userEvent.click(within(option).getByLabelText("Temporal bucket"));
 
       // For some reason, a click won't happen with `userEvent.click`
       // if the test is running together with other tests.
@@ -244,9 +246,9 @@ describe("BreakoutStep", () => {
       const { query } = createQueryWithTemporalBreakout("Quarter");
       setup(createMockNotebookStep({ query }));
 
-      userEvent.click(screen.getByText("Created At: Quarter"));
+      await userEvent.click(screen.getByText("Created At: Quarter"));
       const option = await screen.findByRole("option", { name: "Created At" });
-      userEvent.click(within(option).getByLabelText("Temporal bucket"));
+      await userEvent.click(within(option).getByLabelText("Temporal bucket"));
 
       expect(
         await screen.findByRole("menuitem", { name: "Quarter" }),
@@ -257,14 +259,14 @@ describe("BreakoutStep", () => {
       const { query } = createQueryWithTemporalBreakout("Don't bin");
       setup(createMockNotebookStep({ query }));
 
-      userEvent.click(screen.getByText("Created At"));
+      await userEvent.click(screen.getByText("Created At"));
       const option = await screen.findByRole("option", {
         name: "Created At",
       });
 
       expect(within(option).getByText("Unbinned")).toBeInTheDocument();
 
-      userEvent.click(within(option).getByLabelText("Temporal bucket"));
+      await userEvent.click(within(option).getByLabelText("Temporal bucket"));
 
       // click on More... item as Don't bin is hidden
       // userEvent.click closes popup
@@ -279,8 +281,8 @@ describe("BreakoutStep", () => {
       const { query } = createQueryWithTemporalBreakout("Quarter");
       const { updateQuery } = setup(createMockNotebookStep({ query }));
 
-      userEvent.click(screen.getByText("Created At: Quarter"));
-      userEvent.click(await screen.findByText("Created At"));
+      await userEvent.click(screen.getByText("Created At: Quarter"));
+      await userEvent.click(await screen.findByText("Created At"));
 
       expect(updateQuery).not.toHaveBeenCalled();
     });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/DataStep/DataStep.unit.spec.tsx
@@ -123,8 +123,8 @@ describe("DataStep", () => {
   it("should change a table", async () => {
     const { getNextTableName } = await setup();
 
-    userEvent.click(screen.getByText("Orders"));
-    userEvent.click(await screen.findByText("Products"));
+    await userEvent.click(screen.getByText("Orders"));
+    await userEvent.click(await screen.findByText("Products"));
 
     expect(getNextTableName()).toBe("Products");
   });
@@ -132,7 +132,7 @@ describe("DataStep", () => {
   describe("fields selection", () => {
     it("should render with all columns selected", async () => {
       await setup();
-      userEvent.click(screen.getByLabelText("Pick columns"));
+      await userEvent.click(screen.getByLabelText("Pick columns"));
 
       expect(screen.getByLabelText("Select none")).toBeChecked();
       expect(screen.getByLabelText("ID")).toBeChecked();
@@ -144,7 +144,7 @@ describe("DataStep", () => {
     it("should render with a single column selected", async () => {
       const query = createQueryWithFields(["ID"]);
       await setup(createMockNotebookStep({ query }));
-      userEvent.click(screen.getByLabelText("Pick columns"));
+      await userEvent.click(screen.getByLabelText("Pick columns"));
 
       expect(screen.getByLabelText("Select all")).not.toBeChecked();
       expect(screen.getByLabelText("ID")).toBeChecked();
@@ -156,7 +156,7 @@ describe("DataStep", () => {
     it("should render with multiple columns selected", async () => {
       const query = createQueryWithFields(["ID", "TOTAL"]);
       await setup(createMockNotebookStep({ query }));
-      userEvent.click(screen.getByLabelText("Pick columns"));
+      await userEvent.click(screen.getByLabelText("Pick columns"));
 
       expect(screen.getByLabelText("Select all")).not.toBeChecked();
       expect(screen.getByLabelText("ID")).toBeChecked();
@@ -172,8 +172,8 @@ describe("DataStep", () => {
       const step = createMockNotebookStep({ query });
       const { getNextColumn } = await setup(step);
 
-      userEvent.click(screen.getByLabelText("Pick columns"));
-      userEvent.click(screen.getByLabelText("Tax"));
+      await userEvent.click(screen.getByLabelText("Pick columns"));
+      await userEvent.click(screen.getByLabelText("Tax"));
 
       expect(getNextColumn("ID").selected).toBeTruthy();
       expect(getNextColumn("TAX").selected).toBeTruthy();
@@ -183,8 +183,8 @@ describe("DataStep", () => {
     it("should allow de-selecting a column", async () => {
       const { getNextColumn } = await setup();
 
-      userEvent.click(screen.getByLabelText("Pick columns"));
-      userEvent.click(screen.getByLabelText("Tax"));
+      await userEvent.click(screen.getByLabelText("Pick columns"));
+      await userEvent.click(screen.getByLabelText("Tax"));
 
       expect(getNextColumn("ID").selected).toBeTruthy();
       expect(getNextColumn("TAX").selected).toBeFalsy();
@@ -196,8 +196,8 @@ describe("DataStep", () => {
       const step = createMockNotebookStep({ query });
       const { getNextColumn } = await setup(step);
 
-      userEvent.click(screen.getByLabelText("Pick columns"));
-      userEvent.click(screen.getByLabelText("Select all"));
+      await userEvent.click(screen.getByLabelText("Pick columns"));
+      await userEvent.click(screen.getByLabelText("Select all"));
 
       expect(getNextColumn("ID").selected).toBeTruthy();
       expect(getNextColumn("TAX").selected).toBeTruthy();
@@ -207,8 +207,8 @@ describe("DataStep", () => {
     it("should leave one column when de-selecting all columns", async () => {
       const { getNextQuery } = await setup();
 
-      userEvent.click(screen.getByLabelText("Pick columns"));
-      userEvent.click(screen.getByLabelText("Select none"));
+      await userEvent.click(screen.getByLabelText("Pick columns"));
+      await userEvent.click(screen.getByLabelText("Select none"));
 
       const nextQuery = getNextQuery();
       expect(Lib.fields(nextQuery, 0)).toHaveLength(1);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ExpressionStep.unit.spec.tsx
@@ -45,10 +45,13 @@ describe("Notebook Editor > Expression Step", () => {
   it("should handle adding expression", async () => {
     const { getRecentQuery } = setup();
 
-    userEvent.click(screen.getByRole("img", { name: "add icon" }));
+    await userEvent.click(screen.getByRole("img", { name: "add icon" }));
 
-    userEvent.type(screen.getByLabelText("Expression"), "1 + 1");
-    userEvent.type(screen.getByLabelText("Name"), "new expression{enter}");
+    await userEvent.type(screen.getByLabelText("Expression"), "1 + 1");
+    await userEvent.type(
+      screen.getByLabelText("Name"),
+      "new expression{enter}",
+    );
 
     const recentQuery = getRecentQuery();
     const expressions = Lib.expressions(recentQuery, 0);
@@ -64,11 +67,11 @@ describe("Notebook Editor > Expression Step", () => {
     });
     const { getRecentQuery } = setup({ query });
 
-    userEvent.click(screen.getByText("old name"));
+    await userEvent.click(screen.getByText("old name"));
 
     const nameField = screen.getByLabelText("Name");
-    userEvent.clear(nameField);
-    userEvent.type(nameField, "new name{enter}");
+    await userEvent.clear(nameField);
+    await userEvent.type(nameField, "new name{enter}");
 
     const recentQuery = getRecentQuery();
     const expressions = Lib.expressions(recentQuery, 0);
@@ -78,7 +81,7 @@ describe("Notebook Editor > Expression Step", () => {
     );
   });
 
-  it("should handle removing existing expression", () => {
+  it("should handle removing existing expression", async () => {
     const query = createQueryWithClauses({
       expressions: [{ name: "expression name", operator: "+", args: [1, 1] }],
     });
@@ -89,7 +92,7 @@ describe("Notebook Editor > Expression Step", () => {
       name: "close icon",
     });
 
-    userEvent.click(closeIcon);
+    await userEvent.click(closeIcon);
 
     expect(Lib.expressions(getRecentQuery(), 0)).toHaveLength(0);
   });
@@ -97,10 +100,10 @@ describe("Notebook Editor > Expression Step", () => {
   it("should handle expressions named as existing columns (metabase#39508)", async () => {
     const { getRecentQuery } = setup();
 
-    userEvent.click(screen.getByRole("img", { name: "add icon" }));
+    await userEvent.click(screen.getByRole("img", { name: "add icon" }));
 
-    userEvent.type(screen.getByLabelText("Expression"), "1 + 1");
-    userEvent.type(screen.getByLabelText("Name"), "Total{enter}");
+    await userEvent.type(screen.getByLabelText("Expression"), "1 + 1");
+    await userEvent.type(screen.getByLabelText("Name"), "Total{enter}");
 
     const recentQuery = getRecentQuery();
     const expressions = Lib.expressions(recentQuery, 0);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -202,7 +202,7 @@ describe("Notebook Editor > Join Step", () => {
   it("should open the source query database in RHS table picker", async () => {
     setup();
 
-    userEvent.click(screen.getByLabelText("Right table"));
+    await userEvent.click(screen.getByLabelText("Right table"));
     const popover = await screen.findByTestId("popover");
 
     await waitFor(() => {
@@ -216,11 +216,11 @@ describe("Notebook Editor > Join Step", () => {
   it("should not allow picking a right table from another database", async () => {
     setup();
 
-    userEvent.click(screen.getByLabelText("Right table"));
+    await userEvent.click(screen.getByLabelText("Right table"));
     const popover = await screen.findByTestId("popover");
 
     // Go back to the database list
-    userEvent.click(within(popover).getByText("Sample Database"));
+    await userEvent.click(within(popover).getByText("Sample Database"));
 
     expect(within(popover).getByText("Sample Database")).toBeInTheDocument();
     expect(
@@ -231,9 +231,9 @@ describe("Notebook Editor > Join Step", () => {
   it("should open the LHS column picker after right table is selected and the RHS picker after it", async () => {
     setup();
 
-    userEvent.click(screen.getByLabelText("Right table"));
+    await userEvent.click(screen.getByLabelText("Right table"));
     const tablePicker = await screen.findByTestId("popover");
-    userEvent.click(await within(tablePicker).findByText("Reviews"));
+    await userEvent.click(await within(tablePicker).findByText("Reviews"));
 
     const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
 
@@ -243,7 +243,7 @@ describe("Notebook Editor > Join Step", () => {
       within(lhsColumnPicker).queryByText(/Review/i),
     ).not.toBeInTheDocument();
 
-    userEvent.click(within(lhsColumnPicker).getByText("Total"));
+    await userEvent.click(within(lhsColumnPicker).getByText("Total"));
 
     const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
 
@@ -263,7 +263,7 @@ describe("Notebook Editor > Join Step", () => {
   it("should highlight selected LHS column", async () => {
     setup(createMockNotebookStep({ query: getJoinedQuery() }));
 
-    userEvent.click(screen.getByLabelText("Left column"));
+    await userEvent.click(screen.getByLabelText("Left column"));
     const popover = await screen.findByTestId("lhs-column-picker");
 
     expect(within(popover).getByLabelText("Product ID")).toHaveAttribute(
@@ -279,7 +279,7 @@ describe("Notebook Editor > Join Step", () => {
   it("should highlight selected RHS column", async () => {
     setup(createMockNotebookStep({ query: getJoinedQuery() }));
 
-    userEvent.click(screen.getByLabelText("Right column"));
+    await userEvent.click(screen.getByLabelText("Right column"));
     const popover = await screen.findByTestId("rhs-column-picker");
 
     expect(within(popover).getByLabelText("ID")).toHaveAttribute(
@@ -309,7 +309,7 @@ describe("Notebook Editor > Join Step", () => {
     const { getRecentJoin } = setup();
 
     const popover = screen.getByTestId("popover");
-    userEvent.click(await within(popover).findByText("Products"));
+    await userEvent.click(await within(popover).findByText("Products"));
 
     expect(await screen.findByLabelText("Left column")).toHaveTextContent(
       "Product ID",
@@ -329,9 +329,9 @@ describe("Notebook Editor > Join Step", () => {
     const query = getJoinedQuery();
     const { getRecentJoin } = setup(createMockNotebookStep({ query }));
 
-    userEvent.click(screen.getByLabelText("Left column"));
+    await userEvent.click(screen.getByLabelText("Left column"));
     const popover = await screen.findByTestId("lhs-column-picker");
-    userEvent.click(within(popover).getByText("User ID"));
+    await userEvent.click(within(popover).getByText("User ID"));
 
     const [condition] = getRecentJoin().conditions;
     expect(condition.lhsColumn.longDisplayName).toBe("User ID");
@@ -342,9 +342,9 @@ describe("Notebook Editor > Join Step", () => {
     const query = getJoinedQuery();
     const { getRecentJoin } = setup(createMockNotebookStep({ query }));
 
-    userEvent.click(screen.getByLabelText("Right column"));
+    await userEvent.click(screen.getByLabelText("Right column"));
     const popover = await screen.findByTestId("rhs-column-picker");
-    userEvent.click(within(popover).getByText("Price"));
+    await userEvent.click(within(popover).getByText("Price"));
 
     const [condition] = getRecentJoin().conditions;
     expect(condition.lhsColumn.longDisplayName).toBe("Product ID");
@@ -354,9 +354,9 @@ describe("Notebook Editor > Join Step", () => {
   it("shouldn't allow removing an incomplete condition", async () => {
     setup();
 
-    userEvent.click(screen.getByLabelText("Right table"));
+    await userEvent.click(screen.getByLabelText("Right table"));
     const tablePicker = await screen.findByTestId("popover");
-    userEvent.click(await within(tablePicker).findByText("Reviews"));
+    await userEvent.click(await within(tablePicker).findByText("Reviews"));
 
     expect(screen.queryByLabelText("Remove condition")).not.toBeInTheDocument();
   });
@@ -364,7 +364,7 @@ describe("Notebook Editor > Join Step", () => {
   it("should display temporal unit for date-time columns", async () => {
     setup(createMockNotebookStep({ query: getJoinedQuery() }));
 
-    userEvent.click(screen.getByLabelText("Left column"));
+    await userEvent.click(screen.getByLabelText("Left column"));
     const popover = await screen.findByTestId("lhs-column-picker");
     const numericColumn = within(popover).getByLabelText("Total");
     const dateTimeColumn = within(popover).getByLabelText("Created At");
@@ -382,7 +382,7 @@ describe("Notebook Editor > Join Step", () => {
       createMockNotebookStep({ query: getJoinedQuery() }),
     );
 
-    userEvent.click(screen.getByLabelText("Change join type"));
+    await userEvent.click(screen.getByLabelText("Change join type"));
     let popover = await screen.findByTestId("select-list");
     let leftJoin = within(popover).getByLabelText("Left outer join");
     let rightJoin = within(popover).getByLabelText("Right outer join");
@@ -390,12 +390,12 @@ describe("Notebook Editor > Join Step", () => {
     expect(leftJoin).toHaveAttribute("aria-selected", "true");
     expect(rightJoin).toHaveAttribute("aria-selected", "false");
 
-    userEvent.click(rightJoin);
+    await userEvent.click(rightJoin);
     await waitFor(() =>
       expect(screen.queryByTestId("select-list")).not.toBeInTheDocument(),
     );
 
-    userEvent.click(screen.getByLabelText("Change join type"));
+    await userEvent.click(screen.getByLabelText("Change join type"));
     popover = await screen.findByTestId("select-list");
     leftJoin = within(popover).getByLabelText("Left outer join");
     rightJoin = within(popover).getByLabelText("Right outer join");
@@ -412,7 +412,7 @@ describe("Notebook Editor > Join Step", () => {
       createMockNotebookStep({ query: getJoinedQuery() }),
     );
 
-    userEvent.click(screen.getByLabelText("Change operator"));
+    await userEvent.click(screen.getByLabelText("Change operator"));
     let popover = await screen.findByTestId("select-list");
     let equalsOperator = within(popover).getByLabelText("=");
     let notEqualsOperator = within(popover).getByLabelText("!=");
@@ -420,12 +420,12 @@ describe("Notebook Editor > Join Step", () => {
     expect(equalsOperator).toHaveAttribute("aria-selected", "true");
     expect(notEqualsOperator).toHaveAttribute("aria-selected", "false");
 
-    userEvent.click(notEqualsOperator);
+    await userEvent.click(notEqualsOperator);
     await waitFor(() =>
       expect(screen.queryByTestId("select-list")).not.toBeInTheDocument(),
     );
 
-    userEvent.click(screen.getByLabelText("Change operator"));
+    await userEvent.click(screen.getByLabelText("Change operator"));
     popover = await screen.findByTestId("select-list");
     equalsOperator = within(popover).getByLabelText("=");
     notEqualsOperator = within(popover).getByLabelText("!=");
@@ -442,7 +442,7 @@ describe("Notebook Editor > Join Step", () => {
       const { getRecentJoin } = setup();
 
       const popover = screen.getByTestId("popover");
-      userEvent.click(await within(popover).findByText("Products"));
+      await userEvent.click(await within(popover).findByText("Products"));
 
       await waitFor(() => {
         const { fields } = getRecentJoin();
@@ -454,24 +454,24 @@ describe("Notebook Editor > Join Step", () => {
       const { getRecentJoin } = setup();
 
       const popover = screen.getByTestId("popover");
-      userEvent.click(await within(popover).findByText("Reviews"));
+      await userEvent.click(await within(popover).findByText("Reviews"));
 
-      userEvent.click(await screen.findByLabelText("Pick columns"));
+      await userEvent.click(await screen.findByLabelText("Pick columns"));
       const joinColumnsPicker = await screen.findByTestId(
         "join-columns-picker",
       );
 
       // Excluding a few columns
-      userEvent.click(within(joinColumnsPicker).getByText("Reviewer"));
-      userEvent.click(within(joinColumnsPicker).getByText("Product ID"));
-      userEvent.click(within(joinColumnsPicker).getByText("Created At"));
+      await userEvent.click(within(joinColumnsPicker).getByText("Reviewer"));
+      await userEvent.click(within(joinColumnsPicker).getByText("Product ID"));
+      await userEvent.click(within(joinColumnsPicker).getByText("Created At"));
 
       // Bring Reviewer column back
-      userEvent.click(within(joinColumnsPicker).getByText("Reviewer"));
+      await userEvent.click(within(joinColumnsPicker).getByText("Reviewer"));
 
-      userEvent.click(screen.getByLabelText("Left column"));
+      await userEvent.click(screen.getByLabelText("Left column"));
       const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
-      userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
+      await userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
       await waitFor(() =>
         expect(screen.getByLabelText("Left column")).toHaveTextContent(
           "Product ID",
@@ -479,7 +479,7 @@ describe("Notebook Editor > Join Step", () => {
       );
 
       const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
-      userEvent.click(within(rhsColumnPicker).getByText("Rating"));
+      await userEvent.click(within(rhsColumnPicker).getByText("Rating"));
 
       const { query, fields } = getRecentJoin();
       const columns = fields as Lib.ColumnMetadata[];
@@ -502,18 +502,18 @@ describe("Notebook Editor > Join Step", () => {
       const { getRecentJoin } = setup();
 
       const popover = screen.getByTestId("popover");
-      userEvent.click(await within(popover).findByText("Reviews"));
+      await userEvent.click(await within(popover).findByText("Reviews"));
 
-      userEvent.click(await screen.findByLabelText("Pick columns"));
+      await userEvent.click(await screen.findByLabelText("Pick columns"));
       const joinColumnsPicker = await screen.findByTestId(
         "join-columns-picker",
       );
 
-      userEvent.click(within(joinColumnsPicker).getByText("Select none"));
+      await userEvent.click(within(joinColumnsPicker).getByText("Select none"));
 
-      userEvent.click(screen.getByLabelText("Left column"));
+      await userEvent.click(screen.getByLabelText("Left column"));
       const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
-      userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
+      await userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
       await waitFor(() =>
         expect(screen.getByLabelText("Left column")).toHaveTextContent(
           "Product ID",
@@ -521,7 +521,7 @@ describe("Notebook Editor > Join Step", () => {
       );
 
       const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
-      userEvent.click(within(rhsColumnPicker).getByText("Rating"));
+      await userEvent.click(within(rhsColumnPicker).getByText("Rating"));
 
       const { fields } = getRecentJoin();
       expect(fields).toBe("none");
@@ -532,16 +532,16 @@ describe("Notebook Editor > Join Step", () => {
         createMockNotebookStep({ query: getJoinedQuery() }),
       );
 
-      userEvent.click(screen.getByLabelText("Pick columns"));
+      await userEvent.click(screen.getByLabelText("Pick columns"));
       const picker = await screen.findByTestId("join-columns-picker");
 
       // Excluding a few columns
-      userEvent.click(within(picker).getByText("Vendor"));
-      userEvent.click(within(picker).getByText("Price"));
-      userEvent.click(within(picker).getByText("Category"));
+      await userEvent.click(within(picker).getByText("Vendor"));
+      await userEvent.click(within(picker).getByText("Price"));
+      await userEvent.click(within(picker).getByText("Category"));
 
       // Bring Vendors column back
-      userEvent.click(within(picker).getByText("Vendor"));
+      await userEvent.click(within(picker).getByText("Vendor"));
 
       const { query, fields } = getRecentJoin();
       const columns = fields as Lib.ColumnMetadata[];
@@ -565,9 +565,9 @@ describe("Notebook Editor > Join Step", () => {
         createMockNotebookStep({ query: getJoinedQuery() }),
       );
 
-      userEvent.click(screen.getByLabelText("Pick columns"));
+      await userEvent.click(screen.getByLabelText("Pick columns"));
       const picker = await screen.findByTestId("join-columns-picker");
-      userEvent.click(within(picker).getByText("Select none"));
+      await userEvent.click(within(picker).getByText("Select none"));
 
       const { fields } = getRecentJoin();
       expect(fields).toBe("none");
@@ -616,14 +616,14 @@ describe("Notebook Editor > Join Step", () => {
 
       expect(screen.queryByLabelText("Add condition")).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByLabelText("Right table"));
+      await userEvent.click(screen.getByLabelText("Right table"));
       const popover = await screen.findByTestId("popover");
-      userEvent.click(await within(popover).findByText("Reviews"));
+      await userEvent.click(await within(popover).findByText("Reviews"));
 
       expect(screen.queryByLabelText("Add condition")).not.toBeInTheDocument();
 
       const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
-      userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
+      await userEvent.click(within(lhsColumnPicker).getByText("Product ID"));
       await waitFor(() =>
         expect(screen.getByLabelText("Left column")).toHaveTextContent(
           "Product ID",
@@ -633,7 +633,7 @@ describe("Notebook Editor > Join Step", () => {
       expect(screen.queryByLabelText("Add condition")).not.toBeInTheDocument();
 
       const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
-      userEvent.click(within(rhsColumnPicker).getByText("Rating"));
+      await userEvent.click(within(rhsColumnPicker).getByText("Rating"));
 
       expect(screen.getByLabelText("Add condition")).toBeInTheDocument();
     });
@@ -643,11 +643,11 @@ describe("Notebook Editor > Join Step", () => {
         createMockNotebookStep({ query: getJoinedQuery() }),
       );
 
-      userEvent.click(screen.getByLabelText("Add condition"));
+      await userEvent.click(screen.getByLabelText("Add condition"));
       const conditionContainer = screen.getByTestId("new-join-condition");
 
       const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
-      userEvent.click(within(lhsColumnPicker).getByText("Created At"));
+      await userEvent.click(within(lhsColumnPicker).getByText("Created At"));
       await waitFor(() =>
         expect(
           within(conditionContainer).getByLabelText("Left column"),
@@ -655,7 +655,7 @@ describe("Notebook Editor > Join Step", () => {
       );
 
       const rhsColumnPicker = await screen.findByTestId("rhs-column-picker");
-      userEvent.click(within(rhsColumnPicker).getByText("Created At"));
+      await userEvent.click(within(rhsColumnPicker).getByText("Created At"));
 
       const { conditions } = getRecentJoin();
       const [condition1, condition2] = conditions;
@@ -671,10 +671,10 @@ describe("Notebook Editor > Join Step", () => {
     it("should remove an incomplete condition", async () => {
       setup(createMockNotebookStep({ query: getJoinedQuery() }));
 
-      userEvent.click(screen.getByLabelText("Add condition"));
+      await userEvent.click(screen.getByLabelText("Add condition"));
       let conditionContainer = screen.getByTestId("new-join-condition");
 
-      userEvent.click(
+      await userEvent.click(
         within(conditionContainer).getByLabelText("Remove condition"),
       );
 
@@ -682,18 +682,18 @@ describe("Notebook Editor > Join Step", () => {
         screen.queryByTestId("new-join-condition"),
       ).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByLabelText("Add condition"));
+      await userEvent.click(screen.getByLabelText("Add condition"));
       conditionContainer = screen.getByTestId("new-join-condition");
 
       const lhsColumnPicker = await screen.findByTestId("lhs-column-picker");
-      userEvent.click(within(lhsColumnPicker).getByText("Created At"));
+      await userEvent.click(within(lhsColumnPicker).getByText("Created At"));
       await waitFor(() =>
         expect(
           within(conditionContainer).getByLabelText("Left column"),
         ).toHaveTextContent("Created At"),
       );
 
-      userEvent.click(
+      await userEvent.click(
         within(conditionContainer).getByLabelText("Remove condition"),
       );
       expect(
@@ -718,7 +718,7 @@ describe("Notebook Editor > Join Step", () => {
         within(secondCondition).getByLabelText("Remove condition"),
       ).toBeInTheDocument();
 
-      userEvent.click(
+      await userEvent.click(
         within(secondCondition).getByLabelText("Remove condition"),
       );
 
@@ -744,7 +744,7 @@ describe("Notebook Editor > Join Step", () => {
         screen.queryByLabelText("Remove condition"),
       ).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByLabelText("Add condition"));
+      await userEvent.click(screen.getByLabelText("Add condition"));
 
       const firstCondition = screen.getByTestId("join-condition-0");
       expect(

--- a/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/JoinStep/JoinStep.unit.spec.tsx
@@ -202,7 +202,9 @@ describe("Notebook Editor > Join Step", () => {
   it("should open the source query database in RHS table picker", async () => {
     setup();
 
-    await userEvent.click(screen.getByLabelText("Right table"));
+    await userEvent.click(
+      within(screen.getByLabelText("Right table")).getByRole("button"),
+    );
     const popover = await screen.findByTestId("popover");
 
     await waitFor(() => {
@@ -216,7 +218,9 @@ describe("Notebook Editor > Join Step", () => {
   it("should not allow picking a right table from another database", async () => {
     setup();
 
-    await userEvent.click(screen.getByLabelText("Right table"));
+    await userEvent.click(
+      within(screen.getByLabelText("Right table")).getByRole("button"),
+    );
     const popover = await screen.findByTestId("popover");
 
     // Go back to the database list
@@ -231,7 +235,9 @@ describe("Notebook Editor > Join Step", () => {
   it("should open the LHS column picker after right table is selected and the RHS picker after it", async () => {
     setup();
 
-    await userEvent.click(screen.getByLabelText("Right table"));
+    await userEvent.click(
+      within(screen.getByLabelText("Right table")).getByRole("button"),
+    );
     const tablePicker = await screen.findByTestId("popover");
     await userEvent.click(await within(tablePicker).findByText("Reviews"));
 
@@ -354,7 +360,9 @@ describe("Notebook Editor > Join Step", () => {
   it("shouldn't allow removing an incomplete condition", async () => {
     setup();
 
-    await userEvent.click(screen.getByLabelText("Right table"));
+    await userEvent.click(
+      within(screen.getByLabelText("Right table")).getByRole("button"),
+    );
     const tablePicker = await screen.findByTestId("popover");
     await userEvent.click(await within(tablePicker).findByText("Reviews"));
 
@@ -616,7 +624,9 @@ describe("Notebook Editor > Join Step", () => {
 
       expect(screen.queryByLabelText("Add condition")).not.toBeInTheDocument();
 
-      await userEvent.click(screen.getByLabelText("Right table"));
+      await userEvent.click(
+        within(screen.getByLabelText("Right table")).getByRole("button"),
+      );
       const popover = await screen.findByTestId("popover");
       await userEvent.click(await within(popover).findByText("Reviews"));
 

--- a/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/SortStep/SortStep.unit.spec.tsx
@@ -75,7 +75,7 @@ describe("SortStep", () => {
   it("should display orderable columns", async () => {
     setup();
 
-    userEvent.click(getIcon("add"));
+    await userEvent.click(getIcon("add"));
 
     // Tables
     expect(await screen.findByText("Order")).toBeInTheDocument();
@@ -93,52 +93,52 @@ describe("SortStep", () => {
   it("should add an order by", async () => {
     const { gerRecentOrderByClause } = setup();
 
-    userEvent.click(getIcon("add"));
-    userEvent.click(await screen.findByText("Created At"));
+    await userEvent.click(getIcon("add"));
+    await userEvent.click(await screen.findByText("Created At"));
 
     const orderBy = gerRecentOrderByClause();
     expect(orderBy.displayName).toBe("Created At");
     expect(orderBy.direction).toBe("asc");
   });
 
-  it("shouldn't show already used columns when adding a new order-by", () => {
+  it("shouldn't show already used columns when adding a new order-by", async () => {
     const { query, columnInfo } = createQueryWithOrderBy();
     setup(createMockNotebookStep({ query }));
 
-    userEvent.click(getIcon("add"));
+    await userEvent.click(getIcon("add"));
 
     expect(
       screen.queryByRole("option", { name: columnInfo.displayName }),
     ).not.toBeInTheDocument();
   });
 
-  it("should toggle an order by direction", () => {
+  it("should toggle an order by direction", async () => {
     const { query, columnInfo } = createQueryWithOrderBy();
     const { gerRecentOrderByClause } = setup(createMockNotebookStep({ query }));
 
-    userEvent.click(screen.getByLabelText("Change direction"));
+    await userEvent.click(screen.getByLabelText("Change direction"));
 
     const orderBy = gerRecentOrderByClause();
     expect(orderBy.direction).toBe("desc");
     expect(orderBy.displayName).toBe(columnInfo.displayName);
   });
 
-  it("should change ordered field", () => {
+  it("should change ordered field", async () => {
     const { query, columnInfo } = createQueryWithOrderBy();
     const { gerRecentOrderByClause } = setup(createMockNotebookStep({ query }));
 
-    userEvent.click(screen.getByText(columnInfo.displayName));
-    userEvent.click(screen.getByText("Created At"));
+    await userEvent.click(screen.getByText(columnInfo.displayName));
+    await userEvent.click(screen.getByText("Created At"));
 
     const orderBy = gerRecentOrderByClause();
     expect(orderBy.displayName).toBe("Created At");
   });
 
-  it("should remove an order by", () => {
+  it("should remove an order by", async () => {
     const { query } = createQueryWithOrderBy();
     const { getNextQuery } = setup(createMockNotebookStep({ query }));
 
-    userEvent.click(getIcon("close"));
+    await userEvent.click(getIcon("close"));
 
     const nextQuery = getNextQuery();
     expect(Lib.orderBys(nextQuery, 0)).toHaveLength(0);

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetFormModal/SnippetFormModal.unit.spec.tsx
@@ -122,7 +122,7 @@ describe("SnippetFormModal", () => {
 
     it("can't submit if content is empty", async () => {
       await setup();
-      userEvent.type(screen.getByLabelText(LABEL.NAME), "My snippet");
+      await userEvent.type(screen.getByLabelText(LABEL.NAME), "My snippet");
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
       });
@@ -130,7 +130,7 @@ describe("SnippetFormModal", () => {
 
     it("can't submit if name is empty", async () => {
       await setup();
-      userEvent.type(
+      await userEvent.type(
         screen.getByLabelText(LABEL.CONTENT),
         "WHERE discount > 0",
       );
@@ -142,8 +142,8 @@ describe("SnippetFormModal", () => {
     it("can submit with name and content", async () => {
       await setup();
 
-      userEvent.type(screen.getByLabelText(LABEL.NAME), "My snippet");
-      userEvent.type(
+      await userEvent.type(screen.getByLabelText(LABEL.NAME), "My snippet");
+      await userEvent.type(
         screen.getByLabelText(LABEL.CONTENT),
         "WHERE discount > 0",
       );
@@ -162,7 +162,7 @@ describe("SnippetFormModal", () => {
 
     it("calls onClose when cancel button is clicked", async () => {
       const { onClose } = await setup();
-      userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
       await waitFor(() => {
         expect(onClose).toHaveBeenCalledTimes(1);
       });
@@ -227,7 +227,7 @@ describe("SnippetFormModal", () => {
 
     it("can't submit if content is empty", async () => {
       await setupEditing();
-      userEvent.clear(screen.getByLabelText(LABEL.NAME));
+      await userEvent.clear(screen.getByLabelText(LABEL.NAME));
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
       });
@@ -235,7 +235,7 @@ describe("SnippetFormModal", () => {
 
     it("can't submit if name is empty", async () => {
       await setupEditing();
-      userEvent.clear(screen.getByLabelText(LABEL.CONTENT));
+      await userEvent.clear(screen.getByLabelText(LABEL.CONTENT));
       await waitFor(() => {
         expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
       });
@@ -244,8 +244,8 @@ describe("SnippetFormModal", () => {
     it("can submit with name and content", async () => {
       await setupEditing();
 
-      userEvent.type(screen.getByLabelText(LABEL.NAME), "My snippet");
-      userEvent.type(
+      await userEvent.type(screen.getByLabelText(LABEL.NAME), "My snippet");
+      await userEvent.type(
         screen.getByLabelText(LABEL.CONTENT),
         "WHERE discount > 0",
       );
@@ -264,7 +264,7 @@ describe("SnippetFormModal", () => {
 
     it("calls onClose when cancel button is clicked", async () => {
       const { onClose } = await setupEditing();
-      userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
       await waitFor(() => {
         expect(onClose).toHaveBeenCalledTimes(1);
       });
@@ -272,7 +272,7 @@ describe("SnippetFormModal", () => {
 
     it("closes the modal after archiving", async () => {
       const { onClose } = await setupEditing();
-      userEvent.click(screen.getByText("Archive"));
+      await userEvent.click(screen.getByText("Archive"));
       await waitFor(() => {
         expect(onClose).toHaveBeenCalledTimes(1);
       });

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/tests/common.unit.spec.tsx
@@ -14,7 +14,7 @@ describe("SnippetSidebar (OSS)", () => {
   });
 
   it("should display the `New snippet` but not the `New folder` option", async () => {
-    userEvent.click(getIcon("add"));
+    await userEvent.click(getIcon("add"));
 
     expect(await screen.findByText("New snippet")).toBeInTheDocument();
     expect(screen.queryByText("New folder")).not.toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/tests/enterprise.unit.spec.tsx
@@ -14,7 +14,7 @@ describe("SnippetSidebar (EE no token)", () => {
   });
 
   it("should display the `New snippet` but not the `New folder` option", async () => {
-    userEvent.click(getIcon("add"));
+    await userEvent.click(getIcon("add"));
 
     expect(await screen.findByText("New snippet")).toBeInTheDocument();
     expect(screen.queryByText("New folder")).not.toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/SnippetSidebar/tests/premium.unit.spec.tsx
@@ -28,7 +28,7 @@ describe("SnippetSidebar (EE with token feature)", () => {
 
   it("should display the `New snippet` and the `New folder` option", async () => {
     await setup();
-    userEvent.click(getIcon("add"));
+    await userEvent.click(getIcon("add"));
 
     expect(await screen.findByText("New snippet")).toBeInTheDocument();
     expect(screen.getByText("New folder")).toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/template_tags/TagEditorParam.unit.spec.tsx
@@ -81,9 +81,9 @@ describe("TagEditorParam", () => {
       const input = screen.getByRole("textbox", {
         name: "Filter widget label",
       });
-      userEvent.clear(input);
-      userEvent.type(input, "New");
-      userEvent.tab();
+      await userEvent.clear(input);
+      await userEvent.type(input, "New");
+      await userEvent.tab();
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
@@ -93,7 +93,7 @@ describe("TagEditorParam", () => {
   });
 
   describe("tag type", () => {
-    it("should be able to change the type of the tag", () => {
+    it("should be able to change the type of the tag", async () => {
       const tag = createMockTemplateTag({
         type: "dimension",
         dimension: ["field", PEOPLE.NAME, null],
@@ -101,10 +101,10 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      userEvent.click(screen.getByTestId("variable-type-select"));
-      userEvent.click(screen.getByText("Field Filter"));
-      userEvent.click(screen.getByTestId("variable-type-select"));
-      userEvent.click(screen.getByText("Number"));
+      await userEvent.click(screen.getByTestId("variable-type-select"));
+      await userEvent.click(screen.getByText("Field Filter"));
+      await userEvent.click(screen.getByTestId("variable-type-select"));
+      await userEvent.click(screen.getByText("Number"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
@@ -125,8 +125,8 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      userEvent.click(await screen.findByText("People"));
-      userEvent.click(await screen.findByText("Source"));
+      await userEvent.click(await screen.findByText("People"));
+      await userEvent.click(await screen.findByText("Source"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
@@ -144,8 +144,8 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      userEvent.click(await screen.findByText("People"));
-      userEvent.click(await screen.findByText("Name"));
+      await userEvent.click(await screen.findByText("People"));
+      await userEvent.click(await screen.findByText("Name"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
@@ -163,8 +163,8 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      userEvent.click(await screen.findByText("Orders"));
-      userEvent.click(await screen.findByText("Quantity"));
+      await userEvent.click(await screen.findByText("Orders"));
+      await userEvent.click(await screen.findByText("Quantity"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
@@ -182,8 +182,8 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      userEvent.click(await screen.findByText("Reviews"));
-      userEvent.click(await screen.findByText("Rating"));
+      await userEvent.click(await screen.findByText("Reviews"));
+      await userEvent.click(await screen.findByText("Rating"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
@@ -201,8 +201,8 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      userEvent.click(await screen.findByText("Name"));
-      userEvent.click(await screen.findByText("Address"));
+      await userEvent.click(await screen.findByText("Name"));
+      await userEvent.click(await screen.findByText("Address"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
@@ -212,7 +212,7 @@ describe("TagEditorParam", () => {
   });
 
   describe("tag widget type", () => {
-    it("should be able to set the widget type with options", () => {
+    it("should be able to set the widget type with options", async () => {
       const tag = createMockTemplateTag({
         type: "dimension",
         dimension: ["field", PEOPLE.NAME, null],
@@ -220,10 +220,10 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      userEvent.click(screen.getByTestId("filter-widget-type-select"));
-      userEvent.click(screen.getByText("String"));
-      userEvent.click(screen.getByTestId("filter-widget-type-select"));
-      userEvent.click(screen.getByText("String contains"));
+      await userEvent.click(screen.getByTestId("filter-widget-type-select"));
+      await userEvent.click(screen.getByText("String"));
+      await userEvent.click(screen.getByTestId("filter-widget-type-select"));
+      await userEvent.click(screen.getByText("String contains"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
@@ -233,7 +233,7 @@ describe("TagEditorParam", () => {
       });
     });
 
-    it("should be able to set the widget type without options", () => {
+    it("should be able to set the widget type without options", async () => {
       const tag = createMockTemplateTag({
         type: "dimension",
         dimension: ["field", PEOPLE.NAME, null],
@@ -242,10 +242,10 @@ describe("TagEditorParam", () => {
       });
       const { setTemplateTag } = setup({ tag });
 
-      userEvent.click(screen.getByTestId("filter-widget-type-select"));
-      userEvent.click(screen.getByText("String starts with"));
-      userEvent.click(screen.getByTestId("filter-widget-type-select"));
-      userEvent.click(screen.getByText("String"));
+      await userEvent.click(screen.getByTestId("filter-widget-type-select"));
+      await userEvent.click(screen.getByText("String starts with"));
+      await userEvent.click(screen.getByTestId("filter-widget-type-select"));
+      await userEvent.click(screen.getByText("String"));
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
@@ -255,7 +255,7 @@ describe("TagEditorParam", () => {
       });
     });
 
-    it("should replace old location widget-type values with string/=", () => {
+    it("should replace old location widget-type values with string/=", async () => {
       const tag = createMockTemplateTag({
         type: "dimension",
         dimension: ["field", PEOPLE.NAME, null],
@@ -263,18 +263,18 @@ describe("TagEditorParam", () => {
       });
       setup({ tag });
 
-      userEvent.click(screen.getByTestId("filter-widget-type-select"));
+      await userEvent.click(screen.getByTestId("filter-widget-type-select"));
       expect(screen.getByText("String")).toBeInTheDocument();
     });
   });
 
   describe("tag required", () => {
-    it("should be able to make the tag required", () => {
+    it("should be able to make the tag required", async () => {
       const tag = createMockTemplateTag();
       const { setTemplateTag } = setup({ tag });
 
       const toggleLabel = screen.getByText("Always require a value");
-      userEvent.click(toggleLabel);
+      await userEvent.click(toggleLabel);
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,
@@ -282,22 +282,22 @@ describe("TagEditorParam", () => {
       });
     });
 
-    it("should set the default value when turning required on", () => {
+    it("should set the default value when turning required on", async () => {
       const tag = createMockTemplateTag({ default: "123" });
       const { setParameterValue } = setup({ tag });
 
       const toggleLabel = screen.getByText("Always require a value");
-      userEvent.click(toggleLabel);
+      await userEvent.click(toggleLabel);
 
       expect(setParameterValue).toHaveBeenCalledWith(tag.id, "123");
     });
 
-    it("should not clear the default value when turning required off", () => {
+    it("should not clear the default value when turning required off", async () => {
       const tag = createMockTemplateTag({ required: true, default: "abc" });
       const { setTemplateTag } = setup({ tag });
 
       const toggleLabel = screen.getByText("Always require a value");
-      userEvent.click(toggleLabel);
+      await userEvent.click(toggleLabel);
 
       expect(setTemplateTag).toHaveBeenCalledWith({
         ...tag,

--- a/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionRowCount/QuestionRowCount.unit.spec.tsx
@@ -151,7 +151,7 @@ describe("QuestionRowCount", () => {
         it("allows setting a limit", async () => {
           const { rowCount } = await setup({ question: getCard() });
 
-          userEvent.click(rowCount);
+          await userEvent.click(rowCount);
           const input = await screen.findByPlaceholderText("Pick a limit");
           fireEvent.change(input, { target: { value: "25" } });
           fireEvent.keyPress(input, { key: "Enter", charCode: 13 });
@@ -166,7 +166,7 @@ describe("QuestionRowCount", () => {
             question: getCard({ dataset_query: getDatasetQueryWithLimit(25) }),
           });
 
-          userEvent.click(rowCount);
+          await userEvent.click(rowCount);
           const input = await screen.findByDisplayValue("25");
           fireEvent.change(input, { target: { value: "400" } });
           fireEvent.keyPress(input, { key: "Enter", charCode: 13 });
@@ -181,8 +181,8 @@ describe("QuestionRowCount", () => {
             question: getCard({ dataset_query: getDatasetQueryWithLimit(25) }),
           });
 
-          userEvent.click(rowCount);
-          userEvent.click(
+          await userEvent.click(rowCount);
+          await userEvent.click(
             await screen.findByRole("radio", { name: /Show maximum/i }),
           );
 
@@ -203,7 +203,7 @@ describe("QuestionRowCount", () => {
             screen.queryByRole("button", { name: "Row count" }),
           ).not.toBeInTheDocument();
 
-          userEvent.click(rowCount);
+          await userEvent.click(rowCount);
 
           expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
         });
@@ -261,7 +261,7 @@ describe("QuestionRowCount", () => {
             screen.queryByRole("button", { name: "Row count" }),
           ).not.toBeInTheDocument();
 
-          userEvent.click(rowCount);
+          await userEvent.click(rowCount);
 
           expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
         });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.unit.spec.js
@@ -391,11 +391,11 @@ describe("ViewHeader", () => {
           });
         });
 
-        it("calls save function on title update", () => {
+        it("calls save function on title update", async () => {
           const { onSave } = setup({ card });
           const title = screen.getByTestId("saved-question-header-title");
-          userEvent.clear(title);
-          userEvent.type(title, "New Title{enter}");
+          await userEvent.clear(title);
+          await userEvent.type(title, "New Title{enter}");
           expect(title).toHaveValue("New Title");
           title.blur();
           expect(onSave).toHaveBeenCalled();

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.unit.spec.tsx
@@ -92,7 +92,7 @@ describe("QuestionActions", () => {
       }),
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     await screen.findByRole("dialog");
 
     expect(screen.getByText("Edit query definition")).toBeInTheDocument();
@@ -107,7 +107,7 @@ describe("QuestionActions", () => {
       }),
     });
 
-    userEvent.click(getIcon("ellipsis"));
+    await userEvent.click(getIcon("ellipsis"));
     await screen.findByRole("dialog");
 
     expect(screen.queryByText("Edit query definition")).not.toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionFilters/FilterHeader.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionFilters/FilterHeader.unit.spec.tsx
@@ -93,10 +93,10 @@ describe("FilterHeader", () => {
   it("should update a filter on the last stage", async () => {
     const { getNextQuery, getFilterColumnNameForStage } = setup();
 
-    userEvent.click(screen.getByText("User → Source is Organic"));
-    userEvent.click(await screen.findByLabelText("Filter operator"));
-    userEvent.click(await screen.findByText("Is empty"));
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.click(screen.getByText("User → Source is Organic"));
+    await userEvent.click(await screen.findByLabelText("Filter operator"));
+    await userEvent.click(await screen.findByText("Is empty"));
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(screen.getByText("User → Source is empty")).toBeInTheDocument();
     expect(
@@ -124,9 +124,12 @@ describe("FilterHeader", () => {
   it("should update a filter on the previous stage", async () => {
     const { getNextQuery, getFilterColumnNameForStage } = setup();
 
-    userEvent.click(screen.getByText("Count is greater than 5"));
-    userEvent.type(await screen.findByDisplayValue("5"), "{backspace}110");
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.click(screen.getByText("Count is greater than 5"));
+    await userEvent.type(
+      await screen.findByDisplayValue("5"),
+      "{backspace}110",
+    );
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(screen.getByText("Count is greater than 110")).toBeInTheDocument();
     expect(
@@ -150,10 +153,10 @@ describe("FilterHeader", () => {
     expect(nextColumnName).toBe("Count");
   });
 
-  it("should remove a filter from the last stage", () => {
+  it("should remove a filter from the last stage", async () => {
     const { getNextQuery } = setup();
 
-    userEvent.click(
+    await userEvent.click(
       within(screen.getByText("User → Source is Organic")).getByLabelText(
         "Remove",
       ),
@@ -170,10 +173,10 @@ describe("FilterHeader", () => {
     expect(Lib.filters(query, 1)).toHaveLength(1);
   });
 
-  it("should remove a filter from the previous stage", () => {
+  it("should remove a filter from the previous stage", async () => {
     const { getNextQuery } = setup();
 
-    userEvent.click(
+    await userEvent.click(
       within(screen.getByText("Count is greater than 5")).getByLabelText(
         "Remove",
       ),

--- a/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/QuestionInfoSidebar/tests/common.unit.spec.tsx
@@ -44,7 +44,7 @@ describe("QuestionInfoSidebar", () => {
       await setup({ card });
 
       // show input
-      userEvent.click(screen.getByTestId("editable-text"));
+      await userEvent.click(screen.getByTestId("editable-text"));
 
       const input = screen.getByPlaceholderText("Add description");
       expect(input).toHaveValue(card.description);

--- a/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/view/sidebars/SummarizeSidebar/SummarizeSidebar.unit.spec.tsx
@@ -42,7 +42,7 @@ function createSummarizedCard() {
   });
 }
 
-function setup({
+async function setup({
   card = createAdHocCard(),
   withDefaultAggregation = true,
 }: SetupOpts = {}) {
@@ -78,7 +78,7 @@ function setup({
 
   if (!withDefaultAggregation) {
     const countButton = screen.getByLabelText("Count");
-    userEvent.click(within(countButton).getByLabelText("close icon"));
+    await userEvent.click(within(countButton).getByLabelText("close icon"));
   }
 
   function getNextQuery() {
@@ -111,11 +111,11 @@ function setup({
 
 describe("SummarizeSidebar", () => {
   describe("default aggregation", () => {
-    it("should apply default aggregation for bare rows query", () => {
-      const { getNextAggregations, onQueryChange } = setup();
+    it("should apply default aggregation for bare rows query", async () => {
+      const { getNextAggregations, onQueryChange } = await setup();
 
       expect(screen.getByLabelText("Count")).toBeInTheDocument();
-      userEvent.click(screen.getByText("Done"));
+      await userEvent.click(screen.getByText("Done"));
 
       const aggregations = getNextAggregations();
       const [aggregation] = aggregations;
@@ -124,25 +124,25 @@ describe("SummarizeSidebar", () => {
       expect(onQueryChange).toHaveBeenCalledTimes(1);
     });
 
-    it("should allow to remove a default aggregation", () => {
-      const { getNextAggregations, onQueryChange } = setup();
+    it("should allow to remove a default aggregation", async () => {
+      const { getNextAggregations, onQueryChange } = await setup();
 
       const countButton = screen.getByLabelText("Count");
-      userEvent.click(within(countButton).getByLabelText("close icon"));
+      await userEvent.click(within(countButton).getByLabelText("close icon"));
 
       const aggregations = getNextAggregations();
       expect(aggregations).toHaveLength(0);
       expect(onQueryChange).toHaveBeenCalledTimes(1);
     });
 
-    it("shouldn't apply default aggregation if a query is already aggregated", () => {
-      setup({ card: createSummarizedCard() });
+    it("shouldn't apply default aggregation if a query is already aggregated", async () => {
+      await setup({ card: createSummarizedCard() });
       expect(screen.queryByLabelText("Count")).not.toBeInTheDocument();
     });
   });
 
-  it("should list breakoutable columns", () => {
-    const { metadata } = setup();
+  it("should list breakoutable columns", async () => {
+    const { metadata } = await setup();
     const ordersTable = checkNotNull(metadata.table(ORDERS_ID));
     const productsTable = checkNotNull(metadata.table(PRODUCTS_ID));
     const peopleTable = checkNotNull(metadata.table(PEOPLE_ID));
@@ -161,26 +161,26 @@ describe("SummarizeSidebar", () => {
     );
   });
 
-  it("should list render the info icon on breakout columns", () => {
-    setup();
+  it("should list render the info icon on breakout columns", async () => {
+    await setup();
 
     screen.queryAllByTestId("dimension-list-item").forEach(item => {
       expect(within(item).getByLabelText("More info")).toBeInTheDocument();
     });
   });
 
-  it("shouldn't list breakout columns without an aggregation", () => {
-    setup({ withDefaultAggregation: false });
+  it("shouldn't list breakout columns without an aggregation", async () => {
+    await setup({ withDefaultAggregation: false });
 
     expect(screen.queryByText("Group by")).not.toBeInTheDocument();
     expect(screen.queryAllByTestId("dimension-list-item").length).toBe(0);
   });
 
   it("should allow searching breakout columns", async () => {
-    setup();
+    await setup();
 
     const searchInput = screen.getByPlaceholderText(/Find/);
-    userEvent.type(searchInput, "Created");
+    await userEvent.type(searchInput, "Created");
 
     await waitFor(() =>
       expect(screen.getAllByTestId("dimension-list-item")).toHaveLength(3),
@@ -188,8 +188,8 @@ describe("SummarizeSidebar", () => {
     expect(screen.getAllByLabelText("Created At")).toHaveLength(3);
   });
 
-  it("should highlight selected breakout columns", () => {
-    setup({ card: createSummarizedCard() });
+  it("should highlight selected breakout columns", async () => {
+    await setup({ card: createSummarizedCard() });
 
     const [ordersCreatedAt, peopleCreatedAt] =
       screen.getAllByLabelText("Created At");
@@ -200,8 +200,8 @@ describe("SummarizeSidebar", () => {
     expect(peopleCreatedAt).toHaveAttribute("aria-selected", "false");
   });
 
-  it("should list breakouts added before opening the sidebar in a separate section", () => {
-    setup({ card: createSummarizedCard() });
+  it("should list breakouts added before opening the sidebar in a separate section", async () => {
+    await setup({ card: createSummarizedCard() });
 
     const pinnedColumnList = screen.getByTestId("pinned-dimensions");
     const unpinnedColumnList = screen.getByTestId("unpinned-dimensions");
@@ -224,11 +224,13 @@ describe("SummarizeSidebar", () => {
   });
 
   it("should add an aggregation", async () => {
-    const { getNextAggregations } = setup({ withDefaultAggregation: false });
+    const { getNextAggregations } = await setup({
+      withDefaultAggregation: false,
+    });
 
-    userEvent.click(screen.getByLabelText("Add aggregation"));
-    userEvent.click(await screen.findByText("Average of ..."));
-    userEvent.click(await screen.findByText("Total"));
+    await userEvent.click(screen.getByLabelText("Add aggregation"));
+    await userEvent.click(await screen.findByText("Average of ..."));
+    await userEvent.click(await screen.findByText("Total"));
 
     await waitFor(() => {
       const [aggregation] = getNextAggregations();
@@ -238,10 +240,12 @@ describe("SummarizeSidebar", () => {
   });
 
   it("should add a column-less aggregation", async () => {
-    const { getNextAggregations } = setup({ withDefaultAggregation: false });
+    const { getNextAggregations } = await setup({
+      withDefaultAggregation: false,
+    });
 
-    userEvent.click(screen.getByLabelText("Add aggregation"));
-    userEvent.click(await screen.findByText("Count of rows"));
+    await userEvent.click(screen.getByLabelText("Add aggregation"));
+    await userEvent.click(await screen.findByText("Count of rows"));
 
     await waitFor(() => {
       const [aggregation] = getNextAggregations();
@@ -251,27 +255,27 @@ describe("SummarizeSidebar", () => {
   });
 
   it("shouldn't allow adding an expression aggregation", async () => {
-    setup();
+    await setup();
 
-    userEvent.click(screen.getByLabelText("Add aggregation"));
+    await userEvent.click(screen.getByLabelText("Add aggregation"));
 
     expect(await screen.findByText("Total")).toBeInTheDocument();
     expect(screen.queryByText(/Custom Expression/i)).not.toBeInTheDocument();
   });
 
   it("shouldn't allow changing an aggregation to an expression", async () => {
-    setup({ card: createSummarizedCard() });
+    await setup({ card: createSummarizedCard() });
 
-    userEvent.click(screen.getByText("Max of Quantity"));
-    userEvent.click(await screen.findByLabelText("Back"));
+    await userEvent.click(screen.getByText("Max of Quantity"));
+    await userEvent.click(await screen.findByLabelText("Back"));
 
     expect(screen.queryByText(/Custom Expression/i)).not.toBeInTheDocument();
   });
 
   it("should add a breakout", async () => {
-    const { getNextBreakouts } = setup();
+    const { getNextBreakouts } = await setup();
 
-    userEvent.click(screen.getByText("Category"));
+    await userEvent.click(screen.getByText("Category"));
 
     await waitFor(() => {
       const [breakout] = getNextBreakouts();
@@ -281,17 +285,19 @@ describe("SummarizeSidebar", () => {
   });
 
   it("should add multiple breakouts", async () => {
-    const { getNextBreakouts } = setup();
+    const { getNextBreakouts } = await setup();
 
-    userEvent.click(screen.getByText("Category"));
+    await userEvent.click(screen.getByText("Category"));
     await waitFor(() => {
       const [breakout] = getNextBreakouts();
       expect(breakout.displayName).toBe("Category");
     });
 
     const breakoutOption = screen.getByLabelText("Quantity");
-    userEvent.hover(breakoutOption);
-    userEvent.click(within(breakoutOption).getByLabelText("Add dimension"));
+    await userEvent.hover(breakoutOption);
+    await userEvent.click(
+      within(breakoutOption).getByLabelText("Add dimension"),
+    );
 
     await waitFor(() => expect(getNextBreakouts()).toHaveLength(2));
     const [breakout1, breakout2] = getNextBreakouts();
@@ -300,13 +306,13 @@ describe("SummarizeSidebar", () => {
   });
 
   it("should allow picking a temporal bucket for breakout columns", async () => {
-    const { getNextBreakouts } = setup();
+    const { getNextBreakouts } = await setup();
 
     const [createdAt] = screen.getAllByLabelText("Created At");
-    userEvent.hover(createdAt);
-    userEvent.click(within(createdAt).getByText("by month"));
+    await userEvent.hover(createdAt);
+    await userEvent.click(within(createdAt).getByText("by month"));
     const [quarter] = await screen.findAllByText("Quarter");
-    userEvent.click(quarter);
+    await userEvent.click(quarter);
 
     await waitFor(() => {
       const [breakout] = getNextBreakouts();
@@ -316,13 +322,13 @@ describe("SummarizeSidebar", () => {
   });
 
   it("should allow picking a binning strategy for breakout columns", async () => {
-    const { getNextBreakouts } = setup();
+    const { getNextBreakouts } = await setup();
 
     const [total] = screen.getAllByLabelText("Total");
-    userEvent.hover(total);
-    userEvent.click(within(total).getByText("Auto bin"));
+    await userEvent.hover(total);
+    await userEvent.click(within(total).getByText("Auto bin"));
     const [strategy] = await screen.findAllByText("10 bins");
-    userEvent.click(strategy);
+    await userEvent.click(strategy);
 
     await waitFor(() => {
       const [breakout] = getNextBreakouts();
@@ -332,31 +338,31 @@ describe("SummarizeSidebar", () => {
   });
 
   it("should add a new column instead of replacing when adding a bucketed column", async () => {
-    const { getNextBreakouts } = setup({ card: createSummarizedCard() });
+    const { getNextBreakouts } = await setup({ card: createSummarizedCard() });
 
     const [total] = screen.getAllByLabelText("Total");
-    userEvent.hover(total);
-    userEvent.click(within(total).getByText("Auto bin"));
+    await userEvent.hover(total);
+    await userEvent.click(within(total).getByText("Auto bin"));
     const [strategy] = await screen.findAllByText("10 bins");
-    userEvent.click(strategy);
+    await userEvent.click(strategy);
 
     await waitFor(() => expect(getNextBreakouts()).toHaveLength(3));
   });
 
   it("should remove breakout", async () => {
-    const { getNextBreakouts } = setup({ card: createSummarizedCard() });
+    const { getNextBreakouts } = await setup({ card: createSummarizedCard() });
 
     const [breakout] = screen.getAllByLabelText("Created At");
-    userEvent.click(within(breakout).getByLabelText("Remove dimension"));
+    await userEvent.click(within(breakout).getByLabelText("Remove dimension"));
 
     await waitFor(() => expect(getNextBreakouts()).toHaveLength(1));
     expect(getNextBreakouts()[0].longDisplayName).toBe("Product → Category");
   });
 
   it("should replace breakouts by clicking on a column", async () => {
-    const { getNextBreakouts } = setup({ card: createSummarizedCard() });
+    const { getNextBreakouts } = await setup({ card: createSummarizedCard() });
 
-    userEvent.click(screen.getByText("Quantity"));
+    await userEvent.click(screen.getByText("Quantity"));
 
     await waitFor(() => {
       const [breakout] = getNextBreakouts();
@@ -365,9 +371,9 @@ describe("SummarizeSidebar", () => {
     expect(getNextBreakouts()).toHaveLength(1);
   });
 
-  it("should close on 'Done' button", () => {
-    const { onClose } = setup();
-    userEvent.click(screen.getByText("Done"));
+  it("should close on 'Done' button", async () => {
+    const { onClose } = await setup();
+    await userEvent.click(screen.getByText("Done"));
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.beforeunload-events.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.beforeunload-events.unit.spec.tsx
@@ -108,8 +108,8 @@ describe("QueryBuilder - beforeunload events", () => {
         initialRoute: "/",
       });
 
-      userEvent.click(screen.getByText("New"));
-      userEvent.click(
+      await userEvent.click(screen.getByText("New"));
+      await userEvent.click(
         within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
@@ -128,8 +128,8 @@ describe("QueryBuilder - beforeunload events", () => {
         initialRoute: "/",
       });
 
-      userEvent.click(screen.getByText("New"));
-      userEvent.click(
+      await userEvent.click(screen.getByText("New"));
+      await userEvent.click(
         within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
 
@@ -184,8 +184,8 @@ describe("QueryBuilder - beforeunload events", () => {
       });
 
       expect(screen.queryByText("Count")).not.toBeInTheDocument();
-      userEvent.click(await screen.findByText("Summarize"));
-      userEvent.click(await screen.findByText("Done"));
+      await userEvent.click(await screen.findByText("Summarize"));
+      await userEvent.click(await screen.findByText("Done"));
       expect(await screen.findByText("Count")).toBeInTheDocument();
 
       const mockEvent = callMockEvent(mockEventListener, "beforeunload");
@@ -199,8 +199,8 @@ describe("QueryBuilder - beforeunload events", () => {
       });
 
       expect(screen.queryByText("Count")).not.toBeInTheDocument();
-      userEvent.click(await screen.findByText("Summarize"));
-      userEvent.click(await screen.findByText("Done"));
+      await userEvent.click(await screen.findByText("Summarize"));
+      await userEvent.click(await screen.findByText("Done"));
       expect(await screen.findByText("Count")).toBeInTheDocument();
 
       const mockEvent = callMockEvent(mockEventListener, "beforeunload");

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -150,8 +150,10 @@ describe("QueryBuilder", () => {
 
       expect(inputArea).toHaveValue("SELECT 1");
 
-      userEvent.click(screen.getByTestId("download-button"));
-      userEvent.click(await screen.findByRole("button", { name: ".csv" }));
+      await userEvent.click(screen.getByTestId("download-button"));
+      await userEvent.click(
+        await screen.findByRole("button", { name: ".csv" }),
+      );
 
       expect(mockDownloadEndpoint.called()).toBe(true);
     });
@@ -169,15 +171,17 @@ describe("QueryBuilder", () => {
         screen.getByTestId("mock-native-query-editor"),
       ).getByRole("textbox");
 
-      userEvent.click(inputArea);
-      userEvent.type(inputArea, " union SELECT 2");
+      await userEvent.click(inputArea);
+      await userEvent.type(inputArea, " union SELECT 2");
 
-      userEvent.tab();
+      await userEvent.tab();
 
       expect(inputArea).toHaveValue("SELECT 1 union SELECT 2");
 
-      userEvent.click(screen.getByTestId("download-button"));
-      userEvent.click(await screen.findByRole("button", { name: ".csv" }));
+      await userEvent.click(screen.getByTestId("download-button"));
+      await userEvent.click(
+        await screen.findByRole("button", { name: ".csv" }),
+      );
 
       expect(
         mockDownloadEndpoint.called((url, options) => {

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unsaved-changes-warning.unit.spec.tsx
@@ -65,7 +65,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
       await startNewNotebookModel();
 
-      userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
       expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
     });
@@ -81,8 +81,8 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await startNewNotebookModel();
       await waitForSaveToBeEnabled();
 
-      userEvent.click(screen.getByRole("button", { name: "Save" }));
-      userEvent.click(
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await userEvent.click(
         within(screen.getByTestId("save-question-modal")).getByText("Save"),
       );
 
@@ -124,8 +124,8 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await triggerNotebookQueryChange();
         await waitForSaveToBeEnabled();
 
-        userEvent.click(screen.getByText("Save"));
-        userEvent.click(
+        await userEvent.click(screen.getByText("Save"));
+        await userEvent.click(
           within(screen.getByTestId("save-question-modal")).getByText("Save"),
         );
 
@@ -190,7 +190,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await triggerNotebookQueryChange();
         await waitForSaveChangesToBeEnabled();
 
-        userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+        await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
         expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
       });
@@ -207,7 +207,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await revertNotebookQueryChange();
         await waitForSaveChangesToBeDisabled();
 
-        userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+        await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
         expect(
           screen.queryByTestId("leave-confirmation"),
@@ -223,7 +223,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await triggerNotebookQueryChange();
         await waitForSaveChangesToBeEnabled();
 
-        userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+        await userEvent.click(
+          screen.getByRole("button", { name: "Save changes" }),
+        );
 
         await waitFor(() => {
           expect(history.getCurrentLocation().pathname).toEqual(
@@ -282,7 +284,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
 
         await waitForLoaderToBeRemoved();
 
-        userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+        await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
         expect(
           screen.queryByTestId("leave-confirmation"),
@@ -299,7 +301,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
         await triggerMetadataChange();
         await waitForSaveChangesToBeEnabled();
 
-        userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+        await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
         expect(screen.getByTestId("leave-confirmation")).toBeInTheDocument();
       });
@@ -316,12 +318,14 @@ describe("QueryBuilder - unsaved changes warning", () => {
          * the QueryBuilder gets incompletely intialized.
          * This seems to affect only tests.
          */
-        userEvent.click(screen.getByText("Metadata"));
+        await userEvent.click(screen.getByText("Metadata"));
 
         await triggerMetadataChange();
         await waitForSaveChangesToBeEnabled();
 
-        userEvent.click(screen.getByRole("button", { name: "Save changes" }));
+        await userEvent.click(
+          screen.getByRole("button", { name: "Save changes" }),
+        );
 
         await waitFor(() => {
           expect(history.getCurrentLocation().pathname).toEqual(
@@ -351,7 +355,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNotebookQueryChange();
       await waitForSaveChangesToBeEnabled();
 
-      userEvent.click(screen.getByTestId("editor-tabs-metadata-name"));
+      await userEvent.click(screen.getByTestId("editor-tabs-metadata-name"));
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -360,7 +364,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerMetadataChange();
       await waitForSaveChangesToBeEnabled();
 
-      userEvent.click(screen.getByTestId("editor-tabs-query-name"));
+      await userEvent.click(screen.getByTestId("editor-tabs-query-name"));
 
       expect(
         screen.queryByTestId("leave-confirmation"),
@@ -376,10 +380,10 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNotebookQueryChange();
       await waitForSaveToBeEnabled();
 
-      userEvent.click(screen.getByText("Visualize"));
+      await userEvent.click(screen.getByText("Visualize"));
       await waitForLoaderToBeRemoved();
 
-      userEvent.click(screen.getByLabelText("notebook icon"));
+      await userEvent.click(screen.getByLabelText("notebook icon"));
 
       await waitFor(() => {
         expect(screen.getByText("Visualize")).toBeInTheDocument();
@@ -398,8 +402,8 @@ describe("QueryBuilder - unsaved changes warning", () => {
         initialRoute: "/",
       });
 
-      userEvent.click(screen.getByText("New"));
-      userEvent.click(
+      await userEvent.click(screen.getByText("New"));
+      await userEvent.click(
         within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
@@ -418,8 +422,8 @@ describe("QueryBuilder - unsaved changes warning", () => {
         initialRoute: "/",
       });
 
-      userEvent.click(screen.getByText("New"));
-      userEvent.click(
+      await userEvent.click(screen.getByText("New"));
+      await userEvent.click(
         within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
@@ -437,13 +441,13 @@ describe("QueryBuilder - unsaved changes warning", () => {
         initialRoute: "/",
       });
 
-      userEvent.click(screen.getByText("New"));
-      userEvent.click(
+      await userEvent.click(screen.getByText("New"));
+      await userEvent.click(
         within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
 
-      userEvent.click(
+      await userEvent.click(
         within(screen.getByTestId("query-builder-main")).getByRole("button", {
           name: "Get Answer",
         }),
@@ -462,8 +466,8 @@ describe("QueryBuilder - unsaved changes warning", () => {
       fetchMock.post("path:/api/card", TEST_NATIVE_CARD);
       fetchMock.get("path:/api/table/card__1/query_metadata", TEST_METADATA);
 
-      userEvent.click(screen.getByText("New"));
-      userEvent.click(
+      await userEvent.click(screen.getByText("New"));
+      await userEvent.click(
         within(await screen.findByRole("dialog")).getByText("SQL query"),
       );
       await waitForLoaderToBeRemoved();
@@ -471,10 +475,10 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNativeQueryChange();
       await waitForSaveToBeEnabled();
 
-      userEvent.click(screen.getByText("Save"));
+      await userEvent.click(screen.getByText("Save"));
 
       const saveQuestionModal = screen.getByTestId("save-question-modal");
-      userEvent.type(
+      await userEvent.type(
         within(saveQuestionModal).getByLabelText("Name"),
         TEST_NATIVE_CARD.name,
       );
@@ -483,7 +487,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
           within(saveQuestionModal).getByLabelText(/Which collection/),
         ).toHaveTextContent(TEST_COLLECTION.name);
       });
-      userEvent.click(within(saveQuestionModal).getByText("Save"));
+      await userEvent.click(within(saveQuestionModal).getByText("Save"));
 
       await waitFor(() => {
         expect(saveQuestionModal).not.toBeInTheDocument();
@@ -522,8 +526,10 @@ describe("QueryBuilder - unsaved changes warning", () => {
         initialRoute: `/question/${TEST_NATIVE_CARD.id}`,
       });
 
-      userEvent.click(screen.getByRole("button", { name: "Visualization" }));
-      userEvent.click(screen.getByTestId("Detail-button"));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Visualization" }),
+      );
+      await userEvent.click(screen.getByTestId("Detail-button"));
       await waitForSaveToBeEnabled();
 
       history.push("/redirect");
@@ -557,7 +563,7 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNativeQueryChange();
       await waitForSaveToBeEnabled();
 
-      userEvent.click(
+      await userEvent.click(
         within(screen.getByTestId("query-builder-main")).getByRole("button", {
           name: "Get Answer",
         }),
@@ -577,9 +583,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNativeQueryChange();
       await waitForSaveToBeEnabled();
 
-      userEvent.click(screen.getByText("Save"));
+      await userEvent.click(screen.getByText("Save"));
 
-      userEvent.click(
+      await userEvent.click(
         within(screen.getByTestId("save-question-modal")).getByText("Save"),
       );
 
@@ -609,20 +615,20 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNativeQueryChange();
       await waitForSaveToBeEnabled();
 
-      userEvent.click(screen.getByText("Save"));
+      await userEvent.click(screen.getByText("Save"));
 
       const saveQuestionModal = screen.getByTestId("save-question-modal");
-      userEvent.click(
+      await userEvent.click(
         within(saveQuestionModal).getByText("Save as new question"),
       );
-      userEvent.type(
+      await userEvent.type(
         within(saveQuestionModal).getByPlaceholderText(
           "What is the name of your question?",
         ),
         "New question",
       );
       expect(screen.getByTestId("save-question-modal")).toBeInTheDocument();
-      userEvent.click(within(saveQuestionModal).getByText("Save"));
+      await userEvent.click(within(saveQuestionModal).getByText("Save"));
 
       await waitFor(() => {
         expect(
@@ -695,10 +701,10 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNotebookQueryChange();
       await waitForSaveToBeEnabled();
 
-      userEvent.click(screen.getByText("Visualize"));
+      await userEvent.click(screen.getByText("Visualize"));
       await waitForLoaderToBeRemoved();
 
-      userEvent.click(screen.getByLabelText("notebook icon"));
+      await userEvent.click(screen.getByLabelText("notebook icon"));
 
       await waitFor(() => {
         expect(screen.getByText("Visualize")).toBeInTheDocument();
@@ -718,9 +724,9 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNotebookQueryChange();
       await waitForSaveToBeEnabled();
 
-      userEvent.click(screen.getByText("Save"));
+      await userEvent.click(screen.getByText("Save"));
 
-      userEvent.click(
+      await userEvent.click(
         within(screen.getByTestId("save-question-modal")).getByText("Save"),
       );
 
@@ -750,20 +756,20 @@ describe("QueryBuilder - unsaved changes warning", () => {
       await triggerNotebookQueryChange();
       await waitForSaveToBeEnabled();
 
-      userEvent.click(screen.getByText("Save"));
+      await userEvent.click(screen.getByText("Save"));
 
       const saveQuestionModal = screen.getByTestId("save-question-modal");
-      userEvent.click(
+      await userEvent.click(
         within(saveQuestionModal).getByText("Save as new question"),
       );
-      userEvent.type(
+      await userEvent.type(
         within(saveQuestionModal).getByPlaceholderText(
           "What is the name of your question?",
         ),
         "New question",
       );
       expect(screen.getByTestId("save-question-modal")).toBeInTheDocument();
-      userEvent.click(within(saveQuestionModal).getByText("Save"));
+      await userEvent.click(within(saveQuestionModal).getByText("Save"));
 
       await waitFor(() => {
         expect(

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -322,9 +322,6 @@ export const startNewNotebookModel = async () => {
   await userEvent.click(within(popover).getByText("Sample Database"));
   await waitForLoaderToBeRemoved();
   await userEvent.click(within(popover).getByText("Orders"));
-  await userEvent.click(
-    within(screen.getByTestId("popover")).getByText("Orders"),
-  );
 
   expect(screen.getByRole("button", { name: "Get Answer" })).toBeEnabled();
 };

--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -314,15 +314,17 @@ const getRequests = (state: State): RequestState[] => {
 };
 
 export const startNewNotebookModel = async () => {
-  userEvent.click(screen.getByText("Use the notebook editor"));
+  await userEvent.click(screen.getByText("Use the notebook editor"));
   await waitForLoaderToBeRemoved();
 
-  userEvent.click(screen.getByText("Pick your starting data"));
+  await userEvent.click(screen.getByText("Pick your starting data"));
   const popover = screen.getByTestId("popover");
-  userEvent.click(within(popover).getByText("Sample Database"));
+  await userEvent.click(within(popover).getByText("Sample Database"));
   await waitForLoaderToBeRemoved();
-  userEvent.click(within(popover).getByText("Orders"));
-  userEvent.click(within(screen.getByTestId("popover")).getByText("Orders"));
+  await userEvent.click(within(popover).getByText("Orders"));
+  await userEvent.click(
+    within(screen.getByTestId("popover")).getByText("Orders"),
+  );
 
   expect(screen.getByRole("button", { name: "Get Answer" })).toBeEnabled();
 };
@@ -334,9 +336,9 @@ export const triggerNativeQueryChange = async () => {
     screen.getByTestId("mock-native-query-editor"),
   ).getByRole("textbox");
 
-  userEvent.click(inputArea);
-  userEvent.type(inputArea, "0");
-  userEvent.tab();
+  await userEvent.click(inputArea);
+  await userEvent.type(inputArea, "0");
+  await userEvent.tab();
 };
 
 export const triggerMetadataChange = async () => {
@@ -346,33 +348,33 @@ export const triggerMetadataChange = async () => {
 
   const columnDisplayName = screen.getByTitle("Display name");
 
-  userEvent.click(columnDisplayName);
-  userEvent.type(columnDisplayName, "X");
-  userEvent.tab();
+  await userEvent.click(columnDisplayName);
+  await userEvent.type(columnDisplayName, "X");
+  await userEvent.tab();
 };
 
 export const triggerVisualizationQueryChange = async () => {
-  userEvent.click(screen.getByText("Filter"));
+  await userEvent.click(screen.getByText("Filter"));
 
   const modal = screen.getByRole("dialog");
   const total = within(modal).getByTestId("filter-column-Total");
   const maxInput = within(total).getByPlaceholderText("Max");
-  userEvent.type(maxInput, "1000");
-  userEvent.tab();
+  await userEvent.type(maxInput, "1000");
+  await userEvent.tab();
 
-  userEvent.click(screen.getByTestId("apply-filters"));
+  await userEvent.click(screen.getByTestId("apply-filters"));
 };
 
 export const triggerNotebookQueryChange = async () => {
-  userEvent.click(screen.getByText("Row limit"));
+  await userEvent.click(screen.getByText("Row limit"));
 
   const rowLimitInput = await within(
     screen.getByTestId("step-limit-0-0"),
   ).findByPlaceholderText("Enter a limit");
 
-  userEvent.click(rowLimitInput);
-  userEvent.type(rowLimitInput, "1");
-  userEvent.tab();
+  await userEvent.click(rowLimitInput);
+  await userEvent.type(rowLimitInput, "1");
+  await userEvent.tab();
 };
 
 /**
@@ -384,9 +386,9 @@ export const revertNotebookQueryChange = async () => {
     "Enter a limit",
   );
 
-  userEvent.click(limitInput);
-  userEvent.type(limitInput, "{backspace}");
-  userEvent.tab();
+  await userEvent.click(limitInput);
+  await userEvent.type(limitInput, "{backspace}");
+  await userEvent.tab();
 };
 
 export const waitForSaveChangesToBeEnabled = async () => {

--- a/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/DateOperatorPicker/DateOperatorPicker.unit.spec.tsx
@@ -30,11 +30,11 @@ function setup({
 }
 
 describe("DateOperatorPicker", () => {
-  it("should be able to change the option type", () => {
+  it("should be able to change the option type", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByDisplayValue("All time"));
-    userEvent.click(screen.getByText("Current"));
+    await userEvent.click(screen.getByDisplayValue("All time"));
+    await userEvent.click(screen.getByText("Current"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
@@ -43,7 +43,7 @@ describe("DateOperatorPicker", () => {
     });
   });
 
-  it("should be able to change a specific date value", () => {
+  it("should be able to change a specific date value", async () => {
     const { onChange } = setup({
       value: {
         type: "specific",
@@ -52,7 +52,7 @@ describe("DateOperatorPicker", () => {
       },
     });
 
-    userEvent.click(screen.getByText("15"));
+    await userEvent.click(screen.getByText("15"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "specific",
@@ -61,7 +61,7 @@ describe("DateOperatorPicker", () => {
     });
   });
 
-  it("should be able to change a relative date value", () => {
+  it("should be able to change a relative date value", async () => {
     const { onChange } = setup({
       value: {
         type: "relative",
@@ -70,7 +70,7 @@ describe("DateOperatorPicker", () => {
       },
     });
 
-    userEvent.type(screen.getByLabelText("Interval"), "2");
+    await userEvent.type(screen.getByLabelText("Interval"), "2");
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",

--- a/frontend/src/metabase/querying/components/DatePicker/DatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/DatePicker.unit.spec.tsx
@@ -31,10 +31,10 @@ function setup({
 }
 
 describe("DatePicker", () => {
-  it("should add a filter via shortcut", () => {
+  it("should add a filter via shortcut", async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("Today"));
+    await userEvent.click(screen.getByText("Today"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
@@ -43,14 +43,14 @@ describe("DatePicker", () => {
     });
   });
 
-  it("should add a specific date filter", () => {
+  it("should add a specific date filter", async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("Specific dates…"));
-    userEvent.click(screen.getByText("After"));
-    userEvent.clear(screen.getByLabelText("Date"));
-    userEvent.type(screen.getByLabelText("Date"), "Feb 15, 2020");
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Specific dates…"));
+    await userEvent.click(screen.getByText("After"));
+    await userEvent.clear(screen.getByLabelText("Date"));
+    await userEvent.type(screen.getByLabelText("Date"), "Feb 15, 2020");
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "specific",
@@ -59,7 +59,7 @@ describe("DatePicker", () => {
     });
   });
 
-  it("should update a specific date filter", () => {
+  it("should update a specific date filter", async () => {
     const { onChange } = setup({
       value: {
         type: "specific",
@@ -68,8 +68,8 @@ describe("DatePicker", () => {
       },
     });
 
-    userEvent.click(screen.getByText("20"));
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.click(screen.getByText("20"));
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "specific",
@@ -78,13 +78,13 @@ describe("DatePicker", () => {
     });
   });
 
-  it("should add a relative date filter", () => {
+  it("should add a relative date filter", async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("Relative dates…"));
-    userEvent.clear(screen.getByLabelText("Interval"));
-    userEvent.type(screen.getByLabelText("Interval"), "20");
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Relative dates…"));
+    await userEvent.clear(screen.getByLabelText("Interval"));
+    await userEvent.type(screen.getByLabelText("Interval"), "20");
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
@@ -95,7 +95,7 @@ describe("DatePicker", () => {
     });
   });
 
-  it("should update a relative date filter", () => {
+  it("should update a relative date filter", async () => {
     const { onChange } = setup({
       value: {
         type: "relative",
@@ -106,8 +106,8 @@ describe("DatePicker", () => {
       },
     });
 
-    userEvent.click(screen.getByText("Next"));
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
@@ -118,13 +118,13 @@ describe("DatePicker", () => {
     });
   });
 
-  it("should add an exclude date filter", () => {
+  it("should add an exclude date filter", async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("Exclude…"));
-    userEvent.click(screen.getByText("Days of the week…"));
-    userEvent.click(screen.getByText("Monday"));
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Exclude…"));
+    await userEvent.click(screen.getByText("Days of the week…"));
+    await userEvent.click(screen.getByText("Monday"));
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "exclude",
@@ -134,7 +134,7 @@ describe("DatePicker", () => {
     });
   });
 
-  it("should update an exclude date filter", () => {
+  it("should update an exclude date filter", async () => {
     const { onChange } = setup({
       value: {
         type: "exclude",
@@ -144,10 +144,10 @@ describe("DatePicker", () => {
       },
     });
 
-    userEvent.click(screen.getByText("Monday"));
-    userEvent.click(screen.getByText("Wednesday"));
-    userEvent.click(screen.getByText("Friday"));
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.click(screen.getByText("Monday"));
+    await userEvent.click(screen.getByText("Wednesday"));
+    await userEvent.click(screen.getByText("Friday"));
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "exclude",

--- a/frontend/src/metabase/querying/components/DatePicker/DateShortcutPicker/DateShortcutPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/DateShortcutPicker/DateShortcutPicker.unit.spec.tsx
@@ -32,9 +32,9 @@ function setup({
 }
 
 describe("DateShortcutPicker", () => {
-  it("should be able to create a filter via shortcuts", () => {
+  it("should be able to create a filter via shortcuts", async () => {
     const { onChange } = setup();
-    userEvent.click(screen.getByText("Today"));
+    await userEvent.click(screen.getByText("Today"));
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
       value: "current",
@@ -42,9 +42,9 @@ describe("DateShortcutPicker", () => {
     });
   });
 
-  it("should be able to navigate to a more specific filter type", () => {
+  it("should be able to navigate to a more specific filter type", async () => {
     const { onSelectType } = setup();
-    userEvent.click(screen.getByText("Specific dates…"));
+    await userEvent.click(screen.getByText("Specific dates…"));
     expect(onSelectType).toHaveBeenCalledWith("specific");
   });
 });

--- a/frontend/src/metabase/querying/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/ExcludeDatePicker/ExcludeDatePicker.unit.spec.tsx
@@ -38,13 +38,13 @@ function setup({
 }
 
 describe("ExcludeDatePicker", () => {
-  it("should allow to exclude days", () => {
+  it("should allow to exclude days", async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("Days of the week…"));
-    userEvent.click(screen.getByText("Monday"));
-    userEvent.click(screen.getByText("Sunday"));
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Days of the week…"));
+    await userEvent.click(screen.getByText("Monday"));
+    await userEvent.click(screen.getByText("Sunday"));
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "exclude",
@@ -54,13 +54,13 @@ describe("ExcludeDatePicker", () => {
     });
   });
 
-  it("should allow to exclude months", () => {
+  it("should allow to exclude months", async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("Months of the year…"));
-    userEvent.click(screen.getByText("January"));
-    userEvent.click(screen.getByText("December"));
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Months of the year…"));
+    await userEvent.click(screen.getByText("January"));
+    await userEvent.click(screen.getByText("December"));
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "exclude",
@@ -70,13 +70,13 @@ describe("ExcludeDatePicker", () => {
     });
   });
 
-  it("should allow to exclude quarters", () => {
+  it("should allow to exclude quarters", async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("Quarters of the year…"));
-    userEvent.click(screen.getByText("1st"));
-    userEvent.click(screen.getByText("4th"));
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Quarters of the year…"));
+    await userEvent.click(screen.getByText("1st"));
+    await userEvent.click(screen.getByText("4th"));
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "exclude",
@@ -86,14 +86,14 @@ describe("ExcludeDatePicker", () => {
     });
   });
 
-  it("should allow to exclude hours", () => {
+  it("should allow to exclude hours", async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("Hours of the day…"));
-    userEvent.click(screen.getByText("12 AM"));
-    userEvent.click(screen.getByText("2 AM"));
-    userEvent.click(screen.getByText("5 PM"));
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Hours of the day…"));
+    await userEvent.click(screen.getByText("12 AM"));
+    await userEvent.click(screen.getByText("2 AM"));
+    await userEvent.click(screen.getByText("5 PM"));
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "exclude",
@@ -103,10 +103,10 @@ describe("ExcludeDatePicker", () => {
     });
   });
 
-  it("should allow to exclude empty values", () => {
+  it("should allow to exclude empty values", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByText("Is empty"));
+    await userEvent.click(screen.getByText("Is empty"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "exclude",
@@ -115,10 +115,10 @@ describe("ExcludeDatePicker", () => {
     });
   });
 
-  it("should allow to exclude not empty values", () => {
+  it("should allow to exclude not empty values", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByText("Is not empty"));
+    await userEvent.click(screen.getByText("Is not empty"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "exclude",

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
@@ -15,6 +15,10 @@ const DEFAULT_VALUE: RelativeDatePickerValue = {
 interface SetupOpts {
   value?: RelativeDatePickerValue;
 }
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 function setup({ value = DEFAULT_VALUE }: SetupOpts = {}) {
   const onChange = jest.fn();

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/CurrentDatePicker/CurrentDatePicker.unit.spec.tsx
@@ -30,10 +30,10 @@ describe("CurrentDatePicker", () => {
     jest.setSystemTime(new Date(2020, 0, 1));
   });
 
-  it("should be able to filter by a current interval", () => {
+  it("should be able to filter by a current interval", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByText("Week"));
+    await userEvent.click(screen.getByText("Week"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
@@ -42,10 +42,10 @@ describe("CurrentDatePicker", () => {
     });
   });
 
-  it("should show the date range for the selected interval", () => {
+  it("should show the date range for the selected interval", async () => {
     setup();
 
-    userEvent.hover(screen.getByText("Week"));
+    await userEvent.hover(screen.getByText("Week"));
 
     expect(
       screen.getByText("Right now, this is Dec 29, 2019 – Jan 4, 2020"),

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/CurrentDatePicker/SimpleCurrentDatePicker/SimpleCurrentDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/CurrentDatePicker/SimpleCurrentDatePicker/SimpleCurrentDatePicker.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
@@ -15,6 +15,10 @@ const DEFAULT_VALUE: RelativeDatePickerValue = {
 interface SetupOpts {
   value?: RelativeDatePickerValue;
 }
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 function setup({ value = DEFAULT_VALUE }: SetupOpts = {}) {
   const onChange = jest.fn();

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/CurrentDatePicker/SimpleCurrentDatePicker/SimpleCurrentDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/CurrentDatePicker/SimpleCurrentDatePicker/SimpleCurrentDatePicker.unit.spec.tsx
@@ -32,11 +32,11 @@ describe("SimpleCurrentDatePicker", () => {
     jest.setSystemTime(new Date(2020, 0, 1));
   });
 
-  it("should be able to filter by a current interval", () => {
+  it("should be able to filter by a current interval", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByDisplayValue("Day"));
-    userEvent.click(screen.getByText("Week"));
+    await userEvent.click(screen.getByDisplayValue("Day"));
+    await userEvent.click(screen.getByText("Week"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/DateIntervalPicker.unit.spec.tsx
@@ -55,14 +55,14 @@ describe("DateIntervalPicker", () => {
     direction => {
       const defaultValue = getDefaultValue(direction);
 
-      it("should change the interval", () => {
+      it("should change the interval", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "20");
+        await userEvent.clear(input);
+        await userEvent.type(input, "20");
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -70,18 +70,18 @@ describe("DateIntervalPicker", () => {
         });
         expect(onSubmit).not.toHaveBeenCalled();
 
-        userEvent.type(input, "{enter}");
+        await userEvent.type(input, "{enter}");
         expect(onSubmit).toHaveBeenCalled();
       });
 
-      it("should change the interval with a negative value", () => {
+      it("should change the interval with a negative value", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "-10");
+        await userEvent.clear(input);
+        await userEvent.type(input, "-10");
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -90,15 +90,15 @@ describe("DateIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should coerce zero", () => {
+      it("should coerce zero", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "0");
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.type(input, "0");
+        await userEvent.tab();
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -107,42 +107,42 @@ describe("DateIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should ignore empty values", () => {
+      it("should ignore empty values", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.tab();
 
         expect(input).toHaveValue("30");
         expect(onChange).not.toHaveBeenCalled();
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should ignore invalid values", () => {
+      it("should ignore invalid values", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "abc");
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.type(input, "abc");
+        await userEvent.tab();
 
         expect(input).toHaveValue("30");
         expect(onChange).not.toHaveBeenCalled();
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should allow to change the unit", () => {
+      it("should allow to change the unit", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
-        userEvent.click(screen.getByLabelText("Unit"));
-        userEvent.click(screen.getByText("years"));
+        await userEvent.click(screen.getByLabelText("Unit"));
+        await userEvent.click(screen.getByText("years"));
 
         expect(onChange).toHaveBeenCalledWith({
           ...defaultValue,
@@ -156,8 +156,8 @@ describe("DateIntervalPicker", () => {
           value: defaultValue,
         });
 
-        userEvent.click(screen.getByLabelText("Options"));
-        userEvent.click(await screen.findByText("Include today"));
+        await userEvent.click(screen.getByLabelText("Options"));
+        await userEvent.click(await screen.findByText("Include today"));
 
         expect(onChange).toHaveBeenCalledWith({
           ...defaultValue,
@@ -173,7 +173,7 @@ describe("DateIntervalPicker", () => {
           value: defaultValue,
         });
 
-        userEvent.click(screen.getByLabelText("Options"));
+        await userEvent.click(screen.getByLabelText("Options"));
         expect(await screen.findByText("Include today")).toBeInTheDocument();
         expect(screen.queryByText("Starting from…")).not.toBeInTheDocument();
       });
@@ -184,8 +184,8 @@ describe("DateIntervalPicker", () => {
           canUseRelativeOffsets: true,
         });
 
-        userEvent.click(screen.getByLabelText("Options"));
-        userEvent.click(await screen.findByText("Starting from…"));
+        await userEvent.click(screen.getByLabelText("Options"));
+        await userEvent.click(await screen.findByText("Starting from…"));
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateIntervalPicker/SimpleDateIntervalPicker/SimpleDateIntervalPicker.unit.spec.tsx
@@ -44,14 +44,14 @@ describe("SimpleDateIntervalPicker", () => {
     direction => {
       const defaultValue = getDefaultValue(direction);
 
-      it("should change the interval", () => {
+      it("should change the interval", async () => {
         const { onChange } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "20");
+        await userEvent.clear(input);
+        await userEvent.type(input, "20");
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -59,14 +59,14 @@ describe("SimpleDateIntervalPicker", () => {
         });
       });
 
-      it("should change the interval with a negative value", () => {
+      it("should change the interval with a negative value", async () => {
         const { onChange } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "-10");
+        await userEvent.clear(input);
+        await userEvent.type(input, "-10");
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -74,15 +74,15 @@ describe("SimpleDateIntervalPicker", () => {
         });
       });
 
-      it("should coerce zero", () => {
+      it("should coerce zero", async () => {
         const { onChange } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "0");
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.type(input, "0");
+        await userEvent.tab();
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -90,40 +90,40 @@ describe("SimpleDateIntervalPicker", () => {
         });
       });
 
-      it("should ignore empty values", () => {
+      it("should ignore empty values", async () => {
         const { onChange } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.tab();
 
         expect(input).toHaveValue("30");
         expect(onChange).not.toHaveBeenCalled();
       });
 
-      it("should ignore invalid values", () => {
+      it("should ignore invalid values", async () => {
         const { onChange } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "abc");
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.type(input, "abc");
+        await userEvent.tab();
 
         expect(input).toHaveValue("30");
         expect(onChange).not.toHaveBeenCalled();
       });
 
-      it("should allow to change the unit", () => {
+      it("should allow to change the unit", async () => {
         const { onChange } = setup({
           value: defaultValue,
         });
 
-        userEvent.click(screen.getByLabelText("Unit"));
-        userEvent.click(screen.getByText("years"));
+        await userEvent.click(screen.getByLabelText("Unit"));
+        await userEvent.click(screen.getByText("years"));
 
         expect(onChange).toHaveBeenCalledWith({
           ...defaultValue,

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
@@ -18,6 +18,10 @@ function getDefaultValue(
     offsetUnit: "day",
   };
 }
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 interface SetupOpts {
   value: DateOffsetIntervalValue;

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/DateOffsetIntervalPicker/DateOffsetIntervalPicker.unit.spec.tsx
@@ -51,14 +51,14 @@ describe("DateOffsetIntervalPicker", () => {
     direction => {
       const defaultValue = getDefaultValue(direction);
 
-      it("should change the interval", () => {
+      it("should change the interval", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "20");
+        await userEvent.clear(input);
+        await userEvent.type(input, "20");
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -66,18 +66,18 @@ describe("DateOffsetIntervalPicker", () => {
         });
         expect(onSubmit).not.toHaveBeenCalled();
 
-        userEvent.type(input, "{enter}");
+        await userEvent.type(input, "{enter}");
         expect(onSubmit).toHaveBeenCalled();
       });
 
-      it("should change the interval with a negative value", () => {
+      it("should change the interval with a negative value", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "-10");
+        await userEvent.clear(input);
+        await userEvent.type(input, "-10");
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -86,15 +86,15 @@ describe("DateOffsetIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should coerce zero", () => {
+      it("should coerce zero", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "0");
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.type(input, "0");
+        await userEvent.tab();
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -103,42 +103,42 @@ describe("DateOffsetIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should ignore empty values", () => {
+      it("should ignore empty values", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.tab();
 
         expect(input).toHaveValue("30");
         expect(onChange).not.toHaveBeenCalled();
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should ignore invalid values", () => {
+      it("should ignore invalid values", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "abc");
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.type(input, "abc");
+        await userEvent.tab();
 
         expect(input).toHaveValue("30");
         expect(onChange).not.toHaveBeenCalled();
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should allow to change the unit", () => {
+      it("should allow to change the unit", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
-        userEvent.click(screen.getByLabelText("Unit"));
-        userEvent.click(screen.getByText("years"));
+        await userEvent.click(screen.getByLabelText("Unit"));
+        await userEvent.click(screen.getByText("years"));
 
         expect(onChange).toHaveBeenCalledWith({
           ...defaultValue,
@@ -148,14 +148,14 @@ describe("DateOffsetIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should change the offset interval", () => {
+      it("should change the offset interval", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Starting from interval");
-        userEvent.clear(input);
-        userEvent.type(input, "20");
+        await userEvent.clear(input);
+        await userEvent.type(input, "20");
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -164,14 +164,14 @@ describe("DateOffsetIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should change the offset interval with a negative value", () => {
+      it("should change the offset interval with a negative value", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Starting from interval");
-        userEvent.clear(input);
-        userEvent.type(input, "-10");
+        await userEvent.clear(input);
+        await userEvent.type(input, "-10");
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -180,15 +180,15 @@ describe("DateOffsetIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should accept zero offset interval", () => {
+      it("should accept zero offset interval", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Starting from interval");
-        userEvent.clear(input);
-        userEvent.type(input, "0");
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.type(input, "0");
+        await userEvent.tab();
 
         expect(onChange).toHaveBeenLastCalledWith({
           ...defaultValue,
@@ -197,43 +197,43 @@ describe("DateOffsetIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should ignore an empty offset interval", () => {
+      it("should ignore an empty offset interval", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Starting from interval");
-        userEvent.clear(input);
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.tab();
 
         expect(input).toHaveValue("14");
         expect(onChange).not.toHaveBeenCalled();
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should ignore invalid offset values", () => {
+      it("should ignore invalid offset values", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const input = screen.getByLabelText("Interval");
-        userEvent.clear(input);
-        userEvent.type(input, "abc");
-        userEvent.tab();
+        await userEvent.clear(input);
+        await userEvent.type(input, "abc");
+        await userEvent.tab();
 
         expect(input).toHaveValue("30");
         expect(onChange).not.toHaveBeenCalled();
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should allow to change the offset unit", () => {
+      it("should allow to change the offset unit", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
         const unitText = direction === "last" ? "years ago" : "years from now";
-        userEvent.click(screen.getByLabelText("Starting from unit"));
-        userEvent.click(screen.getByText(unitText));
+        await userEvent.click(screen.getByLabelText("Starting from unit"));
+        await userEvent.click(screen.getByText(unitText));
 
         expect(onChange).toHaveBeenCalledWith({
           ...defaultValue,
@@ -242,7 +242,7 @@ describe("DateOffsetIntervalPicker", () => {
         expect(onSubmit).not.toHaveBeenCalled();
       });
 
-      it("should only show offset units larger or equal to the current one", () => {
+      it("should only show offset units larger or equal to the current one", async () => {
         setup({
           value: {
             ...defaultValue,
@@ -250,7 +250,7 @@ describe("DateOffsetIntervalPicker", () => {
           },
         });
 
-        userEvent.click(screen.getByLabelText("Starting from unit"));
+        await userEvent.click(screen.getByLabelText("Starting from unit"));
 
         expect(screen.getByText(/months/)).toBeInTheDocument();
         expect(screen.getByText(/quarters/)).toBeInTheDocument();
@@ -270,12 +270,12 @@ describe("DateOffsetIntervalPicker", () => {
         expect(screen.getByText(rangeText)).toBeInTheDocument();
       });
 
-      it("should be able to remove the offset", () => {
+      it("should be able to remove the offset", async () => {
         const { onChange, onSubmit } = setup({
           value: defaultValue,
         });
 
-        userEvent.click(screen.getByLabelText("Remove offset"));
+        await userEvent.click(screen.getByLabelText("Remove offset"));
 
         expect(onChange).toHaveBeenCalledWith({
           ...defaultValue,

--- a/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/RelativeDatePicker/RelativeDatePicker.unit.spec.tsx
@@ -39,28 +39,28 @@ function setup({
 describe("RelativeDatePicker", () => {
   it.each(TAB_CASES)(
     "should allow switching between %s to %s tab",
-    (fromTabName, toTabName) => {
+    async (fromTabName, toTabName) => {
       setup();
 
       const fromTab = screen.getByRole("tab", { name: fromTabName });
-      userEvent.click(fromTab);
+      await userEvent.click(fromTab);
       expect(fromTab).toHaveAttribute("aria-selected", "true");
 
       const toTab = screen.getByRole("tab", { name: toTabName });
-      userEvent.click(toTab);
+      await userEvent.click(toTab);
       expect(toTab).toHaveAttribute("aria-selected", "true");
     },
   );
 
-  it("should not lose values when navigating from Past to Next tab", () => {
+  it("should not lose values when navigating from Past to Next tab", async () => {
     setup();
 
-    userEvent.clear(screen.getByLabelText("Interval"));
-    userEvent.type(screen.getByLabelText("Interval"), "20");
-    userEvent.click(screen.getByLabelText("Next"));
+    await userEvent.clear(screen.getByLabelText("Interval"));
+    await userEvent.type(screen.getByLabelText("Interval"), "20");
+    await userEvent.click(screen.getByLabelText("Next"));
     expect(screen.getByLabelText("Interval")).toHaveValue("20");
 
-    userEvent.click(screen.getByLabelText("Past"));
+    await userEvent.click(screen.getByLabelText("Past"));
     expect(screen.getByLabelText("Interval")).toHaveValue("20");
   });
 
@@ -69,22 +69,22 @@ describe("RelativeDatePicker", () => {
       canUseRelativeOffsets: true,
     });
 
-    userEvent.click(screen.getByLabelText("Options"));
-    userEvent.click(await screen.findByText("Starting from…"));
-    userEvent.clear(screen.getByLabelText("Starting from interval"));
-    userEvent.type(screen.getByLabelText("Starting from interval"), "20");
-    userEvent.click(screen.getByLabelText("Next"));
+    await userEvent.click(screen.getByLabelText("Options"));
+    await userEvent.click(await screen.findByText("Starting from…"));
+    await userEvent.clear(screen.getByLabelText("Starting from interval"));
+    await userEvent.type(screen.getByLabelText("Starting from interval"), "20");
+    await userEvent.click(screen.getByLabelText("Next"));
     expect(screen.getByLabelText("Starting from interval")).toHaveValue("20");
 
-    userEvent.click(screen.getByLabelText("Past"));
+    await userEvent.click(screen.getByLabelText("Past"));
     expect(screen.getByLabelText("Starting from interval")).toHaveValue("20");
   });
 
-  it("should allow to submit a current value", () => {
+  it("should allow to submit a current value", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByText("Current"));
-    userEvent.click(screen.getByText("Week"));
+    await userEvent.click(screen.getByText("Current"));
+    await userEvent.click(screen.getByText("Week"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
@@ -93,13 +93,13 @@ describe("RelativeDatePicker", () => {
     });
   });
 
-  it("should allow to submit a past value", () => {
+  it("should allow to submit a past value", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("Interval");
-    userEvent.clear(input);
-    userEvent.type(input, "20");
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.clear(input);
+    await userEvent.type(input, "20");
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
@@ -113,9 +113,9 @@ describe("RelativeDatePicker", () => {
       canUseRelativeOffsets: true,
     });
 
-    userEvent.click(screen.getByLabelText("Options"));
-    userEvent.click(await screen.findByText("Starting from…"));
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.click(screen.getByLabelText("Options"));
+    await userEvent.click(await screen.findByText("Starting from…"));
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
@@ -127,14 +127,14 @@ describe("RelativeDatePicker", () => {
     });
   });
 
-  it("should allow to submit a next value", () => {
+  it("should allow to submit a next value", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByText("Next"));
     const input = screen.getByLabelText("Interval");
-    userEvent.clear(input);
-    userEvent.type(input, "20");
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.clear(input);
+    await userEvent.type(input, "20");
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",
@@ -148,10 +148,10 @@ describe("RelativeDatePicker", () => {
       canUseRelativeOffsets: true,
     });
 
-    userEvent.click(screen.getByText("Next"));
-    userEvent.click(screen.getByLabelText("Options"));
-    userEvent.click(await screen.findByText("Starting from…"));
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByLabelText("Options"));
+    await userEvent.click(await screen.findByText("Starting from…"));
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",

--- a/frontend/src/metabase/querying/components/DatePicker/SimpleDatePicker/SimpleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SimpleDatePicker/SimpleDatePicker.unit.spec.tsx
@@ -30,14 +30,14 @@ function setup({
 }
 
 describe("SimpleDatePicker", () => {
-  it("should be able change and submit the value", () => {
+  it("should be able change and submit the value", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByDisplayValue("All time"));
-    userEvent.click(screen.getByText("Current"));
-    userEvent.click(screen.getByDisplayValue("Day"));
-    userEvent.click(screen.getByText("Month"));
-    userEvent.click(screen.getByText("Apply"));
+    await userEvent.click(screen.getByDisplayValue("All time"));
+    await userEvent.click(screen.getByText("Current"));
+    await userEvent.click(screen.getByDisplayValue("Day"));
+    await userEvent.click(screen.getByText("Month"));
+    await userEvent.click(screen.getByText("Apply"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "relative",

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
@@ -40,12 +40,12 @@ describe("SingleDatePicker", () => {
     jest.setSystemTime(new Date(2020, 0, 15));
   });
 
-  it("should be able to set the date range via the calendar", () => {
+  it("should be able to set the date range via the calendar", async () => {
     const { onChange, onSubmit } = setup();
 
     const calendars = screen.getAllByRole("table");
-    userEvent.click(within(calendars[0]).getByText("12"));
-    userEvent.click(within(calendars[1]).getByText("5"));
+    await userEvent.click(within(calendars[0]).getByText("12"));
+    await userEvent.click(within(calendars[1]).getByText("5"));
 
     expect(onChange).toHaveBeenCalledWith([
       new Date(2020, 0, 12),
@@ -54,14 +54,14 @@ describe("SingleDatePicker", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to set the date range via the calendar when there is time", () => {
+  it("should be able to set the date range via the calendar when there is time", async () => {
     const { onChange, onSubmit } = setup({
       value: [START_DATE_TIME, END_DATE_TIME],
     });
 
     const calendars = screen.getAllByRole("table");
-    userEvent.click(within(calendars[0]).getByText("12"));
-    userEvent.click(within(calendars[1]).getByText("5"));
+    await userEvent.click(within(calendars[0]).getByText("12"));
+    await userEvent.click(within(calendars[1]).getByText("5"));
 
     expect(onChange).toHaveBeenLastCalledWith([
       new Date(2020, 0, 12, 5, 20),
@@ -70,46 +70,46 @@ describe("SingleDatePicker", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to set the date range start via the input", () => {
+  it("should be able to set the date range start via the input", async () => {
     const { onChange, onSubmit } = setup();
 
     const input = screen.getByLabelText("Start date");
-    userEvent.clear(input);
-    userEvent.type(input, "Feb 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Feb 15, 2020");
     expect(onChange).toHaveBeenLastCalledWith([
       new Date(2020, 1, 15),
       END_DATE,
     ]);
     expect(onSubmit).not.toHaveBeenCalled();
 
-    userEvent.type(input, "{enter}");
+    await userEvent.type(input, "{enter}");
     expect(onSubmit).toHaveBeenCalled();
   });
 
-  it("should be able to set the date range start via the input when there is time", () => {
+  it("should be able to set the date range start via the input when there is time", async () => {
     const { onChange, onSubmit } = setup({
       value: [START_DATE_TIME, END_DATE],
     });
 
     const input = screen.getByLabelText("Start date");
-    userEvent.clear(input);
-    userEvent.type(input, "Feb 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Feb 15, 2020");
     expect(onChange).toHaveBeenLastCalledWith([
       new Date(2020, 1, 15, 5, 20),
       END_DATE,
     ]);
     expect(onSubmit).not.toHaveBeenCalled();
 
-    userEvent.type(input, "{enter}");
+    await userEvent.type(input, "{enter}");
     expect(onSubmit).toHaveBeenCalled();
   });
 
-  it("should be able to set the date range end via the input", () => {
+  it("should be able to set the date range end via the input", async () => {
     const { onChange, onSubmit } = setup();
 
     const input = screen.getByLabelText("End date");
-    userEvent.clear(input);
-    userEvent.type(input, "Jul 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Jul 15, 2020");
 
     expect(onChange).toHaveBeenLastCalledWith([
       START_DATE,
@@ -118,14 +118,14 @@ describe("SingleDatePicker", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to set the date range end via the input when there is time", () => {
+  it("should be able to set the date range end via the input when there is time", async () => {
     const { onChange, onSubmit } = setup({
       value: [START_DATE, END_DATE_TIME],
     });
 
     const input = screen.getByLabelText("End date");
-    userEvent.clear(input);
-    userEvent.type(input, "Jul 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Jul 15, 2020");
 
     expect(onChange).toHaveBeenLastCalledWith([
       START_DATE,
@@ -134,13 +134,13 @@ describe("SingleDatePicker", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to add time", () => {
+  it("should be able to add time", async () => {
     const { onChange, onSubmit } = setup();
 
-    userEvent.click(screen.getByText("Add time"));
+    await userEvent.click(screen.getByText("Add time"));
     const input = screen.getByLabelText("Start time");
-    userEvent.clear(input);
-    userEvent.type(input, "11:20");
+    await userEvent.clear(input);
+    await userEvent.type(input, "11:20");
 
     expect(onChange).toHaveBeenLastCalledWith([
       new Date(2020, 0, 10, 11, 20),
@@ -149,14 +149,14 @@ describe("SingleDatePicker", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to update the start time", () => {
+  it("should be able to update the start time", async () => {
     const { onChange, onSubmit } = setup({
       value: [START_DATE_TIME, END_DATE_TIME],
     });
 
     const input = screen.getByLabelText("Start time");
-    userEvent.clear(input);
-    userEvent.type(input, "11:20");
+    await userEvent.clear(input);
+    await userEvent.type(input, "11:20");
 
     expect(onChange).toHaveBeenLastCalledWith([
       new Date(2020, 0, 10, 11, 20),
@@ -165,14 +165,14 @@ describe("SingleDatePicker", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to update the end time", () => {
+  it("should be able to update the end time", async () => {
     const { onChange, onSubmit } = setup({
       value: [START_DATE_TIME, END_DATE_TIME],
     });
 
     const input = screen.getByLabelText("End time");
-    userEvent.clear(input);
-    userEvent.type(input, "11:20");
+    await userEvent.clear(input);
+    await userEvent.type(input, "11:20");
 
     expect(onChange).toHaveBeenLastCalledWith([
       START_DATE_TIME,
@@ -181,12 +181,12 @@ describe("SingleDatePicker", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to remove time", () => {
+  it("should be able to remove time", async () => {
     const { onChange, onSubmit } = setup({
       value: [START_DATE_TIME, END_DATE_TIME],
     });
 
-    userEvent.click(screen.getByText("Remove time"));
+    await userEvent.click(screen.getByText("Remove time"));
 
     expect(screen.queryByLabelText("Start time")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("End time")).not.toBeInTheDocument();

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/DateRangePicker/DateRangePicker.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, within } from "__support__/ui";
 
@@ -14,6 +14,10 @@ interface SetupOpts {
   value?: [Date, Date];
   isNew?: boolean;
 }
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 function setup({
   value = [START_DATE, END_DATE],

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/DateRangePicker/SimpleDateRangePicker/SimpleDateRangePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/DateRangePicker/SimpleDateRangePicker/SimpleDateRangePicker.unit.spec.tsx
@@ -30,12 +30,12 @@ describe("SimpleDateRangePicker", () => {
     jest.setSystemTime(new Date(2020, 0, 15));
   });
 
-  it("should be able to set the date range via the calendar", () => {
+  it("should be able to set the date range via the calendar", async () => {
     const { onChange } = setup();
 
     const calendars = screen.getAllByRole("table");
-    userEvent.click(within(calendars[0]).getByText("12"));
-    userEvent.click(within(calendars[1]).getByText("5"));
+    await userEvent.click(within(calendars[0]).getByText("12"));
+    await userEvent.click(within(calendars[1]).getByText("5"));
 
     expect(onChange).toHaveBeenCalledWith([
       new Date(2020, 0, 12),
@@ -43,14 +43,14 @@ describe("SimpleDateRangePicker", () => {
     ]);
   });
 
-  it("should be able to set the date range via the calendar when there is time", () => {
+  it("should be able to set the date range via the calendar when there is time", async () => {
     const { onChange } = setup({
       value: [START_DATE_TIME, END_DATE_TIME],
     });
 
     const calendars = screen.getAllByRole("table");
-    userEvent.click(within(calendars[0]).getByText("12"));
-    userEvent.click(within(calendars[1]).getByText("5"));
+    await userEvent.click(within(calendars[0]).getByText("12"));
+    await userEvent.click(within(calendars[1]).getByText("5"));
 
     expect(onChange).toHaveBeenLastCalledWith([
       new Date(2020, 0, 12, 5, 20),
@@ -58,12 +58,12 @@ describe("SimpleDateRangePicker", () => {
     ]);
   });
 
-  it("should be able to set the date range start via the input", () => {
+  it("should be able to set the date range start via the input", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("Start date");
-    userEvent.clear(input);
-    userEvent.type(input, "Feb 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Feb 15, 2020");
 
     expect(onChange).toHaveBeenLastCalledWith([
       new Date(2020, 1, 15),
@@ -71,14 +71,14 @@ describe("SimpleDateRangePicker", () => {
     ]);
   });
 
-  it("should be able to set the date range start via the input when there is time", () => {
+  it("should be able to set the date range start via the input when there is time", async () => {
     const { onChange } = setup({
       value: [START_DATE_TIME, END_DATE],
     });
 
     const input = screen.getByLabelText("Start date");
-    userEvent.clear(input);
-    userEvent.type(input, "Feb 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Feb 15, 2020");
 
     expect(onChange).toHaveBeenLastCalledWith([
       new Date(2020, 1, 15, 5, 20),
@@ -86,12 +86,12 @@ describe("SimpleDateRangePicker", () => {
     ]);
   });
 
-  it("should be able to set the date range end via the input", () => {
+  it("should be able to set the date range end via the input", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("End date");
-    userEvent.clear(input);
-    userEvent.type(input, "Jul 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Jul 15, 2020");
 
     expect(onChange).toHaveBeenLastCalledWith([
       START_DATE,
@@ -99,14 +99,14 @@ describe("SimpleDateRangePicker", () => {
     ]);
   });
 
-  it("should be able to set the date range end via the input when there is time", () => {
+  it("should be able to set the date range end via the input when there is time", async () => {
     const { onChange } = setup({
       value: [START_DATE, END_DATE_TIME],
     });
 
     const input = screen.getByLabelText("End date");
-    userEvent.clear(input);
-    userEvent.type(input, "Jul 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Jul 15, 2020");
 
     expect(onChange).toHaveBeenLastCalledWith([
       START_DATE,
@@ -114,13 +114,13 @@ describe("SimpleDateRangePicker", () => {
     ]);
   });
 
-  it("should be able to add time", () => {
+  it("should be able to add time", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByText("Add time"));
+    await userEvent.click(screen.getByText("Add time"));
     const input = screen.getByLabelText("Start time");
-    userEvent.clear(input);
-    userEvent.type(input, "11:20");
+    await userEvent.clear(input);
+    await userEvent.type(input, "11:20");
 
     expect(onChange).toHaveBeenLastCalledWith([
       new Date(2020, 0, 10, 11, 20),
@@ -128,14 +128,14 @@ describe("SimpleDateRangePicker", () => {
     ]);
   });
 
-  it("should be able to update the start time", () => {
+  it("should be able to update the start time", async () => {
     const { onChange } = setup({
       value: [START_DATE_TIME, END_DATE_TIME],
     });
 
     const input = screen.getByLabelText("Start time");
-    userEvent.clear(input);
-    userEvent.type(input, "11:20");
+    await userEvent.clear(input);
+    await userEvent.type(input, "11:20");
 
     expect(onChange).toHaveBeenLastCalledWith([
       new Date(2020, 0, 10, 11, 20),
@@ -143,14 +143,14 @@ describe("SimpleDateRangePicker", () => {
     ]);
   });
 
-  it("should be able to update the end time", () => {
+  it("should be able to update the end time", async () => {
     const { onChange } = setup({
       value: [START_DATE_TIME, END_DATE_TIME],
     });
 
     const input = screen.getByLabelText("End time");
-    userEvent.clear(input);
-    userEvent.type(input, "11:20");
+    await userEvent.clear(input);
+    await userEvent.type(input, "11:20");
 
     expect(onChange).toHaveBeenLastCalledWith([
       START_DATE_TIME,
@@ -158,12 +158,12 @@ describe("SimpleDateRangePicker", () => {
     ]);
   });
 
-  it("should be able to remove time", () => {
+  it("should be able to remove time", async () => {
     const { onChange } = setup({
       value: [START_DATE_TIME, END_DATE_TIME],
     });
 
-    userEvent.click(screen.getByText("Remove time"));
+    await userEvent.click(screen.getByText("Remove time"));
 
     expect(screen.queryByLabelText("Start time")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("End time")).not.toBeInTheDocument();

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/DateRangePicker/SimpleDateRangePicker/SimpleDateRangePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/DateRangePicker/SimpleDateRangePicker/SimpleDateRangePicker.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, within } from "__support__/ui";
 
@@ -13,6 +13,10 @@ const END_DATE_TIME = new Date(2020, 1, 9, 20, 30);
 interface SetupOpts {
   value?: [Date, Date];
 }
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 function setup({ value = [START_DATE, END_DATE] }: SetupOpts = {}) {
   const onChange = jest.fn();

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SingleDatePicker/SimpleSingleDatePicker/SimpleSingleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SingleDatePicker/SimpleSingleDatePicker/SimpleSingleDatePicker.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
@@ -10,6 +10,10 @@ const DATE_TIME = new Date(2020, 0, 10, 10, 20);
 interface SetupOpts {
   value?: Date;
 }
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 function setup({ value = DATE }: SetupOpts = {}) {
   const onChange = jest.fn();

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SingleDatePicker/SimpleSingleDatePicker/SimpleSingleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SingleDatePicker/SimpleSingleDatePicker/SimpleSingleDatePicker.unit.spec.tsx
@@ -27,77 +27,77 @@ describe("SimpleSingleDatePicker", () => {
     jest.setSystemTime(new Date(2020, 0, 15));
   });
 
-  it("should be able to set the date via the calendar", () => {
+  it("should be able to set the date via the calendar", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByText("12"));
+    await userEvent.click(screen.getByText("12"));
 
     expect(onChange).toHaveBeenCalledWith(new Date(2020, 0, 12));
   });
 
-  it("should be able to set the date via the calendar when there is time", () => {
+  it("should be able to set the date via the calendar when there is time", async () => {
     const { onChange } = setup({
       value: DATE_TIME,
     });
 
-    userEvent.click(screen.getByText("12"));
+    await userEvent.click(screen.getByText("12"));
 
     expect(onChange).toHaveBeenCalledWith(new Date(2020, 0, 12, 10, 20));
   });
 
-  it("should be able to set the date via the input", () => {
+  it("should be able to set the date via the input", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("Date");
-    userEvent.clear(input);
-    userEvent.type(input, "Feb 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Feb 15, 2020");
 
     expect(screen.getByText("February 2020")).toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 1, 15));
   });
 
-  it("should be able to set the date via the input when there is time", () => {
+  it("should be able to set the date via the input when there is time", async () => {
     const { onChange } = setup({
       value: DATE_TIME,
     });
 
     const input = screen.getByLabelText("Date");
-    userEvent.clear(input);
-    userEvent.type(input, "Feb 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Feb 15, 2020");
 
     expect(screen.getByText("February 2020")).toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 1, 15, 10, 20));
   });
 
-  it("should be able to add time", () => {
+  it("should be able to add time", async () => {
     const { onChange } = setup();
 
-    userEvent.click(screen.getByText("Add time"));
+    await userEvent.click(screen.getByText("Add time"));
     const input = screen.getByLabelText("Time");
-    userEvent.clear(input);
-    userEvent.type(input, "10:20");
+    await userEvent.clear(input);
+    await userEvent.type(input, "10:20");
 
     expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 0, 10, 10, 20));
   });
 
-  it("should be able to update the time", () => {
+  it("should be able to update the time", async () => {
     const { onChange } = setup({
       value: DATE_TIME,
     });
 
     const input = screen.getByLabelText("Time");
-    userEvent.clear(input);
-    userEvent.type(input, "20:30");
+    await userEvent.clear(input);
+    await userEvent.type(input, "20:30");
 
     expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 0, 10, 20, 30));
   });
 
-  it("should be able to remove time", () => {
+  it("should be able to remove time", async () => {
     const { onChange } = setup({
       value: DATE_TIME,
     });
 
-    userEvent.click(screen.getByText("Remove time"));
+    await userEvent.click(screen.getByText("Remove time"));
 
     expect(screen.queryByLabelText("Time")).not.toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 0, 10));

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 
@@ -11,6 +11,10 @@ interface SetupOpts {
   value?: Date;
   isNew?: boolean;
 }
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 function setup({ value = DATE, isNew = false }: SetupOpts = {}) {
   const onChange = jest.fn();

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SingleDatePicker/SingleDatePicker.unit.spec.tsx
@@ -34,85 +34,85 @@ describe("SingleDatePicker", () => {
     jest.setSystemTime(new Date(2020, 0, 15));
   });
 
-  it("should be able to set the date via the calendar", () => {
+  it("should be able to set the date via the calendar", async () => {
     const { onChange, onSubmit } = setup();
 
-    userEvent.click(screen.getByText("12"));
+    await userEvent.click(screen.getByText("12"));
 
     expect(onChange).toHaveBeenCalledWith(new Date(2020, 0, 12));
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to set the date via the calendar when there is time", () => {
+  it("should be able to set the date via the calendar when there is time", async () => {
     const { onChange, onSubmit } = setup({
       value: DATE_TIME,
     });
 
-    userEvent.click(screen.getByText("12"));
+    await userEvent.click(screen.getByText("12"));
 
     expect(onChange).toHaveBeenCalledWith(new Date(2020, 0, 12, 10, 20));
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to set the date via the input", () => {
+  it("should be able to set the date via the input", async () => {
     const { onChange, onSubmit } = setup();
 
     const input = screen.getByLabelText("Date");
-    userEvent.clear(input);
-    userEvent.type(input, "Feb 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Feb 15, 2020");
     expect(screen.getByText("February 2020")).toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 1, 15));
     expect(onSubmit).not.toHaveBeenCalled();
 
-    userEvent.type(input, "{enter}");
+    await userEvent.type(input, "{enter}");
     expect(onSubmit).toHaveBeenCalled();
   });
 
-  it("should be able to set the date via the input when there is time", () => {
+  it("should be able to set the date via the input when there is time", async () => {
     const { onChange, onSubmit } = setup({
       value: DATE_TIME,
     });
 
     const input = screen.getByLabelText("Date");
-    userEvent.clear(input);
-    userEvent.type(input, "Feb 15, 2020");
+    await userEvent.clear(input);
+    await userEvent.type(input, "Feb 15, 2020");
 
     expect(screen.getByText("February 2020")).toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 1, 15, 10, 20));
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to add time", () => {
+  it("should be able to add time", async () => {
     const { onChange, onSubmit } = setup();
 
-    userEvent.click(screen.getByText("Add time"));
+    await userEvent.click(screen.getByText("Add time"));
     const input = screen.getByLabelText("Time");
-    userEvent.clear(input);
-    userEvent.type(input, "10:20");
+    await userEvent.clear(input);
+    await userEvent.type(input, "10:20");
 
     expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 0, 10, 10, 20));
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to update the time", () => {
+  it("should be able to update the time", async () => {
     const { onChange, onSubmit } = setup({
       value: DATE_TIME,
     });
 
     const input = screen.getByLabelText("Time");
-    userEvent.clear(input);
-    userEvent.type(input, "20:30");
+    await userEvent.clear(input);
+    await userEvent.type(input, "20:30");
 
     expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 0, 10, 20, 30));
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("should be able to remove time", () => {
+  it("should be able to remove time", async () => {
     const { onChange, onSubmit } = setup({
       value: DATE_TIME,
     });
 
-    userEvent.click(screen.getByText("Remove time"));
+    await userEvent.click(screen.getByText("Remove time"));
 
     expect(screen.queryByLabelText("Time")).not.toBeInTheDocument();
     expect(onChange).toHaveBeenLastCalledWith(new Date(2020, 0, 10));

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen, within } from "__support__/ui";
 
@@ -12,6 +12,10 @@ interface SetupOpts {
   availableOperators?: ReadonlyArray<DatePickerOperator>;
   isNew?: boolean;
 }
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 function setup({
   value,

--- a/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/DatePicker/SpecificDatePicker/SpecificDatePicker.unit.spec.tsx
@@ -40,12 +40,12 @@ describe("SpecificDatePicker", () => {
     jest.setSystemTime(new Date(2020, 0, 1));
   });
 
-  it('should be able to set "on" filter', () => {
+  it('should be able to set "on" filter', async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("On"));
-    userEvent.click(screen.getByText("15"));
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("On"));
+    await userEvent.click(screen.getByText("15"));
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "specific",
@@ -54,12 +54,12 @@ describe("SpecificDatePicker", () => {
     });
   });
 
-  it('should be able to set "before" filter', () => {
+  it('should be able to set "before" filter', async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("Before"));
-    userEvent.click(screen.getByText("15"));
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Before"));
+    await userEvent.click(screen.getByText("15"));
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "specific",
@@ -68,13 +68,13 @@ describe("SpecificDatePicker", () => {
     });
   });
 
-  it('should be able to set "after" filter', () => {
+  it('should be able to set "after" filter', async () => {
     const { onChange } = setup({ isNew: true });
 
-    userEvent.click(screen.getByText("After"));
-    userEvent.clear(screen.getByLabelText("Date"));
-    userEvent.type(screen.getByLabelText("Date"), "Feb 15, 2020");
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("After"));
+    await userEvent.clear(screen.getByLabelText("Date"));
+    await userEvent.type(screen.getByLabelText("Date"), "Feb 15, 2020");
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenCalledWith({
       type: "specific",
@@ -83,13 +83,13 @@ describe("SpecificDatePicker", () => {
     });
   });
 
-  it('should be able to set "between" filter', () => {
+  it('should be able to set "between" filter', async () => {
     const { onChange } = setup({ isNew: true });
 
     const calendars = screen.getAllByRole("table");
-    userEvent.click(within(calendars[0]).getByText("12"));
-    userEvent.click(within(calendars[1]).getByText("5"));
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(within(calendars[0]).getByText("12"));
+    await userEvent.click(within(calendars[1]).getByText("5"));
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenLastCalledWith({
       type: "specific",
@@ -98,17 +98,17 @@ describe("SpecificDatePicker", () => {
     });
   });
 
-  it('should swap values for "between" filter when min > max', () => {
+  it('should swap values for "between" filter when min > max', async () => {
     const { onChange } = setup({ isNew: true });
 
     const startDateInput = screen.getByLabelText("Start date");
-    userEvent.clear(startDateInput);
-    userEvent.type(startDateInput, "Feb 15, 2020");
+    await userEvent.clear(startDateInput);
+    await userEvent.type(startDateInput, "Feb 15, 2020");
 
     const endDateInput = screen.getByLabelText("End date");
-    userEvent.clear(endDateInput);
-    userEvent.type(endDateInput, "Dec 29, 2019");
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.clear(endDateInput);
+    await userEvent.type(endDateInput, "Dec 29, 2019");
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(onChange).toHaveBeenLastCalledWith({
       type: "specific",

--- a/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
@@ -105,7 +105,9 @@ describe("QueryColumnPicker", () => {
     expect(orderGroup).toBeChecked();
     expect(orderGroup).toBeDisabled();
 
-    otherColumns.forEach(column => userEvent.click(column));
+    for (const column of otherColumns) {
+      await userEvent.click(column);
+    }
     expect(firstColumn).toBeChecked();
     expect(firstColumn).toBeDisabled();
     expect(orderGroup).toBeEnabled();

--- a/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FieldPanel/FieldPanel.unit.spec.tsx
@@ -30,55 +30,55 @@ function setup({ query = createQuery(), stageIndex = -1 }: SetupOpts = {}) {
 }
 
 describe("QueryColumnPicker", () => {
-  it("should allow to add and remove a column", () => {
+  it("should allow to add and remove a column", async () => {
     setup();
     const taxColumn = screen.getByRole("checkbox", { name: "Tax" });
     const totalColumn = screen.getByRole("checkbox", { name: "Total" });
     expect(taxColumn).toBeChecked();
     expect(totalColumn).toBeChecked();
 
-    userEvent.click(taxColumn);
+    await userEvent.click(taxColumn);
     expect(taxColumn).not.toBeChecked();
     expect(totalColumn).toBeChecked();
 
-    userEvent.click(totalColumn);
+    await userEvent.click(totalColumn);
     expect(taxColumn).not.toBeChecked();
     expect(totalColumn).not.toBeChecked();
 
-    userEvent.click(taxColumn);
+    await userEvent.click(taxColumn);
     expect(taxColumn).toBeChecked();
     expect(totalColumn).not.toBeChecked();
 
-    userEvent.click(totalColumn);
+    await userEvent.click(totalColumn);
     expect(taxColumn).toBeChecked();
     expect(totalColumn).toBeChecked();
   });
 
-  it("should allow to add and remove an implicitly joinable column", () => {
+  it("should allow to add and remove an implicitly joinable column", async () => {
     setup();
     const categoryColumn = screen.getByRole("checkbox", { name: "Category" });
     const vendorColumn = screen.getByRole("checkbox", { name: "Vendor" });
     expect(categoryColumn).not.toBeChecked();
     expect(vendorColumn).not.toBeChecked();
 
-    userEvent.click(categoryColumn);
+    await userEvent.click(categoryColumn);
     expect(categoryColumn).toBeChecked();
     expect(vendorColumn).not.toBeChecked();
 
-    userEvent.click(vendorColumn);
+    await userEvent.click(vendorColumn);
     expect(categoryColumn).toBeChecked();
     expect(vendorColumn).toBeChecked();
 
-    userEvent.click(categoryColumn);
+    await userEvent.click(categoryColumn);
     expect(categoryColumn).not.toBeChecked();
     expect(vendorColumn).toBeChecked();
 
-    userEvent.click(vendorColumn);
+    await userEvent.click(vendorColumn);
     expect(categoryColumn).not.toBeChecked();
     expect(vendorColumn).not.toBeChecked();
   });
 
-  it("should allow to add and remove column groups", () => {
+  it("should allow to add and remove column groups", async () => {
     setup();
     const productGroup = screen.getByRole("checkbox", { name: "Product" });
     const categoryColumn = screen.getByRole("checkbox", { name: "Category" });
@@ -87,18 +87,18 @@ describe("QueryColumnPicker", () => {
     expect(categoryColumn).not.toBeChecked();
     expect(vendorColumn).not.toBeChecked();
 
-    userEvent.click(productGroup);
+    await userEvent.click(productGroup);
     expect(productGroup).toBeChecked();
     expect(categoryColumn).toBeChecked();
     expect(vendorColumn).toBeChecked();
 
-    userEvent.click(productGroup);
+    await userEvent.click(productGroup);
     expect(productGroup).not.toBeChecked();
     expect(categoryColumn).not.toBeChecked();
     expect(vendorColumn).not.toBeChecked();
   });
 
-  it("should not allow to remove the last column from the data source", () => {
+  it("should not allow to remove the last column from the data source", async () => {
     setup();
     const [orderGroup, firstColumn, ...otherColumns] =
       screen.getAllByRole("checkbox");
@@ -111,7 +111,7 @@ describe("QueryColumnPicker", () => {
     expect(orderGroup).toBeEnabled();
     expect(orderGroup).not.toBeChecked();
 
-    userEvent.click(orderGroup);
+    await userEvent.click(orderGroup);
     expect(firstColumn).toBeChecked();
     expect(firstColumn).toBeEnabled();
   });
@@ -132,9 +132,12 @@ describe("QueryColumnPicker", () => {
     expect(customColumn).toBeDisabled();
   });
 
-  it("should allow to search for columns", () => {
+  it("should allow to search for columns", async () => {
     setup();
-    userEvent.type(screen.getByPlaceholderText("Search for a column…"), "a");
+    await userEvent.type(
+      screen.getByPlaceholderText("Search for a column…"),
+      "a",
+    );
 
     const taxColumn = screen.getByRole("checkbox", { name: "Tax" });
     const categoryColumn = screen.getByRole("checkbox", { name: "Category" });
@@ -143,7 +146,7 @@ describe("QueryColumnPicker", () => {
     expect(categoryColumn).toBeInTheDocument();
     expect(vendorColumn).not.toBeInTheDocument();
 
-    userEvent.click(categoryColumn);
+    await userEvent.click(categoryColumn);
     expect(categoryColumn).toBeChecked();
   });
 });

--- a/frontend/src/metabase/querying/components/FilterModal/BooleanFilterEditor/BooleanFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/BooleanFilterEditor/BooleanFilterEditor.unit.spec.tsx
@@ -77,7 +77,7 @@ describe("BooleanFilterEditor", () => {
   const column = findColumn("ORDERS", BOOLEAN_FIELD.name);
 
   describe("new filter", () => {
-    it('should add a "true" filter', () => {
+    it('should add a "true" filter', async () => {
       const { getNextFilterName } = setup({
         query,
         stageIndex,
@@ -86,7 +86,7 @@ describe("BooleanFilterEditor", () => {
 
       const trueCheckbox = screen.getByRole("checkbox", { name: "True" });
       const falseCheckbox = screen.getByRole("checkbox", { name: "False" });
-      userEvent.click(trueCheckbox);
+      await userEvent.click(trueCheckbox);
 
       expect(getNextFilterName()).toBe("Is trial is true");
       expect(trueCheckbox).toBeChecked();
@@ -94,7 +94,7 @@ describe("BooleanFilterEditor", () => {
       expect(screen.queryByText("is")).not.toBeInTheDocument();
     });
 
-    it('should add a "false" filter', () => {
+    it('should add a "false" filter', async () => {
       const { getNextFilterName } = setup({
         query,
         stageIndex,
@@ -103,7 +103,7 @@ describe("BooleanFilterEditor", () => {
 
       const trueCheckbox = screen.getByRole("checkbox", { name: "True" });
       const falseCheckbox = screen.getByRole("checkbox", { name: "False" });
-      userEvent.click(falseCheckbox);
+      await userEvent.click(falseCheckbox);
 
       expect(getNextFilterName()).toBe("Is trial is false");
       expect(trueCheckbox).not.toBeChecked();
@@ -111,7 +111,7 @@ describe("BooleanFilterEditor", () => {
       expect(screen.queryByText("is")).not.toBeInTheDocument();
     });
 
-    it("should allow to remove a filter", () => {
+    it("should allow to remove a filter", async () => {
       const { getNextFilterName } = setup({
         query,
         stageIndex,
@@ -120,22 +120,22 @@ describe("BooleanFilterEditor", () => {
 
       const trueCheckbox = screen.getByRole("checkbox", { name: "True" });
       const falseCheckbox = screen.getByRole("checkbox", { name: "False" });
-      userEvent.click(trueCheckbox);
+      await userEvent.click(trueCheckbox);
       expect(getNextFilterName()).toBe("Is trial is true");
       expect(trueCheckbox).toBeChecked();
       expect(falseCheckbox).not.toBeChecked();
 
-      userEvent.click(trueCheckbox);
+      await userEvent.click(trueCheckbox);
       expect(getNextFilterName()).toBeNull();
       expect(trueCheckbox).not.toBeChecked();
       expect(falseCheckbox).not.toBeChecked();
 
-      userEvent.click(falseCheckbox);
+      await userEvent.click(falseCheckbox);
       expect(getNextFilterName()).toBe("Is trial is false");
       expect(trueCheckbox).not.toBeChecked();
       expect(falseCheckbox).toBeChecked();
 
-      userEvent.click(falseCheckbox);
+      await userEvent.click(falseCheckbox);
       expect(getNextFilterName()).toBeNull();
       expect(trueCheckbox).not.toBeChecked();
       expect(falseCheckbox).not.toBeChecked();
@@ -143,7 +143,7 @@ describe("BooleanFilterEditor", () => {
   });
 
   describe("existing filter", () => {
-    it("should update a filter with one value", () => {
+    it("should update a filter with one value", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         operator: "=",
         values: [true],
@@ -160,7 +160,7 @@ describe("BooleanFilterEditor", () => {
       expect(trueCheckbox).toBeChecked();
       expect(falseCheckbox).not.toBeChecked();
 
-      userEvent.click(falseCheckbox);
+      await userEvent.click(falseCheckbox);
       expect(getNextFilterName()).toBe("Is trial is false");
       expect(trueCheckbox).not.toBeChecked();
       expect(falseCheckbox).toBeChecked();
@@ -184,8 +184,8 @@ describe("BooleanFilterEditor", () => {
       expect(trueCheckbox).not.toBeChecked();
       expect(falseCheckbox).not.toBeChecked();
 
-      userEvent.click(screen.getByText("is empty"));
-      userEvent.click(await screen.findByText("Not empty"));
+      await userEvent.click(screen.getByText("is empty"));
+      await userEvent.click(await screen.findByText("Not empty"));
       expect(getNextFilterName()).toBe("Is trial is not empty");
       expect(screen.getByText("not empty")).toBeInTheDocument();
       expect(
@@ -193,9 +193,11 @@ describe("BooleanFilterEditor", () => {
       ).not.toBeChecked();
       expect(falseCheckbox).not.toBeChecked();
 
-      userEvent.click(screen.getByText("not empty"));
-      userEvent.click(await screen.findByText("Is"));
-      userEvent.click(await screen.findByRole("checkbox", { name: "True" }));
+      await userEvent.click(screen.getByText("not empty"));
+      await userEvent.click(await screen.findByText("Is"));
+      await userEvent.click(
+        await screen.findByRole("checkbox", { name: "True" }),
+      );
       expect(getNextFilterName()).toBe("Is trial is true");
       expect(screen.getByText("is")).toBeInTheDocument();
       expect(trueCheckbox).toBeChecked();

--- a/frontend/src/metabase/querying/components/FilterModal/CoordinateFilterEditor/CoordinateFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/CoordinateFilterEditor/CoordinateFilterEditor.unit.spec.tsx
@@ -54,12 +54,12 @@ describe("CoordinateFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("between"));
-      userEvent.click(await screen.findByText("Is"));
-      userEvent.type(screen.getByLabelText("Filter value"), "10");
-      userEvent.tab();
-      userEvent.type(screen.getByLabelText("Filter value"), "20");
-      userEvent.tab();
+      await userEvent.click(screen.getByText("between"));
+      await userEvent.click(await screen.findByText("Is"));
+      await userEvent.type(screen.getByLabelText("Filter value"), "10");
+      await userEvent.tab();
+      await userEvent.type(screen.getByLabelText("Filter value"), "20");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Latitude is equal to 2 selections");
       expect(onInput).toHaveBeenCalled();
@@ -72,25 +72,25 @@ describe("CoordinateFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("between"));
-      userEvent.click(await screen.findByText("Greater than"));
-      userEvent.type(screen.getByPlaceholderText("Enter a number"), "20");
-      userEvent.tab();
+      await userEvent.click(screen.getByText("between"));
+      await userEvent.click(await screen.findByText("Greater than"));
+      await userEvent.type(screen.getByPlaceholderText("Enter a number"), "20");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Latitude is greater than 20");
       expect(onInput).toHaveBeenCalled();
     });
 
-    it("should add a filter with two values", () => {
+    it("should add a filter with two values", async () => {
       const { getNextFilterName, onInput } = setup({
         query,
         stageIndex,
         column,
       });
 
-      userEvent.type(screen.getByPlaceholderText("Min"), "10");
-      userEvent.type(screen.getByPlaceholderText("Max"), "20");
-      userEvent.tab();
+      await userEvent.type(screen.getByPlaceholderText("Min"), "10");
+      await userEvent.type(screen.getByPlaceholderText("Max"), "20");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Latitude is between 10 and 20");
       expect(onInput).toHaveBeenCalled();
@@ -103,13 +103,22 @@ describe("CoordinateFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("between"));
-      userEvent.click(await screen.findByText("Inside"));
-      userEvent.type(screen.getByPlaceholderText("Lower latitude"), "-10");
-      userEvent.type(screen.getByPlaceholderText("Upper latitude"), "20");
-      userEvent.type(screen.getByPlaceholderText("Left longitude"), "-30");
-      userEvent.type(screen.getByPlaceholderText("Right longitude"), "40");
-      userEvent.tab();
+      await userEvent.click(screen.getByText("between"));
+      await userEvent.click(await screen.findByText("Inside"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Lower latitude"),
+        "-10",
+      );
+      await userEvent.type(screen.getByPlaceholderText("Upper latitude"), "20");
+      await userEvent.type(
+        screen.getByPlaceholderText("Left longitude"),
+        "-30",
+      );
+      await userEvent.type(
+        screen.getByPlaceholderText("Right longitude"),
+        "40",
+      );
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe(
         "Latitude is between -10 and 20 and Longitude is between -30 and 40",
@@ -124,24 +133,24 @@ describe("CoordinateFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("between"));
-      userEvent.click(await screen.findByText("Greater than"));
+      await userEvent.click(screen.getByText("between"));
+      await userEvent.click(await screen.findByText("Greater than"));
       expect(getNextFilterName()).toBeNull();
 
-      userEvent.type(screen.getByPlaceholderText("Enter a number"), "10");
-      userEvent.clear(screen.getByPlaceholderText("Enter a number"));
+      await userEvent.type(screen.getByPlaceholderText("Enter a number"), "10");
+      await userEvent.clear(screen.getByPlaceholderText("Enter a number"));
       expect(getNextFilterName()).toBeNull();
     });
 
-    it("should coerce invalid filter values", () => {
+    it("should coerce invalid filter values", async () => {
       const { getNextFilterName, onInput } = setup({
         query,
         stageIndex,
         column,
       });
 
-      userEvent.type(screen.getByPlaceholderText("Min"), "10");
-      userEvent.tab();
+      await userEvent.type(screen.getByPlaceholderText("Min"), "10");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe(
         "Latitude is greater than or equal to 10",
@@ -151,7 +160,7 @@ describe("CoordinateFilterEditor", () => {
   });
 
   describe("existing filter", () => {
-    it("should update a filter with multiple values", () => {
+    it("should update a filter with multiple values", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         operator: "=",
         values: [10],
@@ -164,13 +173,13 @@ describe("CoordinateFilterEditor", () => {
       });
       expect(screen.getByDisplayValue("10")).toBeInTheDocument();
 
-      userEvent.type(screen.getByLabelText("Filter value"), "20");
-      userEvent.tab();
+      await userEvent.type(screen.getByLabelText("Filter value"), "20");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Latitude is equal to 2 selections");
     });
 
-    it("should update a filter with one value", () => {
+    it("should update a filter with one value", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         operator: ">",
         values: [10],
@@ -182,14 +191,14 @@ describe("CoordinateFilterEditor", () => {
         filter,
       });
 
-      userEvent.clear(screen.getByDisplayValue("10"));
-      userEvent.type(screen.getByPlaceholderText("Enter a number"), "20");
-      userEvent.tab();
+      await userEvent.clear(screen.getByDisplayValue("10"));
+      await userEvent.type(screen.getByPlaceholderText("Enter a number"), "20");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Latitude is greater than 20");
     });
 
-    it("should update a filter with two values", () => {
+    it("should update a filter with two values", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         operator: "between",
         values: [10, 20],
@@ -201,16 +210,16 @@ describe("CoordinateFilterEditor", () => {
         filter,
       });
 
-      userEvent.clear(screen.getByDisplayValue("10"));
-      userEvent.type(screen.getByPlaceholderText("Min"), "15");
-      userEvent.clear(screen.getByDisplayValue("20"));
-      userEvent.type(screen.getByPlaceholderText("Max"), "25");
-      userEvent.tab();
+      await userEvent.clear(screen.getByDisplayValue("10"));
+      await userEvent.type(screen.getByPlaceholderText("Min"), "15");
+      await userEvent.clear(screen.getByDisplayValue("20"));
+      await userEvent.type(screen.getByPlaceholderText("Max"), "25");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Latitude is between 15 and 25");
     });
 
-    it("should update a filter with four values", () => {
+    it("should update a filter with four values", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         operator: "inside",
         values: [20, -30, -10, 40],
@@ -222,15 +231,24 @@ describe("CoordinateFilterEditor", () => {
         filter,
       });
 
-      userEvent.clear(screen.getByDisplayValue("-10"));
-      userEvent.type(screen.getByPlaceholderText("Lower latitude"), "-11");
-      userEvent.clear(screen.getByDisplayValue("20"));
-      userEvent.type(screen.getByPlaceholderText("Upper latitude"), "22");
-      userEvent.clear(screen.getByDisplayValue("-30"));
-      userEvent.type(screen.getByPlaceholderText("Left longitude"), "-33");
-      userEvent.clear(screen.getByDisplayValue("40"));
-      userEvent.type(screen.getByPlaceholderText("Right longitude"), "44");
-      userEvent.tab();
+      await userEvent.clear(screen.getByDisplayValue("-10"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Lower latitude"),
+        "-11",
+      );
+      await userEvent.clear(screen.getByDisplayValue("20"));
+      await userEvent.type(screen.getByPlaceholderText("Upper latitude"), "22");
+      await userEvent.clear(screen.getByDisplayValue("-30"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Left longitude"),
+        "-33",
+      );
+      await userEvent.clear(screen.getByDisplayValue("40"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Right longitude"),
+        "44",
+      );
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe(
         "Latitude is between -11 and 22 and Longitude is between -33 and 44",

--- a/frontend/src/metabase/querying/components/FilterModal/DateFilterEditor/DateFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/DateFilterEditor/DateFilterEditor.unit.spec.tsx
@@ -47,19 +47,19 @@ describe("DateFilterEditor", () => {
   const column = findColumn("ORDERS", "CREATED_AT");
 
   describe("new filter", () => {
-    it("should add a relative date filter from a shortcut", () => {
+    it("should add a relative date filter from a shortcut", async () => {
       const { getNextFilterName } = setup({
         query: defaultQuery,
         stageIndex,
         column,
       });
 
-      userEvent.click(screen.getByText("Last month"));
+      await userEvent.click(screen.getByText("Last month"));
 
       expect(getNextFilterName()).toBe("Created At is in the previous month");
     });
 
-    it("should remove a relative date filter from a shortcut", () => {
+    it("should remove a relative date filter from a shortcut", async () => {
       const { query, filter } = createQueryWithFilter(
         defaultQuery,
         stageIndex,
@@ -82,7 +82,7 @@ describe("DateFilterEditor", () => {
       const button = screen.getByRole("button", { name: "Today" });
       expect(button).toHaveAttribute("aria-selected", "true");
 
-      userEvent.click(button);
+      await userEvent.click(button);
       expect(getNextFilterName()).toBeNull();
     });
 
@@ -93,8 +93,8 @@ describe("DateFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByLabelText("More options"));
-      userEvent.click(await screen.findByText("Last 30 days"));
+      await userEvent.click(screen.getByLabelText("More options"));
+      await userEvent.click(await screen.findByText("Last 30 days"));
 
       expect(getNextFilterName()).toBe("Created At is in the previous 30 days");
     });
@@ -120,7 +120,7 @@ describe("DateFilterEditor", () => {
       });
       expect(screen.getByText("Previous 30 Days")).toBeInTheDocument();
 
-      userEvent.click(screen.getByLabelText("Clear"));
+      await userEvent.click(screen.getByLabelText("Clear"));
       expect(getNextFilterName()).toBe(null);
     });
 
@@ -131,12 +131,12 @@ describe("DateFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByLabelText("More options"));
-      userEvent.click(await screen.findByText("Specific dates…"));
-      userEvent.click(screen.getByText("After"));
-      userEvent.clear(screen.getByLabelText("Date"));
-      userEvent.type(screen.getByLabelText("Date"), "Feb 15, 2020");
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.click(screen.getByLabelText("More options"));
+      await userEvent.click(await screen.findByText("Specific dates…"));
+      await userEvent.click(screen.getByText("After"));
+      await userEvent.clear(screen.getByLabelText("Date"));
+      await userEvent.type(screen.getByLabelText("Date"), "Feb 15, 2020");
+      await userEvent.click(screen.getByText("Add filter"));
 
       expect(getNextFilterName()).toBe("Created At is after Feb 15, 2020");
     });
@@ -159,7 +159,7 @@ describe("DateFilterEditor", () => {
       });
       expect(screen.getByText("Feb 15, 2020")).toBeInTheDocument();
 
-      userEvent.click(screen.getByLabelText("Clear"));
+      await userEvent.click(screen.getByLabelText("Clear"));
       expect(getNextFilterName()).toBe(null);
     });
 
@@ -170,11 +170,11 @@ describe("DateFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByLabelText("More options"));
-      userEvent.click(await screen.findByText("Exclude…"));
-      userEvent.click(screen.getByText("Hours of the day…"));
-      userEvent.click(screen.getByText("5 PM"));
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.click(screen.getByLabelText("More options"));
+      await userEvent.click(await screen.findByText("Exclude…"));
+      await userEvent.click(screen.getByText("Hours of the day…"));
+      await userEvent.click(screen.getByText("5 PM"));
+      await userEvent.click(screen.getByText("Add filter"));
 
       expect(getNextFilterName()).toBe("Created At excludes the hour of 5 PM");
     });
@@ -198,7 +198,7 @@ describe("DateFilterEditor", () => {
       });
       expect(screen.getByText("Excludes 5 PM")).toBeInTheDocument();
 
-      userEvent.click(screen.getByLabelText("Clear"));
+      await userEvent.click(screen.getByLabelText("Clear"));
       expect(getNextFilterName()).toBe(null);
     });
   });

--- a/frontend/src/metabase/querying/components/FilterModal/FilterModal.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/FilterModal.unit.spec.tsx
@@ -60,9 +60,17 @@ describe("FilterModal", () => {
     const { getNextQuery } = setup({ query });
 
     const totalSection = screen.getByTestId("filter-column-Total");
-    userEvent.type(within(totalSection).getByPlaceholderText("Min"), "10");
-    userEvent.type(within(totalSection).getByPlaceholderText("Max"), "20");
-    userEvent.click(screen.getByRole("button", { name: "Apply filters" }));
+    await userEvent.type(
+      within(totalSection).getByPlaceholderText("Min"),
+      "10",
+    );
+    await userEvent.type(
+      within(totalSection).getByPlaceholderText("Max"),
+      "20",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Apply filters" }),
+    );
 
     const nextQuery = getNextQuery();
     expect(Lib.stageCount(nextQuery)).toBe(1);
@@ -72,25 +80,33 @@ describe("FilterModal", () => {
   it("should allow to add filters for implicitly joined tables", async () => {
     const { getNextQuery } = setup({ query });
 
-    userEvent.click(screen.getByRole("tab", { name: "Product" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Product" }));
     await waitForLoaderToBeRemoved();
     const priceSection = screen.getByTestId("filter-column-Price");
-    userEvent.type(within(priceSection).getByPlaceholderText("Min"), "10");
-    userEvent.type(within(priceSection).getByPlaceholderText("Max"), "20");
+    await userEvent.type(
+      within(priceSection).getByPlaceholderText("Min"),
+      "10",
+    );
+    await userEvent.type(
+      within(priceSection).getByPlaceholderText("Max"),
+      "20",
+    );
 
-    userEvent.click(screen.getByRole("tab", { name: "User" }));
+    await userEvent.click(screen.getByRole("tab", { name: "User" }));
     await waitForLoaderToBeRemoved();
     const sourceSection = screen.getByTestId("filter-column-Source");
-    userEvent.click(within(sourceSection).getByText("Organic"));
+    await userEvent.click(within(sourceSection).getByText("Organic"));
 
-    userEvent.click(screen.getByRole("button", { name: "Apply filters" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Apply filters" }),
+    );
 
     const nextQuery = getNextQuery();
     expect(Lib.stageCount(nextQuery)).toBe(1);
     expect(Lib.filters(nextQuery, 0)).toHaveLength(2);
   });
 
-  it("should allow to add post-aggregation filters", () => {
+  it("should allow to add post-aggregation filters", async () => {
     const { getNextQuery } = setup({
       query: createQueryWithClauses({
         aggregations: [{ operatorName: "count" }],
@@ -98,11 +114,16 @@ describe("FilterModal", () => {
       }),
     });
 
-    userEvent.click(screen.getByRole("tab", { name: "Summaries" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Summaries" }));
 
     const countSection = screen.getByTestId("filter-column-Count");
-    userEvent.type(within(countSection).getByPlaceholderText("Min"), "10");
-    userEvent.click(screen.getByRole("button", { name: "Apply filters" }));
+    await userEvent.type(
+      within(countSection).getByPlaceholderText("Min"),
+      "10",
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Apply filters" }),
+    );
 
     const nextQuery = getNextQuery();
     expect(Lib.stageCount(nextQuery)).toBe(2);
@@ -110,11 +131,11 @@ describe("FilterModal", () => {
     expect(Lib.filters(nextQuery, 1)).toHaveLength(1);
   });
 
-  it("should allow to search for columns and add filters", () => {
+  it("should allow to search for columns and add filters", async () => {
     const { getNextQuery } = setup({ query });
 
     const searchInput = screen.getByPlaceholderText("Search for a column…");
-    userEvent.type(searchInput, "created");
+    await userEvent.type(searchInput, "created");
     act(() => jest.advanceTimersByTime(1000));
     const sections = screen.getAllByTestId("filter-column-Created At");
     expect(sections).toHaveLength(3);
@@ -124,10 +145,12 @@ describe("FilterModal", () => {
     expect(within(productsSection).getByText("Products")).toBeInTheDocument();
     expect(within(peopleSection).getByText("People")).toBeInTheDocument();
 
-    userEvent.click(within(ordersSection).getByText("Today"));
-    userEvent.click(within(productsSection).getByText("Yesterday"));
-    userEvent.click(within(peopleSection).getByText("Last month"));
-    userEvent.click(screen.getByRole("button", { name: "Apply filters" }));
+    await userEvent.click(within(ordersSection).getByText("Today"));
+    await userEvent.click(within(productsSection).getByText("Yesterday"));
+    await userEvent.click(within(peopleSection).getByText("Last month"));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Apply filters" }),
+    );
 
     const nextQuery = getNextQuery();
     expect(Lib.stageCount(nextQuery)).toBe(1);
@@ -148,12 +171,14 @@ describe("FilterModal", () => {
       ),
     });
 
-    userEvent.click(screen.getByRole("tab", { name: "Product" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Product" }));
     await waitForLoaderToBeRemoved();
     expect(screen.getByRole("checkbox", { name: "Gadget" })).toBeChecked();
 
-    userEvent.click(screen.getByRole("checkbox", { name: "Widget" }));
-    userEvent.click(screen.getByRole("button", { name: "Apply filters" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Widget" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Apply filters" }),
+    );
     const nextQuery = getNextQuery();
     expect(Lib.stageCount(nextQuery)).toBe(1);
     expect(Lib.filters(nextQuery, 0)).toHaveLength(1);
@@ -173,12 +198,14 @@ describe("FilterModal", () => {
       ),
     });
 
-    userEvent.click(screen.getByRole("tab", { name: "Product" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Product" }));
     await waitForLoaderToBeRemoved();
     expect(screen.getByRole("checkbox", { name: "Gadget" })).toBeChecked();
 
-    userEvent.click(screen.getByRole("checkbox", { name: "Gadget" }));
-    userEvent.click(screen.getByRole("button", { name: "Apply filters" }));
+    await userEvent.click(screen.getByRole("checkbox", { name: "Gadget" }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Apply filters" }),
+    );
     const nextQuery = getNextQuery();
     expect(Lib.stageCount(nextQuery)).toBe(1);
     expect(Lib.filters(nextQuery, 0)).toHaveLength(0);

--- a/frontend/src/metabase/querying/components/FilterModal/NumberFilterEditor/NumberFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/NumberFilterEditor/NumberFilterEditor.unit.spec.tsx
@@ -68,9 +68,9 @@ describe("StringFilterEditor", () => {
         }),
       });
 
-      userEvent.click(screen.getByText("between"));
-      userEvent.click(await screen.findByText("Equal to"));
-      userEvent.click(await screen.findByText("2"));
+      await userEvent.click(screen.getByText("between"));
+      await userEvent.click(await screen.findByText("Equal to"));
+      await userEvent.click(await screen.findByText("2"));
 
       expect(getNextFilterName()).toBe("Quantity is equal to 2");
     });
@@ -82,16 +82,16 @@ describe("StringFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("between"));
-      userEvent.click(await screen.findByText("Equal to"));
-      userEvent.type(screen.getByPlaceholderText("Enter a number"), "15");
-      userEvent.tab();
+      await userEvent.click(screen.getByText("between"));
+      await userEvent.click(await screen.findByText("Equal to"));
+      await userEvent.type(screen.getByPlaceholderText("Enter a number"), "15");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Total is equal to 15");
       expect(onInput).toHaveBeenCalled();
     });
 
-    it("should handle primary keys", () => {
+    it("should handle primary keys", async () => {
       const { getNextFilterName } = setup({
         query,
         stageIndex,
@@ -99,12 +99,12 @@ describe("StringFilterEditor", () => {
       });
       expect(screen.getByText("is")).toBeInTheDocument();
 
-      userEvent.type(screen.getByPlaceholderText("Enter an ID"), "15");
-      userEvent.tab();
+      await userEvent.type(screen.getByPlaceholderText("Enter an ID"), "15");
+      await userEvent.tab();
       expect(getNextFilterName()).toBe("ID is 15");
     });
 
-    it("should handle foreign keys", () => {
+    it("should handle foreign keys", async () => {
       const { getNextFilterName } = setup({
         query,
         stageIndex,
@@ -112,8 +112,8 @@ describe("StringFilterEditor", () => {
       });
       expect(screen.getByText("is")).toBeInTheDocument();
 
-      userEvent.type(screen.getByPlaceholderText("Enter an ID"), "15");
-      userEvent.tab();
+      await userEvent.type(screen.getByPlaceholderText("Enter an ID"), "15");
+      await userEvent.tab();
       expect(getNextFilterName()).toBe("Product ID is 15");
     });
 
@@ -124,10 +124,10 @@ describe("StringFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("between"));
-      userEvent.click(await screen.findByText("Less than"));
-      userEvent.type(screen.getByPlaceholderText("Enter a number"), "20");
-      userEvent.tab();
+      await userEvent.click(screen.getByText("between"));
+      await userEvent.click(await screen.findByText("Less than"));
+      await userEvent.type(screen.getByPlaceholderText("Enter a number"), "20");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Total is less than 20");
       expect(onInput).toHaveBeenCalled();
@@ -140,9 +140,9 @@ describe("StringFilterEditor", () => {
         column,
       });
 
-      userEvent.type(screen.getByPlaceholderText("Min"), "10");
-      userEvent.type(screen.getByPlaceholderText("Max"), "20");
-      userEvent.tab();
+      await userEvent.type(screen.getByPlaceholderText("Min"), "10");
+      await userEvent.type(screen.getByPlaceholderText("Max"), "20");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Total is between 10 and 20");
       expect(onInput).toHaveBeenCalled();
@@ -155,8 +155,8 @@ describe("StringFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("between"));
-      userEvent.click(await screen.findByText("Is empty"));
+      await userEvent.click(screen.getByText("between"));
+      await userEvent.click(await screen.findByText("Is empty"));
 
       expect(getNextFilterName()).toBe("Total is empty");
     });
@@ -168,12 +168,12 @@ describe("StringFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("between"));
-      userEvent.click(await screen.findByText("Greater than"));
+      await userEvent.click(screen.getByText("between"));
+      await userEvent.click(await screen.findByText("Greater than"));
       expect(getNextFilterName()).toBeNull();
 
-      userEvent.type(screen.getByPlaceholderText("Enter a number"), "10");
-      userEvent.clear(screen.getByPlaceholderText("Enter a number"));
+      await userEvent.type(screen.getByPlaceholderText("Enter a number"), "10");
+      await userEvent.clear(screen.getByPlaceholderText("Enter a number"));
       expect(getNextFilterName()).toBeNull();
     });
 
@@ -184,8 +184,8 @@ describe("StringFilterEditor", () => {
         column,
       });
 
-      userEvent.type(screen.getByPlaceholderText("Min"), "10");
-      userEvent.tab();
+      await userEvent.type(screen.getByPlaceholderText("Min"), "10");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Total is greater than or equal to 10");
       expect(onInput).toHaveBeenCalled();
@@ -217,14 +217,14 @@ describe("StringFilterEditor", () => {
       expect(screen.getByRole("checkbox", { name: "2" })).toBeChecked();
       expect(screen.getByRole("checkbox", { name: "3" })).not.toBeChecked();
 
-      userEvent.click(screen.getByRole("checkbox", { name: "3" }));
+      await userEvent.click(screen.getByRole("checkbox", { name: "3" }));
       expect(screen.getByRole("checkbox", { name: "1" })).not.toBeChecked();
       expect(screen.getByRole("checkbox", { name: "2" })).toBeChecked();
       expect(screen.getByRole("checkbox", { name: "3" })).toBeChecked();
       expect(getNextFilterName()).toBe("Quantity is equal to 2 selections");
     });
 
-    it("should handle non-searchable values", () => {
+    it("should handle non-searchable values", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         tableName: "ORDERS",
         columnName: "TOTAL",
@@ -239,13 +239,13 @@ describe("StringFilterEditor", () => {
       });
       expect(screen.getByDisplayValue("10")).toBeInTheDocument();
 
-      userEvent.type(screen.getByLabelText("Filter value"), "20");
-      userEvent.tab();
+      await userEvent.type(screen.getByLabelText("Filter value"), "20");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Total is equal to 2 selections");
     });
 
-    it("should update a filter with one value", () => {
+    it("should update a filter with one value", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         tableName: "ORDERS",
         columnName: "TOTAL",
@@ -259,14 +259,14 @@ describe("StringFilterEditor", () => {
         filter,
       });
 
-      userEvent.clear(screen.getByDisplayValue("10"));
-      userEvent.type(screen.getByPlaceholderText("Enter a number"), "20");
-      userEvent.tab();
+      await userEvent.clear(screen.getByDisplayValue("10"));
+      await userEvent.type(screen.getByPlaceholderText("Enter a number"), "20");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Total is greater than 20");
     });
 
-    it("should update a filter with two values", () => {
+    it("should update a filter with two values", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         tableName: "ORDERS",
         columnName: "TOTAL",
@@ -280,11 +280,11 @@ describe("StringFilterEditor", () => {
         filter,
       });
 
-      userEvent.clear(screen.getByDisplayValue("10"));
-      userEvent.type(screen.getByPlaceholderText("Min"), "15");
-      userEvent.clear(screen.getByDisplayValue("20"));
-      userEvent.type(screen.getByPlaceholderText("Max"), "25");
-      userEvent.tab();
+      await userEvent.clear(screen.getByDisplayValue("10"));
+      await userEvent.type(screen.getByPlaceholderText("Min"), "15");
+      await userEvent.clear(screen.getByDisplayValue("20"));
+      await userEvent.type(screen.getByPlaceholderText("Max"), "25");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Total is between 15 and 25");
     });
@@ -303,8 +303,8 @@ describe("StringFilterEditor", () => {
         filter,
       });
 
-      userEvent.click(screen.getByText("is empty"));
-      userEvent.click(await screen.findByText("Not empty"));
+      await userEvent.click(screen.getByText("is empty"));
+      await userEvent.click(await screen.findByText("Not empty"));
 
       expect(getNextFilterName()).toBe("Total is not empty");
     });

--- a/frontend/src/metabase/querying/components/FilterModal/SegmentFilterEditor/SegmentFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/SegmentFilterEditor/SegmentFilterEditor.unit.spec.tsx
@@ -68,8 +68,8 @@ describe("SegmentFilterEditor", () => {
       segmentItems: getSegmentItems(defaultQuery, stageIndex),
     });
 
-    userEvent.click(screen.getByPlaceholderText("Filter segments"));
-    userEvent.click(await screen.findByText(SEGMENT2.name));
+    await userEvent.click(screen.getByPlaceholderText("Filter segments"));
+    await userEvent.click(await screen.findByText(SEGMENT2.name));
 
     const nextSegmentItems = getNextSegmentItems();
     expect(nextSegmentItems).toHaveLength(1);
@@ -88,7 +88,10 @@ describe("SegmentFilterEditor", () => {
     expect(screen.getByText(SEGMENT1.name)).toBeInTheDocument();
     expect(screen.queryByText(SEGMENT2.name)).not.toBeInTheDocument();
 
-    userEvent.type(screen.getByLabelText("Filter segments"), "{backspace}");
+    await userEvent.type(
+      screen.getByLabelText("Filter segments"),
+      "{backspace}",
+    );
     const nextSegmentItems = getNextSegmentItems();
     expect(nextSegmentItems).toHaveLength(0);
   });

--- a/frontend/src/metabase/querying/components/FilterModal/StringFilterEditor/StringFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/StringFilterEditor/StringFilterEditor.unit.spec.tsx
@@ -88,7 +88,7 @@ describe("StringFilterEditor", () => {
         column,
       });
 
-      userEvent.click(await screen.findByText("Gadget"));
+      await userEvent.click(await screen.findByText("Gadget"));
 
       expect(getNextFilterName()).toBe("Category is Gadget");
     });
@@ -106,26 +106,29 @@ describe("StringFilterEditor", () => {
         },
       });
 
-      userEvent.click(screen.getByText("contains"));
-      userEvent.click(screen.getByText("Is"));
-      userEvent.type(screen.getByPlaceholderText("Search by Email"), "a");
+      await userEvent.click(screen.getByText("contains"));
+      await userEvent.click(screen.getByText("Is"));
+      await userEvent.type(screen.getByPlaceholderText("Search by Email"), "a");
       act(() => jest.advanceTimersByTime(1000));
-      userEvent.click(await screen.findByText("a@metabase.test"));
+      await userEvent.click(await screen.findByText("a@metabase.test"));
 
       expect(getNextFilterName()).toBe("Email is a@metabase.test");
     });
 
-    it("should handle non-searchable values", () => {
+    it("should handle non-searchable values", async () => {
       const { getNextFilterName, onInput } = setup({
         query,
         stageIndex,
         column: findColumn("PEOPLE", "PASSWORD"),
       });
 
-      userEvent.click(screen.getByText("contains"));
-      userEvent.click(screen.getByText("Is"));
-      userEvent.type(screen.getByPlaceholderText("Enter some text"), "Test");
-      userEvent.tab();
+      await userEvent.click(screen.getByText("contains"));
+      await userEvent.click(screen.getByText("Is"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter some text"),
+        "Test",
+      );
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Password is Test");
       expect(onInput).toHaveBeenCalled();
@@ -138,10 +141,13 @@ describe("StringFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("is"));
-      userEvent.click(await screen.findByText("Starts with"));
-      userEvent.type(screen.getByPlaceholderText("Enter some text"), "Ga");
-      userEvent.tab();
+      await userEvent.click(screen.getByText("is"));
+      await userEvent.click(await screen.findByText("Starts with"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter some text"),
+        "Ga",
+      );
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Category starts with Ga");
       expect(onInput).toHaveBeenCalled();
@@ -154,8 +160,8 @@ describe("StringFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("is"));
-      userEvent.click(await screen.findByText("Is empty"));
+      await userEvent.click(screen.getByText("is"));
+      await userEvent.click(await screen.findByText("Is empty"));
 
       expect(getNextFilterName()).toBe("Category is empty");
     });
@@ -167,12 +173,15 @@ describe("StringFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("is"));
-      userEvent.click(await screen.findByText("Starts with"));
+      await userEvent.click(screen.getByText("is"));
+      await userEvent.click(await screen.findByText("Starts with"));
       expect(getNextFilterName()).toBeNull();
 
-      userEvent.type(screen.getByPlaceholderText("Enter some text"), "Ga");
-      userEvent.clear(screen.getByPlaceholderText("Enter some text"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter some text"),
+        "Ga",
+      );
+      await userEvent.clear(screen.getByPlaceholderText("Enter some text"));
       expect(getNextFilterName()).toBeNull();
     });
   });
@@ -198,7 +207,7 @@ describe("StringFilterEditor", () => {
         screen.getByRole("checkbox", { name: "Widget" }),
       ).not.toBeChecked();
 
-      userEvent.click(screen.getByRole("checkbox", { name: "Widget" }));
+      await userEvent.click(screen.getByRole("checkbox", { name: "Widget" }));
       expect(getNextFilterName()).toBe("Category is 2 selections");
     });
 
@@ -223,15 +232,15 @@ describe("StringFilterEditor", () => {
       });
       expect(screen.getByText("a@metabase.test")).toBeInTheDocument();
 
-      userEvent.type(screen.getByLabelText("Filter value"), "b");
+      await userEvent.type(screen.getByLabelText("Filter value"), "b");
       act(() => jest.advanceTimersByTime(1000));
-      userEvent.click(await screen.findByText("b@metabase.test"));
+      await userEvent.click(await screen.findByText("b@metabase.test"));
       expect(getNextFilterName()).toBe("Email is 2 selections");
       expect(screen.getByText("a@metabase.test")).toBeInTheDocument();
       expect(screen.getByText("b@metabase.test")).toBeInTheDocument();
     });
 
-    it("should handle non-searchable values", () => {
+    it("should handle non-searchable values", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         tableName: "PEOPLE",
         columnName: "PASSWORD",
@@ -246,15 +255,15 @@ describe("StringFilterEditor", () => {
       });
       expect(screen.getByText("abc")).toBeInTheDocument();
 
-      userEvent.type(screen.getByLabelText("Filter value"), "bcd");
-      userEvent.tab();
+      await userEvent.type(screen.getByLabelText("Filter value"), "bcd");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Password is 2 selections");
       expect(screen.getByText("abc")).toBeInTheDocument();
       expect(screen.getByText("bcd")).toBeInTheDocument();
     });
 
-    it("should update a filter with one value", () => {
+    it("should update a filter with one value", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         tableName: "PRODUCTS",
         columnName: "CATEGORY",
@@ -268,9 +277,12 @@ describe("StringFilterEditor", () => {
         filter,
       });
 
-      userEvent.clear(screen.getByDisplayValue("Ga"));
-      userEvent.type(screen.getByPlaceholderText("Enter some text"), "Wi");
-      userEvent.tab();
+      await userEvent.clear(screen.getByDisplayValue("Ga"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter some text"),
+        "Wi",
+      );
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Category starts with Wi");
     });
@@ -289,8 +301,8 @@ describe("StringFilterEditor", () => {
         filter,
       });
 
-      userEvent.click(screen.getByText("starts with"));
-      userEvent.click(await screen.findByText("Ends with"));
+      await userEvent.click(screen.getByText("starts with"));
+      await userEvent.click(await screen.findByText("Ends with"));
 
       expect(getNextFilterName()).toBe("Category ends with Ga");
       expect(screen.getByDisplayValue("Ga")).toBeInTheDocument();

--- a/frontend/src/metabase/querying/components/FilterModal/TimeFilterEditor/TimeFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/TimeFilterEditor/TimeFilterEditor.unit.spec.tsx
@@ -104,14 +104,10 @@ describe("TimeFilterEditor", () => {
 
       await userEvent.click(screen.getByText("before"));
       await userEvent.click(await screen.findByText("Between"));
-      await userEvent.type(
-        screen.getByPlaceholderText("Min"),
-        "{selectall}10:15",
-      );
-      await userEvent.type(
-        screen.getByPlaceholderText("Max"),
-        "{selectall}20:40",
-      );
+      await userEvent.clear(screen.getByPlaceholderText("Min"));
+      await userEvent.type(screen.getByPlaceholderText("Min"), "10:15");
+      await userEvent.clear(screen.getByPlaceholderText("Max"));
+      await userEvent.type(screen.getByPlaceholderText("Max"), "20:40");
       await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Time is 10:15 AM – 8:40 PM");

--- a/frontend/src/metabase/querying/components/FilterModal/TimeFilterEditor/TimeFilterEditor.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterModal/TimeFilterEditor/TimeFilterEditor.unit.spec.tsx
@@ -77,16 +77,19 @@ describe("TimeFilterEditor", () => {
   const column = findColumn("ORDERS", TIME_FIELD.name);
 
   describe("new filter", () => {
-    it("should add a filter with one value", () => {
+    it("should add a filter with one value", async () => {
       const { getNextFilterName, onInput } = setup({
         query,
         stageIndex,
         column,
       });
 
-      userEvent.clear(screen.getByPlaceholderText("Enter a time"));
-      userEvent.type(screen.getByPlaceholderText("Enter a time"), "10:20");
-      userEvent.tab();
+      await userEvent.clear(screen.getByPlaceholderText("Enter a time"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter a time"),
+        "10:20",
+      );
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Time is before 10:20 AM");
       expect(onInput).toHaveBeenCalled();
@@ -99,11 +102,17 @@ describe("TimeFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("before"));
-      userEvent.click(await screen.findByText("Between"));
-      userEvent.type(screen.getByPlaceholderText("Min"), "{selectall}10:15");
-      userEvent.type(screen.getByPlaceholderText("Max"), "{selectall}20:40");
-      userEvent.tab();
+      await userEvent.click(screen.getByText("before"));
+      await userEvent.click(await screen.findByText("Between"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Min"),
+        "{selectall}10:15",
+      );
+      await userEvent.type(
+        screen.getByPlaceholderText("Max"),
+        "{selectall}20:40",
+      );
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Time is 10:15 AM – 8:40 PM");
       expect(onInput).toHaveBeenCalled();
@@ -116,8 +125,8 @@ describe("TimeFilterEditor", () => {
         column,
       });
 
-      userEvent.click(screen.getByText("before"));
-      userEvent.click(await screen.findByText("Is empty"));
+      await userEvent.click(screen.getByText("before"));
+      await userEvent.click(await screen.findByText("Is empty"));
 
       expect(getNextFilterName()).toBe("Time is empty");
     });
@@ -129,15 +138,15 @@ describe("TimeFilterEditor", () => {
         column,
       });
 
-      userEvent.clear(screen.getByPlaceholderText("Enter a time"));
-      userEvent.tab();
+      await userEvent.clear(screen.getByPlaceholderText("Enter a time"));
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBeNull();
     });
   });
 
   describe("existing filter", () => {
-    it("should update a filter with one value", () => {
+    it("should update a filter with one value", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         operator: ">",
         values: [new Date(2020, 0, 1, 10, 20)],
@@ -149,14 +158,17 @@ describe("TimeFilterEditor", () => {
         filter,
       });
 
-      userEvent.clear(screen.getByDisplayValue("10:20"));
-      userEvent.type(screen.getByPlaceholderText("Enter a time"), "11:40");
-      userEvent.tab();
+      await userEvent.clear(screen.getByDisplayValue("10:20"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter a time"),
+        "11:40",
+      );
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Time is after 11:40 AM");
     });
 
-    it("should update a filter with two values", () => {
+    it("should update a filter with two values", async () => {
       const { query, stageIndex, column, filter } = createQueryWithFilter({
         operator: "between",
         values: [new Date(2020, 0, 1, 10, 20), new Date(2020, 0, 1, 12, 40)],
@@ -168,11 +180,11 @@ describe("TimeFilterEditor", () => {
         filter,
       });
 
-      userEvent.clear(screen.getByDisplayValue("10:20"));
-      userEvent.type(screen.getByPlaceholderText("Min"), "11:40");
-      userEvent.clear(screen.getByDisplayValue("12:40"));
-      userEvent.type(screen.getByPlaceholderText("Max"), "15:10");
-      userEvent.tab();
+      await userEvent.clear(screen.getByDisplayValue("10:20"));
+      await userEvent.type(screen.getByPlaceholderText("Min"), "11:40");
+      await userEvent.clear(screen.getByDisplayValue("12:40"));
+      await userEvent.type(screen.getByPlaceholderText("Max"), "15:10");
+      await userEvent.tab();
 
       expect(getNextFilterName()).toBe("Time is 11:40 AM – 3:10 PM");
     });
@@ -189,8 +201,8 @@ describe("TimeFilterEditor", () => {
         filter,
       });
 
-      userEvent.click(screen.getByText("is empty"));
-      userEvent.click(await screen.findByText("Not empty"));
+      await userEvent.click(screen.getByText("is empty"));
+      await userEvent.click(await screen.findByText("Not empty"));
 
       expect(getNextFilterName()).toBe("Time is not empty");
     });
@@ -207,8 +219,8 @@ describe("TimeFilterEditor", () => {
         filter,
       });
 
-      userEvent.click(screen.getByText("before"));
-      userEvent.click(await screen.findByText("After"));
+      await userEvent.click(screen.getByText("before"));
+      await userEvent.click(await screen.findByText("After"));
 
       expect(getNextFilterName()).toBe("Time is after 10:20 AM");
     });

--- a/frontend/src/metabase/querying/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/BooleanFilterPicker/BooleanFilterPicker.unit.spec.tsx
@@ -82,7 +82,7 @@ const TEST_CASES: Array<[string, TestCase]> = [
 
 describe("BooleanFilterPicker", () => {
   describe("new filter", () => {
-    it("should render a list of options", () => {
+    it("should render a list of options", async () => {
       setup();
 
       expect(screen.getByText("User → Is Active")).toBeInTheDocument();
@@ -92,7 +92,9 @@ describe("BooleanFilterPicker", () => {
       expect(screen.queryByText("Empty")).not.toBeInTheDocument();
       expect(screen.queryByText("Not empty")).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByRole("button", { name: "More options" }));
+      await userEvent.click(
+        screen.getByRole("button", { name: "More options" }),
+      );
 
       expect(screen.getByLabelText("True")).toBeChecked();
       expect(screen.getByLabelText("False")).not.toBeChecked();
@@ -102,14 +104,16 @@ describe("BooleanFilterPicker", () => {
 
     it.each(TEST_CASES)(
       "should create a filter with the '%s' option",
-      (title, { expectedOperator, expectedValues, isAdvanced }) => {
+      async (title, { expectedOperator, expectedValues, isAdvanced }) => {
         const { getNextFilterParts, getNextFilterColumnName } = setup();
 
         if (isAdvanced) {
-          userEvent.click(screen.getByText("More options"));
+          await userEvent.click(screen.getByText("More options"));
         }
-        userEvent.click(screen.getByLabelText(title));
-        userEvent.click(screen.getByRole("button", { name: "Add filter" }));
+        await userEvent.click(screen.getByLabelText(title));
+        await userEvent.click(
+          screen.getByRole("button", { name: "Add filter" }),
+        );
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -121,12 +125,12 @@ describe("BooleanFilterPicker", () => {
       },
     );
 
-    it("should create a filter via keyboard", () => {
+    it("should create a filter via keyboard", async () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup();
 
       const option = screen.getByLabelText("True");
-      userEvent.click(option);
-      userEvent.type(option, "{enter}");
+      await userEvent.click(option);
+      await userEvent.type(option, "{enter}");
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -137,16 +141,16 @@ describe("BooleanFilterPicker", () => {
       expect(getNextFilterColumnName()).toBe("User → Is Active");
     });
 
-    it("should go back", () => {
+    it("should go back", async () => {
       const { onBack, onChange } = setup();
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });
   });
 
   describe("existing filter", () => {
-    it("should render a list of options", () => {
+    it("should render a list of options", async () => {
       setup(
         createQueryWithBooleanFilter({
           operator: "=",
@@ -161,7 +165,9 @@ describe("BooleanFilterPicker", () => {
       expect(screen.queryByText("Empty")).not.toBeInTheDocument();
       expect(screen.queryByText("Not empty")).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByRole("button", { name: "More options" }));
+      await userEvent.click(
+        screen.getByRole("button", { name: "More options" }),
+      );
 
       expect(screen.getByLabelText("True")).not.toBeChecked();
       expect(screen.getByLabelText("False")).toBeChecked();
@@ -186,16 +192,18 @@ describe("BooleanFilterPicker", () => {
 
     it.each(TEST_CASES)(
       "should create a filter with the '%s' option",
-      (title, { expectedOperator, expectedValues, isAdvanced }) => {
+      async (title, { expectedOperator, expectedValues, isAdvanced }) => {
         const { getNextFilterParts, getNextFilterColumnName } = setup(
           createQueryWithBooleanFilter(),
         );
 
         if (isAdvanced) {
-          userEvent.click(screen.getByText("More options"));
+          await userEvent.click(screen.getByText("More options"));
         }
-        userEvent.click(screen.getByLabelText(title));
-        userEvent.click(screen.getByRole("button", { name: "Update filter" }));
+        await userEvent.click(screen.getByLabelText(title));
+        await userEvent.click(
+          screen.getByRole("button", { name: "Update filter" }),
+        );
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -207,9 +215,9 @@ describe("BooleanFilterPicker", () => {
       },
     );
 
-    it("should go back", () => {
+    it("should go back", async () => {
       const { onBack, onChange } = setup(createQueryWithBooleanFilter());
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });

--- a/frontend/src/metabase/querying/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
@@ -388,9 +388,10 @@ describe("CoordinateFilterPicker", () => {
           const { getNextFilterParts, getNextFilterColumnNames } = setup(opts);
 
           await setOperator("Greater than");
+          await userEvent.clear(screen.getByPlaceholderText("Enter a number"));
           await userEvent.type(
             screen.getByPlaceholderText("Enter a number"),
-            `{selectall}{backspace}${value}`,
+            `${value}`,
           );
           await userEvent.click(screen.getByText("Update filter"));
 
@@ -442,13 +443,12 @@ describe("CoordinateFilterPicker", () => {
           await setOperator("Between");
           const leftInput = screen.getByPlaceholderText("Min");
           const rightInput = screen.getByPlaceholderText("Max");
-          await userEvent.type(leftInput, `{selectall}{backspace}${leftValue}`);
+          await userEvent.clear(leftInput);
+          await userEvent.type(leftInput, `${leftValue}`);
           expect(updateButton).toBeEnabled();
 
-          await userEvent.type(
-            rightInput,
-            `{selectall}{backspace}${rightValue}`,
-          );
+          await userEvent.clear(rightInput);
+          await userEvent.type(rightInput, `${rightValue}`);
           await userEvent.click(updateButton);
 
           const filterParts = getNextFilterParts();
@@ -492,22 +492,17 @@ describe("CoordinateFilterPicker", () => {
         const { getNextFilterParts, getNextFilterColumnNames } = setup(opts);
 
         await setOperator("Inside");
-        await userEvent.type(
-          screen.getByLabelText("Upper latitude"),
-          "{selectall}{backspace}90",
-        );
-        await userEvent.type(
-          screen.getByLabelText("Lower latitude"),
-          "{selectall}{backspace}-90",
-        );
-        await userEvent.type(
-          screen.getByLabelText("Left longitude"),
-          "{selectall}{backspace}-180",
-        );
-        await userEvent.type(
-          screen.getByLabelText("Right longitude"),
-          "{selectall}{backspace}180",
-        );
+        await userEvent.clear(screen.getByLabelText("Upper latitude"));
+        await userEvent.type(screen.getByLabelText("Upper latitude"), "90");
+
+        await userEvent.clear(screen.getByLabelText("Lower latitude"));
+        await userEvent.type(screen.getByLabelText("Lower latitude"), "-90");
+
+        await userEvent.clear(screen.getByLabelText("Left longitude"));
+        await userEvent.type(screen.getByLabelText("Left longitude"), "-180");
+
+        await userEvent.clear(screen.getByLabelText("Right longitude"));
+        await userEvent.type(screen.getByLabelText("Right longitude"), "180");
         await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();

--- a/frontend/src/metabase/querying/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
@@ -96,8 +96,8 @@ function setup({
 }
 
 async function setOperator(operator: string) {
-  userEvent.click(screen.getByLabelText("Filter operator"));
-  userEvent.click(await screen.findByText(operator));
+  await userEvent.click(screen.getByLabelText("Filter operator"));
+  await userEvent.click(await screen.findByText(operator));
 }
 
 describe("CoordinateFilterPicker", () => {
@@ -115,7 +115,7 @@ describe("CoordinateFilterPicker", () => {
     it("should list operators", async () => {
       setup();
 
-      userEvent.click(screen.getByLabelText("Filter operator"));
+      await userEvent.click(screen.getByLabelText("Filter operator"));
       const listbox = await screen.findByRole("listbox");
       const options = within(listbox).getAllByRole("option");
 
@@ -132,11 +132,11 @@ describe("CoordinateFilterPicker", () => {
           const { getNextFilterParts, getNextFilterColumnNames } = setup();
 
           await setOperator("Less than");
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Enter a number"),
             String(value),
           );
-          userEvent.click(screen.getByText("Add filter"));
+          await userEvent.click(screen.getByText("Add filter"));
 
           const filterParts = getNextFilterParts();
           expect(filterParts).toMatchObject({
@@ -154,10 +154,10 @@ describe("CoordinateFilterPicker", () => {
 
         await setOperator("Greater than");
         const input = screen.getByPlaceholderText("Enter a number");
-        userEvent.type(input, "{enter}");
+        await userEvent.type(input, "{enter}");
         expect(onChange).not.toHaveBeenCalled();
 
-        userEvent.type(input, "15{enter}");
+        await userEvent.type(input, "15{enter}");
         expect(onChange).toHaveBeenCalled();
         expect(getNextFilterParts()).toMatchObject({
           operator: ">",
@@ -180,9 +180,9 @@ describe("CoordinateFilterPicker", () => {
           await setOperator("Between");
           const leftInput = screen.getByPlaceholderText("Min");
           const rightInput = screen.getByPlaceholderText("Max");
-          userEvent.type(leftInput, String(leftValue));
-          userEvent.type(rightInput, String(rightValue));
-          userEvent.click(addFilterButton);
+          await userEvent.type(leftInput, String(leftValue));
+          await userEvent.type(rightInput, String(rightValue));
+          await userEvent.click(addFilterButton);
 
           const filterParts = getNextFilterParts();
           expect(filterParts).toMatchObject({
@@ -203,9 +203,9 @@ describe("CoordinateFilterPicker", () => {
         await setOperator("Between");
         const leftInput = screen.getByPlaceholderText("Min");
         const rightInput = screen.getByPlaceholderText("Max");
-        userEvent.type(leftInput, "5");
-        userEvent.type(rightInput, "-10.5");
-        userEvent.click(addFilterButton);
+        await userEvent.type(leftInput, "5");
+        await userEvent.type(rightInput, "-10.5");
+        await userEvent.click(addFilterButton);
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -223,8 +223,8 @@ describe("CoordinateFilterPicker", () => {
         await setOperator("Between");
         const leftInput = screen.getByPlaceholderText("Min");
         const rightInput = screen.getByPlaceholderText("Max");
-        userEvent.type(leftInput, "5");
-        userEvent.type(rightInput, "-10.5{enter}");
+        await userEvent.type(leftInput, "5");
+        await userEvent.type(rightInput, "-10.5{enter}");
 
         expect(onChange).toHaveBeenCalled();
         expect(getNextFilterParts()).toMatchObject({
@@ -244,12 +244,12 @@ describe("CoordinateFilterPicker", () => {
         });
 
         await setOperator("Inside");
-        userEvent.type(screen.getByLabelText("Upper latitude"), "42");
-        userEvent.type(screen.getByLabelText("Lower latitude"), "-42");
+        await userEvent.type(screen.getByLabelText("Upper latitude"), "42");
+        await userEvent.type(screen.getByLabelText("Lower latitude"), "-42");
         expect(addFilterButton).toBeDisabled();
-        userEvent.type(screen.getByLabelText("Left longitude"), "-24");
-        userEvent.type(screen.getByLabelText("Right longitude"), "24");
-        userEvent.click(addFilterButton);
+        await userEvent.type(screen.getByLabelText("Left longitude"), "-24");
+        await userEvent.type(screen.getByLabelText("Right longitude"), "24");
+        await userEvent.click(addFilterButton);
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -270,12 +270,12 @@ describe("CoordinateFilterPicker", () => {
         });
 
         await setOperator("Inside");
-        userEvent.type(screen.getByLabelText("Upper latitude"), "-40");
-        userEvent.type(screen.getByLabelText("Lower latitude"), "42");
+        await userEvent.type(screen.getByLabelText("Upper latitude"), "-40");
+        await userEvent.type(screen.getByLabelText("Lower latitude"), "42");
         expect(addFilterButton).toBeDisabled();
-        userEvent.type(screen.getByLabelText("Left longitude"), "24");
-        userEvent.type(screen.getByLabelText("Right longitude"), "-20");
-        userEvent.click(addFilterButton);
+        await userEvent.type(screen.getByLabelText("Left longitude"), "24");
+        await userEvent.type(screen.getByLabelText("Right longitude"), "-20");
+        await userEvent.click(addFilterButton);
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -294,12 +294,18 @@ describe("CoordinateFilterPicker", () => {
           setup();
 
         await setOperator("Inside");
-        userEvent.type(screen.getByLabelText("Upper latitude"), "-40");
-        userEvent.type(screen.getByLabelText("Lower latitude"), "42{enter}");
+        await userEvent.type(screen.getByLabelText("Upper latitude"), "-40");
+        await userEvent.type(
+          screen.getByLabelText("Lower latitude"),
+          "42{enter}",
+        );
         expect(onChange).not.toHaveBeenCalled();
 
-        userEvent.type(screen.getByLabelText("Left longitude"), "24");
-        userEvent.type(screen.getByLabelText("Right longitude"), "-20{enter}");
+        await userEvent.type(screen.getByLabelText("Left longitude"), "24");
+        await userEvent.type(
+          screen.getByLabelText("Right longitude"),
+          "-20{enter}",
+        );
         expect(getNextFilterParts()).toMatchObject({
           operator: "inside",
           values: [42, -20, -40, 24],
@@ -319,10 +325,10 @@ describe("CoordinateFilterPicker", () => {
         userEvent.click(screen.getByDisplayValue("Between"));
         userEvent.click(screen.getByText("Is"));
         const input = screen.getByPlaceholderText("Enter a number");
-        userEvent.type(input, "5");
-        userEvent.tab();
-        userEvent.type(input, "10");
-        userEvent.click(screen.getByText("Add filter"));
+        await userEvent.type(input, "5");
+        await userEvent.tab();
+        await userEvent.type(input, "10");
+        await userEvent.click(screen.getByText("Add filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -336,9 +342,9 @@ describe("CoordinateFilterPicker", () => {
 
     it("should handle invalid input", async () => {
       setup();
-      userEvent.click(screen.getByDisplayValue("Between"));
-      userEvent.click(screen.getByText("Is"));
-      userEvent.type(
+      await userEvent.click(screen.getByDisplayValue("Between"));
+      await userEvent.click(screen.getByText("Is"));
+      await userEvent.type(
         screen.getByPlaceholderText("Enter a number"),
         "Twenty four",
       );
@@ -346,9 +352,9 @@ describe("CoordinateFilterPicker", () => {
       expect(screen.getByRole("button", { name: "Add filter" })).toBeDisabled();
     });
 
-    it("should go back", () => {
+    it("should go back", async () => {
       const { onBack, onChange } = setup();
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });
@@ -382,11 +388,11 @@ describe("CoordinateFilterPicker", () => {
           const { getNextFilterParts, getNextFilterColumnNames } = setup(opts);
 
           await setOperator("Greater than");
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Enter a number"),
             `{selectall}{backspace}${value}`,
           );
-          userEvent.click(screen.getByText("Update filter"));
+          await userEvent.click(screen.getByText("Update filter"));
 
           const filterParts = getNextFilterParts();
           expect(filterParts).toMatchObject({
@@ -436,11 +442,14 @@ describe("CoordinateFilterPicker", () => {
           await setOperator("Between");
           const leftInput = screen.getByPlaceholderText("Min");
           const rightInput = screen.getByPlaceholderText("Max");
-          userEvent.type(leftInput, `{selectall}{backspace}${leftValue}`);
+          await userEvent.type(leftInput, `{selectall}{backspace}${leftValue}`);
           expect(updateButton).toBeEnabled();
 
-          userEvent.type(rightInput, `{selectall}{backspace}${rightValue}`);
-          userEvent.click(updateButton);
+          await userEvent.type(
+            rightInput,
+            `{selectall}{backspace}${rightValue}`,
+          );
+          await userEvent.click(updateButton);
 
           const filterParts = getNextFilterParts();
           expect(filterParts).toMatchObject({
@@ -483,23 +492,23 @@ describe("CoordinateFilterPicker", () => {
         const { getNextFilterParts, getNextFilterColumnNames } = setup(opts);
 
         await setOperator("Inside");
-        userEvent.type(
+        await userEvent.type(
           screen.getByLabelText("Upper latitude"),
           "{selectall}{backspace}90",
         );
-        userEvent.type(
+        await userEvent.type(
           screen.getByLabelText("Lower latitude"),
           "{selectall}{backspace}-90",
         );
-        userEvent.type(
+        await userEvent.type(
           screen.getByLabelText("Left longitude"),
           "{selectall}{backspace}-180",
         );
-        userEvent.type(
+        await userEvent.type(
           screen.getByLabelText("Right longitude"),
           "{selectall}{backspace}180",
         );
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -523,8 +532,8 @@ describe("CoordinateFilterPicker", () => {
           }),
         );
 
-        userEvent.type(screen.getByLabelText("Filter value"), "5");
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.type(screen.getByLabelText("Filter value"), "5");
+        await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -539,7 +548,7 @@ describe("CoordinateFilterPicker", () => {
     it("should list operators", async () => {
       setup(createQueryWithCoordinateFilter({ operator: "<" }));
 
-      userEvent.click(screen.getByDisplayValue("Less than"));
+      await userEvent.click(screen.getByDisplayValue("Less than"));
       const listbox = await screen.findByRole("listbox");
       const options = within(listbox).getAllByRole("option");
 
@@ -557,7 +566,7 @@ describe("CoordinateFilterPicker", () => {
       const { getNextFilterParts, getNextFilterColumnNames } = setup(opts);
 
       await setOperator("Greater than");
-      userEvent.click(screen.getByText("Update filter"));
+      await userEvent.click(screen.getByText("Update filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -604,9 +613,9 @@ describe("CoordinateFilterPicker", () => {
       expect(updateButton).toBeDisabled();
     });
 
-    it("should go back", () => {
+    it("should go back", async () => {
       const { onBack, onChange } = setup(createQueryWithCoordinateFilter());
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });

--- a/frontend/src/metabase/querying/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/CoordinateFilterPicker/CoordinateFilterPicker.unit.spec.tsx
@@ -322,8 +322,8 @@ describe("CoordinateFilterPicker", () => {
       it("should add a filter with many values", async () => {
         const { getNextFilterParts, getNextFilterColumnNames } = setup();
 
-        userEvent.click(screen.getByDisplayValue("Between"));
-        userEvent.click(screen.getByText("Is"));
+        await userEvent.click(screen.getByDisplayValue("Between"));
+        await userEvent.click(screen.getByText("Is"));
         const input = screen.getByPlaceholderText("Enter a number");
         await userEvent.type(input, "5");
         await userEvent.tab();

--- a/frontend/src/metabase/querying/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/DateFilterPicker/DateFilterPicker.unit.spec.tsx
@@ -74,14 +74,14 @@ describe("DateFilterPicker", () => {
   const initialQuery = createQuery();
   const column = findDateTimeColumn(initialQuery);
 
-  it("should add a filter via shortcut", () => {
+  it("should add a filter via shortcut", async () => {
     const { getNextFilterColumnName, getNextRelativeFilterParts } = setup({
       query: initialQuery,
       column,
       isNew: true,
     });
 
-    userEvent.click(screen.getByText("Today"));
+    await userEvent.click(screen.getByText("Today"));
 
     expect(getNextFilterColumnName()).toBe(COLUMN_NAME);
     expect(getNextRelativeFilterParts()).toMatchObject({
@@ -91,18 +91,18 @@ describe("DateFilterPicker", () => {
     });
   });
 
-  it("should add a specific date filter", () => {
+  it("should add a specific date filter", async () => {
     const { getNextFilterColumnName, getNextSpecificFilterParts } = setup({
       query: initialQuery,
       column,
       isNew: true,
     });
 
-    userEvent.click(screen.getByText("Specific dates…"));
-    userEvent.click(screen.getByText("On"));
-    userEvent.clear(screen.getByLabelText("Date"));
-    userEvent.type(screen.getByLabelText("Date"), "Feb 15, 2020");
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Specific dates…"));
+    await userEvent.click(screen.getByText("On"));
+    await userEvent.clear(screen.getByLabelText("Date"));
+    await userEvent.type(screen.getByLabelText("Date"), "Feb 15, 2020");
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(getNextFilterColumnName()).toBe(COLUMN_NAME);
     expect(getNextSpecificFilterParts()).toMatchObject({
@@ -112,7 +112,7 @@ describe("DateFilterPicker", () => {
     });
   });
 
-  it("should update a specific date filter", () => {
+  it("should update a specific date filter", async () => {
     const { query, filter } = createQueryWithSpecificDateFilter({
       query: initialQuery,
     });
@@ -122,8 +122,8 @@ describe("DateFilterPicker", () => {
       filter,
     });
 
-    userEvent.click(screen.getByText("20"));
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.click(screen.getByText("20"));
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(getNextFilterColumnName()).toBe(COLUMN_NAME);
     expect(getNextSpecificFilterParts()).toMatchObject({
@@ -133,17 +133,17 @@ describe("DateFilterPicker", () => {
     });
   });
 
-  it("should add a relative date filter", () => {
+  it("should add a relative date filter", async () => {
     const { getNextFilterColumnName, getNextRelativeFilterParts } = setup({
       query: initialQuery,
       column,
       isNew: true,
     });
 
-    userEvent.click(screen.getByText("Relative dates…"));
-    userEvent.clear(screen.getByLabelText("Interval"));
-    userEvent.type(screen.getByLabelText("Interval"), "20");
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Relative dates…"));
+    await userEvent.clear(screen.getByLabelText("Interval"));
+    await userEvent.type(screen.getByLabelText("Interval"), "20");
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(getNextFilterColumnName()).toBe(COLUMN_NAME);
     expect(getNextRelativeFilterParts()).toMatchObject({
@@ -155,7 +155,7 @@ describe("DateFilterPicker", () => {
     });
   });
 
-  it("should update a relative date filter", () => {
+  it("should update a relative date filter", async () => {
     const { query, filter } = createQueryWithRelativeDateFilter({
       query: initialQuery,
     });
@@ -165,8 +165,8 @@ describe("DateFilterPicker", () => {
       filter,
     });
 
-    userEvent.click(screen.getByText("Next"));
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.click(screen.getByText("Next"));
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(getNextFilterColumnName()).toBe(COLUMN_NAME);
     expect(getNextRelativeFilterParts()).toMatchObject({
@@ -177,17 +177,17 @@ describe("DateFilterPicker", () => {
     });
   });
 
-  it("should add an exclude date filter", () => {
+  it("should add an exclude date filter", async () => {
     const { getNextFilterColumnName, getNextExcludeFilterParts } = setup({
       query: initialQuery,
       column,
       isNew: true,
     });
 
-    userEvent.click(screen.getByText("Exclude…"));
-    userEvent.click(screen.getByText("Days of the week…"));
-    userEvent.click(screen.getByText("Monday"));
-    userEvent.click(screen.getByText("Add filter"));
+    await userEvent.click(screen.getByText("Exclude…"));
+    await userEvent.click(screen.getByText("Days of the week…"));
+    await userEvent.click(screen.getByText("Monday"));
+    await userEvent.click(screen.getByText("Add filter"));
 
     expect(getNextFilterColumnName()).toBe(COLUMN_NAME);
     expect(getNextExcludeFilterParts()).toMatchObject({
@@ -198,7 +198,7 @@ describe("DateFilterPicker", () => {
     });
   });
 
-  it("should update an exclude date filter", () => {
+  it("should update an exclude date filter", async () => {
     const { query, filter } = createQueryWithExcludeDateFilter({
       query: initialQuery,
     });
@@ -208,10 +208,10 @@ describe("DateFilterPicker", () => {
       filter,
     });
 
-    userEvent.click(screen.getByText("Monday"));
-    userEvent.click(screen.getByText("Wednesday"));
-    userEvent.click(screen.getByText("Friday"));
-    userEvent.click(screen.getByText("Update filter"));
+    await userEvent.click(screen.getByText("Monday"));
+    await userEvent.click(screen.getByText("Wednesday"));
+    await userEvent.click(screen.getByText("Friday"));
+    await userEvent.click(screen.getByText("Update filter"));
 
     expect(getNextFilterColumnName()).toBe(COLUMN_NAME);
     expect(getNextExcludeFilterParts()).toMatchObject({

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterPicker.unit.spec.tsx
@@ -175,13 +175,13 @@ function setup({ query = createQuery(), filter }: SetupOpts = {}) {
 
 describe("FilterPicker", () => {
   describe("without a filter", () => {
-    it("should list filterable columns", () => {
+    it("should list filterable columns", async () => {
       setup();
 
       expect(screen.getByText("Order")).toBeInTheDocument();
       expect(screen.getByText("Discount")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText("Product"));
+      await userEvent.click(screen.getByText("Product"));
       expect(screen.getByText("Category")).toBeInTheDocument();
     });
 
@@ -216,7 +216,7 @@ describe("FilterPicker", () => {
     it("should add a segment filter", async () => {
       const { query, getNextFilter } = setup();
 
-      userEvent.click(screen.getByText("Discounted"));
+      await userEvent.click(screen.getByText("Discounted"));
 
       const filter = getNextFilter();
       const name = Lib.displayInfo(query, 0, filter).displayName;
@@ -226,21 +226,21 @@ describe("FilterPicker", () => {
     describe("filter pickers", () => {
       it.each(WIDGET_TEST_CASES)(
         "should open correct picker for a %s column",
-        (type, query, { section, columnName, pickerId }) => {
+        async (type, query, { section, columnName, pickerId }) => {
           setup();
 
           if (section) {
-            userEvent.click(screen.getByText(section));
+            await userEvent.click(screen.getByText(section));
           }
-          userEvent.click(screen.getByText(columnName));
+          await userEvent.click(screen.getByText(columnName));
 
           expect(screen.getByTestId(pickerId)).toBeInTheDocument();
         },
       );
 
-      it("should open a number picker for a numeric column", () => {
+      it("should open a number picker for a numeric column", async () => {
         setup();
-        userEvent.click(screen.getByText("Total"));
+        await userEvent.click(screen.getByText("Total"));
         expect(screen.getByTestId("number-filter-picker")).toBeInTheDocument();
       });
     });
@@ -250,7 +250,7 @@ describe("FilterPicker", () => {
     it("should highlight the selected column", async () => {
       setup(createQueryWithNumberFilter());
 
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
 
       expect(await screen.findByLabelText("Total")).toHaveAttribute(
         "aria-selected",
@@ -289,8 +289,8 @@ describe("FilterPicker", () => {
       );
       await waitForLoaderToBeRemoved(); // fetching Vendor field values
 
-      userEvent.click(screen.getByLabelText("Back"));
-      userEvent.click(screen.getByText("Category"));
+      await userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByText("Category"));
       await waitForLoaderToBeRemoved(); // fetching Category field values
 
       productCategories.forEach(category => {
@@ -300,9 +300,9 @@ describe("FilterPicker", () => {
         expect(screen.queryByText(vendor)).not.toBeInTheDocument();
       });
 
-      userEvent.click(screen.getByText("Gadget"));
-      userEvent.click(screen.getByText("Gizmo"));
-      userEvent.click(screen.getByText("Update filter"));
+      await userEvent.click(screen.getByText("Gadget"));
+      await userEvent.click(screen.getByText("Gizmo"));
+      await userEvent.click(screen.getByText("Update filter"));
 
       const filter = getNextFilter();
       const filterParts = Lib.stringFilterParts(query, 0, filter);
@@ -343,18 +343,18 @@ describe("FilterPicker", () => {
       });
     });
 
-    it("should initialize widgets correctly after changing a column", () => {
+    it("should initialize widgets correctly after changing a column", async () => {
       const { query, getNextFilter, getNextFilterColumnName } = setup(
         createQueryWithNumberFilter(),
       );
 
-      userEvent.click(screen.getByLabelText("Back"));
-      userEvent.click(screen.getByText("Time"));
+      await userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByText("Time"));
 
       expect(screen.getByLabelText("Filter operator")).toHaveValue("Before");
       expect(screen.getByDisplayValue("00:00")).toBeInTheDocument();
 
-      userEvent.click(screen.getByText("Update filter"));
+      await userEvent.click(screen.getByText("Update filter"));
 
       const filterParts = Lib.timeFilterParts(query, 0, getNextFilter());
       expect(filterParts?.operator).toBe("<");
@@ -362,27 +362,27 @@ describe("FilterPicker", () => {
       expect(getNextFilterColumnName()).toBe("Time");
     });
 
-    it("should change a filter segment", () => {
+    it("should change a filter segment", async () => {
       const { query, getNextFilter } = setup(createQueryWithSegmentFilter());
 
-      userEvent.click(screen.getByText("Many items"));
+      await userEvent.click(screen.getByText("Many items"));
 
       const filter = getNextFilter();
       const name = Lib.displayInfo(query, 0, filter).displayName;
       expect(name).toBe("Many items");
     });
 
-    it("should replace a segment filter with a column filter", () => {
+    it("should replace a segment filter with a column filter", async () => {
       const { query, getNextFilter, getNextFilterColumnName } = setup(
         createQueryWithSegmentFilter(),
       );
 
-      userEvent.click(screen.getByText("Total"));
-      userEvent.click(screen.getByDisplayValue("Between"));
-      userEvent.click(screen.getByText("Equal to"));
+      await userEvent.click(screen.getByText("Total"));
+      await userEvent.click(screen.getByDisplayValue("Between"));
+      await userEvent.click(screen.getByText("Equal to"));
       const input = screen.getByPlaceholderText("Enter a number");
-      userEvent.type(input, "100");
-      userEvent.click(screen.getByText("Update filter"));
+      await userEvent.type(input, "100");
+      await userEvent.click(screen.getByText("Update filter"));
 
       const filter = getNextFilter();
       const filterParts = Lib.numberFilterParts(query, 0, filter);
@@ -411,13 +411,13 @@ describe("FilterPicker", () => {
       });
 
       await waitFor(() => expect(button).toBeEnabled());
-      userEvent.click(button);
+      await userEvent.click(button);
     }
 
     it("should create a filter with a custom expression", async () => {
       const { query, getNextFilter } = setup();
 
-      userEvent.click(screen.getByText(/Custom expression/i));
+      await userEvent.click(screen.getByText(/Custom expression/i));
       await editExpressionAndSubmit("[[Total] > [[Discount]{enter}");
 
       const filter = getNextFilter();

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterPicker.unit.spec.tsx
@@ -406,6 +406,7 @@ describe("FilterPicker", () => {
       // The expression editor applies changes on blur,
       // but for some reason it doesn't work without `act`.
       await act(async () => {
+        await userEvent.clear(input);
         await userEvent.type(input, text, { delay });
         await userEvent.tab();
       });

--- a/frontend/src/metabase/querying/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -234,8 +234,8 @@ describe("NumberFilterPicker", () => {
       it("should add a filter with many values", async () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup();
 
-        userEvent.click(screen.getByDisplayValue("Between"));
-        userEvent.click(screen.getByText("Equal to"));
+        await userEvent.click(screen.getByDisplayValue("Between"));
+        await userEvent.click(screen.getByText("Equal to"));
         const input = screen.getByPlaceholderText("Enter a number");
         await userEvent.type(input, "-5");
         await userEvent.tab();

--- a/frontend/src/metabase/querying/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -90,8 +90,8 @@ function setup({
 }
 
 async function setOperator(operator: string) {
-  userEvent.click(screen.getByLabelText("Filter operator"));
-  userEvent.click(await screen.findByText(operator));
+  await userEvent.click(screen.getByLabelText("Filter operator"));
+  await userEvent.click(await screen.findByText(operator));
 }
 
 describe("NumberFilterPicker", () => {
@@ -109,7 +109,7 @@ describe("NumberFilterPicker", () => {
     it("should list operators", async () => {
       setup();
 
-      userEvent.click(screen.getByLabelText("Filter operator"));
+      await userEvent.click(screen.getByLabelText("Filter operator"));
       const listbox = await screen.findByRole("listbox");
       const options = within(listbox).getAllByRole("option");
 
@@ -126,11 +126,11 @@ describe("NumberFilterPicker", () => {
           const { getNextFilterParts, getNextFilterColumnName } = setup();
 
           await setOperator("Greater than");
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Enter a number"),
             String(value),
           );
-          userEvent.click(screen.getByText("Add filter"));
+          await userEvent.click(screen.getByText("Add filter"));
 
           const filterParts = getNextFilterParts();
           expect(filterParts).toMatchObject({
@@ -148,10 +148,10 @@ describe("NumberFilterPicker", () => {
 
         await setOperator("Greater than");
         const input = screen.getByPlaceholderText("Enter a number");
-        userEvent.type(input, "{enter}");
+        await userEvent.type(input, "{enter}");
         expect(onChange).not.toHaveBeenCalled();
 
-        userEvent.type(input, "15{enter}");
+        await userEvent.type(input, "15{enter}");
         expect(onChange).toHaveBeenCalled();
         expect(getNextFilterParts()).toMatchObject({
           operator: ">",
@@ -174,9 +174,9 @@ describe("NumberFilterPicker", () => {
           await setOperator("Between");
           const leftInput = screen.getByPlaceholderText("Min");
           const rightInput = screen.getByPlaceholderText("Max");
-          userEvent.type(leftInput, String(leftValue));
-          userEvent.type(rightInput, String(rightValue));
-          userEvent.click(addFilterButton);
+          await userEvent.type(leftInput, String(leftValue));
+          await userEvent.type(rightInput, String(rightValue));
+          await userEvent.click(addFilterButton);
 
           const filterParts = getNextFilterParts();
           expect(filterParts).toMatchObject({
@@ -197,9 +197,9 @@ describe("NumberFilterPicker", () => {
         await setOperator("Between");
         const leftInput = screen.getByPlaceholderText("Min");
         const rightInput = screen.getByPlaceholderText("Max");
-        userEvent.type(leftInput, "5");
-        userEvent.type(rightInput, "-10.5");
-        userEvent.click(addFilterButton);
+        await userEvent.type(leftInput, "5");
+        await userEvent.type(rightInput, "-10.5");
+        await userEvent.click(addFilterButton);
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -217,8 +217,8 @@ describe("NumberFilterPicker", () => {
         await setOperator("Between");
         const leftInput = screen.getByPlaceholderText("Min");
         const rightInput = screen.getByPlaceholderText("Max");
-        userEvent.type(leftInput, "5");
-        userEvent.type(rightInput, "-10.5{enter}");
+        await userEvent.type(leftInput, "5");
+        await userEvent.type(rightInput, "-10.5{enter}");
 
         expect(onChange).toHaveBeenCalled();
         expect(getNextFilterParts()).toMatchObject({
@@ -237,10 +237,10 @@ describe("NumberFilterPicker", () => {
         userEvent.click(screen.getByDisplayValue("Between"));
         userEvent.click(screen.getByText("Equal to"));
         const input = screen.getByPlaceholderText("Enter a number");
-        userEvent.type(input, "-5");
-        userEvent.tab();
-        userEvent.type(input, "10");
-        userEvent.click(screen.getByText("Add filter"));
+        await userEvent.type(input, "-5");
+        await userEvent.tab();
+        await userEvent.type(input, "10");
+        await userEvent.click(screen.getByText("Add filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -257,7 +257,7 @@ describe("NumberFilterPicker", () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup();
 
         await setOperator("Is empty");
-        userEvent.click(screen.getByText("Add filter"));
+        await userEvent.click(screen.getByText("Add filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -272,9 +272,9 @@ describe("NumberFilterPicker", () => {
     it("should handle invalid input", async () => {
       setup();
 
-      userEvent.click(screen.getByDisplayValue("Between"));
-      userEvent.click(screen.getByText("Equal to"));
-      userEvent.type(
+      await userEvent.click(screen.getByDisplayValue("Between"));
+      await userEvent.click(screen.getByText("Equal to"));
+      await userEvent.type(
         screen.getByPlaceholderText("Enter a number"),
         "Twenty four",
       );
@@ -282,9 +282,9 @@ describe("NumberFilterPicker", () => {
       expect(screen.getByRole("button", { name: "Add filter" })).toBeDisabled();
     });
 
-    it("should go back", () => {
+    it("should go back", async () => {
       const { onBack, onChange } = setup();
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });
@@ -320,11 +320,11 @@ describe("NumberFilterPicker", () => {
           );
 
           await setOperator("Greater than");
-          userEvent.type(
+          await userEvent.type(
             screen.getByPlaceholderText("Enter a number"),
             `{selectall}{backspace}${value}`,
           );
-          userEvent.click(screen.getByText("Update filter"));
+          await userEvent.click(screen.getByText("Update filter"));
 
           const filterParts = getNextFilterParts();
           expect(filterParts).toMatchObject({
@@ -376,11 +376,14 @@ describe("NumberFilterPicker", () => {
           await setOperator("Between");
           const leftInput = screen.getByPlaceholderText("Min");
           const rightInput = screen.getByPlaceholderText("Max");
-          userEvent.type(leftInput, `{selectall}{backspace}${leftValue}`);
+          await userEvent.type(leftInput, `{selectall}{backspace}${leftValue}`);
           expect(updateButton).toBeEnabled();
 
-          userEvent.type(rightInput, `{selectall}{backspace}${rightValue}`);
-          userEvent.click(updateButton);
+          await userEvent.type(
+            rightInput,
+            `{selectall}{backspace}${rightValue}`,
+          );
+          await userEvent.click(updateButton);
 
           const filterParts = getNextFilterParts();
           expect(filterParts).toMatchObject({
@@ -399,8 +402,8 @@ describe("NumberFilterPicker", () => {
           createQueryWithNumberFilter({ operator: "=", values: [1, 2] }),
         );
 
-        userEvent.type(screen.getByLabelText("Filter value"), "3");
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.type(screen.getByLabelText("Filter value"), "3");
+        await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -429,7 +432,7 @@ describe("NumberFilterPicker", () => {
         );
 
         await setOperator("Is empty");
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -444,7 +447,7 @@ describe("NumberFilterPicker", () => {
     it("should list operators", async () => {
       setup(createQueryWithNumberFilter({ operator: "<" }));
 
-      userEvent.click(screen.getByDisplayValue("Less than"));
+      await userEvent.click(screen.getByDisplayValue("Less than"));
       const listbox = await screen.findByRole("listbox");
       const options = within(listbox).getAllByRole("option");
 
@@ -463,7 +466,7 @@ describe("NumberFilterPicker", () => {
       );
 
       await setOperator("Greater than");
-      userEvent.click(screen.getByText("Update filter"));
+      await userEvent.click(screen.getByText("Update filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -508,9 +511,9 @@ describe("NumberFilterPicker", () => {
       expect(updateButton).toBeDisabled();
     });
 
-    it("should go back", () => {
+    it("should go back", async () => {
       const { onBack, onChange } = setup(createQueryWithNumberFilter());
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });

--- a/frontend/src/metabase/querying/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/NumberFilterPicker/NumberFilterPicker.unit.spec.tsx
@@ -319,11 +319,10 @@ describe("NumberFilterPicker", () => {
             }),
           );
 
+          const input = screen.getByPlaceholderText("Enter a number");
           await setOperator("Greater than");
-          await userEvent.type(
-            screen.getByPlaceholderText("Enter a number"),
-            `{selectall}{backspace}${value}`,
-          );
+          await userEvent.clear(input);
+          await userEvent.type(input, `${value}`);
           await userEvent.click(screen.getByText("Update filter"));
 
           const filterParts = getNextFilterParts();
@@ -376,13 +375,12 @@ describe("NumberFilterPicker", () => {
           await setOperator("Between");
           const leftInput = screen.getByPlaceholderText("Min");
           const rightInput = screen.getByPlaceholderText("Max");
-          await userEvent.type(leftInput, `{selectall}{backspace}${leftValue}`);
+          await userEvent.clear(leftInput);
+          await userEvent.type(leftInput, `${leftValue}`);
           expect(updateButton).toBeEnabled();
 
-          await userEvent.type(
-            rightInput,
-            `{selectall}{backspace}${rightValue}`,
-          );
+          await userEvent.clear(rightInput);
+          await userEvent.type(rightInput, `${rightValue}`);
           await userEvent.click(updateButton);
 
           const filterParts = getNextFilterParts();

--- a/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -89,8 +89,8 @@ function setup({
 }
 
 async function setOperator(operator: string) {
-  userEvent.click(screen.getByLabelText("Filter operator"));
-  userEvent.click(await screen.findByText(operator));
+  await userEvent.click(screen.getByLabelText("Filter operator"));
+  await userEvent.click(await screen.findByText(operator));
 }
 
 describe("StringFilterPicker", () => {
@@ -115,7 +115,7 @@ describe("StringFilterPicker", () => {
     it("should list operators", async () => {
       setup();
 
-      userEvent.click(screen.getByLabelText("Filter operator"));
+      await userEvent.click(screen.getByLabelText("Filter operator"));
       const listbox = await screen.findByRole("listbox");
       const options = within(listbox).getAllByRole("option");
 
@@ -139,12 +139,12 @@ describe("StringFilterPicker", () => {
       expect(screen.getByText("Gizmo")).toBeInTheDocument();
       expect(screen.getByText("Widget")).toBeInTheDocument();
 
-      userEvent.type(screen.getByPlaceholderText("Search the list"), "G");
+      await userEvent.type(screen.getByPlaceholderText("Search the list"), "G");
 
       expect(screen.queryByText("Doohickey")).not.toBeInTheDocument();
-      userEvent.click(screen.getByText("Gadget"));
-      userEvent.click(screen.getByText("Widget"));
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.click(screen.getByText("Gadget"));
+      await userEvent.click(screen.getByText("Widget"));
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -167,13 +167,13 @@ describe("StringFilterPicker", () => {
       });
       await waitForLoaderToBeRemoved();
 
-      userEvent.click(screen.getByDisplayValue("Contains"));
-      userEvent.click(screen.getByText("Is"));
-      userEvent.type(screen.getByPlaceholderText("Search by Email"), "t");
+      await userEvent.click(screen.getByDisplayValue("Contains"));
+      await userEvent.click(screen.getByText("Is"));
+      await userEvent.type(screen.getByPlaceholderText("Search by Email"), "t");
       jest.advanceTimersByTime(500);
-      userEvent.click(await screen.findByText("test@metabase.test"));
+      await userEvent.click(await screen.findByText("test@metabase.test"));
 
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -188,8 +188,11 @@ describe("StringFilterPicker", () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup();
 
       await setOperator("Contains");
-      userEvent.type(screen.getByPlaceholderText("Enter some text"), "green");
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter some text"),
+        "green",
+      );
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -206,10 +209,10 @@ describe("StringFilterPicker", () => {
 
       await setOperator("Contains");
       const input = screen.getByPlaceholderText("Enter some text");
-      userEvent.type(input, "{enter}");
+      await userEvent.type(input, "{enter}");
       expect(onChange).not.toHaveBeenCalled();
 
-      userEvent.type(input, "green{enter}");
+      await userEvent.type(input, "green{enter}");
       expect(onChange).toHaveBeenCalled();
       expect(getNextFilterParts()).toMatchObject({
         operator: "contains",
@@ -224,9 +227,12 @@ describe("StringFilterPicker", () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup();
 
       await setOperator("Does not contain");
-      userEvent.type(screen.getByPlaceholderText("Enter some text"), "Ga");
-      userEvent.click(screen.getByLabelText("Case sensitive"));
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter some text"),
+        "Ga",
+      );
+      await userEvent.click(screen.getByLabelText("Case sensitive"));
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -247,9 +253,9 @@ describe("StringFilterPicker", () => {
       });
       await waitForLoaderToBeRemoved();
 
-      userEvent.click(screen.getByLabelText("Doohickey"));
-      userEvent.click(screen.getByLabelText("Widget"));
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.click(screen.getByLabelText("Doohickey"));
+      await userEvent.click(screen.getByLabelText("Widget"));
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -271,12 +277,12 @@ describe("StringFilterPicker", () => {
       await waitForLoaderToBeRemoved();
 
       const input = screen.getByPlaceholderText("Search the list");
-      userEvent.type(input, "{enter}");
+      await userEvent.type(input, "{enter}");
       expect(onChange).not.toHaveBeenCalled();
 
-      userEvent.click(screen.getByLabelText("Doohickey"));
-      userEvent.click(screen.getByLabelText("Widget"));
-      userEvent.type(input, "{enter}");
+      await userEvent.click(screen.getByLabelText("Doohickey"));
+      await userEvent.click(screen.getByLabelText("Widget"));
+      await userEvent.type(input, "{enter}");
       expect(onChange).toHaveBeenCalled();
       expect(getNextFilterParts()).toMatchObject({
         operator: "=",
@@ -291,7 +297,7 @@ describe("StringFilterPicker", () => {
       const { getNextFilterParts, getNextFilterColumnName } = await setup();
 
       await setOperator("Is empty");
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -307,8 +313,11 @@ describe("StringFilterPicker", () => {
       const { getNextFilterParts } = setup();
 
       await setOperator("Starts with");
-      userEvent.type(screen.getByPlaceholderText("Enter some text"), "123");
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter some text"),
+        "123",
+      );
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -324,8 +333,8 @@ describe("StringFilterPicker", () => {
 
       await setOperator("Contains");
       const input = screen.getByPlaceholderText("Enter some text");
-      userEvent.type(input, "Ga");
-      userEvent.clear(input);
+      await userEvent.type(input, "Ga");
+      await userEvent.clear(input);
 
       expect(screen.getByRole("button", { name: "Add filter" })).toBeDisabled();
     });
@@ -339,7 +348,7 @@ describe("StringFilterPicker", () => {
       await setOperator("Does not contain");
       expect(screen.getByLabelText("Case sensitive")).not.toBeChecked();
 
-      userEvent.click(screen.getByLabelText("Case sensitive"));
+      await userEvent.click(screen.getByLabelText("Case sensitive"));
       await setOperator("Starts with");
       expect(screen.getByLabelText("Case sensitive")).toBeChecked();
 
@@ -351,9 +360,9 @@ describe("StringFilterPicker", () => {
       expect(screen.getByLabelText("Case sensitive")).toBeChecked();
     });
 
-    it("should go back", () => {
+    it("should go back", async () => {
       const { onBack, onChange } = setup();
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });
@@ -382,12 +391,12 @@ describe("StringFilterPicker", () => {
       it("should update a filter", async () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup(opts);
 
-        userEvent.type(
+        await userEvent.type(
           screen.getByDisplayValue("abc"),
           "{selectall}{backspace}foo",
         );
-        userEvent.click(screen.getByLabelText("Case sensitive"));
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.click(screen.getByLabelText("Case sensitive"));
+        await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -426,9 +435,9 @@ describe("StringFilterPicker", () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup(opts);
         await waitForLoaderToBeRemoved();
 
-        userEvent.click(screen.getByLabelText("Gadget"));
-        userEvent.click(screen.getByLabelText("Widget"));
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.click(screen.getByLabelText("Gadget"));
+        await userEvent.click(screen.getByLabelText("Widget"));
+        await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -461,7 +470,7 @@ describe("StringFilterPicker", () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup(opts);
 
         await setOperator("Not empty");
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -477,7 +486,7 @@ describe("StringFilterPicker", () => {
     it("should list operators", async () => {
       setup(createQueryWithStringFilter());
 
-      userEvent.click(screen.getByLabelText("Filter operator"));
+      await userEvent.click(screen.getByLabelText("Filter operator"));
       const listbox = await screen.findByRole("listbox");
       const options = within(listbox).getAllByRole("option");
 
@@ -493,7 +502,7 @@ describe("StringFilterPicker", () => {
       );
 
       await setOperator("Contains");
-      userEvent.click(screen.getByText("Update filter"));
+      await userEvent.click(screen.getByText("Update filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -549,7 +558,7 @@ describe("StringFilterPicker", () => {
 
     it("should go back", async () => {
       const { onBack, onChange } = setup(createQueryWithStringFilter());
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });

--- a/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/StringFilterPicker/StringFilterPicker.unit.spec.tsx
@@ -391,10 +391,10 @@ describe("StringFilterPicker", () => {
       it("should update a filter", async () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup(opts);
 
-        await userEvent.type(
-          screen.getByDisplayValue("abc"),
-          "{selectall}{backspace}foo",
-        );
+        const input = screen.getByRole("textbox", { name: "Filter value" });
+        await userEvent.clear(input);
+
+        await userEvent.type(input, "foo");
         await userEvent.click(screen.getByLabelText("Case sensitive"));
         await userEvent.click(screen.getByText("Update filter"));
 

--- a/frontend/src/metabase/querying/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -69,8 +69,8 @@ function setup({
 }
 
 async function setOperator(operator: string) {
-  userEvent.click(screen.getByLabelText("Filter operator"));
-  userEvent.click(await screen.findByText(operator));
+  await userEvent.click(screen.getByLabelText("Filter operator"));
+  await userEvent.click(await screen.findByText(operator));
 }
 
 describe("TimeFilterPicker", () => {
@@ -92,7 +92,7 @@ describe("TimeFilterPicker", () => {
     it("should list operators", async () => {
       setup();
 
-      userEvent.click(screen.getByDisplayValue("Before"));
+      await userEvent.click(screen.getByDisplayValue("Before"));
       const listbox = await screen.findByRole("listbox");
       const options = within(listbox).getAllByRole("option");
 
@@ -102,10 +102,10 @@ describe("TimeFilterPicker", () => {
       );
     });
 
-    it("should apply a default filter", () => {
+    it("should apply a default filter", async () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup();
 
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -120,8 +120,8 @@ describe("TimeFilterPicker", () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup();
 
       await setOperator("After");
-      userEvent.type(screen.getByDisplayValue("00:00"), "11:15");
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.type(screen.getByDisplayValue("00:00"), "11:15");
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -137,7 +137,7 @@ describe("TimeFilterPicker", () => {
 
       await setOperator("After");
       const input = screen.getByDisplayValue("00:00");
-      userEvent.type(input, "11:15{enter}");
+      await userEvent.type(input, "11:15{enter}");
 
       expect(getNextFilterParts()).toMatchObject({
         operator: ">",
@@ -153,9 +153,9 @@ describe("TimeFilterPicker", () => {
       await setOperator("Between");
 
       const [leftInput, rightInput] = screen.getAllByDisplayValue("00:00");
-      userEvent.type(leftInput, "11:15");
-      userEvent.type(rightInput, "12:30");
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.type(leftInput, "11:15");
+      await userEvent.type(rightInput, "12:30");
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -174,8 +174,8 @@ describe("TimeFilterPicker", () => {
 
       await setOperator("Between");
       const [leftInput, rightInput] = screen.getAllByDisplayValue("00:00");
-      userEvent.type(leftInput, "11:15");
-      userEvent.type(rightInput, "12:30{enter}");
+      await userEvent.type(leftInput, "11:15");
+      await userEvent.type(rightInput, "12:30{enter}");
 
       expect(getNextFilterParts()).toMatchObject({
         operator: "between",
@@ -194,9 +194,9 @@ describe("TimeFilterPicker", () => {
       await setOperator("Between");
 
       const [leftInput, rightInput] = screen.getAllByDisplayValue("00:00");
-      userEvent.type(leftInput, "12:30");
-      userEvent.type(rightInput, "11:15");
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.type(leftInput, "12:30");
+      await userEvent.type(rightInput, "11:15");
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -214,7 +214,7 @@ describe("TimeFilterPicker", () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup();
 
       await setOperator("Is empty");
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -225,11 +225,11 @@ describe("TimeFilterPicker", () => {
       expect(getNextFilterColumnName()).toBe("Time");
     });
 
-    it("should handle invalid input", () => {
+    it("should handle invalid input", async () => {
       const { getNextFilterParts } = setup();
 
-      userEvent.type(screen.getByDisplayValue("00:00"), "32:71");
-      userEvent.click(screen.getByText("Add filter"));
+      await userEvent.type(screen.getByDisplayValue("00:00"), "32:71");
+      await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -239,9 +239,9 @@ describe("TimeFilterPicker", () => {
       });
     });
 
-    it("should go back", () => {
+    it("should go back", async () => {
       const { onBack, onChange } = setup();
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();
     });
@@ -263,13 +263,13 @@ describe("TimeFilterPicker", () => {
         expect(screen.getByText("Update filter")).toBeEnabled();
       });
 
-      it("should update a filter", () => {
+      it("should update a filter", async () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup(
           createQueryWithTimeFilter({ operator: ">" }),
         );
 
-        userEvent.type(screen.getByDisplayValue("00:00"), "20:45");
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.type(screen.getByDisplayValue("00:00"), "20:45");
+        await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -300,7 +300,7 @@ describe("TimeFilterPicker", () => {
         expect(screen.getByText("Update filter")).toBeEnabled();
       });
 
-      it("should update a filter", () => {
+      it("should update a filter", async () => {
         const { getNextFilterParts, getNextFilterColumnName } = setup(
           createQueryWithTimeFilter({
             operator: "between",
@@ -311,8 +311,8 @@ describe("TimeFilterPicker", () => {
           }),
         );
 
-        userEvent.type(screen.getByDisplayValue("11:15"), "8:00");
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.type(screen.getByDisplayValue("11:15"), "8:00");
+        await userEvent.click(screen.getByText("Update filter"));
 
         let filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -324,8 +324,8 @@ describe("TimeFilterPicker", () => {
           ],
         });
 
-        userEvent.type(screen.getByDisplayValue("13:00"), "17:31");
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.type(screen.getByDisplayValue("13:00"), "17:31");
+        await userEvent.click(screen.getByText("Update filter"));
 
         filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -360,7 +360,7 @@ describe("TimeFilterPicker", () => {
         );
 
         await setOperator("Is empty");
-        userEvent.click(screen.getByText("Update filter"));
+        await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
         expect(filterParts).toMatchObject({
@@ -375,7 +375,7 @@ describe("TimeFilterPicker", () => {
     it("should list operators", async () => {
       setup(createQueryWithTimeFilter({ operator: "<" }));
 
-      userEvent.click(screen.getByDisplayValue("Before"));
+      await userEvent.click(screen.getByDisplayValue("Before"));
       const listbox = await screen.findByRole("listbox");
       const options = within(listbox).getAllByRole("option");
 
@@ -394,7 +394,7 @@ describe("TimeFilterPicker", () => {
       );
 
       await setOperator("After");
-      userEvent.click(screen.getByText("Update filter"));
+      await userEvent.click(screen.getByText("Update filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -442,7 +442,7 @@ describe("TimeFilterPicker", () => {
       expect(updateButton).toBeEnabled();
     });
 
-    it("should handle invalid filter value", () => {
+    it("should handle invalid filter value", async () => {
       const { getNextFilterParts } = setup(
         createQueryWithTimeFilter({
           values: [dayjs("32:66", "HH:mm").toDate()],
@@ -452,8 +452,8 @@ describe("TimeFilterPicker", () => {
       // There's no particular reason why 32:66 becomes 09:06
       // We trust the TimeInput to turn it into a valid time value
       const input = screen.getByDisplayValue("09:06");
-      userEvent.type(input, "11:00");
-      userEvent.click(screen.getByText("Update filter"));
+      await userEvent.type(input, "11:00");
+      await userEvent.click(screen.getByText("Update filter"));
 
       const filterParts = getNextFilterParts();
       expect(filterParts).toMatchObject({
@@ -463,12 +463,12 @@ describe("TimeFilterPicker", () => {
       });
     });
 
-    it("should go back", () => {
+    it("should go back", async () => {
       const { onBack, onChange } = setup(
         createQueryWithTimeFilter({ operator: "<" }),
       );
 
-      userEvent.click(screen.getByLabelText("Back"));
+      await userEvent.click(screen.getByLabelText("Back"));
 
       expect(onBack).toHaveBeenCalled();
       expect(onChange).not.toHaveBeenCalled();

--- a/frontend/src/metabase/querying/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/TimeFilterPicker/TimeFilterPicker.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 import dayjs from "dayjs";
 
 import { render, screen, within } from "__support__/ui";
@@ -26,6 +26,17 @@ const EXPECTED_OPERATORS = [
   "Is empty",
   "Not empty",
 ];
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
+
+const typeTime = async (input: HTMLInputElement, text: string) => {
+  await userEvent.type(input, text, {
+    initialSelectionStart: 0,
+    initialSelectionEnd: input.value.length,
+  });
+};
 
 function setup({
   query = createQuery(),
@@ -119,8 +130,10 @@ describe("TimeFilterPicker", () => {
     it("should add a filter with one value", async () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup();
 
+      const input = screen.getByDisplayValue("00:00") as HTMLInputElement;
+
       await setOperator("After");
-      await userEvent.type(screen.getByDisplayValue("00:00"), "11:15");
+      await typeTime(input, "11:15");
       await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
@@ -136,8 +149,8 @@ describe("TimeFilterPicker", () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup();
 
       await setOperator("After");
-      const input = screen.getByDisplayValue("00:00");
-      await userEvent.type(input, "11:15{enter}");
+      const input = screen.getByDisplayValue("00:00") as HTMLInputElement;
+      await typeTime(input, "11:15{enter}");
 
       expect(getNextFilterParts()).toMatchObject({
         operator: ">",
@@ -152,9 +165,11 @@ describe("TimeFilterPicker", () => {
 
       await setOperator("Between");
 
-      const [leftInput, rightInput] = screen.getAllByDisplayValue("00:00");
-      await userEvent.type(leftInput, "11:15");
-      await userEvent.type(rightInput, "12:30");
+      const [leftInput, rightInput] = screen.getAllByDisplayValue(
+        "00:00",
+      ) as HTMLInputElement[];
+      await typeTime(leftInput, "11:15");
+      await typeTime(rightInput, "12:30");
       await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
@@ -173,9 +188,11 @@ describe("TimeFilterPicker", () => {
       const { getNextFilterParts, getNextFilterColumnName } = setup();
 
       await setOperator("Between");
-      const [leftInput, rightInput] = screen.getAllByDisplayValue("00:00");
-      await userEvent.type(leftInput, "11:15");
-      await userEvent.type(rightInput, "12:30{enter}");
+      const [leftInput, rightInput] = screen.getAllByDisplayValue(
+        "00:00",
+      ) as HTMLInputElement[];
+      await typeTime(leftInput, "11:15");
+      await typeTime(rightInput, "12:30{enter}");
 
       expect(getNextFilterParts()).toMatchObject({
         operator: "between",
@@ -193,9 +210,11 @@ describe("TimeFilterPicker", () => {
 
       await setOperator("Between");
 
-      const [leftInput, rightInput] = screen.getAllByDisplayValue("00:00");
-      await userEvent.type(leftInput, "12:30");
-      await userEvent.type(rightInput, "11:15");
+      const [leftInput, rightInput] = screen.getAllByDisplayValue(
+        "00:00",
+      ) as HTMLInputElement[];
+      await typeTime(leftInput, "12:30");
+      await typeTime(rightInput, "11:15");
       await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
@@ -228,7 +247,10 @@ describe("TimeFilterPicker", () => {
     it("should handle invalid input", async () => {
       const { getNextFilterParts } = setup();
 
-      await userEvent.type(screen.getByDisplayValue("00:00"), "32:71");
+      await await typeTime(
+        screen.getByDisplayValue("00:00") as HTMLInputElement,
+        "32:71",
+      );
       await userEvent.click(screen.getByText("Add filter"));
 
       const filterParts = getNextFilterParts();
@@ -268,7 +290,10 @@ describe("TimeFilterPicker", () => {
           createQueryWithTimeFilter({ operator: ">" }),
         );
 
-        await userEvent.type(screen.getByDisplayValue("00:00"), "20:45");
+        await typeTime(
+          screen.getByDisplayValue("00:00") as HTMLInputElement,
+          "20:45",
+        );
         await userEvent.click(screen.getByText("Update filter"));
 
         const filterParts = getNextFilterParts();
@@ -311,7 +336,10 @@ describe("TimeFilterPicker", () => {
           }),
         );
 
-        await userEvent.type(screen.getByDisplayValue("11:15"), "8:00");
+        await typeTime(
+          screen.getByDisplayValue("11:15") as HTMLInputElement,
+          "8:00",
+        );
         await userEvent.click(screen.getByText("Update filter"));
 
         let filterParts = getNextFilterParts();
@@ -324,7 +352,10 @@ describe("TimeFilterPicker", () => {
           ],
         });
 
-        await userEvent.type(screen.getByDisplayValue("13:00"), "17:31");
+        await typeTime(
+          screen.getByDisplayValue("13:00") as HTMLInputElement,
+          "17:31",
+        );
         await userEvent.click(screen.getByText("Update filter"));
 
         filterParts = getNextFilterParts();
@@ -451,8 +482,8 @@ describe("TimeFilterPicker", () => {
 
       // There's no particular reason why 32:66 becomes 09:06
       // We trust the TimeInput to turn it into a valid time value
-      const input = screen.getByDisplayValue("09:06");
-      await userEvent.type(input, "11:00");
+      const input = screen.getByDisplayValue("09:06") as HTMLInputElement;
+      await typeTime(input, "11:00");
       await userEvent.click(screen.getByText("Update filter"));
 
       const filterParts = getNextFilterParts();

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -136,7 +136,7 @@ describe("StringFilterValuePicker", () => {
         fieldValues: PRODUCT_CATEGORY_VALUES,
       });
 
-      userEvent.click(screen.getByText("Widget"));
+      await userEvent.click(screen.getByText("Widget"));
 
       expect(onChange).toHaveBeenCalledWith(["Widget"]);
     });
@@ -150,11 +150,11 @@ describe("StringFilterValuePicker", () => {
         fieldValues: PRODUCT_CATEGORY_VALUES,
       });
 
-      userEvent.type(screen.getByPlaceholderText("Search the list"), "G");
+      await userEvent.type(screen.getByPlaceholderText("Search the list"), "G");
       expect(screen.getByText("Gadget")).toBeInTheDocument();
       expect(screen.queryByText("Doohickey")).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByText("Gadget"));
+      await userEvent.click(screen.getByText("Gadget"));
       expect(onChange).toHaveBeenCalledWith(["Gadget"]);
     });
 
@@ -168,11 +168,14 @@ describe("StringFilterValuePicker", () => {
         fieldValues: PEOPLE_STATE_VALUES,
       });
 
-      userEvent.type(screen.getByPlaceholderText("Search the list"), "CA");
+      await userEvent.type(
+        screen.getByPlaceholderText("Search the list"),
+        "CA",
+      );
       expect(screen.getByText("CA")).toBeInTheDocument();
       expect(screen.queryByText("GA")).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByText("CA"));
+      await userEvent.click(screen.getByText("CA"));
       expect(onChange).toHaveBeenCalledWith(["CA"]);
     });
 
@@ -189,7 +192,7 @@ describe("StringFilterValuePicker", () => {
         screen.getByRole("checkbox", { name: "Widget" }),
       ).not.toBeChecked();
 
-      userEvent.click(screen.getByText("Widget"));
+      await userEvent.click(screen.getByText("Widget"));
       expect(onChange).toHaveBeenCalledWith(["Gadget", "Widget"]);
     });
 
@@ -206,12 +209,12 @@ describe("StringFilterValuePicker", () => {
         screen.getByRole("checkbox", { name: "Gadget" }),
       ).not.toBeChecked();
 
-      userEvent.type(screen.getByPlaceholderText("Search the list"), "T");
+      await userEvent.type(screen.getByPlaceholderText("Search the list"), "T");
       expect(screen.getByText("Test")).toBeInTheDocument();
       expect(screen.getByText("Gadget")).toBeInTheDocument();
       expect(screen.queryByText("Gizmo")).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByText("Gadget"));
+      await userEvent.click(screen.getByText("Gadget"));
       expect(onChange).toHaveBeenCalledWith(["Test", "Gadget"]);
     });
 
@@ -235,11 +238,14 @@ describe("StringFilterValuePicker", () => {
         screen.getByRole("checkbox", { name: "In-progress" }),
       ).not.toBeChecked();
 
-      userEvent.type(screen.getByPlaceholderText("Search the list"), "in");
+      await userEvent.type(
+        screen.getByPlaceholderText("Search the list"),
+        "in",
+      );
       expect(screen.getByText("In-progress")).toBeInTheDocument();
       expect(screen.queryByText("Completed")).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByText("In-progress"));
+      await userEvent.click(screen.getByText("In-progress"));
       expect(onChange).toHaveBeenCalledWith(["t", "p"]);
     });
 
@@ -354,8 +360,8 @@ describe("StringFilterValuePicker", () => {
         screen.queryByPlaceholderText("Search the list"),
       ).not.toBeInTheDocument();
 
-      userEvent.type(input, "Test");
-      userEvent.tab();
+      await userEvent.type(input, "Test");
+      await userEvent.tab();
       expect(onFocus).toHaveBeenCalled();
       expect(onChange).toHaveBeenLastCalledWith(["Test"]);
       expect(onBlur).toHaveBeenCalled();
@@ -407,9 +413,9 @@ describe("StringFilterValuePicker", () => {
         screen.queryByPlaceholderText("Search the list"),
       ).not.toBeInTheDocument();
 
-      userEvent.type(input, "g");
+      await userEvent.type(input, "g");
       act(() => jest.advanceTimersByTime(1000));
-      userEvent.click(await screen.findByText("Gizmo"));
+      await userEvent.click(await screen.findByText("Gizmo"));
       expect(onChange).toHaveBeenLastCalledWith(["Gizmo"]);
     });
   });
@@ -431,9 +437,9 @@ describe("StringFilterValuePicker", () => {
         },
       });
 
-      userEvent.type(screen.getByPlaceholderText("Search by Email"), "a");
+      await userEvent.type(screen.getByPlaceholderText("Search by Email"), "a");
       act(() => jest.advanceTimersByTime(1000));
-      userEvent.click(await screen.findByText("a@metabase.test"));
+      await userEvent.click(await screen.findByText("a@metabase.test"));
 
       expect(onChange).toHaveBeenLastCalledWith(["a@metabase.test"]);
     });
@@ -453,9 +459,9 @@ describe("StringFilterValuePicker", () => {
       });
       expect(screen.getByText("b@metabase.test")).toBeInTheDocument();
 
-      userEvent.type(screen.getByLabelText("Filter value"), "a");
+      await userEvent.type(screen.getByLabelText("Filter value"), "a");
       act(() => jest.advanceTimersByTime(1000));
-      userEvent.click(await screen.findByText("a@metabase.test"));
+      await userEvent.click(await screen.findByText("a@metabase.test"));
 
       expect(onChange).toHaveBeenLastCalledWith([
         "b@metabase.test",
@@ -477,9 +483,9 @@ describe("StringFilterValuePicker", () => {
         },
       });
 
-      userEvent.type(screen.getByPlaceholderText("Search by Email"), "a");
+      await userEvent.type(screen.getByPlaceholderText("Search by Email"), "a");
       act(() => jest.advanceTimersByTime(1000));
-      userEvent.click(await screen.findByText("a@metabase.test"));
+      await userEvent.click(await screen.findByText("a@metabase.test"));
 
       expect(onChange).toHaveBeenLastCalledWith(["a-test"]);
     });
@@ -498,7 +504,10 @@ describe("StringFilterValuePicker", () => {
         },
       });
 
-      userEvent.type(screen.getByPlaceholderText("Search by Email"), "a@b.com");
+      await userEvent.type(
+        screen.getByPlaceholderText("Search by Email"),
+        "a@b.com",
+      );
       expect(onChange).toHaveBeenLastCalledWith(["a@b.com"]);
     });
 
@@ -516,7 +525,7 @@ describe("StringFilterValuePicker", () => {
         },
       });
 
-      userEvent.type(screen.getByLabelText("Filter value"), "a@b.com");
+      await userEvent.type(screen.getByLabelText("Filter value"), "a@b.com");
       expect(onChange).toHaveBeenLastCalledWith(["a@b.com"]);
     });
 
@@ -534,7 +543,7 @@ describe("StringFilterValuePicker", () => {
         },
       });
 
-      userEvent.type(screen.getByLabelText("Filter value"), "a@b");
+      await userEvent.type(screen.getByLabelText("Filter value"), "a@b");
       act(() => jest.advanceTimersByTime(1000));
       expect(screen.getByText("a@b.com")).toBeInTheDocument();
       expect(screen.queryByText("a@b")).not.toBeInTheDocument();
@@ -570,8 +579,11 @@ describe("StringFilterValuePicker", () => {
         values: [],
       });
 
-      userEvent.type(screen.getByPlaceholderText("Enter some text"), "abc");
-      userEvent.tab();
+      await userEvent.type(
+        screen.getByPlaceholderText("Enter some text"),
+        "abc",
+      );
+      await userEvent.tab();
 
       expect(onFocus).toHaveBeenCalled();
       expect(onChange).toHaveBeenLastCalledWith(["abc"]);
@@ -586,8 +598,8 @@ describe("StringFilterValuePicker", () => {
         values: ["abc"],
       });
 
-      userEvent.type(screen.getByLabelText("Filter value"), "bce");
-      userEvent.tab();
+      await userEvent.type(screen.getByLabelText("Filter value"), "bce");
+      await userEvent.tab();
 
       expect(onFocus).toHaveBeenCalled();
       expect(onChange).toHaveBeenLastCalledWith(["abc", "bce"]);
@@ -603,9 +615,9 @@ describe("StringFilterValuePicker", () => {
       });
 
       const input = screen.getByPlaceholderText("Enter some text");
-      userEvent.type(input, "abc");
-      userEvent.clear(input);
-      userEvent.tab();
+      await userEvent.type(input, "abc");
+      await userEvent.clear(input);
+      await userEvent.tab();
 
       expect(onFocus).toHaveBeenCalled();
       expect(onChange).toHaveBeenLastCalledWith([]);
@@ -621,8 +633,8 @@ describe("StringFilterValuePicker", () => {
       });
 
       const input = screen.getByPlaceholderText("Enter some text");
-      userEvent.type(input, " ");
-      userEvent.tab();
+      await userEvent.type(input, " ");
+      await userEvent.tab();
 
       expect(onFocus).toHaveBeenCalled();
       expect(onChange).toHaveBeenLastCalledWith([]);
@@ -637,7 +649,10 @@ describe("StringFilterValuePicker", () => {
         values: ["abc", "bce"],
       });
 
-      userEvent.type(screen.getByLabelText("Filter value"), "{backspace}");
+      await userEvent.type(
+        screen.getByLabelText("Filter value"),
+        "{backspace}",
+      );
 
       expect(onChange).toHaveBeenLastCalledWith(["abc"]);
     });
@@ -650,7 +665,10 @@ describe("StringFilterValuePicker", () => {
         values: ["abc"],
       });
 
-      userEvent.type(screen.getByLabelText("Filter value"), "{backspace}");
+      await userEvent.type(
+        screen.getByLabelText("Filter value"),
+        "{backspace}",
+      );
 
       expect(onChange).toHaveBeenLastCalledWith([]);
     });
@@ -686,7 +704,7 @@ describe("NumberFilterValuePicker", () => {
         }),
       });
 
-      userEvent.click(screen.getByText("20"));
+      await userEvent.click(screen.getByText("20"));
 
       expect(onChange).toHaveBeenCalledWith([20]);
     });
@@ -711,11 +729,14 @@ describe("NumberFilterValuePicker", () => {
         screen.getByRole("checkbox", { name: "In-progress" }),
       ).not.toBeChecked();
 
-      userEvent.type(screen.getByPlaceholderText("Search the list"), "in");
+      await userEvent.type(
+        screen.getByPlaceholderText("Search the list"),
+        "in",
+      );
       expect(screen.getByText("In-progress")).toBeInTheDocument();
       expect(screen.queryByText("Completed")).not.toBeInTheDocument();
 
-      userEvent.click(screen.getByText("In-progress"));
+      await userEvent.click(screen.getByText("In-progress"));
       expect(onChange).toHaveBeenCalledWith([10, 20]);
     });
 
@@ -757,8 +778,8 @@ describe("NumberFilterValuePicker", () => {
       });
 
       const input = screen.getByPlaceholderText("Enter a number");
-      userEvent.type(input, "123");
-      userEvent.tab();
+      await userEvent.type(input, "123");
+      await userEvent.tab();
 
       expect(onFocus).toHaveBeenCalled();
       expect(onChange).toHaveBeenLastCalledWith([123]);
@@ -774,9 +795,9 @@ describe("NumberFilterValuePicker", () => {
       });
 
       const input = screen.getByPlaceholderText("Enter a number");
-      userEvent.type(input, "123");
-      userEvent.clear(input);
-      userEvent.tab();
+      await userEvent.type(input, "123");
+      await userEvent.clear(input);
+      await userEvent.tab();
 
       expect(onFocus).toHaveBeenCalled();
       expect(onChange).toHaveBeenLastCalledWith([]);
@@ -792,8 +813,8 @@ describe("NumberFilterValuePicker", () => {
       });
 
       const input = screen.getByPlaceholderText("Enter a number");
-      userEvent.type(input, "abc");
-      userEvent.tab();
+      await userEvent.type(input, "abc");
+      await userEvent.tab();
 
       expect(onFocus).toHaveBeenCalled();
       expect(onChange).toHaveBeenLastCalledWith([]);
@@ -809,8 +830,8 @@ describe("NumberFilterValuePicker", () => {
       });
 
       const input = screen.getByPlaceholderText("Enter a number");
-      userEvent.type(input, " ");
-      userEvent.tab();
+      await userEvent.type(input, " ");
+      await userEvent.tab();
 
       expect(onFocus).toHaveBeenCalled();
       expect(onChange).toHaveBeenLastCalledWith([]);

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -561,9 +561,8 @@ describe("StringFilterValuePicker", () => {
       const clipboardData = createMockClipboardData({
         getData: () => " abc\r\ndef",
       });
-      userEvent.paste(screen.getByLabelText("Filter value"), "", {
-        clipboardData,
-      });
+      await userEvent.click(screen.getByLabelText("Filter value"));
+      await userEvent.paste(clipboardData);
       expect(onChange).toHaveBeenLastCalledWith(["abc", "def"]);
     });
   });

--- a/frontend/src/metabase/querying/components/TimeseriesChrome/TimeseriesBucketPicker/TimeseriesBucketPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/TimeseriesChrome/TimeseriesBucketPicker/TimeseriesBucketPicker.unit.spec.tsx
@@ -71,8 +71,8 @@ describe("TimeseriesBucketPicker", () => {
     const { query, column } = createQueryWithBreakout({ bucket: null });
     const { getNextBucketName } = setup({ query, column });
 
-    userEvent.click(screen.getByText("Unbinned"));
-    userEvent.click(await screen.findByText("Month"));
+    await userEvent.click(screen.getByText("Unbinned"));
+    await userEvent.click(await screen.findByText("Month"));
 
     expect(getNextBucketName()).toBe("Month");
   });
@@ -81,8 +81,8 @@ describe("TimeseriesBucketPicker", () => {
     const { query, column } = createQueryWithBreakout();
     const { getNextBucketName } = setup({ query, column });
 
-    userEvent.click(screen.getByText("Month"));
-    userEvent.click(await screen.findByText("Year"));
+    await userEvent.click(screen.getByText("Month"));
+    await userEvent.click(await screen.findByText("Year"));
 
     expect(getNextBucketName()).toBe("Year");
   });
@@ -91,8 +91,8 @@ describe("TimeseriesBucketPicker", () => {
     const { query, column } = createQueryWithBreakout();
     const { getNextBucketName } = setup({ query, column });
 
-    userEvent.click(screen.getByText("Month"));
-    userEvent.click(await screen.findByText("Don't bin"));
+    await userEvent.click(screen.getByText("Month"));
+    await userEvent.click(await screen.findByText("Don't bin"));
 
     expect(getNextBucketName()).toBeNull();
   });

--- a/frontend/src/metabase/querying/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.unit.spec.tsx
@@ -70,10 +70,10 @@ describe("TimeseriesFilterPicker", () => {
   it("should allow to add a filter", async () => {
     const { getNextFilterParts } = setup();
 
-    userEvent.click(screen.getByText("All time"));
-    userEvent.click(await screen.findByDisplayValue("All time"));
-    userEvent.click(await screen.findByText("Is empty"));
-    userEvent.click(screen.getByText("Apply"));
+    await userEvent.click(screen.getByText("All time"));
+    await userEvent.click(await screen.findByDisplayValue("All time"));
+    await userEvent.click(await screen.findByText("Is empty"));
+    await userEvent.click(screen.getByText("Apply"));
 
     expect(getNextFilterParts()).toMatchObject({
       operator: "is-null",
@@ -86,11 +86,11 @@ describe("TimeseriesFilterPicker", () => {
     const { query, column, filter } = createQueryWithFilter();
     const { getNextFilterParts } = setup({ query, column, filter });
 
-    userEvent.click(screen.getByText("Jan 10, 2020"));
+    await userEvent.click(screen.getByText("Jan 10, 2020"));
     const input = await screen.findByLabelText("Date");
-    userEvent.clear(input);
-    userEvent.type(input, "Feb 20, 2020");
-    userEvent.click(screen.getByText("Apply"));
+    await userEvent.clear(input);
+    await userEvent.type(input, "Feb 20, 2020");
+    await userEvent.click(screen.getByText("Apply"));
 
     expect(getNextFilterParts()).toMatchObject({
       operator: "=",
@@ -103,10 +103,10 @@ describe("TimeseriesFilterPicker", () => {
     const { query, column, filter } = createQueryWithFilter();
     const { getNextFilterParts } = setup({ query, column, filter });
 
-    userEvent.click(screen.getByText("Jan 10, 2020"));
-    userEvent.click(await screen.findByDisplayValue("On"));
-    userEvent.click(await screen.findByText("All time"));
-    userEvent.click(screen.getByText("Apply"));
+    await userEvent.click(screen.getByText("Jan 10, 2020"));
+    await userEvent.click(await screen.findByDisplayValue("On"));
+    await userEvent.click(await screen.findByText("All time"));
+    await userEvent.click(screen.getByText("Apply"));
 
     expect(getNextFilterParts()).toBeNull();
   });

--- a/frontend/src/metabase/querying/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/TimeseriesChrome/TimeseriesFilterPicker/TimeseriesFilterPicker.unit.spec.tsx
@@ -1,4 +1,4 @@
-import userEvent from "@testing-library/user-event";
+import _userEvent from "@testing-library/user-event";
 
 import { renderWithProviders, screen } from "__support__/ui";
 import * as Lib from "metabase-lib";
@@ -35,6 +35,10 @@ interface SetupOpts {
   column?: Lib.ColumnMetadata;
   filter?: Lib.FilterClause;
 }
+
+const userEvent = _userEvent.setup({
+  advanceTimers: jest.advanceTimersByTime,
+});
 
 function setup({
   query = createQuery(),

--- a/frontend/src/metabase/search/components/DropdownSidebarFilter/DropdownSidebarFilter.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/DropdownSidebarFilter/DropdownSidebarFilter.unit.spec.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable react/prop-types */
-import userEvent from "@testing-library/user-event";
+import userEvent, {
+  PointerEventsCheckLevel,
+} from "@testing-library/user-event";
 import { useState } from "react";
 
 import { renderWithProviders, screen, within } from "__support__/ui";
@@ -79,7 +81,7 @@ describe("DropdownSidebarFilter", () => {
     expect(screen.queryByText("field-set-legend")).not.toBeInTheDocument();
   });
 
-  it("should render filter display, close button, and filter value in the popover when value is initially selected", () => {
+  it("should render filter display, close button, and filter value in the popover when value is initially selected", async () => {
     setup({ value: ["value1"] });
 
     expect(screen.getByTestId("field-set-legend")).toHaveTextContent(
@@ -89,25 +91,25 @@ describe("DropdownSidebarFilter", () => {
     expect(screen.getByTestId("mock-display-component")).toBeInTheDocument();
     expect(screen.getByLabelText("close icon")).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Mock Filter"));
+    await userEvent.click(screen.getByText("Mock Filter"));
     expect(
       within(screen.getByTestId("mock-content-component")).getByText("value1"),
     ).toBeInTheDocument();
   });
 
-  it("should render filter content component when popover is open", () => {
+  it("should render filter content component when popover is open", async () => {
     setup();
-    userEvent.click(screen.getByText("Mock Filter"));
+    await userEvent.click(screen.getByText("Mock Filter"));
     expect(screen.getByTestId("mock-content-component")).toBeInTheDocument();
   });
 
-  it("should apply filter and close popup when apply button is clicked", () => {
+  it("should apply filter and close popup when apply button is clicked", async () => {
     const { onChange } = setup();
-    userEvent.click(screen.getByText("Mock Filter"));
-    userEvent.click(screen.getByRole("button", { name: "Update" }));
+    await userEvent.click(screen.getByText("Mock Filter"));
+    await userEvent.click(screen.getByRole("button", { name: "Update" }));
     expect(screen.getByText("new value")).toBeInTheDocument();
 
-    userEvent.click(screen.getByRole("button", { name: "Apply" }));
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }));
 
     expect(onChange).toHaveBeenCalledWith(["new value"]);
 
@@ -123,17 +125,17 @@ describe("DropdownSidebarFilter", () => {
   it("should revert filter selections when popover is closed", async () => {
     const { onChange } = setup({ value: ["old value"] });
 
-    userEvent.click(screen.getByText("old value"));
-    userEvent.click(screen.getByRole("button", { name: "Update" }));
+    await userEvent.click(screen.getByText("old value"));
+    await userEvent.click(screen.getByRole("button", { name: "Update" }));
     expect(screen.getByText("new value")).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("old value"));
+    await userEvent.click(screen.getByText("old value"));
     expect(onChange).not.toHaveBeenCalled();
     expect(screen.getByTestId("mock-display-component")).toHaveTextContent(
       "old value",
     );
 
-    userEvent.click(screen.getByText("old value"));
+    await userEvent.click(screen.getByText("old value"));
     expect(screen.getByTestId("mock-display-component")).toHaveTextContent(
       "old value",
     );
@@ -141,12 +143,11 @@ describe("DropdownSidebarFilter", () => {
 
   it("should reset filter selections when clear button is clicked", async () => {
     const { onChange } = setup({ value: ["old value"] });
-    userEvent.click(
+    await userEvent.click(
       screen.getByTestId("sidebar-filter-dropdown-button"),
-      undefined,
       // There's a problem with buttons in fieldsets so we have to skip pointer events check for now
       // https://github.com/testing-library/user-event/issues/662
-      { skipPointerEventsCheck: true },
+      { pointerEventsCheck: PointerEventsCheckLevel.Never },
     );
 
     expect(onChange).toHaveBeenCalledWith(null);

--- a/frontend/src/metabase/search/components/SearchFilterDatePicker/SearchFilterDatePicker.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterDatePicker/SearchFilterDatePicker.unit.spec.tsx
@@ -29,9 +29,9 @@ describe("SearchFilterDatePicker", () => {
     expect(screen.queryByText("Exclude…")).not.toBeInTheDocument();
   });
 
-  it("should call onChange when a date is selected", () => {
+  it("should call onChange when a date is selected", async () => {
     const { onChangeMock } = setup();
-    userEvent.click(screen.getByText("Today"));
+    await userEvent.click(screen.getByText("Today"));
     expect(onChangeMock).toHaveBeenCalled();
   });
 

--- a/frontend/src/metabase/search/components/SearchFilterPopoverWrapper/SearchFilterPopoverWrapper.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchFilterPopoverWrapper/SearchFilterPopoverWrapper.unit.spec.tsx
@@ -37,11 +37,11 @@ describe("SearchFilterPopoverWrapper", () => {
     expect(childrenContent).toBeInTheDocument();
   });
 
-  it('should call onApply when the "Apply" button is clicked', () => {
+  it('should call onApply when the "Apply" button is clicked', async () => {
     const { onApply } = setup();
 
     const applyButton = screen.getByText("Apply");
-    userEvent.click(applyButton);
+    await userEvent.click(applyButton);
 
     expect(onApply).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Tables.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Tables.unit.spec.tsx
@@ -42,30 +42,30 @@ const setup = (setupOpts: SetupOpts) => {
 };
 
 describe("SearchResult > Tables", () => {
-  it("tables with initial_sync_status='complete' are clickable", () => {
+  it("tables with initial_sync_status='complete' are clickable", async () => {
     const { link, onClick } = setup({
       name: "Complete Table",
       initial_sync_status: "complete",
     });
-    userEvent.click(link);
+    await userEvent.click(link);
     expect(onClick).toHaveBeenCalled();
   });
 
-  it("tables with initial_sync_status='incomplete' are not clickable", () => {
+  it("tables with initial_sync_status='incomplete' are not clickable", async () => {
     const { link, onClick } = setup({
       name: "Incomplete Table",
       initial_sync_status: "incomplete",
     });
-    userEvent.click(link);
+    await userEvent.click(link);
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  it("tables with initial_sync_status='aborted' are not clickable", () => {
+  it("tables with initial_sync_status='aborted' are not clickable", async () => {
     const { link, onClick } = setup({
       name: "Aborted Table",
       initial_sync_status: "aborted",
     });
-    userEvent.click(link);
+    await userEvent.click(link);
     expect(onClick).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Tables.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult-Tables.unit.spec.tsx
@@ -4,6 +4,7 @@ import {
   setupDatabaseEndpoints,
   setupTableEndpoints,
   setupUsersEndpoints,
+  setupUserRecipientsEndpoint,
 } from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { SearchResult } from "metabase/search/components/SearchResult";
@@ -20,12 +21,15 @@ interface SetupOpts {
   initial_sync_status: InitialSyncStatus;
 }
 
+const USER = createMockUser();
+
 const setup = (setupOpts: SetupOpts) => {
   const TEST_TABLE = createMockTable(setupOpts);
   const TEST_DATABASE = createMockDatabase();
   setupTableEndpoints(TEST_TABLE);
   setupDatabaseEndpoints(TEST_DATABASE);
-  setupUsersEndpoints([createMockUser()]);
+  setupUsersEndpoints([USER]);
+  setupUserRecipientsEndpoint({ users: [USER] });
   const result = createWrappedSearchResult({
     model: "table",
     table_id: TEST_TABLE.id,

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
@@ -3,6 +3,7 @@ import { Route } from "react-router";
 
 import {
   setupCollectionByIdEndpoint,
+  setupUserRecipientsEndpoint,
   setupUsersEndpoints,
 } from "__support__/server-mocks";
 import { getIcon, renderWithProviders, screen } from "__support__/ui";
@@ -35,12 +36,15 @@ const TEST_RESULT_INDEXED_ENTITY = createWrappedSearchResult({
   model_index_id: 1,
 });
 
+const USER = createMockUser();
+
 const setup = ({ result }: { result: WrappedResult }) => {
   setupCollectionByIdEndpoint({
     collections: [TEST_REGULAR_COLLECTION],
   });
 
-  setupUsersEndpoints([createMockUser()]);
+  setupUsersEndpoints([USER]);
+  setupUserRecipientsEndpoint({ users: [USER] });
 
   const { history } = renderWithProviders(
     <Route path="*" component={() => <SearchResult result={result} />} />,

--- a/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchResult/tests/SearchResult.unit.spec.tsx
@@ -78,7 +78,7 @@ describe("SearchResult", () => {
   it("should redirect to search result page when clicking item", async () => {
     const { history } = setup({ result: TEST_RESULT_QUESTION });
 
-    userEvent.click(screen.getByText(TEST_RESULT_QUESTION.name));
+    await userEvent.click(screen.getByText(TEST_RESULT_QUESTION.name));
 
     const expectedPath = TEST_RESULT_QUESTION.getUrl();
 
@@ -97,12 +97,12 @@ describe("SearchResult", () => {
       expect(getIcon("bolt")).toBeInTheDocument();
     });
 
-    it("redirects to x-ray page when clicking on x-ray button", () => {
+    it("redirects to x-ray page when clicking on x-ray button", async () => {
       const { history } = setup({ result: TEST_RESULT_INDEXED_ENTITY });
 
       expect(getIcon("bolt")).toBeInTheDocument();
 
-      userEvent.click(getIcon("bolt"));
+      await userEvent.click(getIcon("bolt"));
 
       const expectedPath = `/auto/dashboard/model_index/${TEST_RESULT_INDEXED_ENTITY.model_index_id}/primary_key/${TEST_RESULT_INDEXED_ENTITY.id}`;
 

--- a/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/SearchUserPicker/SearchUserPicker.unit.spec.tsx
@@ -59,7 +59,7 @@ describe("SearchUserPicker", () => {
 
   it("should show 'No results' when no users match the filter", async () => {
     await setup();
-    userEvent.type(
+    await userEvent.type(
       screen.getByPlaceholderText("Search for someone…"),
       "Charlie",
     );
@@ -87,14 +87,14 @@ describe("SearchUserPicker", () => {
     await setup();
     const searchUserList = within(screen.getByTestId("search-user-list"));
 
-    userEvent.click(searchUserList.getByText("Alice"));
+    await userEvent.click(searchUserList.getByText("Alice"));
     expect(screen.getByTestId("selected-user-button")).toHaveTextContent(
       "Alice",
     );
 
     expect(searchUserList.queryByText("Alice")).not.toBeInTheDocument();
 
-    userEvent.click(searchUserList.getByText("Bob"));
+    await userEvent.click(searchUserList.getByText("Bob"));
     expect(
       screen.getAllByTestId("selected-user-button").map(el => el.textContent),
     ).toEqual(["Alice", "Bob"]);
@@ -115,11 +115,11 @@ describe("SearchUserPicker", () => {
     expect(selectBox.getByText("Alice")).toBeInTheDocument();
     expect(selectBox.getByText("Bob")).toBeInTheDocument();
 
-    userEvent.click(selectBox.getByText("Alice"));
+    await userEvent.click(selectBox.getByText("Alice"));
     expect(screen.getByTestId("selected-user-button")).toHaveTextContent("Bob");
     expect(searchUserList.getByText("Alice")).toBeInTheDocument();
 
-    userEvent.click(selectBox.getByText("Bob"));
+    await userEvent.click(selectBox.getByText("Bob"));
 
     // expect the two users are only in the search list now
     expect(
@@ -131,7 +131,10 @@ describe("SearchUserPicker", () => {
 
   it("should filter users when user types in the search box", async () => {
     await setup();
-    userEvent.type(screen.getByPlaceholderText("Search for someone…"), "Alice");
+    await userEvent.type(
+      screen.getByPlaceholderText("Search for someone…"),
+      "Alice",
+    );
     const searchUserList = within(screen.getByTestId("search-user-list"));
     expect(searchUserList.getByText("Alice")).toBeInTheDocument();
 
@@ -142,10 +145,10 @@ describe("SearchUserPicker", () => {
     const { mockOnChange } = await setup();
 
     const searchUserList = within(screen.getByTestId("search-user-list"));
-    userEvent.click(searchUserList.getByText("Alice"));
-    userEvent.click(searchUserList.getByText("Bob"));
+    await userEvent.click(searchUserList.getByText("Alice"));
+    await userEvent.click(searchUserList.getByText("Bob"));
 
-    userEvent.click(screen.getByText("Apply"));
+    await userEvent.click(screen.getByText("Apply"));
 
     expect(mockOnChange).toHaveBeenCalledWith([1, 2]);
   });
@@ -155,10 +158,10 @@ describe("SearchUserPicker", () => {
       initialSelectedUsers: TEST_USERS.map(user => user.id),
     });
     const searchUserList = within(screen.getByTestId("search-user-select-box"));
-    userEvent.click(searchUserList.getByText("Alice"));
-    userEvent.click(searchUserList.getByText("Bob"));
+    await userEvent.click(searchUserList.getByText("Alice"));
+    await userEvent.click(searchUserList.getByText("Bob"));
 
-    userEvent.click(screen.getByText("Apply"));
+    await userEvent.click(screen.getByText("Apply"));
     expect(mockOnChange).toHaveBeenCalledWith([]);
   });
 });

--- a/frontend/src/metabase/search/components/ToggleSidebarFilter/ToggleSidebarFilter.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/ToggleSidebarFilter/ToggleSidebarFilter.unit.spec.tsx
@@ -67,7 +67,7 @@ describe("ToggleSidebarFilter", () => {
     expect(switchElement).toBeInTheDocument();
   });
 
-  it("should call the onChange function when the switch is toggled", () => {
+  it("should call the onChange function when the switch is toggled", async () => {
     const onChangeMock = jest.fn();
     setup({
       value: undefined,
@@ -75,7 +75,7 @@ describe("ToggleSidebarFilter", () => {
     });
 
     const switchElement = screen.getByRole("checkbox");
-    userEvent.click(switchElement);
+    await userEvent.click(switchElement);
 
     expect(onChangeMock).toHaveBeenCalledTimes(1);
     expect(onChangeMock).toHaveBeenCalledWith(true);

--- a/frontend/src/metabase/search/components/UserListElement/UserListElement.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/UserListElement/UserListElement.unit.spec.tsx
@@ -28,10 +28,10 @@ describe("UserListElement", () => {
     );
   });
 
-  it("should call the onClick function when clicked", () => {
+  it("should call the onClick function when clicked", async () => {
     const { onClickMock } = setup();
 
-    userEvent.click(screen.getByText("Alice Johnson"));
+    await userEvent.click(screen.getByText("Alice Johnson"));
 
     expect(onClickMock).toHaveBeenCalledTimes(1);
     expect(onClickMock).toHaveBeenCalledWith(TEST_USER_LIST_RESULT);

--- a/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.unit.spec.tsx
+++ b/frontend/src/metabase/search/components/filters/TypeFilter/TypeFilterContent.unit.spec.tsx
@@ -156,10 +156,10 @@ describe("TypeFilterContent", () => {
     const options = getCheckboxes();
 
     for (let i = 0; i < options.length; i++) {
-      userEvent.click(options[i]);
+      await userEvent.click(options[i]);
     }
 
-    userEvent.click(screen.getByText("Apply"));
+    await userEvent.click(screen.getByText("Apply"));
     expect(onChangeFilters).toHaveReturnedTimes(1);
     expect(onChangeFilters).toHaveBeenLastCalledWith(TEST_TYPES);
   });
@@ -170,9 +170,9 @@ describe("TypeFilterContent", () => {
     const options = getCheckboxes();
     const checkedOptions = options.filter(option => option.checked);
     for (const checkedOption of checkedOptions) {
-      userEvent.click(checkedOption);
+      await userEvent.click(checkedOption);
     }
-    userEvent.click(screen.getByText("Apply"));
+    await userEvent.click(screen.getByText("Apply"));
     expect(onChangeFilters).toHaveReturnedTimes(1);
     expect(onChangeFilters).toHaveBeenLastCalledWith([]);
   });

--- a/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
+++ b/frontend/src/metabase/search/containers/SearchApp.unit.spec.tsx
@@ -143,7 +143,7 @@ describe("SearchApp", () => {
       expect(getPagination()).toHaveTextContent("1 - 4");
 
       // test next page button
-      userEvent.click(getNextPageButton());
+      await userEvent.click(getNextPageButton());
       await waitForLoaderToBeRemoved();
       expect(getPaginationTotal()).toHaveTextContent(String(TEST_ITEMS.length));
       expect(getPreviousPageButton()).toBeEnabled();
@@ -152,7 +152,7 @@ describe("SearchApp", () => {
       expect(getPagination()).toHaveTextContent("5 - 7");
 
       // test previous page button
-      userEvent.click(getPreviousPageButton());
+      await userEvent.click(getPreviousPageButton());
       await waitForLoaderToBeRemoved();
       expect(getPaginationTotal()).toHaveTextContent(String(TEST_ITEMS.length));
       expect(getPreviousPageButton()).toBeDisabled();
@@ -169,7 +169,7 @@ describe("SearchApp", () => {
           searchText: "Test",
         });
 
-        userEvent.click(
+        await userEvent.click(
           within(screen.getByTestId("type-search-filter")).getByTestId(
             "sidebar-filter-dropdown-button",
           ),
@@ -178,14 +178,14 @@ describe("SearchApp", () => {
         await waitForLoaderToBeRemoved();
 
         const popover = within(screen.getByTestId("popover"));
-        userEvent.click(
+        await userEvent.click(
           popover.getByRole("checkbox", {
             name: TYPE_FILTER_LABELS[
               model as EnabledSearchModelType
             ] as EnabledSearchModelType,
           }),
         );
-        userEvent.click(popover.getByRole("button", { name: "Apply" }));
+        await userEvent.click(popover.getByRole("button", { name: "Apply" }));
 
         const url = history.getCurrentLocation();
         expect(url.query.type).toEqual(model);

--- a/frontend/src/metabase/setup/components/DataUsageStep/DataUsageStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/DataUsageStep/DataUsageStep.unit.spec.tsx
@@ -44,7 +44,7 @@ describe("DataUsageStep", () => {
 
     const toggle = screen.getByRole("switch", { name: /Allow Metabase/ });
     expect(toggle).toBeChecked();
-    userEvent.click(toggle);
+    await userEvent.click(toggle);
 
     await waitFor(() => {
       expect(fetchMock.called(TRACKING_PATH, { method: "PUT" })).toBeTruthy();
@@ -59,7 +59,7 @@ describe("DataUsageStep", () => {
 
     const toggle = screen.getByRole("switch", { name: /Allow Metabase/ });
     expect(toggle).toBeChecked();
-    userEvent.click(toggle);
+    await userEvent.click(toggle);
 
     await waitFor(() => {
       expect(fetchMock.called(TRACKING_PATH, { method: "PUT" })).toBeTruthy();

--- a/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/LanguageStep/LanguageStep.unit.spec.tsx
@@ -43,13 +43,13 @@ describe("LanguageStep", () => {
     expect(screen.getByText(/set to English/)).toBeInTheDocument();
   });
 
-  it("should allow language selection", () => {
+  it("should allow language selection", async () => {
     setup({
       step: "language",
     });
 
     const option = screen.getByRole("radio", { name: "English" });
-    userEvent.click(option);
+    await userEvent.click(option);
 
     expect(option).toBeChecked();
   });

--- a/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.unit.spec.tsx
+++ b/frontend/src/metabase/setup/components/NewsletterForm/NewsletterForm.unit.spec.tsx
@@ -32,7 +32,7 @@ describe("NewsletterForm", () => {
     setup();
     expect(screen.getByDisplayValue(USER_EMAIL)).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Subscribe"));
+    await userEvent.click(screen.getByText("Subscribe"));
     expect(await screen.findByText(/You're subscribed/)).toBeInTheDocument();
     expect(fetchMock.done(SUBSCRIBE_URL)).toBe(true);
   });

--- a/frontend/src/metabase/setup/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/common.unit.spec.tsx
@@ -19,7 +19,7 @@ import {
 describe("setup (OSS)", () => {
   it("default step order should be correct", async () => {
     await setup();
-    skipWelcomeScreen();
+    await skipWelcomeScreen();
     expectSectionToHaveLabel("What's your preferred language?", "1");
     expectSectionToHaveLabel("What should we call you?", "2");
     expectSectionToHaveLabel("What will you use Metabase for?", "3");
@@ -31,35 +31,35 @@ describe("setup (OSS)", () => {
 
   it("should keep steps in order through the whole setup", async () => {
     await setup();
-    skipWelcomeScreen();
+    await skipWelcomeScreen();
     expectSectionsToHaveLabelsInOrder({ from: 0 });
 
-    skipLanguageStep();
+    await skipLanguageStep();
     expectSectionsToHaveLabelsInOrder({ from: 1 });
 
     await submitUserInfoStep();
     expectSectionsToHaveLabelsInOrder({ from: 2 });
 
-    clickNextStep(); // Usage question
+    await clickNextStep(); // Usage question
     expectSectionsToHaveLabelsInOrder({ from: 3 });
 
-    userEvent.click(screen.getByText("I'll add my data later"));
+    await userEvent.click(screen.getByText("I'll add my data later"));
     expectSectionsToHaveLabelsInOrder({ from: 4 });
   });
 
   describe("Usage question", () => {
     async function setupForUsageQuestion() {
       await setup();
-      skipWelcomeScreen();
-      skipLanguageStep();
+      await skipWelcomeScreen();
+      await skipLanguageStep();
       await submitUserInfoStep();
     }
 
     describe("when selecting 'Self service'", () => {
       it("should keep the 'Add your data' step", async () => {
         await setupForUsageQuestion();
-        selectUsageReason("self-service-analytics");
-        clickNextStep();
+        await selectUsageReason("self-service-analytics");
+        await clickNextStep();
 
         expect(screen.getByText("Add your data")).toBeInTheDocument();
 
@@ -74,8 +74,8 @@ describe("setup (OSS)", () => {
 
       it("should not set the flag for the embedding homepage", async () => {
         await setupForUsageQuestion();
-        selectUsageReason("self-service-analytics");
-        clickNextStep();
+        await selectUsageReason("self-service-analytics");
+        await clickNextStep();
 
         screen.getByText("I'll add my data later").click();
 
@@ -90,8 +90,8 @@ describe("setup (OSS)", () => {
     describe("when selecting 'Embedding'", () => {
       it("should hide the 'Add your data' step", async () => {
         await setupForUsageQuestion();
-        selectUsageReason("embedding");
-        clickNextStep();
+        await selectUsageReason("embedding");
+        await clickNextStep();
 
         expect(screen.queryByText("Add your data")).not.toBeInTheDocument();
 
@@ -105,8 +105,8 @@ describe("setup (OSS)", () => {
 
       it("should set the flag for the embed homepage in the local storage", async () => {
         await setupForUsageQuestion();
-        selectUsageReason("embedding");
-        clickNextStep();
+        await selectUsageReason("embedding");
+        await clickNextStep();
 
         screen.getByRole("button", { name: "Finish" }).click();
 
@@ -119,8 +119,8 @@ describe("setup (OSS)", () => {
     describe("when selecting 'A bit of both'", () => {
       it("should keep the 'Add your data' step", async () => {
         await setupForUsageQuestion();
-        selectUsageReason("both");
-        clickNextStep();
+        await selectUsageReason("both");
+        await clickNextStep();
 
         expect(screen.getByText("Add your data")).toBeInTheDocument();
 
@@ -135,8 +135,8 @@ describe("setup (OSS)", () => {
 
       it("should set the flag for the embed homepage in the local storage", async () => {
         await setupForUsageQuestion();
-        selectUsageReason("both");
-        clickNextStep();
+        await selectUsageReason("both");
+        await clickNextStep();
 
         screen.getByText("I'll add my data later").click();
 
@@ -151,8 +151,8 @@ describe("setup (OSS)", () => {
     describe("when selecting 'Not sure yet'", () => {
       it("should keep the 'Add your data' step", async () => {
         await setupForUsageQuestion();
-        selectUsageReason("not-sure");
-        clickNextStep();
+        await selectUsageReason("not-sure");
+        await clickNextStep();
 
         expect(screen.getByText("Add your data")).toBeInTheDocument();
 
@@ -167,8 +167,8 @@ describe("setup (OSS)", () => {
 
       it("should not set the flag for the embedding homepage", async () => {
         await setupForUsageQuestion();
-        selectUsageReason("self-service-analytics");
-        clickNextStep();
+        await selectUsageReason("self-service-analytics");
+        await clickNextStep();
 
         screen.getByText("I'll add my data later").click();
 

--- a/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/enterprise.unit.spec.tsx
@@ -42,7 +42,7 @@ describe("setup (EE, no token)", () => {
 
   it("default step order should be correct, with the commercial step in place", async () => {
     await setupEnterprise();
-    skipWelcomeScreen();
+    await skipWelcomeScreen();
     expectSectionToHaveLabel("What's your preferred language?", "1");
     expectSectionToHaveLabel("What should we call you?", "2");
     expectSectionToHaveLabel("What will you use Metabase for?", "3");
@@ -56,11 +56,11 @@ describe("setup (EE, no token)", () => {
   describe("License activation step", () => {
     async function setupForLicenseStep() {
       await setupEnterprise();
-      skipWelcomeScreen();
-      skipLanguageStep();
+      await skipWelcomeScreen();
+      await skipLanguageStep();
       await submitUserInfoStep();
-      selectUsageReason("embedding"); // to skip the db connection step
-      clickNextStep();
+      await selectUsageReason("embedding"); // to skip the db connection step
+      await clickNextStep();
 
       expect(
         await screen.findByText(
@@ -73,7 +73,7 @@ describe("setup (EE, no token)", () => {
       await setupForLicenseStep();
       setupForTokenCheckEndpoint({ valid: false });
 
-      inputToken(sampleToken);
+      await inputToken(sampleToken);
       await submit();
 
       expect(await errMsg()).toBeInTheDocument();
@@ -82,13 +82,13 @@ describe("setup (EE, no token)", () => {
     it("should have the Activate button disabled when the token is not 64 characters long", async () => {
       await setupForLicenseStep();
 
-      inputToken("a".repeat(63));
+      await inputToken("a".repeat(63));
       expect(await submitBtn()).toBeDisabled();
 
-      userEvent.type(input(), "a"); //64 characters
+      await userEvent.type(input(), "a"); //64 characters
       expect(await submitBtn()).toBeEnabled();
 
-      userEvent.type(input(), "a"); //65 characters
+      await userEvent.type(input(), "a"); //65 characters
       expect(await submitBtn()).toBeDisabled();
     });
 
@@ -96,7 +96,7 @@ describe("setup (EE, no token)", () => {
       await setupForLicenseStep();
       setupForTokenCheckEndpoint({ valid: true });
 
-      inputToken(`    ${sampleToken}   `);
+      await inputToken(`    ${sampleToken}   `);
       expect(input()).toHaveValue(sampleToken);
       expect(await submitBtn()).toBeEnabled();
       const submitCall = await submit();
@@ -111,7 +111,7 @@ describe("setup (EE, no token)", () => {
 
       setupForTokenCheckEndpoint({ valid: true });
 
-      inputToken(sampleToken);
+      await inputToken(sampleToken);
       await submit();
 
       expect(trackLicenseTokenStepSubmitted).toHaveBeenCalledWith(true);
@@ -125,7 +125,7 @@ describe("setup (EE, no token)", () => {
     it("should be possible to skip the step without a token", async () => {
       await setupForLicenseStep();
 
-      clickOnSkip();
+      await clickOnSkip();
 
       expect(trackLicenseTokenStepSubmitted).toHaveBeenCalledWith(false);
 
@@ -139,7 +139,7 @@ describe("setup (EE, no token)", () => {
       await setupForLicenseStep();
       setupForTokenCheckEndpoint({ valid: true });
 
-      inputToken(sampleToken);
+      await inputToken(sampleToken);
       const submitCall = await submit();
 
       expect(await submitCall?.request?.json()).toEqual({
@@ -151,7 +151,8 @@ describe("setup (EE, no token)", () => {
 
 const input = () => screen.getByRole("textbox", { name: "Token" });
 
-const inputToken = (token: string) => userEvent.paste(input(), token);
+const inputToken = async (token: string) =>
+  await userEvent.type(input(), token);
 
 const errMsg = () => screen.findByText(/This token doesn’t seem to be valid/);
 
@@ -165,5 +166,5 @@ const submit = async () => {
   return fetchMock.lastCall(settingEndpoint);
 };
 
-const clickOnSkip = () =>
-  userEvent.click(screen.getByRole("button", { name: "Skip" }));
+const clickOnSkip = async () =>
+  await userEvent.click(screen.getByRole("button", { name: "Skip" }));

--- a/frontend/src/metabase/setup/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium.unit.spec.tsx
@@ -23,7 +23,7 @@ const setupPremium = (opts?: SetupOpts) => {
 describe("setup (EE, hosting feature)", () => {
   it("default step order should be correct, without the commercial step", async () => {
     await setupPremium();
-    skipWelcomeScreen();
+    await skipWelcomeScreen();
     expectSectionToHaveLabel("What's your preferred language?", "1");
     expectSectionToHaveLabel("What should we call you?", "2");
     expectSectionToHaveLabel("What will you use Metabase for?", "3");
@@ -35,7 +35,7 @@ describe("setup (EE, hosting feature)", () => {
 
   it("should not render the license activation step", async () => {
     await setupPremium();
-    skipWelcomeScreen();
+    await skipWelcomeScreen();
     expect(
       screen.queryByText("Activate your commercial license"),
     ).not.toBeInTheDocument();

--- a/frontend/src/metabase/setup/tests/setup.tsx
+++ b/frontend/src/metabase/setup/tests/setup.tsx
@@ -59,13 +59,13 @@ export async function setup({
 export const getSection = (name: string) =>
   screen.getByRole("listitem", { name });
 
-export const clickNextStep = () =>
-  userEvent.click(screen.getByRole("button", { name: "Next" }));
+export const clickNextStep = async () =>
+  await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
-export const skipWelcomeScreen = () =>
-  userEvent.click(screen.getByText("Let's get started"));
+export const skipWelcomeScreen = async () =>
+  await userEvent.click(screen.getByText("Let's get started"));
 
-export const skipLanguageStep = () => clickNextStep();
+export const skipLanguageStep = clickNextStep;
 
 export const submitUserInfoStep = async ({
   firstName = "John",
@@ -74,16 +74,22 @@ export const submitUserInfoStep = async ({
   companyName = "Acme",
   password = "Monkeyabc123",
 } = {}) => {
-  userEvent.type(screen.getByLabelText("First name"), firstName);
-  userEvent.type(screen.getByLabelText("Last name"), lastName);
-  userEvent.type(screen.getByLabelText("Email"), email);
-  userEvent.type(screen.getByLabelText("Company or team name"), companyName);
-  userEvent.type(screen.getByLabelText("Create a password"), password);
-  userEvent.type(screen.getByLabelText("Confirm your password"), password);
+  await userEvent.type(screen.getByLabelText("First name"), firstName);
+  await userEvent.type(screen.getByLabelText("Last name"), lastName);
+  await userEvent.type(screen.getByLabelText("Email"), email);
+  await userEvent.type(
+    screen.getByLabelText("Company or team name"),
+    companyName,
+  );
+  await userEvent.type(screen.getByLabelText("Create a password"), password);
+  await userEvent.type(
+    screen.getByLabelText("Confirm your password"),
+    password,
+  );
   await waitFor(() =>
     expect(screen.getByRole("button", { name: "Next" })).toBeEnabled(),
   );
-  clickNextStep();
+  await clickNextStep();
   // formik+yup validation is async, we need to wait for the submit to finish
   await waitFor(() =>
     expect(
@@ -92,7 +98,7 @@ export const submitUserInfoStep = async ({
   );
 };
 
-export const selectUsageReason = (usageReason: UsageReason) => {
+export const selectUsageReason = async (usageReason: UsageReason) => {
   const label = {
     "self-service-analytics": "Self-service analytics for my own company",
     embedding: "Embedding analytics into my application",
@@ -100,7 +106,7 @@ export const selectUsageReason = (usageReason: UsageReason) => {
     "not-sure": "Not sure yet",
   }[usageReason];
 
-  userEvent.click(screen.getByLabelText(label));
+  await userEvent.click(screen.getByLabelText(label));
 };
 
 export const expectSectionToHaveLabel = (

--- a/frontend/src/metabase/sharing/components/SharingSidebar/tests/common.unit.spec.ts
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/tests/common.unit.spec.ts
@@ -59,7 +59,7 @@ describe("SharingSidebar", () => {
   describe("Slack Subscription sidebar", () => {
     it("should not show advanced filter options in OSS", async () => {
       setup();
-      userEvent.click(await screen.findByText("Send it to Slack"));
+      await userEvent.click(await screen.findByText("Send it to Slack"));
 
       await screen.findByText("Send this dashboard to Slack");
 
@@ -70,7 +70,7 @@ describe("SharingSidebar", () => {
   describe("Email Subscription sidebar", () => {
     it("should not show advanced filter options in OSS", async () => {
       setup();
-      userEvent.click(await screen.findByText("Email it"));
+      await userEvent.click(await screen.findByText("Email it"));
 
       await screen.findByText("Email this dashboard");
 
@@ -80,18 +80,18 @@ describe("SharingSidebar", () => {
     it("should filter out actions and links when sending a test subscription", async () => {
       setup();
 
-      userEvent.click(await screen.findByText("Email it"));
-      userEvent.click(
+      await userEvent.click(await screen.findByText("Email it"));
+      await userEvent.click(
         await screen.findByPlaceholderText(
           "Enter user names or email addresses",
         ),
       );
 
-      userEvent.click(
+      await userEvent.click(
         await screen.findByText(`${user.first_name} ${user.last_name}`),
       );
 
-      userEvent.click(await screen.findByText("Send email now"));
+      await userEvent.click(await screen.findByText("Send email now"));
 
       const payload = await fetchMock
         ?.lastCall("path:/api/pulse/test")

--- a/frontend/src/metabase/sharing/components/SharingSidebar/tests/enterprise.unit.spec.ts
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/tests/enterprise.unit.spec.ts
@@ -9,7 +9,7 @@ describe("SharingSidebar Enterprise Bundle", () => {
     it("should not show advanced filtering options without the feature flag", async () => {
       setup({ isAdmin: true, email: true, hasEnterprisePlugins: true });
 
-      userEvent.click(await screen.findByText("Email it"));
+      await userEvent.click(await screen.findByText("Email it"));
 
       await screen.findByText("Email this dashboard");
 
@@ -21,7 +21,7 @@ describe("SharingSidebar Enterprise Bundle", () => {
     it("should not show advanced filtering options without the feature flag", async () => {
       setup({ isAdmin: true, slack: true, hasEnterprisePlugins: true });
 
-      userEvent.click(await screen.findByText("Send it to Slack"));
+      await userEvent.click(await screen.findByText("Send it to Slack"));
 
       await screen.findByText("Send this dashboard to Slack");
 

--- a/frontend/src/metabase/sharing/components/SharingSidebar/tests/premium.unit.spec.ts
+++ b/frontend/src/metabase/sharing/components/SharingSidebar/tests/premium.unit.spec.ts
@@ -18,7 +18,7 @@ describe("SharingSidebar Premium Features", () => {
         hasEnterprisePlugins: true,
       });
 
-      userEvent.click(await screen.findByText("Email it"));
+      await userEvent.click(await screen.findByText("Email it"));
 
       await screen.findByText("Email this dashboard");
 
@@ -35,7 +35,7 @@ describe("SharingSidebar Premium Features", () => {
         hasEnterprisePlugins: true,
       });
 
-      userEvent.click(await screen.findByText("Send it to Slack"));
+      await userEvent.click(await screen.findByText("Send it to Slack"));
 
       await screen.findByText("Send this dashboard to Slack");
 

--- a/frontend/src/metabase/status/components/DatabaseStatus/DatabaseStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/DatabaseStatus/DatabaseStatus.unit.spec.tsx
@@ -33,7 +33,7 @@ const setup = ({ user, databases }: SetupOpts = {}) => {
 };
 
 describe("DatabaseStatus", () => {
-  it("should toggle between small and large versions", () => {
+  it("should toggle between small and large versions", async () => {
     setup({
       user: createMockUser({ id: 1 }),
       databases: [
@@ -46,10 +46,10 @@ describe("DatabaseStatus", () => {
 
     expect(screen.getByText("Syncing…")).toBeInTheDocument();
 
-    userEvent.click(screen.getByLabelText("chevrondown icon"));
+    await userEvent.click(screen.getByLabelText("chevrondown icon"));
     expect(screen.getByLabelText("Syncing database…")).toBeInTheDocument();
 
-    userEvent.click(screen.getByRole("status"));
+    await userEvent.click(screen.getByRole("status"));
     expect(screen.getByText("Syncing…")).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -354,7 +354,7 @@ describe("FileUploadStatus", () => {
 
     await setupCollectionContent({ collectionId: thirdCollection.id });
 
-    userEvent.upload(
+    await userEvent.upload(
       screen.getByTestId("upload-input"),
       new File(["foo, bar"], "test.csv", { type: "text/csv" }),
     );
@@ -363,20 +363,20 @@ describe("FileUploadStatus", () => {
       await screen.findByText("Select upload destination"),
     ).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Replace data in a model"));
+    await userEvent.click(screen.getByText("Replace data in a model"));
     const submitButton = await screen.findByRole("button", {
       name: "Replace model data",
     });
 
-    userEvent.click(await screen.findByPlaceholderText("Select a model"));
-    userEvent.click(
+    await userEvent.click(await screen.findByPlaceholderText("Select a model"));
+    await userEvent.click(
       await within(await screen.findByRole("listbox")).findByText(
         "my uploaded model",
       ),
     );
 
     await waitFor(() => expect(submitButton).toBeEnabled());
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
 
     act(() => {
       jest.advanceTimersByTime(500);

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -201,7 +201,7 @@ describe("FileUploadStatus", () => {
 
     await setupCollectionContent();
 
-    userEvent.upload(
+    await userEvent.upload(
       screen.getByTestId("upload-input"),
       new File(["foo, bar"], "test.csv", { type: "text/csv" }),
     );
@@ -229,7 +229,7 @@ describe("FileUploadStatus", () => {
 
     await setupCollectionContent({ collectionId: secondCollectionId });
 
-    userEvent.upload(
+    await userEvent.upload(
       screen.getByTestId("upload-input"),
       new File(["foo, bar"], "test.csv", { type: "text/csv" }),
     );
@@ -238,7 +238,7 @@ describe("FileUploadStatus", () => {
       await screen.findByText("Select upload destination"),
     ).toBeInTheDocument();
 
-    userEvent.click(screen.getByRole("button", { name: "Create model" }));
+    await userEvent.click(screen.getByRole("button", { name: "Create model" }));
 
     act(() => {
       jest.advanceTimersByTime(500);
@@ -263,7 +263,7 @@ describe("FileUploadStatus", () => {
 
     await setupCollectionContent({ collectionId: secondCollectionId });
 
-    userEvent.upload(
+    await userEvent.upload(
       screen.getByTestId("upload-input"),
       new File(["foo, bar"], "test.csv", { type: "text/csv" }),
     );
@@ -272,7 +272,7 @@ describe("FileUploadStatus", () => {
       await screen.findByText("Select upload destination"),
     ).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Append to a model"));
+    await userEvent.click(screen.getByText("Append to a model"));
     const submitButton = await screen.findByRole("button", {
       name: "Append to model",
     });
@@ -281,7 +281,7 @@ describe("FileUploadStatus", () => {
     await screen.findByText("my uploaded model");
 
     await waitFor(() => expect(submitButton).toBeEnabled());
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
 
     act(() => {
       jest.advanceTimersByTime(500);
@@ -306,7 +306,7 @@ describe("FileUploadStatus", () => {
 
     await setupCollectionContent({ collectionId: thirdCollection.id });
 
-    userEvent.upload(
+    await userEvent.upload(
       screen.getByTestId("upload-input"),
       new File(["foo, bar"], "test.csv", { type: "text/csv" }),
     );
@@ -315,20 +315,20 @@ describe("FileUploadStatus", () => {
       await screen.findByText("Select upload destination"),
     ).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Append to a model"));
+    await userEvent.click(screen.getByText("Append to a model"));
     const submitButton = await screen.findByRole("button", {
       name: "Append to model",
     });
 
-    userEvent.click(await screen.findByPlaceholderText("Select a model"));
-    userEvent.click(
+    await userEvent.click(await screen.findByPlaceholderText("Select a model"));
+    await userEvent.click(
       await within(await screen.findByRole("listbox")).findByText(
         "my uploaded model",
       ),
     );
 
     await waitFor(() => expect(submitButton).toBeEnabled());
-    userEvent.click(submitButton);
+    await userEvent.click(submitButton);
 
     act(() => {
       jest.advanceTimersByTime(500);
@@ -411,7 +411,7 @@ describe("FileUploadStatus", () => {
 
     await setupCollectionContent();
 
-    userEvent.upload(
+    await userEvent.upload(
       screen.getByTestId("upload-input"),
       new File(["foo, bar"], "test.csv", { type: "text/csv" }),
     );
@@ -432,7 +432,7 @@ describe("FileUploadStatus", () => {
       await screen.findByText("Error uploading your file"),
     ).toBeInTheDocument();
 
-    userEvent.click(await screen.findByText("Show error details"));
+    await userEvent.click(await screen.findByText("Show error details"));
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument();
 
@@ -446,7 +446,7 @@ describe("FileUploadStatus", () => {
 
       await setupCollectionContent();
 
-      userEvent.upload(
+      await userEvent.upload(
         screen.getByTestId("upload-input"),
         new File(["foo, bar"], "test.csv", { type: "text/csv" }),
       );

--- a/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/collections/components/EventCard/EventCard.unit.spec.tsx
@@ -79,7 +79,7 @@ describe("EventCard", () => {
     });
 
     render(<EventCard {...props} />);
-    userEvent.click(screen.getByLabelText("ellipsis icon"));
+    await userEvent.click(screen.getByLabelText("ellipsis icon"));
     await screen.findByRole("dialog");
 
     expect(screen.getByText("Edit event")).toBeInTheDocument();
@@ -99,7 +99,7 @@ describe("EventCard", () => {
     });
 
     render(<EventCard {...props} />);
-    userEvent.click(screen.getByLabelText("ellipsis icon"));
+    await userEvent.click(screen.getByLabelText("ellipsis icon"));
     await screen.findByRole("dialog");
 
     expect(screen.getByText("Unarchive event")).toBeInTheDocument();

--- a/frontend/src/metabase/timelines/collections/components/TimelineDetailsModal/TimelineDetailsModal.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/collections/components/TimelineDetailsModal/TimelineDetailsModal.unit.spec.tsx
@@ -60,14 +60,20 @@ describe("TimelineDetailsModal", () => {
 
     setup(props);
 
-    userEvent.type(screen.getByPlaceholderText("Search for an event"), "RC");
+    await userEvent.type(
+      screen.getByPlaceholderText("Search for an event"),
+      "RC",
+    );
     await waitFor(() => {
       expect(screen.queryByText("Release")).not.toBeInTheDocument();
     });
     expect(screen.getByText("RC1")).toBeInTheDocument();
     expect(screen.getByText("RC2")).toBeInTheDocument();
 
-    userEvent.type(screen.getByPlaceholderText("Search for an event"), "1");
+    await userEvent.type(
+      screen.getByPlaceholderText("Search for an event"),
+      "1",
+    );
     await waitFor(() => {
       expect(screen.queryByText("RC2")).not.toBeInTheDocument();
     });

--- a/frontend/src/metabase/timelines/common/components/DeleteEventModal/DeleteEventModal.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/common/components/DeleteEventModal/DeleteEventModal.unit.spec.tsx
@@ -10,11 +10,11 @@ import type { DeleteEventModalProps } from "./DeleteEventModal";
 import DeleteEventModal from "./DeleteEventModal";
 
 describe("DeleteEventModal", () => {
-  it("should submit modal", () => {
+  it("should submit modal", async () => {
     const props = getProps();
 
     render(<DeleteEventModal {...props} />);
-    userEvent.click(screen.getByText("Delete"));
+    await userEvent.click(screen.getByText("Delete"));
 
     expect(props.onSubmit).toHaveBeenCalled();
   });

--- a/frontend/src/metabase/timelines/common/components/EditTimelineModal/EditTimelineModal.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/common/components/EditTimelineModal/EditTimelineModal.unit.spec.tsx
@@ -12,9 +12,9 @@ describe("EditTimelineModal", () => {
     const name = "Another timeline";
 
     render(<EditTimelineModal {...props} />);
-    userEvent.clear(screen.getByLabelText("Name"));
-    userEvent.type(screen.getByLabelText("Name"), name);
-    userEvent.click(screen.getByText("Update"));
+    await userEvent.clear(screen.getByLabelText("Name"));
+    await userEvent.type(screen.getByLabelText("Name"), name);
+    await userEvent.click(screen.getByText("Update"));
 
     await waitFor(() => {
       expect(props.onSubmit).toHaveBeenCalledWith({ ...props.timeline, name });

--- a/frontend/src/metabase/timelines/common/components/ModalHeader/ModalHeader.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/common/components/ModalHeader/ModalHeader.unit.spec.tsx
@@ -16,7 +16,7 @@ describe("ModalHeader", () => {
     expect(screen.getByText("Actions")).toBeInTheDocument();
   });
 
-  it("should render with close button", () => {
+  it("should render with close button", async () => {
     const onClose = jest.fn();
 
     render(<ModalHeader title="Events" onClose={onClose} />);
@@ -24,7 +24,7 @@ describe("ModalHeader", () => {
     const closeButton = screen.getByLabelText("close icon");
     expect(closeButton).toBeInTheDocument();
 
-    userEvent.click(closeButton);
+    await userEvent.click(closeButton);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/metabase/timelines/common/components/MoveEventModal/MoveEventModal.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/common/components/MoveEventModal/MoveEventModal.unit.spec.tsx
@@ -10,7 +10,7 @@ import type { MoveEventModalProps } from "./MoveEventModal";
 import MoveEventModal from "./MoveEventModal";
 
 describe("MoveEventModal", () => {
-  it("should move an event to a different timeline", () => {
+  it("should move an event to a different timeline", async () => {
     const event = createMockTimelineEvent({ timeline_id: 1 });
     const oldTimeline = createMockTimeline({ id: 1, name: "Builds" });
     const newTimeline = createMockTimeline({ id: 2, name: "Releases" });
@@ -23,8 +23,8 @@ describe("MoveEventModal", () => {
     render(<MoveEventModal {...props} />);
     expect(screen.getByRole("button", { name: "Move" })).toBeDisabled();
 
-    userEvent.click(screen.getByText(newTimeline.name));
-    userEvent.click(screen.getByText("Move"));
+    await userEvent.click(screen.getByText(newTimeline.name));
+    await userEvent.click(screen.getByText("Move"));
     expect(props.onSubmit).toHaveBeenLastCalledWith(
       event,
       newTimeline,

--- a/frontend/src/metabase/timelines/common/components/NewTimelineModal/NewTimelineModal.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/common/components/NewTimelineModal/NewTimelineModal.unit.spec.tsx
@@ -15,12 +15,12 @@ describe("NewTimelineModal", () => {
     const values = createMockTimelineData();
 
     render(<NewTimelineModal {...props} />);
-    userEvent.type(screen.getByLabelText("Name"), values.name);
+    await userEvent.type(screen.getByLabelText("Name"), values.name);
     await waitFor(() => {
       expect(screen.getByText("Create")).toBeEnabled();
     });
 
-    userEvent.click(screen.getByText("Create"));
+    await userEvent.click(screen.getByText("Create"));
     await waitFor(() => {
       expect(props.onSubmit).toHaveBeenCalledWith(values, props.collection);
     });

--- a/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/questions/components/EventCard/EventCard.unit.spec.tsx
@@ -36,7 +36,7 @@ describe("EventCard", () => {
     expect(screen.getByText("January 1, 2020, 10:20 AM")).toBeInTheDocument();
   });
 
-  it("should toggle an event's visibility", () => {
+  it("should toggle an event's visibility", async () => {
     const props = getProps({
       event: createMockTimelineEvent({
         timestamp: "2020-01-01T10:20:00Z",
@@ -50,7 +50,7 @@ describe("EventCard", () => {
 
     expect(checkbox).toBeChecked();
 
-    userEvent.click(screen.getByRole("checkbox"));
+    await userEvent.click(screen.getByRole("checkbox"));
     expect(props.onHideTimelineEvents).toHaveBeenCalled();
   });
 });

--- a/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelineCard/TimelineCard.unit.spec.tsx
@@ -10,7 +10,7 @@ import type { TimelineCardProps } from "./TimelineCard";
 import TimelineCard from "./TimelineCard";
 
 describe("TimelineCard", () => {
-  it("should expand and collapse the card", () => {
+  it("should expand and collapse the card", async () => {
     const props = getProps({
       timeline: createMockTimeline({
         name: "Releases",
@@ -21,14 +21,14 @@ describe("TimelineCard", () => {
     render(<TimelineCard {...props} />);
     expect(screen.queryByText("RC")).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Releases"));
+    await userEvent.click(screen.getByText("Releases"));
     expect(screen.getByText("RC")).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Releases"));
+    await userEvent.click(screen.getByText("Releases"));
     expect(screen.queryByText("RC")).not.toBeInTheDocument();
   });
 
-  it("should toggle visibility of the card", () => {
+  it("should toggle visibility of the card", async () => {
     const props = getProps({
       timeline: createMockTimeline({
         name: "Releases",
@@ -37,7 +37,7 @@ describe("TimelineCard", () => {
     });
 
     render(<TimelineCard {...props} />);
-    userEvent.click(screen.getByRole("checkbox"));
+    await userEvent.click(screen.getByRole("checkbox"));
 
     expect(props.onShowTimelineEvents).toHaveBeenCalled();
   });

--- a/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.unit.spec.tsx
+++ b/frontend/src/metabase/timelines/questions/components/TimelinePanel/TimelinePanel.unit.spec.tsx
@@ -14,26 +14,26 @@ function setup(props: TimelinePanelProps) {
 }
 
 describe("TimelinePanel", () => {
-  it("should allow creating an event and a default timeline", () => {
+  it("should allow creating an event and a default timeline", async () => {
     const props = getProps({
       timelines: [],
       collection: createMockCollection({ can_write: true }),
     });
 
     setup(props);
-    userEvent.click(screen.getByText("Add an event"));
+    await userEvent.click(screen.getByText("Add an event"));
 
     expect(props.onNewEvent).toHaveBeenCalled();
   });
 
-  it("should allow creating an event within existing timelines", () => {
+  it("should allow creating an event within existing timelines", async () => {
     const props = getProps({
       timelines: [createMockTimeline()],
       collection: createMockCollection({ can_write: true }),
     });
 
     setup(props);
-    userEvent.click(screen.getByText("Add an event"));
+    await userEvent.click(screen.getByText("Add an event"));
 
     expect(props.onNewEvent).toHaveBeenCalled();
   });

--- a/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/NumberInput/NumberInput.unit.spec.tsx
@@ -40,40 +40,40 @@ describe("NumberInput", () => {
     expect(input).toHaveValue("20.123");
   });
 
-  it("should allow to enter an integer value", () => {
+  it("should allow to enter an integer value", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("Number");
-    userEvent.type(input, "51");
+    await userEvent.type(input, "51");
 
     expect(onChange).toHaveBeenCalledWith(51);
   });
 
-  it("should allow to enter a fractional value", () => {
+  it("should allow to enter a fractional value", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("Number");
-    userEvent.type(input, "15.16");
+    await userEvent.type(input, "15.16");
 
     expect(onChange).toHaveBeenCalledWith(15.16);
   });
 
-  it("should reset to the correct value on blur", () => {
+  it("should reset to the correct value on blur", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("Number");
-    userEvent.type(input, "12abc");
-    userEvent.tab();
+    await userEvent.type(input, "12abc");
+    await userEvent.tab();
 
     expect(onChange).toHaveBeenCalledWith(12);
   });
 
-  it("should reset to an empty string on blur for invalid values", () => {
+  it("should reset to an empty string on blur for invalid values", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("Number");
-    userEvent.type(input, "abc");
-    userEvent.tab();
+    await userEvent.type(input, "abc");
+    await userEvent.tab();
 
     expect(onChange).toHaveBeenCalledWith("");
   });

--- a/frontend/src/metabase/ui/components/inputs/TextInputBlurChange/TextInputBlurChange.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TextInputBlurChange/TextInputBlurChange.unit.spec.tsx
@@ -10,7 +10,7 @@ describe("InputBlurChange", () => {
     jest.clearAllMocks();
   });
 
-  it('should trigger "onBlurChange" on input blur', () => {
+  it('should trigger "onBlurChange" on input blur', async () => {
     const {
       props: { placeholder },
       mocks: { onBlurChange },
@@ -23,20 +23,20 @@ describe("InputBlurChange", () => {
     // should not be triggered if value hasn't changed
     expect(onBlurChange).toHaveBeenCalledTimes(0);
 
-    userEvent.type(inputEl, "test");
+    await userEvent.type(inputEl, "test");
     inputEl.blur();
 
     expect(onBlurChange).toHaveBeenCalledTimes(1);
     expect(onBlurChange.mock.results[0].value).toBe("test");
   });
 
-  it('should trigger "onBlurChange" on component unmount', () => {
+  it('should trigger "onBlurChange" on component unmount', async () => {
     const {
       props: { placeholder },
       mocks: { onBlurChange },
     } = setup();
 
-    userEvent.type(screen.getByPlaceholderText(placeholder), "test");
+    await userEvent.type(screen.getByPlaceholderText(placeholder), "test");
 
     cleanup();
 
@@ -44,12 +44,12 @@ describe("InputBlurChange", () => {
     expect(onBlurChange.mock.results[0].value).toBe("test");
   });
 
-  it("should set `internalValue` to the normalized value even if the normalized value is the same as the previous one", () => {
+  it("should set `internalValue` to the normalized value even if the normalized value is the same as the previous one", async () => {
     const value = "/";
     setup({ value, normalize: value => (value as string).trim() });
     const input = screen.getByDisplayValue(value) as HTMLInputElement;
-    userEvent.clear(input);
-    userEvent.type(input, "           /         ");
+    await userEvent.clear(input);
+    await userEvent.type(input, "           /         ");
 
     const normalizedValue = "/";
     expect(input.value).toEqual(normalizedValue);

--- a/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/inputs/TimeInput/TimeInput.unit.spec.tsx
@@ -42,25 +42,25 @@ describe("TimeInput", () => {
     expect(input).toHaveValue("12:30");
   });
 
-  it("should allow to enter a time value", () => {
+  it("should allow to enter a time value", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("Time");
-    userEvent.type(input, "10:20");
+    await userEvent.type(input, "10:20");
 
     const time = onChange.mock.lastCall[0] as Date;
     expect(time.getHours()).toBe(10);
     expect(time.getMinutes()).toBe(20);
   });
 
-  it("should reset to the last correct value on blur", () => {
+  it("should reset to the last correct value on blur", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("Time");
-    userEvent.type(input, "10:20");
-    userEvent.clear(input);
-    userEvent.type(input, "12:");
-    userEvent.tab();
+    await userEvent.type(input, "10:20");
+    await userEvent.clear(input);
+    await userEvent.type(input, "12:");
+    await userEvent.tab();
 
     const time = onChange.mock.lastCall[0] as Date;
     expect(time.getHours()).toBe(10);
@@ -68,11 +68,11 @@ describe("TimeInput", () => {
     expect(input).toHaveValue("10:20");
   });
 
-  it("should handle an invalid value", () => {
+  it("should handle an invalid value", async () => {
     const { onChange } = setup();
 
     const input = screen.getByLabelText("Time");
-    userEvent.type(input, "32:71");
+    await userEvent.type(input, "32:71");
 
     expect(input).toHaveValue("03:59");
     expect(onChange).toHaveBeenCalledWith(dayjs("03:59", "HH:mm").toDate());

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
@@ -36,10 +36,10 @@ describe("DelayGroup", () => {
 
     expect(button).toHaveTextContent("delay: true");
 
-    userEvent.hover(button);
+    await userEvent.hover(button);
     expect(button).toHaveTextContent("delay: false");
 
-    userEvent.unhover(button);
+    await userEvent.unhover(button);
     expect(button).toHaveTextContent("delay: false");
 
     act(function () {

--- a/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
+++ b/frontend/src/metabase/ui/components/utils/DelayGroup/DelayGroup.unit.spec.tsx
@@ -29,6 +29,10 @@ describe("DelayGroup", () => {
   it("should be delayed by default and only remove delay after a timeout", async () => {
     jest.useFakeTimers();
 
+    const user = userEvent.setup({
+      advanceTimers: jest.advanceTimersByTime,
+    });
+
     const timeout = 500;
     setup({ timeout });
 
@@ -36,10 +40,11 @@ describe("DelayGroup", () => {
 
     expect(button).toHaveTextContent("delay: true");
 
-    await userEvent.hover(button);
+    await user.hover(button);
+
     expect(button).toHaveTextContent("delay: false");
 
-    await userEvent.unhover(button);
+    await user.unhover(button);
     expect(button).toHaveTextContent("delay: false");
 
     act(function () {

--- a/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ChartCaption.unit.spec.tsx
@@ -78,13 +78,13 @@ describe("ChartCaption", () => {
     expect(screen.getByTestId("legend-caption")).toBeInTheDocument();
   });
 
-  it("should render markdown in description", () => {
+  it("should render markdown in description", async () => {
     setup({
       series: getSeries({ card: createMockCard({ name: "card name" }) }),
       settings: { "card.description": "[link](https://metabase.com)" },
     });
 
-    userEvent.hover(getIcon("info"));
+    await userEvent.hover(getIcon("info"));
 
     const tooltipContent = screen.getByRole("link");
     expect(tooltipContent).toBeInTheDocument();

--- a/frontend/src/metabase/visualizations/components/ChartSettings.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/ChartSettings.unit.spec.js
@@ -125,7 +125,7 @@ describe("ChartSettings", () => {
     expect(screen.queryByText("Foo")).not.toBeInTheDocument();
   });
 
-  it("reset settings should revert to the original card settings with click behavior", () => {
+  it("reset settings should revert to the original card settings with click behavior", async () => {
     const onChange = jest.fn();
 
     const originalVizSettings = createMockVisualizationSettings({
@@ -152,7 +152,7 @@ describe("ChartSettings", () => {
       onChange,
     });
 
-    userEvent.click(screen.getByText("Reset to defaults"));
+    await userEvent.click(screen.getByText("Reset to defaults"));
 
     expect(onChange).toHaveBeenCalledWith({
       ...originalVizSettings,

--- a/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.unit.spec.jsx
+++ b/frontend/src/metabase/visualizations/components/ChartSettingsWidgetPopover.unit.spec.jsx
@@ -70,7 +70,7 @@ it("should change tabs when clicked", async () => {
   //Should Default to rendering formatting
   expect(await screen.findByText("Foo")).toBeInTheDocument();
 
-  userEvent.click(await screen.findByText("Style"));
+  await userEvent.click(await screen.findByText("Style"));
 
   expect(await screen.findByText("Bar")).toBeInTheDocument();
 });

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailView.unit.spec.tsx
@@ -503,7 +503,7 @@ describe("ObjectDetailView", () => {
 
 async function findActionInActionMenu({ name }: Pick<WritebackAction, "name">) {
   const actionsMenu = await screen.findByTestId("actions-menu");
-  userEvent.click(actionsMenu);
+  await userEvent.click(actionsMenu);
   const popover = await screen.findByRole("dialog");
   const action = within(popover).queryByText(name);
   return action;

--- a/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailWrapper.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/ObjectDetail/ObjectDetailWrapper.unit.spec.tsx
@@ -111,12 +111,12 @@ describe("Object Detail Wrapper", () => {
 
     // first tab should focus on the close button, since there's only
     // one element to show here.
-    userEvent.tab();
+    await userEvent.tab();
     expect(screen.getByTestId("object-detail-close-button")).toHaveFocus();
 
     // second tab should *keep* focus on the close button, not go
     // to the body
-    userEvent.tab();
+    await userEvent.tab();
     expect(screen.getByTestId("object-detail-close-button")).toHaveFocus();
   });
 });

--- a/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingsSeriesMultiple.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/settings/ChartNestedSettingsSeriesMultiple.unit.spec.js
@@ -64,7 +64,7 @@ describe("ChartNestedSettingSeries", () => {
     expect(screen.getByRole("img", { name: /bar/i })).toBeInTheDocument();
   });
 
-  it("should show and open 'More options' on visualizations with multiple lines (metabase#17619)", () => {
+  it("should show and open 'More options' on visualizations with multiple lines (metabase#17619)", async () => {
     setup("line", 3);
     //Check that all series are present
     expect(screen.getByDisplayValue("Test 0")).toBeInTheDocument();
@@ -86,7 +86,7 @@ describe("ChartNestedSettingSeries", () => {
     ).not.toBeInTheDocument();
 
     //Expand a section
-    userEvent.click(expandButtons[0]);
+    await userEvent.click(expandButtons[0]);
     expect(screen.getByRole("img", { name: /chevronup/i })).toBeInTheDocument();
     expect(screen.getByText("Line style")).toBeInTheDocument();
     expect(screen.getByText("Show dots on lines")).toBeInTheDocument();
@@ -95,7 +95,7 @@ describe("ChartNestedSettingSeries", () => {
     expect(screen.getByText("Show values for this series")).toBeInTheDocument();
 
     //Expand another section, should only be 1 open section
-    userEvent.click(expandButtons[1]);
+    await userEvent.click(expandButtons[1]);
     expect(screen.getByRole("img", { name: /chevronup/i })).toBeInTheDocument();
   });
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingFieldsPicker.unit.spec.js
@@ -32,7 +32,7 @@ describe("ChartSettingFieldsPicker", () => {
     expect(screen.getByTestId("remove-count")).toBeInTheDocument();
   });
 
-  it("should show you a button to add another metric if there are unused options", () => {
+  it("should show you a button to add another metric if there are unused options", async () => {
     const onChange = jest.fn();
 
     setup({ value: ["avg"], onChange });
@@ -41,12 +41,12 @@ describe("ChartSettingFieldsPicker", () => {
     expect(screen.queryByTestId("remove-avg")).not.toBeInTheDocument();
     expect(screen.getByText("Add another series")).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Add another series"));
+    await userEvent.click(screen.getByText("Add another series"));
 
     expect(onChange).toHaveBeenCalledWith(["avg", "count"]);
   });
 
-  it("should allow you to change an existing metric if there are unused options", () => {
+  it("should allow you to change an existing metric if there are unused options", async () => {
     const onChange = jest.fn();
 
     setup({ value: ["avg"], onChange });
@@ -58,12 +58,12 @@ describe("ChartSettingFieldsPicker", () => {
       screen.getByRole("img", { name: /chevrondown/i }),
     ).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Average of Total"));
+    await userEvent.click(screen.getByText("Average of Total"));
 
     //Check to see that count is in the popover
     expect(screen.getByText("Count")).toBeInTheDocument();
 
-    userEvent.click(screen.getByText("Count"));
+    await userEvent.click(screen.getByText("Count"));
 
     expect(onChange).toHaveBeenCalledWith(["count"]);
   });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingInputNumeric.unit.spec.tsx
@@ -24,47 +24,47 @@ function setup({
   return { input, onChange };
 }
 
-function type({ input, value }: { input: HTMLElement; value: string }) {
-  userEvent.clear(input);
-  userEvent.type(input, value);
+async function type({ input, value }: { input: HTMLElement; value: string }) {
+  await userEvent.clear(input);
+  await userEvent.type(input, value);
   fireEvent.blur(input);
 }
 
 describe("ChartSettingInputNumber", () => {
-  it("allows integer values", () => {
+  it("allows integer values", async () => {
     const { input, onChange } = setup();
 
-    type({ input, value: "123" });
+    await type({ input, value: "123" });
     expect(input).toHaveDisplayValue("123");
     expect(onChange).toHaveBeenCalledWith(123);
 
-    type({ input, value: "-456" });
+    await type({ input, value: "-456" });
     expect(input).toHaveDisplayValue("-456");
     expect(onChange).toHaveBeenCalledWith(-456);
   });
 
-  it("allows decimal values", () => {
+  it("allows decimal values", async () => {
     const { input, onChange } = setup();
 
-    type({ input, value: "1.23" });
+    await type({ input, value: "1.23" });
     expect(input).toHaveDisplayValue("1.23");
     expect(onChange).toHaveBeenCalledWith(1.23);
 
-    type({ input, value: "-4.56" });
+    await type({ input, value: "-4.56" });
     expect(input).toHaveDisplayValue("-4.56");
     expect(onChange).toHaveBeenCalledWith(-4.56);
 
     // multiple decimal places should call onChange with
     // undefined since it's an invalid value
-    type({ input, value: "1.2.3" });
+    await type({ input, value: "1.2.3" });
     expect(input).toHaveDisplayValue("1.2.3");
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
 
-  it("does not allow non-alphanumeric values", () => {
+  it("does not allow non-alphanumeric values", async () => {
     const { input, onChange } = setup();
 
-    type({ input, value: "asdf" });
+    await type({ input, value: "asdf" });
     expect(input).toHaveDisplayValue("");
     expect(onChange).toHaveBeenCalledWith(undefined);
   });

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingLinkUrlInput.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingLinkUrlInput.unit.spec.tsx
@@ -34,7 +34,7 @@ describe("ChartSettingLinkUrlInput", () => {
   it("Shows all options when {{ is typed", async () => {
     const { input, getOptions } = setup();
 
-    userEvent.type(input, "USE - {{{{");
+    await userEvent.type(input, "USE - {{{{");
 
     const options = await getOptions();
 
@@ -46,7 +46,7 @@ describe("ChartSettingLinkUrlInput", () => {
   it("shows filter options while typing", async () => {
     const { input, getOptions } = setup();
 
-    userEvent.type(input, "USE - {{{{p");
+    await userEvent.type(input, "USE - {{{{p");
 
     const options = await getOptions();
 
@@ -60,7 +60,7 @@ describe("ChartSettingLinkUrlInput", () => {
       value: "USE - {{{{p",
     });
 
-    userEvent.click(input);
+    await userEvent.click(input);
 
     const options = await getOptions();
 
@@ -75,11 +75,11 @@ describe("ChartSettingLinkUrlInput", () => {
       onChange,
     });
 
-    userEvent.type(input, "Address - {{{{p");
+    await userEvent.type(input, "Address - {{{{p");
 
     const options = await getOptions();
 
-    userEvent.click(options[1]);
+    await userEvent.click(options[1]);
     input.blur();
 
     expect(onChange).toHaveBeenCalledWith("Address - {{ZIP}}");
@@ -91,12 +91,12 @@ describe("ChartSettingLinkUrlInput", () => {
       onChange,
     });
 
-    userEvent.type(input, "Address - {{{{p");
+    await userEvent.type(input, "Address - {{{{p");
 
     const options = await getOptions();
     expect(options).toHaveLength(2);
 
-    userEvent.type(input, "{arrowdown}{arrowdown}{enter}");
+    await userEvent.type(input, "{arrowdown}{arrowdown}{enter}");
     input.blur();
 
     expect(onChange).toHaveBeenCalledWith("Address - {{ZIP}}");
@@ -110,7 +110,7 @@ describe("ChartSettingLinkUrlInput", () => {
       onChange,
     });
 
-    userEvent.type(input, "{{{{c");
+    await userEvent.type(input, "{{{{c");
 
     const options = await getOptions();
 
@@ -118,7 +118,7 @@ describe("ChartSettingLinkUrlInput", () => {
     expect(options[0]).toHaveTextContent("CITY");
     expect(options[1]).toHaveTextContent("SOURCE");
 
-    userEvent.click(options[0]);
+    await userEvent.click(options[0]);
     input.blur();
 
     expect(onChange).toHaveBeenCalledWith("{{STATE}} - {{CITY}}");

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.unit.spec.tsx
@@ -105,10 +105,20 @@ describe("DatasetColumnSelector", () => {
     expect(items[3]).toHaveTextContent("Subtotal");
   });
 
-  it("should allow to enable a column", () => {
+  it("should display columns without matching setting", () => {
+    setup({ columnSettings: [] });
+    const items = screen.getAllByTestId(/draggable-item/);
+    expect(items).toHaveLength(4);
+    expect(items[0]).toHaveTextContent("ID");
+    expect(items[1]).toHaveTextContent("Total");
+    expect(items[2]).toHaveTextContent("Tax");
+    expect(items[3]).toHaveTextContent("Subtotal");
+  });
+
+  it("should allow to enable a column", async () => {
     const { onChange } = setup();
 
-    enableColumn("Tax");
+    await enableColumn("Tax");
 
     const columnIndex = findColumnIndex("TAX", COLUMN_SETTINGS);
     const newSettings = [...COLUMN_SETTINGS];
@@ -116,10 +126,10 @@ describe("DatasetColumnSelector", () => {
     expect(onChange).toHaveBeenCalledWith(newSettings);
   });
 
-  it("should allow to disable a column", () => {
+  it("should allow to disable a column", async () => {
     const { onChange } = setup();
 
-    disableColumn("ID");
+    await disableColumn("ID");
 
     const columnIndex = findColumnIndex("ID", COLUMN_SETTINGS);
     const newSettings = [...COLUMN_SETTINGS];
@@ -128,12 +138,12 @@ describe("DatasetColumnSelector", () => {
   });
 });
 
-function enableColumn(columnName: string) {
-  userEvent.click(screen.getByTestId(`${columnName}-show-button`));
+async function enableColumn(columnName: string) {
+  await userEvent.click(screen.getByTestId(`${columnName}-show-button`));
 }
 
-function disableColumn(columnName: string) {
-  userEvent.click(screen.getByTestId(`${columnName}-hide-button`));
+async function disableColumn(columnName: string) {
+  await userEvent.click(screen.getByTestId(`${columnName}-hide-button`));
 }
 
 function findColumnIndex(

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingTableColumns/TableColumnPanel/TableColumnPanel.unit.spec.tsx
@@ -105,16 +105,6 @@ describe("DatasetColumnSelector", () => {
     expect(items[3]).toHaveTextContent("Subtotal");
   });
 
-  it("should display columns without matching setting", () => {
-    setup({ columnSettings: [] });
-    const items = screen.getAllByTestId(/draggable-item/);
-    expect(items).toHaveLength(4);
-    expect(items[0]).toHaveTextContent("ID");
-    expect(items[1]).toHaveTextContent("Total");
-    expect(items[2]).toHaveTextContent("Tax");
-    expect(items[3]).toHaveTextContent("Subtotal");
-  });
-
   it("should allow to enable a column", async () => {
     const { onChange } = setup();
 

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.unit.spec.js
@@ -82,20 +82,20 @@ describe("ChartSettingsTableFormatting", () => {
   it("should allow you to add a rule", async () => {
     setup();
     expect(screen.getByText("Conditional formatting")).toBeInTheDocument();
-    userEvent.click(await screen.findByText("Add a rule"));
-    userEvent.click(await screen.findByText("String Column"));
+    await userEvent.click(await screen.findByText("Add a rule"));
+    await userEvent.click(await screen.findByText("String Column"));
     //Dismiss Popup
-    userEvent.click(
+    await userEvent.click(
       await screen.findByText("Which columns should be affected?"),
     );
 
     expect(await screen.findByText("is equal to")).toBeInTheDocument();
 
-    userEvent.type(
+    await userEvent.type(
       await screen.findByTestId("conditional-formatting-value-input"),
       "toucan",
     );
-    userEvent.click(await screen.findByText("Add rule"));
+    await userEvent.click(await screen.findByText("Add rule"));
 
     expect(await screen.findByText("String Column")).toBeInTheDocument();
     expect(await screen.findByText(/is equal to toucan/g)).toBeInTheDocument();
@@ -104,8 +104,8 @@ describe("ChartSettingsTableFormatting", () => {
   it("should only let you choose columns of the same type for a rule", async () => {
     setup();
     expect(screen.getByText("Conditional formatting")).toBeInTheDocument();
-    userEvent.click(await screen.findByText("Add a rule"));
-    userEvent.click(await screen.findByText("String Column"));
+    await userEvent.click(await screen.findByText("Add a rule"));
+    await userEvent.click(await screen.findByText("String Column"));
 
     expect(
       await screen.findByRole("option", { name: "Number Column" }),
@@ -121,17 +121,19 @@ describe("ChartSettingsTableFormatting", () => {
   });
 
   describe("should show appropriate operators based on column selection", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       setup();
-      userEvent.click(screen.getByText("Add a rule"));
+      await userEvent.click(screen.getByText("Add a rule"));
     });
 
-    it("string", () => {
-      userEvent.click(screen.getByText("String Column"));
+    it("string", async () => {
+      await userEvent.click(screen.getByText("String Column"));
       //Dismiss Popup
-      userEvent.click(screen.getByText("Which columns should be affected?"));
+      await userEvent.click(
+        screen.getByText("Which columns should be affected?"),
+      );
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByTestId("conditional-formatting-value-operator-button"),
       );
 
@@ -142,12 +144,14 @@ describe("ChartSettingsTableFormatting", () => {
       });
     });
 
-    it("number", () => {
-      userEvent.click(screen.getByText("Number Column"));
+    it("number", async () => {
+      await userEvent.click(screen.getByText("Number Column"));
       //Dismiss Popup
-      userEvent.click(screen.getByText("Which columns should be affected?"));
+      await userEvent.click(
+        screen.getByText("Which columns should be affected?"),
+      );
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByTestId("conditional-formatting-value-operator-button"),
       );
 
@@ -167,12 +171,14 @@ describe("ChartSettingsTableFormatting", () => {
       ).not.toBeChecked();
     });
 
-    it("boolean", () => {
-      userEvent.click(screen.getByText("Boolean Column"));
+    it("boolean", async () => {
+      await userEvent.click(screen.getByText("Boolean Column"));
       //Dismiss Popup
-      userEvent.click(screen.getByText("Which columns should be affected?"));
+      await userEvent.click(
+        screen.getByText("Which columns should be affected?"),
+      );
 
-      userEvent.click(
+      await userEvent.click(
         screen.getByTestId("conditional-formatting-value-operator-button"),
       );
 

--- a/frontend/src/metabase/visualizations/components/skeletons/ChartSkeleton/ChartSkeleton.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/ChartSkeleton/ChartSkeleton.unit.spec.tsx
@@ -71,21 +71,21 @@ describe("ChartSkeleton", () => {
       expect(screen.queryByLabelText("info icon")).not.toBeInTheDocument();
     });
 
-    it(`should render ${name} visualization with description`, () => {
+    it(`should render ${name} visualization with description`, async () => {
       setup({ name, description: displayDescription, display });
-      userEvent.hover(screen.getByLabelText("info icon"));
+      await userEvent.hover(screen.getByLabelText("info icon"));
       expect(screen.getByText(name)).toBeInTheDocument();
       expect(screen.getByText(displayDescription)).toBeInTheDocument();
     });
 
-    it(`should render ${name} visualization with description and action menu`, () => {
+    it(`should render ${name} visualization with description and action menu`, async () => {
       setup({
         name,
         description: displayDescription,
         actionMenu: MockActionMenu,
         display,
       });
-      userEvent.hover(screen.getByLabelText("info icon"));
+      await userEvent.hover(screen.getByLabelText("info icon"));
       expect(screen.getByText(name)).toBeInTheDocument();
       expect(screen.getByText(displayDescription)).toBeInTheDocument();
       expect(screen.getByText("Action Menu")).toBeInTheDocument();

--- a/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/SkeletonCaption/SkeletonCaption.unit.spec.tsx
@@ -26,10 +26,10 @@ function setup({ description }: { description?: string } = {}) {
 }
 
 describe("SkeletonCaption", () => {
-  it("should show description tooltip with markdown formatting on hover", () => {
+  it("should show description tooltip with markdown formatting on hover", async () => {
     setup({ description: MARKDOWN });
 
-    userEvent.hover(screen.getByTestId("skeleton-description-icon"));
+    await userEvent.hover(screen.getByTestId("skeleton-description-icon"));
 
     const tooltip = screen.getByRole("tooltip");
     expect(tooltip).not.toHaveTextContent(MARKDOWN);

--- a/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/skeletons/StaticSkeleton/StaticSkeleton.unit.spec.tsx
@@ -56,10 +56,10 @@ describe("StaticSkeleton", () => {
       expect(screen.getByText(MARKDOWN_AS_TEXT)).toBeInTheDocument();
     });
 
-    it("should show description tooltip with markdown formatting on hover", () => {
+    it("should show description tooltip with markdown formatting on hover", async () => {
       setup({ description: MARKDOWN });
 
-      userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
+      await userEvent.hover(screen.getByText(MARKDOWN_AS_TEXT));
 
       expect(screen.getByRole("tooltip")).toHaveTextContent(MARKDOWN_AS_TEXT);
     });

--- a/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/shared/components/RowChart/RowChart.unit.spec.tsx
@@ -206,11 +206,11 @@ describe("RowChart", () => {
   });
 
   describe("events", () => {
-    it("should call onClick with the clicked datum info", () => {
+    it("should call onClick with the clicked datum info", async () => {
       const onClick = jest.fn();
 
       const { bars } = setup({ onClick });
-      userEvent.click(bars[0]);
+      await userEvent.click(bars[0]);
 
       expect(onClick).toHaveBeenCalledWith(
         expect.objectContaining({ target: expect.anything() }),
@@ -228,7 +228,7 @@ describe("RowChart", () => {
       onClick.mockClear();
 
       // the last bar
-      userEvent.click(bars[5]);
+      await userEvent.click(bars[5]);
 
       expect(onClick).toHaveBeenCalledWith(
         expect.objectContaining({ target: expect.anything() }),
@@ -244,11 +244,11 @@ describe("RowChart", () => {
       );
     });
 
-    it("should call onHover with the clicked datum info", () => {
+    it("should call onHover with the clicked datum info", async () => {
       const onHover = jest.fn();
 
       const { bars } = setup({ onHover });
-      userEvent.hover(bars[0]);
+      await userEvent.hover(bars[0]);
 
       expect(onHover).toHaveBeenCalledWith(
         expect.objectContaining({ target: expect.anything() }),
@@ -266,7 +266,7 @@ describe("RowChart", () => {
       onHover.mockClear();
 
       // the last bar
-      userEvent.click(bars[5]);
+      await userEvent.click(bars[5]);
 
       expect(onHover).toHaveBeenCalledWith(
         expect.objectContaining({ target: expect.anything() }),

--- a/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Heading/Heading.unit.spec.tsx
@@ -139,14 +139,14 @@ describe("Text", () => {
     });
 
     describe("Edit/Focused", () => {
-      it("should display and focus input when clicked", () => {
+      it("should display and focus input when clicked", async () => {
         const options = {
           settings: getSettingsWithText(""),
           isEditing: true,
         };
         setup(options);
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByTestId("editing-dashboard-heading-preview"),
         );
         expect(
@@ -154,33 +154,33 @@ describe("Text", () => {
         ).toHaveFocus();
       });
 
-      it("should have input placeholder when it has no content", () => {
+      it("should have input placeholder when it has no content", async () => {
         const options = {
           settings: getSettingsWithText(""),
           isEditing: true,
         };
         setup(options);
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByTestId("editing-dashboard-heading-preview"),
         );
         expect(screen.getByPlaceholderText("Heading")).toBeInTheDocument();
       });
 
-      it("should render input text when it has content", () => {
+      it("should render input text when it has content", async () => {
         const options = {
           settings: getSettingsWithText("Example Heading"),
           isEditing: true,
         };
         setup(options);
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByTestId("editing-dashboard-heading-preview"),
         );
         expect(screen.getByDisplayValue("Example Heading")).toBeInTheDocument();
       });
 
-      it("should show input without replacing mapped variables with parameter values", () => {
+      it("should show input without replacing mapped variables with parameter values", async () => {
         const variableName = "variable";
         const text = `Variable: {{${variableName}}}`;
 
@@ -199,7 +199,7 @@ describe("Text", () => {
         setup(options);
 
         // show input by focusing the card
-        userEvent.click(
+        await userEvent.click(
           screen.getByTestId("editing-dashboard-heading-preview"),
         );
         expect(
@@ -207,7 +207,7 @@ describe("Text", () => {
         ).toBeInTheDocument();
       });
 
-      it("should call onUpdateVisualizationSettings on blur", () => {
+      it("should call onUpdateVisualizationSettings on blur", async () => {
         const mockOnUpdateVisualizationSettings = jest.fn();
         const options = {
           settings: getSettingsWithText("text"),
@@ -216,11 +216,11 @@ describe("Text", () => {
         };
         setup(options);
 
-        userEvent.click(
+        await userEvent.click(
           screen.getByTestId("editing-dashboard-heading-preview"),
         );
-        userEvent.type(screen.getByRole("textbox"), "foo");
-        userEvent.tab();
+        await userEvent.type(screen.getByRole("textbox"), "foo");
+        await userEvent.tab();
 
         expect(mockOnUpdateVisualizationSettings).toHaveBeenCalledTimes(1);
         expect(mockOnUpdateVisualizationSettings).toHaveBeenCalledWith({

--- a/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/LinkViz/LinkViz.unit.spec.tsx
@@ -227,14 +227,14 @@ describe("LinkViz", () => {
 
       const searchInput = screen.getByPlaceholderText("https://example.com");
 
-      userEvent.click(searchInput);
+      await userEvent.click(searchInput);
       // There's a race here: as soon the search input is clicked into the text
       // "Loading..." appears and is then replaced by "Question Uno". On CI,
       // `findByText` was sometimes running while "Loading..." was still
       // visible, so the extra expectation ensures good timing
       await waitForLoaderToBeRemoved();
 
-      userEvent.click(await screen.findByText("Question Uno"));
+      await userEvent.click(await screen.findByText("Question Uno"));
 
       expect(changeSpy).toHaveBeenCalledWith({
         link: {
@@ -284,10 +284,10 @@ describe("LinkViz", () => {
 
       const searchInput = screen.getByPlaceholderText("https://example.com");
 
-      userEvent.click(searchInput);
+      await userEvent.click(searchInput);
 
       await screen.findByText("Dashboard Uno");
-      userEvent.click(await screen.findByText("Table Uno"));
+      await userEvent.click(await screen.findByText("Table Uno"));
 
       expect(changeSpy).toHaveBeenCalledWith({
         link: {

--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.unit.spec.js
@@ -132,14 +132,14 @@ describe("PieChart", () => {
 
     expect(screen.getByTestId("detail-value")).toBeVisible();
     expect(screen.getByTestId("detail-value")).toHaveTextContent("2,000");
-    userEvent.click(screen.getByText("Display"));
-    userEvent.click(screen.getByLabelText("Show total"));
+    await userEvent.click(screen.getByText("Display"));
+    await userEvent.click(screen.getByLabelText("Show total"));
 
     await waitFor(() => {
       expect(screen.getByTestId("detail-value")).not.toBeVisible();
     });
 
-    userEvent.click(screen.getByLabelText("Show total"));
+    await userEvent.click(screen.getByLabelText("Show total"));
 
     await waitFor(() => {
       expect(screen.getByTestId("detail-value")).toBeVisible();
@@ -153,14 +153,14 @@ describe("PieChart", () => {
     expect(screen.getByTestId("chart-legend")).toBeVisible();
     expect(screen.getByTestId("chart-legend")).toHaveTextContent("2016");
     expect(screen.getByTestId("chart-legend")).toHaveTextContent("2017");
-    userEvent.click(screen.getByText("Display"));
-    userEvent.click(screen.getByLabelText("Show legend"));
+    await userEvent.click(screen.getByText("Display"));
+    await userEvent.click(screen.getByLabelText("Show legend"));
 
     await waitFor(() => {
       expect(screen.queryByTestId("chart-legend")).not.toBeInTheDocument();
     });
 
-    userEvent.click(screen.getByLabelText("Show legend"));
+    await userEvent.click(screen.getByLabelText("Show legend"));
 
     await waitFor(() => {
       expect(screen.getByTestId("chart-legend")).toBeVisible();
@@ -172,8 +172,8 @@ describe("PieChart", () => {
     expect(screen.getByTestId("chart-legend")).toBeVisible();
     expect(screen.getByTestId("chart-legend")).toHaveTextContent("25%");
     expect(screen.getByTestId("chart-legend")).toHaveTextContent("75%");
-    userEvent.click(screen.getByText("Display"));
-    userEvent.click(screen.getByLabelText("Off"));
+    await userEvent.click(screen.getByText("Display"));
+    await userEvent.click(screen.getByLabelText("Off"));
 
     await waitFor(() => {
       expect(screen.getByTestId("chart-legend")).not.toHaveTextContent("25%");
@@ -189,8 +189,8 @@ describe("PieChart", () => {
     expect(screen.getByTestId("pie-chart")).not.toHaveTextContent("25%");
     expect(screen.getByTestId("pie-chart")).not.toHaveTextContent("75%");
 
-    userEvent.click(screen.getByText("Display"));
-    userEvent.click(screen.getByLabelText("On the chart"));
+    await userEvent.click(screen.getByText("Display"));
+    await userEvent.click(screen.getByLabelText("On the chart"));
 
     await waitFor(() => {
       expect(screen.getByTestId("chart-legend")).not.toHaveTextContent("25%");

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.js
@@ -105,9 +105,14 @@ const setup = () => {
 describe("table settings", () => {
   it("should allow you to update a column name", async () => {
     setup();
-    userEvent.click(await screen.findByTestId("Category-settings-button"));
-    userEvent.type(await screen.findByDisplayValue("Category"), " Updated");
-    userEvent.click(await screen.findByText("Count"));
+    await userEvent.click(
+      await screen.findByTestId("Category-settings-button"),
+    );
+    await userEvent.type(
+      await screen.findByDisplayValue("Category"),
+      " Updated",
+    );
+    await userEvent.click(await screen.findByText("Count"));
     expect(await screen.findByText("Category Updated")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/PivotTable/PivotTable.unit.spec.tsx
@@ -196,7 +196,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
     });
   });
 
-  it("expanding collapsed columns", () => {
+  it("expanding collapsed columns", async () => {
     const hiddenSettings = {
       ...settings,
       "pivot_table.collapsed_rows": {
@@ -221,7 +221,7 @@ describe("Visualizations > PivotTable > PivotTable", () => {
       within(toggleButton).getByRole("img", { name: /add/i }),
     ).toBeInTheDocument();
 
-    userEvent.click(toggleButton);
+    await userEvent.click(toggleButton);
 
     //Ensure that collapsed data is now visible
     columnIndexes.forEach(columnIndex => {

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.unit.spec.js
@@ -41,7 +41,7 @@ describe("MetricForm", () => {
     expect(screen.getByText("12,345")).toBeInTheDocument(); // with compact formatting, we'd have 1
   });
 
-  it("should render description", () => {
+  it("should render description", async () => {
     const DESCRIPTION = "description";
 
     render(
@@ -53,12 +53,12 @@ describe("MetricForm", () => {
       />,
     );
 
-    userEvent.hover(getIcon("info_filled"));
+    await userEvent.hover(getIcon("info_filled"));
 
     expect(screen.getByRole("tooltip")).toHaveTextContent(DESCRIPTION);
   });
 
-  it("should render markdown in description", () => {
+  it("should render markdown in description", async () => {
     const DESCRIPTION = "[link](https://metabase.com)";
 
     render(
@@ -70,7 +70,7 @@ describe("MetricForm", () => {
       />,
     );
 
-    userEvent.hover(getIcon("info_filled"));
+    await userEvent.hover(getIcon("info_filled"));
 
     expect(
       within(screen.getByRole("tooltip")).getByRole("link"),

--- a/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/SmartScalar/SmartScalar.unit.spec.js
@@ -208,7 +208,7 @@ describe("SmartScalar", () => {
       expect(screen.getByText("810.8k")).toBeInTheDocument();
     });
 
-    it("should display tooltip with comparison info if card is not wide enough", () => {
+    it("should display tooltip with comparison info if card is not wide enough", async () => {
       const rows = [
         ["2019-10-01T00:00:00", 50],
         ["2019-11-01T00:00:00", 100],
@@ -231,7 +231,7 @@ describe("SmartScalar", () => {
       expect(screen.queryByText("50")).not.toBeInTheDocument();
 
       // show tool-tip
-      userEvent.hover(lastChange);
+      await userEvent.hover(lastChange);
       expect(screen.queryAllByLabelText("arrow_up icon")).toHaveLength(2);
       expect(screen.queryAllByText("100%")).toHaveLength(2);
       expect(screen.getByText("vs. previous month:")).toBeInTheDocument();

--- a/frontend/src/metabase/visualizations/visualizations/Table.unit.spec.js
+++ b/frontend/src/metabase/visualizations/visualizations/Table.unit.spec.js
@@ -71,9 +71,9 @@ const setup = ({ vizType }) => {
 // these visualizations share column settings, so all the tests should work for both
 ["table", "object"].forEach(vizType => {
   describe(`${vizType} column settings`, () => {
-    it("should show you related columns in structured queries", () => {
+    it("should show you related columns in structured queries", async () => {
       setup({ vizType });
-      userEvent.click(screen.getByText("Add or remove columns"));
+      await userEvent.click(screen.getByText("Add or remove columns"));
 
       expect(screen.getByText("User")).toBeInTheDocument();
       expect(screen.getByText("Product")).toBeInTheDocument();
@@ -86,22 +86,27 @@ const setup = ({ vizType }) => {
 
     it("should allow you to show and hide columns", async () => {
       setup({ vizType });
-      userEvent.click(await screen.findByTestId("Tax-hide-button"));
+      await userEvent.click(await screen.findByTestId("Tax-hide-button"));
 
       expect(
         await screen.findByRole("listitem", { name: "Tax" }),
       ).toHaveAttribute("data-enabled", "false");
 
-      userEvent.click(await screen.findByTestId("Tax-show-button"));
+      await userEvent.click(await screen.findByTestId("Tax-show-button"));
       //If we can see the hide button, then we know it's been added back in.
       expect(await screen.findByTestId("Tax-hide-button")).toBeInTheDocument();
     });
 
     it("should allow you to update a column name", async () => {
       setup({ vizType });
-      userEvent.click(await screen.findByTestId("Subtotal-settings-button"));
-      userEvent.type(await screen.findByDisplayValue("Subtotal"), " Updated");
-      userEvent.click(await screen.findByText("Tax"));
+      await userEvent.click(
+        await screen.findByTestId("Subtotal-settings-button"),
+      );
+      await userEvent.type(
+        await screen.findByDisplayValue("Subtotal"),
+        " Updated",
+      );
+      await userEvent.click(await screen.findByText("Tax"));
       expect(await screen.findByText("Subtotal Updated")).toBeInTheDocument();
     });
   });

--- a/frontend/src/metabase/visualizations/visualizations/Text/Text.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/Text/Text.unit.spec.tsx
@@ -116,27 +116,31 @@ describe("Text", () => {
     });
 
     describe("Edit/Focused", () => {
-      it("should display and focus textarea when clicked", () => {
+      it("should display and focus textarea when clicked", async () => {
         const options = {
           settings: getSettingsWithText(""),
           isEditing: true,
         };
         setup(options);
 
-        userEvent.click(screen.getByTestId("editing-dashboard-text-preview"));
+        await userEvent.click(
+          screen.getByTestId("editing-dashboard-text-preview"),
+        );
         expect(
           screen.getByTestId("editing-dashboard-text-input"),
         ).toHaveFocus();
       });
 
-      it("should have input placeholder when it has no content", () => {
+      it("should have input placeholder when it has no content", async () => {
         const options = {
           settings: getSettingsWithText(""),
           isEditing: true,
         };
         setup(options);
 
-        userEvent.click(screen.getByTestId("editing-dashboard-text-preview"));
+        await userEvent.click(
+          screen.getByTestId("editing-dashboard-text-preview"),
+        );
         expect(
           screen.getByPlaceholderText(
             "You can use Markdown here, and include variables {{like_this}}",
@@ -144,18 +148,20 @@ describe("Text", () => {
         ).toBeInTheDocument();
       });
 
-      it("should render input text when it has content", () => {
+      it("should render input text when it has content", async () => {
         const options = {
           settings: getSettingsWithText("text text text"),
           isEditing: true,
         };
         setup(options);
 
-        userEvent.click(screen.getByTestId("editing-dashboard-text-preview"));
+        await userEvent.click(
+          screen.getByTestId("editing-dashboard-text-preview"),
+        );
         expect(screen.getByDisplayValue("text text text")).toBeInTheDocument();
       });
 
-      it("should call onUpdateVisualizationSettings on blur", () => {
+      it("should call onUpdateVisualizationSettings on blur", async () => {
         const mockOnUpdateVisualizationSettings = jest.fn();
         const options = {
           settings: getSettingsWithText("text"),
@@ -164,9 +170,11 @@ describe("Text", () => {
         };
         setup(options);
 
-        userEvent.click(screen.getByTestId("editing-dashboard-text-preview"));
-        userEvent.type(screen.getByRole("textbox"), "foo");
-        userEvent.tab();
+        await userEvent.click(
+          screen.getByTestId("editing-dashboard-text-preview"),
+        );
+        await userEvent.type(screen.getByRole("textbox"), "foo");
+        await userEvent.tab();
 
         expect(mockOnUpdateVisualizationSettings).toHaveBeenCalledTimes(1);
         expect(mockOnUpdateVisualizationSettings).toHaveBeenCalledWith({

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^11.0.2",
     "@testing-library/react-hooks": "^8.0.0",
-    "@testing-library/user-event": "^13.1.3",
+    "@testing-library/user-event": "^14.5.2",
     "@types/babel__core": "^7.20.4",
     "@types/babel__preset-env": "^7.9.5",
     "@types/color": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4280,12 +4280,10 @@
     "@babel/runtime" "^7.11.2"
     "@testing-library/dom" "^7.26.0"
 
-"@testing-library/user-event@^13.1.3":
-  version "13.5.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-13.5.0.tgz#69d77007f1e124d55314a2b73fd204b333b13295"
-  integrity sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
+"@testing-library/user-event@^14.5.2":
+  version "14.5.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.2.tgz#db7257d727c891905947bd1c1a99da20e03c2ebd"
+  integrity sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==
 
 "@tippyjs/react@^4.2.6":
   version "4.2.6"


### PR DESCRIPTION
Related to #40267

### Description

Upgrades the @testing-library/user-event to v14. This PR updates our tests to accomidate these changes:
- APIs always return a Promise.
- userEvent.paste API has new parameters
- skipPointerEvents has been removed, using pointerEventsCheck: PointerEventsCheckLevel.Never instead
- specialChars export has been removed
- `userEvent.type events` no longer include `keyCode` (came up with TokenField component)
- userEvent.type into `<input type="time" />` elements behaves somewhat oddly, but is mitigated by using the `initialSelectionStart` and `initialSelectionEnd` options
- Checking for `userEvent.click()` on non clickable items has changed somewhat (asserting that promise rejected first)
- using `{selectall}` in type didn't appear to work, but was replaced with `userEvent.clear()`
- when using jest fake timers, we need to pass `{advanceTimers: jest.advanceTimersByTime}` to `userEvent.setup()`

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
