### PR TITLE
cache invalidation

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -84,6 +84,7 @@
   (clojure-indent-style . always-align)
   (cljr-favor-prefix-notation . nil)
   (cljr-insert-newline-after-require . t)
+  (cljr-print-right-margin . 118)
   (clojure-docstring-fill-column . 118)
   (cider-preferred-build-tool . clojure-cli)
   (cider-default-cljs-repl . shadow-select)

--- a/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
@@ -24,7 +24,7 @@
     [:type [:enum :nocache :ttl :duration :schedule :query]]]
    [:multi {:dispatch :type}
     [:nocache  [:map ;; not closed due to a way it's used in tests for clarity
-                [:type keyword?]]]
+                [:type [:= :nocache]]]]
     [:ttl      [:map {:closed true}
                 [:type [:= :ttl]]
                 [:multiplier ms/PositiveInt]
@@ -80,7 +80,8 @@
           item (t2/select-one :model/CacheConfig :id q)]
       (if item
         (-> (:strategy (api.cache/row->config item))
-           (m/assoc-some :invalidated-at (:invalidated_at item)))
+            (m/assoc-some :invalidated-at (t/max (:invalidated_at item)
+                                                 (:cache_invalidated_at card))))
         (when-let [ttl (granular-duration-hours card dashboard-id)]
           {:type     :duration
            :duration ttl
@@ -100,7 +101,7 @@
     (log/debugf "Caching strategy %s should have :duration and :unit" (pr-str strategy))
     (let [duration  (t/duration (:duration strategy) (keyword (:unit strategy)))
           timestamp (t/minus (t/offset-date-time) duration)]
-      (backend.db/prepare-statement conn query-hash timestamp))))
+      (backend.db/prepare-statement conn query-hash (t/max timestamp (:invalidated-at strategy))))))
 
 (defmethod fetch-cache-stmt-ee* :schedule [{:keys [invalidated-at] :as strategy} query-hash conn]
   (if-not invalidated-at

--- a/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
@@ -99,9 +99,10 @@
 (defmethod fetch-cache-stmt-ee* :duration [strategy query-hash conn]
   (if-not (and (:duration strategy) (:unit strategy))
     (log/debugf "Caching strategy %s should have :duration and :unit" (pr-str strategy))
-    (let [duration  (t/duration (:duration strategy) (keyword (:unit strategy)))
-          timestamp (t/minus (t/offset-date-time) duration)]
-      (backend.db/prepare-statement conn query-hash (t/max timestamp (:invalidated-at strategy))))))
+    (let [duration       (t/duration (:duration strategy) (keyword (:unit strategy)))
+          duration-ago   (t/minus (t/offset-date-time) duration)
+          invalidated-at (t/max duration-ago (:invalidated-at strategy))]
+      (backend.db/prepare-statement conn query-hash invalidated-at))))
 
 (defmethod fetch-cache-stmt-ee* :schedule [{:keys [invalidated-at] :as strategy} query-hash conn]
   (if-not invalidated-at

--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.cache.cache-test
   (:require
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [metabase.public-settings :as public-settings]
    [metabase.query-processor.card :as qp.card]
    [metabase.test :as mt]
@@ -111,3 +112,80 @@
                                          :model_id 0
                                          :strategy {:type     "schedule"
                                                     :schedule "0/2 * * * * ?"}})))))))))
