### PR TITLE
Fix unable to migrate to 49 due to v49.00-059 migration

### DIFF
--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -12,6 +12,7 @@
    [clojure.core.match :refer [match]]
    [clojure.java.io :as io]
    [clojure.set :as set]
+   [clojure.string :as str]
    [clojure.walk :as walk]
    [clojurewerkz.quartzite.jobs :as jobs]
    [clojurewerkz.quartzite.scheduler :as qs]
@@ -90,7 +91,15 @@
 ;; metabase.util/upper-case-en
 (defn- upper-case-en
   ^String [s]
-  (.toUpperCase (str s) Locale/US))
+  (when s
+    (.toUpperCase (str s) Locale/US)))
+
+
+;; metabase.util/lower-case-en
+(defn- lower-case-en
+  ^String [s]
+  (when s
+   (.toLowerCase (str s) Locale/US)))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                  MIGRATIONS                                                    |
@@ -903,80 +912,29 @@
 (defn- db-type->to-unified-columns
   "Each unified column is 3 items sequence [table-name, column-name, is-nullable?]"
   [db-type]
-  (case db-type
-    :h2      [[:activity :timestamp false]
-              [:application_permissions_revision :created_at false]
-              [:collection_permission_graph_revision :created_at false]
-              [:core_session :created_at false]
-              [:core_user :date_joined false]
-              [:core_user :last_login true]
-              [:core_user :updated_at true]
-              [:dependency :created_at false]
-              [:dimension :created_at false]
-              [:dimension :updated_at false]
-              [:metabase_database :created_at false]
-              [:metabase_database :updated_at false]
-              [:metabase_field :created_at false]
-              [:metabase_field :updated_at false]
-              [:metabase_field :last_analyzed true]
-              [:metabase_fieldvalues :created_at false]
-              [:metabase_table :created_at false]
-              [:metabase_table :updated_at false]
-              [:metric :created_at false]
-              [:metric :updated_at false]
-              [:permissions_revision :created_at false]
-              [:pulse :created_at false]
-              [:pulse :updated_at false]
-              [:pulse_channel :created_at false]
-              [:pulse_channel :updated_at false]
-              [:recent_views :timestamp false]
-              [:report_card :created_at false]
-              [:report_cardfavorite :created_at false]
-              [:report_cardfavorite :updated_at false]
-              [:report_dashboard :created_at false]
-              [:report_dashboard :updated_at false]
-              [:report_dashboardcard :created_at false]
-              [:report_dashboardcard :updated_at false]
-              [:segment :created_at false]
-              [:segment :updated_at false]]
-    :mysql   [[:activity :timestamp false]
-              [:application_permissions_revision :created_at false]
-              [:collection_permission_graph_revision :created_at false]
-              [:core_session :created_at false]
-              [:core_user :date_joined false]
-              [:core_user :last_login true]
-              [:core_user :updated_at true]
-              [:dependency :created_at false]
-              [:dimension :created_at false]
-              [:dimension :updated_at false]
-              [:metabase_field :created_at false]
-              [:metabase_field :last_analyzed true]
-              [:metabase_field :updated_at false]
-              [:metabase_fieldvalues :created_at false]
-              [:metabase_table :created_at false]
-              [:metabase_table :updated_at false]
-              [:metric :created_at false]
-              [:metric :updated_at false]
-              [:permissions_revision :created_at false]
-              [:pulse :created_at false]
-              [:pulse :updated_at false]
-              [:pulse_channel :created_at false]
-              [:pulse_channel :updated_at false]
-              [:recent_views :timestamp false]
-              [:report_card :created_at false]
-              [:report_cardfavorite :created_at false]
-              [:report_cardfavorite :updated_at false]
-              [:report_dashboard :created_at false]
-              [:report_dashboard :updated_at false]
-              [:segment :created_at false]
-              [:segment :updated_at false]]
-   :postgres [[:application_permissions_revision :created_at false]
-              [:collection_permission_graph_revision :created_at false]
-              [:core_user :updated_at true]
-              [:dimension :updated_at false]
-              [:dimension :created_at false]
-              [:permissions_revision :created_at false]
-              [:recent_views :timestamp false]]))
+  (let [query (case db-type
+                :postgres {:select [:table_name :column_name :is_nullable]
+                           :from   [:information_schema.columns]
+                           :where  [:and
+                                    [:= :data_type "timestamp without time zone"]
+                                    [:= :table_schema :%current_schema]
+                                    [:= :table_catalog :%current_database]]}
+
+                :mysql    {:select [:table_name :column_name :is_nullable]
+                           :from   [:information_schema.columns]
+                           :where  [:and
+                                    [:= :data_type "datetime"]
+                                    [:= :table_schema :%database]]}
+                :h2      {:select [:table_name :column_name :is_nullable]
+                          :from   [:information_schema.columns]
+                          :where  [:= :data_type "TIMESTAMP"]})]
+    (->> (t2/query query)
+         (map #(update-vals % (comp keyword lower-case-en)))
+         (remove (fn [{:keys [table_name]}]
+                   (or (#{:databasechangelog :databasechangeloglock} table_name)
+                       (str/starts-with? (name table_name) "v_"))))
+         (map #(update % :is_nullable (fn [x] (= :yes x))))
+         (map (juxt :table_name :column_name :is_nullable)))))
 
 (defn- alter-table-column-type-sql
   [db-type table column ttype nullable?]

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -932,6 +932,7 @@
          (map #(update-vals % (comp keyword lower-case-en)))
          (remove (fn [{:keys [table_name]}]
                    (or (#{:databasechangelog :databasechangeloglock} table_name)
+                       ;; excludes views
                        (str/starts-with? (name table_name) "v_"))))
          (map #(update % :is_nullable (fn [x] (= :yes x))))
          (map (juxt :table_name :column_name :is_nullable)))))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/40546

In #37160 we added a migration to convert all datetime columns to timestamp with time zone by using a fixed list of what to convert. But it turns out not all instances have the same list, not sure why, could be that liquibase interprets the timestamp columns differently between version/dialect.

This PR removed the fixed list and used a query to get a list of all datetime columns.

Note: I don't think we need to update the checksum because custom migration has the class name, not the implementation. Tested locally.