### PR TITLE
Embedding SDK - CORS

### DIFF
--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -127,10 +127,10 @@
           #(format "%s frame-ancestors %s;" % (if allow-iframes? "*" (or (embedding-app-origin) "'none'")))))
 
 (defn- access-control-headers
-  [embedding-app-origin]
-  {"Access-Control-Allow-Origin"     (embedding-app-origin)
-   "Access-Control-Allow-Headers"    "*"
-   "Access-Control-Expose-Headers"   "X-Metabase-Anti-CSRF-Token"})
+  []
+  {"Access-Control-Allow-Origin"    (embedding-app-origin)
+   "Access-Control-Allow-Headers"   "*"
+   "Access-Control-Expose-Headers"  "X-Metabase-Anti-CSRF-Token"})
 
 (defn- first-embedding-app-origin
   "Return only the first embedding app origin."
@@ -149,7 +149,7 @@
      (cache-prevention-headers))
    strict-transport-security-header
    (content-security-policy-header-with-frame-ancestors allow-iframes? nonce)
-   (when embedding-app-origin (access-control-headers embedding-app-origin))
+   (when (embedding-app-origin) (access-control-headers))
    (when-not allow-iframes?
      ;; Tell browsers not to render our site as an iframe (prevent clickjacking)
      {"X-Frame-Options"                 (if (embedding-app-origin)

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -127,12 +127,10 @@
           #(format "%s frame-ancestors %s;" % (if allow-iframes? "*" (or (embedding-app-origin) "'none'")))))
 
 (defn- access-control-headers
-  []
-  (when (embedding-app-origin)
-    {
-      "Access-Control-Allow-Origin"     (embedding-app-origin)
-      "Access-Control-Allow-Headers"    "*"
-      "Access-Control-Expose-Headers"   "X-Metabase-Anti-CSRF-Token"}))
+  [embedding-app-origin]
+  {"Access-Control-Allow-Origin"     (embedding-app-origin)
+   "Access-Control-Allow-Headers"    "*"
+   "Access-Control-Expose-Headers"   "X-Metabase-Anti-CSRF-Token"})
 
 (defn- first-embedding-app-origin
   "Return only the first embedding app origin."
@@ -151,6 +149,7 @@
      (cache-prevention-headers))
    strict-transport-security-header
    (content-security-policy-header-with-frame-ancestors allow-iframes? nonce)
+   (when embedding-app-origin (access-control-headers embedding-app-origin))
    (when-not allow-iframes?
      ;; Tell browsers not to render our site as an iframe (prevent clickjacking)
      {"X-Frame-Options"                 (if (embedding-app-origin)
@@ -161,8 +160,7 @@
     ;; Prevent Flash / PDF files from including content from site.
     "X-Permitted-Cross-Domain-Policies" "none"
     ;; Tell browser not to use MIME sniffing to guess types of files -- protect against MIME type confusion attacks
-    "X-Content-Type-Options"            "nosniff"}
-    (access-control-headers)))
+    "X-Content-Type-Options"            "nosniff"}))
 
 (defn- add-security-headers* [request response]
   ;; merge is other way around so that handler can override headers

--- a/src/metabase/server/middleware/security.clj
+++ b/src/metabase/server/middleware/security.clj
@@ -126,6 +126,14 @@
           "Content-Security-Policy"
           #(format "%s frame-ancestors %s;" % (if allow-iframes? "*" (or (embedding-app-origin) "'none'")))))
 
+(defn- access-control-headers
+  []
+  (when (embedding-app-origin)
+    {
+      "Access-Control-Allow-Origin"     (embedding-app-origin)
+      "Access-Control-Allow-Headers"    "*"
+      "Access-Control-Expose-Headers"   "X-Metabase-Anti-CSRF-Token"}))
+
 (defn- first-embedding-app-origin
   "Return only the first embedding app origin."
   []
@@ -153,7 +161,8 @@
     ;; Prevent Flash / PDF files from including content from site.
     "X-Permitted-Cross-Domain-Policies" "none"
     ;; Tell browser not to use MIME sniffing to guess types of files -- protect against MIME type confusion attacks
-    "X-Content-Type-Options"            "nosniff"}))
+    "X-Content-Type-Options"            "nosniff"}
+    (access-control-headers)))
 
 (defn- add-security-headers* [request response]
   ;; merge is other way around so that handler can override headers

--- a/src/metabase/server/routes.clj
+++ b/src/metabase/server/routes.clj
@@ -2,7 +2,7 @@
   "Main Compojure routes tables. See https://github.com/weavejester/compojure/wiki/Routes-In-Detail for details about
    how these work. `/api/` routes are in `metabase.api.routes`."
   (:require
-   [compojure.core :refer [context defroutes GET]]
+   [compojure.core :refer [context defroutes GET OPTIONS]]
    [compojure.route :as route]
    [metabase.api.dataset :as api.dataset]
    [metabase.api.routes :as api]
@@ -60,6 +60,9 @@
                 (log/warn e (trs "Error in api/health database check"))
                 {:status 503 :body {:status "Error getting app-db connection"}}))
          {:status 503, :body {:status "initializing", :progress (init-status/progress)}}))
+
+  (OPTIONS "/api/*" [] {:status 200 :body ""})
+
   ;; ^/api/ -> All other API routes
   (context "/api" [] (fn [& args]
                        ;; Redirect naughty users who try to visit a page other than setup if setup is not yet complete


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/40241

### Description

This adds missing CORS headers to be able to use Metabase API through Embedding SDK - a JS library with highlevel components that could be used in client application to embed Metabase analytics.

### How to verify

1. API should support OPTIONS requests
2. If [Interactive Embedding](http://localhost:3000/admin/settings/embedding-in-other-applications) is enabled and [Authorized Origins](http://localhost:3000/admin/settings/embedding-in-other-applications/full-app) value has been set, API should respond with Access-Control headers:

- `Access-Control-Allow-Origin`
- `Access-Control-Allow-Headers`
- `Access-Control-Expose-Headers`

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_
