### PR TITLE
Compose dataset mbql follow-ups

### DIFF
--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -436,7 +436,7 @@ class Question {
    * of Question interface instead of Query interface makes it more convenient to also change the current visualization
    */
 
-  composeQuestionAdhoc(): Question {
+  composeQuestion(): Question {
     if (!this.isSaved()) {
       return this;
     }
@@ -445,6 +445,15 @@ class Question {
     const tableId = getQuestionVirtualTableId(this.id());
     const table = Lib.tableOrCardMetadata(metadata, tableId);
     const query = Lib.queryFromTableOrCardMetadata(metadata, table);
+    return this.setQuery(query);
+  }
+
+  composeQuestionAdhoc(): Question {
+    if (!this.isSaved()) {
+      return this;
+    }
+
+    const query = this.composeQuestion().query();
     return Question.create({ metadata: this.metadata() }).setQuery(query);
   }
 

--- a/frontend/src/metabase-lib/v1/Question.ts
+++ b/frontend/src/metabase-lib/v1/Question.ts
@@ -436,7 +436,7 @@ class Question {
    * of Question interface instead of Query interface makes it more convenient to also change the current visualization
    */
 
-  composeQuestion(): Question {
+  composeQuestionAdhoc(): Question {
     if (!this.isSaved()) {
       return this;
     }
@@ -445,15 +445,6 @@ class Question {
     const tableId = getQuestionVirtualTableId(this.id());
     const table = Lib.tableOrCardMetadata(metadata, tableId);
     const query = Lib.queryFromTableOrCardMetadata(metadata, table);
-    return this.setQuery(query);
-  }
-
-  composeQuestionAdhoc(): Question {
-    if (!this.isSaved()) {
-      return this;
-    }
-
-    const query = this.composeQuestion().query();
     return Question.create({ metadata: this.metadata() }).setQuery(query);
   }
 

--- a/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
+++ b/frontend/src/metabase/models/components/ModelDetailPage/ModelUsageDetails/ModelUsageDetails.tsx
@@ -38,7 +38,7 @@ function ModelUsageDetails({ model, questions, hasNewQuestionLink }: Props) {
           <EmptyStateActionContainer>
             <Button
               as={Link}
-              to={ML_Urls.getUrl(model.composeQuestion())}
+              to={ML_Urls.getUrl(model)}
               icon="add"
             >{t`Create a new question`}</Button>
           </EmptyStateActionContainer>

--- a/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.tsx
+++ b/frontend/src/metabase/parameters/components/ValuesSourceModal/ValuesSourceTypeModal.tsx
@@ -429,7 +429,8 @@ const getFieldByReference = (fields: Field[], fieldReference?: unknown[]) => {
 };
 
 const getSupportedFields = (question: Question) => {
-  const fields = question.composeQuestion().legacyQueryTable()?.fields ?? [];
+  const fields =
+    question.composeQuestionAdhoc().legacyQueryTable()?.fields ?? [];
   return fields.filter(field => field.isString());
 };
 

--- a/frontend/src/metabase/parameters/utils/mapping-options.ts
+++ b/frontend/src/metabase/parameters/utils/mapping-options.ts
@@ -158,7 +158,7 @@ export function getParameterMappingOptions(
     // treat the dataset/model question like it is already composed so that we can apply
     // dataset/model-specific metadata to the underlying dimension options
     const query = isModel
-      ? question.composeQuestion().query()
+      ? question.composeQuestionAdhoc().query()
       : question.query();
     const stageIndex = -1;
     const availableColumns = Lib.filterableColumns(query, stageIndex);

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -334,15 +334,13 @@ export const getQuestion = createSelector(
     }
 
     const type = question.type();
+    const { isEditable } = Lib.queryDisplayInfo(question.query());
 
-    // When opening a model, we swap it's `dataset_query`
-    // with clean query using the model as a source table,
-    // to enable "simple mode" like features
-    // This has to be skipped for users without data permissions
-    // as it would be blocked by the backend as an ad-hoc query
-    // see https://github.com/metabase/metabase/issues/20042
-    const hasDataPermission = !!question.database();
-    return type !== "question" && hasDataPermission
+    // When opening a model or a metric, we construct a question
+    // with a clean, ad-hoc, query.
+    // This has to be skipped for users without data permissions.
+    // See https://github.com/metabase/metabase/issues/20042
+    return type !== "question" && isEditable
       ? question.composeQuestionAdhoc()
       : question;
   },

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -342,7 +342,7 @@ export const getQuestion = createSelector(
     // as it would be blocked by the backend as an ad-hoc query
     // see https://github.com/metabase/metabase/issues/20042
     const hasDataPermission = !!question.database();
-    return type !== "question" && hasDataPermission && !isEditingModel
+    return type !== "question" && hasDataPermission
       ? question.composeQuestionAdhoc()
       : question;
   },

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -343,7 +343,7 @@ export const getQuestion = createSelector(
     // see https://github.com/metabase/metabase/issues/20042
     const hasDataPermission = !!question.database();
     return type !== "question" && hasDataPermission && !isEditingModel
-      ? question.composeQuestion()
+      ? question.composeQuestionAdhoc()
       : question;
   },
 );

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -341,7 +341,7 @@ export const getQuestion = createSelector(
     // This has to be skipped for users without data permissions.
     // See https://github.com/metabase/metabase/issues/20042
     return type !== "question" && isEditable
-      ? question.composeQuestionAdhoc()
+      ? question.composeQuestion()
       : question;
   },
 );

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -371,7 +371,7 @@ function areModelsEquivalent({
     return false;
   }
 
-  const composedOriginal = originalQuestion.composeQuestion();
+  const composedOriginal = originalQuestion.composeQuestionAdhoc();
 
   const isLastRunComposed = areLegacyQueriesEqual(
     lastRunQuestion.datasetQuery(),

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -200,7 +200,7 @@ class Visualization extends PureComponent {
     const question = new Question(card, metadata);
 
     // Datasets in QB should behave as raw tables opened in simple mode
-    // composeQuestion replaces the dataset_query with a clean query using the dataset as a source table
+    // composeQuestion replaces the dataset_query with a clean query using the saved question as a source table
     // Ideally, this logic should happen somewhere else
     return question.type() === "model" &&
       isQueryBuilder &&

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -193,20 +193,9 @@ class Visualization extends PureComponent {
   };
 
   _getQuestionForCardCached(metadata, card) {
-    if (!metadata || !card) {
-      return;
-    }
-    const { isQueryBuilder, queryBuilderMode } = this.props;
-    const question = new Question(card, metadata);
-
-    // Datasets in QB should behave as raw tables opened in simple mode
-    // composeQuestion replaces the dataset_query with a clean query using the saved question as a source table
-    // Ideally, this logic should happen somewhere else
-    return question.type() === "model" &&
-      isQueryBuilder &&
-      queryBuilderMode !== "dataset"
-      ? question.composeQuestion()
-      : question;
+    return card != null && metadata != null
+      ? new Question(card, metadata)
+      : undefined;
   }
 
   getMode(maybeModeOrQueryMode, question) {


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/40181

Remove `composeQuestion` and use `composeQuestionAdhoc` where possible. `getQuestion` cannot be easily migrated as the entire QB seems to depend on the current behavior. 