### PR TITLE
Proof of concept for writing drill-thrus in TS code

### DIFF
--- a/frontend/src/metabase-lib/drill-thru/column-extract.ts
+++ b/frontend/src/metabase-lib/drill-thru/column-extract.ts
@@ -1,0 +1,81 @@
+import { t } from "ttag";
+import * as ML from "cljs/metabase.lib.js";
+import { format_unit } from "cljs/metabase.shared.util.time";
+import type { RowValue } from "metabase-types/api";
+
+import { isDate } from "../column_types";
+
+import type {
+  ColumnMetadata,
+  ClickObjectDataRow,
+  ClickObjectDimension,
+  DrillThru,
+  ExpressionClause,
+  Query,
+} from "../types";
+
+
+export function columnExtractDrill(
+  query: Query,
+  stageIndex: number,
+  column: ColumnMetadata | undefined,
+  value: RowValue | undefined,
+  row: ClickObjectDataRow[] | undefined,
+  dimensions: ClickObjectDimension[] | undefined,
+): DrillThru|null {
+  // This only applies to a header click: value is undefined (not null) and column is defined.
+  // Also the column must be a date or datetime.
+  // TODO: This does not currently work when an extra stage is necessary, eg. when the column in question is an
+  // aggregation. (This needs the equivalent of metabase.lib.drill-thru.column-filter/prepare-query-for-drill-addition,
+  // but that's tightly coupled and should probably get rolled into eg. lib/expression, lib/filter, etc.)
+  if (column && typeof value === "undefined" && isDate(column)) {
+    return {
+      type: "drill-thru/column-extract",
+      displayName: t`(TS) Extract day, month…`, // HACK: Remove the "(TS)" from the name.
+      extractions: ["hour-of-day", "day-of-month", "day-of-week", "month-of-year", "quarter-of-year", "year",]
+          .map(unit => ({ key: unit, displayName: ML.describe_temporal_unit(1, unit), })),
+      column,
+      query,
+      stageNumber: stageIndex,
+    };
+  }
+  return null;
+}
+
+function caseExpression(exprFactory: () => ExpressionClause, unit: string, count: number): ExpressionClause {
+  const cases = [];
+  for (let i = 1; i <= count ; i++) {
+    cases.push([
+      // Check: Inner expression (eg. the month number) = i
+      ML.expression_clause("=", [exprFactory(), i], {}),
+      // Value: The human label for that part.
+      format_unit(i, unit),
+    ]);
+  }
+  return ML.expression_clause("case", [cases, ""], {});
+}
+
+function columnExtractExpression(column: ColumnMetadata, unit: string): ExpressionClause {
+  switch (unit) {
+    case "hour-of-day": return ML.expression_clause("get-hour", [column], {});
+    case "day-of-month": return ML.expression_clause("get-day", [column], {});
+    case "day-of-week": return caseExpression(() => ML.expression_clause("get-day-of-week", [column], {}), unit, 7);
+    case "month-of-year": return caseExpression(() => ML.expression_clause("get-month", [column], {}), unit, 12);
+    case "quarter-of-year": return caseExpression(() => ML.expression_clause("get-quarter", [column], {}), unit, 4);
+    case "year": return ML.expression_clause("get-year", [column], {});
+    default: throw new Error("Unknown unit " + unit + "in column extraction");
+  }
+}
+
+export function applyColumnExtract(
+  query: Query,
+  stageIndex: number,
+  drillThru: DrillThru & {type: string, column: ColumnMetadata},
+  ...args: unknown[]
+): Query {
+  const [unit] = args;
+  const expression = columnExtractExpression(drillThru.column, unit);
+  // TODO: This does not make the names unique; that should be rolled into `lib/expression`.
+  const expressionName = ML.describe_temporal_unit(1, unit);
+  return ML.expression(query, stageIndex, expressionName, expression);
+}

--- a/frontend/src/metabase-lib/drill-thru/index.ts
+++ b/frontend/src/metabase-lib/drill-thru/index.ts
@@ -1,0 +1,52 @@
+import * as ML from "cljs/metabase.lib.js";
+import type { DatasetColumn, RowValue } from "metabase-types/api";
+
+import { applyColumnExtract, columnExtractDrill } from "./column-extract";
+
+import type {
+  ClickObjectDataRow,
+  ClickObjectDimension,
+  DrillThru,
+  Query,
+} from "./types";
+
+
+const TS_DRILLS = [
+  columnExtractDrill,
+];
+
+export function availableDrillThrusTS(
+  query: Query,
+  stageIndex: number,
+  column: DatasetColumn | undefined,
+  value: RowValue | undefined,
+  row: ClickObjectDataRow[] | undefined,
+  dimensions: ClickObjectDimension[] | undefined,
+): DrillThru[] {
+  const mlv2Column = column ? ML.legacy_column__GT_metadata(query, stageIndex, column) : column;
+  return TS_DRILLS
+      .map(drillFn => drillFn(query, stageIndex, mlv2Column, value, row, dimensions))
+      .filter(drill => !!drill);
+}
+
+export function isTSDrill(drillThru: DrillThru): boolean {
+  return drillThru.constructor === Object;
+}
+
+type TSDrillThru<Type extends DrillThruType> = { type: Type };
+
+type ApplyDrill<Drill> =
+    (query: Query, stageIndex: number, drillThru: DrillThru & {type: Type}, ...args: unknown[]) => Query;
+
+const DRILL_APPLICATIONS: Record<DrillThruType, ApplyDrill<DrillThruType>> = {
+  "drill-thru/column-extract": applyColumnExtract,
+};
+
+export function drillThruTS(
+  query: Query,
+  stageIndex: number,
+  drillThru: DrillThru & {type: string},
+  ...args: unknown[]
+): Query {
+  return DRILL_APPLICATIONS[drillThru.type](query, stageIndex, drillThru, ...args);
+}

