### PR TITLE
Updated Permissions UI

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -166,35 +166,30 @@ describe("snapshots", () => {
       [ALL_USERS_GROUP]: {
         [SAMPLE_DB_ID]: {
           // set the data permission so the UI doesn't warn us that "all users has higher permissions than X"
-          data: { schemas: "none", native: "none" },
           "view-data": lowest_read_data_permission,
           "create-queries": "no",
         },
       },
       [DATA_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "all", native: "write" },
           "view-data": "unrestricted",
           "create-queries": "query-builder-and-native",
         },
       },
       [NOSQL_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "all", native: "none" },
           "view-data": "unrestricted",
           "create-queries": "query-builder",
         },
       },
       [COLLECTION_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "none", native: "none" },
           "view-data": lowest_read_data_permission,
           "create-queries": "no",
         },
       },
       [READONLY_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "none", native: "none" },
           "view-data": lowest_read_data_permission,
           "create-queries": "no",
         },

--- a/e2e/support/commands/permissions/sandboxTable.js
+++ b/e2e/support/commands/permissions/sandboxTable.js
@@ -25,7 +25,7 @@ Cypress.Commands.add(
           [db_id]: {
             "view-data": {
               [schema]: {
-                [table_id]: "segmented",
+                [table_id]: "sandboxed",
               },
             },
             "create-queries": "query-builder",

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -243,14 +243,12 @@ describe(
       cy.updatePermissionsGraph({
         [USER_GROUPS.ALL_USERS_GROUP]: {
           [WRITABLE_DB_ID]: {
-            data: { schemas: "none", native: "none" },
             "view-data": "blocked",
             "create-queries": "no",
           },
         },
         [USER_GROUPS.DATA_GROUP]: {
           [WRITABLE_DB_ID]: {
-            data: { schemas: "all", native: "write" },
             "view-data": "unrestricted",
             "create-queries": "query-builder-and-native",
           },

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -255,9 +255,6 @@ describe("permissions", () => {
     cy.updatePermissionsGraph({
       1: {
         [WRITABLE_DB_ID]: {
-          data: {
-            schemas: "block",
-          },
           "view-data": "blocked",
         },
       },
@@ -301,17 +298,11 @@ describe("permissions", () => {
       cy.updatePermissionsGraph({
         [ALL_USERS_GROUP]: {
           [WRITABLE_DB_ID]: {
-            data: {
-              schemas: "block",
-            },
             "view-data": "blocked",
           },
         },
         [NOSQL_GROUP]: {
           [WRITABLE_DB_ID]: {
-            data: {
-              schemas: "all",
-            },
             "view-data": "unrestricted",
             "create-queries": "query-builder",
           },

--- a/e2e/test/scenarios/native-filters/reproductions/15163.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/15163.cy.spec.js
@@ -77,7 +77,6 @@ const dashboardDetails = {
           cy.updatePermissionsGraph({
             [COLLECTION_GROUP]: {
               1: {
-                data: { schemas: "all", native: "none" },
                 "view-data": "unrestricted",
                 "create-queries": "query-builder",
               },

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -378,19 +378,16 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
     cy.updatePermissionsGraph({
       [USER_GROUPS.ALL_USERS_GROUP]: {
         [WRITABLE_DB_ID]: {
-          data: { schemas: "none", native: "none" },
           "view-data": "blocked",
           "create-queries": "no",
         },
       },
       [USER_GROUPS.NOSQL_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "all", native: "write" },
           "view-data": "unrestricted",
           "create-queries": "query-builder-and-native",
         },
         [WRITABLE_DB_ID]: {
-          data: { schemas: "all", native: "none" },
           "view-data": "unrestricted",
           "create-queries": "query-builder",
         },

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -48,14 +48,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     );
 
     assertPermissionTable([
-      ["Accounts", "Unrestricted", "No"],
-      ["Analytic Events", "Unrestricted", "No"],
-      ["Feedback", "Unrestricted", "No"],
-      ["Invoices", "Unrestricted", "No"],
-      ["Orders", "Unrestricted", "No"],
-      ["People", "Unrestricted", "No"],
-      ["Products", "Unrestricted", "No"],
-      ["Reviews", "Unrestricted", "No"],
+      ["Accounts", "Can view", "No"],
+      ["Analytic Events", "Can view", "No"],
+      ["Feedback", "Can view", "No"],
+      ["Invoices", "Can view", "No"],
+      ["Orders", "Can view", "No"],
+      ["People", "Can view", "No"],
+      ["Products", "Can view", "No"],
+      ["Reviews", "Can view", "No"],
     ]);
   });
 
@@ -372,21 +372,21 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.findByText("1 person");
 
         assertPermissionTable([
-          ["Sample Database", "Unrestricted", "Query builder and native"],
+          ["Sample Database", "Can view", "Query builder and native"],
         ]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "Unrestricted", "Query builder and native"],
-          ["Analytic Events", "Unrestricted", "Query builder and native"],
-          ["Feedback", "Unrestricted", "Query builder and native"],
-          ["Invoices", "Unrestricted", "Query builder and native"],
-          ["Orders", "Unrestricted", "Query builder and native"],
-          ["People", "Unrestricted", "Query builder and native"],
-          ["Products", "Unrestricted", "Query builder and native"],
-          ["Reviews", "Unrestricted", "Query builder and native"],
+          ["Accounts", "Can view", "Query builder and native"],
+          ["Analytic Events", "Can view", "Query builder and native"],
+          ["Feedback", "Can view", "Query builder and native"],
+          ["Invoices", "Can view", "Query builder and native"],
+          ["Orders", "Can view", "Query builder and native"],
+          ["People", "Can view", "Query builder and native"],
+          ["Products", "Can view", "Query builder and native"],
+          ["Reviews", "Can view", "Query builder and native"],
         ]);
       });
 
@@ -395,20 +395,20 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         selectSidebarItem("collection");
 
-        assertPermissionTable([["Sample Database", "Unrestricted", "No"]]);
+        assertPermissionTable([["Sample Database", "Can view", "No"]]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "Unrestricted", "No"],
-          ["Analytic Events", "Unrestricted", "No"],
-          ["Feedback", "Unrestricted", "No"],
-          ["Invoices", "Unrestricted", "No"],
-          ["Orders", "Unrestricted", "No"],
-          ["People", "Unrestricted", "No"],
-          ["Products", "Unrestricted", "No"],
-          ["Reviews", "Unrestricted", "No"],
+          ["Accounts", "Can view", "No"],
+          ["Analytic Events", "Can view", "No"],
+          ["Feedback", "Can view", "No"],
+          ["Invoices", "Can view", "No"],
+          ["Orders", "Can view", "No"],
+          ["People", "Can view", "No"],
+          ["Products", "Can view", "No"],
+          ["Reviews", "Can view", "No"],
         ]);
 
         // Navigate back
@@ -421,21 +421,21 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         );
 
         assertPermissionTable([
-          ["Sample Database", "Unrestricted", "Query builder and native"],
+          ["Sample Database", "Can view", "Query builder and native"],
         ]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "Unrestricted", "Query builder and native"],
-          ["Analytic Events", "Unrestricted", "Query builder and native"],
-          ["Feedback", "Unrestricted", "Query builder and native"],
-          ["Invoices", "Unrestricted", "Query builder and native"],
-          ["Orders", "Unrestricted", "Query builder and native"],
-          ["People", "Unrestricted", "Query builder and native"],
-          ["Products", "Unrestricted", "Query builder and native"],
-          ["Reviews", "Unrestricted", "Query builder and native"],
+          ["Accounts", "Can view", "Query builder and native"],
+          ["Analytic Events", "Can view", "Query builder and native"],
+          ["Feedback", "Can view", "Query builder and native"],
+          ["Invoices", "Can view", "Query builder and native"],
+          ["Orders", "Can view", "Query builder and native"],
+          ["People", "Can view", "Query builder and native"],
+          ["Products", "Can view", "Query builder and native"],
+          ["Reviews", "Can view", "Query builder and native"],
         ]);
 
         cy.button("Save changes").click();
@@ -452,14 +452,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.findByText("Save changes").should("not.exist");
 
         assertPermissionTable([
-          ["Accounts", "Unrestricted", "Query builder and native"],
-          ["Analytic Events", "Unrestricted", "Query builder and native"],
-          ["Feedback", "Unrestricted", "Query builder and native"],
-          ["Invoices", "Unrestricted", "Query builder and native"],
-          ["Orders", "Unrestricted", "Query builder and native"],
-          ["People", "Unrestricted", "Query builder and native"],
-          ["Products", "Unrestricted", "Query builder and native"],
-          ["Reviews", "Unrestricted", "Query builder and native"],
+          ["Accounts", "Can view", "Query builder and native"],
+          ["Analytic Events", "Can view", "Query builder and native"],
+          ["Feedback", "Can view", "Query builder and native"],
+          ["Invoices", "Can view", "Query builder and native"],
+          ["Orders", "Can view", "Query builder and native"],
+          ["People", "Can view", "Query builder and native"],
+          ["Products", "Can view", "Query builder and native"],
+          ["Reviews", "Can view", "Query builder and native"],
         ]);
 
         // After saving permissions, user should be able to make further edits without refreshing the page
@@ -512,12 +512,12 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         selectSidebarItem("Sample Database");
 
         assertPermissionTable([
-          ["Administrators", "Unrestricted", "Query builder and native"],
-          ["All Users", "Unrestricted", "No"],
-          ["collection", "Unrestricted", "No"],
-          ["data", "Unrestricted", "Query builder and native"],
-          ["nosql", "Unrestricted", "Query builder only"],
-          ["readonly", "Unrestricted", "No"],
+          ["Administrators", "Can view", "Query builder and native"],
+          ["All Users", "Can view", "No"],
+          ["collection", "Can view", "No"],
+          ["data", "Can view", "Query builder and native"],
+          ["nosql", "Can view", "Query builder only"],
+          ["readonly", "Can view", "No"],
         ]);
 
         modifyPermission(
@@ -527,23 +527,23 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         );
 
         assertPermissionTable([
-          ["Administrators", "Unrestricted", "Query builder and native"],
-          ["All Users", "Unrestricted", "No"],
-          ["collection", "Unrestricted", "No"],
-          ["data", "Unrestricted", "Query builder and native"],
-          ["nosql", "Unrestricted", "Query builder only"],
-          ["readonly", "Unrestricted", "Query builder and native"],
+          ["Administrators", "Can view", "Query builder and native"],
+          ["All Users", "Can view", "No"],
+          ["collection", "Can view", "No"],
+          ["data", "Can view", "Query builder and native"],
+          ["nosql", "Can view", "Query builder only"],
+          ["readonly", "Can view", "Query builder and native"],
         ]);
 
         selectSidebarItem("Orders");
 
         assertPermissionTable([
-          ["Administrators", "Unrestricted", "Query builder and native"],
-          ["All Users", "Unrestricted", "No"],
-          ["collection", "Unrestricted", "No"],
-          ["data", "Unrestricted", "Query builder and native"],
-          ["nosql", "Unrestricted", "Query builder only"],
-          ["readonly", "Unrestricted", "Query builder and native"],
+          ["Administrators", "Can view", "Query builder and native"],
+          ["All Users", "Can view", "No"],
+          ["collection", "Can view", "No"],
+          ["data", "Can view", "Query builder and native"],
+          ["nosql", "Can view", "Query builder only"],
+          ["readonly", "Can view", "Query builder and native"],
         ]);
 
         // Navigate back
@@ -563,12 +563,12 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.findByText("Save changes").should("not.exist");
 
         assertPermissionTable([
-          ["Administrators", "Unrestricted", "Query builder and native"],
-          ["All Users", "Unrestricted", "No"],
-          ["collection", "Unrestricted", "No"],
-          ["data", "Unrestricted", "Query builder and native"],
-          ["nosql", "Unrestricted", "Query builder only"],
-          ["readonly", "Unrestricted", "Query builder and native"],
+          ["Administrators", "Can view", "Query builder and native"],
+          ["All Users", "Can view", "No"],
+          ["collection", "Can view", "No"],
+          ["data", "Can view", "Query builder and native"],
+          ["nosql", "Can view", "Query builder only"],
+          ["readonly", "Can view", "Query builder and native"],
         ]);
       });
 
@@ -641,16 +641,16 @@ describeEE("scenarios > admin > permissions", () => {
     assertPermissionTable([
       [
         "Administrators",
-        "Unrestricted",
+        "Can view",
         "Query builder and native",
         "1 million rows",
         "Yes",
       ],
       ["All Users", "Sandboxed", "No", "1 million rows", "No"],
-      ["collection", "Unrestricted", "No", "No", "No"],
-      ["data", "Unrestricted", "Query builder and native", "No", "No"],
-      ["nosql", "Unrestricted", "Query builder only", "No", "No"],
-      ["readonly", "Unrestricted", "No", "No", "No"],
+      ["collection", "Can view", "No", "No", "No"],
+      ["data", "Can view", "Query builder and native", "No", "No"],
+      ["nosql", "Can view", "Query builder only", "No", "No"],
+      ["readonly", "Can view", "No", "No", "No"],
     ]);
 
     modifyPermission(
@@ -675,16 +675,16 @@ describeEE("scenarios > admin > permissions", () => {
     assertPermissionTable([
       [
         "Administrators",
-        "Unrestricted",
+        "Can view",
         "Query builder and native",
         "1 million rows",
         "Yes",
       ],
       ["All Users", "Sandboxed", "No", "1 million rows", "No"],
-      ["collection", "Unrestricted", "No", "No", "No"],
-      ["data", "Unrestricted", "Query builder and native", "No", "No"],
-      ["nosql", "Unrestricted", "Query builder only", "No", "No"],
-      ["readonly", "Unrestricted", "No", "No", "No"],
+      ["collection", "Can view", "No", "No", "No"],
+      ["data", "Can view", "Query builder and native", "No", "No"],
+      ["nosql", "Can view", "Query builder only", "No", "No"],
+      ["readonly", "Can view", "No", "No", "No"],
     ]);
   });
 
@@ -717,14 +717,14 @@ describeEE("scenarios > admin > permissions", () => {
     modal().button("Save").click();
 
     assertPermissionTable([
-      ["Accounts", "Unrestricted", "No", "1 million rows", "No"],
-      ["Analytic Events", "Unrestricted", "No", "1 million rows", "No"],
-      ["Feedback", "Unrestricted", "No", "1 million rows", "No"],
-      ["Invoices", "Unrestricted", "No", "1 million rows", "No"],
+      ["Accounts", "Can view", "No", "1 million rows", "No"],
+      ["Analytic Events", "Can view", "No", "1 million rows", "No"],
+      ["Feedback", "Can view", "No", "1 million rows", "No"],
+      ["Invoices", "Can view", "No", "1 million rows", "No"],
       ["Orders", "Sandboxed", "No", "1 million rows", "No"],
-      ["People", "Unrestricted", "No", "1 million rows", "No"],
-      ["Products", "Unrestricted", "No", "1 million rows", "No"],
-      ["Reviews", "Unrestricted", "No", "1 million rows", "No"],
+      ["People", "Can view", "No", "1 million rows", "No"],
+      ["Products", "Can view", "No", "1 million rows", "No"],
+      ["Reviews", "Can view", "No", "1 million rows", "No"],
     ]);
 
     modifyPermission(
@@ -769,14 +769,14 @@ describeEE("scenarios > admin > permissions", () => {
     cy.reload();
 
     assertPermissionTable([
-      ["Accounts", "Unrestricted", "No", "1 million rows", "No"],
-      ["Analytic Events", "Unrestricted", "No", "1 million rows", "No"],
-      ["Feedback", "Unrestricted", "No", "1 million rows", "No"],
-      ["Invoices", "Unrestricted", "No", "1 million rows", "No"],
+      ["Accounts", "Can view", "No", "1 million rows", "No"],
+      ["Analytic Events", "Can view", "No", "1 million rows", "No"],
+      ["Feedback", "Can view", "No", "1 million rows", "No"],
+      ["Invoices", "Can view", "No", "1 million rows", "No"],
       ["Orders", "Sandboxed", "No", "1 million rows", "No"],
-      ["People", "Unrestricted", "No", "1 million rows", "No"],
-      ["Products", "Unrestricted", "No", "1 million rows", "No"],
-      ["Reviews", "Unrestricted", "No", "1 million rows", "No"],
+      ["People", "Can view", "No", "1 million rows", "No"],
+      ["Products", "Can view", "No", "1 million rows", "No"],
+      ["Reviews", "Can view", "No", "1 million rows", "No"],
     ]);
   });
 
@@ -790,7 +790,7 @@ describeEE("scenarios > admin > permissions", () => {
       .within(() => {
         isPermissionDisabled(
           DATA_ACCESS_PERMISSION_INDEX,
-          "Unrestricted",
+          "Can view",
           false,
         ).click();
         isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", false);

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -48,22 +48,22 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     );
 
     assertPermissionTable([
-      ["Accounts", "No self-service", "No"],
-      ["Analytic Events", "No self-service", "No"],
-      ["Feedback", "No self-service", "No"],
-      ["Invoices", "No self-service", "No"],
-      ["Orders", "No self-service", "No"],
-      ["People", "No self-service", "No"],
-      ["Products", "No self-service", "No"],
-      ["Reviews", "No self-service", "No"],
+      ["Accounts", "Can view", "No"],
+      ["Analytic Events", "Can view", "No"],
+      ["Feedback", "Can view", "No"],
+      ["Invoices", "Can view", "No"],
+      ["Orders", "Can view", "No"],
+      ["People", "Can view", "No"],
+      ["Products", "Can view", "No"],
+      ["Reviews", "Can view", "No"],
     ]);
   });
 
   it("should display error on failed save", () => {
     // revoke some permissions
     cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
-    cy.icon("eye").first().click();
-    cy.findAllByRole("option").contains("Unrestricted").click();
+    cy.icon("close").first().click();
+    cy.findAllByRole("option").contains("Query builder and native").click();
 
     // stub out the PUT and save
     cy.intercept("PUT", "/api/permissions/graph", req => {
@@ -286,8 +286,8 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
       modifyPermission(
         "Sample Database",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Unrestricted",
+        NATIVE_QUERIES_PERMISSION_INDEX,
+        "Query builder and native",
       );
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -371,20 +371,22 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("1 person");
 
-        assertPermissionTable([["Sample Database", "Unrestricted", "Yes"]]);
+        assertPermissionTable([
+          ["Sample Database", "Can view", "Query builder and native"],
+        ]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "Unrestricted", "Yes"],
-          ["Analytic Events", "Unrestricted", "Yes"],
-          ["Feedback", "Unrestricted", "Yes"],
-          ["Invoices", "Unrestricted", "Yes"],
-          ["Orders", "Unrestricted", "Yes"],
-          ["People", "Unrestricted", "Yes"],
-          ["Products", "Unrestricted", "Yes"],
-          ["Reviews", "Unrestricted", "Yes"],
+          ["Accounts", "Can view", "Query builder and native"],
+          ["Analytic Events", "Can view", "Query builder and native"],
+          ["Feedback", "Can view", "Query builder and native"],
+          ["Invoices", "Can view", "Query builder and native"],
+          ["Orders", "Can view", "Query builder and native"],
+          ["People", "Can view", "Query builder and native"],
+          ["Products", "Can view", "Query builder and native"],
+          ["Reviews", "Can view", "Query builder and native"],
         ]);
       });
 
@@ -393,74 +395,47 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         selectSidebarItem("collection");
 
-        assertPermissionTable([["Sample Database", "No self-service", "No"]]);
+        assertPermissionTable([["Sample Database", "Can view", "No"]]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "No self-service", "No"],
-          ["Analytic Events", "No self-service", "No"],
-          ["Feedback", "No self-service", "No"],
-          ["Invoices", "No self-service", "No"],
-          ["Orders", "No self-service", "No"],
-          ["People", "No self-service", "No"],
-          ["Products", "No self-service", "No"],
-          ["Reviews", "No self-service", "No"],
-        ]);
-
-        modifyPermission(
-          "Orders",
-          DATA_ACCESS_PERMISSION_INDEX,
-          "Unrestricted",
-        );
-
-        modal().within(() => {
-          cy.findByText("Change access to this database to granular?");
-          cy.button("Change").click();
-        });
-
-        assertPermissionTable([
-          ["Accounts", "No self-service", "No"],
-          ["Analytic Events", "No self-service", "No"],
-          ["Feedback", "No self-service", "No"],
-          ["Invoices", "No self-service", "No"],
-          ["Orders", "Unrestricted", "No"],
-          ["People", "No self-service", "No"],
-          ["Products", "No self-service", "No"],
-          ["Reviews", "No self-service", "No"],
+          ["Accounts", "Can view", "No"],
+          ["Analytic Events", "Can view", "No"],
+          ["Feedback", "Can view", "No"],
+          ["Invoices", "Can view", "No"],
+          ["Orders", "Can view", "No"],
+          ["People", "Can view", "No"],
+          ["Products", "Can view", "No"],
+          ["Reviews", "Can view", "No"],
         ]);
 
         // Navigate back
         selectSidebarItem("collection");
 
-        assertPermissionTable([["Sample Database", "Granular", "No"]]);
-
         modifyPermission(
           "Sample Database",
           NATIVE_QUERIES_PERMISSION_INDEX,
-          "Yes",
+          "Query builder and native",
         );
 
-        modal().within(() => {
-          cy.findByText("Allow native query editing?");
-          cy.button("Allow").click();
-        });
-
-        assertPermissionTable([["Sample Database", "Unrestricted", "Yes"]]);
+        assertPermissionTable([
+          ["Sample Database", "Can view", "Query builder and native"],
+        ]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "Unrestricted", "Yes"],
-          ["Analytic Events", "Unrestricted", "Yes"],
-          ["Feedback", "Unrestricted", "Yes"],
-          ["Invoices", "Unrestricted", "Yes"],
-          ["Orders", "Unrestricted", "Yes"],
-          ["People", "Unrestricted", "Yes"],
-          ["Products", "Unrestricted", "Yes"],
-          ["Reviews", "Unrestricted", "Yes"],
+          ["Accounts", "Can view", "Query builder and native"],
+          ["Analytic Events", "Can view", "Query builder and native"],
+          ["Feedback", "Can view", "Query builder and native"],
+          ["Invoices", "Can view", "Query builder and native"],
+          ["Orders", "Can view", "Query builder and native"],
+          ["People", "Can view", "Query builder and native"],
+          ["Products", "Can view", "Query builder and native"],
+          ["Reviews", "Can view", "Query builder and native"],
         ]);
 
         cy.button("Save changes").click();
@@ -468,10 +443,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         modal().within(() => {
           cy.findByText("Save permissions?");
           cy.contains(
-            "collection will be given access to 8 tables in Sample Database.",
-          );
-          cy.contains(
-            "collection will now be able to write native queries for Sample Database.",
+            "collection will now be able to read or write native queries for Sample Database.",
           );
           cy.button("Yes").click();
         });
@@ -480,14 +452,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.findByText("Save changes").should("not.exist");
 
         assertPermissionTable([
-          ["Accounts", "Unrestricted", "Yes"],
-          ["Analytic Events", "Unrestricted", "Yes"],
-          ["Feedback", "Unrestricted", "Yes"],
-          ["Invoices", "Unrestricted", "Yes"],
-          ["Orders", "Unrestricted", "Yes"],
-          ["People", "Unrestricted", "Yes"],
-          ["Products", "Unrestricted", "Yes"],
-          ["Reviews", "Unrestricted", "Yes"],
+          ["Accounts", "Can view", "Query builder and native"],
+          ["Analytic Events", "Can view", "Query builder and native"],
+          ["Feedback", "Can view", "Query builder and native"],
+          ["Invoices", "Can view", "Query builder and native"],
+          ["Orders", "Can view", "Query builder and native"],
+          ["People", "Can view", "Query builder and native"],
+          ["Products", "Can view", "Query builder and native"],
+          ["Reviews", "Can view", "Query builder and native"],
         ]);
 
         // After saving permissions, user should be able to make further edits without refreshing the page
@@ -511,8 +483,8 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         modifyPermission(
           "Sample Database",
-          DATA_ACCESS_PERMISSION_INDEX,
-          "Unrestricted",
+          NATIVE_QUERIES_PERMISSION_INDEX,
+          "Query builder and native",
         );
 
         cy.get("@graph").then(data => {
@@ -540,82 +512,49 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         selectSidebarItem("Sample Database");
 
         assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "No self-service", "No"],
+          ["Administrators", "Can view", "Query builder and native"],
+          ["All Users", "Can view", "No"],
+          ["collection", "Can view", "No"],
+          ["data", "Can view", "Query builder and native"],
+          ["nosql", "Can view", "Query builder only"],
+          ["readonly", "Can view", "No"],
+        ]);
+
+        modifyPermission(
+          "readonly",
+          NATIVE_QUERIES_PERMISSION_INDEX,
+          "Query builder and native",
+        );
+
+        assertPermissionTable([
+          ["Administrators", "Can view", "Query builder and native"],
+          ["All Users", "Can view", "No"],
+          ["collection", "Can view", "No"],
+          ["data", "Can view", "Query builder and native"],
+          ["nosql", "Can view", "Query builder only"],
+          ["readonly", "Can view", "Query builder and native"],
         ]);
 
         selectSidebarItem("Orders");
 
         assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "No self-service", "No"],
-        ]);
-
-        modifyPermission(
-          "readonly",
-          DATA_ACCESS_PERMISSION_INDEX,
-          "Unrestricted",
-        );
-
-        modal().within(() => {
-          cy.findByText("Change access to this database to granular?");
-          cy.button("Change").click();
-        });
-
-        assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "Unrestricted", "No"],
+          ["Administrators", "Can view", "Query builder and native"],
+          ["All Users", "Can view", "No"],
+          ["collection", "Can view", "No"],
+          ["data", "Can view", "Query builder and native"],
+          ["nosql", "Can view", "Query builder only"],
+          ["readonly", "Can view", "Query builder and native"],
         ]);
 
         // Navigate back
         cy.get("a").contains("Sample Database").click();
-
-        assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "Granular", "No"],
-        ]);
-
-        modifyPermission("readonly", NATIVE_QUERIES_PERMISSION_INDEX, "Yes");
-
-        modal().within(() => {
-          cy.findByText("Allow native query editing?");
-          cy.button("Allow").click();
-        });
-
-        assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "Unrestricted", "Yes"],
-        ]);
 
         cy.button("Save changes").click();
 
         modal().within(() => {
           cy.findByText("Save permissions?");
           cy.contains(
-            "readonly will be given access to 8 tables in Sample Database.",
-          );
-          cy.contains(
-            "readonly will now be able to write native queries for Sample Database.",
+            "readonly will now be able to read or write native queries for Sample Database.",
           );
           cy.button("Yes").click();
         });
@@ -624,14 +563,15 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.findByText("Save changes").should("not.exist");
 
         assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "Unrestricted", "Yes"],
+          ["Administrators", "Can view", "Query builder and native"],
+          ["All Users", "Can view", "No"],
+          ["collection", "Can view", "No"],
+          ["data", "Can view", "Query builder and native"],
+          ["nosql", "Can view", "Query builder only"],
+          ["readonly", "Can view", "Query builder and native"],
         ]);
       });
+
       it("should show a modal when a revision changes while an admin is editing", () => {
         cy.intercept("/api/permissions/graph/group/1").as("graph");
         cy.visit("/admin/permissions/");
@@ -640,8 +580,8 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         modifyPermission(
           "Sample Database",
-          DATA_ACCESS_PERMISSION_INDEX,
-          "Unrestricted",
+          NATIVE_QUERIES_PERMISSION_INDEX,
+          "Query builder and native",
         );
 
         cy.get("@graph").then(data => {
@@ -699,12 +639,18 @@ describeEE("scenarios > admin > permissions", () => {
     cy.button("Save").click();
 
     assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows", "Yes"],
+      [
+        "Administrators",
+        "Can view",
+        "Query builder and native",
+        "1 million rows",
+        "Yes",
+      ],
       ["All Users", "Sandboxed", "No", "1 million rows", "No"],
-      ["collection", "No self-service", "No", "No", "No"],
-      ["data", "Unrestricted", "Yes", "No", "No"],
-      ["nosql", "Unrestricted", "No", "No", "No"],
-      ["readonly", "No self-service", "No", "No", "No"],
+      ["collection", "Can view", "No", "No", "No"],
+      ["data", "Can view", "Query builder and native", "No", "No"],
+      ["nosql", "Can view", "Query builder only", "No", "No"],
+      ["readonly", "Can view", "No", "No", "No"],
     ]);
 
     modifyPermission(
@@ -727,12 +673,18 @@ describeEE("scenarios > admin > permissions", () => {
     cy.button("Save changes").click();
 
     assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows", "Yes"],
+      [
+        "Administrators",
+        "Can view",
+        "Query builder and native",
+        "1 million rows",
+        "Yes",
+      ],
       ["All Users", "Sandboxed", "No", "1 million rows", "No"],
-      ["collection", "No self-service", "No", "No", "No"],
-      ["data", "Unrestricted", "Yes", "No", "No"],
-      ["nosql", "Unrestricted", "No", "No", "No"],
-      ["readonly", "No self-service", "No", "No", "No"],
+      ["collection", "Can view", "No", "No", "No"],
+      ["data", "Can view", "Query builder and native", "No", "No"],
+      ["nosql", "Can view", "Query builder only", "No", "No"],
+      ["readonly", "Can view", "No", "No", "No"],
     ]);
   });
 
@@ -765,14 +717,14 @@ describeEE("scenarios > admin > permissions", () => {
     modal().button("Save").click();
 
     assertPermissionTable([
-      ["Accounts", "No self-service", "No", "1 million rows", "No"],
-      ["Analytic Events", "No self-service", "No", "1 million rows", "No"],
-      ["Feedback", "No self-service", "No", "1 million rows", "No"],
-      ["Invoices", "No self-service", "No", "1 million rows", "No"],
+      ["Accounts", "Can view", "No", "1 million rows", "No"],
+      ["Analytic Events", "Can view", "No", "1 million rows", "No"],
+      ["Feedback", "Can view", "No", "1 million rows", "No"],
+      ["Invoices", "Can view", "No", "1 million rows", "No"],
       ["Orders", "Sandboxed", "No", "1 million rows", "No"],
-      ["People", "No self-service", "No", "1 million rows", "No"],
-      ["Products", "No self-service", "No", "1 million rows", "No"],
-      ["Reviews", "No self-service", "No", "1 million rows", "No"],
+      ["People", "Can view", "No", "1 million rows", "No"],
+      ["Products", "Can view", "No", "1 million rows", "No"],
+      ["Reviews", "Can view", "No", "1 million rows", "No"],
     ]);
 
     modifyPermission(
@@ -817,14 +769,14 @@ describeEE("scenarios > admin > permissions", () => {
     cy.reload();
 
     assertPermissionTable([
-      ["Accounts", "No self-service", "No", "1 million rows", "No"],
-      ["Analytic Events", "No self-service", "No", "1 million rows", "No"],
-      ["Feedback", "No self-service", "No", "1 million rows", "No"],
-      ["Invoices", "No self-service", "No", "1 million rows", "No"],
+      ["Accounts", "Can view", "No", "1 million rows", "No"],
+      ["Analytic Events", "Can view", "No", "1 million rows", "No"],
+      ["Feedback", "Can view", "No", "1 million rows", "No"],
+      ["Invoices", "Can view", "No", "1 million rows", "No"],
       ["Orders", "Sandboxed", "No", "1 million rows", "No"],
-      ["People", "No self-service", "No", "1 million rows", "No"],
-      ["Products", "No self-service", "No", "1 million rows", "No"],
-      ["Reviews", "No self-service", "No", "1 million rows", "No"],
+      ["People", "Can view", "No", "1 million rows", "No"],
+      ["Products", "Can view", "No", "1 million rows", "No"],
+      ["Reviews", "Can view", "No", "1 million rows", "No"],
     ]);
   });
 
@@ -838,10 +790,10 @@ describeEE("scenarios > admin > permissions", () => {
       .within(() => {
         isPermissionDisabled(
           DATA_ACCESS_PERMISSION_INDEX,
-          "No self-service",
+          "Can view",
           false,
         ).click();
-        isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", true);
+        isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", false);
       });
 
     popover().contains("Block").click();
@@ -921,8 +873,8 @@ describe("scenarios > admin > permissions", () => {
       .as("permissionsHelpContent")
       .within(() => {
         cy.findByText("Data permissions");
-        cy.findByText("Unrestricted");
-        cy.findByText("Impersonated (Pro)");
+        cy.findByText("Database levels");
+        cy.findByText("Schema and table levels");
         cy.findByLabelText("Close").click();
       });
 

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -48,22 +48,22 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     );
 
     assertPermissionTable([
-      ["Accounts", "No self-service", "No"],
-      ["Analytic Events", "No self-service", "No"],
-      ["Feedback", "No self-service", "No"],
-      ["Invoices", "No self-service", "No"],
-      ["Orders", "No self-service", "No"],
-      ["People", "No self-service", "No"],
-      ["Products", "No self-service", "No"],
-      ["Reviews", "No self-service", "No"],
+      ["Accounts", "Unrestricted", "No"],
+      ["Analytic Events", "Unrestricted", "No"],
+      ["Feedback", "Unrestricted", "No"],
+      ["Invoices", "Unrestricted", "No"],
+      ["Orders", "Unrestricted", "No"],
+      ["People", "Unrestricted", "No"],
+      ["Products", "Unrestricted", "No"],
+      ["Reviews", "Unrestricted", "No"],
     ]);
   });
 
   it("should display error on failed save", () => {
     // revoke some permissions
     cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
-    cy.icon("eye").first().click();
-    cy.findAllByRole("option").contains("Unrestricted").click();
+    cy.icon("close").first().click();
+    cy.findAllByRole("option").contains("Query builder and native").click();
 
     // stub out the PUT and save
     cy.intercept("PUT", "/api/permissions/graph", req => {
@@ -286,8 +286,8 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
       modifyPermission(
         "Sample Database",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Unrestricted",
+        NATIVE_QUERIES_PERMISSION_INDEX,
+        "Query builder and native",
       );
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -371,20 +371,22 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("1 person");
 
-        assertPermissionTable([["Sample Database", "Unrestricted", "Yes"]]);
+        assertPermissionTable([
+          ["Sample Database", "Unrestricted", "Query builder and native"],
+        ]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "Unrestricted", "Yes"],
-          ["Analytic Events", "Unrestricted", "Yes"],
-          ["Feedback", "Unrestricted", "Yes"],
-          ["Invoices", "Unrestricted", "Yes"],
-          ["Orders", "Unrestricted", "Yes"],
-          ["People", "Unrestricted", "Yes"],
-          ["Products", "Unrestricted", "Yes"],
-          ["Reviews", "Unrestricted", "Yes"],
+          ["Accounts", "Unrestricted", "Query builder and native"],
+          ["Analytic Events", "Unrestricted", "Query builder and native"],
+          ["Feedback", "Unrestricted", "Query builder and native"],
+          ["Invoices", "Unrestricted", "Query builder and native"],
+          ["Orders", "Unrestricted", "Query builder and native"],
+          ["People", "Unrestricted", "Query builder and native"],
+          ["Products", "Unrestricted", "Query builder and native"],
+          ["Reviews", "Unrestricted", "Query builder and native"],
         ]);
       });
 
@@ -393,74 +395,47 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         selectSidebarItem("collection");
 
-        assertPermissionTable([["Sample Database", "No self-service", "No"]]);
+        assertPermissionTable([["Sample Database", "Unrestricted", "No"]]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "No self-service", "No"],
-          ["Analytic Events", "No self-service", "No"],
-          ["Feedback", "No self-service", "No"],
-          ["Invoices", "No self-service", "No"],
-          ["Orders", "No self-service", "No"],
-          ["People", "No self-service", "No"],
-          ["Products", "No self-service", "No"],
-          ["Reviews", "No self-service", "No"],
-        ]);
-
-        modifyPermission(
-          "Orders",
-          DATA_ACCESS_PERMISSION_INDEX,
-          "Unrestricted",
-        );
-
-        modal().within(() => {
-          cy.findByText("Change access to this database to granular?");
-          cy.button("Change").click();
-        });
-
-        assertPermissionTable([
-          ["Accounts", "No self-service", "No"],
-          ["Analytic Events", "No self-service", "No"],
-          ["Feedback", "No self-service", "No"],
-          ["Invoices", "No self-service", "No"],
+          ["Accounts", "Unrestricted", "No"],
+          ["Analytic Events", "Unrestricted", "No"],
+          ["Feedback", "Unrestricted", "No"],
+          ["Invoices", "Unrestricted", "No"],
           ["Orders", "Unrestricted", "No"],
-          ["People", "No self-service", "No"],
-          ["Products", "No self-service", "No"],
-          ["Reviews", "No self-service", "No"],
+          ["People", "Unrestricted", "No"],
+          ["Products", "Unrestricted", "No"],
+          ["Reviews", "Unrestricted", "No"],
         ]);
 
         // Navigate back
         selectSidebarItem("collection");
 
-        assertPermissionTable([["Sample Database", "Granular", "No"]]);
-
         modifyPermission(
           "Sample Database",
           NATIVE_QUERIES_PERMISSION_INDEX,
-          "Yes",
+          "Query builder and native",
         );
 
-        modal().within(() => {
-          cy.findByText("Allow native query editing?");
-          cy.button("Allow").click();
-        });
-
-        assertPermissionTable([["Sample Database", "Unrestricted", "Yes"]]);
+        assertPermissionTable([
+          ["Sample Database", "Unrestricted", "Query builder and native"],
+        ]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "Unrestricted", "Yes"],
-          ["Analytic Events", "Unrestricted", "Yes"],
-          ["Feedback", "Unrestricted", "Yes"],
-          ["Invoices", "Unrestricted", "Yes"],
-          ["Orders", "Unrestricted", "Yes"],
-          ["People", "Unrestricted", "Yes"],
-          ["Products", "Unrestricted", "Yes"],
-          ["Reviews", "Unrestricted", "Yes"],
+          ["Accounts", "Unrestricted", "Query builder and native"],
+          ["Analytic Events", "Unrestricted", "Query builder and native"],
+          ["Feedback", "Unrestricted", "Query builder and native"],
+          ["Invoices", "Unrestricted", "Query builder and native"],
+          ["Orders", "Unrestricted", "Query builder and native"],
+          ["People", "Unrestricted", "Query builder and native"],
+          ["Products", "Unrestricted", "Query builder and native"],
+          ["Reviews", "Unrestricted", "Query builder and native"],
         ]);
 
         cy.button("Save changes").click();
@@ -468,10 +443,7 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         modal().within(() => {
           cy.findByText("Save permissions?");
           cy.contains(
-            "collection will be given access to 8 tables in Sample Database.",
-          );
-          cy.contains(
-            "collection will now be able to write native queries for Sample Database.",
+            "collection will now be able to read or write native queries for Sample Database.",
           );
           cy.button("Yes").click();
         });
@@ -480,14 +452,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.findByText("Save changes").should("not.exist");
 
         assertPermissionTable([
-          ["Accounts", "Unrestricted", "Yes"],
-          ["Analytic Events", "Unrestricted", "Yes"],
-          ["Feedback", "Unrestricted", "Yes"],
-          ["Invoices", "Unrestricted", "Yes"],
-          ["Orders", "Unrestricted", "Yes"],
-          ["People", "Unrestricted", "Yes"],
-          ["Products", "Unrestricted", "Yes"],
-          ["Reviews", "Unrestricted", "Yes"],
+          ["Accounts", "Unrestricted", "Query builder and native"],
+          ["Analytic Events", "Unrestricted", "Query builder and native"],
+          ["Feedback", "Unrestricted", "Query builder and native"],
+          ["Invoices", "Unrestricted", "Query builder and native"],
+          ["Orders", "Unrestricted", "Query builder and native"],
+          ["People", "Unrestricted", "Query builder and native"],
+          ["Products", "Unrestricted", "Query builder and native"],
+          ["Reviews", "Unrestricted", "Query builder and native"],
         ]);
 
         // After saving permissions, user should be able to make further edits without refreshing the page
@@ -511,8 +483,8 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         modifyPermission(
           "Sample Database",
-          DATA_ACCESS_PERMISSION_INDEX,
-          "Unrestricted",
+          NATIVE_QUERIES_PERMISSION_INDEX,
+          "Query builder and native",
         );
 
         cy.get("@graph").then(data => {
@@ -540,82 +512,49 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         selectSidebarItem("Sample Database");
 
         assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "No self-service", "No"],
+          ["Administrators", "Unrestricted", "Query builder and native"],
+          ["All Users", "Unrestricted", "No"],
+          ["collection", "Unrestricted", "No"],
+          ["data", "Unrestricted", "Query builder and native"],
+          ["nosql", "Unrestricted", "Query builder only"],
+          ["readonly", "Unrestricted", "No"],
+        ]);
+
+        modifyPermission(
+          "readonly",
+          NATIVE_QUERIES_PERMISSION_INDEX,
+          "Query builder and native",
+        );
+
+        assertPermissionTable([
+          ["Administrators", "Unrestricted", "Query builder and native"],
+          ["All Users", "Unrestricted", "No"],
+          ["collection", "Unrestricted", "No"],
+          ["data", "Unrestricted", "Query builder and native"],
+          ["nosql", "Unrestricted", "Query builder only"],
+          ["readonly", "Unrestricted", "Query builder and native"],
         ]);
 
         selectSidebarItem("Orders");
 
         assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "No self-service", "No"],
-        ]);
-
-        modifyPermission(
-          "readonly",
-          DATA_ACCESS_PERMISSION_INDEX,
-          "Unrestricted",
-        );
-
-        modal().within(() => {
-          cy.findByText("Change access to this database to granular?");
-          cy.button("Change").click();
-        });
-
-        assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "Unrestricted", "No"],
+          ["Administrators", "Unrestricted", "Query builder and native"],
+          ["All Users", "Unrestricted", "No"],
+          ["collection", "Unrestricted", "No"],
+          ["data", "Unrestricted", "Query builder and native"],
+          ["nosql", "Unrestricted", "Query builder only"],
+          ["readonly", "Unrestricted", "Query builder and native"],
         ]);
 
         // Navigate back
         cy.get("a").contains("Sample Database").click();
-
-        assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "Granular", "No"],
-        ]);
-
-        modifyPermission("readonly", NATIVE_QUERIES_PERMISSION_INDEX, "Yes");
-
-        modal().within(() => {
-          cy.findByText("Allow native query editing?");
-          cy.button("Allow").click();
-        });
-
-        assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "Unrestricted", "Yes"],
-        ]);
 
         cy.button("Save changes").click();
 
         modal().within(() => {
           cy.findByText("Save permissions?");
           cy.contains(
-            "readonly will be given access to 8 tables in Sample Database.",
-          );
-          cy.contains(
-            "readonly will now be able to write native queries for Sample Database.",
+            "readonly will now be able to read or write native queries for Sample Database.",
           );
           cy.button("Yes").click();
         });
@@ -624,14 +563,15 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.findByText("Save changes").should("not.exist");
 
         assertPermissionTable([
-          ["Administrators", "Unrestricted", "Yes"],
-          ["All Users", "No self-service", "No"],
-          ["collection", "No self-service", "No"],
-          ["data", "Unrestricted", "Yes"],
-          ["nosql", "Unrestricted", "No"],
-          ["readonly", "Unrestricted", "Yes"],
+          ["Administrators", "Unrestricted", "Query builder and native"],
+          ["All Users", "Unrestricted", "No"],
+          ["collection", "Unrestricted", "No"],
+          ["data", "Unrestricted", "Query builder and native"],
+          ["nosql", "Unrestricted", "Query builder only"],
+          ["readonly", "Unrestricted", "Query builder and native"],
         ]);
       });
+
       it("should show a modal when a revision changes while an admin is editing", () => {
         cy.intercept("/api/permissions/graph/group/1").as("graph");
         cy.visit("/admin/permissions/");
@@ -640,8 +580,8 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         modifyPermission(
           "Sample Database",
-          DATA_ACCESS_PERMISSION_INDEX,
-          "Unrestricted",
+          NATIVE_QUERIES_PERMISSION_INDEX,
+          "Query builder and native",
         );
 
         cy.get("@graph").then(data => {
@@ -699,12 +639,18 @@ describeEE("scenarios > admin > permissions", () => {
     cy.button("Save").click();
 
     assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows", "Yes"],
+      [
+        "Administrators",
+        "Unrestricted",
+        "Query builder and native",
+        "1 million rows",
+        "Yes",
+      ],
       ["All Users", "Sandboxed", "No", "1 million rows", "No"],
-      ["collection", "No self-service", "No", "No", "No"],
-      ["data", "Unrestricted", "Yes", "No", "No"],
-      ["nosql", "Unrestricted", "No", "No", "No"],
-      ["readonly", "No self-service", "No", "No", "No"],
+      ["collection", "Unrestricted", "No", "No", "No"],
+      ["data", "Unrestricted", "Query builder and native", "No", "No"],
+      ["nosql", "Unrestricted", "Query builder only", "No", "No"],
+      ["readonly", "Unrestricted", "No", "No", "No"],
     ]);
 
     modifyPermission(
@@ -727,12 +673,18 @@ describeEE("scenarios > admin > permissions", () => {
     cy.button("Save changes").click();
 
     assertPermissionTable([
-      ["Administrators", "Unrestricted", "Yes", "1 million rows", "Yes"],
+      [
+        "Administrators",
+        "Unrestricted",
+        "Query builder and native",
+        "1 million rows",
+        "Yes",
+      ],
       ["All Users", "Sandboxed", "No", "1 million rows", "No"],
-      ["collection", "No self-service", "No", "No", "No"],
-      ["data", "Unrestricted", "Yes", "No", "No"],
-      ["nosql", "Unrestricted", "No", "No", "No"],
-      ["readonly", "No self-service", "No", "No", "No"],
+      ["collection", "Unrestricted", "No", "No", "No"],
+      ["data", "Unrestricted", "Query builder and native", "No", "No"],
+      ["nosql", "Unrestricted", "Query builder only", "No", "No"],
+      ["readonly", "Unrestricted", "No", "No", "No"],
     ]);
   });
 
@@ -765,14 +717,14 @@ describeEE("scenarios > admin > permissions", () => {
     modal().button("Save").click();
 
     assertPermissionTable([
-      ["Accounts", "No self-service", "No", "1 million rows", "No"],
-      ["Analytic Events", "No self-service", "No", "1 million rows", "No"],
-      ["Feedback", "No self-service", "No", "1 million rows", "No"],
-      ["Invoices", "No self-service", "No", "1 million rows", "No"],
+      ["Accounts", "Unrestricted", "No", "1 million rows", "No"],
+      ["Analytic Events", "Unrestricted", "No", "1 million rows", "No"],
+      ["Feedback", "Unrestricted", "No", "1 million rows", "No"],
+      ["Invoices", "Unrestricted", "No", "1 million rows", "No"],
       ["Orders", "Sandboxed", "No", "1 million rows", "No"],
-      ["People", "No self-service", "No", "1 million rows", "No"],
-      ["Products", "No self-service", "No", "1 million rows", "No"],
-      ["Reviews", "No self-service", "No", "1 million rows", "No"],
+      ["People", "Unrestricted", "No", "1 million rows", "No"],
+      ["Products", "Unrestricted", "No", "1 million rows", "No"],
+      ["Reviews", "Unrestricted", "No", "1 million rows", "No"],
     ]);
 
     modifyPermission(
@@ -817,14 +769,14 @@ describeEE("scenarios > admin > permissions", () => {
     cy.reload();
 
     assertPermissionTable([
-      ["Accounts", "No self-service", "No", "1 million rows", "No"],
-      ["Analytic Events", "No self-service", "No", "1 million rows", "No"],
-      ["Feedback", "No self-service", "No", "1 million rows", "No"],
-      ["Invoices", "No self-service", "No", "1 million rows", "No"],
+      ["Accounts", "Unrestricted", "No", "1 million rows", "No"],
+      ["Analytic Events", "Unrestricted", "No", "1 million rows", "No"],
+      ["Feedback", "Unrestricted", "No", "1 million rows", "No"],
+      ["Invoices", "Unrestricted", "No", "1 million rows", "No"],
       ["Orders", "Sandboxed", "No", "1 million rows", "No"],
-      ["People", "No self-service", "No", "1 million rows", "No"],
-      ["Products", "No self-service", "No", "1 million rows", "No"],
-      ["Reviews", "No self-service", "No", "1 million rows", "No"],
+      ["People", "Unrestricted", "No", "1 million rows", "No"],
+      ["Products", "Unrestricted", "No", "1 million rows", "No"],
+      ["Reviews", "Unrestricted", "No", "1 million rows", "No"],
     ]);
   });
 
@@ -838,10 +790,10 @@ describeEE("scenarios > admin > permissions", () => {
       .within(() => {
         isPermissionDisabled(
           DATA_ACCESS_PERMISSION_INDEX,
-          "No self-service",
+          "Unrestricted",
           false,
         ).click();
-        isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", true);
+        isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", false);
       });
 
     popover().contains("Block").click();
@@ -921,8 +873,8 @@ describe("scenarios > admin > permissions", () => {
       .as("permissionsHelpContent")
       .within(() => {
         cy.findByText("Data permissions");
-        cy.findByText("Unrestricted");
-        cy.findByText("Impersonated (Pro)");
+        cy.findByText("Database levels");
+        cy.findByText("Schema and table levels");
         cy.findByLabelText("Close").click();
       });
 

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -808,13 +808,11 @@ describeEE("scenarios > admin > permissions", () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "block" },
           "view-data": "blocked",
         },
       },
       [COLLECTION_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "block" },
           "view-data": "blocked",
         },
       },
@@ -834,13 +832,11 @@ describeEE("scenarios > admin > permissions", () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "block" },
           "view-data": "blocked",
         },
       },
       [COLLECTION_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "block" },
           "view-data": "blocked",
         },
       },

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -48,22 +48,22 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     );
 
     assertPermissionTable([
-      ["Accounts", "Can view", "No"],
-      ["Analytic Events", "Can view", "No"],
-      ["Feedback", "Can view", "No"],
-      ["Invoices", "Can view", "No"],
-      ["Orders", "Can view", "No"],
-      ["People", "Can view", "No"],
-      ["Products", "Can view", "No"],
-      ["Reviews", "Can view", "No"],
+      ["Accounts", "No self-service", "No"],
+      ["Analytic Events", "No self-service", "No"],
+      ["Feedback", "No self-service", "No"],
+      ["Invoices", "No self-service", "No"],
+      ["Orders", "No self-service", "No"],
+      ["People", "No self-service", "No"],
+      ["Products", "No self-service", "No"],
+      ["Reviews", "No self-service", "No"],
     ]);
   });
 
   it("should display error on failed save", () => {
     // revoke some permissions
     cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
-    cy.icon("close").first().click();
-    cy.findAllByRole("option").contains("Query builder and native").click();
+    cy.icon("eye").first().click();
+    cy.findAllByRole("option").contains("Unrestricted").click();
 
     // stub out the PUT and save
     cy.intercept("PUT", "/api/permissions/graph", req => {
@@ -286,8 +286,8 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
       modifyPermission(
         "Sample Database",
-        NATIVE_QUERIES_PERMISSION_INDEX,
-        "Query builder and native",
+        DATA_ACCESS_PERMISSION_INDEX,
+        "Unrestricted",
       );
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -371,22 +371,20 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("1 person");
 
-        assertPermissionTable([
-          ["Sample Database", "Can view", "Query builder and native"],
-        ]);
+        assertPermissionTable([["Sample Database", "Unrestricted", "Yes"]]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "Can view", "Query builder and native"],
-          ["Analytic Events", "Can view", "Query builder and native"],
-          ["Feedback", "Can view", "Query builder and native"],
-          ["Invoices", "Can view", "Query builder and native"],
-          ["Orders", "Can view", "Query builder and native"],
-          ["People", "Can view", "Query builder and native"],
-          ["Products", "Can view", "Query builder and native"],
-          ["Reviews", "Can view", "Query builder and native"],
+          ["Accounts", "Unrestricted", "Yes"],
+          ["Analytic Events", "Unrestricted", "Yes"],
+          ["Feedback", "Unrestricted", "Yes"],
+          ["Invoices", "Unrestricted", "Yes"],
+          ["Orders", "Unrestricted", "Yes"],
+          ["People", "Unrestricted", "Yes"],
+          ["Products", "Unrestricted", "Yes"],
+          ["Reviews", "Unrestricted", "Yes"],
         ]);
       });
 
@@ -395,47 +393,74 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         selectSidebarItem("collection");
 
-        assertPermissionTable([["Sample Database", "Can view", "No"]]);
+        assertPermissionTable([["Sample Database", "No self-service", "No"]]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "Can view", "No"],
-          ["Analytic Events", "Can view", "No"],
-          ["Feedback", "Can view", "No"],
-          ["Invoices", "Can view", "No"],
-          ["Orders", "Can view", "No"],
-          ["People", "Can view", "No"],
-          ["Products", "Can view", "No"],
-          ["Reviews", "Can view", "No"],
+          ["Accounts", "No self-service", "No"],
+          ["Analytic Events", "No self-service", "No"],
+          ["Feedback", "No self-service", "No"],
+          ["Invoices", "No self-service", "No"],
+          ["Orders", "No self-service", "No"],
+          ["People", "No self-service", "No"],
+          ["Products", "No self-service", "No"],
+          ["Reviews", "No self-service", "No"],
+        ]);
+
+        modifyPermission(
+          "Orders",
+          DATA_ACCESS_PERMISSION_INDEX,
+          "Unrestricted",
+        );
+
+        modal().within(() => {
+          cy.findByText("Change access to this database to granular?");
+          cy.button("Change").click();
+        });
+
+        assertPermissionTable([
+          ["Accounts", "No self-service", "No"],
+          ["Analytic Events", "No self-service", "No"],
+          ["Feedback", "No self-service", "No"],
+          ["Invoices", "No self-service", "No"],
+          ["Orders", "Unrestricted", "No"],
+          ["People", "No self-service", "No"],
+          ["Products", "No self-service", "No"],
+          ["Reviews", "No self-service", "No"],
         ]);
 
         // Navigate back
         selectSidebarItem("collection");
 
+        assertPermissionTable([["Sample Database", "Granular", "No"]]);
+
         modifyPermission(
           "Sample Database",
           NATIVE_QUERIES_PERMISSION_INDEX,
-          "Query builder and native",
+          "Yes",
         );
 
-        assertPermissionTable([
-          ["Sample Database", "Can view", "Query builder and native"],
-        ]);
+        modal().within(() => {
+          cy.findByText("Allow native query editing?");
+          cy.button("Allow").click();
+        });
+
+        assertPermissionTable([["Sample Database", "Unrestricted", "Yes"]]);
 
         // Drill down to tables permissions
         cy.findByTextEnsureVisible("Sample Database").click();
 
         assertPermissionTable([
-          ["Accounts", "Can view", "Query builder and native"],
-          ["Analytic Events", "Can view", "Query builder and native"],
-          ["Feedback", "Can view", "Query builder and native"],
-          ["Invoices", "Can view", "Query builder and native"],
-          ["Orders", "Can view", "Query builder and native"],
-          ["People", "Can view", "Query builder and native"],
-          ["Products", "Can view", "Query builder and native"],
-          ["Reviews", "Can view", "Query builder and native"],
+          ["Accounts", "Unrestricted", "Yes"],
+          ["Analytic Events", "Unrestricted", "Yes"],
+          ["Feedback", "Unrestricted", "Yes"],
+          ["Invoices", "Unrestricted", "Yes"],
+          ["Orders", "Unrestricted", "Yes"],
+          ["People", "Unrestricted", "Yes"],
+          ["Products", "Unrestricted", "Yes"],
+          ["Reviews", "Unrestricted", "Yes"],
         ]);
 
         cy.button("Save changes").click();
@@ -443,7 +468,10 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         modal().within(() => {
           cy.findByText("Save permissions?");
           cy.contains(
-            "collection will now be able to read or write native queries for Sample Database.",
+            "collection will be given access to 8 tables in Sample Database.",
+          );
+          cy.contains(
+            "collection will now be able to write native queries for Sample Database.",
           );
           cy.button("Yes").click();
         });
@@ -452,14 +480,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.findByText("Save changes").should("not.exist");
 
         assertPermissionTable([
-          ["Accounts", "Can view", "Query builder and native"],
-          ["Analytic Events", "Can view", "Query builder and native"],
-          ["Feedback", "Can view", "Query builder and native"],
-          ["Invoices", "Can view", "Query builder and native"],
-          ["Orders", "Can view", "Query builder and native"],
-          ["People", "Can view", "Query builder and native"],
-          ["Products", "Can view", "Query builder and native"],
-          ["Reviews", "Can view", "Query builder and native"],
+          ["Accounts", "Unrestricted", "Yes"],
+          ["Analytic Events", "Unrestricted", "Yes"],
+          ["Feedback", "Unrestricted", "Yes"],
+          ["Invoices", "Unrestricted", "Yes"],
+          ["Orders", "Unrestricted", "Yes"],
+          ["People", "Unrestricted", "Yes"],
+          ["Products", "Unrestricted", "Yes"],
+          ["Reviews", "Unrestricted", "Yes"],
         ]);
 
         // After saving permissions, user should be able to make further edits without refreshing the page
@@ -483,8 +511,8 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         modifyPermission(
           "Sample Database",
-          NATIVE_QUERIES_PERMISSION_INDEX,
-          "Query builder and native",
+          DATA_ACCESS_PERMISSION_INDEX,
+          "Unrestricted",
         );
 
         cy.get("@graph").then(data => {
@@ -512,49 +540,82 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         selectSidebarItem("Sample Database");
 
         assertPermissionTable([
-          ["Administrators", "Can view", "Query builder and native"],
-          ["All Users", "Can view", "No"],
-          ["collection", "Can view", "No"],
-          ["data", "Can view", "Query builder and native"],
-          ["nosql", "Can view", "Query builder only"],
-          ["readonly", "Can view", "No"],
-        ]);
-
-        modifyPermission(
-          "readonly",
-          NATIVE_QUERIES_PERMISSION_INDEX,
-          "Query builder and native",
-        );
-
-        assertPermissionTable([
-          ["Administrators", "Can view", "Query builder and native"],
-          ["All Users", "Can view", "No"],
-          ["collection", "Can view", "No"],
-          ["data", "Can view", "Query builder and native"],
-          ["nosql", "Can view", "Query builder only"],
-          ["readonly", "Can view", "Query builder and native"],
+          ["Administrators", "Unrestricted", "Yes"],
+          ["All Users", "No self-service", "No"],
+          ["collection", "No self-service", "No"],
+          ["data", "Unrestricted", "Yes"],
+          ["nosql", "Unrestricted", "No"],
+          ["readonly", "No self-service", "No"],
         ]);
 
         selectSidebarItem("Orders");
 
         assertPermissionTable([
-          ["Administrators", "Can view", "Query builder and native"],
-          ["All Users", "Can view", "No"],
-          ["collection", "Can view", "No"],
-          ["data", "Can view", "Query builder and native"],
-          ["nosql", "Can view", "Query builder only"],
-          ["readonly", "Can view", "Query builder and native"],
+          ["Administrators", "Unrestricted", "Yes"],
+          ["All Users", "No self-service", "No"],
+          ["collection", "No self-service", "No"],
+          ["data", "Unrestricted", "Yes"],
+          ["nosql", "Unrestricted", "No"],
+          ["readonly", "No self-service", "No"],
+        ]);
+
+        modifyPermission(
+          "readonly",
+          DATA_ACCESS_PERMISSION_INDEX,
+          "Unrestricted",
+        );
+
+        modal().within(() => {
+          cy.findByText("Change access to this database to granular?");
+          cy.button("Change").click();
+        });
+
+        assertPermissionTable([
+          ["Administrators", "Unrestricted", "Yes"],
+          ["All Users", "No self-service", "No"],
+          ["collection", "No self-service", "No"],
+          ["data", "Unrestricted", "Yes"],
+          ["nosql", "Unrestricted", "No"],
+          ["readonly", "Unrestricted", "No"],
         ]);
 
         // Navigate back
         cy.get("a").contains("Sample Database").click();
+
+        assertPermissionTable([
+          ["Administrators", "Unrestricted", "Yes"],
+          ["All Users", "No self-service", "No"],
+          ["collection", "No self-service", "No"],
+          ["data", "Unrestricted", "Yes"],
+          ["nosql", "Unrestricted", "No"],
+          ["readonly", "Granular", "No"],
+        ]);
+
+        modifyPermission("readonly", NATIVE_QUERIES_PERMISSION_INDEX, "Yes");
+
+        modal().within(() => {
+          cy.findByText("Allow native query editing?");
+          cy.button("Allow").click();
+        });
+
+        assertPermissionTable([
+          ["Administrators", "Unrestricted", "Yes"],
+          ["All Users", "No self-service", "No"],
+          ["collection", "No self-service", "No"],
+          ["data", "Unrestricted", "Yes"],
+          ["nosql", "Unrestricted", "No"],
+          ["readonly", "Unrestricted", "Yes"],
+        ]);
 
         cy.button("Save changes").click();
 
         modal().within(() => {
           cy.findByText("Save permissions?");
           cy.contains(
-            "readonly will now be able to read or write native queries for Sample Database.",
+            "readonly will be given access to 8 tables in Sample Database.",
+          );
+          cy.contains(
+            "readonly will now be able to write native queries for Sample Database.",
           );
           cy.button("Yes").click();
         });
@@ -563,15 +624,14 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         cy.findByText("Save changes").should("not.exist");
 
         assertPermissionTable([
-          ["Administrators", "Can view", "Query builder and native"],
-          ["All Users", "Can view", "No"],
-          ["collection", "Can view", "No"],
-          ["data", "Can view", "Query builder and native"],
-          ["nosql", "Can view", "Query builder only"],
-          ["readonly", "Can view", "Query builder and native"],
+          ["Administrators", "Unrestricted", "Yes"],
+          ["All Users", "No self-service", "No"],
+          ["collection", "No self-service", "No"],
+          ["data", "Unrestricted", "Yes"],
+          ["nosql", "Unrestricted", "No"],
+          ["readonly", "Unrestricted", "Yes"],
         ]);
       });
-
       it("should show a modal when a revision changes while an admin is editing", () => {
         cy.intercept("/api/permissions/graph/group/1").as("graph");
         cy.visit("/admin/permissions/");
@@ -580,8 +640,8 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
 
         modifyPermission(
           "Sample Database",
-          NATIVE_QUERIES_PERMISSION_INDEX,
-          "Query builder and native",
+          DATA_ACCESS_PERMISSION_INDEX,
+          "Unrestricted",
         );
 
         cy.get("@graph").then(data => {
@@ -639,18 +699,12 @@ describeEE("scenarios > admin > permissions", () => {
     cy.button("Save").click();
 
     assertPermissionTable([
-      [
-        "Administrators",
-        "Can view",
-        "Query builder and native",
-        "1 million rows",
-        "Yes",
-      ],
+      ["Administrators", "Unrestricted", "Yes", "1 million rows", "Yes"],
       ["All Users", "Sandboxed", "No", "1 million rows", "No"],
-      ["collection", "Can view", "No", "No", "No"],
-      ["data", "Can view", "Query builder and native", "No", "No"],
-      ["nosql", "Can view", "Query builder only", "No", "No"],
-      ["readonly", "Can view", "No", "No", "No"],
+      ["collection", "No self-service", "No", "No", "No"],
+      ["data", "Unrestricted", "Yes", "No", "No"],
+      ["nosql", "Unrestricted", "No", "No", "No"],
+      ["readonly", "No self-service", "No", "No", "No"],
     ]);
 
     modifyPermission(
@@ -673,18 +727,12 @@ describeEE("scenarios > admin > permissions", () => {
     cy.button("Save changes").click();
 
     assertPermissionTable([
-      [
-        "Administrators",
-        "Can view",
-        "Query builder and native",
-        "1 million rows",
-        "Yes",
-      ],
+      ["Administrators", "Unrestricted", "Yes", "1 million rows", "Yes"],
       ["All Users", "Sandboxed", "No", "1 million rows", "No"],
-      ["collection", "Can view", "No", "No", "No"],
-      ["data", "Can view", "Query builder and native", "No", "No"],
-      ["nosql", "Can view", "Query builder only", "No", "No"],
-      ["readonly", "Can view", "No", "No", "No"],
+      ["collection", "No self-service", "No", "No", "No"],
+      ["data", "Unrestricted", "Yes", "No", "No"],
+      ["nosql", "Unrestricted", "No", "No", "No"],
+      ["readonly", "No self-service", "No", "No", "No"],
     ]);
   });
 
@@ -717,14 +765,14 @@ describeEE("scenarios > admin > permissions", () => {
     modal().button("Save").click();
 
     assertPermissionTable([
-      ["Accounts", "Can view", "No", "1 million rows", "No"],
-      ["Analytic Events", "Can view", "No", "1 million rows", "No"],
-      ["Feedback", "Can view", "No", "1 million rows", "No"],
-      ["Invoices", "Can view", "No", "1 million rows", "No"],
+      ["Accounts", "No self-service", "No", "1 million rows", "No"],
+      ["Analytic Events", "No self-service", "No", "1 million rows", "No"],
+      ["Feedback", "No self-service", "No", "1 million rows", "No"],
+      ["Invoices", "No self-service", "No", "1 million rows", "No"],
       ["Orders", "Sandboxed", "No", "1 million rows", "No"],
-      ["People", "Can view", "No", "1 million rows", "No"],
-      ["Products", "Can view", "No", "1 million rows", "No"],
-      ["Reviews", "Can view", "No", "1 million rows", "No"],
+      ["People", "No self-service", "No", "1 million rows", "No"],
+      ["Products", "No self-service", "No", "1 million rows", "No"],
+      ["Reviews", "No self-service", "No", "1 million rows", "No"],
     ]);
 
     modifyPermission(
@@ -769,14 +817,14 @@ describeEE("scenarios > admin > permissions", () => {
     cy.reload();
 
     assertPermissionTable([
-      ["Accounts", "Can view", "No", "1 million rows", "No"],
-      ["Analytic Events", "Can view", "No", "1 million rows", "No"],
-      ["Feedback", "Can view", "No", "1 million rows", "No"],
-      ["Invoices", "Can view", "No", "1 million rows", "No"],
+      ["Accounts", "No self-service", "No", "1 million rows", "No"],
+      ["Analytic Events", "No self-service", "No", "1 million rows", "No"],
+      ["Feedback", "No self-service", "No", "1 million rows", "No"],
+      ["Invoices", "No self-service", "No", "1 million rows", "No"],
       ["Orders", "Sandboxed", "No", "1 million rows", "No"],
-      ["People", "Can view", "No", "1 million rows", "No"],
-      ["Products", "Can view", "No", "1 million rows", "No"],
-      ["Reviews", "Can view", "No", "1 million rows", "No"],
+      ["People", "No self-service", "No", "1 million rows", "No"],
+      ["Products", "No self-service", "No", "1 million rows", "No"],
+      ["Reviews", "No self-service", "No", "1 million rows", "No"],
     ]);
   });
 
@@ -790,10 +838,10 @@ describeEE("scenarios > admin > permissions", () => {
       .within(() => {
         isPermissionDisabled(
           DATA_ACCESS_PERMISSION_INDEX,
-          "Can view",
+          "No self-service",
           false,
         ).click();
-        isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", false);
+        isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", true);
       });
 
     popover().contains("Block").click();
@@ -873,8 +921,8 @@ describe("scenarios > admin > permissions", () => {
       .as("permissionsHelpContent")
       .within(() => {
         cy.findByText("Data permissions");
-        cy.findByText("Database levels");
-        cy.findByText("Schema and table levels");
+        cy.findByText("Unrestricted");
+        cy.findByText("Impersonated (Pro)");
         cy.findByLabelText("Close").click();
       });
 

--- a/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -119,8 +119,6 @@ describeEE("scenarios > admin > permissions", () => {
     // Change data model permission
     modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Granular");
     modifyPermission("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
-    modifyPermission("Orders", DATA_ACCESS_PERMISSION_INDEX, "Unrestricted");
-    cy.button("Change").click();
 
     savePermissionsGraph();
 

--- a/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/data-model-permissions.cy.spec.js
@@ -119,6 +119,8 @@ describeEE("scenarios > admin > permissions", () => {
     // Change data model permission
     modifyPermission("All Users", DATA_MODEL_PERMISSION_INDEX, "Granular");
     modifyPermission("Orders", DATA_MODEL_PERMISSION_INDEX, "Yes");
+    modifyPermission("Orders", DATA_ACCESS_PERMISSION_INDEX, "Unrestricted");
+    cy.button("Change").click();
 
     savePermissionsGraph();
 

--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -8,7 +8,6 @@ import {
   setTokenFeatures,
 } from "e2e/support/helpers";
 
-const DATA_ACCESS_PERMISSION_INDEX = 0;
 const DETAILS_PERMISSION_INDEX = 4;
 
 describeEE(
@@ -24,11 +23,6 @@ describeEE(
       // As an admin, grant database details permissions to all users
       cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
-      modifyPermission(
-        "All Users",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Unrestricted",
-      );
       modifyPermission("All Users", DETAILS_PERMISSION_INDEX, "Yes");
 
       cy.button("Save changes").click();

--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -1,286 +1,71 @@
-import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
-import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  ORDERS_DASHBOARD_ID,
-  ORDERS_QUESTION_ID,
-} from "e2e/support/cypress_sample_instance_data";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import {
   restore,
   modal,
   describeEE,
   assertPermissionForItem,
   modifyPermission,
-  downloadAndAssert,
-  assertSheetRowsCount,
-  sidebar,
-  visitQuestion,
-  visitDashboard,
-  popover,
   setTokenFeatures,
 } from "e2e/support/helpers";
 
-const { ALL_USERS_GROUP } = USER_GROUPS;
+const DETAILS_PERMISSION_INDEX = 4;
 
-const {
-  PRODUCTS_ID,
-  ORDERS_ID,
-  PEOPLE_ID,
-  REVIEWS_ID,
-  ACCOUNTS_ID,
-  ANALYTIC_EVENTS_ID,
-  FEEDBACK_ID,
-  INVOICES_ID,
-} = SAMPLE_DATABASE;
-
-const DATA_ACCESS_PERMISSION_INDEX = 0;
-const DOWNLOAD_PERMISSION_INDEX = 2;
-
-describeEE("scenarios > admin > permissions > data > downloads", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-    setTokenFeatures("all");
-  });
-
-  it("setting downloads permission UI flow should work", () => {
-    cy.log("allows changing download results permission for a database");
-
-    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
-
-    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
-
-    cy.button("Save changes").click();
-
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.findByText("Are you sure you want to do this?");
-      cy.button("Yes").click();
-    });
-
-    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
-
-    cy.log("Make sure we can change download results permission for a table");
-
-    sidebar().contains("Orders").click();
-
-    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "1 million rows");
-
-    cy.button("Save changes").click();
-
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.findByText("Are you sure you want to do this?");
-      cy.button("Yes").click();
-    });
-
-    assertPermissionForItem(
-      "All Users",
-      DOWNLOAD_PERMISSION_INDEX,
-      "1 million rows",
-    );
-  });
-
-  it("respects 'no download' permissions when 'All users' group data permissions are set to `Block` (metabase#22408)", () => {
-    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
-
-    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Block");
-
-    cy.button("Save changes").click();
-
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.findByText("Are you sure you want to do this?");
-      cy.button("Yes").click();
-    });
-
-    // When data permissions are set to `Block`, download permissions are automatically revoked
-    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
-
-    // Normal user belongs to both "data" and "collections" groups.
-    // They both have restricted downloads so this user shouldn't have the right to download anything.
-    cy.signIn("normal");
-
-    visitQuestion(ORDERS_QUESTION_ID);
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Showing first 2,000 rows");
-    cy.icon("download").should("not.exist");
-  });
-
-  it("restricts users from downloading questions", () => {
-    // Restrict downloads for All Users
-    cy.updatePermissionsGraph({
-      [ALL_USERS_GROUP]: {
-        [SAMPLE_DB_ID]: {
-          download: { schemas: "none" },
-        },
-      },
-    });
-
-    cy.signInAsNormalUser();
-
-    visitQuestion(ORDERS_QUESTION_ID);
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Showing first 2,000 rows");
-    cy.icon("download").should("not.exist");
-
-    visitDashboard(ORDERS_DASHBOARD_ID);
-
-    cy.findByTestId("dashcard").within(() => {
-      cy.findByTestId("legend-caption").realHover();
-      cy.findByTestId("dashcard-menu").click();
-    });
-
-    popover().within(() => {
-      cy.findByText("Edit question").should("be.visible");
-      cy.findByText("Download results").should("not.exist");
-    });
-  });
-
-  it("limits users from downloading all results", () => {
-    // Restrict downloads for All Users
-    cy.updatePermissionsGraph({
-      [ALL_USERS_GROUP]: {
-        [SAMPLE_DB_ID]: {
-          download: { schemas: "limited" },
-        },
-      },
-    });
-
-    cy.signInAsNormalUser();
-    visitQuestion(ORDERS_QUESTION_ID);
-
-    downloadAndAssert(
-      { fileType: "xlsx", questionId: ORDERS_QUESTION_ID },
-      assertSheetRowsCount(10000),
-    );
-  });
-
-  describe("native questions", () => {
+describeEE(
+  "scenarios > admin > permissions > database details permissions",
+  () => {
     beforeEach(() => {
-      cy.intercept("POST", "/api/dataset").as("dataset");
-
-      cy.createNativeQuestion(
-        {
-          name: "Native Orders",
-          native: {
-            query: "select * from orders",
-          },
-        },
-        { wrapId: true, idAlias: "nativeQuestionId" },
-      );
+      restore();
+      cy.signInAsAdmin();
+      setTokenFeatures("all");
     });
 
-    it("lets user download results from native queries", () => {
+    it("allows database managers to see and edit database details but not to delete a database (metabase#22293)", () => {
+      // As an admin, grant database details permissions to all users
+      cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+
+      modifyPermission("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+
+      cy.button("Save changes").click();
+
+      modal().within(() => {
+        cy.findByText("Save permissions?");
+        cy.findByText("Are you sure you want to do this?");
+        cy.button("Yes").click();
+      });
+
+      assertPermissionForItem("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+
+      // Normal user should now have the ability to manage databases
       cy.signInAsNormalUser();
 
-      cy.get("@nativeQuestionId").then(id => {
-        visitQuestion(id);
+      cy.visit("/");
+      cy.icon("gear").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Admin settings").should("be.visible").click();
 
-        downloadAndAssert(
-          { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(18760),
-        );
+      cy.location("pathname").should("eq", "/admin/databases");
 
-        // Make sure we can download results from an ad-hoc nested query based on a native question
-        cy.findByText("Explore results").click();
-        cy.wait("@dataset");
+      cy.get("nav")
+        .should("contain", "Databases")
+        .and("not.contain", "Settings")
+        .and("not.contain", "Data Model");
 
-        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(18760));
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Sample Database").click();
 
-        // Make sure we can download results from a native model
-        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
+      cy.findByTestId("database-actions-panel")
+        .should("contain", "Sync database schema now")
+        .and("contain", "Re-scan field values now")
+        .and("contain", "Discard saved field values")
+        .and("not.contain", "Remove this database");
 
-        visitQuestion(id);
-
-        downloadAndAssert(
-          { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(18760),
-        );
+      cy.request({
+        method: "DELETE",
+        url: `/api/database/${SAMPLE_DB_ID}`,
+        failOnStatusCode: false,
+      }).then(({ status }) => {
+        expect(status).to.eq(403);
       });
     });
-
-    it("prevents user from downloading a native question even if only one table doesn't have download permissions", () => {
-      setDownloadPermissionsForProductsTable("none");
-
-      cy.signInAsNormalUser();
-
-      cy.get("@nativeQuestionId").then(id => {
-        visitQuestion(id);
-
-        cy.findByText("Showing first 2,000 rows");
-        cy.icon("download").should("not.exist");
-
-        // Ad-hoc nested query also shouldn't be downloadable
-        cy.findByText("Explore results").click();
-        cy.wait("@dataset");
-
-        cy.findByText("Showing first 2,000 rows");
-        cy.icon("download").should("not.exist");
-
-        // Convert question to a model, which also shouldn't be downloadable
-        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
-
-        visitQuestion(id);
-
-        cy.findByText("Showing first 2,000 rows");
-        cy.icon("download").should("not.exist");
-      });
-    });
-
-    it("limits download results for a native question even if only one table has `limited` download permissions", () => {
-      setDownloadPermissionsForProductsTable("limited");
-
-      cy.signInAsNormalUser();
-
-      cy.get("@nativeQuestionId").then(id => {
-        visitQuestion(id);
-
-        downloadAndAssert(
-          { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(10000),
-        );
-
-        // Ad-hoc nested query based on a native question should also have a download row limit
-        cy.findByText("Explore results").click();
-        cy.wait("@dataset");
-
-        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(10000));
-
-        // Convert question to a model, which should also have a download row limit
-        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
-
-        visitQuestion(id);
-
-        downloadAndAssert(
-          { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(10000),
-        );
-      });
-    });
-  });
-});
-
-function setDownloadPermissionsForProductsTable(permission) {
-  cy.updatePermissionsGraph({
-    [ALL_USERS_GROUP]: {
-      [SAMPLE_DB_ID]: {
-        download: {
-          schemas: {
-            PUBLIC: {
-              [PRODUCTS_ID]: permission,
-              [ORDERS_ID]: "full",
-              [PEOPLE_ID]: "full",
-              [REVIEWS_ID]: "full",
-              [ACCOUNTS_ID]: "full",
-              [ANALYTIC_EVENTS_ID]: "full",
-              [FEEDBACK_ID]: "full",
-              [INVOICES_ID]: "full",
-            },
-          },
-        },
-      },
-    },
-  });
-}
+  },
+);

--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -1,286 +1,77 @@
-import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
-import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import {
-  ORDERS_DASHBOARD_ID,
-  ORDERS_QUESTION_ID,
-} from "e2e/support/cypress_sample_instance_data";
+import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import {
   restore,
   modal,
   describeEE,
   assertPermissionForItem,
   modifyPermission,
-  downloadAndAssert,
-  assertSheetRowsCount,
-  sidebar,
-  visitQuestion,
-  visitDashboard,
-  popover,
   setTokenFeatures,
 } from "e2e/support/helpers";
 
-const { ALL_USERS_GROUP } = USER_GROUPS;
-
-const {
-  PRODUCTS_ID,
-  ORDERS_ID,
-  PEOPLE_ID,
-  REVIEWS_ID,
-  ACCOUNTS_ID,
-  ANALYTIC_EVENTS_ID,
-  FEEDBACK_ID,
-  INVOICES_ID,
-} = SAMPLE_DATABASE;
-
 const DATA_ACCESS_PERMISSION_INDEX = 0;
-const DOWNLOAD_PERMISSION_INDEX = 2;
+const DETAILS_PERMISSION_INDEX = 4;
 
-describeEE("scenarios > admin > permissions > data > downloads", () => {
-  beforeEach(() => {
-    restore();
-    cy.signInAsAdmin();
-    setTokenFeatures("all");
-  });
-
-  it("setting downloads permission UI flow should work", () => {
-    cy.log("allows changing download results permission for a database");
-
-    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
-
-    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
-
-    cy.button("Save changes").click();
-
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.findByText("Are you sure you want to do this?");
-      cy.button("Yes").click();
-    });
-
-    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
-
-    cy.log("Make sure we can change download results permission for a table");
-
-    sidebar().contains("Orders").click();
-
-    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "1 million rows");
-
-    cy.button("Save changes").click();
-
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.findByText("Are you sure you want to do this?");
-      cy.button("Yes").click();
-    });
-
-    assertPermissionForItem(
-      "All Users",
-      DOWNLOAD_PERMISSION_INDEX,
-      "1 million rows",
-    );
-  });
-
-  it("respects 'no download' permissions when 'All users' group data permissions are set to `Block` (metabase#22408)", () => {
-    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
-
-    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Block");
-
-    cy.button("Save changes").click();
-
-    modal().within(() => {
-      cy.findByText("Save permissions?");
-      cy.findByText("Are you sure you want to do this?");
-      cy.button("Yes").click();
-    });
-
-    // When data permissions are set to `Block`, download permissions are automatically revoked
-    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
-
-    // Normal user belongs to both "data" and "collections" groups.
-    // They both have restricted downloads so this user shouldn't have the right to download anything.
-    cy.signIn("normal");
-
-    visitQuestion(ORDERS_QUESTION_ID);
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Showing first 2,000 rows");
-    cy.icon("download").should("not.exist");
-  });
-
-  it("restricts users from downloading questions", () => {
-    // Restrict downloads for All Users
-    cy.updatePermissionsGraph({
-      [ALL_USERS_GROUP]: {
-        [SAMPLE_DB_ID]: {
-          download: { schemas: "none" },
-        },
-      },
-    });
-
-    cy.signInAsNormalUser();
-
-    visitQuestion(ORDERS_QUESTION_ID);
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Showing first 2,000 rows");
-    cy.icon("download").should("not.exist");
-
-    visitDashboard(ORDERS_DASHBOARD_ID);
-
-    cy.findByTestId("dashcard").within(() => {
-      cy.findByTestId("legend-caption").realHover();
-      cy.findByTestId("dashcard-menu").click();
-    });
-
-    popover().within(() => {
-      cy.findByText("Edit question").should("be.visible");
-      cy.findByText("Download results").should("not.exist");
-    });
-  });
-
-  it("limits users from downloading all results", () => {
-    // Restrict downloads for All Users
-    cy.updatePermissionsGraph({
-      [ALL_USERS_GROUP]: {
-        [SAMPLE_DB_ID]: {
-          download: { schemas: "limited" },
-        },
-      },
-    });
-
-    cy.signInAsNormalUser();
-    visitQuestion(ORDERS_QUESTION_ID);
-
-    downloadAndAssert(
-      { fileType: "xlsx", questionId: ORDERS_QUESTION_ID },
-      assertSheetRowsCount(10000),
-    );
-  });
-
-  describe("native questions", () => {
+describeEE(
+  "scenarios > admin > permissions > database details permissions",
+  () => {
     beforeEach(() => {
-      cy.intercept("POST", "/api/dataset").as("dataset");
+      restore();
+      cy.signInAsAdmin();
+      setTokenFeatures("all");
+    });
 
-      cy.createNativeQuestion(
-        {
-          name: "Native Orders",
-          native: {
-            query: "select * from orders",
-          },
-        },
-        { wrapId: true, idAlias: "nativeQuestionId" },
+    it("allows database managers to see and edit database details but not to delete a database (metabase#22293)", () => {
+      // As an admin, grant database details permissions to all users
+      cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+
+      modifyPermission(
+        "All Users",
+        DATA_ACCESS_PERMISSION_INDEX,
+        "Unrestricted",
       );
-    });
+      modifyPermission("All Users", DETAILS_PERMISSION_INDEX, "Yes");
 
-    it("lets user download results from native queries", () => {
+      cy.button("Save changes").click();
+
+      modal().within(() => {
+        cy.findByText("Save permissions?");
+        cy.findByText("Are you sure you want to do this?");
+        cy.button("Yes").click();
+      });
+
+      assertPermissionForItem("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+
+      // Normal user should now have the ability to manage databases
       cy.signInAsNormalUser();
 
-      cy.get("@nativeQuestionId").then(id => {
-        visitQuestion(id);
+      cy.visit("/");
+      cy.icon("gear").click();
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Admin settings").should("be.visible").click();
 
-        downloadAndAssert(
-          { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(18760),
-        );
+      cy.location("pathname").should("eq", "/admin/databases");
 
-        // Make sure we can download results from an ad-hoc nested query based on a native question
-        cy.findByText("Explore results").click();
-        cy.wait("@dataset");
+      cy.get("nav")
+        .should("contain", "Databases")
+        .and("not.contain", "Settings")
+        .and("not.contain", "Data Model");
 
-        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(18760));
+      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+      cy.findByText("Sample Database").click();
 
-        // Make sure we can download results from a native model
-        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
+      cy.findByTestId("database-actions-panel")
+        .should("contain", "Sync database schema now")
+        .and("contain", "Re-scan field values now")
+        .and("contain", "Discard saved field values")
+        .and("not.contain", "Remove this database");
 
-        visitQuestion(id);
-
-        downloadAndAssert(
-          { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(18760),
-        );
+      cy.request({
+        method: "DELETE",
+        url: `/api/database/${SAMPLE_DB_ID}`,
+        failOnStatusCode: false,
+      }).then(({ status }) => {
+        expect(status).to.eq(403);
       });
     });
-
-    it("prevents user from downloading a native question even if only one table doesn't have download permissions", () => {
-      setDownloadPermissionsForProductsTable("none");
-
-      cy.signInAsNormalUser();
-
-      cy.get("@nativeQuestionId").then(id => {
-        visitQuestion(id);
-
-        cy.findByText("Showing first 2,000 rows");
-        cy.icon("download").should("not.exist");
-
-        // Ad-hoc nested query also shouldn't be downloadable
-        cy.findByText("Explore results").click();
-        cy.wait("@dataset");
-
-        cy.findByText("Showing first 2,000 rows");
-        cy.icon("download").should("not.exist");
-
-        // Convert question to a model, which also shouldn't be downloadable
-        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
-
-        visitQuestion(id);
-
-        cy.findByText("Showing first 2,000 rows");
-        cy.icon("download").should("not.exist");
-      });
-    });
-
-    it("limits download results for a native question even if only one table has `limited` download permissions", () => {
-      setDownloadPermissionsForProductsTable("limited");
-
-      cy.signInAsNormalUser();
-
-      cy.get("@nativeQuestionId").then(id => {
-        visitQuestion(id);
-
-        downloadAndAssert(
-          { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(10000),
-        );
-
-        // Ad-hoc nested query based on a native question should also have a download row limit
-        cy.findByText("Explore results").click();
-        cy.wait("@dataset");
-
-        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(10000));
-
-        // Convert question to a model, which should also have a download row limit
-        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
-
-        visitQuestion(id);
-
-        downloadAndAssert(
-          { fileType: "xlsx", questionId: id },
-          assertSheetRowsCount(10000),
-        );
-      });
-    });
-  });
-});
-
-function setDownloadPermissionsForProductsTable(permission) {
-  cy.updatePermissionsGraph({
-    [ALL_USERS_GROUP]: {
-      [SAMPLE_DB_ID]: {
-        download: {
-          schemas: {
-            PUBLIC: {
-              [PRODUCTS_ID]: permission,
-              [ORDERS_ID]: "full",
-              [PEOPLE_ID]: "full",
-              [REVIEWS_ID]: "full",
-              [ACCOUNTS_ID]: "full",
-              [ANALYTIC_EVENTS_ID]: "full",
-              [FEEDBACK_ID]: "full",
-              [INVOICES_ID]: "full",
-            },
-          },
-        },
-      },
-    },
-  });
-}
+  },
+);

--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -1,77 +1,286 @@
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  ORDERS_DASHBOARD_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import {
   restore,
   modal,
   describeEE,
   assertPermissionForItem,
   modifyPermission,
+  downloadAndAssert,
+  assertSheetRowsCount,
+  sidebar,
+  visitQuestion,
+  visitDashboard,
+  popover,
   setTokenFeatures,
 } from "e2e/support/helpers";
 
-const DATA_ACCESS_PERMISSION_INDEX = 0;
-const DETAILS_PERMISSION_INDEX = 4;
+const { ALL_USERS_GROUP } = USER_GROUPS;
 
-describeEE(
-  "scenarios > admin > permissions > database details permissions",
-  () => {
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
-      setTokenFeatures("all");
+const {
+  PRODUCTS_ID,
+  ORDERS_ID,
+  PEOPLE_ID,
+  REVIEWS_ID,
+  ACCOUNTS_ID,
+  ANALYTIC_EVENTS_ID,
+  FEEDBACK_ID,
+  INVOICES_ID,
+} = SAMPLE_DATABASE;
+
+const DATA_ACCESS_PERMISSION_INDEX = 0;
+const DOWNLOAD_PERMISSION_INDEX = 2;
+
+describeEE("scenarios > admin > permissions > data > downloads", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    setTokenFeatures("all");
+  });
+
+  it("setting downloads permission UI flow should work", () => {
+    cy.log("allows changing download results permission for a database");
+
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+
+    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
     });
 
-    it("allows database managers to see and edit database details but not to delete a database (metabase#22293)", () => {
-      // As an admin, grant database details permissions to all users
-      cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
 
-      modifyPermission(
-        "All Users",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Unrestricted",
+    cy.log("Make sure we can change download results permission for a table");
+
+    sidebar().contains("Orders").click();
+
+    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "1 million rows");
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
+    });
+
+    assertPermissionForItem(
+      "All Users",
+      DOWNLOAD_PERMISSION_INDEX,
+      "1 million rows",
+    );
+  });
+
+  it("respects 'no download' permissions when 'All users' group data permissions are set to `Block` (metabase#22408)", () => {
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+
+    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Block");
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
+    });
+
+    // When data permissions are set to `Block`, download permissions are automatically revoked
+    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
+
+    // Normal user belongs to both "data" and "collections" groups.
+    // They both have restricted downloads so this user shouldn't have the right to download anything.
+    cy.signIn("normal");
+
+    visitQuestion(ORDERS_QUESTION_ID);
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Showing first 2,000 rows");
+    cy.icon("download").should("not.exist");
+  });
+
+  it("restricts users from downloading questions", () => {
+    // Restrict downloads for All Users
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [SAMPLE_DB_ID]: {
+          download: { schemas: "none" },
+        },
+      },
+    });
+
+    cy.signInAsNormalUser();
+
+    visitQuestion(ORDERS_QUESTION_ID);
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Showing first 2,000 rows");
+    cy.icon("download").should("not.exist");
+
+    visitDashboard(ORDERS_DASHBOARD_ID);
+
+    cy.findByTestId("dashcard").within(() => {
+      cy.findByTestId("legend-caption").realHover();
+      cy.findByTestId("dashcard-menu").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Edit question").should("be.visible");
+      cy.findByText("Download results").should("not.exist");
+    });
+  });
+
+  it("limits users from downloading all results", () => {
+    // Restrict downloads for All Users
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [SAMPLE_DB_ID]: {
+          download: { schemas: "limited" },
+        },
+      },
+    });
+
+    cy.signInAsNormalUser();
+    visitQuestion(ORDERS_QUESTION_ID);
+
+    downloadAndAssert(
+      { fileType: "xlsx", questionId: ORDERS_QUESTION_ID },
+      assertSheetRowsCount(10000),
+    );
+  });
+
+  describe("native questions", () => {
+    beforeEach(() => {
+      cy.intercept("POST", "/api/dataset").as("dataset");
+
+      cy.createNativeQuestion(
+        {
+          name: "Native Orders",
+          native: {
+            query: "select * from orders",
+          },
+        },
+        { wrapId: true, idAlias: "nativeQuestionId" },
       );
-      modifyPermission("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+    });
 
-      cy.button("Save changes").click();
-
-      modal().within(() => {
-        cy.findByText("Save permissions?");
-        cy.findByText("Are you sure you want to do this?");
-        cy.button("Yes").click();
-      });
-
-      assertPermissionForItem("All Users", DETAILS_PERMISSION_INDEX, "Yes");
-
-      // Normal user should now have the ability to manage databases
+    it("lets user download results from native queries", () => {
       cy.signInAsNormalUser();
 
-      cy.visit("/");
-      cy.icon("gear").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Admin settings").should("be.visible").click();
+      cy.get("@nativeQuestionId").then(id => {
+        visitQuestion(id);
 
-      cy.location("pathname").should("eq", "/admin/databases");
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(18760),
+        );
 
-      cy.get("nav")
-        .should("contain", "Databases")
-        .and("not.contain", "Settings")
-        .and("not.contain", "Data Model");
+        // Make sure we can download results from an ad-hoc nested query based on a native question
+        cy.findByText("Explore results").click();
+        cy.wait("@dataset");
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Sample Database").click();
+        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(18760));
 
-      cy.findByTestId("database-actions-panel")
-        .should("contain", "Sync database schema now")
-        .and("contain", "Re-scan field values now")
-        .and("contain", "Discard saved field values")
-        .and("not.contain", "Remove this database");
+        // Make sure we can download results from a native model
+        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
 
-      cy.request({
-        method: "DELETE",
-        url: `/api/database/${SAMPLE_DB_ID}`,
-        failOnStatusCode: false,
-      }).then(({ status }) => {
-        expect(status).to.eq(403);
+        visitQuestion(id);
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(18760),
+        );
       });
     });
-  },
-);
+
+    it("prevents user from downloading a native question even if only one table doesn't have download permissions", () => {
+      setDownloadPermissionsForProductsTable("none");
+
+      cy.signInAsNormalUser();
+
+      cy.get("@nativeQuestionId").then(id => {
+        visitQuestion(id);
+
+        cy.findByText("Showing first 2,000 rows");
+        cy.icon("download").should("not.exist");
+
+        // Ad-hoc nested query also shouldn't be downloadable
+        cy.findByText("Explore results").click();
+        cy.wait("@dataset");
+
+        cy.findByText("Showing first 2,000 rows");
+        cy.icon("download").should("not.exist");
+
+        // Convert question to a model, which also shouldn't be downloadable
+        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
+
+        visitQuestion(id);
+
+        cy.findByText("Showing first 2,000 rows");
+        cy.icon("download").should("not.exist");
+      });
+    });
+
+    it("limits download results for a native question even if only one table has `limited` download permissions", () => {
+      setDownloadPermissionsForProductsTable("limited");
+
+      cy.signInAsNormalUser();
+
+      cy.get("@nativeQuestionId").then(id => {
+        visitQuestion(id);
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(10000),
+        );
+
+        // Ad-hoc nested query based on a native question should also have a download row limit
+        cy.findByText("Explore results").click();
+        cy.wait("@dataset");
+
+        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(10000));
+
+        // Convert question to a model, which should also have a download row limit
+        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
+
+        visitQuestion(id);
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(10000),
+        );
+      });
+    });
+  });
+});
+
+function setDownloadPermissionsForProductsTable(permission) {
+  cy.updatePermissionsGraph({
+    [ALL_USERS_GROUP]: {
+      [SAMPLE_DB_ID]: {
+        download: {
+          schemas: {
+            PUBLIC: {
+              [PRODUCTS_ID]: permission,
+              [ORDERS_ID]: "full",
+              [PEOPLE_ID]: "full",
+              [REVIEWS_ID]: "full",
+              [ACCOUNTS_ID]: "full",
+              [ANALYTIC_EVENTS_ID]: "full",
+              [FEEDBACK_ID]: "full",
+              [INVOICES_ID]: "full",
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/database-details-permissions.cy.spec.js
@@ -1,71 +1,286 @@
-import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
+import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
+import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
+import {
+  ORDERS_DASHBOARD_ID,
+  ORDERS_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import {
   restore,
   modal,
   describeEE,
   assertPermissionForItem,
   modifyPermission,
+  downloadAndAssert,
+  assertSheetRowsCount,
+  sidebar,
+  visitQuestion,
+  visitDashboard,
+  popover,
   setTokenFeatures,
 } from "e2e/support/helpers";
 
-const DETAILS_PERMISSION_INDEX = 4;
+const { ALL_USERS_GROUP } = USER_GROUPS;
 
-describeEE(
-  "scenarios > admin > permissions > database details permissions",
-  () => {
-    beforeEach(() => {
-      restore();
-      cy.signInAsAdmin();
-      setTokenFeatures("all");
+const {
+  PRODUCTS_ID,
+  ORDERS_ID,
+  PEOPLE_ID,
+  REVIEWS_ID,
+  ACCOUNTS_ID,
+  ANALYTIC_EVENTS_ID,
+  FEEDBACK_ID,
+  INVOICES_ID,
+} = SAMPLE_DATABASE;
+
+const DATA_ACCESS_PERMISSION_INDEX = 0;
+const DOWNLOAD_PERMISSION_INDEX = 2;
+
+describeEE("scenarios > admin > permissions > data > downloads", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    setTokenFeatures("all");
+  });
+
+  it("setting downloads permission UI flow should work", () => {
+    cy.log("allows changing download results permission for a database");
+
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+
+    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
     });
 
-    it("allows database managers to see and edit database details but not to delete a database (metabase#22293)", () => {
-      // As an admin, grant database details permissions to all users
-      cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
 
-      modifyPermission("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+    cy.log("Make sure we can change download results permission for a table");
 
-      cy.button("Save changes").click();
+    sidebar().contains("Orders").click();
 
-      modal().within(() => {
-        cy.findByText("Save permissions?");
-        cy.findByText("Are you sure you want to do this?");
-        cy.button("Yes").click();
-      });
+    modifyPermission("All Users", DOWNLOAD_PERMISSION_INDEX, "1 million rows");
 
-      assertPermissionForItem("All Users", DETAILS_PERMISSION_INDEX, "Yes");
+    cy.button("Save changes").click();
 
-      // Normal user should now have the ability to manage databases
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
+    });
+
+    assertPermissionForItem(
+      "All Users",
+      DOWNLOAD_PERMISSION_INDEX,
+      "1 million rows",
+    );
+  });
+
+  it("respects 'no download' permissions when 'All users' group data permissions are set to `Block` (metabase#22408)", () => {
+    cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
+
+    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Block");
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.findByText("Are you sure you want to do this?");
+      cy.button("Yes").click();
+    });
+
+    // When data permissions are set to `Block`, download permissions are automatically revoked
+    assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
+
+    // Normal user belongs to both "data" and "collections" groups.
+    // They both have restricted downloads so this user shouldn't have the right to download anything.
+    cy.signIn("normal");
+
+    visitQuestion(ORDERS_QUESTION_ID);
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Showing first 2,000 rows");
+    cy.icon("download").should("not.exist");
+  });
+
+  it("restricts users from downloading questions", () => {
+    // Restrict downloads for All Users
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [SAMPLE_DB_ID]: {
+          download: { schemas: "none" },
+        },
+      },
+    });
+
+    cy.signInAsNormalUser();
+
+    visitQuestion(ORDERS_QUESTION_ID);
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Showing first 2,000 rows");
+    cy.icon("download").should("not.exist");
+
+    visitDashboard(ORDERS_DASHBOARD_ID);
+
+    cy.findByTestId("dashcard").within(() => {
+      cy.findByTestId("legend-caption").realHover();
+      cy.findByTestId("dashcard-menu").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Edit question").should("be.visible");
+      cy.findByText("Download results").should("not.exist");
+    });
+  });
+
+  it("limits users from downloading all results", () => {
+    // Restrict downloads for All Users
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [SAMPLE_DB_ID]: {
+          download: { schemas: "limited" },
+        },
+      },
+    });
+
+    cy.signInAsNormalUser();
+    visitQuestion(ORDERS_QUESTION_ID);
+
+    downloadAndAssert(
+      { fileType: "xlsx", questionId: ORDERS_QUESTION_ID },
+      assertSheetRowsCount(10000),
+    );
+  });
+
+  describe("native questions", () => {
+    beforeEach(() => {
+      cy.intercept("POST", "/api/dataset").as("dataset");
+
+      cy.createNativeQuestion(
+        {
+          name: "Native Orders",
+          native: {
+            query: "select * from orders",
+          },
+        },
+        { wrapId: true, idAlias: "nativeQuestionId" },
+      );
+    });
+
+    it("lets user download results from native queries", () => {
       cy.signInAsNormalUser();
 
-      cy.visit("/");
-      cy.icon("gear").click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Admin settings").should("be.visible").click();
+      cy.get("@nativeQuestionId").then(id => {
+        visitQuestion(id);
 
-      cy.location("pathname").should("eq", "/admin/databases");
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(18760),
+        );
 
-      cy.get("nav")
-        .should("contain", "Databases")
-        .and("not.contain", "Settings")
-        .and("not.contain", "Data Model");
+        // Make sure we can download results from an ad-hoc nested query based on a native question
+        cy.findByText("Explore results").click();
+        cy.wait("@dataset");
 
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Sample Database").click();
+        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(18760));
 
-      cy.findByTestId("database-actions-panel")
-        .should("contain", "Sync database schema now")
-        .and("contain", "Re-scan field values now")
-        .and("contain", "Discard saved field values")
-        .and("not.contain", "Remove this database");
+        // Make sure we can download results from a native model
+        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
 
-      cy.request({
-        method: "DELETE",
-        url: `/api/database/${SAMPLE_DB_ID}`,
-        failOnStatusCode: false,
-      }).then(({ status }) => {
-        expect(status).to.eq(403);
+        visitQuestion(id);
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(18760),
+        );
       });
     });
-  },
-);
+
+    it("prevents user from downloading a native question even if only one table doesn't have download permissions", () => {
+      setDownloadPermissionsForProductsTable("none");
+
+      cy.signInAsNormalUser();
+
+      cy.get("@nativeQuestionId").then(id => {
+        visitQuestion(id);
+
+        cy.findByText("Showing first 2,000 rows");
+        cy.icon("download").should("not.exist");
+
+        // Ad-hoc nested query also shouldn't be downloadable
+        cy.findByText("Explore results").click();
+        cy.wait("@dataset");
+
+        cy.findByText("Showing first 2,000 rows");
+        cy.icon("download").should("not.exist");
+
+        // Convert question to a model, which also shouldn't be downloadable
+        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
+
+        visitQuestion(id);
+
+        cy.findByText("Showing first 2,000 rows");
+        cy.icon("download").should("not.exist");
+      });
+    });
+
+    it("limits download results for a native question even if only one table has `limited` download permissions", () => {
+      setDownloadPermissionsForProductsTable("limited");
+
+      cy.signInAsNormalUser();
+
+      cy.get("@nativeQuestionId").then(id => {
+        visitQuestion(id);
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(10000),
+        );
+
+        // Ad-hoc nested query based on a native question should also have a download row limit
+        cy.findByText("Explore results").click();
+        cy.wait("@dataset");
+
+        downloadAndAssert({ fileType: "xlsx" }, assertSheetRowsCount(10000));
+
+        // Convert question to a model, which should also have a download row limit
+        cy.request("PUT", `/api/card/${id}`, { name: "Native Model" });
+
+        visitQuestion(id);
+
+        downloadAndAssert(
+          { fileType: "xlsx", questionId: id },
+          assertSheetRowsCount(10000),
+        );
+      });
+    });
+  });
+});
+
+function setDownloadPermissionsForProductsTable(permission) {
+  cy.updatePermissionsGraph({
+    [ALL_USERS_GROUP]: {
+      [SAMPLE_DB_ID]: {
+        download: {
+          schemas: {
+            PUBLIC: {
+              [PRODUCTS_ID]: permission,
+              [ORDERS_ID]: "full",
+              [PEOPLE_ID]: "full",
+              [REVIEWS_ID]: "full",
+              [ACCOUNTS_ID]: "full",
+              [ANALYTIC_EVENTS_ID]: "full",
+              [FEEDBACK_ID]: "full",
+              [INVOICES_ID]: "full",
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
@@ -80,10 +80,10 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
     );
   });
 
-  it("respects 'no download' permissions when 'All users' group data permissions are set to `Blocked` (metabase#22408)", () => {
+  it("respects 'no download' permissions when 'All users' group data permissions are set to `Block` (metabase#22408)", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
-    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Blocked");
+    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Block");
 
     cy.button("Save changes").click();
 
@@ -93,7 +93,7 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       cy.button("Yes").click();
     });
 
-    // When data permissions are set to `Blocked`, download permissions are automatically revoked
+    // When data permissions are set to `Block`, download permissions are automatically revoked
     assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
 
     // Normal user belongs to both "data" and "collections" groups.

--- a/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
@@ -80,10 +80,10 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
     );
   });
 
-  it("respects 'no download' permissions when 'All users' group data permissions are set to `Block` (metabase#22408)", () => {
+  it("respects 'no download' permissions when 'All users' group data permissions are set to `Blocked` (metabase#22408)", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
-    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Block");
+    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Blocked");
 
     cy.button("Save changes").click();
 
@@ -93,7 +93,7 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
       cy.button("Yes").click();
     });
 
-    // When data permissions are set to `Block`, download permissions are automatically revoked
+    // When data permissions are set to `Blocked`, download permissions are automatically revoked
     assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
 
     // Normal user belongs to both "data" and "collections" groups.

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -127,7 +127,7 @@ describeEE("impersonated permission", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors
       cy.findByText(
-        'Groups with View data access set to "Blocked" can\'t create queries.',
+        "Native query editor access requires full data access.",
       ).should("not.exist");
 
       // Return back to the database view

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -127,7 +127,7 @@ describeEE("impersonated permission", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors
       cy.findByText(
-        "Native query editor access requires full data access.",
+        'Groups with View data access set to "Blocked" can\'t create queries.',
       ).should("not.exist");
 
       // Return back to the database view

--- a/e2e/test/scenarios/permissions/reproductions/13347-cannot-select-saved-question-in-database-without-data-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/13347-cannot-select-saved-question-in-database-without-data-permissions.cy.spec.js
@@ -15,11 +15,13 @@ describe.skip("issue 13347", { tags: "@external" }, () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         1: {
-          data: { schemas: "all", native: "write" },
           "view-data": "unrestricted",
           "create-queries": "query-builder-and-native",
         },
-        [PG_DB_ID]: { data: { schemas: "none", native: "none" } },
+        [PG_DB_ID]: {
+          "view-data": "unrestricted",
+          "create-queries": "no",
+        },
       },
     });
 

--- a/e2e/test/scenarios/permissions/reproductions/14873-regextract-in-sandboxed-table.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/14873-regextract-in-sandboxed-table.cy.spec.js
@@ -21,21 +21,18 @@ describeEE("postgres > user > query", { tags: "@external" }, () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         [PG_DB_ID]: {
-          data: { schemas: "none", native: "none" },
           "view-data": "blocked",
           "create-queries": "no",
         },
       },
       [DATA_GROUP]: {
         [PG_DB_ID]: {
-          data: { schemas: "all", native: "write" },
           "view-data": "unrestricted",
           "create-queries": "query-builder-and-native",
         },
       },
       [COLLECTION_GROUP]: {
         [PG_DB_ID]: {
-          data: { schemas: "none", native: "none" },
           "view-data": "blocked",
           "create-queries": "no",
         },

--- a/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -29,7 +29,7 @@ describeEE("issue 17763", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Blocked").click();
+    cy.findByText("Block").click();
 
     popover().contains("Granular").click();
 
@@ -39,10 +39,11 @@ describeEE("issue 17763", () => {
     );
 
     cy.findByTestId("permission-table").within(() => {
-      cy.findAllByText("Can view").first().click();
+      cy.findAllByText("No self-service").first().click();
     });
 
     popover().within(() => {
+      cy.findByText("Unrestricted");
       cy.findByText("Sandboxed");
     });
   });

--- a/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -39,11 +39,10 @@ describeEE("issue 17763", () => {
     );
 
     cy.findByTestId("permission-table").within(() => {
-      cy.findAllByText("No self-service").first().click();
+      cy.findAllByText("Unrestricted").first().click();
     });
 
     popover().within(() => {
-      cy.findByText("Unrestricted");
       cy.findByText("Sandboxed");
     });
   });

--- a/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -29,7 +29,7 @@ describeEE("issue 17763", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Block").click();
+    cy.findByText("Blocked").click();
 
     popover().contains("Granular").click();
 
@@ -39,7 +39,7 @@ describeEE("issue 17763", () => {
     );
 
     cy.findByTestId("permission-table").within(() => {
-      cy.findAllByText("Unrestricted").first().click();
+      cy.findAllByText("Can view").first().click();
     });
 
     popover().within(() => {

--- a/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -17,7 +17,6 @@ describeEE("issue 17763", () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         1: {
-          data: { schemas: "block", native: "none" },
           "view-data": "blocked",
           "create-queries": "no",
         },

--- a/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -29,7 +29,7 @@ describeEE("issue 17763", () => {
     cy.visit(`/admin/permissions/data/database/${SAMPLE_DB_ID}`);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Block").click();
+    cy.findByText("Blocked").click();
 
     popover().contains("Granular").click();
 
@@ -39,11 +39,10 @@ describeEE("issue 17763", () => {
     );
 
     cy.findByTestId("permission-table").within(() => {
-      cy.findAllByText("No self-service").first().click();
+      cy.findAllByText("Can view").first().click();
     });
 
     popover().within(() => {
-      cy.findByText("Unrestricted");
       cy.findByText("Sandboxed");
     });
   });

--- a/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
@@ -1,22 +1,16 @@
 import { USER_GROUPS } from "e2e/support/cypress_data";
-import {
-  describeEE,
-  restore,
-  popover,
-  setTokenFeatures,
-} from "e2e/support/helpers";
+import { restore, popover } from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
 const url = `/admin/permissions/data/group/${ALL_USERS_GROUP}`;
 
-describeEE("issue 20436", () => {
+describe("issue 20436", () => {
   beforeEach(() => {
     cy.intercept("PUT", "/api/permissions/graph").as("updatePermissions");
 
     restore();
     cy.signInAsAdmin();
-    setTokenFeatures("all");
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
@@ -31,30 +25,29 @@ describeEE("issue 20436", () => {
 
   it("should display correct permissions on the database level after changes on the table level (metabase#20436)", () => {
     cy.visit(url);
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Unrestricted");
 
-    cy.findByTestId("permission-table").within(() => {
-      cy.findByText("Query builder only").click();
-    });
-
-    popover().within(() => {
-      cy.findByText("Granular").click();
-    });
+    // Go the the view where we can change permissions for individual tables
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Sample Database").click();
 
     // Change the permission levels for ANY of the tables - it doesn't matter which one
-    changePermissions("Query builder only", "No");
+    changePermissions("Unrestricted", "No self-service");
 
+    cy.button("Change").click();
     saveChanges();
     cy.wait("@updatePermissions");
 
-    // Now turn it back to previous value
-    changePermissions("No", "Query builder only");
+    // Now turn it back to the "Unrestricted" access
+    changePermissions("No self-service", "Unrestricted");
 
     saveChanges();
     cy.wait("@updatePermissions");
 
     cy.visit(url);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Query builder only");
+    cy.findByText("Unrestricted");
   });
 });
 

--- a/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
@@ -21,7 +21,6 @@ describeEE("issue 20436", () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         1: {
-          data: { schemas: "all", native: "none" },
           "view-data": "unrestricted",
           "create-queries": "query-builder",
         },

--- a/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
@@ -41,13 +41,13 @@ describeEE("issue 20436", () => {
     });
 
     // Change the permission levels for ANY of the tables - it doesn't matter which one
-    changePermissions("No", "Query builder only");
+    changePermissions("Query builder only", "No");
 
     saveChanges();
     cy.wait("@updatePermissions");
 
-    // Now turn it back to the "Unrestricted" access
-    changePermissions("Query builder only", "No");
+    // Now turn it back to previous value
+    changePermissions("No", "Query builder only");
 
     saveChanges();
     cy.wait("@updatePermissions");

--- a/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
@@ -1,16 +1,22 @@
 import { USER_GROUPS } from "e2e/support/cypress_data";
-import { restore, popover } from "e2e/support/helpers";
+import {
+  describeEE,
+  restore,
+  popover,
+  setTokenFeatures,
+} from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
 const url = `/admin/permissions/data/group/${ALL_USERS_GROUP}`;
 
-describe("issue 20436", () => {
+describeEE("issue 20436", () => {
   beforeEach(() => {
     cy.intercept("PUT", "/api/permissions/graph").as("updatePermissions");
 
     restore();
     cy.signInAsAdmin();
+    setTokenFeatures("all");
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
@@ -25,29 +31,30 @@ describe("issue 20436", () => {
 
   it("should display correct permissions on the database level after changes on the table level (metabase#20436)", () => {
     cy.visit(url);
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Unrestricted");
 
-    // Go the the view where we can change permissions for individual tables
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Sample Database").click();
+    cy.findByTestId("permission-table").within(() => {
+      cy.findByText("Query builder only").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Granular").click();
+    });
 
     // Change the permission levels for ANY of the tables - it doesn't matter which one
-    changePermissions("Unrestricted", "No self-service");
+    changePermissions("No", "Query builder only");
 
-    cy.button("Change").click();
     saveChanges();
     cy.wait("@updatePermissions");
 
     // Now turn it back to the "Unrestricted" access
-    changePermissions("No self-service", "Unrestricted");
+    changePermissions("Query builder only", "No");
 
     saveChanges();
     cy.wait("@updatePermissions");
 
     cy.visit(url);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Unrestricted");
+    cy.findByText("Query builder only");
   });
 });
 

--- a/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
@@ -1,16 +1,22 @@
 import { USER_GROUPS } from "e2e/support/cypress_data";
-import { restore, popover } from "e2e/support/helpers";
+import {
+  describeEE,
+  restore,
+  popover,
+  setTokenFeatures,
+} from "e2e/support/helpers";
 
 const { ALL_USERS_GROUP } = USER_GROUPS;
 
 const url = `/admin/permissions/data/group/${ALL_USERS_GROUP}`;
 
-describe("issue 20436", () => {
+describeEE("issue 20436", () => {
   beforeEach(() => {
     cy.intercept("PUT", "/api/permissions/graph").as("updatePermissions");
 
     restore();
     cy.signInAsAdmin();
+    setTokenFeatures("all");
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
@@ -25,29 +31,30 @@ describe("issue 20436", () => {
 
   it("should display correct permissions on the database level after changes on the table level (metabase#20436)", () => {
     cy.visit(url);
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Unrestricted");
 
-    // Go the the view where we can change permissions for individual tables
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Sample Database").click();
+    cy.findByTestId("permission-table").within(() => {
+      cy.findByText("Query builder only").click();
+    });
+
+    popover().within(() => {
+      cy.findByText("Granular").click();
+    });
 
     // Change the permission levels for ANY of the tables - it doesn't matter which one
-    changePermissions("Unrestricted", "No self-service");
+    changePermissions("Query builder only", "No");
 
-    cy.button("Change").click();
     saveChanges();
     cy.wait("@updatePermissions");
 
-    // Now turn it back to the "Unrestricted" access
-    changePermissions("No self-service", "Unrestricted");
+    // Now turn it back to previous value
+    changePermissions("No", "Query builder only");
 
     saveChanges();
     cy.wait("@updatePermissions");
 
     cy.visit(url);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Unrestricted");
+    cy.findByText("Query builder only");
   });
 });
 

--- a/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
@@ -63,10 +63,10 @@ describe("UI elements that make no sense for users without data permissions (met
     setTokenFeatures("all");
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
-        [SAMPLE_DB_ID]: { data: { schemas: "block" }, "view-data": "blocked" },
+        [SAMPLE_DB_ID]: { "view-data": "blocked" },
       },
       [COLLECTION_GROUP]: {
-        [SAMPLE_DB_ID]: { data: { schemas: "block" }, "view-data": "blocked" },
+        [SAMPLE_DB_ID]: { "view-data": "blocked" },
       },
     });
 

--- a/e2e/test/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
@@ -13,10 +13,10 @@ describeEE("issue 22695 ", () => {
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
-        [SAMPLE_DB_ID]: { data: { schemas: "block" }, "view-data": "blocked" },
+        [SAMPLE_DB_ID]: { "view-data": "blocked" },
       },
       [DATA_GROUP]: {
-        [SAMPLE_DB_ID]: { data: { schemas: "block" }, "view-data": "blocked" },
+        [SAMPLE_DB_ID]: { "view-data": "blocked" },
       },
     });
   });

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
@@ -30,9 +30,7 @@
                                             (when group-id [:= :group_id group-id])
                                             (when-not audit-db? [:not [:= :db_id config/audit-db-id]])]})]
      (reduce (fn [acc {:keys [db_id group_id]}]
-               (-> acc
-                  (assoc-in [group_id db_id :view-data] :impersonated)
-                  (assoc-in [group_id db_id :data] {:schemas :impersonated})))
+                (assoc-in acc [group_id db_id :view-data] :impersonated))
              {}
              impersonations))))
 

--- a/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
@@ -62,17 +62,13 @@
   But it's cleaner to keep the audit DB permission paths in the database consistent."
   :feature :audit-app
   [group-id changes]
-  (let [[change-id type] (first (filter #(= (first %) (:id (default-audit-collection))) changes))]
+  (let [[change-id tyype] (first (filter #(= (first %) (:id (default-audit-collection))) changes))]
       (when change-id
-        (let [data-access-value (case type
-                                  :read  :unrestricted
-                                  :none  :no-self-service
-                                  :write (throw (ex-info (tru (str "Unable to make audit collections writable."))
-                                                         {:status-code 400})))
-              create-queries-value (case type
-                                     :read :query-builder
-                                     :none :no)
+        (let [create-queries-value (case tyype
+                                     :read  :query-builder
+                                     :none  :no
+                                     :write (throw (ex-info (tru (str "Unable to make audit collections writable."))
+                                                            {:status-code 400})))
               view-tables         (t2/select :model/Table :db_id perms/audit-db-id :name [:in audit-db-view-names])]
           (doseq [table view-tables]
-            (data-perms/set-table-permission! group-id table :perms/data-access data-access-value)
             (data-perms/set-table-permission! group-id table :perms/create-queries create-queries-value))))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -72,7 +72,7 @@
     (if sandboxed-perms?
       (maybe-filter-fields
        table
-       (data-perms/with-additional-table-permission :perms/data-access (:db_id table) (u/the-id table) :unrestricted
+       (data-perms/with-additional-table-permission :perms/view-data (:db_id table) (u/the-id table) :unrestricted
          (data-perms/with-additional-table-permission :perms/create-queries (:db_id table) (u/the-id table) :query-builder
            (thunk))))
       (thunk))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/permissions/delete_sandboxes.clj
@@ -63,12 +63,13 @@
 (defn- delete-gtaps-for-group-database! [{:keys [group-id database-id], :as context} changes]
   (log/debugf "Deleting unneeded GTAPs for Group %d for Database %d. Graph changes: %s"
               group-id database-id (pr-str changes))
-  (if (#{:unrestricted :blocked :impersonated} changes)
+  (if (#{:unrestricted :legacy-no-self-service :blocked :impersonated} changes)
     (do
       (log/debugf "Group %d %s for Database %d, deleting all GTAPs for this DB"
                   group-id
                   (case changes
                     :unrestricted "now has full data perms"
+                    :legacy-no-self-service "now has full data perms"
                     :blocked      "is now BLOCKED from all non-data-perms access"
                     :impersonated "is now using connection impersonation")
                   database-id)

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -655,8 +655,8 @@
 (deftest fetch-db-test
   (t2.with-temp/with-temp [Database {db-id :id}]
     (testing "A non-admin without self-service perms for a DB cannot fetch the DB normally"
-      (mt/with-all-users-data-perms-graph! {db-id {:data {:view-data      :unrestricted
-                                                          :create-queries :no}}}
+      (mt/with-all-users-data-perms-graph! {db-id {:view-data      :unrestricted
+                                                   :create-queries :no}}
         (mt/user-http-request :rasta :get 403 (format "database/%d?exclude_uneditable_details=true" db-id))))
 
     (testing "A non-admin without self-service perms for a DB can fetch the DB if they have DB details permissions"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -92,7 +92,7 @@
           (testing "group has existing data permissions... :block should remove them"
             (mt/with-model-cleanup [Permissions]
               (mt/with-restored-data-perms-for-group! group-id
-                (data-perms/set-database-permission! group-id (mt/id) :perms/data-access :unrestricted)
+                (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :unrestricted)
                 (grant! group-id)
                 (is (nil? (test-db-perms group-id)))
                 (is (= #{:blocked}
@@ -104,7 +104,7 @@
                                                   [:= :perm_type (u/qualified-name :perms/view-data)]]})))))))))))
 
 (deftest update-graph-delete-sandboxes-test
-  (testing "When setting `:block` permissions any GTAP rows for that Group/Database should get deleted."
+  (testing "When setting `:blocked` permissions any GTAP rows for that Group/Database should get deleted."
     (mt/with-premium-features #{:sandboxes :advanced-permissions}
       (mt/with-model-cleanup [Permissions]
         (mt/with-temp [PermissionsGroup       {group-id :id} {}
@@ -120,7 +120,7 @@
      (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :blocked)
      (is (nil? (test-db-perms group-id)))
      (data-perms/set-table-permission! group-id (mt/id :venues) :perms/view-data :unrestricted)
-     (is (= {"PUBLIC" {(mt/id :venues) :unrestricted}}
+     (is (= {"PUBLIC" :unrestricted}
             (test-db-perms group-id))))))
 
 (deftest update-graph-disallow-native-query-perms-test

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -59,9 +59,7 @@
           "Cards should be created for Audit DB when the content is there."))
 
     (testing "Audit DB starts with no permissions for all users"
-      (is (= {:perms/native-query-editing  :no
-              :perms/manage-database       :no
-              :perms/data-access           :no-self-service
+      (is (= {:perms/manage-database       :no
               :perms/download-results      :one-million-rows
               :perms/manage-table-metadata :no
               :perms/view-data             :unrestricted

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -238,13 +238,12 @@
         (with-gtap-cleanup
           (testing "Test that we can create a new sandbox using the permission graph API"
             (let [graph  (-> (data-perms.graph/api-graph)
-                             (assoc-in [:groups group-id (mt/id) :data :schemas "PUBLIC" table-id-1 :query] :segmented)
+                             (assoc-in [:groups group-id (mt/id) :view-data] {"PUBLIC" {table-id-1 :sandboxed}})
                              (assoc :sandboxes [{:table_id             table-id-1
                                                  :group_id             group-id
                                                  :card_id              card-id-1
                                                  :attribute_remappings {"foo" 1}}]))
                   result (mt/user-http-request :crowberto :put 200 "permissions/graph" graph)]
-              (def graph graph)
               (is (=? [{:id                   (mt/malli=? :int)
                         :table_id             table-id-1
                         :group_id             group-id
@@ -276,7 +275,7 @@
                                                   :table_id table-id-1
                                                   :group_id group-id)
                   graph       (-> (data-perms.graph/api-graph)
-                                  (assoc-in [:groups group-id (mt/id) :data :schemas "PUBLIC" table-id-2 :query] :segmented)
+                                  (assoc-in [:groups group-id (mt/id) :view-data] {"PUBLIC" {table-id-2 :sandboxed}})
                                   (assoc :sandboxes [{:id                   sandbox-id
                                                       :card_id              card-id-1
                                                       :attribute_remappings {"foo" 3}}

--- a/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
@@ -25,8 +25,8 @@
   (testing "Pulses should get sent with the row-level restrictions of the User that created them."
     (letfn [(send-pulse-created-by-user! [user-kw]
               (met/with-gtaps! {:gtaps      {:venues {:query      (mt/mbql-query venues)
-                                                     :remappings {:cat ["variable" [:field (mt/id :venues :category_id) nil]]}}}
-                               :attributes {"cat" 50}}
+                                                      :remappings {:cat ["variable" [:field (mt/id :venues :category_id) nil]]}}}
+                                :attributes {"cat" 50}}
                 (t2.with-temp/with-temp [Card card {:dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
                   ;; `with-gtaps!` binds the current test user; we don't want that falsely affecting results
                   (mt/with-test-user nil
@@ -168,7 +168,7 @@
 (deftest user-attributes-test
   (testing "Pulses should be sandboxed correctly by User login_attributes"
     (met/with-gtaps! {:gtaps      {:venues {:remappings {:price [:dimension [:field (mt/id :venues :price) nil]]}}}
-                     :attributes {"price" "1"}}
+                      :attributes {"price" "1"}}
       (let [query (mt/mbql-query venues)]
         (mt/with-test-user :rasta
           (t2.with-temp/with-temp [Card card {:dataset_query query}]
@@ -188,7 +188,7 @@
 (deftest pulse-preview-test
   (testing "Pulse preview endpoints should be sandboxed"
     (met/with-gtaps! {:gtaps      {:venues {:remappings {:price [:dimension [:field (mt/id :venues :price) nil]]}}}
-                     :attributes {"price" "1"}}
+                      :attributes {"price" "1"}}
       (let [query (mt/mbql-query venues)]
         (mt/with-test-user :rasta
           (t2.with-temp/with-temp [Card card {:dataset_query query}]
@@ -217,7 +217,7 @@
 (deftest csv-downloads-test
   (testing "CSV/XLSX downloads should be sandboxed"
     (met/with-gtaps! {:gtaps      {:venues {:remappings {:price [:dimension [:field (mt/id :venues :price) nil]]}}}
-                     :attributes {"price" "1"}}
+                      :attributes {"price" "1"}}
       (let [query (mt/mbql-query venues)]
         (mt/with-test-user :rasta
           (mt/with-temp [Card                 {card-id :id}  {:dataset_query query}

--- a/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
@@ -48,9 +48,8 @@
                                                                 :table_id             (data/id table-kw)
                                                                 :card_id              card-id
                                                                 :attribute_remappings remappings}]
-           (data-perms/set-table-permission! group (data/id table-kw) :perms/data-access :unrestricted)
-           (data-perms/set-table-permission! group (data/id table-kw) :perms/create-queries :query-builder)
            (data-perms/set-database-permission! group (data/id) :perms/view-data :unrestricted)
+           (data-perms/set-table-permission! group (data/id table-kw) :perms/create-queries :query-builder)
            (do-with-gtap-defs! group more f)))))))
 
 (def ^:private WithGTAPsArgs

--- a/enterprise/backend/test/metabase_enterprise/snippet_collections/api/native_query_snippet_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/snippet_collections/api/native_query_snippet_test.clj
@@ -20,7 +20,7 @@
   (mt/with-non-admin-groups-no-root-collection-for-namespace-perms "snippets"
     (t2.with-temp/with-temp [Collection      normal-collection {:name "Normal Collection", :namespace "snippets"}]
       ;; A user needs native query permissions on *any* database (among other things, in EE) to read/edit/create a NativeQuerySnippet
-      (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/native-query-editing :yes)
+      (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :query-builder-and-native)
       ;; run tests with both a normal Collection and the Root Collection
       (doseq [{collection-name :name, :as collection} [normal-collection root-collection]]
         (testing (format "\nSnippet in %s" collection-name)
@@ -103,7 +103,7 @@
         (mt/with-temp [Collection source {:name "Current Parent Collection", :namespace "snippets"}
                        Collection dest   {:name "New Parent Collection", :namespace "snippets"}]
           ;; A user needs native query permissions on *any* database (among other things, in EE) to read/edit/create a NativeQuerySnippet
-          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/native-query-editing :yes)
+          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :query-builder-and-native)
           (doseq [source-collection [source root-collection]]
             (t2.with-temp/with-temp [NativeQuerySnippet snippet {:collection_id (:id source-collection)}]
               (doseq [dest-collection [dest root-collection]]

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
@@ -105,17 +105,19 @@ const _ImpersonationModal = ({ route, params }: ImpersonationModalProps) => {
         }),
       );
 
-      dispatch(
-        updateImpersonation({
-          attribute,
-          db_id: databaseId,
-          group_id: groupId,
-        }),
-      );
+      if (attribute !== selectedAttribute) {
+        dispatch(
+          updateImpersonation({
+            attribute,
+            db_id: databaseId,
+            group_id: groupId,
+          }),
+        );
+      }
 
       close();
     },
-    [close, databaseId, dispatch, groupId],
+    [close, databaseId, dispatch, groupId, selectedAttribute],
   );
 
   const handleCancel = useCallback(() => {

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
@@ -5,6 +5,11 @@ import { push } from "react-router-redux";
 import { useAsyncFn, useMount } from "react-use";
 
 import { updateDataPermission } from "metabase/admin/permissions/permissions";
+import {
+  DataPermission,
+  DataPermissionType,
+  DataPermissionValue,
+} from "metabase/admin/permissions/types";
 import { useDatabaseQuery } from "metabase/common/hooks";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper/LoadingAndErrorWrapper";
 import { getParentPath } from "metabase/hoc/ModalRoute";
@@ -91,8 +96,11 @@ const _ImpersonationModal = ({ route, params }: ImpersonationModalProps) => {
       dispatch(
         updateDataPermission({
           groupId,
-          permission: { type: "access", permission: "view-data" },
-          value: "impersonated",
+          permission: {
+            type: DataPermissionType.ACCESS,
+            permission: DataPermission.VIEW_DATA,
+          },
+          value: DataPermissionValue.IMPERSONATED,
           entityId: { databaseId },
         }),
       );

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
@@ -91,7 +91,7 @@ const _ImpersonationModal = ({ route, params }: ImpersonationModalProps) => {
       dispatch(
         updateDataPermission({
           groupId,
-          permission: { type: "access", permission: "data" },
+          permission: { type: "access", permission: "view-data" },
           value: "impersonated",
           entityId: { databaseId },
         }),

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/components/ImpersonationModal/ImpersonationModal.tsx
@@ -97,18 +97,17 @@ const _ImpersonationModal = ({ route, params }: ImpersonationModalProps) => {
         }),
       );
 
-      if (attribute !== selectedAttribute) {
-        dispatch(
-          updateImpersonation({
-            attribute,
-            db_id: databaseId,
-            group_id: groupId,
-          }),
-        );
-      }
+      dispatch(
+        updateImpersonation({
+          attribute,
+          db_id: databaseId,
+          group_id: groupId,
+        }),
+      );
+
       close();
     },
-    [close, databaseId, dispatch, groupId, selectedAttribute],
+    [close, databaseId, dispatch, groupId],
   );
 
   const handleCancel = useCallback(() => {

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
@@ -1,6 +1,11 @@
+import _ from "underscore";
+
+import type {
+  DatabaseEntityId,
+  TableEntityId,
+} from "metabase/admin/permissions/types";
 import {
   DataPermission,
-  DatabaseEntityId,
   DataPermissionValue,
 } from "metabase/admin/permissions/types";
 import {
@@ -14,7 +19,7 @@ import type { GroupsPermissions, NativePermissions } from "metabase-types/api";
 export function updateNativePermission(
   permissions: GroupsPermissions,
   groupId: number,
-  entityId: DatabaseEntityId,
+  entityId: DatabaseEntityId & TableEntityId,
   value: NativePermissions,
   database: Database,
   permission: DataPermission,
@@ -46,7 +51,7 @@ export function updateNativePermission(
     groupId,
     entityId.databaseId,
     permission,
-    [],
+    _.compact([(entityId as any).schemaName, (entityId as any).tableId]),
     value,
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
@@ -25,12 +25,12 @@ export function updateNativePermission(
     permission,
   );
 
-  if (value === "write" && schemasPermission !== "impersonated") {
+  if (value !== "no" && schemasPermission !== "impersonated") {
     permissions = updateSchemasPermission(
       permissions,
       groupId,
       { databaseId: entityId.databaseId },
-      "all",
+      "unrestricted",
       database,
       permission,
       false,
@@ -39,7 +39,9 @@ export function updateNativePermission(
   return updatePermission(
     permissions,
     groupId,
-    [entityId.databaseId, permission, "native"],
+    entityId.databaseId,
+    permission,
+    [],
     value,
   );
 }

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
@@ -12,19 +12,14 @@ import {
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { GroupsPermissions, NativePermissions } from "metabase-types/api";
 
-// TODO: rename this as it's more about downgrading certain permissions...
-// likely downgradeNativePermissionsIfNeeded should be a more generic function like
-// downgradePermissionsIfNeeded which could downgrade any other permission in response to one changing
-// -- with that, it seems like it could just be an array of predicates that if match call and update function
-
-export function updateNativePermission(
+export function upgradeViewPermissionsIfNeeded(
   permissions: GroupsPermissions,
   groupId: number,
   entityId: DatabaseEntityId,
   value: NativePermissions,
   database: Database,
 ) {
-  const schemasPermission = getSchemasPermission(
+  const dbPermission = getSchemasPermission(
     permissions,
     groupId,
     { databaseId: entityId.databaseId },
@@ -33,7 +28,7 @@ export function updateNativePermission(
 
   if (
     value === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
-    schemasPermission !== DataPermissionValue.IMPERSONATED
+    dbPermission !== DataPermissionValue.IMPERSONATED
   ) {
     permissions = updateSchemasPermission(
       permissions,
@@ -45,4 +40,6 @@ export function updateNativePermission(
       false,
     );
   }
+
+  return permissions;
 }

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
@@ -12,7 +12,11 @@ import {
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { GroupsPermissions, NativePermissions } from "metabase-types/api";
 
-// TODO: rename this as it's more about downgrading certain permissions at this point
+// TODO: rename this as it's more about downgrading certain permissions...
+// likely downgradeNativePermissionsIfNeeded should be a more generic function like
+// downgradePermissionsIfNeeded which could downgrade any other permission in response to one changing
+// -- with that, it seems like it could just be an array of predicates that if match call and update function
+
 export function updateNativePermission(
   permissions: GroupsPermissions,
   groupId: number,

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
@@ -1,9 +1,6 @@
 import _ from "underscore";
 
-import type {
-  DatabaseEntityId,
-  TableEntityId,
-} from "metabase/admin/permissions/types";
+import type { DatabaseEntityId } from "metabase/admin/permissions/types";
 import {
   DataPermission,
   DataPermissionValue,
@@ -19,7 +16,7 @@ import type { GroupsPermissions, NativePermissions } from "metabase-types/api";
 export function updateNativePermission(
   permissions: GroupsPermissions,
   groupId: number,
-  entityId: DatabaseEntityId & TableEntityId,
+  entityId: DatabaseEntityId,
   value: NativePermissions,
   database: Database,
 ) {

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
@@ -1,6 +1,9 @@
 import _ from "underscore";
 
-import type { DatabaseEntityId } from "metabase/admin/permissions/types";
+import type {
+  DatabaseEntityId,
+  EntityId,
+} from "metabase/admin/permissions/types";
 import {
   DataPermission,
   DataPermissionValue,
@@ -11,6 +14,27 @@ import {
 } from "metabase/admin/permissions/utils/graph";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { GroupsPermissions, NativePermissions } from "metabase-types/api";
+
+export function shouldRestrictNativeQueryPermissions(
+  permissions: GroupsPermissions,
+  groupId: number,
+  entityId: EntityId,
+  _permission: DataPermission,
+  value: DataPermissionValue,
+  _database: Database,
+) {
+  const currDbNativePermission = getSchemasPermission(
+    permissions,
+    groupId,
+    { databaseId: entityId.databaseId },
+    DataPermission.CREATE_QUERIES,
+  );
+
+  return (
+    value === DataPermissionValue.SANDBOXED &&
+    currDbNativePermission === DataPermissionValue.QUERY_BUILDER_AND_NATIVE
+  );
+}
 
 export function upgradeViewPermissionsIfNeeded(
   permissions: GroupsPermissions,

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
@@ -1,6 +1,7 @@
-import type {
+import {
   DataPermission,
   DatabaseEntityId,
+  DataPermissionValue,
 } from "metabase/admin/permissions/types";
 import {
   getSchemasPermission,
@@ -22,17 +23,21 @@ export function updateNativePermission(
     permissions,
     groupId,
     entityId,
-    permission,
+    DataPermission.VIEW_DATA,
   );
 
-  if (value !== "no" && schemasPermission !== "impersonated") {
+  if (
+    (value === DataPermissionValue.QUERY_BUILDER_AND_NATIVE ||
+      value === DataPermissionValue.QUERY_BUILDER) &&
+    schemasPermission !== DataPermissionValue.IMPERSONATED
+  ) {
     permissions = updateSchemasPermission(
       permissions,
       groupId,
       { databaseId: entityId.databaseId },
-      "unrestricted",
+      DataPermissionValue.UNRESTRICTED,
       database,
-      permission,
+      DataPermission.VIEW_DATA,
       false,
     );
   }

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.ts
@@ -10,48 +10,38 @@ import {
 } from "metabase/admin/permissions/types";
 import {
   getSchemasPermission,
-  updatePermission,
   updateSchemasPermission,
 } from "metabase/admin/permissions/utils/graph";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type { GroupsPermissions, NativePermissions } from "metabase-types/api";
 
+// TODO: rename this as it's more about downgrading certain permissions at this point
 export function updateNativePermission(
   permissions: GroupsPermissions,
   groupId: number,
   entityId: DatabaseEntityId & TableEntityId,
   value: NativePermissions,
   database: Database,
-  permission: DataPermission,
 ) {
   const schemasPermission = getSchemasPermission(
     permissions,
     groupId,
-    entityId,
+    { databaseId: entityId.databaseId },
     DataPermission.VIEW_DATA,
   );
 
   if (
-    (value === DataPermissionValue.QUERY_BUILDER_AND_NATIVE ||
-      value === DataPermissionValue.QUERY_BUILDER) &&
+    value === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
     schemasPermission !== DataPermissionValue.IMPERSONATED
   ) {
     permissions = updateSchemasPermission(
       permissions,
       groupId,
-      { databaseId: entityId.databaseId },
+      entityId,
       DataPermissionValue.UNRESTRICTED,
       database,
       DataPermission.VIEW_DATA,
       false,
     );
   }
-  return updatePermission(
-    permissions,
-    groupId,
-    entityId.databaseId,
-    permission,
-    _.compact([(entityId as any).schemaName, (entityId as any).tableId]),
-    value,
-  );
 }

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.unit.spec.ts
@@ -45,7 +45,6 @@ describe("updateNativePermission", () => {
       entityId,
       DataPermissionValue.NO,
       database,
-      DataPermission.CREATE_QUERIES,
     );
 
     expect(updatedGraph).toStrictEqual({
@@ -69,7 +68,6 @@ describe("updateNativePermission", () => {
       entityId,
       DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
       database,
-      DataPermission.CREATE_QUERIES,
     );
 
     expect(updatedGraph).toStrictEqual({
@@ -98,7 +96,6 @@ describe("updateNativePermission", () => {
         entityId,
         DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
         database,
-        DataPermission.CREATE_QUERIES,
       );
 
       expect(updatedGraph).toStrictEqual({
@@ -121,7 +118,6 @@ describe("updateNativePermission", () => {
       entityId,
       DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
       database,
-      DataPermission.CREATE_QUERIES,
     );
 
     expect(updatedGraph).toStrictEqual({

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.unit.spec.ts
@@ -1,10 +1,10 @@
-import Database from "metabase-lib/v1/metadata/Database";
-import type { SchemasPermissions, NativePermissions } from "metabase-types/api";
-import { createMockDatabase } from "metabase-types/api/mocks";
 import {
   DataPermission,
   DataPermissionValue,
 } from "metabase/admin/permissions/types";
+import Database from "metabase-lib/v1/metadata/Database";
+import type { SchemasPermissions, NativePermissions } from "metabase-types/api";
+import { createMockDatabase } from "metabase-types/api/mocks";
 
 import { updateNativePermission } from "./graph";
 const groupId = 10;

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/graph.unit.spec.ts
@@ -30,7 +30,7 @@ describe("updateNativePermission", () => {
       entityId,
       undefined,
       database,
-      "data",
+      "view-data",
     );
 
     expect(updatedGraph).toStrictEqual({
@@ -48,7 +48,7 @@ describe("updateNativePermission", () => {
       entityId,
       "write",
       database,
-      "data",
+      "view-data",
     );
 
     expect(updatedGraph).toStrictEqual({
@@ -79,7 +79,7 @@ describe("updateNativePermission", () => {
         entityId,
         "write",
         database,
-        "data",
+        "view-data",
       );
 
       expect(updatedGraph).toStrictEqual({
@@ -98,7 +98,7 @@ describe("updateNativePermission", () => {
       entityId,
       "write",
       database,
-      "data",
+      "view-data",
     );
 
     expect(updatedGraph).toStrictEqual({

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -31,7 +31,7 @@ const IMPERSONATED_PERMISSION_OPTION = {
 
 const BLOCK_PERMISSION_OPTION = {
   label: t`Block`,
-  value: "block",
+  value: "blocked",
   icon: "close",
   iconColor: "danger",
 };
@@ -81,17 +81,6 @@ if (hasPremiumFeature("advanced_permissions")) {
 
   PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission = value =>
     value === BLOCK_PERMISSION_OPTION.value;
-
-  PLUGIN_ADVANCED_PERMISSIONS.getDatabaseLimitedAccessPermission = value => {
-    if (
-      value === BLOCK_PERMISSION_OPTION.value ||
-      value === IMPERSONATED_PERMISSION_OPTION.value
-    ) {
-      return "none";
-    }
-
-    return null;
-  };
 
   PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled = (value, subject) => {
     return (

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -19,7 +19,10 @@ import {
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { ImpersonationModal } from "./components/ImpersonationModal";
-import { upgradeViewPermissionsIfNeeded } from "./graph";
+import {
+  upgradeViewPermissionsIfNeeded,
+  shouldRestrictNativeQueryPermissions,
+} from "./graph";
 import { getImpersonatedPostAction, advancedPermissionsSlice } from "./reducer";
 import { getImpersonations } from "./selectors";
 
@@ -116,6 +119,9 @@ if (hasPremiumFeature("advanced_permissions")) {
 
   PLUGIN_DATA_PERMISSIONS.upgradeViewPermissionsIfNeeded =
     upgradeViewPermissionsIfNeeded;
+
+  PLUGIN_DATA_PERMISSIONS.shouldRestrictNativeQueryPermissions =
+    shouldRestrictNativeQueryPermissions;
 }
 
 const getDatabaseViewImpersonationModalUrl = (entityId, groupId) => {

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -86,10 +86,7 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled = (value, subject) => {
     return (
       ["tables", "fields"].includes(subject) &&
-      [
-        BLOCK_PERMISSION_OPTION.value,
-        IMPERSONATED_PERMISSION_OPTION.value,
-      ].includes(value)
+      [IMPERSONATED_PERMISSION_OPTION.value].includes(value)
     );
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -19,7 +19,7 @@ import {
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import { ImpersonationModal } from "./components/ImpersonationModal";
-import { updateNativePermission } from "./graph";
+import { upgradeViewPermissionsIfNeeded } from "./graph";
 import { getImpersonatedPostAction, advancedPermissionsSlice } from "./reducer";
 import { getImpersonations } from "./selectors";
 
@@ -114,7 +114,8 @@ if (hasPremiumFeature("advanced_permissions")) {
       push(getEditImpersonationUrl(entityId, groupId, view)),
   });
 
-  PLUGIN_DATA_PERMISSIONS.updateNativePermission = updateNativePermission;
+  PLUGIN_DATA_PERMISSIONS.upgradeViewPermissionsIfNeeded =
+    upgradeViewPermissionsIfNeeded;
 }
 
 const getDatabaseViewImpersonationModalUrl = (entityId, groupId) => {

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -100,7 +100,9 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled = (value, subject) => {
     return (
       ["tables", "fields"].includes(subject) &&
-      DataPermissionValue.IMPERSONATED === value
+      [DataPermissionValue.BLOCKED, DataPermissionValue.IMPERSONATED].includes(
+        value,
+      )
     );
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -86,6 +86,17 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_ADVANCED_PERMISSIONS.isBlockPermission = value =>
     value === BLOCK_PERMISSION_OPTION.value;
 
+  PLUGIN_ADVANCED_PERMISSIONS.getDatabaseLimitedAccessPermission = value => {
+    if (
+      value === BLOCK_PERMISSION_OPTION.value ||
+      value === IMPERSONATED_PERMISSION_OPTION.value
+    ) {
+      return DataPermissionValue.UNRESTRICTED;
+    }
+
+    return null;
+  };
+
   PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled = (value, subject) => {
     return (
       ["tables", "fields"].includes(subject) &&

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -89,7 +89,7 @@ if (hasPremiumFeature("advanced_permissions")) {
   PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled = (value, subject) => {
     return (
       ["tables", "fields"].includes(subject) &&
-      [IMPERSONATED_PERMISSION_OPTION.value].includes(value)
+      DataPermissionValue.IMPERSONATED === value
     );
   };
 

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -1,11 +1,11 @@
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 import {
   getDatabaseFocusPermissionsUrl,
   getGroupFocusPermissionsUrl,
 } from "metabase/admin/permissions/utils/urls";
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 import {
   PLUGIN_REDUCERS,
@@ -31,7 +31,7 @@ const IMPERSONATED_PERMISSION_OPTION = {
 };
 
 const BLOCK_PERMISSION_OPTION = {
-  label: t`Block`,
+  label: t`Blocked`,
   value: DataPermissionValue.BLOCKED,
   icon: "close",
   iconColor: "danger",

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -5,6 +5,7 @@ import {
   getDatabaseFocusPermissionsUrl,
   getGroupFocusPermissionsUrl,
 } from "metabase/admin/permissions/utils/urls";
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { ModalRoute } from "metabase/hoc/ModalRoute";
 import {
   PLUGIN_REDUCERS,
@@ -24,14 +25,14 @@ import { getImpersonations } from "./selectors";
 
 const IMPERSONATED_PERMISSION_OPTION = {
   label: t`Impersonated`,
-  value: "impersonated",
+  value: DataPermissionValue.IMPERSONATED,
   icon: "database",
   iconColor: "warning",
 };
 
 const BLOCK_PERMISSION_OPTION = {
   label: t`Block`,
-  value: "blocked",
+  value: DataPermissionValue.BLOCKED,
   icon: "close",
   iconColor: "danger",
 };
@@ -92,8 +93,9 @@ if (hasPremiumFeature("advanced_permissions")) {
     );
   };
 
-  PLUGIN_ADMIN_PERMISSIONS_DATABASE_POST_ACTIONS["impersonated"] =
-    getImpersonatedPostAction;
+  PLUGIN_ADMIN_PERMISSIONS_DATABASE_POST_ACTIONS[
+    DataPermissionValue.IMPERSONATED
+  ] = getImpersonatedPostAction;
 
   PLUGIN_REDUCERS.advancedPermissionsPlugin = advancedPermissionsSlice.reducer;
 
@@ -105,7 +107,9 @@ if (hasPremiumFeature("advanced_permissions")) {
     state => getImpersonations(state).length > 0,
   );
 
-  PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS["impersonated"].push({
+  PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS[
+    DataPermissionValue.IMPERSONATED
+  ].push({
     label: t`Edit Impersonated`,
     iconColor: "warning",
     icon: "database",

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
@@ -7,7 +7,10 @@ import {
   SAVE_DATA_PERMISSIONS,
   UPDATE_DATA_PERMISSION,
 } from "metabase/admin/permissions/permissions";
-import type { EntityId } from "metabase/admin/permissions/types";
+import {
+  DataPermissionValue,
+  type EntityId,
+} from "metabase/admin/permissions/types";
 import {
   DATABASES_BASE_PATH,
   GROUPS_BASE_PATH,
@@ -62,7 +65,7 @@ export const advancedPermissionsSlice = createSlice({
       .addCase(LOAD_DATA_PERMISSIONS, () => initialState)
       .addCase(SAVE_DATA_PERMISSIONS, () => initialState)
       .addCase(UPDATE_DATA_PERMISSION, (state, { payload }: any) => {
-        if (payload.value === "impersonated") {
+        if (payload?.value === DataPermissionValue.IMPERSONATED) {
           return state;
         }
 

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
@@ -9,7 +9,7 @@ import {
 } from "metabase/admin/permissions/permissions";
 import {
   DataPermissionValue,
-  EntityId,
+  type EntityId,
 } from "metabase/admin/permissions/types";
 import {
   DATABASES_BASE_PATH,

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
@@ -62,7 +62,7 @@ export const advancedPermissionsSlice = createSlice({
       .addCase(LOAD_DATA_PERMISSIONS, () => initialState)
       .addCase(SAVE_DATA_PERMISSIONS, () => initialState)
       .addCase(UPDATE_DATA_PERMISSION, (state, { payload }: any) => {
-        if (payload.value === "impersonated") {
+        if (payload?.value === "impersonated") {
           return state;
         }
 

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
@@ -7,7 +7,10 @@ import {
   SAVE_DATA_PERMISSIONS,
   UPDATE_DATA_PERMISSION,
 } from "metabase/admin/permissions/permissions";
-import type { EntityId } from "metabase/admin/permissions/types";
+import {
+  DataPermissionValue,
+  EntityId,
+} from "metabase/admin/permissions/types";
 import {
   DATABASES_BASE_PATH,
   GROUPS_BASE_PATH,
@@ -62,7 +65,7 @@ export const advancedPermissionsSlice = createSlice({
       .addCase(LOAD_DATA_PERMISSIONS, () => initialState)
       .addCase(SAVE_DATA_PERMISSIONS, () => initialState)
       .addCase(UPDATE_DATA_PERMISSION, (state, { payload }: any) => {
-        if (payload?.value === "impersonated") {
+        if (payload?.value === DataPermissionValue.IMPERSONATED) {
           return state;
         }
 

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/reducer.ts
@@ -7,10 +7,7 @@ import {
   SAVE_DATA_PERMISSIONS,
   UPDATE_DATA_PERMISSION,
 } from "metabase/admin/permissions/permissions";
-import {
-  DataPermissionValue,
-  type EntityId,
-} from "metabase/admin/permissions/types";
+import type { EntityId } from "metabase/admin/permissions/types";
 import {
   DATABASES_BASE_PATH,
   GROUPS_BASE_PATH,
@@ -65,7 +62,7 @@ export const advancedPermissionsSlice = createSlice({
       .addCase(LOAD_DATA_PERMISSIONS, () => initialState)
       .addCase(SAVE_DATA_PERMISSIONS, () => initialState)
       .addCase(UPDATE_DATA_PERMISSION, (state, { payload }: any) => {
-        if (payload?.value === DataPermissionValue.IMPERSONATED) {
+        if (payload.value === "impersonated") {
           return state;
         }
 

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
@@ -9,11 +9,12 @@ import {
 import {
   DataPermission,
   DataPermissionType,
-  EntityId,
-  PermissionSectionConfig,
-  PermissionSubject,
-  SchemaEntityId,
-  TableEntityId,
+  DataPermissionValue,
+  type EntityId,
+  type PermissionSectionConfig,
+  type PermissionSubject,
+  type SchemaEntityId,
+  type TableEntityId,
 } from "metabase/admin/permissions/types";
 import {
   getFieldsPermission,
@@ -22,7 +23,6 @@ import {
 } from "metabase/admin/permissions/utils/graph";
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import type { Group, GroupsPermissions } from "metabase-types/api";
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 
 export const DATA_MODEL_PERMISSION_OPTIONS = {
   none: {

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.ts
@@ -6,8 +6,11 @@ import {
   getPermissionWarning,
   getPermissionWarningModal,
 } from "metabase/admin/permissions/selectors/confirmations";
-import type {
+import {
+  DataPermission,
+  DataPermissionType,
   EntityId,
+  PermissionSectionConfig,
   PermissionSubject,
   SchemaEntityId,
   TableEntityId,
@@ -19,23 +22,24 @@ import {
 } from "metabase/admin/permissions/utils/graph";
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import type { Group, GroupsPermissions } from "metabase-types/api";
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 
 export const DATA_MODEL_PERMISSION_OPTIONS = {
   none: {
     label: t`No`,
-    value: "none",
+    value: DataPermissionValue.NONE,
     icon: "close",
     iconColor: "danger",
   },
   edit: {
     label: t`Yes`,
-    value: "all",
+    value: DataPermissionValue.ALL,
     icon: "check",
     iconColor: "success",
   },
   controlled: {
     label: t`Granular`,
-    value: "controlled",
+    value: DataPermissionValue.CONTROLLED,
     icon: "permissions_limited",
     iconColor: "warning",
   },
@@ -52,24 +56,29 @@ const getPermissionValue = (
   groupId: number,
   entityId: EntityId,
   permissionSubject: PermissionSubject,
-) => {
+): DataPermissionValue => {
   switch (permissionSubject) {
     case "fields":
       return getFieldsPermission(
         permissions,
         groupId,
         entityId as TableEntityId,
-        "data-model",
+        DataPermission.DATA_MODEL,
       );
     case "tables":
       return getTablesPermission(
         permissions,
         groupId,
         entityId as SchemaEntityId,
-        "data-model",
+        DataPermission.DATA_MODEL,
       );
     default:
-      return getSchemasPermission(permissions, groupId, entityId, "data-model");
+      return getSchemasPermission(
+        permissions,
+        groupId,
+        entityId,
+        DataPermission.DATA_MODEL,
+      );
   }
 };
 
@@ -80,7 +89,7 @@ export const buildDataModelPermission = (
   permissions: GroupsPermissions,
   defaultGroup: Group,
   permissionSubject: PermissionSubject,
-) => {
+): PermissionSectionConfig => {
   const hasChildEntities = permissionSubject !== "fields";
 
   const value = getPermissionValue(
@@ -106,7 +115,7 @@ export const buildDataModelPermission = (
     DATA_MODEL_PERMISSIONS_DESC,
   );
 
-  const confirmations = (newValue: string) => [
+  const confirmations = (newValue: DataPermissionValue) => [
     getPermissionWarningModal(
       newValue,
       defaultGroupValue,
@@ -118,8 +127,8 @@ export const buildDataModelPermission = (
   ];
 
   return {
-    permission: "data-model",
-    type: "data-model",
+    permission: DataPermission.DATA_MODEL,
+    type: DataPermissionType.DATA_MODEL,
     isDisabled: isAdmin,
     warning,
     confirmations,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -1,3 +1,4 @@
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import {
@@ -143,7 +144,7 @@ describe("buildDataModelPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations("none");
+        permissionModel.confirmations?.(DataPermissionValue.NONE) ?? [];
 
       expect(downgradePermissionConfirmation?.message).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -161,7 +162,7 @@ describe("buildDataModelPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations("all");
+        permissionModel.confirmations?.(DataPermissionValue.ALL) ?? [];
 
       expect(permissionModel.warning).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -179,7 +180,7 @@ describe("buildDataModelPermission", () => {
         "schemas",
       );
 
-      permissionModel.confirmations("all");
+      permissionModel.confirmations?.(DataPermissionValue.ALL);
 
       expect(permissionModel.warning).toBe(null);
     });

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -1,5 +1,5 @@
-import type { Group, GroupsPermissions } from "metabase-types/api";
 import { DataPermissionValue } from "metabase/admin/permissions/types";
+import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import {
   buildDataModelPermission,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -1,4 +1,3 @@
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import {
@@ -144,7 +143,7 @@ describe("buildDataModelPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations?.(DataPermissionValue.NONE) ?? [];
+        permissionModel.confirmations("none");
 
       expect(downgradePermissionConfirmation?.message).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -162,7 +161,7 @@ describe("buildDataModelPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations?.(DataPermissionValue.ALL) ?? [];
+        permissionModel.confirmations("all");
 
       expect(permissionModel.warning).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -180,7 +179,7 @@ describe("buildDataModelPermission", () => {
         "schemas",
       );
 
-      permissionModel.confirmations?.(DataPermissionValue.ALL);
+      permissionModel.confirmations("all");
 
       expect(permissionModel.warning).toBe(null);
     });

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/data-model-permission.unit.spec.ts
@@ -1,4 +1,5 @@
 import type { Group, GroupsPermissions } from "metabase-types/api";
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 
 import {
   buildDataModelPermission,
@@ -143,7 +144,7 @@ describe("buildDataModelPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations("none");
+        permissionModel.confirmations?.(DataPermissionValue.NONE) ?? [];
 
       expect(downgradePermissionConfirmation?.message).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -161,7 +162,7 @@ describe("buildDataModelPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations("all");
+        permissionModel.confirmations?.(DataPermissionValue.ALL) ?? [];
 
       expect(permissionModel.warning).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -179,7 +180,7 @@ describe("buildDataModelPermission", () => {
         "schemas",
       );
 
-      permissionModel.confirmations("all");
+      permissionModel.confirmations?.(DataPermissionValue.ALL);
 
       expect(permissionModel.warning).toBe(null);
     });

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.ts
@@ -6,8 +6,12 @@ import {
   getPermissionWarning,
   getPermissionWarningModal,
 } from "metabase/admin/permissions/selectors/confirmations";
-import type {
+import {
+  DataPermission,
+  DataPermissionType,
+  DataPermissionValue,
   EntityId,
+  PermissionSectionConfig,
   PermissionSubject,
 } from "metabase/admin/permissions/types";
 import type { Group, GroupsPermissions } from "metabase-types/api";
@@ -15,13 +19,13 @@ import type { Group, GroupsPermissions } from "metabase-types/api";
 export const DETAILS_PERMISSION_OPTIONS = {
   no: {
     label: t`No`,
-    value: "no",
+    value: DataPermissionValue.NO,
     icon: "close",
     iconColor: "danger",
   },
   yes: {
     label: t`Yes`,
-    value: "yes",
+    value: DataPermissionValue.YES,
     icon: "check",
     iconColor: "success",
   },
@@ -47,7 +51,7 @@ export const buildDetailsPermission = (
   permissions: GroupsPermissions,
   defaultGroup: Group,
   permissionSubject: PermissionSubject,
-) => {
+): PermissionSectionConfig | null => {
   if (permissionSubject !== "schemas") {
     return null;
   }
@@ -68,7 +72,7 @@ export const buildDetailsPermission = (
     DETAILS_PERMISSIONS_DESC,
   );
 
-  const confirmations = (newValue: string) => [
+  const confirmations = (newValue: DataPermissionValue) => [
     getPermissionWarningModal(
       newValue,
       defaultGroupValue,
@@ -80,8 +84,8 @@ export const buildDetailsPermission = (
   ];
 
   return {
-    permission: "details",
-    type: "details",
+    permission: DataPermission.DETAILS,
+    type: DataPermissionType.DETAILS,
     value,
     isDisabled: isAdmin,
     isHighlighted: isAdmin,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.ts
@@ -41,7 +41,7 @@ const getDetailsPermission = (
   groupId: number,
   databaseId: number,
 ) =>
-  getIn(permissions, [groupId, databaseId, "details"]) ??
+  getIn(permissions, [groupId, databaseId, DataPermission.DETAILS]) ??
   DETAILS_PERMISSION_OPTIONS.no.value;
 
 export const buildDetailsPermission = (

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.ts
@@ -10,9 +10,9 @@ import {
   DataPermission,
   DataPermissionType,
   DataPermissionValue,
-  EntityId,
-  PermissionSectionConfig,
-  PermissionSubject,
+  type EntityId,
+  type PermissionSectionConfig,
+  type PermissionSubject,
 } from "metabase/admin/permissions/types";
 import type { Group, GroupsPermissions } from "metabase-types/api";
 

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
@@ -1,3 +1,4 @@
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import {
@@ -114,7 +115,7 @@ describe("buildDetailsPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel?.confirmations("no") || [];
+        permissionModel?.confirmations?.(DataPermissionValue.NO) || [];
 
       expect(downgradePermissionConfirmation?.message).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -132,7 +133,7 @@ describe("buildDetailsPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel?.confirmations("yes") ?? [];
+        permissionModel?.confirmations?.(DataPermissionValue.YES) ?? [];
 
       expect(permissionModel?.warning).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
@@ -1,4 +1,5 @@
 import type { Group, GroupsPermissions } from "metabase-types/api";
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 
 import {
   buildDetailsPermission,
@@ -114,7 +115,7 @@ describe("buildDetailsPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel?.confirmations("no") || [];
+        permissionModel?.confirmations?.(DataPermissionValue.NO) || [];
 
       expect(downgradePermissionConfirmation?.message).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -132,7 +133,7 @@ describe("buildDetailsPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel?.confirmations("yes") ?? [];
+        permissionModel?.confirmations?.(DataPermissionValue.YES) ?? [];
 
       expect(permissionModel?.warning).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
@@ -1,4 +1,3 @@
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import {
@@ -115,7 +114,7 @@ describe("buildDetailsPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel?.confirmations?.(DataPermissionValue.NO) || [];
+        permissionModel?.confirmations("no") || [];
 
       expect(downgradePermissionConfirmation?.message).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -133,7 +132,7 @@ describe("buildDetailsPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel?.confirmations?.(DataPermissionValue.YES) ?? [];
+        permissionModel?.confirmations("yes") ?? [];
 
       expect(permissionModel?.warning).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/details-permission.unit.spec.ts
@@ -1,5 +1,5 @@
-import type { Group, GroupsPermissions } from "metabase-types/api";
 import { DataPermissionValue } from "metabase/admin/permissions/types";
+import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import {
   buildDetailsPermission,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -104,7 +104,7 @@ export const buildDownloadPermission = (
   permissionSubject: PermissionSubject,
 ) => {
   const hasChildEntities = permissionSubject !== "fields";
-  const isBlockPermission = dataAccessPermissionValue === "block";
+  const isBlockPermission = dataAccessPermissionValue === "blocked";
 
   const value = isBlockPermission
     ? DOWNLOAD_PERMISSION_OPTIONS.none.value

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -6,8 +6,12 @@ import {
   getPermissionWarning,
   getPermissionWarningModal,
 } from "metabase/admin/permissions/selectors/confirmations";
-import type {
+import {
+  DataPermission,
+  DataPermissionType,
+  DataPermissionValue,
   EntityId,
+  PermissionSectionConfig,
   PermissionSubject,
   SchemaEntityId,
   TableEntityId,
@@ -37,25 +41,25 @@ const getTooltipMessage = (isAdmin: boolean, isBlockedAccess: boolean) => {
 export const DOWNLOAD_PERMISSION_OPTIONS = {
   none: {
     label: t`No`,
-    value: "none",
+    value: DataPermissionValue.NONE,
     icon: "close",
     iconColor: "danger",
   },
   limited: {
     label: t`10 thousand rows`,
-    value: "limited",
+    value: DataPermissionValue.LIMITED,
     icon: "10k",
     iconColor: "accent7",
   },
   full: {
     label: t`1 million rows`,
-    value: "full",
+    value: DataPermissionValue.FULL,
     icon: "1m",
     iconColor: "accent7",
   },
   controlled: {
     label: t`Granular`,
-    value: "controlled",
+    value: DataPermissionValue.CONTROLLED,
     icon: "permissions_limited",
     iconColor: "warning",
   },
@@ -80,17 +84,22 @@ const getPermissionValue = (
         permissions,
         groupId,
         entityId as TableEntityId,
-        "download",
+        DataPermission.DOWNLOAD,
       );
     case "tables":
       return getTablesPermission(
         permissions,
         groupId,
         entityId as SchemaEntityId,
-        "download",
+        DataPermission.DOWNLOAD,
       );
     default:
-      return getSchemasPermission(permissions, groupId, entityId, "download");
+      return getSchemasPermission(
+        permissions,
+        groupId,
+        entityId,
+        DataPermission.DOWNLOAD,
+      );
   }
 };
 
@@ -99,12 +108,13 @@ export const buildDownloadPermission = (
   groupId: number,
   isAdmin: boolean,
   permissions: GroupsPermissions,
-  dataAccessPermissionValue: string,
+  dataAccessPermissionValue: DataPermissionValue,
   defaultGroup: Group,
   permissionSubject: PermissionSubject,
-) => {
+): PermissionSectionConfig => {
   const hasChildEntities = permissionSubject !== "fields";
-  const isBlockPermission = dataAccessPermissionValue === "blocked";
+  const isBlockPermission =
+    dataAccessPermissionValue === DataPermissionValue.BLOCKED;
 
   const value = isBlockPermission
     ? DOWNLOAD_PERMISSION_OPTIONS.none.value
@@ -130,7 +140,7 @@ export const buildDownloadPermission = (
     DOWNLOAD_PERMISSIONS_DESC,
   );
 
-  const confirmations = (newValue: string) => [
+  const confirmations = (newValue: DataPermissionValue) => [
     getPermissionWarningModal(
       newValue,
       defaultGroupValue,
@@ -142,8 +152,8 @@ export const buildDownloadPermission = (
   ];
 
   return {
-    permission: "download",
-    type: "download",
+    permission: DataPermission.DOWNLOAD,
+    type: DataPermissionType.DOWNLOAD,
     isDisabled,
     disabledTooltip,
     value,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.ts
@@ -10,11 +10,11 @@ import {
   DataPermission,
   DataPermissionType,
   DataPermissionValue,
-  EntityId,
-  PermissionSectionConfig,
-  PermissionSubject,
-  SchemaEntityId,
-  TableEntityId,
+  type EntityId,
+  type PermissionSectionConfig,
+  type PermissionSubject,
+  type SchemaEntityId,
+  type TableEntityId,
 } from "metabase/admin/permissions/types";
 import {
   getFieldsPermission,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
@@ -1,3 +1,4 @@
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import {
@@ -30,7 +31,7 @@ const getPermissionGraph = (downloadValue = "all"): GroupsPermissions =>
 
 const isAdmin = true;
 const isNotAdmin = false;
-const dataAccessPermissionValue = "all";
+const dataAccessPermissionValue = DataPermissionValue.UNRESTRICTED;
 
 const defaultGroup: Group = {
   id: defaultGroupId,
@@ -153,7 +154,7 @@ describe("buildDownloadPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations("none");
+        permissionModel.confirmations?.(DataPermissionValue.NONE) ?? [];
 
       expect(downgradePermissionConfirmation?.message).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -172,7 +173,7 @@ describe("buildDownloadPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations("all");
+        permissionModel.confirmations?.(DataPermissionValue.UNRESTRICTED) ?? [];
 
       expect(permissionModel.warning).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
@@ -1,4 +1,3 @@
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import {
@@ -31,7 +30,7 @@ const getPermissionGraph = (downloadValue = "all"): GroupsPermissions =>
 
 const isAdmin = true;
 const isNotAdmin = false;
-const dataAccessPermissionValue = DataPermissionValue.UNRESTRICTED;
+const dataAccessPermissionValue = "all";
 
 const defaultGroup: Group = {
   id: defaultGroupId,
@@ -154,7 +153,7 @@ describe("buildDownloadPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations?.(DataPermissionValue.NONE) ?? [];
+        permissionModel.confirmations("none");
 
       expect(downgradePermissionConfirmation?.message).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -173,7 +172,7 @@ describe("buildDownloadPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations?.(DataPermissionValue.UNRESTRICTED) ?? [];
+        permissionModel.confirmations("all");
 
       expect(permissionModel.warning).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
@@ -1,4 +1,5 @@
 import type { Group, GroupsPermissions } from "metabase-types/api";
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 
 import {
   buildDownloadPermission,
@@ -30,7 +31,7 @@ const getPermissionGraph = (downloadValue = "all"): GroupsPermissions =>
 
 const isAdmin = true;
 const isNotAdmin = false;
-const dataAccessPermissionValue = "all";
+const dataAccessPermissionValue = DataPermissionValue.UNRESTRICTED;
 
 const defaultGroup: Group = {
   id: defaultGroupId,
@@ -153,7 +154,7 @@ describe("buildDownloadPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations("none");
+        permissionModel.confirmations?.(DataPermissionValue.NONE) ?? [];
 
       expect(downgradePermissionConfirmation?.message).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
@@ -172,7 +173,7 @@ describe("buildDownloadPermission", () => {
       );
 
       const [downgradePermissionConfirmation] =
-        permissionModel.confirmations("all");
+        permissionModel.confirmations?.(DataPermissionValue.UNRESTRICTED) ?? [];
 
       expect(permissionModel.warning).toBe(
         'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/download-permission.unit.spec.ts
@@ -1,5 +1,5 @@
-import type { Group, GroupsPermissions } from "metabase-types/api";
 import { DataPermissionValue } from "metabase/admin/permissions/types";
+import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import {
   buildDownloadPermission,

--- a/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
+++ b/enterprise/frontend/src/metabase-enterprise/feature_level_permissions/permission-management/index.ts
@@ -1,4 +1,5 @@
 import type {
+  DataPermissionValue,
   EntityId,
   PermissionSubject,
 } from "metabase/admin/permissions/types";
@@ -13,7 +14,7 @@ export const getFeatureLevelDataPermissions = (
   groupId: number,
   isAdmin: boolean,
   permissions: GroupsPermissions,
-  dataAccessPermissionValue: string,
+  dataAccessPermissionValue: DataPermissionValue,
   defaultGroup: Group,
   permissionSubject: PermissionSubject,
 ) => {

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
@@ -4,6 +4,10 @@ import {
   LOAD_DATA_PERMISSIONS,
 } from "metabase/admin/permissions/permissions";
 import {
+  DataPermission,
+  DataPermissionType,
+} from "metabase/admin/permissions/types";
+import {
   createThunkAction,
   createAction,
   handleActions,
@@ -39,8 +43,11 @@ export const updateTableSandboxingPermission = createThunkAction(
     return dispatch(
       updateDataPermission({
         groupId,
-        permission: { type: "access", permission: "view-data" },
-        value: "sandboxed",
+        permission: {
+          type: DataPermissionType.ACCESS,
+          permission: DataPermission.VIEW_DATA,
+        },
+        value: DataPermissionType.SANDBOXED,
         entityId,
       }),
     );

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
@@ -39,7 +39,7 @@ export const updateTableSandboxingPermission = createThunkAction(
     return dispatch(
       updateDataPermission({
         groupId,
-        permission: { type: "access", permission: "data" },
+        permission: { type: "access", permission: "view-data" },
         value: "controlled",
         entityId,
       }),

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
@@ -5,6 +5,7 @@ import {
 } from "metabase/admin/permissions/permissions";
 import {
   DataPermission,
+  DataPermissionValue,
   DataPermissionType,
 } from "metabase/admin/permissions/types";
 import {
@@ -47,7 +48,7 @@ export const updateTableSandboxingPermission = createThunkAction(
           type: DataPermissionType.ACCESS,
           permission: DataPermission.VIEW_DATA,
         },
-        value: DataPermissionType.SANDBOXED,
+        value: DataPermissionValue.SANDBOXED,
         entityId,
       }),
     );

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
@@ -40,7 +40,7 @@ export const updateTableSandboxingPermission = createThunkAction(
       updateDataPermission({
         groupId,
         permission: { type: "access", permission: "view-data" },
-        value: "controlled",
+        value: "sandboxed",
         entityId,
       }),
     );

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -15,7 +15,6 @@ import {
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS,
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS,
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION,
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_PERMISSION_VALUE,
 } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
@@ -26,7 +25,7 @@ import { getDraftPolicies, hasPolicyChanges } from "./selectors";
 
 const OPTION_SEGMENTED = {
   label: t`Sandboxed`,
-  value: "controlled",
+  value: "sandboxed",
   icon: "permissions_limited",
   iconColor: "brand",
 };
@@ -70,19 +69,15 @@ if (hasPremiumFeature("sandboxes")) {
     />,
   );
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS.push(OPTION_SEGMENTED);
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS["controlled"].push({
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS[OPTION_SEGMENTED.value].push({
     label: t`Edit sandboxed access`,
     iconColor: "brand",
     icon: "pencil",
     actionCreator: (entityId, groupId, view) =>
       push(getEditSegementedAccessUrl(entityId, groupId, view)),
   });
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION["controlled"] =
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION[OPTION_SEGMENTED.value] =
     getEditSegmentedAccessPostAction;
-  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_PERMISSION_VALUE["controlled"] = {
-    read: "all",
-    query: "segmented",
-  };
 
   PLUGIN_DATA_PERMISSIONS.permissionsPayloadExtraSelectors.push(state => {
     const sandboxes = getDraftPolicies(state);

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -1,6 +1,7 @@
 import { push } from "react-router-redux";
 import { t } from "ttag";
 
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 import {
   getDatabaseFocusPermissionsUrl,
   getGroupFocusPermissionsUrl,
@@ -25,7 +26,7 @@ import { getDraftPolicies, hasPolicyChanges } from "./selectors";
 
 const OPTION_SEGMENTED = {
   label: t`Sandboxed`,
-  value: "sandboxed",
+  value: DataPermissionValue.SANDBOXED,
   icon: "permissions_limited",
   iconColor: "brand",
 };

--- a/frontend/src/metabase-types/api/mocks/permissions.ts
+++ b/frontend/src/metabase-types/api/mocks/permissions.ts
@@ -1,3 +1,7 @@
+import {
+  DataPermission,
+  DataPermissionValue,
+} from "metabase/admin/permissions/types";
 import type {
   Database,
   Group,
@@ -5,10 +9,6 @@ import type {
   Impersonation,
   PermissionsGraph,
 } from "metabase-types/api";
-import {
-  DataPermission,
-  DataPermissionValue,
-} from "metabase/admin/permissions/types";
 
 export const createMockPermissionsGraph = ({
   groups,

--- a/frontend/src/metabase-types/api/mocks/permissions.ts
+++ b/frontend/src/metabase-types/api/mocks/permissions.ts
@@ -5,6 +5,10 @@ import type {
   Impersonation,
   PermissionsGraph,
 } from "metabase-types/api";
+import {
+  DataPermission,
+  DataPermissionValue,
+} from "metabase/admin/permissions/types";
 
 export const createMockPermissionsGraph = ({
   groups,
@@ -19,13 +23,12 @@ export const createMockPermissionsGraph = ({
     for (const database of databases) {
       permissionGroups[group.id] = {
         [database.id]: {
-          data: {
-            native: "write",
-            schemas: "all",
-          },
-          download: {
-            native: "full",
-            schemas: "full",
+          [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
+          [DataPermission.CREATE_QUERIES]:
+            DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+          [DataPermission.DOWNLOAD]: {
+            native: DataPermissionValue.FULL,
+            schemas: DataPermissionValue.FULL,
           },
         },
       };

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -1,9 +1,15 @@
+// TODO: retype this file...
+
 import type {
   DatabaseId,
   TableId,
   SchemaName,
   CollectionId,
 } from "metabase-types/api";
+import type {
+  DataPermission,
+  DataPermissionValue,
+} from "metabase/admin/permissions/types";
 
 import type { GroupId } from "./group";
 import type { UserAttribute } from "./user";
@@ -21,14 +27,19 @@ export type GroupPermissions = {
   [key: DatabaseId]: DatabasePermissions;
 };
 
-export type DownloadPermission = "full" | "limited" | "none";
+export type DownloadPermission =
+  | DataPermissionValue.FULL
+  | DataPermissionValue.LIMITED
+  | DataPermissionValue.NONE;
 
 export type DownloadAccessPermission = {
   native?: DownloadSchemasPermission;
   schemas: DownloadSchemasPermission;
 };
 
-export type DetailsPermission = "no" | "yes";
+export type DetailsPermission =
+  | DataPermissionValue.NO
+  | DataPermissionValue.YES;
 
 export type DetailsPermissions = {
   [key: DatabaseId]: DetailsPermission;
@@ -43,10 +54,11 @@ export type DownloadTablePermission =
   | { [key: TableId]: DownloadPermission };
 
 export type DatabasePermissions = {
-  data: DatabaseAccessPermissions;
-  "data-model"?: DataModelPermissions;
-  download?: DownloadAccessPermission;
-  details?: DetailsPermissions;
+  [DataPermission.VIEW_DATA]: SchemasPermissions;
+  [DataPermission.CREATE_QUERIES]?: NativePermissions;
+  [DataPermission.DATA_MODEL]?: DataModelPermissions;
+  [DataPermission.DOWNLOAD]?: DownloadAccessPermission;
+  [DataPermission.DETAILS]?: DetailsPermissions;
 };
 
 export type DataModelPermissions = {
@@ -59,34 +71,32 @@ export type DatabaseAccessPermissions = {
 };
 
 export type NativePermissions =
-  | "query-builder-and-native"
-  | "query-builder"
-  | "no"
+  | DataPermissionValue.QUERY_BUILDER_AND_NATIVE
+  | DataPermissionValue.QUERY_BUILDER
+  | DataPermissionValue.NO
   | undefined;
 
 export type SchemasPermissions =
-  | "all"
-  | "none"
-  | "block"
-  | "impersonated"
+  | DataPermissionValue.UNRESTRICTED
+  | DataPermissionValue.NO
+  | DataPermissionValue.LEGACY_NO_SELF_SERVICE
+  | DataPermissionValue.BLOCKED
+  | DataPermissionValue.IMPERSONATED
   | {
       [key: SchemaName]: TablesPermissions;
     };
 
 export type TablesPermissions =
-  | "all"
-  | "none"
+  | DataPermissionValue.UNRESTRICTED
+  | DataPermissionValue.LEGACY_NO_SELF_SERVICE
   | {
       [key: TableId]: FieldsPermissions;
     };
 
 export type FieldsPermissions =
-  | "all"
-  | "none"
-  | {
-      read: "all";
-      query: "segmented";
-    };
+  | DataPermissionValue.UNRESTRICTED
+  | DataPermissionValue.LEGACY_NO_SELF_SERVICE
+  | DataPermissionValue.SANDBOXED;
 
 export type CollectionPermissionsGraph = {
   groups: CollectionPermissions;

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -58,7 +58,11 @@ export type DatabaseAccessPermissions = {
   schemas: SchemasPermissions;
 };
 
-export type NativePermissions = "write" | undefined;
+export type NativePermissions =
+  | "query-builder-and-native"
+  | "query-builder"
+  | "no"
+  | undefined;
 
 export type SchemasPermissions =
   | "all"

--- a/frontend/src/metabase-types/api/permissions.ts
+++ b/frontend/src/metabase-types/api/permissions.ts
@@ -1,15 +1,13 @@
-// TODO: retype this file...
-
+import type {
+  DataPermission,
+  DataPermissionValue,
+} from "metabase/admin/permissions/types";
 import type {
   DatabaseId,
   TableId,
   SchemaName,
   CollectionId,
 } from "metabase-types/api";
-import type {
-  DataPermission,
-  DataPermissionValue,
-} from "metabase/admin/permissions/types";
 
 import type { GroupId } from "./group";
 import type { UserAttribute } from "./user";

--- a/frontend/src/metabase/admin/permissions/analytics.ts
+++ b/frontend/src/metabase/admin/permissions/analytics.ts
@@ -3,7 +3,7 @@ import * as MetabaseAnalytics from "metabase/lib/analytics";
 import type { DataPermission, TableEntityId } from "./types";
 
 const getEventPrefix = (permission: DataPermission) => {
-  const shouldUseBackwardCompatibleEventName = permission === "data";
+  const shouldUseBackwardCompatibleEventName = permission === "view-data";
   if (shouldUseBackwardCompatibleEventName) {
     return "";
   }

--- a/frontend/src/metabase/admin/permissions/analytics.ts
+++ b/frontend/src/metabase/admin/permissions/analytics.ts
@@ -1,9 +1,10 @@
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 
-import type { DataPermission, TableEntityId } from "./types";
+import { DataPermission, type TableEntityId } from "./types";
 
 const getEventPrefix = (permission: DataPermission) => {
-  const shouldUseBackwardCompatibleEventName = permission === "view-data";
+  const shouldUseBackwardCompatibleEventName =
+    permission === DataPermission.VIEW_DATA;
   if (shouldUseBackwardCompatibleEventName) {
     return "";
   }
@@ -13,7 +14,7 @@ const getEventPrefix = (permission: DataPermission) => {
 
 const getEventName = (entityId: Partial<TableEntityId>, isNative: boolean) => {
   if (isNative) {
-    return "create-queries";
+    return "native";
   }
   if (entityId.tableId != null) {
     return "fields";

--- a/frontend/src/metabase/admin/permissions/analytics.ts
+++ b/frontend/src/metabase/admin/permissions/analytics.ts
@@ -13,7 +13,7 @@ const getEventPrefix = (permission: DataPermission) => {
 
 const getEventName = (entityId: Partial<TableEntityId>, isNative: boolean) => {
   if (isNative) {
-    return "native";
+    return "create-queries";
   }
   if (entityId.tableId != null) {
     return "fields";

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.unit.spec.js
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.unit.spec.js
@@ -1,5 +1,7 @@
 import { render, fireEvent, screen, getIcon } from "__support__/ui";
 
+import { DataPermissionValue } from "../../types";
+
 import { PermissionsSelect } from "./PermissionsSelect";
 
 const options = [
@@ -11,7 +13,7 @@ const options = [
   },
   {
     label: "Limited",
-    value: "controlled",
+    value: DataPermissionValue.CONTROLLED,
     icon: "permissions_limited",
     iconColor: "blue",
   },
@@ -63,7 +65,10 @@ describe("PermissionSelect", () => {
     const [limited] = screen.getAllByRole("option");
     fireEvent.click(limited);
 
-    expect(onChangeMock).toHaveBeenCalledWith("controlled", null);
+    expect(onChangeMock).toHaveBeenCalledWith(
+      DataPermissionValue.CONTROLLED,
+      null,
+    );
   });
 
   it("does not show options after click when disabled", () => {

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.unit.spec.js
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.unit.spec.js
@@ -1,6 +1,7 @@
 import { render, fireEvent, screen, getIcon } from "__support__/ui";
 
 import { PermissionsSelect } from "./PermissionsSelect";
+import { DataPermissionValue } from "../../types";
 
 const options = [
   {
@@ -11,7 +12,7 @@ const options = [
   },
   {
     label: "Limited",
-    value: "controlled",
+    value: DataPermissionValue.CONTROLLED,
     icon: "permissions_limited",
     iconColor: "blue",
   },
@@ -63,7 +64,10 @@ describe("PermissionSelect", () => {
     const [limited] = screen.getAllByRole("option");
     fireEvent.click(limited);
 
-    expect(onChangeMock).toHaveBeenCalledWith("controlled", null);
+    expect(onChangeMock).toHaveBeenCalledWith(
+      DataPermissionValue.CONTROLLED,
+      null,
+    );
   });
 
   it("does not show options after click when disabled", () => {

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.unit.spec.js
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.unit.spec.js
@@ -1,7 +1,5 @@
 import { render, fireEvent, screen, getIcon } from "__support__/ui";
 
-import { DataPermissionValue } from "../../types";
-
 import { PermissionsSelect } from "./PermissionsSelect";
 
 const options = [
@@ -13,7 +11,7 @@ const options = [
   },
   {
     label: "Limited",
-    value: DataPermissionValue.CONTROLLED,
+    value: "controlled",
     icon: "permissions_limited",
     iconColor: "blue",
   },
@@ -65,10 +63,7 @@ describe("PermissionSelect", () => {
     const [limited] = screen.getAllByRole("option");
     fireEvent.click(limited);
 
-    expect(onChangeMock).toHaveBeenCalledWith(
-      DataPermissionValue.CONTROLLED,
-      null,
-    );
+    expect(onChangeMock).toHaveBeenCalledWith("controlled", null);
   });
 
   it("does not show options after click when disabled", () => {

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.unit.spec.js
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelect.unit.spec.js
@@ -1,7 +1,8 @@
 import { render, fireEvent, screen, getIcon } from "__support__/ui";
 
-import { PermissionsSelect } from "./PermissionsSelect";
 import { DataPermissionValue } from "../../types";
+
+import { PermissionsSelect } from "./PermissionsSelect";
 
 const options = [
   {

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.jsx
@@ -11,7 +11,7 @@ import {
 } from "./PermissionsSelectOption.styled";
 
 export const optionShape = {
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   icon: PropTypes.string.isRequired,
   iconColor: PropTypes.string.isRequired,
 };

--- a/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.styled.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsSelect/PermissionsSelectOption.styled.tsx
@@ -17,6 +17,7 @@ export const IconContainer = styled.div<{ color: string }>`
   height: 20px;
   color: ${color("white")};
   background-color: ${props => color(props.color)};
+  flex-shrink: 0;
 `;
 
 export const PermissionsSelectLabel = styled.div`

--- a/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsTable/PermissionsTable.styled.tsx
@@ -20,6 +20,7 @@ export const PermissionsTableRoot = styled.table`
   border-collapse: collapse;
   max-height: 100%;
   overflow-y: auto;
+  min-width: max-content;
 `;
 
 export const PermissionsTableCell = styled.td`

--- a/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
+++ b/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
@@ -31,15 +31,27 @@ export const DATA_PERMISSION_OPTIONS = {
     icon: "eye",
     iconColor: "accent5",
   },
-  none: {
+  no: {
     label: t`No`,
-    value: "none",
+    value: "no",
     icon: "close",
     iconColor: "danger",
   },
   write: {
     label: t`Yes`,
     value: "write",
+    icon: "check",
+    iconColor: "success",
+  },
+  queryBuilder: {
+    label: t`Query builder only`,
+    value: "query-builder",
+    icon: "permissions_limited",
+    iconColor: "warning",
+  },
+  queryBuilderAndNative: {
+    label: t`Query builder and native`,
+    value: "query-builder-and-native",
     icon: "check",
     iconColor: "success",
   },

--- a/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
+++ b/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
@@ -9,7 +9,7 @@ export const DATA_PERMISSION_OPTIONS = {
   unrestricted: {
     label: t`Can view`,
     value: DataPermissionValue.UNRESTRICTED,
-    icon: "check",
+    icon: "eye",
     iconColor: "success",
   },
   controlled: {

--- a/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
+++ b/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
@@ -2,21 +2,22 @@ import { t } from "ttag";
 
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
+import { DataPermissionValue } from "../types";
 
 export const DATA_PERMISSION_OPTIONS = {
-  all: {
+  unrestricted: {
     label: t`Unrestricted`,
-    value: "unrestricted",
+    value: DataPermissionValue.UNRESTRICTED,
     icon: "check",
     iconColor: "success",
   },
   controlled: {
     label: t`Granular`,
-    value: "controlled",
+    value: DataPermissionValue.CONTROLLED,
     icon: "permissions_limited",
     iconColor: "warning",
   },
-  noSelfService: {
+  noSelfServiceDeprecated: {
     label: (
       <>
         {t`No self-service (Deprecated)`}
@@ -27,31 +28,25 @@ export const DATA_PERMISSION_OPTIONS = {
         />
       </>
     ),
-    value: "legacy-no-self-service",
+    value: DataPermissionValue.LEGACY_NO_SELF_SERVICE,
     icon: "eye",
     iconColor: "accent5",
   },
   no: {
     label: t`No`,
-    value: "no",
+    value: DataPermissionValue.NO,
     icon: "close",
     iconColor: "danger",
   },
-  write: {
-    label: t`Yes`,
-    value: "write",
-    icon: "check",
-    iconColor: "success",
-  },
   queryBuilder: {
     label: t`Query builder only`,
-    value: "query-builder",
+    value: DataPermissionValue.QUERY_BUILDER,
     icon: "permissions_limited",
     iconColor: "warning",
   },
   queryBuilderAndNative: {
     label: t`Query builder and native`,
-    value: "query-builder-and-native",
+    value: DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
     icon: "check",
     iconColor: "success",
   },

--- a/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
+++ b/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
@@ -2,11 +2,12 @@ import { t } from "ttag";
 
 import { color } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
+
 import { DataPermissionValue } from "../types";
 
 export const DATA_PERMISSION_OPTIONS = {
   unrestricted: {
-    label: t`Unrestricted`,
+    label: t`Can view`,
     value: DataPermissionValue.UNRESTRICTED,
     icon: "check",
     iconColor: "success",

--- a/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
+++ b/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
@@ -1,9 +1,12 @@
 import { t } from "ttag";
 
+import { color } from "metabase/lib/colors";
+import { Icon } from "metabase/ui";
+
 export const DATA_PERMISSION_OPTIONS = {
   all: {
     label: t`Unrestricted`,
-    value: "all",
+    value: "unrestricted",
     icon: "check",
     iconColor: "success",
   },
@@ -14,8 +17,17 @@ export const DATA_PERMISSION_OPTIONS = {
     iconColor: "warning",
   },
   noSelfService: {
-    label: t`No self-service`,
-    value: "none",
+    label: (
+      <>
+        {t`No self-service (Deprecated)`}
+        <Icon
+          name="warning"
+          color={color("accent5")}
+          style={{ marginBottom: "-3px", marginLeft: ".25rem" }}
+        />
+      </>
+    ),
+    value: "legacy-no-self-service",
     icon: "eye",
     iconColor: "accent5",
   },

--- a/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
+++ b/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
@@ -25,7 +25,7 @@ export const DATA_PERMISSION_OPTIONS = {
         <Icon
           name="warning"
           color={color("accent5")}
-          style={{ marginBottom: "-3px", marginLeft: ".25rem" }}
+          style={{ marginBottom: "-3px", marginInlineStart: ".25rem" }}
         />
       </>
     ),

--- a/frontend/src/metabase/admin/permissions/constants/messages.ts
+++ b/frontend/src/metabase/admin/permissions/constants/messages.ts
@@ -1,7 +1,7 @@
 import { t } from "ttag";
 
 export const UNABLE_TO_CHANGE_ADMIN_PERMISSIONS = t`Administrators always have the highest level of access to everything in Metabase.`;
-export const NATIVE_PERMISSION_REQUIRES_DATA_ACCESS = t`Native query editor access requires full data access.`;
+export const NATIVE_PERMISSION_REQUIRES_DATA_ACCESS = t`Groups with View data access set to "Blocked" can't create queries.`;
 
 export const getLimitedPermissionAvailabilityMessage = () =>
   t`Only available in certain Metabase plans.`;

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -165,7 +165,7 @@ export const updateDataPermission = createThunkAction(
       trackPermissionChange(
         entityId,
         permissionInfo.permission,
-        permissionInfo.type === "native",
+        permissionInfo.type === DataPermissionType.NATIVE,
         value,
       );
 

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -304,9 +304,9 @@ const dataPermissions = handleActions(
 
         if (
           permissionInfo.type === DataPermissionType.NATIVE &&
-          PLUGIN_DATA_PERMISSIONS.updateNativePermission
+          PLUGIN_DATA_PERMISSIONS.upgradeViewPermissionsIfNeeded
         ) {
-          PLUGIN_DATA_PERMISSIONS.updateNativePermission(
+          state = PLUGIN_DATA_PERMISSIONS.upgradeViewPermissionsIfNeeded(
             state,
             groupId,
             entityId,

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -9,7 +9,7 @@ import {
   updateSchemasPermission,
   updateTablesPermission,
   updatePermission,
-  getNativePermission,
+  getSchemasPermission,
 } from "metabase/admin/permissions/utils/graph";
 import { getGroupFocusPermissionsUrl } from "metabase/admin/permissions/utils/urls";
 import Group from "metabase/entities/groups";
@@ -306,7 +306,6 @@ const dataPermissions = handleActions(
           permissionInfo.type === DataPermissionType.NATIVE &&
           PLUGIN_DATA_PERMISSIONS.updateNativePermission
         ) {
-          // TODO: rename plugin...
           PLUGIN_DATA_PERMISSIONS.updateNativePermission(
             state,
             groupId,
@@ -318,9 +317,12 @@ const dataPermissions = handleActions(
         }
 
         // TODO: consolidate this block somehow...
-        const currDbNativePermission = getNativePermission(state, groupId, {
-          databaseId: entityId.databaseId,
-        });
+        const currDbNativePermission = getSchemasPermission(
+          state,
+          groupId,
+          { databaseId: entityId.databaseId },
+          DataPermission.CREATE_QUERIES,
+        );
         const shouldGranulateNative =
           permissionInfo.permission === DataPermission.CREATE_QUERIES &&
           (entityId.tableId != null || entityId.schemaName != null) &&

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -25,8 +25,12 @@ import { getMetadataWithHiddenTables } from "metabase/selectors/metadata";
 import { CollectionsApi, PermissionsApi } from "metabase/services";
 
 import { trackPermissionChange } from "./analytics";
+import {
+  DataPermissionType,
+  DataPermissionValue,
+  DataPermission,
+} from "./types";
 import { isDatabaseEntityId } from "./utils/data-entity-id";
-import { DataPermissionType, DataPermissionValue } from "./types";
 
 const INITIALIZE_DATA_PERMISSIONS =
   "metabase/admin/permissions/INITIALIZE_DATA_PERMISSIONS";
@@ -271,7 +275,9 @@ const dataPermissions = handleActions(
           return updatePermission(
             state,
             groupId,
-            [entityId.databaseId, permissionInfo.type],
+            entityId.databaseId,
+            DataPermission.DETAILS,
+            [],
             value,
           );
         }

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -91,7 +91,7 @@ export const GRANULATE_DATABASE_TABLE_PERMISSIONS =
   "metabase/admin/permissions/GRANULATE_DATABASE_TABLE_PERMISSIONS";
 export const granulateDatabasePermissions = createThunkAction(
   GRANULATE_DATABASE_TABLE_PERMISSIONS,
-  (groupId, entityId, value) => dispatch => {
+  (groupId, entityId, permission, value, defaultValue) => dispatch => {
     // HACK: updatePermission fn sets entities of controlled values (schemas in this case
     // to the previously set value of the parent (database in this case). if the db perm
     // value is set to something other than restrictied before changing to controlled, the
@@ -100,21 +100,14 @@ export const granulateDatabasePermissions = createThunkAction(
       dispatch(
         updateDataPermission({
           groupId,
-          permission: { type: "access", permission: "view-data" },
-          value: "unrestricted",
+          permission,
+          value: defaultValue,
           entityId,
         }),
       );
     }
 
-    dispatch(
-      updateDataPermission({
-        groupId,
-        permission: { type: "access", permission: "view-data" },
-        value,
-        entityId,
-      }),
-    );
+    dispatch(updateDataPermission({ groupId, permission, value, entityId }));
 
     dispatch(push(getGroupFocusPermissionsUrl(groupId, entityId)));
   },
@@ -153,7 +146,7 @@ export const updateDataPermission = createThunkAction(
       trackPermissionChange(
         entityId,
         permissionInfo.permission,
-        permissionInfo.type === "native",
+        permissionInfo.type === "create-queries",
         value,
       );
 
@@ -282,7 +275,7 @@ const dataPermissions = handleActions(
           );
         }
 
-        if (permissionInfo.type === "native") {
+        if (permissionInfo.type === "create-queries") {
           const updateFn =
             PLUGIN_DATA_PERMISSIONS.updateNativePermission ??
             updateNativePermission;

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -98,7 +98,18 @@ export const GRANULATE_DATABASE_TABLE_PERMISSIONS =
 export const granulateDatabasePermissions = createThunkAction(
   GRANULATE_DATABASE_TABLE_PERMISSIONS,
   (groupId, entityId, permission, value, defaultValue) =>
-    (dispatch, getState) => {
+    async (dispatch, getState) => {
+      // NOTE: need to have table and schema data before updates are called as update fns load the values async
+      // without awaiting, meaning the data most likely won't be loaded the first the first time we need it
+      // resulting in a perms graph that is invalid
+      await dispatch(
+        Tables.actions.fetchList({
+          dbId: entityId.databaseId,
+          include_hidden: true,
+          remove_inactive: true,
+        }),
+      );
+
       // HACK: updatePermission fn sets entities of controlled values (schemas in this case
       // to the previously set value of the parent (database in this case). if the db perm
       // value is set to something other than restrictied before changing to controlled, the

--- a/frontend/src/metabase/admin/permissions/permissions.js
+++ b/frontend/src/metabase/admin/permissions/permissions.js
@@ -330,6 +330,31 @@ const dataPermissions = handleActions(
         }
         // TODO: consolidate this block somehow...
 
+        // if view permissions are now going to sandboxed
+        // and the permissions for the db is qb + native
+        // then granulte perms to query builder only
+        //
+
+        //TODO: make this check happen in enterprise code
+        if (
+          value === DataPermissionValue.SANDBOXED &&
+          currDbNativePermission ===
+            DataPermissionValue.QUERY_BUILDER_AND_NATIVE
+        ) {
+          state = updateTablesPermission(
+            state,
+            groupId,
+            {
+              databaseId: entityId.databaseId,
+              schemaName: entityId.schemaName,
+            },
+            DataPermissionValue.QUERY_BUILDER,
+            database,
+            DataPermission.CREATE_QUERIES,
+          );
+        }
+        //TODO: make this check happen in enterprise code
+
         const shouldDowngradeNative =
           permissionInfo.type === DataPermissionType.ACCESS;
 

--- a/frontend/src/metabase/admin/permissions/selectors/collection-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/collection-permissions.ts
@@ -33,9 +33,9 @@ import type {
 
 import { COLLECTION_OPTIONS } from "../constants/collections-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "../constants/messages";
+import type { DataPermissionValue } from "../types";
 
 import { getPermissionWarningModal } from "./confirmations";
-import type { DataPermissionValue } from "../types";
 
 export const collectionsQuery = {
   tree: true,

--- a/frontend/src/metabase/admin/permissions/selectors/collection-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/collection-permissions.ts
@@ -35,6 +35,7 @@ import { COLLECTION_OPTIONS } from "../constants/collections-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "../constants/messages";
 
 import { getPermissionWarningModal } from "./confirmations";
+import type { DataPermissionValue } from "../types";
 
 export const collectionsQuery = {
   tree: true,
@@ -245,7 +246,7 @@ export const getCollectionsPermissionEditor = createSelector(
         collection.id,
       );
 
-      const confirmations = (newValue: string) => [
+      const confirmations = (newValue: DataPermissionValue) => [
         getPermissionWarningModal(
           newValue,
           defaultGroupPermission,

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -100,14 +100,10 @@ export function getPermissionWarningModal(
 }
 
 export function getControlledDatabaseWarningModal(
-  permissions: GroupsPermissions,
-  groupId: Group["id"],
+  currDbPermissionValue: string,
   entityId: EntityId,
 ) {
-  if (
-    getSchemasPermission(permissions, groupId, entityId, "data") !==
-    "controlled"
-  ) {
+  if (currDbPermissionValue !== "controlled") {
     const [entityType, entityTypePlural] = isTableEntityId(entityId)
       ? [t`table`, t`tables`]
       : isSchemaEntityId(entityId)
@@ -132,7 +128,7 @@ export function getRawQueryWarningModal(
     value === "write" &&
     getNativePermission(permissions, groupId, entityId) !== "write" &&
     !["all", "impersonated"].includes(
-      getSchemasPermission(permissions, groupId, entityId, "data"),
+      getSchemasPermission(permissions, groupId, entityId, "view-data"),
     )
   ) {
     return {
@@ -156,7 +152,7 @@ export function getRevokingAccessToAllTablesWarningModal(
 ) {
   if (
     value === "none" &&
-    getSchemasPermission(permissions, groupId, entityId, "data") ===
+    getSchemasPermission(permissions, groupId, entityId, "view-data") ===
       "controlled" &&
     getNativePermission(permissions, groupId, entityId) !== "none"
   ) {
@@ -171,7 +167,7 @@ export function getRevokingAccessToAllTablesWarningModal(
     const afterChangesNoAccessToAnyTable = _.every(
       allTableEntityIds,
       id =>
-        getFieldsPermission(permissions, groupId, id, "data") === "none" ||
+        getFieldsPermission(permissions, groupId, id, "view-data") === "none" ||
         _.isEqual(id, entityId),
     );
     if (afterChangesNoAccessToAnyTable) {

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -17,7 +17,8 @@ import type {
   ConcreteTableId,
 } from "metabase-types/api";
 
-import { DataPermission, DataPermissionValue, EntityId } from "../types";
+import type { EntityId } from "../types";
+import { DataPermission, DataPermissionValue } from "../types";
 
 export const getDefaultGroupHasHigherAccessText = (defaultGroup: Group) =>
   t`The "${defaultGroup.name}" group has a higher level of access than this, which will override this setting. You should limit or revoke the "${defaultGroup.name}" group's access to this item.`;
@@ -127,7 +128,7 @@ export function getRawQueryWarningModal(
   permissions: GroupsPermissions,
   groupId: Group["id"],
   entityId: EntityId,
-  value: string,
+  value: DataPermissionValue,
 ) {
   const nativePermission = getNativePermission(permissions, groupId, entityId);
   const viewPermission = getSchemasPermission(

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -7,7 +7,6 @@ import {
 } from "metabase/admin/permissions/utils/data-entity-id";
 import {
   getFieldsPermission,
-  getNativePermission,
   getSchemasPermission,
 } from "metabase/admin/permissions/utils/graph";
 import type Database from "metabase-lib/v1/metadata/Database";
@@ -130,7 +129,13 @@ export function getRawQueryWarningModal(
   entityId: EntityId,
   value: DataPermissionValue,
 ) {
-  const nativePermission = getNativePermission(permissions, groupId, entityId);
+  const nativePermission = getSchemasPermission(
+    permissions,
+    groupId,
+    entityId,
+    DataPermission.CREATE_QUERIES,
+  );
+
   const viewPermission = getSchemasPermission(
     permissions,
     groupId,
@@ -173,8 +178,12 @@ export function getRevokingAccessToAllTablesWarningModal(
       entityId,
       DataPermission.VIEW_DATA,
     ) === DataPermissionValue.CONTROLLED &&
-    getNativePermission(permissions, groupId, entityId) !==
-      DataPermissionValue.NO
+    getSchemasPermission(
+      permissions,
+      groupId,
+      entityId,
+      DataPermission.CREATE_QUERIES,
+    ) !== DataPermissionValue.NO
   ) {
     // allTableEntityIds contains tables from all schemas
     const allTableEntityIds = database.getTables().map(table => ({

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
@@ -1,5 +1,7 @@
 import { createMockSettingsState } from "metabase-types/store/mocks";
 
+import { DataPermission, DataPermissionValue } from "../../types";
+
 // Database 2 contains an imaginary multi-schema database (like Redshift for instance)
 // Database 3 contains an imaginary database which doesn't have any schemas (like MySQL)
 export const normalizedMetadata = {
@@ -141,47 +143,38 @@ export const initialPermissions = {
   1: {
     // Sample database
     1: {
-      data: {
-        native: "write",
-        schemas: "all",
-      },
+      [DataPermission.CREATE_QUERIES]:
+        DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
     },
     // Imaginary multi-schema
     2: {
-      data: {
-        native: "write",
-        schemas: "all",
-      },
+      [DataPermission.CREATE_QUERIES]:
+        DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
     },
     // Imaginary schemaless
     3: {
-      data: {
-        native: "write",
-        schemas: "all",
-      },
+      [DataPermission.CREATE_QUERIES]:
+        DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
     },
   },
   2: {
     // Sample database
     1: {
-      data: {
-        native: "none",
-        schemas: "none",
-      },
+      [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
     },
     // Imaginary multi-schema
     2: {
-      data: {
-        native: "none",
-        schemas: "none",
-      },
+      [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
     },
     // Imaginary schemaless
     3: {
-      data: {
-        native: "none",
-        schemas: "none",
-      },
+      [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
     },
   },
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
@@ -1,4 +1,5 @@
 import { createMockSettingsState } from "metabase-types/store/mocks";
+import { DataPermission, DataPermissionValue } from "../../types";
 
 // Database 2 contains an imaginary multi-schema database (like Redshift for instance)
 // Database 3 contains an imaginary database which doesn't have any schemas (like MySQL)
@@ -141,47 +142,38 @@ export const initialPermissions = {
   1: {
     // Sample database
     1: {
-      data: {
-        native: "write",
-        schemas: "all",
-      },
+      [DataPermission.CREATE_QUERIES]:
+        DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
     },
     // Imaginary multi-schema
     2: {
-      data: {
-        native: "write",
-        schemas: "all",
-      },
+      [DataPermission.CREATE_QUERIES]:
+        DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
     },
     // Imaginary schemaless
     3: {
-      data: {
-        native: "write",
-        schemas: "all",
-      },
+      [DataPermission.CREATE_QUERIES]:
+        DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
     },
   },
   2: {
     // Sample database
     1: {
-      data: {
-        native: "none",
-        schemas: "none",
-      },
+      [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
     },
     // Imaginary multi-schema
     2: {
-      data: {
-        native: "none",
-        schemas: "none",
-      },
+      [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
     },
     // Imaginary schemaless
     3: {
-      data: {
-        native: "none",
-        schemas: "none",
-      },
+      [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
+      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
     },
   },
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
@@ -1,4 +1,5 @@
 import { createMockSettingsState } from "metabase-types/store/mocks";
+
 import { DataPermission, DataPermissionValue } from "../../types";
 
 // Database 2 contains an imaginary multi-schema database (like Redshift for instance)

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/data-permissions.unit.spec.fixtures.ts
@@ -1,7 +1,5 @@
 import { createMockSettingsState } from "metabase-types/store/mocks";
 
-import { DataPermission, DataPermissionValue } from "../../types";
-
 // Database 2 contains an imaginary multi-schema database (like Redshift for instance)
 // Database 3 contains an imaginary database which doesn't have any schemas (like MySQL)
 export const normalizedMetadata = {
@@ -143,38 +141,47 @@ export const initialPermissions = {
   1: {
     // Sample database
     1: {
-      [DataPermission.CREATE_QUERIES]:
-        DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
-      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
+      data: {
+        native: "write",
+        schemas: "all",
+      },
     },
     // Imaginary multi-schema
     2: {
-      [DataPermission.CREATE_QUERIES]:
-        DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
-      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
+      data: {
+        native: "write",
+        schemas: "all",
+      },
     },
     // Imaginary schemaless
     3: {
-      [DataPermission.CREATE_QUERIES]:
-        DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
-      [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
+      data: {
+        native: "write",
+        schemas: "all",
+      },
     },
   },
   2: {
     // Sample database
     1: {
-      [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
-      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
+      data: {
+        native: "none",
+        schemas: "none",
+      },
     },
     // Imaginary multi-schema
     2: {
-      [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
-      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
+      data: {
+        native: "none",
+        schemas: "none",
+      },
     },
     // Imaginary schemaless
     3: {
-      [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
-      [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
+      data: {
+        native: "none",
+        schemas: "none",
+      },
     },
   },
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -129,23 +129,13 @@ const buildNativePermission = (
   accessPermissionValue: string,
 ): PermissionSectionConfig => {
   const { databaseId } = entityId;
-  const dbViewValue = getSchemasPermission(
-    permissions,
-    groupId,
-    { databaseId },
-    DataPermission.VIEW_DATA,
-  );
-  const dbCreateValue = getNativePermission(permissions, groupId, {
-    databaseId,
-  });
 
-  const isDbViewDataBlocked = dbViewValue === DataPermissionValue.BLOCKED;
-  const isControlledByDb = dbCreateValue !== DataPermissionValue.CONTROLLED;
+  const dbValue = getNativePermission(permissions, groupId, { databaseId });
 
   return {
     permission: DataPermission.CREATE_QUERIES,
     type: DataPermissionType.NATIVE,
-    isDisabled: isDbViewDataBlocked,
+    isDisabled: accessPermissionValue === DataPermissionValue.BLOCKED,
     disabledTooltip: getNativePermissionDisabledTooltip(
       isAdmin,
       accessPermissionValue,
@@ -153,11 +143,11 @@ const buildNativePermission = (
     isHighlighted: isAdmin,
     value: getNativePermission(permissions, groupId, entityId),
     options: _.compact([
-      isControlledByDb && DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
+      dbValue === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
+        DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
       DATA_PERMISSION_OPTIONS.queryBuilder,
       DATA_PERMISSION_OPTIONS.no,
     ]),
-    // TODO: confirmation for no / queryBuilder options will downgrade all other tables to query-builder
   };
 };
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -4,7 +4,6 @@ import { getNativePermissionDisabledTooltip } from "metabase/admin/permissions/s
 import {
   getSchemasPermission,
   getFieldsPermission,
-  getNativePermission,
 } from "metabase/admin/permissions/utils/graph";
 import {
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS,
@@ -130,7 +129,19 @@ const buildNativePermission = (
 ): PermissionSectionConfig => {
   const { databaseId } = entityId;
 
-  const dbValue = getNativePermission(permissions, groupId, { databaseId });
+  const dbValue = getSchemasPermission(
+    permissions,
+    groupId,
+    { databaseId },
+    DataPermission.CREATE_QUERIES,
+  );
+
+  const value = getFieldsPermission(
+    permissions,
+    groupId,
+    entityId,
+    DataPermission.CREATE_QUERIES,
+  );
 
   return {
     permission: DataPermission.CREATE_QUERIES,
@@ -141,7 +152,7 @@ const buildNativePermission = (
       accessPermissionValue,
     ),
     isHighlighted: isAdmin,
-    value: getNativePermission(permissions, groupId, entityId),
+    value,
     options: _.compact([
       dbValue === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
         DATA_PERMISSION_OPTIONS.queryBuilderAndNative,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -18,7 +18,13 @@ import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import { DATA_PERMISSION_OPTIONS } from "../../constants/data-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "../../constants/messages";
-import type { TableEntityId, PermissionSectionConfig } from "../../types";
+import {
+  TableEntityId,
+  PermissionSectionConfig,
+  DataPermission,
+  DataPermissionType,
+  DataPermissionValue,
+} from "../../types";
 import {
   getPermissionWarning,
   getPermissionWarningModal,
@@ -34,25 +40,25 @@ const buildAccessPermission = (
   originalPermissions: GroupsPermissions,
   defaultGroup: Group,
   database: Database,
-) => {
+): PermissionSectionConfig => {
   const value = getFieldsPermission(
     permissions,
     groupId,
     entityId,
-    "view-data",
+    DataPermission.VIEW_DATA,
   );
 
   const originalValue = getFieldsPermission(
     originalPermissions,
     groupId,
     entityId,
-    "view-data",
+    DataPermission.VIEW_DATA,
   );
   const defaultGroupValue = getFieldsPermission(
     permissions,
     defaultGroup.id,
     entityId,
-    "view-data",
+    DataPermission.VIEW_DATA,
   );
 
   const warning = getPermissionWarning(
@@ -67,10 +73,10 @@ const buildAccessPermission = (
     permissions,
     groupId,
     entityId,
-    "view-data",
+    DataPermission.VIEW_DATA,
   );
 
-  const confirmations = (newValue: string) => [
+  const confirmations = (newValue: DataPermissionValue) => [
     getPermissionWarningModal(
       newValue,
       defaultGroupValue,
@@ -89,8 +95,8 @@ const buildAccessPermission = (
   ];
 
   return {
-    permission: "view-data",
-    type: "access",
+    permission: DataPermission.VIEW_DATA,
+    type: DataPermissionType.ACCESS,
     isDisabled:
       isAdmin ||
       PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled(value, "fields"),
@@ -100,10 +106,11 @@ const buildAccessPermission = (
     warning,
     options: PLUGIN_ADVANCED_PERMISSIONS.addTablePermissionOptions(
       _.compact([
-        DATA_PERMISSION_OPTIONS.all,
+        DATA_PERMISSION_OPTIONS.unrestricted,
         ...PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS,
-        originalValue === DATA_PERMISSION_OPTIONS.noSelfService.value &&
-          DATA_PERMISSION_OPTIONS.noSelfService,
+        originalValue ===
+          DATA_PERMISSION_OPTIONS.noSelfServiceDeprecated.value &&
+          DATA_PERMISSION_OPTIONS.noSelfServiceDeprecated,
       ]),
       value,
     ),
@@ -119,13 +126,13 @@ const buildNativePermission = (
   isAdmin: boolean,
   permissions: GroupsPermissions,
   accessPermissionValue: string,
-) => {
+): PermissionSectionConfig => {
   const { databaseId } = entityId;
   const dbValue = getNativePermission(permissions, groupId, { databaseId });
 
   return {
-    permission: "create-queries",
-    type: "native",
+    permission: DataPermission.CREATE_QUERIES,
+    type: DataPermissionType.NATIVE,
     isDisabled: dbValue !== DATA_PERMISSION_OPTIONS.controlled.value,
     disabledTooltip: getNativePermissionDisabledTooltip(
       isAdmin,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -102,14 +102,19 @@ const buildAccessPermission = (
     ]),
     value,
   );
+  const isDisabled =
+    isAdmin ||
+    (!isAdmin &&
+      (options.length <= 1 ||
+        PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled(
+          value,
+          "fields",
+        )));
 
   return {
     permission: DataPermission.VIEW_DATA,
     type: DataPermissionType.ACCESS,
-    isDisabled:
-      isAdmin ||
-      options.length <= 1 ||
-      PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled(value, "fields"),
+    isDisabled,
     disabledTooltip: isAdmin ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS : null,
     isHighlighted: isAdmin,
     value,
@@ -145,7 +150,9 @@ const buildNativePermission = (
   return {
     permission: DataPermission.CREATE_QUERIES,
     type: DataPermissionType.NATIVE,
-    isDisabled: accessPermissionValue === DataPermissionValue.BLOCKED,
+    isDisabled:
+      isAdmin ||
+      (!isAdmin && accessPermissionValue === DataPermissionValue.BLOCKED),
     disabledTooltip: getNativePermissionDisabledTooltip(
       isAdmin,
       accessPermissionValue,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -133,11 +133,7 @@ const buildNativePermission = (
     ),
     isHighlighted: isAdmin,
     value: getNativePermission(permissions, groupId, entityId),
-    options: [
-      DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
-      DATA_PERMISSION_OPTIONS.queryBuilder,
-      DATA_PERMISSION_OPTIONS.no,
-    ],
+    options: [DATA_PERMISSION_OPTIONS.queryBuilder, DATA_PERMISSION_OPTIONS.no],
   };
 };
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -4,6 +4,7 @@ import { getNativePermissionDisabledTooltip } from "metabase/admin/permissions/s
 import {
   getSchemasPermission,
   getFieldsPermission,
+  getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
 import {
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS,
@@ -127,12 +128,10 @@ const buildNativePermission = (
   permissions: GroupsPermissions,
   accessPermissionValue: DataPermissionValue,
 ): PermissionSectionConfig => {
-  const { databaseId } = entityId;
-
-  const dbValue = getSchemasPermission(
+  const schemaValue = getTablesPermission(
     permissions,
     groupId,
-    { databaseId },
+    entityId,
     DataPermission.CREATE_QUERIES,
   );
 
@@ -154,7 +153,7 @@ const buildNativePermission = (
     isHighlighted: isAdmin,
     value,
     options: _.compact([
-      dbValue === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
+      schemaValue === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
         DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
       DATA_PERMISSION_OPTIONS.queryBuilder,
       DATA_PERMISSION_OPTIONS.no,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -126,7 +126,7 @@ const buildNativePermission = (
   groupId: number,
   isAdmin: boolean,
   permissions: GroupsPermissions,
-  accessPermissionValue: string,
+  accessPermissionValue: DataPermissionValue,
 ): PermissionSectionConfig => {
   const { databaseId } = entityId;
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -120,17 +120,24 @@ const buildNativePermission = (
   permissions: GroupsPermissions,
   accessPermissionValue: string,
 ) => {
+  const { databaseId } = entityId;
+  const dbValue = getNativePermission(permissions, groupId, { databaseId });
+
   return {
-    permission: "data",
+    permission: "create-queries",
     type: "native",
-    isDisabled: true,
+    isDisabled: dbValue !== DATA_PERMISSION_OPTIONS.controlled.value,
     disabledTooltip: getNativePermissionDisabledTooltip(
       isAdmin,
       accessPermissionValue,
     ),
     isHighlighted: isAdmin,
     value: getNativePermission(permissions, groupId, entityId),
-    options: [DATA_PERMISSION_OPTIONS.write, DATA_PERMISSION_OPTIONS.none],
+    options: [
+      DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
+      DATA_PERMISSION_OPTIONS.queryBuilder,
+      DATA_PERMISSION_OPTIONS.no,
+    ],
   };
 };
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -53,6 +53,12 @@ describe("getGroupsDataPermissionEditor", () => {
         label: "Can view",
         value: DataPermissionValue.UNRESTRICTED,
       },
+      {
+        icon: "permissions_limited",
+        iconColor: "warning",
+        label: "Granular",
+        value: DataPermissionValue.CONTROLLED,
+      },
     ]);
 
     expect(nativeQueryPermission.value).toEqual(

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -1,9 +1,10 @@
 import type { State } from "metabase-types/store";
 
+import { DataPermissionValue } from "../../types";
+
 import { state as mockState } from "./data-permissions.unit.spec.fixtures";
 
 import { getGroupsDataPermissionEditor } from ".";
-import { DataPermissionValue } from "../../types";
 
 const state = mockState as unknown as State;
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -63,12 +63,6 @@ describe("getGroupsDataPermissionEditor", () => {
         label: "No self-service",
         value: "none",
       },
-      {
-        icon: "permissions_limited",
-        iconColor: "warning",
-        label: "Granular",
-        value: DataPermissionValue.CONTROLLED,
-      },
     ]);
 
     expect(nativeQueryPermission.value).toEqual("write");

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -1,5 +1,7 @@
 import type { State } from "metabase-types/store";
 
+import { DataPermissionValue } from "../../types";
+
 import { state as mockState } from "./data-permissions.unit.spec.fixtures";
 
 import { getGroupsDataPermissionEditor } from ".";
@@ -43,25 +45,13 @@ describe("getGroupsDataPermissionEditor", () => {
 
     const [accessPermission, nativeQueryPermission] =
       entities?.[1].permissions ?? [];
-    expect(accessPermission.value).toEqual("all");
+    expect(accessPermission.value).toEqual(DataPermissionValue.UNRESTRICTED);
     expect(accessPermission.options).toEqual([
       {
-        icon: "check",
-        iconColor: "success",
-        label: "Unrestricted",
-        value: "all",
-      },
-      {
-        icon: "permissions_limited",
-        iconColor: "warning",
-        label: "Granular",
-        value: "controlled",
-      },
-      {
         icon: "eye",
-        iconColor: "accent5",
-        label: "No self-service",
-        value: "none",
+        iconColor: "success",
+        label: "Can view",
+        value: DataPermissionValue.UNRESTRICTED,
       },
       {
         icon: "permissions_limited",
@@ -71,19 +61,33 @@ describe("getGroupsDataPermissionEditor", () => {
       },
     ]);
 
-    expect(nativeQueryPermission.value).toEqual("write");
+    expect(nativeQueryPermission.value).toEqual(
+      DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+    );
     expect(nativeQueryPermission.options).toEqual([
       {
+        label: `Query builder and native`,
+        value: DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
         icon: "check",
         iconColor: "success",
-        label: "Yes",
-        value: "write",
       },
       {
+        label: `Granular`,
+        value: DataPermissionValue.CONTROLLED,
+        icon: "permissions_limited",
+        iconColor: "warning",
+      },
+      {
+        label: `Query builder only`,
+        value: DataPermissionValue.QUERY_BUILDER,
+        icon: "permissions_limited",
+        iconColor: "warning",
+      },
+      {
+        label: `No`,
+        value: DataPermissionValue.NO,
         icon: "close",
         iconColor: "danger",
-        label: "No",
-        value: "none",
       },
     ]);
   });

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -63,6 +63,12 @@ describe("getGroupsDataPermissionEditor", () => {
         label: "No self-service",
         value: "none",
       },
+      {
+        icon: "permissions_limited",
+        iconColor: "warning",
+        label: "Granular",
+        value: DataPermissionValue.CONTROLLED,
+      },
     ]);
 
     expect(nativeQueryPermission.value).toEqual("write");

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -1,7 +1,5 @@
 import type { State } from "metabase-types/store";
 
-import { DataPermissionValue } from "../../types";
-
 import { state as mockState } from "./data-permissions.unit.spec.fixtures";
 
 import { getGroupsDataPermissionEditor } from ".";
@@ -45,13 +43,25 @@ describe("getGroupsDataPermissionEditor", () => {
 
     const [accessPermission, nativeQueryPermission] =
       entities?.[1].permissions ?? [];
-    expect(accessPermission.value).toEqual(DataPermissionValue.UNRESTRICTED);
+    expect(accessPermission.value).toEqual("all");
     expect(accessPermission.options).toEqual([
       {
-        icon: "eye",
+        icon: "check",
         iconColor: "success",
-        label: "Can view",
-        value: DataPermissionValue.UNRESTRICTED,
+        label: "Unrestricted",
+        value: "all",
+      },
+      {
+        icon: "permissions_limited",
+        iconColor: "warning",
+        label: "Granular",
+        value: "controlled",
+      },
+      {
+        icon: "eye",
+        iconColor: "accent5",
+        label: "No self-service",
+        value: "none",
       },
       {
         icon: "permissions_limited",
@@ -61,33 +71,19 @@ describe("getGroupsDataPermissionEditor", () => {
       },
     ]);
 
-    expect(nativeQueryPermission.value).toEqual(
-      DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
-    );
+    expect(nativeQueryPermission.value).toEqual("write");
     expect(nativeQueryPermission.options).toEqual([
       {
-        label: `Query builder and native`,
-        value: DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
         icon: "check",
         iconColor: "success",
+        label: "Yes",
+        value: "write",
       },
       {
-        label: `Granular`,
-        value: DataPermissionValue.CONTROLLED,
-        icon: "permissions_limited",
-        iconColor: "warning",
-      },
-      {
-        label: `Query builder only`,
-        value: DataPermissionValue.QUERY_BUILDER,
-        icon: "permissions_limited",
-        iconColor: "warning",
-      },
-      {
-        label: `No`,
-        value: DataPermissionValue.NO,
         icon: "close",
         iconColor: "danger",
+        label: "No",
+        value: "none",
       },
     ]);
   });

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -48,9 +48,9 @@ describe("getGroupsDataPermissionEditor", () => {
     expect(accessPermission.value).toEqual(DataPermissionValue.UNRESTRICTED);
     expect(accessPermission.options).toEqual([
       {
-        icon: "check",
+        icon: "eye",
         iconColor: "success",
-        label: "Unrestricted",
+        label: "Can view",
         value: DataPermissionValue.UNRESTRICTED,
       },
       {

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -53,12 +53,6 @@ describe("getGroupsDataPermissionEditor", () => {
         label: "Can view",
         value: DataPermissionValue.UNRESTRICTED,
       },
-      {
-        icon: "permissions_limited",
-        iconColor: "warning",
-        label: "Granular",
-        value: DataPermissionValue.CONTROLLED,
-      },
     ]);
 
     expect(nativeQueryPermission.value).toEqual(

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -3,6 +3,7 @@ import type { State } from "metabase-types/store";
 import { state as mockState } from "./data-permissions.unit.spec.fixtures";
 
 import { getGroupsDataPermissionEditor } from ".";
+import { DataPermissionValue } from "../../types";
 
 const state = mockState as unknown as State;
 
@@ -43,41 +44,49 @@ describe("getGroupsDataPermissionEditor", () => {
 
     const [accessPermission, nativeQueryPermission] =
       entities?.[1].permissions ?? [];
-    expect(accessPermission.value).toEqual("all");
+    expect(accessPermission.value).toEqual(DataPermissionValue.UNRESTRICTED);
     expect(accessPermission.options).toEqual([
       {
         icon: "check",
         iconColor: "success",
         label: "Unrestricted",
-        value: "all",
+        value: DataPermissionValue.UNRESTRICTED,
       },
       {
         icon: "permissions_limited",
         iconColor: "warning",
         label: "Granular",
-        value: "controlled",
-      },
-      {
-        icon: "eye",
-        iconColor: "accent5",
-        label: "No self-service",
-        value: "none",
+        value: DataPermissionValue.CONTROLLED,
       },
     ]);
 
-    expect(nativeQueryPermission.value).toEqual("write");
+    expect(nativeQueryPermission.value).toEqual(
+      DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+    );
     expect(nativeQueryPermission.options).toEqual([
       {
+        label: `Query builder and native`,
+        value: DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
         icon: "check",
         iconColor: "success",
-        label: "Yes",
-        value: "write",
       },
       {
+        label: `Granular`,
+        value: DataPermissionValue.CONTROLLED,
+        icon: "permissions_limited",
+        iconColor: "warning",
+      },
+      {
+        label: `Query builder only`,
+        value: DataPermissionValue.QUERY_BUILDER,
+        icon: "permissions_limited",
+        iconColor: "warning",
+      },
+      {
+        label: `No`,
+        value: DataPermissionValue.NO,
         icon: "close",
         iconColor: "danger",
-        label: "No",
-        value: "none",
       },
     ]);
   });

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -81,6 +81,9 @@ const getRouteParams = (
 const getDataPermissions = (state: State) =>
   state.admin.permissions.dataPermissions;
 
+const getOriginalDataPermissions = (state: State) =>
+  state.admin.permissions.originalDataPermissions;
+
 const getGroupRouteParams = (
   _state: State,
   props: { params: RawGroupRouteParams },
@@ -135,6 +138,7 @@ export const getDatabasesPermissionEditor = createSelector(
   getMetadataWithHiddenTables,
   getGroupRouteParams,
   getDataPermissions,
+  getOriginalDataPermissions,
   getGroup,
   Groups.selectors.getList,
   getIsLoadingDatabaseTables,
@@ -142,6 +146,7 @@ export const getDatabasesPermissionEditor = createSelector(
     metadata,
     params,
     permissions: GroupsPermissions,
+    originalPermissions: GroupsPermissions,
     group: Group,
     groups: Group[],
     isLoading,
@@ -169,8 +174,8 @@ export const getDatabasesPermissionEditor = createSelector(
     );
     const columns = [
       { name: getEditorEntityName(params, hasSingleSchema) },
-      { name: t`Data access` },
-      { name: t`Native query editing` },
+      { name: t`View data` },
+      { name: t`Create queries` },
       ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDataColumns(permissionSubject),
     ];
 
@@ -197,6 +202,7 @@ export const getDatabasesPermissionEditor = createSelector(
               groupId,
               isAdmin,
               permissions,
+              originalPermissions,
               defaultGroup,
               database,
             ),
@@ -219,6 +225,7 @@ export const getDatabasesPermissionEditor = createSelector(
               groupId,
               isAdmin,
               permissions,
+              originalPermissions,
               defaultGroup,
             ),
           };
@@ -238,6 +245,7 @@ export const getDatabasesPermissionEditor = createSelector(
               groupId,
               isAdmin,
               permissions,
+              originalPermissions,
               defaultGroup,
               database,
             ),
@@ -302,8 +310,9 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
     getMetadataWithHiddenTables,
     getRouteParams,
     getDataPermissions,
+    getOriginalDataPermissions,
     getOrderedGroups,
-    (metadata, params, permissions, groups) => {
+    (metadata, params, permissions, originalPermissions, groups) => {
       const { databaseId, schemaName, tableId } = params;
       const database = metadata?.database(databaseId);
 
@@ -322,8 +331,8 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
       const permissionSubject = getPermissionSubject(params);
       const columns = [
         { name: t`Group name` },
-        { name: t`Data access` },
-        { name: t`Native query editing` },
+        { name: t`View data` },
+        { name: t`Create queries` },
         ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDataColumns(permissionSubject),
       ];
 
@@ -341,6 +350,7 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
             group.id,
             isAdmin,
             permissions,
+            originalPermissions,
             defaultGroup,
             database,
           );
@@ -353,6 +363,7 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
             group.id,
             isAdmin,
             permissions,
+            originalPermissions,
             defaultGroup,
           );
         } else if (databaseId != null) {
@@ -363,6 +374,7 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
             group.id,
             isAdmin,
             permissions,
+            originalPermissions,
             defaultGroup,
             database,
           );

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -17,13 +17,12 @@ import type { Group, GroupsPermissions } from "metabase-types/api";
 import { DATA_PERMISSION_OPTIONS } from "../../constants/data-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "../../constants/messages";
 import { granulateDatabasePermissions } from "../../permissions";
-import {
+import type {
   DatabaseEntityId,
-  DataPermission,
-  DataPermissionType,
   DataPermissionValue,
   PermissionSectionConfig,
 } from "../../types";
+import { DataPermission, DataPermissionType } from "../../types";
 import {
   getPermissionWarning,
   getPermissionWarningModal,
@@ -75,25 +74,27 @@ const buildAccessPermission = (
     groupId,
   );
 
+  const options = PLUGIN_ADVANCED_PERMISSIONS.addDatabasePermissionOptions(
+    _.compact([
+      DATA_PERMISSION_OPTIONS.unrestricted,
+      DATA_PERMISSION_OPTIONS.controlled,
+      originalAccessPermissionValue ===
+        DATA_PERMISSION_OPTIONS.noSelfServiceDeprecated.value &&
+        DATA_PERMISSION_OPTIONS.noSelfServiceDeprecated,
+    ]),
+    database,
+  );
+
   return {
     permission: DataPermission.VIEW_DATA,
     type: DataPermissionType.ACCESS,
-    isDisabled: isAdmin,
+    isDisabled: isAdmin || options.length <= 1,
     disabledTooltip: isAdmin ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS : null,
     isHighlighted: isAdmin,
     value: accessPermissionValue,
     warning: accessPermissionWarning,
     confirmations: accessPermissionConfirmations,
-    options: PLUGIN_ADVANCED_PERMISSIONS.addDatabasePermissionOptions(
-      _.compact([
-        DATA_PERMISSION_OPTIONS.unrestricted,
-        DATA_PERMISSION_OPTIONS.controlled,
-        originalAccessPermissionValue ===
-          DATA_PERMISSION_OPTIONS.noSelfServiceDeprecated.value &&
-          DATA_PERMISSION_OPTIONS.noSelfServiceDeprecated,
-      ]),
-      database,
-    ),
+    options,
     postActions: {
       controlled: (_, __, ___, accessPermissionValue) =>
         granulateDatabasePermissions(

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -85,7 +85,7 @@ const buildAccessPermission = (
   return {
     permission: DataPermission.VIEW_DATA,
     type: DataPermissionType.ACCESS,
-    isDisabled: isAdmin || options.length <= 1,
+    isDisabled: isAdmin || (!isAdmin && options.length <= 1),
     disabledTooltip: isAdmin ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS : null,
     isHighlighted: isAdmin,
     value: accessPermissionValue,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -89,7 +89,7 @@ const buildAccessPermission = (
       database,
     ),
     postActions: {
-      controlled: (_, __, ___, accessPermissionValue) =>
+      controlled: (_: any, __: any, ___: any, accessPermissionValue: string) =>
         granulateDatabasePermissions(
           groupId,
           entityId,
@@ -162,13 +162,14 @@ const buildNativePermission = (
       DATA_PERMISSION_OPTIONS.no,
     ],
     postActions: {
-      controlled: (_, __, ___, accessPermissionValue) =>
+      // TODO: add better typing
+      controlled: (_: any, __: any, ___: any, accessPermissionValue: string) =>
         granulateDatabasePermissions(
           groupId,
           entityId,
           { type: "native", permission: "create-queries" },
           accessPermissionValue,
-          DATA_PERMISSION_OPTIONS.queryBuilderAndNative.value,
+          DATA_PERMISSION_OPTIONS.queryBuilder.value,
         ),
     },
   };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -119,7 +119,7 @@ const buildNativePermission = (
   isAdmin: boolean,
   permissions: GroupsPermissions,
   defaultGroup: Group,
-  accessPermissionValue: string,
+  accessPermissionValue: DataPermissionValue,
 ): PermissionSectionConfig => {
   const nativePermissionValue = getNativePermission(
     permissions,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -89,13 +89,14 @@ const buildAccessPermission = (
       database,
     ),
     postActions: {
-      controlled: (_, __, ___, accessPermissionValue) => {
-        return granulateDatabasePermissions(
+      controlled: (_, __, ___, accessPermissionValue) =>
+        granulateDatabasePermissions(
           groupId,
           entityId,
+          { type: "access", permission: "view-data" },
           accessPermissionValue,
-        );
-      },
+          DATA_PERMISSION_OPTIONS.all.value,
+        ),
       ...PLUGIN_ADMIN_PERMISSIONS_DATABASE_POST_ACTIONS,
     },
     actions: PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS,
@@ -146,7 +147,7 @@ const buildNativePermission = (
   );
 
   return {
-    permission: "data",
+    permission: "create-queries",
     type: "native",
     isDisabled: disabledTooltip != null,
     disabledTooltip,
@@ -154,7 +155,22 @@ const buildNativePermission = (
     value: nativePermissionValue,
     warning: nativePermissionWarning,
     confirmations: nativePermissionConfirmations,
-    options: [DATA_PERMISSION_OPTIONS.write, DATA_PERMISSION_OPTIONS.none],
+    options: [
+      DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
+      DATA_PERMISSION_OPTIONS.controlled,
+      DATA_PERMISSION_OPTIONS.queryBuilder,
+      DATA_PERMISSION_OPTIONS.no,
+    ],
+    postActions: {
+      controlled: (_, __, ___, accessPermissionValue) =>
+        granulateDatabasePermissions(
+          groupId,
+          entityId,
+          { type: "native", permission: "create-queries" },
+          accessPermissionValue,
+          DATA_PERMISSION_OPTIONS.queryBuilderAndNative.value,
+        ),
+    },
   };
 };
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -82,11 +82,6 @@ const buildAccessPermission = (
     database,
   );
 
-  // HACK: if the only two options are unrestricted and controlled, then let's remove the controlled option
-  if (options.length === 2) {
-    options.pop();
-  }
-
   return {
     permission: DataPermission.VIEW_DATA,
     type: DataPermissionType.ACCESS,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -1,10 +1,7 @@
 import _ from "underscore";
 
 import { getNativePermissionDisabledTooltip } from "metabase/admin/permissions/selectors/data-permissions/shared";
-import {
-  getNativePermission,
-  getSchemasPermission,
-} from "metabase/admin/permissions/utils/graph";
+import { getSchemasPermission } from "metabase/admin/permissions/utils/graph";
 import {
   PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS,
   PLUGIN_ADMIN_PERMISSIONS_DATABASE_POST_ACTIONS,
@@ -121,19 +118,21 @@ const buildNativePermission = (
   defaultGroup: Group,
   accessPermissionValue: DataPermissionValue,
 ): PermissionSectionConfig => {
-  const nativePermissionValue = getNativePermission(
+  const value = getSchemasPermission(
     permissions,
     groupId,
     entityId,
+    DataPermission.CREATE_QUERIES,
   );
 
-  const defaultGroupNativePermissionValue = getNativePermission(
+  const defaultGroupNativePermissionValue = getSchemasPermission(
     permissions,
     defaultGroup.id,
     entityId,
+    DataPermission.CREATE_QUERIES,
   );
   const nativePermissionWarning = getPermissionWarning(
-    nativePermissionValue,
+    value,
     defaultGroupNativePermissionValue,
     null,
     defaultGroup,
@@ -162,7 +161,7 @@ const buildNativePermission = (
     isDisabled: disabledTooltip != null,
     disabledTooltip,
     isHighlighted: isAdmin,
-    value: nativePermissionValue,
+    value,
     warning: nativePermissionWarning,
     confirmations: nativePermissionConfirmations,
     options: [
@@ -181,9 +180,9 @@ const buildNativePermission = (
             permission: DataPermission.CREATE_QUERIES,
           },
           newValue,
-          nativePermissionValue === DataPermissionValue.QUERY_BUILDER_AND_NATIVE
+          value === DataPermissionValue.QUERY_BUILDER_AND_NATIVE
             ? DataPermissionValue.QUERY_BUILDER
-            : nativePermissionValue,
+            : value,
         ),
     },
   };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -17,12 +17,12 @@ import type { Group, GroupsPermissions } from "metabase-types/api";
 import { DATA_PERMISSION_OPTIONS } from "../../constants/data-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "../../constants/messages";
 import { granulateDatabasePermissions } from "../../permissions";
-import type {
-  DatabaseEntityId,
+import type { DatabaseEntityId, PermissionSectionConfig } from "../../types";
+import {
   DataPermissionValue,
-  PermissionSectionConfig,
+  DataPermission,
+  DataPermissionType,
 } from "../../types";
-import { DataPermission, DataPermissionType } from "../../types";
 import {
   getPermissionWarning,
   getPermissionWarningModal,
@@ -105,7 +105,7 @@ const buildAccessPermission = (
             permission: DataPermission.VIEW_DATA,
           },
           accessPermissionValue,
-          DATA_PERMISSION_OPTIONS.unrestricted.value,
+          DataPermissionValue.UNRESTRICTED,
         ),
       ...PLUGIN_ADMIN_PERMISSIONS_DATABASE_POST_ACTIONS,
     },
@@ -172,7 +172,7 @@ const buildNativePermission = (
       DATA_PERMISSION_OPTIONS.no,
     ],
     postActions: {
-      controlled: (_, __, ___, accessPermissionValue) =>
+      controlled: (_, __, ___, newValue) =>
         granulateDatabasePermissions(
           groupId,
           entityId,
@@ -180,8 +180,10 @@ const buildNativePermission = (
             type: DataPermissionType.NATIVE,
             permission: DataPermission.CREATE_QUERIES,
           },
-          accessPermissionValue,
-          DATA_PERMISSION_OPTIONS.queryBuilder.value,
+          newValue,
+          nativePermissionValue === DataPermissionValue.QUERY_BUILDER_AND_NATIVE
+            ? DataPermissionValue.QUERY_BUILDER
+            : nativePermissionValue,
         ),
     },
   };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/shared.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/shared.ts
@@ -4,9 +4,11 @@ import {
 } from "metabase/admin/permissions/constants/messages";
 import { isRestrictivePermission } from "metabase/admin/permissions/utils/graph";
 
+import type { DataPermissionValue } from "../../types";
+
 export const getNativePermissionDisabledTooltip = (
   isAdmin: boolean,
-  accessPermissionValue: string,
+  accessPermissionValue: DataPermissionValue,
 ) => {
   if (isAdmin) {
     return UNABLE_TO_CHANGE_ADMIN_PERMISSIONS;

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -3,7 +3,7 @@ import _ from "underscore";
 
 import { getNativePermissionDisabledTooltip } from "metabase/admin/permissions/selectors/data-permissions/shared";
 import {
-  getNativePermission,
+  getSchemasPermission,
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
 import {
@@ -113,7 +113,19 @@ const buildNativePermission = (
 ): PermissionSectionConfig => {
   const { databaseId } = entityId;
 
-  const dbValue = getNativePermission(permissions, groupId, { databaseId });
+  const dbValue = getSchemasPermission(
+    permissions,
+    groupId,
+    { databaseId },
+    DataPermission.CREATE_QUERIES,
+  );
+
+  const value = getTablesPermission(
+    permissions,
+    groupId,
+    entityId,
+    DataPermission.CREATE_QUERIES,
+  );
 
   return {
     permission: DataPermission.CREATE_QUERIES,
@@ -124,7 +136,7 @@ const buildNativePermission = (
       accessPermissionValue,
     ),
     isHighlighted: isAdmin,
-    value: getNativePermission(permissions, groupId, entityId),
+    value,
     options: _.compact([
       dbValue === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
         DATA_PERMISSION_OPTIONS.queryBuilderAndNative,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -104,7 +104,7 @@ const buildNativePermission = (
   accessPermissionValue: string,
 ) => {
   return {
-    permission: "data",
+    permission: "create-queries",
     type: "native",
     isDisabled: true,
     disabledTooltip: getNativePermissionDisabledTooltip(
@@ -113,7 +113,11 @@ const buildNativePermission = (
     ),
     isHighlighted: isAdmin,
     value: getNativePermission(permissions, groupId, entityId),
-    options: [DATA_PERMISSION_OPTIONS.write, DATA_PERMISSION_OPTIONS.none],
+    options: [
+      DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
+      DATA_PERMISSION_OPTIONS.queryBuilder,
+      DATA_PERMISSION_OPTIONS.no,
+    ],
   };
 };
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -109,7 +109,7 @@ const buildNativePermission = (
   groupId: number,
   isAdmin: boolean,
   permissions: GroupsPermissions,
-  accessPermissionValue: string,
+  accessPermissionValue: DataPermissionValue,
 ): PermissionSectionConfig => {
   const { databaseId } = entityId;
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -91,8 +91,12 @@ const buildAccessPermission = (
     type: DataPermissionType.ACCESS,
     isDisabled:
       isAdmin ||
-      options.length <= 1 ||
-      PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled(value, "tables"),
+      (!isAdmin &&
+        (options.length <= 1 ||
+          PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled(
+            value,
+            "tables",
+          ))),
     isHighlighted: isAdmin,
     disabledTooltip: isAdmin ? UNABLE_TO_CHANGE_ADMIN_PERMISSIONS : null,
     value,
@@ -129,7 +133,9 @@ const buildNativePermission = (
   return {
     permission: DataPermission.CREATE_QUERIES,
     type: DataPermissionType.NATIVE,
-    isDisabled: accessPermissionValue === DataPermissionValue.BLOCKED,
+    isDisabled:
+      isAdmin ||
+      (!isAdmin && accessPermissionValue === DataPermissionValue.BLOCKED),
     disabledTooltip: getNativePermissionDisabledTooltip(
       isAdmin,
       accessPermissionValue,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -14,12 +14,12 @@ import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import { DATA_PERMISSION_OPTIONS } from "../../constants/data-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "../../constants/messages";
-import type {
+import type { PermissionSectionConfig, SchemaEntityId } from "../../types";
+import {
   DataPermissionValue,
-  PermissionSectionConfig,
-  SchemaEntityId,
+  DataPermission,
+  DataPermissionType,
 } from "../../types";
-import { DataPermission, DataPermissionType } from "../../types";
 import { getGroupFocusPermissionsUrl } from "../../utils/urls";
 import {
   getControlledDatabaseWarningModal,
@@ -112,13 +112,13 @@ const buildNativePermission = (
   accessPermissionValue: string,
 ): PermissionSectionConfig => {
   const { databaseId } = entityId;
+
   const dbValue = getNativePermission(permissions, groupId, { databaseId });
-  const isControlledByDb = dbValue !== DATA_PERMISSION_OPTIONS.controlled.value;
 
   return {
     permission: DataPermission.CREATE_QUERIES,
     type: DataPermissionType.NATIVE,
-    isDisabled: isControlledByDb,
+    isDisabled: accessPermissionValue === DataPermissionValue.BLOCKED,
     disabledTooltip: getNativePermissionDisabledTooltip(
       isAdmin,
       accessPermissionValue,
@@ -126,7 +126,8 @@ const buildNativePermission = (
     isHighlighted: isAdmin,
     value: getNativePermission(permissions, groupId, entityId),
     options: _.compact([
-      isControlledByDb && DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
+      dbValue === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
+        DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
       DATA_PERMISSION_OPTIONS.queryBuilder,
       DATA_PERMISSION_OPTIONS.no,
     ]),

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -14,7 +14,13 @@ import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import { DATA_PERMISSION_OPTIONS } from "../../constants/data-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "../../constants/messages";
-import type { PermissionSectionConfig, SchemaEntityId } from "../../types";
+import {
+  DataPermission,
+  DataPermissionType,
+  DataPermissionValue,
+  PermissionSectionConfig,
+  SchemaEntityId,
+} from "../../types";
 import { getGroupFocusPermissionsUrl } from "../../utils/urls";
 import {
   getControlledDatabaseWarningModal,
@@ -29,26 +35,26 @@ const buildAccessPermission = (
   permissions: GroupsPermissions,
   originalPermissions: GroupsPermissions,
   defaultGroup: Group,
-) => {
+): PermissionSectionConfig => {
   const value = getTablesPermission(
     permissions,
     groupId,
     entityId,
-    "view-data",
+    DataPermission.VIEW_DATA,
   );
 
   const originalValue = getTablesPermission(
     originalPermissions,
     groupId,
     entityId,
-    "view-data",
+    DataPermission.VIEW_DATA,
   );
 
   const defaultGroupValue = getTablesPermission(
     permissions,
     defaultGroup.id,
     entityId,
-    "view-data",
+    DataPermission.VIEW_DATA,
   );
 
   const warning = getPermissionWarning(
@@ -59,7 +65,7 @@ const buildAccessPermission = (
     groupId,
   );
 
-  const confirmations = (newValue: string) => [
+  const confirmations = (newValue: DataPermissionValue) => [
     getPermissionWarningModal(
       newValue,
       defaultGroupValue,
@@ -71,8 +77,8 @@ const buildAccessPermission = (
   ];
 
   return {
-    permission: "view-data",
-    type: "access",
+    permission: DataPermission.VIEW_DATA,
+    type: DataPermissionType.ACCESS,
     isDisabled:
       isAdmin ||
       PLUGIN_ADVANCED_PERMISSIONS.isAccessPermissionDisabled(value, "tables"),
@@ -86,10 +92,11 @@ const buildAccessPermission = (
     },
     options: PLUGIN_ADVANCED_PERMISSIONS.addSchemaPermissionOptions(
       _.compact([
-        DATA_PERMISSION_OPTIONS.all,
+        DATA_PERMISSION_OPTIONS.unrestricted,
         DATA_PERMISSION_OPTIONS.controlled,
-        originalValue === DATA_PERMISSION_OPTIONS.noSelfService.value &&
-          DATA_PERMISSION_OPTIONS.noSelfService,
+        originalValue ===
+          DATA_PERMISSION_OPTIONS.noSelfServiceDeprecated.value &&
+          DATA_PERMISSION_OPTIONS.noSelfServiceDeprecated,
       ]),
       value,
     ),
@@ -102,10 +109,10 @@ const buildNativePermission = (
   isAdmin: boolean,
   permissions: GroupsPermissions,
   accessPermissionValue: string,
-) => {
+): PermissionSectionConfig => {
   return {
-    permission: "create-queries",
-    type: "native",
+    permission: DataPermission.CREATE_QUERIES,
+    type: DataPermissionType.NATIVE,
     isDisabled: true,
     disabledTooltip: getNativePermissionDisabledTooltip(
       isAdmin,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -113,11 +113,7 @@ const buildNativePermission = (
     ),
     isHighlighted: isAdmin,
     value: getNativePermission(permissions, groupId, entityId),
-    options: [
-      DATA_PERMISSION_OPTIONS.queryBuilderAndNative,
-      DATA_PERMISSION_OPTIONS.queryBuilder,
-      DATA_PERMISSION_OPTIONS.no,
-    ],
+    options: [DATA_PERMISSION_OPTIONS.queryBuilder, DATA_PERMISSION_OPTIONS.no],
   };
 };
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -1,4 +1,3 @@
-import { push } from "react-router-redux";
 import _ from "underscore";
 
 import { getNativePermissionDisabledTooltip } from "metabase/admin/permissions/selectors/data-permissions/shared";
@@ -14,14 +13,13 @@ import type { Group, GroupsPermissions } from "metabase-types/api";
 
 import { DATA_PERMISSION_OPTIONS } from "../../constants/data-permissions";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "../../constants/messages";
-import { granulateDatabasePermissions } from "../../permissions";
+import { navigateToGranularPermissions } from "../../permissions";
 import type { PermissionSectionConfig, SchemaEntityId } from "../../types";
 import {
   DataPermissionValue,
   DataPermission,
   DataPermissionType,
 } from "../../types";
-import { getGroupFocusPermissionsUrl } from "../../utils/urls";
 import {
   getControlledDatabaseWarningModal,
   getPermissionWarning,
@@ -103,7 +101,7 @@ const buildAccessPermission = (
     warning,
     confirmations,
     postActions: {
-      controlled: () => push(getGroupFocusPermissionsUrl(groupId, entityId)),
+      controlled: () => navigateToGranularPermissions(groupId, entityId),
     },
     options,
   };
@@ -119,7 +117,7 @@ const buildNativePermission = (
   const dbValue = getSchemasPermission(
     permissions,
     groupId,
-    entityId,
+    { databaseId: entityId.databaseId },
     DataPermission.CREATE_QUERIES,
   );
 
@@ -150,19 +148,7 @@ const buildNativePermission = (
       DATA_PERMISSION_OPTIONS.no,
     ]),
     postActions: {
-      controlled: (_, __, ___, newValue) =>
-        granulateDatabasePermissions(
-          groupId,
-          entityId,
-          {
-            type: DataPermissionType.NATIVE,
-            permission: DataPermission.CREATE_QUERIES,
-          },
-          newValue,
-          value === DataPermissionValue.QUERY_BUILDER_AND_NATIVE
-            ? DataPermissionValue.QUERY_BUILDER
-            : value,
-        ),
+      controlled: () => navigateToGranularPermissions(groupId, entityId),
     },
   };
 };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -1,4 +1,5 @@
 import { push } from "react-router-redux";
+import _ from "underscore";
 
 import { getNativePermissionDisabledTooltip } from "metabase/admin/permissions/selectors/data-permissions/shared";
 import {
@@ -26,14 +27,28 @@ const buildAccessPermission = (
   groupId: number,
   isAdmin: boolean,
   permissions: GroupsPermissions,
+  originalPermissions: GroupsPermissions,
   defaultGroup: Group,
 ) => {
-  const value = getTablesPermission(permissions, groupId, entityId, "data");
+  const value = getTablesPermission(
+    permissions,
+    groupId,
+    entityId,
+    "view-data",
+  );
+
+  const originalValue = getTablesPermission(
+    originalPermissions,
+    groupId,
+    entityId,
+    "view-data",
+  );
+
   const defaultGroupValue = getTablesPermission(
     permissions,
     defaultGroup.id,
     entityId,
-    "data",
+    "view-data",
   );
 
   const warning = getPermissionWarning(
@@ -52,11 +67,11 @@ const buildAccessPermission = (
       defaultGroup,
       groupId,
     ),
-    getControlledDatabaseWarningModal(permissions, groupId, entityId),
+    getControlledDatabaseWarningModal(newValue, entityId),
   ];
 
   return {
-    permission: "data",
+    permission: "view-data",
     type: "access",
     isDisabled:
       isAdmin ||
@@ -70,11 +85,12 @@ const buildAccessPermission = (
       controlled: () => push(getGroupFocusPermissionsUrl(groupId, entityId)),
     },
     options: PLUGIN_ADVANCED_PERMISSIONS.addSchemaPermissionOptions(
-      [
+      _.compact([
         DATA_PERMISSION_OPTIONS.all,
         DATA_PERMISSION_OPTIONS.controlled,
-        DATA_PERMISSION_OPTIONS.noSelfService,
-      ],
+        originalValue === DATA_PERMISSION_OPTIONS.noSelfService.value &&
+          DATA_PERMISSION_OPTIONS.noSelfService,
+      ]),
       value,
     ),
   };
@@ -106,6 +122,7 @@ export const buildTablesPermissions = (
   groupId: number,
   isAdmin: boolean,
   permissions: GroupsPermissions,
+  originalPermissions: GroupsPermissions,
   defaultGroup: Group,
 ): PermissionSectionConfig[] => {
   const accessPermission = buildAccessPermission(
@@ -113,6 +130,7 @@ export const buildTablesPermissions = (
     groupId,
     isAdmin,
     permissions,
+    originalPermissions,
     defaultGroup,
   );
 

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
@@ -21,8 +21,6 @@ import { PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES } from "metabase/plugins";
 import { createMockGroup } from "metabase-types/api/mocks/group";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
-const NATIVE_QUERIES_PERMISSION_INDEX = 1;
-
 const TEST_DATABASE = createSampleDatabase();
 
 // Order is important here for test to pass, since admin options aren't editable
@@ -64,13 +62,10 @@ const setup = async () => {
 };
 
 const editDatabasePermission = async () => {
-  const permissionsSelectElem =
-    screen.getAllByTestId("permissions-select")[
-      NATIVE_QUERIES_PERMISSION_INDEX
-    ];
+  const permissionsSelectElem = screen.getAllByTestId("permissions-select")[0];
   fireEvent.click(permissionsSelectElem);
 
-  const clickElement = screen.getByLabelText(/close icon/);
+  const clickElement = screen.getByLabelText("eye icon");
   fireEvent.click(clickElement);
 
   await delay(0);

--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
@@ -21,6 +21,8 @@ import { PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES } from "metabase/plugins";
 import { createMockGroup } from "metabase-types/api/mocks/group";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
+const NATIVE_QUERIES_PERMISSION_INDEX = 1;
+
 const TEST_DATABASE = createSampleDatabase();
 
 // Order is important here for test to pass, since admin options aren't editable
@@ -62,10 +64,13 @@ const setup = async () => {
 };
 
 const editDatabasePermission = async () => {
-  const permissionsSelectElem = screen.getAllByTestId("permissions-select")[0];
+  const permissionsSelectElem =
+    screen.getAllByTestId("permissions-select")[
+      NATIVE_QUERIES_PERMISSION_INDEX
+    ];
   fireEvent.click(permissionsSelectElem);
 
-  const clickElement = screen.getByLabelText("eye icon");
+  const clickElement = screen.getByLabelText(/close icon/);
   fireEvent.click(clickElement);
 
   await delay(0);

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -21,6 +21,8 @@ import { PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES } from "metabase/plugins";
 import { createMockGroup } from "metabase-types/api/mocks/group";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
+const NATIVE_QUERIES_PERMISSION_INDEX = 1;
+
 const TEST_DATABASE = createSampleDatabase();
 
 const TEST_GROUPS = [
@@ -63,10 +65,13 @@ const setup = async ({
 };
 
 const editDatabasePermission = async () => {
-  const permissionsSelectElem = screen.getAllByTestId("permissions-select")[0];
+  const permissionsSelectElem =
+    screen.getAllByTestId("permissions-select")[
+      NATIVE_QUERIES_PERMISSION_INDEX
+    ];
   fireEvent.click(permissionsSelectElem);
 
-  const clickElement = screen.getByLabelText("eye icon");
+  const clickElement = screen.getByLabelText(/close icon/);
   fireEvent.click(clickElement);
 
   await delay(0);

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -21,8 +21,6 @@ import { PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES } from "metabase/plugins";
 import { createMockGroup } from "metabase-types/api/mocks/group";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";
 
-const NATIVE_QUERIES_PERMISSION_INDEX = 1;
-
 const TEST_DATABASE = createSampleDatabase();
 
 const TEST_GROUPS = [
@@ -65,13 +63,10 @@ const setup = async ({
 };
 
 const editDatabasePermission = async () => {
-  const permissionsSelectElem =
-    screen.getAllByTestId("permissions-select")[
-      NATIVE_QUERIES_PERMISSION_INDEX
-    ];
+  const permissionsSelectElem = screen.getAllByTestId("permissions-select")[0];
   fireEvent.click(permissionsSelectElem);
 
-  const clickElement = screen.getByLabelText(/close icon/);
+  const clickElement = screen.getByLabelText("eye icon");
   fireEvent.click(clickElement);
 
   await delay(0);

--- a/frontend/src/metabase/admin/permissions/types.ts
+++ b/frontend/src/metabase/admin/permissions/types.ts
@@ -37,7 +37,12 @@ export type TableEntityId = SchemaEntityId & {
 export type EntityId = DatabaseEntityId &
   Partial<Omit<TableEntityId, "databaseId">>;
 
-export type DataPermission = "data" | "download" | "data-model" | "details";
+export type DataPermission =
+  | "view-data"
+  | "create-queries"
+  | "download"
+  | "data-model"
+  | "details";
 
 export type PermissionSubject = "schemas" | "tables" | "fields";
 

--- a/frontend/src/metabase/admin/permissions/types.ts
+++ b/frontend/src/metabase/admin/permissions/types.ts
@@ -63,14 +63,13 @@ export enum DataPermissionValue {
   QUERY_BUILDER_AND_NATIVE = "query-builder-and-native",
   SANDBOXED = "sandboxed",
   UNRESTRICTED = "unrestricted",
-  // TODO: turn off none all below and see what errors appear
-  // download values
+  // download specific values
   NONE = "none",
   LIMITED = "limited",
   FULL = "full",
-  // details values
+  // details specific values
   YES = "yes",
-  // data model
+  // data model specific values
   ALL = "all",
 }
 

--- a/frontend/src/metabase/admin/permissions/types.ts
+++ b/frontend/src/metabase/admin/permissions/types.ts
@@ -37,39 +37,84 @@ export type TableEntityId = SchemaEntityId & {
 export type EntityId = DatabaseEntityId &
   Partial<Omit<TableEntityId, "databaseId">>;
 
-export type DataPermission =
-  | "view-data"
-  | "create-queries"
-  | "download"
-  | "data-model"
-  | "details";
+export enum DataPermission {
+  VIEW_DATA = "view-data",
+  CREATE_QUERIES = "create-queries",
+  DOWNLOAD = "download",
+  DATA_MODEL = "data-model",
+  DETAILS = "details",
+}
+
+export enum DataPermissionType {
+  ACCESS = "access",
+  NATIVE = "native",
+  DETAILS = "details",
+  DOWNLOAD = "download",
+  DATA_MODEL = "data-model",
+}
+
+export enum DataPermissionValue {
+  BLOCKED = "blocked",
+  CONTROLLED = "controlled",
+  IMPERSONATED = "impersonated",
+  LEGACY_NO_SELF_SERVICE = "legacy-no-self-service",
+  NO = "no",
+  QUERY_BUILDER = "query-builder",
+  QUERY_BUILDER_AND_NATIVE = "query-builder-and-native",
+  SANDBOXED = "sandboxed",
+  UNRESTRICTED = "unrestricted",
+  // TODO: turn off none all below and see what errors appear
+  // download values
+  NONE = "none",
+  LIMITED = "limited",
+  FULL = "full",
+  // details values
+  YES = "yes",
+  // data model
+  ALL = "all",
+}
 
 export type PermissionSubject = "schemas" | "tables" | "fields";
 
 export type PermissionSectionConfig = {
-  permission: string;
-  type: string;
+  permission: DataPermission;
+  type: DataPermissionType;
+  value: DataPermissionValue;
   isDisabled: boolean;
   disabledTooltip: string | null;
   isHighlighted: boolean;
-  value: string;
-  warning: string | null;
+  warning?: string | null;
   options: {
     label: string;
     value: string;
     icon: string;
     iconColor: string;
   }[];
-  actions: {
-    controlled: {
-      label: string;
-      icon: string;
-      iconColor: string;
-      actionCreator: (...args: unknown[]) => void;
-    }[];
-  };
-  postActions: {
-    controlled: null | ((...args: unknown[]) => void);
-  };
-  confirmations: unknown[];
+  actions?: Partial<
+    Record<
+      DataPermissionValue,
+      | {
+          label: string;
+          icon: string;
+          iconColor: string;
+          actionCreator: (...args: unknown[]) => void;
+        }[]
+      | undefined
+    >
+  >;
+  postActions?: Partial<
+    Record<
+      DataPermissionValue,
+      ((...args: unknown[]) => void) | null | undefined
+    >
+  >;
+  confirmations?: (newValue: DataPermissionValue) => (
+    | {
+        title: string;
+        message: string;
+        confirmButtonText: string;
+        cancelButtonText: string;
+      }
+    | undefined
+  )[];
 };

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -38,7 +38,7 @@ function getPermissionPath(
   return [groupId, databaseId, permission, "schemas", ...(nestedPath || [])];
 }
 
-const elludedDefaultValues: Record<DataPermission, DataPermissionValue> = {
+const omittedDefaultValues: Record<DataPermission, DataPermissionValue> = {
   [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
   [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
   [DataPermission.DOWNLOAD]: DataPermissionValue.NONE,
@@ -46,10 +46,10 @@ const elludedDefaultValues: Record<DataPermission, DataPermissionValue> = {
   [DataPermission.DETAILS]: DataPermissionValue.NO,
 };
 
-function getElludedPermissionValue(
+function getOmittedPermissionValue(
   permission: DataPermission,
 ): DataPermissionValue {
-  return elludedDefaultValues[permission] ?? DataPermissionValue.NO;
+  return omittedDefaultValues[permission] ?? DataPermissionValue.NO;
 }
 
 interface GetPermissionParams {
@@ -74,7 +74,7 @@ const getPermission = ({
   if (isControlledType && typeof value === "object") {
     return DataPermissionValue.CONTROLLED;
   }
-  return value ? value : getElludedPermissionValue(permission);
+  return value ? value : getOmittedPermissionValue(permission);
 };
 
 export function updatePermission(

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -17,6 +17,19 @@ import type {
 export const isRestrictivePermission = (value: string) =>
   value === "block" || value === "none";
 
+// util to ease migration of perms attributes into a flatter structure
+function getDataPermissionPath(
+  databaseId: number,
+  permission: DataPermission,
+  nestedPath?: Array<string | number>,
+) {
+  if (permission === "view-data" || permission === "create-queries") {
+    return [databaseId, permission, ...(nestedPath || [])];
+  } else {
+    return [databaseId, permission, "schemas", ...(nestedPath || [])];
+  }
+}
+
 export function getPermission(
   permissions: GroupsPermissions,
   groupId: number,
@@ -82,7 +95,7 @@ export const getSchemasPermission = (
   return getPermission(
     permissions,
     groupId,
-    [databaseId, permission, "schemas"],
+    getDataPermissionPath(databaseId, permission),
     true,
   );
 };
@@ -113,7 +126,7 @@ export const getTablesPermission = (
     return getPermission(
       permissions,
       groupId,
-      [databaseId, permission, "schemas", schemaName || ""],
+      getDataPermissionPath(databaseId, permission, [schemaName || ""]),
       true,
     );
   } else {
@@ -140,7 +153,10 @@ export const getFieldsPermission = (
     return getPermission(
       permissions,
       groupId,
-      [databaseId, permission, "schemas", schemaName ?? "", tableId],
+      getDataPermissionPath(databaseId, permission, [
+        schemaName ?? "",
+        tableId,
+      ]),
       true,
     );
   } else {
@@ -332,7 +348,7 @@ export function updateFieldsPermission(
   permissions = updatePermission(
     permissions,
     groupId,
-    [databaseId, permission, "schemas", schemaName, tableId],
+    getDataPermissionPath(databaseId, permission, [schemaName, tableId]),
     ((PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_PERMISSION_VALUE as any)[
       value
     ] as any) || value,
@@ -365,7 +381,7 @@ export function updateTablesPermission(
   permissions = updatePermission(
     permissions,
     groupId,
-    [databaseId, permission, "schemas", schemaName || ""],
+    getDataPermissionPath(databaseId, permission, [schemaName || ""]),
     value,
     tableIds,
   );
@@ -404,7 +420,7 @@ export function updateSchemasPermission(
   return updatePermission(
     permissions,
     groupId,
-    [databaseId, permission, "schemas"],
+    getDataPermissionPath(databaseId, permission),
     value,
     schemaNamesOrNoSchema,
   );

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -431,7 +431,7 @@ export function updateSchemasPermission(
     schemaNames.length > 0 &&
     !(schemaNames.length === 1 && schemaNames[0] === null)
       ? schemaNames
-      : [""];
+      : [];
 
   if (downgradeNative) {
     permissions = downgradeNativePermissionsIfNeeded(

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -13,11 +13,15 @@ import type {
 } from "../../types";
 import { DataPermission, DataPermissionValue } from "../../types";
 
-export const isRestrictivePermission = (value: string) =>
-  value === "blocked" || value === "no";
+export const isRestrictivePermission = (value: DataPermissionValue) =>
+  value === DataPermissionValue.BLOCKED || value === DataPermissionValue.NO;
 
 // permission that do not have a nested shemas/native key
-const flatPermissions = new Set(["details", "view-data", "create-queries"]);
+const flatPermissions = new Set([
+  DataPermission.DETAILS,
+  DataPermission.VIEW_DATA,
+  DataPermission.CREATE_QUERIES,
+]);
 
 // util to ease migration of perms attributes into a flatter structure
 function getPermissionPath(

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -34,7 +34,7 @@ function getPermissionPath(
 }
 
 const elludedDefaultValues: Record<DataPermission, DataPermissionValue> = {
-  [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
+  [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
   [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
   [DataPermission.DOWNLOAD]: DataPermissionValue.NONE,
   [DataPermission.DATA_MODEL]: DataPermissionValue.NONE,

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -187,7 +187,6 @@ export function downgradeNativePermissionsIfNeeded(
   groupId: number,
   { databaseId }: DatabaseEntityId,
   value: any,
-  database: Database,
   permission: DataPermission,
 ) {
   const currentSchemas = getSchemasPermission(
@@ -319,7 +318,6 @@ export function inferAndUpdateEntityPermissions(
         groupId,
         { databaseId },
         schemasPermissionValue,
-        database,
         permission,
       );
     }
@@ -418,7 +416,6 @@ export function updateSchemasPermission(
       groupId,
       { databaseId },
       value,
-      database,
       permission,
     );
   }

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -130,19 +130,6 @@ export const getSchemasPermission = (
   });
 };
 
-export const getNativePermission = (
-  permissions: GroupsPermissions,
-  groupId: number,
-  entityId: any, // TODO: fix typing, getFieldsPermission should probably be replaced with getPermission
-): DataPermissionValue => {
-  return getFieldsPermission(
-    permissions,
-    groupId,
-    entityId,
-    DataPermission.CREATE_QUERIES,
-  );
-};
-
 export const getTablesPermission = (
   permissions: GroupsPermissions,
   groupId: number,

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -34,7 +34,7 @@ function getPermissionPath(
 }
 
 const elludedDefaultValues: Record<DataPermission, DataPermissionValue> = {
-  [DataPermission.VIEW_DATA]: DataPermissionValue.UNRESTRICTED,
+  [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
   [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
   [DataPermission.DOWNLOAD]: DataPermissionValue.NONE,
   [DataPermission.DATA_MODEL]: DataPermissionValue.NONE,
@@ -206,9 +206,7 @@ export function downgradeNativePermissionsIfNeeded(
   const currentSchemas = getSchemasPermission(
     permissions,
     groupId,
-    {
-      databaseId,
-    },
+    { databaseId },
     permission,
   );
   const currentNative = getNativePermission(permissions, groupId, {

--- a/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
@@ -4,6 +4,7 @@ import type {
   Group,
   GroupsPermissions,
 } from "metabase-types/api";
+import { DataPermission } from "../../types";
 
 import {
   getFieldsPermission,
@@ -51,7 +52,7 @@ function diffDatabasePermissions(
         schemaName: table.schema_name || "",
         tableId: table.id as ConcreteTableId,
       },
-      "view-data",
+      DataPermission.VIEW_DATA,
     );
     const newFieldsPerm = getFieldsPermission(
       newPerms,
@@ -61,7 +62,7 @@ function diffDatabasePermissions(
         schemaName: table.schema_name || "",
         tableId: table.id as ConcreteTableId,
       },
-      "view-data",
+      DataPermission.VIEW_DATA,
     );
     if (oldFieldsPerm !== newFieldsPerm) {
       if (isRestrictivePermission(newFieldsPerm)) {

--- a/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
@@ -9,7 +9,7 @@ import { DataPermission } from "../../types";
 
 import {
   getFieldsPermission,
-  getNativePermission,
+  getSchemasPermission,
   isRestrictivePermission,
 } from "./data-permissions";
 
@@ -33,13 +33,19 @@ function diffDatabasePermissions(
     grantedTables: {},
     revokedTables: {},
   };
-  // get the native permisisons for this db
-  const oldNativePerm = getNativePermission(oldPerms, groupId, {
-    databaseId: database.id,
-  });
-  const newNativePerm = getNativePermission(newPerms, groupId, {
-    databaseId: database.id,
-  });
+  // get the native permissions for this db
+  const oldNativePerm = getSchemasPermission(
+    oldPerms,
+    groupId,
+    { databaseId: database.id },
+    DataPermission.CREATE_QUERIES,
+  );
+  const newNativePerm = getSchemasPermission(
+    newPerms,
+    groupId,
+    { databaseId: database.id },
+    DataPermission.CREATE_QUERIES,
+  );
   if (oldNativePerm !== newNativePerm) {
     databaseDiff.native = newNativePerm;
   }

--- a/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
@@ -51,7 +51,7 @@ function diffDatabasePermissions(
         schemaName: table.schema_name || "",
         tableId: table.id as ConcreteTableId,
       },
-      "data",
+      "view-data",
     );
     const newFieldsPerm = getFieldsPermission(
       newPerms,
@@ -61,7 +61,7 @@ function diffDatabasePermissions(
         schemaName: table.schema_name || "",
         tableId: table.id as ConcreteTableId,
       },
-      "data",
+      "view-data",
     );
     if (oldFieldsPerm !== newFieldsPerm) {
       if (isRestrictivePermission(newFieldsPerm)) {

--- a/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/permissions-diff.ts
@@ -4,6 +4,7 @@ import type {
   Group,
   GroupsPermissions,
 } from "metabase-types/api";
+
 import { DataPermission } from "../../types";
 
 import {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -97,7 +97,7 @@ export const PLUGIN_DATA_PERMISSIONS: {
     state: State,
   ) => Record<string, unknown>)[];
   hasChanges: ((state: State) => boolean)[];
-  updateNativePermission:
+  upgradeViewPermissionsIfNeeded:
     | ((
         permissions: GroupsPermissions,
         groupId: number,
@@ -110,7 +110,7 @@ export const PLUGIN_DATA_PERMISSIONS: {
 } = {
   permissionsPayloadExtraSelectors: [],
   hasChanges: [],
-  updateNativePermission: null,
+  upgradeViewPermissionsIfNeeded: null,
 };
 
 // user form fields, e.x. login attributes

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -85,13 +85,10 @@ export const PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES = [];
 export const PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES = [];
 export const PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS = [];
 export const PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS = {
-  controlled: [],
+  sandboxed: [],
 };
 export const PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION = {
-  controlled: null,
-};
-export const PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_PERMISSION_VALUE = {
-  controlled: null,
+  sandboxed: null,
 };
 
 export const PLUGIN_DATA_PERMISSIONS: {

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -8,6 +8,7 @@ import type {
   DatabaseEntityId,
   PermissionSubject,
   DataPermissionValue,
+  EntityId,
 } from "metabase/admin/permissions/types";
 import type { ADMIN_SETTINGS_SECTIONS } from "metabase/admin/settings/selectors";
 import type {
@@ -97,6 +98,15 @@ export const PLUGIN_DATA_PERMISSIONS: {
     state: State,
   ) => Record<string, unknown>)[];
   hasChanges: ((state: State) => boolean)[];
+  shouldRestrictNativeQueryPermissions: (
+    permissions: GroupsPermissions,
+    groupId: number,
+    entityId: EntityId,
+    permission: DataPermission,
+    value: DataPermissionValue,
+    database: Database,
+  ) => boolean;
+
   upgradeViewPermissionsIfNeeded:
     | ((
         permissions: GroupsPermissions,
@@ -111,6 +121,7 @@ export const PLUGIN_DATA_PERMISSIONS: {
   permissionsPayloadExtraSelectors: [],
   hasChanges: [],
   upgradeViewPermissionsIfNeeded: null,
+  shouldRestrictNativeQueryPermissions: () => false,
 };
 
 // user form fields, e.x. login attributes

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -7,6 +7,7 @@ import type {
   DataPermission,
   DatabaseEntityId,
   PermissionSubject,
+  DataPermissionValue,
 } from "metabase/admin/permissions/types";
 import type { ADMIN_SETTINGS_SECTIONS } from "metabase/admin/settings/selectors";
 import type {
@@ -313,7 +314,7 @@ export const PLUGIN_FEATURE_LEVEL_PERMISSIONS = {
     _groupId: number,
     _isAdmin: boolean,
     _permissions: GroupsPermissions,
-    _dataAccessPermissionValue: string,
+    _dataAccessPermissionValue: DataPermissionValue,
     _defaultGroup: Group,
     _permissionSubject: PermissionSubject,
   ) => {

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6117,6 +6117,16 @@ databaseChangeLog:
                   remarks: The estimated row count
 
   - changeSet:
+      id: v50.2024-03-24T19:34:11
+      author: noahmoss
+      comment: Clean up deprecated view-data and native-query-editing permissions
+      rollback: # handled by the rollbacks for `v50.2024-02-26T22:15:54` and `v50.2024-02-26T22:15:55`
+      changes:
+        - sql:
+            sql: >
+              DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type = 'perms/native-query-editing';
+
+  - changeSet:
       id: v50.2024-03-25T14:53:00
       author: tsmacdonald
       comment: Add query_field.direct_reference

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -27,10 +27,8 @@
 (def ^:private ->api-keys
   {:perms/view-data             :view-data
    :perms/create-queries        :create-queries
-   :perms/data-access           :data
    :perms/download-results      :download
    :perms/manage-table-metadata :data-model
-   :perms/native-query-editing  :native
    :perms/manage-database       :details})
 
 (def ^:private ->api-vals
@@ -40,14 +38,10 @@
    :perms/create-queries        {:query-builder-and-native :query-builder-and-native
                                  :query-builder            :query-builder
                                  :no                       :no}
-   :perms/data-access           {:unrestricted    :all
-                                 :no-self-service nil
-                                 :block           :block}
    :perms/download-results      {:one-million-rows  :full
                                  :ten-thousand-rows :limited
                                  :no                nil}
    :perms/manage-table-metadata {:yes :all :no nil}
-   :perms/native-query-editing  {:yes :write :no nil}
    :perms/manage-database       {:yes :yes :no :no}})
 
 (defenterprise add-impersonations-to-permissions-graph
@@ -73,10 +67,7 @@
    Unless it's :data perms, in which case, leave it out only if it's no-self-service"
   [type :- data-perms/PermissionType
    value :- data-perms/PermissionValue]
-  (if (= type :perms/data-access)
-    ;; for `:perms/data-access`, `:no-self-service` is the default (block  is a 'negative' permission),  so we should ellide
-    (= value :no-self-service)
-    (= (data-perms/least-permissive-value type) value)))
+  (= (data-perms/least-permissive-value type) value))
 
 (defn- rename-or-ellide-kv
   "Renames a kv pair from the data-permissions-graph to an API-style data permissions graph (which we send to the client)."
@@ -118,13 +109,10 @@
   "Transforms a 'leaf' value with db-level or table-level perms in the data permissions graph into an API-style data permissions value.
   There's some tricks in here that ellide table-level and table-level permissions values that are the most-permissive setting."
   [perm-map]
-  (let [granular-keys [:perms/native-query-editing :perms/data-access
-                       :perms/download-results :perms/manage-table-metadata
+  (let [granular-keys [:perms/download-results :perms/manage-table-metadata
                        :perms/view-data :perms/create-queries]]
     (m/deep-merge
      (into {} (keep rename-or-ellide-kv (apply dissoc perm-map granular-keys)))
-     (granular-perm-rename perm-map :perms/data-access [:data :schemas])
-     (granular-perm-rename perm-map :perms/native-query-editing [:data :native])
      (granular-perm-rename perm-map :perms/download-results [:download :schemas])
      (granular-perm-rename perm-map :perms/manage-table-metadata [:data-model :schemas])
      (granular-perm-rename perm-map :perms/view-data [:view-data])
@@ -135,13 +123,12 @@
                (fn [db-id->perms]
                  (update-vals db-id->perms rename-perm))))
 
-(def ^:private legacy-admin-perms
-   {:data {:native :write, :schemas :all},
-    :download {:schemas :full},
-    :data-model {:schemas :all},
-    :details :yes
-    :view-data :unrestricted
-    :create-queries :query-builder-and-native})
+(def ^:private admin-perms
+   {:view-data      :unrestricted
+    :create-queries :query-builder-and-native
+    :download       {:schemas :full}
+    :data-model     {:schemas :all}
+    :details        :yes})
 
 (defn- add-admin-perms-to-permissions-graph
   "These are not stored in the data-permissions table, but the API expects them to be there (for legacy reasons), so here we populate it.
@@ -155,7 +142,7 @@
       ;; Don't add admin perms when we're fetching the perms for a specific non-admin group
       api-graph
       (reduce (fn [api-graph db-id]
-                (assoc-in api-graph [admin-group-id db-id] legacy-admin-perms))
+                (assoc-in api-graph [admin-group-id db-id] admin-perms))
               api-graph
               db-ids))))
 
@@ -298,64 +285,6 @@
         :none
         (data-perms/set-database-permission! group-id db-id :perms/download-results :no)))))
 
-(defn- update-native-data-access-permissions!
-  [group-id db-id new-native-perms]
-  (data-perms/set-database-permission! group-id db-id :perms/native-query-editing (case new-native-perms
-                                                                                    :write :yes
-                                                                                    :none  :no)))
-
-(defn- update-table-level-data-access-permissions!
-  [group-id db-id schema new-table-perms]
-  (let [new-table-perms
-        (-> new-table-perms
-            (update-vals (fn [table-perm]
-                           (if (map? table-perm)
-                             (if (#{:all :segmented} (table-perm :query))
-                               ;; `:segmented` indicates that the table is sandboxed, but we should set :perms/data-access
-                               ;; permissions to :unrestricted and rely on the `sandboxes` table as the source of truth
-                               ;; for sandboxing.
-                               :unrestricted
-                               :no-self-service)
-                             (case table-perm
-                               :all  :unrestricted
-                               :none :no-self-service))))
-            (update-keys (fn [table-id] {:id table-id :db_id db-id :schema schema})))]
-    (data-perms/set-table-permissions! group-id :perms/data-access new-table-perms)))
-
-(defn- update-schema-level-data-access-permissions!
-  [group-id db-id schema new-schema-perms]
-  (if (map? new-schema-perms)
-    (update-table-level-data-access-permissions! group-id db-id schema new-schema-perms)
-    (let [tables (t2/select :model/Table :db_id db-id :schema (not-empty schema))]
-      (when (seq tables)
-        (case new-schema-perms
-          :all
-          (data-perms/set-table-permissions! group-id :perms/data-access (zipmap tables (repeat :unrestricted)))
-
-          :none
-          (data-perms/set-table-permissions! group-id :perms/data-access (zipmap tables (repeat :no-self-service))))))))
-
-(defn- update-db-level-data-access-permissions!
-  [group-id db-id new-db-perms]
-  (when-let [new-native-perms (:native new-db-perms)]
-    (update-native-data-access-permissions! group-id db-id new-native-perms))
-  (when-let [schemas (:schemas new-db-perms)]
-    (if (map? schemas)
-      (doseq [[schema schema-changes] schemas]
-        (update-schema-level-data-access-permissions! group-id db-id schema schema-changes))
-      (case schemas
-        (:all :impersonated)
-        (data-perms/set-database-permission! group-id db-id :perms/data-access :unrestricted)
-
-        :none
-        (data-perms/set-database-permission! group-id db-id :perms/data-access :no-self-service)
-
-        :block
-        (do
-          (when-not (premium-features/has-feature? :advanced-permissions)
-            (throw (ee-permissions-exception :block)))
-          (data-perms/set-database-permission! group-id db-id :perms/data-access :block))))))
-
 (defn- update-details-perms!
   [group-id db-id value]
   (data-perms/set-database-permission! group-id db-id :perms/manage-database value))
@@ -383,12 +312,34 @@
     (when new-db-perms
       (data-perms/set-database-permission! group-id db-id :perms/create-queries new-db-perms))))
 
+(defn- update-table-level-view-data-permissions!
+  [group-id db-id schema new-table-perms]
+  (let [new-table-perms (->
+                         (update-keys
+                          new-table-perms
+                          (fn [table-id] {:id table-id :db_id db-id :schema schema}))
+                         (update-vals (fn [table-perm]
+                                        (case table-perm
+                                          :unrestricted           :unrestricted
+                                          ;; If the table is sandboxed, we set `view-data` to `unrestricted` since
+                                          ;; sandboxes are stored separately in the `sandboxes` table
+                                          :sandboxed              :unrestricted
+                                          :legacy-no-self-service :legacy-no-self-service))))]
+    (data-perms/set-table-permissions! group-id :perms/view-data new-table-perms)))
+
+(defn- update-schema-level-view-data-permissions!
+  [group-id db-id schema new-schema-perms]
+  (if (map? new-schema-perms)
+    (update-table-level-view-data-permissions! group-id db-id schema new-schema-perms)
+    (let [tables (t2/select :model/Table :db_id db-id :schema (not-empty schema))]
+      (when (seq tables)
+        (data-perms/set-table-permissions! group-id :perms/view-data (zipmap tables (repeat new-schema-perms)))))))
+
 (defn- update-db-level-view-data-permissions!
   [group-id db-id new-db-perms]
   (if (map? new-db-perms)
-    ;; view-data is only set granularly when some tables are sandboxed, but sandboxes are stored in the `sandboxes`
-    ;; table, so we treat the DB as unrestricted in `data_permissions` and apply sandboxing policies separately
-    (data-perms/set-database-permission! group-id db-id :perms/view-data :unrestricted)
+    (doseq [[schema new-schema-perms] new-db-perms]
+      (update-schema-level-view-data-permissions! group-id db-id schema new-schema-perms))
     (case new-db-perms
       (:unrestricted :impersonated)
       (data-perms/set-database-permission! group-id db-id :perms/view-data :unrestricted)
@@ -457,7 +408,6 @@
        (case perm-type
          :view-data      (update-db-level-view-data-permissions! group-id db-id new-perms)
          :create-queries (update-db-level-create-queries-permissions! group-id db-id new-perms)
-         :data           (update-db-level-data-access-permissions! group-id db-id new-perms)
          :download       (update-db-level-download-permissions! group-id db-id new-perms)
          :data-model     (update-db-level-metadata-permissions! group-id db-id new-perms)
          :details        (update-details-perms! group-id db-id new-perms)))))

--- a/src/metabase/models/data_permissions/graph.clj
+++ b/src/metabase/models/data_permissions/graph.clj
@@ -344,6 +344,10 @@
       (:unrestricted :impersonated)
       (data-perms/set-database-permission! group-id db-id :perms/view-data :unrestricted)
 
+      ;; Support setting legacy-no-self-service for testing purposes, though the UI shouldn't allow it normally
+      :legacy-no-self-service
+      (data-perms/set-database-permission! group-id db-id :perms/view-data :legacy-no-self-service)
+
       :blocked
       (do
         (when-not (premium-features/has-feature? :advanced-permissions)

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -114,29 +114,19 @@
     (let [all-users-group  (perms-group/all-users)
           non-magic-groups (perms-group/non-magic-groups)
           non-admin-groups (conj non-magic-groups all-users-group)]
-      ;; We only set native-query-editing and manage-database permissions here, because they are only ever set at the
-      ;; database-level. Perms which can have table-level granularity are set in the `define-after-insert` hook for
-      ;; tables.
       (if (:is_audit database)
         (doseq [group non-admin-groups]
           (data-perms/set-database-permission! group database :perms/view-data :unrestricted)
-          (data-perms/set-database-permission! group database :perms/data-access :no-self-service)
           (data-perms/set-database-permission! group database :perms/create-queries :no)
-          (data-perms/set-database-permission! group database :perms/native-query-editing :no)
           (data-perms/set-database-permission! group database :perms/download-results :one-million-rows))
         (do
           (data-perms/set-database-permission! all-users-group database :perms/view-data :unrestricted)
           (data-perms/set-database-permission! all-users-group database :perms/create-queries :query-builder-and-native)
-          (data-perms/set-database-permission! all-users-group database :perms/data-access :unrestricted)
-          (data-perms/set-database-permission! all-users-group database :perms/native-query-editing :yes)
           (data-perms/set-database-permission! all-users-group database :perms/download-results :one-million-rows)
           (doseq [group non-magic-groups]
             (data-perms/set-database-permission! group database :perms/view-data :unrestricted)
             (data-perms/set-database-permission! group database :perms/create-queries :no)
-            (data-perms/set-database-permission! group database :perms/download-results :no)
-            (data-perms/set-database-permission! group database :perms/data-access :no-self-service)
-            (data-perms/set-database-permission! group database :perms/native-query-editing :no))))
-
+            (data-perms/set-database-permission! group database :perms/download-results :no))))
       (doseq [group non-admin-groups]
         (data-perms/set-database-permission! group database :perms/manage-table-metadata :no)
         (data-perms/set-database-permission! group database :perms/manage-database :no)))))
@@ -399,8 +389,8 @@
                          ;; you need to define it :)
                          false)))
                    settings)
-                   (when (not= <> settings)
-                     (log/debug "Redacting non-user-readable database settings during json encoding.")))))))
+                  (when (not= <> settings)
+                    (log/debug "Redacting non-user-readable database settings during json encoding.")))))))
    json-generator))
 
 ;;; ------------------------------------------------ Serialization ----------------------------------------------------

--- a/src/metabase/models/native_query_snippet/permissions.clj
+++ b/src/metabase/models/native_query_snippet/permissions.clj
@@ -9,7 +9,7 @@
 (defn has-any-native-permissions?
   "Checks whether the current user has native query permissions for any database."
   []
-  (data-perms/user-has-any-perms-of-type? api/*current-user-id* :perms/native-query-editing))
+  (data-perms/user-has-any-perms-of-type? api/*current-user-id* :perms/create-queries))
 
 (defenterprise can-read?
   "Can the current User read this `snippet`?"

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -99,10 +99,8 @@
     (doseq [db-id (t2/select-pks-vec :model/Database)]
       (data-perms/set-database-permission! group db-id :perms/view-data             :unrestricted)
       (data-perms/set-database-permission! group db-id :perms/create-queries        :no)
-      (data-perms/set-database-permission! group db-id :perms/data-access           :no-self-service)
       (data-perms/set-database-permission! group db-id :perms/download-results      :no)
       (data-perms/set-database-permission! group db-id :perms/manage-table-metadata :no)
-      (data-perms/set-database-permission! group db-id :perms/native-query-editing  :no)
       (data-perms/set-database-permission! group db-id :perms/manage-database       :no))))
 
 (t2/define-after-insert :model/PermissionsGroup

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -45,17 +45,17 @@
 ;; Is calculating permissions for queries complicated? Some would say so. Refer to this handy flow chart to see how
 ;; things get calculated.
 ;;
-;;                         perms-set
-;;                             |
-;;                             |
-;;                             |
-;;      native query? <--------+------- > mbql query?
-;;            ↓                               ↓
-;; {:perms/native-query-editing :yes}     legacy-mbql-required-perms
-;;                                            |
-;;                     no source card  <------+----> has source card
-;;                             ↓                          ↓
-;;       {:perms/view-data {table-id :unrestricted}} source-card-read-perms
+;;                                  perms-set
+;;                                      |
+;;                                      |
+;;                                      |
+;;               native query? <--------+---------> mbql query?
+;;                     ↓                                     ↓
+;;    {:perms/create-queries :query-builder-and-native}  legacy-mbql-required-perms
+;;                                                           |
+;;                                  no source card  <--------+------> has source card
+;;                                          ↓                            ↓
+;;                    {:perms/view-data {table-id :unrestricted}}  source-card-read-perms
 ;;
 
 (mu/defn query->source-table-ids :- [:set [:or [:= ::native] ::lib.schema.id/table]]
@@ -139,7 +139,7 @@
 
 (defn required-perms
   "Returns a map representing the permissions requried to run `query`. The map has the optional keys
-  :paths (containing legacy permission paths), :perms/data-access, and :perms/native-query-editing."
+  :paths (containing legacy permission paths), :perms/view-data, and :perms/create-queries."
   [query & {:as perms-opts}]
   (if (empty? query)
     {}
@@ -170,7 +170,7 @@
     (when (= (:perms/create-queries required-perms) :query-builder-and-native)
       (or (= (:perms/create-queries gtap-perms) :query-builder-and-native)
           (= (data-perms/full-db-permission-for-user api/*current-user-id* :perms/create-queries db-id) :query-builder-and-native)
-          (throw (perms-exception {db-id {:perms/native-query-editing :yes}}))))
+          (throw (perms-exception {db-id {:perms/create-queries :query-builder-and-native}}))))
     (when (= (:perms/view-data required-perms) :unrestricted)
       (or (= (:perms/view-data gtap-perms) :unrestricted)
           (= :unrestricted (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data db-id))

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -72,15 +72,15 @@
           non-admin-groups (conj non-magic-groups all-users-group)]
       ;; Data access permissions
       (if (= (:db_id table) config/audit-db-id)
-        ;; Tables in audit DB should start out with no-self-service in all groups
         (do
-         (data-perms/set-new-table-permissions! non-admin-groups table :perms/create-queries :no)
-         (data-perms/set-new-table-permissions! non-admin-groups table :perms/data-access :no-self-service))
+         ;; Tables in audit DB should start out with no query access in all groups
+         (data-perms/set-new-table-permissions! non-admin-groups table :perms/view-data :unrestricted)
+         (data-perms/set-new-table-permissions! non-admin-groups table :perms/create-queries :no))
         (do
+          ;; Normal tables start out with unrestricted data access in all groups, but query access only in All Users
+          (data-perms/set-new-table-permissions! (conj non-magic-groups all-users-group) table :perms/view-data :unrestricted)
           (data-perms/set-new-table-permissions! [all-users-group] table :perms/create-queries :query-builder)
-          (data-perms/set-new-table-permissions! non-magic-groups table :perms/create-queries :no)
-          (data-perms/set-new-table-permissions! [all-users-group] table :perms/data-access :unrestricted)
-          (data-perms/set-new-table-permissions! non-magic-groups table :perms/data-access :no-self-service)))
+          (data-perms/set-new-table-permissions! non-magic-groups table :perms/create-queries :no)))
       ;; Download permissions
       (data-perms/set-new-table-permissions! [all-users-group] table :perms/download-results :one-million-rows)
       (data-perms/set-new-table-permissions! non-magic-groups table :perms/download-results :no)

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -216,14 +216,12 @@
                            (count (csv/read-csv result)))))))]
         (mt/with-no-data-perms-for-all-users!
           (testing "with data perms"
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/data-access :no-self-service)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/download-results :one-million-rows)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :query-builder)
             (do-test))
           (testing "with collection perms only"
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/download-results :one-million-rows)
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/data-access :no-self-service)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
             (do-test)))))))
@@ -331,7 +329,6 @@
           (mt/with-no-data-perms-for-all-users!
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :query-builder)
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/data-access :unrestricted)
             (is (malli= [:map
                          [:permissions-error? [:= true]]
                          [:message            [:= "You do not have permissions to run this query."]]]

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -145,7 +145,8 @@
       (t2.with-temp/with-temp [Database {db-id :id}]
         (let [graph (mt/user-http-request :crowberto :get 200 "permissions/graph")]
           (is (partial= {:groups {(u/the-id (perms-group/admin))
-                                  {db-id {:data {:native "write" :schemas "all"}}}}}
+                                  {db-id {:view-data "unrestricted"
+                                          :create-queries "query-builder-and-native"}}}}
                         graph)))))
 
     (testing "make sure a non-admin cannot fetch the perms graph from the API"
@@ -156,7 +157,7 @@
     (testing "make sure we can fetch the perms graph from the API"
       (t2.with-temp/with-temp [PermissionsGroup {group-id :id :as group}    {}
                                Database         db                          {}]
-        (data-perms/set-database-permission! group db :perms/data-access :unrestricted)
+        (data-perms/set-database-permission! group db :perms/view-data :unrestricted)
         (let [graph (mt/user-http-request :crowberto :get 200 (format "permissions/graph/group/%s" group-id))]
           (is (mc/validate nat-int? (:revision graph)))
           (is (perm-test-util/validate-graph-api-groups (:groups graph)))
@@ -167,7 +168,7 @@
     (testing "make sure we can fetch the perms graph from the API"
       (t2.with-temp/with-temp [PermissionsGroup group       {}
                                Database         {db-id :id} {}]
-        (data-perms/set-database-permission! group db-id :perms/data-access :unrestricted)
+        (data-perms/set-database-permission! group db-id :perms/view-data :unrestricted)
         (let [graph (mt/user-http-request :crowberto :get 200 (format "permissions/graph/db/%s" db-id))]
           (is (mc/validate nat-int? (:revision graph)))
           (is (perm-test-util/validate-graph-api-groups (:groups graph)))
@@ -176,15 +177,14 @@
 (deftest update-perms-graph-test
   (testing "PUT /api/permissions/graph"
     (testing "make sure we can update the perms graph from the API"
-      (let [db-id (mt/id :venues)]
-        (t2.with-temp/with-temp [PermissionsGroup group]
-          (mt/user-http-request
-           :crowberto :put 200 "permissions/graph"
-           (assoc-in (data-perms.graph/api-graph)
-                     [:groups (u/the-id group) (mt/id) :data :schemas]
-                     {"PUBLIC" {db-id :all}}))
-          (is (= {db-id :all}
-                 (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"]))))))))
+      (t2.with-temp/with-temp [PermissionsGroup group]
+        (mt/user-http-request
+         :crowberto :put 200 "permissions/graph"
+         (assoc-in (data-perms.graph/api-graph)
+                   [:groups (u/the-id group) (mt/id) :view-data]
+                   :unrestricted))
+        (is (= :unrestricted
+               (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :view-data])))))))
 
 (deftest update-perms-graph-table-specific-perms-test
   (testing "PUT /api/permissions/graph"
@@ -194,10 +194,11 @@
           (mt/user-http-request
            :crowberto :put 200 "permissions/graph"
            (assoc-in (data-perms.graph/api-graph)
-                     [:groups (u/the-id group) (mt/id) :data :schemas]
-                     {"PUBLIC" {(mt/id :venues) :all}}))
-          (is (= {(mt/id :venues) :all}
-                 (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"]))))))))
+                     [:groups (u/the-id group) (mt/id) :create-queries]
+                     {"PUBLIC" {(mt/id :venues) :query-builder
+                                (mt/id :orders) :no}}))
+          (is (= {(mt/id :venues) :query-builder}
+                 (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :create-queries "PUBLIC"]))))))))
 
 (deftest update-perms-graph-perms-for-new-db-test
   (testing "PUT /api/permissions/graph"
@@ -239,7 +240,7 @@
                                         :crowberto :put 200 url
                                         (assoc-in (data-perms.graph/api-graph)
                                                   ;; Get a new revision number each time
-                                                  [:groups (u/the-id group) db-id :data :schemas] :all)))
+                                                  [:groups (u/the-id group) db-id :view-data] :unrestricted)))
               returned-g     (do-perm-put "permissions/graph")
               returned-g-two (do-perm-put "permissions/graph?skip-graph=false")
               no-returned-g  (do-perm-put "permissions/graph?skip-graph=true")]
@@ -264,27 +265,32 @@
         (mt/user-http-request
          :crowberto :put 200 "permissions/graph"
          (assoc-in (data-perms.graph/api-graph)
-                   [:groups (u/the-id group) (mt/id) :data :schemas] {"PUBLIC" {table-id :all}}))
+                   [:groups (u/the-id group) (mt/id) :view-data] :unrestricted))
         (is (= #{:unrestricted}
                (set (t2/select-fn-set :perm_value :model/DataPermissions
                                       :group_id  (u/the-id group)
-                                      :table_id  table-id
-                                      :perm_type :perms/data-access))))
+                                      :perm_type :perms/view-data))))
         (mt/user-http-request
          :crowberto :put 200 "permissions/graph"
          (assoc-in (data-perms.graph/api-graph)
                    [:groups (u/the-id group) (mt/id)]
-                   {:data {:native "none" :schemas "none"}}))
-        (is (= #{:no-self-service}
+                   {:view-data :unrestricted
+                    :create-queries :no}))
+        (is (= #{:unrestricted}
                (set (t2/select-fn-set :perm_value :model/DataPermissions
                                       :group_id  (u/the-id group)
                                       :db_id     (mt/id)
-                                      :perm_type :perms/data-access))))
+                                      :perm_type :perms/view-data))))
+        (is (= #{:no}
+               (set (t2/select-fn-set :perm_value :model/DataPermissions
+                                      :group_id  (u/the-id group)
+                                      :db_id     (mt/id)
+                                      :perm_type :perms/create-queries))))
         (is (= #{}
                (set (t2/select-fn-set :perm_value :model/DataPermissions
                                       :group_id  (u/the-id group)
                                       :table_id  table-id
-                                      :perm_type :perms/data-access))))))))
+                                      :perm_type :perms/view-data))))))))
 
 (deftest update-perms-graph-error-test
   (testing "PUT /api/permissions/graph"

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -713,7 +713,7 @@
                                                               {:query "SELECT * FROM venues LIMIT 1"})}
                      DashboardCard _ {:dashboard_id dashboard-id
                                       :card_id      card-id}]
-        (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/native-query-editing :yes)
+        (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
         (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3]]
                (-> (@#'metabase.pulse/execute-dashboard {:creator_id (mt/user->id :rasta)} dashboard)
                    first :result :data :rows)))))))

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -61,7 +61,7 @@
               (events/publish-event! :event/table-read {:object table :user-id (u/id user)})
               (is (true? (:has_access (latest-view (u/id user) (u/id table)))))
 
-              (data-perms/set-table-permission! (perms-group/all-users) (mt/id :users) :perms/data-access :no-self-service)
+              (data-perms/set-table-permission! (perms-group/all-users) (mt/id :users) :perms/create-queries :no)
               (events/publish-event! :event/table-read {:object table :user-id (u/id user)})
               (is (false? (:has_access (latest-view (u/id user) (u/id table))))))))))))
 

--- a/test/metabase/models/data_permissions/graph_test.clj
+++ b/test/metabase/models/data_permissions/graph_test.clj
@@ -18,7 +18,7 @@
                                                                   :schema "PUBLIC"}]
       ;; Clear default perms for the group
       (db/delete! :model/DataPermissions :group_id group-id-1)
-      (testing "data-access permissions can be updated via API-style graph"
+      (testing "data permissions can be updated via API-style graph"
         (are [api-graph db-graph] (= db-graph
                                      (do
                                        (data-perms.graph/update-data-perms-graph!* api-graph)
@@ -62,7 +62,7 @@
                                                                   :schema "PUBLIC"}]
       ;; Clear default perms for the group
       (db/delete! :model/DataPermissions :group_id group-id-1)
-      (testing "data-access permissions can be updated via API-style graph"
+      (testing "data permissions can be updated via API-style graph"
         (are [api-graph db-graph] (= db-graph
                                      (do
                                        (data-perms.graph/update-data-perms-graph!* api-graph)
@@ -143,59 +143,54 @@
           ;; Setting granular data access permissions
           {group-id-1
            {database-id-1
-            {:data
-             {:native :none
-              :schemas {"PUBLIC"
-                        {table-id-1 :all
-                         table-id-2 :none}
-                        ""
-                        {table-id-3 :all}}}}}}
+            {:create-queries :no
+             :view-data {"PUBLIC"
+                         {table-id-1 :unrestricted
+                          table-id-2 :legacy-no-self-service}
+                         ""
+                         {table-id-3 :unrestricted}}}}}
           {group-id-1
            {database-id-1
-            {:perms/native-query-editing :no
-             :perms/data-access {"PUBLIC"
-                                 {table-id-1 :unrestricted
-                                  table-id-2 :no-self-service}
-                                 ""
-                                 {table-id-3 :unrestricted}}}}}
+            {:perms/create-queries :no
+             :perms/view-data {"PUBLIC"
+                               {table-id-1 :unrestricted
+                                table-id-2 :legacy-no-self-service}
+                               ""
+                               {table-id-3 :unrestricted}}}}}
 
           ;; Restoring full data access and native query permissions
           {group-id-1
            {database-id-1
-            {:data
-             {:native :write
-              :schemas :all}}}}
+            {:create-queries :query-builder-and-native
+             :view-data :unrestricted}}}
           {group-id-1
            {database-id-1
-            {:perms/native-query-editing :yes
-             :perms/data-access :unrestricted}}}
+            {:perms/create-queries :query-builder-and-native
+             :perms/view-data :unrestricted}}}
 
           ;; Setting data access permissions at the schema-level
           {group-id-1
            {database-id-1
-            {:data
-             {:native :none
-              :schemas {"PUBLIC" :all
-                        ""       :none}}}}}
+            {:create-queries :no
+             :view-data {"PUBLIC" :unrestricted
+                         "" :legacy-no-self-service}}}}
           {group-id-1
            {database-id-1
-            {:perms/native-query-editing :no
-             :perms/data-access {"PUBLIC"
-                                 {table-id-1 :unrestricted
-                                  table-id-2 :unrestricted}
-                                 ""
-                                 {table-id-3 :no-self-service}}}}}
+            {:perms/create-queries :no
+             :perms/view-data {"PUBLIC"
+                               {table-id-1 :unrestricted
+                                table-id-2 :unrestricted}
+                               ""
+                               {table-id-3 :legacy-no-self-service}}}}}
 
-          ;; Setting block permissions for the database also sets :native-query-editing and :downlaod-results to :no
-          {group-id-1
-           {database-id-1
-            {:data
-             {:native :none
-              :schemas :block}}}}
+          ;; Setting block permissions for the database also sets :create-queries and :download-results to :no
           {group-id-1
             {database-id-1
-             {:perms/native-query-editing :no
-              :perms/data-access :block
+             {:view-data :blocked}}}
+          {group-id-1
+            {database-id-1
+             {:perms/create-queries :no
+              :perms/view-data :blocked
               :perms/download-results :no}}})))))
 
 (deftest update-db-level-download-permissions!-test
@@ -358,92 +353,69 @@
 ;; ------------------------------ API Graph Tests ------------------------------
 
 (deftest ellide?-test
-  (is (#'data-perms.graph/ellide?      :perms/data-access :no-self-service))
-  (is (not (#'data-perms.graph/ellide? :perms/data-access :block))))
-
-(defn- remove-download:native [graph]
-  (walk/postwalk
-   (fn [x]
-     (if (and
-          (instance? clojure.lang.MapEntry x)
-          (= :download (first x)))
-       (update x 1 dissoc :native)
-       x))
-   graph))
+  (is (not (#'data-perms.graph/ellide? :perms/view-data :unrestricted)))
+  (is (#'data-perms.graph/ellide? :perms/view-data :blocked)))
 
 (defn replace-empty-map-with-nil [graph]
   (walk/postwalk
    (fn [x] (if (= x {}) nil x))
    graph))
 
-(defn- api-graph=
-  "When checking equality between api perm graphs:
-  - download.native is not used by the client, so we remove it when checking equality:
-  - {} vs nil is also a distinction without a difference:"
-  [a b]
-  (= (remove-download:native (replace-empty-map-with-nil a))
-     (remove-download:native (replace-empty-map-with-nil b))))
-
 (deftest perms-are-renamed-test
   (testing "Perm keys and values are correctly renamed, and permissions are ellided as necessary"
     (are [db-graph api-graph] (= api-graph (-> db-graph
                                                (#'data-perms.graph/rename-perm)
                                                (#'data-perms.graph/remove-empty-vals)))
-      {:perms/data-access :unrestricted}           {:data {:schemas :all}}
-      {:perms/data-access :no-self-service}        {}
-      {:perms/data-access :block}                  {:data {:schemas :block}}
-      {:perms/native-query-editing :yes}           {:data {:native :write}}
-      {:perms/native-query-editing :no}            {}
-      {:perms/download-results :one-million-rows}  {:download {:schemas :full}}
-      {:perms/download-results :ten-thousand-rows} {:download {:schemas :limited}}
-      {:perms/download-results :no}                {}
-      {:perms/manage-table-metadata :yes}          {:data-model {:schemas :all}}
-      {:perms/manage-table-metadata :no}           {}
-      {:perms/manage-database :yes}                {:details :yes}
-      {:perms/manage-database :no}                 {}
+      {:perms/view-data :unrestricted}                  {:view-data :unrestricted}
+      {:perms/view-data :legacy-no-self-service}        {:view-data :legacy-no-self-service}
+      {:perms/view-data :blocked}                       {}
+      {:perms/create-queries :query-builder-and-native} {:create-queries :query-builder-and-native}
+      {:perms/create-queries :query-builder}            {:create-queries :query-builder}
+      {:perms/create-queries :no}                       {}
+      {:perms/download-results :one-million-rows}       {:download {:schemas :full}}
+      {:perms/download-results :ten-thousand-rows}      {:download {:schemas :limited}}
+      {:perms/download-results :no}                     {}
+      {:perms/manage-table-metadata :yes}               {:data-model {:schemas :all}}
+      {:perms/manage-table-metadata :no}                {}
+      {:perms/manage-database :yes}                     {:details :yes}
+      {:perms/manage-database :no}                      {}
       ;; with schemas:
-      {:perms/data-access
+      {:perms/view-data
        {"PUBLIC" {1 :unrestricted
-                  2 :no-self-service}}}            {:data {:schemas {"PUBLIC" {1 :all}}}}
-      {:perms/data-access
+                  2 :legacy-no-self-service}}}          {:view-data {"PUBLIC" {1 :unrestricted
+                                                                               2 :legacy-no-self-service}}}
+      {:perms/view-data
        {"PUBLIC" {1 :unrestricted
-                  2 :unrestricted}}}               {:data {:schemas {"PUBLIC" :all}}}
-      {:perms/data-access
-       {"PUBLIC" {1 :no-self-service
-                  2 :no-self-service}}}            {}
+                  2 :unrestricted}}}                    {:view-data {"PUBLIC" :unrestricted}}
+      {:perms/view-data
+       {"PUBLIC" {1 :legacy-no-self-service
+                  2 :legacy-no-self-service}}}          {:view-data {"PUBLIC" :legacy-no-self-service}}
       {:perms/download-results
        {"PUBLIC" {1 :one-million-rows
-                  2 :no}}}                         {:download {:schemas {"PUBLIC" {1 :full}}}}
+                  2 :no}}}                              {:download {:schemas {"PUBLIC" {1 :full}}}}
       {:perms/download-results
        {"PUBLIC" {1 :one-million-rows
-                  2 :ten-thousand-rows}}}          {:download {:schemas {"PUBLIC" {1 :full
-                                                                                   2 :limited}}}}
+                  2 :ten-thousand-rows}}}               {:download {:schemas {"PUBLIC" {1 :full
+                                                                                        2 :limited}}}}
       {:perms/manage-table-metadata
-       {"PUBLIC" {1 :yes}}}                        {:data-model {:schemas {"PUBLIC" :all}}}
+       {"PUBLIC" {1 :yes}}}                             {:data-model {:schemas {"PUBLIC" :all}}}
       {:perms/manage-table-metadata
-       {"PUBLIC" {1 :no}}}                         {}
+       {"PUBLIC" {1 :no}}}                              {}
       {:perms/manage-table-metadata
        {"PUBLIC" {1 :yes
-                  2 :no}}}                         {:data-model {:schemas {"PUBLIC" {1 :all}}}}
+                  2 :no}}}                              {:data-model {:schemas {"PUBLIC" {1 :all}}}}
       ;; multiple schemas
-      {:perms/data-access
+      {:perms/view-data
        {"PUBLIC" {1 :unrestricted}
-        "OTHER" {2 :no-self-service}
-        "SECRET" {3 :block}}}                      {:data {:schemas {"PUBLIC" :all, "SECRET" :block}}}
-      {:perms/data-access
+        "OTHER" {2 :legacy-no-self-service}}}           {:view-data {"PUBLIC" :unrestricted
+                                                                     "OTHER" :legacy-no-self-service}}
+      {:perms/view-data
        {"PUBLIC" {1 :unrestricted
-                  2 :no-self-service}
-        "OTHER" {3 :no-self-service
-                 4 :no-self-service}}}             {:data {:schemas {"PUBLIC" {1 :all}}}})))
-
-(deftest rename-perm-test
-  (is (api-graph=
-       (#'data-perms.graph/rename-perm {:perms/data-access :unrestricted
-                                        :perms/native-query-editing :yes
-                                        :perms/manage-database :no
-                                        :perms/download-results :one-million-rows
-                                        :perms/manage-table-metadata :no})
-       {:data {:native :write, :schemas :all} :download {:native :full, :schemas :full}})))
+                  2 :legacy-no-self-service}
+        "OTHER" {3 :legacy-no-self-service
+                 4 :legacy-no-self-service}}}           {:view-data {"PUBLIC" {1 :unrestricted
+                                                                               2 :legacy-no-self-service}
+                                                                     "OTHER" :legacy-no-self-service}})))
 
 (defn constrain-graph
   "Filters out all non `group-id`X`db-id` permissions"
@@ -452,23 +424,23 @@
       (assoc :groups {group-id (get-in graph [:groups group-id])})
       (assoc-in [:groups group-id] {db-id (get-in graph [:groups group-id db-id])})))
 
-(defn- test-data-graph [group]
-  (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"]))
+(defn- test-query-graph [group]
+  (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :create-queries "PUBLIC"]))
 
 (deftest graph-set-partial-permissions-for-table-test
   (testing "Test that setting partial permissions for a table retains permissions for other tables -- #3888"
     (mt/with-temp [:model/PermissionsGroup group]
       (testing "before"
         ;; first, graph permissions only for VENUES
-        (data-perms/set-table-permission! group (mt/id :venues) :perms/data-access :unrestricted)
-        (is (= {(mt/id :venues) :all}
-               (test-data-graph group))))
+        (data-perms/set-table-permission! group (mt/id :venues) :perms/create-queries :query-builder)
+        (is (= {(mt/id :venues) :query-builder}
+               (test-query-graph group))))
       (testing "after"
         ;; next, grant permissions via `update-graph!` for CATEGORIES as well. Make sure permissions for VENUES are
         ;; retained (#3888)
-        (data-perms/set-table-permission! group (mt/id :categories) :perms/data-access :unrestricted)
-        (is (= {(mt/id :categories) :all, (mt/id :venues) :all}
-               (test-data-graph group)))))))
+        (data-perms/set-table-permission! group (mt/id :categories) :perms/create-queries :query-builder)
+        (is (= {(mt/id :categories) :query-builder, (mt/id :venues) :query-builder}
+               (test-query-graph group)))))))
 
 (deftest audit-db-update-test
   (testing "Throws exception when we attempt to change the audit db permission manually."
@@ -479,50 +451,60 @@
            (data-perms.graph/update-data-perms-graph! [(u/the-id group) config/audit-db-id :data :schemas] :all))))))
 
 (deftest update-graph-validate-db-perms-test
-  (testing "Check that validation of DB `:schemas` and `:native` perms doesn't fail if only one of them changes"
-    (mt/with-temp [:model/Database {db-id :id}]
-      (mt/with-no-data-perms-for-all-users!
-        (let [ks [:groups (u/the-id (perms-group/all-users)) db-id :data]]
-          (letfn [(perms []
-                    (get-in (data-perms.graph/api-graph) ks))
-                  (set-perms! [new-perms]
-                    (data-perms.graph/update-data-perms-graph! (assoc-in (data-perms.graph/api-graph) ks new-perms))
-                    (perms))]
-            (testing "Should initially have no perms"
-              (is (= {:schemas :block}
-                     (perms))))
-            (testing "grant schema perms"
-              (is (= {:schemas :all}
-                     (set-perms! {:schemas :all}))))
-            (testing "grant native perms"
-              (is (= {:schemas :all, :native :write}
-                     (set-perms! {:schemas :all, :native :write}))))
-            (testing "revoke native perms"
-              (is (= {:schemas :all}
-                     (set-perms! {:schemas :all, :native :none}))))
-            (testing "revoke schema perms"
-              (is (= nil
-                     (set-perms! {:schemas :none}))))
-            (testing "disallow schemas :none + :native :write"
-              (is (thrown-with-msg?
-                   Exception
-                   #"Invalid DB permissions: If you have write access for native queries, you must have data access to all schemas."
-                   (set-perms! {:schemas :none, :native :write})))
-              (is (= nil
-                     (perms))))))))))
+  (testing "Check that validation of native query perms doesn't fail if only one of them changes"
+    (mt/with-additional-premium-features #{:advanced-permissions}
+      (mt/with-temp [:model/Database {db-id :id}]
+        (mt/with-no-data-perms-for-all-users!
+          (let [ks [:groups (u/the-id (perms-group/all-users)) db-id]]
+            (letfn [(perms []
+                      (get-in (data-perms.graph/api-graph) ks))
+                    (set-perms! [new-perms]
+                      (data-perms.graph/update-data-perms-graph! (assoc-in (data-perms.graph/api-graph) ks new-perms))
+                      (perms))]
+              (testing "Should initially have no perms"
+                (is (= nil
+                       (perms))))
+              (testing "grant unrestricted data perms"
+                (is (= {:view-data :unrestricted}
+                       (set-perms! {:view-data :unrestricted}))))
+              (testing "grant native query perms"
+                (is (= {:view-data :unrestricted
+                        :create-queries :query-builder-and-native}
+                       (set-perms! {:view-data :unrestricted
+                                    :create-queries :query-builder-and-native}))))
+              (testing "revoke native perms"
+                (is (= {:view-data :unrestricted
+                        :create-queries :query-builder}
+                       (set-perms! {:view-data :unrestricted
+                                    :create-queries :query-builder}))))
+              (testing "revoke schema perms"
+                (is (= nil
+                       (set-perms! {:view-data :blocked}))))
+              (testing "disallow blocked data access + native querying"
+                (is (thrown-with-msg?
+                     Exception
+                     #"Invalid DB permissions: If you have write access for native queries, you must have data access to all schemas."
+                     (set-perms! {:view-data :blocked
+                                  :create-queries :query-builder-and-native})))
+                (is (= nil
+                       (perms)))))))))))
 
 (deftest no-op-partial-graph-updates
   (testing "Partial permission graphs with no changes to the existing graph do not error when run repeatedly (#25221)"
-    (mt/with-temp [:model/PermissionsGroup group]
-      ;; Bind *current-user* so that permission revisions are written, which was the source of the original error
-      (mt/with-current-user (mt/user->id :rasta)
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:data {:native :none :schemas :none}}}}
-                                                              :revision (:revision (data-perms.graph/api-graph))})))
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:data {:native :none :schemas :none}}}}
-                                                              :revision (:revision (data-perms.graph/api-graph))})))
-
-        (data-perms/set-database-permission! group (mt/id) :perms/data-access :unrestricted)
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:data {:native :write :schemas :all}}}}
-                                                              :revision (:revision (data-perms.graph/api-graph))})))
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:data {:native :write :schemas :all}}}}
-                                                              :revision (:revision (data-perms.graph/api-graph))})))))))
+    (mt/with-additional-premium-features #{:advanced-permissions}
+      (mt/with-temp [:model/PermissionsGroup group]
+        ;; Bind *current-user* so that permission revisions are written, which was the source of the original error
+        (mt/with-current-user (mt/user->id :rasta)
+          (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :blocked
+                                                                                                    :create-queries :no}}}
+                                                                :revision (:revision (data-perms.graph/api-graph))})))
+          (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :blocked
+                                                                                                    :create-queries :no}}}
+                                                                :revision (:revision (data-perms.graph/api-graph))})))
+          (data-perms/set-database-permission! group (mt/id) :perms/view-data :unrestricted)
+          (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :unrestricted
+                                                                                                    :create-queries :query-builder}}}
+                                                                :revision (:revision (data-perms.graph/api-graph))})))
+          (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :unrestricted
+                                                                                                    :create-queries :query-builder}}}
+                                                                :revision (:revision (data-perms.graph/api-graph))}))))))))

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -12,22 +12,21 @@
 (deftest ^:parallel coalesce-test
   (testing "`coalesce` correctly returns the most permissive value by default"
     (are [expected args] (= expected (apply data-perms/coalesce args))
-      :unrestricted    [:perms/data-access #{:unrestricted :restricted :none}]
-      :no-self-service [:perms/data-access #{:no-self-service :none}]
-      :block           [:perms/data-access #{:block}]
-      nil              [:perms/data-access #{}])))
+      :unrestricted    [:perms/view-data   #{:unrestricted :legacy-no-self-service :blocked}]
+      :blocked         [:perms/view-data #{:blocked}]
+      nil              [:perms/view-data #{}])))
 
 (deftest ^:parallel at-least-as-permissive?-test
   (testing "at-least-as-permissive? correctly compares permission values"
-   (is (data-perms/at-least-as-permissive? :perms/data-access :unrestricted :unrestricted))
-   (is (data-perms/at-least-as-permissive? :perms/data-access :unrestricted :no-self-service))
-   (is (data-perms/at-least-as-permissive? :perms/data-access :unrestricted :block))
-   (is (not (data-perms/at-least-as-permissive? :perms/data-access :no-self-service :unrestricted)))
-   (is (data-perms/at-least-as-permissive? :perms/data-access :no-self-service :no-self-service))
-   (is (data-perms/at-least-as-permissive? :perms/data-access :no-self-service :block))
-   (is (not (data-perms/at-least-as-permissive? :perms/data-access :block :unrestricted)))
-   (is (not (data-perms/at-least-as-permissive? :perms/data-access :block :no-self-service)))
-   (is (data-perms/at-least-as-permissive? :perms/data-access :block :block))))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :unrestricted :unrestricted))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :unrestricted :legacy-no-self-service))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :unrestricted :blocked))
+   (is (not (data-perms/at-least-as-permissive? :perms/view-data :legacy-no-self-service :unrestricted)))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :legacy-no-self-service :legacy-no-self-service))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :legacy-no-self-service :blocked))
+   (is (not (data-perms/at-least-as-permissive? :perms/view-data :blocked :unrestricted)))
+   (is (not (data-perms/at-least-as-permissive? :perms/view-data :blocked :legacy-no-self-service)))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :blocked :blocked))))
 
 (deftest set-database-permission!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}    {}
@@ -39,21 +38,21 @@
                                                        :perm_type perm-type))]
      (mt/with-restored-data-perms-for-group! group-id
        (testing "`set-database-permission!` correctly updates an individual database's permissions"
-         (data-perms/set-database-permission! group-id database-id :perms/native-query-editing :no)
-         (is (= :no (perm-value :perms/native-query-editing)))
-         (data-perms/set-database-permission! group-id database-id :perms/native-query-editing :yes)
-         (is (= :yes (perm-value :perms/native-query-editing))))
+         (data-perms/set-database-permission! group-id database-id :perms/create-queries :no)
+         (is (= :no (perm-value :perms/create-queries)))
+         (data-perms/set-database-permission! group-id database-id :perms/create-queries :query-builder)
+         (is (= :query-builder (perm-value :perms/create-queries))))
 
-       (testing "`set-database-permission!` sets native query permissions to :no if data access is set to :block"
-         (data-perms/set-database-permission! group-id database-id :perms/data-access :block)
-         (is (= :block (perm-value :perms/data-access)))
-         (is (= :no (perm-value :perms/native-query-editing))))
+       (testing "`set-database-permission!` sets native query permissions to :no if data access is set to :blocked"
+         (data-perms/set-database-permission! group-id database-id :perms/view-data :blocked)
+         (is (= :blocked (perm-value :perms/view-data)))
+         (is (= :no (perm-value :perms/create-queries))))
 
        (testing "A database-level permission cannot be set to an invalid value"
          (is (thrown-with-msg?
               ExceptionInfo
-              #"Permission type :perms/native-query-editing cannot be set to :invalid-value"
-              (data-perms/set-database-permission! group-id database-id :perms/native-query-editing :invalid-value))))))))
+              #"Permission type :perms/create-queries cannot be set to :invalid-value"
+              (data-perms/set-database-permission! group-id database-id :perms/create-queries :invalid-value))))))))
 
 (deftest set-table-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}      {}
@@ -64,71 +63,71 @@
                  :model/Table            {table-id-2 :id}    {:db_id database-id}
                  :model/Table            {table-id-3 :id}    {:db_id database-id}
                  :model/Table            {table-id-4 :id}    {:db_id database-id-2}]
-    (let [data-access-perm-value (fn [table-id] (t2/select-one-fn :perm_value :model/DataPermissions
-                                                                  :db_id     database-id
-                                                                  :group_id  group-id
-                                                                  :table_id  table-id
-                                                                  :perm_type :perms/data-access))]
+    (let [create-queries-perm-value (fn [table-id] (t2/select-one-fn :perm_value :model/DataPermissions
+                                                                   :db_id     database-id
+                                                                   :group_id  group-id
+                                                                   :table_id  table-id
+                                                                   :perm_type :perms/create-queries))]
       (mt/with-restored-data-perms-for-group! group-id
         (testing "`set-table-permissions!` can set individual table permissions to different values"
-          (data-perms/set-table-permissions! group-id :perms/data-access {table-id-1 :no-self-service
-                                                                          table-id-2 :unrestricted
-                                                                          table-id-3 :no-self-service})
-          (is (= :no-self-service (data-access-perm-value table-id-1)))
-          (is (= :unrestricted    (data-access-perm-value table-id-2)))
-          (is (= :no-self-service (data-access-perm-value table-id-3))))
+          (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-1 :no
+                                                                             table-id-2 :query-builder
+                                                                             table-id-3 :no})
+          (is (= :no            (create-queries-perm-value table-id-1)))
+          (is (= :query-builder (create-queries-perm-value table-id-2)))
+          (is (= :no            (create-queries-perm-value table-id-3))))
 
         (testing "`set-table-permissions!` can set individual table permissions passed in as the full tables"
-          (data-perms/set-table-permissions! group-id :perms/data-access {table-1 :unrestricted})
-          (is (= :unrestricted (data-access-perm-value table-id-1))))
+          (data-perms/set-table-permissions! group-id :perms/create-queries {table-1 :query-builder})
+          (is (= :query-builder (create-queries-perm-value table-id-1))))
 
         (testing "`set-table-permission!` coalesces table perms to a DB-level value if they're all the same"
-          (data-perms/set-table-permissions! group-id :perms/data-access {table-id-1 :no-self-service
-                                                                          table-id-2 :no-self-service})
-          (is (= :no-self-service (data-access-perm-value nil)))
-          (is (nil?               (data-access-perm-value table-id-1)))
-          (is (nil?               (data-access-perm-value table-id-2)))
-          (is (nil?               (data-access-perm-value table-id-3))))
+          (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-1 :no
+                                                                             table-id-2 :no})
+          (is (= :no (create-queries-perm-value nil)))
+          (is (nil?  (create-queries-perm-value table-id-1)))
+          (is (nil?  (create-queries-perm-value table-id-2)))
+          (is (nil?  (create-queries-perm-value table-id-3))))
 
         (testing "`set-table-permission!` breaks table perms out again if any are modified"
-          (data-perms/set-table-permissions! group-id :perms/data-access {table-id-2 :unrestricted
-                                                                          table-id-3 :no-self-service})
-          (is (nil?               (data-access-perm-value nil)))
-          (is (= :no-self-service (data-access-perm-value table-id-1)))
-          (is (= :unrestricted    (data-access-perm-value table-id-2)))
-          (is (= :no-self-service (data-access-perm-value table-id-3))))
+          (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-2 :query-builder
+                                                                             table-id-3 :no})
+          (is (nil?             (create-queries-perm-value nil)))
+          (is (= :no            (create-queries-perm-value table-id-1)))
+          (is (= :query-builder (create-queries-perm-value table-id-2)))
+          (is (= :no            (create-queries-perm-value table-id-3))))
 
         (testing "A non table-level permission cannot be set"
           (is (thrown-with-msg?
                ExceptionInfo
-               #"Permission type :perms/native-query-editing cannot be set on tables."
-               (data-perms/set-table-permissions! group-id :perms/native-query-editing {table-id-1 :yes}))))
+               #"Permission type :perms/manage-database cannot be set on tables."
+               (data-perms/set-table-permissions! group-id :perms/manage-database {table-id-1 :yes}))))
 
         (testing "A table-level permission cannot be set to an invalid value"
           (is (thrown-with-msg?
                ExceptionInfo
-               #"Permission type :perms/data-access cannot be set to :invalid"
-               (data-perms/set-table-permissions! group-id :perms/data-access {table-id-1 :invalid}))))
+               #"Permission type :perms/create-queries cannot be set to :invalid"
+               (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-1 :invalid}))))
 
         (testing "A table-level permission cannot be set to :block"
           (is (thrown-with-msg?
                ExceptionInfo
                #"Block permissions must be set at the database-level only."
-               (data-perms/set-table-permissions! group-id :perms/data-access {table-id-1 :block}))))
+               (data-perms/set-table-permissions! group-id :perms/view-data {table-id-1 :blocked}))))
 
         (testing "Table-level permissions can only be set in bulk for tables in the same database"
           (is (thrown-with-msg?
                ExceptionInfo
                #"All tables must belong to the same database."
-               (data-perms/set-table-permissions! group-id :perms/data-access {table-id-3 :unrestricted
-                                                                               table-id-4 :unrestricted}))))
+               (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-3 :query-builder
+                                                                                  table-id-4 :query-builder}))))
 
-        (testing "Setting block permissions at the database level clears table-level data access perms"
-          (data-perms/set-database-permission! group-id database-id :perms/data-access :block)
-          (is (= :block (data-access-perm-value nil)))
-          (is (nil?     (data-access-perm-value table-id-1)))
-          (is (nil?     (data-access-perm-value table-id-2)))
-          (is (nil?     (data-access-perm-value table-id-3))))))))
+        (testing "Setting block permissions at the database level clears table-level query query perms"
+          (data-perms/set-database-permission! group-id database-id :perms/view-data :blocked)
+          (is (= :no (create-queries-perm-value nil)))
+          (is (nil?  (create-queries-perm-value table-id-1)))
+          (is (nil?  (create-queries-perm-value table-id-2)))
+          (is (nil?  (create-queries-perm-value table-id-3))))))))
 
 (deftest database-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}
@@ -142,29 +141,29 @@
                  :model/Database                   {database-id-2 :id} {}]
     (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
       (testing "`database-permission-for-user` coalesces permissions from all groups a user is in"
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
-        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/native-query-editing :no)
-        (is (= :yes (data-perms/database-permission-for-user user-id :perms/native-query-editing database-id-1))))
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/manage-database :yes)
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/manage-database :no)
+        (is (= :yes (data-perms/database-permission-for-user user-id :perms/manage-database database-id-1))))
 
       (testing "`database-permission-for-user` falls back to the least permissive value if no value exists for the user"
         (t2/delete! :model/DataPermissions :db_id database-id-2)
-        (is (= :no (data-perms/database-permission-for-user user-id :perms/native-query-editing database-id-2))))
+        (is (= :no (data-perms/database-permission-for-user user-id :perms/manage-database database-id-2))))
 
       (testing "Admins always have the most permissive value, regardless of group membership"
-        (is (= :yes (data-perms/database-permission-for-user (mt/user->id :crowberto) :perms/native-query-editing database-id-2)))))
+        (is (= :yes (data-perms/database-permission-for-user (mt/user->id :crowberto) :perms/manage-database database-id-2)))))
 
     (testing "caching works as expected"
       (binding [api/*current-user-id* user-id]
         (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
-          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
+          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/manage-database :yes)
           (data-perms/with-relevant-permissions-for-user user-id
             ;; retrieve the cache now so it doesn't get counted in the call-count
             @data-perms/*permissions-for-user*
             ;; make the cache wrong
-            (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :no)
+            (data-perms/set-database-permission! group-id-1 database-id-1 :perms/manage-database :no)
             ;; the cached value is used
             (t2/with-call-count [call-count]
-              (is (= :yes (data-perms/database-permission-for-user user-id :perms/native-query-editing database-id-1)))
+              (is (= :yes (data-perms/database-permission-for-user user-id :perms/manage-database database-id-1)))
               (is (zero? (call-count))))))))))
 
 (deftest table-permission-for-user-test
@@ -180,28 +179,30 @@
                  :model/Table                      {table-id-2 :id}  {:db_id database-id}]
     (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
       (testing "`table-permission-for-user` coalesces permissions from all groups a user is in"
-        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-        (data-perms/set-table-permission! group-id-2 table-id-1 :perms/data-access :no-self-service)
-        (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/data-access database-id table-id-1))))
+        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+        (data-perms/set-table-permission! group-id-2 table-id-1 :perms/create-queries :no)
+        (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/create-queries :no)
+        (is (= :query-builder (data-perms/table-permission-for-user user-id :perms/create-queries database-id table-id-1))))
 
       (testing "`table-permission-for-user` falls back to the least permissive value if no value exists for the user"
         (t2/delete! :model/DataPermissions :db_id database-id)
-        (is (= :block (data-perms/table-permission-for-user user-id :perms/data-access database-id table-id-2))))
+        (is (= :no (data-perms/table-permission-for-user user-id :perms/create-queries database-id table-id-2))))
 
       (testing "Admins always have the most permissive value, regardless of group membership"
-        (is (= :unrestricted (data-perms/table-permission-for-user (mt/user->id :crowberto) :perms/data-access database-id table-id-2)))))
+        (is (= :query-builder-and-native (data-perms/table-permission-for-user (mt/user->id :crowberto) :perms/create-queries database-id table-id-2)))))
+
     (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
       (testing "caching works as expected"
         (binding [api/*current-user-id* user-id]
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
           (data-perms/with-relevant-permissions-for-user user-id
             ;; retrieve the cache now so it doesn't get counted in the call count
             @data-perms/*permissions-for-user*
             ;; make the cache wrong
-            (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
+            (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :no)
             ;; the cached value is used
             (t2/with-call-count [call-count]
-              (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/data-access database-id table-id-1)))
+              (is (= :query-builder (data-perms/table-permission-for-user user-id :perms/create-queries database-id table-id-1)))
               (is (zero? (call-count))))))))))
 
 (deftest permissions-for-user-test
@@ -226,56 +227,56 @@
       (t2/delete! :model/DataPermissions :group_id group-id-1)
       (t2/delete! :model/DataPermissions :group_id group-id-2)
       (testing "A single user's data permissions can be fetched as a graph"
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/data-access :unrestricted)
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
-        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/data-access :no-self-service)
-        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/native-query-editing :no)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/view-data :unrestricted)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/create-queries :query-builder-and-native)
+        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/view-data :blocked)
+        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/create-queries :no)
         (is (partial=
              {database-id-1
-              {:perms/data-access :unrestricted
-               :perms/native-query-editing :yes}
+              {:perms/view-data :unrestricted
+               :perms/create-queries :query-builder-and-native}
               database-id-2
-              {:perms/data-access :block
-               :perms/native-query-editing :no}}
+              {:perms/view-data :blocked
+               :perms/create-queries :no}}
              (data-perms/permissions-for-user user-id-1))))
 
       (testing "Perms from multiple groups are coalesced"
-        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/data-access :no-self-service)
-        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/native-query-editing :no)
-        (data-perms/set-database-permission! group-id-2 database-id-2 :perms/data-access :unrestricted)
-        (data-perms/set-database-permission! group-id-2 database-id-2 :perms/native-query-editing :yes)
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/view-data :unrestricted)
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/create-queries :no)
+        (data-perms/set-database-permission! group-id-2 database-id-2 :perms/view-data :unrestricted)
+        (data-perms/set-database-permission! group-id-2 database-id-2 :perms/create-queries :query-builder-and-native)
         (is (partial=
              {database-id-1
-              {:perms/data-access :unrestricted
-               :perms/native-query-editing :yes}
+              {:perms/view-data :unrestricted
+               :perms/create-queries :query-builder-and-native}
               database-id-2
-              {:perms/data-access :unrestricted
-               :perms/native-query-editing :yes}}
+              {:perms/view-data :unrestricted
+               :perms/create-queries :query-builder-and-native}}
              (data-perms/permissions-for-user user-id-1))))
 
       (testing "Table-level perms are included if they're more permissive than any database-level perms"
-        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
-        (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
+        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :no)
+        (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :query-builder)
         (is (partial=
              {database-id-1
-              {:perms/data-access {table-id-1 :block
-                                   table-id-2 :unrestricted}}}
+              {:perms/create-queries {table-id-1 :no
+                                      table-id-2 :query-builder}}}
              (data-perms/permissions-for-user user-id-1))))
 
       (testing "Table-level perms are not included if a database-level perm is more permissive"
-        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/data-access :unrestricted)
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/create-queries :query-builder-and-native)
         (is (partial=
              {database-id-1
-              {:perms/data-access :unrestricted}}
+              {:perms/create-queries :query-builder-and-native}}
              (data-perms/permissions-for-user user-id-1))))
 
       (testing "Admins always have full permissions"
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/data-access :no-self-service)
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :no)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/view-data :blocked)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/create-queries :no)
         (is (partial=
              {database-id-1
-              {:perms/data-access :unrestricted
-               :perms/native-query-editing :yes
+              {:perms/view-data :unrestricted
+               :perms/create-queries :query-builder-and-native
                :perms/manage-database :yes
                :perms/manage-table-metadata :yes
                :perms/download-results :one-million-rows}}
@@ -296,28 +297,28 @@
       ;; Clear the default permissions for the groups
       (t2/delete! :model/DataPermissions :group_id group-id-1)
       (t2/delete! :model/DataPermissions :group_id group-id-2)
-      (testing "Data access and native query permissions can be fetched as a graph"
-        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-        (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :no-self-service)
-        (data-perms/set-table-permission! group-id-1 table-id-3 :perms/data-access :unrestricted)
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
-        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/native-query-editing :no)
-        (data-perms/set-table-permission! group-id-2 table-id-1 :perms/data-access :no-self-service)
+      (testing "Data and query permissions can be fetched as a graph"
+        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/view-data :unrestricted)
+        (data-perms/set-table-permission! group-id-1 table-id-2 :perms/view-data :legacy-no-self-service)
+        (data-perms/set-table-permission! group-id-1 table-id-3 :perms/view-data :unrestricted)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/create-queries :query-builder-and-native)
+        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/create-queries :no)
+        (data-perms/set-table-permission! group-id-2 table-id-1 :perms/view-data :legacy-no-self-service)
         (is (partial=
              {group-id-1
-              {database-id-1 {:perms/data-access
+              {database-id-1 {:perms/view-data
                               {"PUBLIC"
                                {table-id-1 :unrestricted
-                                table-id-2 :no-self-service}}
-                              :perms/native-query-editing :yes}
-               database-id-2 {:perms/data-access
+                                table-id-2 :legacy-no-self-service}}
+                              :perms/create-queries :query-builder-and-native}
+               database-id-2 {:perms/view-data
                               {""
                                {table-id-3 :unrestricted}}
-                              :perms/native-query-editing :no}}
+                              :perms/create-queries :no}}
               group-id-2
-              {database-id-1 {:perms/data-access
+              {database-id-1 {:perms/view-data
                               {"PUBLIC"
-                               {table-id-1 :no-self-service}}}}}
+                               {table-id-1 :legacy-no-self-service}}}}}
              (data-perms/data-permissions-graph))))
 
       (testing "Additional data permissions are included when set"
@@ -337,30 +338,30 @@
 
       (testing "Data permissions graph can be filtered by group ID, database ID, and permission type"
         (is (= {group-id-1
-                {database-id-1 {:perms/data-access
+                {database-id-1 {:perms/view-data
                                 {"PUBLIC"
                                  {table-id-1 :unrestricted
-                                  table-id-2 :no-self-service}}
-                                :perms/native-query-editing :yes
+                                  table-id-2 :legacy-no-self-service}}
+                                :perms/create-queries :query-builder-and-native
                                 :perms/manage-table-metadata
                                 {"PUBLIC"
                                  {table-id-1 :yes}}}
-                 database-id-2 {:perms/data-access
+                 database-id-2 {:perms/view-data
                                 {""
                                  {table-id-3 :unrestricted}}
                                 :perms/download-results
                                 {""
                                  {table-id-3 :one-million-rows}}
                                 :perms/manage-database :yes
-                                :perms/native-query-editing :no}}}
+                                :perms/create-queries :no}}}
                (data-perms/data-permissions-graph :group-id group-id-1)))
 
         (is (= {group-id-1
-                {database-id-1 {:perms/data-access
+                {database-id-1 {:perms/view-data
                                 {"PUBLIC"
                                  {table-id-1 :unrestricted
-                                  table-id-2 :no-self-service}}
-                                :perms/native-query-editing :yes
+                                  table-id-2 :legacy-no-self-service}}
+                                :perms/create-queries :query-builder-and-native
                                 :perms/manage-table-metadata
                                 {"PUBLIC"
                                  {table-id-1 :yes}}}}}
@@ -368,28 +369,28 @@
                                                   :db-id database-id-1)))
 
         (is (= {group-id-1
-                {database-id-1 {:perms/data-access
+                {database-id-1 {:perms/view-data
                                 {"PUBLIC"
                                  {table-id-1 :unrestricted
-                                  table-id-2 :no-self-service}}}}}
+                                  table-id-2 :legacy-no-self-service}}}}}
                (data-perms/data-permissions-graph :group-id group-id-1
                                                   :db-id database-id-1
-                                                  :perm-type :perms/data-access)))))))
+                                                  :perm-type :perms/view-data)))))))
 
 (deftest most-restrictive-per-group-works
-  (is (= #{:unrestricted}
-         (#'data-perms/most-restrictive-per-group :perms/data-access [{:group-id 1 :value :unrestricted}])))
-  (is (= #{:no-self-service}
-         (#'data-perms/most-restrictive-per-group :perms/data-access [{:group-id 1 :value :unrestricted}
-                                                                      {:group-id 1 :value :no-self-service}])))
-  (is (= #{:no-self-service :unrestricted}
-         (#'data-perms/most-restrictive-per-group :perms/data-access [{:group-id 1 :value :unrestricted}
-                                                                      {:group-id 1 :value :no-self-service}
-                                                                      {:group-id 2 :value :unrestricted}])))
-  (is (= #{:block}
-         (#'data-perms/most-restrictive-per-group :perms/data-access [{:group-id 1 :value :block}
-                                                                      {:group-id 1 :value :no-self-service}
-                                                                      {:group-id 1 :value :unrestricted}]))))
+  (is (= #{:query-builder-and-native}
+         (#'data-perms/most-restrictive-per-group :perms/create-queries [{:group-id 1 :value :query-builder-and-native}])))
+  (is (= #{:no}
+         (#'data-perms/most-restrictive-per-group :perms/create-queries [{:group-id 1 :value :query-builder}
+                                                                         {:group-id 1 :value :no}])))
+  (is (= #{:no :query-builder-and-native}
+         (#'data-perms/most-restrictive-per-group :perms/create-queries [{:group-id 1 :value :query-builder-and-native}
+                                                                         {:group-id 1 :value :no}
+                                                                         {:group-id 2 :value :query-builder-and-native}])))
+  (is (= #{:no}
+         (#'data-perms/most-restrictive-per-group :perms/create-queries [{:group-id 1 :value :no}
+                                                                         {:group-id 1 :value :query-builder}
+                                                                         {:group-id 1 :value :query-builder-and-native}]))))
 
 (deftest full-schema-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}
@@ -406,28 +407,28 @@
         ;; Clear the default permissions for the groups
         (t2/delete! :model/DataPermissions :group_id group-id-1)
         (testing "'Full' schema-level permission for a group is the lowest permission available for a table in the schema"
-          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
-          (is (= :unrestricted (data-perms/full-schema-permission-for-user
-                                user-id-1 :perms/data-access database-id-1 "schema_1"))))
+          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :query-builder)
+          (is (= :query-builder (data-perms/full-schema-permission-for-user
+                                 user-id-1 :perms/create-queries database-id-1 "schema_1"))))
         (testing "Dropping permission for one table means we lose full schema permissions"
-          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :no-self-service)
-          (is (= :no-self-service (data-perms/full-schema-permission-for-user
-                                   user-id-1 :perms/data-access database-id-1 "schema_1"))))
+          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :no)
+          (is (= :no (data-perms/full-schema-permission-for-user
+                      user-id-1 :perms/create-queries database-id-1 "schema_1"))))
         (testing "Permissions don't merge across groups"
           ;; even if a user has `unrestricted` access to all tables in a schema, that doesn't count as `unrestricted`
           ;; access to the schema unless it was granted to a *single group*.
-          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
-          (is (= :no-self-service (data-perms/full-schema-permission-for-user
-                                   user-id-1 :perms/data-access database-id-1 "schema_1"))))))))
+          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :query-builder)
+          (is (= :no (data-perms/full-schema-permission-for-user
+                      user-id-1 :perms/create-queries database-id-1 "schema_1"))))))))
 
 (deftest most-permissive-database-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}
@@ -442,26 +443,19 @@
         ;; Clear the default permissions for the groups
         (t2/delete! :model/DataPermissions :group_id group-id-1)
         (testing "We get back the highest permission available for a table in the database"
-          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
-          (is (= :unrestricted (data-perms/most-permissive-database-permission-for-user
-                                user-id-1 :perms/data-access database-id-1))))
+          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :query-builder)
+          (is (= :query-builder (data-perms/most-permissive-database-permission-for-user
+                                 user-id-1 :perms/create-queries database-id-1))))
         (testing "Dropping permission for one table has no effect"
-          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :no-self-service)
-          (is (= :unrestricted (data-perms/most-permissive-database-permission-for-user
-                                user-id-1 :perms/data-access database-id-1))))
-        (testing "Blocks work like usual"
-          ;; If I am blocked by one group, `:no-self-service` is overriden and I end up with `:block` permission.
-          (data-perms/set-database-permission! all-users-group-id database-id-1 :perms/data-access :block)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :no-self-service)
-          (is (= :block (data-perms/most-permissive-database-permission-for-user
-                         user-id-1 :perms/data-access database-id-1))))))))
+          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :no)
+          (is (= :query-builder (data-perms/most-permissive-database-permission-for-user
+                                 user-id-1 :perms/create-queries database-id-1))))))))
 
 (deftest set-new-table-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}
@@ -474,35 +468,35 @@
                                                       :db_id     db-id
                                                       :group_id  group-id
                                                       :table_id  table-id
-                                                      :perm_type :perms/data-access))]
+                                                      :perm_type :perms/create-queries))]
       (mt/with-restored-data-perms-for-group! group-id
         (testing "New table inherits DB-level permission if set"
-          (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id table-id-2 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id table-id-3 :perms/data-access :unrestricted)
+          (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-3 :perms/create-queries :query-builder)
           (mt/with-temp [:model/Table {table-id-4 :id} {:db_id db-id :schema "PUBLIC"}]
-            (is (= :unrestricted (perm-value nil)))
+            (is (= :query-builder (perm-value nil)))
             (is (nil? (perm-value table-id-4)))))
 
         (testing "New table inherits uniform permission value from schema"
-          (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id table-id-2 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id table-id-3 :perms/data-access :no-self-service)
+          (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-3 :perms/create-queries :no)
           (mt/with-temp [:model/Table {table-id-4 :id} {:db_id db-id :schema "PUBLIC"}]
-            (is (= :unrestricted (perm-value table-id-4))))
+            (is (= :query-builder (perm-value table-id-4))))
 
-          (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id table-id-3 :perms/data-access :unrestricted)
+          (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id table-id-3 :perms/create-queries :query-builder)
           (mt/with-temp [:model/Table {table-id-4 :id} {:db_id db-id :schema "PUBLIC"}]
-            (is (= :no-self-service (perm-value table-id-4)))))
+            (is (= :no (perm-value table-id-4)))))
 
         (testing "New table uses default value when schema permissions are not uniform"
-          (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id table-id-3 :perms/data-access :no-self-service)
+          (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id table-id-3 :perms/create-queries :no)
           (mt/with-temp [:model/Table {table-id-4 :id} {:db_id db-id :schema "PUBLIC"}]
-            (is (= :no-self-service (perm-value table-id-4)))))))))
+            (is (= :no (perm-value table-id-4)))))))))
 
 (deftest additional-table-permissions-works
   (mt/with-temp [:model/PermissionsGroup           {group-id :id} {}
@@ -515,16 +509,19 @@
     (mt/with-no-data-perms-for-all-users!
       (testing "we can override the existing permission, using normal coalesce logic"
         (mt/with-restored-data-perms-for-group! group-id
-          (data-perms/set-database-permission! group-id db-id :perms/data-access :no-self-service)
-          (data-perms/with-additional-table-permission :perms/data-access db-id table-id :unrestricted
-            (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/data-access db-id table-id))))))
-      (testing "normal coalesce logic applies, so e.g. `:block` will override `:no-self-service`"
+          (data-perms/set-database-permission! group-id db-id :perms/view-data :legacy-no-self-service)
+          (data-perms/with-additional-table-permission :perms/view-data db-id table-id :unrestricted
+            (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id))))))
+      ;; `legacy-no-self-service` is deprecated and is only different from `unrestricted` in its coalescing behavior
+      (testing "normal coalesce logic applies, so e.g. `:blocked` will override `:legacy-no-self-service`"
         (mt/with-restored-data-perms-for-group! group-id
-          (is (= :block (data-perms/table-permission-for-user user-id :perms/data-access db-id table-id)))
-          (data-perms/with-additional-table-permission :perms/data-access db-id table-id :no-self-service
-            (is (= :block (data-perms/table-permission-for-user user-id :perms/data-access db-id table-id))))))
+          (data-perms/set-database-permission! group-id db-id :perms/view-data :blocked)
+          (is (= :blocked (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id)))
+          (data-perms/with-additional-table-permission :perms/view-data db-id table-id :legacy-no-self-service
+            (is (= :blocked (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id))))))
       (testing "... but WILL NOT override `:unrestricted`"
         (mt/with-restored-data-perms-for-group! group-id
-          (is (= :block (data-perms/table-permission-for-user user-id :perms/data-access db-id table-id)))
-          (data-perms/with-additional-table-permission :perms/data-access db-id table-id :unrestricted
-            (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/data-access db-id table-id)))))))))
+          (data-perms/set-database-permission! group-id db-id :perms/view-data :blocked)
+          (is (= :blocked (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id)))
+          (data-perms/with-additional-table-permission :perms/view-data db-id table-id :unrestricted
+            (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id)))))))))

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -44,9 +44,7 @@
                 {db-id
                  {:perms/view-data             :unrestricted
                   :perms/create-queries        :query-builder-and-native
-                  :perms/data-access           :unrestricted
                   :perms/download-results      :one-million-rows
-                  :perms/native-query-editing  :yes
                   :perms/manage-table-metadata :no
                   :perms/manage-database       :no}}}
                (data-perms/data-permissions-graph :group-id all-users-group-id :db-id db-id))))
@@ -57,8 +55,6 @@
                {:perms/view-data             :unrestricted
                 :perms/create-queries        :no
                 :perms/download-results      :no
-                :perms/data-access           :no-self-service
-                :perms/native-query-editing  :no
                 :perms/manage-table-metadata :no
                 :perms/manage-database       :no}}}
              (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))

--- a/test/metabase/models/permissions_group_test.clj
+++ b/test/metabase/models/permissions_group_test.clj
@@ -155,9 +155,7 @@
            {db-id
             {:perms/view-data :unrestricted,
              :perms/create-queries :no,
-             :perms/data-access :no-self-service,
              :perms/download-results :no,
              :perms/manage-table-metadata :no,
-             :perms/native-query-editing :no,
              :perms/manage-database :no}}}
           (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))

--- a/test/metabase/models/table_test.clj
+++ b/test/metabase/models/table_test.clj
@@ -98,8 +98,6 @@
               {db-id
                {:perms/view-data             :unrestricted
                 :perms/create-queries        :query-builder-and-native
-                :perms/data-access           :unrestricted
-                :perms/native-query-editing  :yes
                 :perms/download-results      :one-million-rows
                 :perms/manage-table-metadata :no
                 :perms/manage-database       :no}}}
@@ -111,8 +109,6 @@
             {db-id
              {:perms/view-data             :unrestricted
               :perms/create-queries        :no
-              :perms/data-access           :no-self-service
-              :perms/native-query-editing  :no
               :perms/download-results      :no
               :perms/manage-table-metadata :no
               :perms/manage-database       :no}}}
@@ -120,7 +116,7 @@
 
       (testing "A new table has appropriate defaults, when perms are already set granularly for the DB"
         (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
-        (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :unrestricted)
+        (data-perms/set-table-permission! group-id table-id-1 :perms/view-data :unrestricted)
         (data-perms/set-table-permission! group-id table-id-1 :perms/download-results :one-million-rows)
         (data-perms/set-table-permission! group-id table-id-1 :perms/manage-table-metadata :yes)
         (mt/with-temp [:model/Table {table-id-3 :id} {:db_id  db-id
@@ -133,11 +129,6 @@
                                                 {table-id-1 :query-builder
                                                  table-id-2 :no
                                                  table-id-3 :no}}
-                  :perms/data-access           {"PUBLIC"
-                                                {table-id-1 :unrestricted
-                                                 table-id-2 :no-self-service
-                                                 table-id-3 :no-self-service}}
-                  :perms/native-query-editing  :no
                   :perms/download-results      {"PUBLIC"
                                                 {table-id-1 :one-million-rows
                                                  table-id-2 :no
@@ -155,7 +146,7 @@
      :model/Table    {table-id-1 :id} {:db_id db-id}
      :model/Table    {}               {:db_id db-id}]
     (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/create-queries :query-builder-and-native)
-    (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/data-access :unrestricted)
+    (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/view-data :unrestricted)
     (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/download-results :one-million-rows)
     (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/manage-table-metadata :yes)
     (is (true? (t2/exists? :model/DataPermissions :table_id table-id-1)))


### PR DESCRIPTION
Closes #40852

### Description

**High level:**
Updated UI to handle the new permissions graph and definitions for `view-data` and `create-queries` permissions and removes the usage of `data`'s `schema` and `native` options.

**Specifics:**
- Updates UI to display new permissions options
- Enables query creation options to be granular
- Handles updates permissions relationships and auto-upgrading/downgrading related permissions as needed (e.g. downgrade all `create-queries` permissions from `query-builder-and-native` to `query-builder` for all tables in all schemas when a `view-data` permission becomes `sandboxed`)
- Refactors the UI to use enums / increase type safety

### How to verify

- Go to permissions page and play around / try to break it!


### Checklist

- [x] Tests have been added/updated to cover changes in this PR~
Tests have been updated, but no new tests have been added. This will come in a follow up PR to help this be a bit more focused (it's only getting merged into our integration branch so no worries there).

