### PR TITLE
Add breakpoints to the Mantine theme overrides

### DIFF
--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -39,6 +39,13 @@ import {
 import { getThemeColors } from "./utils/colors";
 
 export const getThemeOverrides = (): MantineThemeOverride => ({
+  breakpoints: {
+    xs: "23em",
+    sm: "40em",
+    md: "60em",
+    lg: "80em",
+    xl: "120em",
+  },
   colors: getThemeColors(),
   primaryColor: "brand",
   primaryShade: 0,


### PR DESCRIPTION
### What does this PR accomplish?
This PR adds our custom breakpoints to the Mantine theme overrides. The values are taken from here: https://github.com/metabase/metabase/blob/master/frontend/src/metabase/css/core/breakpoints.module.css