### PR TITLE
[MBQL lib] `suggestedJoinConditions` accepts a join position for edits

### DIFF
--- a/src/metabase/lib/js.cljs
+++ b/src/metabase/lib/js.cljs
@@ -1344,11 +1344,16 @@
   Question, or another query. Suggested conditions will be returned if the existing query has a foreign key to the
   primary key of the `joinable`. (See #31175 for more info.)
 
+  When editing a join, the `position` (0-based index) of the join should be provided. Any columns introduced by that
+  join or later joins are treated as not available for join conditions.
+
   Returns `[]` if we cannot determine any \"obvious\" join conditions.
 
   > **Code health:** Healthy"
-  [a-query stage-number joinable]
-  (to-array (lib.core/suggested-join-conditions a-query stage-number joinable)))
+  ([a-query stage-number joinable]
+   (to-array (lib.core/suggested-join-conditions a-query stage-number joinable)))
+  ([a-query stage-number joinable position]
+   (to-array (lib.core/suggested-join-conditions a-query stage-number joinable position))))
 
 (defn ^:export join-fields
   "Get the fields list associated with `a-join`. That is, the set of fields from the *joinable* which are being joined

--- a/test/metabase/lib/join_test.cljc
+++ b/test/metabase/lib/join_test.cljc
@@ -1348,3 +1348,55 @@
   (testing "Include the names of joined tables in suggested query names (#24703)"
     (is (= "Venues + Categories"
            (lib/suggested-name lib.tu/query-with-join)))))
+
+(deftest ^:parallel suggested-join-conditions-with-position-test
+  (testing "when editing the _i_th join, columns from that and later joins should not be suggested"
+    ;; We want a case where the existing join contains an FK for the new RHS table, but the original table doesn't.
+    ;; Products + Orders works for this: Orders.USER_ID is an FK to People.ID, but Products has no such link.
+    (let [products->orders  (lib/join-clause (meta/table-metadata :orders)
+                                             [(lib/= (meta/field-metadata :products :id)
+                                                     (meta/field-metadata :orders :product-id))])
+          products->reviews (lib/join-clause (meta/table-metadata :reviews)
+                                             [(lib/= (meta/field-metadata :products :id)
+                                                     (meta/field-metadata :reviews :product-id))])]
+      (testing "Products + Orders"
+        (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :products))
+                        (lib/join products->orders))]
+          (testing "for a new join (no position), Orders.USER_ID is suggested for joining People"
+            (is (=? [[:= {}
+                      [:field {:join-alias "Orders"} (meta/id :orders :user-id)]
+                      [:field {}                     (meta/id :people :id)]]]
+                    (lib/suggested-join-conditions query -1 (meta/table-metadata :people)))))
+          (testing "but when editing that join, Orders.USER_ID is not visible and no condition is suggested"
+            (is (=? nil
+                    (lib/suggested-join-conditions query -1 (meta/table-metadata :people) 0))))))
+      (testing "Products + Reviews + Orders"
+        (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :products))
+                        (lib/join products->reviews)
+                        (lib/join products->orders))]
+          (testing "for a new join (no position), Orders.USER_ID is suggested for joining People"
+            (is (=? [[:= {}
+                      [:field {:join-alias "Orders"} (meta/id :orders :user-id)]
+                      [:field {}                     (meta/id :people :id)]]]
+                    (lib/suggested-join-conditions query -1 (meta/table-metadata :people)))))
+          (testing "but when editing *either* join, Orders.USER_ID is not visible and no condition is suggested"
+            (doseq [position [0 1]]
+              (is (=? nil
+                      (lib/suggested-join-conditions query -1 (meta/table-metadata :people) position)))))))
+      (testing "Products + Orders + Reviews"
+        (let [query (-> (lib/query meta/metadata-provider (meta/table-metadata :products))
+                        (lib/join products->orders)
+                        (lib/join products->reviews))]
+          (testing "for a new join (no position), Orders.USER_ID is suggested for joining People"
+            (is (=? [[:= {}
+                      [:field {:join-alias "Orders"} (meta/id :orders :user-id)]
+                      [:field {}                     (meta/id :people :id)]]]
+                    (lib/suggested-join-conditions query -1 (meta/table-metadata :people)))))
+          (testing "when editing the second join, the first join's keys are still available"
+            (is (=? [[:= {}
+                      [:field {:join-alias "Orders"} (meta/id :orders :user-id)]
+                      [:field {}                     (meta/id :people :id)]]]
+                    (lib/suggested-join-conditions query -1 (meta/table-metadata :people) 1))))
+          (testing "but when editing the first join, Orders.USER_ID is not visible and no condition is suggested"
+            (is (=? nil
+                    (lib/suggested-join-conditions query -1 (meta/table-metadata :people) 0)))))))))


### PR DESCRIPTION
This optional fourth argument will disregard all joins at `position` and
later when suggesting conditions. This is useful when editing a join's
RHS, which wipes out the condition. We don't want to generate a
suggested condition that's based on keys from the RHS of the join we
just edited, or from later joins.

Fixes #40916. Part of #40890.

