### PR TITLE
Fix N+1 in checking write permission for collection

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_app/api/user.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/api/user.clj
@@ -17,8 +17,8 @@
   Otherwise return an empty map."
   []
   (let [custom-reports     (audit-db/default-custom-reports-collection)
-        question-overview  (audit-db/entity-id->object :model/Dashboard audit-db/default-question-overview-entity-id)
-        dashboard-overview (audit-db/entity-id->object :model/Dashboard audit-db/default-dashboard-overview-entity-id)]
+        question-overview  (audit-db/memoized-select-audit-entity :model/Dashboard audit-db/default-question-overview-entity-id)
+        dashboard-overview (audit-db/memoized-select-audit-entity :model/Dashboard audit-db/default-dashboard-overview-entity-id)]
     (merge
      {}
      (when (mi/can-read? (audit-db/default-custom-reports-collection))

--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -83,13 +83,12 @@
   "Default Dashboard Overview (this is a dashboard) entity id."
   "bJEYb0o5CXlfWFcIztDwJ")
 
-(defn entity-id->object
+(def ^{:arglists '([model entity-id])} entity-id->object
   "Returns the object from entity id and model. Memoizes from entity id.
   Should only be used for audit/pre-loaded objects."
-  [model entity-id]
-  ((mdb/memoize-for-application-db
-    (fn [entity-id]
-      (t2/select-one model :entity_id entity-id))) entity-id))
+  (mdb/memoize-for-application-db
+   (fn [model entity-id]
+     (t2/select-one model :entity_id entity-id))))
 
 (defenterprise default-custom-reports-collection
   "Default custom reports collection."

--- a/enterprise/backend/test/metabase_enterprise/audit_app/api/user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_app/api/user_test.clj
@@ -8,8 +8,11 @@
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
+
+(use-fixtures :once (fixtures/initialize :db))
 
 (deftest delete-subscriptions-test
   (testing "DELETE /api/ee/audit-app/user/:id/subscriptions"

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -66,13 +66,16 @@
   (derive ::mi/read-policy.full-perms-for-perms-set)
   (derive ::mi/write-policy.full-perms-for-perms-set))
 
+(defn- default-audit-collection?
+  [{:keys [id] :as _col}]
+  (= id (:id (perms/default-audit-collection))))
+
 (defmethod mi/can-write? Collection
   ([instance]
-   (mi/can-write? :model/Collection (:id instance)))
-  ([model pk]
-   (if (= pk (:id (perms/default-audit-collection)))
-     false
-     (mi/current-user-has-full-permissions? :write model pk))))
+   (and (not (default-audit-collection? instance))
+        (mi/current-user-has-full-permissions? :write instance)))
+  ([_model pk]
+   (mi/can-write? (t2/select-one :model/Collection pk))))
 
 (defmethod mi/can-read? Collection
   ([instance]


### PR DESCRIPTION
Found by the trick I did in #40272

This checks is done in many places, but to show you some numbers, here are how it changes in the API
Setup: an instance with 20 collections
Before:
```
GET /api/collection 200 17.1 ms (25 DB calls)
GET /api/collection/27/items 200 27.4 ms (26 DB calls)
```

After:
```
GET /api/collection 200 6.2 ms (4 DB calls)
GET /apt/collection/307/items 200 18.7 ms (5 DB calls)
```