### PR TITLE
Migrate `dashboard.module.css`

### DIFF
--- a/e2e/test/scenarios/dashboard-cards/reproductions/20637-add-series-to-dashcard.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/reproductions/20637-add-series-to-dashcard.cy.spec.js
@@ -23,9 +23,7 @@ describe("adding an additional series to a dashcard (metabase#20637)", () => {
     // make sure the card query endpoint was used
     cy.wait("@additionalSeriesCardQuery");
 
-    cy.get(".AddSeriesModal").within(() => {
-      cy.findByText("Done").click();
-    });
+    cy.findByTestId("add-series-modal").button("Done").click();
     saveDashboard();
 
     // refresh the page and make sure the dashcard query endpoint was used

--- a/e2e/test/scenarios/organization/official-collections.cy.spec.js
+++ b/e2e/test/scenarios/organization/official-collections.cy.spec.js
@@ -235,9 +235,9 @@ function testOfficialQuestionBadgeInRegularDashboard(expectBadge = true) {
   cy.visit("/collection/root");
   cy.findByText("Regular Dashboard").click();
 
-  cy.get(".DashboardGrid").within(() => {
-    cy.icon("badge").should(expectBadge ? "exist" : "not.exist");
-  });
+  cy.findByTestId("dashboard-grid")
+    .icon("badge")
+    .should(expectBadge ? "exist" : "not.exist");
 }
 
 function openCollection(collectionName) {

--- a/e2e/test/scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js
+++ b/e2e/test/scenarios/sharing/reproductions/21559-subscription-bar-sent-as-scalar.cy.spec.js
@@ -53,9 +53,7 @@ describe("issue 21559", { tags: "@external" }, () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(q2Details.name).click();
-    cy.get(".AddSeriesModal").within(() => {
-      cy.findByText("Done").click();
-    });
+    cy.findByTestId("add-series-modal").button("Done").click();
 
     // Make sure visualization changed to bars
     cy.get(".bar").should("have.length", 2);

--- a/e2e/test/scenarios/visualizations-charts/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/18061-maps-only-nulls-crash-frontend.cy.spec.js
@@ -116,7 +116,7 @@ describe("issue 18061", () => {
       cy.findByTestId("qb-filters-panel")
         .findByText("ID is less than 2")
         .should("be.visible");
-      cy.get(".PinMap").should("be.visible");
+      cy.get("[data-element-id=pin-map]").should("be.visible");
 
       cy.window().should("have.prop", "beforeReload", true);
     });
@@ -146,12 +146,12 @@ describe("issue 18061", () => {
       cy.findByText("18061D");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("18061");
-      cy.get(".PinMap");
+      cy.get("[data-element-id=pin-map]");
 
       addFilter("Twitter");
       cy.location("search").should("eq", "?category=Twitter");
       cy.findAllByTestId("no-results-image");
-      cy.get(".PinMap").should("not.exist");
+      cy.get("[data-element-id=pin-map]").should("not.exist");
     });
   });
 });

