### PR TITLE
Remove lingering Joda Time references

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -82,7 +82,6 @@
   io.prometheus/simpleclient_hotspot        {:mvn/version "0.16.0"}             ; prometheus jvm collector
   io.prometheus/simpleclient_jetty          {:mvn/version "0.16.0"}             ; prometheus jetty collector
   javax.servlet/servlet-api                 {:mvn/version "2.5"}                ; used by ring's multipart-params (file upload)
-  joda-time/joda-time                       {:mvn/version "2.12.5"}
   kixi/stats                                {:mvn/version "0.5.5"               ; Various statistic measures implemented as transducers
                                              :exclusions  [org.clojure/data.avl]}
   lambdaisland/uri                          {:mvn/version "1.19.155"}           ; Used by openai-clojure
@@ -102,8 +101,7 @@
                                              :exclusions  [lambdaisland/uri]}   ; OpenAI
   net.i2p.crypto/eddsa                      {:mvn/version "0.3.0"}              ; ED25519 key support (optional dependency for org.apache.sshd/sshd-core)
   net.redhogs.cronparser/cron-parser-core   {:mvn/version "3.5"                 ; describe Cron schedule in human-readable language
-                                             :exclusions  [joda-time/joda-time  ; exclude joda time 2.3 which has outdated timezone information
-                                                           org.slf4j/slf4j-api]}
+                                             :exclusions  [org.slf4j/slf4j-api]}
   net.sf.cssbox/cssbox                      {:mvn/version "5.0.1"               ; HTML / CSS rendering
                                              :exclusions  [org.slf4j/slf4j-api
                                                            junit/junit]}

--- a/docs/developers-guide/driver-changelog.md
+++ b/docs/developers-guide/driver-changelog.md
@@ -68,6 +68,8 @@ title: Driver interface changelog
   fussy BigQuery working. (More on this soon.) If all else fails, you can always specify that your driver does not
   support `:window-functions`, and it will fall back to using the old broken implementation.
 
+- `metabase.driver.common/class->base-type` no longer supports Joda Time classes. They have been deprecated since 2019.
+
 ## Metabase 0.49.1
 
 - Another driver feature has been added: `describe-fields`. If a driver opts-in to supporting this feature, The

--- a/src/metabase/driver/common.clj
+++ b/src/metabase/driver/common.clj
@@ -7,9 +7,7 @@
    [metabase.public-settings :as public-settings]
    [metabase.util.i18n :refer [deferred-tru]]
    [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
-  (:import
-   (org.joda.time DateTime)))
+   [metabase.util.malli :as mu]))
 
 (set! *warn-on-reflection* true)
 
@@ -247,11 +245,10 @@
     java.math.BigInteger           :type/BigInteger
     Number                         :type/Number
     String                         :type/Text
-    ;; java.sql types and Joda-Time types should be considered DEPRECATED
+    ;; java.sql types should be considered DEPRECATED
     java.sql.Date                  :type/Date
     java.sql.Timestamp             :type/DateTime
     java.util.Date                 :type/Date
-    DateTime                       :type/DateTime
     java.util.UUID                 :type/UUID
     clojure.lang.IPersistentMap    :type/Dictionary
     clojure.lang.IPersistentVector :type/Array

--- a/src/metabase/task/send_pulses.clj
+++ b/src/metabase/task/send_pulses.clj
@@ -100,8 +100,8 @@
                                  (time/now)
                                  (time/to-time-zone (time/now) (time/time-zone-for-id reporting-timezone)))
             curr-hour          (time/hour now)
-            ;; joda time produces values of 1-7 here (Mon -> Sun) and we subtract 1 from it to
-            ;; make the values zero based to correspond to the indexes in pulse-channel/days-of-week
+            ;; clj-time produces values of 1-7 here (Mon -> Sun), so we subtract 1 from it to make the values
+            ;; zero-based to correspond to the indices in pulse-channel/days-of-week
             curr-weekday       (->> (dec (time/day-of-week now))
                                     (get pulse-channel/days-of-week)
                                     :id)

--- a/test/metabase/driver/mysql_test.clj
+++ b/test/metabase/driver/mysql_test.clj
@@ -231,15 +231,20 @@
           (is (= ["2018-04-18T00:00:00+08:00"]
                  (run-query-with-report-timezone "Asia/Hong_Kong"))))
 
+        ;; [August, 2018]
         ;; This tests a similar scenario, but one in which the JVM timezone is in Hong Kong, but the report timezone
         ;; is in Los Angeles. The Joda Time date parsing functions for the most part default to UTC. Our tests all run
         ;; with a UTC JVM timezone. This test catches a bug where we are incorrectly assuming a date is in UTC when
         ;; the JVM timezone is different.
         ;;
         ;; The original bug can be found here: https://github.com/metabase/metabase/issues/8262. The MySQL driver code
-        ;; was parsing the date using JodateTime's date parser, which is in UTC. The MySQL driver code was assuming
+        ;; was parsing the date using Joda Time's date parser, which is in UTC. The MySQL driver code was assuming
         ;; that date was in the system timezone rather than UTC which caused an incorrect conversion and with the
-        ;; trucation, let to it being off by a day
+        ;; trucation, let to it being off by a day.
+        ;;
+        ;; [April, 2024]
+        ;; We no longer use Joda Time at all (this logic has been pulled out to qp.timezone, and uses java-time), but
+        ;; are keeping the test in place since it's still a legitimate case.
         (testing "date formatting when system-timezone != report-timezone"
           (is (= ["2018-04-18T00:00:00-07:00"]
                  (run-query-with-report-timezone "America/Los_Angeles"))))))))


### PR DESCRIPTION
[Fixes #13922]

Joda Time is still used by a couple libraries, but we no longer use it directly and are protected against the bug that required version-hacking (#13867).

Do I need to document that we don't convert 

```
$ clojure -X:deps tree | ack joda -B 6
      . com.google.code.findbugs/jsr305 3.0.2
      X com.google.guava/guava 31.1-jre :use-top
  . org.clojure/spec.alpha 0.3.218
  . com.onelogin/java-saml 2.9.0
    . com.onelogin/java-saml-core 2.9.0
      X org.slf4j/slf4j-api 1.7.35 :use-top
      . joda-time/joda-time 2.10.6
      X org.apache.commons/commons-lang3 3.12.0 :use-top
      X org.apache.santuario/xmlsec 2.2.3 :older-version
      X commons-codec/commons-codec 1.15 :use-top
    X org.slf4j/slf4j-api 1.7.35 :use-top
    . joda-time/joda-time 2.10.6 :newer-version
--
org.apache.logging.log4j/log4j-jul 2.23.1
  X org.apache.logging.log4j/log4j-api 2.23.1 :use-top
org.clojure/tools.macro 0.2.0
com.gfredericks/test.chuck 0.2.14
  X org.clojure/test.check 1.1.0 :superseded
  . clj-time/clj-time 0.15.2
    X joda-time/joda-time 2.10 :older-version
  . com.andrewmcveigh/cljs-time 0.5.2
  X instaparse/instaparse 1.4.10 :use-top
metabase/throttle 1.0.2
  X org.clojure/math.numeric-tower 0.0.4 :use-top
net.redhogs.cronparser/cron-parser-core 3.5
  X org.apache.commons/commons-lang3 3.3.2 :use-top
  X joda-time/joda-time 2.3 :superseded
```