### PR TITLE
[docs] some format fixes

### DIFF
--- a/docs/questions/native-editor/referencing-saved-questions-in-queries.md
+++ b/docs/questions/native-editor/referencing-saved-questions-in-queries.md
@@ -6,7 +6,7 @@ redirect_from:
 
 ## Referencing models and saved questions
 
-With SQL databases, we can use a [model][model] or an existing question as the basis for a new query, or as a common table expression [CTE][CTE].
+With SQL databases, we can use a [model][model] or an existing question as the basis for a new query, or as a common table expression [CTE][cte].
 
 For example, let's say we have a lot of data spread across a number of tables, but people are most interested in a subset of that data. We can perform a complicated query once to return those results, and save that question as a model, which people can refer to in their queries just like they would with any other table.
 
@@ -37,14 +37,21 @@ FROM gizmo_orders
 When this query is run, the `{% raw %}{{#5-gizmo-orders-in-2019}}{% endraw %}` tag will be substituted with the SQL query of the referenced question, surrounded by parentheses. So it'll look like this under the hood:
 
 ```
-WITH gizmo_orders AS (SELECT *
-FROM   orders AS o
-       INNER JOIN products AS p
-               ON o.product_id = p.id
-WHERE  p.category = 'Gizmo'
-       AND o.created_at BETWEEN '2019-01-01' AND '2019-12-31')
-SELECT count(*)
-FROM gizmo_orders
+WITH
+  gizmo_orders AS (
+    SELECT
+      *
+    FROM
+      orders AS o
+      INNER JOIN products AS p ON o.product_id = p.id
+    WHERE
+      p.category = 'Gizmo'
+      AND o.created_at BETWEEN '2019-01-01' AND '2019-12-31'
+  )
+SELECT
+  count(*)
+FROM
+  gizmo_orders
 ```
 
 ## Limitations and tradeoffs
@@ -60,7 +67,6 @@ FROM gizmo_orders
 - [SQL Snippets vs Saved Questions vs. Views](https://www.metabase.com/learn/building-analytics/sql-templates/organizing-sql.html)
 - [SQL troubleshooting guide](../../troubleshooting-guide/sql.md).
 - [Segments and Metrics](../../data-modeling/segments-and-metrics.md)
-
 
 [cte]: https://www.metabase.com/learn/sql-questions/sql-cte
 [model]: ../../data-modeling/models.md

--- a/docs/questions/native-editor/sql-parameters.md
+++ b/docs/questions/native-editor/sql-parameters.md
@@ -18,7 +18,7 @@ Field Filter, a special type of filter, have a [slightly different syntax](#fiel
 
 This example defines a **Text** variable called `category`:
 
-```sql
+```
 {% raw %}
 SELECT
   count(*)
@@ -31,7 +31,7 @@ WHERE
 
 Metabase will read the variable and attach a filter widget to the query, which people can use to change the value inserted into the `cat` variable with quotes. So if someone entered "Gizmo" into the filter widget, the query Metabase would run would be:
 
-```sql
+```
 SELECT
   count(*)
 FROM
@@ -118,7 +118,7 @@ Let's say you want to create a Field Filter that filters the `People` table by s
 
 The syntax for Field Filters differs from a Text, Number, or Date variable.
 
-```sql
+```
 {% raw %}
 SELECT
   *
@@ -196,7 +196,7 @@ The reason is that field filters generate SQL based on the mapped field; Metabas
 
 Your main query should be aware of all the tables that your Field Filter variable is pointing to, otherwise you'll get a SQL syntax error. For example, let's say that your main query includes a field filter like this:
 
-```sql
+```
 {% raw %}
 SELECT
   *
@@ -209,7 +209,7 @@ WHERE
 
 Let's say the `{% raw %}{{ product_category }}{% endraw %}` variable refers to another question that uses the `Products` table. For the field filter to work, you'll need to include a join to `Products` in your main query.
 
-```sql
+```
 {% raw %}
 SELECT
   *
@@ -248,7 +248,7 @@ In the variables sidebar, you can set a default value for your variable. This va
 
 You can also define default values directly in your query by enclosing comment syntax inside the end brackets of an optional parameter.
 
-```sql
+```
 WHERE column = [[ {% raw %}{{ your_parameter }}{% endraw %} --]] your_default_value
 ```
 
@@ -256,7 +256,7 @@ The comment will "activate" whenever you pass a value to `your_parameter`.
 
 This is useful when defining complex default values (for example, if your default value is a function like `CURRENT_DATE`). Here's a PostgreSQL example that sets the default value of a Date filter to the current date using `CURRENT_DATE`:
 
-```sql
+```
 {% raw %}
 SELECT
   *
@@ -286,7 +286,7 @@ To make a clause optional in your native query, type `[[brackets around a {% raw
 
 In this example, if no value is given to `cat`, then the query will just select all the rows from the `products` table. But if `cat` does have a value, like "Widget", then the query will only grab the products with a category type of Widget:
 
-```sql
+```
 {% raw %}
 SELECT
   count(*)
@@ -297,7 +297,7 @@ FROM
 
 To use multiple optional clauses, you must include at least one regular `WHERE` clause followed by optional clauses, each starting with `AND`:
 
-```sql
+```
 {% raw %}
 SELECT
   count(*)


### PR DESCRIPTION
Fixing the indentation, and removing syntax highlight in one article because the highlighter there was assigning random languages:
![image](https://github.com/metabase/metabase/assets/16640109/d376d8c5-c9a5-4770-9fff-8471f665fbb3)
![image](https://github.com/metabase/metabase/assets/16640109/a20a17e8-5e3f-4d8f-8db1-a0b9600afc6a)

(the highlighter needs to be fixed and then we can put language back if we want to)