### PR TITLE
model indexing: clear errors in success pathway

### DIFF
--- a/src/metabase/models/model_index.clj
+++ b/src/metabase/models/model_index.clj
@@ -135,6 +135,7 @@ don't, (and shouldn't) care that those are expressions. They are just another fi
                                  additions-part)))))
           (t2/update! ModelIndex (:id model-index)
                       {:indexed_at :%now
+                       :error      nil
                        :state      (if (> (count values-to-index) max-indexed-values)
                                      "overflow"
                                      "indexed")}))


### PR DESCRIPTION
if a previous run had an error, it will remain present but the state would be "indexed". We should just clear that error.

Follow up to https://github.com/metabase/metabase/pull/40642

Not clearing the error message leads to states where state is "indexed" and error is "ERROR: column "pk_ref" does not exist Position: 68". Not terrible but could be cleaner. An invariant that state = "error" iff error != nil is a good one.