### PR TITLE
Add auto formatting to stacked charts

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -89,15 +89,14 @@ export function getDataLabelFormatter(
     settings,
   });
 
-  const valueFormatter = (value: unknown) =>
-    renderingContext.formatValue(value, {
+  const valueGetter = getMetricDisplayValueGetter(settings);
+  const valueFormatter = (value: RowValue) =>
+    renderingContext.formatValue(valueGetter(value), {
       ...(settings.column?.(seriesModel.column) ?? {}),
       jsx: false,
       compact: isCompact,
       ...formattingOptions,
     });
-
-  const valueGetter = getMetricDisplayValueGetter(settings);
 
   return (params: CallbackDataParams) => {
     const value = (params.data as Datum)[labelDataKey];
@@ -105,7 +104,7 @@ export function getDataLabelFormatter(
     if (value == null) {
       return " ";
     }
-    return valueFormatter(valueGetter(value));
+    return valueFormatter(value);
   };
 }
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -82,8 +82,8 @@ export function getDataLabelFormatter(
 ) {
   const isCompact = shouldRenderCompact({
     dataset,
+    getValue: (datum: Datum) => datum[labelDataKey],
     formattingOptions,
-    labelDataKey,
     renderingContext,
     seriesModel,
     settings,
@@ -110,15 +110,15 @@ export function getDataLabelFormatter(
 
 function shouldRenderCompact({
   dataset,
+  getValue,
   formattingOptions = {},
-  labelDataKey,
   renderingContext,
   seriesModel,
   settings,
 }: {
   dataset: ChartDataset;
-  formattingOptions: OptionsType;
-  labelDataKey: DataKey;
+  getValue: (datum: Datum) => RowValue;
+  formattingOptions?: OptionsType;
   renderingContext: RenderingContext;
   seriesModel: SeriesModel;
   settings: ComputedVisualizationSettings;
@@ -132,7 +132,7 @@ function shouldRenderCompact({
   // for "auto" we use compact if it shortens avg label length by >3 chars
   const getAvgLength = (compact: boolean) => {
     const lengths = dataset.map(datum => {
-      const value = datum[labelDataKey];
+      const value = getValue(datum);
       return renderingContext.formatValue(value, {
         ...(settings.column?.(seriesModel.column) ?? {}),
         jsx: false,
@@ -433,35 +433,14 @@ const generateStackOption = (
       ...seriesOptionFromStack.label,
       position: signKey === POSITIVE_STACK_TOTAL_DATA_KEY ? "top" : "bottom",
       show: true,
-      formatter: (
-        params: LabelLayoutOptionCallbackParams & { data: Datum },
-      ) => {
-        let stackValue: number | null = null;
-        stackDataKeys.forEach(stackDataKeys => {
-          const seriesValue = params.data[stackDataKeys];
-          if (
-            typeof seriesValue === "number" &&
-            ((signKey === POSITIVE_STACK_TOTAL_DATA_KEY && seriesValue > 0) ||
-              (signKey === NEGATIVE_STACK_TOTAL_DATA_KEY && seriesValue < 0))
-          ) {
-            stackValue = (stackValue ?? 0) + seriesValue;
-          }
-        });
-
-        if (stackValue === null) {
-          return " ";
-        }
-
-        const valueGetter = getMetricDisplayValueGetter(settings);
-        const valueFormatter = (value: RowValue) =>
-          renderingContext.formatValue(valueGetter(value), {
-            ...(settings.column?.(seriesModel.column) ?? {}),
-            jsx: false,
-            compact: settings["graph.label_value_formatting"] === "compact",
-          });
-
-        return valueFormatter(stackValue);
-      },
+      formatter: getStackedDataLabelFormatter(
+        chartModel.transformedDataset,
+        seriesModel,
+        signKey,
+        stackDataKeys,
+        settings,
+        renderingContext,
+      ),
     },
     labelLayout: {
       hideOverlap: settings["graph.label_value_frequency"] === "fit",
@@ -474,6 +453,62 @@ const generateStackOption = (
     },
   };
 };
+
+function getStackedDataLabelFormatter(
+  dataset: ChartDataset,
+  seriesModel: SeriesModel,
+  signKey: StackTotalDataKey,
+  stackDataKeys: DataKey[],
+  settings: ComputedVisualizationSettings,
+  renderingContext: RenderingContext,
+) {
+  const isCompact = shouldRenderCompact({
+    dataset,
+    getValue: (datum: Datum) =>
+      getStackTotalValue(datum, stackDataKeys, signKey),
+    renderingContext,
+    seriesModel,
+    settings,
+  });
+
+  return (params: LabelLayoutOptionCallbackParams & { data: Datum }) => {
+    const stackValue = getStackTotalValue(params.data, stackDataKeys, signKey);
+
+    if (stackValue === null) {
+      return " ";
+    }
+
+    const valueGetter = getMetricDisplayValueGetter(settings);
+    const valueFormatter = (value: RowValue) =>
+      renderingContext.formatValue(valueGetter(value), {
+        ...(settings.column?.(seriesModel.column) ?? {}),
+        jsx: false,
+        compact: isCompact,
+      });
+
+    return valueFormatter(stackValue);
+  };
+}
+
+function getStackTotalValue(
+  data: Datum,
+  stackDataKeys: DataKey[],
+  signKey: StackTotalDataKey,
+): number | null {
+  let stackValue: number | null = null;
+  stackDataKeys.forEach(stackDataKey => {
+    const seriesValue = data[stackDataKey];
+    if (
+      typeof seriesValue === "number" &&
+      ((signKey === POSITIVE_STACK_TOTAL_DATA_KEY && seriesValue > 0) ||
+        (signKey === NEGATIVE_STACK_TOTAL_DATA_KEY && seriesValue < 0))
+    ) {
+      stackValue = (stackValue ?? 0) + seriesValue;
+    }
+  });
+
+  return stackValue;
+}
 
 export const getStackTotalsSeries = (
   chartModel: CartesianChartModel,


### PR DESCRIPTION
- Closes: https://github.com/metabase/metabase/issues/39583
  - When I first tackled this issue, I did not realize that stacked charts had a separate data label formatting path. So this PR is to fix up stacked charts auto formatting.

**Before**

https://github.com/metabase/metabase/assets/22608765/96495b11-f0ff-469f-835f-7198251a85d2

**After**

https://github.com/metabase/metabase/assets/22608765/67a9a6ad-08ec-4d2a-83fd-ce7abecdba1a