### PR TITLE
show unexpected and multiple timezones warnings

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -31,6 +31,7 @@ import type {
   DateRange,
   TimeSeriesXAxisModel,
   NumericXAxisModel,
+  ShowWarning,
 } from "metabase/visualizations/echarts/cartesian/model/types";
 import {
   computeTimeseriesDataInverval,
@@ -487,6 +488,7 @@ export function getTimeSeriesXAxisModel(
   settings: ComputedVisualizationSettings,
   label: string | undefined,
   renderingContext: RenderingContext,
+  showWarning?: ShowWarning,
 ): TimeSeriesXAxisModel {
   const xValues = dataset.map(datum => datum[X_AXIS_DATA_KEY]);
   const dimensionColumn = dimensionModel.column;
@@ -496,6 +498,7 @@ export function getTimeSeriesXAxisModel(
     xValues,
     rawSeries,
     dimensionModel,
+    showWarning,
   );
   const { interval: dataTimeSeriesInterval, timezone } = timeSeriesInfo;
   const formatter = (value: RowValue, unit?: DateTimeAbsoluteUnit) => {
@@ -600,6 +603,7 @@ export function getXAxisModel(
   dataset: ChartDataset,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
+  showWarning?: ShowWarning,
 ): XAxisModel {
   const label = settings["graph.x_axis.labels_enabled"]
     ? settings["graph.x_axis.title_text"]
@@ -615,6 +619,7 @@ export function getXAxisModel(
       settings,
       label,
       renderingContext,
+      showWarning,
     );
   }
 
@@ -697,6 +702,7 @@ function getTimeSeriesXAxisInfo(
   xValues: RowValue[],
   rawSeries: RawSeries,
   dimensionModel: DimensionModel,
+  showWarning?: ShowWarning,
 ) {
   // We need three pieces of information to define a timeseries range:
   // 1. interval - it's really the "unit": month, day, etc
@@ -707,7 +713,7 @@ function getTimeSeriesXAxisInfo(
       .map(column => (isAbsoluteDateTimeUnit(column.unit) ? column.unit : null))
       .filter(isNotNull),
   );
-  const timezone = getTimezone(rawSeries);
+  const timezone = getTimezone(rawSeries, showWarning);
   const interval = (computeTimeseriesDataInverval(xValues, unit) ?? {
     count: 1,
     unit: "day",

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/index.ts
@@ -110,6 +110,7 @@ export const getCartesianChartModel = (
     dataset,
     settings,
     renderingContext,
+    showWarning,
   );
   const yAxisScaleTransforms = getAxisTransforms(
     settings["graph.y_axis.scale"],

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/axis.ts
@@ -6,6 +6,7 @@ import type {
   DateRange,
   DimensionModel,
   Extent,
+  ShowWarning,
   TimeSeriesXAxisModel,
   WaterfallXAxisModel,
 } from "metabase/visualizations/echarts/cartesian/model/types";
@@ -34,6 +35,7 @@ export const getWaterfallXAxisModel = (
   dataset: ChartDataset,
   settings: ComputedVisualizationSettings,
   renderingContext: RenderingContext,
+  showWarning?: ShowWarning,
 ): WaterfallXAxisModel => {
   const xAxisModel = getXAxisModel(
     dimensionModel,
@@ -41,6 +43,7 @@ export const getWaterfallXAxisModel = (
     dataset,
     settings,
     renderingContext,
+    showWarning,
   );
 
   const hasTotal = !!settings["waterfall.show_total"];

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/index.ts
@@ -60,6 +60,7 @@ export const getWaterfallChartModel = (
     dataset,
     settings,
     renderingContext,
+    showWarning,
   );
   if (
     xAxisModel.axisType === "value" ||


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39562

### Description

Shows warnings related to timezones.

### Demo

Not really sure how to test this one locally without setting up multiple databases in different timezones. We could merge this and later confirm is works on the echarts cloud instance for the relevant questions.