### PR TITLE
Show query execution time in the QB footer for MBQL queries

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewFooter.jsx
@@ -46,9 +46,8 @@ const ViewFooter = ({
     return null;
   }
 
-  const { isEditable, isNative } = Lib.queryDisplayInfo(question.query());
-  const hasDataPermission = isEditable;
-  const hideChartSettings = result.error && !hasDataPermission;
+  const { isEditable } = Lib.queryDisplayInfo(question.query());
+  const hideChartSettings = result.error && !isEditable;
   const type = question.type();
 
   return (
@@ -109,7 +108,7 @@ const ViewFooter = ({
             result,
             isObjectDetail,
           }) && <QuestionRowCount key="row_count" />,
-          isNative && <ExecutionTime time={result.running_time} />,
+          <ExecutionTime key="execution_time" time={result.running_time} />,
           QuestionLastUpdated.shouldRender({ result }) && (
             <QuestionLastUpdated
               key="last-updated"

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -1,7 +1,12 @@
 import userEvent from "@testing-library/user-event";
 import fetchMock from "fetch-mock";
 
-import { screen, waitFor, within } from "__support__/ui";
+import {
+  screen,
+  waitFor,
+  waitForLoaderToBeRemoved,
+  within,
+} from "__support__/ui";
 import registerVisualizations from "metabase/visualizations/register";
 import { createMockCard, createMockDataset } from "metabase-types/api/mocks";
 
@@ -104,6 +109,23 @@ describe("QueryBuilder", () => {
     });
 
     describe("query execution time", () => {
+      it("renders query execution time for mbql questions", async () => {
+        await setup({
+          card: TEST_CARD,
+          dataset: createMockDataset({
+            running_time: 123,
+          }),
+        });
+
+        const [runButton] = screen.getAllByTestId("run-button");
+        userEvent.click(runButton);
+        await waitForLoaderToBeRemoved();
+
+        const executionTime = screen.getByTestId("execution-time");
+        expect(executionTime).toBeInTheDocument();
+        expect(executionTime).toHaveTextContent("123 ms");
+      });
+
       it("renders query execution time for native questions", async () => {
         await setup({
           card: TEST_NATIVE_CARD,
@@ -115,12 +137,6 @@ describe("QueryBuilder", () => {
         const executionTime = screen.getByTestId("execution-time");
         expect(executionTime).toBeInTheDocument();
         expect(executionTime).toHaveTextContent("123 ms");
-      });
-
-      it("does not render query execution time for non-native questions", async () => {
-        await setup({ card: TEST_CARD });
-
-        expect(screen.queryByTestId("execution-time")).not.toBeInTheDocument();
       });
     });
   });


### PR DESCRIPTION
Previously it worked only for native queries. Now we make it work for all queries.
Context https://metaboat.slack.com/archives/C01LQQ2UW03/p1712015613990139

<img width="1728" alt="Screenshot 2024-04-02 at 14 10 26" src="https://github.com/metabase/metabase/assets/8542534/fc604846-d947-4859-a492-ddc136c4b1f3">
