### PR TITLE
Fix `flaky onboarding/command-palette.cy.spec.js`

### DIFF
--- a/e2e/support/helpers/e2e-command-palette-helpers.js
+++ b/e2e/support/helpers/e2e-command-palette-helpers.js
@@ -1,5 +1,5 @@
 export const commandPalette = () => cy.findByTestId("command-palette");
-export const openCommandPalette = () => cy.get("body").type("{ctrl+k}");
+export const openCommandPalette = () => cy.get("body").type("{ctrl+k}{cmd+k}");
 export const closeCommandPalette = () => cy.get("body").type("{esc}");
 export const commandPaletteSearch = () =>
   cy.findByPlaceholderText("Jump to...");

--- a/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
+++ b/e2e/test/scenarios/onboarding/command-palette.cy.spec.js
@@ -43,16 +43,16 @@ describe("command palette", () => {
       cy.log("Should search entities and docs");
       commandPaletteSearch().type("Orders, Count");
 
-      cy.findByRole("option", { name: /Orders, Count/ }).should("exist");
+      cy.findByRole("option", { name: "Orders, Count" }).should("exist");
       cy.findByText('Search documentation for "Orders, Count"').should("exist");
 
       // Since the command palette list is virtualized, we will search for a few
       // to ensure they're reachable
       commandPaletteSearch().clear().type("People");
-      cy.findByRole("option", { name: /People/ }).should("exist");
+      cy.findByRole("option", { name: "People" }).should("exist");
 
       commandPaletteSearch().clear().type("Uploads");
-      cy.findByRole("option", { name: /Settings - Uploads/ }).should("exist");
+      cy.findByRole("option", { name: "Settings - Uploads" }).should("exist");
     });
 
     cy.log("We can close the command palette using escape");
@@ -67,7 +67,7 @@ describe("command palette", () => {
 
     commandPalette().within(() => {
       commandPaletteSearch().type("Nested");
-      cy.findByRole("option", { name: /Enable Nested Queries/ }).click();
+      cy.findByRole("option", { name: "Enable Nested Queries" }).click();
     });
 
     cy.findByTestId("enable-nested-queries-setting").should("be.visible");
@@ -79,7 +79,7 @@ describe("command palette", () => {
 
     commandPalette().within(() => {
       commandPaletteSearch().clear().type("Week");
-      cy.findByRole("option", { name: /First day of the week/ }).click();
+      cy.findByRole("option", { name: "First day of the week" }).click();
     });
 
     cy.location("pathname").should("contain", "settings/localization");

--- a/frontend/src/metabase/palette/components/PaletteResults.tsx
+++ b/frontend/src/metabase/palette/components/PaletteResults.tsx
@@ -92,6 +92,7 @@ export const PaletteResults = () => {
                   <Flex gap=".5rem" style={{ minWidth: 0 }}>
                     {item.icon && (
                       <Icon
+                        aria-hidden
                         name={(item.icon as IconName) || "click"}
                         color={
                           active ? color("brand-light") : color("text-light")
@@ -116,6 +117,7 @@ export const PaletteResults = () => {
                   </Flex>
                   {active && (
                     <Flex
+                      aria-hidden
                       gap="0.5rem"
                       fw={400}
                       style={{


### PR DESCRIPTION
It's weird that I always see it failing locally, so I'm not sure why this test hasn't been failing consistently on CI.

Closes https://github.com/metabase/metabase/issues/41072

### Description

Adjust the accessibility tree, so that we could get the exact item we want in Cypress rather than relying on partial matching with regex which is more prone to error.

### How to verify

The tests in `e2e/test/scenarios/onboarding/command-palette.cy.spec.js` pass.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] [Stress test results](https://github.com/metabase/metabase/actions/runs/8567995035) [20/20] ✅ 

### Note
I'm not backporting this because the [original PR also wasn't backported.](https://github.com/metabase/metabase/pull/39268)
