### PR TITLE
correcting input ref on ListSearchField

### DIFF
--- a/frontend/src/metabase/components/ListSearchField/ListSearchField.jsx
+++ b/frontend/src/metabase/components/ListSearchField/ListSearchField.jsx
@@ -20,8 +20,7 @@ export default function ListSearchField({ autoFocus, ...props }) {
 
   return (
     <Input
-      autoFocus
-      ref={inputRef}
+      inputRef={inputRef}
       data-testid="list-search-field"
       {...props}
       leftIcon="search"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/36074

### Description
When scrolling in an Accordion List that is large enough and has a search field, we would find ourselves snapping to the top of the list anytime we scrolled up (scrolling down was fine) because we were focusing the search at the top of the list. It looks like this was introduced last year when we refactored out the <TextInput> component, and we passed in the incorrect ref. Changing to inputRef allows the useEffect to work properly and maintain focus without taking over the scroll

### How to verify

1. Go to any saved model (can duplicate one from Metabase Analytics)
2. Edit Metadata -> pick a column -> click column type dropdown
3. scroll freely

### Demo
![chrome_mbbczqC2AD](https://github.com/metabase/metabase/assets/1328979/bbcd52c0-e919-4fe5-83f4-fadb452597d6)

### Checklist

I was unable to write a test for this that would fail before the changes and pass afterwards. The way cypress handles scrolling, it would pass every time. After spending some time on it, I decided that it likely wasn't worth the time investment, but I'm happy to revisit it if other have ideas.
- [ ] ~Tests have been added/updated to cover changes in this PR~
