### PR TITLE
Fix flaky `visualizations-tabular/object_detail.cy.spec.js`

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -164,7 +164,10 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     createQuestion(questionDetails, { visitQuestion: true });
 
     cy.get(".cellData").contains("4966277046676").realHover();
-    cy.findByTestId("detail-shortcut").findByRole("button").click();
+    cy.findByTestId("detail-shortcut")
+      .findByRole("button")
+      .should("be.visible")
+      .click();
 
     cy.findByRole("dialog").findByTestId("fk-relation-orders").click();
 

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -163,7 +163,10 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
 
     createQuestion(questionDetails, { visitQuestion: true });
 
-    cy.get(".cellData").contains("4966277046676").realHover();
+    cy.get(".cellData")
+      .contains("4966277046676")
+      .realHover()
+      .trigger("mousemove", { clientX: 1 });
     cy.findByTestId("detail-shortcut")
       .findByRole("button")
       .should("be.visible")


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41084

### Description
This fixes the problem by ensuring that before we click the button it should be visible, I suspect this was caused by the slow runner and when we click the button before it was disabled, it will still used [the old `onclick` handler which was bound to other object.](https://github.com/metabase/metabase/blob/b7d1bb2139f2b309a43e9e9e9ddaba258bfde625/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx#L959)

### How to verify

Makes sure the stress test passes

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
- [x] [Stress tests `master` failed] ❌ (https://github.com/metabase/metabase/actions/runs/8571030763/job/23490362410)
- [ ] [Stress tests this PR](https://github.com/metabase/metabase/actions/runs/8571497224) [x/20]