### PR TITLE
Add types for CSS modules 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -95,7 +95,9 @@
         ]
       }
     ],
-    "complexity": ["error", { "max": 54 }]
+    "complexity": ["error", { "max": 54 }],
+    "postcss-modules/no-unused-class": "off",
+    "postcss-modules/no-undef-class": "error"
   },
   "globals": {
     "before": true,
@@ -118,7 +120,8 @@
     "plugin:react-hooks/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:import/typescript"
+    "plugin:import/typescript",
+    "plugin:postcss-modules/recommended"
   ],
   "settings": {
     "import/internal-regex": "^metabase/|^metabase-lib/",
@@ -130,6 +133,9 @@
     "import/ignore": ["\\.css$"],
     "react": {
       "version": "detect"
+    },
+    "postcss-modules": {
+      "baseDir": "./frontend/src"
     }
   },
   "parserOptions": {

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.tsx
@@ -7,7 +7,7 @@ import Breadcrumbs from "metabase/components/Breadcrumbs";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import AdminS from "metabase/css/admin.module.css";
-import CS from "metabase/css/index.module.css";
+import CS from "metabase/css/core/index.css";
 import { formatDateTimeWithUnit } from "metabase/lib/formatting/date";
 import { Stack, Title, Text, Button, Group, Icon } from "metabase/ui";
 import { getThemeOverrides } from "metabase/ui/theme";

--- a/frontend/src/metabase/css/core/bordered.module.css
+++ b/frontend/src/metabase/css/core/bordered.module.css
@@ -55,7 +55,8 @@
 }
 
 :global(.border-error),
-.border-error {
+.border-error,
+.borderError {
   border-color: var(--color-error) !important;
 }
 
@@ -64,7 +65,8 @@
 }
 
 :global(.border-brand),
-.border-brand {
+.border-brand,
+.borderBrand {
   border-color: var(--color-brand) !important;
 }
 
@@ -80,7 +82,8 @@
   border: none !important;
 }
 
-.border-bottom {
+.border-bottom,
+.borderBottom {
   border-bottom: var(--border-size) dashed var(--color-border);
 }
 

--- a/frontend/src/metabase/css/core/float.module.css
+++ b/frontend/src/metabase/css/core/float.module.css
@@ -1,9 +1,11 @@
 :global(.float-left),
-.float-left {
+.float-left,
+.floatLeft {
   float: left;
 }
 
 :global(.float-right),
-.float-right {
+.float-right,
+.floatRight {
   float: right;
 }

--- a/frontend/src/metabase/css/core/spacing.module.css
+++ b/frontend/src/metabase/css/core/spacing.module.css
@@ -10,12 +10,14 @@
 }
 
 :global(.ml-auto),
-.ml-auto {
+.ml-auto,
+.mlAuto {
   margin-left: auto;
 }
 
 :global(.mr-auto),
-.mr-auto {
+.mr-auto,
+.mrAuto {
   margin-right: auto;
 }
 
@@ -430,7 +432,6 @@
 
 @media screen and (--breakpoint-min-sm) {
   /* padding */
-
   /* 0 */
   :global(.sm-p0) {
     padding: 0;
@@ -484,7 +485,6 @@
   }
 
   /* 2 */
-
   :global(.sm-p2) {
     padding: var(--padding-2);
   }
@@ -516,7 +516,6 @@
   }
 
   /* 3 */
-
   :global(.sm-p3) {
     padding: var(--padding-3);
   }
@@ -548,7 +547,6 @@
   }
 
   /* 4 */
-
   :global(.sm-p4) {
     padding: var(--padding-4);
   }
@@ -580,7 +578,6 @@
   }
 
   /* margin */
-
   /* 0 */
   :global(.sm-m0) {
     margin: 0;
@@ -634,7 +631,6 @@
   }
 
   /* 2 */
-
   :global(.sm-m2) {
     margin: var(--margin-2);
   }
@@ -666,7 +662,6 @@
   }
 
   /* 3 */
-
   :global(.sm-m3) {
     margin: var(--margin-3);
   }
@@ -698,7 +693,6 @@
   }
 
   /* 4 */
-
   :global(.sm-m4) {
     margin: var(--margin-4);
   }
