### PR TITLE
[MBQL lib] Don't enforce expression types when converting from legacy

### DIFF
--- a/src/metabase/lib/convert.cljc
+++ b/src/metabase/lib/convert.cljc
@@ -16,8 +16,8 @@
    [metabase.lib.schema.ref :as lib.schema.ref]
    [metabase.lib.util :as lib.util]
    [metabase.util :as u]
-   [metabase.util.log :as log]
-   [metabase.util.malli :as mu])
+   [metabase.util.malli :as mu]
+   #?@(:clj ([metabase.util.log :as log])))
   #?@(:cljs [(:require-macros [metabase.lib.convert :refer [with-aggregation-list]])]))
 
 (def ^:private ^:dynamic *pMBQL-uuid->legacy-index*
@@ -49,25 +49,29 @@
   #{:aggregation :breakout :expressions :fields :filters :order-by :joins})
 
 (defn- clean-stage-schema-errors [almost-stage]
-  (loop [almost-stage almost-stage
-         removals []]
-    (if-let [[error-type error-location] (->> (mc/explain ::lib.schema/stage.mbql almost-stage)
-                                              :errors
-                                              (filter (comp stage-keys first :in))
-                                              (map (juxt :type :in))
-                                              first)]
-      (let [new-stage (clean-location almost-stage error-type error-location)]
-        (log/warnf "Clean: Removing bad clause in %s due to error %s:\n%s"
-                   (u/colorize :yellow (pr-str error-location))
-                   (u/colorize :yellow (pr-str (or error-type
-                                                   ;; if `error-type` is missing, which seems to happen sometimes,
-                                                   ;; fall back to humanizing the entire error.
-                                                   (me/humanize (mc/explain ::lib.schema/stage.mbql almost-stage)))))
-                   (u/colorize :red (u/pprint-to-str (first (data/diff almost-stage new-stage)))))
-        (if (= new-stage almost-stage)
-          almost-stage
-          (recur new-stage (conj removals [error-type error-location]))))
-      almost-stage)))
+  (binding [lib.schema.expression/*suppress-expression-type-check?* true]
+    (loop [almost-stage almost-stage
+           removals []]
+      (if-let [[error-type error-location] (->> (mc/explain ::lib.schema/stage.mbql almost-stage)
+                                                :errors
+                                                (filter (comp stage-keys first :in))
+                                                (map (juxt :type :in))
+                                                first)]
+        (let [new-stage  (clean-location almost-stage error-type error-location)
+              error-desc (pr-str (or error-type
+                                     ;; if `error-type` is missing, which seems to happen sometimes,
+                                     ;; fall back to humanizing the entire error.
+                                     (me/humanize (mc/explain ::lib.schema/stage.mbql almost-stage))))]
+          #?(:cljs (js/console.warn "Clean: Removing bad clause due to error!" error-location error-desc
+                                    (u/pprint-to-str (first (data/diff almost-stage new-stage))))
+             :clj  (log/warnf "Clean: Removing bad clause in %s due to error %s:\n%s"
+                              (u/colorize :yellow (pr-str error-location))
+                              (u/colorize :yellow error-desc)
+                              (u/colorize :red (u/pprint-to-str (first (data/diff almost-stage new-stage))))))
+          (if (= new-stage almost-stage)
+            almost-stage
+            (recur new-stage (conj removals [error-type error-location]))))
+        almost-stage))))
 
 (defn- clean-stage-ref-errors [almost-stage]
   (reduce (fn [almost-stage [loc _]]

--- a/src/metabase/lib/filter.cljc
+++ b/src/metabase/lib/filter.cljc
@@ -194,16 +194,15 @@
   (let [->display-name #(lib.metadata.calculation/display-name query stage-number % style)
         ->unbucketed-display-name #(-> %
                                        (update 1 dissoc :temporal-unit)
-                                       ->display-name)
-        temporal? #(lib.util/original-isa? % :type/Temporal)]
+                                       ->display-name)]
     (lib.util.match/match-one expr
-      [:between _ (x :guard temporal?) (y :guard string?) (z :guard string?)]
+      [:between _ x (y :guard string?) (z :guard string?)]
       (i18n/tru "{0} is {1}"
                 (->unbucketed-display-name x)
                 (shared.ut/format-diff y z))
 
       [:between _
-       [:+ _ (x :guard temporal?) [:interval _ n unit]]
+       [:+ _ x [:interval _ n unit]]
        [:relative-datetime _ n2 unit2]
        [:relative-datetime _ 0 _]]
       (i18n/tru "{0} is in the {1}, starting {2} ago"
@@ -212,7 +211,7 @@
                 (inflections/pluralize n (name unit)))
 
       [:between _
-       [:+ _ (x :guard temporal?) [:interval _ n unit]]
+       [:+ _ x [:interval _ n unit]]
        [:relative-datetime _ 0 _]
        [:relative-datetime _ n2 unit2]]
       (i18n/tru "{0} is in the {1}, starting {2} from now"

--- a/src/metabase/lib/query.cljc
+++ b/src/metabase/lib/query.cljc
@@ -13,6 +13,7 @@
    [metabase.lib.normalize :as lib.normalize]
    [metabase.lib.schema :as lib.schema]
    [metabase.lib.schema.common :as lib.schema.common]
+   [metabase.lib.schema.expression :as lib.schema.expression]
    [metabase.lib.schema.id :as lib.schema.id]
    [metabase.lib.util :as lib.util]
    [metabase.lib.util.match :as lib.util.match]
@@ -62,7 +63,8 @@
 (mu/defn can-run :- :boolean
   "Returns whether the query is runnable. Manually validate schema for cljs."
   [query :- ::lib.schema/query]
-  (and (mc/validate ::lib.schema/query query)
+  (and (binding [lib.schema.expression/*suppress-expression-type-check?* true]
+         (mc/validate ::lib.schema/query query))
        (boolean (can-run-method query))))
 
 (mu/defn can-save :- :boolean

--- a/src/metabase/lib/schema/expression.cljc
+++ b/src/metabase/lib/schema/expression.cljc
@@ -76,6 +76,16 @@
             (i18n/tru "type-of {0} returned an invalid type {1}" (pr-str expr) (pr-str expr-type)))
     (is-type? expr-type base-type)))
 
+(def ^:dynamic *suppress-expression-type-check?*
+  "Set this `true` to skip any type checks for expressions. This is useful while constructing expressions in MLv2 with
+  full metadata, but it breaks during legacy conversion in some cases.
+
+  In particular, if you override the metadata for a column to eg. treat a `:type/Integer` columns as a `:type/Instant`
+  with `:Coercion/UNIXSeconds->DateTime`, it will have `:base-type :type/Integer` and `:effective-type :type/Instant`.
+  But when converting from legacy, the `:field` refs in eg. a filter will only have `:base-type :type/Integer`, and then
+  the filter fails Malli validation. See #41122."
+  false)
+
 (defn- expression-schema
   "Schema that matches the following rules:
 
@@ -94,7 +104,8 @@
     [false [:ref :metabase.lib.schema.literal/literal]]]
    [:fn
     {:error/message description}
-    #(type-of? % base-type)]])
+    #(or *suppress-expression-type-check?*
+         (type-of? % base-type))]])
 
 (mr/def ::boolean
   (expression-schema :type/Boolean "expression returning a boolean"))

--- a/src/metabase/lib/schema/filter.cljc
+++ b/src/metabase/lib/schema/filter.cljc
@@ -21,9 +21,10 @@
       {:error/message "arguments should be comparable"}
       (fn [[_tag _opts & args]]
         (let [argv (vec args)]
-          (every? true? (map (fn [[i j]]
-                               (expression/comparable-expressions? (get argv i) (get argv j)))
-                             compared-position-pairs))))]]))
+          (or expression/*suppress-expression-type-check?*
+              (every? true? (map (fn [[i j]]
+                                   (expression/comparable-expressions? (get argv i) (get argv j)))
+                                 compared-position-pairs)))))]]))
 
 (doseq [op [:and :or]]
   (mbql-clause/define-catn-mbql-clause op :- :type/Boolean

--- a/test/metabase/lib/convert_test.cljc
+++ b/test/metabase/lib/convert_test.cljc
@@ -774,3 +774,19 @@
       (is (=? {:type  :query
                :query {:expressions {"expr" [:+ 1 2]}}}
               (lib.convert/->legacy-MBQL query))))))
+
+(deftest ^:parallel convert-with-broken-expression-types-test
+  (testing "be flexible when converting from legacy, metadata type overrides are soometimes dropped (#41122)"
+    (let [legacy {:database (meta/id)
+                  :type     :query
+                  :query    {:filter [:between [:+
+                                                [:field 40 {:base-type :type/Integer}]
+                                                [:interval 1 :year]]
+                                      [:relative-datetime -2 :month]
+                                      [:relative-datetime 0 :month]]}}]
+      (is (=? {:stages [{:filters [[:between {} [:+ {}
+                                                 [:field {:base-type :type/Integer} 40]
+                                                 [:interval {} 1 :year]]
+                                    [:relative-datetime {} -2 :month]
+                                    [:relative-datetime {} 0 :month]]]}]}
+              (lib.convert/->pMBQL legacy))))))

--- a/test/metabase/query_processor/middleware/annotate_test.clj
+++ b/test/metabase/query_processor/middleware/annotate_test.clj
@@ -620,7 +620,7 @@
             (add-column-info
              (lib.tu.macros/mbql-query venues
                {:aggregation [[:count]
-                              [:sum]
+                              [:sum $price]
                               [:count]
                               [:aggregation-options [:count] {:display-name "count_2"}]]})
              {:cols [{:name "count", :display_name "count", :base_type :type/Number}


### PR DESCRIPTION
These type checks are useful when constructing clauses with full MLv2
metadata available, but when converting from legacy the `:field` refs
have only `:base-type`.

If a column has its metadata overridden to eg. coerce a string or
integer into a date, its `:base-type` will remain `:type/Integer` or
`:type/Text` and the `:effective-type` will be `:type/Date` etc.

This change skips the type check while converting from legacy, and
while checking `can-run`. Eventually this should be replaced with
tracking `:effective-type` on refs or using real metdata, instead of
relying on the `:base-type` only.

Fixes #41122.

