### PR TITLE
No error message on preview api error

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
@@ -7,8 +7,6 @@ import _ from "underscore";
 import QuestionResultLoader from "metabase/containers/QuestionResultLoader";
 import Button from "metabase/core/components/Button";
 import CS from "metabase/css/core/index.css";
-import { useModalOpen } from "metabase/hooks/use-modal-open";
-import { isReducedMotionPreferred } from "metabase/lib/dom";
 import { Icon } from "metabase/ui";
 import Visualization from "metabase/visualizations/components/Visualization";
 import * as Lib from "metabase-lib";
@@ -83,11 +81,6 @@ const NotebookStepPreview = ({ step, onClose }) => {
 };
 
 const VisualizationPreview = ({ rawSeries, result, error }) => {
-  const { open } = useModalOpen();
-  const preferReducedMotion = isReducedMotionPreferred();
-
-  const transitionDuration = preferReducedMotion ? 80 : 700;
-
   const err = coerceError(error || result?.error);
 
   return (
@@ -98,8 +91,7 @@ const VisualizationPreview = ({ rawSeries, result, error }) => {
         p2: err,
       })}
       style={{
-        height: err ? "auto" : getPreviewHeightForResult(result) / (2 - open),
-        transition: `height ${transitionDuration}ms cubic-bezier(0, 0, 0.2, 1)`,
+        height: err ? "auto" : getPreviewHeightForResult(result),
       }}
     />
   );

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
@@ -80,7 +80,7 @@ const NotebookStepPreview = ({ step, onClose }) => {
   );
 };
 
