### PR TITLE
enable text selection on non-brushable charts

### DIFF
--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.styled.tsx
@@ -1,0 +1,8 @@
+import styled from "@emotion/styled";
+
+export const EChartsRendererRoot = styled.div`
+  // HACK: zrender adds user-select: none to the root svg element which prevents users from selecting text on charts
+  & svg {
+    user-select: auto !important;
+  }
+`;

--- a/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.tsx
+++ b/frontend/src/metabase/visualizations/components/EChartsRenderer/EChartsRenderer.tsx
@@ -8,6 +8,8 @@ import type {
   ZREventHandler,
 } from "metabase/visualizations/types/echarts";
 
+import { EChartsRendererRoot } from "./EChartsRenderer.styled";
+
 export interface EChartsRendererProps {
   option: EChartsOption;
   eventHandlers?: EChartsEventHandler[];
@@ -73,5 +75,5 @@ export const EChartsRenderer = ({
       );
   }, [zrEventHandlers]);
 
-  return <div ref={chartElemRef} />;
+  return <EChartsRendererRoot ref={chartElemRef} />;
 };


### PR DESCRIPTION
Part of https://github.com/metabase/metabase/issues/38915

### Description

Text on charts was not selectable because `zrender` adds `user-select: none` to the root SVG so we have to override it. However, the selection still won't work on charts where brushing is enabled.

### How to verify

- Create a line chart with ordinal x-axis
- Ensure you can select axis ticks, names on the chart
