### PR TITLE
Fix tests for ms1 after updating on master

### DIFF
--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -52,9 +52,9 @@ describe("EmbedHomepage (OSS)", () => {
 
   it("should set 'embedding-homepage' to 'dismissed-done' when dismissing as done", async () => {
     setup();
-    userEvent.hover(screen.getByText("Hide these"));
+    await userEvent.hover(screen.getByText("Hide these"));
 
-    userEvent.click(screen.getByText("Embedding done, all good"));
+    await userEvent.click(screen.getByText("Embedding done, all good"));
 
     const lastCall = fetchMock.lastCall(
       "path:/api/setting/embedding-homepage",

--- a/frontend/src/metabase/setup/tests/premium.unit.spec.tsx
+++ b/frontend/src/metabase/setup/tests/premium.unit.spec.tsx
@@ -48,12 +48,12 @@ describe("setup (EE, hosting and embedding feature)", () => {
 
   it("should set 'setup-license-active-at-setup' to true", async () => {
     await setupPremium();
-    skipWelcomeScreen();
-    skipLanguageStep();
+    await skipWelcomeScreen();
+    await skipLanguageStep();
     await submitUserInfoStep();
 
-    selectUsageReason("embedding");
-    clickNextStep();
+    await selectUsageReason("embedding");
+    await clickNextStep();
 
     screen.getByText("Finish").click();
 


### PR DESCRIPTION
For MS1 of https://github.com/metabase/metabase/issues/40005

After I merged master on the MS1 branch, it got the latest updates which required `await` before `userEvents` so tests failed, this fixes that