### PR TITLE
Fix a flaky test in revision history suite

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -46,7 +46,7 @@ export function sidebar() {
 }
 
 export function rightSidebar() {
-  return cy.findAllByTestId("sidebar-right");
+  return cy.findByTestId("sidebar-right");
 }
 
 export function leftSidebar() {

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -86,6 +86,10 @@ describe("revision history", () => {
               sidebar().findByText("Orders, Count").click();
               cy.wait("@cardQuery");
               saveDashboard();
+
+              // this is dirty, but seems like the only reliable way
+              // to wait until SET_DASHBOARD_EDITING is dispatched,
+              // so it doesn't close the revisions sidebar
               cy.wait("@fetchDashboard");
               cy.wait(100);
 

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -74,7 +74,7 @@ describe("revision history", () => {
             });
 
             it("shouldn't create a rearrange revision when adding a card (metabase#6884)", () => {
-              cy.intercept("PUT", "/api/dashboard/*").as("updateDashboard");
+              cy.intercept("GET", "/api/dashboard/*").as("fetchDashboard");
               cy.intercept("POST", "/api/card/*/query").as("cardQuery");
 
               cy.createDashboard().then(({ body }) => {
@@ -86,7 +86,8 @@ describe("revision history", () => {
               sidebar().findByText("Orders, Count").click();
               cy.wait("@cardQuery");
               saveDashboard();
-              cy.wait("@updateDashboard");
+              cy.wait("@fetchDashboard");
+              rightSidebar().should("not.exist");
 
               openRevisionHistory();
               rightSidebar().within(() => {

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -12,6 +12,8 @@ import {
   questionInfoButton,
   rightSidebar,
   openQuestionsSidebar,
+  editDashboard,
+  sidebar,
 } from "e2e/support/helpers";
 
 const PERMISSIONS = {
@@ -34,12 +36,13 @@ describe("revision history", () => {
 
     it("shouldn't render revision history steps when there was no diff (metabase#1926)", () => {
       cy.createDashboard().then(({ body }) => {
-        visitAndEditDashboard(body.id);
+        visitDashboard(body.id);
+        editDashboard();
       });
 
       // Save the dashboard without any changes made to it (TODO: we should probably disable "Save" button in the first place)
       saveDashboard();
-      cy.icon("pencil").click();
+      editDashboard();
       saveDashboard();
 
       openRevisionHistory();
@@ -72,19 +75,21 @@ describe("revision history", () => {
 
             it("shouldn't create a rearrange revision when adding a card (metabase#6884)", () => {
               cy.createDashboard().then(({ body }) => {
-                visitAndEditDashboard(body.id);
+                visitDashboard(body.id);
+                editDashboard();
               });
+
               openQuestionsSidebar();
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText("Orders, Count").click();
+              sidebar().findByText("Orders, Count").click();
               saveDashboard();
+
               openRevisionHistory();
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText(/added a card/)
-                .siblings("button")
-                .should("not.exist");
-              // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-              cy.findByText(/rearranged the cards/).should("not.exist");
+              rightSidebar().within(() => {
+                cy.findByText(/added a card/)
+                  .siblings("button")
+                  .should("not.exist");
+                cy.findByText(/rearranged the cards/).should("not.exist");
+              });
             });
 
             // skipped because it's super flaky in CI
@@ -183,11 +188,6 @@ describe("revision history", () => {
 
 function clickRevert(event_name, index = 0) {
   cy.findAllByLabelText(event_name).eq(index).click();
-}
-
-function visitAndEditDashboard(id) {
-  visitDashboard(id);
-  cy.icon("pencil").click();
 }
 
 function openRevisionHistory() {

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -74,6 +74,9 @@ describe("revision history", () => {
             });
 
             it("shouldn't create a rearrange revision when adding a card (metabase#6884)", () => {
+              cy.intercept("PUT", "/api/dashboard/*").as("updateDashboard");
+              cy.intercept("POST", "/api/card/*/query").as("cardQuery");
+
               cy.createDashboard().then(({ body }) => {
                 visitDashboard(body.id);
                 editDashboard();
@@ -81,7 +84,9 @@ describe("revision history", () => {
 
               openQuestionsSidebar();
               sidebar().findByText("Orders, Count").click();
+              cy.wait("@cardQuery");
               saveDashboard();
+              cy.wait("@updateDashboard");
 
               openRevisionHistory();
               rightSidebar().within(() => {

--- a/e2e/test/scenarios/collections/revision-history.cy.spec.js
+++ b/e2e/test/scenarios/collections/revision-history.cy.spec.js
@@ -87,7 +87,7 @@ describe("revision history", () => {
               cy.wait("@cardQuery");
               saveDashboard();
               cy.wait("@fetchDashboard");
-              rightSidebar().should("not.exist");
+              cy.wait(100);
 
               openRevisionHistory();
               rightSidebar().within(() => {


### PR DESCRIPTION
(drafted for stress testing)

Cleans up and fixes a flaky test. The root cause seems to be a race condition that sometimes happens when we add a card to a dashboard and try to save it too quickly.