### PR TITLE
[WIP] Use between for Zoom in drill

### DIFF
--- a/src/metabase/lib/drill_thru/zoom_in_bins.cljc
+++ b/src/metabase/lib/drill_thru/zoom_in_bins.cljc
@@ -129,6 +129,5 @@
    stage-number                                 :- :int
    {:keys [column min-value max-value new-binning]} :- ::lib.schema.drill-thru/drill-thru.zoom-in.binning]
   (-> query
-      (lib.filter/filter stage-number (lib.filter/>= column min-value))
-      (lib.filter/filter stage-number (lib.filter/< column max-value))
+      (lib.filter/filter stage-number (lib.filter/between column min-value max-value))
       (update-breakout stage-number column new-binning)))


### PR DESCRIPTION
https://metaboat.slack.com/archives/C0645JP1W81/p1711668067916299

How to verify:
- New -> Orders 
- Aggregate by Count, Breakout by Total (Auto)
- Visualize
- Click on a bar and Zoom in

<img width="1728" alt="Screenshot 2024-03-29 at 08 59 09" src="https://github.com/metabase/metabase/assets/8542534/f41cfc77-81ba-4032-b7bf-4e9ec025e8cd">
<img width="1728" alt="Screenshot 2024-03-29 at 08 59 15" src="https://github.com/metabase/metabase/assets/8542534/84c9898a-2937-4da3-b025-9f7c987bf445">

Please note that this filter is not the same as the previous one!

Before
<img width="578" alt="Screenshot 2024-03-29 at 09 03 12" src="https://github.com/metabase/metabase/assets/8542534/aa1c9f76-257a-4159-91e9-4f37821d0be6">

Now
<img width="632" alt="Screenshot 2024-03-29 at 09 02 45" src="https://github.com/metabase/metabase/assets/8542534/4d41e162-0b25-4c5b-b5ba-6b5808300391">

