### PR TITLE
increase activation distance for dashboard parameter dragging

### DIFF
--- a/e2e/support/helpers/e2e-ui-elements-helpers.js
+++ b/e2e/support/helpers/e2e-ui-elements-helpers.js
@@ -179,7 +179,9 @@ export const moveDnDKitElement = (
       button: 0,
     })
     .wait(200)
-    .trigger("pointermove", 5, 5, {
+    // This initial move needs to be greater than the activation constraint
+    // of the pointer sensor
+    .trigger("pointermove", 20, 20, {
       force: true,
       isPrimary: true,
       button: 0,

--- a/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/editor.cy.spec.js
@@ -14,6 +14,7 @@ import {
   startNewQuestion,
   setTokenFeatures,
   openTable,
+  moveDnDKitElement,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS_ID, REVIEWS, REVIEWS_ID, PEOPLE_ID } =
@@ -283,7 +284,10 @@ describe("scenarios > admin > datamodel > editor", () => {
 
     it("should allow sorting fields in the custom order", () => {
       visitTableMetadata({ tableId: PRODUCTS_ID });
-      moveField(0, 200);
+      //moveField(0, 200);
+      moveDnDKitElement(cy.findAllByTestId("grabber").first(), {
+        vertical: 200,
+      });
       cy.wait("@updateFieldOrder");
       openProductsTable();
       assertTableHeader([
@@ -656,28 +660,6 @@ const searchAndSelectValue = (newValue, searchText = newValue) => {
 
 const getFieldSection = fieldName => {
   return cy.findByLabelText(fieldName);
-};
-
-const moveField = (fieldIndex, deltaY) => {
-  cy.findAllByTestId("grabber")
-    .eq(fieldIndex)
-    .trigger("pointerdown", 0, 0, { force: true, button: 0, isPrimary: true })
-    .wait(200)
-    .trigger("pointermove", 5, 5, { force: true, button: 0, isPrimary: true })
-    .wait(200)
-    //cy.get("#ColumnsList")
-    .trigger("pointermove", 10, deltaY, {
-      force: true,
-      button: 0,
-      isPrimary: true,
-    })
-    .wait(200)
-    .trigger("pointerup", 10, deltaY, {
-      force: true,
-      button: 0,
-      isPrimary: true,
-    })
-    .wait(200);
 };
 
 const setTableOrder = order => {

--- a/e2e/test/scenarios/native-filters/reproductions/9357.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/9357.cy.spec.js
@@ -1,4 +1,8 @@
-import { restore, openNativeEditor } from "e2e/support/helpers";
+import {
+  restore,
+  openNativeEditor,
+  moveDnDKitElement,
+} from "e2e/support/helpers";
 
 import * as SQLFilter from "../helpers/e2e-sql-filter-helpers";
 
@@ -15,24 +19,9 @@ describe("issue 9357", () => {
     );
 
     // Drag the firstparameter to last position
-    cy.get("fieldset")
-      .findAllByRole("listitem")
-      .first()
-      .trigger("pointerdown", 0, 0, { force: true, isPrimary: true, button: 0 })
-      .wait(200)
-      .trigger("pointermove", 5, 5, { force: true, isPrimary: true, button: 0 })
-      .wait(200)
-      .trigger("pointermove", 430, 5, {
-        force: true,
-        isPrimary: true,
-        button: 0,
-      })
-      .wait(200)
-      .trigger("pointerup", 430, 5, {
-        force: true,
-        isPrimary: true,
-        button: 0,
-      });
+    moveDnDKitElement(cy.get("fieldset").findAllByRole("listitem").first(), {
+      horizontal: 430,
+    });
 
     // Ensure they're in the right order
     cy.findAllByText("Variable name").parent().as("variableField");

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableColumnList/MetadataTableColumnList.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableColumnList/MetadataTableColumnList.tsx
@@ -65,7 +65,7 @@ const MetadataTableColumnList = ({
   const isHidden = visibility_type != null;
 
   const pointerSensor = useSensor(PointerSensor, {
-    activationConstraint: { distance: 0 },
+    activationConstraint: { distance: 15 },
   });
 
   const sortedFields = useMemo(

--- a/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
+++ b/frontend/src/metabase/nav/containers/MainNavbar/MainNavbarContainer/BookmarkList/BookmarkList.tsx
@@ -123,7 +123,7 @@ const BookmarkList = ({
   }, [bookmarks]);
 
   const pointerSensor = useSensor(PointerSensor, {
-    activationConstraint: { distance: 0 },
+    activationConstraint: { distance: 15 },
   });
 
   const onToggleBookmarks = useCallback(isVisible => {

--- a/frontend/src/metabase/parameters/components/ParametersList.jsx
+++ b/frontend/src/metabase/parameters/components/ParametersList.jsx
@@ -34,7 +34,7 @@ function ParametersList({
   enableParameterRequiredBehavior,
 }) {
   const pointerSensor = useSensor(PointerSensor, {
-    activationConstraint: { distance: 5 },
+    activationConstraint: { distance: 15 },
   });
 
   const visibleValuePopulatedParameters = useMemo(

--- a/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/steps/ClauseStep/ClauseStep.tsx
@@ -114,7 +114,7 @@ function ClauseStepDndContext<T>({
   onReorder,
 }: ClauseStepDndContextProps<T>) {
   const pointerSensor = useSensor(PointerSensor, {
-    activationConstraint: { distance: 0 },
+    activationConstraint: { distance: 15 },
   });
 
   const handleSortEnd: DndContextProps["onDragEnd"] = useCallback(

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingOrderedItems/ChartSettingOrderedItems.tsx
@@ -43,7 +43,7 @@ export function ChartSettingOrderedItems<T extends SortableItem>({
 }: ChartSettingOrderedItemsProps<T>) {
   const isDragDisabled = items.length < 1;
   const pointerSensor = useSensor(PointerSensor, {
-    activationConstraint: { distance: 0 },
+    activationConstraint: { distance: 15 },
   });
 
   const renderItem = useCallback(

--- a/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
+++ b/frontend/src/metabase/visualizations/components/settings/ChartSettingsTableFormatting.jsx
@@ -184,7 +184,7 @@ const SortableRuleList = ({ rules, cols, onEdit, onRemove, onMove }) => {
   const getId = rule => rule.id.toString();
 
   const pointerSensor = useSensor(PointerSensor, {
-    activationConstraint: { distance: 0 },
+    activationConstraint: { distance: 15 },
   });
 
   const handleSortEnd = ({ id, newIndex }) => {


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40914

### Description
Increase the activation distance for dragging parameters from 5px to 15px. This keeps the UX fairly nice while ensuring that the drag is more intentional. This will also impact dragging query parameters in native queries.

### How to verify

1. Go to a dashboard with filter params, and click edit
2. drag parameters to re-order them. Re-ordering should still work as it always has, but clicking and dragging < `15px` should still register as a click and open the side panel

### Demo
![chrome_Fb9alPPI1a](https://github.com/metabase/metabase/assets/1328979/77d80543-605a-4324-ad88-7e34be8fdc4b)

### Checklist
I wasn't able to come up with an e2e test that would simulate the behavior I was looking for. Triggering a click event on the draggable element always resulted in the side panel opening :/. Open to suggestions if anyone has ideas though!

- [ ] ~Tests have been added/updated to cover changes in this PR~
