### PR TITLE
Simple sync exceptions

### DIFF
--- a/src/metabase/sync/util.clj
+++ b/src/metabase/sync/util.clj
@@ -192,7 +192,7 @@
          (do
            (log/warn e message)
            e)
-         (throw (ex-info (format "%s: %s" message (ex-message e)) {:f f} e)))))))
+         (throw e))))))
 
 (defmacro with-error-handling
   "Execute `body` in a way that catches and logs any Exceptions thrown, and returns `nil` if they do so. Pass a
@@ -464,7 +464,7 @@
                              (do
                                (log/warn e (format "Error running step ''%s'' for %s" step-name (name-for-logging database)))
                                {:throwable e})
-                             (throw (ex-info (format "Error in sync step %s: %s" step-name (ex-message e)) {} e)))))))
+                             (throw e))))))
         end-time   (t/zoned-date-time)]
     [step-name (assoc results
                       :start-time start-time

--- a/test/metabase/test/data/impl/get_or_create.clj
+++ b/test/metabase/test/data/impl/get_or_create.clj
@@ -156,10 +156,7 @@
     (catch Throwable e
       (log/errorf e "create-database! failed; destroying %s database %s" driver (pr-str database-name))
       (tx/destroy-db! driver database-definition)
-      (throw (ex-info (format "Failed to create %s '%s' test database: %s" driver database-name (ex-message e))
-                      {:driver        driver
-                       :database-name database-name}
-                      e)))))
+      (throw e))))
 
 (defn- create-database-with-bound-settings! [driver dbdef]
   (letfn [(thunk []


### PR DESCRIPTION
Sync has over-engineered exception handling when we run tests that just makes the error messages worse and harder to find what the root cause is.

It chops off the most useful part of the stack trace and adds more layers of ExceptionInfo than we need to diagnose issues. Hand-crafted error messages are nice but long stack traces are better.

This PR removes most of the unnecessary layers of `ex-info`, while leaving the most important one that contains the connection info. This doesn't affect production, since these changes only affect the branches of the code where `*log-exceptions-and-continue?*` is false, which is only the case in tests.

Before: 
```
                clojure.lang.ExceptionInfo: Failed to create :redshift 'bird-flocks' test database: Failed to sync test database "bird-flocks": Error in sync step Sync redshift Database 483 ''bird-flocks'': Error in sync step Sync metadata for redshift Database 483 ''bird-flocks'': ERROR: relation "2024_03_21_3326bb73_b456_4070_8107_2c148dfc311c_schema.pvwhotmytavqnqdumsvp" does not exist
    database-name: "bird-flocks"
           driver: :redshift
                clojure.lang.ExceptionInfo: Failed to sync test database "bird-flocks": Error in sync step Sync redshift Database 483 ''bird-flocks'': Error in sync step Sync metadata for redshift Database 483 ''bird-flocks'': ERROR: relation "2024_03_21_3326bb73_b456_4070_8107_2c148dfc311c_schema.pvwhotmytavqnqdumsvp" does not exist
    connection-details: {:host "***",
                         :port 5439,
                         :db "testdb",
                         :user "metabase_ci",
                         :password "***",
                         :schema-filters-type "inclusion",
                         :schema-filters-patterns "spectrum,2024_03_21_44ff71dc_9bf0_4546_9f27_ba81017f999a_schema"}
         database-name: "bird-flocks"
                driver: :redshift
                clojure.lang.ExceptionInfo: Error in sync step Sync redshift Database 483 ''bird-flocks'': Error in sync step Sync metadata for redshift Database 483 ''bird-flocks'': ERROR: relation "2024_03_21_3326bb73_b456_4070_8107_2c148dfc311c_schema.pvwhotmytavqnqdumsvp" does not exist
    f: #object[metabase.sync$fn__111172$_AMPERSAND_f__111174$fn__111176 0x5deaf34c "metabase.sync$fn__111172$_AMPERSAND_f__111174$fn__111176@5deaf34c"]
                clojure.lang.ExceptionInfo: Error in sync step Sync metadata for redshift Database 483 ''bird-flocks'': ERROR: relation "2024_03_21_3326bb73_b456_4070_8107_2c148dfc311c_schema.pvwhotmytavqnqdumsvp" does not exist
    f: #object[metabase.sync.sync_metadata$fn__111154$_AMPERSAND_f__111155$fn__111156 0x3cf1a958 "metabase.sync.sync_metadata$fn__111154$_AMPERSAND_f__111155$fn__111156@3cf1a958"]
com.amazon.redshift.util.RedshiftException: ERROR: relation "2024_03_21_3326bb73_b456_4070_8107_2c148dfc311c_schema.pvwhotmytavqnqdumsvp" does not exist
              SQLState: "42P01"
             errorCode: 0
    serverErrorMessage: #object[com.amazon.redshift.util.ServerErrorMessage 0x6b391c1f "ERROR: relation \"2024_03_21_3326bb73_b456_4070_8107_2c148dfc311c_schema.pvwhotmytavqnqdumsvp\" does not exist"]
  com.amazon.redshift.core.v3.QueryExecutorImpl.receiveErrorResponse  QueryExecutorImpl.java: 2648
com.amazon.redshift.core.v3.QueryExecutorImpl.processResultsOnThread  QueryExecutorImpl.java: 2295
            com.amazon.redshift.core.v3.QueryExecutorImpl.access$000  QueryExecutorImpl.java:   82
  com.amazon.redshift.core.v3.QueryExecutorImpl$RingBufferThread.run  QueryExecutorImpl.java: 3128
```

After:
```
                clojure.lang.ExceptionInfo: Failed to sync test database "interval_900": Error executing query: ERROR: schema "amqzgmzvzrpuneihlxqp" does not exist
    connection-details: {:host "***",
                         :port 5439,
                         :db "testdb",
                         :user "metabase_ci",
                         :password "***",
                         :schema-filters-type "inclusion",
                         :schema-filters-patterns "spectrum,2024_04_04_99820259_e07b_477e_ab06_7880b119f044_schema"}
         database-name: "interval_900"
                driver: :redshift
                clojure.lang.ExceptionInfo: Error executing query: ERROR: schema "amqzgmzvzrpuneihlxqp" does not exist
    driver: :redshift
    params: (1 "" "PRIMARY KEY" "2024_04_04_99820259_e07b_477e_ab06_7880b119f044_schema" "spectrum")
       sql: ["SELECT"
             "  \"c\".\"column_name\" AS \"name\","
             "  \"c\".\"data_type\" AS \"database-type\","
             "  \"c\".\"ordinal_position\" - ? AS \"database-position\","
             "  \"c\".\"schema_name\" AS \"table-schema\","
             "  \"c\".\"table_name\" AS \"table-name\","
             "  \"pk\".\"column_name\" IS NOT"
             "NULL AS"
             "  \"pk?\","
             "  CASE"
             ...]
com.amazon.redshift.util.RedshiftException: ERROR: schema "amqzgmzvzrpuneihlxqp" does not exist
              SQLState: "3F000"
             errorCode: 0
    serverErrorMessage: #object[com.amazon.redshift.util.ServerErrorMessage 0x5122c485 "ERROR: schema \"amqzgmzvzrpuneihlxqp\" does not exist"]
         com.amazon.redshift.core.v3.QueryExecutorImpl.receiveErrorResponse          QueryExecutorImpl.java: 2648
       com.amazon.redshift.core.v3.QueryExecutorImpl.processResultsOnThread          QueryExecutorImpl.java: 2295
               com.amazon.redshift.core.v3.QueryExecutorImpl.processResults          QueryExecutorImpl.java: 1886
               com.amazon.redshift.core.v3.QueryExecutorImpl.processResults          QueryExecutorImpl.java: 1878
                      com.amazon.redshift.core.v3.QueryExecutorImpl.execute          QueryExecutorImpl.java:  375
             com.amazon.redshift.jdbc.RedshiftStatementImpl.executeInternal      RedshiftStatementImpl.java:  519
                     com.amazon.redshift.jdbc.RedshiftStatementImpl.execute      RedshiftStatementImpl.java:  440
        com.amazon.redshift.jdbc.RedshiftPreparedStatement.executeWithFlags  RedshiftPreparedStatement.java:  202
            com.amazon.redshift.jdbc.RedshiftPreparedStatement.executeQuery  RedshiftPreparedStatement.java:  117
            com.mchange.v2.c3p0.impl.NewProxyPreparedStatement.executeQuery  NewProxyPreparedStatement.java: 1471
                             metabase.driver.sql-jdbc.execute/eval108061/fn                     execute.clj:  555
                                                                        ...                                      
  metabase.driver.sql-jdbc.execute/execute-statement-or-prepared-statement!                     execute.clj:  568
               metabase.driver.sql-jdbc.execute/reducible-query/reify/fn/fn                     execute.clj:  733
                  metabase.driver.sql-jdbc.execute/reducible-query/reify/fn                     execute.clj:  731
                                  metabase.driver.redshift/eval296070/fn/fn                    redshift.clj:  186
                                     metabase.driver.sql-jdbc.execute/fn/&f                     execute.clj:  334
                                     metabase.driver.sql-jdbc.execute/fn/fn                     execute.clj:  317
                                     metabase.driver.redshift/eval296070/fn                    redshift.clj:  171
                                                                        ...                                      
              metabase.driver.sql-jdbc.execute/reducible-query/reify/reduce                     execute.clj:  725
                                                     clojure.core/transduce                        core.clj: 6947
                                               clojure.core.Eduction/reduce                        core.clj: 7751
                                                     clojure.core/transduce                        core.clj: 6947
                                               clojure.core.Eduction/reduce                        core.clj: 7751
                                                     clojure.core/transduce                        core.clj: 6947
                                metabase.sync.sync-metadata.fields/fn/&f/fn                      fields.clj:   77
                                  metabase.sync.util/do-with-error-handling                        util.clj:  189
                                   metabase.sync.sync-metadata.fields/fn/&f                      fields.clj:   74
                                   metabase.sync.sync-metadata.fields/fn/fn                      fields.clj:   71
                                   metabase.sync.sync-metadata.fields/fn/&f                      fields.clj:  118
                                   metabase.sync.sync-metadata.fields/fn/fn                      fields.clj:  111
                                                                        ...                                      
                                                         clojure.core/apply                        core.clj:  669
                                                metabase.sync.util/fn/&f/fn                        util.clj:  461
                                                                        ...                                      
                          metabase.sync.util/with-start-and-finish-logging*                        util.clj:  130
                     metabase.sync.util/with-start-and-finish-debug-logging                        util.clj:  148
                                                   metabase.sync.util/fn/&f                        util.clj:  456
                                                   metabase.sync.util/fn/fn                        util.clj:  451
                                                metabase.sync.util/fn/&f/fn                        util.clj:  567
                                                   metabase.sync.util/fn/&f                        util.clj:  565
                                                   metabase.sync.util/fn/fn                        util.clj:  559
                                       metabase.sync.sync-metadata/fn/&f/fn               sync_metadata.clj:   70
                                  metabase.sync.util/do-with-error-handling                        util.clj:  189
                                                    clojure.core/partial/fn                        core.clj: 2647
                                               metabase.driver/eval74814/fn                      driver.clj:  764
                                                                        ...                                      
                                      metabase.sync.util/sync-in-context/fn                        util.clj:  165
                             metabase.sync.util/with-db-logging-disabled/fn                        util.clj:  157
                          metabase.sync.util/with-start-and-finish-logging*                        util.clj:  130
                        metabase.sync.util/with-start-and-finish-logging/fn                        util.clj:  142
                                                metabase.sync.util/fn/&f/fn                        util.clj:  116
                         metabase.sync.util/with-duplicate-ops-prevented/fn                        util.clj:   88
                                                   metabase.sync.util/fn/&f                        util.clj:  214
                                                   metabase.sync.util/fn/fn                        util.clj:  208
                                          metabase.sync.sync-metadata/fn/&f               sync_metadata.clj:   68
                                          metabase.sync.sync-metadata/fn/fn               sync_metadata.clj:   65
                                                     metabase.sync/fn/&f/fn                        sync.clj:   52
                                  metabase.sync.util/do-with-error-handling                        util.clj:  189
                                                    clojure.core/partial/fn                        core.clj: 2647
                                               metabase.driver/eval74814/fn                      driver.clj:  764
                                                                        ...                                      
                                      metabase.sync.util/sync-in-context/fn                        util.clj:  165
                             metabase.sync.util/with-db-logging-disabled/fn                        util.clj:  157
                          metabase.sync.util/with-start-and-finish-logging*                        util.clj:  130
                        metabase.sync.util/with-start-and-finish-logging/fn                        util.clj:  142
                                                metabase.sync.util/fn/&f/fn                        util.clj:  116
                         metabase.sync.util/with-duplicate-ops-prevented/fn                        util.clj:   88
                                                   metabase.sync.util/fn/&f                        util.clj:  214
                                                   metabase.sync.util/fn/fn                        util.clj:  208
                                                        metabase.sync/fn/&f                        sync.clj:   51
                                                        metabase.sync/fn/fn                        sync.clj:   37
metabase.test.data.impl.get-or-create/sync-newly-created-database!/fn/fn/fn               get_or_create.clj:  122
   metabase.test.data.impl.get-or-create/sync-newly-created-database!/fn/fn               get_or_create.clj:  121
      metabase.test.data.impl.get-or-create/sync-newly-created-database!/fn               get_or_create.clj:  118
                                        clojure.core/binding-conveyor-fn/fn                        core.clj: 2047
                                                                        ...                                      
                                        java.util.concurrent.FutureTask.run                 FutureTask.java:  264
                          java.util.concurrent.ThreadPoolExecutor.runWorker         ThreadPoolExecutor.java: 1128
                         java.util.concurrent.ThreadPoolExecutor$Worker.run         ThreadPoolExecutor.java:  628
                                                       java.lang.Thread.run                     Thread.java:  829
```