### PR TITLE
Prevent NPE when formatting geographic coords

### DIFF
--- a/src/metabase/formatter.clj
+++ b/src/metabase/formatter.clj
@@ -205,15 +205,16 @@
 
 (defn format-geographic-coordinates
   "Format longitude/latitude values as 0.00000000° N|S|E|W"
-  [lon-or-lat ^double v]
-  (let [dir        (case lon-or-lat
+  [lon-or-lat v]
+  (str (when (number? v)
+         (let [v   (double v)
+               dir (case lon-or-lat
                      :type/Latitude (if (neg? v) "S" "N")
                      :type/Longitude (if (neg? v) "W" "E")
-                     nil)
-        base-value (Math/abs v)]
-    (if dir
-      (format "%.8f° %s" base-value dir)
-      (str v))))
+                     nil)]
+           (if dir
+             (format "%.8f° %s" (Math/abs v) dir)
+             v)))))
 
 (mu/defn create-formatter
   "Create a formatter for a column based on its timezone, column metadata, and visualization-settings"

--- a/test/metabase/formatter_test.clj
+++ b/test/metabase/formatter_test.clj
@@ -159,4 +159,7 @@
              (formatter/format-geographic-coordinates :type/Latitude 0))))
     (testing "A non-coordinate type just stringifies the value"
       (is (= "0.0"
-             (formatter/format-geographic-coordinates :type/Froobitude 0))))))
+             (formatter/format-geographic-coordinates :type/Froobitude 0))))
+    (testing "We handle missing values"
+      (is (= ""
+             (formatter/format-geographic-coordinates :type/Longitude nil))))))

--- a/test/metabase/pulse/render/body_test.clj
+++ b/test/metabase/pulse/render/body_test.clj
@@ -47,7 +47,9 @@
 (def ^:private example-test-data
   [[1 34.0996 "2014-04-01T08:30:00.0000" "Stout Burgers & Beers"]
    [2 34.0406 "2014-12-05T15:15:00.0000" "The Apple Pan"]
-   [3 34.0474 "2014-08-01T12:45:00.0000" "The Gorbals"]])
+   [3 34.0474 "2014-08-01T12:45:00.0000" "The Gorbals"]
+   [4 0       "2018-09-01T19:32:00.0000" "The Tipsy Tardigrade"]
+   [5 nil     "2022-10-12T05:55:00.0000" "The Bungalow"]])
 
 (defn- col-counts [results]
   (set (map (comp count :row) results)))
@@ -167,14 +169,18 @@
 (deftest format-result-rows
   (is (= [{:bar-width nil, :row [(number "1" 1) "34.09960000° N" "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
           {:bar-width nil, :row [(number "2" 2) "34.04060000° N" "December 5, 2014, 3:15 PM" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3" 3) "34.04740000° N" "August 1, 2014, 12:45 PM" "The Gorbals"]}]
+          {:bar-width nil, :row [(number "3" 3) "34.04740000° N" "August 1, 2014, 12:45 PM" "The Gorbals"]}
+          {:bar-width nil, :row [(number "4" 4)  "0.00000000° N" "September 1, 2018, 7:32 PM" "The Tipsy Tardigrade"]}
+          {:bar-width nil, :row [(number "5" 5) "" "October 12, 2022, 5:55 AM" "The Bungalow"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows example-test-data})))))
 
 ;; Testing the bar-column, which is the % of this row relative to the max of that column
 (deftest bar-column
   (is (= [{:bar-width (float 85.249), :row [(number "1" 1) "34.09960000° N" "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
           {:bar-width (float 85.1015), :row [(number "2" 2) "34.04060000° N" "December 5, 2014, 3:15 PM" "The Apple Pan"]}
-          {:bar-width (float 85.1185), :row [(number "3" 3) "34.04740000° N" "August 1, 2014, 12:45 PM" "The Gorbals"]}]
+          {:bar-width (float 85.1185), :row [(number "3" 3) "34.04740000° N" "August 1, 2014, 12:45 PM" "The Gorbals"]}
+          {:bar-width (float 0.0), :row [(number "4" 4) "0.00000000° N" "September 1, 2018, 7:32 PM" "The Tipsy Tardigrade"]}
+          {:bar-width nil, :row [(number "5" 5) "" "October 12, 2022, 5:55 AM" "The Bungalow"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz {} {:cols test-columns :rows example-test-data}
                  {:bar-column second, :min-value 0, :max-value 40})))))
 
@@ -241,7 +247,9 @@
 (deftest cols-with-semantic-types
   (is (= [{:bar-width nil, :row [(number "1" 1) "34.09960000° N" "April 1, 2014, 8:30 AM" "Stout Burgers & Beers"]}
           {:bar-width nil, :row [(number "2" 2) "34.04060000° N" "December 5, 2014, 3:15 PM" "The Apple Pan"]}
-          {:bar-width nil, :row [(number "3" 3) "34.04740000° N" "August 1, 2014, 12:45 PM" "The Gorbals"]}]
+          {:bar-width nil, :row [(number "3" 3) "34.04740000° N" "August 1, 2014, 12:45 PM" "The Gorbals"]}
+          {:bar-width nil, :row [(number "4" 4) "0.00000000° N" "September 1, 2018, 7:32 PM" "The Tipsy Tardigrade"]}
+          {:bar-width nil, :row [(number "5" 5) "" "October 12, 2022, 5:55 AM" "The Bungalow"]}]
          (rest (#'body/prep-for-html-rendering pacific-tz
                  {}
                  {:cols test-columns-with-date-semantic-type :rows example-test-data})))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40472

### Description

The related issue's stacktrace does not expose the line number, likely due to partial application, but this fixes the only plausible way I see an NPE being thrown.

### How to verify

Looking on stats, I do not see any null values for longitude or langitude in Accounts, and could not reproduce the issue.

Going to look at reproducing with an uploaded model.

Update: reproduced using a basic CSV - [npe.csv](https://github.com/metabase/metabase/files/14741461/npe.csv)
