### PR TITLE
Do not update Pie chart state unnecessary

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/PieChart/PieChart.jsx
@@ -283,7 +283,9 @@ export default class PieChart extends Component {
         groupElement.getBoundingClientRect().width >= 120 &&
         settings["pie.show_total"];
 
-      this.setState({ showChartDetail });
+      if (showChartDetail !== this.state.showChartDetail) {
+        this.setState({ showChartDetail });
+      }
     });
 
     if (


### PR DESCRIPTION
### Description

We don't need to update state unnecessary and trigger re-render of the PieChart 

context https://metaboat.slack.com/archives/C01LQQ2UW03/p1711965588484829


### How to verify

Add a pie chart to the dashboard
open devtools and start perf profiling
scroll up and down - check the results 

it shouldn't look like this (many small bars)
<img width="856" alt="image" src="https://github.com/metabase/metabase/assets/125459446/2ff3348a-a191-4bb0-8a2b-1ad03f8f4727">


<img width="567" alt="Screenshot 2024-04-01 at 15 47 45" src="https://github.com/metabase/metabase/assets/125459446/bfac49d2-c5dd-46d9-8c6a-a2dc1d6fa94e">



### Demo


https://github.com/metabase/metabase/assets/125459446/691ab024-53f5-44b9-969c-9cf4c31bdabc



### Checklist

- [ ] Tests have been added/updated to cover changes in this PR