@@ -732,7 +726,6 @@
 
 @media screen and (--breakpoint-min-md) {
   /* padding */
-
   /* 0 */
   :global(.md-p0) {
     padding: 0;
@@ -786,7 +779,6 @@
   }
 
   /* 2 */
-
   :global(.md-p2) {
     padding: var(--padding-2);
   }
@@ -818,7 +810,6 @@
   }
 
   /* 3 */
-
   :global(.md-p3) {
     padding: var(--padding-3);
   }
@@ -850,7 +841,6 @@
   }
 
   /* 4 */
-
   :global(.md-p4) {
     padding: var(--padding-4);
   }
@@ -882,7 +872,6 @@
   }
 
   /* margin */
-
   /* 0 */
   :global(.md-m0) {
     margin: 0;
@@ -936,7 +925,6 @@
   }
 
   /* 2 */
-
   :global(.md-m2) {
     margin: var(--margin-2);
   }
@@ -968,7 +956,6 @@
   }
 
   /* 3 */
-
   :global(.md-m3) {
     margin: var(--margin-3);
   }
@@ -1000,7 +987,6 @@
   }
 
   /* 4 */
-
   :global(.md-m4) {
     margin: var(--margin-4);
   }
@@ -1034,7 +1020,6 @@
 
 @media screen and (--breakpoint-min-lg) {
   /* padding */
-
   /* 0 */
   :global(.lg-p0) {
     padding: 0;
@@ -1088,7 +1073,6 @@
   }
 
   /* 2 */
-
   :global(.lg-p2) {
     padding: var(--padding-2);
   }
@@ -1120,7 +1104,6 @@
   }
 
   /* 3 */
-
   :global(.lg-p3) {
     padding: var(--padding-3);
   }
@@ -1152,7 +1135,6 @@
   }
 
   /* 4 */
-
   :global(.lg-p4) {
     padding: var(--padding-4);
   }
@@ -1184,7 +1166,6 @@
   }
 
   /* margin */
-
   /* 0 */
   :global(.lg-m0) {
     margin: 0;
@@ -1238,7 +1219,6 @@
   }
 
   /* 2 */
-
   :global(.lg-m2) {
     margin: var(--margin-2);
   }
@@ -1270,7 +1250,6 @@
   }
 
   /* 3 */
-
   :global(.lg-m3) {
     margin: var(--margin-3);
   }
@@ -1302,7 +1281,6 @@
   }
 
   /* 4 */
-
   :global(.lg-m4) {
     margin: var(--margin-4);
   }
@@ -1336,7 +1314,6 @@
 
 @media screen and (--breakpoint-min-xl) {
   /* padding */
-
   /* 0 */
   :global(.xl-p0) {
     padding: 0;
@@ -1390,7 +1367,6 @@
   }
 
   /* 2 */
-
   :global(.xl-p2) {
     padding: var(--padding-2);
   }
@@ -1422,7 +1398,6 @@
   }
 
   /* 3 */
-
   :global(.xl-p3) {
     padding: var(--padding-3);
   }
@@ -1454,7 +1429,6 @@
   }
 
   /* 4 */
-
   :global(.xl-p4) {
     padding: var(--padding-4);
   }
@@ -1486,7 +1460,6 @@
   }
 
   /* margin */
-
   /* 0 */
   :global(.xl-m0) {
     margin: 0;
@@ -1540,7 +1513,6 @@
   }
 
   /* 2 */
-
   :global(.xl-m2) {
     margin: var(--margin-2);
   }
@@ -1572,7 +1544,6 @@
   }
 
   /* 3 */
-
   :global(.xl-m3) {
     margin: var(--margin-3);
   }
@@ -1604,7 +1575,6 @@
   }
 
   /* 4 */
-
   :global(.xl-m4) {
     margin: var(--margin-4);
   }

--- a/frontend/src/metabase/css/core/spacing.module.css
+++ b/frontend/src/metabase/css/core/spacing.module.css
@@ -432,6 +432,7 @@
 
 @media screen and (--breakpoint-min-sm) {
   /* padding */
+
   /* 0 */
   :global(.sm-p0) {
     padding: 0;
@@ -485,6 +486,7 @@
   }
 
   /* 2 */
+
   :global(.sm-p2) {
     padding: var(--padding-2);
   }
@@ -516,6 +518,7 @@
   }
 
   /* 3 */
