### PR TITLE
asynchronously load libraries for png and pdf exports

### DIFF
--- a/frontend/src/metabase/visualizations/lib/save-chart-image.ts
+++ b/frontend/src/metabase/visualizations/lib/save-chart-image.ts
@@ -1,5 +1,4 @@
 import { css } from "@emotion/react";
-import html2canvas from "html2canvas";
 
 export const SAVING_DOM_IMAGE_CLASS = "saving-dom-image";
 export const SAVING_DOM_IMAGE_HIDDEN_CLASS = "saving-dom-image-hidden";
@@ -22,6 +21,7 @@ export const saveChartImage = async (selector: string, fileName: string) => {
 
   node.classList.add(SAVING_DOM_IMAGE_CLASS);
 
+  const { default: html2canvas } = await import("html2canvas");
   const canvas = await html2canvas(node, {
     useCORS: true,
   });

--- a/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
+++ b/frontend/src/metabase/visualizations/lib/save-dashboard-pdf.ts
@@ -1,6 +1,3 @@
-import html2canvas from "html2canvas";
-import jspdf from "jspdf";
-
 import { color } from "metabase/lib/colors";
 
 import { SAVING_DOM_IMAGE_CLASS } from "./save-chart-image";
@@ -17,6 +14,7 @@ export const saveDashboardPdf = async (
     return;
   }
 
+  const { default: html2canvas } = await import("html2canvas");
   const image = await html2canvas(node, {
     useCORS: true,
     onclone: (doc: Document, node: HTMLElement) => {
@@ -35,6 +33,7 @@ export const saveDashboardPdf = async (
   const pdfWidth = imageWidth;
   const pdfHeight = imageHeight + 80;
 
+  const { default: jspdf } = await import("jspdf");
   const pdf = new jspdf({
     unit: "px",
     hotfixes: ["px_scaling"],


### PR DESCRIPTION
Epic https://github.com/metabase/metabase/issues/41032

### Description

Reduces the size of the vendor bundle by extracting heavy libraries used for pdf and png exports which should not block the initial app loading.

Before
<img width="319" alt="Screenshot 2024-04-04 at 11 19 37 AM" src="https://github.com/metabase/metabase/assets/14301985/32149389-b82b-4b32-a55b-2dceb3c0c9df">

After
<img width="322" alt="Screenshot 2024-04-04 at 11 13 33 AM" src="https://github.com/metabase/metabase/assets/14301985/16550f4a-0bd8-42f7-a3e4-0796c5fa683f">

### How to verify

- Ensure png and pdf exports are not broken
- Using webpack bundle analyzer you can confirm the `vendor` chunk size

### Demo

<video src="https://github.com/metabase/metabase/assets/14301985/bd19b9b3-2150-434c-a2a6-3348d5a1b8cf" />

