### PR TITLE
cache invalidation via removal of query_cache entries

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -84,6 +84,7 @@
   (clojure-indent-style . always-align)
   (cljr-favor-prefix-notation . nil)
   (cljr-insert-newline-after-require . t)
+  (cljr-print-right-margin . 118)
   (clojure-docstring-fill-column . 118)
   (cider-preferred-build-tool . clojure-cli)
   (cider-default-cljs-repl . shadow-select)

--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -1,6 +1,7 @@
 (ns metabase-enterprise.cache.cache-test
   (:require
    [clojure.test :refer :all]
+   [java-time.api :as t]
    [metabase.public-settings :as public-settings]
    [metabase.query-processor.card :as qp.card]
    [metabase.test :as mt]
@@ -111,3 +112,83 @@
                                          :model_id 0
                                          :strategy {:type     "schedule"
                                                     :schedule "0/2 * * * * ?"}})))))))))
+
+
+(deftest invalidation-test
+  (mt/discard-setting-changes [enable-query-caching]
+    (public-settings/enable-query-caching! true)
+    (mt/with-model-cleanup [:model/CacheConfig
+                            [:model/QueryCache :updated_at]]
+      (mt/with-premium-features #{:cache-granular-controls :audit-app}
+        (mt/with-temp [:model/Dashboard     dash {}
+                       :model/Card          card {:database_id   (mt/id)
+                                                  :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
+                                                                                        :limit    5})}
+                       :model/Card          card2 {:database_id   (mt/id)
+                                                   :dataset_query (mt/mbql-query venues {:order-by [[:asc $id]]
+                                                                                         :limit    5})}
+                       :model/DashboardCard _    {:dashboard_id (:id dash)
+                                                  :card_id      (:id card)}
+                       :model/CacheConfig   _    {:model          "database"
+                                                  :model_id       (mt/id)
+                                                  :strategy       "schedule"
+                                                  :config         {:schedule "0 * * * * ?"}
+                                                  :invalidated_at (t/offset-date-time)}
+                       :model/CacheConfig _      {:model          "dashboard"
+                                                  :model_id       (:id dash)
+                                                  :strategy       "schedule"
+                                                  :config         {:schedule "0 * * * * ?"}
+                                                  :invalidated_at (t/offset-date-time)}]
+
+          (is (=? {:data [{:model "database" :model_id (mt/id)}]}
+                  (mt/user-http-request :crowberto :get 200 "cache/"
+                                        :model "database")))
+
+          (testing "making a query will cache it"
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
+            (is (=? {:cached true :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
+            (is (=? {:cached true :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card2))))))
+
+          (testing "invalidation drops cache for every card with the same query"
+            (is (=? {:count 1}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :question (:id card2) :include :overrides)))
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
+            (is (=? {:count 1}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :question (:id card2) :include :overrides)))
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card2))))))
+
+          (testing "but invalidating a whole config drops cache for all affected cards"
+            (is (=? {:count 1}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :database (mt/id))))
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card)))))
+            ;; we need to drop it again so that new cache is not being used
+            (is (=? {:count 1}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :database (mt/id))))
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card2))))))
+
+          (testing "when invalidating database config with no overrides, dashboard-related queries will still have it"
+            (is (=? {:count 1}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :database (mt/id))))
+            (is (=? {:cached true :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card))
+                                          {:dashboard_id (:id dash)}))))
+
+          (testing "but with overrides - will go through every card and mark cache invalidated"
+            (is (=? {:count 1}
+                    (mt/user-http-request :crowberto :post 200 "cache/invalidate"
+                                          :include :overrides :database (mt/id))))
+            (is (=? {:cached false :data some?}
+                    (mt/user-http-request :crowberto :post 202 (format "card/%d/query" (:id card))
+                                          {:dashboard_id (:id dash)})))))))))

--- a/src/metabase/api/cache.clj
+++ b/src/metabase/api/cache.clj
@@ -196,7 +196,8 @@
         {:status 400
          :body   {:message (tru "You have to provide correct database, dashboard or question ids to invalidate cache.")}}
 