--- a/frontend/src/metabase-lib/drills.ts
+++ b/frontend/src/metabase-lib/drills.ts
@@ -1,6 +1,8 @@
 import * as ML from "cljs/metabase.lib.js";
 import type { DatasetColumn, RowValue } from "metabase-types/api";
 
+import { availableDrillThrusTS, drillThruTS, isTSDrill } from "./drill-thru";
+
 import type {
   FilterDrillDetails,
   ColumnMetadata,
@@ -28,7 +30,7 @@ export function availableDrillThrus(
     value,
     row,
     dimensions,
-  );
+  ).concat(availableDrillThrusTS(query, stageIndex, column, value, row, dimensions));
 }
 
 // TODO: Precise types for each of the various extra args?
@@ -38,7 +40,11 @@ export function drillThru(
   drillThru: DrillThru,
   ...args: unknown[]
 ): Query {
-  return ML.drill_thru(query, stageIndex, drillThru, ...args);
+  // If the drillThru is a vanilla TS objects, this drill is implemented in TS.
+  return isTSDrill(drillThru) ?
+    drillThruTS(query, stageIndex, drillThru, ...args) :
+    // If it's another class (eg. a CLJS map), then it's implemented in CLJS.
+    ML.drill_thru(query, stageIndex, drillThru, ...args);
 }
 
 export function filterDrillDetails(drillThru: DrillThru): FilterDrillDetails {

--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -229,9 +229,13 @@
   ;; Attaches a cached display-info blob to `x`, in case it gets called again for the same object.
   ;; TODO: Keying by stage is probably unnecessary - if we eg. fetched a column from different stages, it would be a
   ;; different object. Test that idea and remove the stage from the cache key.
-  (lib.cache/side-channel-cache
-    (keyword "display-info-outer" (str "stage-" stage-number)) x
-    #(display-info* a-query stage-number %)))
+  (if (object? x)
+    ;; If the input is a vanilla JS object, simply return it as-is.
+    ;; This allows TS values to slot in next to CLJS ones and be treated as opaque.
+    x
+    (lib.cache/side-channel-cache
+      (keyword "display-info-outer" (str "stage-" stage-number)) x
+      #(display-info* a-query stage-number %))))
 
 (defn ^:export order-by-clause
   "Create an order-by clause independently of a query, e.g. for `replace` or whatever."

--- a/src/metabase/lib/schema/expression/conditional.cljc
+++ b/src/metabase/lib/schema/expression/conditional.cljc
@@ -50,13 +50,14 @@
 ;;; believe it or not, a `:case` clause really has the syntax [:case {} [[pred1 expr1] [pred2 expr2] ...]]
 (mr/def ::case-subclause
   [:tuple
-   {:error/message "Valid :case [pred expr] pair"}
+   {:error/message    "Valid :case [pred expr] pair"
+    :decode/normalize vec}
    #_pred [:ref ::expression/boolean]
    #_expr [:ref ::expression/expression]])
 
 (mbql-clause/define-catn-mbql-clause :case
   ;; TODO -- we should further constrain this so all of the exprs are of the same type
-  [:pred-expr-pairs [:sequential {:min 1} [:ref ::case-subclause]]]
+  [:pred-expr-pairs [:sequential {:min 1, :decode/normalize vec} [:ref ::case-subclause]]]
   [:default [:? [:schema [:ref ::expression/expression]]]])
 
 (defmethod expression/type-of-method :case

--- a/src/metabase/shared/util/time.cljc
+++ b/src/metabase/shared/util/time.cljc
@@ -73,11 +73,11 @@
     :else           (throw (ex-info "Unknown input to coerce-to-time; expecting a string"
                                     {:value value}))))
 
-(defn format-unit
+(defn ^:export format-unit
   "Formats a temporal-value (iso date/time string, int for hour/minute) given the temporal-bucketing unit.
    If unit is nil, formats the full date/time"
   [temporal-value unit]
-  (internal/format-unit temporal-value unit))
+  (internal/format-unit temporal-value (keyword unit)))
 
 (defn format-diff
   "Formats a time difference between two temporal values.


### PR DESCRIPTION
Here's a somewhat hacky example of what implementing a drill in TS would look like.

It reimplements the "Extract" drill for date/time columns in TS.

To try it, query Orders and click the header for Created At. The original Clojure implementation is still there, and the new one is `(TS) Extract day, month...`.

There's a couple of hacks here, most notable it doesn't work correctly if an extra stage is required. I'm still thinking about a good design for how to add that to MLv2 in a sensible way for the library. My best guess currently looks like this:

```typescript
function filterableBy(query, stageIndex, column: Lib.MetadataColumn): [newQuery: Lib.Query, newStageIndex: number, column: Lib.MetadataColumn];
```

So that we can correctly render the filter UI. For a regular column that returns the three parameters unchanged.
But if it's an aggregation or breakout column, then it returns:

- `query`, with a new stage appended **if** there wasn't already a later stage than `stageIndex`
- `stageIndex` for the right stage to target
- `column` is the "view" of that column in the target stage; eg. the aggregation as it gets returned from the earlier stage.

This is tricky but important for correctly rendering the filter UI. This is why drills that build filters for the clicked column return a query, stage number and column as part of the drill's `displayInfo`.


**Comments welcome!**
