### PR TITLE
Prevent QB header from jumping between modes

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/View.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View.styled.tsx
@@ -59,7 +59,7 @@ export const BorderedViewTitleHeader = styled(ViewTitleHeader)`
   border-bottom: 1px solid ${color("border")};
   padding-top: 8px;
   padding-bottom: 8px;
-  height: ${headerHeight};
+  min-height: ${headerHeight};
 `;
 
 export const QueryBuilderViewHeaderContainer = styled.div`

--- a/frontend/src/metabase/query_builder/components/view/View.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View.styled.tsx
@@ -42,10 +42,24 @@ export const QueryBuilderMain = styled.main<{ isSidebarOpen: boolean }>`
   }
 `;
 
+/**
+ * The height of the header for the query builder view.
+ * Currently hard coded based on the observation from the dev tools.
+ * It prevents the header from jumping when the notebook view is toggled.
+ *
+ * If we want to calculate this heaight based on the children of the header,
+ * we have to take into account the size of the buttons being used, as well as
+ * their line-height + font size. We should add the padding and the border to that.
+ *
+ * @link https://github.com/metabase/metabase/issues/40334
+ */
+const headerHeight = "4rem";
+
 export const BorderedViewTitleHeader = styled(ViewTitleHeader)`
   border-bottom: 1px solid ${color("border")};
   padding-top: 8px;
   padding-bottom: 8px;
+  height: ${headerHeight};
 `;
 
 export const QueryBuilderViewHeaderContainer = styled.div`


### PR DESCRIPTION
This PR fixes https://github.com/metabase/metabase/issues/40334 by applying a fixed height to the header. This height is a few pixels larger than the sum of the height of the tallest child + padding + border.

We can solve this in a more refined way, but this should do for now.
Left a comment in the code.

### Before
![Kapture 2024-03-19 at 23 04 10](https://github.com/metabase/metabase/assets/31325167/80a8a62c-b34b-4646-8fdc-97bffd7b69f8)

### After
![Kapture 2024-03-19 at 23 17 48](https://github.com/metabase/metabase/assets/31325167/7e4203bc-0c17-4b45-a49f-5e1bbe35bb6d)