+
   :global(.sm-p3) {
     padding: var(--padding-3);
   }
@@ -547,6 +550,7 @@
   }
 
   /* 4 */
+
   :global(.sm-p4) {
     padding: var(--padding-4);
   }
@@ -578,6 +582,7 @@
   }
 
   /* margin */
+
   /* 0 */
   :global(.sm-m0) {
     margin: 0;
@@ -631,6 +636,7 @@
   }
 
   /* 2 */
+
   :global(.sm-m2) {
     margin: var(--margin-2);
   }
@@ -662,6 +668,7 @@
   }
 
   /* 3 */
+
   :global(.sm-m3) {
     margin: var(--margin-3);
   }
@@ -693,6 +700,7 @@
   }
 
   /* 4 */
+
   :global(.sm-m4) {
     margin: var(--margin-4);
   }
@@ -726,6 +734,7 @@
 
 @media screen and (--breakpoint-min-md) {
   /* padding */
+
   /* 0 */
   :global(.md-p0) {
     padding: 0;
@@ -779,6 +788,7 @@
   }
 
   /* 2 */
+
   :global(.md-p2) {
     padding: var(--padding-2);
   }
@@ -810,6 +820,7 @@
   }
 
   /* 3 */
+
   :global(.md-p3) {
     padding: var(--padding-3);
   }
@@ -841,6 +852,7 @@
   }
 
   /* 4 */
+
   :global(.md-p4) {
     padding: var(--padding-4);
   }
@@ -872,6 +884,7 @@
   }
 
   /* margin */
+
   /* 0 */
   :global(.md-m0) {
     margin: 0;
@@ -925,6 +938,7 @@
   }
 
   /* 2 */
+
   :global(.md-m2) {
     margin: var(--margin-2);
   }
@@ -956,6 +970,7 @@
   }
 
   /* 3 */
+
   :global(.md-m3) {
     margin: var(--margin-3);
   }
@@ -987,6 +1002,7 @@
   }
 
   /* 4 */
+
   :global(.md-m4) {
     margin: var(--margin-4);
   }
@@ -1020,6 +1036,7 @@
 
 @media screen and (--breakpoint-min-lg) {
   /* padding */
+
   /* 0 */
   :global(.lg-p0) {
     padding: 0;
@@ -1073,6 +1090,7 @@
   }
 
   /* 2 */
+
   :global(.lg-p2) {
     padding: var(--padding-2);
   }
@@ -1104,6 +1122,7 @@
   }
 
   /* 3 */
+
   :global(.lg-p3) {
     padding: var(--padding-3);
   }
@@ -1135,6 +1154,7 @@
   }
 
   /* 4 */
+
   :global(.lg-p4) {
     padding: var(--padding-4);
   }
@@ -1166,6 +1186,7 @@
   }
 
   /* margin */
+
   /* 0 */
   :global(.lg-m0) {
     margin: 0;
@@ -1219,6 +1240,7 @@
   }
 
   /* 2 */
+
   :global(.lg-m2) {
     margin: var(--margin-2);
   }
@@ -1250,6 +1272,7 @@
   }
 
   /* 3 */
+
   :global(.lg-m3) {
     margin: var(--margin-3);
   }
@@ -1281,6 +1304,7 @@
   }
 
   /* 4 */
+
   :global(.lg-m4) {
     margin: var(--margin-4);
   }
@@ -1314,6 +1338,7 @@
 
 @media screen and (--breakpoint-min-xl) {
   /* padding */
+
   /* 0 */
   :global(.xl-p0) {
     padding: 0;
@@ -1367,6 +1392,7 @@
   }
 
   /* 2 */
+
   :global(.xl-p2) {
     padding: var(--padding-2);
   }
@@ -1398,6 +1424,7 @@
   }
 
   /* 3 */
+
   :global(.xl-p3) {
     padding: var(--padding-3);
   }
@@ -1429,6 +1456,7 @@
   }
 
   /* 4 */
+
   :global(.xl-p4) {
     padding: var(--padding-4);
   }
@@ -1460,6 +1488,7 @@
   }
 
   /* margin */
+
   /* 0 */
   :global(.xl-m0) {
     margin: 0;
@@ -1513,6 +1542,7 @@
   }
 
   /* 2 */
