### PR TITLE
show warning for unaggregated dimension

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -14,7 +14,10 @@ import {
   getCardSeriesModels,
   getDimensionModel,
 } from "metabase/visualizations/echarts/cartesian/model/series";
-import type { CartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import type {
+  CartesianChartModel,
+  ShowWarning,
+} from "metabase/visualizations/echarts/cartesian/model/types";
 import { getScatterPlotDataset } from "metabase/visualizations/echarts/cartesian/scatter/model";
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
@@ -72,6 +75,7 @@ export const getCartesianChartModel = (
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
+  showWarning?: ShowWarning,
 ): CartesianChartModel => {
   // rawSeries has more than one element when two or more cards are combined on a dashboard
   const hasMultipleCards = rawSeries.length > 1;
@@ -96,7 +100,7 @@ export const getCartesianChartModel = (
       dataset = getScatterPlotDataset(rawSeries, cardsColumns);
       break;
     default:
-      dataset = getJoinedCardsDataset(rawSeries, cardsColumns);
+      dataset = getJoinedCardsDataset(rawSeries, cardsColumns, showWarning);
   }
   dataset = sortDataset(dataset, settings["graph.x_axis.scale"]);
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -202,3 +202,5 @@ export type CartesianChartModel = BaseCartesianChartModel & {
   insights: Insight[];
   bubbleSizeDomain: Extent | null;
 };
+
+export type ShowWarning = (warning: string) => void;

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -8,7 +8,10 @@ import {
   getCardSeriesModels,
   getDimensionModel,
 } from "metabase/visualizations/echarts/cartesian/model/series";
-import type { BaseCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
+import type {
+  BaseCartesianChartModel,
+  ShowWarning,
+} from "metabase/visualizations/echarts/cartesian/model/types";
 import { getCartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import type {
   ComputedVisualizationSettings,
@@ -29,6 +32,7 @@ export const getWaterfallChartModel = (
   rawSeries: RawSeries,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
+  showWarning?: ShowWarning,
 ): BaseCartesianChartModel => {
   // Waterfall chart support one card only
   const [singleRawSeries] = rawSeries;
@@ -46,7 +50,7 @@ export const getWaterfallChartModel = (
     renderingContext,
   );
 
-  let dataset = getJoinedCardsDataset(rawSeries, cardsColumns);
+  let dataset = getJoinedCardsDataset(rawSeries, cardsColumns, showWarning);
   dataset = sortDataset(dataset, settings["graph.x_axis.scale"]);
 
   const xAxisModel = getWaterfallXAxisModel(

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import { color } from "metabase/lib/colors";
 import { formatValue } from "metabase/lib/formatting";
@@ -26,10 +26,16 @@ export function useModelsAndOption({
   height,
   timelineEvents,
   selectedTimelineEventIds,
+  onRender,
 }: VisualizationProps) {
   const seriesToRender = useMemo(
     () => (isPlaceholder ? transformedSeries : rawSeries),
     [isPlaceholder, transformedSeries, rawSeries],
+  );
+
+  const showWarning = useCallback(
+    (warning: string) => onRender({ warnings: [warning] }),
+    [onRender],
   );
 
   const renderingContext: RenderingContext = useMemo(
@@ -59,9 +65,10 @@ export function useModelsAndOption({
           seriesToRender,
           settings,
           renderingContext,
+          showWarning,
         );
     }
-  }, [card.display, seriesToRender, settings, renderingContext]);
+  }, [card.display, seriesToRender, settings, renderingContext, showWarning]);
 
   const chartMeasurements = useMemo(
     () =>

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-models-and-option.ts
@@ -59,6 +59,7 @@ export function useModelsAndOption({
           seriesToRender,
           settings,
           renderingContext,
+          showWarning,
         );
       default:
         return getCartesianChartModel(


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/39562

### Description

Shows the warning symbol and message in the query builder view when the chart's dataset has unaggregated dimension values.

I'll add the other warnings in child PRs.

### Demo

![Screenshot 2024-03-28 at 12.08.04 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/ba4c93f3-5e58-4ce4-9a85-5d75c5310d34.png)

![Screenshot 2024-03-28 at 12.08.10 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/e4035a60-68a2-46b7-b262-58fa88995c86.png)

![Screenshot 2024-03-28 at 12.15.05 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/83815a94-1e4a-468a-876f-3b39effb8b1b.png)
