### PR TITLE
New default DB permissions

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -601,6 +601,7 @@
    metabase-enterprise.sandbox.test-util/with-gtaps!                            macros.metabase-enterprise.sandbox.test-util/with-gtaps!
    metabase-enterprise.serialization.test-util/with-world                       macros.metabase-enterprise.serialization.test-util/with-world
    metabase-enterprise.test/with-gtaps!                                         macros.metabase-enterprise.sandbox.test-util/with-gtaps!
+   metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!  macros.metabase-enterprise.advanced-permissions.api.util-test/with-impersonations!
    metabase.api.card-test/with-ordered-items                                    macros.metabase.api.card-test/with-ordered-items
    metabase.api.collection-test/with-collection-hierarchy                       macros.metabase.api.collection-test/with-collection-hierarchy
    metabase.api.collection-test/with-some-children-of-collection                macros.metabase.api.collection-test/with-some-children-of-collection

--- a/.clj-kondo/hooks/clojure/core.clj
+++ b/.clj-kondo/hooks/clojure/core.clj
@@ -122,6 +122,7 @@
      metabase.test.data.impl/copy-db-tables-and-fields!
      metabase.test.data.impl/get-or-create-database!
      metabase.test.data.impl/get-or-create-test-data-db!
+     metabase.test.data.impl/set-temp-db-permissions!
      metabase.test.data.interface/create-db!
      metabase.test.data.interface/destroy-db!
      metabase.test.data.oracle/create-user!

--- a/.clj-kondo/hooks/clojure/core.clj
+++ b/.clj-kondo/hooks/clojure/core.clj
@@ -122,7 +122,7 @@
      metabase.test.data.impl/copy-db-tables-and-fields!
      metabase.test.data.impl/get-or-create-database!
      metabase.test.data.impl/get-or-create-test-data-db!
-     metabase.test.data.impl/set-temp-db-permissions!
+     metabase.test.data.impl.get-or-create/set-test-db-permissions!
      metabase.test.data.interface/create-db!
      metabase.test.data.interface/destroy-db!
      metabase.test.data.oracle/create-user!

