### PR TITLE
export List from metabase/ui

### DIFF
--- a/frontend/src/metabase/ui/components/typography/List/List.stories.mdx
+++ b/frontend/src/metabase/ui/components/typography/List/List.stories.mdx
@@ -30,14 +30,14 @@ export const argTypes = {
 
 <Meta
   title="Typography/List"
-  component={Text}
+  component={List}
   args={args}
   argTypes={argTypes}
 />
 
-# Text
+# List
 
-Our themed wrapper around [Mantine List](https://v6.mantine.dev/core/List/).
+Our themed wrapper around [Mantine List](https://v6.mantine.dev/core/list/).
 
 export const DefaultTemplate = args => (
   <List {...args}>

--- a/frontend/src/metabase/ui/components/typography/List/List.stories.mdx
+++ b/frontend/src/metabase/ui/components/typography/List/List.stories.mdx
@@ -1,0 +1,58 @@
+import { Fragment } from "react";
+import { Canvas, Story, Meta } from "@storybook/addon-docs";
+import { Box, Grid, List } from "metabase/ui";
+
+export const args = {
+  size: "md",
+  type: "ordered",
+  withPadding: false,
+};
+
+export const sampleArgs = {
+  size: "md",
+  type: "ordered",
+  withPadding: false,
+};
+
+export const argTypes = {
+  size: {
+    options: ["xs", "sm", "md", "lg"],
+    control: { type: "inline-radio" },
+  },
+  type: {
+    options: ["ordered", "unordered"],
+    control: { type: "inline-radio" },
+  },
+  withPadding: {
+    control: { type: "boolean" },
+  },
+};
+
+<Meta
+  title="Typography/List"
+  component={Text}
+  args={args}
+  argTypes={argTypes}
+/>
+
+# Text
+
+Our themed wrapper around [Mantine List](https://v6.mantine.dev/core/List/).
+
+export const DefaultTemplate = args => (
+  <List {...args}>
+    <List.Item>Clone or download repository from GitHub</List.Item>
+    <List.Item>Install dependencies with yarn</List.Item>
+    <List.Item>To start development server run npm start command</List.Item>
+    <List.Item>
+      Run tests to make sure your changes do not break the build
+    </List.Item>
+    <List.Item>Submit a pull request once you are done</List.Item>
+  </List>
+);
+
+export const Default = DefaultTemplate.bind({});
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+</Canvas>

--- a/frontend/src/metabase/ui/components/typography/List/List.stories.mdx
+++ b/frontend/src/metabase/ui/components/typography/List/List.stories.mdx
@@ -1,6 +1,6 @@
 import { Fragment } from "react";
 import { Canvas, Story, Meta } from "@storybook/addon-docs";
-import { Box, Grid, List } from "metabase/ui";
+import { Box, Grid, List, Icon } from "metabase/ui";
 
 export const args = {
   size: "md",
@@ -55,4 +55,26 @@ export const Default = DefaultTemplate.bind({});
 
 <Canvas>
   <Story name="Default">{Default}</Story>
+</Canvas>
+
+export const WithIconsTemplate = args => {
+  return (
+    <List {...args} icon={<Icon name="check" />}>
+      <List.Item>Clone or download repository from GitHub</List.Item>
+      <List.Item>Install dependencies with yarn</List.Item>
+      <List.Item>To start development server run npm start command</List.Item>
+      <List.Item icon={<Icon name="alert" />}>
+        Run tests to make sure your changes do not break the build
+      </List.Item>
+      <List.Item icon={<Icon name="add" />}>
+        Submit a pull request once you are done
+      </List.Item>
+    </List>
+  );
+};
+
+export const WithIcons = WithIconsTemplate.bind({});
+
+<Canvas>
+  <Story name="WithIcons">{WithIcons}</Story>
 </Canvas>

--- a/frontend/src/metabase/ui/components/typography/List/List.styled.tsx
+++ b/frontend/src/metabase/ui/components/typography/List/List.styled.tsx
@@ -1,0 +1,17 @@
+import type { MantineThemeOverride } from "@mantine/core";
+
+export const getListOverrides = (): MantineThemeOverride["components"] => ({
+  List: {
+    styles: () => {
+      return {
+        root: {
+          // to revert "none" from the reset
+          listStyleType: "revert",
+        },
+        item: {
+          lineHeight: "1.5",
+        },
+      };
+    },
+  },
+});

--- a/frontend/src/metabase/ui/components/typography/List/List.styled.tsx
+++ b/frontend/src/metabase/ui/components/typography/List/List.styled.tsx
@@ -2,7 +2,7 @@ import type { MantineThemeOverride } from "@mantine/core";
 
 export const getListOverrides = (): MantineThemeOverride["components"] => ({
   List: {
-    styles: () => {
+    styles: theme => {
       return {
         root: {
           // to revert "none" from the reset
@@ -10,6 +10,7 @@ export const getListOverrides = (): MantineThemeOverride["components"] => ({
         },
         item: {
           lineHeight: "1.5",
+          color: theme.fn.themeColor("text-dark"),
         },
       };
     },

--- a/frontend/src/metabase/ui/components/typography/List/index.ts
+++ b/frontend/src/metabase/ui/components/typography/List/index.ts
@@ -1,0 +1,3 @@
+export { List } from "@mantine/core";
+export type { ListProps } from "@mantine/core";
+export { getListOverrides } from "./List.styled";

--- a/frontend/src/metabase/ui/components/typography/index.ts
+++ b/frontend/src/metabase/ui/components/typography/index.ts
@@ -1,3 +1,4 @@
 export * from "./Text";
 export * from "./Title";
 export * from "./Anchor";
+export * from "./List";

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -34,6 +34,7 @@ import {
   getTimeInputOverrides,
   getTitleOverrides,
   getTooltipOverrides,
+  getListOverrides,
 } from "./components";
 import { getThemeColors } from "./utils/colors";
 
@@ -127,5 +128,6 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
     ...getTitleOverrides(),
     ...getTooltipOverrides(),
     ...getHoverCardOverrides(),
+    ...getListOverrides(),
   },
 });


### PR DESCRIPTION
### Description

This re-exports the mantine List component from metabase/ui

Not sure if "Typography"  is the correct folder, wasn't sure where to put it.

### Demo

<img width="627" alt="image" src="https://github.com/metabase/metabase/assets/1914270/e768f777-4d07-4d51-a60a-ee9ddf3c617c">
<img width="645" alt="image" src="https://github.com/metabase/metabase/assets/1914270/92d3026e-9a20-4729-ab49-b5b4c1a548d1">

