### PR TITLE
Deprecate MLv1 metadata

### DIFF
--- a/frontend/src/metabase-lib/v1/metadata/Database.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Database.ts
@@ -19,6 +19,9 @@ interface Database extends Omit<NormalizedDatabase, "tables" | "schemas"> {
   metadata?: Metadata;
 }
 
+/**
+ * @deprecated use RTK Query endpoints and plain api objects from metabase-types/api
+ */
 class Database {
   private readonly _plainObject: NormalizedDatabase;
 

--- a/frontend/src/metabase-lib/v1/metadata/Field.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Field.ts
@@ -70,6 +70,9 @@ const LONG_TEXT_MIN = 80;
  * Wrapper class for field metadata objects. Belongs to a Table.
  */
 
+/**
+ * @deprecated use RTK Query endpoints and plain api objects from metabase-types/api
+ */
 class FieldInner extends Base {
   id: FieldId | FieldReference;
   name: string;

--- a/frontend/src/metabase-lib/v1/metadata/ForeignKey.ts
+++ b/frontend/src/metabase-lib/v1/metadata/ForeignKey.ts
@@ -10,6 +10,9 @@ interface ForeignKey
   metadata?: Metadata;
 }
 
+/**
+ * @deprecated use RTK Query endpoints and plain api objects from metabase-types/api
+ */
 class ForeignKey {
   private readonly _plainObject: NormalizedForeignKey;
 

--- a/frontend/src/metabase-lib/v1/metadata/Metadata.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Metadata.ts
@@ -35,6 +35,12 @@ interface MetadataOpts {
   settings?: Settings;
 }
 
+/**
+ * @deprecated The class shouldn't be used for anything but to create a MetadataProvider instance from MBQL lib.
+ *
+ *   For finding a database/table/field/card by id, use the corresponding RTK query endpoints.
+ *   Do not rely on data being implicitly loaded in some other place.
+ */
 class Metadata {
   databases: Record<string, Database> = {};
   schemas: Record<string, Schema> = {};
@@ -50,8 +56,7 @@ class Metadata {
   }
 
   /**
-   * @deprecated this won't be sorted or filtered in a meaningful way
-   * @returns {Database[]}
+   * @deprecated load data via RTK Query - useListDatabasesQuery
    */
   databasesList({ savedQuestions = true } = {}): Database[] {
     return _.chain(this.databases)
@@ -62,53 +67,78 @@ class Metadata {
   }
 
   /**
-   * @deprecated this won't be sorted or filtered in a meaningful way
-   * @returns {Table[]}
+   * @deprecated load data via RTK Query - useListDatabaseSchemaTablesQuery
    */
   tablesList(): Table[] {
     return Object.values(this.tables);
   }
 
+  /**
+   * @deprecated load data via RTK Query - useListFieldsQuery
+   */
   fieldsList(): Field[] {
     return Object.values(this.fields);
   }
 
   /**
-   * @deprecated this won't be sorted or filtered in a meaningful way
-   * @returns {Metric[]}
+   * @deprecated load data via RTK Query - useListMetricsQuery
    */
   metricsList(): Metric[] {
     return Object.values(this.metrics);
   }
 
+  /**
+   * @deprecated load data via RTK Query - useListSegmentsQuery
+   */
   segmentsList(): Segment[] {
     return Object.values(this.segments);
   }
 
+  /**
+   * @deprecated load data via RTK Query - useGetSegmentQuery
+   */
   segment(segmentId: SegmentId | undefined | null): Segment | null {
     return (segmentId != null && this.segments[segmentId]) || null;
   }
 
+  /**
+   * @deprecated load data via RTK Query - useGetMetricQuery
+   */
   metric(metricId: MetricId | undefined | null): Metric | null {
     return (metricId != null && this.metrics[metricId]) || null;
   }
 
+  /**
+   * @deprecated load data via RTK Query - useGetDatabaseQuery
+   */
   database(databaseId: DatabaseId | undefined | null): Database | null {
     return (databaseId != null && this.databases[databaseId]) || null;
   }
 
+  /**
+   * @deprecated load data via RTK Query - useListDatabasesQuery({ saved: true })
+   */
   savedQuestionsDatabase() {
     return this.databases[SAVED_QUESTIONS_VIRTUAL_DB_ID];
   }
 
+  /**
+   * @deprecated load data via RTK Query - useListSchemasQuery or useListDatabaseSchemaTablesQuery
+   */
   schema(schemaId: SchemaId | undefined | null): Schema | null {
     return (schemaId != null && this.schemas[schemaId]) || null;
   }
 
+  /**
+   * @deprecated load data via RTK Query - useGetTableQuery or useGetTableMetadataQuery
+   */
   table(tableId: TableId | undefined | null): Table | null {
     return (tableId != null && this.tables[tableId]) || null;
   }
 
+  /**
+   * @deprecated load data via RTK Query - useGetFieldQuery
+   */
   field(
     fieldId: FieldId | FieldReference | string | undefined | null,
     tableId?: TableId | undefined | null,
@@ -126,6 +156,9 @@ class Metadata {
     return this.fields[uniqueId] || null;
   }
 
+  /**
+   * @deprecated load data via RTK Query - useGetCardQuery
+   */
   question(cardId: CardId | undefined | null): Question | null {
     return (cardId != null && this.questions[cardId]) || null;
   }

--- a/frontend/src/metabase-lib/v1/metadata/Metric.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Metric.ts
@@ -9,6 +9,9 @@ interface Metric extends Omit<NormalizedMetric, "table"> {
   metadata?: Metadata;
 }
 
+/**
+ * @deprecated use RTK Query endpoints and plain api objects from metabase-types/api
+ */
 class Metric {
   private readonly _plainObject: NormalizedMetric;
 

--- a/frontend/src/metabase-lib/v1/metadata/Schema.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Schema.ts
@@ -11,6 +11,9 @@ interface Schema extends Omit<NormalizedSchema, "database" | "tables"> {
   metadata?: Metadata;
 }
 
+/**
+ * @deprecated use RTK Query endpoints and plain api objects from metabase-types/api
+ */
 class Schema {
   private readonly _plainObject: NormalizedSchema;
 

--- a/frontend/src/metabase-lib/v1/metadata/Segment.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Segment.ts
@@ -8,6 +8,9 @@ interface Segment extends Omit<NormalizedSegment, "table"> {
   metadata?: Metadata;
 }
 
+/**
+ * @deprecated use RTK Query endpoints and plain api objects from metabase-types/api
+ */
 class Segment {
   private readonly _plainObject: NormalizedSegment;
 

--- a/frontend/src/metabase-lib/v1/metadata/Table.ts
+++ b/frontend/src/metabase-lib/v1/metadata/Table.ts
@@ -32,6 +32,9 @@ interface Table
   metadata?: Metadata;
 }
 
+/**
+ * @deprecated use RTK Query endpoints and plain api objects from metabase-types/api
+ */
 class Table {
   private readonly _plainObject: NormalizedTable;
 


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/40898

We should no longer load data via the entity framework and work with entity abstractions. The way to go is to use specific API endpoints that are properly cached and invalidated, and write code that uses data obtained from API endpoints directly and do not rely on some implicit global cache for all entities.