### PR TITLE
Trigger a query limit update on blur while in notebook mode

### DIFF
--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -45,7 +45,7 @@ describe("scenarios > models query editor", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Row limit").click();
-      cy.findByPlaceholderText("Enter a limit").type("2");
+      cy.findByPlaceholderText("Enter a limit").type("2").blur();
 
       cy.findByTestId("run-button").click();
       cy.wait("@dataset");
@@ -81,7 +81,7 @@ describe("scenarios > models query editor", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Row limit").click();
-      cy.findByPlaceholderText("Enter a limit").type("2");
+      cy.findByPlaceholderText("Enter a limit").type("2").blur();
 
       cy.findByTestId("run-button").click();
       cy.wait("@dataset");

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -701,7 +701,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 
     cy.button("Row limit").click();
     cy.findByTestId("step-limit-0-0").within(() => {
-      cy.findByPlaceholderText("Enter a limit").type("5");
+      cy.findByPlaceholderText("Enter a limit").type("5").blur();
 
       cy.icon("play").click();
       assertTableRowCount(5);

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -706,7 +706,7 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
       cy.icon("play").click();
       assertTableRowCount(5);
 
-      cy.findByDisplayValue("5").type("{selectall}50");
+      cy.findByDisplayValue("5").type("{selectall}50").blur();
       cy.button("Refresh").click();
       assertTableRowCount(10);
     });

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.unit.spec.tsx
@@ -1,3 +1,5 @@
+import userEvent from "@testing-library/user-event";
+
 import {
   setupDatabasesEndpoints,
   setupSearchEndpoints,
@@ -75,5 +77,18 @@ describe("NotebookStep", () => {
     expect(
       screen.queryByRole("button", { name: "Remove step" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("sets the row limit only on blur", () => {
+    const step = createMockNotebookStep({ type: "limit" });
+    const { updateQuery } = setup({ step });
+
+    const input = screen.getByPlaceholderText("Enter a limit");
+    userEvent.type(input, "38");
+    userEvent.type(input, "clear");
+    userEvent.type(input, "42");
+    input.blur();
+
+    expect(updateQuery).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/steps.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/steps.ts
@@ -10,7 +10,7 @@ import { DataStep } from "../steps/DataStep";
 import { ExpressionStep } from "../steps/ExpressionStep";
 import { FilterStep } from "../steps/FilterStep";
 import { JoinStep } from "../steps/JoinStep";
-import LimitStep from "../steps/LimitStep";
+import { LimitStep } from "../steps/LimitStep";
 import SortStep from "../steps/SortStep";
 import SummarizeStep from "../steps/SummarizeStep";
 import type { NotebookStepUiComponentProps } from "../types";

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.tsx
@@ -1,4 +1,4 @@
-import type * as React from "react";
+import type { ChangeEvent, FocusEvent } from "react";
 import { useState } from "react";
 import { t } from "ttag";
 
@@ -19,15 +19,15 @@ export function LimitStep({
   const limit = Lib.currentLimit(query, stageIndex);
   const [value, setValue] = useState(typeof limit === "number" ? limit : "");
 
-  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
-    const nextLimit = parseInt(e.target.value, 0);
+  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+    const nextLimit = parseInt(event.target.value, 0);
     if (nextLimit >= 1) {
       updateQuery(Lib.limit(query, stageIndex, nextLimit));
     }
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
   };
 
   return (

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.tsx
@@ -1,4 +1,5 @@
 import type * as React from "react";
+import { useState } from "react";
 import { t } from "ttag";
 
 import LimitInput from "metabase/query_builder/components/LimitInput";
@@ -16,13 +17,17 @@ function LimitStep({
   const { stageIndex } = step;
 
   const limit = Lib.currentLimit(query, stageIndex);
-  const value = typeof limit === "number" ? limit : "";
+  const [value, setValue] = useState(typeof limit === "number" ? limit : "");
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const nextLimit = parseInt(e.target.value, 0);
     if (nextLimit >= 1) {
       updateQuery(Lib.limit(query, stageIndex, nextLimit));
     }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
   };
 
   return (
@@ -33,6 +38,7 @@ function LimitStep({
         value={value}
         placeholder={t`Enter a limit`}
         small
+        onBlur={handleBlur}
         onChange={handleChange}
       />
     </NotebookCell>

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.tsx
@@ -8,7 +8,7 @@ import * as Lib from "metabase-lib";
 import { NotebookCell } from "../../NotebookCell";
 import type { NotebookStepUiComponentProps } from "../../types";
 
-function LimitStep({
+export function LimitStep({
   query,
   step,
   color,
@@ -44,6 +44,3 @@ function LimitStep({
     </NotebookCell>
   );
 }
-
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export default LimitStep;

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.unit.spec.tsx
@@ -3,7 +3,7 @@ import * as Lib from "metabase-lib";
 
 import { createMockNotebookStep, DEFAULT_QUERY } from "../../test-utils";
 
-import LimitStep from "./LimitStep";
+import { LimitStep } from "./LimitStep";
 
 const DEFAULT_LIMIT = 10;
 const QUERY_WITH_LIMIT = Lib.limit(DEFAULT_QUERY, 0, DEFAULT_LIMIT);

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/LimitStep.unit.spec.tsx
@@ -49,6 +49,7 @@ describe("LimitStep", () => {
     const limitInput = screen.getByPlaceholderText("Enter a limit");
 
     fireEvent.change(limitInput, { target: { value: "52" } });
+    fireEvent.blur(limitInput);
 
     expect(Lib.currentLimit(getNextQuery(), 0)).toBe(52);
   });
@@ -59,6 +60,7 @@ describe("LimitStep", () => {
 
     const limitInput = screen.getByPlaceholderText("Enter a limit");
     fireEvent.change(limitInput, { target: { value: "1000" } });
+    fireEvent.blur(limitInput);
 
     expect(Lib.currentLimit(getNextQuery(), 0)).toBe(1000);
   });

--- a/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/index.ts
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/LimitStep/index.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line import/no-default-export -- deprecated usage
-export { default } from "./LimitStep";
+export { LimitStep } from "./LimitStep";


### PR DESCRIPTION
### Description
This PR addresses the [review comment](https://github.com/metabase/metabase/pull/40595#discussion_r1539044070) from https://github.com/metabase/metabase/pull/40595.

We're now updating the query limit on blur, which improves the performance of the notebook GUI editor. It was previously updating on every change.

Nit: This PR also removes the default export and starts using a named export for the `LimitStep` component.

### How to verify
1. Open any table or a saved question in a notebook mode
2. It might be helpful to open a native query preview sidebar so that you have a visual feedback
3. Add a row limit to the query
4. Either enter the limit via keyboard, or click the up arrow in the number input
5. You should not see the query change and you should not see a new request in the network tab until this input element loses focus

### Demo
Before
![Kapture 2024-03-26 at 16 56 16](https://github.com/metabase/metabase/assets/31325167/79ddfa4e-09a0-4d28-9393-e8d68aa28267)

Now
![Kapture 2024-03-26 at 16 57 55](https://github.com/metabase/metabase/assets/31325167/0df34cd2-a566-41b0-8cd1-bc1471ef8725)


### Checklist
- [x] Tests have been added/updated to cover changes in this PR
