### PR TITLE
docs - mention of raw unformatted results

### DIFF
--- a/docs/questions/sharing/exporting-results.md
+++ b/docs/questions/sharing/exporting-results.md
@@ -29,7 +29,7 @@ Metabase will export the raw results of a question without applying any of the [
 
 ## Exporting data via a public link
 
-You can also create a [public link](../sharing/public-links.md) that people can use to download data in a specific format.
+You can also create a [public link](../sharing/public-links.md#public-link-to-export-question-results-in-csv-xlsx-json) that people can use to download data in a specific format, as well as [raw, unformatted question results](public-links.md#exporting-unformatted-question-results).
 
 ## Exporting question data via alerts
 

--- a/docs/questions/sharing/exporting-results.md
+++ b/docs/questions/sharing/exporting-results.md
@@ -29,7 +29,7 @@ Metabase will export the raw results of a question without applying any of the [
 
 ## Exporting data via a public link
 
-You can also create a [public link](../sharing/public-links.md#public-link-to-export-question-results-in-csv-xlsx-json) that people can use to download data in a specific format, as well as [raw, unformatted question results](public-links.md#exporting-unformatted-question-results).
+You can also create a [public link](../sharing/public-links.md#public-link-to-export-question-results-in-csv-xlsx-json) that people can use to download data in a specific format, as well as [raw, unformatted question results](public-links.md#exporting-raw-unformatted-question-results).
 
 ## Exporting question data via alerts
 

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -47,6 +47,16 @@ To create a public link that people can use to download the results of a questio
 
 ![Public export](../images/public-export.png)
 
+### Exporting unformatted question results
+
+By default, Metabase will export the results of a question that include any formatting you added (for example, if you formatted a column with floats to display as a percentage (o.42 -> 42%)). To export the raw, unformatted rows, you'll need to append `?format_rows=false` to the URL. For example, if you create a public link for a CSV download, the URL would look like:
+
+```html
+https://www.example.com/public/question/cf347ce0-90bb-4669-b73b-56c73edd10cb.csv?format_rows=false
+```
+
+See docs for the [export format endpoint](https://www.metabase.com/docs/latest/api/public#get-apipubliccarduuidqueryexport-format).
+
 ## Simulating drill-through with public links
 
 Metabase's automatic [drill-through](https://www.metabase.com/learn/questions/drill-through) won't work on public dashboards because public links don't give people access to your raw data.

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -47,7 +47,7 @@ To create a public link that people can use to download the results of a questio
 
 ![Public export](../images/public-export.png)
 
-### Exporting unformatted question results
+### Exporting raw, unformatted question results
 
 To export the raw, unformatted rows, you'll need to append `?format_rows=false` to the URL Metabase generates. For example, if you create a public link for a CSV download, the URL would look like:
 

--- a/docs/questions/sharing/public-links.md
+++ b/docs/questions/sharing/public-links.md
@@ -49,11 +49,13 @@ To create a public link that people can use to download the results of a questio
 
 ### Exporting unformatted question results
 
-By default, Metabase will export the results of a question that include any formatting you added (for example, if you formatted a column with floats to display as a percentage (o.42 -> 42%)). To export the raw, unformatted rows, you'll need to append `?format_rows=false` to the URL. For example, if you create a public link for a CSV download, the URL would look like:
+To export the raw, unformatted rows, you'll need to append `?format_rows=false` to the URL Metabase generates. For example, if you create a public link for a CSV download, the URL would look like:
 
 ```html
 https://www.example.com/public/question/cf347ce0-90bb-4669-b73b-56c73edd10cb.csv?format_rows=false
 ```
+
+By default, Metabase will export the results of a question that include any formatting you added (for example, if you formatted a column with floats to display as a percentage (o.42 -> 42%)).
 
 See docs for the [export format endpoint](https://www.metabase.com/docs/latest/api/public#get-apipubliccarduuidqueryexport-format).
 


### PR DESCRIPTION
Clarifies how you can add `?format_rows=false` to public link export URL to download unformatted results.