### PR TITLE
Add `location` and `effective_location` to search

### DIFF
--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -333,7 +333,7 @@
                                (filter (fn [[_k v]] (= v :text)))
                                (map first)
                                (remove #{:collection_authority_level :moderated_status
-                                         :initial_sync_status :pk_ref}))
+                                         :initial_sync_status :pk_ref :location}))
         case-clauses      (as-> columns-to-search <>
                             (map (fn [col] [:like [:lower col] match]) <>)
                             (interleave <> (repeat [:inline 0]))
@@ -448,6 +448,9 @@
         xf                 (comp
                             (map t2.realize/realize)
                             (map to-toucan-instance)
+                            (map #(if (t2/instance-of? :model/Collection %)
+                                    (t2/hydrate % :effective_location)
+                                    (assoc % :effective_location nil)))
                             (filter (partial check-permissions-for-model (:archived? search-ctx)))
                             ;; MySQL returns `:bookmark` and `:archived` as `1` or `0` so convert those to boolean as
                             ;; needed

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -147,6 +147,8 @@
    :bookmark            :boolean
    ;; returned for everything except Collection
    :updated_at          :timestamp
+   ;; returned only for Collection
+   :location            :text
    ;; returned for Card only, used for scoring and displays
    :dashboardcard_count :integer
    :last_edited_at      :timestamp
@@ -299,6 +301,7 @@
         [:name :collection_name]
         [:type :collection_type]
         [:authority_level :collection_authority_level]
+        :location
         bookmark-col))
 
 (defmethod columns-for-model "segment"

--- a/test/metabase/api/search_test.clj
+++ b/test/metabase/api/search_test.clj
@@ -42,6 +42,8 @@
 
 (def ^:private default-search-row
   {:archived                   false
+   :effective_location         nil
+   :location                   nil
    :bookmark                   nil
    :collection                 default-collection
    :collection_authority_level nil
@@ -100,6 +102,8 @@
                                             :model "collection"
                                             ;; TODO the default-collection data for this doesn't make sense:
                                             :collection (assoc default-collection :id true :name true)
+                                            :effective_location "/"
+                                            :location "/"
                                             :updated_at false
                                             :can_write true))
 


### PR DESCRIPTION
For collections retrieved from the Search API, attach `location` and `effective_location` so the frontend knows... where they're located.

Fixes https://github.com/metabase/metabase/issues/40395