### PR TITLE
fix modal padding

### DIFF
--- a/frontend/src/metabase/admin/settings/components/ApiKeys/CreateApiKeyModal.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/CreateApiKeyModal.tsx
@@ -36,7 +36,6 @@ export const CreateApiKeyModal = ({ onClose }: { onClose: () => void }) => {
     return (
       <Modal
         size="30rem"
-        padding="xl"
         opened
         onClose={onClose}
         title={t`Create a new API Key`}

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -223,7 +223,7 @@ export const SaveQuestionModal = ({
             enableReinitialize
           >
             {({ values, setValues }) => (
-              <Modal.Content p="md" data-testid="save-question-modal">
+              <Modal.Content data-testid="save-question-modal">
                 <Modal.Header>
                   <Modal.Title>{title}</Modal.Title>
                   <Flex align="center" justify="flex-end" gap="sm">

--- a/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx
@@ -17,7 +17,7 @@ export const getModalOverrides = (): MantineThemeOverride["components"] => ({
       },
     }),
     defaultProps: {
-      p: DEFAULT_MODAL_SPACING,
+      padding: DEFAULT_MODAL_SPACING,
     },
   },
   ModalRoot: {
@@ -27,6 +27,7 @@ export const getModalOverrides = (): MantineThemeOverride["components"] => ({
       shadow: "md",
       radius: "sm",
       withinPortal: true,
+      padding: DEFAULT_MODAL_SPACING,
     },
   },
   ModalHeader: {

--- a/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Modal/Modal.styled.tsx
@@ -3,7 +3,7 @@ import { t } from "ttag";
 
 // See `zIndex` prop at https://v6.mantine.dev/core/modal/?t=props
 export const DEFAULT_MODAL_Z_INDEX = 200;
-const DEFAULT_MODAL_SPACING = "lg";
+const DEFAULT_MODAL_SPACING = "xl";
 
 export const getModalOverrides = (): MantineThemeOverride["components"] => ({
   Modal: {
@@ -16,6 +16,9 @@ export const getModalOverrides = (): MantineThemeOverride["components"] => ({
         backgroundColor: theme.fn.rgba(theme.fn.themeColor("bg-black"), 0.6),
       },
     }),
+    defaultProps: {
+      p: DEFAULT_MODAL_SPACING,
+    },
   },
   ModalRoot: {
     defaultProps: {
@@ -28,13 +31,7 @@ export const getModalOverrides = (): MantineThemeOverride["components"] => ({
   },
   ModalHeader: {
     defaultProps: {
-      p: DEFAULT_MODAL_SPACING,
       pb: "sm",
-    },
-  },
-  ModalBody: {
-    defaultProps: {
-      p: DEFAULT_MODAL_SPACING,
     },
   },
   ModalCloseButton: {


### PR DESCRIPTION
Attempt to fix https://github.com/metabase/metabase/issues/41042

# Context

We sometimes use `<Modal>` directly, and sometimes we use the "long version"  of using the subcomponents (Modal.Root, Modal.Content etc)

The <Modal> component renders a structure like (simplified):
```
<{Equivalent of Modal.Root}>
  <Modal.Content>
    <Modal.Header/>
    <Modal.Body>
      {children}
    </Modal.Body>
  </Modal.Content>
</{Equivalent of Modal.Root}>
```
We had some default props on Modal.Body and Modal.Header, which were overriding the `padding` prop passed to `<Modal>`.
At the same time in some places we were passing a custom padding to `Modal.Content`, this was being *added* to the default ones for `Modal.Header` and `Modal.Body`. -> it's possible in some modals we're using the wrong padding by mistake (eg: the SaveQuestionModal has currently a padding of 40, which is not even in our theme)

# Solution

The solution I came with was to set the default padding to both Modal and to Modal.Root, they will both correctly forward it to both `Modal.Header` and `Modal.Body`.
In this way we are able to just pass the padding we want to either Modal or Modal.Root and it should work.

⚠️ Note that we should pass it to `Modal.Root`, and not to `Modal.Content`, otherwise the padding will be added to the default padding

In this PR I'm just "fixing"  `CreateApiKeyModal` and `SaveQuestionModal`, if the solution gets approved I/we'll have to fix all instances and make sure we're using the correct padding.


# How to verify
We need to verify that:
- the default padding of 32 is set for both `Modal` and `Modal.Root`
- both `Modal` and `Modal.Root` allow setting a custom padding via `padding` (`p` has weird behaviours, I'd avoid it)

For `Modal` we can test `CreateApiKeyModal` and for `Modal.Root` we can use `SaveQuestionModal`
