### PR TITLE
Fix data labels blur on single series

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -44,6 +44,14 @@ import {
 import type { ChartMeasurements } from "../chart-measurements/types";
 import { getSeriesYAxisIndex } from "./utils";
 
+const getBlurLabelStyle = (
+  settings: ComputedVisualizationSettings,
+  hasMultipleSeries: boolean,
+) => ({
+  show: settings["graph.show_values"] && !hasMultipleSeries,
+  opacity: hasMultipleSeries ? CHART_STYLE.opacity.blur : 1,
+});
+
 export const getBarLabelLayout =
   (
     dataset: ChartDataset,
@@ -258,9 +266,7 @@ const buildEChartsBarSeries = (
       },
     },
     blur: {
-      label: {
-        show: settings["graph.show_values"] && !hasMultipleSeries,
-      },
+      label: getBlurLabelStyle(settings, hasMultipleSeries),
       itemStyle: {
         opacity: CHART_STYLE.opacity.blur,
       },
@@ -356,9 +362,7 @@ const buildEChartsLineAreaSeries = (
       },
     },
     blur: {
-      label: {
-        show: settings["graph.show_values"] && !hasMultipleSeries,
-      },
+      label: getBlurLabelStyle(settings, hasMultipleSeries),
       itemStyle: {
         opacity: isSymbolVisible ? blurOpacity : 0,
       },

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -49,7 +49,7 @@ const getBlurLabelStyle = (
   hasMultipleSeries: boolean,
 ) => ({
   show: settings["graph.show_values"] && !hasMultipleSeries,
-  opacity: hasMultipleSeries ? CHART_STYLE.opacity.blur : 1,
+  opacity: 1,
 });
 
 export const getBarLabelLayout =


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40183

### Description

Fixes when data labels are enabled and a chart has only one series labels on non-hovered items were blurred.

### How to verify

- New -> Orders: Created at by Month
- Enable data labels
- Hover dots
- Ensure no labels get blurred

### Demo

<img width="1004" alt="Screenshot 2024-03-29 at 10 42 14 AM" src="https://github.com/metabase/metabase/assets/14301985/7ff94a7c-7e88-484c-b466-50648457e70a">

### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
