### PR TITLE
Creator sentiment emails iterate

### DIFF
--- a/src/metabase/email/messages.clj
+++ b/src/metabase/email/messages.clj
@@ -289,31 +289,24 @@
                :message      (stencil/render-file "metabase/email/follow_up_email" context)}]
     (email/send-message! email)))
 
-(defn- creator-sentiment-blob
-  "Create a blob of instance/user data to be sent to the creator sentiment survey."
-  [instance-data created_at num_dashboards num_questions num_models]
-  (-> {:instance instance-data
-       :user     {:created_at     created_at
-                  :num_dashboards num_dashboards
-                  :num_questions  num_questions
-                  :num_models     num_models}}
-      json/generate-string
-      .getBytes
-      codecs/bytes->b64-str))
+
 
 (defn send-creator-sentiment-email!
-  "Format and send an email to a creator with a link to a survey. Can include info about the instance and the creator
-  if [[public-settings/anon-tracking-enabled]] is true."
-  [{:keys [email created_at first_name num_dashboards num_questions num_models]} instance-data]
+  "Format and send an email to a creator with a link to a survey. If a [[blob]] is included, it will be turned into json
+  and then base64 encoded."
+  [{:keys [email first_name]} blob]
   {:pre [(u/email? email)]}
-  (let [blob    (when (public-settings/anon-tracking-enabled)
-                  (creator-sentiment-blob instance-data created_at num_dashboards num_questions num_models))
+  (let [encoded-info    (when blob
+                          (-> blob
+                              json/generate-string
+                              .getBytes
+                              codecs/bytes->b64-str))
         context (merge (common-context)
                        {:emailType  "notification"
                         :logoHeader true
                         :first-name first_name
                         :link       (cond-> "https://metabase.com/feedback/creator"
-                                      blob (str "?context=" blob))}
+                                      encoded-info (str "?context=" encoded-info))}
                        (when-not (premium-features/is-hosted?)
                          {:self-hosted (public-settings/site-url)}))
         message {:subject      "Metabase would love your take on something"

--- a/src/metabase/task/creator_sentiment_emails.clj
+++ b/src/metabase/task/creator_sentiment_emails.clj
@@ -14,7 +14,10 @@
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.task :as task]
    [metabase.util.log :as log]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2])
+  (:import
+   (java.util Locale)
+   (java.time.temporal WeekFields)))
 
 (set! *warn-on-reflection* true)
 
@@ -69,28 +72,26 @@
 
 (defn- send-creator-sentiment-emails!
   "Send an email to the instance admin following up on their experience with Metabase thus far."
-  []
+  [current-week]
   ;; we need access to email AND the instance must have surveys enabled.
   (when (and (email/email-configured?)
              (email/surveys-enabled))
     (let [instance-data (when (public-settings/anon-tracking-enabled)
                           (fetch-instance-data))
           all-creators  (fetch-creators (premium-features/enable-whitelabeling?))
-          month         (- (.getValue (t/month)) 1)
-          this-month    (fn [c] (= month (-> c :email hash (mod 12))))
-          recipients    (filter this-month all-creators)]
+          this-week?    (fn [c] (= current-week (-> c :email hash (mod 52))))
+          recipients    (filter this-week? all-creators)]
       (log/infof "Sending surveys to %d creators of a total %d"
                  (count all-creators) (count recipients))
       (doseq [creator recipients]
-        ;; Send the email if the creator's email hash matches the current month
-        (when (= (-> creator :email hash (mod 12)) month)
-          (try
-            (messages/send-creator-sentiment-email! creator instance-data)
-            (catch Throwable e
-              (log/error e "Problem sending creator sentiment email:"))))))))
+        (try
+          (messages/send-creator-sentiment-email! creator instance-data)
+          (catch Throwable e
+            (log/error e "Problem sending creator sentiment email:")))))))
 
 (jobs/defjob ^{:doc "Sends out a monthly survey to a portion of the creators."} CreatorSentimentEmail [_]
-  (send-creator-sentiment-emails!))
+  (let [current-week (.get (t/local-date) (.weekOfWeekBasedYear (WeekFields/of (Locale/getDefault))))]
+    (send-creator-sentiment-emails! current-week)))
 
 (def ^:private creator-sentiment-emails-job-key     "metabase.task.creator-sentiment-emails.job")
 (def ^:private creator-sentiment-emails-trigger-key "metabase.task.creator-sentiment-emails.trigger")
