### PR TITLE
Allow CollectionMover to display API errors

### DIFF
--- a/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
@@ -29,8 +29,12 @@ const MoveCollectionModalView = ({
 }: MoveCollectionModalProps): JSX.Element => {
   const handleMove = useCallback(
     async (destination: { id: CollectionId }) => {
-      await onMove(collection, destination);
-      onClose();
+      try {
+        await onMove(collection, destination);
+        onClose();
+      } catch (e) {
+        console.log("caught error", e);
+      }
     },
     [collection, onMove, onClose],
   );
@@ -76,8 +80,7 @@ export const MoveCollectionModal = ({
     <MoveCollectionModalView
       collection={collection}
       onMove={async (source, destination) => {
-        const result = await dispatch(Collections.actions.setCollection(source, destination).catch(e => e))
-        console.log('dispatch await result', result);
+        await dispatch(Collections.actions.setCollection(source, destination));
       }}
       onClose={onClose}
     />

--- a/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
@@ -75,9 +75,10 @@ export const MoveCollectionModal = ({
   return (
     <MoveCollectionModalView
       collection={collection}
-      onMove={(source, destination) =>
-        dispatch(Collections.actions.setCollection(source, destination))
-      }
+      onMove={async (source, destination) => {
+        const result = await dispatch(Collections.actions.setCollection(source, destination).catch(e => e))
+        console.log('dispatch await result', result);
+      }}
       onClose={onClose}
     />
   );

--- a/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
+++ b/frontend/src/metabase/collections/components/MoveCollectionModal/MoveCollectionModal.tsx
@@ -29,12 +29,8 @@ const MoveCollectionModalView = ({
 }: MoveCollectionModalProps): JSX.Element => {
   const handleMove = useCallback(
     async (destination: { id: CollectionId }) => {
-      try {
-        await onMove(collection, destination);
-        onClose();
-      } catch (e) {
-        console.log("caught error", e);
-      }
+      await onMove(collection, destination);
+      onClose();
     },
     [collection, onMove, onClose],
   );

--- a/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
+++ b/frontend/src/metabase/common/components/CollectionPicker/components/CollectionPickerModal.tsx
@@ -54,19 +54,19 @@ export const CollectionPickerModal = ({
   }>();
 
   const handleItemSelect = useCallback(
-    (item: CollectionPickerItem) => {
+    async (item: CollectionPickerItem) => {
       if (options.hasConfirmButtons) {
         setSelectedItem(item);
       } else {
-        onChange(item);
+        await onChange(item);
       }
     },
     [onChange, options],
   );
 
-  const handleConfirm = () => {
+  const handleConfirm = async () => {
     if (selectedItem) {
-      onChange(selectedItem);
+      await onChange(selectedItem);
     }
   };
 

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
@@ -1,10 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { t } from "ttag";
 
-import Collections from "metabase/entities/collections";
 import { color } from "metabase/lib/colors";
-import { useSelector } from "metabase/lib/redux";
-import { Button, Flex } from "metabase/ui";
+import { Button, Flex, Text } from "metabase/ui";
 
 export const ButtonBar = ({
   onConfirm,
@@ -21,6 +19,7 @@ export const ButtonBar = ({
   confirmButtonText?: string;
   cancelButtonText?: string;
 }) => {
+  const [error, setError] = useState<string | null>(null);
   useEffect(() => {
     const handleEnter = (e: KeyboardEvent) => {
       if (canConfirm && e.key === "Enter") {
@@ -33,19 +32,21 @@ export const ButtonBar = ({
     };
   }, [canConfirm, onConfirm]);
 
-  const err = useSelector(Collections.selectors.getError);
-
-  console.log('err selector', err)
-
   return (
     <Flex
       justify="space-between"
+      align="center"
       p="md"
       style={{
         borderTop: `1px solid ${color("border")}`,
       }}
     >
       <Flex gap="md">{actionButtons}</Flex>
+      {error && (
+        <Text color="error" px="md" lh="1rem">
+          {error}
+        </Text>
+      )}
       <Flex gap="md">
         <Button onClick={onCancel} type="button">
           {cancelButtonText ?? t`Cancel`}
@@ -53,11 +54,12 @@ export const ButtonBar = ({
         <Button
           ml={1}
           variant="filled"
-          onClick={() => {
+          onClick={async () => {
             try {
-              onConfirm();
-            } catch(e) {
-              console.error('buttonbar', e)
+              setError(null);
+              await onConfirm();
+            } catch (e: any) {
+              setError(e?.data?.message ?? t`An error occurred`);
             }
           }}
           disabled={!canConfirm}

--- a/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
+++ b/frontend/src/metabase/common/components/EntityPicker/components/EntityPickerModal/ButtonBar.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
 import { t } from "ttag";
 
+import Collections from "metabase/entities/collections";
 import { color } from "metabase/lib/colors";
+import { useSelector } from "metabase/lib/redux";
 import { Button, Flex } from "metabase/ui";
 
 export const ButtonBar = ({
@@ -31,6 +33,10 @@ export const ButtonBar = ({
     };
   }, [canConfirm, onConfirm]);
 
+  const err = useSelector(Collections.selectors.getError);
+
+  console.log('err selector', err)
+
   return (
     <Flex
       justify="space-between"
@@ -47,7 +53,13 @@ export const ButtonBar = ({
         <Button
           ml={1}
           variant="filled"
-          onClick={onConfirm}
+          onClick={() => {
+            try {
+              onConfirm();
+            } catch(e) {
+              console.error('buttonbar', e)
+            }
+          }}
           disabled={!canConfirm}
         >
           {confirmButtonText ?? t`Select`}

--- a/frontend/src/metabase/containers/MoveModal.tsx
+++ b/frontend/src/metabase/containers/MoveModal.tsx
@@ -39,7 +39,7 @@ export const MoveModal = ({
         id: initialCollectionId,
         model: "collection",
       }}
-      onChange={newCollection => onMove({ id: newCollection.id })}
+      onChange={async newCollection => await onMove({ id: newCollection.id })}
       options={{
         showSearch: true,
         allowCreateNew: true,


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/40675

## Description

Currently, there's one error case that will be  better handled by https://github.com/metabase/metabase/issues/40395 where you can select an invalid move target when searching. Before this change it would fail silently leaving users confused about why nothing happened. This simply surfaces the API error.

![Screen Shot 2024-03-27 at 1 42 00 PM](https://github.com/metabase/metabase/assets/30528226/a547c773-9662-48c7-b4de-47bec4ecef79)
