### PR TITLE
ParseSQL: select *

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -76,7 +76,7 @@
   io.github.eerohele/pp                     {:git/tag "2024-01-04.60"           ; super fast pretty-printing library
                                              :git/sha "a428751"
                                              :git/url "https://github.com/eerohele/pp"}
-  io.github.metabase/macaw                  {:mvn/version "0.1.23"}             ; Parse native SQL queries
+  io.github.metabase/macaw                  {:mvn/version "0.1.24"}             ; Parse native SQL queries
   ;; The 2.X line of Resilience4j requires Java 17, so we cannot upgrade this dependency until that is our minimum JVM version
   io.github.resilience4j/resilience4j-retry {:mvn/version "1.7.1" #_ "must be 1.7.1"} ; Support for retrying operations
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6068,6 +6068,22 @@ databaseChangeLog:
                   type: bigint
                   remarks: The estimated row count
 
+  - changeSet:
+      id: v50.2024-03-25T14:53:00
+      author: tsmacdonald
+      comment: Add query_field.direct_reference
+      changes:
+        - addColumn:
+            tableName: query_field
+            columns:
+              - column:
+                  name: direct_reference
+                  type: ${boolean.type}
+                  remarks: "Is the Field referenced directly or via a wildcard"
+                  constraints:
+                    nullable: false
+                  defaultValue: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -135,7 +135,9 @@
                                                     :from   [[(t2/table-name :model/QueryField) :qf]]
                                                     :join   [[(t2/table-name :model/Field) :f] [:= :f.id :qf.field_id]
                                                              [(t2/table-name :model/Table) :t] [:= :t.id :f.table_id]]
-                                                    :where  [:= :f.active false]}))
+                                                    :where  [:and
+                                                             [:= :f.active false]
+                                                             [:= :qf.direct_reference true]]}))
         card-ids              (keys card-id->query-fields)
         add-query-fields      (fn [{:keys [id] :as card}]
                                 (assoc card :query_fields (card-id->query-fields id)))]

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -9,11 +9,15 @@
    [clojure.string :as str]
    [macaw.core :as mac]
    [metabase.config :as config]
+   [metabase.models.table :as table]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
    [net.sf.jsqlparser JSQLParserException]))
+
+(comment
+  table/keep-me)
 
 (def ^:dynamic *parse-queries-in-test?*
   "Normally, a native card's query is parsed on every create/update. For most tests, this is an unnecessary

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -69,18 +69,15 @@
                                                  {:where [:and
                                                           [:= :t.db_id db-id]
                                                           [:= true :f.active]
-                                                          (if (seq table-names)
-                                                            [:in :%lower.t/name (map normalize-name table-names)]
-                                                            ;; if no tables, nothing is selectable
-                                                            false)]})))]
-
-    (if has-wildcard?
+                                                          [:in :%lower.t/name
+                                                               (map normalize-name table-names)]]})))]
+    (cond
       ;; select * from ...
       ;; so, get everything in all the tables
-      (active-fields-from-tables tables)
-      ;; select foo.* from ..
+      (and has-wildcard? (seq tables)) (active-fields-from-tables tables)
+      ;; select foo.* from ...
       ;; limit to the named tables
-      (active-fields-from-tables table-wildcards))))
+      (seq table-wildcards)            (active-fields-from-tables table-wildcards))))
 
 (defn- field-ids-for-card
   "Returns a `{:direct #{...} :indirect #{...}}` map with field IDs that (may) be referenced in the given cards's query. Errs on the side of optimism:

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -9,15 +9,11 @@
    [clojure.string :as str]
    [macaw.core :as mac]
    [metabase.config :as config]
-   [metabase.models.table :as table]
    [metabase.util :as u]
    [metabase.util.log :as log]
    [toucan2.core :as t2])
   (:import
    [net.sf.jsqlparser JSQLParserException]))
