### PR TITLE
[WIP] Remove binning by default for numeric columns

### DIFF
--- a/src/metabase/lib/binning.cljc
+++ b/src/metabase/lib/binning.cljc
@@ -73,15 +73,17 @@
     x]
    (available-binning-strategies-method query stage-number x)))
 
-(mu/defn default-auto-bin :- ::lib.schema.binning/binning-option
+(mu/defn auto-bin :- ::lib.schema.binning/binning-option
   "Returns the basic auto-binning strategy.
 
   Public because it's used directly by some drill-thrus."
   []
   {:lib/type     :option/binning
    :display-name (i18n/tru "Auto bin")
-   :default      true
    :mbql         {:strategy :default}})
+
+(defn- with-default-binning-option [m]
+  (assoc m :default true))
 
 (defn- with-binning-option-type [m]
   (assoc m :lib/type :option/binning))
@@ -90,7 +92,7 @@
   "List of binning options for numeric fields. These split the data evenly into a fixed number of bins."
   []
   (mapv with-binning-option-type
-        [(default-auto-bin)
+        [(auto-bin)
          {:display-name (i18n/tru "10 bins")  :mbql {:strategy :num-bins :num-bins 10}}
          {:display-name (i18n/tru "50 bins")  :mbql {:strategy :num-bins :num-bins 50}}
          {:display-name (i18n/tru "100 bins") :mbql {:strategy :num-bins :num-bins 100}}]))
@@ -100,7 +102,7 @@
   ranges as necessary, with each range being a certain number of degrees wide."
   []
   (mapv with-binning-option-type
-        [(default-auto-bin)
+        [(with-default-binning-option (auto-bin))
          {:display-name (i18n/tru "Bin every 0.1 degrees") :mbql {:strategy :bin-width :bin-width 0.1}}
          {:display-name (i18n/tru "Bin every 1 degree")    :mbql {:strategy :bin-width :bin-width 1.0}}
          {:display-name (i18n/tru "Bin every 10 degrees")  :mbql {:strategy :bin-width :bin-width 10.0}}

--- a/src/metabase/lib/drill_thru/distribution.cljc
+++ b/src/metabase/lib/drill_thru/distribution.cljc
@@ -68,7 +68,7 @@
 
     (and (lib.types.isa/numeric? column)
          (not (lib.types.isa/foreign-key? column)))
-    (lib.binning/with-binning column (lib.binning/default-auto-bin))
+    (lib.binning/with-binning column (lib.binning/auto-bin))
 
     :else
     column))


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/40729

How to verify:
- New -> Sample -> Orders
- Add breakout -> Total (see no binning is applied by default)
- Switch data to People
- Add breakout -> Latitude (see the binning strategy is still there)

Tests TBD

<img width="1040" alt="Screenshot 2024-03-28 at 17 47 44" src="https://github.com/metabase/metabase/assets/8542534/708ec895-d8db-417b-9ea0-64514ef32fb4">
<img width="1346" alt="Screenshot 2024-03-28 at 17 47 52" src="https://github.com/metabase/metabase/assets/8542534/5a5688d4-7e35-4b17-ae38-b5086290fad1">
<img width="1496" alt="Screenshot 2024-03-28 at 17 48 20" src="https://github.com/metabase/metabase/assets/8542534/15967cd6-5cdb-414a-8285-9bab7daf8c86">
