### PR TITLE
Initialize `isNativePreviewSidebarOpen` as false if it's `undefined`

### DIFF
--- a/frontend/src/metabase-types/store/mocks/qb.ts
+++ b/frontend/src/metabase-types/store/mocks/qb.ts
@@ -25,6 +25,7 @@ export const createMockQueryBuilderUIControlsState = (
   previousQueryBuilderMode: false,
   snippetCollectionId: null,
   datasetEditorTab: "query",
+  isNativePreviewSidebarOpen: false,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/store/qb.ts
+++ b/frontend/src/metabase-types/store/qb.ts
@@ -34,7 +34,7 @@ export interface QueryBuilderUIControls {
   previousQueryBuilderMode: boolean;
   snippetCollectionId: number | null;
   datasetEditorTab: DatasetEditorTab;
-  isNativePreviewSidebarOpen: boolean;
+  isNativePreviewSidebarOpen?: boolean;
 }
 
 export interface QueryBuilderLoadingControls {

--- a/frontend/src/metabase-types/store/qb.ts
+++ b/frontend/src/metabase-types/store/qb.ts
@@ -34,6 +34,7 @@ export interface QueryBuilderUIControls {
   previousQueryBuilderMode: boolean;
   snippetCollectionId: number | null;
   datasetEditorTab: DatasetEditorTab;
+  isNativePreviewSidebarOpen: boolean;
 }
 
 export interface QueryBuilderLoadingControls {

--- a/frontend/src/metabase-types/store/qb.ts
+++ b/frontend/src/metabase-types/store/qb.ts
@@ -34,7 +34,7 @@ export interface QueryBuilderUIControls {
   previousQueryBuilderMode: boolean;
   snippetCollectionId: number | null;
   datasetEditorTab: DatasetEditorTab;
-  isNativePreviewSidebarOpen?: boolean;
+  isNativePreviewSidebarOpen: boolean;
 }
 
 export interface QueryBuilderLoadingControls {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -391,6 +391,9 @@ async function handleQBInit(
       }),
     );
   }
+
+  // We need this to be boolean even if it's undefined initially
+  uiControls.isNativePreviewSidebarOpen ??= false;
 }
 
 export const initializeQB =

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -391,9 +391,6 @@ async function handleQBInit(
       }),
     );
   }
-
-  // We need this to be boolean even if it's undefined initially
-  uiControls.isNativePreviewSidebarOpen ??= false;
 }
 
 export const initializeQB =

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.unit.spec.ts
@@ -832,5 +832,10 @@ describe("QB Actions > initializeQB", () => {
       });
       expect(result.uiControls.isShowingNewbModal).toBeFalsy();
     });
+
+    it("initializes `isNativePreviewSidebarOpen` value as false when it is undefined", async () => {
+      const { result } = await setupOrdersTable();
+      expect(result.uiControls.isNativePreviewSidebarOpen).toBe(false);
+    });
   });
 });

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
@@ -28,9 +28,7 @@ export const ToggleNativeQueryPreview = ({
   question,
 }: ToggleNativeQueryPreviewProps): JSX.Element => {
   const dispatch = useDispatch();
-  const {
-    isNativePreviewSidebarOpen,
-  }: { isNativePreviewSidebarOpen?: boolean } = useSelector(getUiControls);
+  const { isNativePreviewSidebarOpen } = useSelector(getUiControls);
 
   const engineType = getEngineNativeType(question.database()?.engine);
   const tooltip = isNativePreviewSidebarOpen

--- a/frontend/src/metabase/query_builder/reducers.js
+++ b/frontend/src/metabase/query_builder/reducers.js
@@ -90,6 +90,7 @@ const DEFAULT_UI_CONTROLS = {
   previousQueryBuilderMode: false,
   snippetCollectionId: null,
   datasetEditorTab: "query", // "query" / "metadata"
+  isNativePreviewSidebarOpen: false,
 };
 
 const DEFAULT_LOADING_CONTROLS = {


### PR DESCRIPTION
This PR makes sure that the redux `qb.uiControls.isNativePreviewSidebarOpen` setting is initialized as `false` even when it is initially `undefined`, i.e. before the user explicitly sets its value.