### PR TITLE
CSV Replacement Frontend

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -45,6 +45,7 @@ describeWithSnowplow(
       cy.intercept("POST", "/api/dataset").as("dataset");
       cy.intercept("POST", "/api/card/from-csv").as("uploadCSV");
       cy.intercept("POST", "/api/table/*/append-csv").as("appendCSV");
+      cy.intercept("POST", "/api/table/*/replace-csv").as("replaceCSV");
     });
 
     it("Can upload a CSV file to an empty postgres schema", () => {
@@ -173,7 +174,10 @@ describeWithSnowplow(
               `Showing ${validTestFiles[0].rowCount} rows`,
             );
 
-            appendFile(validTestFiles[0]);
+            uploadToExisting({
+              testFile: validTestFiles[0],
+              uploadMode: "append",
+            });
             cy.findByTestId("view-footer").findByText(
               `Showing ${validTestFiles[0].rowCount * 2} rows`,
             );
@@ -185,7 +189,44 @@ describeWithSnowplow(
               `Showing ${validTestFiles[0].rowCount} rows`,
             );
 
-            appendFile(validTestFiles[1], false);
+            uploadToExisting({
+              testFile: validTestFiles[1],
+              valid: false,
+              uploadMode: "append",
+            });
+            cy.findByTestId("view-footer").findByText(
+              `Showing ${validTestFiles[0].rowCount} rows`,
+            );
+          });
+        });
+
+        describe("CSV replacement", () => {
+          it("Can replace data in an existing table", () => {
+            uploadFile(validTestFiles[0]);
+            cy.findByTestId("view-footer").findByText(
+              `Showing ${validTestFiles[0].rowCount} rows`,
+            );
+
+            uploadToExisting({
+              testFile: validTestFiles[0],
+              uploadMode: "replace",
+            });
+            cy.findByTestId("view-footer").findByText(
+              `Showing ${validTestFiles[0].rowCount} rows`,
+            );
+          });
+
+          it("Cannot data in a table with a different schema", () => {
+            uploadFile(validTestFiles[0]);
+            cy.findByTestId("view-footer").findByText(
+              `Showing ${validTestFiles[0].rowCount} rows`,
+            );
+
+            uploadToExisting({
+              testFile: validTestFiles[1],
+              valid: false,
+              uploadMode: "replace",
+            });
             cy.findByTestId("view-footer").findByText(
               `Showing ${validTestFiles[0].rowCount} rows`,
             );
@@ -332,12 +373,24 @@ function uploadFile(testFile, valid = true) {
   }
 }
 
-function appendFile(testFile, valid = true) {
+function uploadToExisting({ testFile, valid = true, uploadMode = "append" }) {
   // assumes we're already looking at an uploadable model page
-  cy.findByTestId("qb-header").icon("upload");
+  cy.findByTestId("qb-header").icon("upload").click();
+
+  const uploadOptions = {
+    append: "Append data to this model",
+    replace: "Replace all data in this model",
+  };
+
+  const uploadEndpoints = {
+    append: "@appendCSV",
+    replace: "@replaceCSV",
+  };
+
+  popover().findByText(uploadOptions[uploadMode]).click();
 
   cy.fixture(`${FIXTURE_PATH}/${testFile.fileName}`).then(file => {
-    cy.get("#append-file-input").selectFile(
+    cy.get("#upload-file-input").selectFile(
       {
         contents: Cypress.Buffer.from(file),
         fileName: testFile.fileName,
@@ -352,13 +405,16 @@ function appendFile(testFile, valid = true) {
       .should("contain", "Uploading data to")
       .and("contain", testFile.fileName);
 
-    cy.wait("@appendCSV");
+    cy.wait(uploadEndpoints[uploadMode]);
 
-    cy.findByTestId("status-root-container").findByText(/Data added to/i, {
-      timeout: 10 * 1000,
-    });
+    cy.findByTestId("status-root-container").findByText(
+      /Data (added|replaced)/i,
+      {
+        timeout: 10 * 1000,
+      },
+    );
   } else {
-    cy.wait("@appendCSV");
+    cy.wait(uploadEndpoints[uploadMode]);
 
     cy.findByTestId("status-root-container").findByText(
       "Error uploading your file",

--- a/frontend/src/metabase-types/store/upload.ts
+++ b/frontend/src/metabase-types/store/upload.ts
@@ -8,6 +8,7 @@ export type FileUpload = {
   tableId?: TableId;
   message?: string;
   error?: string;
+  uploadMode?: "append" | "create" | "replace";
   id: number;
 };
 

--- a/frontend/src/metabase-types/store/upload.ts
+++ b/frontend/src/metabase-types/store/upload.ts
@@ -1,5 +1,11 @@
 import type { CollectionId, TableId } from "metabase-types/api";
 
+export enum UploadMode {
+  append = "append",
+  create = "create",
+  replace = "replace",
+}
+
 export type FileUpload = {
   status: "complete" | "in-progress" | "error";
   name: string;
@@ -8,7 +14,7 @@ export type FileUpload = {
   tableId?: TableId;
   message?: string;
   error?: string;
-  uploadMode?: "append" | "create" | "replace";
+  uploadMode?: UploadMode;
   id: number;
 };
 

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContent.tsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContent.tsx
@@ -75,8 +75,11 @@ export function CollectionContent({
     modelId,
     collectionId,
     tableId,
+    uploadMode,
   }: UploadFileProps) =>
-    dispatch(uploadFileAction({ file, modelId, collectionId, tableId }));
+    dispatch(
+      uploadFileAction({ file, modelId, collectionId, tableId, uploadMode }),
+    );
 
   const error =
     bookmarksError || databasesError || collectionsError || collectionError;

--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.jsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.jsx
@@ -77,10 +77,16 @@ export function CollectionContentView({
   };
 
   const handleUploadFile = useCallback(
-    ({ collectionId, tableId, modelId }) => {
+    ({ collectionId, tableId, modelId, uploadMode }) => {
       if (uploadedFile && (collectionId || tableId)) {
         closeModelUploadModal();
-        uploadFile({ file: uploadedFile, collectionId, tableId, modelId });
+        uploadFile({
+          file: uploadedFile,
+          collectionId,
+          tableId,
+          modelId,
+          uploadMode,
+        });
       }
     },
     [uploadFile, uploadedFile, closeModelUploadModal],

--- a/frontend/src/metabase/collections/components/ModelUploadModal.tsx
+++ b/frontend/src/metabase/collections/components/ModelUploadModal.tsx
@@ -13,19 +13,18 @@ import {
   Icon,
 } from "metabase/ui";
 import type { CollectionId, TableId, CardId } from "metabase-types/api";
+import { UploadMode } from "metabase-types/store/upload";
 
 import { findLastEditedCollectionItem } from "./utils";
 
-enum UploadMode {
-  append = "append",
-  create = "create",
-  replace = "replace",
-}
-
 type CollectionOrTableIdProps =
-  | { uploadMode: "create"; collectionId: CollectionId; tableId?: never }
   | {
-      uploadMode: "append" | "replace";
+      uploadMode: UploadMode.create;
+      collectionId: CollectionId;
+      tableId?: never;
+    }
+  | {
+      uploadMode: UploadMode.append | UploadMode.replace;
       collectionId?: never;
       tableId: TableId;
       modelId?: CardId;
@@ -73,7 +72,7 @@ export function ModelUploadModal({
   );
 
   const handleUpload = () => {
-    if (uploadMode !== "create" && tableId) {
+    if (uploadMode !== UploadMode.create && tableId) {
       const modelForTableId = uploadableModels.find(
         model => model.based_on_upload === Number(tableId),
       );
@@ -84,14 +83,14 @@ export function ModelUploadModal({
       });
     }
 
-    return onUpload({ collectionId, uploadMode: "create" });
+    return onUpload({ collectionId, uploadMode: UploadMode.create });
   };
 
   useEffect(() => {
     // if we trigger the modal, and there's no uploadable models, just
     // automatically upload a new one
     if (opened && uploadableModels.length === 0) {
-      onUpload({ collectionId, uploadMode: "create" });
+      onUpload({ collectionId, uploadMode: UploadMode.create });
       onClose();
     }
   }, [onUpload, onClose, collectionId, uploadableModels, opened]);

--- a/frontend/src/metabase/collections/components/ModelUploadModal.tsx
+++ b/frontend/src/metabase/collections/components/ModelUploadModal.tsx
@@ -19,11 +19,17 @@ import { findLastEditedCollectionItem } from "./utils";
 enum UploadMode {
   append = "append",
   create = "create",
+  replace = "replace",
 }
 
 type CollectionOrTableIdProps =
-  | { collectionId: CollectionId; tableId?: never }
-  | { collectionId?: never; tableId: TableId; modelId?: CardId };
+  | { uploadMode: "create"; collectionId: CollectionId; tableId?: never }
+  | {
+      uploadMode: "append" | "replace";
+      collectionId?: never;
+      tableId: TableId;
+      modelId?: CardId;
+    };
 
 export function ModelUploadModal({
   opened,
@@ -33,7 +39,11 @@ export function ModelUploadModal({
 }: {
   opened: boolean;
   onClose: () => void;
-  onUpload: ({ collectionId, tableId }: CollectionOrTableIdProps) => void;
+  onUpload: ({
+    collectionId,
+    tableId,
+    uploadMode,
+  }: CollectionOrTableIdProps) => void;
   collectionId: CollectionId;
 }) {
   const [uploadMode, setUploadMode] = useState<UploadMode>(UploadMode.create);
@@ -63,24 +73,25 @@ export function ModelUploadModal({
   );
 
   const handleUpload = () => {
-    if (uploadMode === "append" && tableId) {
+    if (uploadMode !== "create" && tableId) {
       const modelForTableId = uploadableModels.find(
         model => model.based_on_upload === Number(tableId),
       );
       return onUpload({
         tableId: Number(tableId),
         modelId: modelForTableId?.id,
+        uploadMode: uploadMode,
       });
     }
 
-    return onUpload({ collectionId });
+    return onUpload({ collectionId, uploadMode: "create" });
   };
 
   useEffect(() => {
     // if we trigger the modal, and there's no uploadable models, just
     // automatically upload a new one
     if (opened && uploadableModels.length === 0) {
-      onUpload({ collectionId });
+      onUpload({ collectionId, uploadMode: "create" });
       onClose();
     }
   }, [onUpload, onClose, collectionId, uploadableModels, opened]);
@@ -90,6 +101,17 @@ export function ModelUploadModal({
   }
 
   const isFormValid = uploadMode === UploadMode.create || !!tableId;
+
+  const buttonText = (() => {
+    switch (uploadMode) {
+      case UploadMode.create:
+        return t`Create model`;
+      case UploadMode.append:
+        return t`Append to model`;
+      case UploadMode.replace:
+        return t`Replace model data`;
+    }
+  })();
 
   return (
     <Modal
@@ -116,8 +138,13 @@ export function ModelUploadModal({
             label={t`Append to a model`}
             value={UploadMode.append}
           />
+          <Radio
+            mt="md"
+            label={t`Replace data in a model`}
+            value={UploadMode.replace}
+          />
         </Radio.Group>
-        {uploadMode === UploadMode.append && (
+        {uploadMode !== UploadMode.create && (
           <Select
             icon={<Icon name="model" />}
             placeholder="Select a model"
@@ -136,7 +163,7 @@ export function ModelUploadModal({
       <Flex justify="flex-end" gap="sm">
         <Button onClick={onClose}>Cancel</Button>
         <Button onClick={handleUpload} variant="filled" disabled={!isFormValid}>
-          {uploadMode === UploadMode.append ? t`Append` : t`Create`}
+          {buttonText}
         </Button>
       </Flex>
     </Modal>

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionActions/QuestionActions.tsx
@@ -28,6 +28,7 @@ import {
   checkCanBeModel,
   checkDatabaseCanPersistDatasets,
 } from "metabase-lib/v1/metadata/utils/models";
+import { UploadMode } from "metabase-types/store/upload";
 
 import { canUploadToQuestion } from "../../../../../selectors";
 import { ViewHeaderIconButtonContainer } from "../../ViewHeader.styled";
@@ -72,7 +73,7 @@ export const QuestionActions = ({
   onInfoClick,
   onModelPersistenceChange,
 }: Props) => {
-  const [uploadMode, setUploadMode] = useState<"append" | "replace">("append");
+  const [uploadMode, setUploadMode] = useState<UploadMode>(UploadMode.append);
   const isMetabotEnabled = useSetting("is-metabot-enabled");
   const canUpload = useSelector(canUploadToQuestion(question));
 
@@ -231,7 +232,9 @@ export const QuestionActions = ({
 
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const handleUploadClick = (newUploadMode: "append" | "replace") => {
+  const handleUploadClick = (
+    newUploadMode: UploadMode.append | UploadMode.replace,
+  ) => {
     if (fileInputRef.current) {
       setUploadMode(newUploadMode);
       fileInputRef.current.click();
@@ -302,27 +305,19 @@ export const QuestionActions = ({
                 <Menu.Dropdown>
                   <Menu.Item
                     icon={<Icon name="add" />}
-                    onClick={() => handleUploadClick("append")}
+                    onClick={() => handleUploadClick(UploadMode.append)}
                   >
                     {t`Append data to this model`}
                   </Menu.Item>
 
                   <Menu.Item
                     icon={<Icon name="refresh" />}
-                    onClick={() => handleUploadClick("replace")}
+                    onClick={() => handleUploadClick(UploadMode.replace)}
                   >
                     {t`Replace all data in this model`}
                   </Menu.Item>
                 </Menu.Dropdown>
               </Menu>
-              {/* <Button
-                onlyIcon
-                icon="upload"
-                iconSize={HEADER_ICON_SIZE}
-                onClick={handleUploadClick}
-                color={infoButtonColor}
-                data-testid="qb-header-append-button"
-              /> */}
             </ViewHeaderIconButtonContainer>
           </Tooltip>
         </>

--- a/frontend/src/metabase/redux/uploads.ts
+++ b/frontend/src/metabase/redux/uploads.ts
@@ -12,6 +12,7 @@ import { CardApi, MetabaseApi } from "metabase/services";
 import type { CardId, CollectionId, TableId } from "metabase-types/api";
 import type { Dispatch, State } from "metabase-types/store";
 import type { FileUploadState } from "metabase-types/store/upload";
+import { UploadMode } from "metabase-types/store/upload";
 
 export const UPLOAD_FILE_TO_COLLECTION = "metabase/collection/UPLOAD_FILE";
 export const UPLOAD_FILE_START = "metabase/collection/UPLOAD_FILE_START";
@@ -42,7 +43,7 @@ export interface UploadFileProps {
   collectionId?: CollectionId;
   tableId?: TableId;
   modelId?: CardId;
-  uploadMode: "append" | "create" | "replace";
+  uploadMode: UploadMode;
   reloadQuestionData?: boolean;
 }
 
@@ -91,11 +92,11 @@ export const uploadFile = createThunkAction(
 
         const response = await (() => {
           switch (uploadMode) {
-            case "append":
+            case UploadMode.append:
               return MetabaseApi.tableAppendCSV({ tableId, formData });
-            case "replace":
+            case UploadMode.replace:
               return MetabaseApi.tableReplaceCSV({ tableId, formData });
-            case "create":
+            case UploadMode.create:
             default:
               return CardApi.uploadCSV({ formData });
           }

--- a/frontend/src/metabase/redux/uploads.unit.spec.js
+++ b/frontend/src/metabase/redux/uploads.unit.spec.js
@@ -35,6 +35,17 @@ const mockAppendCSV = (valid = true) => {
   );
 };
 
+const mockReplaceCSV = (valid = true) => {
+  fetchMock.post(
+    "glob:*/api/table/*/replace-csv",
+    valid
+      ? "3"
+      : {
+          throws: { data: { message: "It's dead Jim" } },
+        },
+  );
+};
+
 describe("csv uploads", () => {
   describe("actions", () => {
     let dispatch;
@@ -58,7 +69,9 @@ describe("csv uploads", () => {
     it("should handle file upload success", async () => {
       mockUploadCSV();
 
-      await uploadFile({ file, collectionId: "root" })(dispatch);
+      await uploadFile({ file, collectionId: "root", uploadMode: "create" })(
+        dispatch,
+      );
       jest.advanceTimersByTime(NOTIFICATION_DELAY);
 
       expect(dispatch).toHaveBeenCalledWith({
@@ -74,6 +87,7 @@ describe("csv uploads", () => {
         type: UPLOAD_FILE_END,
         payload: {
           id: now,
+          uploadMode: "create",
           modelId: 3,
         },
       });
@@ -89,7 +103,7 @@ describe("csv uploads", () => {
     it("should handle file append success", async () => {
       mockAppendCSV();
 
-      await uploadFile({ file, tableId: 123 })(dispatch);
+      await uploadFile({ file, tableId: 123, uploadMode: "append" })(dispatch);
       jest.advanceTimersByTime(NOTIFICATION_DELAY);
 
       expect(dispatch).toHaveBeenCalledWith({
@@ -106,6 +120,39 @@ describe("csv uploads", () => {
         payload: {
           id: now,
           modelId: 3,
+          uploadMode: "append",
+        },
+      });
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: UPLOAD_FILE_CLEAR,
+        payload: {
+          id: now,
+        },
+      });
+    });
+
+    it("should handle file replace success", async () => {
+      mockReplaceCSV();
+
+      await uploadFile({ file, tableId: 123, uploadMode: "replace" })(dispatch);
+      jest.advanceTimersByTime(NOTIFICATION_DELAY);
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: UPLOAD_FILE_START,
+        payload: {
+          id: now,
+          name: "test.csv",
+          tableId: 123,
+        },
+      });
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: UPLOAD_FILE_END,
+        payload: {
+          id: now,
+          modelId: 3,
+          uploadMode: "replace",
         },
       });
 
@@ -120,7 +167,9 @@ describe("csv uploads", () => {
     it("should handle file upload error", async () => {
       mockUploadCSV(false);
 
-      await uploadFile({ file, collectionId: "root" })(dispatch);
+      await uploadFile({ file, collectionId: "root", uploadMode: "create" })(
+        dispatch,
+      );
       jest.advanceTimersByTime(NOTIFICATION_DELAY);
 
       expect(dispatch).toHaveBeenCalledWith({
@@ -144,7 +193,11 @@ describe("csv uploads", () => {
     it("Error on oversized files", async () => {
       const bigFile = new File([""], "test.csv");
       Object.defineProperty(bigFile, "size", { value: 200 * 1024 * 1024 + 1 });
-      await uploadFile({ file: bigFile, collectionId: "root" })(dispatch);
+      await uploadFile({
+        file: bigFile,
+        collectionId: "root",
+        uploadMode: "create",
+      })(dispatch);
       jest.advanceTimersByTime(NOTIFICATION_DELAY);
 
       expect(dispatch).toHaveBeenCalledWith({

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -364,6 +364,10 @@ export const MetabaseApi = {
     formData: true,
     fetch: true,
   }),
+  tableReplaceCSV: POST("/api/table/:tableId/replace-csv", {
+    formData: true,
+    fetch: true,
+  }),
   field_get: GET("/api/field/:fieldId"),
   // field_summary:               GET("/api/field/:fieldId/summary"),
   field_values: GET("/api/field/:fieldId/values"),

--- a/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatus/FileUploadStatus.unit.spec.tsx
@@ -238,7 +238,7 @@ describe("FileUploadStatus", () => {
       await screen.findByText("Select upload destination"),
     ).toBeInTheDocument();
 
-    userEvent.click(screen.getByRole("button", { name: "Create" }));
+    userEvent.click(screen.getByRole("button", { name: "Create model" }));
 
     act(() => {
       jest.advanceTimersByTime(500);
@@ -273,7 +273,9 @@ describe("FileUploadStatus", () => {
     ).toBeInTheDocument();
 
     userEvent.click(screen.getByText("Append to a model"));
-    const submitButton = await screen.findByRole("button", { name: "Append" });
+    const submitButton = await screen.findByRole("button", {
+      name: "Append to model",
+    });
 
     // only appendable model should be pre-selected
     await screen.findByText("my uploaded model");
@@ -314,7 +316,9 @@ describe("FileUploadStatus", () => {
     ).toBeInTheDocument();
 
     userEvent.click(screen.getByText("Append to a model"));
-    const submitButton = await screen.findByRole("button", { name: "Append" });
+    const submitButton = await screen.findByRole("button", {
+      name: "Append to model",
+    });
 
     userEvent.click(await screen.findByPlaceholderText("Select a model"));
     userEvent.click(
@@ -341,6 +345,55 @@ describe("FileUploadStatus", () => {
     expect(
       await screen.findByRole("link", { name: "Start exploring" }),
     ).toHaveAttribute("href", "/model/3");
+    await screen.findByText("Data added to Fancy Table");
+  });
+
+  it("Should allow replacing data in a model", async () => {
+    jest.useFakeTimers({ advanceTimers: true });
+    fetchMock.post("path:/api/table/123/replace-csv", "3", { delay: 1000 });
+
+    await setupCollectionContent({ collectionId: thirdCollection.id });
+
+    userEvent.upload(
+      screen.getByTestId("upload-input"),
+      new File(["foo, bar"], "test.csv", { type: "text/csv" }),
+    );
+
+    expect(
+      await screen.findByText("Select upload destination"),
+    ).toBeInTheDocument();
+
+    userEvent.click(screen.getByText("Replace data in a model"));
+    const submitButton = await screen.findByRole("button", {
+      name: "Replace model data",
+    });
+
+    userEvent.click(await screen.findByPlaceholderText("Select a model"));
+    userEvent.click(
+      await within(await screen.findByRole("listbox")).findByText(
+        "my uploaded model",
+      ),
+    );
+
+    await waitFor(() => expect(submitButton).toBeEnabled());
+    userEvent.click(submitButton);
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(
+      await screen.findByText(/Uploading data to Fancy Table/i),
+    ).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(
+      await screen.findByRole("link", { name: "Start exploring" }),
+    ).toHaveAttribute("href", "/model/3");
+    await screen.findByText("Data replaced in Fancy Table");
   });
 
   it("Should show an error message on error", async () => {

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
@@ -90,9 +90,15 @@ const getTitle = (
   uploadDestination: Collection | Table,
 ) => {
   const isDone = uploads.every(isUploadCompleted);
+  const isOnlyReplace = uploads.every(
+    upload => upload.uploadMode === "replace",
+  );
   const isError = uploads.some(isUploadAborted);
 
   if (isDone) {
+    if (isOnlyReplace) {
+      return t`Data replaced in ${uploadDestination.name}`;
+    }
     return t`Data added to ${uploadDestination.name}`;
   } else if (isError) {
     return t`Error uploading your file`;

--- a/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
+++ b/frontend/src/metabase/status/components/FileUploadStatusLarge/FileUploadStatusLarge.tsx
@@ -12,7 +12,7 @@ import {
 import { Box, Stack } from "metabase/ui";
 import type Table from "metabase-lib/v1/metadata/Table";
 import type { Collection } from "metabase-types/api";
-import type { FileUpload } from "metabase-types/store/upload";
+import { UploadMode, type FileUpload } from "metabase-types/store/upload";
 
 import StatusLarge from "../StatusLarge";
 
@@ -91,7 +91,7 @@ const getTitle = (
 ) => {
   const isDone = uploads.every(isUploadCompleted);
   const isOnlyReplace = uploads.every(
-    upload => upload.uploadMode === "replace",
+    upload => upload.uploadMode === UploadMode.replace,
   );
   const isError = uploads.some(isUploadAborted);
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40469

### Description

Adds a "replace" option for uploading CSVs

1. From a collection
![uploadModal](https://github.com/metabase/metabase/assets/30528226/76de497d-8229-4a9b-a908-5de97f3763d8)

2. From within an uploaded model
![withinModel](https://github.com/metabase/metabase/assets/30528226/5bd4d427-b814-4a6a-a98d-aabf3e714bd4)

### How to verify

1. Go to a collection with uploaded models, see that you can now replace their data
2. go to an uploaded model, see that you can now replace its data
3. all that model's data should be replaced!

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
