### PR TITLE
Backport security fixes for 47

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -68,7 +68,7 @@
   honeysql/honeysql                         {:mvn/version "1.0.461"             ; Transform Clojure data structures to SQL
                                              :exclusions  [org.clojure/clojurescript]}
   inflections/inflections                   {:mvn/version "0.14.1"}             ; Clojure/Script library used for prularizing words
-  info.sunng/ring-jetty9-adapter            {:mvn/version "0.18.5"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver.
+  info.sunng/ring-jetty9-adapter            {:mvn/version "0.22.4"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver (Jetty 12 requires JDK 17+).
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
   clj-commons/clj-yaml                      {:mvn/version "1.0.26"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.520"}
@@ -96,7 +96,7 @@
   net.sf.cssbox/cssbox                      {:mvn/version "5.0.0"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api]}
   net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20220705"} ; Java implementation of the JQ json query language
-  org.apache.commons/commons-compress       {:mvn/version "1.25.0"}             ; compression utils
+  org.apache.commons/commons-compress       {:mvn/version "1.26.0"}             ; compression utils
   org.apache.commons/commons-lang3          {:mvn/version "3.14.0"}             ; helper methods for working with java.lang stuff
   org.apache.logging.log4j/log4j-1.2-api    {:mvn/version "2.20.0"}             ; apache logging framework
   org.apache.logging.log4j/log4j-api        {:mvn/version "2.20.0"}             ; add compatibility with log4j 1.2
@@ -143,7 +143,7 @@
   ;; The 3.X line of development for mariadb-java-client only supports the jdbc:mariadb protocol, so use 2.X for now.
   org.mariadb.jdbc/mariadb-java-client      {:mvn/version "2.7.6"}              ; MySQL/MariaDB driver
   org.mindrot/jbcrypt                       {:mvn/version "0.4"}                ; Crypto library
-  org.postgresql/postgresql                 {:mvn/version "42.5.4"}             ; Postgres driver
+  org.postgresql/postgresql                 {:mvn/version "42.7.2"}             ; Postgres driver
   org.quartz-scheduler/quartz               {:mvn/version "2.3.2"}              ; Quartz job scheduler, provided by quartzite but this is a newer version.
   org.slf4j/slf4j-api                       {:mvn/version "2.0.6"}              ; abstraction for logging frameworks -- allows end user to plug in desired logging framework at deployment time
   org.tcrawley/dynapath                     {:mvn/version "1.1.0"}              ; Dynamically add Jars (e.g. Oracle or Vertica) to classpath

--- a/deps.edn
+++ b/deps.edn
@@ -137,7 +137,7 @@
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
   org.eclipse.jetty/jetty-server            {:mvn/version "11.0.14"}            ; web server
   org.flatland/ordered                      {:mvn/version "1.15.10"}            ; ordered maps & sets
-  org.graalvm.js/js                         {:mvn/version "22.3.1"}             ; JavaScript engine
+  org.graalvm.js/js                         {:mvn/version "22.3.5"}             ; JavaScript engine
   org.liquibase/liquibase-core              {:mvn/version "4.11.0"              ; migration management (Java lib)
                                              :exclusions  [ch.qos.logback/logback-classic]}
   ;; The 3.X line of development for mariadb-java-client only supports the jdbc:mariadb protocol, so use 2.X for now.

--- a/deps.edn
+++ b/deps.edn
@@ -8,11 +8,14 @@
                                              :exclusions  [org.clojure/clojure
                                                            org.clojure/clojurescript]}
   amalloy/ring-gzip-middleware              {:mvn/version "0.1.4"}              ; Ring middleware to GZIP responses if client can handle it
-  bigml/histogram                           {:mvn/version "4.1.4"}              ; Histogram data structure
+  bigml/histogram                           {:mvn/version "4.1.4"               ; Histogram data structure
+                                             :exclusions  [junit/junit]}
   buddy/buddy-core                          {:mvn/version "1.10.413"            ; various cryptographic functions
                                              :exclusions  [commons-codec/commons-codec
                                                            org.bouncycastle/bcpkix-jdk15on
-                                                           org.bouncycastle/bcprov-jdk15on]}
+                                                           org.bouncycastle/bcprov-jdk15on
+                                                           org.bouncycastle/bcpkix-jdk18on
+                                                           org.bouncycastle/bcprov-jdk18on]}
   buddy/buddy-sign                          {:mvn/version "3.4.333"}            ; JSON Web Tokens; High-Level message signing library
   camel-snake-kebab/camel-snake-kebab       {:mvn/version "0.4.3"}              ; util functions for converting between camel, snake, and kebob case
   cheshire/cheshire                         {:mvn/version "5.11.0"}             ; fast JSON encoding (used by Ring JSON middleware)
