### PR TITLE
dismiss without feedback for the embedding homepage

### DIFF
--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -8,6 +8,7 @@ import {
   expectNoBadSnowplowEvents,
   isEE,
   main,
+  popover,
   resetSnowplow,
   restore,
 } from "e2e/support/helpers";
@@ -319,20 +320,24 @@ describe("scenarios > setup", () => {
 
     cy.location("pathname").should("eq", "/");
 
-    // main().findByText("Embed Metabase in your app").should("exist");
+    main()
+      .findByText("Get started with Embedding Metabase in your app")
+      .should("exist");
 
-    // main()
-    //   .findByRole("link", { name: "Learn more" })
-    //   .should("have.attr", "href")
-    //   .and(
-    //     "match",
-    //     /https:\/\/www.metabase.com\/docs\/[^\/]*\/embedding\/start\.html\?utm_media=embed-minimal-homepage/,
-    //   );
+    // should persist page loads
+    cy.reload();
 
-    // cy.reload();
+    main()
+      .findByText("Get started with Embedding Metabase in your app")
+      .should("exist");
 
-    // // should only show up once
-    // main().findByText("Embed Metabase in your app").should("not.exist");
+    main().findByText("Hide these").realHover();
+
+    popover().findByText("Embedding done, all good").click();
+
+    main()
+      .findByText("Get started with Embedding Metabase in your app")
+      .should("not.exist");
   });
 });
 

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -1,14 +1,17 @@
 import { useMemo } from "react";
 
+import { updateSetting } from "metabase/admin/settings/settings";
 import { useSetting } from "metabase/common/hooks";
 import { getPlan } from "metabase/common/utils/plan";
-import { useSelector } from "metabase/lib/redux";
+import { useDispatch, useSelector } from "metabase/lib/redux";
 import { isEEBuild } from "metabase/lib/utils";
 import { getDocsUrl, getSetting } from "metabase/selectors/settings";
 
 import { EmbedHomepageView } from "./EmbedHomepageView";
+import type { EmbedHomepageDismissReason } from "./types";
 
 export const EmbedHomepage = () => {
+  const dispatch = useDispatch();
   const embeddingAutoEnabled = useSetting("setup-embedding-autoenabled");
   const licenseActiveAtSetup = useSetting("setup-license-active-at-setup");
   const exampleDashboardId = undefined; // will come from a setting
@@ -47,8 +50,13 @@ export const EmbedHomepage = () => {
     return "static";
   }, [plan]);
 
