### PR TITLE
Include usage count in upload table list

### DIFF
--- a/src/metabase/api/table.clj
+++ b/src/metabase/api/table.clj
@@ -51,8 +51,14 @@
 (api/defendpoint GET "/uploaded"
   "Get all `Tables` visible to the current user which were created by uploading a file."
   []
-  (as-> (t2/select Table, :active true, :is_upload true, {:order-by [[:name :asc]]}) tables
-        (filterv mi/can-read? tables)))
+  (->> (t2/select Table {:select    [:t.*, [[:count :c.id] :usage_count]]
+                         :from      [[:metabase_table :t]]
+                         :left-join [[:report_card :c] [:= :t.id :c.table_id]]
+                         :group-by  [:t.id]
+                         :where     [:and
+                                     [:= :t.active true]
+                                     [:= :t.is_upload true]]})
+       (filterv mi/can-read?)))
 
 (api/defendpoint GET "/:id"
   "Get `Table` with ID."

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -138,7 +138,7 @@
 (deftest list-uploaded-tables-test
   (testing "GET /api/table/uploaded"
     (testing "These should come back in alphabetical order and include relevant metadata"
-      (with-tables-as-uploads [:categories :reviews :venues]
+      (with-tables-as-uploads [:categories :reviews]
         (t2.with-temp/with-temp [Card {} {:table_id (mt/id :categories)}
                                  Card {} {:table_id (mt/id :reviews)}
                                  Card {} {:table_id (mt/id :reviews)}]
@@ -156,12 +156,6 @@
                       :id           (mt/id :reviews)
                       :schema       "PUBLIC"
                       :usage_count  2
-                      :entity_type  "entity/GenericTable"}
-                     {:name         (mt/format-name "venues")
-                      :display_name "Venues"
-                      :id           (mt/id :venues)
-                      :schema       "PUBLIC"
-                      :usage_count  0
                       :entity_type  "entity/GenericTable"}}
                    (->> result
                         (filter #(= (:db_id %) (mt/id)))    ; prevent stray tables from affecting unit test results


### PR DESCRIPTION
References https://github.com/metabase/metabase/issues/36369

### Description

I failed to look through the mock-ups before, and see that we need to know the schema, created time, and number of questions / models using it.  The first two were already present, I just updated the test to demonstrate that, but the last one needed to be calculated. I don't see any reason that this number can't include metrics as well in future, so I haven't explicitly excluded them.

When SQL parsing is online we probably want to count the indirect usages as well, and probably MBQL joins etc too, but this is probably good enough for a v1.