### PR TITLE
Command Palette UI adjustments

### DIFF
--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -49,7 +49,7 @@ describe("command palette", () => {
       // Since the command palette list is virtualized, we will search for a few
       // to ensure they're reachable
       commandPaletteSearch().clear().type("People");
-      cy.findByRole("option", { name: /Admin - People/ }).should("exist");
+      cy.findByRole("option", { name: /People/ }).should("exist");
 
       commandPaletteSearch().clear().type("Uploads");
       cy.findByRole("option", { name: /Settings - Uploads/ }).should("exist");

--- a/frontend/src/metabase/admin/app/components/SettingsCommandPaletteActions.tsx
+++ b/frontend/src/metabase/admin/app/components/SettingsCommandPaletteActions.tsx
@@ -6,7 +6,6 @@ import { useMount } from "react-use";
 import { getSections } from "metabase/admin/settings/selectors";
 import { initializeSettings } from "metabase/admin/settings/settings";
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import { Icon } from "metabase/ui";
 
 type AdminSetting = {
   key: string;
@@ -54,7 +53,7 @@ export const SettingsCommandPaletteActions = () => {
                 }),
               );
             },
-            icon: <Icon name="gear" />,
+            icon: "gear",
           })),
       ];
       return acc;

--- a/frontend/src/metabase/palette/components/Palette.styled.tsx
+++ b/frontend/src/metabase/palette/components/Palette.styled.tsx
@@ -4,15 +4,16 @@ import { KBarSearch } from "kbar";
 import { color } from "metabase/lib/colors";
 
 export const PaletteInput = styled(KBarSearch)`
-  padding: 0.5rem;
+  padding: 0.75rem;
   font-weight: bold;
   width: 100%;
   border-radius: 0.5rem;
   border: 1px solid ${color("border")};
   background: ${color("bg-light")};
   color: ${color("text-dark")};
+  line-height: 1rem;
 
   &:focus {
-    outline: none;
+    outline: 1px solid ${color("brand")};
   }
 `;