+
   :global(.xl-m2) {
     margin: var(--margin-2);
   }
@@ -1544,6 +1574,7 @@
   }
 
   /* 3 */
+
   :global(.xl-m3) {
     margin: var(--margin-3);
   }
@@ -1575,6 +1606,7 @@
   }
 
   /* 4 */
+
   :global(.xl-m4) {
     margin: var(--margin-4);
   }

--- a/frontend/src/metabase/css/core/transitions.module.css
+++ b/frontend/src/metabase/css/core/transitions.module.css
@@ -1,4 +1,5 @@
 :global(.transition-color),
-.transition-color {
+.transition-color,
+.transitionColor {
   transition: color 0.3s linear;
 }

--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { replace } from "react-router-redux";
 import screenfull from "screenfull";
 
-import CS from "metabase/css/core/spacing.module.css";
+import CS from "metabase/css/core/index.css";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { parseHashOptions, stringifyHashOptions } from "metabase/lib/browser";
 

--- a/frontend/src/metabase/reference/components/FieldTypeDetail.jsx
+++ b/frontend/src/metabase/reference/components/FieldTypeDetail.jsx
@@ -19,7 +19,7 @@ const FieldTypeDetail = ({
   <div className={cx(D.detail)}>
     <div className={D.detailBody}>
       <div className={D.detailTitle}>
-        <span className={D.detailName}>{t`Field type`}</span>
+        <span>{t`Field type`}</span>
       </div>
       <div className={cx(D.detailSubtitle, { mt1: true })}>
         <span>

--- a/frontend/src/metabase/reference/components/FieldsToGroupBy.jsx
+++ b/frontend/src/metabase/reference/components/FieldsToGroupBy.jsx
@@ -29,7 +29,7 @@ class FieldsToGroupBy extends Component {
       <div>
         <div className={D.detailBody}>
           <div className={D.detailTitle}>
-            <span className={D.detailName}>{title}</span>
+            <span>{title}</span>
           </div>
           <div className={S.usefulQuestions}>
             {fields &&

--- a/frontend/src/metabase/reference/components/ReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/ReferenceHeader.jsx
@@ -36,9 +36,7 @@ const ReferenceHeader = ({
         </Ellipsified>
 
         {headerLink && (
-          /* TODO: there is only L.headerButton, so either change to
-          L.headerButton or remove */
-          <div key="2" className={cx(CS.flexFull, S.headerButton)}>
+          <div key="2" className={cx(CS.flexFull, L.headerButton)}>
             <Link
               to={headerLink}
               className={cx(ButtonsS.Button, ButtonsS.ButtonBorderless, CS.ml3)}

--- a/frontend/src/metabase/reference/components/UsefulQuestions.jsx
+++ b/frontend/src/metabase/reference/components/UsefulQuestions.jsx
@@ -11,7 +11,7 @@ const UsefulQuestions = ({ questions }) => (
   <div className={D.detail}>
     <div className={D.detailBody}>
       <div className={D.detailTitle}>
-        <span className={D.detailName}>{t`Potentially useful questions`}</span>
+        <span>{t`Potentially useful questions`}</span>
       </div>
       <div className={S.usefulQuestions}>
         {questions.map((question, index, questions) => (

--- a/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
+++ b/frontend/src/metabase/sharing/components/PulsesListSidebar.jsx
@@ -190,13 +190,7 @@ function PulseDetails({ pulse, parameters }) {
   return (
     <div className={cx("text-medium", CS.hoverChild)}>
       <ul
-        className={cx(
-          CS.flex,
-          CS.flexColumn,
-          CS.scrollX,
-          CS.scrollY,
-          CS.textUnspaced,
-        )}
+        className={cx(CS.flex, CS.flexColumn, CS.scrollX, CS.scrollY)}
         style={{ maxHeight: 130 }}
       >
         {recipientText && (

--- a/package.json
+++ b/package.json
@@ -240,6 +240,7 @@
     "eslint-plugin-jest": "^27.2.0",
     "eslint-plugin-jest-dom": "^4.0.3",
     "eslint-plugin-no-only-tests": "^2.4.0",
+    "eslint-plugin-postcss-modules": "^2.0.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^5.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9237,6 +9237,14 @@ dc@2.1.9:
     crossfilter2 "~1.3"
     d3 "^3"
 
+deasync@^0.1.0:
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.29.tgz#8bbbf9d0b235c561b36edd440b6272f1de6c572c"
+  integrity sha512-EBtfUhVX23CE9GR6m+F8WPeImEE4hR/FW9RkK0PMl9V1t283s0elqsTD8EZjaKX28SY1BW2rYfCgNsAYdpamUw==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^1.7.1"
+
 debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
@@ -10354,6 +10362,22 @@ eslint-plugin-no-only-tests@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz#7d565434aa7d16ccc7eea957c391d98f827332ca"
   integrity sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
+
+eslint-plugin-postcss-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-postcss-modules/-/eslint-plugin-postcss-modules-2.0.0.tgz#d136d6fb5bd9afa6ac73c22aea85212aa2531806"
+  integrity sha512-82usNIaeAEHKbQOnbSs+H3d9nP6TKD2zBZC/wuedbGMTbF8XGkdxI83kptTE6BcvIWgnLPciVa8voe6zIw4ddw==
+  dependencies:
+    anymatch "^3.0.0"
+    camelcase "^6.0.0"
+    deasync "^0.1.0"
+    icss-utils "^5.1.0"
+    postcss "^8.3.0"
+    postcss-load-config "^3.1.0"
+    postcss-modules-extract-imports "~3.0.0"
+    postcss-modules-local-by-default "^4.0.0"
+    postcss-modules-scope "^3.0.0"
+    postcss-modules-values "^4.0.0"
 
 eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
@@ -14467,6 +14491,11 @@ lilconfig@2.0.6:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
   integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
 
+lilconfig@^2.0.5:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
+  integrity sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -16072,6 +16101,11 @@ node-abort-controller@^3.0.1:
   resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
   integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
 
+node-addon-api@^1.7.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
+  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
+
 node-dir@^0.1.10:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
@@ -17327,6 +17361,14 @@ postcss-lab-function@^2.0.1:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
+postcss-load-config@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.4.tgz#1ab2571faf84bb078877e1d07905eabe9ebda855"
+  integrity sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==
+  dependencies:
+    lilconfig "^2.0.5"
+    yaml "^1.10.2"
+
 postcss-loader@7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-7.0.2.tgz#b53ff44a26fba3688eee92a048c7f2d4802e23bb"
@@ -17373,7 +17415,7 @@ postcss-modules-extract-imports@^2.0.0:
   dependencies:
     postcss "^7.0.5"
 
-postcss-modules-extract-imports@^3.0.0:
+postcss-modules-extract-imports@^3.0.0, postcss-modules-extract-imports@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
   integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
@@ -17635,6 +17677,15 @@ postcss@^8.2.15:
     nanoid "^3.1.30"
     picocolors "^1.0.0"
     source-map-js "^0.6.2"
+
+postcss@^8.3.0:
+  version "8.4.38"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
+  integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.0.0"
+    source-map-js "^1.2.0"
 
 postcss@^8.4.33:
   version "8.4.35"
@@ -19944,7 +19995,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-js@1.2.0, source-map-js@^0.6.2, source-map-js@^1.0.1, source-map-js@^1.0.2:
+source-map-js@1.2.0, source-map-js@^0.6.2, source-map-js@^1.0.1, source-map-js@^1.0.2, source-map-js@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
@@ -22726,7 +22777,7 @@ yaml-lint@~1.6.0:
     js-yaml "^4.1.0"
     nconf "^0.12.0"
 
-yaml@^1.10.0:
+yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==


### PR DESCRIPTION
> [!Note]
> We need to wait for https://github.com/metabase/metabase/pull/41173 to be merged into this PR first.

### Description

Adds types for CSS modules to all of the `.module.css` files. With this PR, we'll be able to spot missing CSS classes with the TS type checker.

The main inclusion here is a `build:css` script, which generates `.css.d.ts` and `.css.d.ts.map` files for all of the CSS module files within the frontend codebase. 

We also probably want to put this into some of the `build` scripts to make sure that our mappings stay up-to-date, so I'd like to open up the discussion here before we merge anything.


### How to verify

Pull the PR. Go to any CSS module and add/change one of the classes to something obviously invalid. Run the `build:css` script, and then run `yarn type-check`. You should see an error about the typechecking.