### PR TITLE
Use a released version of source-map-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,7 +307,7 @@
     "@types/react": "^17.0.77",
     "@types/react-dom": "^17.0.11",
     "set-value": "4.0.1",
-    "source-map-js": "git+https://github.com/7rulnik/source-map-js#6e5dfccf75f84f619d3646188aef7ef7cf8f6376",
+    "source-map-js": "1.2.0",
     "unset-value": "2.0.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19956,9 +19956,10 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-js@^0.6.2, source-map-js@^1.0.1, source-map-js@^1.0.2, "source-map-js@git+https://github.com/7rulnik/source-map-js#6e5dfccf75f84f619d3646188aef7ef7cf8f6376":
-  version "1.0.2"
-  resolved "git+https://github.com/7rulnik/source-map-js#6e5dfccf75f84f619d3646188aef7ef7cf8f6376"
+source-map-js@1.2.0, source-map-js@^0.6.2, source-map-js@^1.0.1, source-map-js@^1.0.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
+  integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
 source-map-loader@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
### Description

The fix from Braden was released finally https://github.com/7rulnik/source-map-js/releases/tag/v1.0.3, so we can stop sticking to a commit