### PR TITLE
Accommodate wide icons in nav and admin nav

### DIFF
--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
@@ -112,6 +112,9 @@ class LogoIcon extends Component {
     } else {
       element.removeAttribute("height");
     }
+    element.style.maxWidth = "100%";
+    element.style.maxHeight = "32px";
+    element.style.height = "auto";
   }
 
   render() {

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LogoIcon.jsx
@@ -114,11 +114,13 @@ class LogoIcon extends Component {
     }
     element.style.maxWidth = "100%";
     element.style.maxHeight = "32px";
+    element.style.minHeight = "100%";
     element.style.height = "auto";
   }
 
   render() {
-    const { dark, style, className } = this.props;
+    const { dark, style = {}, className } = this.props;
+    style.height ||= "32px";
     return (
       <span
         ref={c => (this._container = c)}

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
@@ -80,7 +80,7 @@ export const AdminExitLink = styled(Link)`
 export const AdminLogoContainer = styled.div`
   display: flex;
   min-width: 32px;
-  max-width: 12rem;
+  max-width: 20rem;
   overflow: hidden;
   height: 32px;
   align-items: center;

--- a/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
+++ b/frontend/src/metabase/nav/components/AdminNavbar/AdminNavbar.styled.tsx
@@ -80,6 +80,8 @@ export const AdminExitLink = styled(Link)`
 export const AdminLogoContainer = styled.div`
   display: flex;
   min-width: 32px;
+  max-width: 12rem;
+  overflow: hidden;
   height: 32px;
   align-items: center;
   justify-content: center;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -9,7 +9,6 @@ export const LogoLink = styled(Link)<{ isSmallAppBar: boolean }>`
   align-items: center;
   justify-content: center;
   border-radius: 0.375rem;
-  width: 2.25rem;
   height: 3.25rem;
   opacity: 1;
   ${props =>

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -11,7 +11,6 @@ export const LogoLink = styled(Link)<{ isSmallAppBar: boolean }>`
   height: 3.25rem;
   min-width: 2.25rem;
   max-width: 14rem;
-  overflow-x: hidden;
   line-height: 0;
   opacity: 1;
 `;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -10,6 +10,9 @@ export const LogoLink = styled(Link)<{ isSmallAppBar: boolean }>`
   justify-content: center;
   border-radius: 0.375rem;
   height: 3.25rem;
+  max-width: 12rem;
+  overflow-x: hidden;
+  line-height: 0;
   opacity: 1;
   ${props =>
     !props.isSmallAppBar &&

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -10,6 +10,7 @@ export const LogoLink = styled(Link)<{ isSmallAppBar: boolean }>`
   justify-content: center;
   border-radius: 0.375rem;
   height: 3.25rem;
+  min-width: 2.25rem;
   max-width: 12rem;
   overflow-x: hidden;
   line-height: 0;

--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -1,4 +1,3 @@
-import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import Link from "metabase/core/components/Link";
@@ -11,13 +10,8 @@ export const LogoLink = styled(Link)<{ isSmallAppBar: boolean }>`
   border-radius: 0.375rem;
   height: 3.25rem;
   min-width: 2.25rem;
-  max-width: 12rem;
+  max-width: 14rem;
   overflow-x: hidden;
   line-height: 0;
   opacity: 1;
-  ${props =>
-    !props.isSmallAppBar &&
-    css`
-      margin-right: 2rem;
-    `}
 `;


### PR DESCRIPTION
Closes #40153

### Description

Updates the main navigation bar and admin navigation bar to accommodate wide icons.

### How to verify

Describe the steps to verify that the changes are working as expected.

In Settings > Appearance (`/admin/settings/whitelabel/branding`), upload the following wide logo and confirm that the admin navigation bar and main navigation bar are still usable. Ensure that in the main navigation bar, the icon that toggles the sidebar is clearly visible. Ensure that in the admin navigation bar, the text 'Metabase Admin' is visible when the viewport is wider than 1280px.

![wide-logo](https://github.com/metabase/metabase/assets/130925/7d280b32-78a4-4ac7-9070-f5aa95477d5f)
Download from: https://github.com/metabase/metabase/assets/130925/7d280b32-78a4-4ac7-9070-f5aa95477d5f

Then do the same with this extremely wide logo to confirm that the nav bars remain functional regardless of how wide the logo is.

![very-wide-logo](https://github.com/metabase/metabase/assets/130925/79f4c4cc-25e7-4a5a-b4e4-62cb2e0bce1f)
Download from: https://github.com/metabase/metabase/assets/130925/79f4c4cc-25e7-4a5a-b4e4-62cb2e0bce1f

### Demo

[Loom (2m32s)](https://www.loom.com/share/96bacb45b50c42129393feb8e555a988?sid=33e9a7ff-59c0-424b-943b-308e848d5aa3)

[Loom illustrating how the icons get scaled on narrow viewports (2m35s)](https://www.loom.com/share/67265dff349e4cc28ca62a514dfce9a2?sid=32b186bc-64be-4959-a956-935f9504f678)

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR