### PR TITLE
[MLv2] Return correct drill-thrus for single-row aggregates

### DIFF
--- a/src/metabase/lib/drill_thru/quick_filter.cljc
+++ b/src/metabase/lib/drill_thru/quick_filter.cljc
@@ -11,6 +11,9 @@
 
   - Column can be filtered upon (exists in `filterableColumns`)
 
+  - If the column is an aggregation, there must be breakouts. It doesn't make sense to filter on the value of a single
+    row aggregation.
+
   - For `null` value, allow only `=` and `≠` operators, which map to `is-null` and `not-null` filter operators
 
   - For date and numeric columns, allow `<`, `>`, `=`, `≠` operators
@@ -100,12 +103,15 @@
 
   Note that this returns a single `::drill-thru` value with 1 or more `:operators`; these are rendered as a set of small
   buttons in a single row of the drop-down."
-  [query                                           :- ::lib.schema/query
-   stage-number                                    :- :int
-   {:keys [column column-ref value], :as _context} :- ::lib.schema.drill-thru/context]
+  [query                                                      :- ::lib.schema/query
+   stage-number                                               :- :int
+   {:keys [column column-ref dimensions value], :as _context} :- ::lib.schema.drill-thru/context]
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
              column
              (some? value) ; Deliberately allows value :null, only a missing value should fail this test.
+             ;; If this is an aggregation, there must be breakouts (dimensions).
+             (or (not= (:lib/source column) :source/aggregations)
+                 (seq dimensions))
              (not (lib.types.isa/structured?  column))
              (not (lib.types.isa/primary-key? column))
              (not (lib.types.isa/foreign-key? column)))

--- a/src/metabase/lib/drill_thru/underlying_records.cljc
+++ b/src/metabase/lib/drill_thru/underlying_records.cljc
@@ -11,10 +11,9 @@
 
   Requirements:
 
-  - Not empty `dimensions`, i.e. at least 1 breakout in the query
+  - Either: A single-row aggregation, or not empty `dimensions`, i.e. at least 1 breakout in the query
 
   Query transformation:
-
 
   - Drop all query stages where there are no aggregation clauses until the last one.
 
@@ -67,12 +66,16 @@
   ;; So dimensions is exactly what we want.
   ;; It returns the table name and row count, since that's used for pluralization of the name.
 
+  ;; Clicking on a single-row aggregation, there's no dimensions, but we should support underlying records.
+
   ;; Clicking on a chart legend for eg. COUNT(Orders) by Products.CATEGORY and Orders.CREATED_AT has a context like:
   ;; - column is nil
   ;; - value is nil
   ;; - dimensions holds only the legend's column, eg. Products.CATEGORY.
   (when (and (lib.drill-thru.common/mbql-stage? query stage-number)
-             (not-empty dimensions)
+             ;; Underlying records requires an aggregation. Either we clicked the aggregation, or there are dimensions.
+             (or (= (:lib/source column) :source/aggregations)
+                 (not-empty dimensions))
              ;; Either we need both column and value (cell/map/data point click) or neither (chart legend click).
              (or (and column (some? value))
                  (and (nil? column) (nil? value)))

--- a/test/metabase/lib/drill_thru/quick_filter_test.cljc
+++ b/test/metabase/lib/drill_thru/quick_filter_test.cljc
@@ -16,10 +16,12 @@
   (testing "quick-filter is avaiable for cell clicks on non-PK/FK columns"
     (canned/canned-test
       :drill-thru/quick-filter
-      (fn [_test-case context {:keys [click column-type]}]
+      (fn [_test-case {:keys [column dimensions] :as _context} {:keys [click column-kind column-type]}]
         (and (= click :cell)
              (not (#{:pk :fk} column-type))
-             (not (lib.types.isa/structured? (:column context))))))))
+             (not (lib.types.isa/structured? column))
+             (or (not= column-kind :aggregation)
+                 (seq dimensions)))))))
 
 (deftest ^:parallel returns-quick-filter-test-1
   (lib.drill-thru.tu/test-returns-drill

--- a/test/metabase/lib/drill_thru/underlying_records_test.cljc
+++ b/test/metabase/lib/drill_thru/underlying_records_test.cljc
@@ -22,7 +22,7 @@
   (testing "underlying-records is available for non-header clicks with at least one breakout"
     (canned/canned-test
       :drill-thru/underlying-records
-      (fn [_test-case context {:keys [click]}]
+      (fn [_test-case context {:keys [click column-kind]}]
         ;; TODO: The docs claim that underlying-records works on pivot cells, and so it does, but the so-called pivot case
         ;; never occurs in actual pivot tables!
         ;; - Clicks on row/column "headers", (that is, breakout values like a month or product category) look like regular
@@ -33,7 +33,8 @@
         ;; code that should be setting the aggregation :value for cell clicks?
         ;; Tech debt issue: #39380
         (and (#{:cell #_:pivot :legend} click)
-             (seq (:dimensions context)))))))
+             (or (seq (:dimensions context))
+                 (= column-kind :aggregation)))))))
 
 (deftest ^:parallel returns-underlying-records-test-1
   (lib.drill-thru.tu/test-returns-drill

--- a/test/metabase/lib/drill_thru_test.cljc
+++ b/test/metabase/lib/drill_thru_test.cljc
@@ -428,7 +428,7 @@
                                                                 {:name "≠"}]}
                                :underlying-records {:lib/type   :metabase.lib.drill-thru/drill-thru
                                                     :type       :drill-thru/underlying-records
-                                                    :row-count  457
+                                                    :row-count  pos-int?
                                                     :table-name "Orders"}
                                :zoom-in.timeseries {:lib/type     :metabase.lib.drill-thru/drill-thru
                                                     :display-name "See this month by week"
@@ -446,7 +446,7 @@
         (let [context (merge (basic-context count-column 123)
                              {:row row})]
           (testing (str "\ncontext =\n" (u/pprint-to-str context))
-            (is (=? (map expected-drills [:pivot :quick-filter])
+            (is (=? (map expected-drills [:pivot :underlying-records])
                     (lib/available-drill-thrus query -1 context)))
             (test-drill-applications query context)))
         (testing "with :dimensions"
@@ -480,12 +480,12 @@
                                :location [{:name "CITY"}
                                           {:name "STATE"}
                                           {:name "ZIP"}]}}
-                   {:lib/type :metabase.lib.drill-thru/drill-thru
-                    :type     :drill-thru/quick-filter
-                    :operators [{:name "<"}
-                                {:name ">"}
-                                {:name "="}
-                                {:name "≠"}]}]
+                   {:lib/type   :metabase.lib.drill-thru/drill-thru
+                    :type       :drill-thru/underlying-records
+                    :row-count  pos-int?
+                    :table-name "Orders"
+                    :dimensions nil
+                    :column-ref [:aggregation {} #_uuid string?]}]
                   (lib/available-drill-thrus query -1 context)))
           (test-drill-applications query context))))))
 


### PR DESCRIPTION
They were showing "break out by" and quick filters, when they should be
showing "break out by" and "See these Orders".

These are the `pivot` and `underlying-records` drills, internally.

Fixes #40174.