-const VisualizationPreview = ({ rawSeries, result, error }) => {
+export const VisualizationPreview = ({ rawSeries, result, error }) => {
   const err = coerceError(error || result?.error);
 
   return (

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
@@ -88,17 +88,17 @@ const VisualizationPreview = ({ rawSeries, result, error }) => {
 
   const transitionDuration = preferReducedMotion ? 80 : 700;
 
+  const err = coerceError(error || result?.error);
+
   return (
     <Visualization
       rawSeries={rawSeries}
-      error={coerceError(error || result?.error)}
+      error={err}
       className={cx("bordered shadowed rounded bg-white", {
-        p2: result && result.error,
+        p2: err,
       })}
       style={{
-        height: open
-          ? getPreviewHeightForResult(result)
-          : getPreviewHeightForResult(result) / 2,
+        height: err ? "auto" : getPreviewHeightForResult(result) / (2 - open),
         transition: `height ${transitionDuration}ms cubic-bezier(0, 0, 0.2, 1)`,
       }}
     />

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
@@ -69,8 +69,12 @@ const NotebookStepPreview = ({ step, onClose }) => {
         </PreviewButtonContainer>
       ) : (
         <QuestionResultLoader question={activeQuestion}>
-          {({ rawSeries, result }) => (
-            <VisualizationPreview rawSeries={rawSeries} result={result} />
+          {({ rawSeries, result, error }) => (
+            <VisualizationPreview
+              rawSeries={rawSeries}
+              result={result}
+              error={error}
+            />
           )}
         </QuestionResultLoader>
       )}
@@ -78,7 +82,7 @@ const NotebookStepPreview = ({ step, onClose }) => {
   );
 };
 
-const VisualizationPreview = ({ rawSeries, result }) => {
+const VisualizationPreview = ({ rawSeries, result, error }) => {
   const { open } = useModalOpen();
   const preferReducedMotion = isReducedMotionPreferred();
 
@@ -87,7 +91,7 @@ const VisualizationPreview = ({ rawSeries, result }) => {
   return (
     <Visualization
       rawSeries={rawSeries}
-      error={result && result.error}
+      error={coerceError(error || result?.error)}
       className={cx("bordered shadowed rounded bg-white", {
         p2: result && result.error,
       })}
@@ -104,6 +108,22 @@ const VisualizationPreview = ({ rawSeries, result }) => {
 function getPreviewHeightForResult(result) {
   const rowCount = result ? result.data.rows.length : 1;
   return rowCount * 36 + 36 + 2;
+}
+
+function coerceError(err) {
+  if (!err) {
+    return null;
+  }
+
+  if (typeof err === "string") {
+    return err;
+  }
+
+  if (typeof err.message === "string") {
+    return err.message;
+  }
+
+  return t`Could not fetch preview`;
 }
 
 export default NotebookStepPreview;

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.jsx
@@ -81,7 +81,7 @@ const NotebookStepPreview = ({ step, onClose }) => {
 };
 
 export const VisualizationPreview = ({ rawSeries, result, error }) => {
-  const err = coerceError(error || result?.error);
+  const err = getErrorMessage(error || result?.error);
 
   return (
     <Visualization
@@ -102,7 +102,7 @@ function getPreviewHeightForResult(result) {
   return rowCount * 36 + 36 + 2;
 }
 
-function coerceError(err) {
+function getErrorMessage(err) {
   if (!err) {
     return null;
   }

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.unit.spec.tsx
@@ -2,33 +2,39 @@ import { renderWithProviders, screen } from "__support__/ui";
 
 import { VisualizationPreview } from "./NotebookStepPreview";
 
-test("vizualization preview should render an error message when an error occurs (metabase#40724)", () => {
-  renderWithProviders(
-    <VisualizationPreview
-      rawSeries={null}
-      result={null}
-      error={{ status: 0 }}
-    />,
-  );
-  expect(screen.getByText("Could not fetch preview")).toBeInTheDocument();
-});
+describe("VisualizationPreview", () => {
+  it("should render an error message when an error occurs (metabase#40724)", () => {
+    renderWithProviders(
+      <VisualizationPreview
+        rawSeries={null}
+        result={null}
+        error={{ status: 0 }}
+      />,
+    );
+    expect(screen.getByText("Could not fetch preview")).toBeInTheDocument();
+  });
 
-test("vizualization preview a custom error message when an error occurs (metabase#40724)", () => {
-  const message = "This is a custom message";
-  renderWithProviders(
-    <VisualizationPreview rawSeries={null} result={null} error={{ message }} />,
-  );
-  expect(screen.getByText(message)).toBeInTheDocument();
-});
+  it("should render a custom error message when an error occurs (metabase#40724)", () => {
+    const message = "This is a custom message";
+    renderWithProviders(
+      <VisualizationPreview
+        rawSeries={null}
+        result={null}
+        error={{ message }}
+      />,
+    );
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
 
-test("vizualization preview an error message when an error is passed from the results (metabase#40724)", () => {
-  const message = "This is a custom message";
-  renderWithProviders(
-    <VisualizationPreview
-      rawSeries={null}
-      result={{ error: message }}
-      error={null}
-    />,
-  );
-  expect(screen.getByText(message)).toBeInTheDocument();
+  it("should render an error message when an error is passed from the results (metabase#40724)", () => {
+    const message = "This is a custom message";
+    renderWithProviders(
+      <VisualizationPreview
+        rawSeries={null}
+        result={{ error: message }}
+        error={null}
+      />,
+    );
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStepPreview.unit.spec.tsx
@@ -1,0 +1,34 @@
+import { renderWithProviders, screen } from "__support__/ui";
+
+import { VisualizationPreview } from "./NotebookStepPreview";
+
+test("vizualization preview should render an error message when an error occurs (metabase#40724)", () => {
+  renderWithProviders(
+    <VisualizationPreview
+      rawSeries={null}
+      result={null}
+      error={{ status: 0 }}
+    />,
+  );
+  expect(screen.getByText("Could not fetch preview")).toBeInTheDocument();
+});
+
+test("vizualization preview a custom error message when an error occurs (metabase#40724)", () => {
+  const message = "This is a custom message";
+  renderWithProviders(
+    <VisualizationPreview rawSeries={null} result={null} error={{ message }} />,
+  );
+  expect(screen.getByText(message)).toBeInTheDocument();
+});
+
+test("vizualization preview an error message when an error is passed from the results (metabase#40724)", () => {
+  const message = "This is a custom message";
+  renderWithProviders(
+    <VisualizationPreview
+      rawSeries={null}
+      result={{ error: message }}
+      error={null}
+    />,
+  );
+  expect(screen.getByText(message)).toBeInTheDocument();
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40724

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question → Sample Dataset → Orders
2. Disable network requests
3. Click the Preview button
4. Make sure an error message appears, not just a loading spinner

Additionally (and optionally): I've removed the buggy implementation of the height animation for the preview container. The browser is doing rendering a lot of things so the animation was very choppy, and it does not add much value. If this doesn't belong in this PR, I'm happy to remove it.

### Demo

<img width="732" alt="Screenshot 2024-04-03 at 19 12 23" src="https://github.com/metabase/metabase/assets/1250185/be89bf4b-5c7a-4fc4-9f7d-5150c0617347">
