### PR TITLE
Email to alert admins about legacy-no-self-service permissions

### DIFF
--- a/src/metabase/email/_header.mustache
+++ b/src/metabase/email/_header.mustache
@@ -1,6 +1,6 @@
 <html>
 <head>
-  <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,900;1,100;1,300;1,400;1,700;1,900" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,900;1,100;1,300;1,400;1,700;1,900" rel="stylesheet">
   <style>
     * {
       mso-line-height-rule: exactly;

--- a/src/metabase/email/legacy_no_self_service.mustache
+++ b/src/metabase/email/legacy_no_self_service.mustache
@@ -1,5 +1,10 @@
 {{> metabase/email/_header }}
-<div class="card-container" style="color: {{colorTextMedium}};">
+<style>
+  strong: {
+    font-weight: 600;
+  }
+</style>
+<div class="card-container" style="color: {{colorTextDark}}; font-weight: 300;">
 
   <p style="font-weight: 500; font-size: 0.875em; line-height: 1.375em; color: {{colorTextMedium}};">
     <i>(This email is sent directly from {{instanceURL}}, it doesn't go through any external services)</i>
@@ -8,7 +13,7 @@
   <p>Hi {{userName}},</p>
   <p>We updated our permissions model in Metabase 50, and you’ll need to update the new <strong>View data</strong> permission for a few groups that we can’t automatically update for you.</p>
 
-  <h2>What you need to update</h2>
+  <h4>What you need to update</h4>
 
   <p>Please review your Metabase permissions and change all groups that have their <strong>View data</strong> access set to <strong>No self-service (deprecated)</strong> to one of the new <strong>View data</strong> permission types:</p>
   <ul>
@@ -19,7 +24,7 @@
   </ul>
   <p>For which permission level is right for each group, see our <a href="https://www.notion.so/44cc72d46f9048068750f7598dd403f8?pvs=21">docs on permissions</a>.</p>
 
-  <h2>The groups you need to update</h2>
+  <h4>The groups you need to update</h4>
 
   <p>The following groups currently have their <strong>View data</strong> access set to "No self-service (deprecated)"</p>
   <ul>
@@ -32,7 +37,7 @@
 
   <p>In a future release, Metabase will convert any group that still has the <strong>View data</strong> access level set to "Block". We're defaulting to "Block", the least permissive View access, to prevent any unintended access to data.</p>
 
-  <h2>Why did we change our permissions model?</h2>
+  <h4>Why did we change our permissions model?</h4>
 
   <p>For an explanation about what changed and why, check out this doc on <a href="#">permission improvements in Metabase</a>.</p>
 

--- a/src/metabase/email/legacy_no_self_service.mustache
+++ b/src/metabase/email/legacy_no_self_service.mustache
@@ -22,20 +22,21 @@
     <li>Sandboxed</li>
     <li>Block</li>
   </ul>
-  <p>For which permission level is right for each group, see our <a href="https://www.notion.so/44cc72d46f9048068750f7598dd403f8?pvs=21">docs on permissions</a>.</p>
+  <p>For which permission level is right for each group, see our <a href="#">docs on permissions</a>.</p>
 
   <h4>The groups you need to update</h4>
 
-  <p>The following groups currently have their <strong>View data</strong> access set to "No self-service (deprecated)"</p>
+  <p>The following groups currently have their <strong>View data</strong> access set to <strong>No self-service (deprecated)</strong></p>
   <ul>
    {{#groups}}
       <li><a href="{{instanceURL}}/admin/permissions/data/group/{{id}}" style="color: #336699;">{{name}}</a></li>
    {{/groups}}
   </ul>
 
-  <p>If you take no action, Metabase will change the groups' <strong>View data</strong> access from "No self-service (deprecated)" to "Block"</p>
+  <p>If the group's <strong>View data</strong> access is set to "Granular" for a database, be sure to check the <strong>View data</strong> access for individual schemas and tables.</p>
 
-  <p>In a future release, Metabase will convert any group that still has the <strong>View data</strong> access level set to "Block". We're defaulting to "Block", the least permissive View access, to prevent any unintended access to data.</p>
+  <p>In a future release, if a group's <strong>View data</strong> access for a database (or any of its schemas or tables) is still set to <strong>No self-service (deprecated)</strong>, Metabase will automatically change that group's <strong>View data</strong> access for the entire database to <strong>Blocked</strong>.
+  We're defaulting to <strong>Blocked</strong>, the least permissive <strong>View data</strong> access, to prevent any unintended access to data.</p>
 
   <h4>Why did we change our permissions model?</h4>
 

--- a/src/metabase/email/legacy_no_self_service.mustache
+++ b/src/metabase/email/legacy_no_self_service.mustache
@@ -1,0 +1,47 @@
+{{> metabase/email/_header }}
+<div class="card-container" style="color: {{colorTextMedium}};">
+
+  <p style="font-weight: 500; font-size: 0.875em; line-height: 1.375em; color: {{colorTextMedium}};">
+    <i>(This email is sent directly from {{instanceURL}}, it doesn't go through any external services)</i>
+  </p>
+
+  <p>Hi {{userName}},</p>
+  <p>We updated our permissions model in Metabase 50, and you’ll need to update the new <strong>View data</strong> permission for a few groups that we can’t automatically update for you.</p>
+
+  <h2>What you need to update</h2>
+
+  <p>Please review your Metabase permissions and change all groups that have their <strong>View data</strong> access set to <strong>No self-service (deprecated)</strong> to one of the new <strong>View data</strong> permission types:</p>
+  <ul>
+    <li>Unrestricted</li>
+    <li>Impersonated</li>
+    <li>Sandboxed</li>
+    <li>Block</li>
+  </ul>
+  <p>For which permission level is right for each group, see our <a href="https://www.notion.so/44cc72d46f9048068750f7598dd403f8?pvs=21">docs on permissions</a>.</p>
+
+  <h2>The groups you need to update</h2>
+
+  <p>The following groups currently have their <strong>View data</strong> access set to "No self-service (deprecated)"</p>
+  <ul>
+   {{#groups}}
+      <li><a href="{{instanceURL}}/admin/permissions/data/group/{{id}}" style="color: #336699;">{{name}}</a></li>
+   {{/groups}}
+  </ul>
+
+  <p>If you take no action, Metabase will change the groups' <strong>View data</strong> access from "No self-service (deprecated)" to "Block"</p>
+
+  <p>In a future release, Metabase will convert any group that still has the <strong>View data</strong> access level set to "Block". We're defaulting to "Block", the least permissive View access, to prevent any unintended access to data.</p>
+
+  <h2>Why did we change our permissions model?</h2>
+
+  <p>For an explanation about what changed and why, check out this doc on <a href="#">permission improvements in Metabase</a>.</p>
+
+  <p>And apologies for the hassle. This new permissions model should make permissions a lot easier to reason about going forward.</p>
+
+  <p>Please reach us out at help@metabase.com if you have any questions.</p>
+
+  <p>Thank you,</p>
+
+  <p>- The Metabase Team</p>
+</div>
+{{> metabase/email/_footer }}

--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -96,7 +96,7 @@
 
 ;;; Various Context Helper Fns. Used to build Stencil template context
 
-(defn- common-context
+(defn common-context
   "Context that is used across multiple email templates, and that is the same for all emails"
   []
   {:applicationName           (public-settings/application-name)

--- a/src/metabase/task/legacy_no_self_service_emails.clj
+++ b/src/metabase/task/legacy_no_self_service_emails.clj
@@ -34,7 +34,7 @@
         (email/send-email-retrying!
          {:recipients   [(:email admin)]
           :message-type :html
-          :subject      "[Metabase] Please update your permissions for groups with View data access set to \"No self-service (deprecated)\""
+          :subject      "[Metabase] Please update groups with deprecated view access"
           :message      (stencil/render-file
                          template-path
                          (merge (messages/common-context)

--- a/src/metabase/task/legacy_no_self_service_emails.clj
+++ b/src/metabase/task/legacy_no_self_service_emails.clj
@@ -1,0 +1,56 @@
+(ns metabase.task.legacy-no-self-service-emails
+  (:require
+   [clojurewerkz.quartzite.jobs :as jobs]
+   [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.email :as email]
+   [metabase.email.messages :as messages]
+   [metabase.task :as task]
+   [metabase.util.log :as log]
+   [metabase.util.urls :as urls]
+   [stencil.core :as stencil]
+   [toucan2.core :as t2]))
+
+(set! *warn-on-reflection* true)
+
+(def ^:private template-path (str "metabase/email/legacy_no_self_service.mustache"))
+
+(defn- legacy-no-self-service-groups
+  "Returns a list of groups that have `legacy-no-self-service` as their `view-data` permissions level for any database."
+  []
+  (t2/select :model/PermissionsGroup
+             {:select-distinct [[:pg.id :id] [:pg.name :name]]
+              :from [[:permissions_group :pg]]
+              :join [[:data_permissions :dp] [:= :dp.group_id :pg.id]]
+              :where [:= :dp.perm_value "legacy-no-self-service"]}))
+
+(defn- legacy-no-self-service-email
+  "Sends an email to all admins if the instance has any `legacy-no-self-service` permissions in any groups"
+  []
+  (when (email/email-configured?)
+    (when-let [groups (not-empty (legacy-no-self-service-groups))]
+      (log/info "Sending email to admins about deprecation of `no-self-service`")
+      (doseq [admin (t2/select :model/User :is_superuser true)]
+        (email/send-email-retrying!
+         {:recipients   [(:email admin)]
+          :message-type :html
+          :subject      "[Metabase] Please update your permissions for groups with View data access set to \"No self-service (deprecated)\""
+          :message      (stencil/render-file
+                         template-path
+                         (merge (messages/common-context)
+                                {:userName    (:first_name admin)
+                                 :groups      groups
+                                 :instanceURL (urls/site-url)}))})))))
+
+(jobs/defjob ^{:doc "Send email to admins to warn about deprecation of `no-self-service`. This only runs once."}
+  LegacyNoSelfServiceEmail [_ctx]
+  (legacy-no-self-service-email))
+
+(defmethod task/init! ::SendLegacyNoSelfServiceEmail [_job-name]
+  (let [job     (jobs/build
+                 (jobs/of-type LegacyNoSelfServiceEmail)
+                 (jobs/with-identity (jobs/key "metabase.task.legacy-no-self-service-emails.job"))
+                 (jobs/store-durably))
+        trigger (triggers/build
+                 (triggers/with-identity (triggers/key "metabase.task.legacy-no-self-service-emails.trigger"))
+                 (triggers/start-now))]
+    (task/schedule-task! job trigger)))

--- a/src/metabase/task/legacy_no_self_service_emails.clj
+++ b/src/metabase/task/legacy_no_self_service_emails.clj
@@ -2,6 +2,7 @@
   (:require
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.triggers :as triggers]
+   [metabase.config :as config]
    [metabase.email :as email]
    [metabase.email.messages :as messages]
    [metabase.task :as task]
@@ -26,7 +27,7 @@
 (defn- legacy-no-self-service-email
   "Sends an email to all admins if the instance has any `legacy-no-self-service` permissions in any groups"
   []
-  (when (email/email-configured?)
+  (when (and config/ee-available? (email/email-configured?))
     (when-let [groups (not-empty (legacy-no-self-service-groups))]
       (log/info "Sending email to admins about deprecation of `no-self-service`")
       (doseq [admin (t2/select :model/User :is_superuser true)]

--- a/test/metabase/task/legacy_no_self_service_emails_test.clj
+++ b/test/metabase/task/legacy_no_self_service_emails_test.clj
@@ -1,0 +1,26 @@
+(ns metabase.task.legacy-no-self-service-emails-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.models.data-permissions :as data-perms]
+   [metabase.models.permissions-group :as perms-group]
+   [metabase.task.legacy-no-self-service-emails
+    :as legacy-no-self-service-emails]
+   [metabase.test :as mt]))
+
+(deftest legacy-no-self-service-groups-test
+  (testing "legacy-no-self-service-groups returns a list of groups with any `legacy-no-self-service` permissions"
+    (mt/with-full-data-perms-for-all-users!
+      (is (= 0 (count (#'legacy-no-self-service-emails/legacy-no-self-service-groups))))
+
+      ;; `legacy-no-self-service` set at the DB-level
+      (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :legacy-no-self-service)
+      (is (= [(perms-group/all-users)]
+             (#'legacy-no-self-service-emails/legacy-no-self-service-groups)))
+
+      (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
+      (is (= 0 (count (#'legacy-no-self-service-emails/legacy-no-self-service-groups))))
+
+      ;; `legacy-no-self-service` set at the table-level
+      (data-perms/set-table-permission! (perms-group/all-users) (mt/id :venues) :perms/view-data :legacy-no-self-service)
+      (is (= [(perms-group/all-users)]
+             (#'legacy-no-self-service-emails/legacy-no-self-service-groups))))))


### PR DESCRIPTION
* Adds an email that runs once to alert admins about no self-service permissions being deprecated.
* Contains a list of the groups that have the `legacy-no-self-service` permission which need to be checked
* Currently this is a one-time email which will run on upgrade to 50. If we want to run this again on future versions until the actual removal of `legacy-no-self-service` occurs, I think we can just add migrations to remove the trigger from the DB so that it will be recreated. Alternatively I could look into writing an automatic mechanism but this is the easiest solution.