### PR TITLE
Revert liquibase version to fix tests

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -153,7 +153,7 @@
   org.eclipse.jetty.websocket/websocket-jetty-server {:mvn/version "11.0.20"}   ; ring-jetty-adapter needs that
   org.flatland/ordered                      {:mvn/version "1.15.11"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.5"}             ; JavaScript engine
-  org.liquibase/liquibase-core              {:mvn/version "4.25.1"              ; migration management (Java lib)
+  org.liquibase/liquibase-core              {:mvn/version "4.21.1"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
   ;; The 3.X line of development for mariadb-java-client only supports the jdbc:mariadb protocol, so use 2.X for now.
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.10"}             ; MySQL/MariaDB driver


### PR DESCRIPTION
[Slack discussion](https://metaboat.slack.com/archives/CKZEMT1MJ/p1710831335780959?thread_ts=1710830406.521509&cid=CKZEMT1MJ)

This is likely caused by https://github.com/metabase/metabase/pull/40229