### PR TITLE
Fix unable to save a question after converting to SQL

### DIFF
--- a/e2e/test/scenarios/question/reproductions/40422-convert-sql.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/40422-convert-sql.cy.spec.js
@@ -1,0 +1,46 @@
+import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  createQuestion,
+  modal,
+  openNotebook,
+  queryBuilderHeader,
+  restore,
+  visitQuestion,
+} from "e2e/support/helpers";
+
+const questionDetails = {
+  name: "40422",
+  query: {
+    "source-table": `card__${ORDERS_QUESTION_ID}`,
+  },
+};
+
+describe("issue 40422", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsNormalUser();
+    cy.intercept("POST", "api/dataset/native").as("datasetNative");
+    cy.intercept("PUT", "/api/card/*").as("updateCard");
+  });
+
+  it("should be possible to save a question based on a table after converting to SQL (metabase#40422)", () => {
+    visitQuestion(ORDERS_QUESTION_ID);
+    convertToSqlAndSave();
+  });
+
+  it("should be possible to save a question based on another question after converting to SQL (metabase#40422)", () => {
+    createQuestion(questionDetails, { visitQuestion: true });
+    convertToSqlAndSave();
+  });
+});
+
+function convertToSqlAndSave() {
+  openNotebook();
+  queryBuilderHeader().button("View the SQL").click();
+  cy.wait("@datasetNative");
+  modal().button("Convert this question to SQL").click();
+  cy.findByTestId("native-query-editor").should("be.visible");
+  queryBuilderHeader().findByText("Save").click();
+  modal().last().findByText("Save").click();
+  cy.wait("@updateCard");
+}

--- a/frontend/src/metabase/query_builder/components/view/ConvertQueryModal/utils.ts
+++ b/frontend/src/metabase/query_builder/components/view/ConvertQueryModal/utils.ts
@@ -1,20 +1,21 @@
-import { checkNotNull } from "metabase/lib/types";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 import type { DatasetQuery } from "metabase-types/api";
 
 export function createDatasetQuery(
-  query: string,
+  queryText: string,
   question: Question,
 ): DatasetQuery {
-  const tableId = question.legacyQueryTableId();
-  const collection =
-    tableId === null || typeof tableId === "undefined"
-      ? undefined
-      : question.metadata().tables[tableId]?.name;
+  const query = question.query();
+  const databaseId = Lib.databaseID(query);
+  const tableId = Lib.sourceTableOrCardId(query);
+  const table = tableId ? Lib.tableOrCardMetadata(query, tableId) : undefined;
+  const tableName = table ? Lib.displayInfo(query, -1, table).name : undefined;
+  const extras = tableName ? { collection: tableName } : {};
 
   return {
     type: "native",
-    native: { query, "template-tags": {}, collection },
-    database: checkNotNull(question.databaseId()),
+    native: { query: queryText, "template-tags": {}, ...extras },
+    database: databaseId,
   };
 }


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/40422

The problem appeared when we started using `can-run` for native queries in https://github.com/metabase/metabase/pull/40288. There is an issue with `malli` validation for `collection` field for native queries https://github.com/metabase/metabase/blob/c27b67692137ebd7641e80e1c19174920c71cc14/src/metabase/lib/schema.cljc#L54 It requires the `collection` to be a non-empty string or not present at all, while previously we allowed `undefined` to stay temporary in the QB state. This PR fixes the issue by excluding `undefined` `collection`.

Before
<img width="1319" alt="Screenshot 2024-03-21 at 07 25 46" src="https://github.com/metabase/metabase/assets/8542534/a4396797-eb7b-4d83-9ba0-2e920a5f23f3">

After
<img width="1336" alt="Screenshot 2024-03-21 at 07 24 20" src="https://github.com/metabase/metabase/assets/8542534/962a5862-10fe-4399-a527-16645647f408">
