### PR TITLE
do not print stacktrace when client closes connection too early

### DIFF
--- a/src/metabase/query_processor/streaming.clj
+++ b/src/metabase/query_processor/streaming.clj
@@ -142,8 +142,8 @@
         (log/debug "Finished writing results; closing results writer.")
         (try
           (qp.si/finish! results-writer result)
-          (catch EofException _
-            (log/error "Client closed connection prematurely")))
+          (catch EofException e
+            (log/error e "Client closed connection prematurely")))
         (u/ignore-exceptions
           (.flush os)
           (.close os)))


### PR DESCRIPTION
Our frontend can close connection too early, for example when you change any of parameters. This is most obvious in #36775, but any long-running connection could be interrupted early. We have no way to understand that connection is closed apart from just catching an exception and dealing with it.

Also not like we can do much with it... This error could be handled in `metabase.async.streaming-response/delay-output-stream`, but it feels like users of that proxy deserve to know that connection was closed.