### PR TITLE
Clean up deprecated data permission types

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -166,35 +166,30 @@ describe("snapshots", () => {
       [ALL_USERS_GROUP]: {
         [SAMPLE_DB_ID]: {
           // set the data permission so the UI doesn't warn us that "all users has higher permissions than X"
-          data: { schemas: "none", native: "none" },
           "view-data": lowest_read_data_permission,
           "create-queries": "no",
         },
       },
       [DATA_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "all", native: "write" },
           "view-data": "unrestricted",
           "create-queries": "query-builder-and-native",
         },
       },
       [NOSQL_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "all", native: "none" },
           "view-data": "unrestricted",
           "create-queries": "query-builder",
         },
       },
       [COLLECTION_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "none", native: "none" },
           "view-data": lowest_read_data_permission,
           "create-queries": "no",
         },
       },
       [READONLY_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "none", native: "none" },
           "view-data": lowest_read_data_permission,
           "create-queries": "no",
         },

--- a/e2e/support/commands/permissions/sandboxTable.js
+++ b/e2e/support/commands/permissions/sandboxTable.js
@@ -25,7 +25,7 @@ Cypress.Commands.add(
           [db_id]: {
             "view-data": {
               [schema]: {
-                [table_id]: "segmented",
+                [table_id]: "sandboxed",
               },
             },
             "create-queries": "query-builder",

--- a/e2e/test/scenarios/actions/model-actions.cy.spec.js
+++ b/e2e/test/scenarios/actions/model-actions.cy.spec.js
@@ -243,14 +243,12 @@ describe(
       cy.updatePermissionsGraph({
         [USER_GROUPS.ALL_USERS_GROUP]: {
           [WRITABLE_DB_ID]: {
-            data: { schemas: "none", native: "none" },
             "view-data": "blocked",
             "create-queries": "no",
           },
         },
         [USER_GROUPS.DATA_GROUP]: {
           [WRITABLE_DB_ID]: {
-            data: { schemas: "all", native: "write" },
             "view-data": "unrestricted",
             "create-queries": "query-builder-and-native",
           },

--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -255,9 +255,6 @@ describe("permissions", () => {
     cy.updatePermissionsGraph({
       1: {
         [WRITABLE_DB_ID]: {
-          data: {
-            schemas: "block",
-          },
           "view-data": "blocked",
         },
       },
@@ -301,17 +298,11 @@ describe("permissions", () => {
       cy.updatePermissionsGraph({
         [ALL_USERS_GROUP]: {
           [WRITABLE_DB_ID]: {
-            data: {
-              schemas: "block",
-            },
             "view-data": "blocked",
           },
         },
         [NOSQL_GROUP]: {
           [WRITABLE_DB_ID]: {
-            data: {
-              schemas: "all",
-            },
             "view-data": "unrestricted",
             "create-queries": "query-builder",
           },

--- a/e2e/test/scenarios/native-filters/reproductions/15163.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/15163.cy.spec.js
@@ -77,7 +77,6 @@ const dashboardDetails = {
           cy.updatePermissionsGraph({
             [COLLECTION_GROUP]: {
               1: {
-                data: { schemas: "all", native: "none" },
                 "view-data": "unrestricted",
                 "create-queries": "query-builder",
               },

--- a/e2e/test/scenarios/native/native.cy.spec.js
+++ b/e2e/test/scenarios/native/native.cy.spec.js
@@ -378,19 +378,16 @@ describe("no native access", { tags: ["@external", "@quarantine"] }, () => {
     cy.updatePermissionsGraph({
       [USER_GROUPS.ALL_USERS_GROUP]: {
         [WRITABLE_DB_ID]: {
-          data: { schemas: "none", native: "none" },
           "view-data": "blocked",
           "create-queries": "no",
         },
       },
       [USER_GROUPS.NOSQL_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "all", native: "write" },
           "view-data": "unrestricted",
           "create-queries": "query-builder-and-native",
         },
         [WRITABLE_DB_ID]: {
-          data: { schemas: "all", native: "none" },
           "view-data": "unrestricted",
           "create-queries": "query-builder",
         },

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -808,13 +808,11 @@ describeEE("scenarios > admin > permissions", () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "block" },
           "view-data": "blocked",
         },
       },
       [COLLECTION_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "block" },
           "view-data": "blocked",
         },
       },
@@ -834,13 +832,11 @@ describeEE("scenarios > admin > permissions", () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "block" },
           "view-data": "blocked",
         },
       },
       [COLLECTION_GROUP]: {
         [SAMPLE_DB_ID]: {
-          data: { schemas: "block" },
           "view-data": "blocked",
         },
       },

--- a/e2e/test/scenarios/permissions/reproductions/13347-cannot-select-saved-question-in-database-without-data-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/13347-cannot-select-saved-question-in-database-without-data-permissions.cy.spec.js
@@ -15,11 +15,13 @@ describe.skip("issue 13347", { tags: "@external" }, () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         1: {
-          data: { schemas: "all", native: "write" },
           "view-data": "unrestricted",
           "create-queries": "query-builder-and-native",
         },
-        [PG_DB_ID]: { data: { schemas: "none", native: "none" } },
+        [PG_DB_ID]: {
+          "view-data": "unrestricted",
+          "create-queries": "no",
+        },
       },
     });
 

--- a/e2e/test/scenarios/permissions/reproductions/14873-regextract-in-sandboxed-table.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/14873-regextract-in-sandboxed-table.cy.spec.js
@@ -21,21 +21,18 @@ describeEE("postgres > user > query", { tags: "@external" }, () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         [PG_DB_ID]: {
-          data: { schemas: "none", native: "none" },
           "view-data": "blocked",
           "create-queries": "no",
         },
       },
       [DATA_GROUP]: {
         [PG_DB_ID]: {
-          data: { schemas: "all", native: "write" },
           "view-data": "unrestricted",
           "create-queries": "query-builder-and-native",
         },
       },
       [COLLECTION_GROUP]: {
         [PG_DB_ID]: {
-          data: { schemas: "none", native: "none" },
           "view-data": "blocked",
           "create-queries": "no",
         },

--- a/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/17763-cannot-edit-granular-after-block.cy.spec.js
@@ -17,7 +17,6 @@ describeEE("issue 17763", () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         1: {
-          data: { schemas: "block", native: "none" },
           "view-data": "blocked",
           "create-queries": "no",
         },

--- a/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/20436-incorrect-display-of-database-permissions-level.cy.spec.js
@@ -21,7 +21,6 @@ describeEE("issue 20436", () => {
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         1: {
-          data: { schemas: "all", native: "none" },
           "view-data": "unrestricted",
           "create-queries": "query-builder",
         },

--- a/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22447-illogical-UI-elements-for-nodata.cy.spec.js
@@ -63,10 +63,10 @@ describe("UI elements that make no sense for users without data permissions (met
     setTokenFeatures("all");
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
-        [SAMPLE_DB_ID]: { data: { schemas: "block" }, "view-data": "blocked" },
+        [SAMPLE_DB_ID]: { "view-data": "blocked" },
       },
       [COLLECTION_GROUP]: {
-        [SAMPLE_DB_ID]: { data: { schemas: "block" }, "view-data": "blocked" },
+        [SAMPLE_DB_ID]: { "view-data": "blocked" },
       },
     });
 

--- a/e2e/test/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/reproductions/22695-search-databases-no-permissions.cy.spec.js
@@ -13,10 +13,10 @@ describeEE("issue 22695 ", () => {
 
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
-        [SAMPLE_DB_ID]: { data: { schemas: "block" }, "view-data": "blocked" },
+        [SAMPLE_DB_ID]: { "view-data": "blocked" },
       },
       [DATA_GROUP]: {
-        [SAMPLE_DB_ID]: { data: { schemas: "block" }, "view-data": "blocked" },
+        [SAMPLE_DB_ID]: { "view-data": "blocked" },
       },
     });
   });

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/models/connection_impersonation.clj
@@ -30,9 +30,7 @@
                                             (when group-id [:= :group_id group-id])
                                             (when-not audit-db? [:not [:= :db_id config/audit-db-id]])]})]
      (reduce (fn [acc {:keys [db_id group_id]}]
-               (-> acc
-                  (assoc-in [group_id db_id :view-data] :impersonated)
-                  (assoc-in [group_id db_id :data] {:schemas :impersonated})))
+                (assoc-in acc [group_id db_id :view-data] :impersonated))
              {}
              impersonations))))
 

--- a/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
+++ b/enterprise/backend/src/metabase_enterprise/audit_app/permissions.clj
@@ -62,17 +62,13 @@
   But it's cleaner to keep the audit DB permission paths in the database consistent."
   :feature :audit-app
   [group-id changes]
-  (let [[change-id type] (first (filter #(= (first %) (:id (default-audit-collection))) changes))]
+  (let [[change-id tyype] (first (filter #(= (first %) (:id (default-audit-collection))) changes))]
       (when change-id
-        (let [data-access-value (case type
-                                  :read  :unrestricted
-                                  :none  :no-self-service
-                                  :write (throw (ex-info (tru (str "Unable to make audit collections writable."))
-                                                         {:status-code 400})))
-              create-queries-value (case type
-                                     :read :query-builder
-                                     :none :no)
+        (let [create-queries-value (case tyype
+                                     :read  :query-builder
+                                     :none  :no
+                                     :write (throw (ex-info (tru (str "Unable to make audit collections writable."))
+                                                            {:status-code 400})))
               view-tables         (t2/select :model/Table :db_id perms/audit-db-id :name [:in audit-db-view-names])]
           (doseq [table view-tables]
-            (data-perms/set-table-permission! group-id table :perms/data-access data-access-value)
             (data-perms/set-table-permission! group-id table :perms/create-queries create-queries-value))))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/table.clj
@@ -72,7 +72,7 @@
     (if sandboxed-perms?
       (maybe-filter-fields
        table
-       (data-perms/with-additional-table-permission :perms/data-access (:db_id table) (u/the-id table) :unrestricted
+       (data-perms/with-additional-table-permission :perms/view-data (:db_id table) (u/the-id table) :unrestricted
          (data-perms/with-additional-table-permission :perms/create-queries (:db_id table) (u/the-id table) :query-builder
            (thunk))))
       (thunk))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -57,11 +57,12 @@
   is bound."
   :feature :sandboxes
   []
-  (when-not *is-superuser?*
+  (boolean
+   (when-not *is-superuser?*
     (if *current-user-id*
       (let [enforced-sandboxes (enforced-sandboxes-for *current-user-id*)]
-        (boolean (seq enforced-sandboxes)))
+        (seq enforced-sandboxes))
       ;; If no *current-user-id* is bound we can't check for sandboxes, so we should throw in this case to avoid
       ;; returning `false` for users who should actually be sandboxes.
       (throw (ex-info (str (tru "No current user found"))
-                      {:status-code 403})))))
+                      {:status-code 403}))))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -57,11 +57,11 @@
   is bound."
   :feature :sandboxes
   []
-  (boolean
-   (when-not *is-superuser?*
-     (if *current-user-id*
-       (seq (enforced-sandboxes-for *current-user-id*))
-       ;; If no *current-user-id* is bound we can't check for sandboxes, so we should throw in this case to avoid
-       ;; returning `false` for users who should actually be sandboxes.
-       (throw (ex-info (str (tru "No current user found"))
-                       {:status-code 403}))))))
+  (when-not *is-superuser?*
+    (if *current-user-id*
+      (let [enforced-sandboxes (enforced-sandboxes-for *current-user-id*)]
+        (boolean (seq enforced-sandboxes)))
+      ;; If no *current-user-id* is bound we can't check for sandboxes, so we should throw in this case to avoid
+      ;; returning `false` for users who should actually be sandboxes.
+      (throw (ex-info (str (tru "No current user found"))
+                      {:status-code 403})))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/api/util.clj
@@ -59,10 +59,9 @@
   []
   (boolean
    (when-not *is-superuser?*
-    (if *current-user-id*
-      (let [enforced-sandboxes (enforced-sandboxes-for *current-user-id*)]
-        (seq enforced-sandboxes))
-      ;; If no *current-user-id* is bound we can't check for sandboxes, so we should throw in this case to avoid
-      ;; returning `false` for users who should actually be sandboxes.
-      (throw (ex-info (str (tru "No current user found"))
-                      {:status-code 403}))))))
+     (if *current-user-id*
+       (seq (enforced-sandboxes-for *current-user-id*))
+       ;; If no *current-user-id* is bound we can't check for sandboxes, so we should throw in this case to avoid
+       ;; returning `false` for users who should actually be sandboxes.
+       (throw (ex-info (str (tru "No current user found"))
+                       {:status-code 403}))))))

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -198,7 +198,9 @@
 (t2/define-before-insert :model/GroupTableAccessPolicy
   [{:keys [table_id group_id], :as gtap}]
   (let [db-id (database/table-id->database-id table_id)]
-    (data-perms/set-database-permission! group_id db-id :perms/native-query-editing :no))
+    ;; Remove native query access to the DB when saving a sandbox
+    (when (= (data-perms/table-permission-for-group group_id :perms/create-queries db-id table_id) :query-builder-and-native)
+      (data-perms/set-database-permission! group_id db-id :perms/create-queries :query-builder)))
   (u/prog1 gtap
     (check-columns-match-table gtap)))
 

--- a/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
+++ b/enterprise/backend/src/metabase_enterprise/sandbox/models/group_table_access_policy.clj
@@ -131,9 +131,7 @@
                                       (when-not audit? [:not [:= :t.db_id config/audit-db-id]])]})]
     ;; Incorporate each sandbox policy into the permissions graph.
     (reduce (fn [acc {:keys [group_id table_id db_id schema]}]
-              (-> acc
-                (merge-sandbox-into-graph group_id table_id db_id schema [:data :schemas] {:query :segmented, :read :all})
-                (merge-sandbox-into-graph group_id table_id db_id schema [:view-data] :sandboxed)))
+              (merge-sandbox-into-graph acc group_id table_id db_id schema [:view-data] :sandboxed))
             graph
             sandboxes)))
 

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/common_test.clj
@@ -655,8 +655,8 @@
 (deftest fetch-db-test
   (t2.with-temp/with-temp [Database {db-id :id}]
     (testing "A non-admin without self-service perms for a DB cannot fetch the DB normally"
-      (mt/with-all-users-data-perms-graph! {db-id {:data {:view-data      :unrestricted
-                                                          :create-queries :no}}}
+      (mt/with-all-users-data-perms-graph! {db-id {:view-data      :unrestricted
+                                                   :create-queries :no}}
         (mt/user-http-request :rasta :get 403 (format "database/%d?exclude_uneditable_details=true" db-id))))
 
     (testing "A non-admin without self-service perms for a DB can fetch the DB if they have DB details permissions"

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -92,7 +92,7 @@
           (testing "group has existing data permissions... :block should remove them"
             (mt/with-model-cleanup [Permissions]
               (mt/with-restored-data-perms-for-group! group-id
-                (data-perms/set-database-permission! group-id (mt/id) :perms/data-access :unrestricted)
+                (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :unrestricted)
                 (grant! group-id)
                 (is (nil? (test-db-perms group-id)))
                 (is (= #{:blocked}

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -120,7 +120,7 @@
      (data-perms/set-database-permission! group-id (mt/id) :perms/view-data :blocked)
      (is (nil? (test-db-perms group-id)))
      (data-perms/set-table-permission! group-id (mt/id :venues) :perms/view-data :unrestricted)
-     (is (= {"PUBLIC" {(mt/id :venues) :unrestricted}}
+     (is (= {"PUBLIC" :unrestricted}
             (test-db-perms group-id))))))
 
 (deftest update-graph-disallow-native-query-perms-test

--- a/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/advanced_permissions/models/permissions/block_permissions_test.clj
@@ -104,7 +104,7 @@
                                                   [:= :perm_type (u/qualified-name :perms/view-data)]]})))))))))))
 
 (deftest update-graph-delete-sandboxes-test
-  (testing "When setting `:block` permissions any GTAP rows for that Group/Database should get deleted."
+  (testing "When setting `:blocked` permissions any GTAP rows for that Group/Database should get deleted."
     (mt/with-premium-features #{:sandboxes :advanced-permissions}
       (mt/with-model-cleanup [Permissions]
         (mt/with-temp [PermissionsGroup       {group-id :id} {}

--- a/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/audit_db_test.clj
@@ -59,9 +59,7 @@
           "Cards should be created for Audit DB when the content is there."))
 
     (testing "Audit DB starts with no permissions for all users"
-      (is (= {:perms/native-query-editing  :no
-              :perms/manage-database       :no
-              :perms/data-access           :no-self-service
+      (is (= {:perms/manage-database       :no
               :perms/download-results      :one-million-rows
               :perms/manage-table-metadata :no
               :perms/view-data             :unrestricted

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/gtap_test.clj
@@ -238,13 +238,12 @@
         (with-gtap-cleanup
           (testing "Test that we can create a new sandbox using the permission graph API"
             (let [graph  (-> (data-perms.graph/api-graph)
-                             (assoc-in [:groups group-id (mt/id) :data :schemas "PUBLIC" table-id-1 :query] :segmented)
+                             (assoc-in [:groups group-id (mt/id) :view-data] {"PUBLIC" {table-id-1 :sandboxed}})
                              (assoc :sandboxes [{:table_id             table-id-1
                                                  :group_id             group-id
                                                  :card_id              card-id-1
                                                  :attribute_remappings {"foo" 1}}]))
                   result (mt/user-http-request :crowberto :put 200 "permissions/graph" graph)]
-              (def graph graph)
               (is (=? [{:id                   (mt/malli=? :int)
                         :table_id             table-id-1
                         :group_id             group-id
@@ -276,7 +275,7 @@
                                                   :table_id table-id-1
                                                   :group_id group-id)
                   graph       (-> (data-perms.graph/api-graph)
-                                  (assoc-in [:groups group-id (mt/id) :data :schemas "PUBLIC" table-id-2 :query] :segmented)
+                                  (assoc-in [:groups group-id (mt/id) :view-data] {"PUBLIC" {table-id-2 :sandboxed}})
                                   (assoc :sandboxes [{:id                   sandbox-id
                                                       :card_id              card-id-1
                                                       :attribute_remappings {"foo" 3}}

--- a/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/pulse_test.clj
@@ -25,8 +25,8 @@
   (testing "Pulses should get sent with the row-level restrictions of the User that created them."
     (letfn [(send-pulse-created-by-user! [user-kw]
               (met/with-gtaps! {:gtaps      {:venues {:query      (mt/mbql-query venues)
-                                                     :remappings {:cat ["variable" [:field (mt/id :venues :category_id) nil]]}}}
-                               :attributes {"cat" 50}}
+                                                      :remappings {:cat ["variable" [:field (mt/id :venues :category_id) nil]]}}}
+                                :attributes {"cat" 50}}
                 (t2.with-temp/with-temp [Card card {:dataset_query (mt/mbql-query venues {:aggregation [[:count]]})}]
                   ;; `with-gtaps!` binds the current test user; we don't want that falsely affecting results
                   (mt/with-test-user nil
@@ -168,7 +168,7 @@
 (deftest user-attributes-test
   (testing "Pulses should be sandboxed correctly by User login_attributes"
     (met/with-gtaps! {:gtaps      {:venues {:remappings {:price [:dimension [:field (mt/id :venues :price) nil]]}}}
-                     :attributes {"price" "1"}}
+                      :attributes {"price" "1"}}
       (let [query (mt/mbql-query venues)]
         (mt/with-test-user :rasta
           (t2.with-temp/with-temp [Card card {:dataset_query query}]
@@ -188,7 +188,7 @@
 (deftest pulse-preview-test
   (testing "Pulse preview endpoints should be sandboxed"
     (met/with-gtaps! {:gtaps      {:venues {:remappings {:price [:dimension [:field (mt/id :venues :price) nil]]}}}
-                     :attributes {"price" "1"}}
+                      :attributes {"price" "1"}}
       (let [query (mt/mbql-query venues)]
         (mt/with-test-user :rasta
           (t2.with-temp/with-temp [Card card {:dataset_query query}]
@@ -217,7 +217,7 @@
 (deftest csv-downloads-test
   (testing "CSV/XLSX downloads should be sandboxed"
     (met/with-gtaps! {:gtaps      {:venues {:remappings {:price [:dimension [:field (mt/id :venues :price) nil]]}}}
-                     :attributes {"price" "1"}}
+                      :attributes {"price" "1"}}
       (let [query (mt/mbql-query venues)]
         (mt/with-test-user :rasta
           (mt/with-temp [Card                 {card-id :id}  {:dataset_query query}

--- a/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/test_util.clj
@@ -48,9 +48,8 @@
                                                                 :table_id             (data/id table-kw)
                                                                 :card_id              card-id
                                                                 :attribute_remappings remappings}]
-           (data-perms/set-table-permission! group (data/id table-kw) :perms/data-access :unrestricted)
-           (data-perms/set-table-permission! group (data/id table-kw) :perms/create-queries :query-builder)
            (data-perms/set-database-permission! group (data/id) :perms/view-data :unrestricted)
+           (data-perms/set-table-permission! group (data/id table-kw) :perms/create-queries :query-builder)
            (do-with-gtap-defs! group more f)))))))
 
 (def ^:private WithGTAPsArgs

--- a/enterprise/backend/test/metabase_enterprise/snippet_collections/api/native_query_snippet_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/snippet_collections/api/native_query_snippet_test.clj
@@ -20,7 +20,7 @@
   (mt/with-non-admin-groups-no-root-collection-for-namespace-perms "snippets"
     (t2.with-temp/with-temp [Collection      normal-collection {:name "Normal Collection", :namespace "snippets"}]
       ;; A user needs native query permissions on *any* database (among other things, in EE) to read/edit/create a NativeQuerySnippet
-      (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/native-query-editing :yes)
+      (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :query-builder-and-native)
       ;; run tests with both a normal Collection and the Root Collection
       (doseq [{collection-name :name, :as collection} [normal-collection root-collection]]
         (testing (format "\nSnippet in %s" collection-name)
@@ -103,7 +103,7 @@
         (mt/with-temp [Collection source {:name "Current Parent Collection", :namespace "snippets"}
                        Collection dest   {:name "New Parent Collection", :namespace "snippets"}]
           ;; A user needs native query permissions on *any* database (among other things, in EE) to read/edit/create a NativeQuerySnippet
-          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/native-query-editing :yes)
+          (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :query-builder-and-native)
           (doseq [source-collection [source root-collection]]
             (t2.with-temp/with-temp [NativeQuerySnippet snippet {:collection_id (:id source-collection)}]
               (doseq [dest-collection [dest root-collection]]

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6117,6 +6117,16 @@ databaseChangeLog:
                   remarks: The estimated row count
 
   - changeSet:
+      id: v50.2024-03-24T19:34:11
+      author: noahmoss
+      comment: Clean up deprecated view-data and native-query-editing permissions
+      rollback: # handled by the rollbacks for `v50.2024-02-26T22:15:54` and `v50.2024-02-26T22:15:55`
+      changes:
+        - sql:
+            sql: >
+              DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type = 'perms/native-query-editing';
+
+  - changeSet:
       id: v50.2024-03-25T14:53:00
       author: tsmacdonald
       comment: Add query_field.direct_reference

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -234,7 +234,7 @@
   "Returns the effective permission value for a given *group*, permission type, and database ID"
   [group-id perm-type database-id]
   (when (not= :model/Database (model-by-perm-type perm-type))
-    (throw (ex-info (tru "Permission type {0} is not a data-level permission." perm-type)
+    (throw (ex-info (tru "Permission type {0} is not a database-level permission." perm-type)
                     {perm-type (Permissions perm-type)})))
   (let [perm-values (t2/select-fn-set :value
                                       :model/DataPermissions

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -672,12 +672,10 @@
                                            {:perm_type   perm-type
                                             :group_id    group-id
                                             :perm_value  (case existing-db-perm-value
-                                                           ;; `:query-builder-and-native` can only be set at the
-                                                           ;; database level. So if we're setting a particular table
-                                                           ;; to something other than `:query-builder-and-native` when
-                                                           ;; the *database* had that permission, the db-level
-                                                           ;; permission needs to be dropped to `:query-builder`.
+                                                           ;; If the previous database-level permission can't be set at
+                                                           ;; the table-level, we need to provide a new default
                                                            :query-builder-and-native :query-builder
+                                                           :blocked                  :unrestricted
                                                            existing-db-perm-value)
                                             :db_id       db-id
                                             :table_id    (:id table)

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -43,7 +43,9 @@
 
 
 (def Permissions
-  "Permissions which apply to individual databases or tables"
+  "Permissions which apply to individual databases or tables."
+  ;; `legacy-no-self-service` is a deprecated permission which behaves the same as `:unrestricted` but does not override
+  ;; `:blocked` in other groups
   {:perms/view-data             {:model :model/Table :values [:unrestricted :legacy-no-self-service :blocked]}
    :perms/create-queries        {:model :model/Table :values [:query-builder-and-native :query-builder :no]}
    :perms/download-results      {:model :model/Table :values [:one-million-rows :ten-thousand-rows :no]}
@@ -186,10 +188,7 @@
 
 (mu/defn database-permission-for-user :- PermissionValue
   "Returns the effective permission value for a given user, permission type, and database ID. If the user has
-  multiple permissions for the given type in different groups, they are coalesced into a single value.
-
-  For permissions which can be set at the table-level or the database-level, this function will return the database-level
-  permission if the user has it."
+  multiple permissions for the given type in different groups, they are coalesced into a single value."
   [user-id perm-type database-id]
   (when (not= :model/Database (model-by-perm-type perm-type))
     (throw (ex-info (tru "Permission type {0} is a table-level permission." perm-type)

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -114,29 +114,19 @@
     (let [all-users-group  (perms-group/all-users)
           non-magic-groups (perms-group/non-magic-groups)
           non-admin-groups (conj non-magic-groups all-users-group)]
-      ;; We only set native-query-editing and manage-database permissions here, because they are only ever set at the
-      ;; database-level. Perms which can have table-level granularity are set in the `define-after-insert` hook for
-      ;; tables.
       (if (:is_audit database)
         (doseq [group non-admin-groups]
           (data-perms/set-database-permission! group database :perms/view-data :unrestricted)
-          (data-perms/set-database-permission! group database :perms/data-access :no-self-service)
           (data-perms/set-database-permission! group database :perms/create-queries :no)
-          (data-perms/set-database-permission! group database :perms/native-query-editing :no)
           (data-perms/set-database-permission! group database :perms/download-results :one-million-rows))
         (do
           (data-perms/set-database-permission! all-users-group database :perms/view-data :unrestricted)
           (data-perms/set-database-permission! all-users-group database :perms/create-queries :query-builder-and-native)
-          (data-perms/set-database-permission! all-users-group database :perms/data-access :unrestricted)
-          (data-perms/set-database-permission! all-users-group database :perms/native-query-editing :yes)
           (data-perms/set-database-permission! all-users-group database :perms/download-results :one-million-rows)
           (doseq [group non-magic-groups]
             (data-perms/set-database-permission! group database :perms/view-data :unrestricted)
             (data-perms/set-database-permission! group database :perms/create-queries :no)
-            (data-perms/set-database-permission! group database :perms/download-results :no)
-            (data-perms/set-database-permission! group database :perms/data-access :no-self-service)
-            (data-perms/set-database-permission! group database :perms/native-query-editing :no))))
-
+            (data-perms/set-database-permission! group database :perms/download-results :no))))
       (doseq [group non-admin-groups]
         (data-perms/set-database-permission! group database :perms/manage-table-metadata :no)
         (data-perms/set-database-permission! group database :perms/manage-database :no)))))
@@ -399,8 +389,8 @@
                          ;; you need to define it :)
                          false)))
                    settings)
-                   (when (not= <> settings)
-                     (log/debug "Redacting non-user-readable database settings during json encoding.")))))))
+                  (when (not= <> settings)
+                    (log/debug "Redacting non-user-readable database settings during json encoding.")))))))
    json-generator))
 
 ;;; ------------------------------------------------ Serialization ----------------------------------------------------

--- a/src/metabase/models/native_query_snippet/permissions.clj
+++ b/src/metabase/models/native_query_snippet/permissions.clj
@@ -9,7 +9,7 @@
 (defn has-any-native-permissions?
   "Checks whether the current user has native query permissions for any database."
   []
-  (data-perms/user-has-any-perms-of-type? api/*current-user-id* :perms/native-query-editing))
+  (data-perms/user-has-any-perms-of-type? api/*current-user-id* :perms/create-queries))
 
 (defenterprise can-read?
   "Can the current User read this `snippet`?"

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -99,10 +99,8 @@
     (doseq [db-id (t2/select-pks-vec :model/Database)]
       (data-perms/set-database-permission! group db-id :perms/view-data             :unrestricted)
       (data-perms/set-database-permission! group db-id :perms/create-queries        :no)
-      (data-perms/set-database-permission! group db-id :perms/data-access           :no-self-service)
       (data-perms/set-database-permission! group db-id :perms/download-results      :no)
       (data-perms/set-database-permission! group db-id :perms/manage-table-metadata :no)
-      (data-perms/set-database-permission! group db-id :perms/native-query-editing  :no)
       (data-perms/set-database-permission! group db-id :perms/manage-database       :no))))
 
 (t2/define-after-insert :model/PermissionsGroup

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -139,7 +139,7 @@
 
 (defn required-perms
   "Returns a map representing the permissions requried to run `query`. The map has the optional keys
-  :paths (containing legacy permission paths), :perms/data-access, and :perms/native-query-editing."
+  :paths (containing legacy permission paths), :perms/view-data, and :perms/create-queries."
   [query & {:as perms-opts}]
   (if (empty? query)
     {}

--- a/src/metabase/models/query/permissions.clj
+++ b/src/metabase/models/query/permissions.clj
@@ -45,17 +45,17 @@
 ;; Is calculating permissions for queries complicated? Some would say so. Refer to this handy flow chart to see how
 ;; things get calculated.
 ;;
-;;                         perms-set
-;;                             |
-;;                             |
-;;                             |
-;;      native query? <--------+------- > mbql query?
-;;            ↓                               ↓
-;; {:perms/native-query-editing :yes}     legacy-mbql-required-perms
-;;                                            |
-;;                     no source card  <------+----> has source card
-;;                             ↓                          ↓
-;;       {:perms/view-data {table-id :unrestricted}} source-card-read-perms
+;;                                  perms-set
+;;                                      |
+;;                                      |
+;;                                      |
+;;               native query? <--------+---------> mbql query?
+;;                     ↓                                     ↓
+;;    {:perms/create-queries :query-builder-and-native}  legacy-mbql-required-perms
+;;                                                           |
+;;                                  no source card  <--------+------> has source card
+;;                                          ↓                            ↓
+;;                    {:perms/view-data {table-id :unrestricted}}  source-card-read-perms
 ;;
 
 (mu/defn query->source-table-ids :- [:set [:or [:= ::native] ::lib.schema.id/table]]
@@ -170,7 +170,7 @@
     (when (= (:perms/create-queries required-perms) :query-builder-and-native)
       (or (= (:perms/create-queries gtap-perms) :query-builder-and-native)
           (= (data-perms/full-db-permission-for-user api/*current-user-id* :perms/create-queries db-id) :query-builder-and-native)
-          (throw (perms-exception {db-id {:perms/native-query-editing :yes}}))))
+          (throw (perms-exception {db-id {:perms/create-queries :query-builder-and-native}}))))
     (when (= (:perms/view-data required-perms) :unrestricted)
       (or (= (:perms/view-data gtap-perms) :unrestricted)
           (= :unrestricted (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data db-id))

--- a/src/metabase/models/table.clj
+++ b/src/metabase/models/table.clj
@@ -72,15 +72,15 @@
           non-admin-groups (conj non-magic-groups all-users-group)]
       ;; Data access permissions
       (if (= (:db_id table) config/audit-db-id)
-        ;; Tables in audit DB should start out with no-self-service in all groups
         (do
-         (data-perms/set-new-table-permissions! non-admin-groups table :perms/create-queries :no)
-         (data-perms/set-new-table-permissions! non-admin-groups table :perms/data-access :no-self-service))
+         ;; Tables in audit DB should start out with no query access in all groups
+         (data-perms/set-new-table-permissions! non-admin-groups table :perms/view-data :unrestricted)
+         (data-perms/set-new-table-permissions! non-admin-groups table :perms/create-queries :no))
         (do
+          ;; Normal tables start out with unrestricted data access in all groups, but query access only in All Users
+          (data-perms/set-new-table-permissions! (conj non-magic-groups all-users-group) table :perms/view-data :unrestricted)
           (data-perms/set-new-table-permissions! [all-users-group] table :perms/create-queries :query-builder)
-          (data-perms/set-new-table-permissions! non-magic-groups table :perms/create-queries :no)
-          (data-perms/set-new-table-permissions! [all-users-group] table :perms/data-access :unrestricted)
-          (data-perms/set-new-table-permissions! non-magic-groups table :perms/data-access :no-self-service)))
+          (data-perms/set-new-table-permissions! non-magic-groups table :perms/create-queries :no)))
       ;; Download permissions
       (data-perms/set-new-table-permissions! [all-users-group] table :perms/download-results :one-million-rows)
       (data-perms/set-new-table-permissions! non-magic-groups table :perms/download-results :no)

--- a/test/metabase/api/dataset_test.clj
+++ b/test/metabase/api/dataset_test.clj
@@ -216,14 +216,12 @@
                            (count (csv/read-csv result)))))))]
         (mt/with-no-data-perms-for-all-users!
           (testing "with data perms"
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/data-access :no-self-service)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/download-results :one-million-rows)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :query-builder)
             (do-test))
           (testing "with collection perms only"
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/download-results :one-million-rows)
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/data-access :no-self-service)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
             (do-test)))))))
@@ -331,7 +329,6 @@
           (mt/with-no-data-perms-for-all-users!
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/view-data :unrestricted)
             (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :query-builder)
-            (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/data-access :unrestricted)
             (is (malli= [:map
                          [:permissions-error? [:= true]]
                          [:message            [:= "You do not have permissions to run this query."]]]

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -274,9 +274,9 @@
          :crowberto :put 200 "permissions/graph"
          (assoc-in (data-perms.graph/api-graph)
                    [:groups (u/the-id group) (mt/id)]
-                   {:view-data :blocked
+                   {:view-data :unrestricted
                     :create-queries :no}))
-        (is (= #{:blocked}
+        (is (= #{:unrestricted}
                (set (t2/select-fn-set :perm_value :model/DataPermissions
                                       :group_id  (u/the-id group)
                                       :db_id     (mt/id)

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -145,7 +145,8 @@
       (t2.with-temp/with-temp [Database {db-id :id}]
         (let [graph (mt/user-http-request :crowberto :get 200 "permissions/graph")]
           (is (partial= {:groups {(u/the-id (perms-group/admin))
-                                  {db-id {:data {:native "write" :schemas "all"}}}}}
+                                  {db-id {:view-data "unrestricted"
+                                          :create-queries "query-builder-and-native"}}}}
                         graph)))))
 
     (testing "make sure a non-admin cannot fetch the perms graph from the API"
@@ -156,7 +157,7 @@
     (testing "make sure we can fetch the perms graph from the API"
       (t2.with-temp/with-temp [PermissionsGroup {group-id :id :as group}    {}
                                Database         db                          {}]
-        (data-perms/set-database-permission! group db :perms/data-access :unrestricted)
+        (data-perms/set-database-permission! group db :perms/view-data :unrestricted)
         (let [graph (mt/user-http-request :crowberto :get 200 (format "permissions/graph/group/%s" group-id))]
           (is (mc/validate nat-int? (:revision graph)))
           (is (perm-test-util/validate-graph-api-groups (:groups graph)))
@@ -167,7 +168,7 @@
     (testing "make sure we can fetch the perms graph from the API"
       (t2.with-temp/with-temp [PermissionsGroup group       {}
                                Database         {db-id :id} {}]
-        (data-perms/set-database-permission! group db-id :perms/data-access :unrestricted)
+        (data-perms/set-database-permission! group db-id :perms/view-data :unrestricted)
         (let [graph (mt/user-http-request :crowberto :get 200 (format "permissions/graph/db/%s" db-id))]
           (is (mc/validate nat-int? (:revision graph)))
           (is (perm-test-util/validate-graph-api-groups (:groups graph)))
@@ -176,15 +177,14 @@
 (deftest update-perms-graph-test
   (testing "PUT /api/permissions/graph"
     (testing "make sure we can update the perms graph from the API"
-      (let [db-id (mt/id :venues)]
-        (t2.with-temp/with-temp [PermissionsGroup group]
-          (mt/user-http-request
-           :crowberto :put 200 "permissions/graph"
-           (assoc-in (data-perms.graph/api-graph)
-                     [:groups (u/the-id group) (mt/id) :data :schemas]
-                     {"PUBLIC" {db-id :all}}))
-          (is (= {db-id :all}
-                 (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"]))))))))
+      (t2.with-temp/with-temp [PermissionsGroup group]
+        (mt/user-http-request
+         :crowberto :put 200 "permissions/graph"
+         (assoc-in (data-perms.graph/api-graph)
+                   [:groups (u/the-id group) (mt/id) :view-data]
+                   :unrestricted))
+        (is (= :unrestricted
+               (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :view-data])))))))
 
 (deftest update-perms-graph-table-specific-perms-test
   (testing "PUT /api/permissions/graph"
@@ -194,10 +194,11 @@
           (mt/user-http-request
            :crowberto :put 200 "permissions/graph"
            (assoc-in (data-perms.graph/api-graph)
-                     [:groups (u/the-id group) (mt/id) :data :schemas]
-                     {"PUBLIC" {(mt/id :venues) :all}}))
-          (is (= {(mt/id :venues) :all}
-                 (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"]))))))))
+                     [:groups (u/the-id group) (mt/id) :create-queries]
+                     {"PUBLIC" {(mt/id :venues) :query-builder
+                                (mt/id :orders) :no}}))
+          (is (= {(mt/id :venues) :query-builder}
+                 (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :create-queries "PUBLIC"]))))))))
 
 (deftest update-perms-graph-perms-for-new-db-test
   (testing "PUT /api/permissions/graph"
@@ -239,7 +240,7 @@
                                         :crowberto :put 200 url
                                         (assoc-in (data-perms.graph/api-graph)
                                                   ;; Get a new revision number each time
-                                                  [:groups (u/the-id group) db-id :data :schemas] :all)))
+                                                  [:groups (u/the-id group) db-id :view-data] :unrestricted)))
               returned-g     (do-perm-put "permissions/graph")
               returned-g-two (do-perm-put "permissions/graph?skip-graph=false")
               no-returned-g  (do-perm-put "permissions/graph?skip-graph=true")]
@@ -264,27 +265,32 @@
         (mt/user-http-request
          :crowberto :put 200 "permissions/graph"
          (assoc-in (data-perms.graph/api-graph)
-                   [:groups (u/the-id group) (mt/id) :data :schemas] {"PUBLIC" {table-id :all}}))
+                   [:groups (u/the-id group) (mt/id) :view-data] :unrestricted))
         (is (= #{:unrestricted}
                (set (t2/select-fn-set :perm_value :model/DataPermissions
                                       :group_id  (u/the-id group)
-                                      :table_id  table-id
-                                      :perm_type :perms/data-access))))
+                                      :perm_type :perms/view-data))))
         (mt/user-http-request
          :crowberto :put 200 "permissions/graph"
          (assoc-in (data-perms.graph/api-graph)
                    [:groups (u/the-id group) (mt/id)]
-                   {:data {:native "none" :schemas "none"}}))
-        (is (= #{:no-self-service}
+                   {:view-data :blocked
+                    :create-queries :no}))
+        (is (= #{:blocked}
                (set (t2/select-fn-set :perm_value :model/DataPermissions
                                       :group_id  (u/the-id group)
                                       :db_id     (mt/id)
-                                      :perm_type :perms/data-access))))
+                                      :perm_type :perms/view-data))))
+        (is (= #{:no}
+               (set (t2/select-fn-set :perm_value :model/DataPermissions
+                                      :group_id  (u/the-id group)
+                                      :db_id     (mt/id)
+                                      :perm_type :perms/create-queries))))
         (is (= #{}
                (set (t2/select-fn-set :perm_value :model/DataPermissions
                                       :group_id  (u/the-id group)
                                       :table_id  table-id
-                                      :perm_type :perms/data-access))))))))
+                                      :perm_type :perms/view-data))))))))
 
 (deftest update-perms-graph-error-test
   (testing "PUT /api/permissions/graph"

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -713,7 +713,7 @@
                                                               {:query "SELECT * FROM venues LIMIT 1"})}
                      DashboardCard _ {:dashboard_id dashboard-id
                                       :card_id      card-id}]
-        (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/native-query-editing :yes)
+        (data-perms/set-database-permission! (perms-group/all-users) (mt/id) :perms/create-queries :no)
         (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3]]
                (-> (@#'metabase.pulse/execute-dashboard {:creator_id (mt/user->id :rasta)} dashboard)
                    first :result :data :rows)))))))

--- a/test/metabase/events/view_log_test.clj
+++ b/test/metabase/events/view_log_test.clj
@@ -61,7 +61,7 @@
               (events/publish-event! :event/table-read {:object table :user-id (u/id user)})
               (is (true? (:has_access (latest-view (u/id user) (u/id table)))))
 
-              (data-perms/set-table-permission! (perms-group/all-users) (mt/id :users) :perms/data-access :no-self-service)
+              (data-perms/set-table-permission! (perms-group/all-users) (mt/id :users) :perms/create-queries :no)
               (events/publish-event! :event/table-read {:object table :user-id (u/id user)})
               (is (false? (:has_access (latest-view (u/id user) (u/id table))))))))))))
 

--- a/test/metabase/models/data_permissions/graph_test.clj
+++ b/test/metabase/models/data_permissions/graph_test.clj
@@ -18,7 +18,7 @@
                                                                   :schema "PUBLIC"}]
       ;; Clear default perms for the group
       (db/delete! :model/DataPermissions :group_id group-id-1)
-      (testing "data-access permissions can be updated via API-style graph"
+      (testing "data permissions can be updated via API-style graph"
         (are [api-graph db-graph] (= db-graph
                                      (do
                                        (data-perms.graph/update-data-perms-graph!* api-graph)
@@ -62,7 +62,7 @@
                                                                   :schema "PUBLIC"}]
       ;; Clear default perms for the group
       (db/delete! :model/DataPermissions :group_id group-id-1)
-      (testing "data-access permissions can be updated via API-style graph"
+      (testing "data permissions can be updated via API-style graph"
         (are [api-graph db-graph] (= db-graph
                                      (do
                                        (data-perms.graph/update-data-perms-graph!* api-graph)
@@ -143,59 +143,54 @@
           ;; Setting granular data access permissions
           {group-id-1
            {database-id-1
-            {:data
-             {:native :none
-              :schemas {"PUBLIC"
-                        {table-id-1 :all
-                         table-id-2 :none}
-                        ""
-                        {table-id-3 :all}}}}}}
+            {:create-queries :no
+             :view-data {"PUBLIC"
+                         {table-id-1 :unrestricted
+                          table-id-2 :legacy-no-self-service}
+                         ""
+                         {table-id-3 :unrestricted}}}}}
           {group-id-1
            {database-id-1
-            {:perms/native-query-editing :no
-             :perms/data-access {"PUBLIC"
-                                 {table-id-1 :unrestricted
-                                  table-id-2 :no-self-service}
-                                 ""
-                                 {table-id-3 :unrestricted}}}}}
+            {:perms/create-queries :no
+             :perms/view-data {"PUBLIC"
+                               {table-id-1 :unrestricted
+                                table-id-2 :legacy-no-self-service}
+                               ""
+                               {table-id-3 :unrestricted}}}}}
 
           ;; Restoring full data access and native query permissions
           {group-id-1
            {database-id-1
-            {:data
-             {:native :write
-              :schemas :all}}}}
+            {:create-queries :query-builder-and-native
+             :view-data :unrestricted}}}
           {group-id-1
            {database-id-1
-            {:perms/native-query-editing :yes
-             :perms/data-access :unrestricted}}}
+            {:perms/create-queries :query-builder-and-native
+             :perms/view-data :unrestricted}}}
 
           ;; Setting data access permissions at the schema-level
           {group-id-1
            {database-id-1
-            {:data
-             {:native :none
-              :schemas {"PUBLIC" :all
-                        ""       :none}}}}}
+            {:create-queries :no
+             :view-data {"PUBLIC" :unrestricted
+                         "" :legacy-no-self-service}}}}
           {group-id-1
            {database-id-1
-            {:perms/native-query-editing :no
-             :perms/data-access {"PUBLIC"
-                                 {table-id-1 :unrestricted
-                                  table-id-2 :unrestricted}
-                                 ""
-                                 {table-id-3 :no-self-service}}}}}
+            {:perms/create-queries :no
+             :perms/view-data {"PUBLIC"
+                               {table-id-1 :unrestricted
+                                table-id-2 :unrestricted}
+                               ""
+                               {table-id-3 :legacy-no-self-service}}}}}
 
-          ;; Setting block permissions for the database also sets :native-query-editing and :downlaod-results to :no
-          {group-id-1
-           {database-id-1
-            {:data
-             {:native :none
-              :schemas :block}}}}
+          ;; Setting block permissions for the database also sets :create-queries and :download-results to :no
           {group-id-1
             {database-id-1
-             {:perms/native-query-editing :no
-              :perms/data-access :block
+             {:view-data :blocked}}}
+          {group-id-1
+            {database-id-1
+             {:perms/create-queries :no
+              :perms/view-data :blocked
               :perms/download-results :no}}})))))
 
 (deftest update-db-level-download-permissions!-test
@@ -358,92 +353,69 @@
 ;; ------------------------------ API Graph Tests ------------------------------
 
 (deftest ellide?-test
-  (is (#'data-perms.graph/ellide?      :perms/data-access :no-self-service))
-  (is (not (#'data-perms.graph/ellide? :perms/data-access :block))))
-
-(defn- remove-download:native [graph]
-  (walk/postwalk
-   (fn [x]
-     (if (and
-          (instance? clojure.lang.MapEntry x)
-          (= :download (first x)))
-       (update x 1 dissoc :native)
-       x))
-   graph))
+  (is (not (#'data-perms.graph/ellide? :perms/view-data :unrestricted)))
+  (is (#'data-perms.graph/ellide? :perms/view-data :blocked)))
 
 (defn replace-empty-map-with-nil [graph]
   (walk/postwalk
    (fn [x] (if (= x {}) nil x))
    graph))
 
-(defn- api-graph=
-  "When checking equality between api perm graphs:
-  - download.native is not used by the client, so we remove it when checking equality:
-  - {} vs nil is also a distinction without a difference:"
-  [a b]
-  (= (remove-download:native (replace-empty-map-with-nil a))
-     (remove-download:native (replace-empty-map-with-nil b))))
-
 (deftest perms-are-renamed-test
   (testing "Perm keys and values are correctly renamed, and permissions are ellided as necessary"
     (are [db-graph api-graph] (= api-graph (-> db-graph
                                                (#'data-perms.graph/rename-perm)
                                                (#'data-perms.graph/remove-empty-vals)))
-      {:perms/data-access :unrestricted}           {:data {:schemas :all}}
-      {:perms/data-access :no-self-service}        {}
-      {:perms/data-access :block}                  {:data {:schemas :block}}
-      {:perms/native-query-editing :yes}           {:data {:native :write}}
-      {:perms/native-query-editing :no}            {}
-      {:perms/download-results :one-million-rows}  {:download {:schemas :full}}
-      {:perms/download-results :ten-thousand-rows} {:download {:schemas :limited}}
-      {:perms/download-results :no}                {}
-      {:perms/manage-table-metadata :yes}          {:data-model {:schemas :all}}
-      {:perms/manage-table-metadata :no}           {}
-      {:perms/manage-database :yes}                {:details :yes}
-      {:perms/manage-database :no}                 {}
+      {:perms/view-data :unrestricted}                  {:view-data :unrestricted}
+      {:perms/view-data :legacy-no-self-service}        {:view-data :legacy-no-self-service}
+      {:perms/view-data :blocked}                       {}
+      {:perms/create-queries :query-builder-and-native} {:create-queries :query-builder-and-native}
+      {:perms/create-queries :query-builder}            {:create-queries :query-builder}
+      {:perms/create-queries :no}                       {}
+      {:perms/download-results :one-million-rows}       {:download {:schemas :full}}
+      {:perms/download-results :ten-thousand-rows}      {:download {:schemas :limited}}
+      {:perms/download-results :no}                     {}
+      {:perms/manage-table-metadata :yes}               {:data-model {:schemas :all}}
+      {:perms/manage-table-metadata :no}                {}
+      {:perms/manage-database :yes}                     {:details :yes}
+      {:perms/manage-database :no}                      {}
       ;; with schemas:
-      {:perms/data-access
+      {:perms/view-data
        {"PUBLIC" {1 :unrestricted
-                  2 :no-self-service}}}            {:data {:schemas {"PUBLIC" {1 :all}}}}
-      {:perms/data-access
+                  2 :legacy-no-self-service}}}          {:view-data {"PUBLIC" {1 :unrestricted
+                                                                               2 :legacy-no-self-service}}}
+      {:perms/view-data
        {"PUBLIC" {1 :unrestricted
-                  2 :unrestricted}}}               {:data {:schemas {"PUBLIC" :all}}}
-      {:perms/data-access
-       {"PUBLIC" {1 :no-self-service
-                  2 :no-self-service}}}            {}
+                  2 :unrestricted}}}                    {:view-data {"PUBLIC" :unrestricted}}
+      {:perms/view-data
+       {"PUBLIC" {1 :legacy-no-self-service
+                  2 :legacy-no-self-service}}}          {:view-data {"PUBLIC" :legacy-no-self-service}}
       {:perms/download-results
        {"PUBLIC" {1 :one-million-rows
-                  2 :no}}}                         {:download {:schemas {"PUBLIC" {1 :full}}}}
+                  2 :no}}}                              {:download {:schemas {"PUBLIC" {1 :full}}}}
       {:perms/download-results
        {"PUBLIC" {1 :one-million-rows
-                  2 :ten-thousand-rows}}}          {:download {:schemas {"PUBLIC" {1 :full
-                                                                                   2 :limited}}}}
+                  2 :ten-thousand-rows}}}               {:download {:schemas {"PUBLIC" {1 :full
+                                                                                        2 :limited}}}}
       {:perms/manage-table-metadata
-       {"PUBLIC" {1 :yes}}}                        {:data-model {:schemas {"PUBLIC" :all}}}
+       {"PUBLIC" {1 :yes}}}                             {:data-model {:schemas {"PUBLIC" :all}}}
       {:perms/manage-table-metadata
-       {"PUBLIC" {1 :no}}}                         {}
+       {"PUBLIC" {1 :no}}}                              {}
       {:perms/manage-table-metadata
        {"PUBLIC" {1 :yes
-                  2 :no}}}                         {:data-model {:schemas {"PUBLIC" {1 :all}}}}
+                  2 :no}}}                              {:data-model {:schemas {"PUBLIC" {1 :all}}}}
       ;; multiple schemas
-      {:perms/data-access
+      {:perms/view-data
        {"PUBLIC" {1 :unrestricted}
-        "OTHER" {2 :no-self-service}
-        "SECRET" {3 :block}}}                      {:data {:schemas {"PUBLIC" :all, "SECRET" :block}}}
-      {:perms/data-access
+        "OTHER" {2 :legacy-no-self-service}}}           {:view-data {"PUBLIC" :unrestricted
+                                                                     "OTHER" :legacy-no-self-service}}
+      {:perms/view-data
        {"PUBLIC" {1 :unrestricted
-                  2 :no-self-service}
-        "OTHER" {3 :no-self-service
-                 4 :no-self-service}}}             {:data {:schemas {"PUBLIC" {1 :all}}}})))
-
-(deftest rename-perm-test
-  (is (api-graph=
-       (#'data-perms.graph/rename-perm {:perms/data-access :unrestricted
-                                        :perms/native-query-editing :yes
-                                        :perms/manage-database :no
-                                        :perms/download-results :one-million-rows
-                                        :perms/manage-table-metadata :no})
-       {:data {:native :write, :schemas :all} :download {:native :full, :schemas :full}})))
+                  2 :legacy-no-self-service}
+        "OTHER" {3 :legacy-no-self-service
+                 4 :legacy-no-self-service}}}           {:view-data {"PUBLIC" {1 :unrestricted
+                                                                               2 :legacy-no-self-service}
+                                                                     "OTHER" :legacy-no-self-service}})))
 
 (defn constrain-graph
   "Filters out all non `group-id`X`db-id` permissions"
@@ -452,23 +424,23 @@
       (assoc :groups {group-id (get-in graph [:groups group-id])})
       (assoc-in [:groups group-id] {db-id (get-in graph [:groups group-id db-id])})))
 
-(defn- test-data-graph [group]
-  (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :data :schemas "PUBLIC"]))
+(defn- test-query-graph [group]
+  (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :create-queries "PUBLIC"]))
 
 (deftest graph-set-partial-permissions-for-table-test
   (testing "Test that setting partial permissions for a table retains permissions for other tables -- #3888"
     (mt/with-temp [:model/PermissionsGroup group]
       (testing "before"
         ;; first, graph permissions only for VENUES
-        (data-perms/set-table-permission! group (mt/id :venues) :perms/data-access :unrestricted)
-        (is (= {(mt/id :venues) :all}
-               (test-data-graph group))))
+        (data-perms/set-table-permission! group (mt/id :venues) :perms/create-queries :query-builder)
+        (is (= {(mt/id :venues) :query-builder}
+               (test-query-graph group))))
       (testing "after"
         ;; next, grant permissions via `update-graph!` for CATEGORIES as well. Make sure permissions for VENUES are
         ;; retained (#3888)
-        (data-perms/set-table-permission! group (mt/id :categories) :perms/data-access :unrestricted)
-        (is (= {(mt/id :categories) :all, (mt/id :venues) :all}
-               (test-data-graph group)))))))
+        (data-perms/set-table-permission! group (mt/id :categories) :perms/create-queries :query-builder)
+        (is (= {(mt/id :categories) :query-builder, (mt/id :venues) :query-builder}
+               (test-query-graph group)))))))
 
 (deftest audit-db-update-test
   (testing "Throws exception when we attempt to change the audit db permission manually."
@@ -479,35 +451,40 @@
            (data-perms.graph/update-data-perms-graph! [(u/the-id group) config/audit-db-id :data :schemas] :all))))))
 
 (deftest update-graph-validate-db-perms-test
-  (testing "Check that validation of DB `:schemas` and `:native` perms doesn't fail if only one of them changes"
+  (testing "Check that validation of native query perms doesn't fail if only one of them changes"
     (mt/with-temp [:model/Database {db-id :id}]
       (mt/with-no-data-perms-for-all-users!
-        (let [ks [:groups (u/the-id (perms-group/all-users)) db-id :data]]
+        (let [ks [:groups (u/the-id (perms-group/all-users)) db-id]]
           (letfn [(perms []
                     (get-in (data-perms.graph/api-graph) ks))
                   (set-perms! [new-perms]
                     (data-perms.graph/update-data-perms-graph! (assoc-in (data-perms.graph/api-graph) ks new-perms))
                     (perms))]
             (testing "Should initially have no perms"
-              (is (= {:schemas :block}
+              (is (= nil
                      (perms))))
-            (testing "grant schema perms"
-              (is (= {:schemas :all}
-                     (set-perms! {:schemas :all}))))
-            (testing "grant native perms"
-              (is (= {:schemas :all, :native :write}
-                     (set-perms! {:schemas :all, :native :write}))))
+            (testing "grant unrestricted data perms"
+              (is (= {:view-data :unrestricted}
+                     (set-perms! {:view-data :unrestricted}))))
+            (testing "grant native query perms"
+              (is (= {:view-data :unrestricted
+                      :create-queries :query-builder-and-native}
+                     (set-perms! {:view-data :unrestricted
+                                  :create-queries :query-builder-and-native}))))
             (testing "revoke native perms"
-              (is (= {:schemas :all}
-                     (set-perms! {:schemas :all, :native :none}))))
+              (is (= {:view-data :unrestricted
+                      :create-queries :query-builder}
+                     (set-perms! {:view-data :unrestricted
+                                  :create-queries :query-builder}))))
             (testing "revoke schema perms"
               (is (= nil
-                     (set-perms! {:schemas :none}))))
-            (testing "disallow schemas :none + :native :write"
+                     (set-perms! {:view-data :blocked}))))
+            (testing "disallow blocked data access + native querying"
               (is (thrown-with-msg?
                    Exception
                    #"Invalid DB permissions: If you have write access for native queries, you must have data access to all schemas."
-                   (set-perms! {:schemas :none, :native :write})))
+                   (set-perms! {:view-data :blocked
+                                :create-queries :query-builder-and-native})))
               (is (= nil
                      (perms))))))))))
 
@@ -516,13 +493,16 @@
     (mt/with-temp [:model/PermissionsGroup group]
       ;; Bind *current-user* so that permission revisions are written, which was the source of the original error
       (mt/with-current-user (mt/user->id :rasta)
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:data {:native :none :schemas :none}}}}
+        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :blocked
+                                                                                                  :create-queries :no}}}
                                                               :revision (:revision (data-perms.graph/api-graph))})))
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:data {:native :none :schemas :none}}}}
+        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :blocked
+                                                                                                  :create-queries :no}}}
                                                               :revision (:revision (data-perms.graph/api-graph))})))
-
-        (data-perms/set-database-permission! group (mt/id) :perms/data-access :unrestricted)
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:data {:native :write :schemas :all}}}}
+        (data-perms/set-database-permission! group (mt/id) :perms/view-data :unrestricted)
+        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :unrestricted
+                                                                                                  :create-queries :query-builder}}}
                                                               :revision (:revision (data-perms.graph/api-graph))})))
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:data {:native :write :schemas :all}}}}
+        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :unrestricted
+                                                                                                  :create-queries :query-builder}}}
                                                               :revision (:revision (data-perms.graph/api-graph))})))))))

--- a/test/metabase/models/data_permissions/graph_test.clj
+++ b/test/metabase/models/data_permissions/graph_test.clj
@@ -490,19 +490,20 @@
 
 (deftest no-op-partial-graph-updates
   (testing "Partial permission graphs with no changes to the existing graph do not error when run repeatedly (#25221)"
-    (mt/with-temp [:model/PermissionsGroup group]
-      ;; Bind *current-user* so that permission revisions are written, which was the source of the original error
-      (mt/with-current-user (mt/user->id :rasta)
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :blocked
-                                                                                                  :create-queries :no}}}
-                                                              :revision (:revision (data-perms.graph/api-graph))})))
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :blocked
-                                                                                                  :create-queries :no}}}
-                                                              :revision (:revision (data-perms.graph/api-graph))})))
-        (data-perms/set-database-permission! group (mt/id) :perms/view-data :unrestricted)
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :unrestricted
-                                                                                                  :create-queries :query-builder}}}
-                                                              :revision (:revision (data-perms.graph/api-graph))})))
-        (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :unrestricted
-                                                                                                  :create-queries :query-builder}}}
-                                                              :revision (:revision (data-perms.graph/api-graph))})))))))
+    (mt/with-additional-premium-features #{:advanced-permissions}
+      (mt/with-temp [:model/PermissionsGroup group]
+        ;; Bind *current-user* so that permission revisions are written, which was the source of the original error
+        (mt/with-current-user (mt/user->id :rasta)
+          (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :blocked
+                                                                                                    :create-queries :no}}}
+                                                                :revision (:revision (data-perms.graph/api-graph))})))
+          (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :blocked
+                                                                                                    :create-queries :no}}}
+                                                                :revision (:revision (data-perms.graph/api-graph))})))
+          (data-perms/set-database-permission! group (mt/id) :perms/view-data :unrestricted)
+          (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :unrestricted
+                                                                                                    :create-queries :query-builder}}}
+                                                                :revision (:revision (data-perms.graph/api-graph))})))
+          (is (nil? (data-perms.graph/update-data-perms-graph! {:groups {(u/the-id group) {(mt/id) {:view-data :unrestricted
+                                                                                                    :create-queries :query-builder}}}
+                                                                :revision (:revision (data-perms.graph/api-graph))}))))))))

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -12,22 +12,21 @@
 (deftest ^:parallel coalesce-test
   (testing "`coalesce` correctly returns the most permissive value by default"
     (are [expected args] (= expected (apply data-perms/coalesce args))
-      :unrestricted    [:perms/data-access #{:unrestricted :restricted :none}]
-      :no-self-service [:perms/data-access #{:no-self-service :none}]
-      :block           [:perms/data-access #{:block}]
-      nil              [:perms/data-access #{}])))
+      :unrestricted    [:perms/view-data   #{:unrestricted :legacy-no-self-service :blocked}]
+      :blocked         [:perms/view-data #{:blocked}]
+      nil              [:perms/view-data #{}])))
 
 (deftest ^:parallel at-least-as-permissive?-test
   (testing "at-least-as-permissive? correctly compares permission values"
-   (is (data-perms/at-least-as-permissive? :perms/data-access :unrestricted :unrestricted))
-   (is (data-perms/at-least-as-permissive? :perms/data-access :unrestricted :no-self-service))
-   (is (data-perms/at-least-as-permissive? :perms/data-access :unrestricted :block))
-   (is (not (data-perms/at-least-as-permissive? :perms/data-access :no-self-service :unrestricted)))
-   (is (data-perms/at-least-as-permissive? :perms/data-access :no-self-service :no-self-service))
-   (is (data-perms/at-least-as-permissive? :perms/data-access :no-self-service :block))
-   (is (not (data-perms/at-least-as-permissive? :perms/data-access :block :unrestricted)))
-   (is (not (data-perms/at-least-as-permissive? :perms/data-access :block :no-self-service)))
-   (is (data-perms/at-least-as-permissive? :perms/data-access :block :block))))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :unrestricted :unrestricted))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :unrestricted :legacy-no-self-service))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :unrestricted :blocked))
+   (is (not (data-perms/at-least-as-permissive? :perms/view-data :legacy-no-self-service :unrestricted)))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :legacy-no-self-service :legacy-no-self-service))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :legacy-no-self-service :blocked))
+   (is (not (data-perms/at-least-as-permissive? :perms/view-data :blocked :unrestricted)))
+   (is (not (data-perms/at-least-as-permissive? :perms/view-data :blocked :legacy-no-self-service)))
+   (is (data-perms/at-least-as-permissive? :perms/view-data :blocked :blocked))))
 
 (deftest set-database-permission!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}    {}
@@ -39,21 +38,21 @@
                                                        :perm_type perm-type))]
      (mt/with-restored-data-perms-for-group! group-id
        (testing "`set-database-permission!` correctly updates an individual database's permissions"
-         (data-perms/set-database-permission! group-id database-id :perms/native-query-editing :no)
-         (is (= :no (perm-value :perms/native-query-editing)))
-         (data-perms/set-database-permission! group-id database-id :perms/native-query-editing :yes)
-         (is (= :yes (perm-value :perms/native-query-editing))))
+         (data-perms/set-database-permission! group-id database-id :perms/create-queries :no)
+         (is (= :no (perm-value :perms/create-queries)))
+         (data-perms/set-database-permission! group-id database-id :perms/create-queries :query-builder)
+         (is (= :query-builder (perm-value :perms/create-queries))))
 
-       (testing "`set-database-permission!` sets native query permissions to :no if data access is set to :block"
-         (data-perms/set-database-permission! group-id database-id :perms/data-access :block)
-         (is (= :block (perm-value :perms/data-access)))
-         (is (= :no (perm-value :perms/native-query-editing))))
+       (testing "`set-database-permission!` sets native query permissions to :no if data access is set to :blocked"
+         (data-perms/set-database-permission! group-id database-id :perms/view-data :blocked)
+         (is (= :blocked (perm-value :perms/view-data)))
+         (is (= :no (perm-value :perms/create-queries))))
 
        (testing "A database-level permission cannot be set to an invalid value"
          (is (thrown-with-msg?
               ExceptionInfo
-              #"Permission type :perms/native-query-editing cannot be set to :invalid-value"
-              (data-perms/set-database-permission! group-id database-id :perms/native-query-editing :invalid-value))))))))
+              #"Permission type :perms/create-queries cannot be set to :invalid-value"
+              (data-perms/set-database-permission! group-id database-id :perms/create-queries :invalid-value))))))))
 
 (deftest set-table-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}      {}
@@ -64,71 +63,71 @@
                  :model/Table            {table-id-2 :id}    {:db_id database-id}
                  :model/Table            {table-id-3 :id}    {:db_id database-id}
                  :model/Table            {table-id-4 :id}    {:db_id database-id-2}]
-    (let [data-access-perm-value (fn [table-id] (t2/select-one-fn :perm_value :model/DataPermissions
-                                                                  :db_id     database-id
-                                                                  :group_id  group-id
-                                                                  :table_id  table-id
-                                                                  :perm_type :perms/data-access))]
+    (let [create-queries-perm-value (fn [table-id] (t2/select-one-fn :perm_value :model/DataPermissions
+                                                                   :db_id     database-id
+                                                                   :group_id  group-id
+                                                                   :table_id  table-id
+                                                                   :perm_type :perms/create-queries))]
       (mt/with-restored-data-perms-for-group! group-id
         (testing "`set-table-permissions!` can set individual table permissions to different values"
-          (data-perms/set-table-permissions! group-id :perms/data-access {table-id-1 :no-self-service
-                                                                          table-id-2 :unrestricted
-                                                                          table-id-3 :no-self-service})
-          (is (= :no-self-service (data-access-perm-value table-id-1)))
-          (is (= :unrestricted    (data-access-perm-value table-id-2)))
-          (is (= :no-self-service (data-access-perm-value table-id-3))))
+          (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-1 :no
+                                                                             table-id-2 :query-builder
+                                                                             table-id-3 :no})
+          (is (= :no            (create-queries-perm-value table-id-1)))
+          (is (= :query-builder (create-queries-perm-value table-id-2)))
+          (is (= :no            (create-queries-perm-value table-id-3))))
 
         (testing "`set-table-permissions!` can set individual table permissions passed in as the full tables"
-          (data-perms/set-table-permissions! group-id :perms/data-access {table-1 :unrestricted})
-          (is (= :unrestricted (data-access-perm-value table-id-1))))
+          (data-perms/set-table-permissions! group-id :perms/create-queries {table-1 :query-builder})
+          (is (= :query-builder (create-queries-perm-value table-id-1))))
 
         (testing "`set-table-permission!` coalesces table perms to a DB-level value if they're all the same"
-          (data-perms/set-table-permissions! group-id :perms/data-access {table-id-1 :no-self-service
-                                                                          table-id-2 :no-self-service})
-          (is (= :no-self-service (data-access-perm-value nil)))
-          (is (nil?               (data-access-perm-value table-id-1)))
-          (is (nil?               (data-access-perm-value table-id-2)))
-          (is (nil?               (data-access-perm-value table-id-3))))
+          (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-1 :no
+                                                                             table-id-2 :no})
+          (is (= :no (create-queries-perm-value nil)))
+          (is (nil?  (create-queries-perm-value table-id-1)))
+          (is (nil?  (create-queries-perm-value table-id-2)))
+          (is (nil?  (create-queries-perm-value table-id-3))))
 
         (testing "`set-table-permission!` breaks table perms out again if any are modified"
-          (data-perms/set-table-permissions! group-id :perms/data-access {table-id-2 :unrestricted
-                                                                          table-id-3 :no-self-service})
-          (is (nil?               (data-access-perm-value nil)))
-          (is (= :no-self-service (data-access-perm-value table-id-1)))
-          (is (= :unrestricted    (data-access-perm-value table-id-2)))
-          (is (= :no-self-service (data-access-perm-value table-id-3))))
+          (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-2 :query-builder
+                                                                             table-id-3 :no})
+          (is (nil?             (create-queries-perm-value nil)))
+          (is (= :no            (create-queries-perm-value table-id-1)))
+          (is (= :query-builder (create-queries-perm-value table-id-2)))
+          (is (= :no            (create-queries-perm-value table-id-3))))
 
         (testing "A non table-level permission cannot be set"
           (is (thrown-with-msg?
                ExceptionInfo
-               #"Permission type :perms/native-query-editing cannot be set on tables."
-               (data-perms/set-table-permissions! group-id :perms/native-query-editing {table-id-1 :yes}))))
+               #"Permission type :perms/manage-database cannot be set on tables."
+               (data-perms/set-table-permissions! group-id :perms/manage-database {table-id-1 :yes}))))
 
         (testing "A table-level permission cannot be set to an invalid value"
           (is (thrown-with-msg?
                ExceptionInfo
-               #"Permission type :perms/data-access cannot be set to :invalid"
-               (data-perms/set-table-permissions! group-id :perms/data-access {table-id-1 :invalid}))))
+               #"Permission type :perms/create-queries cannot be set to :invalid"
+               (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-1 :invalid}))))
 
         (testing "A table-level permission cannot be set to :block"
           (is (thrown-with-msg?
                ExceptionInfo
                #"Block permissions must be set at the database-level only."
-               (data-perms/set-table-permissions! group-id :perms/data-access {table-id-1 :block}))))
+               (data-perms/set-table-permissions! group-id :perms/view-data {table-id-1 :blocked}))))
 
         (testing "Table-level permissions can only be set in bulk for tables in the same database"
           (is (thrown-with-msg?
                ExceptionInfo
                #"All tables must belong to the same database."
-               (data-perms/set-table-permissions! group-id :perms/data-access {table-id-3 :unrestricted
-                                                                               table-id-4 :unrestricted}))))
+               (data-perms/set-table-permissions! group-id :perms/create-queries {table-id-3 :query-builder
+                                                                                  table-id-4 :query-builder}))))
 
-        (testing "Setting block permissions at the database level clears table-level data access perms"
-          (data-perms/set-database-permission! group-id database-id :perms/data-access :block)
-          (is (= :block (data-access-perm-value nil)))
-          (is (nil?     (data-access-perm-value table-id-1)))
-          (is (nil?     (data-access-perm-value table-id-2)))
-          (is (nil?     (data-access-perm-value table-id-3))))))))
+        (testing "Setting block permissions at the database level clears table-level query query perms"
+          (data-perms/set-database-permission! group-id database-id :perms/view-data :blocked)
+          (is (= :no (create-queries-perm-value nil)))
+          (is (nil?  (create-queries-perm-value table-id-1)))
+          (is (nil?  (create-queries-perm-value table-id-2)))
+          (is (nil?  (create-queries-perm-value table-id-3))))))))
 
 (deftest database-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}
@@ -142,29 +141,29 @@
                  :model/Database                   {database-id-2 :id} {}]
     (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
       (testing "`database-permission-for-user` coalesces permissions from all groups a user is in"
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
-        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/native-query-editing :no)
-        (is (= :yes (data-perms/database-permission-for-user user-id :perms/native-query-editing database-id-1))))
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/manage-database :yes)
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/manage-database :no)
+        (is (= :yes (data-perms/database-permission-for-user user-id :perms/manage-database database-id-1))))
 
       (testing "`database-permission-for-user` falls back to the least permissive value if no value exists for the user"
         (t2/delete! :model/DataPermissions :db_id database-id-2)
-        (is (= :no (data-perms/database-permission-for-user user-id :perms/native-query-editing database-id-2))))
+        (is (= :no (data-perms/database-permission-for-user user-id :perms/manage-database database-id-2))))
 
       (testing "Admins always have the most permissive value, regardless of group membership"
-        (is (= :yes (data-perms/database-permission-for-user (mt/user->id :crowberto) :perms/native-query-editing database-id-2)))))
+        (is (= :yes (data-perms/database-permission-for-user (mt/user->id :crowberto) :perms/manage-database database-id-2)))))
 
     (testing "caching works as expected"
       (binding [api/*current-user-id* user-id]
         (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
-          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
+          (data-perms/set-database-permission! group-id-1 database-id-1 :perms/manage-database :yes)
           (data-perms/with-relevant-permissions-for-user user-id
             ;; retrieve the cache now so it doesn't get counted in the call-count
             @data-perms/*permissions-for-user*
             ;; make the cache wrong
-            (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :no)
+            (data-perms/set-database-permission! group-id-1 database-id-1 :perms/manage-database :no)
             ;; the cached value is used
             (t2/with-call-count [call-count]
-              (is (= :yes (data-perms/database-permission-for-user user-id :perms/native-query-editing database-id-1)))
+              (is (= :yes (data-perms/database-permission-for-user user-id :perms/manage-database database-id-1)))
               (is (zero? (call-count))))))))))
 
 (deftest table-permission-for-user-test
@@ -180,28 +179,30 @@
                  :model/Table                      {table-id-2 :id}  {:db_id database-id}]
     (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
       (testing "`table-permission-for-user` coalesces permissions from all groups a user is in"
-        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-        (data-perms/set-table-permission! group-id-2 table-id-1 :perms/data-access :no-self-service)
-        (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/data-access database-id table-id-1))))
+        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+        (data-perms/set-table-permission! group-id-2 table-id-1 :perms/create-queries :no)
+        (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/create-queries :no)
+        (is (= :query-builder (data-perms/table-permission-for-user user-id :perms/create-queries database-id table-id-1))))
 
       (testing "`table-permission-for-user` falls back to the least permissive value if no value exists for the user"
         (t2/delete! :model/DataPermissions :db_id database-id)
-        (is (= :block (data-perms/table-permission-for-user user-id :perms/data-access database-id table-id-2))))
+        (is (= :no (data-perms/table-permission-for-user user-id :perms/create-queries database-id table-id-2))))
 
       (testing "Admins always have the most permissive value, regardless of group membership"
-        (is (= :unrestricted (data-perms/table-permission-for-user (mt/user->id :crowberto) :perms/data-access database-id table-id-2)))))
+        (is (= :query-builder-and-native (data-perms/table-permission-for-user (mt/user->id :crowberto) :perms/create-queries database-id table-id-2)))))
+
     (mt/with-restored-data-perms-for-groups! [group-id-1 group-id-2]
       (testing "caching works as expected"
         (binding [api/*current-user-id* user-id]
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
           (data-perms/with-relevant-permissions-for-user user-id
             ;; retrieve the cache now so it doesn't get counted in the call count
             @data-perms/*permissions-for-user*
             ;; make the cache wrong
-            (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
+            (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :no)
             ;; the cached value is used
             (t2/with-call-count [call-count]
-              (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/data-access database-id table-id-1)))
+              (is (= :query-builder (data-perms/table-permission-for-user user-id :perms/create-queries database-id table-id-1)))
               (is (zero? (call-count))))))))))
 
 (deftest permissions-for-user-test
@@ -226,56 +227,56 @@
       (t2/delete! :model/DataPermissions :group_id group-id-1)
       (t2/delete! :model/DataPermissions :group_id group-id-2)
       (testing "A single user's data permissions can be fetched as a graph"
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/data-access :unrestricted)
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
-        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/data-access :no-self-service)
-        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/native-query-editing :no)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/view-data :unrestricted)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/create-queries :query-builder-and-native)
+        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/view-data :blocked)
+        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/create-queries :no)
         (is (partial=
              {database-id-1
-              {:perms/data-access :unrestricted
-               :perms/native-query-editing :yes}
+              {:perms/view-data :unrestricted
+               :perms/create-queries :query-builder-and-native}
               database-id-2
-              {:perms/data-access :block
-               :perms/native-query-editing :no}}
+              {:perms/view-data :blocked
+               :perms/create-queries :no}}
              (data-perms/permissions-for-user user-id-1))))
 
       (testing "Perms from multiple groups are coalesced"
-        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/data-access :no-self-service)
-        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/native-query-editing :no)
-        (data-perms/set-database-permission! group-id-2 database-id-2 :perms/data-access :unrestricted)
-        (data-perms/set-database-permission! group-id-2 database-id-2 :perms/native-query-editing :yes)
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/view-data :unrestricted)
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/create-queries :no)
+        (data-perms/set-database-permission! group-id-2 database-id-2 :perms/view-data :unrestricted)
+        (data-perms/set-database-permission! group-id-2 database-id-2 :perms/create-queries :query-builder-and-native)
         (is (partial=
              {database-id-1
-              {:perms/data-access :unrestricted
-               :perms/native-query-editing :yes}
+              {:perms/view-data :unrestricted
+               :perms/create-queries :query-builder-and-native}
               database-id-2
-              {:perms/data-access :unrestricted
-               :perms/native-query-editing :yes}}
+              {:perms/view-data :unrestricted
+               :perms/create-queries :query-builder-and-native}}
              (data-perms/permissions-for-user user-id-1))))
 
       (testing "Table-level perms are included if they're more permissive than any database-level perms"
-        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
-        (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
+        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :no)
+        (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :query-builder)
         (is (partial=
              {database-id-1
-              {:perms/data-access {table-id-1 :block
-                                   table-id-2 :unrestricted}}}
+              {:perms/create-queries {table-id-1 :no
+                                      table-id-2 :query-builder}}}
              (data-perms/permissions-for-user user-id-1))))
 
       (testing "Table-level perms are not included if a database-level perm is more permissive"
-        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/data-access :unrestricted)
+        (data-perms/set-database-permission! group-id-2 database-id-1 :perms/create-queries :query-builder-and-native)
         (is (partial=
              {database-id-1
-              {:perms/data-access :unrestricted}}
+              {:perms/create-queries :query-builder-and-native}}
              (data-perms/permissions-for-user user-id-1))))
 
       (testing "Admins always have full permissions"
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/data-access :no-self-service)
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :no)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/view-data :blocked)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/create-queries :no)
         (is (partial=
              {database-id-1
-              {:perms/data-access :unrestricted
-               :perms/native-query-editing :yes
+              {:perms/view-data :unrestricted
+               :perms/create-queries :query-builder-and-native
                :perms/manage-database :yes
                :perms/manage-table-metadata :yes
                :perms/download-results :one-million-rows}}
@@ -296,28 +297,28 @@
       ;; Clear the default permissions for the groups
       (t2/delete! :model/DataPermissions :group_id group-id-1)
       (t2/delete! :model/DataPermissions :group_id group-id-2)
-      (testing "Data access and native query permissions can be fetched as a graph"
-        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-        (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :no-self-service)
-        (data-perms/set-table-permission! group-id-1 table-id-3 :perms/data-access :unrestricted)
-        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/native-query-editing :yes)
-        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/native-query-editing :no)
-        (data-perms/set-table-permission! group-id-2 table-id-1 :perms/data-access :no-self-service)
+      (testing "Data and query permissions can be fetched as a graph"
+        (data-perms/set-table-permission! group-id-1 table-id-1 :perms/view-data :unrestricted)
+        (data-perms/set-table-permission! group-id-1 table-id-2 :perms/view-data :legacy-no-self-service)
+        (data-perms/set-table-permission! group-id-1 table-id-3 :perms/view-data :unrestricted)
+        (data-perms/set-database-permission! group-id-1 database-id-1 :perms/create-queries :query-builder-and-native)
+        (data-perms/set-database-permission! group-id-1 database-id-2 :perms/create-queries :no)
+        (data-perms/set-table-permission! group-id-2 table-id-1 :perms/view-data :legacy-no-self-service)
         (is (partial=
              {group-id-1
-              {database-id-1 {:perms/data-access
+              {database-id-1 {:perms/view-data
                               {"PUBLIC"
                                {table-id-1 :unrestricted
-                                table-id-2 :no-self-service}}
-                              :perms/native-query-editing :yes}
-               database-id-2 {:perms/data-access
+                                table-id-2 :legacy-no-self-service}}
+                              :perms/create-queries :query-builder-and-native}
+               database-id-2 {:perms/view-data
                               {""
                                {table-id-3 :unrestricted}}
-                              :perms/native-query-editing :no}}
+                              :perms/create-queries :no}}
               group-id-2
-              {database-id-1 {:perms/data-access
+              {database-id-1 {:perms/view-data
                               {"PUBLIC"
-                               {table-id-1 :no-self-service}}}}}
+                               {table-id-1 :legacy-no-self-service}}}}}
              (data-perms/data-permissions-graph))))
 
       (testing "Additional data permissions are included when set"
@@ -337,30 +338,30 @@
 
       (testing "Data permissions graph can be filtered by group ID, database ID, and permission type"
         (is (= {group-id-1
-                {database-id-1 {:perms/data-access
+                {database-id-1 {:perms/view-data
                                 {"PUBLIC"
                                  {table-id-1 :unrestricted
-                                  table-id-2 :no-self-service}}
-                                :perms/native-query-editing :yes
+                                  table-id-2 :legacy-no-self-service}}
+                                :perms/create-queries :query-builder-and-native
                                 :perms/manage-table-metadata
                                 {"PUBLIC"
                                  {table-id-1 :yes}}}
-                 database-id-2 {:perms/data-access
+                 database-id-2 {:perms/view-data
                                 {""
                                  {table-id-3 :unrestricted}}
                                 :perms/download-results
                                 {""
                                  {table-id-3 :one-million-rows}}
                                 :perms/manage-database :yes
-                                :perms/native-query-editing :no}}}
+                                :perms/create-queries :no}}}
                (data-perms/data-permissions-graph :group-id group-id-1)))
 
         (is (= {group-id-1
-                {database-id-1 {:perms/data-access
+                {database-id-1 {:perms/view-data
                                 {"PUBLIC"
                                  {table-id-1 :unrestricted
-                                  table-id-2 :no-self-service}}
-                                :perms/native-query-editing :yes
+                                  table-id-2 :legacy-no-self-service}}
+                                :perms/create-queries :query-builder-and-native
                                 :perms/manage-table-metadata
                                 {"PUBLIC"
                                  {table-id-1 :yes}}}}}
@@ -368,28 +369,28 @@
                                                   :db-id database-id-1)))
 
         (is (= {group-id-1
-                {database-id-1 {:perms/data-access
+                {database-id-1 {:perms/view-data
                                 {"PUBLIC"
                                  {table-id-1 :unrestricted
-                                  table-id-2 :no-self-service}}}}}
+                                  table-id-2 :legacy-no-self-service}}}}}
                (data-perms/data-permissions-graph :group-id group-id-1
                                                   :db-id database-id-1
-                                                  :perm-type :perms/data-access)))))))
+                                                  :perm-type :perms/view-data)))))))
 
 (deftest most-restrictive-per-group-works
-  (is (= #{:unrestricted}
-         (#'data-perms/most-restrictive-per-group :perms/data-access [{:group-id 1 :value :unrestricted}])))
-  (is (= #{:no-self-service}
-         (#'data-perms/most-restrictive-per-group :perms/data-access [{:group-id 1 :value :unrestricted}
-                                                                      {:group-id 1 :value :no-self-service}])))
-  (is (= #{:no-self-service :unrestricted}
-         (#'data-perms/most-restrictive-per-group :perms/data-access [{:group-id 1 :value :unrestricted}
-                                                                      {:group-id 1 :value :no-self-service}
-                                                                      {:group-id 2 :value :unrestricted}])))
-  (is (= #{:block}
-         (#'data-perms/most-restrictive-per-group :perms/data-access [{:group-id 1 :value :block}
-                                                                      {:group-id 1 :value :no-self-service}
-                                                                      {:group-id 1 :value :unrestricted}]))))
+  (is (= #{:query-builder-and-native}
+         (#'data-perms/most-restrictive-per-group :perms/create-queries [{:group-id 1 :value :query-builder-and-native}])))
+  (is (= #{:no}
+         (#'data-perms/most-restrictive-per-group :perms/create-queries [{:group-id 1 :value :query-builder}
+                                                                         {:group-id 1 :value :no}])))
+  (is (= #{:no :query-builder-and-native}
+         (#'data-perms/most-restrictive-per-group :perms/create-queries [{:group-id 1 :value :query-builder-and-native}
+                                                                         {:group-id 1 :value :no}
+                                                                         {:group-id 2 :value :query-builder-and-native}])))
+  (is (= #{:no}
+         (#'data-perms/most-restrictive-per-group :perms/create-queries [{:group-id 1 :value :no}
+                                                                         {:group-id 1 :value :query-builder}
+                                                                         {:group-id 1 :value :query-builder-and-native}]))))
 
 (deftest full-schema-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}
@@ -406,28 +407,28 @@
         ;; Clear the default permissions for the groups
         (t2/delete! :model/DataPermissions :group_id group-id-1)
         (testing "'Full' schema-level permission for a group is the lowest permission available for a table in the schema"
-          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
-          (is (= :unrestricted (data-perms/full-schema-permission-for-user
-                                user-id-1 :perms/data-access database-id-1 "schema_1"))))
+          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :query-builder)
+          (is (= :query-builder (data-perms/full-schema-permission-for-user
+                                 user-id-1 :perms/create-queries database-id-1 "schema_1"))))
         (testing "Dropping permission for one table means we lose full schema permissions"
-          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :no-self-service)
-          (is (= :no-self-service (data-perms/full-schema-permission-for-user
-                                   user-id-1 :perms/data-access database-id-1 "schema_1"))))
+          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :no)
+          (is (= :no (data-perms/full-schema-permission-for-user
+                      user-id-1 :perms/create-queries database-id-1 "schema_1"))))
         (testing "Permissions don't merge across groups"
           ;; even if a user has `unrestricted` access to all tables in a schema, that doesn't count as `unrestricted`
           ;; access to the schema unless it was granted to a *single group*.
-          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
-          (is (= :no-self-service (data-perms/full-schema-permission-for-user
-                                   user-id-1 :perms/data-access database-id-1 "schema_1"))))))))
+          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :query-builder)
+          (is (= :no (data-perms/full-schema-permission-for-user
+                      user-id-1 :perms/create-queries database-id-1 "schema_1"))))))))
 
 (deftest most-permissive-database-permission-for-user-test
   (mt/with-temp [:model/PermissionsGroup           {group-id-1 :id}    {}
@@ -442,26 +443,19 @@
         ;; Clear the default permissions for the groups
         (t2/delete! :model/DataPermissions :group_id group-id-1)
         (testing "We get back the highest permission available for a table in the database"
-          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :unrestricted)
-          (is (= :unrestricted (data-perms/most-permissive-database-permission-for-user
-                                user-id-1 :perms/data-access database-id-1))))
+          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :query-builder)
+          (is (= :query-builder (data-perms/most-permissive-database-permission-for-user
+                                 user-id-1 :perms/create-queries database-id-1))))
         (testing "Dropping permission for one table has no effect"
-          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :no-self-service)
-          (is (= :unrestricted (data-perms/most-permissive-database-permission-for-user
-                                user-id-1 :perms/data-access database-id-1))))
-        (testing "Blocks work like usual"
-          ;; If I am blocked by one group, `:no-self-service` is overriden and I end up with `:block` permission.
-          (data-perms/set-database-permission! all-users-group-id database-id-1 :perms/data-access :block)
-          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/data-access :no-self-service)
-          (is (= :block (data-perms/most-permissive-database-permission-for-user
-                         user-id-1 :perms/data-access database-id-1))))))))
+          (data-perms/set-table-permission! all-users-group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! all-users-group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id-1 table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id-1 table-id-2 :perms/create-queries :no)
+          (is (= :query-builder (data-perms/most-permissive-database-permission-for-user
+                                 user-id-1 :perms/create-queries database-id-1))))))))
 
 (deftest set-new-table-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}
@@ -474,35 +468,35 @@
                                                       :db_id     db-id
                                                       :group_id  group-id
                                                       :table_id  table-id
-                                                      :perm_type :perms/data-access))]
+                                                      :perm_type :perms/create-queries))]
       (mt/with-restored-data-perms-for-group! group-id
         (testing "New table inherits DB-level permission if set"
-          (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id table-id-2 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id table-id-3 :perms/data-access :unrestricted)
+          (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-3 :perms/create-queries :query-builder)
           (mt/with-temp [:model/Table {table-id-4 :id} {:db_id db-id :schema "PUBLIC"}]
-            (is (= :unrestricted (perm-value nil)))
+            (is (= :query-builder (perm-value nil)))
             (is (nil? (perm-value table-id-4)))))
 
         (testing "New table inherits uniform permission value from schema"
-          (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id table-id-2 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id table-id-3 :perms/data-access :no-self-service)
+          (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-3 :perms/create-queries :no)
           (mt/with-temp [:model/Table {table-id-4 :id} {:db_id db-id :schema "PUBLIC"}]
-            (is (= :unrestricted (perm-value table-id-4))))
+            (is (= :query-builder (perm-value table-id-4))))
 
-          (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id table-id-3 :perms/data-access :unrestricted)
+          (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id table-id-3 :perms/create-queries :query-builder)
           (mt/with-temp [:model/Table {table-id-4 :id} {:db_id db-id :schema "PUBLIC"}]
-            (is (= :no-self-service (perm-value table-id-4)))))
+            (is (= :no (perm-value table-id-4)))))
 
         (testing "New table uses default value when schema permissions are not uniform"
-          (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :unrestricted)
-          (data-perms/set-table-permission! group-id table-id-2 :perms/data-access :no-self-service)
-          (data-perms/set-table-permission! group-id table-id-3 :perms/data-access :no-self-service)
+          (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id table-id-3 :perms/create-queries :no)
           (mt/with-temp [:model/Table {table-id-4 :id} {:db_id db-id :schema "PUBLIC"}]
-            (is (= :no-self-service (perm-value table-id-4)))))))))
+            (is (= :no (perm-value table-id-4)))))))))
 
 (deftest additional-table-permissions-works
   (mt/with-temp [:model/PermissionsGroup           {group-id :id} {}
@@ -515,16 +509,19 @@
     (mt/with-no-data-perms-for-all-users!
       (testing "we can override the existing permission, using normal coalesce logic"
         (mt/with-restored-data-perms-for-group! group-id
-          (data-perms/set-database-permission! group-id db-id :perms/data-access :no-self-service)
-          (data-perms/with-additional-table-permission :perms/data-access db-id table-id :unrestricted
-            (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/data-access db-id table-id))))))
-      (testing "normal coalesce logic applies, so e.g. `:block` will override `:no-self-service`"
+          (data-perms/set-database-permission! group-id db-id :perms/view-data :legacy-no-self-service)
+          (data-perms/with-additional-table-permission :perms/view-data db-id table-id :unrestricted
+            (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id))))))
+      ;; `legacy-no-self-service` is deprecated and is only different from `unrestricted` in its coalescing behavior
+      (testing "normal coalesce logic applies, so e.g. `:blocked` will override `:legacy-no-self-service`"
         (mt/with-restored-data-perms-for-group! group-id
-          (is (= :block (data-perms/table-permission-for-user user-id :perms/data-access db-id table-id)))
-          (data-perms/with-additional-table-permission :perms/data-access db-id table-id :no-self-service
-            (is (= :block (data-perms/table-permission-for-user user-id :perms/data-access db-id table-id))))))
+          (data-perms/set-database-permission! group-id db-id :perms/view-data :blocked)
+          (is (= :blocked (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id)))
+          (data-perms/with-additional-table-permission :perms/view-data db-id table-id :legacy-no-self-service
+            (is (= :blocked (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id))))))
       (testing "... but WILL NOT override `:unrestricted`"
         (mt/with-restored-data-perms-for-group! group-id
-          (is (= :block (data-perms/table-permission-for-user user-id :perms/data-access db-id table-id)))
-          (data-perms/with-additional-table-permission :perms/data-access db-id table-id :unrestricted
-            (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/data-access db-id table-id)))))))))
+          (data-perms/set-database-permission! group-id db-id :perms/view-data :blocked)
+          (is (= :blocked (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id)))
+          (data-perms/with-additional-table-permission :perms/view-data db-id table-id :unrestricted
+            (is (= :unrestricted (data-perms/table-permission-for-user user-id :perms/view-data db-id table-id)))))))))

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -44,9 +44,7 @@
                 {db-id
                  {:perms/view-data             :unrestricted
                   :perms/create-queries        :query-builder-and-native
-                  :perms/data-access           :unrestricted
                   :perms/download-results      :one-million-rows
-                  :perms/native-query-editing  :yes
                   :perms/manage-table-metadata :no
                   :perms/manage-database       :no}}}
                (data-perms/data-permissions-graph :group-id all-users-group-id :db-id db-id))))
@@ -57,8 +55,6 @@
                {:perms/view-data             :unrestricted
                 :perms/create-queries        :no
                 :perms/download-results      :no
-                :perms/data-access           :no-self-service
-                :perms/native-query-editing  :no
                 :perms/manage-table-metadata :no
                 :perms/manage-database       :no}}}
              (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))

--- a/test/metabase/models/permissions_group_test.clj
+++ b/test/metabase/models/permissions_group_test.clj
@@ -155,9 +155,7 @@
            {db-id
             {:perms/view-data :unrestricted,
              :perms/create-queries :no,
-             :perms/data-access :no-self-service,
              :perms/download-results :no,
              :perms/manage-table-metadata :no,
-             :perms/native-query-editing :no,
              :perms/manage-database :no}}}
           (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))

--- a/test/metabase/models/table_test.clj
+++ b/test/metabase/models/table_test.clj
@@ -98,8 +98,6 @@
               {db-id
                {:perms/view-data             :unrestricted
                 :perms/create-queries        :query-builder-and-native
-                :perms/data-access           :unrestricted
-                :perms/native-query-editing  :yes
                 :perms/download-results      :one-million-rows
                 :perms/manage-table-metadata :no
                 :perms/manage-database       :no}}}
@@ -111,8 +109,6 @@
             {db-id
              {:perms/view-data             :unrestricted
               :perms/create-queries        :no
-              :perms/data-access           :no-self-service
-              :perms/native-query-editing  :no
               :perms/download-results      :no
               :perms/manage-table-metadata :no
               :perms/manage-database       :no}}}
@@ -120,7 +116,7 @@
 
       (testing "A new table has appropriate defaults, when perms are already set granularly for the DB"
         (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
-        (data-perms/set-table-permission! group-id table-id-1 :perms/data-access :unrestricted)
+        (data-perms/set-table-permission! group-id table-id-1 :perms/view-data :unrestricted)
         (data-perms/set-table-permission! group-id table-id-1 :perms/download-results :one-million-rows)
         (data-perms/set-table-permission! group-id table-id-1 :perms/manage-table-metadata :yes)
         (mt/with-temp [:model/Table {table-id-3 :id} {:db_id  db-id
@@ -133,11 +129,6 @@
                                                 {table-id-1 :query-builder
                                                  table-id-2 :no
                                                  table-id-3 :no}}
-                  :perms/data-access           {"PUBLIC"
-                                                {table-id-1 :unrestricted
-                                                 table-id-2 :no-self-service
-                                                 table-id-3 :no-self-service}}
-                  :perms/native-query-editing  :no
                   :perms/download-results      {"PUBLIC"
                                                 {table-id-1 :one-million-rows
                                                  table-id-2 :no
@@ -155,7 +146,7 @@
      :model/Table    {table-id-1 :id} {:db_id db-id}
      :model/Table    {}               {:db_id db-id}]
     (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/create-queries :query-builder-and-native)
-    (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/data-access :unrestricted)
+    (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/view-data :unrestricted)
     (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/download-results :one-million-rows)
     (data-perms/set-table-permission! (perms-group/all-users) table-id-1 :perms/manage-table-metadata :yes)
     (is (true? (t2/exists? :model/DataPermissions :table_id table-id-1)))


### PR DESCRIPTION
This PR removes the old `data-access` and `native-query-editing` permissions entirely: from the DB and from the code. This ensures that everything is migrated over to `view-data` and `create-queries`.

I've also updated a couple small spots that were still using the old permissions which slipped through the cracks, and updated a lot of tests that were still relying on the old permission types.