### PR TITLE
Handle null value for field in CategoryFingerprint

### DIFF
--- a/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.jsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.jsx
@@ -50,7 +50,7 @@ export function CategoryFingerprint({
   });
 
   const fieldValues = fieldData ? fieldData.values : [];
-  const distinctCount = field.fingerprint?.global?.["distinct-count"];
+  const distinctCount = field?.fingerprint?.global?.["distinct-count"];
   const formattedDistinctCount = formatNumber(distinctCount);
 
   const showDistinctCount = isLoading || distinctCount != null;

--- a/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.unit.spec.js
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnFingerprintInfo/CategoryFingerprint.unit.spec.js
@@ -53,4 +53,11 @@ describe("CategoryFingerprint", () => {
       expect(await screen.findByText("4 distinct values")).toBeInTheDocument();
     });
   });
+
+  it("should not throw an error when the field cannot be found", () => {
+    setup({ field: { id: 99942 } });
+    expect(
+      screen.queryByText("Getting distinct values..."),
+    ).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40860

### Description

Fixes the bug by handling the case where the `field` parameter is `null`.

I cannot reproduce this bug locally with models, so I'll keep investigating why this is the case.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
