### PR TITLE
Basic version of CSV replacement, with only basic testing

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -9,6 +9,11 @@ title: Driver interface changelog
 - The Metabase `metabase.mbql.*` namespaces have been moved to `metabase.legacy-mbql.*`. You probably didn't need to
   use these namespaces in your driver, but if you did, please update them.
 
+- The multimethod `metabase.driver/truncate!` has been added. This method is used to delete a table's rows in the most
+  efficient way possible, even if this means skipping triggers or resetting the auto_increment counters.
+  This is currently only required for drivers that support the `:uploads` feature, and has a default implementation for
+  JDBC-based drivers.
+
 ## Metabase 0.49.1
 
 - Another driver feature has been added: `describe-fields`. If a driver opts-in to supporting this feature, The

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -10,9 +10,8 @@ title: Driver interface changelog
   use these namespaces in your driver, but if you did, please update them.
 
 - The multimethod `metabase.driver/truncate!` has been added. This method is used to delete a table's rows in the most
-  efficient way possible, even if this means skipping triggers or resetting the auto_increment counters.
-  This is currently only required for drivers that support the `:uploads` feature, and has a default implementation for
-  JDBC-based drivers.
+  efficient way possible. This is currently only required for drivers that support the `:uploads` feature, and has
+  a default implementation for JDBC-based drivers.
 
 ## Metabase 0.49.1
 

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -718,11 +718,11 @@
                                   action
                                   :table-id (:id table-a)
                                   :user-id (mt/user->id :rasta))]
-                (doseq [[schema-perms can-append? test-string]
-                        [[:all true "Data permissions on schema should succeed"]
-                         [:none false "No permissions on schema should fail"]
-                         [{(:id table-a) :all} true "Data permissions on table should succeed"]
-                         [{(:id table-b) :all} false "Data permissions only on another table in the same schema should fail"]]]
+                (doseq [[schema-perms          can-append? test-string]
+                        [[:all                 true        "Data permissions on schema should succeed"]
+                         [:none                false       "No permissions on schema should fail"]
+                         [{(:id table-a) :all} true        "Data permissions on table should succeed"]
+                         [{(:id table-b) :all} false       "Data permissions only on another table in the same schema should fail"]]]
                   (testing test-string
                     (mt/with-all-users-data-perms-graph! {db-id {:data {:native :none, :schemas {(or schema-name "") schema-perms}}}}
                       (if can-append?

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -744,13 +744,12 @@
                               action
                               :table-id (:id table-a)
                               :user-id (mt/user->id :rasta))]
-            (doseq [native-permissions [:none :write]]
-              (testing (format "With blocked perms it should fail with {:native %s}" native-permissions)
-                (mt/with-all-users-data-perms-graph! {db-id {:data {:native native-permissions, :schemas :block}}}
-                  (is (thrown-with-msg?
-                       clojure.lang.ExceptionInfo
-                       #"You don't have permissions to do that\."
-                       (append-csv!))))))))))))
+            (testing "With blocked perms it should fail"
+              (mt/with-all-users-data-perms-graph! {db-id {:data {:native :none, :schemas :block}}}
+                (is (thrown-with-msg?
+                     clojure.lang.ExceptionInfo
+                     #"You don't have permissions to do that\."
+                     (append-csv!)))))))))))
 
 (deftest get-database-can-upload-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads :schemas)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -704,47 +704,53 @@
             (mt/with-all-users-data-perms-graph! {db-id {:data {:native :write, :schemas :all}}}
               (is (some? (upload-csv!))))))))))
 
