### PR TITLE
prevent waterfall from not showing anything when pow or log x-axis scale has been selected previously

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/settings.ts
@@ -31,6 +31,7 @@ import {
   getSeriesOrderVisibilitySettings,
   getYAxisAutoRangeDefault,
   isStackingValueValid,
+  isXAxisScaleValid,
 } from "metabase/visualizations/shared/settings/cartesian-chart";
 import {
   getCardsColumns,
@@ -238,6 +239,7 @@ export const computeStaticComboChartSettings = (
     settings,
     "graph.x_axis.scale",
     getDefaultXAxisScale(settings),
+    isXAxisScaleValid(rawSeries, settings),
   );
 
   fillWithDefaultValue(settings, "graph.goal_label", getDefaultGoalLabel());

--- a/frontend/src/metabase/visualizations/lib/settings/graph.js
+++ b/frontend/src/metabase/visualizations/lib/settings/graph.js
@@ -36,6 +36,7 @@ import {
   getSeriesOrderVisibilitySettings,
   getYAxisAutoRangeDefault,
   isStackingValueValid,
+  isXAxisScaleValid,
   STACKABLE_DISPLAY_TYPES,
 } from "metabase/visualizations/shared/settings/cartesian-chart";
 import {
@@ -450,6 +451,7 @@ export const GRAPH_AXIS_SETTINGS = {
       "graph.x_axis._is_numeric",
       "graph.x_axis._is_histogram",
     ],
+    isValid: isXAxisScaleValid,
     getDefault: (series, vizSettings) => getDefaultXAxisScale(vizSettings),
     getProps: ([{ data }], vizSettings) => {
       const dimensionColumn = data.cols.find(

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -6,6 +6,7 @@ import type {
   CardDisplayType,
   DatasetColumn,
   DatasetData,
+  RawSeries,
   SeriesOrderSetting,
 } from "metabase-types/api";
 import { getFriendlyName } from "metabase/visualizations/lib/utils";
@@ -172,6 +173,23 @@ export const getDefaultXAxisScale = (
     return "linear";
   }
   return "ordinal";
+};
+
+const WATERFALL_UNSUPPORTED_X_AXIS_SCALES = ["pow", "log"];
+export const isXAxisScaleValid = (
+  series: RawSeries,
+  settings: ComputedVisualizationSettings,
+) => {
+  const isWaterfall = series[0].card.display === "waterfall";
+  const xAxisScale = settings["graph.x_axis.scale"];
+  if (
+    isWaterfall &&
+    xAxisScale != null &&
+    WATERFALL_UNSUPPORTED_X_AXIS_SCALES.includes(xAxisScale)
+  ) {
+    return false;
+  }
+  return true;
 };
 
 export const getDefaultGoalLabel = () => t`Goal`;

--- a/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
+++ b/frontend/src/metabase/visualizations/shared/settings/cartesian-chart.ts
@@ -182,14 +182,11 @@ export const isXAxisScaleValid = (
 ) => {
   const isWaterfall = series[0].card.display === "waterfall";
   const xAxisScale = settings["graph.x_axis.scale"];
-  if (
-    isWaterfall &&
-    xAxisScale != null &&
-    WATERFALL_UNSUPPORTED_X_AXIS_SCALES.includes(xAxisScale)
-  ) {
-    return false;
-  }
-  return true;
+  return (
+    !isWaterfall ||
+    xAxisScale == null ||
+    !WATERFALL_UNSUPPORTED_X_AXIS_SCALES.includes(xAxisScale)
+  );
 };
 
 export const getDefaultGoalLabel = () => t`Goal`;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38842

### Description

We wanted to remove log/pow x-axis scale types for relative date x-axis values like day-of-month on waterfall charts. This has been implemented here https://github.com/metabase/metabase/pull/37947 so it is not possible to select it now. This PR is a follow up that adds settings validation and in case if `pow` or `log` scales has been already saved, the chart will be rendered with the `linear` scale.

### How to verify

- Create a waterfall chart with x-axis scale that uses day-of-week unit
- In the app db update `graph.x_axis.scale` viz setting to `pow`
- Ensure when you open the card it shows `linear` x-axis scale selected and it is not possible to select `pow` or `log`

<img width="1721" alt="Screenshot 2024-03-22 at 10 03 02 PM" src="https://github.com/metabase/metabase/assets/14301985/c518921f-96e6-430a-afc2-70d9fca6559b">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
