### PR TITLE
Fix flaky object-detail test

### DIFF
--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -164,7 +164,12 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     createQuestion(questionDetails, { visitQuestion: true });
 
     cy.get(".cellData").contains("4966277046676").realHover();
-    cy.findByTestId("detail-shortcut").findByRole("button").click();
+    cy.findByTestId("detail-shortcut")
+      // cypress sometimes messes up where to show this button, so we hover over it second time
+      .realHover()
+      .findByRole("button")
+      .should("be.visible")
+      .click();
 
     cy.findByRole("dialog").findByTestId("fk-relation-orders").click();
 

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -163,6 +163,8 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
 
     createQuestion(questionDetails, { visitQuestion: true });
 
+    // there should be a hover instead of click
+    // but realHover is flaky
     cy.get(".cellData").contains("4966277046676").click();
 
     cy.findByTestId("detail-shortcut")

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -164,10 +164,10 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
     createQuestion(questionDetails, { visitQuestion: true });
 
     cy.get(".cellData").contains("4966277046676").realHover();
-    cy.findByTestId("detail-shortcut")
-      // cypress sometimes messes up where to show this button, so we hover over it second time
-      .realHover()
+    // cy.findByTestId("detail-shortcut") is flaky
+    cy.get("#gutter-column")
       .findByRole("button")
+      .realHover()
       .should("be.visible")
       .click();
 

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -163,11 +163,10 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
 
     createQuestion(questionDetails, { visitQuestion: true });
 
-    cy.get(".cellData").contains("4966277046676").realHover();
-    // cy.findByTestId("detail-shortcut") is flaky
-    cy.get("#gutter-column")
+    cy.get(".cellData").contains("4966277046676").click();
+
+    cy.findByTestId("detail-shortcut")
       .findByRole("button")
-      .realHover()
       .should("be.visible")
       .click();
 


### PR DESCRIPTION
Fixes https://github.com/metabase/metabase/issues/41084

### Description

Fix for flaky object_detail e2e spec.

`realHover` is not reliable ~on water~ at CI unfortunately, so I had to replace it with `click`

![image](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbjRvdXFzaWI2YzYwMjNuZG16azN5ejdhMzY3bno0amthNWJsa3dvaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ixJI8li5Zn8VfoRgac/giphy.gif)


### How to verify

[stress test](https://github.com/metabase/metabase/actions/runs/8574089488/job/23500165177)