### PR TITLE
40232 sortable with popovers

### DIFF
--- a/e2e/test/scenarios/native-filters/reproductions/40232-dragging-filters.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/40232-dragging-filters.cy.spec.js
@@ -1,0 +1,34 @@
+import {
+  restore,
+  openNativeEditor,
+  filterWidget,
+  popover,
+  moveDnDKitElement,
+} from "e2e/support/helpers";
+
+import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
+
+describe("issue 31606", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should not start drag and drop from clicks on popovers", () => {
+    openNativeEditor();
+
+    SQLFilter.enterParameterizedQuery("{{foo}} {{bar}}");
+
+    cy.findAllByRole("radio", { name: "Search box" }).first().click();
+    filterWidget().first().click();
+
+    moveDnDKitElement(popover().findByText("Add filter"), {
+      horizontal: 300,
+    });
+
+    filterWidget()
+      .should("have.length", 2)
+      .first()
+      .should("contain.text", "Foo");
+  });
+});

--- a/e2e/test/scenarios/native-filters/reproductions/9357.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/9357.cy.spec.js
@@ -16,6 +16,7 @@ describe("issue 9357", () => {
 
     // Drag the firstparameter to last position
     cy.get("fieldset")
+      .findAllByRole("listitem")
       .first()
       .trigger("pointerdown", 0, 0, { force: true, isPrimary: true, button: 0 })
       .wait(200)

--- a/frontend/src/metabase/core/components/Sortable/SortableList.tsx
+++ b/frontend/src/metabase/core/components/Sortable/SortableList.tsx
@@ -2,12 +2,10 @@ import type {
   DragOverEvent,
   DragStartEvent,
   Modifier,
-  PointerSensorOptions,
   SensorDescriptor,
 } from "@dnd-kit/core";
-import { DndContext, DragOverlay, PointerSensor } from "@dnd-kit/core";
+import { DndContext, DragOverlay } from "@dnd-kit/core";
 import { SortableContext, arrayMove } from "@dnd-kit/sortable";
-import type { PointerEvent } from "react";
 import { useState, useMemo, useEffect } from "react";
 import _ from "underscore";
 
@@ -125,30 +123,3 @@ export const SortableList = <T,>({
     </DndContext>
   );
 };
-
-// Custom sensor to limit the pointer sensor to start dragging only when the target
-// is a child of the current target in the dom. This avoids dragging when dealing with
-// sortable elements that contain popovers etc.
-export class PointerChildSensor extends PointerSensor {
-  static activators = [
-    {
-      eventName: "onPointerDown" as const,
-      handler: (
-        { nativeEvent: event, target, currentTarget }: PointerEvent,
-        { onActivation }: PointerSensorOptions,
-      ) => {
-        if (!event.isPrimary || event.button !== 0) {
-          return false;
-        }
-
-        if (!(target instanceof Element) || !currentTarget.contains(target)) {
-          return false;
-        }
-
-        onActivation?.({ event });
-
-        return true;
-      },
-    },
-  ];
-}

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -11,6 +11,7 @@ import { DateRelativeWidget } from "metabase/components/DateRelativeWidget";
 import { DateSingleWidget } from "metabase/components/DateSingleWidget";
 import PopoverWithTrigger from "metabase/components/PopoverWithTrigger";
 import { TextWidget } from "metabase/components/TextWidget";
+import { Sortable } from "metabase/core/components/Sortable";
 import FormattedParameterValue from "metabase/parameters/components/FormattedParameterValue";
 import { WidgetStatusIcon } from "metabase/parameters/components/WidgetStatusIcon";
 import { NumberInputWidget } from "metabase/parameters/components/widgets/NumberInputWidget";
@@ -154,6 +155,21 @@ class ParameterValueWidget extends Component {
     }
   }
 
+  wrapSortable(children) {
+    const { disableSort = true, parameter } = this.props;
+
+    return (
+      <Sortable
+        id={parameter.id}
+        draggingStyle={{ opacity: 0.5 }}
+        disabled={disableSort}
+        role="listitem"
+      >
+        {children}
+      </Sortable>
+    );
+  }
+
   render() {
     const {
       parameter,
@@ -170,7 +186,7 @@ class ParameterValueWidget extends Component {
     const showTypeIcon = !isEditing && !hasValue && !isFocused;
 
     if (noPopover) {
-      return (
+      return this.wrapSortable(
         <ParameterValueWidgetTrigger
           className={cx(S.noPopover, className)}
           hasValue={hasValue}
@@ -189,7 +205,7 @@ class ParameterValueWidget extends Component {
             onPopoverClose={this.onPopoverClose}
           />
           {this.getActionIcon()}
-        </ParameterValueWidgetTrigger>
+        </ParameterValueWidgetTrigger>,
       );
     }
 
@@ -203,7 +219,7 @@ class ParameterValueWidget extends Component {
       <PopoverWithTrigger
         ref={this.valuePopover}
         targetOffsetX={16}
-        triggerElement={
+        triggerElement={this.wrapSortable(
           <ParameterValueWidgetTrigger
             ref={this.trigger}
             hasValue={hasValue}
@@ -226,8 +242,8 @@ class ParameterValueWidget extends Component {
               />
             </div>
             {this.getActionIcon()}
-          </ParameterValueWidgetTrigger>
-        }
+          </ParameterValueWidgetTrigger>,
+        )}
         target={this.getTargetRef}
         // make sure the full date picker will expand to fit the dual calendars
         autoWidth={parameter.type === "date/all-options"}

--- a/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterValueWidget.jsx
@@ -61,6 +61,7 @@ class ParameterValueWidget extends Component {
     // Don't use in settings sidebars.
     enableRequiredBehavior: PropTypes.bool,
     mimicMantine: PropTypes.bool,
+    isSortable: PropTypes.bool,
   };
 
   state = { isFocused: false };
@@ -156,13 +157,13 @@ class ParameterValueWidget extends Component {
   }
 
   wrapSortable(children) {
-    const { disableSort = true, parameter } = this.props;
+    const { isSortable = false, parameter } = this.props;
 
     return (
       <Sortable
         id={parameter.id}
         draggingStyle={{ opacity: 0.5 }}
-        disabled={disableSort}
+        disabled={!isSortable}
         role="listitem"
       >
         {children}

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
@@ -2,6 +2,8 @@
 import PropTypes from "prop-types";
 import { Component } from "react";
 
+import { Sortable } from "metabase/core/components/Sortable";
+
 import ParameterValueWidget from "../ParameterValueWidget";
 
 import {
@@ -27,6 +29,7 @@ export class ParameterWidget extends Component {
   static defaultProps = {
     parameter: null,
     commitImmediately: false,
+    isSortable: false,
   };
 
   renderPopover(value, setValue, placeholder, isFullscreen) {
@@ -39,6 +42,8 @@ export class ParameterWidget extends Component {
       parameters,
       setParameterValueToDefault,
       enableParameterRequiredBehavior,
+      isSortable,
+      isEditing,
     } = this.props;
 
     const isEditingParameter = editingParameter?.id === parameter.id;
@@ -59,6 +64,8 @@ export class ParameterWidget extends Component {
         commitImmediately={commitImmediately}
         setParameterValueToDefault={setParameterValueToDefault}
         enableRequiredBehavior={enableParameterRequiredBehavior}
+        isSortable={isSortable}
+        disableSort={!isEditing}
       />
     );
   }
@@ -109,18 +116,25 @@ export class ParameterWidget extends Component {
     };
 
     const renderEditing = () => (
-      <ParameterContainer
-        isEditingParameter={isEditingParameter}
-        onClick={() =>
-          setEditingParameter(isEditingParameter ? null : parameter.id)
-        }
+      <Sortable
+        id={parameter.id}
+        draggingStyle={{ opacity: 0.5 }}
+        disabled={!isEditing}
+        role="listitem"
       >
-        <div className="mr1" onClick={e => e.stopPropagation()}>
-          {dragHandle}
-        </div>
-        {parameter.name}
-        <SettingsIcon name="gear" size={16} />
-      </ParameterContainer>
+        <ParameterContainer
+          isEditingParameter={isEditingParameter}
+          onClick={() =>
+            setEditingParameter(isEditingParameter ? null : parameter.id)
+          }
+        >
+          <div className="mr1" onClick={e => e.stopPropagation()}>
+            {dragHandle}
+          </div>
+          {parameter.name}
+          <SettingsIcon name="gear" size={16} />
+        </ParameterContainer>
+      </Sortable>
     );
 
     if (isFullscreen) {

--- a/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
+++ b/frontend/src/metabase/parameters/components/ParameterWidget/ParameterWidget.jsx
@@ -64,8 +64,7 @@ export class ParameterWidget extends Component {
         commitImmediately={commitImmediately}
         setParameterValueToDefault={setParameterValueToDefault}
         enableRequiredBehavior={enableParameterRequiredBehavior}
-        isSortable={isSortable}
-        disableSort={!isEditing}
+        isSortable={isSortable && isEditing}
       />
     );
   }

--- a/frontend/src/metabase/parameters/components/ParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/ParametersList.jsx
@@ -1,13 +1,9 @@
 /* eslint-disable react/prop-types */
-import { useSensor } from "@dnd-kit/core";
+import { useSensor, PointerSensor } from "@dnd-kit/core";
 import cx from "classnames";
 import { useCallback, useMemo } from "react";
 
-import {
-  SortableList,
-  Sortable,
-  PointerChildSensor,
-} from "metabase/core/components/Sortable";
+import { SortableList } from "metabase/core/components/Sortable";
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import { Icon } from "metabase/ui";
 
@@ -36,7 +32,7 @@ function ParametersList({
   setEditingParameter,
   enableParameterRequiredBehavior,
 }) {
-  const pointerSensor = useSensor(PointerChildSensor, {
+  const pointerSensor = useSensor(PointerSensor, {
     activationConstraint: { distance: 5 },
   });
 
@@ -55,40 +51,34 @@ function ParametersList({
   );
 
   const renderItem = ({ item: valuePopulatedParameter, id }) => (
-    <Sortable
-      id={id}
+    <ParameterWidget
       key={`sortable-${id}`}
-      disabled={!isEditing}
-      draggingStyle={{ opacity: 0.5 }}
-      role="listitem"
-    >
-      <ParameterWidget
-        className={cx({ mb2: vertical })}
-        isEditing={isEditing}
-        isFullscreen={isFullscreen}
-        isNightMode={isNightMode}
-        parameter={valuePopulatedParameter}
-        parameters={parameters}
-        question={question}
-        dashboard={dashboard}
-        editingParameter={editingParameter}
-        setEditingParameter={setEditingParameter}
-        setValue={
-          setParameterValue &&
-          (value => setParameterValue(valuePopulatedParameter.id, value))
-        }
-        setParameterValueToDefault={setParameterValueToDefault}
-        enableParameterRequiredBehavior={enableParameterRequiredBehavior}
-        commitImmediately={commitImmediately}
-        dragHandle={
-          isEditing && setParameterIndex ? (
-            <div className="flex layout-centered cursor-grab text-inherit">
-              <Icon name="grabber" />
-            </div>
-          ) : null
-        }
-      />
-    </Sortable>
+      className={cx({ mb2: vertical })}
+      isEditing={isEditing}
+      isFullscreen={isFullscreen}
+      isNightMode={isNightMode}
+      parameter={valuePopulatedParameter}
+      parameters={parameters}
+      question={question}
+      dashboard={dashboard}
+      editingParameter={editingParameter}
+      setEditingParameter={setEditingParameter}
+      setValue={
+        setParameterValue &&
+        (value => setParameterValue(valuePopulatedParameter.id, value))
+      }
+      setParameterValueToDefault={setParameterValueToDefault}
+      enableParameterRequiredBehavior={enableParameterRequiredBehavior}
+      commitImmediately={commitImmediately}
+      dragHandle={
+        isEditing && setParameterIndex ? (
+          <div className="flex layout-centered cursor-grab text-inherit">
+            <Icon name="grabber" />
+          </div>
+        ) : null
+      }
+      isSortable
+    />
   );
 
   return visibleValuePopulatedParameters.length > 0 ? (

--- a/frontend/src/metabase/parameters/components/ParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/ParametersList.jsx
@@ -1,9 +1,13 @@
 /* eslint-disable react/prop-types */
-import { useSensor, PointerSensor } from "@dnd-kit/core";
+import { useSensor } from "@dnd-kit/core";
 import cx from "classnames";
 import { useCallback, useMemo } from "react";
 
-import { SortableList, Sortable } from "metabase/core/components/Sortable";
+import {
+  SortableList,
+  Sortable,
+  PointerChildSensor,
+} from "metabase/core/components/Sortable";
 import { getVisibleParameters } from "metabase/parameters/utils/ui";
 import { Icon } from "metabase/ui";
 
@@ -32,9 +36,10 @@ function ParametersList({
   setEditingParameter,
   enableParameterRequiredBehavior,
 }) {
-  const pointerSensor = useSensor(PointerSensor, {
-    activationConstraint: { distance: 0 },
+  const pointerSensor = useSensor(PointerChildSensor, {
+    activationConstraint: { distance: 5 },
   });
+
   const visibleValuePopulatedParameters = useMemo(
     () => getVisibleParameters(parameters, hideParameters),
     [parameters, hideParameters],


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40232

### Description
Bug was caused by the sortable element wrapping entire popover components, rather than only their triggers that are rendered on screen. This change moves the sortable element down to the different types of parameters, and if there are popovers then only the trigger is wrapped with `<Sortable>`

### How to verify
1. New -> SQL Query
2. Create a query with some parameters, and change one to be a search box
3. Click the parameter to open the popover, and try dragging the popover to the right. It should not move the parameter

### Demo
![chrome_o2h78ln8iT](https://github.com/metabase/metabase/assets/1328979/fcd7a592-7182-45c4-b171-8c31731a7fbe)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
