### PR TITLE
Re-enable the button that converts a query into its native counterpart [PoC/task-3]

### DIFF
--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -310,13 +310,14 @@ describe("scenarios > question > native", () => {
 
     cy.button("View the SQL").click();
     cy.wait("@datasetNative");
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText(/FROM "PUBLIC"."ORDERS"/).should("be.visible");
+    cy.get("code")
+      .contains(/FROM "PUBLIC"."ORDERS"/)
+      .should("be.visible");
 
     cy.button("Convert this question to SQL").click();
-    runQuery();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Showing 1 row").should("be.visible");
+    cy.findByTestId("question-row-count")
+      .contains("Showing 1 row")
+      .should("be.visible");
   });
 
   describe("prompts", () => {

--- a/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/15946-mongo-pre-select-table.cy.spec.js
@@ -17,11 +17,7 @@ describe("issue 15946", { tags: "@mongo" }, () => {
 
   it("converting a question to the native query should pre-select a table (metabase#15946)", () => {
     cy.findByTestId("query-builder-root").icon("sql").click();
-
-    cy.get(".Modal")
-      .findByText("Convert this question to a native query")
-      .click();
-    cy.get(".Modal").should("not.exist");
+    cy.button("Convert this question to a native query").click();
 
     cy.get(".GuiBuilder-data").contains(MONGO_DB_NAME);
     cy.get(".GuiBuilder-data").contains("Orders");

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -23,6 +23,7 @@ import {
   modal,
   pickEntity,
   hovercard,
+  openNotebook,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -210,12 +211,10 @@ describe("scenarios > question > new", () => {
     openOrdersTable();
 
     cy.url().should("include", "question#");
-    // Isolate icons within "QueryBuilder" scope because there is also `.Icon-sql` in top navigation
-    cy.findByTestId("query-builder-root").icon("notebook").click();
+    openNotebook();
     cy.url().should("include", "question/notebook#");
     cy.findByTestId("query-builder-root").icon("sql").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Convert this question to SQL").click();
+    cy.button("Convert this question to SQL").click();
     cy.url().should("include", "question#");
   });
 

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 import { connect } from "react-redux";
 import { t } from "ttag";
 
-import Button from "metabase/core/components/Button";
 import { getEngineNativeType } from "metabase/lib/engine";
 import { useDispatch } from "metabase/lib/redux";
 import { updateQuestion, setUIControls } from "metabase/query_builder/actions";
@@ -10,6 +9,7 @@ import {
   getNativeQueryFn,
   getQuestion,
 } from "metabase/query_builder/selectors";
+import { Button } from "metabase/ui";
 import type Question from "metabase-lib/v1/Question";
 import type { NativeQueryForm } from "metabase-types/api";
 import type { State } from "metabase-types/store";
@@ -66,7 +66,7 @@ const NativeQueryPreviewSidebar = ({
       onClose={onClose}
     >
       {query && (
-        <Button primary onClick={handleConvertClick}>
+        <Button variant="subtle" onClick={handleConvertClick}>
           {BUTTON_TITLE[engineType]}
         </Button>
       )}

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -18,7 +18,7 @@ import { NativeQueryPreview, useNativeQuery } from "../NativeQueryPreview";
 
 import { createDatasetQuery } from "./utils";
 
-const MODAL_TITLE = {
+const TITLE = {
   sql: t`SQL for this question`,
   json: t`Native query for this question`,
 };
@@ -31,13 +31,11 @@ const BUTTON_TITLE = {
 interface NativeQueryPreviewSidebarProps {
   question: Question;
   onLoadQuery: () => Promise<NativeQueryForm>;
-  onClose?: () => void;
 }
 
 const NativeQueryPreviewSidebar = ({
   question,
   onLoadQuery,
-  onClose,
 }: NativeQueryPreviewSidebarProps): JSX.Element => {
   const engineType = getEngineNativeType(question.database()?.engine);
   const { query, error, isLoading } = useNativeQuery(question, onLoadQuery);
@@ -53,17 +51,14 @@ const NativeQueryPreviewSidebar = ({
 
     dispatch(updateQuestion(newQuestion, { shouldUpdateUrl: true, run: true }));
     dispatch(setUIControls({ isNativeEditorOpen: true }));
-
-    onClose?.();
-  }, [question, query, onClose, dispatch]);
+  }, [question, query, dispatch]);
 
   return (
     <NativeQueryPreview
-      title={MODAL_TITLE[engineType]}
+      title={TITLE[engineType]}
       query={query}
       error={error}
       isLoading={isLoading}
-      onClose={onClose}
     >
       {query && (
         <Button variant="subtle" onClick={handleConvertClick}>

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -52,12 +52,7 @@ export const NotebookContainer = ({
       onTransitionEnd={handleTransitionEnd}
     >
       {shouldShowNotebook && <Notebook {...props} />}
-      {isNativePreviewSidebarOpen && (
-        <NativeQueryPreviewSidebar
-          onUpdateQuestion={() => {}}
-          onSetUIControls={() => {}}
-        />
-      )}
+      {isNativePreviewSidebarOpen && <NativeQueryPreviewSidebar />}
     </Flex>
   );
 };


### PR DESCRIPTION
This is the third task in the Milestone 1 (PoC) of https://github.com/metabase/metabase/issues/40254.
It merges into the `sql-sidebar-preview-poc` that's being used as a "feature" branch for this milestone.

## What does this PR accomplish?
- Adds back the ability to convert a GUI query into a native ad hoc question
- Replaces the old `Button` component with a Mantine variant and changes the styling of the "Convert this question..." button to match the design
- Updates and fixes failing E2E tests

### Tech details
By using `useDispatch` we've greatly simplified this component. After this change, it basically needs no props from the parent.

### Demo
![Kapture 2024-03-21 at 00 00 09](https://github.com/metabase/metabase/assets/31325167/d493f4fa-a3a1-45c2-bbb4-067887335bfa)

## The Scope
- Clicking the button opens the native query editor and converts the GUI query to the native one
> [!important]
> Closing a notebook editor does intentionally NOT update the `uiControls` state for the preview sidebar because we need to preserve the user preference.

## Out of Scope
- Styling
- Preserving the state to the localStorage or to the user setting
- Full E2E test coverage