### PR TITLE
Fix bumping minor version past 10

### DIFF
--- a/release/src/version-helpers.ts
+++ b/release/src/version-helpers.ts
@@ -159,7 +159,6 @@ export const getNextVersions = (versionString: string): string[] => {
   // minor releases -> next minor release
   const [major, minor] = versionString
     .replace(/(v1|v0)\./, "")
-    .replace(/.0$/, "")
     .split(".")
     .map(Number);
 

--- a/release/src/version-helpers.unit.spec.ts
+++ b/release/src/version-helpers.unit.spec.ts
@@ -358,6 +358,7 @@ describe("version-helpers", () => {
       const testCases: [string, string[]][] = [
         ["v0.75.1", ["v0.75.2"]],
         ["v0.75.1.0", ["v0.75.2"]], // disregards extra .0
+        ["v0.75.10", ["v0.75.11"]], // handles multi-digit minor
         ["v0.79.99", ["v0.79.100"]],
         ["v0.79.99.0", ["v0.79.100"]],
       ];


### PR DESCRIPTION
### Description

This aims to fix an [edge case](https://github.com/metabase/metabase/actions/runs/8510983672/job/23309926325) where publishing version `v0.49.10` attempts to create milestone `49.1` instead of `49.11`.

~~I'm not sure how to run these unit tests, so flying blind and hoping CI will guide me.~~

```
> npx jest release/src/version-helpers.unit.spec.ts

...

    getNextVersions
      ✓ should get next versions for a major release
      ✓ should handle ee and oss versions
      ✓ should get next versions for a minor release
      ✓ should not get next versions for a patch release
      ✓ should not get next versions for an RC release
      ✓ should throw an error for an invalid version string (1 ms)

...

Test Suites: 1 passed, 1 total
Tests:       88 passed, 88 total
Snapshots:   0 total
Time:        0.256 s, estimated 1 s
```