### PR TITLE
Log sync errors in CI to debug redshift flakes

### DIFF
--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -10,6 +10,7 @@
     <Logger name="metabase-enterprise" level="FATAL"/>
     <Logger name="liquibase" level="FATAL"/>
     <Logger name="metabase.test.data.interface" level="INFO"/>
+    <Logger name="metabase.test.data.impl.get-or-create" level="ERROR"/>
 
     <Root level="FATAL">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
This adds error level logging to `metabase.test.data.impl.get-or-create` to get stack traces for redshift sync flakes in CI. This will only log during testing. 