### PR TITLE
Implement CSV separator inference

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -444,9 +444,11 @@
                         ;; Create a separate reader per separator, as the line-breaking behaviour depends on the parser.
                         (with-open [reader (bom/bom-reader file)]
                           (->> (csv/read-csv reader :separator s)
-                               (map count)
+                               ;; we only consider the header row and the first data row
                                (take 2)
-                               vec)))]
+                               (map count)
+                               ;; realise the list before the reader closes
+                               doall)))]
     (->> (map (juxt identity count-columns) separators)
          ;; We cannot have more data columns than header columns
          ;; We currently support files without any data rows, and these get a free pass.

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -447,7 +447,7 @@
                                ;; we only consider the header row and the first data row
                                (take 2)
                                (map count)
-                               ;; realise the list before the reader closes
+                               ;; realize the list before the reader closes
                                doall)))]
     (->> (map (juxt identity count-columns) separators)
          ;; We cannot have more data columns than header columns

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -445,7 +445,8 @@
                        [(.readLine ^BufferedReader rdr)
                         (.readLine ^BufferedReader rdr)])
         count-columns (fn [line s]
-                        (-> line (csv/read-csv :separator s) first count))
+                        (when line
+                          (-> line (csv/read-csv :separator s) first count)))
         header-columns (partial count-columns header)
         data-columns (partial count-columns row)]
     (->> separators

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -459,7 +459,7 @@
          ;; - Splitting the header at least once
          ;; - Giving a consistent column split for the first two lines of the file
          ;; - The number of fields in the header
-         ;; - The precedence order in how we define them, e.g.. bia towards comma
+         ;; - The precedence order in how we define them, e.g.. bias towards comma
          (sort-by (fn [[_ [header-column-count data-column-count]]]
                     [(when header-column-count
                        (> header-column-count 1))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -455,11 +455,15 @@
          (remove (fn [[_s [header-column-count data-column-count]]]
                    (when data-column-count
                      (> data-column-count header-column-count))))
-         ;; Prefer separators which create a consistent number of columns, as we will fail on a mismatch.
-         ;; Given consistency, prefer the separator which creates the most header columns.
-         ;; Break ties according to the order we defined the separators.
+         ;; Prefer separators according to the follow criteria, in order:
+         ;; - Splitting the header at least once
+         ;; - Giving a consistent column split for the first two lines of the file
+         ;; - The number of fields in the header
+         ;; - The precedence order in how we define them, e.g.. bia towards comma
          (sort-by (fn [[_ [header-column-count data-column-count]]]
-                    [(= header-column-count data-column-count)
+                    [(when header-column-count
+                       (> header-column-count 1))
+                     (= header-column-count data-column-count)
                      header-column-count])
                   u/reverse-compare)
          ffirst

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -452,15 +452,15 @@
     (->> (map (juxt identity count-columns) separators)
          ;; We cannot have more data columns than header columns
          ;; We currently support files without any data rows, and these get a free pass.
-         (remove (fn [[_s [header-columns data-columns]]]
-                   (when data-columns
-                     (> data-columns header-columns))))
+         (remove (fn [[_s [header-column-count data-column-count]]]
+                   (when data-column-count
+                     (> data-column-count header-column-count))))
          ;; Prefer separators which create a consistent number of columns, as we will fail on a mismatch.
          ;; Given consistency, prefer the separator which creates the most header columns.
          ;; Break ties according to the order we defined the separators.
-         (sort-by (fn [[_ [header-columns data-columns]]]
-                    [(= header-columns data-columns)
-                     header-columns])
+         (sort-by (fn [[_ [header-column-count data-column-count]]]
+                    [(= header-column-count data-column-count)
+                     header-column-count])
                   u/reverse-compare)
          ffirst
          assert-inferred-separator)))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/34325

### Description

This updates CSV uploads to support semicolon and tab separated files.

The algorithm is as follows:

- Filter out separators which would result in more data columns that headers.
  - This is because this kind of data would previously have caused an unhandled exception.
- Rank the separators according to the following criteria in descending order:
  1. Whether they split the header into at least two columns.
     - Not even seeing the separator is the biggest counter indicator.
  2. Whether they split the header and the first row into the same number of columns.
     - If these counts are not the same, we will fail the upload in the next step, with a helpful error message.
  3. Prefer separators based on how many distinct columns they identify.
     - The more they are used, the less likely they are incidental, hopefully. We rely on (2) here to protect us from say a lot of thousands separator commas.
  4. Break ties according to a preference for commas over semicolons over tabs.
     - In general we call them CSVs for a reason.

It would also be nice to handle both single and double quotes, but that is left for a future extension. I'm not sure how we'd want ranking to work in this 2d parameter space. It's also fairly likely that the first quoted value is not in the first two lines, so we might need a more holistic approach.

We add support for semicolon and tab separated files, but not space separated (SSV) files yet. The reason for this is that the parser we're using only supports single character separators, and space separated files might use multiple spaces in order to visually align columns.