### PR TITLE
Release migration locks during shutdown

### DIFF
--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -84,6 +84,9 @@
   (task/stop-scheduler!)
   (server/stop-web-server!)
   (prometheus/shutdown!)
+  ;; This timeout was chosen based on a 30s default termination grace period in Kubernetes.
+  (let [timeout-seconds 20]
+    (mdb/release-migration-locks! timeout-seconds))
   (log/info "Metabase Shutdown COMPLETE"))
 
 (defenterprise ensure-audit-db-installed!

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -74,7 +74,7 @@
   [timeout-seconds]
   (if (db-is-set-up?)
     :done
-    (mdb.setup/release-migration-locks! timeout-seconds)))
+    (mdb.setup/release-migration-locks! (data-source) timeout-seconds)))
 
 (defn memoize-for-application-db
   "Like [[clojure.core/memoize]], but only memoizes for the current application database; memoized values will be

--- a/src/metabase/db.clj
+++ b/src/metabase/db.clj
@@ -69,6 +69,13 @@
         (reset! (:status mdb.connection/*application-db*) ::setup-finished))))
   :done)
 
+(defn release-migration-locks!
+  "Wait up to `timeout-seconds` for the current process to release all migration locks, otherwise force release them."
+  [timeout-seconds]
+  (if (db-is-set-up?)
+    :done
+    (mdb.setup/release-migration-locks! timeout-seconds)))
+
 (defn memoize-for-application-db
   "Like [[clojure.core/memoize]], but only memoizes for the current application database; memoized values will be
   ignored if the app DB is dynamically rebound. For TTL memoization with [[clojure.core.memoize]], set

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -270,7 +270,7 @@
       (let [url (liquibase->url liquibase)]
         (doseq [instance instances]
           (when (= url (liquibase->url instance))
-            (log/warnf "Releasing liquibase lock on %s before migrations finished" url)
+            (log/warn "Releasing liquibase lock before migrations finished")
             (release-lock-if-needed! liquibase)))))))
 
 (def ^:private ^:dynamic *lock-depth* 0)

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -248,12 +248,13 @@
 
 (defn wait-for-all-locks
   "Wait up to a maximum of `timeout-seconds` for the given Liquibase instance to release the migration lock."
-  [sleep-ms timeout-seconds]
+  [sleep-ms timeout-ms]
+  (log/warn (locked-instances))
   (let [done? #(empty? (locked-instances))]
     (if (done?)
       :none
       (do (log/info "Waiting for migration lock(s) to be released")
-          (wait-until done? sleep-ms (* timeout-seconds 1000))))))
+          (wait-until done? sleep-ms timeout-ms)))))
 
 (defn release-all-locks-if-needed!
   "Release all locks held by this process."

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -268,7 +268,8 @@
       (let [url (liquibase->url liquibase)]
         (doseq [instance instances]
           (when (= url (liquibase->url instance))
-            (release-lock-if-needed! liquibase)))))))
+            (log/warnf "Releasing liquibase lock on %s before migrations finished" url)
+            (release-lock-if-needed! instance #_liquibase)))))))
 
 (def ^:private ^:dynamic *lock-depth* 0)
 

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -233,12 +233,11 @@
   (.hasChangeLogLock (lock-service liquibase)))
 
 (defn- wait-until [done? ^long sleep-ms timeout-ms]
-  (let [deadline   (+ (System/nanoTime) (* 1e6 timeout-ms))
-        timed-out? #(>= (System/nanoTime) deadline)]
+  (let [deadline (+ (System/nanoTime) (* 1e6 timeout-ms))]
     (loop []
       (if (done?)
         :done
-        (if (timed-out?)
+        (if (>= (System/nanoTime) deadline)
           :timed-out
           (do (Thread/sleep sleep-ms)
               (recur)))))))

--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -257,7 +257,7 @@
 
 (defn- liquibase->url [^Liquibase liquibase]
   ;; Need to this cast to get access to the metadata. We currently only use JDBC app databases.
-  (let [conn ^JdbcConnection (.getConnection (-> liquibase (.getDatabase)))]
+  (let [conn ^JdbcConnection (.. liquibase getDatabase getConnection)]
     (-> conn .getMetaData .getURL)))
 
 (defn release-concurrent-locks!

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -167,6 +167,18 @@
          (run-schema-migrations! data-source auto-migrate?))))
   :done)
 
+(defn release-migration-locks!
+  "Wait up to `timeout-seconds` for the current process to release all migration locks, otherwise force release them."
+  [timeout-seconds]
+  (let [sleep-ms   100
+        timeout-ms (* 1000 timeout-seconds)]
+    (case (liquibase/wait-for-all-locks sleep-ms timeout-ms)
+      :none nil
+      :done (log/info "Migration lock(s) have been released")
+      :timed-out (do (log/warn "Releasing liquibase locks on shutdown")
+                     (liquibase/release-all-locks-if-needed!))))
+  :done)
+
 ;;;; Toucan Setup.
 
 ;;; Done at namespace load time these days.

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -169,7 +169,7 @@
 
 (defn release-migration-locks!
   "Wait up to `timeout-seconds` for the current process to release all migration locks, otherwise force release them."
-  [timeout-seconds]
+  [data-source timeout-seconds]
   (let [sleep-ms   100
         timeout-ms (* 1000 timeout-seconds)]
     (case (liquibase/wait-for-all-locks sleep-ms timeout-ms)
@@ -178,7 +178,7 @@
       :timed-out (do (log/warn "Releasing liquibase locks on shutdown")
                      ;; There's an infinitesimal chance that we released the lock and another server took it between
                      ;; the timeout, and the mutations we now make to these lock tables - but we can't detect that.
-                     (liquibase/release-all-locks-if-needed!))))
+                     (liquibase/release-concurrent-locks! data-source))))
   :done)
 
 ;;;; Toucan Setup.

--- a/src/metabase/db/setup.clj
+++ b/src/metabase/db/setup.clj
@@ -176,6 +176,8 @@
       :none nil
       :done (log/info "Migration lock(s) have been released")
       :timed-out (do (log/warn "Releasing liquibase locks on shutdown")
+                     ;; There's an infinitesimal chance that we released the lock and another server took it between
+                     ;; the timeout, and the mutations we now make to these lock tables - but we can't detect that.
                      (liquibase/release-all-locks-if-needed!))))
   :done)
 

--- a/test/metabase/db/liquibase_test.clj
+++ b/test/metabase/db/liquibase_test.clj
@@ -119,7 +119,7 @@
                @released
                (deliver locked? (liquibase/holding-lock? liquibase))))
             @locked
-            (liquibase/release-all-locks-if-needed!)
+            (liquibase/release-concurrent-locks! conn)
             (deliver released true)
             (testing "The lock is released before the migration finishes"
               (is (not @locked?)))))))))

--- a/test/metabase/db/liquibase_test.clj
+++ b/test/metabase/db/liquibase_test.clj
@@ -10,7 +10,6 @@
    [metabase.driver.sql-jdbc.connection :as sql-jdbc.conn]
    [metabase.driver.sql-jdbc.execute :as sql-jdbc.execute]
    [metabase.test :as mt]
-   [metabase.util.log :as log]
    [metabase.util.yaml :as u.yaml]
    [next.jdbc :as next.jdbc]
    [toucan2.core :as t2]))
@@ -116,14 +115,9 @@
                 locked?  (promise)]
             (future
              (liquibase/with-scope-locked liquibase
-               (let [liquibase-conn (.. liquibase getDatabase getConnection)]
-                 (is (liquibase/holding-lock? liquibase))
-                 (deliver locked true)
-                 (log/info "Starting mock migration transaction")
-                 (.setAutoCommit liquibase-conn false)
-                 @released
-                 (.commit liquibase-conn))
-               (log/info "Finished mock migration transaction")
+               (is (liquibase/holding-lock? liquibase))
+               (deliver locked true)
+               @released
                (deliver locked? (liquibase/holding-lock? liquibase))))
             @locked
             (liquibase/release-concurrent-locks! conn)

--- a/test/metabase/db/liquibase_test.clj
+++ b/test/metabase/db/liquibase_test.clj
@@ -98,14 +98,14 @@
               (liquibase/with-scope-locked liquibase
                 (is (= :timed-out (liquibase/wait-for-all-locks sleep-ms timeout-ms)))))
             (testing "Will return successfully if the lock is released while we are waiting"
-              (let [timeout-ms 200
-                    lock-latch (CountDownLatch. 1)
+              (let [timeout-ms    200
+                    lock-latch    (CountDownLatch. 1)
                     release-latch (CountDownLatch. 1)
-                    result (future (.await lock-latch)
-                                   (liquibase/wait-for-all-locks sleep-ms timeout-ms))
-                    _ (future (.await lock-latch)
-                              (Thread/sleep 50)
-                              (.countDown release-latch))]
+                    result        (future (.await lock-latch)
+                                          (liquibase/wait-for-all-locks sleep-ms timeout-ms))
+                    _             (future (.await lock-latch)
+                                          (Thread/sleep 50)
+                                          (.countDown release-latch))]
                 (liquibase/with-scope-locked liquibase
                   (.countDown lock-latch)
                   (.await release-latch))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/37866

### Description

This change updates our shutdown hooks to avoid leaving orphaned migration locks in the database, which require manual action to resolve.

If any locks are still held, we will wait a bit to see if they are released on their own, and otherwise we force release them.

While it's not ideal to release the locks while the migrations are still running, they are at least within a transaction, and their underlying connection is also closed thereafter preventing further statements from being run.