### PR TITLE
Use transaction for CSV replacement atomicity

### DIFF
--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -9,9 +9,15 @@ title: Driver interface changelog
 - The Metabase `metabase.mbql.*` namespaces have been moved to `metabase.legacy-mbql.*`. You probably didn't need to
   use these namespaces in your driver, but if you did, please update them.
 
-- The multimethod `metabase.driver/truncate!` has been added. This method is used to delete a table's rows in the most
-  efficient way possible. This is currently only required for drivers that support the `:uploads` feature, and has
-  a default implementation for JDBC-based drivers.
+- The multimethod `metabase.driver/delete!` has been added. This method is used to delete rows from a table.
+  This is currently only required for drivers that support the `:uploads` feature, and has a default implementation for
+  JDBC-based drivers. Implementations should support transactions if relevant for the given driver.
+
+- The multimethod `metabase.driver/with-transaction*` has been added. This method is used to create a scope within
+  which querying and mutating the contents of tables will be done atomically.
+  This is currently only relevant to drivers that support the `:uploads` feature, and has a default implementation for
+  JDBC-based drivers. The method is optional, but will improve the user experience when dealing with failing or
+  concurrent operations on uploaded tables.
 
 ## Metabase 0.49.1
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -940,13 +940,26 @@
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 
-(defmulti truncate!
+(defmulti with-transaction*
+  "Executes the given thunk within a transaction, if the given driver supports transactions."
+  {:added "0.50.0", :arglists '([driver db-id thunk])}
+  dispatch-on-initialized-driver
+  :hierarchy #'hierarchy)
+
+(defmethod with-transaction* ::driver [_ _ thunk]
+  (thunk nil))
+
+(defmacro with-transaction
+  "Executes the given body within a transaction, if the given driver supports transactions."
+  {:added "0.50.0", :arglists '([driver db-id & body])}
+  [driver db-id & body]
+  `(with-transaction* ~driver ~db-id (fn [_conn#] ~@body)))
+
+(defmulti delete!
   "Delete the current contents of `table-name`.
-  If something like a SQL TRUNCATE statement is supported, we use that, but may otherwise fall back to explicitly
-  deleting rows, or dropping and recreating the table.
-  Depending on the driver, the semantics can vary on whether triggers are fired, AUTO_INCREMENT is reset etc.
-  The application assumes that the implementation can be rolled back if inside a transaction."
-  {:added "0.50.0", :arglists '([driver db-id table-name])}
+  Currently only supports fully truncating the query, but may introduce support for restricting the scope in future.
+  If the driver supports transactions, then it must support this operation being run within a transaction."
+  {:added "0.50.0", :arglists '([driver db-id table-name & args])}
   dispatch-on-initialized-driver
   :hierarchy #'hierarchy)
 

--- a/src/metabase/driver.clj
+++ b/src/metabase/driver.clj
@@ -947,13 +947,13 @@
   :hierarchy #'hierarchy)
 
 (defmethod with-transaction* ::driver [_ _ thunk]
-  (thunk nil))
+  (thunk))
 
 (defmacro with-transaction
   "Executes the given body within a transaction, if the given driver supports transactions."
   {:added "0.50.0", :arglists '([driver db-id & body])}
   [driver db-id & body]
-  `(with-transaction* ~driver ~db-id (fn [_conn#] ~@body)))
+  `(with-transaction* ~driver ~db-id (fn [] ~@body)))
 
 (defmulti delete!
   "Delete the current contents of `table-name`.

--- a/src/metabase/driver/sql_jdbc.clj
+++ b/src/metabase/driver/sql_jdbc.clj
@@ -150,7 +150,10 @@
 
 (def ^:private ^:dynamic *tx-connections* {})
 
-(defn- local-conn [db-id]
+(defn- local-conn
+  "If called with a transaction for the given database in dynamic scope, return the corresponding connection.
+  Otherwise, return a non-transactional connection."
+  [db-id]
   (or (get *tx-connections* db-id)
       (sql-jdbc.conn/db->pooled-connection-spec db-id)))
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -808,14 +808,14 @@
                                   :generated-columns (if create-auto-pk? 1 0)
                                   :size-mb           (file-size-mb file)
                                   :upload-seconds    (since-ms timer)}
+              db-id              (:id database)
               table-name         (table-identifier table)]
 
           (try
-            (let [db-id (:id database)]
-              (driver/with-transaction driver db-id
-                (when replace-rows?
-                  (driver/delete! driver db-id table-name))
-                (driver/insert-into! driver db-id table-name normed-header parsed-rows)))
+            (driver/with-transaction driver db-id
+              (when replace-rows?
+                (driver/delete! driver db-id table-name))
+              (driver/insert-into! driver db-id table-name normed-header parsed-rows))
             (catch Throwable e
               (throw (ex-info (ex-message e) {:status-code 422}))))
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -807,12 +807,15 @@
                                   :num-columns       (count new-types)
                                   :generated-columns (if create-auto-pk? 1 0)
                                   :size-mb           (file-size-mb file)
-                                  :upload-seconds    (since-ms timer)}]
+                                  :upload-seconds    (since-ms timer)}
+              table-name         (table-identifier table)]
 
           (try
-            (when replace-rows?
-              (driver/truncate! driver (:id database) (table-identifier table)))
-            (driver/insert-into! driver (:id database) (table-identifier table) normed-header parsed-rows)
+            (let [db-id (:id database)]
+              (driver/with-transaction driver db-id
+                (when replace-rows?
+                  (driver/delete! driver db-id table-name))
+                (driver/insert-into! driver db-id table-name normed-header parsed-rows)))
             (catch Throwable e
               (throw (ex-info (ex-message e) {:status-code 422}))))
 


### PR DESCRIPTION
Refers https://github.com/metabase/metabase/issues/38788

### Description

This introduces an over-arching transaction when replacing Upload tables, so that any failures during insertion will rollback the preceding truncation.