### PR TITLE
Allow group managers to view all people

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/user_test.clj
@@ -2,18 +2,52 @@
   "Tests that would logically be included in `metabase.api.user-test` but are separate as they are enterprise only."
   (:require
    [clojure.test :refer :all]
+   [metabase-enterprise.test :as met]
    [metabase.test :as mt]
    [metabase.test.fixtures :as fixtures]
+   [metabase.util :as u]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (use-fixtures :once (fixtures/initialize :test-users-personal-collections))
 
+;; Non-segmented users are allowed to ask for a list of all of the users in the Metabase instance. Pulse email lists
+;; are an example usage of this. Segmented users should not have that ability. Instead they should only see
+;; themselves. This test checks that GET /api/user/recipients for a segmented user only returns themselves, including
+;; for Permissions Group Managers.
+(deftest segmented-user-list-test
+  (testing "GET /api/user/recipients"
+    (testing "sanity check: normally returns more than just me"
+      (is (seq (disj (->> (mt/user-http-request :rasta :get 200 "user/recipients")
+                          :data
+                          (map :email)
+                          set)
+                     "rasta@metabase.com"))))
+    (testing "a sandboxed user will see only themselves"
+      (met/with-gtaps! {:gtaps {:venues {}}}
+        (is (= ["rasta@metabase.com"]
+               (->> (mt/user-http-request :rasta :get 200 "user/recipients")
+                    :data
+                    (map :email))))
+        (testing "... even if they are a group manager"
+          (mt/with-premium-features #{:advanced-permissions :sandboxes}
+            (mt/with-group [group {:name "a group"}]
+              (let [membership (t2/select-one :model/PermissionsGroupMembership
+                                              :group_id (u/the-id group)
+                                              :user_id (mt/user->id :rasta))]
+                (t2/update! :model/PermissionsGroupMembership :id (:id membership)
+                            {:is_group_manager true}))
+              (let [result (mt/user-http-request :rasta :get 200 "user/recipients")]
+                (is (= ["rasta@metabase.com"]
+                       (map :email (:data result))))
+                (is (= 1 (count (:data result))))
+                (is (= 1 (:total result)))))))))))
+
 (deftest get-user-attributes-test
-  (testing "requires sandbox enabled"
-    (mt/with-premium-features #{}
+  (mt/with-premium-features #{}
+    (testing "requires sandbox enabled"
       (is (= "Sandboxes is a paid feature not currently available to your instance. Please upgrade to use it. Learn more at metabase.com/upgrade/"
-           (mt/user-http-request :crowberto :get 402 "mt/user/attributes")))))
+             (mt/user-http-request :crowberto :get 402 "mt/user/attributes")))))
 
   (mt/with-premium-features #{:sandboxes}
     (testing "requires admin"

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -266,7 +266,7 @@
     (cond
       ;; if they're sandboxed OR if they're a superuser, ignore the setting and just give them nothing or everything,
       ;; respectively.
-      (premium-features/sandboxed-or-impersonated-user?)
+      (premium-features/sandboxed-user?)
       (just-me)
 
       api/*is-superuser?*

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -128,24 +128,22 @@
                  (mt/user-http-request :rasta :get 403 "user" :group_id group-id2))))
         (if config/ee-available?
           ;; Group management is an EE feature
-          (testing "manager can get users from their groups"
-            (is (= #{"lucky@metabase.com"
-                     "rasta@metabase.com"}
-                   (->> ((mt/user-http-request :rasta :get 200 "user" :group_id group-id1) :data)
-                        (filter mt/test-user?)
-                        (map :email)
-                        set)))
-            (is (= #{"lucky@metabase.com"
-                     "rasta@metabase.com"}
-                   (->> ((mt/user-http-request :rasta :get 200 "user") :data)
-                        (filter mt/test-user?)
-                        (map :email)
-                        set)))
-            (testing "see users from all groups the user manages"
+          (do
+            (testing "manager can get all users in their group"
+              (is (= #{"lucky@metabase.com"
+                       "rasta@metabase.com"}
+                     (->> ((mt/user-http-request :rasta :get 200 "user" :group_id group-id1) :data)
+                          (filter mt/test-user?)
+                          (map :email)
+                          set))))
+            (testing "manager can't get all users in another group"
+              (is (= "You don't have permissions to do that."
+                     (mt/user-http-request :rasta :get 403 "user" :group_id group-id2))))
+            (testing "manager can get all users"
               (is (= #{"lucky@metabase.com"
                        "rasta@metabase.com"
                        "crowberto@metabase.com"}
-                     (->> ((mt/user-http-request :lucky :get 200 "user") :data)
+                     (->> ((mt/user-http-request :rasta :get 200 "user") :data)
                           (filter mt/test-user?)
                           (map :email)
                           set)))))


### PR DESCRIPTION
Fixes #40328

[Our documentation](https://www.metabase.com/docs/latest/people-and-groups/managing#group-managers) states that:

> Group managers can:
>
> - View all people in the Admin settings > People tab.

This fixes enforcement to be aligned with the documentation. This behavior makes sense, because as the docs also state, Group Managers should be allowed to *add* people to the group they manage, which they can only do if they can see those people!

The first commit also removed a faulty test, which was described as:
```
;; Non-segmented users are allowed to ask for a list of all of the users in the Metabase instance. Pulse email lists
;; are an example usage of this. Segmented users should not have that ability. Instead they should only see
;; themselves. This test checks that GET /api/user for a segmented user only returns themselves
```

but actually failed to test this in a relevant way (because it was testing the `GET /api/user` endpoint rather than the `GET /api/user/recipients` endpoint). The test had continued to pass only because the user was the only member of the group they managed.

I initially thought this behavior wasn't desired, but as it turns out, it *is* in fact documented behavior to disallow sandboxed users from seeing any email suggestions. Investigating, I found that a bug was allowing sandboxed users to see all users on the `/api/user/recipients` endpoint if the user-visibility setting was set to `:all`.

Thus, the second commit fixes the bug and re-adds the (fixed) test. A sandboxed user now only sees their own user when hitting `/api/user/recipients`.
