### PR TITLE
serialize result_metadata for any card

### DIFF
--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -872,8 +872,8 @@ saved later when it is ready."
 (defmethod serdes/extract-query "Card" [_ opts]
   (serdes/extract-query-collections Card opts))
 
-(defn- export-result-metadata [card metadata]
-  (when (and metadata (model? card))
+(defn- export-result-metadata [metadata]
+  (when metadata
     (for [m metadata]
       (-> (dissoc m :fingerprint)
           (m/update-existing :table_id  serdes/*export-table-fk*)
@@ -912,7 +912,7 @@ saved later when it is ready."
         (update :parameters             serdes/export-parameters)
         (update :parameter_mappings     serdes/export-parameter-mappings)
         (update :visualization_settings serdes/export-visualization-settings)
-        (update :result_metadata        (partial export-result-metadata card))
+        (update :result_metadata        export-result-metadata)
         (dissoc :cache_invalidated_at))
     (catch Exception e
       (throw (ex-info (format "Failed to export Card: %s" (ex-message e)) {:card card} e)))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -695,9 +695,9 @@
                                                            :result_metadata metadata}]
         (doseq [card-id [card1-id card2-id]]
           (let [extracted (serdes/extract-one "Card" nil (t2/select-one :model/Card :id card-id))]
-            (when (= card-id card2-id)
-              (is (= :model
-                     (:type extracted))))
+            ;; card2 is model, but card1 is not
+            (is (= (= card-id card2-id)
+                   (= :model (:type extracted))))
             (is (string? (:display_name (first (:result_metadata extracted)))))
             ;; this is a quick comparison, since the actual stored metadata is quite complex
             (is (= (map :display_name metadata)

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -687,23 +687,21 @@
 (deftest ^:parallel extract-test
   (let [metadata (qp.preprocess/query->expected-cols (mt/mbql-query venues))
         query    (mt/mbql-query venues)]
-    (testing "normal cards omit result_metadata"
-      (t2.with-temp/with-temp [:model/Card {card-id :id} {:dataset_query   query
-                                                          :result_metadata metadata}]
-        (let [extracted (serdes/extract-one "Card" nil (t2/select-one :model/Card :id card-id))]
-          (is (not (:dataset extracted)))
-          (is (nil? (:result_metadata extracted))))))
-    (testing "dataset cards (models) retain result_metadata"
-      (t2.with-temp/with-temp [:model/Card {card-id :id} {:type            :model
-                                                          :dataset_query   query
-                                                          :result_metadata metadata}]
-        (let [extracted (serdes/extract-one "Card" nil (t2/select-one :model/Card :id card-id))]
-          (is (= :model
-                 (:type extracted)))
-          (is (string? (:display_name (first (:result_metadata extracted)))))
-          ;; this is a quick comparison, since the actual stored metadata is quite complex
-          (is (= (map :display_name metadata)
-                 (map :display_name (:result_metadata extracted)))))))))
+    (testing "every card retains result_metadata"
+      (t2.with-temp/with-temp [:model/Card {card1-id :id} {:dataset_query   query
+                                                           :result_metadata metadata}
+                               :model/Card {card2-id :id} {:type            :model
+                                                           :dataset_query   query
+                                                           :result_metadata metadata}]
+        (doseq [card-id [card1-id card2-id]]
+          (let [extracted (serdes/extract-one "Card" nil (t2/select-one :model/Card :id card-id))]
+            (when (= card-id card2-id)
+              (is (= :model
+                     (:type extracted))))
+            (is (string? (:display_name (first (:result_metadata extracted)))))
+            ;; this is a quick comparison, since the actual stored metadata is quite complex
+            (is (= (map :display_name metadata)
+                   (map :display_name (:result_metadata extracted))))))))))
 
 ;;; ------------------------------------------ Viz Settings Tests  ------------------------------------------
 


### PR DESCRIPTION
We need this for every card, since when a normal question depends on a native question - their result_metadata won't be updated when opening a dashboard, which leads to front-end not understanding how to connect the parameters, and errors during queries.
