### PR TITLE
enableMouseEvents on EmbedModal to allow selecting with the mouse on …

### DIFF
--- a/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
+++ b/frontend/src/metabase/public/components/EmbedModal/EmbedModal.tsx
@@ -58,6 +58,8 @@ export const EmbedModal = ({ children, isOpen, onClose }: EmbedModalProps) => {
       title={isEmbeddingSetupStage ? t`Embed ${applicationName}` : undefined}
       fit
       formModal={false}
+      // needed to allow selecting with the mouse on the code samples
+      enableMouseEvents
     >
       {!isEmbeddingSetupStage && (
         <EmbedModalHeader onClose={onEmbedClose} onBack={goBackToEmbedModal}>


### PR DESCRIPTION
### Description

Reported by Kelvin [on slack](https://metaboat.slack.com/archives/C063Q3F1HPF/p1711702840230249)

After https://github.com/metabase/metabase/pull/40144 dragging over code samples no longer select the code.

This seems to have been caused by changes to how we block events in EventSandbox.

This pr contains the "minimum fix" (ie: 1 line change)  which is just to bypass that and allow mouse events, we could also have passed down the array of events we want to whitelist (this would need a change also to the Modal component).

I'm not sure if enabling mouse events will cause unwanted changes, I tried to click around and it seems to behave normally.

It seems like if we used Modal from `metabase/ui` we don't have the issue, so if we still encounter issues with this solution we may think about migrating to that.

### How to verify

- Open the embed modal on a dashboard
- See try and select some code sample by dragging the mouse

### Demo

https://github.com/metabase/metabase/assets/1914270/8b5fb103-d1de-4305-a701-8a646437b9c7


