### PR TITLE
make qp.middleware.cache-test/min-ttl-test pass consistently

### DIFF
--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -248,11 +248,10 @@
       (mt/wait-for-result save-chan)
       (is (= :cached (run-query))))))
 
-#_
 (deftest min-ttl-test
   (testing "if the cache takes less than the min TTL to execute, it shouldn't be cached"
     (with-mock-cache [save-chan]
-      (mt/with-temporary-setting-values [query-caching-min-ttl 60]
+      (mt/with-temporary-setting-values [query-caching-min-ttl 1000]
         (run-query)
         (is (= :metabase.test.util.async/timed-out
                (mt/wait-for-result save-chan)))
@@ -262,11 +261,10 @@
   (testing "...but if it takes *longer* than the min TTL, it should be cached"
     (with-mock-cache [save-chan]
       (mt/with-temporary-setting-values [query-caching-min-ttl 0.1]
-        (binding [*query-execution-delay-ms* 120]
-          (run-query)
-          (mt/wait-for-result save-chan)
-          (is (= :cached
-                 (run-query))))))))
+        (run-query)
+        (mt/wait-for-result save-chan)
+        (is (= :cached
+               (run-query)))))))
 
 (deftest invalid-cache-entry-test
   (testing "We should handle invalid cache entries gracefully"


### PR DESCRIPTION
Undoing #40963 plus in theory test should be more reliable now. 

Default settings for `run-query` (with delay of 10 ms) make it run for 13-14 ms locally, but I imagine it could be significantly worse than that on a busy CI server. So getting this time up to 1000 ms should make this much more reliable.

On the contrary, there is no need to slow down query to 120 ms if a lower margin is 0.1 ms, default settings should be plently slow to trigger caching.