### PR TITLE
Sort official collections first in API endpoints

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -98,7 +98,8 @@
                         :id
                         (collection/permissions-set->visible-collection-ids permissions-set))]
                ;; Order NULL collection types first so that audit collections are last
-               :order-by [[[[:case [:= :type nil] 0 :else 1]] :asc]
+               :order-by [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
+                          [[[:case [:= :type nil] 0 :else 1]] :asc]
                           [:%lower.name :asc]]})
    exclude-other-user-collections (remove-other-users-personal-subcollections api/*current-user-id*)))
 
@@ -712,7 +713,8 @@
   treatment of nulls in the different app db types."
   [sort-info db-type]
   ;; always put "Metabase Analytics" last
-  (into [[[[:case [:= :collection_type nil] 0 :else 1]] :asc]]
+  (into [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
+         [[[:case [:= :collection_type nil] 0 :else 1]] :asc]]
         (case sort-info
           nil                     [[:%lower.name :asc]]
           [:name :asc]            [[:%lower.name :asc]]

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1001,29 +1001,34 @@
   ;; we always place "special" collection types (i.e. "Metabase Analytics") last
   (testing "Default sort"
     (doseq [app-db [:mysql :h2 :postgres]]
-      (is (= [[[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+      (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
+              [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
               [:%lower.name :asc]]
              (api.collection/children-sort-clause nil app-db)))))
   (testing "Sorting by last-edited-at"
-    (is (= [[[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+    (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
+            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
             [:%isnull.last_edit_timestamp]
             [:last_edit_timestamp :asc]
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:last-edited-at :asc] :mysql)))
-    (is (= [[[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+    (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
+            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
             [:last_edit_timestamp :nulls-last]
             [:last_edit_timestamp :asc]
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:last-edited-at :asc] :postgres))))
   (testing "Sorting by last-edited-by"
-    (is (= [[[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+    (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
+            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
             [:last_edit_last_name :nulls-last]
             [:last_edit_last_name :asc]
             [:last_edit_first_name :nulls-last]
             [:last_edit_first_name :asc]
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:last-edited-by :asc] :postgres)))
-    (is (= [[[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+    (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
+            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
             [:%isnull.last_edit_last_name]
             [:last_edit_last_name :asc]
             [:%isnull.last_edit_first_name]
@@ -1031,11 +1036,13 @@
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:last-edited-by :asc] :mysql))))
   (testing "Sortinb by model"
-    (is (= [[[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+    (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
+            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
             [:model_ranking :asc]
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:model :asc] :postgres)))
-    (is (= [[[[:case [:= :collection_type nil] 0 :else 1]] :asc]
+    (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
+            [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
             [:model_ranking :desc]
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:model :desc] :mysql)))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -1035,7 +1035,7 @@
             [:last_edit_first_name :asc]
             [:%lower.name :asc]]
            (api.collection/children-sort-clause [:last-edited-by :asc] :mysql))))
-  (testing "Sortinb by model"
+  (testing "Sorting by model"
     (is (= [[[[:case [:= :authority_level "official"] 0 :else 1]] :asc]
             [[[:case [:= :collection_type nil] 0 :else 1]] :asc]
             [:model_ranking :asc]


### PR DESCRIPTION
For both `/api/collection/tree` and `/api/collection/items`, sort collections with official collections coming first.