--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -47,7 +47,7 @@ const PaletteContainer = () => {
       <Center>
         <Card
           ref={ref}
-          w="60vw"
+          w="640px"
           mt="10vh"
           p="0"
           style={{

--- a/frontend/src/metabase/palette/components/Palette.tsx
+++ b/frontend/src/metabase/palette/components/Palette.tsx
@@ -43,7 +43,7 @@ const PaletteContainer = () => {
   });
 
   return (
-    <Overlay blur="2" opacity={0.2}>
+    <Overlay opacity={0.5}>
       <Center>
         <Card
           ref={ref}

--- a/frontend/src/metabase/palette/components/PaletteFooter.tsx
+++ b/frontend/src/metabase/palette/components/PaletteFooter.tsx
@@ -12,17 +12,9 @@ export const PaletteFooter = () => {
         borderTop: `1px solid ${color("border")}`,
       }}
     >
-      <Flex gap=".33rem">
-        <Icon color={color("text-light")} name="sort" />
-        <Text tt="uppercase" weight="bold" size="10px" color={color("medium")}>
-          {t`Select`}
-        </Text>
-      </Flex>
-      <Flex gap=".33rem">
-        <Icon name="enter_or_return" color={color("text-light")} />
-        <Text tt="uppercase" weight="bold" size="10px" color={color("medium")}>
-          {t`Open`}
-        </Text>
+      <Flex gap=".33rem" c={color("text-medium")} lh="1rem">
+        <Icon name="sort" />
+        <Text size="12px">{t`Select`}</Text>
       </Flex>
     </Flex>
   );

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -41,7 +41,7 @@ export const PaletteResults = () => {
     <Flex align="stretch" direction="column" p="0.75rem 0">
       <KBarResults
         items={processedResults}
-        maxHeight={500}
+        maxHeight={530}
         onRender={({
           item,
           active,

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -1,10 +1,12 @@
 import { useKBar, useMatches, KBarResults, type ActionImpl } from "kbar";
 import { useState } from "react";
 import { useDebounce } from "react-use";
+import { t } from "ttag";
 import _ from "underscore";
 
 import { color } from "metabase/lib/colors";
 import { SEARCH_DEBOUNCE_DURATION } from "metabase/lib/constants";
+import type { IconName } from "metabase/ui";
 import { Flex, Box, Icon } from "metabase/ui";
 
 import { useCommandPalette } from "../hooks/useCommandPalette";
@@ -47,34 +49,57 @@ export const PaletteResults = () => {
           item: string | ActionImpl;
           active: boolean;
         }) => {
+          const isFirst = processedResults[0] === item;
+
           return (
-            <Flex
-              bg={active ? color("brand-light") : "none"}
-              c={active ? color("brand") : color("text-medium")}
-              lh="1rem"
-              mx="1rem"
-              fw={700}
-              style={{
-                cursor: "pointer",
-                borderRadius: "0.5rem",
-              }}
-            >
+            <Flex lh="1rem" pb="2px">
               {typeof item === "string" ? (
-                <Box tt="uppercase" fw={700} fz="10px" p="0.5rem">
+                <Box
+                  px="1.5rem"
+                  fz="14px"
+                  pt="1rem"
+                  pb="0.5rem"
+                  style={
+                    isFirst
+                      ? undefined
+                      : {
+                          borderTop: `1px solid ${color("border")}`,
+                          marginTop: "1rem",
+                        }
+                  }
+                  w="100%"
+                >
                   {item}
                 </Box>
               ) : (
                 <Flex
                   p=".75rem"
+                  mx="1.5rem"
                   w="100%"
                   align="center"
                   justify="space-between"
+                  fw={700}
+                  style={{
+                    cursor: "pointer",
+                    borderRadius: "0.5rem",
+                  }}
+                  bg={active ? color("brand") : "none"}
+                  c={active ? color("white") : color("text-dark")}
                 >
                   <Flex gap=".5rem">
-                    {item.icon || <Icon name="click" />}
+                    <Icon
+                      name={(item.icon as IconName) || "click"}
+                      color={
+                        active ? color("brand-light") : color("text-light")
+                      }
+                    />
                     {item.name}
                   </Flex>
-                  {active && <Icon name="enter_or_return" />}
+                  {active && (
+                    <Flex gap="0.5rem" fw={400}>
+                      {t`Open`} <Icon name="enter_or_return" />
+                    </Flex>
+                  )}
                 </Flex>
               )}
             </Flex>

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -75,28 +75,53 @@ export const PaletteResults = () => {
                 <Flex
                   p=".75rem"
                   mx="1.5rem"
-                  w="100%"
+                  miw="0"
                   align="center"
                   justify="space-between"
+                  gap="0.5rem"
                   fw={700}
                   style={{
                     cursor: "pointer",
                     borderRadius: "0.5rem",
+                    flexGrow: 1,
+                    flexBasis: 0,
                   }}
                   bg={active ? color("brand") : "none"}
                   c={active ? color("white") : color("text-dark")}
                 >
-                  <Flex gap=".5rem">
-                    <Icon
-                      name={(item.icon as IconName) || "click"}
-                      color={
-                        active ? color("brand-light") : color("text-light")
-                      }
-                    />
-                    {item.name}
+                  <Flex gap=".5rem" style={{ minWidth: 0 }}>
+                    {item.icon && (
+                      <Icon
+                        name={(item.icon as IconName) || "click"}
+                        color={
+                          active ? color("brand-light") : color("text-light")
+                        }
+                        style={{
+                          flexBasis: "16px",
+                        }}
+                      />
+                    )}
+                    <Box
+                      component="span"
+                      style={{
+                        flexGrow: 1,
+                        flexBasis: 0,
+                        textOverflow: "ellipsis",
+                        overflowX: "hidden",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {item.name}
+                    </Box>
                   </Flex>
                   {active && (
-                    <Flex gap="0.5rem" fw={400}>
+                    <Flex
+                      gap="0.5rem"
+                      fw={400}
+                      style={{
+                        flexBasis: 60,
+                      }}
+                    >
                       {t`Open`} <Icon name="enter_or_return" />
                     </Flex>
                   )}

--- a/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.unit.spec.tsx
@@ -119,6 +119,6 @@ describe("PaletteResults", () => {
   it("should provide links to admin pages", async () => {
     setup({ query: "permi" });
     expect(await screen.findByText("Admin")).toBeInTheDocument();
-    expect(await screen.findByText("Admin - Permissions")).toBeInTheDocument();
+    expect(await screen.findByText("Permissions")).toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -169,8 +169,8 @@ export const useCommandPalette = ({
   const adminActions = useMemo<KBarAction[]>(() => {
     return adminPaths.map(adminPath => ({
       id: `admin-page-${adminPath.key}`,
-      name: `Admin - ${adminPath.name}`,
-      icon: "link",
+      name: `${adminPath.name}`,
+      icon: "gear",
       perform: () => dispatch(push(adminPath.path)),
       section: "admin",
     }));
@@ -188,7 +188,7 @@ export const useCommandPalette = ({
       .map(([slug, section]) => ({
         id: `admin-settings-${slug}`,
         name: `Settings - ${section.name}`,
-        icon: "link",
+        icon: "gear",
         perform: () => dispatch(push(`/admin/settings/${slug}`)),
         section: "admin",
       }));

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -20,7 +20,6 @@ import {
   getSettings,
 } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
-import { Icon } from "metabase/ui";
 import type { SearchResult } from "metabase-types/api";
 
 export type PalettePageId = "root" | "admin_settings";
@@ -44,7 +43,7 @@ export const useCommandPalette = ({
     isLoading: isSearchLoading,
   } = useSearchListQuery<SearchResult>({
     enabled: !!debouncedSearchText,
-    query: { q: debouncedSearchText, limit: 5 },
+    query: { q: debouncedSearchText, limit: 20 },
     reload: true,
   });
 
@@ -69,7 +68,7 @@ export const useCommandPalette = ({
           : t`View documentation`,
         section: "docs",
         keywords: query, // Always match the query string
-        icon: () => <Icon name="document" />,
+        icon: "document",
         perform: () => {
           if (query) {
             window.open(getDocsSearchUrl({ query }));
@@ -112,7 +111,7 @@ export const useCommandPalette = ({
             return {
               id: `search-result-${result.id}`,
               name: result.name,
-              icon: <Icon {...wrappedResult.getIcon()} />,
+              icon: wrappedResult.getIcon().name,
               section: "search",
               perform: () => {
                 dispatch(closeModal());
@@ -149,7 +148,7 @@ export const useCommandPalette = ({
       ret.push({
         id: `recent-item-${getName(item)}`,
         name: getName(item),
-        icon: <Icon name={getIcon(item).name} />,
+        icon: getIcon(item).name,
         section: "recent",
         perform: () => {
           dispatch(push(Urls.modelToUrl(item) ?? ""));
@@ -160,13 +159,16 @@ export const useCommandPalette = ({
     return ret;
   }, [dispatch, recentItems]);
 
-  useRegisterActions(recentItemsActions, [recentItemsActions]);
+  useRegisterActions(hasQuery ? [] : recentItemsActions, [
+    recentItemsActions,
+    hasQuery,
+  ]);
 
   const adminActions = useMemo<KBarAction[]>(() => {
     return adminPaths.map(adminPath => ({
       id: `admin-page-${adminPath.key}`,
       name: `Admin - ${adminPath.name}`,
-      icon: <Icon name="link" />,
+      icon: "link",
       perform: () => dispatch(push(adminPath.path)),
       section: "admin",
     }));
@@ -184,7 +186,7 @@ export const useCommandPalette = ({
       .map(([slug, section]) => ({
         id: `admin-settings-${slug}`,
         name: `Settings - ${section.name}`,
-        icon: <Icon name="link" />,
+        icon: "link",
         perform: () => dispatch(push(`/admin/settings/${slug}`)),
         section: "admin",
       }));

--- a/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPalette.tsx
@@ -97,37 +97,39 @@ export const useCommandPalette = ({
         keywords: query,
         section: "search",
       });
-    } else if (searchError) {
-      ret.push({
-        id: "search-error",
-        name: t`Could not load search results`,
-        section: "search",
-      });
-    } else if (debouncedSearchText) {
-      if (searchResults?.length) {
-        ret.push(
-          ...searchResults.map(result => {
-            const wrappedResult = Search.wrapEntity(result, dispatch);
-            return {
-              id: `search-result-${result.id}`,
-              name: result.name,
-              icon: wrappedResult.getIcon().name,
-              section: "search",
-              perform: () => {
-                dispatch(closeModal());
-                dispatch(push(wrappedResult.getUrl()));
-              },
-            };
-          }),
-        );
-      } else {
+    } else {
+      if (searchError) {
         ret.push({
-          id: "no-search-results",
-          name: t`No results for “${query}”`,
-          keywords: query,
+          id: "search-error",
+          name: t`Could not load search results`,
           section: "search",
-          perform: () => {}, // will simply close the command palette. It's possible we can remove this item
         });
+      } else if (debouncedSearchText) {
+        if (searchResults?.length) {
+          ret.push(
+            ...searchResults.map(result => {
+              const wrappedResult = Search.wrapEntity(result, dispatch);
+              return {
+                id: `search-result-${result.id}`,
+                name: result.name,
+                icon: wrappedResult.getIcon().name,
+                section: "search",
+                perform: () => {
+                  dispatch(closeModal());
+                  dispatch(push(wrappedResult.getUrl()));
+                },
+              };
+            }),
+          );
+        } else {
+          ret.push({
+            id: "no-search-results",
+            name: t`No results for “${debouncedSearchText}”`,
+            keywords: debouncedSearchText,
+            section: "search",
+            perform: () => {}, // will simply close the command palette. It's possible we can remove this item
+          });
+        }
       }
     }
     return ret;

--- a/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
+++ b/frontend/src/metabase/palette/hooks/useCommandPaletteBasicActions.tsx
@@ -17,7 +17,6 @@ import {
   getHasNativeWrite,
   getHasDatabaseWithActionsEnabled,
 } from "metabase/selectors/data";
-import { Icon } from "metabase/ui";
 
 export const useCommandPaletteBasicActions = ({
   isLoggedIn,
@@ -58,7 +57,7 @@ export const useCommandPaletteBasicActions = ({
         id: "new_question",
         name: t`New question`,
         section: "basic",
-        icon: <Icon name="insight" />,
+        icon: "insight",
         perform: () => {
           dispatch(closeModal());
           dispatch(
@@ -80,7 +79,7 @@ export const useCommandPaletteBasicActions = ({
         id: "new_query",
         name: t`New SQL query`,
         section: "basic",
-        icon: <Icon name="sql" />,
+        icon: "sql",
         perform: () => {
           dispatch(closeModal());
           dispatch(
@@ -102,7 +101,7 @@ export const useCommandPaletteBasicActions = ({
           id: "new_dashboard",
           name: t`New dashboard`,
           section: "basic",
-          icon: <Icon name="dashboard" />,
+          icon: "dashboard",
           perform: () => {
             openNewModal("dashboard");
           },
@@ -111,7 +110,7 @@ export const useCommandPaletteBasicActions = ({
           id: "new_collection",
           name: t`New collection`,
           section: "basic",
-          icon: <Icon name="collection" />,
+          icon: "collection",
           perform: () => {
             openNewModal("collection");
           },
@@ -124,7 +123,7 @@ export const useCommandPaletteBasicActions = ({
         id: "new_model",
         name: t`New model`,
         section: "basic",
-        icon: <Icon name="model" />,
+        icon: "model",
         perform: () => {
           dispatch(closeModal());
           dispatch(push("model/new"));
@@ -137,7 +136,7 @@ export const useCommandPaletteBasicActions = ({
         id: "new_action",
         name: t`New action`,
         section: "basic",
-        icon: <Icon name="bolt" />,
+        icon: "bolt",
         perform: () => {
           openNewModal("action");
         },
@@ -149,7 +148,7 @@ export const useCommandPaletteBasicActions = ({
         id: "navigate_data",
         name: t`Browse Data`,
         section: "basic",
-        icon: <Icon name="database" />,
+        icon: "database",
         perform: () => {
           dispatch(push("/browse"));
         },

--- a/frontend/src/metabase/palette/utils.ts
+++ b/frontend/src/metabase/palette/utils.ts
@@ -12,9 +12,9 @@ export const processResults = (results: (string | ActionImpl)[]) => {
   const search = processSection(t`Search results`, groupedResults["search"]);
   const recent = processSection(t`Recent items`, groupedResults["recent"]);
   const admin = processSection(t`Admin`, groupedResults["admin"]);
-  const docs = groupedResults["docs"] || [];
+  const docs = processSection(t`Documentation`, groupedResults["docs"]);
 
-  return [...actions.slice(0, 6), ...search, ...recent, ...admin, ...docs];
+  return [...actions.slice(0, 6), ...recent, ...admin, ...search, ...docs];
 };
 
 export const processSection = (sectionName: string, items?: ActionImpl[]) => {

--- a/frontend/src/metabase/palette/utils.unit.spec.ts
+++ b/frontend/src/metabase/palette/utils.unit.spec.ts
@@ -71,11 +71,11 @@ describe("command palette utils", () => {
       expect(processResults([...testActions, ...testRecent])).toHaveLength(12);
       expect(
         processResults([...testRecent, ...testAdmin, ...testDoc]),
-      ).toHaveLength(18);
+      ).toHaveLength(19);
     });
 
-    it("should not add a header to doc", () => {
-      expect(processResults([...testDoc])).toHaveLength(1);
+    it("should add a header to doc", () => {
+      expect(processResults([...testDoc])).toHaveLength(2);
     });
 
     it("should enforce a specific order", () => {
@@ -96,7 +96,7 @@ describe("command palette utils", () => {
       );
       const adminIndex = results.findIndex(action => action === "Admin");
 
-      [actionsIndex, searchIndex, recentsIndex, adminIndex].forEach(
+      [actionsIndex, recentsIndex, adminIndex, searchIndex].forEach(
         (val, i, arr) => {
           expect(val).not.toBe(-1);
           const next = arr[i + 1] || Infinity; //can't call expect in an if, so this lets us do the last comparison


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40631

### Description
Styling adjustments to the command palette. Mostly positioning and structure. Also moved search results to the bottom of the palette

### How to verify

Describe the steps to verify that the changes are working as expected.

1. Open the command palette
2. Allow your eyes to experience the joy of aligned items, consistent spacing, and better colors
3. Search for some entities and see the results show up at the bottom of the list

### Demo
![image](https://github.com/metabase/metabase/assets/1328979/0d230343-3155-41cd-b37d-717ad7689521)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