-(deftest append-csv-data-perms-test
+(deftest update-csv-data-perms-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (testing "CSV appends should be blocked without data access to the schema"
-      (let [schema-name (sql.tx/session-schema driver/*driver*)]
-        (upload-test/with-upload-table!
-          [table-a (upload-test/create-upload-table! :schema-name schema-name)]
+    (doseq [action [:metabase.upload/append :metabase.upload/replace]]
+      (testing (format "CSV %s should be blocked without data access to the schema" action)
+        (let [schema-name (sql.tx/session-schema driver/*driver*)]
           (upload-test/with-upload-table!
-            [table-b (upload-test/create-upload-table! :schema-name schema-name)]
-            (let [db-id       (u/the-id (mt/db))
-                  append-csv! #(upload-test/append-csv-with-defaults!
-                                :table-id (:id table-a)
-                                :user-id (mt/user->id :rasta))]
-              (doseq [[schema-perms          can-append? test-string]
-                      [[:all                 true        "Data permissions on schema should succeed"]
-                       [:none                false       "No permissions on schema should fail"]
-                       [{(:id table-a) :all} true        "Data permissions on table should succeed"]
-                       [{(:id table-b) :all} false       "Data permissions only on another table in the same schema should fail"]]]
-                (testing test-string
-                  (mt/with-all-users-data-perms-graph! {db-id {:data {:native :none, :schemas {(or schema-name "") schema-perms}}}}
-                    (if can-append?
-                      (is (some? (append-csv!)))
-                      (is (thrown-with-msg?
-                           clojure.lang.ExceptionInfo
-                           #"You don't have permissions to do that\."
-                           (append-csv!))))))))))))))
+            [table-a (upload-test/create-upload-table! :schema-name schema-name)]
+            (upload-test/with-upload-table!
+              [table-b (upload-test/create-upload-table! :schema-name schema-name)]
+              (let [db-id       (u/the-id (mt/db))
+                    append-csv! #(upload-test/update-csv-with-defaults!
+                                  action
+                                  :table-id (:id table-a)
+                                  :user-id (mt/user->id :rasta))]
+                (doseq [[schema-perms can-append? test-string]
+                        [[:all true "Data permissions on schema should succeed"]
+                         [:none false "No permissions on schema should fail"]
+                         [{(:id table-a) :all} true "Data permissions on table should succeed"]
+                         [{(:id table-b) :all} false "Data permissions only on another table in the same schema should fail"]]]
+                  (testing test-string
+                    (mt/with-all-users-data-perms-graph! {db-id {:data {:native :none, :schemas {(or schema-name "") schema-perms}}}}
+                      (if can-append?
+                        (is (some? (append-csv!)))
+                        (is (thrown-with-msg?
+                             clojure.lang.ExceptionInfo
+                             #"You don't have permissions to do that\."
+                             (append-csv!)))))))))))))))
 
-(deftest append-csv-block-perms-test
+(deftest update-csv-block-perms-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (testing "Appends should be blocked if the user has blocked data access to the database, unless they have native query editing perms too"
-      (upload-test/with-upload-table!
-        [table-a (upload-test/create-upload-table!)]
-        (let [db-id       (u/the-id (mt/db))
-              append-csv! #(upload-test/append-csv-with-defaults!
-                            :table-id (:id table-a)
-                            :user-id (mt/user->id :rasta))]
-          (testing "With blocked perms it should fail"
-            (mt/with-all-users-data-perms-graph! {db-id {:data {:native :none, :schemas :block}}}
-              (is (thrown-with-msg?
-                   clojure.lang.ExceptionInfo
-                   #"You don't have permissions to do that\."
-                   (append-csv!))))))))))
+    (doseq [action [:metabase.upload/append :metabase.upload/replace]]
+      (testing (format "We will block %s if the user has blocked data access to the database, even if they have native query editing"
+                       action)
+        (upload-test/with-upload-table!
+          [table-a (upload-test/create-upload-table!)]
+          (let [db-id       (u/the-id (mt/db))
+                append-csv! #(upload-test/update-csv-with-defaults!
+                              action
+                              :table-id (:id table-a)
+                              :user-id (mt/user->id :rasta))]
+            (doseq [native-permissions [:none :write]]
+              (testing (format "With blocked perms it should fail with {:native %s}" native-permissions)
+                (mt/with-all-users-data-perms-graph! {db-id {:data {:native native-permissions, :schemas :block}}}
+                  (is (thrown-with-msg?
+                       clojure.lang.ExceptionInfo
+                       #"You don't have permissions to do that\."
+                       (append-csv!))))))))))))
 
 (deftest get-database-can-upload-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads :schemas)

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -940,6 +940,16 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
+(defmulti truncate!
+  "Delete the current contents of `table-name`.
+  If something like a SQL TRUNCATE statement is supported, we use that, but may otherwise fall back to explicitly
+  deleting rows, or dropping and recreating the table.
+  Depending on the driver, the semantics on whether triggers are fired, AUTO_INCREMENT is reset etc, are allowed to vary.
+  The application assumes that the implementation can be rolled back if inside a transaction."
+  {:added "0.50.0", :arglists '([driver db-id table-name])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
 (defmulti insert-into!
   "Insert `values` into a table named `table-name`. `values` is a lazy sequence of rows, where each row's order matches
    `column-names`.

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -944,7 +944,7 @@
   "Delete the current contents of `table-name`.
   If something like a SQL TRUNCATE statement is supported, we use that, but may otherwise fall back to explicitly
   deleting rows, or dropping and recreating the table.
-  Depending on the driver, the semantics on whether triggers are fired, AUTO_INCREMENT is reset etc, are allowed to vary.
+  Depending on the driver, the semantics can vary on whether triggers are fired, AUTO_INCREMENT is reset etc.
   The application assumes that the implementation can be rolled back if inside a transaction."
   {:added "0.50.0", :arglists '([driver db-id table-name])}
   dispatch-on-initialized-driver

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -154,7 +154,8 @@
         sql        (sql/format {:truncate table-name}
                                :quoted true
                                :dialect (sql.qp/quote-style driver))]
-    (qp.writeback/execute-write-sql! db-id sql)))
+    (jdbc/with-db-transaction [conn (sql-jdbc.conn/db->pooled-connection-spec db-id)]
+      (jdbc/execute! conn sql))))
 
 (defmethod driver/insert-into! :sql-jdbc
   [driver db-id table-name column-names values]

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -148,6 +148,14 @@
                                :dialect (sql.qp/quote-style driver)))]
     (qp.writeback/execute-write-sql! db-id sql)))
 
+(defmethod driver/truncate! :sql-jdbc
+  [driver db-id table-name]
+  (let [table-name (keyword table-name)
+        sql        (sql/format {:truncate table-name}
+                               :quoted true
+                               :dialect (sql.qp/quote-style driver))]
+    (qp.writeback/execute-write-sql! db-id sql)))
+
 (defmethod driver/insert-into! :sql-jdbc
   [driver db-id table-name column-names values]
   (let [table-name (keyword table-name)

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -428,8 +428,8 @@
 (defn- file-size-mb [csv-file]
   (/ (.length ^File csv-file) 1048576.0))
 
-(defn- create-from-csv!
-  "Loads a table from a CSV file. If the table already exists, it will throw an error.
+(defn- load-from-csv!
+  "Creates a table from a CSV file. If the table already exists, it will throw an error.
    Returns the file size, number of rows, and number of columns."
   [driver db-id table-name ^File csv-file]
   (with-open [reader (bom/bom-reader csv-file)]
@@ -585,7 +585,7 @@
                                    (unique-table-name driver)
                                    (u/lower-case-en))
             schema+table-name (table-identifier {:schema schema-name :name table-name})
-            stats             (create-from-csv! driver (:id database) schema+table-name file)
+            stats             (load-from-csv! driver (:id database) schema+table-name file)
             ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async
             table             (sync-tables/create-or-reactivate-table! database {:name table-name :schema (not-empty schema-name)})
             _set_is_upload    (t2/update! :model/Table (:id table) {:is_upload true})
@@ -715,8 +715,7 @@
            (field->db-type driver field->new-type)
             args)))
 
-(defn- append-csv!*
-  [database table file]
+(defn- update-with-csv! [database table file & {:keys [replace-rows?]}]
   (try
     (with-open [reader (bom/bom-reader file)]
       (let [timer              (start-timer)
@@ -754,6 +753,8 @@
                                 :upload-seconds    (since-ms timer)}]
 
         (try
+          (when replace-rows?
+            (driver/truncate! driver (:id database) (table-identifier table)))
           (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)
           (catch Throwable e
             (throw (ex-info (ex-message e) {:status-code 422}))))
@@ -785,7 +786,7 @@
       (snowplow/track-event! ::snowplow/csv-append-failed api/*current-user-id* (fail-stats file))
       (throw e))))
 
-(defn- can-append-error
+(defn- can-update-error
   "Returns an ExceptionInfo object if the user cannot upload to the given database and schema. Returns nil otherwise."
   [db table]
   (or (can-use-uploads-error db)
@@ -798,33 +799,39 @@
         (ex-info (tru "You don''t have permissions to do that.")
                  {:status-code 403}))))
 
-(defn- check-can-append
+(defn- check-can-update
   "Throws an error if the user cannot upload to the given database and schema."
   [db table]
-  (when-let [error (can-append-error db table)]
+  (when-let [error (can-update-error db table)]
     (throw error)))
 
 (defn can-upload-to-table?
   "Returns true if the user can upload to the given database and table, and false otherwise."
   [db table]
-  (nil? (can-append-error db table)))
+  (nil? (can-update-error db table)))
 
 ;;; +--------------------------------------------------
-;;; |  public interface for appending to uploaded table
+;;; |  public interface for updating an uploaded table
 ;;; +--------------------------------------------------
 
-(mu/defn append-csv!
-  "Main entry point for appending to uploaded tables with a CSV file.
+(def update-action-schema
+  "The :action values supported by [[update-csv!]]"
+  [:enum ::append ::replace])
+
+(mu/defn update-csv!
+  "Main entry point for updating an uploaded table with a CSV file.
   This will create an auto-incrementing primary key (auto-pk) column in the table for drivers that supported uploads
-  before auto-pk columns were introduced by metabase#36249."
-  [{:keys [^File file table-id]}
+  before auto-pk columns were introduced by metabase#36249, if it does not already exist."
+  [{:keys [^File file table-id action]}
    :- [:map
        [:table-id ms/PositiveInt]
-       [:file (ms/InstanceOfClass File)]]]
+       [:file (ms/InstanceOfClass File)]
+       [:action update-action-schema]]]
   (let [table    (api/check-404 (t2/select-one :model/Table :id table-id))
-        database (table/database table)]
-    (check-can-append database table)
-    (append-csv!* database table file)))
+        database (table/database table)
+        replace? (= ::replace action)]
+    (check-can-update database table)
+    (update-with-csv! database table file :replace-rows? replace?)))
 
 ;;; +--------------------------------
 ;;; |  hydrate based_on_upload for FE

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -428,7 +428,7 @@
 (defn- file-size-mb [csv-file]
   (/ (.length ^File csv-file) 1048576.0))
 
-(defn- load-from-csv!
+(defn- create-from-csv!
   "Creates a table from a CSV file. If the table already exists, it will throw an error.
    Returns the file size, number of rows, and number of columns."
   [driver db-id table-name ^File csv-file]
@@ -585,7 +585,7 @@
                                    (unique-table-name driver)
                                    (u/lower-case-en))
             schema+table-name (table-identifier {:schema schema-name :name table-name})
-            stats             (load-from-csv! driver (:id database) schema+table-name file)
+            stats             (create-from-csv! driver (:id database) schema+table-name file)
             ;; Sync immediately to create the Table and its Fields; the scan is settings-dependent and can be async
             table             (sync-tables/create-or-reactivate-table! database {:name table-name :schema (not-empty schema-name)})
             _set_is_upload    (t2/update! :model/Table (:id table) {:is_upload true})

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -898,7 +898,10 @@
 ;;; |                                          POST /api/table/:id/append-csv                                        |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
-(defn append-csv-via-api!
+(defn- append-csv! [options]
+  (@#'api.table/update-csv! (assoc options :action :metabase.upload/append)))
+
+(defn- append-csv-via-api!
   "Upload a small CSV file to the given collection ID. Default args can be overridden"
   []
   (mt/with-current-user (mt/user->id :rasta)
@@ -906,8 +909,8 @@
       (let [file  (upload-test/csv-file-with ["name" "Luke Skywalker" "Darth Vader"] (mt/random-name))
             table (upload-test/create-upload-table!)]
         (mt/with-current-user (mt/user->id :crowberto)
-          (@#'api.table/append-csv! {:id   (:id table)
-                                     :file file}))))))
+          (append-csv! {:table-id (:id table)
+                        :file     file}))))))
 
 (deftest append-csv-test
   (mt/test-driver :h2
@@ -931,6 +934,50 @@
                 table (upload-test/create-upload-table!)]
             (is (.exists file) "File should exist before append-csv!")
             (mt/with-current-user (mt/user->id :crowberto)
-              (@#'api.table/append-csv! {:id   (:id table)
-                                         :file file}))
+              (append-csv! {:table-id (:id table)
+                            :file     file}))
             (is (not (.exists file)) "File should be deleted after append-csv!")))))))
+
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                          POST /api/table/:id/replace-csv                                        |
+;;; +----------------------------------------------------------------------------------------------------------------+
+
+(defn- replace-csv! [options]
+  (@#'api.table/update-csv! (assoc options :action :metabase.upload/replace)))
+
+(defn- replace-csv-via-api!
+  "Upload a small CSV file to the given collection ID. Default args can be overridden"
+  []
+  (mt/with-current-user (mt/user->id :rasta)
+                        (mt/with-empty-db
+                         (let [file  (upload-test/csv-file-with ["name" "Luke Skywalker" "Darth Vader"] (mt/random-name))
+                               table (upload-test/create-upload-table!)]
+                           (mt/with-current-user (mt/user->id :crowberto)
+                             (replace-csv! {:table-id (:id table)
+                                            :file     file}))))))
+
+(deftest replace-csv-test
+  (mt/test-driver :h2
+    (mt/with-empty-db
+     (testing "Happy path"
+       (mt/with-temporary-setting-values [uploads-enabled true]
+         (is (= {:status 200, :body nil}
+                (replace-csv-via-api!)))))
+     (testing "Failure paths return an appropriate status code and a message in the body"
+       (mt/with-temporary-setting-values [uploads-enabled false]
+         (is (= {:status 422, :body {:message "Uploads are not enabled."}}
+                (replace-csv-via-api!))))))))
+
+(deftest replace-csv-deletes-file-test
+  (testing "File gets deleted after replacing"
+    (mt/test-driver :h2
+      (mt/with-current-user (mt/user->id :rasta)
+        (mt/with-empty-db
+         (let [filename (mt/random-name)
+               file     (upload-test/csv-file-with ["name" "Luke Skywalker" "Darth Vader"] filename)
+               table    (upload-test/create-upload-table!)]
+           (is (.exists file) "File should exist before replace-csv!")
+           (mt/with-current-user (mt/user->id :crowberto)
+             (replace-csv! {:table-id (:id table)
+                            :file     file}))
+           (is (not (.exists file)) "File should be deleted after replace-csv!")))))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -570,7 +570,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -619,7 +619,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -654,7 +654,7 @@
                                 ["2022-01-01T12:00:00+07:30" "2022-01-01T04:30:00Z"]]]
             (testing "Fields exists after sync"
               (with-upload-table!
-                [table (do (@#'upload/load-from-csv!
+                [table (do (@#'upload/create-from-csv!
                             driver/*driver*
                             (mt/id)
                             table-name
@@ -674,7 +674,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -719,7 +719,7 @@
         (is (pos? length-limit) "driver/table-name-length-limit has been set")
         (with-mysql-local-infile-on-and-off
           (with-upload-table!
-            [table (do (@#'upload/load-from-csv!
+            [table (do (@#'upload/create-from-csv!
                         driver/*driver*
                         (mt/id)
                         table-name
@@ -742,7 +742,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-upload-table!
         [table (let [table-name (mt/random-name)]
-                 (@#'upload/load-from-csv!
+                 (@#'upload/create-from-csv!
                   driver/*driver*
                   (mt/id)
                   table-name
@@ -760,7 +760,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -779,7 +779,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -802,7 +802,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -827,7 +827,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -851,7 +851,7 @@
         (with-mysql-local-infile-on-and-off
           (with-upload-table!
             [table (let [table-name (mt/random-name)]
-                     (@#'upload/load-from-csv!
+                     (@#'upload/create-from-csv!
                       driver/*driver*
                       (mt/id)
                       table-name
@@ -870,7 +870,7 @@
         (with-mysql-local-infile-on-and-off
           (with-upload-table!
             [table (let [table-name (mt/random-name)]
-                     (@#'upload/load-from-csv!
+                     (@#'upload/create-from-csv!
                       driver/*driver*
                       (mt/id)
                       table-name
@@ -889,7 +889,7 @@
         (with-mysql-local-infile-on-and-off
           (with-upload-table!
             [table (let [table-name (mt/random-name)]
-                     (@#'upload/load-from-csv!
+                     (@#'upload/create-from-csv!
                       driver/*driver*
                       (mt/id)
                       table-name
@@ -910,7 +910,7 @@
       (testing "Can upload a CSV with missing values"
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -931,7 +931,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -952,7 +952,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -973,7 +973,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -993,7 +993,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/load-from-csv!
+                   (@#'upload/create-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -1014,7 +1014,7 @@
     (mt/test-drivers [:postgres]
       (with-upload-table!
         [table (let [table-name (mt/random-name)]
-                 (@#'upload/load-from-csv!
+                 (@#'upload/create-from-csv!
                   driver/*driver*
                   (mt/id)
                   table-name
@@ -1158,7 +1158,7 @@
                   (last (snowplow-test/pop-event-data-and-user-id!)))))
 
         (testing "Failures when creating a CSV Upload will publish statistics to Snowplow"
-          (mt/with-dynamic-redefs [upload/load-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
+          (mt/with-dynamic-redefs [upload/create-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
             (try (upload-example-csv!)
                  (catch Throwable _
                    nil))
@@ -1589,7 +1589,7 @@
            (io/delete-file file)))
 
        (testing "Failures when appending to CSV Uploads will publish statistics to Snowplow"
-         (mt/with-dynamic-redefs [upload/load-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
+         (mt/with-dynamic-redefs [upload/create-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
            (let [csv-rows ["mispelled_name, unexpected_column" "Duke Cakewalker, r2dj"]
                  file     (csv-file-with csv-rows (mt/random-name))]
              (try
@@ -1901,7 +1901,7 @@
       (with-mysql-local-infile-on-and-off
        (with-upload-table!
          [table (let [table-name (mt/random-name)]
-                  (@#'upload/load-from-csv!
+                  (@#'upload/create-from-csv!
                    driver/*driver*
                    (mt/id)
                    table-name
@@ -1952,7 +1952,7 @@
               file     (csv-file-with csv-rows (mt/random-name))]
           (is (some? (replace-csv! {:file file, :table-id (:id table)})))
           (let [table-rows (rows-for-table table)
-                ;; For MySQL the primary key incrementer will be reset, but for Postgres and H2 it will not.
+                ;; Some drivers may reset the primary key on truncate, so we only test that they are ascending
                 first-pk   (ffirst table-rows)]
             (is (= [[first-pk 1 1]
                     [(inc first-pk) 1 1]]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1316,7 +1316,7 @@
 
 (defn append-csv-with-defaults!
   "Upload a small CSV file to a newly created default table, or an existing table if `table-id` is provided. Default args can be overridden."
-  [& options]
+  [& {:as options}]
   (update-csv-with-defaults! ::upload/append options))
 
 (defn catch-ex-info* [f]

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -570,7 +570,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -619,7 +619,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -654,7 +654,7 @@
                                 ["2022-01-01T12:00:00+07:30" "2022-01-01T04:30:00Z"]]]
             (testing "Fields exists after sync"
               (with-upload-table!
-                [table (do (@#'upload/create-from-csv!
+                [table (do (@#'upload/load-from-csv!
                             driver/*driver*
                             (mt/id)
                             table-name
@@ -674,7 +674,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -719,7 +719,7 @@
         (is (pos? length-limit) "driver/table-name-length-limit has been set")
         (with-mysql-local-infile-on-and-off
           (with-upload-table!
-            [table (do (@#'upload/create-from-csv!
+            [table (do (@#'upload/load-from-csv!
                         driver/*driver*
                         (mt/id)
                         table-name
@@ -742,7 +742,7 @@
     (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
       (with-upload-table!
         [table (let [table-name (mt/random-name)]
-                 (@#'upload/create-from-csv!
+                 (@#'upload/load-from-csv!
                   driver/*driver*
                   (mt/id)
                   table-name
@@ -760,7 +760,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -779,7 +779,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -802,7 +802,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -827,7 +827,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -851,7 +851,7 @@
         (with-mysql-local-infile-on-and-off
           (with-upload-table!
             [table (let [table-name (mt/random-name)]
-                     (@#'upload/create-from-csv!
+                     (@#'upload/load-from-csv!
                       driver/*driver*
                       (mt/id)
                       table-name
@@ -870,7 +870,7 @@
         (with-mysql-local-infile-on-and-off
           (with-upload-table!
             [table (let [table-name (mt/random-name)]
-                     (@#'upload/create-from-csv!
+                     (@#'upload/load-from-csv!
                       driver/*driver*
                       (mt/id)
                       table-name
@@ -889,7 +889,7 @@
         (with-mysql-local-infile-on-and-off
           (with-upload-table!
             [table (let [table-name (mt/random-name)]
-                     (@#'upload/create-from-csv!
+                     (@#'upload/load-from-csv!
                       driver/*driver*
                       (mt/id)
                       table-name
@@ -910,7 +910,7 @@
       (testing "Can upload a CSV with missing values"
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -931,7 +931,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -952,7 +952,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -973,7 +973,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -993,7 +993,7 @@
       (with-mysql-local-infile-on-and-off
         (with-upload-table!
           [table (let [table-name (mt/random-name)]
-                   (@#'upload/create-from-csv!
+                   (@#'upload/load-from-csv!
                     driver/*driver*
                     (mt/id)
                     table-name
@@ -1014,7 +1014,7 @@
     (mt/test-drivers [:postgres]
       (with-upload-table!
         [table (let [table-name (mt/random-name)]
-                 (@#'upload/create-from-csv!
+                 (@#'upload/load-from-csv!
                   driver/*driver*
                   (mt/id)
                   table-name
@@ -1045,11 +1045,21 @@
                           first
                           :value))))))))
 
-(defn append-csv!
-  "Wraps [[upload/append-csv!]] setting [[upload/*sync-synchronously?*]] to `true` for test purposes."
-  [& args]
+(defn- update-csv-synchronously!
+  "Wraps [[upload/upload-csv!]] setting [[upload/*sync-synchronously?*]] to `true` for test purposes."
+  [options]
   (binding [upload/*sync-synchronously?* true]
-    (apply upload/append-csv! args)))
+    (upload/update-csv! options)))
+
+(defn- append-csv!
+  "Shorthand for synchronously appending to a CSV"
+  [options]
+  (update-csv-synchronously! (assoc options :action ::upload/append)))
+
+(defn- replace-csv!
+  "Shorthand for synchronously replacing a CSV"
+  [options]
+  (update-csv-synchronously! (assoc options :action ::upload/replace)))
 
 (deftest create-csv-upload!-schema-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads :schemas)
@@ -1143,7 +1153,7 @@
                   (last (snowplow-test/pop-event-data-and-user-id!)))))
 
         (testing "Failures when creating a CSV Upload will publish statistics to Snowplow"
-          (mt/with-dynamic-redefs [upload/create-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
+          (mt/with-dynamic-redefs [upload/load-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
             (try (upload-example-csv!)
                  (catch Throwable _
                    nil))
@@ -1570,7 +1580,7 @@
            (io/delete-file file)))
 
        (testing "Failures when appending to CSV Uploads will publish statistics to Snowplow"
-         (mt/with-dynamic-redefs [upload/create-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
+         (mt/with-dynamic-redefs [upload/load-from-csv! (fn [_ _ _ _] (throw (Exception.)))]
            (let [csv-rows ["mispelled_name, unexpected_column" "Duke Cakewalker, r2dj"]
                  file     (csv-file-with csv-rows (mt/random-name))]
              (try
@@ -1882,7 +1892,7 @@
       (with-mysql-local-infile-on-and-off
        (with-upload-table!
          [table (let [table-name (mt/random-name)]
-                  (@#'upload/create-from-csv!
+                  (@#'upload/load-from-csv!
                    driver/*driver*
                    (mt/id)
                    table-name
@@ -1914,6 +1924,29 @@
                   [2 1 1]
                   [3 1 1]]
                  (rows-for-table table)))
+
+          (io/delete-file file))))))
+
+(deftest replace-from-csv-int-and-float-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+    (testing "Append should handle a mix of int and float-or-int values being appended to an int column"
+      (with-upload-table! [table (create-upload-table!
+                                  :col->upload-type (ordered-map/ordered-map
+                                                     :_mb_row_id ::upload/auto-incrementing-int-pk
+                                                     :number_1 ::upload/int
+                                                     :number_2 ::upload/int)
+                                  :rows [[1, 1]])]
+
+        (let [csv-rows ["number-1, number-2"
+                        "1.0, 1"
+                        "1  , 1.0"]
+              file     (csv-file-with csv-rows (mt/random-name))]
+          (is (some? (replace-csv! {:file file, :table-id (:id table)})))
+          ;; For MySQL the primary key incrementer will be reset, but for Postgres and H2 it will not.
+          (let [pk-offset (case driver/*driver* :mysql -1 0)]
+            (is (= [[(+ pk-offset 2) 1 1]
+                    [(+ pk-offset 3) 1 1]]
+                   (rows-for-table table))))
 
           (io/delete-file file))))))
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40364
Closes https://github.com/metabase/metabase/issues/40365

### Description

This PR adds a working API for CSV replacement. 

It does this by refactoring the append code to be generic update code and introducing a new `:action` parameter.

By "basic version", I mean we're doing the simplest thing that could possibly work with the least code changes. This might be all we need though! We just need to stress testing failures and race conditions to check we have the desired behavior across all the drivers.

By "basic testing", I mean that we've copied the API tests 1-1 (but they're very thing) and adapted a single Component Integration test to kick the tires. Since we're sharing 99% of the code, it doesn't make sense to double the test running time, but we need to ensure the key edge cases are all being covered.

### Checklist

- [x] Discuss using `DELETE` for MySQL to match Postgres and H2 semantics.
- [x] Update driver changelog
- [x] Set the correct version added metadata on the new multi-method
- [x] ~~Better test cover~~ Good enough IMHO, follow-up in https://github.com/metabase/metabase/issues/40368