### PR TITLE
Fix nil schema for tables in REST API

### DIFF
--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -1148,8 +1148,7 @@
                               ;; a non-nil value means Table is hidden -- see [[metabase.models.table/visibility-types]]
                               {:where [:= :visibility_type nil]})))
          filter-schemas
-         ;; for `nil` schemas return the empty string
-         (map #(if (nil? %) "" %))
+         (map #(api.table/format-schema-for-response %))
          distinct
          sort)))
 

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -487,7 +487,8 @@
         (update :tables (if remove_inactive?
                           (fn [tables]
                             (filter :active tables))
-                          identity)))))
+                          identity))
+        (update :tables (mapv #(api.table/format-table-for-response %))))))
 
 (api/defendpoint GET "/:id/metadata"
   "Get metadata about a `Database`, including all of its `Tables` and `Fields`. Returns DB, fields, and field values.

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -6,6 +6,7 @@
    [medley.core :as m]
    [metabase.analytics.snowplow :as snowplow]
    [metabase.api.common :as api]
+   [metabase.api.table :as api.table]
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
    [metabase.models.collection :as collection]
@@ -451,6 +452,9 @@
                             (map #(if (t2/instance-of? :model/Collection %)
                                     (t2/hydrate % :effective_location)
                                     (assoc % :effective_location nil)))
+                            (map #(if (t2/instance-of? :model/Table %)
+                                   (update % :table_schema api.table/format-schema-for-response)
+                                   %))
                             (filter (partial check-permissions-for-model (:archived? search-ctx)))
                             ;; MySQL returns `:bookmark` and `:archived` as `1` or `0` so convert those to boolean as
                             ;; needed

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -41,9 +41,14 @@
   "Schema for a valid table field ordering."
   (into [:enum] (map name table/field-orderings)))
 
-(defn- format-table-for-response [table]
+(defn format-schema-for-response
+  [schema]
   ;; for `nil` schemas return the empty string
-  (update table :schema #(if (nil? %) "" %)))
+  (if (nil? schema) "" schema))
+
+(defn format-table-for-response
+  [table]
+  (update table :schema format-schema-for-response))
 
 (api/defendpoint GET "/"
   "Get all `Tables`."

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -332,6 +332,8 @@
         (m/dissoc-in [:db :details])
         (assoc-dimension-options db)
         format-fields-for-response
+        ;; for `nil` schemas return the empty string
+        (update :schema #(if (nil? %) "" %))
         (update :fields (partial filter (fn [{visibility-type :visibility_type}]
                                           (case (keyword visibility-type)
                                             :hidden    include-hidden-fields?

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -56,7 +56,7 @@
   (as-> (t2/select Table, :active true, {:order-by [[:name :asc]]}) tables
     (t2/hydrate tables :db)
     (filterv mi/can-read? tables)
-    (mapv format-table-for-response)))
+    (mapv #(format-table-for-response %))))
 
 (api/defendpoint GET "/:id"
   "Get `Table` with ID."

--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -41,12 +41,17 @@
   "Schema for a valid table field ordering."
   (into [:enum] (map name table/field-orderings)))
 
+(defn- format-table-for-response [table]
+  ;; for `nil` schemas return the empty string
+  (update table :schema #(if (nil? %) "" %)))
+
 (api/defendpoint GET "/"
   "Get all `Tables`."
   []
   (as-> (t2/select Table, :active true, {:order-by [[:name :asc]]}) tables
     (t2/hydrate tables :db)
-    (filterv mi/can-read? tables)))
+    (filterv mi/can-read? tables)
+    (mapv format-table-for-response)))
 
 (api/defendpoint GET "/:id"
   "Get `Table` with ID."
@@ -57,7 +62,8 @@
                             api/write-check
                             api/read-check)]
     (-> (api-perm-check-fn Table id)
-        (t2/hydrate :db :pk_field))))
+        (t2/hydrate :db :pk_field)
+        format-table-for-response)))
 
 (defn- update-table!*
   "Takes an existing table and the changes, updates in the database and optionally calls `table/update-field-positions!`
@@ -331,9 +337,8 @@
         (t2/hydrate :db [:fields [:target :has_field_values] :dimensions :has_field_values] :segments :metrics)
         (m/dissoc-in [:db :details])
         (assoc-dimension-options db)
+        format-table-for-response
         format-fields-for-response
-        ;; for `nil` schemas return the empty string
-        (update :schema #(if (nil? %) "" %))
         (update :fields (partial filter (fn [{visibility-type :visibility_type}]
                                           (case (keyword visibility-type)
                                             :hidden    include-hidden-fields?


### PR DESCRIPTION
Same as https://github.com/metabase/metabase/blob/0a15637f1398fb3e9f9f31e55fb027a21e2d2f88/src/metabase/api/database.clj#L1151

Some endpoints return `nil` schema while others return an empty string. This causes issues on the FE and we'd like to make things consistent in the REST API.