@@ -103,6 +104,6 @@
                  (triggers/with-identity (triggers/key creator-sentiment-emails-trigger-key))
                  (triggers/start-now)
                  (triggers/with-schedule
-                   ;; Fire at 2am on the second saturday of the month
-                   (cron/cron-schedule "0 0 2 ? * 7#2")))]
+                   ;; Fire at 2am every saturday
+                   (cron/cron-schedule "0 0 2 ? * 7")))]
     (task/schedule-task! job trigger)))

--- a/test/metabase/task/creator_sentiment_emails_test.clj
+++ b/test/metabase/task/creator_sentiment_emails_test.clj
@@ -1,9 +1,7 @@
 (ns ^:mb/once metabase.task.creator-sentiment-emails-test
   (:require
    [clojure.test :refer :all]
-   [java-time.api :as t]
    [metabase.email-test :as et :refer [inbox]]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :as premium-features]
    [metabase.task.creator-sentiment-emails :as creator-sentiment-emails]
    [metabase.test :as mt]
@@ -12,60 +10,45 @@
 (deftest send-creator-sentiment-emails!-test
   (mt/with-fake-inbox
     (testing "Make sure we only send emails when surveys-enabled is true"
-      (mt/with-temporary-setting-values [surveys-enabled false]
-        (with-redefs [creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}   ;; mods to 1, this email would be sent if surveys-enabled was true
-                                                                       {:email "b@metabase.com"}   ;; mods to 4
-                                                                       {:email "c@metabase.com"}]) ;; mods to 2
-                      t/month (constantly (t/month 2))]
-          (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-          (is (= 0
-                 (-> @inbox vals first count))))))
+      (doseq [enabled? [true false]]
+        (mt/reset-inbox!)
+        (mt/with-temporary-setting-values [surveys-enabled enabled?]
+          (with-redefs [creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"} ;; mods to 45, this email would be sent if surveys-enabled was true
+                                                                         {:email "b@metabase.com"} ;; mods to 4
+                                                                         {:email "c@metabase.com"}]) ;; mods to 26
+                        ]
+            (#'creator-sentiment-emails/send-creator-sentiment-emails! 45)
+            (is (= (if enabled? 1 0)
+                   (-> @inbox vals first count))
+                (str "error when enabled? is " enabled?))))))
 
     (mt/with-temporary-setting-values [surveys-enabled true]
-      (testing "Make sure that send-creator-sentiment-emails! only sends emails to creators with the correct month hash."
-        (with-redefs [creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}   ;; mods to 1
+      (testing "Make sure that send-creator-sentiment-emails! only sends emails to creators with the correct week hash."
+        (with-redefs [creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}   ;; mods to 45
                                                                        {:email "b@metabase.com"}   ;; mods to 4
-                                                                       {:email "c@metabase.com"}]) ;; mods to 2
-                      t/month (constantly (t/month 2))]
-          (#'creator-sentiment-emails/send-creator-sentiment-emails!)
+                                                                       {:email "c@metabase.com"}]) ;; mods to 26
+                      ]
+          (#'creator-sentiment-emails/send-creator-sentiment-emails! 45)
           (is (= 1
-                 (-> @inbox vals first count)))))
+                 (-> @inbox vals first count))))))
 
