### PR TITLE
Resolve crash due to missing stageIndex parameter in available-metrics

### DIFF
--- a/e2e/support/helpers/index.js
+++ b/e2e/support/helpers/index.js
@@ -36,4 +36,3 @@ export * from "./e2e-models-metadata-helpers";
 export * from "./e2e-ui-elements-overflow-helpers";
 export * from "./e2e-relative-date-picker-helpers";
 export * from "./e2e-command-palette-helpers";
-export * from "./e2e-table-metadata-helpers";

--- a/e2e/support/helpers/index.js
+++ b/e2e/support/helpers/index.js
@@ -36,3 +36,4 @@ export * from "./e2e-models-metadata-helpers";
 export * from "./e2e-ui-elements-overflow-helpers";
 export * from "./e2e-relative-date-picker-helpers";
 export * from "./e2e-command-palette-helpers";
+export * from "./e2e-table-metadata-helpers";

--- a/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -264,7 +264,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
     it("should save the metric using custom expressions (metabase#13022)", () => {
       createMetric({
         name: "13022_Metric",
-        desription: "desc",
+        description: "desc",
         table_id: ORDERS_ID,
         definition: {
           "source-table": ORDERS_ID,

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -22,8 +22,9 @@ import {
   summarize,
   visitQuestionAdhoc,
   visualize,
-  createMetric,
+  createQuestion,
 } from "e2e/support/helpers";
+import { createMetric } from "e2e/support/helpers/e2e-table-metadata-helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
   SAMPLE_DATABASE;
@@ -799,10 +800,8 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
         aggregation: [["sum", ["field", ORDERS.SUBTOTAL, null]]],
       },
     }).then(({ body }) => {
-      cy.wrap(body.id).as("metricId");
-    });
+      const metricId = body.id;
 
-    cy.get("@metricId").then(metricId => {
       const questionDetails = {
         query: {
           "source-table": ORDERS_ID,
@@ -810,16 +809,15 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
           aggregation: [["metric", metricId]],
         },
       };
-      cy.createQuestion(questionDetails, { visitQuestion: true });
+
+      createQuestion(questionDetails, { visitQuestion: true });
     });
 
     openNotebook();
 
     getNotebookStep("summarize").contains("Revenue").click();
 
-    popover().within(() => {
-      cy.findByTestId("expression-editor-textfield").contains("[Revenue]");
-    });
+    popover().findByTestId("expression-editor-textfield").contains("[Revenue]");
   });
 });
 

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -22,6 +22,7 @@ import {
   summarize,
   visitQuestionAdhoc,
   visualize,
+  createMetric,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PEOPLE_ID, PRODUCTS, PRODUCTS_ID } =
@@ -632,12 +633,6 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
 
     it("should support custom columns", () => {
-      // startNewQuestion();
-      // popover().within(() => {
-      //   cy.findByText("QA Postgres12").click();
-      //   cy.findByText("Products").click();
-      // });
-
       addCustomColumn();
       enterCustomColumnDetails({
         formula: "Price * 10",
@@ -670,12 +665,6 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
     });
 
     it("should support Summarize side panel", () => {
-      // startNewQuestion();
-      // popover().within(() => {
-      //   cy.findByText("QA Postgres12").click();
-      //   cy.findByText("Products").click();
-      // });
-
       visualize();
 
       summarize();
@@ -797,6 +786,39 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       name: "ID is 1",
       index: 1,
       horizontal: -100,
+    });
+  });
+
+  it("should not crash notebook when metric is used as an aggregation and breakout is applied (metabase#40553)", () => {
+    createMetric({
+      name: "Revenue",
+      description: "Sum of orders subtotal",
+      table_id: ORDERS_ID,
+      definition: {
+        "source-table": ORDERS_ID,
+        aggregation: [["sum", ["field", ORDERS.SUBTOTAL, null]]],
+      },
+    }).then(({ body }) => {
+      cy.wrap(body.id).as("metricId");
+    });
+
+    cy.get("@metricId").then(metricId => {
+      const questionDetails = {
+        query: {
+          "source-table": ORDERS_ID,
+          breakout: [["field", ORDERS.CREATED_AT, null]],
+          aggregation: [["metric", metricId]],
+        },
+      };
+      cy.createQuestion(questionDetails, { visitQuestion: true });
+    });
+
+    openNotebook();
+
+    getNotebookStep("summarize").contains("Revenue").click();
+
+    popover().within(() => {
+      cy.findByTestId("expression-editor-textfield").contains("[Revenue]");
     });
   });
 });

--- a/frontend/src/metabase-lib/metrics.ts
+++ b/frontend/src/metabase-lib/metrics.ts
@@ -3,8 +3,11 @@ import type { MetricId } from "metabase-types/api";
 
 import type { MetricMetadata, Query } from "./types";
 
