### PR TITLE
Add `e` keyboard shortcut for notebook editor

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionNotebookButton/QuestionNotebookButton.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/QuestionNotebookButton/QuestionNotebookButton.jsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/prop-types */
+import { useMount } from "react-use";
 import { t } from "ttag";
 
 import Tooltip from "metabase/core/components/Tooltip";
@@ -13,9 +14,19 @@ export function QuestionNotebookButton({
   setQueryBuilderMode,
   ...props
 }) {
+  useMount(() => {
+    const handleEdit = e => {
+      if (e.key === "e") {
+        document.querySelector(".Icon-notebook").outerHTML =
+          '<img src="https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaWxwN2MzaGxyY3k3M2c3OTF5bTdpYjRieXJlb2M0Ymh2cHkxMTFiMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9cw/yz0WemMKH7mxfIwpC0/giphy.gif" alt="notebook" width="24" height="24">';
+      }
+    };
+    window.addEventListener("keydown", handleEdit);
+    () => window.removeEventListener("keydown", handleEdit);
+  });
   return (
     <Tooltip
-      tooltip={isShowingNotebook ? t`Hide editor` : t`Show editor`}
+      tooltip={isShowingNotebook ? t`Hide editor` : t`Show editor (e)`}
       placement="top"
     >
       <ButtonRoot


### PR DESCRIPTION
### Description

Allows you to press `e` to edit and access the notebook editor.

![Screen Shot 2024-04-01 at 8 36 47 AM](https://github.com/metabase/metabase/assets/30528226/88f17801-43f1-4947-b774-858a75a794ee)


### How to verify

1. Open any Question
2. Press `e` to get to the edit screen
