### PR TITLE
stub css modules for static viz

### DIFF
--- a/package.json
+++ b/package.json
@@ -268,6 +268,7 @@
     "mutationobserver-shim": "^0.3.7",
     "mysql2": "^3.6.3",
     "node-polyfill-webpack-plugin": "2.0.1",
+    "null-loader": "^4.0.1",
     "pg": "^8.8.0",
     "postcss": "8.4.19",
     "postcss-color-mod-function": "^3.0.3",

--- a/webpack.static-viz.config.js
+++ b/webpack.static-viz.config.js
@@ -48,6 +48,10 @@ module.exports = env => {
     module: {
       rules: [
         {
+          test: /\.css$/i,
+          use: "null-loader",
+        },
+        {
           test: /\.(tsx?|jsx?)$/,
           exclude: /node_modules|cljs/,
           use: [{ loader: "babel-loader", options: BABEL_CONFIG }],
@@ -90,10 +94,6 @@ module.exports = env => {
       ],
     },
     plugins: [
-      new IgnorePlugin({
-        resourceRegExp: /\.css$/, // regular expression to ignore all CSS files
-        contextRegExp: /./,
-      }),
       new StatsWriterPlugin({
         stats: {
           modules: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16300,6 +16300,14 @@ nth-check@2.0.1, nth-check@^1.0.2, nth-check@^2.0.0, nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/pull/40561

### Description

The static viz bundle does not use any CSS that may be imported because it renders SVGs or HTML with inline styles for email clients. However, some of our code including formatting started importing CSS modules. This PR stubs them so that the code does not fail in runtime.

[Slack convo](https://metaboat.slack.com/archives/C505ZNNH4/p1711549227366189)

### How to verify

- CI must be green
- Dashboard subscriptions should render charts

### Checklist

- [-] Tests have been added/updated to cover changes in this PR
