### PR TITLE
Make Noah the codeowner for permissions et al

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 src/metabase @camsaul
 modules @camsaul
-enterprise/backend @camsaul
+enterprise/backend @noahmoss
+src/metabase/**/*permissions* @noahmoss
+src/metabase/integrations @noahmoss

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,10 @@
 src/metabase @camsaul
 modules @camsaul
-enterprise/backend @noahmoss
+enterprise/backend @camsaul
+enterprise/backend/src/metabase_enterprise/advanced_permissions @noahmoss
+enterprise/backend/src/metabase_enterprise/audit_app @noahmoss
+enterprise/backend/src/metabase_enterprise/sso @noahmoss
+enterprise/backend/src/metabase_enterprise/task/truncate_audit_table.clj @noahmoss
+enterprise/backend/src/metabase_enterprise/internal_user.clj @noahmoss
 src/metabase/**/*permissions* @noahmoss
 src/metabase/integrations @noahmoss


### PR DESCRIPTION
et al = `integrations` (OSS google auth, LDAP and Slack integrations) + `enterprise` (audit, advanced SSO, advanced config stuff).  `enterprise` also has LLM which doesn't really have a codeowner now, but it also doesn't need one.
