### PR TITLE
Trend Chart Viz Should Use Proper Card execute in Rendering

### DIFF
--- a/src/metabase/models/dashboard_card.clj
+++ b/src/metabase/models/dashboard_card.clj
@@ -114,17 +114,15 @@
       (t2/hydrate :series)))
 
 (defn dashcard->multi-cards
-  "Return the cards which are other cards with respect to this dashboard card
-  in multiple series display for dashboard
+  "Return the cards which have been added to this dashcard using the 'add series' dashboard feature.
 
-  Dashboard (and dashboard only) has this thing where you're displaying multiple cards entirely.
+  Dashboards allow Line, Area, and Bar dashcards to have other questions (series) added to them
+  so that several Questions are displayed in a single dashcard.
 
-  This is actually completely different from the combo display,
-  which is a visualization type in visualization option.
+  It's important to know that this is different from the combo display,
+  which is its own visualization type for Questions.
 
-  This is also actually completely different from having multiple series display
-  from the visualization with same type (line bar or whatever),
-  which is a separate option in line area or bar visualization"
+  This is also different from having multiple series displayed on Line, Area, or Bar Questions."
   [dashcard]
   (mdb.query/query {:select    [:newcard.*]
                     :from      [[:report_dashboardcard :dashcard]]

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -922,6 +922,16 @@
       (h value)]
      :render/text (str value)}))
 
+;; the `:javascript_visualization` render method
+;; is and will continue to handle more and more 'isomorphic' chart types.
+;; Isomorphic in this context just means the frontend Code is mostly shared between the app and the static-viz
+;; As of 2024-03-21, isomorphic chart types include: line, area, bar (LAB), and trend charts
+;; Because this effort began with LAB charts, this method is written to handle multi-series dashcards.
+;; Trend charts were added more recently and will not have multi-series.
+;; Despite this, the function `pu/execute-multi-card` will still correctly execute dashcards.
+;; This conditional is here to cover the case of trend charts in Alerts (not subscriptions). Alerts
+;; exist on Questions and thus have no associated dashcard, which causes `pu/execute-multi-card` to fail.
+
 (mu/defmethod render :javascript_visualization :- formatter/RenderedPulseCard
   [_chart-type render-type _timezone-id card dashcard data]
   (let [combined-cards-results (if dashcard

--- a/src/metabase/pulse/render/body.clj
+++ b/src/metabase/pulse/render/body.clj
@@ -924,7 +924,9 @@
 
 (mu/defmethod render :javascript_visualization :- formatter/RenderedPulseCard
   [_chart-type render-type _timezone-id card dashcard data]
-  (let [combined-cards-results (pu/execute-multi-card card dashcard)
+  (let [combined-cards-results (if dashcard
+                                 (pu/execute-multi-card card dashcard)
+                                 (pu/execute-card {:creator_id (:creator_id card)} (:id card)))
         cards-with-data        (map (fn [c d] {:card c :data d})
                                     (cons card (map :card combined-cards-results))
                                     (cons data (map #(get-in % [:result :data]) combined-cards-results)))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -851,7 +851,8 @@
                :type     :query
                :query
                {:source-table (mt/id :orders)
-                :aggregation  [[:count]]}}]
+                :aggregation  [[:count]]
+                :breakout     [[:field (mt/id :orders :created_at) {:base-type :type/DateTime, :temporal-unit :month}]]}}]
         ;; Alerts are set on Questions. They run through the 'pulse' code the same as subscriptions,
         ;; But will not have any Dashcard data associated, which caused an error in the static-viz render code
         ;; which implicitly expected a DashCard to exist

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -843,3 +843,27 @@
                                                              :visualization_settings viz}]
             (testing "the render succeeds with unknown column settings keys"
               (is (seq (render.tu/render-card-as-hickory card-id))))))))))
+
+(deftest trend-chart-renders-in-alerts-test
+  (testing "Trend charts render successfully in Alerts. (#39854)"
+    (mt/dataset test-data
+      (let [q {:database (mt/id)
+               :type     :query
+               :query
+               {:source-table (mt/id :orders)
+                :aggregation  [[:count]]}}]
+        ;; Alerts are set on Questions. They run through the 'pulse' code the same as subscriptions,
+        ;; But will not have any Dashcard data associated, which caused an error in the static-viz render code
+        ;; which implicitly expected a DashCard to exist
+        ;; Here, we simulate an Alert (NOT a subscription) by only providing a card and not mocking a DashCard.
+        (mt/with-temp [:model/Card {card-id :id} {:display       :smartscalar
+                                                  :dataset_query q}]
+          (let [doc       (render.tu/render-card-as-hickory card-id)
+                span-text (->> doc
+                               (hik.s/select (hik.s/tag :span))
+                               (mapv (comp first :content))
+                               (filter string?)
+                               (filter #(str/includes? % "previous month")))]
+            ;; we look for content that we are certain comes from a
+            ;; successfully rendered trend chart.
+            (is (= ["vs. previous month: "] span-text))))))))

--- a/test/metabase/pulse/render/test_util.clj
+++ b/test/metabase/pulse/render/test_util.clj
@@ -656,9 +656,9 @@
                                                    {:image-src   s
                                                     :render-type :inline})]
       (let [content (-> (render/render-pulse-card :inline "UTC" card nil results)
-                            :content)]
+                        :content)]
         (-> content
-              (edit-nodes img-node-with-svg? img-node->svg-node) ;; replace the :img tag with its parsed SVG.
-              hiccup/html
-              hik/parse
-              hik/as-hickory)))))
+            (edit-nodes img-node-with-svg? img-node->svg-node) ;; replace the :img tag with its parsed SVG.
+            hiccup/html
+            hik/parse
+            hik/as-hickory)))))


### PR DESCRIPTION
Fixes: #39854

See the issue for a screenshot of the failure. After this fix:

![image](https://github.com/metabase/metabase/assets/21064735/0296b825-ab2e-4b36-9240-b8cc3d95b536)

The core of the issue is that `metabase.pulse.render.body/render` `:javascript_visualization` was first written for only line, area, and bar chart types. These types allow the user to add other questions to display on the same dashcard (Only in Dashobards), and the function `metabase.pulse.util/execute-multi-card` requires that a dashcard is passed in.

In the case of a subscription, this function works correctly (even though the trend chart won't actually have multi-series data). In the case of an alert, which exists on Questions, not dashboards, there is no dashcard.

So, this PR fixes this by using `metabase.pulse.util/execute-card` directly when there is no dashcard.