### PR TITLE
ignore duplicated metrics columns in viz settings

### DIFF
--- a/frontend/src/metabase/visualizations/lib/graph/columns.ts
+++ b/frontend/src/metabase/visualizations/lib/graph/columns.ts
@@ -1,3 +1,4 @@
+import _ from "underscore";
 import type {
   DatasetColumn,
   DatasetData,
@@ -91,7 +92,7 @@ export const getCartesianChartColumns = (
   );
 
   const metrics = getColumnDescriptors(
-    (settings["graph.metrics"] ?? []).filter(isNotNull),
+    _.uniq((settings["graph.metrics"] ?? []).filter(isNotNull)),
     columns,
   );
 

--- a/frontend/src/metabase/visualizations/lib/graph/columns.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/lib/graph/columns.unit.spec.ts
@@ -1,0 +1,25 @@
+import { createMockColumn } from "metabase-types/api/mocks";
+import { getCartesianChartColumns } from "./columns";
+
+describe("getCartesianChartColumns", () => {
+  it("should ignore duplicated metrics in settings while preserving the order", () => {
+    const dimensionColumn = createMockColumn({ name: "dimension" });
+    const metricColumn = createMockColumn({ name: "metric" });
+    const metricColumn2 = createMockColumn({ name: "metric2" });
+    const columns = [dimensionColumn, metricColumn, metricColumn2];
+
+    expect(
+      getCartesianChartColumns(columns, {
+        "graph.dimensions": ["dimension"],
+        "graph.metrics": ["metric2", "metric2", "metric", "metric", "metric"],
+      }),
+    ).toStrictEqual({
+      bubbleSize: undefined,
+      dimension: { column: dimensionColumn, index: 0 },
+      metrics: [
+        { column: metricColumn2, index: 2 },
+        { column: metricColumn, index: 1 },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40179

### Description

It is not possible to pick the same column twice for y-axis but previously it was possible and already saved questions with duplicated columns may break charts. This PR filters out duplicated columns.

### How to verify

Check the spec. The full scenario can be tested by modifying viz settings json manually by adding the same metric two times.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
