### PR TITLE
Clarify that backport/no-backport is an internal thing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,9 @@
 > [!IMPORTANT]
-> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.
+> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label
+> to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this
+> PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71)
+> in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not
+> apply to you, and the label will be taken care of by your reviewer.
 
 > **Warning**
 >

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> If you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details.
+> For those employed by Metabase: if you are merging into master, please add either a `backport` or a `no-backport` label to this PR. You will not be able to merge until you do this step. Refer to the section [Do I need to backport this PR?](https://www.notion.so/metabase/Metabase-Branching-Strategy-6eb577d5f61142aa960a626d6bbdfeb3?pvs=4#89f80d6f17714a0198aeb66c0efd1b71) in the Metabase Branching Strategy document for more details. If you're not employed by Metabase, this section does not apply to you, and the label will be taken care of by your reviewer.
 
 > **Warning**
 >


### PR DESCRIPTION
External contributors ask about the notion doc they can't access and about the labels they are not expected to set a few times per month. This is not the experience we should give to people who not only take their time to contribute to metabase, but also actually read the PR template.

(slightly duplicated condition in the beginning and the end of the paragraph — "For those employed [...] If you're not employed [...]" — is on purpose)
