### PR TITLE
39333 Deduplicate is-clause?

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/query_processor.clj
@@ -16,6 +16,7 @@
                                             $size $skip $sort $strcasecmp $subtract $sum $toLower $unwind $year]]
    [metabase.driver.util :as driver.u]
    [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util.match :as lib.util.match]
@@ -728,7 +729,7 @@
                    [:<= field max-val]]))
 
 (defn- str-match-pattern [field options prefix value suffix]
-  (if (mbql.u/is-clause? ::not value)
+  (if (schema.helpers/is-clause? ::not value)
     {$not (str-match-pattern field options prefix (second value) suffix)}
     (do
       (assert (and (contains? #{nil "^"} prefix) (contains? #{nil "$"} suffix))
@@ -1013,7 +1014,7 @@
      [(field-alias field-or-expr) (format "$_id.%s" (field-alias field-or-expr))])
    (for [ag aggregations
          :let [ag-name (annotate/aggregation-name (:query *query*) ag)]]
-     [ag-name (if (mbql.u/is-clause? :distinct (unwrap-named-ag ag))
+     [ag-name (if (schema.helpers/is-clause? :distinct (unwrap-named-ag ag))
                 {$size (str \$ ag-name)}
                 true)])))
 

--- a/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
+++ b/modules/drivers/sqlserver/src/metabase/driver/sqlserver.clj
@@ -17,6 +17,7 @@
    [metabase.driver.sql.query-processor :as sql.qp]
    [metabase.driver.sql.util :as sql.u]
    [metabase.driver.sql.util.unprepare :as unprepare]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.query-processor.interface :as qp.i]
@@ -411,7 +412,7 @@
   The `year`, `month`, and `day` can make use of indexes whereas `DateFromParts` cannot. The optimized version of the
   query is much more efficient. See #9934 for more details."
   [field-clause]
-  (when (mbql.u/is-clause? :field field-clause)
+  (when (schema.helpers/is-clause? :field field-clause)
     (let [[_ id-or-name {:keys [temporal-unit], :as opts}] field-clause]
       (when (#{:year :month :day} temporal-unit)
         (mapv

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -15,6 +15,7 @@
    [metabase.events :as events]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.lib.util.match :as lib.util.match]
@@ -931,7 +932,7 @@
                                   (mbql.u/check-clause :dimension))]
         :when dimension
         :let  [ttag      (get-template-tag dimension card)
-               dimension (condp mbql.u/is-clause? dimension
+               dimension (condp schema.helpers/is-clause? dimension
                            :field        dimension
                            :expression   dimension
                            :template-tag (:dimension ttag)

--- a/src/metabase/automagic_dashboards/util.clj
+++ b/src/metabase/automagic_dashboards/util.clj
@@ -6,6 +6,7 @@
    [medley.core :as m]
    [metabase.legacy-mbql.predicates :as mbql.preds]
    [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.models.field :refer [Field]]
@@ -41,11 +42,11 @@
   (filter #(-> % :entity_type (isa? tablespec)) tables))
 
 (def ^{:arglists '([metric]) :doc "Is metric a saved metric?"} saved-metric?
-  (every-pred (partial mbql.u/is-clause? :metric)
+  (every-pred (partial schema.helpers/is-clause? :metric)
               (complement mbql.u/ga-metric-or-segment?)))
 
 (def ^{:arglists '([metric]) :doc "Is this a custom expression?"} custom-expression?
-  (partial mbql.u/is-clause? :aggregation-options))
+  (partial schema.helpers/is-clause? :aggregation-options))
 
 (def ^{:arglists '([metric]) :doc "Is this an adhoc metric?"} adhoc-metric?
   (complement (some-fn saved-metric? custom-expression?)))

--- a/src/metabase/domain_entities/specs.clj
+++ b/src/metabase/domain_entities/specs.clj
@@ -4,7 +4,7 @@
    [malli.transform :as mtx]
    [medley.core :as m]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
-   [metabase.legacy-mbql.util :as mbql.u]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.util.yaml :as yaml]))
 
 (def MBQL
@@ -13,7 +13,7 @@
    {:decode/domain-entity-spec mbql.normalize/normalize
     :decode/transform-spec     mbql.normalize/normalize
     :error/message             "valid MBQL clause"}
-   mbql.u/mbql-clause?])
+   schema.helpers/mbql-clause?])
 
 (def FieldType
   "Field type designator -- a keyword derived from `type/*`"

--- a/src/metabase/driver/common/parameters/dates.clj
+++ b/src/metabase/driver/common/parameters/dates.clj
@@ -5,6 +5,7 @@
    [java-time.api :as t]
    [medley.core :as m]
    [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.schema.parameter :as lib.schema.parameter]
    [metabase.models.params :as params]
@@ -174,7 +175,7 @@
 (defn- with-temporal-unit-if-field
   [clause unit]
   (cond-> clause
-    (mbql.u/is-clause? :field clause) (mbql.u/with-temporal-unit unit)))
+    (schema.helpers/is-clause? :field clause) (mbql.u/with-temporal-unit unit)))
 
 (def ^:private relative-date-string-decoders
   [{:parser #(= % "today")

--- a/src/metabase/driver/sql/query_processor.clj
+++ b/src/metabase/driver/sql/query_processor.clj
@@ -9,6 +9,7 @@
    [metabase.driver.common :as driver.common]
    [metabase.driver.sql.query-processor.deprecated :as sql.qp.deprecated]
    [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.schema.common :as lib.schema.common]
@@ -688,7 +689,7 @@
    (->honeysql driver power)])
 
 (defn- interval? [expr]
-  (mbql.u/is-clause? :interval expr))
+  (schema.helpers/is-clause? :interval expr))
 
 (defmethod ->honeysql [:sql :+]
   [driver [_ & args]]

--- a/src/metabase/legacy_mbql/normalize.cljc
+++ b/src/metabase/legacy_mbql/normalize.cljc
@@ -33,6 +33,7 @@
    [clojure.walk :as walk]
    [medley.core :as m]
    [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.shared.util.i18n :as i18n]
@@ -561,7 +562,7 @@
   ;; if you specify a `:temporal-unit` for the Field inside a `:time-interval`, remove it. The unit in
   ;; `:time-interval` takes precedence.
   (let [field (cond-> (canonicalize-implicit-field-id field)
-                (mbql.u/is-clause? :field field) (mbql.u/update-field-options dissoc :temporal-unit))]
+                (schema.helpers/is-clause? :field field) (mbql.u/update-field-options dissoc :temporal-unit))]
     (into [:time-interval field] args)))
 
 ;; all the other filter types have an implict field ID for the first arg

--- a/src/metabase/legacy_mbql/schema/helpers.cljc
+++ b/src/metabase/legacy_mbql/schema/helpers.cljc
@@ -24,8 +24,14 @@
         :rest     [:* (wrap-clause-arg-schema arg-schema)]
         (wrap-clause-arg-schema vector-arg-schema)))))
 
-;; TODO - this is a copy of the one in the [[metabase.legacy-mbql.util]] namespace. We need to reorganize things a bit so we
-;; can use the same fn and avoid circular refs
+(defn mbql-clause?
+  "True if `x` is an MBQL clause (a sequence with a keyword as its first arg). (Since this is used by the code in
+  `normalize` this handles pre-normalized clauses as well.)"
+  [x]
+  (and (sequential? x)
+       (not (map-entry? x))
+       (keyword? (first x))))
+
 (defn is-clause?
   "If `x` an MBQL clause, and an instance of clauses defined by keyword(s) `k-or-ks`?
 
@@ -33,8 +39,7 @@
     (is-clause? #{:+ :- :* :/} [:+ 10 20]) ; -> true"
   [k-or-ks x]
   (and
-   (vector? x)
-   (keyword? (first x))
+   (mbql-clause? x)
    (if (coll? k-or-ks)
      ((set k-or-ks) (first x))
      (= k-or-ks (first x)))))

--- a/src/metabase/models/params.clj
+++ b/src/metabase/models/params.clj
@@ -16,7 +16,7 @@
    [metabase.db.query :as mdb.query]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.legacy-mbql.schema :as mbql.s]
-   [metabase.legacy-mbql.util :as mbql.u]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.util.match :as lib.util.match]
    [metabase.models.field-values :as field-values]
