### PR TITLE
Deprecate Entity Framework

### DIFF
--- a/frontend/src/metabase/entities/actions/actions.ts
+++ b/frontend/src/metabase/entities/actions/actions.ts
@@ -92,6 +92,9 @@ const enableImplicitActionsForModel =
 const CREATE_PUBLIC_LINK = "metabase/entities/actions/CREATE_PUBLIC_LINK";
 const DELETE_PUBLIC_LINK = "metabase/entities/actions/DELETE_PUBLIC_LINK";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Actions = createEntity({
   name: "actions",
   nameOne: "action",

--- a/frontend/src/metabase/entities/alerts.js
+++ b/frontend/src/metabase/entities/alerts.js
@@ -6,6 +6,9 @@ import { AlertApi } from "metabase/services";
 
 export const UNSUBSCRIBE = "metabase/entities/alerts/unsubscribe";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Alerts = createEntity({
   name: "alerts",
   nameOne: "alert",

--- a/frontend/src/metabase/entities/bookmarks.js
+++ b/frontend/src/metabase/entities/bookmarks.js
@@ -11,6 +11,9 @@ import { BookmarkApi } from "metabase/services";
 
 const REORDER_ACTION = `metabase/entities/bookmarks/REORDER_ACTION`;
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Bookmarks = createEntity({
   name: "bookmarks",
   nameOne: "bookmark",

--- a/frontend/src/metabase/entities/collections/collections.ts
+++ b/frontend/src/metabase/entities/collections/collections.ts
@@ -21,6 +21,9 @@ type EntityInCollection = {
   collection?: Collection;
 };
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Collections = createEntity({
   name: "collections",
   path: "/api/collection",

--- a/frontend/src/metabase/entities/dashboards.js
+++ b/frontend/src/metabase/entities/dashboards.js
@@ -24,6 +24,9 @@ const FAVORITE_ACTION = `metabase/entities/dashboards/FAVORITE`;
 const UNFAVORITE_ACTION = `metabase/entities/dashboards/UNFAVORITE`;
 const COPY_ACTION = `metabase/entities/dashboards/COPY`;
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Dashboards = createEntity({
   name: "dashboards",
   nameOne: "dashboard",

--- a/frontend/src/metabase/entities/database-candidates.js
+++ b/frontend/src/metabase/entities/database-candidates.js
@@ -1,6 +1,9 @@
 import { createEntity } from "metabase/lib/entities";
 import { AutoApi } from "metabase/services";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const DatabaseCandidates = createEntity({
   name: "databaseCandidates",
   api: {

--- a/frontend/src/metabase/entities/databases.js
+++ b/frontend/src/metabase/entities/databases.js
@@ -31,6 +31,9 @@ export const FETCH_DATABASE_SCHEMAS =
 export const FETCH_DATABASE_IDFIELDS =
   "metabase/entities/database/FETCH_DATABASE_IDFIELDS";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Databases = createEntity({
   name: "databases",
   path: "/api/database",

--- a/frontend/src/metabase/entities/fields.js
+++ b/frontend/src/metabase/entities/fields.js
@@ -44,6 +44,9 @@ export const ADD_REMAPPINGS = "metabase/entities/fields/ADD_REMAPPINGS";
 export const ADD_PARAM_VALUES = "metabase/entities/fields/ADD_PARAM_VALUES";
 export const ADD_FIELDS = "metabase/entities/fields/ADD_FIELDS";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Fields = createEntity({
   name: "fields",
   path: "/api/field",

--- a/frontend/src/metabase/entities/groups.js
+++ b/frontend/src/metabase/entities/groups.js
@@ -8,6 +8,9 @@ import {
 import { createEntity } from "metabase/lib/entities";
 import { PermissionsApi } from "metabase/services";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Groups = createEntity({
   name: "groups",
   path: "/api/permissions/group",

--- a/frontend/src/metabase/entities/indexed-entities/indexed-entities.ts
+++ b/frontend/src/metabase/entities/indexed-entities/indexed-entities.ts
@@ -8,6 +8,9 @@ import { createEntity } from "metabase/lib/entities";
 import { indexedEntity as indexedEntityUrl } from "metabase/lib/urls";
 import { IndexedEntitySchema } from "metabase/schema";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 export const IndexedEntities = createEntity({
   name: "indexedEntities",
   nameOne: "indexedEntity",

--- a/frontend/src/metabase/entities/metrics.js
+++ b/frontend/src/metabase/entities/metrics.js
@@ -4,6 +4,9 @@ import * as Urls from "metabase/lib/urls";
 import { MetricSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Metrics = createEntity({
   name: "metrics",
   nameOne: "metric",

--- a/frontend/src/metabase/entities/model-indexes/model-indexes.ts
+++ b/frontend/src/metabase/entities/model-indexes/model-indexes.ts
@@ -12,6 +12,9 @@ import type { IndexedEntity } from "metabase-types/api/modelIndexes";
 import * as actions from "./actions";
 import * as utils from "./utils";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 export const ModelIndexes = createEntity({
   name: "modelIndexes",
   nameOne: "modelIndex",

--- a/frontend/src/metabase/entities/persisted-models.js
+++ b/frontend/src/metabase/entities/persisted-models.js
@@ -12,6 +12,9 @@ const getPersistedModelInfoByModelId = createSelector(
     Object.values(persistedModels).find(info => info.card_id === modelId),
 );
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const PersistedModels = createEntity({
   name: "persistedModels",
   nameOne: "persistedModel",

--- a/frontend/src/metabase/entities/popular-items.js
+++ b/frontend/src/metabase/entities/popular-items.js
@@ -17,6 +17,9 @@ export const getIcon = item => {
   return entity.objectSelectors.getIcon(item.model_object, options);
 };
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const PopularItems = createEntity({
   name: "popularItems",
   nameOne: "popularItem",

--- a/frontend/src/metabase/entities/pulses.js
+++ b/frontend/src/metabase/entities/pulses.js
@@ -10,6 +10,9 @@ import { PulseApi } from "metabase/services";
 
 export const UNSUBSCRIBE = "metabase/entities/pulses/unsubscribe";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Pulses = createEntity({
   name: "pulses",
   nameOne: "pulse",

--- a/frontend/src/metabase/entities/questions.js
+++ b/frontend/src/metabase/entities/questions.js
@@ -21,6 +21,9 @@ import {
 
 import forms from "./questions/forms";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Questions = createEntity({
   name: "questions",
   nameOne: "question",

--- a/frontend/src/metabase/entities/recent-items.js
+++ b/frontend/src/metabase/entities/recent-items.js
@@ -17,6 +17,9 @@ export const getIcon = item => {
   return entity.objectSelectors.getIcon(item.model_object, options);
 };
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const RecentItems = createEntity({
   name: "recentItems",
   nameOne: "recentItem",

--- a/frontend/src/metabase/entities/revisions.js
+++ b/frontend/src/metabase/entities/revisions.js
@@ -6,6 +6,9 @@ import Questions from "./questions";
 
 const listRevisions = GET("/api/revision");
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Revision = createEntity({
   name: "revisions",
   api: {

--- a/frontend/src/metabase/entities/schemas.js
+++ b/frontend/src/metabase/entities/schemas.js
@@ -18,6 +18,9 @@ import {
 
 // This is a weird entity because we don't have actual schema objects
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 export default createEntity({
   name: "schemas",
   schema: SchemaSchema,

--- a/frontend/src/metabase/entities/search.js
+++ b/frontend/src/metabase/entities/search.js
@@ -15,6 +15,9 @@ import Segments from "./segments";
 import SnippetCollections from "./snippet-collections";
 import Snippets from "./snippets";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 export default createEntity({
   name: "search",
   path: "/api/search",

--- a/frontend/src/metabase/entities/segments.js
+++ b/frontend/src/metabase/entities/segments.js
@@ -4,6 +4,9 @@ import * as Urls from "metabase/lib/urls";
 import { SegmentSchema } from "metabase/schema";
 import { getMetadata } from "metabase/selectors/metadata";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Segments = createEntity({
   name: "segments",
   nameOne: "segment",

--- a/frontend/src/metabase/entities/snippet-collections.js
+++ b/frontend/src/metabase/entities/snippet-collections.js
@@ -9,6 +9,9 @@ import NormalCollections, {
 import { createEntity, undo } from "metabase/lib/entities";
 import { SnippetCollectionSchema } from "metabase/schema";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const SnippetCollections = createEntity({
   name: "snippetCollections",
   schema: SnippetCollectionSchema,

--- a/frontend/src/metabase/entities/snippets.js
+++ b/frontend/src/metabase/entities/snippets.js
@@ -1,5 +1,8 @@
 import { createEntity } from "metabase/lib/entities";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Snippets = createEntity({
   name: "snippets",
   nameOne: "snippet",

--- a/frontend/src/metabase/entities/tables.js
+++ b/frontend/src/metabase/entities/tables.js
@@ -46,6 +46,9 @@ export const FETCH_TABLE_FOREIGN_KEYS =
 export const UPDATE_TABLE_FIELD_ORDER =
   "metabase/entities/UPDATE_TABLE_FIELD_ORDER";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Tables = createEntity({
   name: "tables",
   nameOne: "table",

--- a/frontend/src/metabase/entities/tasks.js
+++ b/frontend/src/metabase/entities/tasks.js
@@ -1,5 +1,8 @@
 import { createEntity } from "metabase/lib/entities";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 export default createEntity({
   name: "tasks",
   path: "/api/task",

--- a/frontend/src/metabase/entities/timeline-events.js
+++ b/frontend/src/metabase/entities/timeline-events.js
@@ -3,6 +3,9 @@ import { t } from "ttag";
 import { createEntity, undo } from "metabase/lib/entities";
 import { TimelineEventSchema } from "metabase/schema";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const TimelineEvents = createEntity({
   name: "timelineEvents",
   nameOne: "timelineEvent",

--- a/frontend/src/metabase/entities/timelines.js
+++ b/frontend/src/metabase/entities/timelines.js
@@ -10,6 +10,9 @@ import { TimelineApi, TimelineEventApi } from "metabase/services";
 
 import TimelineEvents from "./timeline-events";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Timelines = createEntity({
   name: "timelines",
   nameOne: "timeline",

--- a/frontend/src/metabase/entities/users.js
+++ b/frontend/src/metabase/entities/users.js
@@ -24,6 +24,9 @@ function loadMemberships() {
 const getUserList = GET("/api/user");
 const getRecipientsList = GET("/api/user/recipients");
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const Users = createEntity({
   name: "users",
   nameOne: "user",

--- a/frontend/src/metabase/lib/entities.js
+++ b/frontend/src/metabase/lib/entities.js
@@ -88,6 +88,9 @@ import {
 import requestsReducer, { setRequestUnloaded } from "metabase/redux/requests";
 import { addUndo } from "metabase/redux/undo";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 export function createEntity(def) {
   const entity = { ...def };
 

--- a/frontend/src/metabase/lib/entities.unit.spec.js
+++ b/frontend/src/metabase/lib/entities.unit.spec.js
@@ -4,6 +4,9 @@ import promise from "redux-promise";
 import { createEntity, combineEntities } from "metabase/lib/entities";
 import requestsReducer from "metabase/redux/requests";
 
+/**
+ * @deprecated use "metabase/api" instead
+ */
 const widgets = createEntity({
   name: "widgets",
   api: {


### PR DESCRIPTION
RTK query exposed via `metabase/api` is now the default way for working with api requests and caching response data.