### PR TITLE
Fix `:dataset_query`

### DIFF
--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -422,7 +422,7 @@
     (->> (map #(assoc %2 :dataset_query %1) queries-parsed rows)
          upload/model-hydrate-based-on-upload
          (map #(assoc %2 :dataset_query %1) queries-before)
-         (post-process-collection-children collection :card))))
+         (post-process-collection-children :card collection))))
 
 (defmethod collection-children-query :card
   [_ collection options]


### PR DESCRIPTION
... among other things.

The order of arguments was wrong here, causing the default implementation of `post-process-collection-childre` to be called. The implementation for `:card` ends up removing the `:dataset_query` entirely, which is what was intended.
