### PR TITLE
Autodescribe Question Prompt adjustments

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/llm/tasks/describe_question.clj
+++ b/enterprise/backend/src/metabase_enterprise/llm/tasks/describe_question.clj
@@ -36,20 +36,32 @@
                                    (fn [rsp] (rename-keys rsp {:friendly_title   :title
                                                                :friendly_summary :description}))))]
     (client
-      {:messages
-       [{:role    "system"
-         :content "You are a helpful assistant that fills in the missing \"friendly_title\" and
-                        \"friendly_summary\" keys in a json fragment. You like to occasionally use emojis to express
-                        yourself but are otherwise very serious and professional."}
-        {:role    "assistant"
-         :content (cond-> "The \"display\" key is how I intend to present the final data."
-                    (seq visualization_settings)
-                    (str " The \"visualization_settings\" key has chart settings."))}
-        {:role    "assistant"
-         :content "The parts you replace are \"%%FILL_THIS_TITLE_IN%%\" and \"%%FILL_THIS_SUMMARY_IN%%\"."}
-        {:role    "assistant"
-         :content "Return only a json object with the \"friendly_title\" and \"friendly_summary\" fields and nothing else."}
-        {:role    "assistant"
-         :content "The \"friendly_title\" must be no more than 64 characters long."}
-        {:role    "user"
-         :content json-str}]})))
+     {:messages
+      [{:role "system"
+        :content
+        "You are a helpful assistant that fills in the missing \"friendly_title\" and
+         \"friendly_summary\" keys in a json fragment.
+
+         Your summary and title should:
+          - be concise
+          - be informative
+          - be easy to understand by a non-technical audience from a variety of backgrounds
+          - be discoverable by search engines
+          - include caveats and limitations from filters (the query clauses) if applicable
+          - not have caveats stated as fact but rather as suggestions
+          - not explicitly talk about the visualization type
+          - not provide any conclusions about the data
+
+         You like to occasionally use emojis to express yourself but are otherwise very serious and professional."}
+       {:role    "assistant"
+        :content (cond-> "The \"display\" key is how I intend to present the final data."
+                   (seq visualization_settings)
+                   (str " The \"visualization_settings\" key has chart settings."))}
+       {:role    "assistant"
+        :content "The parts you replace are \"%%FILL_THIS_TITLE_IN%%\" and \"%%FILL_THIS_SUMMARY_IN%%\"."}
+       {:role    "assistant"
+        :content "Return only a json object with the \"friendly_title\" and \"friendly_summary\" fields and nothing else."}
+       {:role    "assistant"
+        :content "The \"friendly_title\" must be no more than 64 characters long."}
+       {:role    "user"
+        :content json-str}]})))


### PR DESCRIPTION
In a working meeting, some prompt adjustments were tried. This change felt like the best incremental improvement, considering feedback from users on stats.

We attempted to guide the LLM to return descriptions that:

 - don't state the chart type as if its *very* important (we can see what it is already, so its not that important)
 - do call out caveats and important specifics as implied by the question's filters, aggregations, and breakouts
 - are descriptive but not verbose
 - try not to state caveats too strongly

Here's an example auto-describe from before:
<img width="1080" alt="image" src="https://github.com/metabase/metabase/assets/21064735/dcfbb44c-1cd7-4f7c-a1cb-e4ec2d79082a">


And here's one from after:
<img width="1080" alt="image" src="https://github.com/metabase/metabase/assets/21064735/9921cdbf-1764-42f2-8110-f4962ecd3dae">