+
+
+(deftest invalidation-test
+  (mt/discard-setting-changes [enable-query-caching]
+    (public-settings/enable-query-caching! true)
+    (mt/with-model-cleanup [:model/CacheConfig
+                            [:model/QueryCache :updated_at]]
+      (mt/with-premium-features #{:cache-granular-controls :audit-app}
+        (mt/with-temp [:model/Dashboard     dash {}
+                       :model/Card          card {:database_id   (mt/id)
+                                                  :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
+                                                                                        :limit    5})}
+                       :model/Card          card2 {:database_id   (mt/id)
+                                                   :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
+                                                                                         :limit    5})}
+                       :model/DashboardCard _    {:dashboard_id (:id dash)
+                                                  :card_id      (:id card)}
+                       :model/CacheConfig   _    {:model          "database"
+                                                  :model_id       (mt/id)
+                                                  :strategy       "schedule"
+                                                  :config         {:schedule "0 * * * * ?"}
+                                                  :invalidated_at (t/offset-date-time)}
+                       :model/CacheConfig _      {:model          "dashboard"
+                                                  :model_id       (:id dash)
+                                                  :strategy       "schedule"
+                                                  :config         {:schedule "0 * * * * ?"}
+                                                  :invalidated_at (t/offset-date-time)}]
+
+          (is (=? {:data [{:model "database" :model_id (mt/id)}]}
+                  (mt/user-http-request :crowberto :get 200 "cache/"
+                                        :model "database")))
+
+          (testing "making a query will cache it"
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
+            (is (=? {:cached true :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
+            (is (=? {:cached true :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card2))))))
+
+          (testing "invalidation drops cache only for affected card"
+            (is (=? {:count 1}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :question (:id card2) :include :overrides)))
+            (is (=? {:cached true :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card2))))))
+
+          (testing "but invalidating a whole config drops cache for all affected cards"
+            (is (=? {:count 1}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :database (mt/id))))
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
+            ;; we need to drop it again so that new cache is not being used
+            (is (=? {:count 1}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :database (mt/id))))
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card2))))))
+
+          (testing "when invalidating database config with no overrides, dashboard-related queries will still have it"
+            (is (=? {:count 1}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :database (mt/id))))
+            (is (=? {:cached true :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card))
+                                          {:dashboard_id (:id dash)}))))
+
+          (testing "but with overrides - will go through every card and mark cache invalidated"
+            (is (=? {:count 2}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :include :overrides :database (mt/id))))
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card))
+                                          {:dashboard_id (:id dash)})))))))))

--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -120,72 +120,66 @@
     (mt/with-model-cleanup [:model/CacheConfig
                             [:model/QueryCache :updated_at]]
       (mt/with-premium-features #{:cache-granular-controls :audit-app}
-        (mt/with-temp [:model/Dashboard     dash {}
-                       :model/Card          card {:database_id   (mt/id)
-                                                  :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
-                                                                                        :limit    5})}
-                       :model/Card          card2 {:database_id   (mt/id)
-                                                   :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
-                                                                                         :limit    5})}
-                       :model/DashboardCard _    {:dashboard_id (:id dash)
-                                                  :card_id      (:id card)}
-                       :model/CacheConfig   _    {:model          "database"
-                                                  :model_id       (mt/id)
-                                                  :strategy       "schedule"
-                                                  :config         {:schedule "0 * * * * ?"}
-                                                  :invalidated_at (t/offset-date-time)}
-                       :model/CacheConfig _      {:model          "dashboard"
-                                                  :model_id       (:id dash)
-                                                  :strategy       "schedule"
-                                                  :config         {:schedule "0 * * * * ?"}
-                                                  :invalidated_at (t/offset-date-time)}]
+        (mt/with-temp [:model/Dashboard     dash           {}
+                       :model/Card          {card1-id :id} {:database_id   (mt/id)
+                                                            :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
+                                                                                                  :limit    5})}
+                       :model/Card          {card2-id :id} {:database_id   (mt/id)
+                                                            :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
+                                                                                                  :limit    5})}
+                       :model/DashboardCard _              {:dashboard_id (:id dash)
+                                                            :card_id      card1-id}
+                       :model/CacheConfig   _              {:model          "database"
+                                                            :model_id       (mt/id)
+                                                            :strategy       "schedule"
+                                                            :config         {:schedule "0 * * * * ?"}
+                                                            :invalidated_at (t/offset-date-time)}
+                       :model/CacheConfig   _              {:model          "dashboard"
+                                                            :model_id       (:id dash)
+                                                            :strategy       "schedule"
+                                                            :config         {:schedule "0 * * * * ?"}
+                                                            :invalidated_at (t/offset-date-time)}]
+          (let [run-query! (fn [card-id & params]
+                             (-> (apply mt/user-http-request :crowberto :post 202 (format "card/%d/query" card-id) params)
+                                 (select-keys [:cached])))
+                invalidate! (fn [status & args]
+                              (apply mt/user-http-request :crowberto :post status "cache/invalidate" args))]
 
-          (is (=? {:data [{:model "database" :model_id (mt/id)}]}
-                  (mt/user-http-request :crowberto :get 200 "cache/"
-                                        :model "database")))
+            (is (=? {:data [{:model "database" :model_id (mt/id)}]}
+                    (mt/user-http-request :crowberto :get 200 "cache/"
+                                          :model "database")))
 
-          (testing "making a query will cache it"
-            (is (=? {:cached false :data some?}
-                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
-            (is (=? {:cached true :data some?}
-                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
-            (is (=? {:cached true :data some?}
-                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card2))))))
+            (testing "making a query will cache it"
+              (is (=? {:cached false :data some?}
+                      (run-query! card1-id)))
+              (is (=? {:cached true :data some?}
+                      (run-query! card1-id)))
+              (is (=? {:cached true :data some?}
+                      (run-query! card2-id))))
 
-          (testing "invalidation drops cache only for affected card"
-            (is (=? {:count 1}
-                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
-                                          :question (:id card2) :include :overrides)))
-            (is (=? {:cached true :data some?}
-                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
-            (is (=? {:cached false :data some?}
-                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card2))))))
+            (testing "invalidation drops cache only for affected card"
+              (is (=? {:count 1}
+                      (invalidate! 200 :question card2-id :include :overrides)))
+              (is (=? {:cached true :data some?}
+                      (run-query! card1-id)))
+              (is (=? {:cached false :data some?}
+                      (run-query! card2-id))))
 