+  const onDismiss = (reason: EmbedHomepageDismissReason) => {
+    dispatch(updateSetting({ key: "embedding-homepage", value: reason }));
+  };
+
   return (
     <EmbedHomepageView
+      onDismiss={onDismiss}
       exampleDashboardId={exampleDashboardId}
       embeddingAutoEnabled={embeddingAutoEnabled}
       licenseActiveAtSetup={licenseActiveAtSetup}

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -2,16 +2,27 @@ import { Link } from "react-router";
 import { jt, t } from "ttag";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
-import { Anchor, Card, Group, Stack, Tabs, Text, Title } from "metabase/ui";
+import {
+  Anchor,
+  Card,
+  Group,
+  Menu,
+  Stack,
+  Tabs,
+  Text,
+  Title,
+} from "metabase/ui";
 
 import { InteractiveTabContent } from "./InteractiveTabContent";
 import { StaticTabContent } from "./StaticTabContent";
+import type { EmbedHomepageDismissReason } from "./types";
 
 export type EmbedHomepageViewProps = {
   embeddingAutoEnabled: boolean;
   exampleDashboardId?: number;
   licenseActiveAtSetup: boolean;
   defaultTab: "interactive" | "static";
+  onDismiss: (reason: EmbedHomepageDismissReason) => void;
   // links
   interactiveEmbeddingQuickstartUrl: string;
   embeddingDocsUrl: string;
@@ -26,12 +37,33 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
     defaultTab,
     embeddingDocsUrl,
     analyticsDocsUrl,
+    onDismiss,
   } = props;
   return (
     <Stack maw={550}>
-      <Group>
+      <Group position="apart">
         {/*  eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
         <Text fw="bold">{t`Get started with Embedding Metabase in your app`}</Text>
+        <Menu trigger="hover">
+          <Menu.Target>
+            <Text
+              fw="bold"
+              color="brand"
+              style={{ cursor: "default" }}
+            >{t`Hide these`}</Text>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item
+              onClick={() => onDismiss("dismissed-done")}
+            >{t`Embedding done, all good`}</Menu.Item>
+            <Menu.Item
+              onClick={() => onDismiss("dismissed-run-into-issues")}
+            >{t`I ran into issues`}</Menu.Item>
+            <Menu.Item
+              onClick={() => onDismiss("dismissed-run-into-issues")}
+            >{t`I'm not interested right now`}</Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
       </Group>
       <Card px="xl" py="lg">
         {/* eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -1,3 +1,6 @@
+import userEvent from "@testing-library/user-event";
+import fetchMock from "fetch-mock";
+
 import { screen } from "__support__/ui";
 
 import { setup } from "./setup";
@@ -45,5 +48,22 @@ describe("EmbedHomepage (OSS)", () => {
     expect(
       screen.getByText("Embedding has been automatically enabled for you"),
     ).toBeInTheDocument();
+  });
+
+  it("should set 'embedding-homepage' to 'dismissed-done' when dismissing as done", async () => {
+    setup();
+    userEvent.hover(screen.getByText("Hide these"));
+
+    userEvent.click(screen.getByText("Embedding done, all good"));
+
+    const lastCall = fetchMock.lastCall(
+      "path:/api/setting/embedding-homepage",
+      {
+        method: "PUT",
+      },
+    );
+
+    const body = await lastCall?.request?.json();
+    expect(body).toEqual({ value: "dismissed-done" });
   });
 });

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
@@ -1,7 +1,17 @@
+import fetchMock from "fetch-mock";
+
 import { setupEnterprisePlugins } from "__support__/enterprise";
+import {
+  setupPropertiesEndpoints,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
 import { renderWithProviders } from "__support__/ui";
 import type { Settings, TokenFeatures } from "metabase-types/api";
-import { createMockTokenFeatures } from "metabase-types/api/mocks";
+import {
+  createMockSettings,
+  createMockTokenFeatures,
+  createMockSettingDefinition,
+} from "metabase-types/api/mocks";
 import {
   createMockSettingsState,
   createMockState,
@@ -21,6 +31,10 @@ export async function setup({
   settings = {},
 }: SetupOpts = {}) {
   jest.clearAllMocks();
+
+  fetchMock.put("path:/api/setting/embedding-homepage", 200);
+  setupSettingsEndpoints([createMockSettingDefinition()]);
+  setupPropertiesEndpoints(createMockSettings());
 
   const state = createMockState({
     settings: createMockSettingsState({

--- a/frontend/src/metabase/home/components/EmbedHomepage/types.ts
+++ b/frontend/src/metabase/home/components/EmbedHomepage/types.ts
@@ -1,0 +1,6 @@
+import type { Settings } from "metabase-types/api";
+
+export type EmbedHomepageDismissReason = Exclude<
+  Settings["embedding-homepage"],
+  "visible" | "hidden"
+>;


### PR DESCRIPTION
Part of  [[Epic] Initial homepage experience for embedding admins](https://github.com/metabase/metabase/issues/40005)

This is stacked on top of [connect settings to the embed homepage and show it (+262 −37)](https://github.com/metabase/metabase/pull/40528)


## Description

This adds the possibility to dismiss the embedding homepage


## Demo

https://github.com/metabase/metabase/assets/1914270/9b27377b-32a3-46ae-9676-3673bb82cf7a

