### PR TITLE
Cards with Results Should Show up in Subscriptions

### DIFF
--- a/src/metabase/pulse.clj
+++ b/src/metabase/pulse.clj
@@ -80,7 +80,7 @@
                    :run           (^:once fn* [query info]
                                    (qp/process-query
                                     (qp/userland-query-with-default-constraints query info))))]
-      (when-not (and (get-in dashcard [:visualization_settings :card.hide_empty]) (is-card-empty? result))
+      (when-not (and (get-in dashcard [:visualization_settings :card.hide_empty]) (is-card-empty? (assoc card :result result)))
         {:card     card
          :dashcard dashcard
          :result   result

--- a/test/metabase/dashboard_subscription_test.clj
+++ b/test/metabase/dashboard_subscription_test.clj
@@ -243,15 +243,19 @@
                     result))))))
 
 (deftest ^:parallel execute-dashboard-test-2
-  (testing "hides empty card when card.hide_empty is true"
+  (testing "hides empty card when card.hide_empty is true and there are no results."
     (mt/with-temp [Card          {card-id-1 :id} {:dataset_query (mt/mbql-query venues)}
-                   Card          {card-id-2 :id} {:dataset_query (mt/mbql-query venues)}
+                   Card          {card-id-2 :id} {:dataset_query (assoc-in (mt/mbql-query venues) [:query :limit] 0)}
+                   Card          {card-id-3 :id} {:dataset_query (assoc-in (mt/mbql-query venues) [:query :limit] 0)}
+                   Card          {card-id-4 :id} {:dataset_query (mt/mbql-query venues)}
                    Dashboard     {dashboard-id :id, :as dashboard} {:name "Birdfeed Usage"}
                    DashboardCard _ {:dashboard_id dashboard-id :card_id card-id-1}
                    DashboardCard _ {:dashboard_id dashboard-id :card_id card-id-2 :visualization_settings {:card.hide_empty true}}
+                   DashboardCard _ {:dashboard_id dashboard-id :card_id card-id-3}
+                   DashboardCard _ {:dashboard_id dashboard-id :card_id card-id-4}
                    User {user-id :id} {}]
       (let [result (@#'metabase.pulse/execute-dashboard {:creator_id user-id} dashboard)]
-        (is (= (count result) 1))))))
+        (is (= 3 (count result)))))))
 
 (deftest ^:parallel execute-dashboard-test-3
   (testing "dashboard cards are ordered correctly -- by rows, and then by columns (#17419)"


### PR DESCRIPTION
Fixes: #40726

This PR fixes a bug where setting 'Hide this card if there are no results' in a Dashcard's viz-settings would hide the card even when there were results.

screenshot of the setting:
![image](https://github.com/metabase/metabase/assets/21064735/dae8cd58-7a1c-4ad9-bd0b-3a2fb97bd364)

And the sent subscription:
![image](https://github.com/metabase/metabase/assets/21064735/e3426767-ce1a-4f47-b4e3-7f0b308bd6bb)
