### PR TITLE
Feedback for the Embedding Homepage

### DIFF
--- a/frontend/src/metabase/api/product-feedback.ts
+++ b/frontend/src/metabase/api/product-feedback.ts
@@ -1,6 +1,6 @@
 import { Api } from "./api";
 
-export const productFeedbackApi = Api.injectEndpoints({
+const productFeedbackApi = Api.injectEndpoints({
   endpoints: builder => ({
     sendProductFeedback: builder.mutation<
       void,

--- a/frontend/src/metabase/api/product-feedback.ts
+++ b/frontend/src/metabase/api/product-feedback.ts
@@ -4,12 +4,12 @@ export const productFeedbackApi = Api.injectEndpoints({
   endpoints: builder => ({
     sendProductFeedback: builder.mutation<
       void,
-      { comments: string; email?: string }
+      { comments: string; email?: string; source: string }
     >({
-      query: ({ comments, email }) => ({
+      query: ({ comments, email, source }) => ({
         method: "POST",
-        url: `/api/product-feedback`,
-        body: { comments, email },
+        url: `/api/util/product-feedback`,
+        body: { comments, email, source },
       }),
     }),
   }),

--- a/frontend/src/metabase/api/product-feedback.ts
+++ b/frontend/src/metabase/api/product-feedback.ts
@@ -4,7 +4,7 @@ const productFeedbackApi = Api.injectEndpoints({
   endpoints: builder => ({
     sendProductFeedback: builder.mutation<
       void,
-      { comments: string; email?: string; source: string }
+      { comments?: string; email?: string; source: string }
     >({
       query: ({ comments, email, source }) => ({
         method: "POST",

--- a/frontend/src/metabase/api/product-feedback.ts
+++ b/frontend/src/metabase/api/product-feedback.ts
@@ -1,0 +1,18 @@
+import { Api } from "./api";
+
+export const productFeedbackApi = Api.injectEndpoints({
+  endpoints: builder => ({
+    sendProductFeedback: builder.mutation<
+      void,
+      { comments: string; email?: string }
+    >({
+      query: ({ comments, email }) => ({
+        method: "POST",
+        url: `/api/product-feedback`,
+        body: { comments, email },
+      }),
+    }),
+  }),
+});
+
+export const { useSendProductFeedbackMutation } = productFeedbackApi;

--- a/frontend/src/metabase/api/product-feedback.ts
+++ b/frontend/src/metabase/api/product-feedback.ts
@@ -4,12 +4,18 @@ const productFeedbackApi = Api.injectEndpoints({
   endpoints: builder => ({
     sendProductFeedback: builder.mutation<
       void,
-      { comments?: string; email?: string; source: string }
+      { comment?: string; email?: string; source: string }
     >({
-      query: ({ comments, email, source }) => ({
+      query: ({ comment, email, source }) => ({
         method: "POST",
         url: `/api/util/product-feedback`,
-        body: { comments, email, source },
+        body: {
+          // harbormaster expects the field `comments`, we use `comment` because it
+          // reflects better what it's shown in the UI
+          comments: comment,
+          email,
+          source,
+        },
       }),
     }),
   }),

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -1,6 +1,7 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { updateSetting } from "metabase/admin/settings/settings";
+import { useSendProductFeedbackMutation } from "metabase/api/product-feedback";
 import { useSetting } from "metabase/common/hooks";
 import { getPlan } from "metabase/common/utils/plan";
 import { useDispatch, useSelector } from "metabase/lib/redux";
@@ -8,13 +9,16 @@ import { isEEBuild } from "metabase/lib/utils";
 import { getDocsUrl, getSetting } from "metabase/selectors/settings";
 
 import { EmbedHomepageView } from "./EmbedHomepageView";
+import { FeedbackModal } from "./FeedbackModal";
 import type { EmbedHomepageDismissReason } from "./types";
 
 export const EmbedHomepage = () => {
+  const [feedbackModalOpened, setFeedbackModalOpened] = useState(false);
   const dispatch = useDispatch();
   const embeddingAutoEnabled = useSetting("setup-embedding-autoenabled");
   const licenseActiveAtSetup = useSetting("setup-license-active-at-setup");
   const exampleDashboardId = useSetting("example-dashboard-id");
+  const [sendProductFeedback] = useSendProductFeedbackMutation();
 
   const interactiveEmbeddingQuickStartUrl = useSelector(state =>
     // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
@@ -51,22 +55,51 @@ export const EmbedHomepage = () => {
   }, [plan]);
 
   const onDismiss = (reason: EmbedHomepageDismissReason) => {
-    dispatch(updateSetting({ key: "embedding-homepage", value: reason }));
+    if (reason === "dismissed-run-into-issues") {
+      setFeedbackModalOpened(true);
+    } else {
+      dispatch(updateSetting({ key: "embedding-homepage", value: reason }));
+    }
+  };
+
+  const onFeedbackSubmit = ({
+    feedback,
+    email,
+  }: {
+    feedback: string;
+    email: string;
+  }) => {
+    dispatch(
+      updateSetting({
+        key: "embedding-homepage",
+        value: "dismiss-run-into-issues",
+      }),
+    );
+
+    setFeedbackModalOpened(false);
+    sendProductFeedback({ comments: feedback, email });
   };
 
   return (
-    <EmbedHomepageView
-      onDismiss={onDismiss}
-      exampleDashboardId={exampleDashboardId}
-      embeddingAutoEnabled={embeddingAutoEnabled}
-      licenseActiveAtSetup={licenseActiveAtSetup}
-      defaultTab={defaultTab}
-      interactiveEmbeddingQuickstartUrl={interactiveEmbeddingQuickStartUrl}
-      embeddingDocsUrl={embeddingDocsUrl}
-      // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
-      analyticsDocsUrl="https://www.metabase.com/learn/customer-facing-analytics/"
-      learnMoreInteractiveEmbedUrl={learnMoreInteractiveEmbedding}
-      learnMoreStaticEmbedUrl={learnMoreStaticEmbedding}
-    />
+    <>
+      <EmbedHomepageView
+        onDismiss={onDismiss}
+        exampleDashboardId={exampleDashboardId}
+        embeddingAutoEnabled={embeddingAutoEnabled}
+        licenseActiveAtSetup={licenseActiveAtSetup}
+        defaultTab={defaultTab}
+        interactiveEmbeddingQuickstartUrl={interactiveEmbeddingQuickStartUrl}
+        embeddingDocsUrl={embeddingDocsUrl}
+        // eslint-disable-next-line no-unconditional-metabase-links-render -- only visible to admins
+        analyticsDocsUrl="https://www.metabase.com/learn/customer-facing-analytics/"
+        learnMoreInteractiveEmbedUrl={learnMoreInteractiveEmbedding}
+        learnMoreStaticEmbedUrl={learnMoreStaticEmbedding}
+      />
+      <FeedbackModal
+        opened={feedbackModalOpened}
+        onClose={() => setFeedbackModalOpened(false)}
+        onSubmit={onFeedbackSubmit}
+      />
+    </>
   );
 };

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -66,8 +66,8 @@ export const EmbedHomepage = () => {
     feedback,
     email,
   }: {
-    feedback: string;
-    email: string;
+    feedback?: string;
+    email?: string;
   }) => {
     dispatch(
       updateSetting({

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -77,7 +77,11 @@ export const EmbedHomepage = () => {
     );
 
     setFeedbackModalOpened(false);
-    sendProductFeedback({ comments: feedback, email });
+    sendProductFeedback({
+      comments: feedback,
+      email: email || undefined,
+      source: "embedding-homepage-dismiss",
+    });
   };
 
   return (

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -79,7 +79,7 @@ export const EmbedHomepage = () => {
     setFeedbackModalOpened(false);
     sendProductFeedback({
       comments: feedback,
-      email: email || undefined,
+      email: email,
       source: "embedding-homepage-dismiss",
     });
   };

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -63,10 +63,10 @@ export const EmbedHomepage = () => {
   };
 
   const onFeedbackSubmit = ({
-    feedback,
+    comment,
     email,
   }: {
-    feedback?: string;
+    comment?: string;
     email?: string;
   }) => {
     dispatch(
@@ -78,7 +78,7 @@ export const EmbedHomepage = () => {
 
     setFeedbackModalOpened(false);
     sendProductFeedback({
-      comments: feedback,
+      comment,
       email: email,
       source: "embedding-homepage-dismiss",
     });

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -44,7 +44,7 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
       <Group position="apart">
         {/*  eslint-disable-next-line no-literal-metabase-strings -- only visible to admins */}
         <Text fw="bold">{t`Get started with Embedding Metabase in your app`}</Text>
-        <Menu trigger="hover">
+        <Menu trigger="hover" closeDelay={200}>
           <Menu.Target>
             <Text
               fw="bold"

--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -60,7 +60,7 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
               onClick={() => onDismiss("dismissed-run-into-issues")}
             >{t`I ran into issues`}</Menu.Item>
             <Menu.Item
-              onClick={() => onDismiss("dismissed-run-into-issues")}
+              onClick={() => onDismiss("dismissed-not-interested-now")}
             >{t`I'm not interested right now`}</Menu.Item>
           </Menu.Dropdown>
         </Menu>

--- a/frontend/src/metabase/home/components/EmbedHomepage/FeedbackModal.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/FeedbackModal.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { t } from "ttag";
+
+import {
+  Button,
+  Group,
+  Modal,
+  rem,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+  Title,
+} from "metabase/ui";
+
+type FeedbackModalProps = {
+  opened: boolean;
+  onClose: () => void;
+  onSubmit: (feedback: { feedback: string; email: string }) => void;
+};
+
+export const FeedbackModal = ({
+  opened,
+  onClose,
+  onSubmit,
+}: FeedbackModalProps) => {
+  const [feedback, setFeedback] = useState("");
+  const [email, setEmail] = useState("");
+  const handleSubmit = () => onSubmit({ feedback, email });
+
+  return (
+    <Modal
+      size={rem(530)}
+      padding="xl"
+      opened={opened}
+      withCloseButton={false}
+      onClose={onClose}
+    >
+      <Title pb="sm">{t`How can we improve embedding?`}</Title>
+      <Stack spacing="lg">
+        {/* eslint-disable-next-line no-literal-metabase-strings -- only admins can see this component */}
+        <Text>{t`Please let us know what happened. We’re always looking for ways to improve Metabase.`}</Text>
+
+        <Textarea
+          label={t`Feedback`}
+          name="feedback"
+          placeholder={t`Tell us what happened`}
+          onChange={e => setFeedback(e.currentTarget.value)}
+          minRows={3}
+        />
+
+        <TextInput
+          label={t`Email`}
+          name="email"
+          placeholder={t`Leave your email if you want us to follow up with you`}
+          onChange={e => setEmail(e.currentTarget.value)}
+        />
+
+        <Group position="right">
+          <Button onClick={onClose}>{t`Cancel`}</Button>
+          <Button variant="filled" onClick={handleSubmit}>
+            {feedback.length > 0 ? t`Send` : t`Skip`}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+};

--- a/frontend/src/metabase/home/components/EmbedHomepage/FeedbackModal.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/FeedbackModal.tsx
@@ -16,7 +16,7 @@ import {
 type FeedbackModalProps = {
   opened: boolean;
   onClose: () => void;
-  onSubmit: (feedback: { feedback: string; email: string }) => void;
+  onSubmit: (feedback: { feedback?: string; email?: string }) => void;
 };
 
 export const FeedbackModal = ({
@@ -26,7 +26,11 @@ export const FeedbackModal = ({
 }: FeedbackModalProps) => {
   const [feedback, setFeedback] = useState("");
   const [email, setEmail] = useState("");
-  const handleSubmit = () => onSubmit({ feedback, email });
+  const handleSubmit = () =>
+    onSubmit({
+      feedback: feedback.trim() || undefined,
+      email: email.trim() || undefined,
+    });
 
   return (
     <Modal
@@ -51,6 +55,7 @@ export const FeedbackModal = ({
 
         <TextInput
           label={t`Email`}
+          type="email"
           name="email"
           placeholder={t`Leave your email if you want us to follow up with you`}
           onChange={e => setEmail(e.currentTarget.value)}

--- a/frontend/src/metabase/home/components/EmbedHomepage/FeedbackModal.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/FeedbackModal.tsx
@@ -59,7 +59,9 @@ export const FeedbackModal = ({
         <Group position="right">
           <Button onClick={onClose}>{t`Cancel`}</Button>
           <Button variant="filled" onClick={handleSubmit}>
-            {feedback.length > 0 ? t`Send` : t`Skip`}
+            {feedback.trim().length + email.trim().length > 0
+              ? t`Send`
+              : t`Skip`}
           </Button>
         </Group>
       </Stack>

--- a/frontend/src/metabase/home/components/EmbedHomepage/FeedbackModal.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/FeedbackModal.tsx
@@ -16,7 +16,7 @@ import {
 type FeedbackModalProps = {
   opened: boolean;
   onClose: () => void;
-  onSubmit: (feedback: { feedback?: string; email?: string }) => void;
+  onSubmit: (feedback: { comment?: string; email?: string }) => void;
 };
 
 export const FeedbackModal = ({
@@ -24,11 +24,11 @@ export const FeedbackModal = ({
   onClose,
   onSubmit,
 }: FeedbackModalProps) => {
-  const [feedback, setFeedback] = useState("");
+  const [comment, setComment] = useState("");
   const [email, setEmail] = useState("");
   const handleSubmit = () =>
     onSubmit({
-      feedback: feedback.trim() || undefined,
+      comment: comment.trim() || undefined,
       email: email.trim() || undefined,
     });
 
@@ -47,9 +47,9 @@ export const FeedbackModal = ({
 
         <Textarea
           label={t`Feedback`}
-          name="feedback"
+          name="comment"
           placeholder={t`Tell us what happened`}
-          onChange={e => setFeedback(e.currentTarget.value)}
+          onChange={e => setComment(e.currentTarget.value)}
           minRows={3}
         />
 
@@ -64,7 +64,7 @@ export const FeedbackModal = ({
         <Group position="right">
           <Button onClick={onClose}>{t`Cancel`}</Button>
           <Button variant="filled" onClick={handleSubmit}>
-            {feedback.trim().length + email.trim().length > 0
+            {comment.trim().length + email.trim().length > 0
               ? t`Send`
               : t`Skip`}
           </Button>

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -1,9 +1,13 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { screen } from "__support__/ui";
+import { screen, waitForElementToBeRemoved } from "__support__/ui";
 
-import { getLastHomepageSettingSettingCall, setup } from "./setup";
+import {
+  queryFeedbackModal,
+  getLastHomepageSettingSettingCall,
+  setup,
+} from "./setup";
 
 describe("EmbedHomepage (OSS)", () => {
   it("should default to the static tab for OSS builds", () => {
@@ -112,6 +116,8 @@ describe("EmbedHomepage (OSS)", () => {
       await userEvent.click(screen.getByText("Cancel"));
 
       expect(getLastHomepageSettingSettingCall()).toBeUndefined();
+
+      await waitForElementToBeRemoved(() => queryFeedbackModal());
     });
 
     it("should dismiss when submitting feedback - even if empty", async () => {
@@ -126,6 +132,8 @@ describe("EmbedHomepage (OSS)", () => {
 
       const body = await lastCall?.request?.json();
       expect(body).toEqual({ value: "dismiss-run-into-issues" });
+
+      await waitForElementToBeRemoved(() => queryFeedbackModal());
     });
 
     it("should send feedback when submitting the modal", async () => {
@@ -153,7 +161,6 @@ describe("EmbedHomepage (OSS)", () => {
           method: "POST",
         },
       );
-      expect(feedbackCall).not.toBeUndefined();
 
       const feedbackBody = await feedbackCall?.request?.json();
 
@@ -162,6 +169,8 @@ describe("EmbedHomepage (OSS)", () => {
         email: "user@example.org",
         source: "embedding-homepage-dismiss",
       });
+
+      await waitForElementToBeRemoved(() => queryFeedbackModal());
     });
   });
 });

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -157,9 +157,10 @@ describe("EmbedHomepage (OSS)", () => {
 
       const feedbackBody = await feedbackCall?.request?.json();
 
-      expect(feedbackBody).toMatchObject({
+      expect(feedbackBody).toEqual({
         comments: "I had an issue with X",
         email: "user@example.org",
+        source: "embedding-homepage-dismiss",
       });
     });
   });

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -107,6 +107,34 @@ describe("EmbedHomepage (OSS)", () => {
       ).toBeInTheDocument();
     });
 
+    it("should display 'Skip' in the button when inputs are empty, 'Send' if any input has content", async () => {
+      setup();
+      await userEvent.hover(screen.getByText("Hide these"));
+
+      await userEvent.click(screen.getByText("I ran into issues"));
+
+      expect(screen.getByText("Skip")).toBeInTheDocument();
+
+      await userEvent.type(
+        screen.getByLabelText("Feedback"),
+        "I had an issue with X",
+      );
+
+      expect(screen.queryByText("Skip")).not.toBeInTheDocument();
+      expect(screen.getByText("Send")).toBeInTheDocument();
+
+      await userEvent.clear(screen.getByLabelText("Feedback"));
+      expect(screen.getByText("Skip")).toBeInTheDocument();
+
+      await userEvent.type(
+        screen.getByLabelText("Email"),
+        "example@example.org",
+      );
+
+      expect(screen.queryByText("Skip")).not.toBeInTheDocument();
+      expect(screen.getByText("Send")).toBeInTheDocument();
+    });
+
     it("should not dismiss the homepage when the user cancels the feedback modal", async () => {
       setup();
       await userEvent.hover(screen.getByText("Hide these"));

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -92,37 +92,35 @@ describe("EmbedHomepage (OSS)", () => {
   });
 
   describe("Feedback modal", () => {
-    // should ask for feedback when dismissing because of issues
-    it("should ask for feedback when dismissing because of issues", () => {
+    it("should ask for feedback when dismissing because of issues", async () => {
       setup();
-      userEvent.hover(screen.getByText("Hide these"));
+      await userEvent.hover(screen.getByText("Hide these"));
 
-      userEvent.click(screen.getByText("I ran into issues"));
+      await userEvent.click(screen.getByText("I ran into issues"));
 
       expect(
         screen.getByText("How can we improve embedding?"),
       ).toBeInTheDocument();
     });
 
-    it("should not dismiss the homepage when the user cancels the feedback modal", () => {
+    it("should not dismiss the homepage when the user cancels the feedback modal", async () => {
       setup();
-      userEvent.hover(screen.getByText("Hide these"));
+      await userEvent.hover(screen.getByText("Hide these"));
 
-      userEvent.click(screen.getByText("I ran into issues"));
+      await userEvent.click(screen.getByText("I ran into issues"));
 
-      userEvent.click(screen.getByText("Cancel"));
+      await userEvent.click(screen.getByText("Cancel"));
 
       expect(getLastHomepageSettingSettingCall()).toBeUndefined();
     });
 
-    // should dismiss when submitting feedback - even if empty
     it("should dismiss when submitting feedback - even if empty", async () => {
       setup();
-      userEvent.hover(screen.getByText("Hide these"));
+      await userEvent.hover(screen.getByText("Hide these"));
 
-      userEvent.click(screen.getByText("I ran into issues"));
+      await userEvent.click(screen.getByText("I ran into issues"));
 
-      userEvent.click(screen.getByText("Skip"));
+      await userEvent.click(screen.getByText("Skip"));
 
       const lastCall = getLastHomepageSettingSettingCall();
 
@@ -130,31 +128,33 @@ describe("EmbedHomepage (OSS)", () => {
       expect(body).toEqual({ value: "dismiss-run-into-issues" });
     });
 
-    // should send feedback when submitting the modal
     it("should send feedback when submitting the modal", async () => {
       setup();
-      userEvent.hover(screen.getByText("Hide these"));
+      await userEvent.hover(screen.getByText("Hide these"));
 
-      userEvent.click(screen.getByText("I ran into issues"));
+      await userEvent.click(screen.getByText("I ran into issues"));
 
-      userEvent.type(
+      await userEvent.type(
         screen.getByLabelText("Feedback"),
         "I had an issue with X",
       );
-      userEvent.type(screen.getByLabelText("Email"), "user@example.org");
 
-      userEvent.click(screen.getByText("Send"));
+      await userEvent.type(screen.getByLabelText("Email"), "user@example.org");
 
-      // dismisses the embeddimg homepage
+      await userEvent.click(screen.getByText("Send"));
+
       const lastCall = getLastHomepageSettingSettingCall();
       const body = await lastCall?.request?.json();
       expect(body).toEqual({ value: "dismiss-run-into-issues" });
 
-      // feedback call
-      const feedbackCall = fetchMock.lastCall("path:/api/product-feedback", {
-        method: "POST",
-      });
+      const feedbackCall = fetchMock.lastCall(
+        "path:/api/util/product-feedback",
+        {
+          method: "POST",
+        },
+      );
       expect(feedbackCall).not.toBeUndefined();
+
       const feedbackBody = await feedbackCall?.request?.json();
 
       expect(feedbackBody).toMatchObject({

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -95,6 +95,18 @@ describe("EmbedHomepage (OSS)", () => {
     expect(body).toEqual({ value: "dismissed-done" });
   });
 
+  it("should set 'embedding-homepage' to 'dismissed-not-interested-now' when dismissing because not interested", async () => {
+    setup();
+    await userEvent.hover(screen.getByText("Hide these"));
+
+    await userEvent.click(screen.getByText("I'm not interested right now"));
+
+    const lastCall = getLastHomepageSettingSettingCall();
+
+    const body = await lastCall?.request?.json();
+    expect(body).toEqual({ value: "dismissed-not-interested-now" });
+  });
+
   describe("Feedback modal", () => {
     const setupForFeedbackModal = async () => {
       setup();

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
@@ -60,5 +60,10 @@ export const getLastHomepageSettingSettingCall = () =>
     method: "PUT",
   });
 
+export const getLastFeedbackCall = () =>
+  fetchMock.lastCall("path:/api/util/product-feedback", {
+    method: "POST",
+  });
+
 export const queryFeedbackModal = () =>
   screen.queryByText("How can we improve embedding?");

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
@@ -6,7 +6,7 @@ import {
   setupPropertiesEndpoints,
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
-import { renderWithProviders } from "__support__/ui";
+import { screen, renderWithProviders } from "__support__/ui";
 import type { Settings, TokenFeatures } from "metabase-types/api";
 import {
   createMockSettings,
@@ -59,3 +59,6 @@ export const getLastHomepageSettingSettingCall = () =>
   fetchMock.lastCall("path:/api/setting/embedding-homepage", {
     method: "PUT",
   });
+
+export const queryFeedbackModal = () =>
+  screen.queryByText("How can we improve embedding?");

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
@@ -34,7 +34,7 @@ export async function setup({
   jest.clearAllMocks();
 
   fetchMock.put("path:/api/setting/embedding-homepage", 200);
-  fetchMock.post("path:/api/product-feedback", 200);
+  fetchMock.post("path:/api/util/product-feedback", 200);
   setupSettingsEndpoints([createMockSettingDefinition()]);
   setupPropertiesEndpoints(createMockSettings());
 

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
@@ -34,6 +34,7 @@ export async function setup({
   jest.clearAllMocks();
 
   fetchMock.put("path:/api/setting/embedding-homepage", 200);
+  fetchMock.post("path:/api/product-feedback", 200);
   setupSettingsEndpoints([createMockSettingDefinition()]);
   setupPropertiesEndpoints(createMockSettings());
 
@@ -53,3 +54,8 @@ export async function setup({
     withRouter: true,
   });
 }
+
+export const getLastHomepageSettingSettingCall = () =>
+  fetchMock.lastCall("path:/api/setting/embedding-homepage", {
+    method: "PUT",
+  });

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -2,14 +2,20 @@
   "Random utilty endpoints for things that don't belong anywhere else in particular, e.g. endpoints for certain admin
   page tasks."
   (:require
+   [cheshire.core :as json]
+   [clj-http.client :as http]
    [compojure.core :refer [GET POST]]
    [crypto.random :as crypto-random]
+   [environ.core :refer [env]]
    [metabase.analytics.prometheus :as prometheus]
    [metabase.analytics.stats :as stats]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
+   [metabase.config :as config]
    [metabase.logger :as logger]
    [metabase.troubleshooting :as troubleshooting]
+   [metabase.util.log :as log]
+   [metabase.util.malli :as mu]
    [metabase.util.malli.schema :as ms]
    [ring.util.response :as response]))
 
@@ -37,6 +43,37 @@
    Intended for use when creating a value for `embedding-secret-key`."
   []
   {:token (crypto-random/hex 32)})
+
+(defn- product-feedback-url
+  "Product feedback url. When not prod, reads `MB_PRODUCT_FEEDBACK_URL` from the environment to prevent development
+  feedback from hitting the endpoint."
+  []
+  (if config/is-prod?
+    "https://store-api.metabase.com/api/v1/crm/product-feedback"
+    (env :mb-product-feedback-url)))
+
+(mu/defn send-feedback!
+  "Sends the feedback to the api endpoint"
+  [comments :- [:maybe ms/NonBlankString]
+   source :- ms/NonBlankString
+   email :- [:maybe ms/NonBlankString]]
+  (try (http/post (product-feedback-url)
+                  {:content-type :json
+                   :body         (json/generate-string {:comments comments
+                                                        :source   source
+                                                        :email    email})})
+       (catch Exception e
+         (log/warn e)
+         (throw e))))
+
+(api/defendpoint POST "/product-feedback"
+  "Endpoint to provide feedback from the product"
+  [:as {{:keys [comments source email]} :body}]
+  {comments [:maybe ms/NonBlankString]
+   source ms/NonBlankString
+   email [:maybe ms/NonBlankString]}
+  (future (send-feedback! comments source email))
+  api/generic-204-no-content)
 
 (api/defendpoint GET "/bug_report_details"
   "Returns version and system information relevant to filing a bug report against Metabase."

--- a/src/metabase/api/util.clj
+++ b/src/metabase/api/util.clj
@@ -49,7 +49,7 @@
   feedback from hitting the endpoint."
   []
   (if config/is-prod?
-    "https://store-api.metabase.com/api/v1/crm/product-feedback"
+    "https://prod-feedback.metabase.com/api/v1/crm/product-feedback"
     (env :mb-product-feedback-url)))
 
 (mu/defn send-feedback!

--- a/test/metabase/api/util_test.clj
+++ b/test/metabase/api/util_test.clj
@@ -1,7 +1,9 @@
 (ns metabase.api.util-test
   "Tests for /api/util"
   (:require
+   [clojure.string :as str]
    [clojure.test :refer :all]
+   [metabase.api.util :as api.util]
    [metabase.test :as mt]
    [metabase.util.log :as log]))
 
@@ -57,3 +59,24 @@
              (mt/user-http-request :rasta :get 403 "util/diagnostic_info/connection_pool_info"))))
     (testing "Call successful for superusers"
       (is (map? (mt/user-http-request :crowberto :get 200 "util/diagnostic_info/connection_pool_info"))))))
+
+(deftest product-feedback-tests
+  (testing "requires non-blank source"
+    (let [payload  {:comments "foo"
+                    :email    "foo"}
+          response (mt/user-http-request :crowberto :post 400 "util/product-feedback" payload)]
+      (testing (str "without " :source)
+        (is (= {:errors          {:source "value must be a non-blank string."},
+                :specific-errors {:source ["should be a string, received: nil" "non-blank string, received: nil"]}}
+               response)))))
+  (testing "fires the proxy in background"
+    (let [sent? (promise)]
+      (with-redefs [api.util/send-feedback! (fn [comments source email]
+                                              (doseq [prop [comments source email]]
+                                                (is (not (str/blank? prop)) "got a blank property to send-feedback!"))
+                                              (deliver sent? true))]
+        (mt/user-http-request :crowberto :post 204 "util/product-feedback"
+                              {:comments "I like Metabase"
+                               :email    "happy_user@test.com"
+                               :source   "Analytics Inc"})
+        (is (true? (deref sent? 2000 ::timedout)))))))


### PR DESCRIPTION
Part of  [[Epic] Initial homepage experience for embedding admins](https://github.com/metabase/metabase/issues/40005)


### Description

This is the feedback modal shown when a user dismiss the embedding homepage.
This PR contains the endpoint added with [product-feedback endpoint](https://github.com/metabase/metabase/pull/40974)


Note: due to https://github.com/metabase/metabase/issues/41042 the padding on the modal is not working properly

### How to test
If you want to test if the request is actually made, you can set `MB_PRODUCT_FEEDBACK_URL` to point to a local echo server and see what it sends.
I'll check this anyway while pointing it to staging and asking to Filipe if the data shows up on the staging db

### Demo
(recorded with a fix about the padding that eventually got dropped)

https://github.com/metabase/metabase/assets/1914270/c9bba1c7-ed96-4c8f-ad8f-f21d50902f2a


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
