### PR TITLE
set embedding-secret-key when embedding is enabled

### DIFF
--- a/e2e/snapshot-creators/default.cy.snap.js
+++ b/e2e/snapshot-creators/default.cy.snap.js
@@ -86,10 +86,13 @@ describe("snapshots", () => {
 
   function updateSettings() {
     cy.request("PUT", "/api/setting/enable-public-sharing", { value: true });
-    cy.request("PUT", "/api/setting/enable-embedding", { value: true });
-    cy.request("PUT", "/api/setting/embedding-secret-key", {
-      value: METABASE_SECRET_KEY,
-    });
+    cy.request("PUT", "/api/setting/enable-embedding", { value: true }).then(
+      () => {
+        cy.request("PUT", "/api/setting/embedding-secret-key", {
+          value: METABASE_SECRET_KEY,
+        });
+      },
+    );
 
     // update the Sample db connection string so it is valid in both CI and locally
     cy.request("GET", `/api/database/${SAMPLE_DB_ID}`).then(response => {

--- a/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
+++ b/e2e/test/scenarios/onboarding/setup/setup.cy.spec.ts
@@ -315,7 +315,17 @@ describe("scenarios > setup", () => {
       cy.button("Finish").click();
 
       // Finish & Subscribe
+      cy.intercept("GET", "/api/session/properties").as("properties");
       cy.findByText("Take me to Metabase").click();
+    });
+
+    cy.log(
+      "Make sure the embedding secret key is set after embedding has been autoenabled",
+    );
+    cy.wait("@properties").then(request => {
+      expect(request.response?.body["embedding-secret-key"]?.length).to.equal(
+        64,
+      );
     });
 
     cy.location("pathname").should("eq", "/");

--- a/frontend/src/metabase/admin/settings/selectors.js
+++ b/frontend/src/metabase/admin/settings/selectors.js
@@ -15,7 +15,7 @@ import {
 } from "metabase/plugins";
 import { refreshCurrentUser } from "metabase/redux/user";
 import { getUserIsAdmin } from "metabase/selectors/user";
-import { PersistedModelsApi, UtilApi } from "metabase/services";
+import { PersistedModelsApi } from "metabase/services";
 
 import {
   trackTrackingPermissionChanged,
@@ -448,22 +448,6 @@ export const ADMIN_SETTINGS_SECTIONS = {
         display_name: t`Embedding`,
         description: null,
         widget: EmbeddingSwitchWidget,
-        onChanged: async (
-          oldValue,
-          newValue,
-          settingsValues,
-          onChangeSetting,
-        ) => {
-          // Generate a secret key if none already exists
-          if (
-            !oldValue &&
-            newValue &&
-            !settingsValues["embedding-secret-key"]
-          ) {
-            const result = await UtilApi.random_token();
-            await onChangeSetting("embedding-secret-key", result.token);
-          }
-        },
       },
       {
         key: "-static-embedding",

--- a/src/metabase/embed/settings.clj
+++ b/src/metabase/embed/settings.clj
@@ -1,6 +1,8 @@
 (ns metabase.embed.settings
   "Settings related to embedding Metabase in other applications."
   (:require
+   [clojure.string :as str]
+   [crypto.random :as crypto-random]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
    [metabase.models.setting :as setting :refer [defsetting]]
@@ -25,6 +27,8 @@
   :setter     (fn [new-value]
                 (when (not= new-value (setting/get-value-of-type :boolean :enable-embedding))
                   (setting/set-value-of-type! :boolean :enable-embedding new-value)
+                  (when (and new-value (str/blank? (setting/get :embedding-secret-key)))
+                    (setting/set! :embedding-secret-key (crypto-random/hex 32)))
                   (let [snowplow-payload {:embedding-app-origin-set   (boolean (embedding-app-origin))
                                           :number-embedded-questions  (t2/count :model/Card :enable_embedding true)
                                           :number-embedded-dashboards (t2/count :model/Dashboard :enable_embedding true)}]

--- a/src/metabase/embed/settings.clj
+++ b/src/metabase/embed/settings.clj
@@ -7,6 +7,7 @@
    [metabase.api.common :as api]
    [metabase.models.setting :as setting :refer [defsetting]]
    [metabase.public-settings :as public-settings]
+   [metabase.util.embed :as embed]
    [metabase.util.i18n :as i18n :refer [deferred-tru]]
    [toucan2.core :as t2]))
 
@@ -27,8 +28,8 @@
   :setter     (fn [new-value]
                 (when (not= new-value (setting/get-value-of-type :boolean :enable-embedding))
                   (setting/set-value-of-type! :boolean :enable-embedding new-value)
-                  (when (and new-value (str/blank? (setting/get :embedding-secret-key)))
-                    (setting/set! :embedding-secret-key (crypto-random/hex 32)))
+                  (when (and new-value (str/blank? (embed/embedding-secret-key)))
+                    (embed/embedding-secret-key! (crypto-random/hex 32)))
                   (let [snowplow-payload {:embedding-app-origin-set   (boolean (embedding-app-origin))
                                           :number-embedded-questions  (t2/count :model/Card :enable_embedding true)
                                           :number-embedded-dashboards (t2/count :model/Dashboard :enable_embedding true)}]


### PR DESCRIPTION
Note: this is stacked on top of a bunch of PRs from https://github.com/metabase/metabase/issues/40005

### Description

In [add new settings for embedding homepage](https://github.com/metabase/metabase/pull/40455) I enable embedding when the user is interested in embedding, but I don't set the secret key.
This cause the embed modal to crash as it expects to find it.

The solution I attempted in this PR is to move the logic to set the secret key from the FE to the BE, on the setter of the setting, so that when the embedding is enabled, if no secret key is found, a new one is created.

I think this is a more robust solution now that we have two places to enable embedding.



### How to verify

- Do a setup of a new instance and answer that you're interested in embedding
- if you go to the settings you should find the secret key populated

or

- Do a setup saying you're interested in embedding
- Enable embedding manually
- You should also find the populated secret key for static embedding (as it's already on master from the FE)

