### PR TITLE
fix ticks auto rotation

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/axis.ts
@@ -610,6 +610,7 @@ export function getXAxisModel(
     : undefined;
 
   const xAxisScale = settings["graph.x_axis.scale"];
+  const isScatter = rawSeries[0].card.display === "scatter";
 
   if (xAxisScale === "timeseries") {
     return getTimeSeriesXAxisModel(
@@ -630,7 +631,7 @@ export function getXAxisModel(
       xAxisScale,
       settings,
       label,
-      rawSeries[0].card.display !== "scatter",
+      !isScatter,
       renderingContext,
     );
   }
@@ -656,12 +657,17 @@ export function getXAxisModel(
       computeNumericDataInverval(dataset.map(datum => datum[X_AXIS_DATA_KEY]))
     : undefined;
 
+  const valuesCount = isScatter
+    ? new Set(dataset.map(datum => datum[X_AXIS_DATA_KEY])).size
+    : dataset.length;
+
   return {
     formatter,
     label,
     isHistogram,
     histogramInterval,
     axisType: "category",
+    valuesCount,
   };
 }
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/types.ts
@@ -1,7 +1,6 @@
 import type { Dayjs } from "dayjs";
 import type { OptionAxisType } from "echarts/types/src/coord/axisCommonTypes";
 
-import type { OptionsType } from "metabase/lib/formatting/types";
 import type {
   X_AXIS_DATA_KEY,
   NEGATIVE_STACK_TOTAL_DATA_KEY,
@@ -93,7 +92,7 @@ export type Datum = Record<DataKey, RowValue> & {
 export type ChartDataset<D extends Datum = Datum> = D[];
 export type Extent = [number, number];
 export type SeriesExtents = Record<DataKey, Extent>;
-export type AxisFormatter = (value: RowValue, options?: OptionsType) => string;
+export type AxisFormatter = (value: RowValue) => string;
 export type TimeSeriesAxisFormatter = (
   value: RowValue,
   unit?: DateTimeAbsoluteUnit,
@@ -133,6 +132,7 @@ export type CategoryXAxisModel = BaseXAxisModel & {
   isHistogram: boolean;
   histogramInterval?: number;
   formatter: AxisFormatter;
+  valuesCount: number;
 };
 
 export type NumericXAxisModel = BaseXAxisModel &

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/axis.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/model/axis.ts
@@ -100,5 +100,6 @@ export const getWaterfallXAxisModel = (
   return {
     ...xAxisModel,
     totalXValue,
+    valuesCount: xAxisModel.valuesCount + 1,
   };
 };


### PR DESCRIPTION
### Description

Fixes ticks auto rotation logic to simulate old behavior. Also fixes incorrect dimensionWidth computation which did not work correctly on ungrouped datasets and continous scale scales with sparse data.

### Demo

#### Wide
**dc.js**
<img width="1693" alt="Screenshot 2024-04-05 at 1 09 24 PM" src="https://github.com/metabase/metabase/assets/14301985/d7e5f5d5-e4b0-4245-876e-bcdf3e7d142c">

**echarts**
<img width="1692" alt="Screenshot 2024-04-05 at 1 09 16 PM" src="https://github.com/metabase/metabase/assets/14301985/2026df7c-e6e7-4333-9ce0-b384ca85775c">

#### Min width for 45 degree rotation

**dc.js**
<img width="823" alt="Screenshot 2024-04-05 at 1 09 51 PM" src="https://github.com/metabase/metabase/assets/14301985/cb5dc79d-1d9b-4e92-910a-3d76984081bb">

**echarts**
<img width="825" alt="Screenshot 2024-04-05 at 1 09 46 PM" src="https://github.com/metabase/metabase/assets/14301985/1f256509-860d-4e27-8963-67d2d88a6b72">

#### Slightly narrower

**dc.js**
<img width="770" alt="Screenshot 2024-04-05 at 1 10 04 PM" src="https://github.com/metabase/metabase/assets/14301985/50819211-48e2-44a1-a20e-944a03c09f4a">

**echarts**
<img width="765" alt="Screenshot 2024-04-05 at 1 10 08 PM" src="https://github.com/metabase/metabase/assets/14301985/83b2d3bc-35a6-41ec-a99c-d094e4fbee67">