-      (mt/reset-inbox!)
-      (testing "Make sure context is included when anon tracking is enabled"
-        (with-redefs [public-settings/anon-tracking-enabled (constantly true)
-                      creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
-                      t/month (constantly (t/month 2))]
-          (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-          (is (= 1
-                 (count (et/regex-email-bodies #"creator\?context=")))))))
-
-    (mt/reset-inbox!)
-    (testing "Make sure context isn't included when anon tracking is enabled"
-      (with-redefs [public-settings/anon-tracking-enabled (constantly false)
-                    creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
-                    t/month (constantly (t/month 2))]
-        (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-        (is (= 0
-               (count (et/regex-email-bodies #"creator\?context="))))))
-
-    (mt/reset-inbox!)
+    (testing "Make sure context is included when anon tracking is enabled"
+      (doseq [tracking-enabled? [true false]]
+        (mt/reset-inbox!)
+        (mt/with-temporary-setting-values [anon-tracking-enabled tracking-enabled?]
+          (with-redefs [creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])]
+            (#'creator-sentiment-emails/send-creator-sentiment-emails! 45)
+            (is (= (if tracking-enabled? 1 0)
+                   (count (et/regex-email-bodies #"creator\?context="))))))))
     (testing "Make sure external services message is included when is self hosted"
-      (with-redefs [premium-features/is-hosted? (constantly false)
-                    creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
-                    t/month (constantly (t/month 2))]
-        (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-        (is (= 1
-               (count (et/regex-email-bodies #"external services"))))))))
-
-    (mt/reset-inbox!)
-    (testing "Make sure external services isn't included when not self hosted"
-        (with-redefs [premium-features/is-hosted? (constantly true)
-                      creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
-                      t/month (constantly (t/month 2))]
-          (#'creator-sentiment-emails/send-creator-sentiment-emails!)
-          (is (= 0
-                 (count (et/regex-email-bodies #"external services"))))))
+      (doseq [hosted? [true false]]
+        (mt/reset-inbox!)
+        (with-redefs [creator-sentiment-emails/fetch-creators (fn [_] [{:email "a@metabase.com"}])
+                      ;; can't use mt/with-temporary-setting-values because of a custom :getter
+                      premium-features/is-hosted? (constantly hosted?)]
+          (#'creator-sentiment-emails/send-creator-sentiment-emails! 45)
+          (is (= (if hosted? 0 1)
+                 (count (et/regex-email-bodies #"external services")))))))))
 
 (deftest fetch-creators-test
   (let [creator-id 33


### PR DESCRIPTION
Fix a few issues on creator sentiment emails:

#### Version and number of databases not included

These are fixed by this part of the diff: a typo and included the number of databases
```diff
@@ -61,36 +64,47 @@
 (defn- fetch-instance-data []
   {:created_at     (snowplow/instance-creation)
    :plan           (fetch-plan-info)
-   :verison        (config/mb-version-info :tag)
+   :version        (config/mb-version-info :tag)
    :num_users      (t2/count :model/User :is_active true, :type "personal")
    :num_dashboards (t2/count :model/Dashboard :archived false)
+   :num_databases  (t2/count :model/Database :is_audit false)
    :num_questions  (t2/count :model/Card :archived false :type "question")
    :num_models     (t2/count :model/Card :archived false :type "model")})

```

##### Send emails weekly

```diff
(defn- send-creator-sentiment-emails!
   "Send an email to the instance admin following up on their experience with Metabase thus far."
-  []
+  [current-week]
   ;; we need access to email AND the instance must have surveys enabled.
   (when (and (email/email-configured?)
              (email/surveys-enabled))
-    (let [instance-data (when (public-settings/anon-tracking-enabled)
-                          (fetch-instance-data))
+    (let [instance-data (fetch-instance-data)
           all-creators  (fetch-creators (premium-features/enable-whitelabeling?))
-          month         (- (.getValue (t/month)) 1)
-          this-month    (fn [c] (= month (-> c :email hash (mod 12))))
-          recipients    (filter this-month all-creators)]
+          this-week?    (fn [c] (= current-week (-> c :email hash (mod 52)))) ;; <- mod 52 and pass in current-week
+          recipients    (filter this-week? all-creators)
+          blob          (if (public-settings/anon-tracking-enabled)
+                          (fn [creator]
+                            (user-instance-info instance-data creator))
+                          (constantly nil))]
       (log/infof "Sending surveys to %d creators of a total %d"
                  (count all-creators) (count recipients))
       (doseq [creator recipients]
-        ;; Send the email if the creator's email hash matches the current month
-        (when (= (-> creator :email hash (mod 12)) month)
-          (try
-            (messages/send-creator-sentiment-email! creator instance-data)
-            (catch Throwable e
-              (log/error e "Problem sending creator sentiment email:"))))))))
+        (try
+          (messages/send-creator-sentiment-email! creator (blob creator))
+          (catch Throwable e
+            (log/error e "Problem sending creator sentiment email:")))))))
 ```
#### Cleanup
While i was in there, cleaned up a bit.

I found that the "blob" was spread out in a few places:
- sql query selecting creators would grab number of dashboards, etc
- instance info would grab plan, user count, some others
- email message would combine them but only if a setting was set, then base64 encode it

now the "blob" is created in the namespace next to the functions that query the db and fetch the instance info. Easy to follow what is going on. It also has the flag that prevents the blob (`(public-settings/anon-tracking-enabled)`) and then the email function just needs the email, first name, and a blob. 

Compare the signatures:

```diff
 (defn send-creator-sentiment-email!
-  "Format and send an email to a creator with a link to a survey. Can include info about the instance and the creator
-  if [[public-settings/anon-tracking-enabled]] is true."
-  [{:keys [email created_at first_name num_dashboards num_questions num_models]} instance-data]
   ;;             ^^^^--- complicated user structure                              ^-- opaque blob that was used
+  "Format and send an email to a creator with a link to a survey. If a [[blob]] is included, it will be turned into json
+  and then base64 encoded."
+  [{:keys [email first_name]} blob]
   ;;       ^^- simple user    ^-- blob is just json -> bytes -> b64
   {:pre [(u/email? email)]}
-  (let [blob    (when (public-settings/anon-tracking-enabled)
-                  (creator-sentiment-blob instance-data created_at num_dashboards num_questions num_models))
+  (let [encoded-info    (when blob
+                          (-> blob
+                              json/generate-string
+                              .getBytes
+                              codecs/bytes->b64-str))
```

#### The email
<img width="992" alt="image" src="https://github.com/metabase/metabase/assets/6377293/2af81988-9824-4e38-9bcd-bd427fcd77e3">

Link of survey:

```clojure
creator-sentiment-emails-test=> (let [context "eyJpbnN0YW5jZSI6eyJjcmVhdGVkX2F0IjoiMjAyNC0wMy0yOVQwMTo1MTowMi4xOVoiLCJwbGFuIjoicHJvLXNlbGYtaG9zdGVkL2VudGVycHJpc2Utc2VsZi1ob3N0ZWQiLCJ2ZXJzaW9uIjoidjAuNDkuMC1TTkFQU0hPVCIsIm51bV91c2VycyI6MiwibnVtX2Rhc2hib2FyZHMiOjEwLCJudW1fZGF0YWJhc2VzIjozLCJudW1fcXVlc3Rpb25zIjo2NSwibnVtX21vZGVscyI6MTV9LCJ1c2VyIjp7ImNyZWF0ZWRfYXQiOiIyMDI0LTAzLTI5VDEzOjU1OjMzLjE5NTQwOVoiLCJudW1fZGFzaGJvYXJkcyI6MywibnVtX3F1ZXN0aW9ucyI6MywibnVtX21vZGVscyI6Mn19"]
                                  (-> context buddy.core.codecs/b64->str cheshire.core/parse-string))
{"instance" {"created_at" "2024-03-29T01:51:02.19Z",
             "plan" "pro-self-hosted/enterprise-self-hosted",
             "version" "v0.49.0-SNAPSHOT",
             "num_users" 2,
             "num_dashboards" 10,
             "num_databases" 3,
             "num_questions" 65,
             "num_models" 15},
 "user" {"created_at" "2024-03-29T13:55:33.195409Z",
         "num_dashboards" 3,
         "num_questions" 3,
         "num_models" 2}}
```

(note I temporarily lowered the threshold for number of dashboards and questions required to found as a "creator" to send the email)