### PR TITLE
Preserve notebook native preview user preferences

### DIFF
--- a/.clj-kondo/hooks/metabase/models/setting.clj
+++ b/.clj-kondo/hooks/metabase/models/setting.clj
@@ -92,7 +92,8 @@
      metabot-get-prompt-templates-url
      metabot-prompt-generator-token-limit
      multi-setting-read-only
-     notebook-native-preview-preferences
+     notebook-native-preview-shown
+     notebook-native-preview-sidebar-width
      notification-link-base-url
      num-metabot-choices
      openai-api-key

--- a/.clj-kondo/hooks/metabase/models/setting.clj
+++ b/.clj-kondo/hooks/metabase/models/setting.clj
@@ -92,6 +92,7 @@
      metabot-get-prompt-templates-url
      metabot-prompt-generator-token-limit
      multi-setting-read-only
+     notebook-native-preview-preferences
      notification-link-base-url
      num-metabot-choices
      openai-api-key

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -32,7 +32,7 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     cy.signInAsAdmin();
   });
 
-  it("should show empty sidebar when no data source is selcted", () => {
+  it("should show empty sidebar when no data source is selected", () => {
     cy.intercept("POST", "/api/dataset/native").as("nativeDataset");
     openReviewsTable({ mode: "notebook", limit: 1 });
     cy.findByLabelText("View the SQL").click();

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -2,7 +2,10 @@ import { onlyOn } from "@cypress/skip-test";
 
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { ORDERS_QUESTION_ID } from "e2e/support/cypress_sample_instance_data";
+import {
+  ORDERS_QUESTION_ID,
+  ORDERS_COUNT_QUESTION_ID,
+} from "e2e/support/cypress_sample_instance_data";
 import {
   restore,
   openReviewsTable,
@@ -175,6 +178,34 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
       expect(sidebarWidth).to.be.gt(initialSidebarWidth);
       expect(sidebarWidth).to.eq(maxSidebarWidth);
     });
+
+    cy.log("User preferences should be preserved across sessions");
+    cy.signOut();
+    cy.signInAsAdmin();
+    visitQuestion(ORDERS_COUNT_QUESTION_ID);
+    openNotebook();
+    cy.findByTestId("native-query-preview-sidebar")
+      .should("be.visible")
+      .then($sidebar => {
+        const sidebarWidth = $sidebar[0].getBoundingClientRect().width;
+        expect(sidebarWidth).to.eq(maxSidebarWidth);
+      });
+
+    cy.log("Preferences should not be shared across users");
+    cy.signOut();
+    cy.signInAsNormalUser();
+    visitQuestion(ORDERS_COUNT_QUESTION_ID);
+    openNotebook();
+    cy.findByTestId("native-query-preview-sidebar").should("not.exist");
+
+    cy.findByLabelText("View the SQL").click();
+
+    cy.findByTestId("native-query-preview-sidebar")
+      .should("be.visible")
+      .then($sidebar => {
+        const sidebarWidth = $sidebar[0].getBoundingClientRect().width;
+        expect(sidebarWidth).to.eq(minSidebarWidth);
+      });
   });
 });
 

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -199,7 +199,6 @@ describe("scenarios > question > notebook > native query preview sidebar", () =>
     cy.findByTestId("native-query-preview-sidebar").should("not.exist");
 
     cy.findByLabelText("View the SQL").click();
-
     cy.findByTestId("native-query-preview-sidebar")
       .should("be.visible")
       .then($sidebar => {
@@ -433,7 +432,7 @@ type ResizeSidebarCallback = (
   sidebarWidth: number,
 ) => void;
 
-function resizeSidebar(amount: number, cb: ResizeSidebarCallback) {
+function resizeSidebar(amountX: number, cb: ResizeSidebarCallback) {
   cy.intercept("PUT", "/api/setting/notebook-native-preview-sidebar-width").as(
     "updateSidebarWidth",
   );
@@ -450,7 +449,7 @@ function resizeSidebar(amount: number, cb: ResizeSidebarCallback) {
 
     cy.findByTestId("notebook-native-preview-resize-handle")
       .realMouseDown(options)
-      .realMouseMove(amount, 0, options)
+      .realMouseMove(amountX, 0, options)
       .realMouseUp(options);
 
     cy.wait(["@updateSidebarWidth", "@sessionProperties"]);

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -231,9 +231,7 @@ export const createMockSettings = (
   "embedding-homepage": "hidden",
   "setup-embedding-autoenabled": false,
   "setup-license-active-at-setup": false,
-  "notebook-native-preview-preferences": {
-    sidebar_shown: false,
-    sidebar_width: null,
-  },
+  "notebook-native-preview-shown": false,
+  "notebook-native-preview-sidebar-width": null,
   ...opts,
 });

--- a/frontend/src/metabase-types/api/mocks/settings.ts
+++ b/frontend/src/metabase-types/api/mocks/settings.ts
@@ -231,5 +231,9 @@ export const createMockSettings = (
   "embedding-homepage": "hidden",
   "setup-embedding-autoenabled": false,
   "setup-license-active-at-setup": false,
+  "notebook-native-preview-preferences": {
+    sidebar_shown: false,
+    sidebar_width: null,
+  },
   ...opts,
 });

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -307,6 +307,10 @@ export interface UserSettings {
   "dismissed-browse-models-banner"?: boolean;
   "dismissed-custom-dashboard-toast"?: boolean;
   "last-used-native-database-id"?: number | null;
+  "notebook-native-preview-preferences": {
+    sidebar_shown: boolean;
+    sidebar_width: number | null;
+  };
 }
 
 export type Settings = InstanceSettings &

--- a/frontend/src/metabase-types/api/settings.ts
+++ b/frontend/src/metabase-types/api/settings.ts
@@ -307,10 +307,8 @@ export interface UserSettings {
   "dismissed-browse-models-banner"?: boolean;
   "dismissed-custom-dashboard-toast"?: boolean;
   "last-used-native-database-id"?: number | null;
-  "notebook-native-preview-preferences": {
-    sidebar_shown: boolean;
-    sidebar_width: number | null;
-  };
+  "notebook-native-preview-shown"?: boolean;
+  "notebook-native-preview-sidebar-width"?: number | null;
 }
 
 export type Settings = InstanceSettings &

--- a/frontend/src/metabase-types/store/mocks/qb.ts
+++ b/frontend/src/metabase-types/store/mocks/qb.ts
@@ -25,6 +25,8 @@ export const createMockQueryBuilderUIControlsState = (
   previousQueryBuilderMode: false,
   snippetCollectionId: null,
   datasetEditorTab: "query",
+  isShowingNotebookNativePreview: false,
+  notebookNativePreviewSidebarWidth: null,
   ...opts,
 });
 

--- a/frontend/src/metabase-types/store/qb.ts
+++ b/frontend/src/metabase-types/store/qb.ts
@@ -34,6 +34,8 @@ export interface QueryBuilderUIControls {
   previousQueryBuilderMode: boolean;
   snippetCollectionId: number | null;
   datasetEditorTab: DatasetEditorTab;
+  isShowingNotebookNativePreview: boolean;
+  notebookNativePreviewSidebarWidth: number | null;
 }
 
 export interface QueryBuilderLoadingControls {

--- a/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
+++ b/frontend/src/metabase/query_builder/actions/core/initializeQB.ts
@@ -8,7 +8,11 @@ import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { deserializeCardFromUrl, loadCard } from "metabase/lib/card";
 import { isNotNull } from "metabase/lib/types";
 import * as Urls from "metabase/lib/urls";
-import { getIsEditingInDashboard } from "metabase/query_builder/selectors";
+import {
+  getIsEditingInDashboard,
+  getIsNotebookNativePreviewShown,
+  getNotebookNativePreviewSidebarWidth,
+} from "metabase/query_builder/selectors";
 import { loadMetadataForCard } from "metabase/questions/actions";
 import { setErrorPage } from "metabase/redux/app";
 import { getMetadata } from "metabase/selectors/metadata";
@@ -362,6 +366,12 @@ async function handleQBInit(
   });
 
   const objectId = params?.objectId || queryParams?.objectId;
+
+  uiControls.isShowingNotebookNativePreview = getIsNotebookNativePreviewShown(
+    getState(),
+  );
+  uiControls.notebookNativePreviewSidebarWidth =
+    getNotebookNativePreviewSidebarWidth(getState());
 
   dispatch({
     type: INITIALIZE_QB,

--- a/frontend/src/metabase/query_builder/actions/ui.js
+++ b/frontend/src/metabase/query_builder/actions/ui.js
@@ -2,6 +2,7 @@ import { createAction } from "redux-actions";
 
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { createThunkAction } from "metabase/lib/redux";
+import { updateUserSetting } from "metabase/redux/settings";
 import { UserApi } from "metabase/services";
 
 import { updateUrl } from "./navigation";
@@ -77,3 +78,21 @@ export const navigateBackToDashboard = createAction(NAVIGATE_BACK_TO_DASHBOARD);
 
 export const CLOSE_QB = "metabase/qb/CLOSE_QB";
 export const closeQB = createAction(CLOSE_QB);
+
+/**
+ * @param {boolean} isShown
+ */
+export const setNotebookNativePreviewState = isShown =>
+  updateUserSetting({
+    key: "notebook-native-preview-shown",
+    value: isShown,
+  });
+
+/**
+ * @param {number} width
+ */
+export const setNotebookNativePreviewSidebarWidth = width =>
+  updateUserSetting({
+    key: "notebook-native-preview-sidebar-width",
+    value: width,
+  });

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -67,8 +67,8 @@ export const NotebookContainer = ({
   const Handle = forwardRef<HTMLDivElement, Partial<ResizableBoxProps>>(
     function Handle(props, ref) {
       const handleWidth = 6;
-      // 0.5 accounts for the border width of 1px
-      const left = rem(-(handleWidth / 2 + 0.5));
+      const borderWidth = 1;
+      const left = rem(-((handleWidth + borderWidth) / 2));
 
       return (
         <Box

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -6,7 +6,10 @@ import { useWindowSize } from "react-use";
 
 import { color, darken } from "metabase/lib/colors";
 import { useSelector, useDispatch } from "metabase/lib/redux";
-import { setUIControls } from "metabase/query_builder/actions";
+import {
+  setNotebookNativePreviewSidebarWidth,
+  setUIControls,
+} from "metabase/query_builder/actions";
 import Notebook from "metabase/query_builder/components/notebook/Notebook";
 import { NativeQueryPreviewSidebar } from "metabase/query_builder/components/view/NativeQueryPreviewSidebar";
 import { getUiControls } from "metabase/query_builder/selectors";
@@ -52,9 +55,10 @@ export const NotebookContainer = ({
     _event: SyntheticEvent,
     data: ResizeCallbackData,
   ) => {
-    dispatch(
-      setUIControls({ notebookNativePreviewSidebarWidth: data.size.width }),
-    );
+    const { width } = data.size;
+
+    dispatch(setUIControls({ notebookNativePreviewSidebarWidth: width }));
+    dispatch(setNotebookNativePreviewSidebarWidth(width));
   };
 
   const transformStyle = isOpen ? "translateY(0)" : "translateY(-100%)";

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -31,7 +31,7 @@ export const NotebookContainer = ({
     isOpen && setShouldShowNotebook(isOpen);
   }, [isOpen]);
 
-  const { isNativePreviewSidebarOpen, nativePreviewSidebarWidth } =
+  const { isShowingNotebookNativePreview, nativePreviewSidebarWidth } =
     useSelector(getUiControls);
 
   const minNotebookWidth = 640;
@@ -108,13 +108,13 @@ export const NotebookContainer = ({
         </Box>
       )}
 
-      {isNativePreviewSidebarOpen && windowWidth < 1280 && (
+      {isShowingNotebookNativePreview && windowWidth < 1280 && (
         <Box pos="absolute" inset={0}>
           <NativeQueryPreviewSidebar />
         </Box>
       )}
 
-      {isNativePreviewSidebarOpen && windowWidth >= 1280 && (
+      {isShowingNotebookNativePreview && windowWidth >= 1280 && (
         <ResizableBox
           width={sidebarWidth}
           minConstraints={[minSidebarWidth, 0]}

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -71,6 +71,7 @@ export const NotebookContainer = ({
 
       return (
         <Box
+          data-testid="notebook-native-preview-resize-handle"
           ref={ref}
           {...props}
           pos="absolute"

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -31,13 +31,13 @@ export const NotebookContainer = ({
     isOpen && setShouldShowNotebook(isOpen);
   }, [isOpen]);
 
-  const { isShowingNotebookNativePreview, nativePreviewSidebarWidth } =
+  const { isShowingNotebookNativePreview, notebookNativePreviewSidebarWidth } =
     useSelector(getUiControls);
 
   const minNotebookWidth = 640;
   const minSidebarWidth = 428;
   const maxSidebarWidth = windowWidth - minNotebookWidth;
-  const sidebarWidth = nativePreviewSidebarWidth || minSidebarWidth;
+  const sidebarWidth = notebookNativePreviewSidebarWidth || minSidebarWidth;
 
   const handleTransitionEnd: TransitionEventHandler<HTMLDivElement> = (
     event,
@@ -52,7 +52,9 @@ export const NotebookContainer = ({
     _event: SyntheticEvent,
     data: ResizeCallbackData,
   ) => {
-    dispatch(setUIControls({ nativePreviewSidebarWidth: data.size.width }));
+    dispatch(
+      setUIControls({ notebookNativePreviewSidebarWidth: data.size.width }),
+    );
   };
 
   const transformStyle = isOpen ? "translateY(0)" : "translateY(-100%)";

--- a/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NotebookContainer/NotebookContainer.tsx
@@ -41,6 +41,7 @@ export const NotebookContainer = ({
   const minSidebarWidth = 428;
   const maxSidebarWidth = windowWidth - minNotebookWidth;
   const sidebarWidth = notebookNativePreviewSidebarWidth || minSidebarWidth;
+  const windowBreakpoint = 1280;
 
   const handleTransitionEnd: TransitionEventHandler<HTMLDivElement> = (
     event,
@@ -115,13 +116,13 @@ export const NotebookContainer = ({
         </Box>
       )}
 
-      {isShowingNotebookNativePreview && windowWidth < 1280 && (
+      {isShowingNotebookNativePreview && windowWidth < windowBreakpoint && (
         <Box pos="absolute" inset={0}>
           <NativeQueryPreviewSidebar />
         </Box>
       )}
 
-      {isShowingNotebookNativePreview && windowWidth >= 1280 && (
+      {isShowingNotebookNativePreview && windowWidth >= windowBreakpoint && (
         <ResizableBox
           width={sidebarWidth}
           minConstraints={[minSidebarWidth, 0]}

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
@@ -31,28 +31,28 @@ export const ToggleNativeQueryPreview = ({
 }: ToggleNativeQueryPreviewProps): JSX.Element => {
   const dispatch = useDispatch();
   const {
-    isNativePreviewSidebarOpen,
-  }: { isNativePreviewSidebarOpen?: boolean } = useSelector(getUiControls);
+    isShowingNotebookNativePreview,
+  }: { isShowingNotebookNativePreview: boolean } = useSelector(getUiControls);
 
   const engineType = getEngineNativeType(question.database()?.engine);
-  const tooltip = isNativePreviewSidebarOpen
+  const tooltip = isShowingNotebookNativePreview
     ? BUTTON_TOOLTIP_CLOSE[engineType]
     : BUTTON_TOOLTIP[engineType];
 
   const handleClick = () => {
     dispatch(
       setUIControls({
-        isNativePreviewSidebarOpen: !isNativePreviewSidebarOpen,
+        isShowingNotebookNativePreview: !isShowingNotebookNativePreview,
       }),
     );
 
-    trackNotebookNativePreviewShown(question, !isNativePreviewSidebarOpen);
+    trackNotebookNativePreviewShown(question, !isShowingNotebookNativePreview);
   };
 
   return (
     <Tooltip label={tooltip} position="top">
       <SqlButton
-        isSelected={isNativePreviewSidebarOpen}
+        isSelected={isShowingNotebookNativePreview}
         onClick={handleClick}
         aria-label={tooltip}
       >

--- a/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
+++ b/frontend/src/metabase/query_builder/components/view/ViewHeader/components/ToggleNativeQueryPreview/ToggleNativeQueryPreview.tsx
@@ -2,7 +2,10 @@ import { t } from "ttag";
 
 import { getEngineNativeType } from "metabase/lib/engine";
 import { useDispatch, useSelector } from "metabase/lib/redux";
-import { setUIControls } from "metabase/query_builder/actions";
+import {
+  setNotebookNativePreviewState,
+  setUIControls,
+} from "metabase/query_builder/actions";
 import { getUiControls } from "metabase/query_builder/selectors";
 import { Icon, Tooltip } from "metabase/ui";
 import * as Lib from "metabase-lib";
@@ -45,6 +48,8 @@ export const ToggleNativeQueryPreview = ({
         isShowingNotebookNativePreview: !isShowingNotebookNativePreview,
       }),
     );
+
+    dispatch(setNotebookNativePreviewState(!isShowingNotebookNativePreview));
 
     trackNotebookNativePreviewShown(question, !isShowingNotebookNativePreview);
   };

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -1088,3 +1088,9 @@ export const getSubmittableQuestion = (state, question) => {
 
   return submittableQuestion;
 };
+
+export const getIsNotebookNativePreviewShown = state =>
+  getSetting(state, "notebook-native-preview-shown");
+
+export const getNotebookNativePreviewSidebarWidth = state =>
+  getSetting(state, "notebook-native-preview-sidebar-width");

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -482,7 +482,7 @@
   :default    false)
 
 (defsetting notebook-native-preview-sidebar-width
-  (deferred-tru "Last used sidebar width for the native query preview in the notebook.")
+  (deferred-tru "Last user set sidebar width for the native query preview in the notebook.")
   :user-local :only
   :visibility :authenticated
   :type       :integer

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -474,13 +474,19 @@
   :default    false
   :audit      :never)
 
-(defsetting notebook-native-preview-preferences
-  (deferred-tru "User preferences for the native query preview in the notebook.")
+(defsetting notebook-native-preview-shown
+  (deferred-tru "User preference for the state of the native query preview in the notebook.")
   :user-local :only
   :visibility :authenticated
-  :type       :json
-  :default    {:sidebar_shown false
-               :sidebar_width nil})
+  :type       :boolean
+  :default    false)
+
+(defsetting notebook-native-preview-sidebar-width
+  (deferred-tru "Last used sidebar width for the native query preview in the notebook.")
+  :user-local :only
+  :visibility :authenticated
+  :type       :integer
+  :default    nil)
 
 ;;; ## ------------------------------------------ AUDIT LOG ------------------------------------------
 

--- a/src/metabase/models/user.clj
+++ b/src/metabase/models/user.clj
@@ -474,6 +474,14 @@
   :default    false
   :audit      :never)
 
+(defsetting notebook-native-preview-preferences
+  (deferred-tru "User preferences for the native query preview in the notebook.")
+  :user-local :only
+  :visibility :authenticated
+  :type       :json
+  :default    {:sidebar_shown false
+               :sidebar_width nil})
+
 ;;; ## ------------------------------------------ AUDIT LOG ------------------------------------------
 
 (defmethod audit-log/model-details :model/User


### PR DESCRIPTION
## What does this PR accomplish?
This PR adds two new entries to the user-local backend settings. Their sole purpose is to store the user preferences when it comes to the notebook native (query) preview.
- `notebook-native-preview-shown` (remembers the state of the preview)
    - I used "shown" instead of "open" because we're already using this terminology in the related Snowplow analytics
- `notebook-native-preview-sidebar-width` (remembers the last user-set sidebar width)

Speaking about the semantics, this PR also renames the previous entries used for the Redux store (uiControls) from:
- `isNativePreviewSidebarOpen` -> `isShowingNotebookNativePreview`
- `nativePreviewSidebarWidth` -> `notebookNativePreviewSidebarWidth`


```[tasklist]
### Tasks
- [x] Add backend setting
- [x] Add frontend types
- [x] Add Redux `action`(s)
- [x] Update `NativeQueryPreviewSidebar.tsx`
- [x] Update `NotebookContainer.tsx`
- [x] Add tests
```

> [!Important]
> The internal decision has been made to keep using both Redux and BE settings in parallel until we migrate settings endpoints to RTK. We're treating Redux as a fallback in meantime.

Technically, we're reading the BE settings and updating the Redux store while initializing the query builder. This gives us the option to read the values from the Redux store anywhere in the app, while only having to (dispatch) update BE settings from the application.

### How to test?
Toggling the native preview sidebar and resizing it should now be preserved as a user-local backend setting. This means that you should be able to log out and log in again, and your previous preferences should be preserved.

Alternatively, run the supplied E2E test.