### PR TITLE
Fix flaky whitelabel test

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -340,7 +340,7 @@ describeEE("formatting > whitelabel", () => {
         .clear()
         .type("/test-2")
         .blur();
-      cy.wait(["@putLandingPage", "@getSettings"]);
+      undoToast().findByText("Changes saved").should("be.visible");
 
       // set to valid value then test invalid value is not persisted
       cy.findByLabelText("Landing page custom destination")

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -327,7 +327,7 @@ describeEE("formatting > whitelabel", () => {
         .clear()
         .type("/test-1")
         .blur();
-      cy.wait(["@putLandingPage", "@getSettings"]);
+      undoToast().findByText("Changes saved").should("be.visible");
 
       cy.findByTestId("landing-page-error").should("not.exist");
       cy.findByRole("navigation").findByText("Exit admin").click();

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LandingPageWidget/LandingPageWidget.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/LandingPageWidget/LandingPageWidget.tsx
@@ -9,13 +9,10 @@ import { getRelativeLandingPageUrl } from "./utils";
 
 interface Props {
   settingValues: EnterpriseSettings;
-  onChangeSetting: (
-    key: "landing-page",
-    value: EnterpriseSettings["landing-page"],
-  ) => Promise<void>;
+  onChange: (value: EnterpriseSettings["landing-page"]) => Promise<void>;
 }
 
-export function LandingPageWidget({ onChangeSetting, settingValues }: Props) {
+export function LandingPageWidget({ onChange, settingValues }: Props) {
   const [error, setError] = useState<string | null>(null);
 
   const normalize = (value: string | number | null) => {
@@ -33,7 +30,7 @@ export function LandingPageWidget({ onChangeSetting, settingValues }: Props) {
     } else {
       setError(null);
       try {
-        await onChangeSetting("landing-page", relativeUrl);
+        await onChange(relativeUrl);
       } catch (e: any) {
         setError(e?.data?.message || t`Something went wrong`);
       }


### PR DESCRIPTION
[Report from Slack](https://metaboat.slack.com/archives/C063Q3F1HPF/p1711008869877899)

### Description

`PLUGIN_LANDING_PAGE` uses `MetabaseSettings` under the hood. This plugin is used to determine where we should redirect the users to using the setting `landing-page`.
https://github.com/metabase/metabase/blob/27c3bb1d92459e321fe1bff4f01856d790032542/frontend/src/metabase/routes.jsx#L129

The problem was caused by how we sync the updated settings to `MetabaseSettings`. Previously, after updating the setting, we only waited for the setting to be saved, but never for `GET /api/session/properties` to complete.

`GET /api/session/properties` is used by `MetabaseSettings` to sync all the setting values.
https://github.com/metabase/metabase/blob/27c3bb1d92459e321fe1bff4f01856d790032542/frontend/src/metabase/redux/settings.ts#L17

I tried waiting for `GET /api/session/properties` in Cypress, but it turned out this Promise got resolved after we exit the admin page somehow
https://github.com/metabase/metabase/blob/27c3bb1d92459e321fe1bff4f01856d790032542/frontend/src/metabase/redux/settings.ts#L13

I also found out that we used `onChangeSetting` for landing page widget which called a different callback.
- `onChangeSetting` calls [`handleChangeSetting`](https://github.com/metabase/metabase/blob/27c3bb1d92459e321fe1bff4f01856d790032542/frontend/src/metabase/admin/settings/app/components/SettingsEditor/SettingsEditor.jsx#L155). This callback doesn't show the notification toast that the setting has been updated.
- `onChange` calls [`updateSetting`](https://github.com/metabase/metabase/blob/27c3bb1d92459e321fe1bff4f01856d790032542/frontend/src/metabase/admin/settings/app/components/SettingsEditor/SettingsEditor.jsx#L83). This callback will show the notification toast that the setting has been updated.

After changing to use `onChange`, this callback also ensures that we `await` some actions we dispatch which include the one action that calls `GET /api/session/propertie` which is used by [`PLUGIN_LANDING_PAGE`](https://github.com/metabase/metabase/blob/27c3bb1d92459e321fe1bff4f01856d790032542/frontend/src/metabase/routes.jsx#L129) that I mentioned earlier.

So if we instruct Cypress to wait for the toast to appear, we could ensure `GET /api/session/propertie` would have been responded at that point, so the test should not fail.

### How to verify

Locally it's easy to run `"should allow users to provide internal urls"` inside `e2e/test/scenarios/admin-2/whitelabel.cy.spec.js`. And throttle the network speed in Cypress screen, I used "Fast 3G".

### Demo
We didn't show the notification toast previously.
![image](https://github.com/metabase/metabase/assets/1937582/86b94a28-401c-43e2-babc-5d4c18b75955)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [Stress test result](https://github.com/metabase/metabase/actions/runs/8375641729) 20/20 passed
