### PR TITLE
Fix bad Table Metadata Icon

### DIFF
--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataSchemaList/MetadataSchemaList.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataSchemaList/MetadataSchemaList.tsx
@@ -80,7 +80,7 @@ const MetadataSchemaList = ({
   return (
     <aside className={cx(AdminS.AdminList, CS.flexNoShrink)}>
       <div className={AdminS.AdminListSearch}>
-        <Icon name="search" size={16} />
+        <Icon className={AdminS.Icon} name="search" size={16} />
         <input
           className={cx(AdminS.AdminInput, CS.pl4, CS.borderBottom)}
           type="text"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40737

### Description

Fixes bad placement of icon in the schema picker in the Table Metadata section of the Admin section.

Before:

![image](https://github.com/metabase/metabase/assets/25306947/699f63b2-1227-450f-b039-a0c20cca06cb)


After:

<img width="299" alt="image" src="https://github.com/metabase/metabase/assets/25306947/e833d1f7-4eee-4eb5-8840-5e4a52c9f87d">


### How to verify

- Add a database with multiple schemas
- Go to Admin > Table Metadata of that database
- Make sure that the icon is aligned with the input.