### PR TITLE
Add analytics events for the native code preview in a notebook

### DIFF
--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -16,6 +16,12 @@ import {
   createQuestion,
   saveSavedQuestion,
   withDatabase,
+  describeWithSnowplow,
+  resetSnowplow,
+  enableTracking,
+  expectGoodSnowplowEvent,
+  expectGoodSnowplowEvents,
+  expectNoBadSnowplowEvents,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -307,6 +313,45 @@ describe(
       cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
       cy.findByTestId("selected-table").should("have.text", "Products");
       cy.get(".cellData").should("contain", "Small Marble Shoes");
+    });
+  },
+);
+
+describeWithSnowplow(
+  "scenarios > notebook > native query preview sidebar tracking events",
+  () => {
+    beforeEach(() => {
+      resetSnowplow();
+      restore();
+      cy.signInAsAdmin();
+      enableTracking();
+    });
+
+    afterEach(() => {
+      expectNoBadSnowplowEvents();
+    });
+
+    it("should track `notebook_native_preview_shown|hidden` events", () => {
+      cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
+      openReviewsTable({ mode: "notebook", limit: 1 });
+      expectGoodSnowplowEvents(1); // page view
+
+      cy.findByLabelText("View the SQL").click();
+      cy.wait("@nativeDataset");
+      cy.findByTestId("native-query-preview-sidebar").should("exist");
+
+      expectGoodSnowplowEvent({
+        event: "notebook_native_preview_shown",
+      });
+
+      cy.findByLabelText("Hide the SQL").click();
+      cy.findByTestId("native-query-preview-sidebar").should("not.exist");
+
+      expectGoodSnowplowEvent({
+        event: "notebook_native_preview_hidden",
+      });
+
+      expectGoodSnowplowEvents(3);
     });
   },
 );

--- a/frontend/src/metabase/query_builder/analytics.js
+++ b/frontend/src/metabase/query_builder/analytics.js
@@ -21,3 +21,11 @@ export const trackTurnIntoModelClicked = question => {
     question_id: question.id(),
   });
 };
+
+export const trackNotebookNativePreviewShown = isShown => {
+  trackSchemaEvent("question", "1-0-3", {
+    event: isShown
+      ? "notebook_native_preview_shown"
+      : "notebook_native_preview_hidden",
+  });
+};

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
@@ -8,6 +8,8 @@ import { Icon, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
 import type Question from "metabase-lib/v1/Question";
 
+import { trackNotebookNativePreviewShown } from "../../../../../analytics";
+
 import { SqlButton } from "./ToggleNativeQueryPreview.styled";
 
 const BUTTON_TOOLTIP = {
@@ -37,12 +39,15 @@ export const ToggleNativeQueryPreview = ({
     ? BUTTON_TOOLTIP_CLOSE[engineType]
     : BUTTON_TOOLTIP[engineType];
 
-  const handleClick = () =>
+  const handleClick = () => {
     dispatch(
       setUIControls({
         isNativePreviewSidebarOpen: !isNativePreviewSidebarOpen,
       }),
     );
+
+    trackNotebookNativePreviewShown(!isNativePreviewSidebarOpen);
+  };
 
   return (
     <Tooltip label={tooltip} position="top">

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/question/jsonschema/1-0-3
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/question/jsonschema/1-0-3
@@ -55,9 +55,16 @@
     },
     "question_id": {
       "description": "Unique identifier for the question within the Metabase instance",
-      "type": "integer",
-      "minimum": 0,
-      "maximum": 2147483647
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "description": "Unique question identifier",
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 2147483647
+      }
     },
     "database_id": {
       "description": "Unique identifier(s) for the database connection(s) used to create the question",

--- a/snowplow/iglu-client-embedded/schemas/com.metabase/question/jsonschema/1-0-3
+++ b/snowplow/iglu-client-embedded/schemas/com.metabase/question/jsonschema/1-0-3
@@ -1,0 +1,76 @@
+{
+  "$schema": "http://iglucentral.com/schemas/com.snowplowanalytics.self-desc/schema/jsonschema/1-0-0#",
+  "description": "Events related to questions",
+  "self": {
+    "vendor": "com.metabase",
+    "name": "question",
+    "format": "jsonschema",
+    "version": "1-0-3"
+  },
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Event name",
+      "type": "string",
+      "enum": [
+        "new_question_saved",
+        "turn_into_model_clicked",
+        "notebook_native_preview_shown",
+        "notebook_native_preview_hidden"
+      ],
+      "maxLength": 1024
+    },
+    "type": {
+      "description": "String identifying the type of the question when it is saved",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "simple_question",
+        "custom_question",
+        "native_question"
+      ],
+      "maxLength": 1024
+    },
+    "method": {
+      "description": "String indicating whether or not the question was created based off of an existing question",
+      "type": [
+        "string",
+        "null"
+      ],
+      "enum": [
+        "from_scratch",
+        "existing_question"
+      ],
+      "maxLength": 1024
+    },
+    "visualization_type": {
+      "description": "String describing the type of visualization used for the question",
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 1024
+    },
+    "question_id": {
+      "description": "Unique identifier for the question within the Metabase instance",
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647
+    },
+    "database_id": {
+      "description": "Unique identifier(s) for the database connection(s) used to create the question",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "minimum": 0,
+      "maximum": 2147483647
+    }
+  },
+  "required": [
+    "event"
+  ],
+  "additionalProperties": true
+}


### PR DESCRIPTION
### What does this PR accomplish?
Resolves #40948 by:
- Updating an existing `question` schema to `1-0-3`
- Adding two new events to that schema
    - `notebook_native_preview_shown`
    - `notebook_native_preview_hidden`
- Exposing these events on the frontend and hooking the native query preview toggle to send those quests on click
- Adding E2E tests that cover this behavior

### Additional notes
To make the review easier, here's the actual schema diff between versions `1-0-2` and `1-0-3`
https://www.diffchecker.com/FQe8EUy2/

(the link will expire in seven days)