-          (testing "but invalidating a whole config drops cache for all affected cards"
-            (is (=? {:count 1}
-                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
-                                          :database (mt/id))))
-            (is (=? {:cached false :data some?}
-                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
-            ;; we need to drop it again so that new cache is not being used
-            (is (=? {:count 1}
-                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
-                                          :database (mt/id))))
-            (is (=? {:cached false :data some?}
-                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card2))))))
+            (testing "but invalidating a whole config drops cache for any affected card"
+              (doseq [card-id [card1-id card2-id]]
+                (is (=? {:count 1}
+                        (invalidate! 200 :database (mt/id))))
+                (is (=? {:cached false :data some?}
+                        (run-query! card-id {:ignore_cache true})))))
 
-          (testing "when invalidating database config with no overrides, dashboard-related queries will still have it"
-            (is (=? {:count 1}
-                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
-                                          :database (mt/id))))
-            (is (=? {:cached true :data some?}
-                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card))
-                                          {:dashboard_id (:id dash)}))))
+            (testing "when invalidating database config with no overrides, dashboard-related queries will still have it"
+              (is (=? {:count 1}
+                      (invalidate! 200 :database (mt/id))))
+              (is (=? {:cached true :data some?}
+                      (run-query! card1-id {:dashboard_id (:id dash)}))))
 
-          (testing "but with overrides - will go through every card and mark cache invalidated"
-            (is (=? {:count 2}
-                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
-                                          :include :overrides :database (mt/id))))
-            (is (=? {:cached false :data some?}
-                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card))
-                                          {:dashboard_id (:id dash)})))))))))
+            (testing "but with overrides - will go through every card and mark cache invalidated"
+              (is (=? {:count 2}
+                      (invalidate! 200 :include :overrides :database (mt/id))))
+              (is (=? {:cached false :data some?}
+                      (run-query! card1-id {:dashboard_id (:id dash)}))))))))))

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6125,7 +6125,7 @@ databaseChangeLog:
               - column:
                   name: cache_invalidated_at
                   type: ${timestamp_type}
-                  remarks: 'If cache should be invalidated earlier than strategy expects it to'
+                  remarks: 'An invalidation time that can supersede cache_config.invalidated_at'
                   constraints:
                     nullable: true
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6114,6 +6114,21 @@ databaseChangeLog:
         - customChange:
             class: "metabase.db.custom_migrations.CreateInternalUser"
 