-        (let [cnt (cache.i/purge-old-entries! cache/*backend* :hash hashes)]
+        (let [cnt (apply + (for [part (partition-all 1000 hashes)]
+                             (cache.i/purge-old-entries! cache/*backend* :hash part)))]
           {:message (tru "Invalidated {0} cache entries." cnt)
            :count   cnt})))))
 

--- a/src/metabase/models.clj
+++ b/src/metabase/models.clj
@@ -107,6 +107,7 @@
  [bookmark DashboardBookmark]
  [bookmark CollectionBookmark]
  [bookmark BookmarkOrdering]
+ [cache-config CacheConfig]
  [card Card]
  [collection Collection]
  [c-perm-revision CollectionPermissionGraphRevision]

--- a/src/metabase/models/cache_config.clj
+++ b/src/metabase/models/cache_config.clj
@@ -5,6 +5,8 @@
    [methodical.core :as methodical]
    [toucan2.core :as t2]))
 
+(def CacheConfig "Cache configuration" :model/CacheConfig)
+
 (doto :model/CacheConfig
   (derive :metabase/model)
   (derive :hook/timestamped?))

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -47,7 +47,7 @@
 (defn- purge! [backend]
   (try
     (log/tracef "Purging cache entries older than %s" (u/format-seconds (public-settings/query-caching-max-ttl)))
-    (i/purge-old-entries! backend (public-settings/query-caching-max-ttl))
+    (i/purge-old-entries! backend :max-age-seconds (public-settings/query-caching-max-ttl))
     (log/trace "Successfully purged old cache entries.")
     :done
     (catch Throwable e

--- a/src/metabase/query_processor/middleware/cache_backend/db.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/db.clj
@@ -1,6 +1,5 @@
 (ns metabase.query-processor.middleware.cache-backend.db
   (:require
-   [clojure.math :as math]
    [java-time.api :as t]
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
@@ -18,11 +17,8 @@
 
 (set! *warn-on-reflection* true)
 
-(defn- seconds-ago [n]
-  (let [[unit n] (if-not (integer? n)
-                   [:millisecond (long (* 1000 n))]
-                   [:second n])]
-    (u.date/add (t/offset-date-time) unit (- n))))
+(defn- ms-ago [n]
+  (u.date/add (t/offset-date-time) :millisecond (- n)))
 
 (def ^:private ^{:arglists '([])} cached-results-query-sql
   ;; this is memoized for a given application DB so we can deliver cached results EXTRA FAST and not have to spend an
@@ -64,10 +60,9 @@
   ^PreparedStatement [strategy query-hash ^Connection conn]
   (if-not (:avg-execution-ms strategy)
     (log/debugf "Caching strategy %s needs :avg-execution-ms to work" (pr-str strategy))
-    (let [max-age-seconds (math/round (/ (* (:multiplier strategy)
-                                            (:avg-execution-ms strategy))
-                                         1000.0))]
-      (prepare-statement conn query-hash (seconds-ago max-age-seconds)))))
+    (let [max-age-ms (* (:multiplier strategy)
+                        (:avg-execution-ms strategy))]
+      (prepare-statement conn query-hash (ms-ago max-age-ms)))))
 
 (defenterprise fetch-cache-stmt
   "Returns prepared statement for a given strategy and query hash - on EE. Returns `::oss` on OSS."
@@ -92,15 +87,16 @@
 
 (defn- purge-old-cache-entries!
   "Delete any cache entries that are older than the global max age `max-cache-entry-age-seconds` (currently 3 months)."
-  [max-age-seconds]
-  {:pre [(number? max-age-seconds)]}
-  (log/tracef "Purging old cache entries.")
+  [criteria value]
+  (log/tracef "Purging cache entries.")
   (try
-    (t2/delete! (t2/table-name QueryCache)
-                :updated_at [:<= (seconds-ago max-age-seconds)])
+    (case criteria
+      :max-age-seconds (t2/delete! (t2/table-name QueryCache)
+                                   :updated_at [:<= (ms-ago (long (* value 1000)))])
+      :hash            (t2/delete! (t2/table-name QueryCache)
+                                   :query_hash [:in value]))
     (catch Throwable e
-      (log/error e "Error purging old cache entries")))
-  nil)
+      (log/error e "Error purging old cache entries"))))
 
 (defn- save-results!
   "Save the `results` of query with `query-hash`, updating an existing QueryCache entry if one already exists, otherwise
@@ -129,5 +125,5 @@
       (save-results! query-hash is)
       nil)
 
-    (purge-old-entries! [_ max-age-seconds]
-      (purge-old-cache-entries! max-age-seconds))))
+    (purge-old-entries! [_ criteria value]
+      (purge-old-cache-entries! criteria value))))

--- a/src/metabase/query_processor/middleware/cache_backend/interface.clj
+++ b/src/metabase/query_processor/middleware/cache_backend/interface.clj
@@ -28,9 +28,11 @@
     "Add a cache entry with the `results` of running query with byte array `query-hash`. This should replace any prior
   entries for `query-hash` and update the cache timestamp to the current system time.")
 
-  (purge-old-entries! [this max-age-seconds]
-    "Purge all cache entries older than `max-age-seconds`. Will be called periodically when this backend is in use.
-  `max-age-seconds` may be floating-point."))
+  (purge-old-entries! [this criteria value]
+    "Purge cache entries based on `criteria` and `value`. Valid criterias are:
+  - `:max-age-seconds` - purges all entries older than `value` seconds. Will be called periodically when this backend
+    is in use.
+  - `:hash` - purges all entries with `query-hash` in `value` vector."))
 
 (defmacro with-cached-results
   "Macro version for consuming `cached-results` from a `backend`.

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -80,10 +80,11 @@
           (log/tracef "Save results for %s --> store: %s" hex-hash (pretty/pretty this)))
         (a/>!! save-chan results))
 
-      (purge-old-entries! [this max-age-seconds]
+      (purge-old-entries! [this criteria value]
+        (assert (= criteria :max-age-seconds))
         (swap! store (fn [store]
                        (into {} (filter (fn [[_ {:keys [created]}]]
-                                          (t/after? created (t/minus (t/instant) (t/seconds max-age-seconds))))
+                                          (t/after? created (t/minus (t/instant) (t/seconds value))))
                                         store))))
         (log/tracef "Purge old entries --> store: %s" (pretty/pretty this))
         (a/>!! purge-chan ::purge)))))


### PR DESCRIPTION
New endpoint accepts entity and entity ids in form of `database=1&dashboard=2&question=3`. If you don't supply `&include=overrides`, then it tries to find configs directly referencing supplied entities and updates their `invalidated_at`. If you supply `&include=overrides`, removes `query_cache` entries for all referenced cards.

EE-only.

A variant of #40774 

resolves #40548
