### PR TITLE
Fix bad spacing on notebook action buttons

### DIFF
--- a/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
+++ b/frontend/src/metabase/query_builder/components/notebook/NotebookStep/NotebookStep.tsx
@@ -73,7 +73,7 @@ function NotebookStep({
               key={`actionButton_${stepUi.title}`}
               className={cx({
                 [cx(CS.mr2, CS.mt2)]: isLastStep,
-                mr1: !isLastStep,
+                [CS.mr1]: !isLastStep,
               })}
               color={stepUi.getColor()}
               large={hasLargeActionButtons}


### PR DESCRIPTION
### Description

Fixes the lack of spacing that #40518 caused.


Before:
![image](https://github.com/metabase/metabase/assets/25306947/acea620b-89ae-45b5-9b6c-5bcb71a3f240)


After:
<img width="544" alt="image" src="https://github.com/metabase/metabase/assets/25306947/8c2102e3-17d5-4719-bef3-72d249f996b2">


### How to verify


1. Create a new question
2. Click `X` on the filter and summarize steps, and add a row limit.
3. You should see the filter/summarize/join data buttons under the `Data` step together. Those buttons should be spaced apart as shown in the `After` section mentioned above