### PR TITLE
Windows doesn't know what a UnixPath is: use Path

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/audit_db.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_db.clj
@@ -18,7 +18,7 @@
    [toucan2.core :as t2])
   (:import
    (java.util.jar JarEntry JarFile)
-   (sun.nio.fs UnixPath)))
+   (java.nio.file Path)))
 
 (set! *warn-on-reflection* true)
 
@@ -219,7 +219,7 @@
 (defn analytics-checksum
   "Hashes the contents of all non-dir files in the `analytics-dir-resource`."
   []
-  (->> ^UnixPath (instance-analytics-plugin-dir (plugins/plugins-dir))
+  (->> ^Path (instance-analytics-plugin-dir (plugins/plugins-dir))
        (.toFile)
        file-seq
        (remove fs/directory?)


### PR DESCRIPTION
I type hinted something with `sun.nio.fs.UnixPath`, but should have used the interface: `java.nio.file.Path`.

When running the jar on windows, there is no `sun.nio.fs.UnixPath`, so the app cannot start, since it's looking up the class but it isn't there.

[private link to logs from running a jar produced from this branch here](https://metaboat.slack.com/files/U037YBQFRR7/F06QHES2M6W/windows_metabase?origin_team=T078VCLCR&origin_channel=D061RBH3LUW)