### PR TITLE
Strip .tsv file extension

### DIFF
--- a/e2e/test/scenarios/collections/uploads.cy.spec.js
+++ b/e2e/test/scenarios/collections/uploads.cy.spec.js
@@ -31,8 +31,8 @@ const validTestFiles = [
   },
   {
     fileName: "pokedex.tsv",
-    tableName: "pokedex_tsv", // TODO, remove _tsv extension when backend logic changes
-    humanName: "Pokedex.tsv", // TODO, remove .tsv extension when backend logic changes
+    tableName: "pokedex",
+    humanName: "Pokedex",
     rowCount: 202,
   },
 ];

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -635,7 +635,7 @@
     (try
       (let [timer             (start-timer)
             driver            (driver.u/database->driver database)
-            filename-prefix   (or (second (re-matches #"(.*)\.csv$" filename))
+            filename-prefix   (or (second (re-matches #"(.*)\.(csv|tsv)$" filename))
                                   filename)
             table-name        (->> (str table-prefix filename-prefix)
                                    (unique-table-name driver)


### PR DESCRIPTION
### Description

Thus updates the upload backend to treat `.tsv` extensions the same way as `.csv` ones - by stripping it from the model and table names.

To be honest, I'm not sure why we don't strip *any* extension, but just taking one step for now.