### PR TITLE
Fix flaky test caused by unmounted HoverCard

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -1,6 +1,6 @@
 // various Metabase-specific "scoping" functions like inside popover/modal/navbar/main/sidebar content area
 export const POPOVER_ELEMENT =
-  ".popover[data-state~='visible'],[data-position]:not(.emotion-HoverCard-dropdown)";
+  ".popover[data-state~='visible'],[data-element-id=mantine-popover]";
 
 export function popover() {
   cy.get(POPOVER_ELEMENT).should("be.visible");

--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -7,11 +7,6 @@ export function popover() {
   return cy.get(POPOVER_ELEMENT);
 }
 
-export function mantinePopover() {
-  const MANTINE_POPOVER = "[data-element-id=mantine-popover]";
-  return cy.get(MANTINE_POPOVER).should("be.visible");
-}
-
 const HOVERCARD_ELEMENT = ".emotion-HoverCard-dropdown[role='dialog']:visible";
 
 export function hovercard() {

--- a/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
+++ b/e2e/test/scenarios/admin-2/whitelabel.cy.spec.js
@@ -4,7 +4,6 @@ import {
   describeEE,
   entityPickerModal,
   main,
-  mantinePopover,
   modal,
   popover,
   restore,
@@ -156,7 +155,7 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "Login and unsubscribe pages",
           }).click();
-          mantinePopover().findByText("Custom").click();
+          popover().findByText("Custom").click();
           /**
            * Clicking "Choose File" doesn't actually open the file browser on Cypress,
            * so I need to use `selectFile` with the file input instead.
@@ -178,7 +177,7 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "Login and unsubscribe pages",
           }).click();
-          mantinePopover().findByText("Custom").click();
+          popover().findByText("Custom").click();
           cy.log("test uploading a corrupted file");
           cy.findByTestId("login-page-illustration-setting").within(() => {
             cy.findByTestId("file-input").selectFile(
@@ -230,7 +229,7 @@ describeEE("formatting > whitelabel", () => {
           cy.findByTestId("login-page-illustration-setting")
             .findByRole("searchbox", { name: "Login and unsubscribe pages" })
             .click();
-          mantinePopover().findByText("Custom").click();
+          popover().findByText("Custom").click();
           cy.findByTestId("login-page-illustration-setting").within(() => {
             cy.findByTestId("file-input").selectFile(
               {
@@ -270,7 +269,7 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "Login and unsubscribe pages",
           }).click();
-          mantinePopover().findByText("No illustration").click();
+          popover().findByText("No illustration").click();
 
           cy.signOut();
           cy.visit("/");
@@ -291,7 +290,7 @@ describeEE("formatting > whitelabel", () => {
           );
 
           cy.findByRole("searchbox", { name: "Landing page" }).click();
-          mantinePopover().findByText("Custom").click();
+          popover().findByText("Custom").click();
 
           cy.findByTestId("landing-page-illustration-setting").within(() => {
             cy.findByTestId("file-input").selectFile(
@@ -321,7 +320,7 @@ describeEE("formatting > whitelabel", () => {
           cy.visit("/admin/settings/whitelabel/conceal-metabase");
 
           cy.findByLabelText("Landing page").click();
-          mantinePopover().findByText("No illustration").click();
+          popover().findByText("No illustration").click();
 
           cy.visit("/");
           cy.findByTestId("landing-page-illustration").should("not.exist");
@@ -339,7 +338,7 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "When calculations return no results",
           }).click();
-          mantinePopover().findByText("Custom").click();
+          popover().findByText("Custom").click();
 
           cy.findByTestId("no-data-illustration-setting").within(() => {
             cy.findByTestId("file-input").selectFile(
@@ -398,7 +397,7 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "When calculations return no results",
           }).click();
-          mantinePopover().findByText("No illustration").click();
+          popover().findByText("No illustration").click();
 
           visitDashboard("@dashboardId");
           cy.findByAltText("No results").should("not.exist");
@@ -421,7 +420,7 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "When no objects can be found",
           }).click();
-          mantinePopover().findByText("Custom").click();
+          popover().findByText("Custom").click();
 
           cy.findByTestId("no-object-illustration-setting").within(() => {
             cy.findByTestId("file-input").selectFile(
@@ -474,7 +473,7 @@ describeEE("formatting > whitelabel", () => {
           cy.findByRole("searchbox", {
             name: "When no objects can be found",
           }).click();
-          mantinePopover().findByText("No illustration").click();
+          popover().findByText("No illustration").click();
 
           cy.findByRole("navigation").findByText("Exit admin").click();
           appBar().findByText("New").click();

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 
 import useSequencedContentCloseHandler from "metabase/hooks/use-sequenced-content-close-handler";
 import type { HoverCardProps } from "metabase/ui";
@@ -36,12 +36,10 @@ export function Popover({
   const { setupCloseHandler, removeCloseHandler } =
     useSequencedContentCloseHandler();
 
-  const ref = useRef(null);
   const handleOpen = useCallback(() => {
-    setupCloseHandler(ref.current, () => setIsOpen(false));
     group.onOpen();
     setIsOpen(true);
-  }, [setupCloseHandler, group]);
+  }, [group]);
 
   const handleClose = useCallback(() => {
     removeCloseHandler();
@@ -60,14 +58,19 @@ export function Popover({
       transitionProps={{
         duration: group.shouldDelay ? POPOVER_TRANSITION_DURATION : 0,
       }}
-      keepMounted
     >
       <HoverCard.Target>{children}</HoverCard.Target>
       <Dropdown>
         {/* HACK: adds an element between the target and the card */}
         {/* to avoid the card from disappearing */}
         <Target />