@@ -36,7 +39,7 @@
   com.github.seancorfield/next.jdbc         {:git/url "https://github.com/seancorfield/next-jdbc.git"
                                              :sha     "8f372917a4b8b55c893ef6586f9ffe8dce4cbc7e"} ; for https://github.com/seancorfield/next-jdbc/issues/245; when this makes it to a release we can switch to that.
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.3"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
-  com.google.guava/guava                    {:mvn/version "32.0.1-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
+  com.google.guava/guava                    {:mvn/version "32.1.3-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
   com.fasterxml.jackson.core/jackson-databind
                                             {:mvn/version "2.14.2"}             ; JSON processor used by snowplow-java-tracker
   com.fasterxml.woodstox/woodstox-core      {:mvn/version "6.5.0"}              ; trans dep of commons-codec (pinned version due to CVE-2022-40151)
@@ -80,20 +83,27 @@
   joda-time/joda-time                       {:mvn/version "2.12.2"}
   kixi/stats                                {:mvn/version "0.5.5"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
+  lambdaisland/uri                          {:mvn/version "1.16.134"}           ; Used by opanai-clojure. security bump
   medley/medley                             {:mvn/version "1.4.0"}              ; lightweight lib of useful functions
   metabase/connection-pool                  {:mvn/version "1.2.0"}              ; simple wrapper around C3P0. JDBC connection pools
-  metabase/saml20-clj                       {:mvn/version "2.2.2"}              ; EE SAML integration.
+  metabase/saml20-clj                       {:mvn/version "2.2.4"              ; EE SAML integration.
+                                             :exclusions [org.bouncycastle/bcpkix-jdk15on
+                                                          org.bouncycastle/bcprov-jdk15on
+                                                          org.bouncycastle/bcpkix-jdk18on
+                                                          org.bouncycastle/bcprov-jdk18on]}
   metabase/throttle                         {:mvn/version "1.0.2"}              ; Tools for throttling access to API endpoints and other code pathways
   metosin/malli                             {:mvn/version "0.10.2"}             ; Data-driven Schemas for Clojure/Script and babashka
   nano-id/nano-id                           {:mvn/version "1.0.0"}              ; NanoID generator for generating entity_ids
   net.cgrand/macrovich                      {:mvn/version "0.2.1"}              ; utils for writing macros for both Clojure & ClojureScript
-  net.clojars.wkok/openai-clojure           {:mvn/version "0.5.0"}              ; OpenAI
+  net.clojars.wkok/openai-clojure           {:mvn/version "0.14.0"
+                                             :exclusions  [lambdaisland/uri]}   ; OpenAI
   net.i2p.crypto/eddsa                      {:mvn/version "0.3.0"}              ; ED25519 key support (optional dependency for org.apache.sshd/sshd-core)
   net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"                 ; describe Cron schedule in human-readable language
                                              :exclusions  [joda-time/joda-time  ; exclude joda time 2.3 which has outdated timezone information
                                                            org.slf4j/slf4j-api]}
   net.sf.cssbox/cssbox                      {:mvn/version "5.0.0"               ; HTML / CSS rendering
-                                             :exclusions  [org.slf4j/slf4j-api]}
+                                             :exclusions  [org.slf4j/slf4j-api
+                                                           junit/junit]}
   net.thisptr/jackson-jq                    {:mvn/version "1.0.0-preview.20220705"} ; Java implementation of the JQ json query language
   org.apache.commons/commons-compress       {:mvn/version "1.26.0"}             ; compression utils
   org.apache.commons/commons-lang3          {:mvn/version "3.14.0"}             ; helper methods for working with java.lang stuff
@@ -113,8 +123,8 @@
   org.apache.sshd/sshd-core                 {:mvn/version "2.10.0"}             ; ssh tunneling and test server
   org.apache.xmlgraphics/batik-all          {:mvn/version "1.16"}               ; SVG -> image
   org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client
-  org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.70"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
-  org.bouncycastle/bcprov-jdk15on           {:mvn/version "1.70"}
+  org.bouncycastle/bcpkix-jdk18on           {:mvn/version "1.77"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
+  org.bouncycastle/bcprov-jdk18on           {:mvn/version "1.77"}
   org.clojure/clojure                       {:mvn/version "1.11.2"}
   org.clojure/core.async                    {:mvn/version "1.6.673"
                                              :exclusions  [org.clojure/tools.reader]}

--- a/deps.edn
+++ b/deps.edn
@@ -68,7 +68,6 @@
   honeysql/honeysql                         {:mvn/version "1.0.461"             ; Transform Clojure data structures to SQL
                                              :exclusions  [org.clojure/clojurescript]}
   inflections/inflections                   {:mvn/version "0.14.1"}             ; Clojure/Script library used for prularizing words
-  info.sunng/ring-jetty9-adapter            {:mvn/version "0.22.4"}             ; Drop-in replacement for official Ring Jetty adapter. Supports Jetty 11 webserver (Jetty 12 requires JDK 17+).
   instaparse/instaparse                     {:mvn/version "1.4.12"}             ; Make your own parser
   clj-commons/clj-yaml                      {:mvn/version "1.0.26"}             ; Clojure wrapper for YAML library SnakeYAML
   io.github.camsaul/toucan2                 {:mvn/version "1.0.520"}
@@ -135,7 +134,8 @@
   org.clojure/tools.namespace               {:mvn/version "1.4.4"}
   org.clojure/tools.reader                  {:mvn/version "1.3.6"}
   org.clojure/tools.trace                   {:mvn/version "0.7.11"}             ; function tracing
-  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.14"}            ; web server
+  org.eclipse.jetty/jetty-server            {:mvn/version "11.0.20"}            ; web server
+  org.eclipse.jetty.websocket/websocket-jetty-server {:mvn/version "11.0.20"}   ; ring-jetty-adapter needs that
   org.flatland/ordered                      {:mvn/version "1.15.10"}            ; ordered maps & sets
   org.graalvm.js/js                         {:mvn/version "22.3.5"}             ; JavaScript engine
   org.liquibase/liquibase-core              {:mvn/version "4.11.0"              ; migration management (Java lib)
@@ -154,7 +154,10 @@
   prismatic/schema                          {:mvn/version "1.4.1"}              ; Data schema declaration and validation library
   redux/redux                               {:mvn/version "0.1.4"}              ; Utility functions for building and composing transducers
   riddley/riddley                           {:mvn/version "0.2.0"}              ; code walking lib -- used interally by Potemkin, manifold, etc.
-  ring/ring-core                            {:mvn/version "1.9.6"}              ; web server (Jetty wrapper)
+  ring/ring-core                            {:mvn/version "1.11.0"}             ; HTTP abstraction
+  ring/ring-jetty-adapter                   {:mvn/version "1.11.0"              ; Jetty adapter
+                                             :exclusions [org.eclipse.jetty/jetty-server
+                                                          org.eclipse.jetty.websocket/websocket-jetty-server]}
   ring/ring-json                            {:mvn/version "0.5.1"}              ; Ring middleware for reading/writing JSON automatically
   slingshot/slingshot                       {:mvn/version "0.12.2"}             ; enhanced throw/catch, used by other deps
   stencil/stencil                           {:mvn/version "0.5.0"}              ; Mustache templates for Clojure

--- a/deps.edn
+++ b/deps.edn
@@ -115,7 +115,7 @@
   org.clojars.pntblnk/clj-ldap              {:mvn/version "0.0.17"}             ; LDAP client
   org.bouncycastle/bcpkix-jdk15on           {:mvn/version "1.70"}               ; Bouncy Castle crypto library -- explicit version of BC specified to resolve illegal reflective access errors
   org.bouncycastle/bcprov-jdk15on           {:mvn/version "1.70"}
-  org.clojure/clojure                       {:mvn/version "1.11.1"}
+  org.clojure/clojure                       {:mvn/version "1.11.2"}
   org.clojure/core.async                    {:mvn/version "1.6.673"
                                              :exclusions  [org.clojure/tools.reader]}
   org.clojure/core.logic                    {:mvn/version "1.0.1"}              ; optimized pattern matching library for Clojure

--- a/modules/drivers/googleanalytics/deps.edn
+++ b/modules/drivers/googleanalytics/deps.edn
@@ -7,4 +7,6 @@
   com.google.oauth-client/google-oauth-client        {:mvn/version "1.34.1"}
   ;; for some reason, Google stopped depending on google-http-client-jackson2 from google-api-client somewhere between
   ;; 1.30.7 and 1.32.1, so we must explicitly bring it in because the google driver uses it directly
-  com.google.http-client/google-http-client-jackson2 {:mvn/version "1.43.1"}}}
+  com.google.http-client/google-http-client-jackson2 {:mvn/version "1.43.1"}
+  ;; Pin codec to work around vulnerabilities in version brought in by google-http-client-jackson2
+  commons-codec/commons-codec                        {:mvn/version "1.16.0"}}}

