### PR TITLE
Fix parsing integers after floats in CSV upload

### DIFF
--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -175,7 +175,9 @@
                    number-regex
                    "\\s*" upload-parsing/currency-regex "?")))
 
-(defn- int-regex [number-separators]
+(defn- int-regex
+  "Matches numbers which do not have a decimal separator."
+  [number-separators]
   (with-parens
     (with-currency
       (case number-separators
@@ -184,7 +186,9 @@
         ", " #"\d[\d \u00A0]*"
         ".’" #"\d[\d’]*"))))
 
-(defn- float-or-int-regex [number-separators]
+(defn- float-or-int-regex
+  "Matches integral numbers, even if they have a decimal separator - e.g. 2 or 2.0"
+  [number-separators]
   (with-parens
    (with-currency
     (case number-separators
@@ -193,14 +197,16 @@
       ", " #"\d[\d \u00A0]*(\,[0.]+)?"
       ".’" #"\d[\d’]*(\.[0.]+)?"))))
 
-(defn- float-regex [number-separators]
+(defn- float-regex
+  "Matches numbers, regardless of whether they have a decimal separator - e.g. 2, 2.0, or 2.2"
+  [number-separators]
   (with-parens
     (with-currency
       (case number-separators
-        ("." ".,") #"\d[\d,]*\.\d+"
-        ",." #"\d[\d.]*\,[\d]+"
-        ", " #"\d[\d \u00A0]*\,[\d.]+"
-        ".’" #"\d[\d’]*\.[\d.]+"))))
+        ("." ".,") #"\d[\d,]*(\.\d+)?"
+        ",." #"\d[\d.]*(\,[\d]+)?"
+        ", " #"\d[\d \u00A0]*(\,[\d.]+)?"
+        ".’" #"\d[\d’]*(\.[\d.]+)?"))))
 
 (defmacro does-not-throw?
   "Returns true if the given body does not throw an exception."
@@ -248,8 +254,7 @@
   [{:keys [number-separators] :as _settings}]
   (let [int?          (regex-matcher (int-regex number-separators))
         float-or-int? (regex-matcher (float-or-int-regex number-separators))
-        only-float?   (regex-matcher (float-regex number-separators))
-        float?        #(or (only-float? %) (int? %))]
+        float?        (regex-matcher (float-regex number-separators))]
     {::*boolean-int*   boolean-int-string?
      ::boolean         boolean-string?
      ::offset-datetime offset-datetime-string?

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -252,17 +252,17 @@
 
 (mu/defn ^:private settings->type->check :- type->check-schema
   [{:keys [number-separators] :as _settings}]
-  (let [int?          (regex-matcher (int-regex number-separators))
+  (let [int-string?   (regex-matcher (int-regex number-separators))
         float-or-int? (regex-matcher (float-or-int-regex number-separators))
-        float?        (regex-matcher (float-regex number-separators))]
+        float-string? (regex-matcher (float-regex number-separators))]
     {::*boolean-int*   boolean-int-string?
      ::boolean         boolean-string?
      ::offset-datetime offset-datetime-string?
      ::date            date-string?
      ::datetime        datetime-string?
-     ::int             int?
+     ::int             int-string?
      ::*float-or-int*  float-or-int?
-     ::float           float?
+     ::float           float-string?
      ::varchar-255     varchar-255?
      ::text            (constantly true)}))
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -248,7 +248,8 @@
   [{:keys [number-separators] :as _settings}]
   (let [int?          (regex-matcher (int-regex number-separators))
         float-or-int? (regex-matcher (float-or-int-regex number-separators))
-        float?        (regex-matcher (float-regex number-separators))]
+        only-float?   (regex-matcher (float-regex number-separators))
+        float?        #(or (only-float? %) (int? %))]
     {::*boolean-int*   boolean-int-string?
      ::boolean         boolean-string?
      ::offset-datetime offset-datetime-string?

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1914,6 +1914,25 @@
                    [2 1.0 1.0]]
                   (rows-for-table table)))))))))
 
+(deftest create-from-csv-int-and-non-integral-float-test
+  (testing "Creation should handle a mix of int and float values in any order"
+    (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+      (with-mysql-local-infile-on-and-off
+       (with-upload-table!
+         [table (let [table-name (mt/random-name)]
+                  (@#'upload/create-from-csv!
+                   driver/*driver*
+                   (mt/id)
+                   table-name
+                   (csv-file-with ["float-1,float-2"
+                                   "1,   1.1"
+                                   "1.1, 1"]))
+                  (sync-upload-test-table! :database (mt/db) :table-name table-name))]
+         (testing "Check the data was uploaded into the table correctly"
+           (is (= [[1 1.0 1.1]
+                   [2 1.1 1.0]]
+                  (rows-for-table table)))))))))
+
 (deftest append-from-csv-int-and-float-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (testing "Append should handle a mix of int and float-or-int values being appended to an int column"


### PR DESCRIPTION
### Description

This fixes a show-stopping bug I was lucky to notice when testing a quickly thrown together file for testing a CSV export bug.

The issue is that the `float?` detector would return false for integer literals. This violates the assumption that every parent type's detector is will return true for all values of its children types.

The result of this bug is that putting integers after floats in a column would result in it detecting a varchar type, when it should still be a float.

### How to verify

Added a basic test case to cover this.