### PR TITLE
Preserve negative sign on parenthesized zero floats when parsing

### DIFF
--- a/src/metabase/upload/parsing.clj
+++ b/src/metabase/upload/parsing.clj
@@ -153,6 +153,7 @@
                            :parsed-string  (.substring deparenthesized-s 0 parsed-idx)
                            :ignored-string (.substring deparenthesized-s parsed-idx)}))))
       (if has-parens?
+        ;; By casting to double we ensure that the sign is preserved for 0.0
         (- (double parsed-number))
         parsed-number))))
 

--- a/src/metabase/upload/parsing.clj
+++ b/src/metabase/upload/parsing.clj
@@ -153,7 +153,7 @@
                            :parsed-string  (.substring deparenthesized-s 0 parsed-idx)
                            :ignored-string (.substring deparenthesized-s parsed-idx)}))))
       (if has-parens?
-        (- parsed-number)
+        (- (double parsed-number))
         parsed-number))))
 
 (defn- parse-number

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -123,11 +123,11 @@
            ["-0,0"       -0.0           float-or-int-type ",."]
            ["-0,0"       -0.0           float-or-int-type ", "]
            ["-0.0"       -0.0           float-or-int-type ".’"]
-           ["(0.0)"      0              float-or-int-type "."]  ;; These values should also be parsed as -0.0
-           ["(0.0)"      0              float-or-int-type ".,"] ;; TODO: Fix this subtle bug in our parser 🥴
-           ["(0,0)"      0              float-or-int-type ",."]
-           ["(0,0)"      0              float-or-int-type ", "]
-           ["(0.0)"      0              float-or-int-type ".’"]
+           ["(0.0)"      -0.0           float-or-int-type "."]
+           ["(0.0)"      -0.0           float-or-int-type ".,"]
+           ["(0,0)"      -0.0           float-or-int-type ",."]
+           ["(0,0)"      -0.0           float-or-int-type ", "]
+           ["(0.0)"      -0.0           float-or-int-type ".’"]
            ["-4300.00€"  -4300          float-or-int-type ".,"]
            ["£1,000.00"  1000           float-or-int-type]
            ["£1,000.00"  1000           float-or-int-type "."]


### PR DESCRIPTION
### Description

This fixes a very subtle bug where we preserve the negative sign in the database for `-0.0` but not for `(0.0)`.
 
See https://github.com/metabase/metabase/pull/40275/files#r1530728193