### PR TITLE
show invalid date warning

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs";
 import { t } from "ttag";
 
 import { getObjectKeys, getObjectValues } from "metabase/lib/objects";
@@ -26,8 +25,9 @@ import type {
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
 import { getNumberOr } from "metabase/visualizations/lib/settings/row-values";
 import {
-  unaggregatedDataWarning,
+  invalidDateWarning,
   nullDimensionWarning,
+  unaggregatedDataWarning,
 } from "metabase/visualizations/lib/warnings";
 import type { ComputedVisualizationSettings } from "metabase/visualizations/types";
 import { isMetric } from "metabase-lib/v1/types/utils/isa";
@@ -38,6 +38,8 @@ import type {
   SingleSeries,
   XAxisScale,
 } from "metabase-types/api";
+
+import { tryGetDate } from "../utils/timeseries";
 
 import { isCategoryAxis, isNumericAxis, isTimeSeriesAxis } from "./guards";
 import { signedLog, signedSquareRoot } from "./transforms";
@@ -591,27 +593,33 @@ export const applyVisualizationSettingsDataTransformations = (
 
 export const sortDataset = (
   dataset: ChartDataset,
-  xAxisScale?: XAxisScale,
+  xAxisScale: XAxisScale | undefined,
+  showWarning?: ShowWarning,
 ): ChartDataset => {
+  if (xAxisScale === "ordinal") {
+    return dataset;
+  }
+
   if (xAxisScale === "timeseries") {
     return sortByDimension(dataset, (left, right) => {
-      if (typeof left === "string" && typeof right === "string") {
-        return dayjs(left).valueOf() - dayjs(right).valueOf();
+      const leftDate = tryGetDate(left);
+      const rightDate = tryGetDate(right);
+
+      if (leftDate == null || rightDate == null) {
+        showWarning?.(invalidDateWarning(leftDate == null ? left : right).text);
+        return 0;
       }
-      return 0;
+
+      return leftDate.valueOf() - rightDate.valueOf();
     });
   }
 
-  if (xAxisScale !== "ordinal") {
-    return sortByDimension(dataset, (left, right) => {
-      if (typeof left === "number" && typeof right === "number") {
-        return left - right;
-      }
-      return 0;
-    });
-  }
-
-  return dataset;
+  return sortByDimension(dataset, (left, right) => {
+    if (typeof left === "number" && typeof right === "number") {
+      return left - right;
+    }
+    return 0;
+  });
 };
 
 /**

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -102,7 +102,7 @@ export const getCartesianChartModel = (
     default:
       dataset = getJoinedCardsDataset(rawSeries, cardsColumns, showWarning);
   }
-  dataset = sortDataset(dataset, settings["graph.x_axis.scale"]);
+  dataset = sortDataset(dataset, settings["graph.x_axis.scale"], showWarning);
 
   const xAxisModel = getXAxisModel(
     dimensionModel,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -52,7 +52,7 @@ export const getWaterfallChartModel = (
   );
 
   let dataset = getJoinedCardsDataset(rawSeries, cardsColumns, showWarning);
-  dataset = sortDataset(dataset, settings["graph.x_axis.scale"]);
+  dataset = sortDataset(dataset, settings["graph.x_axis.scale"], showWarning);
 
   const xAxisModel = getWaterfallXAxisModel(
     dimensionModel,


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/39562

### Description

Shows a warning when a chart with a timeseries x-axis scale has non-date values in the dimension column.

### Demo

![Screenshot 2024-03-28 at 1.50.12 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/b9111ed9-bf66-40dd-a758-320a5250bee5.png)

![Screenshot 2024-03-28 at 1.50.36 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/c3d4474e-d8a2-42e4-8f0f-94d4264c5b46.png)