-export function availableMetrics(query: Query): MetricMetadata[] {
-  return ML.available_metrics(query);
+export function availableMetrics(
+  query: Query,
+  stageIndex: number,
+): MetricMetadata[] {
+  return ML.available_metrics(query, stageIndex);
 }
 
 export function metricMetadata(

--- a/frontend/src/metabase-lib/v1/expressions/format.ts
+++ b/frontend/src/metabase-lib/v1/expressions/format.ts
@@ -135,7 +135,7 @@ function formatMetric([, metricId]: FieldReference, options: Options) {
     throw new Error("`query` is a required parameter to format expressions");
   }
 
-  const metric = Lib.availableMetrics(query).find(metric => {
+  const metric = Lib.availableMetrics(query, stageIndex).find(metric => {
     const [_, availableMetricId] = Lib.legacyRef(query, stageIndex, metric);
 
     return availableMetricId === metricId;

--- a/frontend/src/metabase-lib/v1/expressions/format.ts
+++ b/frontend/src/metabase-lib/v1/expressions/format.ts
@@ -142,7 +142,7 @@ function formatMetric([, metricId]: FieldReference, options: Options) {
   });
 
   if (!metric) {
-    throw "metric with ID does not exist: " + metricId;
+    throw new Error(`metric with ID: ${metricId} does not exist`);
   }
 
   const displayInfo = Lib.displayInfo(query, stageIndex, metric);
@@ -158,9 +158,11 @@ function formatLegacyMetric(
   const metric = _.findWhere(checkNotNull(legacyQuery.table()).metrics ?? [], {
     id: metricId,
   });
+
   if (!metric) {
-    throw "metric with ID does not exist: " + metricId;
+    throw new Error(`metric with ID: "${metricId}" does not exist`);
   }
+
   return formatMetricName(metric.name, options);
 }
 
@@ -184,7 +186,7 @@ function formatSegment([, segmentId]: FieldReference, options: Options) {
   });
 
   if (!segment) {
-    throw "segment with ID does not exist: " + segmentId;
+    throw new Error("segment with ID does not exist: " + segmentId);
   }
 
   const displayInfo = Lib.displayInfo(query, stageIndex, segment);
@@ -202,7 +204,7 @@ function formatLegacySegment(
     { id: Number(segmentId) },
   );
   if (!segment) {
-    throw "segment with ID does not exist: " + segmentId;
+    throw new Error("segment with ID does not exist: " + segmentId);
   }
   return formatSegmentName(segment.name, options);
 }

--- a/frontend/src/metabase-lib/v1/expressions/index.ts
+++ b/frontend/src/metabase-lib/v1/expressions/index.ts
@@ -68,7 +68,7 @@ export function parseMetric(
   metricName: string,
   { query, stageIndex }: { query: Lib.Query; stageIndex: number },
 ) {
-  const metrics = Lib.availableMetrics(query);
+  const metrics = Lib.availableMetrics(query, stageIndex);
 
   const metric = metrics.find(metric => {
     const displayInfo = Lib.displayInfo(query, stageIndex, metric);

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -198,7 +198,7 @@ export function suggest({
     }
 
     if (startRule === "aggregation") {
-      const metrics = Lib.availableMetrics(query);
+      const metrics = Lib.availableMetrics(query, stageIndex);
 
       if (metrics) {
         suggestions.push(

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -89,7 +89,7 @@ export function AggregationPicker({
   const sections = useMemo(() => {
     const sections: Section[] = [];
 
-    const metrics = Lib.availableMetrics(query);
+    const metrics = Lib.availableMetrics(query, stageIndex);
     const databaseId = Lib.databaseID(query);
     const database = metadata.database(databaseId);
     const canUseExpressions = database?.hasFeature("expression-aggregations");

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1024,8 +1024,8 @@
 (defn ^:export available-metrics
   "Get a list of Metrics that you may consider using as aggregations for a query. Returns JS array of opaque Metric
   metadata objects."
-  [a-query]
-  (to-array (lib.core/available-metrics a-query)))
+  [a-query stage-number]
+  (to-array (lib.core/available-metrics a-query stage-number)))
 
 (defn ^:export joinable-columns
   "Return information about the fields that you can pass to [[with-join-fields]] when constructing a join against


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/40553

The problem was that we didn't pass the `stage-number` to `available-metrics`. `available-metrics` by default used the index of the last stage in the query, which results in an empty array in all cases where the query has more than 1 stage.

<img width="793" alt="Screenshot 2024-03-26 at 13 40 09" src="https://github.com/metabase/metabase/assets/8542534/444873a2-42c7-4fa2-ba0b-f1f9415aae9b">

### How to verify
- create a new question (e.g. Orders table) and create a new metric if you don't have any
- use your metric as an aggregation, use any breakout (e.g. created at)
- now click again on metric from aggregation - UI shouldn't crash, you must see a popover opened with your metric in the popover


https://github.com/metabase/metabase/assets/125459446/f20a2d41-2d57-41cc-a1f4-3ed7a13c9a8a

### Tests

One e2e test is included, it covers:
- metric is available and correct when you want to use it for Aggregation
- metric is available and correct when you want to change already applied Aggregation 