### PR TITLE
Testing parity for appending to and replacing uploads

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/upload_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/upload_test.clj
@@ -10,17 +10,18 @@
 
 (use-fixtures :once (fixtures/initialize :db :test-users))
 
-(deftest uploads-disabled-for-sandboxed-user-test
+(deftest create-disabled-for-sandboxed-user-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
     (met/with-gtaps-for-user! :rasta {:gtaps {:venues {}}}
       (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
             (upload-test/upload-example-csv! {:grant-permission? false}))))))
 
-(deftest appends-disabled-for-sandboxed-user-test
+(deftest update-disabled-for-sandboxed-user-test
   (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
-    (met/with-gtaps-for-user! :rasta {:gtaps {:venues {}}}
-      (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
-            (upload-test/append-csv-with-defaults! :user-id (mt/user->id :rasta)))))))
+    (doseq [verb [:metabase.upload/append :metabase.upload/replace]]
+      (met/with-gtaps-for-user! :rasta {:gtaps {:venues {}}}
+        (is (thrown-with-msg? Exception #"Uploads are not permitted for sandboxed users\."
+              (upload-test/update-csv-with-defaults! verb :user-id (mt/user->id :rasta))))))))
 
 (deftest based-on-upload-for-sandboxed-user-test
   (mt/with-temporary-setting-values [uploads-enabled true]


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40368

### Description

This duplicates all `append` tests for `replace`, with the relevant amendments.

Since the code paths and behavior are so similar, and the suite is already very slow for some drivers, we now run the `append` tests for H2 only, as `replace` tests a superset of the behavior.

There's a lot of indentation added, so be sure to [ignore whitespace](https://github.com/metabase/metabase/pull/40899/files?w=1).