### PR TITLE
Small bit of api doc styling

### DIFF
--- a/resources/openapi/index.html
+++ b/resources/openapi/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Metabase API doc</title>
     <script src="rapidoc-min.js"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,400;0,700;0,900;1,400;1,700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <!-- https://rapidocweb.com/api.html -->

--- a/resources/openapi/index.html
+++ b/resources/openapi/index.html
@@ -11,7 +11,9 @@
               render-style="read"
               heading-text="Metabase"
               show-header="false"
-              allow-server-selection="false">
+              allow-server-selection="false"
+              regular-font="Lato, sans-serif"
+              primary-color="#509ee3">
     </rapi-doc>
   </body>
 </html>

--- a/src/metabase/api/routes.clj
+++ b/src/metabase/api/routes.clj
@@ -87,7 +87,7 @@
       "/"               (-> (respond "index.html")
                             ;; Better would be to append this to our CSP, but there is no good way right now and it's
                             ;; just a single page. Necessary for rapidoc to work, script injects styles in runtime.
-                            (assoc-in [:headers "Content-Security-Policy"] "style-src 'unsafe-inline'"))
+                            (assoc-in [:headers "Content-Security-Policy"] "script-src 'self' 'unsafe-inline'"))
       "/rapidoc-min.js" (respond "rapidoc-min.js")
       "/openapi.json"   (merge
                          (api/openapi-object (resolve 'metabase.api.routes/routes))


### PR DESCRIPTION
Tiny tweak to our new Rapidoc powered api docs to use Metabase brand color and specify Lato as the intended `regular-font`. 

![Screenshot 2024-03-21 at 9 35 53 AM](https://github.com/metabase/metabase/assets/5248953/4b6c1f66-85bc-4f04-82be-6c83bba18928)
