### PR TITLE
Disable saving models without up-to-date result_metadata

### DIFF
--- a/e2e/support/helpers/e2e-misc-helpers.js
+++ b/e2e/support/helpers/e2e-misc-helpers.js
@@ -54,6 +54,15 @@ export function runNativeQuery({ wait = true } = {}) {
   cy.icon("play").should("not.exist");
 }
 
+export function focusNativeEditor() {
+  return cy
+    .findByTestId("native-query-editor")
+    .should("be.visible")
+    .should("have.class", "ace_editor")
+    .click()
+    .should("have.class", "ace_focus");
+}
+
 /**
  * Intercepts a request and returns resolve function that allows
  * the request to continue

--- a/e2e/test/scenarios/models/create.cy.spec.js
+++ b/e2e/test/scenarios/models/create.cy.spec.js
@@ -26,10 +26,10 @@ describe("scenarios > models > create", () => {
     cy.findByTestId("editor-tabs-metadata").should("be.disabled");
 
     cy.get(".ace_editor").should("be.visible").type("select * from ORDERS");
+    cy.findByTestId("native-query-editor-container").icon("play").click();
+    cy.wait("@dataset");
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save").click();
-
+    cy.findByTestId("dataset-edit-bar").button("Save").click();
     cy.findByPlaceholderText("What is the name of your model?").type(modelName);
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -47,6 +47,8 @@ describe("scenarios > models > create", () => {
 
     navigateToNewModelPage();
     cy.get(".ace_editor").should("be.visible").type("select * from ORDERS");
+    cy.findByTestId("native-query-editor-container").icon("play").click();
+    cy.wait("@dataset");
 
     cy.findByTestId("dataset-edit-bar").within(() => {
       cy.contains("button", "Save").click();

--- a/e2e/test/scenarios/models/reproductions/22518.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/22518.cy.spec.js
@@ -9,7 +9,7 @@ describe("issue 22518", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();
-
+    cy.intercept("POST", "/api/dataset").as("dataset");
     cy.createNativeQuestion(
       {
         native: {
@@ -27,9 +27,10 @@ describe("issue 22518", () => {
     cy.findByText("Edit query definition").click();
 
     cy.get(".ace_content").type(", 'b' bar");
+    cy.findByTestId("native-query-editor-container").icon("play").click();
+    cy.wait("@dataset");
 
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Save changes").click();
+    cy.findByTestId("dataset-edit-bar").button("Save changes").click();
 
     cy.findAllByTestId("header-cell")
       .should("have.length", 3)

--- a/e2e/test/scenarios/models/reproductions/37009-stale-result-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/37009-stale-result-metadata.cy.spec.js
@@ -1,0 +1,74 @@
+import {
+  focusNativeEditor,
+  modal,
+  openQuestionActions,
+  popover,
+  restore,
+} from "e2e/support/helpers";
+
+describe("issue 37009", () => {
+  beforeEach(() => {
+    restore();
+    cy.intercept("POST", "/api/dataset").as("dataset");
+    cy.intercept("POST", "/api/card").as("saveCard");
+    cy.intercept("PUT", "/api/card/*").as("updateCard");
+    cy.signInAsNormalUser();
+  });
+
+  it("should prevent saving new and updating existing models without result_metadata (metabase#37009)", () => {
+    cy.visit("/model/new");
+    cy.findByTestId("new-model-options")
+      .findByText("Use a native query")
+      .click();
+
+    focusNativeEditor().type("select * from products");
+    cy.findByTestId("dataset-edit-bar")
+      .button("Save")
+      .should("be.disabled")
+      .trigger("mouseenter", { force: true });
+    cy.findByRole("tooltip").should(
+      "have.text",
+      "You must run the query before you can save this model",
+    );
+    cy.findByTestId("native-query-editor-container").icon("play").click();
+    cy.wait("@dataset");
+    cy.findByRole("tooltip").should("not.exist");
+    cy.findByTestId("dataset-edit-bar")
+      .button("Save")
+      .should("be.enabled")
+      .click();
+    modal()
+      .last()
+      .within(() => {
+        cy.findByLabelText("Name").type("Model");
+        cy.findByText("Save").click();
+      });
+    cy.wait("@saveCard")
+      .its("request.body")
+      .its("result_metadata")
+      .should("not.be.null");
+
+    openQuestionActions();
+    popover().findByText("Edit query definition").click();
+    focusNativeEditor().type(" WHERE CATEGORY = 'Gadget'");
+    cy.findByTestId("dataset-edit-bar")
+      .button("Save changes")
+      .should("be.disabled")
+      .trigger("mouseenter", { force: true });
+    cy.findByRole("tooltip").should(
+      "have.text",
+      "You must run the query before you can save this model",
+    );
+    cy.findByTestId("native-query-editor-container").icon("play").click();
+    cy.wait("@dataset");
+    cy.findByRole("tooltip").should("not.exist");
+    cy.findByTestId("dataset-edit-bar")
+      .button("Save changes")
+      .should("be.enabled")
+      .click();
+    cy.wait("@updateCard")
+      .its("request.body")
+      .its("result_metadata")
+      .should("not.be.null");
+  });
+});


### PR DESCRIPTION
Manually backports https://github.com/metabase/metabase/pull/40087 to 48

No MBQL lib, no mantine etc :(

<img width="1728" alt="Screenshot 2024-04-02 at 13 29 27" src="https://github.com/metabase/metabase/assets/8542534/516f5c4c-cce8-4df2-8b6e-cf31426bbf6b">
<img width="1728" alt="Screenshot 2024-04-02 at 13 29 33" src="https://github.com/metabase/metabase/assets/8542534/7ec09766-eefc-4d3d-874d-7c5d77756b03">
