### PR TITLE
Add `identity-obj-proxy` for better Jest testing with CSS modules

### DIFF
--- a/frontend/test/metabase/lib/formatting.unit.spec.js
+++ b/frontend/test/metabase/lib/formatting.unit.spec.js
@@ -268,8 +268,8 @@ describe("formatting", () => {
       });
       // it's not actually a link
       expect(isElementOfType(formatted, ExternalLink)).toEqual(false);
-      // expect the text to be in a div (which has link formatting) rather than ExternalLink
-      expect(formatted.props["data-testid"]).toEqual("link-formatted-text");
+      // it is formatted as a link cell for the dashboard level click behavior
+      expect(formatted.props.className).toEqual("link linkWrappable");
     });
     it("should render image", () => {
       const formatted = formatValue("http://metabase.com/logo.png", {
@@ -498,8 +498,8 @@ describe("formatting", () => {
 
         // it is not a link set on the question level
         expect(isElementOfType(formatted, ExternalLink)).toEqual(false);
-        // expect the text to be in a div (which has link formatting) rather than ExternalLink
-        expect(formatted.props["data-testid"]).toEqual("link-formatted-text");
+        // it is formatted as a link cell for the dashboard level click behavior
+        expect(formatted.props.className).toEqual("link linkWrappable");
       });
     });
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 /** @type {import('jest').Config} */
 const config = {
   moduleNameMapper: {
-    "\\.(css|less)$": "<rootDir>/frontend/test/__mocks__/styleMock.js",
+    "\\.(css|less)$": "identity-obj-proxy",
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/frontend/test/__mocks__/fileMock.js",
     "^promise-loader\\?global\\!metabase-lib\\/v1\\/metadata\\/utils\\/ga-metadata$":

--- a/package.json
+++ b/package.json
@@ -247,6 +247,7 @@
     "glob": "^7.1.1",
     "html-webpack-plugin": "5.5.0",
     "husky": "^8.0.2",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^29.5.0",
     "jest-canvas-mock": "^2.4.0",
     "jest-environment-jsdom": "^29.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11964,6 +11964,11 @@ handlebars@^4.7.7:
   optionalDependencies:
     uglify-js "^3.1.4"
 
+harmony-reflect@^1.4.6:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.6.2.tgz#31ecbd32e648a34d030d86adb67d4d47547fe710"
+  integrity sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==
+
 has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -12518,6 +12523,13 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  integrity sha512-00n6YnVHKrinT9t0d9+5yZC6UBNJANpYEQvL2LlX6Ab9lnmxzIRcEmTPuyGScvl1+jKuCICX1Z0Ab1pPKKdikA==
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
### Description

I noticed that some of tests were failing because they would expect a certain class to be defined on the `div`. For whatever reason, when using CSS modules instead of global classes, these classes would default to `undefined` instead of the actual class name, and cause tests to fail. Ideally, adding this package and modifying the jest config should _in theory_ solve this problem.

### How to verify

Will include instructions once I find a good demo test

### Demo

_Upload a demo video or before/after screenshots if sensible or remove the section_

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
