### PR TITLE
Remove the aggregation item tooltips

### DIFF
--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.styled.tsx
@@ -31,14 +31,3 @@ export const ColumnPickerHeaderTitle = styled.span`
   font-weight: 700;
   font-size: 1.17em;
 `;
-
-export const InfoIconContainer = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
-  padding-right: 0.5rem;
-
-  opacity: 0.7;
-  cursor: pointer;
-`;

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -18,7 +18,6 @@ import {
   ColumnPickerHeaderContainer,
   ColumnPickerHeaderTitleContainer,
   ColumnPickerHeaderTitle,
-  InfoIconContainer,
 } from "./AggregationPicker.styled";
 
 interface AggregationPickerProps {
@@ -251,7 +250,6 @@ export function AggregationPicker({
         itemIsSelected={checkIsItemSelected}
         renderItemName={renderItemName}
         renderItemDescription={omitItemDescription}
-        renderItemExtra={renderItemExtra}
         // disable scrollbars inside the list
         style={{ overflow: "visible" }}
         maxHeight={Infinity}
@@ -282,17 +280,6 @@ function renderItemName(item: ListItem) {
 }
 
 function omitItemDescription() {
-  return null;
-}
-
-function renderItemExtra(item: ListItem) {
-  if (item.description) {
-    return (
-      <InfoIconContainer>
-        <Icon name="question" size={20} tooltip={item.description} />
-      </InfoIconContainer>
-    );
-  }
   return null;
 }
 

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.unit.spec.tsx
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import { createMockMetadata } from "__support__/metadata";
 import { createMockEntitiesState } from "__support__/store";
-import { renderWithProviders, screen, within } from "__support__/ui";
+import { renderWithProviders, screen } from "__support__/ui";
 import { checkNotNull } from "metabase/lib/types";
 import * as Lib from "metabase-lib";
 import {
@@ -232,20 +232,6 @@ describe("AggregationPicker", () => {
       });
     });
 
-    it("should show operator descriptions", () => {
-      setup();
-
-      const sumOfOption = screen.getByRole("option", { name: "Sum of ..." });
-      const infoIcon = within(sumOfOption).getByRole("img", {
-        name: "question icon",
-      });
-      userEvent.hover(infoIcon);
-
-      expect(screen.getByRole("tooltip")).toHaveTextContent(
-        "Sum of all the values of a column",
-      );
-    });
-
     it("should apply a column-less operator", () => {
       const { getRecentClauseInfo } = setup();
 
@@ -368,22 +354,6 @@ describe("AggregationPicker", () => {
     it("shouldn't list metrics for other tables", () => {
       setupMetrics({ metadata: createMetadata({ metrics: [TEST_METRIC] }) });
       expect(screen.queryByText(PRODUCT_METRIC.name)).not.toBeInTheDocument();
-    });
-
-    it("should show a description for each metric", () => {
-      setupMetrics({ metadata: createMetadata({ metrics: [TEST_METRIC] }) });
-
-      const metricOption = screen.getByRole("option", {
-        name: TEST_METRIC.name,
-      });
-      const infoIcon = within(metricOption).getByRole("img", {
-        name: "question icon",
-      });
-      userEvent.hover(infoIcon);
-
-      expect(screen.getByRole("tooltip")).toHaveTextContent(
-        TEST_METRIC.description,
-      );
     });
 
     it("should allow picking a metric", () => {


### PR DESCRIPTION
This PR removes redundant tooltips with an explanation for each individual aggregation option.

Before
![image](https://github.com/metabase/metabase/assets/31325167/c2bb311b-f2a5-4096-9435-db82ba3c10cc)

After
![Kapture 2024-03-21 at 18 05 02](https://github.com/metabase/metabase/assets/31325167/30ead6c0-c8d0-485d-aaf0-801c08ac5730)

