### PR TITLE
fix normalized chart crashes when trend lines enabled but there is no insights data

### DIFF
--- a/frontend/src/metabase/visualizations/lib/trends.js
+++ b/frontend/src/metabase/visualizations/lib/trends.js
@@ -33,6 +33,9 @@ function computeExpression(node, x) {
 const msToDays = ms => ms / (24 * 60 * 60 * 1000);
 
 export function getNormalizedStackedTrendDatas(trendDatas) {
+  if (trendDatas.length === 0) {
+    return [];
+  }
   const count = trendDatas[0].length;
   const sums = _.range(count).map(i =>
     trendDatas.reduce((sum, trendData) => sum + trendData[i][1], 0),

--- a/frontend/src/metabase/visualizations/lib/trends.unit.spec.js
+++ b/frontend/src/metabase/visualizations/lib/trends.unit.spec.js
@@ -36,4 +36,8 @@ describe("getNormalizedStackedTrendDatas", () => {
       ]),
     ]);
   });
+
+  it("should return an empty array when there is no trend data", () => {
+    expect(getNormalizedStackedTrendDatas([])).toStrictEqual([]);
+  });
 });


### PR DESCRIPTION
### Description

Trend lines are built from `insights` data coming with the query dataset from BE. However, it is not present on charts with breakouts, but `trends.js` did not handle this case well.

[Slack report](https://metaboat.slack.com/archives/C05MPF0TM3L/p1711369889828309)

### How to verify

- New question -> Orders by Created At: month
- Enable trend line
- Add another summarization dimension: Product -> Category
- Make it an area chart and enable stacking: "Stack – 100%"
- The chart should not be broken

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