-
-(comment
-  table/keep-me)
 
 (def ^:dynamic *parse-queries-in-test?*
   "Normally, a native card's query is parsed on every create/update. For most tests, this is an unnecessary
@@ -44,8 +40,9 @@
 
 (def ^:private field-and-table-fragment
   "HoneySQL fragment to get the Field and Table"
-  {:from [[(t2/table-name :model/Field) :f]]
-   :join [[(t2/table-name :model/Table) :t] [:= :table_id :t.id]]})
+  {:from [[:metabase_field :f]]
+   ;; (t2/table-name :model/Table) doesn't work on CI since models/table.clj hasn't been loaded
+   :join [[:metabase_table :t] [:= :table_id :t.id]]})
 
 (defn- direct-field-ids-for-query
   "Very naively selects the IDs of Fields that could be used in the query. Improvements to this are planned for Q2 2024,

--- a/src/metabase/native_query_analyzer.clj
+++ b/src/metabase/native_query_analyzer.clj
@@ -5,6 +5,7 @@
   1. Translate Metabase-isms into generic SQL that Macaw can understand.
   2. Contain Metabase-specific business logic."
   (:require
+   [clojure.set :as set]
    [clojure.string :as str]
    [macaw.core :as mac]
    [metabase.config :as config]
@@ -37,35 +38,70 @@
       (str/replace "\"" "")
       u/lower-case-en))
 
