### PR TITLE
Add data-display/Image to "metabase/ui"

### DIFF
--- a/frontend/src/metabase/ui/components/data-display/Image/Image.stories.mdx
+++ b/frontend/src/metabase/ui/components/data-display/Image/Image.stories.mdx
@@ -7,6 +7,7 @@ export const args = {
   width: 120,
   height: 120,
   fit: "cover",
+  position: "center",
   src: noResultsSource,
   alt: "No search results",
 };
@@ -16,6 +17,12 @@ export const argTypes = {
     control: {
       type: "inline-radio",
       options: ["cover", "contain", "fill", "none", "scale-down"],
+    },
+  },
+  position: {
+    control: {
+      type: "inline-radio",
+      options: ["top left", "top", "center", "bottom", "bottom right"],
     },
   },
   src: {
@@ -50,4 +57,16 @@ export const Default = DefaultTemplate.bind({});
 
 <Canvas>
   <Story name="Default">{Default}</Story>
+</Canvas>
+
+### Image position
+
+export const BackgroundPosition = DefaultTemplate.bind({});
+BackgroundPosition.args = {
+  width: 80,
+  position: "top left",
+};
+
+<Canvas>
+  <Story name="BackgroundPosition">{BackgroundPosition}</Story>
 </Canvas>

--- a/frontend/src/metabase/ui/components/data-display/Image/Image.stories.mdx
+++ b/frontend/src/metabase/ui/components/data-display/Image/Image.stories.mdx
@@ -1,0 +1,53 @@
+import noResultsSource from "assets/img/no_results.svg";
+import { Fragment } from "react";
+import { Canvas, Story, Meta } from "@storybook/addon-docs";
+import { Box, Image, Stack, Text } from "metabase/ui";
+
+export const args = {
+  width: 120,
+  height: 120,
+  fit: "cover",
+  src: noResultsSource,
+  alt: "No search results",
+};
+
+export const argTypes = {
+  fit: {
+    control: {
+      type: "inline-radio",
+      options: ["cover", "contain", "fill", "none", "scale-down"],
+    },
+  },
+  src: {
+    control: { type: "file", accept: "image/jpeg,image/png,image/svg+xml" },
+  },
+};
+
+<Meta
+  title="Data display/Image"
+  component={Image}
+  args={args}
+  argTypes={argTypes}
+/>
+
+# Image
+
+Our themed wrapper around [Mantine Image](https://v6.mantine.dev/core/image/).
+
+## Docs
+
+- [Mantine Image Docs](https://v6.mantine.dev/core/image/)
+
+## Examples
+
+export const DefaultTemplate = args => (
+  <Box maw="20rem">
+    <Image {...args} />
+  </Box>
+);
+
+export const Default = DefaultTemplate.bind({});
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+</Canvas>

--- a/frontend/src/metabase/ui/components/data-display/Image/Image.tsx
+++ b/frontend/src/metabase/ui/components/data-display/Image/Image.tsx
@@ -1,0 +1,12 @@
+import { Image as MantineImage } from "@mantine/core";
+
+import type { ImageProps } from "./index";
+
+export function Image({ position, ...mantineImageProps }: ImageProps) {
+  return (
+    <MantineImage
+      {...mantineImageProps}
+      styles={{ image: { objectPosition: position } }}
+    />
+  );
+}

--- a/frontend/src/metabase/ui/components/data-display/Image/index.ts
+++ b/frontend/src/metabase/ui/components/data-display/Image/index.ts
@@ -1,0 +1,2 @@
+export { Image } from "@mantine/core";
+export type { ImageProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/data-display/Image/index.ts
+++ b/frontend/src/metabase/ui/components/data-display/Image/index.ts
@@ -1,2 +1,0 @@
-export { Image } from "@mantine/core";
-export type { ImageProps } from "@mantine/core";

--- a/frontend/src/metabase/ui/components/data-display/Image/index.tsx
+++ b/frontend/src/metabase/ui/components/data-display/Image/index.tsx
@@ -1,16 +1,8 @@
 import type { ImageProps as MantineImageProps } from "@mantine/core";
-import { Image as MantineImage } from "@mantine/core";
 import type { CSSProperties } from "react";
 
 export interface ImageProps extends MantineImageProps {
   position: CSSProperties["position"];
 }
 
-export function Image({ position, ...mantineImageProps }: ImageProps) {
-  return (
-    <MantineImage
-      {...mantineImageProps}
-      styles={{ image: { objectPosition: position } }}
-    />
-  );
-}
+export { Image } from "./Image";

--- a/frontend/src/metabase/ui/components/data-display/Image/index.tsx
+++ b/frontend/src/metabase/ui/components/data-display/Image/index.tsx
@@ -1,0 +1,16 @@
+import type { ImageProps as MantineImageProps } from "@mantine/core";
+import { Image as MantineImage } from "@mantine/core";
+import type { CSSProperties } from "react";
+
+export interface ImageProps extends MantineImageProps {
+  position: CSSProperties["position"];
+}
+
+export function Image({ position, ...mantineImageProps }: ImageProps) {
+  return (
+    <MantineImage
+      {...mantineImageProps}
+      styles={{ image: { objectPosition: position } }}
+    />
+  );
+}

--- a/frontend/src/metabase/ui/components/data-display/index.ts
+++ b/frontend/src/metabase/ui/components/data-display/index.ts
@@ -1,2 +1,3 @@
 export * from "./Accordion";
 export * from "./Card";
+export * from "./Image";


### PR DESCRIPTION
### Rationale
This epic https://github.com/metabase/metabase/issues/39246 works on a bunch of illustrations that will be rendered as an `img` tag. So instead of having to have `*.styled.ts` every place I want to customize the illustration.

### Description
This PR adds [Image](https://v6.mantine.dev/core/image/) to "metabase/ui"

### Demo
![Screenshot 2024-03-20 at 9 17 25 PM](https://github.com/metabase/metabase/assets/1937582/d2396cc9-b991-49af-9f55-f22ffd1971f6)

