### PR TITLE
Cleanup can-save

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -461,7 +461,7 @@ function ViewTitleHeaderRightSide(props) {
   );
 
   const canSave = Lib.canSave(question.query());
-  const isSaveDisabled = !canSave || !isEditable;
+  const isSaveDisabled = !canSave;
   const disabledSaveTooltip = getDisabledSaveTooltip(
     isEditable,
     requiredTemplateTags,

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -76,7 +76,8 @@
 (mu/defn can-save :- :boolean
   "Returns whether the query can be saved."
   [query :- ::lib.schema/query]
-  (and (can-run query)
+  (and (lib.metadata/editable? query)
+       (can-run query)
        (boolean (can-save-method query))))
 
 (mu/defn query-with-stages :- ::lib.schema/query

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -188,5 +188,11 @@
            (lib.query/query meta/metadata-provider
              {:database 74001, :type :query, :query {:source-table 74040}})))))
 
-(deftest ^:parallel can-save-mbql-test
-  (is (lib.query/can-save lib.tu/venues-query)))
+(deftest ^:parallel can-save-test
+  (mu/disable-enforcement
+    (are [can-save? query]
+      (= can-save?  (lib.query/can-save query))
+      true lib.tu/venues-query
+      false (assoc lib.tu/venues-query :database nil)           ; database unknown - no permissions
+      true (lib/native-query meta/metadata-provider "SELECT")
+      false (lib/native-query meta/metadata-provider ""))))


### PR DESCRIPTION
Currently the FE uses `can-save` in combination with `:is-editable` flag. We should fix this implicit contract and make `can-save` do the right thing under the hood.