### PR TITLE
Raise model index limit

### DIFF
--- a/src/metabase/models/model_index.clj
+++ b/src/metabase/models/model_index.clj
@@ -123,7 +123,7 @@ don't, (and shouldn't) care that those are expressions. They are just another fi
             (when (seq deletions)
               (t2/delete! ModelIndexValue
                           :model_index_id (:id model-index)
-                          :pk_ref [:in (->> deletions (map first))]))
+                          :model_pk [:in (->> deletions (map first))]))
             (when (seq additions)
               (t2/insert! ModelIndexValue
                           (map (fn [[id v]]
@@ -137,6 +137,9 @@ don't, (and shouldn't) care that those are expressions. They are just another fi
                                      "overflow"
                                      "indexed")}))
         (catch Exception e
+          (log/error (format "Error saving model-index values for model-index: %d, model: %d"
+                             (:id model-index) (:model-id model-index))
+                     e)
           (t2/update! ModelIndex (:id model-index)
                       {:state      "error"
                        :error      (ex-message e)

--- a/src/metabase/models/model_index.clj
+++ b/src/metabase/models/model_index.clj
@@ -46,7 +46,7 @@
 (def max-indexed-values
   "Maximum number of values we will index. Actually take one more than this to test if there are more than the
   threshold."
-  5000)
+  25000)
 
 ;;;; indexing functions
 

--- a/test/metabase/models/model_index_test.clj
+++ b/test/metabase/models/model_index_test.clj
@@ -146,10 +146,13 @@
       (doseq [[scenario query [field-refs]]
               (remove nil?
                       [[:mbql (mt/mbql-query products {:fields [$id $title]})]
-                       [:mbql-custom-column (mt/mbql-query products {:expressions
-                                                                     {"full-name"
-                                                                      [:concat $title "custom"]}})
-                        [(mt/$ids [$products.id [:expression "full-name"]])]]
+                       [:mbql-custom-column (mt/mbql-query products
+                                                           {:expressions
+                                                            {"inc-id"
+                                                             [:+ $id 1]
+                                                             "full-name"
+                                                             [:concat $title "custom"]}})
+                        [[[:expression "inc-id"] [:expression "full-name"]]]]
                        [:native (mt/native-query
                                  (qp.compile/compile
                                   (mt/mbql-query products {:fields [$id $title]})))]
@@ -181,6 +184,7 @@
                                                                :value_ref value-ref})]
               (is (nil? error))
               ;; oracle returns BigDecimal ids so need `number?` rather than `int?`
+              (is (> (count values) 0))
               (is (mc/validate [:sequential [:tuple number? string?]] values)
                   (-> (mc/validate [:sequential [:tuple int? string?]] values)
                       (me/humanize))))))))))

--- a/test/metabase/models/model_index_test.clj
+++ b/test/metabase/models/model_index_test.clj
@@ -214,10 +214,10 @@
                                                                :pk_ref    pk-ref
                                                                :value_ref value-ref})]
               (is (nil? error))
-              ;; oracle returns BigDecimal ids so need `number?` rather than `int?`
               (is (> (count values) 0))
+              ;; oracle returns BigDecimal ids so need `number?` rather than `int?`
               (is (mc/validate [:sequential [:tuple number? string?]] values)
-                  (-> (mc/validate [:sequential [:tuple int? string?]] values)
+                  (-> (mc/explain [:sequential [:tuple number? string?]] values)
                       (me/humanize))))))))))
 
 (defn- test-index


### PR DESCRIPTION
closes https://github.com/metabase/metabase/issues/40639
closes https://github.com/metabase/metabase/issues/40640

#### Raise the limit of model index values.

We previously only kept 5,000 values from a model. This proved to be too low in practice. On stats we have the following models with the following cardinalities:

| model id | row count |
|  -----------|-----------|
| 10149            | 3983             |
| 15189            | 85               |
| 15130            | 23195            |
| 11654            | 1193             |
| 6736             | 14437            |

This raises the count of rows that we allow to 25,000.

There are a few impacts:
- When diffing the sets, how big of a memory pressure do we have (at most 25,000 strings in a set, and 25,000 strings in another set). This seems fine. Perhaps we should add a substring to the strings. I think this can be follow up work
- When updating the values, make sure our sql statements aren't too large. (uses `(doseq [additions-part (partition-all 10000 additions)] ....)` to ensure we are bounded)
- Search shouldn't bog down. The model index values table has an index `"unique_model_index_value_model_index_id_model_pk" UNIQUE CONSTRAINT, btree (model_index_id, model_pk)` on the model_index_id and primary key but not on the value. This is presumably a table scan and the table has the capability to get much larger. We should watch stats and see how this behaves in practice.

#### Bugs fixed while in there.

This also fixes https://github.com/metabase/metabase/issues/40639. The issue has full repro but the gist is that we used to do this logic:
- get all current values in index
- get all values in the model we want to index
- set difference to find new values, set difference to find old values
- remove any old values (error here)
- add any new values

The error in "remove any old values" was that we used a column on the `model_index` table rather than the column on the `model_index_value` table (`pk_ref` was used instead of `model_pk`). This meant every model index that had values that went away went into an error state. Appropriate tests and a fix are included here.
<img width="1027" alt="image" src="https://github.com/metabase/metabase/assets/6377293/e2ec0772-a087-4b48-b7bf-63419ae38519">

#### After this PR
Every column in the above screenshot should now be "indexed". One is correctly indexed; one is "overflow", meaning it has more than 5,000 values. The others in the "error" state should correctly be indexed, adding new values and removing values no longer present.