-        <WidthBound ref={ref}>{isOpen && content}</WidthBound>
+        <WidthBound
+          ref={node => {
+            setupCloseHandler(node, () => setIsOpen(false));
+          }}
+        >
+          {isOpen && content}
+        </WidthBound>
       </Dropdown>
     </HoverCard>
   );

--- a/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Popover/index.tsx
@@ -6,15 +6,12 @@ export { getPopoverOverrides } from "./Popover.styled";
 
 const MantinePopoverDropdown = Popover.Dropdown;
 
-const PopoverDropdown = Object.assign(function PopoverDropdown(
-  props: PopoverDropdownProps,
-) {
+const PopoverDropdown = function PopoverDropdown(props: PopoverDropdownProps) {
   return (
     <MantinePopoverDropdown {...props} data-element-id="mantine-popover" />
   );
-},
-MantinePopoverDropdown);
-
-Popover.Dropdown = PopoverDropdown as typeof MantinePopoverDropdown;
+};
+PopoverDropdown.displayName = MantinePopoverDropdown.displayName;
+Popover.Dropdown = PopoverDropdown;
 
 export { Popover };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39991

### Description

The problem occurred because somehow sometimes, the test would not unmount the [fake columns](https://github.com/metabase/metabase/blob/359a8dacc6b656a83bc0709e66753a024514ea06/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx#L270) we used to measure the table size. And when that happened, `popover()` E2E util will find not only the open popover, but also `MetadataInfo/Popover` which has a different class `.mantine-HoverCard-dropdown` than what we exclude in that util `.emotion-HoverCard-dropdown`. I believe this is because we use `ReactDOM.render` and didn't render this under any provider that changes its prefix.

The fix is to change the way info dot popover works. Previously it will always mount, so the selector for `popover()` in our E2E tests would always find these info dots.

Since we only render these info dots when we hover over it, `popover()` won't find more than 1 element.


### How to verify

The main component changed is the `MetadataInfo/Popover` which is used in 3 places.
1. Table info dot > Browse a table > See the info dot beside the table name
1. Query column info dot > Browse a table > Hover over the column name
1. Table column info dot > Native query > Add a parameter and set it to Field Filter > Select a table > See the info dot beside any field

So, we need to verify that those 3 HoverCard still works as expected by hover over it and see if clicking inside the hover card should not close it.

### Demo
1. QueryColumnInfoPopover
    ![image](https://github.com/metabase/metabase/assets/1937582/23ce2127-dc3f-46d6-91eb-9b7198fd7060)
1. TableColumnInfoPopover
    ![image](https://github.com/metabase/metabase/assets/1937582/de84e536-49f4-4a91-aa5f-56a9cb621871)
1. TableInfoPopover
    ![image](https://github.com/metabase/metabase/assets/1937582/31fd48af-aaea-449e-b56b-600d8a978e59)


### Checklist

- [x] Tests have been added/updated to cover changes in this PR


### Note
- I didn't backport this because the [original PR that introduced `MetadataInfo/Popover`](https://github.com/metabase/metabase/pull/39296) isn't backported.
- [Stress test result](https://github.com/metabase/metabase/actions/runs/8541267532) 20/20 ✅ 