### PR TITLE
Echarts — Set min bar width

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/constants/style.ts
@@ -4,6 +4,7 @@ export const CHART_STYLE = {
     zIndexLineArea: 3, // https://github.com/metabase/metabase/issues/40209
     barWidth: 0.8,
     histogramBarWidth: 0.995,
+    barMinWidth: 27,
   },
   axisTicksMarginX: 5,
   axisTicksMarginY: 10,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -284,6 +284,7 @@ const buildEChartsBarSeries = (
       yAxisWithBarSeriesCount,
       !!stackName,
     ),
+    barMinWidth: CHART_STYLE.series.barMinWidth,
     encode: {
       y: seriesModel.dataKey,
       x: X_AXIS_DATA_KEY,


### PR DESCRIPTION
Related to #40206 

Certain bar charts can become very narrow (1px per bar) after resizing
As an example, see the dashboard mentioned in the issue

I couldn't reproduce it locally, and I couldn't find the spot that would make the bars so narrow (I guess it should be the [`computeBarWidth` function](https://github.com/metabase/metabase/blob/fa4c7e1f5722fe636cd065e99d0853fe3ebac13a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts#L212), but again I couldn't verify it locally). This PR just sets the `barMinWidth` option to prevent something like that from happening.