### PR TITLE
Use RTKQuery for API calls in the native preview sidebar [PoC/extras]

### DIFF
--- a/frontend/src/metabase/api/dataset.ts
+++ b/frontend/src/metabase/api/dataset.ts
@@ -3,7 +3,7 @@ import type { NativeQueryForm, DatasetQuery } from "metabase-types/api";
 
 export const datasetApi = Api.injectEndpoints({
   endpoints: builder => ({
-    createNativeDataset: builder.mutation<NativeQueryForm, DatasetQuery>({
+    getNativeDataset: builder.query<NativeQueryForm, DatasetQuery>({
       query: input => ({
         method: "POST",
         url: "/api/dataset/native",
@@ -13,4 +13,4 @@ export const datasetApi = Api.injectEndpoints({
   }),
 });
 
-export const { useCreateNativeDatasetMutation } = datasetApi;
+export const { useGetNativeDatasetQuery } = datasetApi;

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -51,11 +51,14 @@ export const NativeQueryPreviewSidebar = (): JSX.Element => {
     dispatch(setUIControls({ isNativeEditorOpen: true }));
   }, [question, query, dispatch]);
 
+  const isError = (error: unknown) =>
+    typeof error === "string" ? error : undefined;
+
   return (
     <NativeQueryPreview
       title={TITLE[engineType]}
       query={query}
-      error={error}
+      error={isError(error)}
       isLoading={isLoading}
     >
       {query && (

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -46,14 +46,14 @@ export const NativeQueryPreviewSidebar = (): JSX.Element => {
     dispatch(setUIControls({ isNativeEditorOpen: true }));
   }, [question, query, dispatch]);
 
-  const isError = (error: unknown) =>
+  const getErrorMessage = (error: unknown) =>
     typeof error === "string" ? error : undefined;
 
   return (
     <NativeQueryPreview
       title={TITLE[engineType]}
       query={query}
-      error={isError(error)}
+      error={getErrorMessage(error)}
       isLoading={isLoading}
     >
       {query && (

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -24,7 +24,7 @@ const BUTTON_TITLE = {
   json: t`Convert this question to a native query`,
 };
 
-const NativeQueryPreviewSidebar = (): JSX.Element => {
+export const NativeQueryPreviewSidebar = (): JSX.Element => {
   const dispatch = useDispatch();
   const question = checkNotNull(useSelector(getQuestion));
   const [createNativeDataset, datasetResult] = useCreateNativeDatasetMutation();
@@ -66,6 +66,3 @@ const NativeQueryPreviewSidebar = (): JSX.Element => {
     </NativeQueryPreview>
   );
 };
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default NativeQueryPreviewSidebar;

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -1,17 +1,14 @@
 import { useCallback, useEffect } from "react";
-import { connect } from "react-redux";
 import { t } from "ttag";
 
 import { useCreateNativeDatasetMutation } from "metabase/api";
 import { getEngineNativeType } from "metabase/lib/engine";
-import { useDispatch } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
+import { checkNotNull } from "metabase/lib/types";
 import { updateQuestion, setUIControls } from "metabase/query_builder/actions";
 import { getQuestion } from "metabase/query_builder/selectors";
 import { Button } from "metabase/ui";
 import * as Lib from "metabase-lib";
-import type Question from "metabase-lib/v1/Question";
-import type { NativeQueryForm } from "metabase-types/api";
-import type { State } from "metabase-types/store";
 
 import { NativeQueryPreview } from "../NativeQueryPreview";
 
@@ -27,15 +24,9 @@ const BUTTON_TITLE = {
   json: t`Convert this question to a native query`,
 };
 
-interface NativeQueryPreviewSidebarProps {
-  question: Question;
-  onLoadQuery: () => Promise<NativeQueryForm>;
-}
-
-const NativeQueryPreviewSidebar = ({
-  question,
-}: NativeQueryPreviewSidebarProps): JSX.Element => {
+const NativeQueryPreviewSidebar = (): JSX.Element => {
   const dispatch = useDispatch();
+  const question = checkNotNull(useSelector(getQuestion));
   const [createNativeDataset, datasetResult] = useCreateNativeDatasetMutation();
 
   const engineType = getEngineNativeType(question.database()?.engine);
@@ -76,10 +67,5 @@ const NativeQueryPreviewSidebar = ({
   );
 };
 
-const mapStateToProps = (state: State) => ({
-  // FIXME: remove the non-null assertion operator
-  question: getQuestion(state)!,
-});
-
 // eslint-disable-next-line import/no-default-export -- deprecated usage
-export default connect(mapStateToProps)(NativeQueryPreviewSidebar);
+export default NativeQueryPreviewSidebar;

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { t } from "ttag";
 
-import { useCreateNativeDatasetMutation } from "metabase/api";
+import { useGetNativeDatasetQuery } from "metabase/api";
 import { getEngineNativeType } from "metabase/lib/engine";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
@@ -27,16 +27,11 @@ const BUTTON_TITLE = {
 export const NativeQueryPreviewSidebar = (): JSX.Element => {
   const dispatch = useDispatch();
   const question = checkNotNull(useSelector(getQuestion));
-  const [createNativeDataset, datasetResult] = useCreateNativeDatasetMutation();
 
   const engineType = getEngineNativeType(question.database()?.engine);
 
-  useEffect(() => {
-    const payload = Lib.toLegacyQuery(question.query());
-    createNativeDataset(payload);
-  }, [createNativeDataset, question]);
-
-  const { data, error, isLoading } = datasetResult;
+  const payload = Lib.toLegacyQuery(question.query());
+  const { data, error, isLoading } = useGetNativeDatasetQuery(payload);
   const query = data?.query;
 
   const handleConvertClick = useCallback(() => {

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./NativeQueryPreviewSidebar";
+export { NativeQueryPreviewSidebar } from "./NativeQueryPreviewSidebar";

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 
 import { useSelector } from "metabase/lib/redux";
 import Notebook from "metabase/query_builder/components/notebook/Notebook";
-import NativeQueryPreviewSidebar from "metabase/query_builder/components/view/NativeQueryPreviewSidebar";
+import { NativeQueryPreviewSidebar } from "metabase/query_builder/components/view/NativeQueryPreviewSidebar";
 import { getUiControls } from "metabase/query_builder/selectors";
 import { Flex } from "metabase/ui";
 


### PR DESCRIPTION
This is a first task in a Milestone 1, extras tasklist of #40254

This PR utilizes RTK Query for API requests in a native query preview sidebar.
Namely, we're using it to send a `POST /api/dataset/native` request, which returns the native query string we're displaying in the sidebar.

Additionally, this PR fetches the `question` using `useSelector`. This allowed us to use a named export, and to not rely on other components for props.

## Demo
![Kapture 2024-03-21 at 14 51 53](https://github.com/metabase/metabase/assets/31325167/ed42213c-e184-4be3-955b-5f0ef3ece0fd)


### Testing
All tests should still pass.