### PR TITLE
Use series names in click/hover object `data`

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -139,6 +139,7 @@ export const getEventColumnsData = (
   const isBreakoutSeries =
     seriesModel != null && "breakoutColumn" in seriesModel;
 
+  const seriesModelsByDataKey = _.indexBy(chartModel.seriesModels, "dataKey");
   return getSameCardDataKeys(datum, seriesModel)
     .map(dataKey => {
       const value = datum[dataKey];
@@ -153,9 +154,10 @@ export const getEventColumnsData = (
       }
 
       const col = chartModel.columnByDataKey[dataKey];
+      const columnSeriesModel = seriesModelsByDataKey[dataKey];
 
       return {
-        key: col.display_name, // TODO: use the title from the viz settings
+        key: columnSeriesModel?.name ?? col.display_name,
         value: value ?? NULL_DISPLAY_VALUE,
         col,
       };


### PR DESCRIPTION
Closes #39578 

Updates `getEventColumnsData` (used to build `clicked` and `hovered` objects) to prefer the series name over the column display name when provided.

### Demo

**Before**

![before](https://github.com/metabase/metabase/assets/17258145/61a69009-98ac-4862-bf65-307324a721fd)

**After**

![after](https://github.com/metabase/metabase/assets/17258145/0c4382f9-9026-4ef4-806e-3ca8cca6c7c8)
