### PR TITLE
Use MLv2 to determine whether a query can be previewed

### DIFF
--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -684,7 +684,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     cy.log(
       "Preview should not be possible without the source data (metabase#40608)",
     );
-    cy.findByTestId("step-data-0-0")
+    getNotebookStep("data")
       .as("dataStep")
       .within(() => {
         cy.findByText("Pick your starting data").should("exist");
@@ -695,8 +695,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     cy.get("@dataStep").icon("play").should("not.be.visible");
     popover().findByTextEnsureVisible("Orders").click();
 
-    cy.findByTestId("step-filter-0-0").icon("play").should("not.be.visible");
-    cy.findByTestId("step-summarize-0-0").icon("play").should("not.be.visible");
+    getNotebookStep("filter").icon("play").should("not.be.visible");
+    getNotebookStep("summarize").icon("play").should("not.be.visible");
 
     cy.get("@dataStep").within(() => {
       cy.icon("play").click();
@@ -708,7 +708,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
 
     cy.button("Row limit").click();
-    cy.findByTestId("step-limit-0-0").within(() => {
+    getNotebookStep("limit").within(() => {
       cy.findByPlaceholderText("Enter a limit").type("5").realPress("Tab");
 
       cy.icon("play").click();

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -695,6 +695,9 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     cy.get("@dataStep").icon("play").should("not.be.visible");
     popover().findByTextEnsureVisible("Orders").click();
 
+    cy.findByTestId("step-filter-0-0").icon("play").should("not.be.visible");
+    cy.findByTestId("step-summarize-0-0").icon("play").should("not.be.visible");
+
     cy.get("@dataStep").within(() => {
       cy.icon("play").click();
       assertTableRowCount(10);

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -684,18 +684,18 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     cy.log(
       "Preview should not be possible without the source data (metabase#40608)",
     );
-    cy.findByTestId("step-data-0-0").within(() => {
-      cy.findByText("Pick your starting data").should("exist");
-      cy.icon("play").should("not.be.visible");
-    });
+    cy.findByTestId("step-data-0-0")
+      .as("dataStep")
+      .within(() => {
+        cy.findByText("Pick your starting data").should("exist");
+        cy.icon("play").should("not.be.visible");
+      });
 
-    popover().within(() => {
-      cy.findByTextEnsureVisible("Raw Data").click();
-      cy.icon("play").should("not.be.visible");
-      cy.findByTextEnsureVisible("Orders").click();
-    });
+    popover().findByTextEnsureVisible("Raw Data").click();
+    cy.get("@dataStep").icon("play").should("not.be.visible");
+    popover().findByTextEnsureVisible("Orders").click();
 
-    cy.findByTestId("step-data-0-0").within(() => {
+    cy.get("@dataStep").within(() => {
       cy.icon("play").click();
       assertTableRowCount(10);
       cy.findByTextEnsureVisible("Subtotal");

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -678,8 +678,22 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
   });
 
-  it("should properly render previews (metabase#28726), (metabase#29959)", () => {
-    openOrdersTable({ mode: "notebook" });
+  it("should properly render previews (metabase#28726, metabase#29959, metabase#40608)", () => {
+    startNewQuestion();
+
+    cy.log(
+      "Preview should not be possible without the source data (metabase#40608)",
+    );
+    cy.findByTestId("step-data-0-0").within(() => {
+      cy.findByText("Pick your starting data").should("exist");
+      cy.icon("play").should("not.be.visible");
+    });
+
+    popover().within(() => {
+      cy.findByTextEnsureVisible("Raw Data").click();
+      cy.findByTextEnsureVisible("Orders").click();
+    });
+
     cy.findByTestId("step-data-0-0").within(() => {
       cy.icon("play").click();
       assertTableRowCount(10);
@@ -691,12 +705,12 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
     cy.button("Row limit").click();
     cy.findByTestId("step-limit-0-0").within(() => {
-      cy.findByPlaceholderText("Enter a limit").type("5").blur();
+      cy.findByPlaceholderText("Enter a limit").type("5").realPress("Tab");
 
       cy.icon("play").click();
       assertTableRowCount(5);
 
-      cy.findByDisplayValue("5").type("{selectall}50").blur();
+      cy.findByDisplayValue("5").type("{selectall}50").realPress("Tab");
       cy.button("Refresh").click();
       assertTableRowCount(10);
     });

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -691,6 +691,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
     popover().within(() => {
       cy.findByTextEnsureVisible("Raw Data").click();
+      cy.icon("play").should("not.be.visible");
       cy.findByTextEnsureVisible("Orders").click();
     });
 

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -9,6 +9,7 @@ import { useToggle } from "metabase/hooks/use-toggle";
 import { color as c } from "metabase/lib/colors";
 import { Icon } from "metabase/ui";
 import type { Query } from "metabase-lib";
+import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 
 import NotebookStepPreview from "../NotebookStepPreview";
@@ -105,7 +106,7 @@ function NotebookStep({
   } = STEP_UI[step.type] || {};
 
   const color = getColor();
-  const canPreview = Boolean(step.getPreviewQuery);
+  const canPreview = Lib.canRun(step.query);
   const hasPreviewButton = !isPreviewOpen && canPreview;
   const canRevert = typeof step.revert === "function" && !readOnly;
 

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -106,7 +106,7 @@ function NotebookStep({
   } = STEP_UI[step.type] || {};
 
   const color = getColor();
-  const canPreview = Lib.canRun(step.query);
+  const canPreview = Lib.canRun(step.query) && step.active && step.visible;
   const hasPreviewButton = !isPreviewOpen && canPreview;
   const canRevert = typeof step.revert === "function" && !readOnly;
 


### PR DESCRIPTION
### What does this PR accomplish?

It fixes #40608 by determining whether the query can run as a precondition to showing the preview button.

### How to verify
1. Start a new question
2. Make sure that the preview button doesn't exist before you select a data source

or

Run a provided E2E reproduction.

### Demo
![Kapture 2024-04-02 at 21 15 58](https://github.com/metabase/metabase/assets/31325167/180f8725-a8fe-4fa3-b0ec-41a81b02aae5)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
