### PR TITLE
Fix models utils using mbql directly

### DIFF
--- a/frontend/src/metabase-lib/v1/metadata/utils/models.ts
+++ b/frontend/src/metabase-lib/v1/metadata/utils/models.ts
@@ -6,11 +6,11 @@ import type NativeQuery from "metabase-lib/v1/queries/NativeQuery";
 import { isSameField } from "metabase-lib/v1/queries/utils/field-ref";
 import type {
   DatasetColumn,
+  FieldId,
   FieldReference,
   ModelCacheRefreshStatus,
   TableColumnOrderSetting,
   TemplateTag,
-  FieldId,
 } from "metabase-types/api";
 
 type FieldMetadata = {
@@ -111,23 +111,21 @@ export function checkCanBeModel(question: Question) {
 }
 
 export function isAdHocModelQuestion(
-  question: Question,
+  question?: Question,
   originalQuestion?: Question,
 ) {
-  const query = question.query();
-  const { isNative } = Lib.queryDisplayInfo(query);
-  if (!originalQuestion || isNative) {
+  if (!question || !originalQuestion) {
     return false;
   }
 
   const isModel =
     question.type() === "model" || originalQuestion.type() === "model";
-  const isSameCard = question.id() === originalQuestion.id();
+  const isSameQuestion = question.id() === originalQuestion.id();
   const isSelfReferencing =
-    Lib.sourceTableOrCardId(query) ===
+    Lib.sourceTableOrCardId(question.query()) ===
     getQuestionVirtualTableId(originalQuestion.id());
 
-  return isModel && isSameCard && isSelfReferencing;
+  return isModel && isSameQuestion && isSelfReferencing;
 }
 
 export function checkCanRefreshModelCache(

--- a/frontend/src/metabase-lib/v1/metadata/utils/models.unit.spec.js
+++ b/frontend/src/metabase-lib/v1/metadata/utils/models.unit.spec.js
@@ -7,7 +7,6 @@ import {
   checkCanRefreshModelCache,
   getModelCacheSchemaName,
   isAdHocModelQuestion,
-  isAdHocModelQuestionCard,
   getDatasetMetadataCompletenessPercentage,
 } from "metabase-lib/v1/metadata/utils/models";
 import {
@@ -191,7 +190,7 @@ describe("data model utils", () => {
     });
   });
 
-  describe("isAdHocModelQuestion & isAdHocModelQuestionCard", () => {
+  describe("isAdHocModelQuestion", () => {
     it("returns false when original question is not provided", () => {
       const modelCard = createStructuredModelCard({ id: 1 });
       const composedModelCard = createSavedStructuredCard({
@@ -202,7 +201,6 @@ describe("data model utils", () => {
       const question = new Question(composedModelCard, metadata);
 
       expect(isAdHocModelQuestion(question)).toBe(false);
-      expect(isAdHocModelQuestionCard(question.card())).toBe(false);
     });
 
     it("returns false for native questions", () => {
@@ -212,7 +210,6 @@ describe("data model utils", () => {
       const question = metadata.question(card.id);
 
       expect(isAdHocModelQuestion(question, question)).toBe(false);
-      expect(isAdHocModelQuestionCard(card, card)).toBe(false);
     });
 
     it("identifies when model goes into ad-hoc exploration mode", () => {
@@ -227,9 +224,6 @@ describe("data model utils", () => {
       const question = new Question(composedModelCard, metadata);
 
       expect(isAdHocModelQuestion(question, originalQuestion)).toBe(true);
-      expect(
-        isAdHocModelQuestionCard(question.card(), originalQuestion.card()),
-      ).toBe(true);
     });
 
     it("returns false when IDs don't match", () => {
@@ -244,9 +238,6 @@ describe("data model utils", () => {
       const question = new Question(composedModelCard, metadata);
 
       expect(isAdHocModelQuestion(question, originalQuestion)).toBe(false);
-      expect(
-        isAdHocModelQuestionCard(question.card(), originalQuestion.card()),
-      ).toBe(false);
     });
 
     it("returns false when questions are not models", () => {
@@ -261,9 +252,6 @@ describe("data model utils", () => {
       const question = new Question(composedModelCard, metadata);
 
       expect(isAdHocModelQuestion(question, originalQuestion)).toBe(false);
-      expect(
-        isAdHocModelQuestionCard(question.card(), originalQuestion.card()),
-      ).toBe(false);
     });
 
     it("returns false when potential ad-hoc model question is not self-referencing", () => {
@@ -278,9 +266,6 @@ describe("data model utils", () => {
       const question = new Question(composedModelCard, metadata);
 
       expect(isAdHocModelQuestion(question, originalQuestion)).toBe(false);
-      expect(
-        isAdHocModelQuestionCard(question.card(), originalQuestion.card()),
-      ).toBe(false);
     });
   });
 

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -31,7 +31,7 @@ import {
 } from "metabase/visualizations/lib/table";
 import { getColumnExtent } from "metabase/visualizations/lib/utils";
 import * as Lib from "metabase-lib";
-import { isAdHocModelQuestionCard } from "metabase-lib/v1/metadata/utils/models";
+import { isAdHocModelQuestion } from "metabase-lib/v1/metadata/utils/models";
 import { isID, isPK, isFK } from "metabase-lib/v1/types/utils/isa";
 import { memoizeClass } from "metabase-lib/v1/utils";
 
@@ -142,14 +142,14 @@ class TableInteractive extends Component {
   }
 
   UNSAFE_componentWillReceiveProps(newProps) {
-    const { card, data } = this.props;
-    const { card: nextCard, data: nextData } = newProps;
+    const { question, data } = this.props;
+    const { question: nextQuestion, data: nextData } = newProps;
 
     const isDataChange =
       data && nextData && !_.isEqual(data.cols, nextData.cols);
     const isDatasetStatusChange =
-      isAdHocModelQuestionCard(nextCard, card) ||
-      isAdHocModelQuestionCard(card, nextCard);
+      isAdHocModelQuestion(nextQuestion, question) ||
+      isAdHocModelQuestion(question, nextQuestion);
 
     if (isDataChange && !isDatasetStatusChange) {
       this.resetColumnWidths();


### PR DESCRIPTION
Models utils used MBQL directly without using MBQL lib. This caused issues in the metrics branch. This PR uses MBQL lib for this task.