### PR TITLE
Caching tests flakes

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/caching/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/caching/strategies.clj
@@ -34,7 +34,7 @@
     [:ttl      [:map {:closed true}
                 [:type [:= :ttl]]
                 [:multiplier ms/PositiveInt]
-                [:min_duration ms/PositiveInt]]]
+                [:min_duration ms/IntGreaterThanOrEqualToZero]]]
     [:duration [:map {:closed true}
                 [:type [:= :duration]]
                 [:duration ms/PositiveInt]

--- a/enterprise/backend/src/metabase_enterprise/caching/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/caching/strategies.clj
@@ -34,7 +34,7 @@
     [:ttl      [:map {:closed true}
                 [:type [:= :ttl]]
                 [:multiplier ms/PositiveInt]
-                [:min_duration ms/IntGreaterThanOrEqualToZero]]]
+                [:min_duration_ms ms/IntGreaterThanOrEqualToZero]]]
     [:duration [:map {:closed true}
                 [:type [:= :duration]]
                 [:duration ms/PositiveInt]

--- a/enterprise/backend/test/metabase_enterprise/caching/strategies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/caching/strategies_test.clj
@@ -68,7 +68,7 @@
           (testing "strategy = ttl"
             (let [query (assoc query :cache-strategy {:type             :ttl
                                                       :multiplier       10
-                                                      :min_duration     0
+                                                      :min-duration-ms  0
                                                       :avg-execution-ms 500})]
               (testing "Results are stored and available immediately"
                 (mt/with-clock #t "2024-02-13T10:00:00Z"
@@ -87,10 +87,10 @@
 
         (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
           (testing "strategy = duration"
-            (let [query (assoc query :cache-strategy {:type         :duration
-                                                      :duration     1
-                                                      :unit         "minutes"
-                                                      :min_duration 0})]
+            (let [query (assoc query :cache-strategy {:type            :duration
+                                                      :duration        1
+                                                      :unit            "minutes"
+                                                      :min-duration-ms 0})]
               (testing "Results are stored and available immediately"
                 (mt/with-clock #t "2024-02-13T10:00:00Z"
                   (is (=? (mkres nil)
@@ -165,8 +165,8 @@
                        :model/CacheConfig _c1 {:model    "question"
                                                :model_id (:id card1)
                                                :strategy :ttl
-                                               :config   {:multiplier   100
-                                                          :min_duration 0}}
+                                               :config   {:multiplier      100
+                                                          :min_duration_ms 0}}
                        :model/CacheConfig _c2 {:model    "question"
                                                :model_id (:id card2)
                                                :strategy :duration

--- a/enterprise/backend/test/metabase_enterprise/caching/strategies_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/caching/strategies_test.clj
@@ -53,232 +53,234 @@
                  (:cache-strategy (#'qp.card/query-for-card card [] {} {} {:dashboard-id (u/the-id dash)})))))))))
 
 (deftest caching-strategies
-  (mt/discard-setting-changes [enable-query-caching]
-    (public-settings/enable-query-caching! true)
-    (mt/with-premium-features #{:cache-granular-controls}
+  (mt/with-empty-h2-app-db
+    (mt/discard-setting-changes [enable-query-caching]
+      (public-settings/enable-query-caching! true)
+      (mt/with-premium-features #{:cache-granular-controls}
 
-      (let [query (mt/mbql-query venues {:order-by [[:asc $id]] :limit 5})
-            mkres (fn [input]
-                    {:cache/details (if input
-                                      {:cached true, :updated_at input, :hash some?}
-                                      {:stored true, :hash some?})
-                     :row_count     5
-                     :status        :completed})]
-        (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-          (testing "strategy = ttl"
-            (let [query (assoc query :cache-strategy {:type             :ttl
-                                                      :multiplier       10
-                                                      :min-duration-ms  0
-                                                      :avg-execution-ms 500})]
-              (testing "Results are stored and available immediately"
-                (mt/with-clock #t "2024-02-13T10:00:00Z"
-                  (is (=? (mkres nil)
-                          (-> (qp/process-query query) (dissoc :data))))
-                  (is (=? (mkres #t "2024-02-13T10:00:00Z")
-                          (-> (qp/process-query query) (dissoc :data))))))
-              (testing "4 seconds past that results are still there - 10 * 500 = 5 seconds"
-                (mt/with-clock #t "2024-02-13T10:00:04Z"
-                  (is (=? (mkres #t "2024-02-13T10:00:00Z")
-                          (-> (qp/process-query query) (dissoc :data))))))
-              (testing "6 seconds later results are unavailable"
-                (mt/with-clock #t "2024-02-13T10:00:06Z"
-                  (is (=? (mkres nil)
-                          (-> (qp/process-query query) (dissoc :data)))))))))
-
-        (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-          (testing "strategy = duration"
-            (let [query (assoc query :cache-strategy {:type            :duration
-                                                      :duration        1
-                                                      :unit            "minutes"
-                                                      :min-duration-ms 0})]
-              (testing "Results are stored and available immediately"
-                (mt/with-clock #t "2024-02-13T10:00:00Z"
-                  (is (=? (mkres nil)
-                          (-> (qp/process-query query) (dissoc :data))))
-                  (is (=? (mkres #t "2024-02-13T10:00:00Z")
-                          (-> (qp/process-query query) (dissoc :data)))))
-                (mt/with-clock #t "2024-02-13T10:00:59Z"
-                  (is (=? (mkres #t "2024-02-13T10:00:00Z")
-                          (-> (qp/process-query query) (dissoc :data)))))
-                (mt/with-clock #t "2024-02-13T10:01:01Z"
-                  (is (=? (mkres nil)
-                          (-> (qp/process-query query) (dissoc :data)))))))))
-
-        (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-          (testing "strategy = schedule"
-            (let [query (assoc query :cache-strategy {:type           :schedule
-                                                      :schedule       "0/2 * * * *"
-                                                      :invalidated-at (t/offset-date-time #t "2024-02-13T10:00:00Z")})]
-              (testing "Results are stored and available immediately"
-                (mt/with-clock #t "2024-02-13T10:01:00Z"
-                  (is (=? (mkres nil)
-                          (-> (qp/process-query query) (dissoc :data))))
-                  (is (=? (mkres #t "2024-02-13T10:01:00Z")
-                          (-> (qp/process-query query) (dissoc :data))))))
-              (let [query (assoc-in query [:cache-strategy :invalidated-at] (t/offset-date-time #t "2024-02-13T10:02:00Z"))]
-                (testing "Cache is invalidated when schedule ran after the query"
-                  (mt/with-clock #t "2024-02-13T10:03:00Z"
+        (let [query (mt/mbql-query venues {:order-by [[:asc $id]] :limit 5})
+              mkres (fn [input]
+                      {:cache/details (if input
+                                        {:cached true, :updated_at input, :hash some?}
+                                        {:stored true, :hash some?})
+                       :row_count     5
+                       :status        :completed})]
+          (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+            (testing "strategy = ttl"
+              (let [query (assoc query :cache-strategy {:type             :ttl
+                                                        :multiplier       10
+                                                        :min-duration-ms  0
+                                                        :avg-execution-ms 500})]
+                (testing "Results are stored and available immediately"
+                  (mt/with-clock #t "2024-02-13T10:00:00Z"
                     (is (=? (mkres nil)
+                            (-> (qp/process-query query) (dissoc :data))))
+                    (is (=? (mkres #t "2024-02-13T10:00:00Z")
                             (-> (qp/process-query query) (dissoc :data))))))
-                (testing "schedule did not run - cache is still intact"
-                  (mt/with-clock #t "2024-02-13T10:08:00Z"
-                    (is (=? (mkres #t "2024-02-13T10:03:00Z")
-                            (-> (qp/process-query query) (dissoc :data))))))))))
-
-        (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-          (testing "strategy = query"
-            (let [query (assoc query :cache-strategy {:type           :query
-                                                      :field_id       0
-                                                      :aggregation    "max"
-                                                      :schedule       "0/2 * * * *"
-                                                      :invalidated-at (t/offset-date-time #t "2024-02-13T11:00:00Z")})]
-              (testing "Results are stored and available immediately"
-                (mt/with-clock #t "2024-02-13T11:01:00Z"
-                  (is (=? (mkres nil)
-                          (-> (qp/process-query query) (dissoc :data))))
-                  (is (=? (mkres #t "2024-02-13T11:01:00Z")
-                          (-> (qp/process-query query) (dissoc :data))))))
-              (let [query (assoc-in query [:cache-strategy :invalidated-at] (t/offset-date-time #t "2024-02-13T11:02:00Z"))]
-                (testing "Cache is invalidated when schedule ran after the query"
-                  (mt/with-clock #t "2024-02-13T11:03:00Z"
+                (testing "4 seconds past that results are still there - 10 * 500 = 5 seconds"
+                  (mt/with-clock #t "2024-02-13T10:00:04Z"
+                    (is (=? (mkres #t "2024-02-13T10:00:00Z")
+                            (-> (qp/process-query query) (dissoc :data))))))
+                (testing "6 seconds later results are unavailable"
+                  (mt/with-clock #t "2024-02-13T10:00:06Z"
                     (is (=? (mkres nil)
+                            (-> (qp/process-query query) (dissoc :data)))))))))
+
+          (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+            (testing "strategy = duration"
+              (let [query (assoc query :cache-strategy {:type            :duration
+                                                        :duration        1
+                                                        :unit            "minutes"
+                                                        :min-duration-ms 0})]
+                (testing "Results are stored and available immediately"
+                  (mt/with-clock #t "2024-02-13T10:00:00Z"
+                    (is (=? (mkres nil)
+                            (-> (qp/process-query query) (dissoc :data))))
+                    (is (=? (mkres #t "2024-02-13T10:00:00Z")
+                            (-> (qp/process-query query) (dissoc :data)))))
+                  (mt/with-clock #t "2024-02-13T10:00:59Z"
+                    (is (=? (mkres #t "2024-02-13T10:00:00Z")
+                            (-> (qp/process-query query) (dissoc :data)))))
+                  (mt/with-clock #t "2024-02-13T10:01:01Z"
+                    (is (=? (mkres nil)
+                            (-> (qp/process-query query) (dissoc :data)))))))))
+
+          (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+            (testing "strategy = schedule"
+              (let [query (assoc query :cache-strategy {:type           :schedule
+                                                        :schedule       "0/2 * * * *"
+                                                        :invalidated-at (t/offset-date-time #t "2024-02-13T10:00:00Z")})]
+                (testing "Results are stored and available immediately"
+                  (mt/with-clock #t "2024-02-13T10:01:00Z"
+                    (is (=? (mkres nil)
+                            (-> (qp/process-query query) (dissoc :data))))
+                    (is (=? (mkres #t "2024-02-13T10:01:00Z")
                             (-> (qp/process-query query) (dissoc :data))))))
-                (testing "schedule did not run - cache is still intact"
-                  (mt/with-clock #t "2024-02-13T11:08:00Z"
-                    (is (=? (mkres #t "2024-02-13T11:03:00Z")
-                            (-> (qp/process-query query) (dissoc :data))))))))))))))
+                (let [query (assoc-in query [:cache-strategy :invalidated-at] (t/offset-date-time #t "2024-02-13T10:02:00Z"))]
+                  (testing "Cache is invalidated when schedule ran after the query"
+                    (mt/with-clock #t "2024-02-13T10:03:00Z"
+                      (is (=? (mkres nil)
+                              (-> (qp/process-query query) (dissoc :data))))))
+                  (testing "schedule did not run - cache is still intact"
+                    (mt/with-clock #t "2024-02-13T10:08:00Z"
+                      (is (=? (mkres #t "2024-02-13T10:03:00Z")
+                              (-> (qp/process-query query) (dissoc :data))))))))))
+
+          (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+            (testing "strategy = query"
+              (let [query (assoc query :cache-strategy {:type           :query
+                                                        :field_id       0
+                                                        :aggregation    "max"
+                                                        :schedule       "0/2 * * * *"
+                                                        :invalidated-at (t/offset-date-time #t "2024-02-13T11:00:00Z")})]
+                (testing "Results are stored and available immediately"
+                  (mt/with-clock #t "2024-02-13T11:01:00Z"
+                    (is (=? (mkres nil)
+                            (-> (qp/process-query query) (dissoc :data))))
+                    (is (=? (mkres #t "2024-02-13T11:01:00Z")
+                            (-> (qp/process-query query) (dissoc :data))))))
+                (let [query (assoc-in query [:cache-strategy :invalidated-at] (t/offset-date-time #t "2024-02-13T11:02:00Z"))]
+                  (testing "Cache is invalidated when schedule ran after the query"
+                    (mt/with-clock #t "2024-02-13T11:03:00Z"
+                      (is (=? (mkres nil)
+                              (-> (qp/process-query query) (dissoc :data))))))
+                  (testing "schedule did not run - cache is still intact"
+                    (mt/with-clock #t "2024-02-13T11:08:00Z"
+                      (is (=? (mkres #t "2024-02-13T11:03:00Z")
+                              (-> (qp/process-query query) (dissoc :data)))))))))))))))
 
 (deftest e2e-advanced-caching
-  (mt/discard-setting-changes [enable-query-caching]
-    (public-settings/enable-query-caching! true)
-    (mt/with-premium-features #{:cache-granular-controls}
-      (mt/dataset (mt/dataset-definition "caching1"
-                                         ["table"
-                                          [{:field-name "value" :indexed? true :base-type :type/Text}]
-                                          [["a"] ["b"] ["c"]]])
-        (mt/with-temp [:model/Card       card1 {:dataset_query (mt/mbql-query table)}
-                       :model/Card       card2 {:dataset_query (mt/mbql-query table)}
-                       :model/Card       card3 {:dataset_query (mt/mbql-query table)}
-                       :model/Card       card4 {:dataset_query (mt/mbql-query table)}
-                       :model/Card       card5 {:dataset_query (mt/mbql-query table)}
+  (mt/with-empty-h2-app-db
+    (mt/discard-setting-changes [enable-query-caching]
+      (public-settings/enable-query-caching! true)
+      (mt/with-premium-features #{:cache-granular-controls}
+        (mt/dataset (mt/dataset-definition "caching1"
+                                           ["table"
+                                            [{:field-name "value" :indexed? true :base-type :type/Text}]
+                                            [["a"] ["b"] ["c"]]])
+          (mt/with-temp [:model/Card       card1 {:dataset_query (mt/mbql-query table)}
+                         :model/Card       card2 {:dataset_query (mt/mbql-query table)}
+                         :model/Card       card3 {:dataset_query (mt/mbql-query table)}
+                         :model/Card       card4 {:dataset_query (mt/mbql-query table)}
+                         :model/Card       card5 {:dataset_query (mt/mbql-query table)}
 
-                       :model/CacheConfig _c1 {:model    "question"
-                                               :model_id (:id card1)
-                                               :strategy :ttl
-                                               :config   {:multiplier      100
-                                                          :min_duration_ms 0}}
-                       :model/CacheConfig _c2 {:model    "question"
-                                               :model_id (:id card2)
-                                               :strategy :duration
-                                               :config   {:duration 1
-                                                          :unit     "minutes"}}
-                       :model/CacheConfig _c3 {:model    "question"
-                                               :model_id (:id card3)
-                                               :strategy :schedule
-                                               :config   {:schedule "0 0/2 * * * ? *"}}
-                       :model/CacheConfig c4  {:model    "question"
-                                               :model_id (:id card4)
-                                               :strategy :query
-                                               :config   {:field_id    (mt/id :table :id)
-                                                          :aggregation "max"
-                                                          :schedule    "0 0/2 * * * ? *"}}]
-          (let [t     (fn [seconds]
-                        (t/plus #t "2024-02-13T10:00:00Z" (t/duration seconds :seconds)))
-                mkres (fn [input]
-                        {:cache/details (if input
-                                          {:cached true, :updated_at input, :hash some?}
-                                          {:stored true, :hash some?})
-                         :row_count     3
-                         :status        :completed})]
-            (testing "strategy = ttl"
-              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                (mt/with-clock (t 0)
-                  (let [q (with-redefs [query/average-execution-time-ms (constantly 1000)]
-                            (#'qp.card/query-for-card card1 [] {} {} {}))]
-                    (is (=? {:type :ttl}
-                            (:cache-strategy q)))
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query q) (dissoc :data))))
-                    (testing "There is cache on second call"
-                      (is (=? (mkres (t 0))
-                              (-> (qp/process-query q) (dissoc :data)))))
-                    (testing "No cache after expiration"
-                      (mt/with-clock (t 101) ;; avg execution time 1s * multiplier 100 + 1
-                        (is (=? (mkres nil)
-                                (-> (qp/process-query q) (dissoc :data))))))))))
+                         :model/CacheConfig _c1 {:model    "question"
+                                                 :model_id (:id card1)
+                                                 :strategy :ttl
+                                                 :config   {:multiplier      100
+                                                            :min_duration_ms 0}}
+                         :model/CacheConfig _c2 {:model    "question"
+                                                 :model_id (:id card2)
+                                                 :strategy :duration
+                                                 :config   {:duration 1
+                                                            :unit     "minutes"}}
+                         :model/CacheConfig _c3 {:model    "question"
+                                                 :model_id (:id card3)
+                                                 :strategy :schedule
+                                                 :config   {:schedule "0 0/2 * * * ? *"}}
+                         :model/CacheConfig c4  {:model    "question"
+                                                 :model_id (:id card4)
+                                                 :strategy :query
+                                                 :config   {:field_id    (mt/id :table :id)
+                                                            :aggregation "max"
+                                                            :schedule    "0 0/2 * * * ? *"}}]
+            (let [t     (fn [seconds]
+                          (t/plus #t "2024-02-13T10:00:00Z" (t/duration seconds :seconds)))
+                  mkres (fn [input]
+                          {:cache/details (if input
+                                            {:cached true, :updated_at input, :hash some?}
+                                            {:stored true, :hash some?})
+                           :row_count     3
+                           :status        :completed})]
+              (testing "strategy = ttl"
+                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                  (mt/with-clock (t 0)
+                    (let [q (with-redefs [query/average-execution-time-ms (constantly 1000)]
+                              (#'qp.card/query-for-card card1 [] {} {} {}))]
+                      (is (=? {:type :ttl}
+                              (:cache-strategy q)))
+                      (is (=? (mkres nil)
+                              (-> (qp/process-query q) (dissoc :data))))
+                      (testing "There is cache on second call"
+                        (is (=? (mkres (t 0))
+                                (-> (qp/process-query q) (dissoc :data)))))
+                      (testing "No cache after expiration"
+                        (mt/with-clock (t 101) ;; avg execution time 1s * multiplier 100 + 1
+                          (is (=? (mkres nil)
+                                  (-> (qp/process-query q) (dissoc :data))))))))))
 
-            (testing "strategy = duration"
-              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                (mt/with-clock (t 0)
-                  (let [q (#'qp.card/query-for-card card2 [] {} {} {})]
-                    (is (=? {:type :duration}
-                            (:cache-strategy q)))
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query q) (dissoc :data))))
-                    (testing "There is cache on the next call"
-                      (is (=? (mkres (t 0))
-                              (-> (qp/process-query q) (dissoc :data)))))
-                    (testing "No cache after expiration"
-                      (mt/with-clock (t 61)
-                        (is (=? (mkres nil)
-                                (-> (qp/process-query q) (dissoc :data))))))))))
+              (testing "strategy = duration"
+                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                  (mt/with-clock (t 0)
+                    (let [q (#'qp.card/query-for-card card2 [] {} {} {})]
+                      (is (=? {:type :duration}
+                              (:cache-strategy q)))
+                      (is (=? (mkres nil)
+                              (-> (qp/process-query q) (dissoc :data))))
+                      (testing "There is cache on the next call"
+                        (is (=? (mkres (t 0))
+                                (-> (qp/process-query q) (dissoc :data)))))
+                      (testing "No cache after expiration"
+                        (mt/with-clock (t 61)
+                          (is (=? (mkres nil)
+                                  (-> (qp/process-query q) (dissoc :data))))))))))
 
-            (testing "strategy = schedule"
-              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                (mt/with-clock (t 0)
-                  (is (pos? (#'task.caching/refresh-schedule-configs!)))
-                  (let [q (#'qp.card/query-for-card card3 [] {} {} {})]
-                    (is (=? {:type :schedule}
-                            (:cache-strategy q)))
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query q) (dissoc :data))))
-                    (testing "There is cache on second call"
-                      (is (=? (mkres (t 0))
-                              (-> (qp/process-query q) (dissoc :data)))))))
-                (testing "No cache after job ran again"
-                  (mt/with-clock (t 121)
+              (testing "strategy = schedule"
+                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                  (mt/with-clock (t 0)
                     (is (pos? (#'task.caching/refresh-schedule-configs!)))
-                    (let [q (#'qp.card/query-for-card card3 {} {} {} {})]
+                    (let [q (#'qp.card/query-for-card card3 [] {} {} {})]
+                      (is (=? {:type :schedule}
+                              (:cache-strategy q)))
                       (is (=? (mkres nil)
-                              (-> (qp/process-query q) (dissoc :data)))))))))
+                              (-> (qp/process-query q) (dissoc :data))))
+                      (testing "There is cache on second call"
+                        (is (=? (mkres (t 0))
+                                (-> (qp/process-query q) (dissoc :data)))))))
+                  (testing "No cache after job ran again"
+                    (mt/with-clock (t 121)
+                      (is (pos? (#'task.caching/refresh-schedule-configs!)))
+                      (let [q (#'qp.card/query-for-card card3 {} {} {} {})]
+                        (is (=? (mkres nil)
+                                (-> (qp/process-query q) (dissoc :data)))))))))
 
-            (testing "strategy = query"
-              (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
-                (mt/with-clock (t 0)
-                  (is (pos? (#'task.caching/refresh-query-configs!)))
-                  (let [q (#'qp.card/query-for-card card4 [] {} {} {})]
-                    (is (=? {:type :query}
-                            (:cache-strategy q)))
-                    (is (=? (mkres nil)
-                            (-> (qp/process-query q) (dissoc :data))))
-                    (testing "There is cache on second call"
-                      (is (= 1 (count (t2/select :model/QueryCache))))
-                      (is (=? (mkres (t 0))
-                              (-> (qp/process-query q) (dissoc :data)))))))
-
-                (mt/with-clock (t 121)
-                  (is (pos? (#'task.caching/refresh-query-configs!)))
-                  (testing "Nothing to run, because it's already scheduled for later"
-                    (is (nil? (#'task.caching/refresh-query-configs!))))
-                  (testing "Job ran again, but state has not changed, so there's still cache"
-                    (let [q (#'qp.card/query-for-card card4 {} {} {} {})]
-                      (is (=? (mkres (t 0))
-                              (-> (qp/process-query q) (dissoc :data)))))))
-
-                (mt/with-clock (t 242)
-                  (let [state (:state (t2/select-one :model/CacheConfig :id (:id c4)))]
-                    (t2/update! :model/CacheConfig {:id (:id c4)} {:config (assoc (:config c4)
-                                                                                  :field_id (mt/id :table :value))})
+              (testing "strategy = query"
+                (mt/with-model-cleanup [[:model/QueryCache :updated_at]]
+                  (mt/with-clock (t 0)
                     (is (pos? (#'task.caching/refresh-query-configs!)))
-                    (testing "Marker has changed"
-                      (is (not= state
-                                (:state (t2/select-one :model/CacheConfig :id (:id c4)))))))
-                  (testing "No cache after the data has changed"
-                    (let [q (#'qp.card/query-for-card card4 {} {} {} {})]
+                    (let [q (#'qp.card/query-for-card card4 [] {} {} {})]
+                      (is (=? {:type :query}
+                              (:cache-strategy q)))
                       (is (=? (mkres nil)
-                              (-> (qp/process-query q) (dissoc :data)))))))))
+                              (-> (qp/process-query q) (dissoc :data))))
+                      (testing "There is cache on second call"
+                        (is (= 1 (count (t2/select :model/QueryCache))))
+                        (is (=? (mkres (t 0))
+                                (-> (qp/process-query q) (dissoc :data)))))))
 
-            (testing "default strategy = ttl"
-              (let [q (#'qp.card/query-for-card card5 [] {} {} {})]
-                (is (=? {:type :ttl}
-                        (:cache-strategy q)))))))))))
+                  (mt/with-clock (t 121)
+                    (is (pos? (#'task.caching/refresh-query-configs!)))
+                    (testing "Nothing to run, because it's already scheduled for later"
+                      (is (nil? (#'task.caching/refresh-query-configs!))))
+                    (testing "Job ran again, but state has not changed, so there's still cache"
+                      (let [q (#'qp.card/query-for-card card4 {} {} {} {})]
+                        (is (=? (mkres (t 0))
+                                (-> (qp/process-query q) (dissoc :data)))))))
+
+                  (mt/with-clock (t 242)
+                    (let [state (:state (t2/select-one :model/CacheConfig :id (:id c4)))]
+                      (t2/update! :model/CacheConfig {:id (:id c4)} {:config (assoc (:config c4)
+                                                                                    :field_id (mt/id :table :value))})
+                      (is (pos? (#'task.caching/refresh-query-configs!)))
+                      (testing "Marker has changed"
+                        (is (not= state
+                                  (:state (t2/select-one :model/CacheConfig :id (:id c4)))))))
+                    (testing "No cache after the data has changed"
+                      (let [q (#'qp.card/query-for-card card4 {} {} {} {})]
+                        (is (=? (mkres nil)
+                                (-> (qp/process-query q) (dissoc :data)))))))))
+
+              (testing "default strategy = ttl"
+                (let [q (#'qp.card/query-for-card card5 [] {} {} {})]
+                  (is (=? {:type :ttl}
+                          (:cache-strategy q))))))))))))

--- a/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/query_processor/middleware/row_level_restrictions_test.clj
@@ -736,7 +736,7 @@
                                          :cache-strategy {:type             :ttl
                                                           :multiplier       60
                                                           :avg-execution-ms 10
-                                                          :min-duration     0})))]
+                                                          :min-duration-ms  0})))]
         (testing "Run the query, should not be cached"
           (let [result (run-query)]
             (is (= nil
@@ -1051,7 +1051,7 @@
                           (let [results (qp/process-query (assoc query :cache-strategy {:type             :ttl
                                                                                         :multiplier       60
                                                                                         :avg-execution-ms 10
-                                                                                        :min-duration     0}))]
+                                                                                        :min-duration-ms  0}))]
                             {:cached?  (boolean (:cached (:cache/details results)))
                              :num-rows (count (mt/rows results))}))]
           (mt/with-temporary-setting-values [enable-query-caching true]

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -42,9 +42,9 @@
   [card dashboard-id]
   (when (public-settings/enable-query-caching)
     (or (granular-cache-strategy card dashboard-id)
-        {:type         :ttl
-         :multiplier   (public-settings/query-caching-ttl-ratio)
-         :min_duration (long (* (public-settings/query-caching-min-ttl) 1000))})))
+        {:type            :ttl
+         :multiplier      (public-settings/query-caching-ttl-ratio)
+         :min_duration_ms (long (* (public-settings/query-caching-min-ttl) 1000))})))
 
 (defn- enrich-strategy [strategy query]
   (case (:type strategy)

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -103,13 +103,13 @@
        (add-object-to-cache! (if (map? result)
                                (m/dissoc-in result [:data :rows])
                                {}))
-       (let [duration-ms  (/ (- (System/nanoTime) start-time-ns) 1e6)
-             min-duration (:min-duration strategy 0)
-             eligible?    (and @has-rows?
-                               (> duration-ms min-duration))]
+       (let [duration-ms     (/ (- (System/nanoTime) start-time-ns) 1e6)
+             min-duration-ms (:min-duration-ms strategy 0)
+             eligible?       (and @has-rows?
+                                  (> duration-ms min-duration-ms))]
          (log/infof "Query took %s to run; minimum for cache eligibility is %s; %s"
                     (u/format-milliseconds duration-ms)
-                    (u/format-milliseconds min-duration)
+                    (u/format-milliseconds min-duration-ms)
                     (if eligible? "eligible" "not eligible"))
          (when eligible?
            (cache-results! query-hash))

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -118,7 +118,7 @@
   {:type             :ttl
    :multiplier       60
    :avg-execution-ms 1000
-   :min-duration     (public-settings/query-caching-min-ttl)})
+   :min-duration-ms  (public-settings/query-caching-min-ttl)})
 
 (defn- test-query [query-kvs]
   (merge {:cache-strategy (ttl-strategy), :lib/type :mbql/query, :stages [{:abc :def}]} query-kvs))

--- a/test/metabase/query_processor/preprocess_test.clj
+++ b/test/metabase/query_processor/preprocess_test.clj
@@ -16,8 +16,8 @@
         (let [query            (assoc (mt/mbql-query venues {:order-by [[:asc $id]], :limit 5})
                                       :cache-strategy {:type             :ttl
                                                        :multiplier       60
-                                                       :avg-execution-ms 10
-                                                       :min-duration     0})
+                                                       :avg-execution-ms 100
+                                                       :min-duration-ms  0})
               run-query        (fn []
                                  (let [results (qp/process-query query)]
                                    {:cached?  (boolean (:cached (:cache/details results)))


### PR DESCRIPTION
Caching turned out to have dangerously close timings so that tests fail regularly on master.

Also `min-duration` to `min-duration-ms` is something I noticed just now, but akin to `avg-execution-ms` could help us catch some bugs (it already cleared some misunderstanding on the front-end).