### PR TITLE
Fix loading metadata for models

### DIFF
--- a/frontend/src/metabase/query_builder/containers/test-utils.tsx
+++ b/frontend/src/metabase/query_builder/containers/test-utils.tsx
@@ -286,6 +286,8 @@ export const setup = async ({
   );
 
   await waitForLoadingRequests(getState);
+  await waitForLoaderToBeRemoved();
+  await waitForLoadingRequests(getState);
 
   return {
     container,

--- a/frontend/src/metabase/questions/actions.ts
+++ b/frontend/src/metabase/questions/actions.ts
@@ -2,6 +2,7 @@ import { loadMetadataForDependentItems } from "metabase/redux/metadata";
 import { getMetadata } from "metabase/selectors/metadata";
 import * as Lib from "metabase-lib";
 import Question from "metabase-lib/v1/Question";
+import { getQuestionVirtualTableId } from "metabase-lib/v1/metadata/utils/saved-questions";
 import type { Card } from "metabase-types/api";
 import type { Dispatch, GetState } from "metabase-types/store";
 
@@ -13,11 +14,16 @@ export const loadMetadataForCard =
   (card: Card, options?: LoadMetadataOptions) =>
   async (dispatch: Dispatch, getState: GetState) => {
     const question = new Question(card, getMetadata(getState()));
-    const dependencies = Lib.dependentMetadata(question.query());
+    const loadAdhocMetadata =
+      question.isSaved() && question.type() !== "question";
+    const dependencies = [...Lib.dependentMetadata(question.query())];
+    if (loadAdhocMetadata) {
+      const tableId = getQuestionVirtualTableId(question.id());
+      dependencies.push({ id: tableId, type: "table" });
+    }
     await dispatch(loadMetadataForDependentItems(dependencies, options));
 
-    // metadata for an ad-hoc question based on this question
-    if (question.isSaved() && question.type() !== "question") {
+    if (loadAdhocMetadata) {
       const questionWithMetadata = new Question(card, getMetadata(getState()));
       const adhocQuestion = questionWithMetadata.composeQuestionAdhoc();
       const adhocDependencies = Lib.dependentMetadata(adhocQuestion.query());


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/41071

How to verify:
- Create a model based on Accounts table from the sample DB
- Add this model to a dashboard
- Save and refresh
- The page shouldn't break

For some reason it always works in E2E, and I couldn't break it. I think it's because CLJS uses `defer` and does some tricks with timers that I don't understand 