### PR TITLE
Allow saving native questions with required parameters without defaults

### DIFF
--- a/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-field-filter.cy.spec.js
@@ -50,18 +50,8 @@ describe("scenarios > filters > sql filters > field filter", () => {
       });
     }
 
-    it("needs a default value to save the query, but allows running it", () => {
+    it("does not need a default value to run and save the query", () => {
       SQLFilter.toggleRequired();
-      SQLFilter.getRunQueryButton().should("not.be.disabled");
-      SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
-
-      SQLFilter.getSaveQueryButton().realHover();
-      cy.get("body").findByText(
-        'The "Filter" variable requires a default value but none was provided.',
-      );
-
-      setDefaultFieldValue(4);
-
       SQLFilter.getRunQueryButton().should("not.be.disabled");
       SQLFilter.getSaveQueryButton().should("not.have.attr", "disabled");
     });

--- a/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/sql-filters.cy.spec.js
@@ -49,17 +49,8 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     });
 
     describe("required tag", () => {
-      it("needs a default value to save the query, but allows running it", () => {
+      it("does not need a default value to run and save the query", () => {
         SQLFilter.toggleRequired();
-        SQLFilter.getRunQueryButton().should("not.be.disabled");
-        SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
-
-        SQLFilter.getSaveQueryButton().realHover();
-        cy.get("body").findByText(
-          'The "TextFilter" variable requires a default value but none was provided.',
-        );
-
-        SQLFilter.setDefaultValue("Some text");
         SQLFilter.getRunQueryButton().should("not.be.disabled");
         SQLFilter.getSaveQueryButton().should("not.have.attr", "disabled");
       });
@@ -128,18 +119,8 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     });
 
     describe("required tag", () => {
-      it("needs a default value to save the query, but allows running it", () => {
+      it("does not need a default value to run and save the query", () => {
         SQLFilter.toggleRequired();
-        SQLFilter.getRunQueryButton().should("not.be.disabled");
-        SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
-
-        SQLFilter.getSaveQueryButton().realHover();
-
-        cy.get("body").findByText(
-          'The "NumberFilter" variable requires a default value but none was provided.',
-        );
-
-        SQLFilter.setDefaultValue("33");
         SQLFilter.getRunQueryButton().should("not.be.disabled");
         SQLFilter.getSaveQueryButton().should("not.have.attr", "disabled");
       });
@@ -230,19 +211,8 @@ describe("scenarios > filters > sql filters > basic filter types", () => {
     }
 
     describe("required tag", () => {
-      it("needs a default value to save the query, but allows running it", () => {
+      it("does not need a default value to run and save the query", () => {
         SQLFilter.toggleRequired();
-        SQLFilter.getRunQueryButton().should("not.be.disabled");
-        SQLFilter.getSaveQueryButton().should("have.attr", "disabled");
-
-        SQLFilter.getSaveQueryButton().realHover();
-
-        cy.get("body").findByText(
-          'The "DateFilter" variable requires a default value but none was provided.',
-        );
-
-        setDefaultDate();
-
         SQLFilter.getRunQueryButton().should("not.be.disabled");
         SQLFilter.getSaveQueryButton().should("not.have.attr", "disabled");
       });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -80,8 +80,6 @@ const viewTitleHeaderPropTypes = {
 
   className: PropTypes.string,
   style: PropTypes.object,
-
-  requiredTemplateTags: PropTypes.array,
 };
 
 export function ViewTitleHeader(props) {
@@ -396,7 +394,6 @@ ViewTitleHeaderRightSide.propTypes = {
   isShowingQuestionInfoSidebar: PropTypes.bool,
   onModelPersistenceChange: PropTypes.func,
   onQueryChange: PropTypes.func,
-  requiredTemplateTags: PropTypes.array,
 };
 
 function ViewTitleHeaderRightSide(props) {
@@ -429,7 +426,6 @@ function ViewTitleHeaderRightSide(props) {
     onCloseQuestionInfo,
     onOpenQuestionInfo,
     onModelPersistenceChange,
-    requiredTemplateTags,
   } = props;
   const isShowingNotebook = queryBuilderMode === "notebook";
   const { isEditable } = Lib.queryDisplayInfo(question.query());
@@ -462,11 +458,7 @@ function ViewTitleHeaderRightSide(props) {
 
   const canSave = Lib.canSave(question.query());
   const isSaveDisabled = !canSave;
-  const disabledSaveTooltip = getDisabledSaveTooltip(
-    isEditable,
-    requiredTemplateTags,
-    canSave,
-  );
+  const disabledSaveTooltip = getDisabledSaveTooltip(isEditable);
 
   return (
     <ViewHeaderActionPanel data-testid="qb-header-action-panel">
@@ -556,39 +548,8 @@ function ViewTitleHeaderRightSide(props) {
 
 ViewTitleHeader.propTypes = viewTitleHeaderPropTypes;
 
-function getDisabledSaveTooltip(
-  isEditable,
-  requiredTemplateTags = [],
-  canSave,
-) {
+function getDisabledSaveTooltip(isEditable) {
   if (!isEditable) {
     return t`You don't have permission to save this question.`;
   }
-
-  const missingValueRequiredTTags = requiredTemplateTags.filter(
-    tag => tag.required && !tag.default,
-  );
-
-  if (!canSave) {
-    return getMissingRequiredTemplateTagsTooltip(missingValueRequiredTTags);
-  }
-
-  // Having an empty tooltip text is ok because it won't be shown.
-  return "";
-}
-
-function getMissingRequiredTemplateTagsTooltip(requiredTemplateTags = []) {
-  if (!requiredTemplateTags.length) {
-    return "";
-  }
-
-  const names = requiredTemplateTags
-    .map(tag => `"${tag["display-name"] ?? tag.name}"`)
-    .join(", ");
-
-  return ngettext(
-    msgid`The ${names} variable requires a default value but none was provided.`,
-    `The ${names} variables require default values but none were provided.`,
-    requiredTemplateTags.length,
-  );
 }

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/ViewHeader.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import { useEffect, useCallback, useState } from "react";
 import { usePrevious } from "react-use";
-import { t, ngettext, msgid } from "ttag";
+import { t } from "ttag";
 
 import Link from "metabase/core/components/Link";
 import Tooltip from "metabase/core/components/Tooltip";

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.jsx
@@ -82,7 +82,6 @@ import {
   getCardAutocompleteResultsFn,
   isResultsMetadataDirty,
   getShouldShowUnsavedChangesWarning,
-  getRequiredTemplateTags,
   getEmbeddedParameterVisibility,
 } from "../selectors";
 import { isNavigationAllowed } from "../utils";
@@ -168,7 +167,6 @@ const mapStateToProps = (state, props) => {
 
     reportTimezone: getSetting(state, "report-timezone-long"),
 
-    requiredTemplateTags: getRequiredTemplateTags(state),
     getEmbeddedParameterVisibility: slug =>
       getEmbeddedParameterVisibility(state, slug),
   };

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1017,16 +1017,6 @@ export const getTemplateTags = createSelector([getCard], card =>
   getIn(card, ["dataset_query", "native", "template-tags"]),
 );
 
-export const getRequiredTemplateTags = createSelector(
-  [getTemplateTags],
-  templateTags =>
-    templateTags
-      ? Object.keys(templateTags)
-          .filter(key => templateTags[key].required)
-          .map(key => templateTags[key])
-      : [],
-);
-
 export const getEmbeddingParameters = createSelector([getCard], card => {
   if (!card?.enable_embedding) {
     return {};

--- a/src/metabase/lib/native.cljc
+++ b/src/metabase/lib/native.cljc
@@ -260,18 +260,3 @@
   [query :- ::lib.schema/query]
   (assert-native-query! (lib.util/query-stage query 0))
   (:engine (lib.metadata/database query)))
-
-(defn- has-default?
-  "Whether the template tag has a non-empty default value.
-
-  Empty values are nil, '', []. Everything else is not empty."
-  [{value :default}]
-  (if (or (string? value) (vector? value))
-    (not-empty value)
-    (some? value)))
-
-(defmethod lib.query/can-save-method :mbql.stage/native
-  [query]
-  (every? (fn [{:keys [required] :as tag}]
-            (or (not required) (has-default? tag)))
-          (vals (template-tags query))))

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -64,21 +64,11 @@
   (and (mc/validate ::lib.schema/query query)
        (boolean (can-run-method query))))
 
-(defmulti can-save-method
-  "Returns whether the query can be saved based on first stage :lib/type."
-  (fn [query]
-    (:lib/type (lib.util/query-stage query 0))))
-
-(defmethod can-save-method :default
-  [_query]
-  true)
-
 (mu/defn can-save :- :boolean
   "Returns whether the query can be saved."
   [query :- ::lib.schema/query]
   (and (lib.metadata/editable? query)
-       (can-run query)
-       (boolean (can-save-method query))))
+       (can-run query)))
 
 (mu/defn query-with-stages :- ::lib.schema/query
   "Create a query from a sequence of stages."

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -324,26 +324,6 @@
            :required true
            :default default}}))
 
-(deftest ^:parallel can-save-native-test
-  (is (lib/can-save (lib/native-query meta/metadata-provider "select 1")))
-  (is (lib/can-save (lib/native-query meta/metadata-provider "select * {{foo}}")))
-  (is (lib/can-save (lib/with-template-tags
-                      (lib/native-query meta/metadata-provider "select * {{foo}}")
-                      {"foo" {:type :text
-                              :id "1"
-                              :name "foo"
-                              :display-name "foo"}})))
-  (is (lib/can-save (query-with-default 1)))
-  (is (lib/can-save (query-with-default "A")))
-  (is (lib/can-save (query-with-default [""])))
-  (is (lib/can-save (query-with-default ["A"])))
-  (is (lib/can-save (query-with-default [1])))
-  (is (not (lib/can-save (query-with-default nil))))
-  (is (not (lib/can-save (query-with-default ""))))
-  (is (not (lib/can-save (query-with-default []))))
-  (mu/disable-enforcement
-    (is (not (lib/can-save (lib/native-query meta/metadata-provider ""))))))
-
 (deftest ^:parallel engine-test
   (is (= :h2 (lib/engine lib.tu/native-query))))
 

--- a/test/metabase/lib/native_test.cljc
+++ b/test/metabase/lib/native_test.cljc
@@ -314,16 +314,6 @@
     (is (not (lib/can-run (update-in (lib/native-query (metadata-provider-requiring-collection) "select * {{foo}}" nil {:collection "foobar"})
                                      [:stages 0] dissoc :collection))))))
 
-(defn- query-with-default [default]
-  (lib/with-template-tags
-   (lib/native-query meta/metadata-provider "select * {{foo}}")
-   {"foo" {:type :text
-           :id "1"
-           :name "foo"
-           :display-name "foo"
-           :required true
-           :default default}}))
-
 (deftest ^:parallel engine-test
   (is (= :h2 (lib/engine lib.tu/native-query))))
 


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/40250
Slack thread https://metaboat.slack.com/archives/C01LQQ2UW03/p1711630839179969

We no longer require "required" parameters to have default values in native queries, as before 49.

How to verify:
- New -> SQL query -> `SELECT {{f}}`
- Make `f` required and do not provide a default value
- You can still run **and** save the query even if it's invalid