### PR TITLE
Handle invalid file drop

### DIFF
--- a/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.jsx
+++ b/frontend/src/metabase/collections/components/CollectionContent/CollectionContentView.jsx
@@ -3,6 +3,7 @@ import cx from "classnames";
 import { useCallback, useEffect, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { usePrevious } from "react-use";
+import { t } from "ttag";
 
 import ErrorBoundary from "metabase/ErrorBoundary";
 import BulkActions from "metabase/collections/components/BulkActions";
@@ -18,6 +19,8 @@ import Search from "metabase/entities/search";
 import { useListSelect } from "metabase/hooks/use-list-select";
 import { usePagination } from "metabase/hooks/use-pagination";
 import { useToggle } from "metabase/hooks/use-toggle";
+import { useDispatch } from "metabase/lib/redux";
+import { addUndo } from "metabase/redux/undo";
 
 import { ModelUploadModal } from "../ModelUploadModal";
 import UploadOverlay from "../UploadOverlay";
@@ -114,7 +117,19 @@ export function CollectionContentView({
     setIsBookmarked(shouldBeBookmarked);
   }, [bookmarks, collectionId]);
 
+  const dispatch = useDispatch();
+
   const onDrop = acceptedFiles => {
+    if (!acceptedFiles.length) {
+      dispatch(
+        addUndo({
+          message: t`Invalid file type`,
+          toastColor: "error",
+          icon: "warning",
+        }),
+      );
+      return;
+    }
     saveFile(acceptedFiles[0]);
   };
 


### PR DESCRIPTION
@crisptrutski noted that if you drop an invalid file into a collection, you don't get any error feedback. This adds a small error toast if you drop only invalid files.

![invalid toast](https://github.com/metabase/metabase/assets/30528226/f8ee1b65-df8c-415c-9105-da1bedf5ba82)