@@ -68,7 +68,7 @@
   "Wrap a raw Field ID in a `:field` clause if needed."
   [field-id-or-form]
   (cond
-    (mbql.u/mbql-clause? field-id-or-form)
+    (schema.helpers/mbql-clause? field-id-or-form)
     field-id-or-form
 
     (integer? field-id-or-form)
@@ -114,9 +114,9 @@
   ID it references (if any)."
   [target card]
   (let [target (mbql.normalize/normalize target)]
-    (when (mbql.u/is-clause? :dimension target)
+    (when (schema.helpers/is-clause? :dimension target)
       (let [[_ dimension] target
-            field-form    (if (mbql.u/is-clause? :template-tag dimension)
+            field-form    (if (schema.helpers/is-clause? :template-tag dimension)
                             (template-tag->field-form dimension card)
                             dimension)]
         ;; Being extra safe here since we've got many reports on this cause loading dashboard to fail

--- a/src/metabase/query_processor/middleware/annotate.clj
+++ b/src/metabase/query_processor/middleware/annotate.clj
@@ -7,6 +7,7 @@
    [metabase.driver.common :as driver.common]
    [metabase.legacy-mbql.normalize :as mbql.normalize]
    [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
@@ -139,7 +140,7 @@
     true
 
     :+
-    (some (partial mbql.u/is-clause? :interval) (rest clause))
+    (some (partial schema.helpers/is-clause? :interval) (rest clause))
 
     _ false))
 
@@ -160,28 +161,28 @@
     (number? expression)
     {:base_type :type/Number}
 
-    (mbql.u/is-clause? :field expression)
+    (schema.helpers/is-clause? :field expression)
     (col-info-for-field-clause {} expression)
 
-    (mbql.u/is-clause? :coalesce expression)
+    (schema.helpers/is-clause? :coalesce expression)
     (select-keys (infer-expression-type (second expression)) type-info-columns)
 
-    (mbql.u/is-clause? :length expression)
+    (schema.helpers/is-clause? :length expression)
     {:base_type :type/BigInteger}
 
-    (mbql.u/is-clause? :case expression)
+    (schema.helpers/is-clause? :case expression)
     (let [[_ clauses] expression]
       (some
        (fn [[_ expression]]
          ;; get the first non-nil val
          (when (and (not= expression nil)
-                    (or (not (mbql.u/is-clause? :value expression))
+                    (or (not (schema.helpers/is-clause? :value expression))
                         (let [[_ value] expression]
                           (not= value nil))))
            (select-keys (infer-expression-type expression) type-info-columns)))
        clauses))
 
-    (mbql.u/is-clause? :convert-timezone expression)
+    (schema.helpers/is-clause? :convert-timezone expression)
     {:converted_timezone (nth expression 2)
      :base_type          :type/DateTime}
 
@@ -198,10 +199,10 @@
     (merge (select-keys (infer-expression-type (second expression)) [:converted_timezone])
      {:base_type :type/DateTime})
 
-    (mbql.u/is-clause? mbql.s/string-functions expression)
+    (schema.helpers/is-clause? mbql.s/string-functions expression)
     {:base_type :type/Text}
 
-    (mbql.u/is-clause? mbql.s/numeric-functions expression)
+    (schema.helpers/is-clause? mbql.s/numeric-functions expression)
     {:base_type :type/Float}
 
     :else

--- a/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
+++ b/src/metabase/query_processor/middleware/optimize_temporal_filters.clj
@@ -3,6 +3,7 @@
   `optimize-temporal-filters` for more details."
   (:require
    [clojure.walk :as walk]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util.match :as lib.util.match]
@@ -191,7 +192,7 @@
 
 (defn- optimize-temporal-filters* [query]
   (lib.util.match/replace query
-    (_ :guard (partial mbql.u/is-clause? (set (keys (methods optimize-filter)))))
+    (_ :guard (partial schema.helpers/is-clause? (set (keys (methods optimize-filter)))))
     (or (when (can-optimize-filter? &match)
           (u/prog1 (optimize-filter &match)
             (if <>

--- a/src/metabase/query_processor/middleware/parameters/mbql.clj
+++ b/src/metabase/query_processor/middleware/parameters/mbql.clj
@@ -4,6 +4,7 @@
    [metabase.driver.common.parameters.dates :as params.dates]
    [metabase.driver.common.parameters.operators :as params.ops]
    [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.convert :as lib.convert]
    [metabase.lib.core :as lib]
@@ -80,7 +81,7 @@
     ;; TODO - We can't tell the difference between a dashboard parameter (convert to an MBQL filter) and a native
     ;; query template tag parameter without this. There's should be a better, less fragile way to do this. (Not 100%
     ;; sure why, but this is needed for GTAPs to work.)
-    (mbql.u/is-clause? :template-tag field)
+    (schema.helpers/is-clause? :template-tag field)
     nil
 
     ;; single-value, non-date param. Generate MBQL [= [field <field> nil] <value>] clause

--- a/src/metabase/query_processor/middleware/wrap_value_literals.clj
+++ b/src/metabase/query_processor/middleware/wrap_value_literals.clj
@@ -4,6 +4,7 @@
   (:require
    [java-time.api :as t]
    [metabase.legacy-mbql.schema :as mbql.s]
+   [metabase.legacy-mbql.schema.helpers :as schema.helpers]
    [metabase.legacy-mbql.util :as mbql.u]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.util.match :as lib.util.match]
@@ -231,7 +232,7 @@
 
 ;;; -------------------------------------------- wrap-literals-in-clause ---------------------------------------------
 
-(def ^:private raw-value? (complement mbql.u/mbql-clause?))
+(def ^:private raw-value? (complement schema.helpers/mbql-clause?))
 
 (defn wrap-value-literals-in-mbql
   "Given a normalized mbql query (important to desugar forms like `[:does-not-contain ...]` -> `[:not [:contains


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39333

I have signed the contributor license agreement.

Note: The branching strategy document is not public so I don't know whether to add the `backport` or `no-backport` label to this PR.

### Description

I am interested in contributing to Metabase and so picked up https://github.com/metabase/metabase/issues/39333.

This PR removes the duplication of the `mbql-clause?` and `is-clause?` functions in `metabase.legacy-mbql.util` and `metabase.legacy-mbql.schema.helpers` by moving the functions to `metabase.legacy-mbql.schema.helpers` and removing them from `metabase.legacy-mbql.util`.

I think this is consistent with the rest of the code, because the `util` namespace already depended on the `schema.helper` namespace and the `mbql-clause?` and `is-clause?` functions 'fit' with the other functions in `schema.helpers`, which are also about clauses. The impact on the rest of the codebase is that a number of namespaces have been changed to reference `schema.helpers` instead of `util`.

### How to verify

The `mbql-clause?` and `is-clause?` functions are covered indirectly by tests, so I haven't added or updated any tests for this change.

### Demo

N/A

### Checklist

- [x] Tests have been added/updated to cover changes in this PR [no tests needed to be added/updated]
