### PR TITLE
fix showing comparison tooltip on single series

### DIFF
--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -328,9 +328,10 @@ export const STACKABLE_SETTINGS = {
 export const TOOLTIP_SETTINGS = {
   "graph.tooltip_type": {
     getDefault: (_series, settings) => {
-      return settings["stackable.stack_display"] != null
-        ? "series_comparison"
-        : "default";
+      const shouldShowComparisonTooltip =
+        settings["stackable.stack_display"] != null &&
+        settings["stackable.stack_type"] != null;
+      return shouldShowComparisonTooltip ? "series_comparison" : "default";
     },
     hidden: true,
     readDependencies: ["stackable.stack_display"],


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39550

### Description

Fixes showing the comparison tooltip on a single series bar/area charts.

### How to verify

Create a bar chart with a single series
Ensure the tooltip shows key-values

### Demo

Before
<img width="533" alt="Screenshot 2024-03-18 at 8 37 36 PM" src="https://github.com/metabase/metabase/assets/14301985/fd7d79a8-ddb7-47a8-9901-ec3d2212a1e4">

After
<img width="457" alt="Screenshot 2024-03-18 at 8 36 51 PM" src="https://github.com/metabase/metabase/assets/14301985/fcdc8380-23e5-451b-b723-ab0bcd3d99f8">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