--- a/.clj-kondo/macros/metabase_enterprise/advanced_permissions/api/util_test.clj
+++ b/.clj-kondo/macros/metabase_enterprise/advanced_permissions/api/util_test.clj
@@ -1,0 +1,6 @@
+(ns macros.metabase-enterprise.advanced-permissions.api.util-test
+  (:require [macros.common]))
+
+(defmacro with-impersonations! [impersonations-and-attributes-map & body]
+  `(let [~(macros.common/ignore-unused '&group) ~impersonations-and-attributes-map]
+     ~@body))

--- a/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
+++ b/e2e/test/scenarios/actions/actions-in-object-detail-view.cy.spec.js
@@ -1,6 +1,6 @@
 import moment from "moment-timezone"; // eslint-disable-line no-restricted-imports -- deprecated usage
 
-import { WRITABLE_DB_ID } from "e2e/support/cypress_data";
+import { USER_GROUPS, WRITABLE_DB_ID } from "e2e/support/cypress_data";
 import {
   popover,
   resetTestTable,
@@ -18,6 +18,8 @@ const FIRST_SCORE_ROW_ID = 11;
 const SECOND_SCORE_ROW_ID = 12;
 const UPDATED_SCORE = 987654321;
 const UPDATED_SCORE_FORMATTED = "987,654,321";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
 
 const DASHBOARD = {
   name: "Test dashboard",
@@ -38,6 +40,15 @@ describe(
       resetTestTable({ type: "postgres", table: WRITABLE_TEST_TABLE });
       restore("postgres-writable");
       asAdmin(() => {
+        cy.updatePermissionsGraph({
+          [ALL_USERS_GROUP]: {
+            [WRITABLE_DB_ID]: {
+              "view-data": "unrestricted",
+              "create-queries": "query-builder-and-native",
+            },
+          },
+        });
+
         resyncDatabase({
           dbId: WRITABLE_DB_ID,
           tableName: WRITABLE_TEST_TABLE,

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -12,7 +12,7 @@ const mongoName = "QA Mongo";
 const postgresName = "QA Postgres12";
 const additionalPG = "New Database";
 
-const { DATA_GROUP } = USER_GROUPS;
+const { ALL_USERS_GROUP, DATA_GROUP } = USER_GROUPS;
 
 describe(
   "scenarios > question > native > database source",
@@ -25,6 +25,14 @@ describe(
 
       restore("postgres-12");
       cy.signInAsAdmin();
+      cy.updatePermissionsGraph({
+        [ALL_USERS_GROUP]: {
+          [PG_DB_ID]: {
+            "view-data": "unrestricted",
+            "create-queries": "query-builder-and-native",
+          },
+        },
+      });
     });
 
     it("smoketest: persisting last used database should work, and it should be user-specific setting", () => {

--- a/e2e/test/scenarios/native/native-database-source.cy.spec.js
+++ b/e2e/test/scenarios/native/native-database-source.cy.spec.js
@@ -11,6 +11,7 @@ const PG_DB_ID = 2;
 const mongoName = "QA Mongo";
 const postgresName = "QA Postgres12";
 const additionalPG = "New Database";
+const ADDITIONAL_PG_DB_ID = 3;
 
 const { ALL_USERS_GROUP, DATA_GROUP } = USER_GROUPS;
 
@@ -141,7 +142,7 @@ describe(
     });
 
     describe("permissions", () => {
-      it("users with 'No self-service' data permissions should be able to choose only the databases they can query against", () => {
+      it("users should be able to choose the databases they can run native queries against", () => {
         cy.signIn("nodata");
 
         startNativeQuestion();
@@ -156,6 +157,14 @@ describe(
         cy.signInAsAdmin();
 
         addPostgresDatabase(additionalPG);
+        cy.updatePermissionsGraph({
+          [ALL_USERS_GROUP]: {
+            [ADDITIONAL_PG_DB_ID]: {
+              "view-data": "unrestricted",
+              "create-queries": "query-builder-and-native",
+            },
+          },
+        });
 
         cy.signIn("nodata");
         startNativeQuestion();

--- a/e2e/test/scenarios/native/native-mongo.cy.spec.js
+++ b/e2e/test/scenarios/native/native-mongo.cy.spec.js
@@ -1,6 +1,9 @@
+import { USER_GROUPS } from "e2e/support/cypress_data";
 import { restore } from "e2e/support/helpers";
 
 const MONGO_DB_NAME = "QA Mongo";
+const MONGO_DB_ID = 2;
+const { ALL_USERS_GROUP } = USER_GROUPS;
 
 describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
   before(() => {
@@ -8,6 +11,14 @@ describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
     restore("mongo-5");
+    cy.updatePermissionsGraph({
+      [ALL_USERS_GROUP]: {
+        [MONGO_DB_ID]: {
+          "view-data": "unrestricted",
+          "create-queries": "query-builder-and-native",
+        },
+      },
+    });
     cy.signInAsNormalUser();
 
     cy.visit("/");

--- a/e2e/test/scenarios/native/native-mongo.cy.spec.js
+++ b/e2e/test/scenarios/native/native-mongo.cy.spec.js
@@ -11,6 +11,7 @@ describe("scenarios > question > native > mongo", { tags: "@mongo" }, () => {
     cy.intercept("POST", "/api/dataset").as("dataset");
 
     restore("mongo-5");
+    cy.signInAsAdmin();
     cy.updatePermissionsGraph({
       [ALL_USERS_GROUP]: {
         [MONGO_DB_ID]: {

--- a/e2e/test/scenarios/permissions/view-data/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data/impersonated.cy.spec.js
@@ -44,14 +44,7 @@ describeEE("scenarios > admin > permissions > view data > impersonated", () => {
 
     assertPermissionTable([
       ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
-      [
-        "QA Postgres12",
-        "Impersonated",
-        "Query builder and native",
-        "1 million rows",
-        "No",
-        "No",
-      ],
+      ["QA Postgres12", "Impersonated", "No", "1 million rows", "No", "No"],
     ]);
 
     // Checking it shows the right state on the tables level
@@ -70,7 +63,7 @@ describeEE("scenarios > admin > permissions > view data > impersonated", () => {
       ].map(tableName => [
         tableName,
         "Impersonated",
-        "Query builder and native",
+        "No",
         "1 million rows",
         "No",
         "No",
@@ -93,14 +86,7 @@ describeEE("scenarios > admin > permissions > view data > impersonated", () => {
 
     assertPermissionTable([
       ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
-      [
-        "QA Postgres12",
-        "Impersonated",
-        "Query builder and native",
-        "1 million rows",
-        "No",
-        "No",
-      ],
+      ["QA Postgres12", "Impersonated", "No", "1 million rows", "No", "No"],
     ]);
   });
 
@@ -165,7 +151,7 @@ describeEE("scenarios > admin > permissions > view data > impersonated", () => {
       ].map(tableName => [
         tableName,
         "Can view",
-        "Query builder and native",
+        "No",
         "1 million rows",
         "No",
         "No",
@@ -177,14 +163,7 @@ describeEE("scenarios > admin > permissions > view data > impersonated", () => {
     // On database level it got reset to Can view too
     assertPermissionTable([
       ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
-      [
-        "QA Postgres12",
-        "Can view",
-        "Query builder and native",
-        "1 million rows",
-        "No",
-        "No",
-      ],
+      ["QA Postgres12", "Can view", "No", "1 million rows", "No", "No"],
     ]);
   });
 

--- a/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/sandbox/api/field_test.clj
@@ -13,8 +13,8 @@
 (deftest fetch-field-test
   (testing "GET /api/field/:id"
     (met/with-gtaps! {:gtaps      {:venues {:query      (mt.tu/restricted-column-query (mt/id))
-                                           :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
-                     :attributes {:cat 50}}
+                                            :remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
+                      :attributes {:cat 50}}
       (testing "Can I fetch a Field that I don't have read access for if I have segmented table access for it?"
         (let [result (mt/user-http-request :rasta :get 200 (str "field/" (mt/id :venues :name)))]
           (is (map? result))
@@ -88,10 +88,10 @@
                     (let [password (mt/random-name)]
                       (t2.with-temp/with-temp [User another-user {:password password}]
                         (met/with-gtaps-for-user! another-user {:gtaps      {:venues
-                                                                            {:remappings
-                                                                             {:cat
-                                                                              [:dimension (mt/id :venues :category_id)]}}}
-                                                               :attributes {:cat 5 #_BBQ}}
+                                                                             {:remappings
+                                                                              {:cat
+                                                                               [:dimension (mt/id :venues :category_id)]}}}
+                                                                :attributes {:cat 5 #_BBQ}}
                           (is (= {:field_id        (mt/id :venues :name)
                                   :values          [["Baby Blues BBQ"]
                                                     ["Bludso's BBQ"]
@@ -113,17 +113,17 @@
         (is (= [[1 "$"] [2 "$$"] [3 "$$$"] [4 "$$$$"]]
                (:values (mt/user-http-request :rasta :get 200 (format "field/%d/values" field-id)))))
         (met/with-gtaps! {:gtaps      {:venues
-                                      {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
-                         :attributes {:cat 4}}
+                                       {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}}}
+                          :attributes {:cat 4}}
           (is (= [[1 "$"] [3 "$$$"]]
                  (:values (mt/user-http-request :rasta :get 200 (format "field/%d/values" (mt/id :venues :price)))))))))))
 
 (deftest search-test
   (testing "GET /api/field/:id/search/:search-id"
     (met/with-gtaps! {:gtaps      {:venues
-                                  {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
-                                   :query      (mt.tu/restricted-column-query (mt/id))}}
-                     :attributes {:cat 50}}
+                                   {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                    :query      (mt.tu/restricted-column-query (mt/id))}}
+                      :attributes {:cat 50}}
       (testing (str "Searching via the query builder needs to use a GTAP when the user has segmented permissions. "
                     "This tests out a field search on a table with segmented permissions")
         ;; Rasta Toucan is only allowed to see Venues that are in the "Mexican" category [category_id = 50]. So
@@ -139,10 +139,10 @@
 
 (deftest caching-test
   (met/with-gtaps! {:gtaps
-                   {:venues
-                    {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
-                     :query      (mt.tu/restricted-column-query (mt/id))}}
-                   :attributes {:cat 50}}
+                    {:venues
+                     {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                      :query      (mt.tu/restricted-column-query (mt/id))}}
+                    :attributes {:cat 50}}
     (let [field (t2/select-one Field :id (mt/id :venues :name))]
       ;; Make sure FieldValues are populated
       (field-values/get-or-create-full-field-values! field)
@@ -159,9 +159,9 @@
         (let [password (mt/random-name)]
           (t2.with-temp/with-temp [User another-user {:password password}]
             (met/with-gtaps-for-user! another-user {:gtaps      {:venues
-                                                                {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
-                                                                 :query      (mt.tu/restricted-column-query (mt/id))}}
-                                                   :attributes {:cat 5}}
+                                                                 {:remappings {:cat [:variable [:field (mt/id :venues :category_id) nil]]}
+                                                                  :query      (mt.tu/restricted-column-query (mt/id))}}
+                                                    :attributes {:cat 5}}
               (mt/user-http-request another-user :get 200 (str "field/" (:id field) "/values"))
               ;; create another one for the new user
               (is (= 2 (t2/count FieldValues

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -643,9 +643,12 @@
   [group-or-id db-or-id]
   (let [group-id             (u/the-id group-or-id)
         view-data-level      (new-database-view-data-permission-level group-id)
-        create-queries-level (lowest-permission-level-in-any-database group-id :perms/create-queries)
-        download-level       (if (= view-data-level :blocked) :no
-                                 (lowest-permission-level-in-any-database group-id :perms/download-results))]
+        create-queries-level (or (lowest-permission-level-in-any-database group-id :perms/create-queries)
+                                 :query-builder-and-native)
+        download-level       (if (= view-data-level :blocked)
+                               :no
+                               (or (lowest-permission-level-in-any-database group-id :perms/download-results)
+                                   :one-million-rows))]
     (set-database-permission! group-or-id db-or-id :perms/view-data view-data-level)
     (set-database-permission! group-or-id db-or-id :perms/create-queries create-queries-level)
     (set-database-permission! group-or-id db-or-id :perms/download-results download-level)

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -154,7 +154,6 @@
         (doseq [group non-admin-groups]
           (data-perms/set-database-permission! group database :perms/view-data :unrestricted)
           (data-perms/set-database-permission! group database :perms/create-queries :no)
-          (data-perms/set-database-permission! group database :perms/native-query-editing :no)
           (data-perms/set-database-permission! group database :perms/download-results :one-million-rows)
           (data-perms/set-database-permission! group database :perms/manage-table-metadata :no)
           (data-perms/set-database-permission! group database :perms/manage-database :no))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -144,7 +144,10 @@
         (doseq [group non-admin-groups]
           (data-perms/set-database-permission! group database :perms/view-data :unrestricted)
           (data-perms/set-database-permission! group database :perms/create-queries :no)
-          (data-perms/set-database-permission! group database :perms/download-results :one-million-rows))
+          (data-perms/set-database-permission! group database :perms/native-query-editing :no)
+          (data-perms/set-database-permission! group database :perms/download-results :one-million-rows)
+          (data-perms/set-database-permission! group database :perms/manage-table-metadata :no)
+          (data-perms/set-database-permission! group database :perms/manage-database :no))
         (doseq [group non-admin-groups]
           (data-perms/set-new-database-permissions! group database))))))
 

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -145,17 +145,8 @@
           (data-perms/set-database-permission! group database :perms/view-data :unrestricted)
           (data-perms/set-database-permission! group database :perms/create-queries :no)
           (data-perms/set-database-permission! group database :perms/download-results :one-million-rows))
-        (do
-          (data-perms/set-database-permission! all-users-group database :perms/view-data :unrestricted)
-          (data-perms/set-database-permission! all-users-group database :perms/create-queries :query-builder-and-native)
-          (data-perms/set-database-permission! all-users-group database :perms/download-results :one-million-rows)
-          (doseq [group non-magic-groups]
-            (data-perms/set-database-permission! group database :perms/view-data :unrestricted)
-            (data-perms/set-database-permission! group database :perms/create-queries :no)
-            (data-perms/set-database-permission! group database :perms/download-results :no))))
-      (doseq [group non-admin-groups]
-        (data-perms/set-database-permission! group database :perms/manage-table-metadata :no)
-        (data-perms/set-database-permission! group database :perms/manage-database :no)))))
+        (doseq [group non-admin-groups]
+          (data-perms/set-new-database-permissions! group database))))))
 
 (t2/define-after-insert :model/Database
   [database]

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -1,7 +1,6 @@
 (ns metabase.models.database
   (:require
    [clojure.core.match :refer [match]]
-   [clojure.test :as t]
    [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.config :as config]
@@ -28,8 +27,7 @@
    [methodical.core :as methodical]
    [toucan2.core :as t2]
    [toucan2.realize :as t2.realize]
-   [toucan2.tools.with-temp :as t2.with-temp]
-   [toucan2.util :as t2.u]))
+   [toucan2.tools.with-temp :as t2.with-temp]))
 
 
 ;;; ----------------------------------------------- Entity & Lifecycle -----------------------------------------------
@@ -57,30 +55,14 @@
   (derive :metabase/model)
   (derive :hook/timestamped?))
 
-(methodical/defmethod t2.with-temp/do-with-temp* :model/Database
-  [model explicit-attributes f]
-  (assert (some? model) (format "%s model cannot be nil." `with-temp))
-  (when (some? explicit-attributes)
-    (assert (map? explicit-attributes) (format "attributes passed to %s must be a map." `with-temp)))
-  (let [defaults          (t2.with-temp/with-temp-defaults model)
-        merged-attributes (merge {} defaults explicit-attributes)]
-    (t2.u/try-with-error-context ["with temp" {::model               model
-                                               ::explicit-attributes explicit-attributes
-                                               ::default-attributes  defaults
-                                               ::merged-attributes   merged-attributes}]
-      (log/debugf "Create temporary %s with attributes %s" model merged-attributes)
-      (let [temp-object (first (t2/insert-returning-instances! model merged-attributes))]
-        (log/debugf "[with-temp] => %s" temp-object)
-        (try
-          (t/testing (format "\nwith temporary %s with attributes\n%s\n"
-                             (pr-str model)
-                             (u/pprint-to-str merged-attributes))
-           (data-perms/set-database-permission! (perms-group/all-users) temp-object :perms/view-data :unrestricted)
-           (data-perms/set-database-permission! (perms-group/all-users) temp-object :perms/create-queries :query-builder-and-native)
-           (data-perms/set-database-permission! (perms-group/all-users) temp-object :perms/download-results :one-million-rows)
-           (f temp-object))
-         (finally
-           (t2/delete! model :toucan/pk ((t2/select-pks-fn model) temp-object))))))))
+(methodical/defmethod t2.with-temp/do-with-temp* :before :model/Database
+  [_model _explicit-attributes f]
+  (fn [temp-object]
+    ;; Grant All Users full perms on the temp-object so that tests don't have to manually set permissions
+    (data-perms/set-database-permission! (perms-group/all-users) temp-object :perms/view-data :unrestricted)
+    (data-perms/set-database-permission! (perms-group/all-users) temp-object :perms/create-queries :query-builder-and-native)
+    (data-perms/set-database-permission! (perms-group/all-users) temp-object :perms/download-results :one-million-rows)
+    (f temp-object)))
 
 (defn- should-read-audit-db?
   "Audit Database should only be fetched if audit app is enabled."

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -746,7 +746,7 @@
                    :headers))))
       (testing " handles large numbers of tables and fields sensibly with prefix"
         (mt/with-model-cleanup [Field Table Database]
-          (let [tmp-db (first (t2/insert-returning-instances! Database {:name "Temp Autocomplete Pagination DB" :engine "h2" :details "{}"}))]
+          (mt/with-temp [Database tmp-db {:name "Temp Autocomplete Pagination DB" :engine "h2"}]
             ;; insert more than 50 temporary tables and fields
             (doseq [i (range 60)]
               (let [tmp-tbl (first (t2/insert-returning-instances! Table {:name (format "My Table %d" i) :db_id (u/the-id tmp-db) :active true}))]

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -461,59 +461,71 @@
   (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
                  :model/Database         {db-id-1 :id}  {}
                  :model/Database         {db-id-2 :id}  {}]
-    ;; First delete the default permissions for the group so we start with a clean slate
-    (t2/delete! :model/DataPermissions :group_id group-id)
-    (testing "Data permissions... "
-      (testing "A new database gets `unrestricted` perms if a group only has `unrestricted` (or `legacy-no-self-service`) perms for other databases"
-        (data-perms/set-database-permission! group-id db-id-1 :perms/view-data :unrestricted)
-        (mt/with-temp [:model/Database {new-db-id :id} {}]
-          (is (= :unrestricted (t2/select-one-fn :perm_value
-                                                 :model/DataPermissions
-                                                 :db_id     new-db-id
-                                                 :group_id  group-id
-                                                 :perm_type :perms/view-data))))
-        (data-perms/set-database-permission! group-id db-id-1 :perms/view-data :legacy-no-self-service)
-        (mt/with-temp [:model/Database {new-db-id :id} {}]
-          (is (= :unrestricted (t2/select-one-fn :perm_value
-                                                 :model/DataPermissions
-                                                 :db_id     new-db-id
-                                                 :group_id  group-id
-                                                 :perm_type :perms/view-data)))))
-      (testing "A new database gets `blocked` data perms if a group has `blocked` perms for any database"
-        (data-perms/set-database-permission! group-id db-id-2 :perms/view-data :blocked)
-        (mt/with-temp [:model/Database {new-db-id :id} {}]
-          (is (= :blocked (t2/select-one-fn :perm_value
-                                            :model/DataPermissions
-                                            :db_id     new-db-id
-                                            :group_id  group-id
-                                            :perm_type :perms/view-data))))))
+    (mt/with-model-cleanup [:model/Database]
+      ;; First delete the default permissions for the group so we start with a clean slate
+      (t2/delete! :model/DataPermissions :group_id group-id)
+      (testing "Data permissions... "
+        (testing "A new database gets `unrestricted` perms if a group only has `unrestricted` (or `legacy-no-self-service`) perms for other databases"
+          (data-perms/set-database-permission! group-id db-id-1 :perms/view-data :unrestricted)
+          ;; We don't use `with-temp` to create the new Database because it always grants permissions automatically
+          (let [new-db-id (t2/insert-returning-pk! :model/Database {:name "Test" :engine "h2" :details "{}"})]
+            (is (= :unrestricted (t2/select-one-fn :perm_value
+                                                   :model/DataPermissions
+                                                   :db_id     new-db-id
+                                                   :group_id  group-id
+                                                   :perm_type :perms/view-data)))
+            (t2/delete! :model/Database :id new-db-id))
 
-    (t2/delete! :model/DataPermissions :group_id group-id)
-    (testing "Query permissions... "
-      (testing "A new database gets `query-builder-and-native` query permissions if a group only has `query-builder-and-native` for other databases"
-        (data-perms/set-database-permission! group-id db-id-1 :perms/create-queries :query-builder-and-native)
-        (mt/with-temp [:model/Database {new-db-id :id} {}]
-          (is (= :query-builder-and-native (t2/select-one-fn :perm_value
-                                                             :model/DataPermissions
-                                                             :db_id     new-db-id
-                                                             :group_id  group-id
-                                                             :perm_type :perms/create-queries)))))
-      (testing "A new database gets `query-builder` query permissions if a group has `query-builder` for any database"
-        (data-perms/set-database-permission! group-id db-id-2 :perms/create-queries :query-builder)
-        (mt/with-temp [:model/Database {new-db-id :id} {}]
-          (is (= :query-builder (t2/select-one-fn :perm_value
-                                                  :model/DataPermissions
-                                                  :db_id     new-db-id
-                                                  :group_id  group-id
-                                                  :perm_type :perms/create-queries)))))
-      (testing "A new database gets `no` query permissions if a group has `no` for any database"
-        (data-perms/set-database-permission! group-id db-id-2 :perms/create-queries :no)
-        (mt/with-temp [:model/Database {new-db-id :id} {}]
-          (is (= :no (t2/select-one-fn :perm_value
-                                       :model/DataPermissions
-                                       :db_id     new-db-id
-                                       :group_id  group-id
-                                       :perm_type :perms/create-queries))))))))
+          (data-perms/set-database-permission! group-id db-id-1 :perms/view-data :legacy-no-self-service)
+          (let [new-db-id (t2/insert-returning-pk! :model/Database {:name "Test" :engine "h2" :details "{}"})]
+            (is (= :unrestricted (t2/select-one-fn :perm_value
+                                                   :model/DataPermissions
+                                                   :db_id     new-db-id
+                                                   :group_id  group-id
+                                                   :perm_type :perms/view-data)))
+            (t2/delete! :model/Database :id new-db-id)))
+
+        (testing "A new database gets `blocked` data perms if a group has `blocked` perms for any database"
+          (data-perms/set-database-permission! group-id db-id-2 :perms/view-data :blocked)
+          (let [new-db-id (t2/insert-returning-pk! :model/Database {:name "Test" :engine "h2" :details "{}"})]
+            (is (= :blocked (t2/select-one-fn :perm_value
+                                              :model/DataPermissions
+                                              :db_id     new-db-id
+                                              :group_id  group-id
+                                              :perm_type :perms/view-data)))
+            (t2/delete! :model/Database :id new-db-id))))
+
+      (t2/delete! :model/DataPermissions :group_id group-id)
+      (testing "Query permissions... "
+        (testing "A new database gets `query-builder-and-native` query permissions if a group only has `query-builder-and-native` for other databases"
+          (data-perms/set-database-permission! group-id db-id-1 :perms/create-queries :query-builder-and-native)
+          (let [new-db-id (t2/insert-returning-pk! :model/Database {:name "Test" :engine "h2" :details "{}"})]
+            (is (= :query-builder-and-native (t2/select-one-fn :perm_value
+                                                               :model/DataPermissions
+                                                               :db_id     new-db-id
+                                                               :group_id  group-id
+                                                               :perm_type :perms/create-queries)))
+            (t2/delete! :model/Database :id new-db-id)))
+
+        (testing "A new database gets `query-builder` query permissions if a group has `query-builder` for any database"
+          (data-perms/set-database-permission! group-id db-id-2 :perms/create-queries :query-builder)
+          (let [new-db-id (t2/insert-returning-pk! :model/Database {:name "Test" :engine "h2" :details "{}"})]
+            (is (= :query-builder (t2/select-one-fn :perm_value
+                                                    :model/DataPermissions
+                                                    :db_id     new-db-id
+                                                    :group_id  group-id
+                                                    :perm_type :perms/create-queries)))
+            (t2/delete! :model/Database :id new-db-id)))
+
+        (testing "A new database gets `no` query permissions if a group has `no` for any database"
+          (data-perms/set-database-permission! group-id db-id-2 :perms/create-queries :no)
+          (let [new-db-id (t2/insert-returning-pk! :model/Database {:name "Test" :engine "h2" :details "{}"})]
+            (is (= :no (t2/select-one-fn :perm_value
+                                         :model/DataPermissions
+                                         :db_id     new-db-id
+                                         :group_id  group-id
+                                         :perm_type :perms/create-queries)))
+            (t2/delete! :model/Database :id new-db-id)))))))
 
 (deftest set-new-table-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -458,33 +458,62 @@
                                  user-id-1 :perms/create-queries database-id-1))))))))
 
 (deftest set-new-database-permissions!-test
-  (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}
-                 :model/Database         {db-id :id}      {}]
+  (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                 :model/Database         {db-id-1 :id}  {}
+                 :model/Database         {db-id-2 :id}  {}]
     ;; First delete the default permissions for the group so we start with a clean slate
     (t2/delete! :model/DataPermissions :group_id group-id)
-    (testing "A new database gets `blocked` data perms if a group has `blocked` perms for another database"
-      (data-perms/set-database-permission! group-id db-id :perms/view-data :blocked)
-      (mt/with-temp [:model/Database {new-db-id :id} {}]
-        (is (= :blocked (t2/select-one-fn :perm_value
-                                          :model/DataPermissions
-                                          :db_id     new-db-id
-                                          :group_id  group-id
-                                          :perm_type :perms/view-data)))))
-    (testing "A new database gets `unrestricted` data perms if a group only has `unrestricted` (or `legacy-no-self-service`) perms other databases"
-      (data-perms/set-database-permission! group-id db-id :perms/view-data :unrestricted)
-      (mt/with-temp [:model/Database {new-db-id :id} {}]
-        (is (= :unrestricted (t2/select-one-fn :perm_value
-                                               :model/DataPermissions
-                                               :db_id     new-db-id
-                                               :group_id  group-id
-                                               :perm_type :perms/view-data))))
-      (data-perms/set-database-permission! group-id db-id :perms/view-data :legacy-no-self-service)
-      (mt/with-temp [:model/Database {new-db-id :id} {}]
-        (is (= :unrestricted (t2/select-one-fn :perm_value
-                                               :model/DataPermissions
-                                               :db_id     new-db-id
-                                               :group_id  group-id
-                                               :perm_type :perms/view-data)))))))
+    (testing "Data permissions... "
+      (testing "A new database gets `unrestricted` perms if a group only has `unrestricted` (or `legacy-no-self-service`) perms for other databases"
+        (data-perms/set-database-permission! group-id db-id-1 :perms/view-data :unrestricted)
+        (mt/with-temp [:model/Database {new-db-id :id} {}]
+          (is (= :unrestricted (t2/select-one-fn :perm_value
+                                                 :model/DataPermissions
+                                                 :db_id     new-db-id
+                                                 :group_id  group-id
+                                                 :perm_type :perms/view-data))))
+        (data-perms/set-database-permission! group-id db-id-1 :perms/view-data :legacy-no-self-service)
+        (mt/with-temp [:model/Database {new-db-id :id} {}]
+          (is (= :unrestricted (t2/select-one-fn :perm_value
+                                                 :model/DataPermissions
+                                                 :db_id     new-db-id
+                                                 :group_id  group-id
+                                                 :perm_type :perms/view-data)))))
+      (testing "A new database gets `blocked` data perms if a group has `blocked` perms for any database"
+        (data-perms/set-database-permission! group-id db-id-2 :perms/view-data :blocked)
+        (mt/with-temp [:model/Database {new-db-id :id} {}]
+          (is (= :blocked (t2/select-one-fn :perm_value
+                                            :model/DataPermissions
+                                            :db_id     new-db-id
+                                            :group_id  group-id
+                                            :perm_type :perms/view-data))))))
+
+    (t2/delete! :model/DataPermissions :group_id group-id)
+    (testing "Query permissions... "
+      (testing "A new database gets `query-builder-and-native` query permissions if a group only has `query-builder-and-native` for other databases"
+        (data-perms/set-database-permission! group-id db-id-1 :perms/create-queries :query-builder-and-native)
+        (mt/with-temp [:model/Database {new-db-id :id} {}]
+          (is (= :query-builder-and-native (t2/select-one-fn :perm_value
+                                                             :model/DataPermissions
+                                                             :db_id     new-db-id
+                                                             :group_id  group-id
+                                                             :perm_type :perms/create-queries)))))
+      (testing "A new database gets `query-builder` query permissions if a group has `query-builder` for any database"
+        (data-perms/set-database-permission! group-id db-id-2 :perms/create-queries :query-builder)
+        (mt/with-temp [:model/Database {new-db-id :id} {}]
+          (is (= :query-builder (t2/select-one-fn :perm_value
+                                                  :model/DataPermissions
+                                                  :db_id     new-db-id
+                                                  :group_id  group-id
+                                                  :perm_type :perms/create-queries)))))
+      (testing "A new database gets `no` query permissions if a group has `no` for any database"
+        (data-perms/set-database-permission! group-id db-id-2 :perms/create-queries :no)
+        (mt/with-temp [:model/Database {new-db-id :id} {}]
+          (is (= :no (t2/select-one-fn :perm_value
+                                       :model/DataPermissions
+                                       :db_id     new-db-id
+                                       :group_id  group-id
+                                       :perm_type :perms/create-queries))))))))
 
 (deftest set-new-table-permissions!-test
   (mt/with-temp [:model/PermissionsGroup {group-id :id}   {}

--- a/test/metabase/models/data_permissions_test.clj
+++ b/test/metabase/models/data_permissions_test.clj
@@ -483,16 +483,6 @@
                                                    :db_id     new-db-id
                                                    :group_id  group-id
                                                    :perm_type :perms/view-data)))
-            (t2/delete! :model/Database :id new-db-id)))
-
-        (testing "A new database gets `blocked` data perms if a group has `blocked` perms for any database"
-          (data-perms/set-database-permission! group-id db-id-2 :perms/view-data :blocked)
-          (let [new-db-id (t2/insert-returning-pk! :model/Database {:name "Test" :engine "h2" :details "{}"})]
-            (is (= :blocked (t2/select-one-fn :perm_value
-                                              :model/DataPermissions
-                                              :db_id     new-db-id
-                                              :group_id  group-id
-                                              :perm_type :perms/view-data)))
             (t2/delete! :model/Database :id new-db-id))))
 
       (t2/delete! :model/DataPermissions :group_id group-id)

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -8,10 +8,8 @@
    [metabase.driver.util :as driver.u]
    [metabase.lib.test-util :as lib.tu]
    [metabase.models :refer [Database]]
-   [metabase.models.data-permissions :as data-perms]
    [metabase.models.database :as database]
    [metabase.models.interface :as mi]
-   [metabase.models.permissions-group :as perms-group]
    [metabase.models.secret :as secret :refer [Secret]]
    [metabase.models.serialization :as serdes]
    [metabase.query-processor.store :as qp.store]
@@ -33,31 +31,6 @@
           (when (str/ends-with? trigger-key (str \. db-id))
             trigger))
         (:triggers (task/job-info "metabase.task.sync-and-analyze.job"))))
-
-(deftest set-new-database-permissions!-test
-  (testing "New permissions are set appropriately for a new database, for all groups"
-    (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
-                   :model/Database         {db-id :id}    {}]
-      ;; All Users group should have native query editing abilities, but not database management
-      (let [all-users-group-id (u/the-id (perms-group/all-users))]
-        (is (= {all-users-group-id
-                {db-id
-                 {:perms/view-data             :unrestricted
-                  :perms/create-queries        :query-builder-and-native
-                  :perms/download-results      :one-million-rows
-                  :perms/manage-table-metadata :no
-                  :perms/manage-database       :no}}}
-               (data-perms/data-permissions-graph :group-id all-users-group-id :db-id db-id))))
-
-      ;; Other groups should have no DB-level perms
-      (is (= {group-id
-              {db-id
-               {:perms/view-data             :unrestricted
-                :perms/create-queries        :no
-                :perms/download-results      :no
-                :perms/manage-table-metadata :no
-                :perms/manage-database       :no}}}
-             (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))
 
 (deftest cleanup-permissions-after-delete-db-test
   (mt/with-temp [:model/Database {db-id :id} {}]

--- a/test/metabase/test/data/impl.clj
+++ b/test/metabase/test/data/impl.clj
@@ -7,8 +7,6 @@
    [metabase.driver.util :as driver.u]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.models :refer [Database Field FieldValues Secret Table]]
-   [metabase.models.data-permissions :as data-perms]
-   [metabase.models.permissions-group :as perms-group]
    [metabase.models.secret :as secret]
    [metabase.plugins.classloader :as classloader]
    [metabase.test.data.dataset-definitions :as defs]
@@ -324,12 +322,6 @@
                  prop->old-id)))
       database)))
 
-(defn- set-temp-db-permissions!
-  [new-db-id]
-  (data-perms/set-database-permission! (perms-group/all-users) new-db-id :perms/view-data :unrestricted)
-  (data-perms/set-database-permission! (perms-group/all-users) new-db-id :perms/create-queries :query-builder-and-native)
-  (data-perms/set-database-permission! (perms-group/all-users) new-db-id :perms/download-results :one-million-rows))
-
 (def ^:dynamic *db-is-temp-copy?*
   "Whether the current test database is a temp copy created with the [[metabase.test/with-temp-copy-of-db]] macro."
   false)
@@ -343,7 +335,7 @@
         {new-db-id :id, :as new-db} (first (t2/insert-returning-instances! Database original-db))]
     (try
       (copy-db-tables-and-fields! old-db-id new-db-id)
-      (set-temp-db-permissions! new-db-id)
+      (test.data.impl.get-or-create/set-test-db-permissions! new-db-id)
       (binding [*db-is-temp-copy?* true]
         (do-with-db new-db f))
       (finally


### PR DESCRIPTION
* Sets new database permissions dynamically for each group, based on the permissions for existing databases. 
  * Sets data perms to `:blocked` on EE if the group has any other DBs which are blocked/sandboxed/impersonated.
  * Sets query and download perms to the lowest permission level in any DB 
* Updates `with-temp` (via implementing a `:before` method for `do-with-temp*`) and test dataset creation to automatically grant perms for test DBs