### PR TITLE
Quickfix heigth on row picker

### DIFF
--- a/frontend/src/metabase/common/components/FieldPicker/FieldPicker.styled.tsx
+++ b/frontend/src/metabase/common/components/FieldPicker/FieldPicker.styled.tsx
@@ -28,7 +28,6 @@ export const ItemList = styled.ul`
 
 export const ToggleItem = styled.li`
   border-bottom: 1px solid ${color("border")};
-  padding-bottom: 0.5em;
   margin-bottom: 0.5em;
 
   ${ItemTitle} {
@@ -43,12 +42,9 @@ export const Label = styled(HoverParent)`
   padding-right: 0;
   border-radius: 6px;
   cursor: pointer;
+  min-height: 2.25rem;
 
   &:hover {
     background: ${color("bg-medium")};
-  }
-
-  ${ToggleItem} & {
-    padding: 0.5em;
   }
 `;

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.tsx
@@ -29,7 +29,7 @@ function ConnectedTables({ table, onConnectedTableClick }: Props) {
       <LabelContainer color="text-dark">
         <Label>{t`Connected to these tables`}</Label>
       </LabelContainer>
-      {fkTables.map(fkTable => {
+      {fkTables.slice(0, 8).map(fkTable => {
         return onConnectedTableClick ? (
           <ConnectedTableButton
             key={fkTable.id}

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.unit.spec.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.unit.spec.tsx
@@ -72,4 +72,37 @@ describe("ConnectedTables", () => {
     expect(screen.getByText("Foo")).toBeInTheDocument();
     expect(screen.getByText("Bar")).toBeInTheDocument();
   });
+
+  it("should limit the number of connected tables to 8", () => {
+    const fks = new Array(20).fill(0).map((_, idx) =>
+      createMockForeignKey({
+        origin_id: idx,
+        origin: createMockField({
+          id: idx,
+          table_id: 21 + idx,
+          table: createMockTable({
+            id: 21 + idx,
+            display_name: `Bar-${idx + 1}`,
+          }),
+        }),
+      }),
+    );
+
+    setup({
+      table: {
+        ...TABLE_WITH_FKS,
+        fks,
+      },
+    });
+
+    expect(screen.getByText("Bar-1")).toBeInTheDocument();
+    expect(screen.getByText("Bar-2")).toBeInTheDocument();
+    expect(screen.getByText("Bar-3")).toBeInTheDocument();
+    expect(screen.getByText("Bar-4")).toBeInTheDocument();
+    expect(screen.getByText("Bar-5")).toBeInTheDocument();
+    expect(screen.getByText("Bar-6")).toBeInTheDocument();
+    expect(screen.getByText("Bar-7")).toBeInTheDocument();
+    expect(screen.getByText("Bar-8")).toBeInTheDocument();
+    expect(screen.queryByText("Bar-9")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.unit.spec.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.unit.spec.tsx
@@ -74,7 +74,7 @@ describe("ConnectedTables", () => {
   });
 
   it("should limit the number of connected tables to 8", () => {
-    const fks = Array.from({length: 20}).map((_, idx) =>
+    const fks = Array.from({ length: 20 }).map((_, idx) =>
       createMockForeignKey({
         origin_id: idx,
         origin: createMockField({
@@ -95,14 +95,6 @@ describe("ConnectedTables", () => {
       },
     });
 
-    expect(screen.getByText("Bar-1")).toBeInTheDocument();
-    expect(screen.getByText("Bar-2")).toBeInTheDocument();
-    expect(screen.getByText("Bar-3")).toBeInTheDocument();
-    expect(screen.getByText("Bar-4")).toBeInTheDocument();
-    expect(screen.getByText("Bar-5")).toBeInTheDocument();
-    expect(screen.getByText("Bar-6")).toBeInTheDocument();
-    expect(screen.getByText("Bar-7")).toBeInTheDocument();
-    expect(screen.getByText("Bar-8")).toBeInTheDocument();
-    expect(screen.queryByText("Bar-9")).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Bar-\d/)).toHaveLength(8);
   });
 });

--- a/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.unit.spec.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfo/ConnectedTables.unit.spec.tsx
@@ -74,7 +74,7 @@ describe("ConnectedTables", () => {
   });
 
   it("should limit the number of connected tables to 8", () => {
-    const fks = new Array(20).fill(0).map((_, idx) =>
+    const fks = Array.from({length: 20}).map((_, idx) =>
       createMockForeignKey({
         origin_id: idx,
         origin: createMockField({


### PR DESCRIPTION
This is part of https://github.com/metabase/metabase/issues/40863

- Fixes a bug where the height of the rows in the column picker was wrong when there is no info icon
- limits the number of connected tables shown to 8

### How to verify

- New Question -> Invoices
- Select the column picker dropdown
- Ensure that the rows are of the correct height


### Demo

<img width="338" alt="Screenshot 2024-04-04 at 18 09 48" src="https://github.com/metabase/metabase/assets/1250185/1735dc18-b539-42a7-9a11-d72043cfc620">
