### PR TITLE
Minimize echarts shape transitions

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/index.ts
@@ -25,6 +25,7 @@ export const getSharedEChartsOptions = (isPlaceholder: boolean) => ({
   useUTC: true,
   animation: !isPlaceholder,
   animationDuration: 0,
+  animationDurationUpdate: 1, // by setting this to 1ms we visually eliminate shape transitions while preserving opacity transitions
   toolbox: {
     show: false,
   },


### PR DESCRIPTION
### Description

Previously, we did not have any smooth shape transitions so this PR minimizes them by setting `animationDurationUpdate` to 1. If we set it to zero, then opacity transitions on hover won't work.

### How to verify

Check that charts do not have visible shape transitions when resizing, changing granularity.