### PR TITLE
Relax public action execution throttler to allow 10 requests every second

### DIFF
--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -618,9 +618,9 @@
    The goal of rate limiting should be to prevent very obvious abuse, but it should
    be relatively lax so we don't annoy legitimate users."
   (throttle/make-throttler :action-uuid
-                           :attempts-threshold 1
-                           :initial-delay-ms 100
-                           :attempt-ttl-ms 100
+                           :attempts-threshold 10
+                           :initial-delay-ms 1000
+                           :attempt-ttl-ms 1000
                            :delay-exponent 1))
 
 (api/defendpoint POST "/action/:uuid/execute"

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -614,10 +614,14 @@
      :qp            qp.pivot/run-pivot-query)))
 
 (def ^:private action-execution-throttle
-  "Rate limit at 1 action per second on a per action basis.
+  "Rate limit at 1 action per 100 ms (10 per second) on a per action basis.
    The goal of rate limiting should be to prevent very obvious abuse, but it should
    be relatively lax so we don't annoy legitimate users."
-  (throttle/make-throttler :action-uuid :attempts-threshold 1 :initial-delay-ms 1000 :delay-exponent 1))
+  (throttle/make-throttler :action-uuid
+                           :attempts-threshold 1
+                           :initial-delay-ms 100
+                           :attempt-ttl-ms 100
+                           :delay-exponent 1))
 
 (api/defendpoint POST "/action/:uuid/execute"
   "Execute the Action.

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -614,7 +614,7 @@
      :qp            qp.pivot/run-pivot-query)))
 
 (def ^:private action-execution-throttle
-  "Rate limit at 1 action per 100 ms (10 per second) on a per action basis.
+  "Rate limit at 10 actions per 1000 ms on a per action basis.
    The goal of rate limiting should be to prevent very obvious abuse, but it should
    be relatively lax so we don't annoy legitimate users."
   (throttle/make-throttler :action-uuid


### PR DESCRIPTION
Before, we throttled public actions conservatively to 1 request per second. Now we limit to 10 every second.

If there’s more than one request in a given 1000 milliseconds, only the first 10 requests will succeed.

Unfortunately the throttler implementation is pretty limiting, and doesn’t allow you to do things like: if there’s 10 requests in a second, make the user wait 10 seconds before resetting the throttler. 

context:
https://metaboat.slack.com/archives/C05MPF0TM3L/p1711044058337469?thread_ts=1706042975.259839&cid=C05MPF0TM3L

I tested this with my clojure REPL, and it works as expected. The tests written for this stuff mock the throttler so there's no tests on the throttler settings itself.