### PR TITLE
Make Collection Picker child-aware

### DIFF
--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -441,16 +441,10 @@ describeEE("formatting > whitelabel", () => {
           popover().findByText("Dashboard").click();
           modal().findByTestId("collection-picker-button").click();
           entityPickerModal().within(() => {
-            cy.findByText(emptyCollectionName).click();
             cy.readFile("e2e/support/assets/logo.jpeg", "base64").then(
               logo_data => {
                 const imageDataUrl = `data:image/jpeg;base64,${logo_data}`;
                 cy.wrap(imageDataUrl).as("imageDataUrl");
-                cy.findByAltText("No results").should(
-                  "have.attr",
-                  "src",
-                  imageDataUrl,
-                );
               },
             );
 

--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -94,6 +94,8 @@ export interface CollectionItem {
   database_id?: DatabaseId;
   moderated_status?: string;
   type?: string;
+  here?: CollectionItemModel[];
+  below?: CollectionItemModel[];
   can_write?: boolean;
   "last-edit-info"?: LastEditInfo;
   location?: string;

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
@@ -7,7 +7,7 @@ import { useCollectionQuery } from "metabase/common/hooks";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { useSelector } from "metabase/lib/redux";
 import { getUserPersonalCollectionId } from "metabase/selectors/user";
-import type { Collection, SearchListQuery, SearchRequest } from "metabase-types/api";
+import type { Collection, SearchRequest } from "metabase-types/api";
 
 import {
   LoadingSpinner,

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPicker.tsx
@@ -19,6 +19,7 @@ import {
   generateKey,
   getCollectionIdPath,
   getParentCollectionId,
+  getPathLevelForItem,
   getStateFromIdPath,
   isFolder,
 } from "../utils";
@@ -89,12 +90,10 @@ export const CollectionPickerInner = (
 
   const handleItemSelect = useCallback(
     (item: CollectionPickerItem) => {
-      // set selected item at the correct level
-      const parentCollectionId = item?.collection_id || "root";
-
-      const pathLevel = path.findIndex(
-        level =>
-          String(level?.query?.collection) === String(parentCollectionId),
+      const pathLevel = getPathLevelForItem(
+        item,
+        path,
+        userPersonalCollectionId,
       );
 
       const newPath = path.slice(0, pathLevel + 1);
@@ -103,7 +102,7 @@ export const CollectionPickerInner = (
       setPath(newPath);
       onItemSelect(item);
     },
-    [path, onItemSelect, setPath],
+    [path, onItemSelect, setPath, userPersonalCollectionId],
   );
 
   const handleNewCollection = useCallback(
@@ -171,8 +170,6 @@ export const CollectionPickerInner = (
           // start with the current item selected if we can
           onItemSelect({
             ...currentCollection,
-            here: ["collection"],
-            below: ["collection"],
             model: "collection",
           });
         }

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -50,7 +50,7 @@ export const CollectionPickerModal = ({
   ] = useToggle(false);
 
   const pickerRef = useRef<{
-    onFolderSelect: (item: { folder: CollectionPickerItem }) => void;
+    onNewCollection: (item: CollectionPickerItem) => void;
   }>();
 
   const handleItemSelect = useCallback(
@@ -99,8 +99,8 @@ export const CollectionPickerModal = ({
     },
   ];
 
-  const handleNewCollectionCreate = (folder: CollectionPickerItem) => {
-    pickerRef.current?.onFolderSelect({ folder });
+  const handleNewCollectionCreate = (newCollection: CollectionPickerItem) => {
+    pickerRef.current?.onNewCollection(newCollection);
   };
 
   return (

--- a/frontend/src/metabase/common/components/CollectionPicker/components/PersonalCollectionItemList.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/PersonalCollectionItemList.tsx
@@ -48,6 +48,7 @@ const getSortedTopLevelPersonalCollections = (
     .map(
       (collection: Collection): CollectionPickerItem => ({
         ...collection,
+        here: ["collection"], // until this endpoint gives this to us, pretend they all have content
         model: "collection",
       }),
     )

--- a/frontend/src/metabase/common/components/CollectionPicker/components/RootItemList.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/RootItemList.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import { useCollectionQuery } from "metabase/common/hooks";
+import { useCollectionQuery, useSearchListQuery } from "metabase/common/hooks";
 import { PERSONAL_COLLECTIONS } from "metabase/entities/collections";
 import { useSelector } from "metabase/lib/redux";
 import { getUser, getUserIsAdmin } from "metabase/selectors/user";
@@ -15,6 +15,8 @@ const personalCollectionsRoot: CollectionPickerItem = {
   model: "collection",
   location: "/",
   description: "",
+  here: ["collection"],
+  below: ["collection"],
 };
 
 /**
@@ -41,6 +43,17 @@ export const RootItemList = ({
     });
 
   const {
+    data: personalCollectionItems,
+    isLoading: isLoadingPersonalCollectionItems,
+  } = useSearchListQuery({
+    query: {
+      collection: currentUser?.personal_collection_id,
+      models: ["collection"],
+    },
+    enabled: !!currentUser?.personal_collection_id,
+  });
+
+  const {
     data: rootCollection,
     isLoading: isLoadingRootCollecton,
     error: rootCollectionError,
@@ -54,6 +67,7 @@ export const RootItemList = ({
         collectionsData.push({
           ...rootCollection,
           model: "collection",
+          here: ["collection"],
           location: "/",
           name:
             options.namespace === "snippets"
@@ -64,6 +78,7 @@ export const RootItemList = ({
         collectionsData.push({
           name: t`Collections`,
           id: "root",
+          here: ["collection"],
           description: null,
           can_write: false,
           model: "collection",
@@ -80,7 +95,9 @@ export const RootItemList = ({
     ) {
       collectionsData.push({
         ...personalCollection,
+        here: personalCollectionItems?.length ? ["collection"] : [],
         model: "collection",
+        can_write: true,
         location: personalCollection.location || "/",
       });
 
@@ -97,12 +114,17 @@ export const RootItemList = ({
     isAdmin,
     options,
     rootCollectionError,
+    personalCollectionItems,
   ]);
 
   return (
     <ItemList
       items={data}
-      isLoading={isLoadingRootCollecton || isLoadingPersonalCollecton}
+      isLoading={
+        isLoadingRootCollecton ||
+        isLoadingPersonalCollecton ||
+        isLoadingPersonalCollectionItems
+      }
       onClick={onClick}
       selectedItem={selectedItem}
       isFolder={isFolder}

--- a/frontend/src/metabase/common/components/CollectionPicker/components/RootItemList.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/RootItemList.tsx
@@ -98,7 +98,6 @@ export const RootItemList = ({
         here: personalCollectionItems?.length ? ["collection"] : [],
         model: "collection",
         can_write: true,
-        location: personalCollection.location || "/",
       });
 
       if (isAdmin) {

--- a/frontend/src/metabase/common/components/CollectionPicker/types.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/types.ts
@@ -3,6 +3,7 @@ import type {
   SearchRequest,
   SearchModelType,
   SearchResult,
+  CollectionItemModel,
 } from "metabase-types/api";
 
 import type {
@@ -19,6 +20,9 @@ export type CollectionPickerItem = TypeWithModel<
     location?: string | null;
     effective_location?: string | null;
     is_personal?: boolean;
+    collection_id?: CollectionId;
+    here?: CollectionItemModel[];
+    below?: CollectionItemModel[];
   };
 
 export type CollectionPickerOptions = EntityPickerModalOptions & {

--- a/frontend/src/metabase/common/components/CollectionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/utils.ts
@@ -6,7 +6,7 @@ import type {
   SearchModelType,
 } from "metabase-types/api";
 
-import type { PickerState, IsFolder, TypeWithModel } from "../EntityPicker";
+import type { PickerState } from "../EntityPicker";
 
 import type { CollectionPickerItem } from "./types";
 
@@ -62,6 +62,8 @@ export const getStateFromIdPath = ({
         name: "",
         model: "collection",
         id: idPath[0],
+        here: ["collection"],
+        below: ["collection"],
       },
     },
   ];
@@ -80,6 +82,8 @@ export const getStateFromIdPath = ({
             name: "",
             model: "collection",
             id: nextLevelId,
+            here: ["collection"],
+            below: ["collection"],
           }
         : null,
     });
@@ -88,13 +92,18 @@ export const getStateFromIdPath = ({
   return statePath;
 };
 
-export const isFolder: IsFolder<
-  CollectionId,
-  SearchModelType,
-  CollectionPickerItem
-> = <Item extends TypeWithModel<CollectionId, SearchModelType>>(item: Item) => {
-  return item.model === "collection";
+export const isFolder = (item: CollectionPickerItem): boolean => {
+  return Boolean(
+    item.model === "collection" && item?.here?.includes("collection"),
+  );
 };
 
 export const generateKey = (query?: SearchRequest) =>
   JSON.stringify(query ?? "root");
+
+export const getParentCollectionId = (
+  location: string | null,
+): CollectionId => {
+  const parentCollectionId = location?.split("/").filter(Boolean).reverse()[0];
+  return parentCollectionId ? Number(parentCollectionId) : "root";
+};

--- a/frontend/src/metabase/common/components/CollectionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/utils.ts
@@ -1,10 +1,6 @@
 import { isRootCollection } from "metabase/collections/utils";
 import { PERSONAL_COLLECTIONS } from "metabase/entities/collections";
-import type {
-  CollectionId,
-  SearchRequest,
-  SearchModelType,
-} from "metabase-types/api";
+import type { CollectionId, SearchRequest } from "metabase-types/api";
 
 import type { PickerState } from "../EntityPicker";
 
@@ -110,7 +106,7 @@ export const getParentCollectionId = (
 
 export const getPathLevelForItem = (
   item: CollectionPickerItem,
-  path: PickerState<CollectionPickerItem, SearchListQuery>,
+  path: PickerState<CollectionPickerItem, SearchRequest>,
   userPersonalCollectionId?: CollectionId,
 ): number => {
   if (item.id === userPersonalCollectionId) {

--- a/frontend/src/metabase/common/components/CollectionPicker/utils.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/utils.ts
@@ -107,3 +107,20 @@ export const getParentCollectionId = (
   const parentCollectionId = location?.split("/").filter(Boolean).reverse()[0];
   return parentCollectionId ? Number(parentCollectionId) : "root";
 };
+
+export const getPathLevelForItem = (
+  item: CollectionPickerItem,
+  path: PickerState<CollectionPickerItem, SearchListQuery>,
+  userPersonalCollectionId?: CollectionId,
+): number => {
+  if (item.id === userPersonalCollectionId) {
+    return 0;
+  }
+
+  const parentCollectionId = item?.collection_id || "root";
+
+  // set selected item at the correct level
+  return path.findIndex(
+    level => String(level?.query?.collection) === String(parentCollectionId),
+  );
+};

--- a/frontend/src/metabase/common/components/CollectionPicker/utils.unit.spec.ts
+++ b/frontend/src/metabase/common/components/CollectionPicker/utils.unit.spec.ts
@@ -1,4 +1,4 @@
-import { getCollectionIdPath } from "./utils";
+import { getCollectionIdPath, getParentCollectionId } from "./utils";
 
 describe("CollectionPicker > utils", () => {
   describe("getCollectionIdPath", () => {
@@ -130,6 +130,21 @@ describe("CollectionPicker > utils", () => {
       );
 
       expect(path).toEqual(["root", 6, 7, 8, 9]);
+    });
+  });
+
+  describe("getParentCollectionId", () => {
+    it("should get the root collection for null values", () => {
+      expect(getParentCollectionId(null)).toEqual("root");
+      expect(getParentCollectionId("")).toEqual("root");
+      // @ts-expect-error testing invalid input
+      expect(getParentCollectionId(undefined)).toEqual("root");
+    });
+
+    it("should get the last item in a slash-separated list", () => {
+      expect(getParentCollectionId("/1/2/3/4/5/")).toEqual(5);
+      expect(getParentCollectionId("1/2/3/4/5")).toEqual(5);
+      expect(getParentCollectionId("/100/200/300/400/500/")).toEqual(500);
     });
   });
 });

--- a/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import { t } from "ttag";
 
 import { VirtualizedList } from "metabase/components/VirtualizedList";
-import { NoObjectError } from "metabase/components/errors/NoObjectError";
 import { LoadingAndErrorWrapper } from "metabase/public/containers/PublicAction/PublicAction.styled";
 import { Box, Center, Icon, NavLink } from "metabase/ui";
 

--- a/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/ItemList/ItemList.tsx
@@ -2,11 +2,10 @@ import type React from "react";
 import { useMemo } from "react";
 import { t } from "ttag";
 
-import EmptyState from "metabase/components/EmptyState";
 import { VirtualizedList } from "metabase/components/VirtualizedList";
 import { NoObjectError } from "metabase/components/errors/NoObjectError";
 import { LoadingAndErrorWrapper } from "metabase/public/containers/PublicAction/PublicAction.styled";
-import { Box, Center, Flex, Icon, NavLink } from "metabase/ui";
+import { Box, Center, Icon, NavLink } from "metabase/ui";
 
 import type { TypeWithModel } from "../../types";
 import { getIcon, isSelectedItem } from "../../utils";
@@ -59,24 +58,13 @@ export const ItemList = <
     return (
       <Box miw={310} h="100%" aria-label={t`loading`}>
         <Center p="lg" h="100%">
-          <DelayedLoadingSpinner delay={200} />
+          <DelayedLoadingSpinner delay={300} />
         </Center>
       </Box>
     );
   }
 
-  if (items && !items.length) {
-    // empty array
-    return (
-      <Flex justify="center" align="center" direction="column" h="100%">
-        <EmptyState
-          illustrationElement={<NoObjectError aria-label={t`empty`} />}
-        />
-      </Flex>
-    );
-  }
-
-  if (!items) {
+  if (!items || !items.length) {
     return null;
   }
 

--- a/frontend/src/metabase/common/components/EntityPicker/components/NestedItemPicker/NestedItemPicker.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/NestedItemPicker/NestedItemPicker.tsx
@@ -10,9 +10,11 @@ import type {
   IsFolder,
   TypeWithModel,
 } from "../../types";
+import { isSelectedItem } from "../../utils";
 import { AutoScrollBox } from "../AutoScrollBox";
 
 import { ListBox } from "./NestedItemPicker.styled";
+import { findLastSelectedItem } from "./utils";
 
 export interface NestedItemPickerProps<
   Id,
@@ -56,6 +58,8 @@ export function NestedItemPicker<
     }
   };
 
+  const lastSelectedItem = findLastSelectedItem(path);
+
   return (
     <AutoScrollBox
       data-testid="nested-item-picker"
@@ -64,6 +68,12 @@ export function NestedItemPicker<
       <Flex h="100%" w="fit-content">
         {path.map((level, index) => {
           const { query, selectedItem } = level;
+
+          const isCurrentLevel = Boolean(
+            selectedItem &&
+              lastSelectedItem &&
+              isSelectedItem(selectedItem, lastSelectedItem),
+          );
 
           return (
             <ListBox
@@ -76,7 +86,7 @@ export function NestedItemPicker<
                   selectedItem={selectedItem}
                   options={options}
                   onClick={(item: Item) => handleClick(item)}
-                  isCurrentLevel={index === path.length - 2}
+                  isCurrentLevel={isCurrentLevel}
                   shouldDisableItem={shouldDisableItem}
                   isFolder={isFolder}
                 />

--- a/frontend/src/metabase/common/components/EntityPicker/components/NestedItemPicker/utils.ts
+++ b/frontend/src/metabase/common/components/EntityPicker/components/NestedItemPicker/utils.ts
@@ -1,0 +1,13 @@
+import type { PickerState } from "../../types";
+
+// reverse-traverse the statePath to find the last selected item
+export const findLastSelectedItem = <Item, Query>(
+  statePath: PickerState<Item, Query>,
+) => {
+  for (let i = statePath.length - 1; i >= 0; i--) {
+    if (statePath[i].selectedItem) {
+      return statePath[i].selectedItem;
+    }
+  }
+  return undefined;
+};

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -82,6 +82,10 @@ const setup = async (
     fetchMock.get("path:/api/collection", TEST_COLLECTIONS);
     fetchMock.get("path:/api/collection/root", ROOT_TEST_COLLECTION);
     setupCollectionByIdEndpoint({ collections: [BOBBY_TEST_COLLECTION] });
+    setupCollectionItemsEndpoint({
+      collection: BOBBY_TEST_COLLECTION,
+      collectionItems: [],
+    });
   }
 
   const settings = mockSettings({ "enable-query-caching": isCachingEnabled });
@@ -761,6 +765,10 @@ describe("SaveQuestionModal", () => {
           },
         });
         setupCollectionByIdEndpoint({ collections: [COLLECTION.PARENT] });
+        setupCollectionItemsEndpoint({
+          collection: BOBBY_TEST_COLLECTION,
+          collectionItems: [],
+        });
       });
       it("should create collection inside nested folder", async () => {
         await userEvent.click(collDropdown());

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -78,6 +78,11 @@ function setup({
     collectionItems: [createMockCollectionItemFromCollection(COLLECTION.CHILD)],
   });
 
+  setupCollectionItemsEndpoint({
+    collection: COLLECTION.PERSONAL,
+    collectionItems: [],
+  });
+
   collections
     .filter(c => c.id !== "root")
     .forEach(c => fetchMock.get(`path:/api/collection/${c.id}`, c));

--- a/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
+++ b/frontend/src/metabase/dashboard/containers/CreateDashboardModal.unit.spec.tsx
@@ -9,17 +9,13 @@ import {
 import { mockSettings } from "__support__/settings";
 import { createMockEntitiesState } from "__support__/store";
 import {
-  within,
   renderWithProviders,
   screen,
   waitFor,
   mockGetBoundingClientRect,
   mockScrollBy,
 } from "__support__/ui";
-import {
-  PERSONAL_COLLECTION,
-  ROOT_COLLECTION,
-} from "metabase/entities/collections";
+import { ROOT_COLLECTION } from "metabase/entities/collections";
 import {
   createMockCollection,
   createMockCollectionItemFromCollection,
@@ -202,42 +198,6 @@ describe("CreateDashboardModal", () => {
 
       await waitFor(() => expect(dashModalTitle()).toBeInTheDocument());
       expect(nameField()).toHaveValue(name);
-    });
-    it("should allow selecting, but not navigating into collections without children", async () => {
-      setup();
-      await waitFor(async () =>
-        expect(await dashModalTitle()).toBeInTheDocument(),
-      );
-
-      await userEvent.click(collDropdown());
-
-      const personalCollectionButton = await screen.findByRole("button", {
-        name: new RegExp(PERSONAL_COLLECTION.name),
-      });
-      const firstPickerColumn = await screen.findByTestId(
-        "item-picker-level-0",
-      );
-      const ourAnalyticsButton = within(firstPickerColumn).getByRole("button", {
-        name: /Our analytics/i,
-      });
-
-      expect(
-        within(personalCollectionButton).queryByLabelText("chevronright icon"),
-      ).not.toBeInTheDocument();
-      expect(
-        within(ourAnalyticsButton).getByLabelText("chevronright icon"),
-      ).toBeInTheDocument();
-
-      expect(personalCollectionButton).not.toHaveAttribute("data-active");
-      await userEvent.click(personalCollectionButton);
-      expect(personalCollectionButton).toHaveAttribute("data-active", "true");
-
-      // selecting an empty collection should not show another column
-      await waitFor(() =>
-        expect(
-          screen.queryByTestId("item-picker-level-1"),
-        ).not.toBeInTheDocument(),
-      );
     });
 
     it("should create collection inside nested folder", async () => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39432

### Description

Uses the snazzy new api properties to display whether collections have sub-collections that we can traverse into

![Screen Shot 2024-03-26 at 5 22 01 PM](https://github.com/metabase/metabase/assets/30528226/99b11aa3-91ff-41e9-8484-630881732223)

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