+  - changeSet:
+      id: v50.2024-03-29T10:00:00
+      author: piranha
+      comment: 'Granular cache invalidation'
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: cache_invalidated_at
+                  type: ${timestamp_type}
+                  remarks: 'If cache should be invalidated earlier than strategy expects it to'
+                  constraints:
+                    nullable: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/cache.clj
+++ b/src/metabase/api/cache.clj
@@ -196,15 +196,15 @@
               (invalidate-cards database dashboard question)
               (invalidate-cache-configs database dashboard question))]
     (case [(= include :overrides) (pos? cnt)]
-      [false false] {:status 400
+      [true false]  {:status 404
+                     :body   {:message (tru "Could not find any cached questions for the given database, dashboard, or questions ids.")}}
+      [true true]   {:status 200
+                     :body   {:message (tru "Invalidated cache for {0} question(s)." cnt)
+                              :count   cnt}}
+      [false false] {:status 404
                      :body   {:message (tru "Could not find a cache configuration to invalidate.")}}
       [false true]  {:status 200
-                     :body   {:message (tru "Updated {0} cache configuration(s)." cnt)
-                              :count   cnt}}
-      [true false]  {:status 400
-                     :body   {:message (tru "You have to provide correct database, dashboard or question ids to invalidate cache.")}}
-      [true true]   {:status 200
-                     :body   {:message (tru "Marked {0} questions for cache invalidation." cnt)
+                     :body   {:message (tru "Invalidated {0} cache configuration(s)." cnt)
                               :count   cnt}})))
 
 (api/define-routes)

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -321,7 +321,8 @@
         multipart?      (get (meta method) :multipart false)
         handler-wrapper (if multipart? mp/wrap-multipart-params identity)
         schema          (into [:map] (for [[k v] arg->schema]
-                                       [(keyword k) v]))]
+                                       [(keyword k) v]))
+        quoted-args     (list 'quote args)]
     `(def ~(vary-meta fn-name
                       merge
                       {:doc          route-doc
@@ -329,6 +330,7 @@
                        :method       method-kw
                        :path         route
                        :schema       schema
+                       :args         quoted-args
                        :is-endpoint? true}
                       (meta method))
        ;; The next form is a copy of `compojure/compile-route`, with the sole addition of the call to

--- a/src/metabase/api/common/openapi.clj
+++ b/src/metabase/api/common/openapi.clj
@@ -43,6 +43,29 @@
     :else
     param))
 
+(defn- fix-schema ;; TODO: unify this with `fix-type` somehow?
+  "`fix-type` counterpart, but for requestBody"
+  [{:keys [required] :as schema}]
+  (let [not-required (atom #{})]
+    (-> schema
+        (update :properties (fn [props]
+                              (into {}
+                                    (for [[k v] props]
+                                      [k
+                                       (cond
+                                         (and (:oneOf v)
+                                              (= (second (:oneOf v)) {:type "null"}))
+                                         (do
+                                           (swap! not-required conj k)
+                                           (assoc (first (:oneOf v)) :description (:description v)))
+
+                                         (= (:enum v) ["true" "false" true false])
+                                         (-> (dissoc v :enum) (assoc :type "boolean"))
+
+                                         :else
+                                         v)]))))
+        (assoc :required (vec (remove @not-required required))))))
+
 (defn- path->openapi [path]
   (str/replace path #":([^/]+)" "{$1}"))
 
@@ -65,18 +88,19 @@
 
 (defn- schema->params
   "https://spec.openapis.org/oas/latest.html#parameter-object"
-  [method full-path schema]
+  [full-path args schema]
   (let [{:keys [properties required]} (json-schema-transform schema)
         required                      (set required)
-        in-path?                      (set (map (comp keyword second) (re-seq #"\{([^}]+)\}" full-path)))]
-    (for [[k schema] properties
-          :when      (or (in-path? k) (= method :get))]
+        in-path?                      (set (map (comp keyword second) (re-seq #"\{([^}]+)\}" full-path)))
+        in-query?                     (into #{} (map #(if (symbol? %) (keyword %) %) args))]
+    (for [[k param-schema] properties
+          :when            (or (in-path? k) (in-query? k))]
       (fix-type
        (cond-> {:in          (if (in-path? k) :path :query)
                 :name        k
                 :required    (contains? required k)
-                :schema      (dissoc schema :description)}
-         (:description schema) (assoc :description (:description schema)))))))
+                :schema      (dissoc param-schema :description)}
+         (:description schema) (assoc :description (:description param-schema)))))))
 
 (defn- defendpoint->path-item
   "Generate OpenAPI desc for a single handler
@@ -84,7 +108,7 @@
   https://spec.openapis.org/oas/latest.html#path-item-object"
   [tag full-path handler-var]
   (let [{:keys [method] :as data} (meta handler-var)
-        params                    (schema->params method full-path (:schema data))
+        params                    (schema->params full-path (:args data) (:schema data))
         non-body-param?           (set (map :name params))
         body                      (when (not= method :get)
                                     (into [:map] (remove #(non-body-param? (first %)) (rest (:schema data)))))
@@ -97,7 +121,8 @@
                                       (:doc data))
                      :parameters params}
               tag  (assoc :tags [tag])
-              body (assoc :requestBody {:content {ctype {:schema (json-schema-transform body)}}}))}))
+              body (assoc :requestBody {:content {ctype {:schema (fix-schema
+                                                                  (json-schema-transform body))}}}))}))
 
 (defn openapi-object
   "Generate base object for OpenAPI (/paths and /components/schemas)

--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -107,6 +107,7 @@
  [bookmark DashboardBookmark]
  [bookmark CollectionBookmark]
  [bookmark BookmarkOrdering]
+ [cache-config CacheConfig]
  [card Card]
  [collection Collection]
  [c-perm-revision CollectionPermissionGraphRevision]

--- a/src/metabase/models/cache_config.clj
+++ b/src/metabase/models/cache_config.clj
@@ -5,6 +5,8 @@
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
+(def CacheConfig "Cache configuration" :model/CacheConfig)
+
 (doto :model/CacheConfig
   (derive :metabase/model)
   (derive :hook/timestamped?))

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -189,7 +189,8 @@
 ;;; --------------------------------------------------- Revisions ----------------------------------------------------
 
 (def ^:private excluded-columns-for-card-revision
-  [:id :created_at :updated_at :entity_id :creator_id :public_uuid :made_public_by_id :metabase_version :initially_published_at])
+  [:id :created_at :updated_at :entity_id :creator_id :public_uuid :made_public_by_id :metabase_version
+   :initially_published_at :cache_invalidated_at])
 
 (defmethod revision/revert-to-revision! :model/Card
   [model id user-id serialized-card]
@@ -914,7 +915,8 @@ saved later when it is ready."
         (update :parameters             serdes/export-parameters)
         (update :parameter_mappings     serdes/export-parameter-mappings)
         (update :visualization_settings serdes/export-visualization-settings)
-        (update :result_metadata        (partial export-result-metadata card)))
+        (update :result_metadata        (partial export-result-metadata card))
+        (dissoc :cache_invalidated_at))
     (catch Exception e
       (throw (ex-info (format "Failed to export Card: %s" (ex-message e)) {:card card} e)))))
 

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -209,8 +209,9 @@
   (let [dash-viz (when (and (not= context :question)
                             dashcard-id)
                    (t2/select-one-fn :visualization_settings :model/DashboardCard :id dashcard-id))
-        card     (api/read-check (t2/select-one [Card :id :name :dataset_query :database_id :cache_ttl :collection_id
-                                                 :type :result_metadata :visualization_settings]
+        card     (api/read-check (t2/select-one [Card :id :name :dataset_query :database_id :collection_id
+                                                 :type :result_metadata :visualization_settings
+                                                 :cache_ttl :cache_invalidated_at]
                                                 :id card-id))
         query    (-> (query-for-card card parameters constraints middleware {:dashboard-id dashboard-id})
                      (update :viz-settings (fn [viz] (merge viz dash-viz)))

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -20,6 +20,9 @@
 (defn- ms-ago [n]
   (u.date/add (t/offset-date-time) :millisecond (- n)))
 
+(defn- seconds-ago [n]
+  (ms-ago (long (* 1000 n))))
+
 (def ^:private ^{:arglists '([])} cached-results-query-sql
   ;; this is memoized for a given application DB so we can deliver cached results EXTRA FAST and not have to spend an
   ;; extra microsecond compiling the same exact query every time. :shrug:
@@ -92,7 +95,7 @@
   (log/tracef "Purging old cache entries.")
   (try
     (t2/delete! (t2/table-name QueryCache)
-                :updated_at [:<= (ms-ago (long (* max-age-seconds 1000)))])
+                :updated_at [:<= (seconds-ago max-age-seconds)])
     (catch Throwable e
       (log/error e "Error purging old cache entries")))
   nil)

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -63,9 +63,10 @@
   ^PreparedStatement [strategy query-hash ^Connection conn]
   (if-not (:avg-execution-ms strategy)
     (log/debugf "Caching strategy %s needs :avg-execution-ms to work" (pr-str strategy))
-    (let [max-age-ms (* (:multiplier strategy)
-                        (:avg-execution-ms strategy))]
-      (prepare-statement conn query-hash (t/max (ms-ago max-age-ms) (:invalidated-at strategy))))))
+    (let [max-age-ms     (* (:multiplier strategy)
+                        (:avg-execution-ms strategy))
+          invalidated-at (t/max (ms-ago max-age-ms) (:invalidated-at strategy))]
+      (prepare-statement conn query-hash invalidated-at))))
 
 (defenterprise fetch-cache-stmt
   "Returns prepared statement for a given strategy and query hash - on EE. Returns `::oss` on OSS."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -84,7 +84,8 @@
    :cache_ttl              nil
    :average_query_time     nil
    :last_query_start       nil
-   :result_metadata        nil})
+   :result_metadata        nil
+   :cache_invalidated_at   nil})
 
 ;; Used in dashboard tests
 (def card-defaults-no-hydrate

--- a/test/metabase/api/common/openapi_test.clj
+++ b/test/metabase/api/common/openapi_test.clj
@@ -62,14 +62,11 @@
                            :required    true
                            :description some?
                            :schema      {:type    "integer"
-                                         :minimum 1}}]
-            :requestBody {:content
-                          {"application/json"
-                           {:schema
-                            {:type       "object",
-                             :properties {:value {:description some?
-                                                  :$ref        "#/components/schemas/metabase.lib.schema.common~1non-blank-string"}},
-                             :required   [:value]}}}}}}
+                                         :minimum 1}}
+                          {:in :query,
+                           :name :value,
+                           :required true,
+                           :schema {:$ref "#/components/schemas/metabase.lib.schema.common~1non-blank-string"}}]}}
           (#'openapi/defendpoint->path-item nil "/{id}" #'POST_:id)))
   (is (=? {:post
            {:parameters  [{:in          :path
@@ -78,10 +75,8 @@
                            :description some?
                            :schema      {:type    "integer"
                                          :minimum 1}}]
-            ;; TODO: no properties since we did not spec anything
-            :requestBody {:content
-                          {"multipart/form-data"
-                           {:schema {:type "object", :properties {}}}}}}}
+            ;; TODO: no :requestBody since we did not spec anything
+            }}
           (#'openapi/defendpoint->path-item nil "/{id}" #'POST_:id_upload))))
 
 (deftest ^:parallel openapi-object-test


### PR DESCRIPTION
New endpoint accepts entity and entity ids in form of `database=1&dashboard=2&question=3`. If you don't supply `&include=overrides`, then it tries to find configs directly referencing supplied entities and updates their `invalidated_at`. If you supply `&include=overrides`, all the referenced cards are updated (`report_card.cache_invalidated_at`).

Cache strategies then select the maximum `invalidated_at` in their logic. EE-only.

resolves #40548
