### PR TITLE
refactor pow scale to use NumericAxisScaleTransforms

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/chart-measurements/index.ts
@@ -2,6 +2,7 @@ import type {
   AxisFormatter,
   BaseCartesianChartModel,
   ChartDataset,
+  NumericAxisScaleTransforms,
   YAxisModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import type {
@@ -22,6 +23,7 @@ import type {
 
 const getYAxisTicksWidth = (
   axisModel: YAxisModel,
+  yAxisScaleTransforms: NumericAxisScaleTransforms,
   settings: ComputedVisualizationSettings,
   { measureText, fontFamily }: RenderingContext,
 ): number => {
@@ -33,8 +35,10 @@ const getYAxisTicksWidth = (
     ...CHART_STYLE.axisTicks,
     family: fontFamily,
   };
-
-  const valuesToMeasure = [...axisModel.extent];
+  // extents need to be untransformed to get the value of the tick label
+  const valuesToMeasure = axisModel.extent.map(extent =>
+    yAxisScaleTransforms.fromEChartsAxisValue(extent),
+  );
 
   if (!settings["graph.y_axis.auto_range"]) {
     const customRangeValues = [
@@ -164,14 +168,19 @@ export const getTicksDimensions = (
 
   if (chartModel.leftAxisModel) {
     ticksDimensions.yTicksWidthLeft =
-      getYAxisTicksWidth(chartModel.leftAxisModel, settings, renderingContext) +
-      CHART_STYLE.axisTicksMarginY;
+      getYAxisTicksWidth(
+        chartModel.leftAxisModel,
+        chartModel.yAxisScaleTransforms,
+        settings,
+        renderingContext,
+      ) + CHART_STYLE.axisTicksMarginY;
   }
 
   if (chartModel.rightAxisModel) {
     ticksDimensions.yTicksWidthRight =
       getYAxisTicksWidth(
         chartModel.rightAxisModel,
+        chartModel.yAxisScaleTransforms,
         settings,
         renderingContext,
       ) + CHART_STYLE.axisTicksMarginY;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -32,6 +32,7 @@ import {
 } from "metabase/visualizations/echarts/cartesian/constants/dataset";
 import { isMetric } from "metabase-lib/types/utils/isa";
 import { isCategoryAxis, isNumericAxis } from "./guards";
+import { signedSquareRoot } from "./transforms";
 
 /**
  * Sums two metric column values.
@@ -309,12 +310,6 @@ const getStackedAreasInterpolateTransform = (
   };
 };
 
-const getSign = (value: number) => (value >= 0 ? 1 : -1);
-// TODO dedupe this function
-function signedSquareRoot(value: number) {
-  return getSign(value) * Math.sqrt(Math.abs(value));
-}
-
 function getStackedPowerTransform(seriesDataKeys: DataKey[]): TransformFn {
   return (datum: Datum) => {
     const transformedSeriesValues: Record<DataKey, number> = {};
@@ -430,12 +425,9 @@ export const applyVisualizationSettingsDataTransformations = (
       condition: settings["stackable.stack_type"] === "normalized",
       fn: getNormalizedDatasetTransform(seriesDataKeys),
     },
-    {
-      condition: true, // TODO remove constant condition
-      fn: getKeyBasedDatasetTransform(seriesDataKeys, value =>
-        yAxisScaleTransforms.toEChartsAxisValue(value),
-      ),
-    },
+    getKeyBasedDatasetTransform(seriesDataKeys, value =>
+      yAxisScaleTransforms.toEChartsAxisValue(value),
+    ),
     {
       condition:
         settings["graph.y_axis.scale"] === "pow" &&

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -24,6 +24,7 @@ import {
 } from "metabase/visualizations/echarts/cartesian/model/axis";
 import { getScatterPlotDataset } from "metabase/visualizations/echarts/cartesian/scatter/model";
 import { getTrendLineModelAndDatasets } from "./trend-line";
+import { getYAxisScaleTransforms } from "./transforms";
 
 const SUPPORTED_AUTO_SPLIT_TYPES = ["line", "area", "bar", "combo"];
 
@@ -105,11 +106,16 @@ export const getCartesianChartModel = (
     settings,
     renderingContext,
   );
+  const yAxisScaleTransforms = getYAxisScaleTransforms(
+    settings["graph.y_axis.scale"],
+    settings["stackable.stack_type"],
+  );
 
   const transformedDataset = applyVisualizationSettingsDataTransformations(
     dataset,
     xAxisModel,
     seriesModels,
+    yAxisScaleTransforms,
     settings,
   );
 
@@ -131,6 +137,7 @@ export const getCartesianChartModel = (
   const { trendLinesSeries, trendLinesDataset } = getTrendLineModelAndDatasets(
     seriesModels,
     dataset,
+    yAxisScaleTransforms,
     insights,
     settings,
     renderingContext,
@@ -140,6 +147,7 @@ export const getCartesianChartModel = (
     dataset,
     transformedDataset,
     seriesModels,
+    yAxisScaleTransforms,
     columnByDataKey,
     dimensionModel,
     insights,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/transforms.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/transforms.ts
@@ -1,0 +1,45 @@
+import type { NumericScale, StackType } from "metabase-types/api";
+import { isNumber } from "metabase/lib/types";
+import type { NumericAxisScaleTransforms } from "./types";
+
+function getSign(value: number) {
+  return value >= 0 ? 1 : -1;
+}
+
+function signedSquareRoot(value: number) {
+  return getSign(value) * Math.sqrt(Math.abs(value));
+}
+
+export function getYAxisScaleTransforms(
+  scale: NumericScale | undefined,
+  stackType?: StackType,
+): NumericAxisScaleTransforms {
+  if (scale === "pow") {
+    return {
+      toEChartsAxisValue: value => {
+        if (!isNumber(value)) {
+          return null;
+        }
+        // Transformation for stacked charts occurs in model/dataset.ts
+        if (stackType != null) {
+          return value;
+        }
+        return signedSquareRoot(value);
+      },
+      fromEChartsAxisValue: value => {
+        return Math.pow(value, 2) * getSign(value);
+      },
+    };
+  }
+  // TODO re-implement log y-axis scale
+
+  return {
+    toEChartsAxisValue: value => {
+      if (!isNumber(value)) {
+        return null;
+      }
+      return value;
+    },
+    fromEChartsAxisValue: value => value,
+  };
+}

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/transforms.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/transforms.ts
@@ -6,7 +6,7 @@ function getSign(value: number) {
   return value >= 0 ? 1 : -1;
 }
 
-function signedSquareRoot(value: number) {
+export function signedSquareRoot(value: number) {
   return getSign(value) * Math.sqrt(Math.abs(value));
 }
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -180,6 +180,8 @@ export type BaseCartesianChartModel = {
   transformedDataset: ChartDataset;
   trendLinesDataset: TrendDataset;
   trendLinesSeries: TrendLineSeriesModel[];
+  yAxisScaleTransforms: NumericAxisScaleTransforms;
+
   leftAxisModel: YAxisModel | null;
   rightAxisModel: YAxisModel | null;
   xAxisModel: XAxisModel;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/axis.ts
@@ -2,7 +2,6 @@ import type {
   AxisBaseOption,
   AxisBaseOptionCommon,
   CategoryAxisBaseOption,
-  LogAxisBaseOption,
   TimeAxisBaseOption,
   ValueAxisBaseOption,
 } from "echarts/types/src/coord/axisCommonTypes";
@@ -14,6 +13,7 @@ import type {
 import type {
   BaseCartesianChartModel,
   Extent,
+  NumericAxisScaleTransforms,
   NumericXAxisModel,
   TimeSeriesXAxisModel,
   YAxisModel,
@@ -211,7 +211,7 @@ export const buildNumericDimensionAxis = (
   settings: ComputedVisualizationSettings,
   chartMeasurements: ChartMeasurements,
   renderingContext: RenderingContext,
-): ValueAxisBaseOption | LogAxisBaseOption => {
+): ValueAxisBaseOption => {
   const {
     fromEChartsAxisValue: fromAxisValue,
     isPadded,
@@ -320,6 +320,7 @@ export const buildCategoricalDimensionAxis = (
 
 export const buildMetricAxis = (
   axisModel: YAxisModel,
+  yAxisScaleTransforms: NumericAxisScaleTransforms,
   ticksWidth: number,
   settings: ComputedVisualizationSettings,
   position: "left" | "right",
@@ -330,6 +331,7 @@ export const buildMetricAxis = (
   const nameGap = getAxisNameGap(ticksWidth);
 
   const range = getYAxisRange(axisModel, settings);
+  // TODO remove this line once we migrate log scale to axisModel transforms
   const axisType = settings["graph.y_axis.scale"] === "log" ? "log" : "value";
 
   return {
@@ -362,7 +364,10 @@ export const buildMetricAxis = (
       show: !!settings["graph.y_axis.axis_enabled"],
       ...getTicksDefaultOption(renderingContext),
       // @ts-expect-error TODO: figure out EChart types
-      formatter: value => axisModel.formatter(value),
+      formatter: rawValue =>
+        axisModel.formatter(
+          yAxisScaleTransforms.fromEChartsAxisValue(rawValue),
+        ),
     },
   };
 };
@@ -379,6 +384,7 @@ const buildMetricsAxes = (
     axes.push(
       buildMetricAxis(
         chartModel.leftAxisModel,
+        chartModel.yAxisScaleTransforms,
         chartMeasurements.ticksDimensions.yTicksWidthLeft,
         settings,
         "left",
@@ -393,6 +399,7 @@ const buildMetricsAxes = (
     axes.push(
       buildMetricAxis(
         chartModel.rightAxisModel,
+        chartModel.yAxisScaleTransforms,
         chartMeasurements.ticksDimensions.yTicksWidthRight,
         settings,
         "right",

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/types.ts
@@ -1,6 +1,13 @@
 import type { RegisteredSeriesOption } from "echarts";
 
+import type { Datum } from "../model/types";
+import type { TREND_LINE_DATA_KEY } from "../constants/dataset";
+
 export type EChartsSeriesOption =
   | RegisteredSeriesOption["line"]
   | RegisteredSeriesOption["bar"]
   | RegisteredSeriesOption["scatter"];
+
+export type TrendDataset = (Datum & {
+  [TREND_LINE_DATA_KEY]: number;
+})[];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/dataset.ts
@@ -6,11 +6,9 @@ import type {
   ChartDataset,
   Datum,
   WaterfallXAxisModel,
+  NumericAxisScaleTransforms,
 } from "metabase/visualizations/echarts/cartesian/model/types";
-import {
-  applySquareRootScaling,
-  replaceValues,
-} from "metabase/visualizations/echarts/cartesian/model/dataset";
+import { replaceValues } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import {
   WATERFALL_DATA_KEYS,
   WATERFALL_END_KEY,
@@ -57,6 +55,7 @@ const replaceZerosForLogScale = (dataset: ChartDataset): ChartDataset => {
 
 export const getWaterfallDataset = (
   dataset: ChartDataset,
+  yAxisScaleTransforms: NumericAxisScaleTransforms,
   originalSeriesKey: DataKey,
   settings: ComputedVisualizationSettings,
   xAxisModel: WaterfallXAxisModel,
@@ -106,7 +105,8 @@ export const getWaterfallDataset = (
       transformedDataset,
       (dataKey: DataKey, value: RowValue) =>
         WATERFALL_DATA_KEYS.includes(dataKey)
-          ? applySquareRootScaling(value)
+          ? // TODO use this more generally for both pow and log scales
+            yAxisScaleTransforms.toEChartsAxisValue(value)
           : value,
     );
   } else if (settings["graph.y_axis.scale"] === "log") {

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -16,6 +16,7 @@ import {
 } from "metabase/visualizations/echarts/cartesian/model/dataset";
 import { getYAxisModel } from "metabase/visualizations/echarts/cartesian/model/axis";
 import { WATERFALL_END_KEY, WATERFALL_TOTAL_KEY } from "../constants";
+import { getYAxisScaleTransforms } from "../../model/transforms";
 import {
   extendOriginalDatasetWithTotalDatum,
   getWaterfallDataset,
@@ -53,9 +54,13 @@ export const getWaterfallChartModel = (
     settings,
     renderingContext,
   );
+  const yAxisScaleTransforms = getYAxisScaleTransforms(
+    settings["graph.y_axis.scale"],
+  );
 
   const transformedDataset = getWaterfallDataset(
     dataset,
+    yAxisScaleTransforms,
     seriesModel.dataKey,
     settings,
     xAxisModel,
@@ -82,6 +87,7 @@ export const getWaterfallChartModel = (
     dataset: originalDatasetWithTotal,
     transformedDataset,
     seriesModels: [seriesModel],
+    yAxisScaleTransforms,
     columnByDataKey,
     dimensionModel,
     xAxisModel,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
@@ -107,6 +107,7 @@ export const buildEChartsWaterfallSeries = (
     ...buildEChartsLabelOptions(
       seriesModel,
       dataset,
+      chartModel.yAxisScaleTransforms,
       settings,
       renderingContext,
       settings["graph.show_values"],
@@ -114,6 +115,7 @@ export const buildEChartsWaterfallSeries = (
     formatter: getDataLabelFormatter(
       seriesModel,
       dataset,
+      chartModel.yAxisScaleTransforms,
       settings,
       key,
       renderingContext,


### PR DESCRIPTION
Preparation for 
https://github.com/metabase/metabase/issues/38780
https://github.com/metabase/metabase/issues/40212

### Description

In order to fix the aforementioned log scale issues, we will need to use our own data transformations for the log scale, instead of using echarts' built in option.

Before doing that, I am refactoring the power y-axis scale to use a more generalized transformation system, similar to what we do for the x-axis scales. That way, power and log y-axis scales can use a unified transformation system, and do not have be dealt with uniquely at different touch points (e.g. tick labels, data labels, chart measurements, etc).

### Demo

![Screenshot 2024-03-21 at 11.38.21 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/cb283ea4-b0d8-4ba1-861b-d9559e81121f.png)

### Checklist

~~- [ ] Tests have been added/updated to cover changes in this PR~~

_Don't need to add new tests right now since this is just a refactor, but will confirm existing tests don't fail._
