### PR TITLE
Add help text icon in expression editor suggestions

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -70,13 +70,13 @@ export function suggest({
 
   const partialSource = source.slice(0, targetOffset);
   const matchPrefix = partialMatch(partialSource);
+  const database = getDatabase(query, metadata);
 
   if (!matchPrefix || _.last(matchPrefix) === "]") {
     // no keystroke to match? show help text for the enclosing function
     const functionDisplayName = enclosingFunction(partialSource);
     if (functionDisplayName) {
       const name = getMBQLName(functionDisplayName);
-      const database = getDatabase(query, metadata);
 
       if (name && database) {
         const helpText = getHelpText(name, database, reportTimezone);
@@ -112,7 +112,6 @@ export function suggest({
     },
   );
 
-  const database = getDatabase(query, metadata);
   if (_.first(matchPrefix) !== "[") {
     suggestions.push({
       type: "functions",
@@ -258,7 +257,6 @@ export function suggest({
     const { icon } = suggestions[0];
     if (icon === "function") {
       const name = getMBQLName(matchPrefix);
-      const database = getDatabase(query, metadata);
 
       if (name && database) {
         const helpText = getHelpText(name, database, reportTimezone);

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -31,6 +31,7 @@ export type Suggestion = {
   order: number;
   range?: [number, number];
   column?: Lib.ColumnMetadata;
+  helpText?: HelpText;
 };
 
 const suggestionText = (func: MBQLClauseFunctionConfig) => {
@@ -268,6 +269,23 @@ export function suggest({
       }
     }
   }
+
+  // add help text to the suggestion if possible
+  suggestions = suggestions.map(suggestion => {
+    if (!database || suggestion.type !== "functions") {
+      return suggestion;
+    }
+
+    const name = getMBQLName(suggestion.name);
+    if (!name) {
+      return suggestion;
+    }
+
+    return {
+      ...suggestion,
+      helpText: getHelpText(name, database, reportTimezone),
+    };
+  });
 
   return { suggestions };
 }

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -120,6 +120,9 @@ export function suggest({
       index: targetOffset,
       icon: "function",
       order: 1,
+      helpText: database
+        ? getHelpText("case", database, reportTimezone)
+        : undefined,
     });
     suggestions.push(
       ...Array.from(EXPRESSION_FUNCTIONS)
@@ -134,6 +137,9 @@ export function suggest({
           index: targetOffset,
           icon: "function",
           order: 1,
+          helpText: database
+            ? getHelpText(func.displayName, database, reportTimezone)
+            : undefined,
         })),
     );
     if (startRule === "aggregation") {
@@ -267,23 +273,6 @@ export function suggest({
       }
     }
   }
-
-  // add help text to the suggestion if possible
-  suggestions = suggestions.map(suggestion => {
-    if (!database || suggestion.type !== "functions") {
-      return suggestion;
-    }
-
-    const name = getMBQLName(suggestion.name);
-    if (!name) {
-      return suggestion;
-    }
-
-    return {
-      ...suggestion,
-      helpText: getHelpText(name, database, reportTimezone),
-    };
-  });
 
   return { suggestions };
 }

--- a/frontend/src/metabase-lib/v1/expressions/suggest.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.unit.spec.ts
@@ -526,6 +526,37 @@ describe("metabase/lib/expression/suggest", () => {
         });
       });
     });
+
+    it("should add the helptext for function suggestions", () => {
+      expect(
+        suggest_({
+          source: "con",
+          ...expressionOpts,
+          query: createQuery({
+            metadata,
+            query: DEFAULT_QUERY,
+          }),
+          stageIndex: -1,
+          metadata,
+          getColumnIcon: () => "icon",
+        }).suggestions,
+      ).toEqual([
+        expect.objectContaining({
+          type: "functions",
+          text: "concat(",
+          helpText: expect.objectContaining({
+            name: "concat",
+          }),
+        }),
+        expect.objectContaining({
+          type: "functions",
+          text: "contains(",
+          helpText: expect.objectContaining({
+            name: "contains",
+          }),
+        }),
+      ]);
+    });
   });
 });
 

--- a/frontend/src/metabase/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/ColumnInfoIcon/ColumnInfoIcon.tsx
@@ -10,12 +10,12 @@ import {
   QueryColumnInfoPopover,
   TableColumnInfoPopover,
 } from "../ColumnInfoPopover";
-import { PopoverHoverTarget, HoverParent, defaultDelay } from "../InfoIcon";
+import { PopoverHoverTarget, HoverParent } from "../InfoIcon";
 export { HoverParent };
 
 export function QueryColumnInfoIcon({
   className,
-  delay = defaultDelay,
+  delay,
   ...props
 }: QueryColumnInfoPopoverProps) {
   const { query, stageIndex, column } = props;
@@ -43,7 +43,7 @@ QueryColumnInfoIcon.HoverParent = HoverParent;
 
 export function TableColumnInfoIcon({
   className,
-  delay = defaultDelay,
+  delay,
   field,
   ...props
 }: TableColumnInfoPopoverProps) {

--- a/frontend/src/metabase/components/MetadataInfo/InfoIcon/constants.ts
+++ b/frontend/src/metabase/components/MetadataInfo/InfoIcon/constants.ts
@@ -1,1 +1,0 @@
-export const defaultDelay: [number, number] = [250, 150];

--- a/frontend/src/metabase/components/MetadataInfo/InfoIcon/index.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/InfoIcon/index.tsx
@@ -1,2 +1,1 @@
-export * from "./constants";
 export * from "./InfoIcon.styled";

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.styled.tsx
@@ -19,4 +19,5 @@ export const Target = styled.div`
   top: -10px;
   bottom: -10px;
   min-height: 5px;
+  z-index: -1;
 `;

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.styled.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.styled.tsx
@@ -2,9 +2,9 @@ import styled from "@emotion/styled";
 
 import { HoverCard } from "metabase/ui";
 
-export const WidthBound = styled.div`
-  width: 300px;
+export const WidthBound = styled.div<{ width?: number }>`
   font-size: 14px;
+  width: ${props => props.width ?? 300}px;
 `;
 
 export const Dropdown = styled(HoverCard.Dropdown)`

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ReactNode, MouseEvent } from "react";
 import { useCallback, useState } from "react";
 
 import useSequencedContentCloseHandler from "metabase/hooks/use-sequenced-content-close-handler";
@@ -66,7 +66,11 @@ export function Popover({
       }}
     >
       <HoverCard.Target>{children}</HoverCard.Target>
-      <Dropdown>
+      <Dropdown
+        onClick={stopPropagation}
+        onMouseDown={stopPropagation}
+        onMouseUp={stopPropagation}
+      >
         {/* HACK: adds an element between the target and the card */}
         {/* to avoid the card from disappearing */}
         <Target />
@@ -81,4 +85,8 @@ export function Popover({
       </Dropdown>
     </HoverCard>
   );
+}
+
+function stopPropagation(evt: MouseEvent) {
+  evt.stopPropagation();
 }

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
@@ -60,6 +60,10 @@ export function Popover({
       transitionProps={{
         duration: group.shouldDelay ? POPOVER_TRANSITION_DURATION : 0,
       }}
+      middlewares={{
+        shift: true,
+        flip: false,
+      }}
     >
       <HoverCard.Target>{children}</HoverCard.Target>
       <Dropdown>

--- a/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/Popover/Popover.tsx
@@ -5,7 +5,7 @@ import useSequencedContentCloseHandler from "metabase/hooks/use-sequenced-conten
 import type { HoverCardProps } from "metabase/ui";
 import { HoverCard, useDelayGroup } from "metabase/ui";
 
-export const POPOVER_DELAY: [number, number] = [1000, 300];
+export const POPOVER_DELAY: [number, number] = [250, 150];
 export const POPOVER_TRANSITION_DURATION = 150;
 
 import { WidthBound, Dropdown, Target } from "./Popover.styled";
@@ -19,6 +19,7 @@ export type PopoverProps = Pick<
   "children" | "position" | "disabled"
 > & {
   delay?: [number, number];
+  width?: number;
   content: ReactNode;
 };
 
@@ -27,6 +28,7 @@ export function Popover({
   disabled,
   delay = POPOVER_DELAY,
   content,
+  width,
   children,
 }: PopoverProps) {
   const group = useDelayGroup();
@@ -65,6 +67,7 @@ export function Popover({
         {/* to avoid the card from disappearing */}
         <Target />
         <WidthBound
+          width={width}
           ref={node => {
             setupCloseHandler(node, () => setIsOpen(false));
           }}

--- a/frontend/src/metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon.tsx
+++ b/frontend/src/metabase/components/MetadataInfo/TableInfoIcon/TableInfoIcon.tsx
@@ -1,6 +1,6 @@
 import { t } from "ttag";
 
-import { PopoverHoverTarget, HoverParent, defaultDelay } from "../InfoIcon";
+import { PopoverHoverTarget, HoverParent } from "../InfoIcon";
 import type { TableInfoPopoverProps } from "../TableInfoPopover";
 import { TableInfoPopover } from "../TableInfoPopover";
 export { HoverParent };
@@ -11,7 +11,7 @@ type TableInfoIconProps = TableInfoPopoverProps & {
 
 export function TableInfoIcon({
   className,
-  delay = defaultDelay,
+  delay,
   table,
   ...props
 }: TableInfoIconProps) {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
@@ -47,7 +47,7 @@ export const ExpressionEditorHelpTextContent = ({
     <>
       {/* Prevent stealing focus from input box causing the help text to be closed (metabase#17548) */}
       <Container
-        onMouseDown={e => e.preventDefault()}
+        onMouseDown={evt => evt.preventDefault()}
         data-testid="expression-helper-popover"
       >
         <FunctionHelpCode data-testid="expression-helper-popover-structure">

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
@@ -21,23 +21,88 @@ import {
   LearnMoreIcon,
 } from "./ExpressionEditorHelpText.styled";
 
-export interface ExpressionEditorHelpTextProps {
+export type ExpressionEditorHelpTextContentProps = {
   helpText: HelpText | null | undefined;
-  width: number | undefined;
-  target: React.RefObject<HTMLElement>;
-}
+};
+
+export type ExpressionEditorHelpTextProps =
+  ExpressionEditorHelpTextContentProps & {
+    target: React.RefObject<HTMLElement>;
+    width: number | undefined;
+  };
+
+export const ExpressionEditorHelpTextContent = ({
+  helpText,
+}: ExpressionEditorHelpTextContentProps) => {
+  const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+
+  if (!helpText) {
+    return null;
+  }
+
+  const { description, structure, args } = helpText;
+
+  return (
+    <>
+      {/* Prevent stealing focus from input box causing the help text to be closed (metabase#17548) */}
+      <Container
+        onMouseDown={e => e.preventDefault()}
+        data-testid="expression-helper-popover"
+      >
+        <FunctionHelpCode data-testid="expression-helper-popover-structure">
+          {structure}
+          {args != null && (
+            <>
+              (
+              {args.map(({ name }, index) => (
+                <span key={name}>
+                  <FunctionHelpCodeArgument>{name}</FunctionHelpCodeArgument>
+                  {index + 1 < args.length && ", "}
+                </span>
+              ))}
+              )
+            </>
+          )}
+        </FunctionHelpCode>
+        <Divider />
+
+        <div>{description}</div>
+
+        {args != null && (
+          <ArgumentsGrid data-testid="expression-helper-popover-arguments">
+            {args.map(({ name, description: argDescription }) => (
+              <React.Fragment key={name}>
+                <ArgumentTitle>{name}</ArgumentTitle>
+                <div>{argDescription}</div>
+              </React.Fragment>
+            ))}
+          </ArgumentsGrid>
+        )}
+
+        <BlockSubtitleText>{t`Example`}</BlockSubtitleText>
+        <ExampleCode>{helpText.example}</ExampleCode>
+        {showMetabaseLinks && (
+          <DocumentationLink
+            href={MetabaseSettings.docsUrl(getHelpDocsUrl(helpText))}
+            target="_blank"
+          >
+            <LearnMoreIcon name="reference" size={12} />
+            {t`Learn more`}
+          </DocumentationLink>
+        )}
+      </Container>
+    </>
+  );
+};
 
 export const ExpressionEditorHelpText = ({
   helpText,
   width,
   target,
 }: ExpressionEditorHelpTextProps) => {
-  const showMetabaseLinks = useSelector(getShowMetabaseLinks);
   if (!helpText) {
     return null;
   }
-
-  const { description, structure, args } = helpText;
 
   return (
     <TippyPopover
@@ -46,59 +111,7 @@ export const ExpressionEditorHelpText = ({
       placement="bottom-start"
       visible
       zIndex={300}
-      content={
-        <>
-          {/* Prevent stealing focus from input box causing the help text to be closed (metabase#17548) */}
-          <Container
-            onMouseDown={e => e.preventDefault()}
-            data-testid="expression-helper-popover"
-          >
-            <FunctionHelpCode data-testid="expression-helper-popover-structure">
-              {structure}
-              {args != null && (
-                <>
-                  (
-                  {args.map(({ name }, index) => (
-                    <span key={name}>
-                      <FunctionHelpCodeArgument>
-                        {name}
-                      </FunctionHelpCodeArgument>
-                      {index + 1 < args.length && ", "}
-                    </span>
-                  ))}
-                  )
-                </>
-              )}
-            </FunctionHelpCode>
-            <Divider />
-
-            <div>{description}</div>
-
-            {args != null && (
-              <ArgumentsGrid data-testid="expression-helper-popover-arguments">
-                {args.map(({ name, description: argDescription }) => (
-                  <React.Fragment key={name}>
-                    <ArgumentTitle>{name}</ArgumentTitle>
-                    <div>{argDescription}</div>
-                  </React.Fragment>
-                ))}
-              </ArgumentsGrid>
-            )}
-
-            <BlockSubtitleText>{t`Example`}</BlockSubtitleText>
-            <ExampleCode>{helpText.example}</ExampleCode>
-            {showMetabaseLinks && (
-              <DocumentationLink
-                href={MetabaseSettings.docsUrl(getHelpDocsUrl(helpText))}
-                target="_blank"
-              >
-                <LearnMoreIcon name="reference" size={12} />
-                {t`Learn more`}
-              </DocumentationLink>
-            )}
-          </Container>
-        </>
-      }
+      content={<ExpressionEditorHelpTextContent helpText={helpText} />}
     />
   );
 };

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.tsx
@@ -1,4 +1,5 @@
-import * as React from "react";
+import type { RefObject } from "react";
+import { Fragment } from "react";
 import { t } from "ttag";
 
 import TippyPopover from "metabase/components/Popover/TippyPopover";
@@ -27,7 +28,7 @@ export type ExpressionEditorHelpTextContentProps = {
 
 export type ExpressionEditorHelpTextProps =
   ExpressionEditorHelpTextContentProps & {
-    target: React.RefObject<HTMLElement>;
+    target: RefObject<HTMLElement>;
     width: number | undefined;
   };
 
@@ -71,10 +72,10 @@ export const ExpressionEditorHelpTextContent = ({
         {args != null && (
           <ArgumentsGrid data-testid="expression-helper-popover-arguments">
             {args.map(({ name, description: argDescription }) => (
-              <React.Fragment key={name}>
+              <Fragment key={name}>
                 <ArgumentTitle>{name}</ArgumentTitle>
                 <div>{argDescription}</div>
-              </React.Fragment>
+              </Fragment>
             ))}
           </ArgumentsGrid>
         )}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/index.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/index.ts
@@ -1,1 +1,4 @@
-export { ExpressionEditorHelpText } from "./ExpressionEditorHelpText";
+export {
+  ExpressionEditorHelpText,
+  ExpressionEditorHelpTextContent,
+} from "./ExpressionEditorHelpText";

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -5,11 +5,7 @@ import { Component, Fragment } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
-// import { HoverParent } from "metabase/components/MetadataInfo/ColumnInfoIcon";
-import {
-  HoverParent,
-  // PopoverHoverTarget,
-} from "metabase/components/MetadataInfo/InfoIcon";
+import { HoverParent } from "metabase/components/MetadataInfo/InfoIcon";
 import { Popover } from "metabase/components/MetadataInfo/Popover";
 import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -83,6 +83,10 @@ export default class ExpressionEditorSuggestions extends Component {
     event.preventDefault();
     event.stopPropagation();
 
+    if (event.target.tagName === "A" || event.target.tagName === "BUTTON") {
+      return;
+    }
+
     this.props.onSuggestionMouseDown && this.props.onSuggestionMouseDown(index);
   }
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/prop-types */
 import cx from "classnames";
 import PropTypes from "prop-types";
-import { Component, Fragment } from "react";
+import { Component } from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -112,15 +112,14 @@ export default class ExpressionEditorSuggestions extends Component {
               className={CS.pb1}
             >
               {suggestions.map((suggestion, i) => (
-                <Fragment key={`$suggestion-${i}`}>
-                  <ExpressionEditorSuggestionsListItem
-                    query={query}
-                    stageIndex={stageIndex}
-                    suggestion={suggestion}
-                    isHighlighted={i === highlightedIndex}
-                    onMouseDownCapture={this.createOnMouseDownHandler(i)}
-                  />
-                </Fragment>
+                <ExpressionEditorSuggestionsListItem
+                  key={`suggestion-${i}`}
+                  query={query}
+                  stageIndex={stageIndex}
+                  suggestion={suggestion}
+                  isHighlighted={i === highlightedIndex}
+                  onMouseDownCapture={this.createOnMouseDownHandler(i)}
+                />
               ))}
             </ExpressionList>
           }

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -2,14 +2,21 @@
 import cx from "classnames";
 import PropTypes from "prop-types";
 import { Component, Fragment } from "react";
+import { t } from "ttag";
 import _ from "underscore";
 
-import { HoverParent } from "metabase/components/MetadataInfo/ColumnInfoIcon";
+// import { HoverParent } from "metabase/components/MetadataInfo/ColumnInfoIcon";
+import {
+  HoverParent,
+  // PopoverHoverTarget,
+} from "metabase/components/MetadataInfo/InfoIcon";
+import { Popover } from "metabase/components/MetadataInfo/Popover";
 import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
 import { isObscured } from "metabase/lib/dom";
 import { DelayGroup, Icon } from "metabase/ui";
 
+import { ExpressionEditorHelpTextContent } from "./ExpressionEditorHelpText";
 import {
   ExpressionListItem,
   ExpressionList,
@@ -18,6 +25,7 @@ import {
   SuggestionSpanRoot,
   SuggestionTitle,
   QueryColumnInfoIcon,
+  PopoverHoverTarget,
 } from "./ExpressionEditorSuggestions.styled";
 
 const SuggestionSpan = ({ suggestion, isHighlighted }) => {
@@ -133,7 +141,7 @@ function ExpressionEditorSuggestionsListItem({
   isHighlighted,
   onMouseDownCapture,
 }) {
-  const { icon } = suggestion;
+  const { icon, helpText } = suggestion;
   const { normal, highlighted } = colorForIcon(icon);
 
   return (
@@ -158,12 +166,27 @@ function ExpressionEditorSuggestionsListItem({
             data-ignore-outside-clicks
           />
         </SuggestionTitle>
-        <QueryColumnInfoIcon
-          query={query}
-          stageIndex={stageIndex}
-          column={suggestion.column}
-          position="right"
-        />
+        {helpText && (
+          <Popover
+            position="right"
+            content={<ExpressionEditorHelpTextContent helpText={helpText} />}
+            width={450}
+          >
+            <PopoverHoverTarget
+              name="info_filled"
+              hasDescription
+              aria-label={t`More info`}
+            />
+          </Popover>
+        )}
+        {!helpText && (
+          <QueryColumnInfoIcon
+            query={query}
+            stageIndex={stageIndex}
+            column={suggestion.column}
+            position="right"
+          />
+        )}
       </ExpressionListItem>
     </HoverParent>
   );

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.jsx
@@ -122,7 +122,7 @@ export default class ExpressionEditorSuggestions extends Component {
                   stageIndex={stageIndex}
                   suggestion={suggestion}
                   isHighlighted={i === highlightedIndex}
-                  onMouseDownCapture={this.createOnMouseDownHandler(i)}
+                  onMouseDown={this.createOnMouseDownHandler(i)}
                 />
               ))}
             </ExpressionList>
@@ -138,7 +138,7 @@ function ExpressionEditorSuggestionsListItem({
   stageIndex,
   suggestion,
   isHighlighted,
-  onMouseDownCapture,
+  onMouseDown,
 }) {
   const { icon, helpText } = suggestion;
   const { normal, highlighted } = colorForIcon(icon);
@@ -146,7 +146,7 @@ function ExpressionEditorSuggestionsListItem({
   return (
     <HoverParent>
       <ExpressionListItem
-        onMouseDownCapture={onMouseDownCapture}
+        onMouseDown={onMouseDown}
         isHighlighted={isHighlighted}
         className={cx(CS.hoverParent, CS.hoverInherit)}
         data-ignore-outside-clicks

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.styled.tsx
@@ -2,6 +2,10 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import { QueryColumnInfoIcon as BaseQueryColumnInfoIcon } from "metabase/components/MetadataInfo/ColumnInfoIcon";
+import {
+  HoverParent,
+  PopoverHoverTarget as BasePopoverHoverTarget,
+} from "metabase/components/MetadataInfo/InfoIcon";
 import TippyPopover from "metabase/components/Popover/TippyPopover";
 import { alpha, color } from "metabase/lib/colors";
 
@@ -59,4 +63,15 @@ export const QueryColumnInfoIcon = styled(BaseQueryColumnInfoIcon)`
   padding: 0;
   margin-left: auto;
   padding: 0.3125rem 0;
+`;
+
+export const PopoverHoverTarget = styled(BasePopoverHoverTarget)`
+  padding: 0;
+  margin-left: auto;
+  padding: 0.3125rem 0;
+  visibility: hidden;
+
+  ${HoverParent}:hover & {
+    visibility: visible;
+  }
 `;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -32,11 +32,15 @@ function Wrapper(props: WrapperProps) {
   );
 }
 
-function setup() {
+type SetupOpts = {
+  source: string;
+};
+
+function setup(opts: SetupOpts) {
   const query = createQuery({ metadata: METADATA });
   const stageIndex = 0;
   const { suggestions } = suggest({
-    source: "[",
+    source: opts.source,
     query,
     stageIndex,
     metadata: METADATA,
@@ -60,7 +64,17 @@ function setup() {
 
 describe("ExpressionEditorSuggestions", () => {
   test("suggestions items should show column info icon", async () => {
-    setup();
+    setup({ source: "[" });
+
+    await screen.findAllByTestId("expression-suggestions-list-item");
+
+    expect(screen.getAllByLabelText("More info").length).toBeGreaterThanOrEqual(
+      1,
+    );
+  });
+
+  test("suggestions items should show function helptext info icons", async () => {
+    setup({ source: "con" });
 
     await screen.findAllByTestId("expression-suggestions-list-item");
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -1,7 +1,7 @@
 import { useRef } from "react";
 
 import { createMockMetadata } from "__support__/metadata";
-import { renderWithProviders, screen } from "__support__/ui";
+import { renderWithProviders, screen, waitFor } from "__support__/ui";
 import { getColumnIcon } from "metabase/common/utils/columns";
 import type * as Lib from "metabase-lib";
 import { createQuery } from "metabase-lib/test-helpers";
@@ -66,7 +66,9 @@ describe("ExpressionEditorSuggestions", () => {
   test("suggestions items should show column info icon", async () => {
     setup({ source: "[" });
 
-    await screen.findAllByTestId("expression-suggestions-list-item");
+    await waitFor(() =>
+      screen.findAllByTestId("expression-suggestions-list-item"),
+    );
 
     expect(screen.getAllByLabelText("More info").length).toBeGreaterThanOrEqual(
       1,
@@ -76,7 +78,9 @@ describe("ExpressionEditorSuggestions", () => {
   test("suggestions items should show function helptext info icons", async () => {
     setup({ source: "con" });
 
-    await screen.findAllByTestId("expression-suggestions-list-item");
+    await waitFor(() =>
+      screen.findAllByTestId("expression-suggestions-list-item"),
+    );
 
     expect(screen.getAllByLabelText("More info").length).toBeGreaterThanOrEqual(
       1,


### PR DESCRIPTION
Related to https://github.com/metabase/metabase/issues/40863

### Description

Add an info icon that has a help text popover on the expression editor suggestions.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question → Sample Dataset → Orders
2. Add filters → Custom Expression
3. Type `co`
4. Hover the `concat` suggestion, an info icon should show up
5. Hover the info icon, the helptext for `concat` should appear

### Demo

<img width="763" alt="Screenshot 2024-04-05 at 11 38 41" src="https://github.com/metabase/metabase/assets/1250185/1cc7f8f5-4cab-4ec5-8536-dc8f36d850e8">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