--- a/e2e/test/scenarios/visualizations-charts/reproductions/21665-multi-series-frontend-reload.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/21665-multi-series-frontend-reload.cy.spec.js
@@ -47,9 +47,7 @@ describe("issue 21665", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(Q2.name).click();
 
-    cy.get(".AddSeriesModal").within(() => {
-      cy.button("Done").click();
-    });
+    cy.findByTestId("add-series-modal").button("Done").click();
 
     saveDashboard();
     cy.wait("@getDashboard");

--- a/e2e/test/scenarios/visualizations-charts/reproductions/30058-32075-map-visualizations.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/30058-32075-map-visualizations.cy.spec.js
@@ -51,7 +51,7 @@ describe("issue 32075", () => {
     visualize();
 
     cy.findByTestId("TableInteractive-root").should("not.exist");
-    cy.get(".PinMap").should("exist");
+    cy.get("[data-element-id=pin-map]").should("exist");
   });
 
   it("should still display visualization as a map after adding another column to group by", () => {
@@ -63,7 +63,7 @@ describe("issue 32075", () => {
     visualize();
 
     cy.findByTestId("TableInteractive-root").should("not.exist");
-    cy.get(".PinMap").should("exist");
+    cy.get("[data-element-id=pin-map]").should("exist");
   });
 
   it("should still display visualization as a map after adding another aggregation", () => {
@@ -75,7 +75,7 @@ describe("issue 32075", () => {
     visualize();
 
     cy.findByTestId("TableInteractive-root").should("not.exist");
-    cy.get(".PinMap").should("exist");
+    cy.get("[data-element-id=pin-map]").should("exist");
   });
 
   it("should change display to default after removing a column to group by when map is not sensible anymore", () => {
@@ -86,7 +86,7 @@ describe("issue 32075", () => {
     removeSummaryGroupingField({ field: "Latitude: Auto binned" });
     visualize();
 
-    cy.get(".PinMap").should("not.exist");
+    cy.get("[data-element-id=pin-map]").should("not.exist");
     cy.get(".LineAreaBarChart").should("exist");
   });
 });

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -80,7 +80,7 @@
   pointer-events: all;
 }
 
-:global(.PinMapUpdateButton--disabled) {
+.PinMapUpdateButtonDisabled {
   pointer-events: none;
   color: var(--color-text-light);
 }

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -75,7 +75,7 @@
   pointer-events: none;
 }
 
-.DashEditing :global(.PinMap) {
+.DashEditing .PinMap {
   /* allow map to pan. need to stopPropagation in PinMap to prevent weird dragging interaction */
   pointer-events: all;
 }

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -162,13 +162,14 @@
   opacity: 0.01;
 }
 
+/* .react-grid-placeholder is a global class from `react-grid-layout` */
 .DashEditing :global(.react-grid-placeholder) {
   z-index: 0;
   background-color: var(--color-bg-light) !important;
   transition: all 0.15s linear;
 }
 
-:global(.Modal.AddSeriesModal) {
+:global(.Modal).AddSeriesModal {
   height: 80%;
   max-height: 600px;
   width: 80%;

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -105,13 +105,13 @@
   border: 1px solid var(--color-brand);
 }
 
-.DashEditing .DashCard :global(.Visualization-slow-spinner) {
+.DashEditing .DashCard .VisualizationSlowSpinner {
   position: absolute;
   right: -2px;
   top: -2px;
 }
 
-.DashEditing .DashCard:hover :global(.Visualization-slow-spinner) {
+.DashEditing .DashCard:hover .VisualizationSlowSpinner {
   opacity: 0;
   transition: opacity 0.15s linear;
 }

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -85,11 +85,12 @@
   color: var(--color-text-light);
 }
 
+/* .react-draggable*, .react-resizable* are 3rd party library classes */
 .DashEditing .DashCard:global(.react-draggable-dragging) .Card {
   box-shadow: 3px 3px 8px var(--color-shadow);
 }
 
-:global(.BrandColorResizeHandle .react-resizable-handle::after) {
+.BrandColorResizeHandle :global(.react-resizable-handle::after) {
   border-color: var(--color-brand) !important;
 }
 

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -67,11 +67,11 @@
   transition: border 0.3s, background-color 0.3s;
 }
 
-.DashEditing :global(.Card-title:first-of-type) {
+.DashEditing .CardTitle:first-of-type {
   margin-top: 0.5rem;
 }
 
-.DashEditing :global(.Card-title) {
+.DashEditing .CardTitle {
   pointer-events: none;
 }
 

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -59,23 +59,23 @@
   transition: background-color 1s linear, border 1s linear;
 }
 
-:global(.Dash--editing) {
+.DashEditing {
   margin-top: 1.5em;
 }
 
-:global(.Dash--editing) .DashCard .Card {
+.DashEditing .DashCard .Card {
   transition: border 0.3s, background-color 0.3s;
 }
 
-:global(.Dash--editing .Card-title:first-of-type) {
+.DashEditing :global(.Card-title:first-of-type) {
   margin-top: 0.5rem;
 }
 
-:global(.Dash--editing .Card-title) {
+.DashEditing :global(.Card-title) {
   pointer-events: none;
 }
 
-:global(.Dash--editing .PinMap) {
+.DashEditing :global(.PinMap) {
   /* allow map to pan. need to stopPropagation in PinMap to prevent weird dragging interaction */
   pointer-events: all;
 }
@@ -85,7 +85,7 @@
   color: var(--color-text-light);
 }
 
-:global(.Dash--editing) .DashCard:global(.react-draggable-dragging) .Card {
+.DashEditing .DashCard:global(.react-draggable-dragging) .Card {
   box-shadow: 3px 3px 8px var(--color-shadow);
 }
 
@@ -93,33 +93,33 @@
   border-color: var(--color-brand) !important;
 }
 
-:global(.Dash--editing) .DashCard:global(.react-draggable-dragging),
-:global(.Dash--editing) .DashCard:global(.react-resizable-resizing) {
+.DashEditing .DashCard:global(.react-draggable-dragging),
+.DashEditing .DashCard:global(.react-resizable-resizing) {
   z-index: 3;
 }
 
-:global(.Dash--editing) .DashCard:global(.react-draggable-dragging) .Card,
-:global(.Dash--editing) .DashCard:global(.react-resizable-resizing) .Card {
+.DashEditing .DashCard:global(.react-draggable-dragging) .Card,
+.DashEditing .DashCard:global(.react-resizable-resizing) .Card {
   background-color: var(--color-bg-medium) !important;
   border: 1px solid var(--color-brand);
 }
 
-:global(.Dash--editing) .DashCard :global(.Visualization-slow-spinner) {
+.DashEditing .DashCard :global(.Visualization-slow-spinner) {
   position: absolute;
   right: -2px;
   top: -2px;
 }
 
-:global(.Dash--editing) .DashCard:hover :global(.Visualization-slow-spinner) {
+.DashEditing .DashCard:hover :global(.Visualization-slow-spinner) {
   opacity: 0;
   transition: opacity 0.15s linear;
 }
 
-:global(.Dash--editing) .DashCard {
+.DashEditing .DashCard {
   cursor: move;
 }
 
-:global(.Dash--editing) .DashCard :global(.react-resizable-handle) {
+.DashEditing .DashCard :global(.react-resizable-handle) {
   position: absolute;
   width: 40px;
   height: 40px;
@@ -132,7 +132,7 @@
   background: none; /* hide default RGL's resize handle */
 }
 
-:global(.Dash--editing) .DashCard :global(.react-resizable-handle::after) {
+.DashEditing .DashCard :global(.react-resizable-handle::after) {
   content: "";
   position: absolute;
   width: 8px;
@@ -146,26 +146,22 @@
   opacity: 0.01;
 }
 
-:global(.Dash--editing)
-  .DashCard
-  :global(.react-resizable-handle:hover::after) {
+.DashEditing .DashCard :global(.react-resizable-handle:hover::after) {
   border-color: var(--color-border);
 }
 
-:global(.Dash--editing)
-  .DashCard:hover
-  :global(.react-resizable-handle::after) {
+.DashEditing .DashCard:hover :global(.react-resizable-handle::after) {
   opacity: 1;
 }
 
-:global(.Dash--editing)
+.DashEditing
   .DashCard:global(.react-draggable-dragging .react-resizable-handle::after),
-:global(.Dash--editing)
+.DashEditing
   .DashCard:global(.react-resizable-resizing .react-resizable-handle::after) {
   opacity: 0.01;
 }
 
-:global(.Dash--editing .react-grid-placeholder) {
+.DashEditing :global(.react-grid-placeholder) {
   z-index: 0;
   background-color: var(--color-bg-light) !important;
   transition: all 0.15s linear;

--- a/frontend/src/metabase/css/dashboard.module.css
+++ b/frontend/src/metabase/css/dashboard.module.css
@@ -169,6 +169,11 @@
   transition: all 0.15s linear;
 }
 
+/* Used in frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.styled.tsx */
+/* stylelint-disable-next-line block-no-empty */
+.DashDragging {
+}
+
 :global(.Modal).AddSeriesModal {
   height: 80%;
   max-height: 600px;

--- a/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashCard/DashCardActionsPanel/DashCardActionsPanel.styled.tsx
@@ -54,7 +54,7 @@ export const DashCardActionsPanelContainer = styled("div", {
     pointer-events: all;
   }
 
-  .Dash--dragging & {
+  .${DashboardS.DashDragging} & {
     display: none;
   }
 `;

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -595,7 +595,7 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
     return (
       <GridLayout
         className={cx("DashboardGrid", {
-          "Dash--editing": this.isEditingLayout,
+          [DashboardS.DashEditing]: this.isEditingLayout,
           "Dash--dragging": this.state.isDragging,
         })}
         layouts={layouts}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -574,7 +574,7 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
           EmbedFrameS.DashCard,
           LegendS.DashCard,
           {
-            BrandColorResizeHandle: shouldChangeResizeHandle,
+            [DashboardS.BrandColorResizeHandle]: shouldChangeResizeHandle,
           },
         )}
         isAnimationDisabled={this.state.isAnimationPaused}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -594,9 +594,9 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
     const rowHeight = this.getRowHeight();
     return (
       <GridLayout
-        className={cx("DashboardGrid", {
+        className={cx({
           [DashboardS.DashEditing]: this.isEditingLayout,
-          "Dash--dragging": this.state.isDragging,
+          [DashboardS.DashDragging]: this.state.isDragging,
         })}
         layouts={layouts}
         breakpoints={GRID_BREAKPOINTS}

--- a/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.tsx
@@ -372,7 +372,7 @@ class DashboardGrid extends Component<DashboardGridProps, DashboardGridState> {
       !!addSeriesModalDashCard && isQuestionDashCard(addSeriesModalDashCard);
     return (
       <Modal
-        className="Modal AddSeriesModal"
+        className={cx("Modal", DashboardS.AddSeriesModal)}
         data-testid="add-series-modal"
         isOpen={isOpen}
       >

--- a/frontend/src/metabase/visualizations/components/LegendHeader.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHeader.jsx
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import { Component } from "react";
 
 import CS from "metabase/css/core/index.css";
+import DashboardS from "metabase/css/dashboard.module.css";
 import { getAccentColors } from "metabase/lib/colors/groups";
 
 import ExplicitSize from "../../components/ExplicitSize";
@@ -59,7 +60,7 @@ class LegendHeader extends Component {
       <div
         className={cx(
           styles.LegendHeader,
-          "Card-title",
+          DashboardS.CardTitle,
           CS.textDefault,
           CS.textSmaller,
           CS.mx1,

--- a/frontend/src/metabase/visualizations/components/PinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.jsx
@@ -8,6 +8,7 @@ import _ from "underscore";
 
 import ButtonsS from "metabase/css/components/buttons.module.css";
 import CS from "metabase/css/core/index.css";
+import DashboardS from "metabase/css/dashboard.module.css";
 import { LatitudeLongitudeError } from "metabase/visualizations/lib/errors";
 import { hasLatitudeAndLongitudeColumns } from "metabase-lib/v1/types/utils/isa";
 
@@ -186,9 +187,10 @@ export default class PinMap extends Component {
 
     return (
       <div
+        data-element-id="pin-map"
         className={cx(
           className,
-          "PinMap",
+          DashboardS.PinMap,
           CS.relative,
           CS.hoverParent,
           CS.hoverVisibility,

--- a/frontend/src/metabase/visualizations/components/PinMap.jsx
+++ b/frontend/src/metabase/visualizations/components/PinMap.jsx
@@ -243,7 +243,7 @@ export default class PinMap extends Component {
                 ButtonsS.ButtonSmall,
                 CS.mb1,
                 {
-                  "PinMapUpdateButton--disabled": disableUpdateButton,
+                  [DashboardS.PinMapUpdateButtonDisabled]: disableUpdateButton,
                 },
               )}
               onClick={this.updateSettings}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.jsx
@@ -9,6 +9,7 @@ import _ from "underscore";
 import ErrorBoundary from "metabase/ErrorBoundary";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import CS from "metabase/css/core/index.css";
+import DashboardS from "metabase/css/dashboard.module.css";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { formatNumber } from "metabase/lib/formatting";
 import { equals } from "metabase/lib/utils";
@@ -418,7 +419,7 @@ class Visualization extends PureComponent {
       <VisualizationActionButtonsContainer>
         {isSlow && !loading && (
           <VisualizationSlowSpinner
-            className="Visualization-slow-spinner"
+            className={DashboardS.VisualizationSlowSpinner}
             size={18}
             isUsuallySlow={isSlow === "usually-slow"}
           />

--- a/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.jsx
+++ b/frontend/src/metabase/visualizations/visualizations/Scalar/Scalar.jsx
@@ -224,7 +224,7 @@ export class Scalar extends Component {
       <ScalarWrapper>
         <div
           className={cx(
-            "Card-title",
+            DashboardS.CardTitle,
             CS.textDefault,
             CS.textSmaller,
             CS.absolute,


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/38811
Sub-task https://github.com/metabase/metabase/issues/40910


### Description

Migrate classes in `dashboard.module.css` that are only present in this file. There are more classes in this file that haven't been migrated because:
1. They appear in other CSS files
1. They are global classes from 3rd party libraries

### How to verify

1. Dashboard looks fine.
1. Editing dashboard view looks fine.
1. Adding a new series modal looks fine.

### Demo
<img width="1444" alt="Screenshot 2024-04-02 at 10 34 53 PM" src="https://github.com/metabase/metabase/assets/1937582/439e4477-0388-48e4-a85b-9156dc3deeaa">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
