### PR TITLE
Moving new item modals to be global

### DIFF
--- a/frontend/src/metabase-types/store/mocks/state.ts
+++ b/frontend/src/metabase-types/store/mocks/state.ts
@@ -35,5 +35,6 @@ export const createMockState = (
   settings: createMockSettingsState(),
   setup: createMockSetupState(),
   upload: createMockUploadState(),
+  modal: null,
   ...opts,
 });

--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -16,6 +16,7 @@ import type { SettingsState } from "./settings";
 import type { SetupState } from "./setup";
 import type { FileUploadState } from "./upload";
 
+type modalName = null | "collection" | "dashboard" | "action";
 export interface State {
   admin: AdminState;
   app: AppState;
@@ -32,6 +33,7 @@ export interface State {
   settings: SettingsState;
   setup: SetupState;
   upload: FileUploadState;
+  modal: modalName;
 }
 
 export type Dispatch<T = any> = (action: T) => void;

--- a/frontend/src/metabase/App.tsx
+++ b/frontend/src/metabase/App.tsx
@@ -30,6 +30,7 @@ import type { AppErrorDescriptor, State } from "metabase-types/store";
 
 import { AppContainer, AppContent, AppContentContainer } from "./App.styled";
 import ErrorBoundary from "./ErrorBoundary";
+import { NewModals } from "./new/components/NewModals/NewModals";
 
 const getErrorComponent = ({ status, data, context }: AppErrorDescriptor) => {
   if (status === 403 || data?.error_code === "unauthorized") {
@@ -111,6 +112,7 @@ function App({
             </AppContent>
             <UndoListing />
             <StatusListing />
+            <NewModals />
           </AppContentContainer>
         </AppContainer>
       </ScrollToTop>

--- a/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
+++ b/frontend/src/metabase/collections/containers/CreateCollectionModal.tsx
@@ -52,6 +52,7 @@ function CreateCollectionModal({
       size="lg"
       data-testid="new-collection-modal"
     >
+      <Modal.Overlay />
       <Modal.Content p="md">
         <Modal.Header>
           <Modal.Title>{t`New collection`}</Modal.Title>

--- a/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
+++ b/frontend/src/metabase/components/NewItemMenu/NewItemMenu.tsx
@@ -1,19 +1,14 @@
 import type { LocationDescriptor } from "history";
 import type { ReactNode } from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { t } from "ttag";
 
-import ActionCreator from "metabase/actions/containers/ActionCreator";
-import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
 import EntityMenu from "metabase/components/EntityMenu";
-import Modal from "metabase/components/Modal";
-import { CreateDashboardModalConnected } from "metabase/dashboard/containers/CreateDashboardModal";
-import { useSelector } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import * as Urls from "metabase/lib/urls";
+import { setOpenModal } from "metabase/redux/ui";
 import { getSetting } from "metabase/selectors/settings";
-import type { CollectionId, WritebackAction } from "metabase-types/api";
-
-type ModalType = "new-action" | "new-dashboard" | "new-collection";
+import type { CollectionId } from "metabase-types/api";
 
 export interface NewItemMenuProps {
   className?: string;
@@ -51,24 +46,11 @@ const NewItemMenu = ({
   hasDatabaseWithJsonEngine,
   hasDatabaseWithActionsEnabled,
   onCloseNavbar,
-  onChangeLocation,
 }: NewItemMenuProps) => {
-  const [modal, setModal] = useState<ModalType>();
+  const dispatch = useDispatch();
 
   const lastUsedDatabaseId = useSelector(state =>
     getSetting(state, "last-used-native-database-id"),
-  );
-
-  const handleModalClose = useCallback(() => {
-    setModal(undefined);
-  }, []);
-
-  const handleActionCreated = useCallback(
-    (action: WritebackAction) => {
-      const nextLocation = Urls.modelDetail({ id: action.model_id }, "actions");
-      onChangeLocation(nextLocation);
-    },
-    [onChangeLocation],
   );
 
   const menuItems = useMemo(() => {
@@ -107,12 +89,12 @@ const NewItemMenu = ({
       {
         title: t`Dashboard`,
         icon: "dashboard",
-        action: () => setModal("new-dashboard"),
+        action: () => dispatch(setOpenModal("dashboard")),
       },
       {
         title: t`Collection`,
         icon: "folder",
-        action: () => setModal("new-collection"),
+        action: () => dispatch(setOpenModal("collection")),
       },
     );
     if (hasNativeWrite) {
@@ -132,7 +114,7 @@ const NewItemMenu = ({
       items.push({
         title: t`Action`,
         icon: "bolt",
-        action: () => setModal("new-action"),
+        action: () => dispatch(setOpenModal("action")),
       });
     }
 
@@ -146,54 +128,22 @@ const NewItemMenu = ({
     onCloseNavbar,
     hasDatabaseWithJsonEngine,
     lastUsedDatabaseId,
+    dispatch,
   ]);
 
   return (
-    <>
-      <EntityMenu
-        className={className}
-        items={menuItems}
-        trigger={trigger}
-        triggerIcon={triggerIcon}
-        tooltip={triggerTooltip}
-        // I've disabled this transition, since it results in the menu
-        // sometimes not appearing until content finishes loading on complex
-        // dashboards and questions #39303
-        // TODO: Try to restore this transition once we upgrade to React 18 and can prioritize this update
-        transitionDuration={0}
-      />
-      {modal && (
-        <>
-          {modal === "new-collection" ? (
-            <Modal onClose={handleModalClose}>
-              <CreateCollectionModal
-                collectionId={collectionId}
-                onClose={handleModalClose}
-              />
-            </Modal>
-          ) : modal === "new-dashboard" ? (
-            <Modal onClose={handleModalClose}>
-              <CreateDashboardModalConnected
-                collectionId={collectionId}
-                onClose={handleModalClose}
-              />
-            </Modal>
-          ) : modal === "new-action" ? (
-            <Modal
-              wide
-              enableTransition={false}
-              onClose={handleModalClose}
-              closeOnClickOutside
-            >
-              <ActionCreator
-                onSubmit={handleActionCreated}
-                onClose={handleModalClose}
-              />
-            </Modal>
-          ) : null}
-        </>
-      )}
-    </>
+    <EntityMenu
+      className={className}
+      items={menuItems}
+      trigger={trigger}
+      triggerIcon={triggerIcon}
+      tooltip={triggerTooltip}
+      // I've disabled this transition, since it results in the menu
+      // sometimes not appearing until content finishes loading on complex
+      // dashboards and questions #39303
+      // TODO: Try to restore this transition once we upgrade to React 18 and can prioritize this update
+      transitionDuration={0}
+    />
   );
 };
 

--- a/frontend/src/metabase/new/components/NewModals/NewModals.tsx
+++ b/frontend/src/metabase/new/components/NewModals/NewModals.tsx
@@ -36,12 +36,10 @@ export const NewModals = withRouter((props: WithRouterProps) => {
   switch (currentNewModal) {
     case "collection":
       return (
-        <Modal onClose={handleModalClose}>
-          <CreateCollectionModal
-            onClose={handleModalClose}
-            collectionId={collectionId}
-          />
-        </Modal>
+        <CreateCollectionModal
+          onClose={handleModalClose}
+          collectionId={collectionId}
+        />
       );
 
     case "dashboard":

--- a/frontend/src/metabase/new/components/NewModals/NewModals.tsx
+++ b/frontend/src/metabase/new/components/NewModals/NewModals.tsx
@@ -1,0 +1,73 @@
+import { useCallback } from "react";
+import type { WithRouterProps } from "react-router";
+import { withRouter } from "react-router";
+import { push } from "react-router-redux";
+
+import ActionCreator from "metabase/actions/containers/ActionCreator";
+import CreateCollectionModal from "metabase/collections/containers/CreateCollectionModal";
+import Modal from "metabase/components/Modal";
+import { CreateDashboardModalConnected } from "metabase/dashboard/containers/CreateDashboardModal";
+import Collections from "metabase/entities/collections/collections";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import * as Urls from "metabase/lib/urls";
+import { closeModal } from "metabase/redux/ui";
+import { currentOpenModal } from "metabase/selectors/ui";
+import type { WritebackAction } from "metabase-types/api";
+
+export const NewModals = withRouter((props: WithRouterProps) => {
+  const currentNewModal = useSelector(currentOpenModal);
+  const dispatch = useDispatch();
+  const collectionId = useSelector(state =>
+    Collections.selectors.getInitialCollectionId(state, props),
+  );
+
+  const handleActionCreated = useCallback(
+    (action: WritebackAction) => {
+      const nextLocation = Urls.modelDetail({ id: action.model_id }, "actions");
+      dispatch(push(nextLocation));
+    },
+    [dispatch],
+  );
+
+  const handleModalClose = useCallback(() => {
+    dispatch(closeModal());
+  }, [dispatch]);
+
+  switch (currentNewModal) {
+    case "collection":
+      return (
+        <Modal onClose={handleModalClose}>
+          <CreateCollectionModal
+            onClose={handleModalClose}
+            collectionId={collectionId}
+          />
+        </Modal>
+      );
+
+    case "dashboard":
+      return (
+        <Modal onClose={handleModalClose}>
+          <CreateDashboardModalConnected
+            onClose={handleModalClose}
+            collectionId={collectionId}
+          />
+        </Modal>
+      );
+    case "action":
+      return (
+        <Modal
+          wide
+          closeOnClickOutside
+          onClose={handleModalClose}
+          enableTransition={false}
+        >
+          <ActionCreator
+            onClose={handleModalClose}
+            onSubmit={handleActionCreated}
+          />
+        </Modal>
+      );
+    default:
+      return null;
+  }
+});

--- a/frontend/src/metabase/reducers-common.js
+++ b/frontend/src/metabase/reducers-common.js
@@ -7,6 +7,7 @@ import embed from "metabase/redux/embed";
 import entities, { enhanceRequestsReducer } from "metabase/redux/entities";
 import requests from "metabase/redux/requests";
 import { settings } from "metabase/redux/settings";
+import { modal } from "metabase/redux/ui";
 import undo from "metabase/redux/undo";
 import upload from "metabase/redux/uploads";
 import { currentUser } from "metabase/redux/user";
@@ -24,4 +25,5 @@ export default {
   upload,
   auth,
   [Api.reducerPath]: Api.reducer,
+  modal,
 };

--- a/frontend/src/metabase/redux/ui.ts
+++ b/frontend/src/metabase/redux/ui.ts
@@ -1,0 +1,15 @@
+import { createAction, handleActions } from "metabase/lib/redux";
+
+export const SET_OPEN_MODAL = "metabase/ui/SET_OPEN_MODAL";
+export const CLOSE_MODAL = "metabase/ui/CLOSE_MODAL";
+
+export const setOpenModal = createAction(SET_OPEN_MODAL);
+export const closeModal = createAction(CLOSE_MODAL);
+
+export const modal = handleActions(
+  {
+    [SET_OPEN_MODAL]: (state, { payload }) => payload,
+    [CLOSE_MODAL]: () => null,
+  },
+  null,
+);

--- a/frontend/src/metabase/selectors/ui.ts
+++ b/frontend/src/metabase/selectors/ui.ts
@@ -1,0 +1,3 @@
+import type { State } from "metabase-types/store";
+
+export const currentOpenModal = (state: State) => state.modal;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40312

### Description
PR to move new item modals (dashboard/collection/action) out of the NewMenuItem component and into a more accessible place. This is in preparation for the command palette as we should be able to open these modals from the admin app as well. This PR should have no obvious changes to the end user

### How to verify

1. Select New -> Collection / Dashboard / Action.
2. The modal should appear and function as it always has 

### Demo
![chrome_mT4yFOxrXM](https://github.com/metabase/metabase/assets/1328979/1cd797a4-2a4c-4537-9513-23905fb9a246)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
