### PR TITLE
Restore logo margin

### DIFF
--- a/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
+++ b/frontend/src/metabase/nav/components/AppBar/AppBarLogo.styled.tsx
@@ -1,3 +1,4 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import Link from "metabase/core/components/Link";
@@ -13,4 +14,9 @@ export const LogoLink = styled(Link)<{ isSmallAppBar: boolean }>`
   max-width: 14rem;
   line-height: 0;
   opacity: 1;
+  ${props =>
+    !props.isSmallAppBar &&
+    css`
+      margin-inline-end: 2rem;
+    `}
 `;


### PR DESCRIPTION
Restores missing margin on logo

On `master`:
![image](https://github.com/metabase/metabase/assets/130925/b1477007-7c1c-46dd-b31f-eeb7bdb42b05)

On this branch:
![image](https://github.com/metabase/metabase/assets/130925/aebe3ee5-aa8a-4c39-a107-e6ef3fb7c2f3)
