### PR TITLE
Fix e2e util `cypressWaitAll`

### DIFF
--- a/e2e/support/commands/api/composite/createDashboardWithQuestions.js
+++ b/e2e/support/commands/api/composite/createDashboardWithQuestions.js
@@ -15,7 +15,7 @@ Cypress.Commands.add(
             dashcardResponse => dashcardResponse.body.card,
           );
           return {
-            questions: questions,
+            questions,
             dashboard,
           };
         });

--- a/e2e/support/commands/api/composite/createDashboardWithQuestions.js
+++ b/e2e/support/commands/api/composite/createDashboardWithQuestions.js
@@ -10,9 +10,12 @@ Cypress.Commands.add(
           questions.map(query =>
             cy.createQuestionAndAddToDashboard(query, dashboard.id),
           ),
-        ).then(questions => {
+        ).then(dashcardResponses => {
+          const questions = dashcardResponses.map(
+            dashcardResponse => dashcardResponse.body.card,
+          );
           return {
-            questions,
+            questions: questions,
             dashboard,
           };
         });

--- a/e2e/support/commands/api/composite/createQuestionAndAddToDashboard.js
+++ b/e2e/support/commands/api/composite/createQuestionAndAddToDashboard.js
@@ -26,7 +26,7 @@ Cypress.Commands.add(
             })
             .then(response => ({
               ...response,
-              body: response.body.dashcards[0],
+              body: response.body.dashcards.at(-1),
             })),
         ),
     ),

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -102,7 +102,7 @@ export function interceptPromise(method, path) {
 const cypressWaitAllRecursive = (results, commands) => {
   const [nextCommand, ...restCommands] = commands;
   if (!nextCommand) {
-    return results;
+    return;
   }
 
   return nextCommand.then(result => {

--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -99,28 +99,29 @@ export function interceptPromise(method, path) {
  *   cy.visit(`/dashboard/1`);
  * });
  */
-const cypressWaitAllRecursive = (results, currentCommand, commands) => {
-  return currentCommand.then(result => {
+const cypressWaitAllRecursive = (results, commands) => {
+  const [nextCommand, ...restCommands] = commands;
+  if (!nextCommand) {
+    return results;
+  }
+
+  return nextCommand.then(result => {
     results.push(result);
 
-    const [nextCommand, ...rest] = Array.from(commands);
-
     if (nextCommand == null) {
-      return results;
+      return;
     }
 
-    return cypressWaitAllRecursive(results, nextCommand, rest);
+    return cypressWaitAllRecursive(results, restCommands);
   });
 };
 
 export const cypressWaitAll = function (commands) {
   const results = [];
 
-  return cypressWaitAllRecursive(
-    results,
-    cy.wrap(null, { log: false }),
-    commands,
-  );
+  return cy.wrap(results).then(() => {
+    cypressWaitAllRecursive(results, commands);
+  });
 };
 
 /**


### PR DESCRIPTION
### Description

While working on PR #40139, I need to be able to get the result from `cypressWaitAll` which doesn't work as intended. Moreover, the response from `createQuestionAndAddToDashboard` was also incorrect when creating more than 1 question. So this took a lot of time to debug

The return value from `cypressWaitAll` should now yield the correct results.

### How to verify

1. Use `cypressWaitAll(yourCommand).then(results => console.log(results))` and you should see the results instead of `null`

### Checklist

- [ ] ~Tests have been added/updated to cover changes in this PR~ Only change the util, I hope no tests would fail though.

### Note
I fixed this another way, but with the same concept previously and all tests are green, now I just refactored it and wait for the CI to go green again.