-(defn- field-ids-for-query
+(def ^:private field-and-table-fragment
+  "HoneySQL fragment to get the Field and Table"
+  {:from [[(t2/table-name :model/Field) :f]]
+   :join [[(t2/table-name :model/Table) :t] [:= :table_id :t.id]]})
+
+(defn- direct-field-ids-for-query
   "Very naively selects the IDs of Fields that could be used in the query. Improvements to this are planned for Q2 2024,
   c.f. Milestone 3 of https://github.com/metabase/metabase/issues/36911"
-  [q db-id]
-  (try
-    (let [{:keys [columns tables]} (mac/query->components (mac/parsed-query q))]
-      (t2/select-pks-set :model/Field {:from [[(t2/table-name :model/Field) :f]]
-                                       :join [[(t2/table-name :model/Table) :t] [:= :table_id :t.id]]
-                                       :where [:and
-                                               [:= :t.db_id db-id]
-                                               (if (seq tables)
-                                                 [:in :%lower.t/name (map normalize-name tables)]
-                                                 true)
-                                               (if (seq columns)
-                                                 [:in :%lower.f/name (map normalize-name columns)]
-                                                 true)]}))
-    (catch JSQLParserException e
-      (log/error e "Error parsing native query"))))
+  [{:keys [columns tables] :as _parsed-query} db-id]
+  (t2/select-pks-set :model/Field (merge field-and-table-fragment
+                                         {:where [:and
+                                                  [:= :t.db_id db-id]
+                                                  (if (seq tables)
+                                                    [:in :%lower.t/name (map normalize-name tables)]
+                                                    ;; if we don't know what tables it's from, look everywhere
+                                                    true)
+                                                  (if (seq columns)
+                                                    [:in :%lower.f/name (map normalize-name columns)]
+                                                    ;; if there are no columns, it must be a select * or similar
+                                                    false)]})))
+
+(defn- indirect-field-ids-for-query
+  "Similar to direct-field-ids-for-query, but for wildcard selects"
+  [{:keys [table-wildcards has-wildcard? tables] :as _parsed-query} db-id]
+  (let [active-fields-from-tables
+        (fn [table-names]
+          (t2/select-pks-set :model/Field (merge field-and-table-fragment
+                                                 {:where [:and
+                                                          [:= :t.db_id db-id]
+                                                          [:= true :f.active]
+                                                          (if (seq table-names)
+                                                            [:in :%lower.t/name (map normalize-name table-names)]
+                                                            ;; if no tables, nothing is selectable
+                                                            false)]})))]
+
+    (if has-wildcard?
+      ;; select * from ...
+      ;; so, get everything in all the tables
+      (active-fields-from-tables tables)
+      ;; select foo.* from ..
+      ;; limit to the named tables
+      (active-fields-from-tables table-wildcards))))
 
 (defn- field-ids-for-card
-  "Returns a list of field IDs that (may) be referenced in the given cards's query. Errs on the side of optimism:
+  "Returns a `{:direct #{...} :indirect #{...}}` map with field IDs that (may) be referenced in the given cards's query. Errs on the side of optimism:
   i.e., it may return fields that are *not* in the query, and is unlikely to fail to return fields that are in the
   query.
 
+  Direct references are columns that are named in the query; indirect ones are from wildcards. If a field could be both direct and indirect, it will *only* show up in the `:direct` set.
+
   Returns `nil` (and logs the error) if there was a parse error."
   [card]
-  (let [{native-query :native
-         db-id        :database} (:dataset_query card)]
-    (field-ids-for-query (:query native-query) db-id)))
+  (try
+    (let [{native-query :native
+           db-id        :database} (:dataset_query card)
+          parsed-query             (mac/query->components (mac/parsed-query (:query native-query)))
+          direct-ids               (direct-field-ids-for-query parsed-query db-id)
+          indirect-ids             (set/difference
+                                    (indirect-field-ids-for-query parsed-query db-id)
+                                    direct-ids)]
+      {:direct   direct-ids
+       :indirect indirect-ids})
+    (catch JSQLParserException e
+      (log/error e "Error parsing native query"))))
 
 (defn update-query-fields-for-card!
   "Clears QueryFields associated with this card and creates fresh, up-to-date-ones.
@@ -76,8 +112,13 @@
   [{card-id :id, query :dataset_query :as card}]
   (when (and (active?)
              (= :native (:type query)))
-    (let [query-field-records (map (fn [field-id] {:card_id  card-id :field_id field-id})
-                                   (field-ids-for-card card))]
+    (let [{:keys [direct indirect]} (field-ids-for-card card)
+          id->record (fn [direct? field-id] {:card_id          card-id
+                                             :field_id         field-id
+                                             :direct_reference direct?})
+          query-field-records (concat
+                               (map (partial id->record true) direct)
+                               (map (partial id->record false) indirect))]
       ;; This feels inefficient at first glance, but the number of records should be quite small and doing some sort
       ;; of upsert-or-delete would involve comparisons in Clojure-land that are more expensive than just "killing and
       ;; filling" the records.

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -301,10 +301,14 @@
                    :model/Card         relevant-card            {:name "Card with stale query"}
                    :model/Card         not-stale-card           {:name "Card whose columns are up to date"}
                    :model/Card         irrelevant-card          {:name "Card with no QueryFields at all"}
+                   :model/Card         select-*-card            {:name "Card with only wildcard refs"}
                    :model/QueryField   _                        {:card_id  (u/the-id relevant-card)
                                                                  :field_id inactive-field-id}
                    :model/QueryField   _                        {:card_id  (u/the-id not-stale-card)
-                                                                 :field_id active-field-id}]
+                                                                 :field_id active-field-id}
+                   :model/QueryField   _                        {:card_id  (u/the-id select-*-card)
+                                                                 :field_id inactive-field-id
+                                                                 :direct_reference false}]
       (with-cards-in-readable-collection [relevant-card not-stale-card irrelevant-card]
         (is (=? [{:name         "Card with stale query"
                   :query_fields [{:card_id  (u/the-id relevant-card)

--- a/test/metabase/models/query_field_test.clj
+++ b/test/metabase/models/query_field_test.clj
@@ -1,16 +1,20 @@
 (ns metabase.models.query-field-test
   (:require
+   [clojure.set :as set]
    [clojure.test :refer :all]
    [metabase.native-query-analyzer :as query-analyzer]
    [metabase.test :as mt]
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
-(def ^:private query-field-keys [:card_id :field_id])
+(def ^:private query-field-keys [:card_id :field_id :direct_reference])
+
+(defn- qf->map [query-field]
+  (select-keys query-field query-field-keys))
 
 (defn- query-fields-for-card
   [card-id]
-  (t2/select-fn-set #(select-keys % query-field-keys) :model/QueryField
+  (t2/select-fn-set qf->map :model/QueryField
                     :card_id card-id))
 
 (defn- do-with-test-setup [f]
@@ -48,10 +52,12 @@
 
 (deftest query-fields-created-by-queries-test
   (with-test-setup
-    (let [total-qf {:card_id  card-id
-                    :field_id total-id}
-          tax-qf   {:card_id  card-id
-                    :field_id tax-id}]
+    (let [total-qf {:card_id          card-id
+                    :field_id         total-id
+                    :direct_reference true}
+          tax-qf   {:card_id          card-id
+                    :field_id         tax-id
+                    :direct_reference true}]
 
       (testing "A freshly created card has relevant corresponding QueryFields"
         (is (= #{total-qf}
@@ -72,3 +78,38 @@
     (testing "Updating a query with bogus columns does not create QueryFields"
       (trigger-parse! card-id "SELECT DOES, NOT_EXIST FROM orders")
       (is (empty? (t2/select :model/QueryField :card_id card-id))))))
+
+(deftest wildcard-test
+  (with-test-setup
+    (let [total-qf {:card_id          card-id
+                    :field_id         total-id
+                    :direct_reference false}
+          tax-qf   {:card_id          card-id
+                    :field_id         tax-id
+                    :direct_reference false}]
+      (testing "simple select *"
+        (trigger-parse! card-id "select * from orders")
+        (let [qfs (query-fields-for-card card-id)]
+          (is (= 9 (count qfs)))
+          (is (not-every? :direct_reference qfs))
+          (is (set/subset? #{total-qf tax-qf} qfs)))))))
+
+(deftest table-wildcard-test
+    (with-test-setup
+    (let [total-qf {:card_id          card-id
+                    :field_id         total-id
+                    :direct_reference true}
+          tax-qf   {:card_id          card-id
+                    :field_id         tax-id
+                    :direct_reference true}]
+      (testing "mix of select table.* and named columns"
+        (trigger-parse! card-id "select p.*, o.tax, o.total from orders o join people p on p.id = o.user_id")
+        (let [qfs (query-fields-for-card card-id)]
+          ;; TODO: o.id is a bug; the query only has p.id but we don't link tables and columns yet
+          ;; c.f. Milestone 3 of https://github.com/metabase/metabase/issues/36911
+          (is (= (+ 13 #_people 2 #_tax-and-total 1 #_o.user_id 1 #_o.id)
+                 (count qfs)))
+          ;; 13 total, but id is referenced directly
+          (is (= 12 (t2/count :model/QueryField :card_id card-id :direct_reference false)))
+          ;; subset since it also includes the PKs/FKs
+          (is (set/subset? #{total-qf tax-qf} (t2/select-fn-set qf->map :model/QueryField :card_id card-id :direct_reference true))))))))

--- a/test/metabase/models/query_field_test.clj
+++ b/test/metabase/models/query_field_test.clj
@@ -95,7 +95,7 @@
           (is (set/subset? #{total-qf tax-qf} qfs)))))))
 
 (deftest table-wildcard-test
-    (with-test-setup
+  (with-test-setup
     (let [total-qf {:card_id          card-id
                     :field_id         total-id
                     :direct_reference true}
@@ -112,4 +112,5 @@
           ;; 13 total, but id is referenced directly
           (is (= 12 (t2/count :model/QueryField :card_id card-id :direct_reference false)))
           ;; subset since it also includes the PKs/FKs
-          (is (set/subset? #{total-qf tax-qf} (t2/select-fn-set qf->map :model/QueryField :card_id card-id :direct_reference true))))))))
+          (is (set/subset? #{total-qf tax-qf}
+                           (t2/select-fn-set qf->map :model/QueryField :card_id card-id :direct_reference true))))))))


### PR DESCRIPTION
This follows up on [the Macaw PR](https://github.com/metabase/macaw/pull/13).

You'll recall that the basic idea is that Macaw now returns a boolean wildcard flag for `select *` type expressions and a set of tables for `select foo.*, bar.*` type expressions.

Our logic on the Metabase side is:

1. For a `select *`, select all active fields for all the tables in the query
2. For a `select foo.*`, select all active fields for, specifically, the `foo` table
3. Create `QueryField` objects for them, but set the new `direct_reference` field to `false`. (For named columns (`select f.bar`) then `direct_reference` is `true`, of course)
4. Cards with a `select *` won't be stale even if the fields change around, so the stale cards endpoint only pays attention to direct references.

Fixes https://github.com/metabase/metabase/issues/40247