### PR TITLE
hide null values from stacked tooltip

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -191,7 +191,6 @@ export const getStackedTooltipModel = (
       formatter,
     };
   });
-
   const [headerRows, bodyRows] = _.partition(
     rows,
     (_row, index) => index === seriesIndex,
@@ -210,7 +209,7 @@ export const getStackedTooltipModel = (
   return {
     headerTitle,
     headerRows,
-    bodyRows,
+    bodyRows: bodyRows.filter(row => row.value != null),
     totalFormatter: formatter,
     showTotal: true,
     showPercentages: true,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39606

### Description

This PR hides null values in the stacked tooltip. Previously, they were shown as `(empty)`

### How to verify

1. New question -> Orders by Created At: week, breakout by Product -> Category
2. Using brushing zoom in on the beginning of the chart where some breakout series have nulls
3. Hover and ensure there are no null values in the tooltip

### Demo

<img width="978" alt="Screenshot 2024-03-29 at 4 23 35 AM" src="https://github.com/metabase/metabase/assets/14301985/75f0207d-7ec3-4853-a006-99543f4b1a1e">

<img width="970" alt="Screenshot 2024-03-29 at 4 23 30 AM" src="https://github.com/metabase/metabase/assets/14301985/6fd25a68-7855-436e-89a3-e1b54cd7df5b">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
