### PR TITLE
Do not sort suggested columns, metrics, segments by name 

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -247,10 +247,9 @@ export function suggest({
 
   suggestions = suggestions.filter(suggestion => suggestion.range);
 
-  // deduplicate suggestions and sort by type
+  // deduplicate suggestions
   suggestions = _.chain(suggestions)
     .uniq(suggestion => suggestion.text)
-    .sortBy("order")
     .value();
 
   // the only suggested function equals the prefix match?

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -153,6 +153,7 @@ export function suggest({
           })),
       );
     }
+    suggestions = _.sortBy(suggestions, "text");
   }
 
   if (_.last(matchPrefix) !== "]") {

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -249,7 +249,6 @@ export function suggest({
   // deduplicate suggestions and sort by type then name
   suggestions = _.chain(suggestions)
     .uniq(suggestion => suggestion.text)
-    .sortBy("text")
     .sortBy("order")
     .value();
 

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -247,7 +247,7 @@ export function suggest({
 
   suggestions = suggestions.filter(suggestion => suggestion.range);
 
-  // deduplicate suggestions and sort by type then name
+  // deduplicate suggestions and sort by type
   suggestions = _.chain(suggestions)
     .uniq(suggestion => suggestion.text)
     .sortBy("order")


### PR DESCRIPTION
Product doc https://www.notion.so/metabase/Show-foreign-suggested-fields-lower-in-custom-expressions-480f47dc3c3e46d0adf253f75066176d

Now we only sort functions by name and leave other sections untouched. Their order is determined by MBQL lib and would be the same as in other places.

![image](https://github.com/metabase/metabase/assets/8542534/080df905-fb01-4138-a6dc-92d3e43329e3)
