### PR TITLE
Trim clipboard data in filter widgets

### DIFF
--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -541,18 +541,6 @@ describe("StringFilterValuePicker", () => {
       expect(onChange).toHaveBeenLastCalledWith(["a@b.com", "a@b"]);
     });
 
-    it("should trim free-form input", async () => {
-      const { onChange } = await setupStringPicker({
-        query,
-        stageIndex,
-        column,
-        values: [],
-      });
-
-      userEvent.type(screen.getByLabelText("Filter value"), " abc \t");
-      expect(onChange).toHaveBeenLastCalledWith(["abc"]);
-    });
-
     it("should trim clipboard data", async () => {
       const { onChange } = await setupStringPicker({
         query,

--- a/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
+++ b/frontend/src/metabase/querying/components/FilterValuePicker/FilterValuePicker.unit.spec.tsx
@@ -6,6 +6,7 @@ import {
 } from "__support__/server-mocks";
 import {
   act,
+  createMockClipboardData,
   renderWithProviders,
   screen,
   waitForLoaderToBeRemoved,
@@ -538,6 +539,35 @@ describe("StringFilterValuePicker", () => {
       expect(screen.getByText("a@b.com")).toBeInTheDocument();
       expect(screen.queryByText("a@b")).not.toBeInTheDocument();
       expect(onChange).toHaveBeenLastCalledWith(["a@b.com", "a@b"]);
+    });
+
+    it("should trim free-form input", async () => {
+      const { onChange } = await setupStringPicker({
+        query,
+        stageIndex,
+        column,
+        values: [],
+      });
+
+      userEvent.type(screen.getByLabelText("Filter value"), " abc \t");
+      expect(onChange).toHaveBeenLastCalledWith(["abc"]);
+    });
+
+    it("should trim clipboard data", async () => {
+      const { onChange } = await setupStringPicker({
+        query,
+        stageIndex,
+        column,
+        values: [],
+      });
+
+      const clipboardData = createMockClipboardData({
+        getData: () => " abc\r\ndef",
+      });
+      userEvent.paste(screen.getByLabelText("Filter value"), "", {
+        clipboardData,
+      });
+      expect(onChange).toHaveBeenLastCalledWith(["abc", "def"]);
     });
   });
 

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -59,10 +59,9 @@ export function MultiAutocomplete({
   const handleSearchChange = (newSearchValue: string) => {
     setSearchValue(newSearchValue);
 
-    const newValue = getFreeFormValue(searchValue);
-    const isValid = shouldCreate?.(newValue, []);
+    const isValid = shouldCreate?.(newSearchValue, []);
     if (isValid) {
-      setSelectedValues([...lastSelectedValues, newValue]);
+      setSelectedValues([...lastSelectedValues, newSearchValue]);
     } else {
       setSelectedValues(lastSelectedValues);
     }
@@ -73,7 +72,7 @@ export function MultiAutocomplete({
     const values = text.split(/[\n,]/g);
     if (values.length > 1) {
       const validValues = [...new Set(values)]
-        .map(getFreeFormValue)
+        .map(value => value.trim())
         .filter(value => shouldCreate?.(value, []));
       if (validValues.length > 0) {
         event.preventDefault();
@@ -127,8 +126,4 @@ function getAvailableSelectItems(
   }, new Map<string, string>());
 
   return [...mapping.entries()].map(([value, label]) => ({ value, label }));
-}
-
-function getFreeFormValue(searchValue: string) {
-  return searchValue.trim();
 }

--- a/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
+++ b/frontend/src/metabase/ui/components/inputs/MultiAutocomplete/MultiAutocomplete.tsx
@@ -59,9 +59,10 @@ export function MultiAutocomplete({
   const handleSearchChange = (newSearchValue: string) => {
     setSearchValue(newSearchValue);
 
-    const isValid = shouldCreate?.(newSearchValue, []);
+    const newValue = getFreeFormValue(searchValue);
+    const isValid = shouldCreate?.(newValue, []);
     if (isValid) {
-      setSelectedValues([...lastSelectedValues, newSearchValue]);
+      setSelectedValues([...lastSelectedValues, newValue]);
     } else {
       setSelectedValues(lastSelectedValues);
     }
@@ -71,10 +72,9 @@ export function MultiAutocomplete({
     const text = event.clipboardData.getData("Text");
     const values = text.split(/[\n,]/g);
     if (values.length > 1) {
-      const uniqueValues = [...new Set(values)];
-      const validValues = uniqueValues.filter(value =>
-        shouldCreate?.(value, []),
-      );
+      const validValues = [...new Set(values)]
+        .map(getFreeFormValue)
+        .filter(value => shouldCreate?.(value, []));
       if (validValues.length > 0) {
         event.preventDefault();
         const newSelectedValues = [...lastSelectedValues, ...validValues];
@@ -127,4 +127,8 @@ function getAvailableSelectItems(
   }, new Map<string, string>());
 
   return [...mapping.entries()].map(([value, label]) => ({ value, label }));
+}
+
+function getFreeFormValue(searchValue: string) {
+  return searchValue.trim();
 }

--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -243,4 +243,14 @@ export const mockScrollBy = () => {
   window.Element.prototype.scrollBy = jest.fn();
 };
 
+/**
+ * jsdom doesn't have DataTransfer
+ */
+export function createMockClipboardData(
+  opts?: Partial<DataTransfer>,
+): DataTransfer {
+  const clipboardData = { ...opts };
+  return clipboardData as unknown as DataTransfer;
+}
+
 export * from "@testing-library/react";


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/40265

Additional fix for the issue. We need to remove windows-like separators in clipboard data before setting the filter value.