### PR TITLE
[Metrics V2] Allow metrics to be saved with breakouts

### DIFF
--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -79,8 +79,7 @@
   [query card-type]
   (or (not= card-type :metric)
       (let [last-stage (lib.util/query-stage query -1)]
-        (and (empty? (:breakout last-stage))
-             (= (-> last-stage :aggregation count) 1)))))
+        (= (-> last-stage :aggregation count) 1))))
 
 (mu/defn can-save :- :boolean
   "Returns whether `query` for a card of `card-type` can be saved."

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -799,7 +799,7 @@
                            (assoc :type :metric))
           invalid-card (-> card-name
                            (card-with-name-and-query
-                            (-> query (lib/breakout (first (lib/breakoutable-columns query)))))
+                             (-> query (lib/aggregate (lib/sum (lib.metadata/field query (mt/id :venues :id))))))
                            (assoc :type :metric))]
       (mt/with-full-data-perms-for-all-users!
         (mt/with-model-cleanup [:model/Card]
@@ -814,13 +814,13 @@
                                       (merge
                                        (mt/with-temp-defaults :model/Card)
                                        updated-card)))
-              (testing "Update fails if there is a breakout"
+              (testing "Update fails if there are multiple aggregations"
                 (let [response (mt/user-http-request :rasta :put 400 (str "card/" card-id)
                                                      (merge
                                                       (mt/with-temp-defaults :model/Card)
                                                       invalid-card))]
                   (is (= "Card of type metric is invalid, cannot be saved." response))))))
-          (testing "Creation fails if there is a breakout"
+          (testing "Creation fails if there are multiple aggregations"
             (let [response (mt/user-http-request :rasta :post 400 "card"
                                                  (merge
                                                   (mt/with-temp-defaults :model/Card)

--- a/test/metabase/lib/query_test.cljc
+++ b/test/metabase/lib/query_test.cljc
@@ -201,4 +201,7 @@
                           (lib/aggregate (lib/count)))
       false :metric   (-> lib.tu/venues-query
                           (lib/aggregate (lib/count))
+                          (lib/aggregate (lib/sum (meta/field-metadata :venues :id))))
+      true  :metric   (-> lib.tu/venues-query
+                          (lib/aggregate (lib/count))
                           (lib/breakout (first (lib/breakoutable-columns lib.tu/venues-query)))))))


### PR DESCRIPTION
Fixes #41016
Fixes #41017 

A breakout on a metric will act as the default breakout when used by a consuming query.

This step allows saving the metric with a breakout.
