### PR TITLE
Expand and explain the `NativeQueryForm` type

### DIFF
--- a/frontend/src/metabase-types/api/dataset.ts
+++ b/frontend/src/metabase-types/api/dataset.ts
@@ -115,7 +115,12 @@ export interface ErrorEmbedDataset {
   status: string;
 }
 
+/**
+ * This is the type of the `POST /api/dataset/native` response.
+ * We're mostly ignoring the `params` on the FE. It's added to the type only for completeness.
+ */
 export interface NativeQueryForm {
+  params: unknown;
   query: string;
 }
 


### PR DESCRIPTION
This PR expands the `NativeQueryForm` type for completeness and explains why `params` is typed as `unknown.

see: https://metaboat.slack.com/archives/CKZEMT1MJ/p1710935556623019