### PR TITLE
Improve native sidebar basic styling [PoC/task-4] 

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.module.css
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.module.css
@@ -1,0 +1,11 @@
+.container {
+  position: absolute;
+  inset: 0;
+  background-color: white;
+
+  @media screen and (--breakpoint-min-md) {
+    position: relative;
+    flex: 1;
+    max-width: 37.5rem;
+  }
+}

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -82,7 +82,7 @@ export const NativeQueryPreviewSidebar = (): JSX.Element => {
             <Box mt="sm">{getErrorMessage(error)}</Box>
           </Flex>
         )}
-        {query && (
+        {!error && query && (
           <AceEditor
             value={query}
             mode={aceMode}

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -1,3 +1,4 @@
+import cx from "classnames";
 import { useCallback } from "react";
 import AceEditor from "react-ace";
 import { t } from "ttag";
@@ -14,6 +15,7 @@ import { getQuestion } from "metabase/query_builder/selectors";
 import { Box, Button, Flex, Icon, rem } from "metabase/ui";
 import * as Lib from "metabase-lib";
 
+import SB from "./NativeQueryPreviewSidebar.module.css";
 import { createDatasetQuery } from "./utils";
 
 const TITLE = {
@@ -56,10 +58,9 @@ export const NativeQueryPreviewSidebar = (): JSX.Element => {
 
   return (
     <Flex
+      className={cx(SB.container)}
       role="complementary"
       direction="column"
-      miw={480}
-      maw="40%"
       style={{ borderLeft: borderStyle }}
     >
       <Box
@@ -96,6 +97,8 @@ export const NativeQueryPreviewSidebar = (): JSX.Element => {
               width="100%"
               fontSize={12}
               style={{ backgroundColor: color("bg-light") }}
+              showPrintMargin={false}
+              wrapEnabled={true}
             />
           </NativeQueryEditorRoot>
         )}

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -9,6 +9,7 @@ import { getEngineNativeType } from "metabase/lib/engine";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
 import { updateQuestion, setUIControls } from "metabase/query_builder/actions";
+import { NativeQueryEditorRoot } from "metabase/query_builder/components/NativeQueryEditor/NativeQueryEditor.styled";
 import { getQuestion } from "metabase/query_builder/selectors";
 import { Box, Button, Flex, Icon, rem } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -57,7 +58,8 @@ export const NativeQueryPreviewSidebar = (): JSX.Element => {
     <Flex
       role="complementary"
       direction="column"
-      w={480}
+      miw={480}
+      maw="40%"
       style={{ borderLeft: borderStyle }}
     >
       <Box
@@ -83,17 +85,19 @@ export const NativeQueryPreviewSidebar = (): JSX.Element => {
           </Flex>
         )}
         {!error && query && (
-          <AceEditor
-            value={query}
-            mode={aceMode}
-            readOnly
-            height="100%"
-            highlightActiveLine={false}
-            navigateToFileEnd={false}
-            width="100%"
-            fontSize={12}
-            style={{ backgroundColor: color("bg-light") }}
-          />
+          <NativeQueryEditorRoot style={{ height: "100%", flex: 1 }}>
+            <AceEditor
+              value={query}
+              mode={aceMode}
+              readOnly
+              height="100%"
+              highlightActiveLine={false}
+              navigateToFileEnd={false}
+              width="100%"
+              fontSize={12}
+              style={{ backgroundColor: color("bg-light") }}
+            />
+          </NativeQueryEditorRoot>
         )}
       </Box>
       <Box ta="end" p="1.5rem">

--- a/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
+++ b/frontend/src/metabase/query_builder/components/view/NativeQueryPreviewSidebar/NativeQueryPreviewSidebar.tsx
@@ -1,16 +1,17 @@
 import { useCallback } from "react";
+import AceEditor from "react-ace";
 import { t } from "ttag";
 
 import { useGetNativeDatasetQuery } from "metabase/api";
+import { DelayedLoadingSpinner } from "metabase/common/components/EntityPicker/components/LoadingSpinner";
+import { color } from "metabase/lib/colors";
 import { getEngineNativeType } from "metabase/lib/engine";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { checkNotNull } from "metabase/lib/types";
 import { updateQuestion, setUIControls } from "metabase/query_builder/actions";
 import { getQuestion } from "metabase/query_builder/selectors";
-import { Button } from "metabase/ui";
+import { Box, Button, Flex, Icon, rem } from "metabase/ui";
 import * as Lib from "metabase-lib";
-
-import { NativeQueryPreview } from "../NativeQueryPreview";
 
 import { createDatasetQuery } from "./utils";
 
@@ -49,18 +50,59 @@ export const NativeQueryPreviewSidebar = (): JSX.Element => {
   const getErrorMessage = (error: unknown) =>
     typeof error === "string" ? error : undefined;
 
+  const borderStyle = `1px solid ${color("border")}`;
+  const aceMode = getEngineNativeType(engineType);
+
   return (
-    <NativeQueryPreview
-      title={TITLE[engineType]}
-      query={query}
-      error={getErrorMessage(error)}
-      isLoading={isLoading}
+    <Flex
+      role="complementary"
+      direction="column"
+      w={480}
+      style={{ borderLeft: borderStyle }}
     >
-      {query && (
-        <Button variant="subtle" onClick={handleConvertClick}>
-          {BUTTON_TITLE[engineType]}
-        </Button>
-      )}
-    </NativeQueryPreview>
+      <Box
+        component="header"
+        c={color("text-dark")}
+        fz={rem(20)}
+        lh={rem(24)}
+        fw="bold"
+        ta="start"
+        p="1.5rem"
+      >
+        {TITLE[engineType]}
+      </Box>
+      <Box
+        style={{ flex: 1, borderTop: borderStyle, borderBottom: borderStyle }}
+      >
+        {isLoading && <DelayedLoadingSpinner delay={1000} />}
+        {error && (
+          <Flex align="center" justify="center" h="100%" direction="column">
+            <Icon name="warning" size="2rem" color={color("error")} />
+            {t`Error generating the query.`}
+            <Box mt="sm">{getErrorMessage(error)}</Box>
+          </Flex>
+        )}
+        {query && (
+          <AceEditor
+            value={query}
+            mode={aceMode}
+            readOnly
+            height="100%"
+            highlightActiveLine={false}
+            navigateToFileEnd={false}
+            width="100%"
+            fontSize={12}
+            style={{ backgroundColor: color("bg-light") }}
+          />
+        )}
+      </Box>
+      <Box ta="end" p="1.5rem">
+        {query && (
+          <Button variant="subtle" p={0} onClick={handleConvertClick}>
+            {BUTTON_TITLE[engineType]}
+          </Button>
+        )}
+      </Box>
+    </Flex>
   );
 };

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.styled.tsx
@@ -3,12 +3,21 @@ import styled from "@emotion/styled";
 import IconButtonWrapper from "metabase/components/IconButtonWrapper";
 import { color } from "metabase/lib/colors";
 
-export const SqlButton = styled(IconButtonWrapper)`
-  color: ${color("text-dark")};
-  padding: 0.5rem;
+interface SqlButtonProps {
+  isSelected?: boolean;
+}
+
+export const SqlButton = styled(IconButtonWrapper)<SqlButtonProps>`
+  color: ${({ isSelected }) =>
+    isSelected ? color("white") : color("text-dark")};
+  background-color: ${({ isSelected }) => isSelected && color("brand")};
+  height: 2rem;
+  width: 2rem;
 
   &:hover {
     color: ${color("brand")};
     background-color: ${color("bg-medium")};
+    border: 1px solid ${color("brand")};
+    transition: all 200ms linear;
   }
 `;

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
@@ -46,7 +46,11 @@ export const ToggleNativeQueryPreview = ({
 
   return (
     <Tooltip label={tooltip} position="top">
-      <SqlButton onClick={handleClick} aria-label={tooltip}>
+      <SqlButton
+        isSelected={isNativePreviewSidebarOpen}
+        onClick={handleClick}
+        aria-label={tooltip}
+      >
         <Icon size="1rem" name="sql" />
       </SqlButton>
     </Tooltip>


### PR DESCRIPTION
This is the fourth task in the Milestone 1 (PoC) of https://github.com/metabase/metabase/issues/40254.
It merges into the `sql-sidebar-preview-poc` that's being used as a "feature" branch for this milestone.

## What does this PR accomplish?
- It introduces Ace editor in readonly mode with the full code highlighting support, and with line numbers
    - It reuses the styles that we apply to the actual `NativeQueryEditor`
- It introduces the Loading state
    - As per design, the loader appears only if the query is still loading after 1s
    - [Video preview](https://github.com/metabase/metabase/assets/31325167/6646c8e2-6a6b-4fb9-916f-a7e3eac8127f)
- It introduces the (very basic) error state  - more like a placeholder for what will later become the proper error screen
    - [Image preview](https://github.com/metabase/metabase/assets/31325167/9f13d3d9-ae8c-4680-80b1-3c1eb3fe5481)
- It provides the rudimentary support for mobile screen sizes
    - The sidebar replaces the notebook view completely and takes up the fill screen width (see demo)

### Demo
![Kapture 2024-03-22 at 16 06 37](https://github.com/metabase/metabase/assets/31325167/1a8c2632-5235-415d-9296-6bf142ef6e40)

---
## The Scope
- Code highlighting and line numbers in the native editor
- The rudimentary mobile support for the native sidebar
- Handle the styling for the toggle icon when it is active

## Out of Scope
- Pixel perfect styling
- Resizable sidebar
---

# Follow up tasks
- Find a better way to reuse code editor styles across components
- Use Mantine for icon wrappers and unify the approach we're using in view header (https://github.com/metabase/metabase/issues/40523)
- Determine the real shape of the error + update the error state once the design is ready
- Remove the active line styling in the ace editor gutter