--- a/modules/drivers/mongo/deps.edn
+++ b/modules/drivers/mongo/deps.edn
@@ -2,4 +2,6 @@
  ["src" "resources"]
 
  :deps
- {com.novemberain/monger {:mvn/version "3.6.0"}}}
+ {com.google.guava/guava {:mvn/version "32.1.3-jre"}
+  com.novemberain/monger {:mvn/version "3.6.0"
+                          :exclusions [com.google.guava/guava]}}}

--- a/modules/drivers/sparksql/deps.edn
+++ b/modules/drivers/sparksql/deps.edn
@@ -4,7 +4,8 @@
  ;; Exclusions below are all either things that are already part of metabase-core, or provide conflicting
  ;; implementations of things like log4j <-> slf4j, or are part of both hadoop-common and hive-jdbc;
  :deps
- {org.apache.hive/hive-jdbc
+ {org.apache.thrift/libthrift {:mvn/version "0.19.0"}
+  org.apache.hive/hive-jdbc
   {:mvn/version "3.1.3"
    :exclusions  [aopalliance/aopalliance
                  ch.qos.logback/logback-classic

--- a/src/metabase/analytics/prometheus.clj
+++ b/src/metabase/analytics/prometheus.clj
@@ -17,7 +17,7 @@
    [metabase.util.log :as log]
    [potemkin :as p]
    [potemkin.types :as p.types]
-   [ring.adapter.jetty9 :as ring-jetty])
+   [ring.adapter.jetty :as ring-jetty])
   (:import
    (io.prometheus.client Collector GaugeMetricFamily)
    (io.prometheus.client.hotspot GarbageCollectorExports MemoryPoolsExports StandardExports ThreadExports)

--- a/src/metabase/async/streaming_response.clj
+++ b/src/metabase/async/streaming_response.clj
@@ -11,7 +11,7 @@
    [metabase.util.log :as log]
    [potemkin.types :as p.types]
    [pretty.core :as pretty]
-   [ring.adapter.jetty9.common :as common]
+   [ring.util.jakarta.servlet :as servlet]
    [ring.util.response :as response])
   (:import
    (java.io BufferedWriter OutputStream OutputStreamWriter)
@@ -189,7 +189,7 @@
       (let [gzip?   (should-gzip-response? request-map)
             headers (cond-> (assoc (merge headers (:headers response-map)) "Content-Type" content-type)
                       gzip? (assoc "Content-Encoding" "gzip"))]
-        (#'common/set-headers response headers)
+        (#'servlet/set-headers response headers)
         (let [output-stream-delay (output-stream-delay gzip? response)
               delay-os            (delay-output-stream output-stream-delay)]
           (start-async-cancel-loop! request finished-chan canceled-chan)

--- a/src/metabase/server.clj
+++ b/src/metabase/server.clj
@@ -9,8 +9,8 @@
    [metabase.util :as u]
    [metabase.util.i18n :refer [trs]]
    [metabase.util.log :as log]
-   [ring.adapter.jetty9 :as ring-jetty]
-   [ring.adapter.jetty9.servlet :as servlet])
+   [ring.adapter.jetty :as ring-jetty]
+   [ring.util.jakarta.servlet :as servlet])
   (:import
    (jakarta.servlet AsyncContext)
    (jakarta.servlet.http HttpServletRequest HttpServletResponse)

--- a/src/metabase/server/protocols.clj
+++ b/src/metabase/server/protocols.clj
@@ -1,7 +1,7 @@
 (ns metabase.server.protocols
   (:require
    [potemkin.types :as p.types]
-   [ring.adapter.jetty9.servlet :as servlet]))
+   [ring.util.jakarta.servlet :as servlet]))
 
 (p.types/defprotocol+ Respond
   "Protocol for converting API endpoint responses to something Jetty can handle."

--- a/test/metabase/api/common/internal_test.clj
+++ b/test/metabase/api/common/internal_test.clj
@@ -15,7 +15,7 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.malli.schema :as ms]
-   [ring.adapter.jetty9 :as jetty]))
+   [ring.adapter.jetty :as jetty]))
 
 (set! *warn-on-reflection* true)
 

--- a/test/metabase/api/geojson_test.clj
+++ b/test/metabase/api/geojson_test.clj
@@ -8,7 +8,7 @@
    [metabase.test :as mt]
    [metabase.util :as u]
    [metabase.util.schema :as su]
-   [ring.adapter.jetty9 :as ring-jetty]
+   [ring.adapter.jetty :as ring-jetty]
    [schema.core :as s]))
 
 (set! *warn-on-reflection* true)


### PR DESCRIPTION
Manually backport all security fixes we added to 48 and another new one.

2 PRs we added to 48
- https://github.com/metabase/metabase/pull/40229
- https://github.com/metabase/metabase/pull/40242

1 new backport for the security fixes that haven't been merged to 47
- https://github.com/metabase/metabase/pull/36504