### PR TITLE
Fix unable to disable scan field values

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/serialization/v2/e2e_test.clj
@@ -100,7 +100,7 @@
 (defn- clean-entity
  "Removes any comparison-confounding fields, like `:created_at`."
  [entity]
- (dissoc entity :created_at :result_metadata))
+ (dissoc entity :created_at :result_metadata :metadata_sync_schedule :cache_field_values_schedule))
 
 #_{:clj-kondo/ignore [:metabase/i-like-making-cams-eyes-bleed-with-horrifically-long-tests]}
 (deftest e2e-storage-ingestion-test

--- a/frontend/src/metabase-types/api/database.ts
+++ b/frontend/src/metabase-types/api/database.ts
@@ -74,7 +74,7 @@ export interface DatabaseData {
 
 export interface DatabaseSchedules {
   metadata_sync?: ScheduleSettings;
-  cache_field_values?: ScheduleSettings;
+  cache_field_values?: ScheduleSettings | null;
 }
 
 export interface DatabaseUsageInfo {

--- a/frontend/src/metabase/databases/utils/schema.ts
+++ b/frontend/src/metabase/databases/utils/schema.ts
@@ -29,7 +29,7 @@ export const getValidationSchema = (
     details: Yup.object(Object.fromEntries(entries)),
     schedules: Yup.object({
       metadata_sync: SCHEDULE_SCHEMA.default(undefined),
-      cache_field_values: SCHEDULE_SCHEMA.default(undefined),
+      cache_field_values: SCHEDULE_SCHEMA.nullable().default(undefined),
     }),
     auto_run_queries: Yup.boolean().nullable().default(true),
     refingerprint: Yup.boolean().nullable().default(false),

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6129,6 +6129,17 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  - changeSet:
+      id: v50.2024-04-09T10:00:00
+      author: qnkhuat
+      comment: Drop not null constraint on metabase_database.cache_field_values_schedule
+      changes:
+        - dropNotNullConstraint:
+            tableName: metabase_database
+            columnName: cache_field_values_schedule
+      # nothing because it should always be like this
+      rollback:
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5575,6 +5575,18 @@ databaseChangeLog:
       rollback:
 
   - changeSet:
+      id: v49.2024-04-09T10:00:02
+      author: qnkhuat
+      comment: Add null as default value for metabase_database.cache_field_values_schedule
+      changes:
+        - addDefaultValue:
+            defaultValue: "null"
+            tableName: metabase_database
+            columnName: cache_field_values_schedule
+      # nothing because it should always be like this
+      rollback:
+
+  - changeSet:
       id: v50.2024-01-04T13:52:51
       author: noahmoss
       comment: Data permissions table

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5559,6 +5559,7 @@ databaseChangeLog:
         - dropNotNullConstraint:
             tableName: metabase_database
             columnName: cache_field_values_schedule
+            columnDataType: varchar(254)
       # nothing because it should always be like this
       rollback:
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5566,7 +5566,7 @@ databaseChangeLog:
   - changeSet:
       id: v49.2024-04-09T10:00:01
       author: qnkhuat
-      comment: Drop not null constraint on metabase_database.cache_field_values_schedule
+      comment: Drop default value on metabase_database.cache_field_values_schedule
       changes:
         - dropDefaultValue:
             tableName: metabase_database

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5552,6 +5552,28 @@ databaseChangeLog:
             class: "metabase.db.custom_migrations.DeleteTruncateAuditLogTask"
 
   - changeSet:
+      id: v49.2024-04-09T10:00:00
+      author: qnkhuat
+      comment: Drop not null constraint on metabase_database.cache_field_values_schedule
+      changes:
+        - dropNotNullConstraint:
+            tableName: metabase_database
+            columnName: cache_field_values_schedule
+      # nothing because it should always be like this
+      rollback:
+
+  - changeSet:
+      id: v49.2024-04-09T10:00:01
+      author: qnkhuat
+      comment: Drop not null constraint on metabase_database.cache_field_values_schedule
+      changes:
+        - dropDefaultValue:
+            tableName: metabase_database
+            columnName: cache_field_values_schedule
+      # nothing because it should always be like this
+      rollback:
+
+  - changeSet:
       id: v50.2024-01-04T13:52:51
       author: noahmoss
       comment: Data permissions table
@@ -6128,28 +6150,6 @@ databaseChangeLog:
                   remarks: 'An invalidation time that can supersede cache_config.invalidated_at'
                   constraints:
                     nullable: true
-
-  - changeSet:
-      id: v50.2024-04-09T10:00:00
-      author: qnkhuat
-      comment: Drop not null constraint on metabase_database.cache_field_values_schedule
-      changes:
-        - dropNotNullConstraint:
-            tableName: metabase_database
-            columnName: cache_field_values_schedule
-      # nothing because it should always be like this
-      rollback:
-
-  - changeSet:
-      id: v50.2024-04-09T10:00:01
-      author: qnkhuat
-      comment: Drop not null constraint on metabase_database.cache_field_values_schedule
-      changes:
-        - dropDefaultValue:
-            tableName: metabase_database
-            columnName: cache_field_values_schedule
-      # nothing because it should always be like this
-      rollback:
 
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6140,6 +6140,17 @@ databaseChangeLog:
       # nothing because it should always be like this
       rollback:
 
+  - changeSet:
+      id: v50.2024-04-09T10:00:01
+      author: qnkhuat
+      comment: Drop not null constraint on metabase_database.cache_field_values_schedule
+      changes:
+        - dropDefaultValue:
+            tableName: metabase_database
+            columnName: cache_field_values_schedule
+      # nothing because it should always be like this
+      rollback:
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -990,7 +990,7 @@
                                          (merge (:settings existing-database) settings))})))
                     ;; cache_field_values_schedule is nullable
                     (when (or
-                           ;; turned on advanced sync options
+                           ;; turn on advanced sync options
                            (and (get-in existing-database [:details :let-user-control-scheduling])
                                 (not (:failed-fingerprints details)))
                            ;; user's controling the schedules, then we'll always attempt to update the schedule

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -784,23 +784,23 @@
   [{:keys [details is_on_demand is_full_sync] :as db} schedules]
   (let [let-user-control-scheduling (:let-user-control-scheduling details)]
     (merge
-     (dissoc db :schedules)
-     #p (sync.schedules/schedule-map->cron-strings
-         (match #p [(true? let-user-control-scheduling) is_full_sync is_on_demand]
-           [false _ _]
-           (sync.schedules/default-randomized-schedule)
+     db
+     (sync.schedules/schedule-map->cron-strings
+      (match [(true? let-user-control-scheduling) is_full_sync is_on_demand]
+        [false _ _]
+        (sync.schedules/default-randomized-schedule)
 
-           ;; regularly on a schedule
-           ;; sync both steps, schedule should be provided
-           [true true false]
-           (do
-            (assert (every? #(some? (% schedules)) [:cache_field_values :metadata_sync]))
-            (sync.schedules/scheduling schedules))
+        ;; regularly on a schedule
+        ;; sync both steps, schedule should be provided
+        [true true false]
+        (do
+         (assert (every? #(some? (% schedules)) [:cache_field_values :metadata_sync]))
+         (sync.schedules/scheduling schedules))
 
-           ;; Only when adding a new filter or never, I'll do it myself
-           ;; -> Sync metadata only
-           [true false _]
-           (sync.schedules/scheduling (dissoc schedules :cache_field_values)))))))
+        ;; Only when adding a new filter or never, I'll do it myself
+        ;; -> Sync metadata only
+        [true false _]
+        (sync.schedules/scheduling (dissoc schedules :cache_field_values)))))))
 
 (api/defendpoint POST "/"
   "Add a new `Database`."

--- a/src/metabase/api/database.clj
+++ b/src/metabase/api/database.clj
@@ -797,14 +797,11 @@
     ;; "Only when adding a new filter" or "Never, I'll do it myself"
     ;; -> Sync metadata only
     [true false _]
-    ;; schedules should only contains metadata_sync, but FE might sending both
-    ;; so we just manually dissoc it here
     (-> schedules
         (sync.schedules/schedule-map->cron-strings)
-        ;; make sure the schedule for :cache_field_values_schedule is nil
-        ;; in case FE still send a schedule for it
+        ;; schedules should only contains metadata_sync, but FE might sending both
+        ;; so we just manually nullify it here
         (assoc :cache_field_values_schedule nil))))
-
 
 (api/defendpoint POST "/"
   "Add a new `Database`."

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -229,7 +229,7 @@
 
 (t2/define-before-update :model/Database
   [database]
-  (let [database-with-changes                (mi/pre-update-changes database)
+  (let [database-with-changes                (mi/row-with-changes database)
         {new-metadata-schedule    :metadata_sync_schedule,
          new-fieldvalues-schedule :cache_field_values_schedule,
          new-engine               :engine
@@ -254,9 +254,6 @@
                                 (not (driver/database-supports? (or new-engine existing-engine) :nested-field-columns database-with-changes)))
                      (update :details dissoc :json_unfolding))
                    handle-secrets-changes)
-        ;; TODO - this logic would make more sense in post-update if such a method existed
-        ;; if the sync operation schedules have changed, we need to reschedule this DB
-        #_(update-schedules-if-changes! (t2/original database-with-changes) (t2/changes database))
         ;; This maintains a constraint that if a driver doesn't support actions, it can never be enabled
         ;; If we drop support for actions for a driver, we'd need to add a migration to disable actions for all databases
         (when (and (:database-enable-actions (or new-settings existing-settings))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -277,9 +277,9 @@
               ;; reschedule the database. Make sure we're passing back the old schedule if one of the two wasn't
               ;; supplied
               (schedule-tasks!
-               #p (assoc database
-                         :metadata_sync_schedule      new-metadata-schedule
-                         :cache_field_values_schedule new-fieldvalues-schedule)))))
+               (assoc database
+                      :metadata_sync_schedule      new-metadata-schedule
+                      :cache_field_values_schedule new-fieldvalues-schedule)))))
         ;; This maintains a constraint that if a driver doesn't support actions, it can never be enabled
         ;; If we drop support for actions for a driver, we'd need to add a migration to disable actions for all databases
         (when (and (:database-enable-actions (or new-settings existing-settings))

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -386,8 +386,8 @@
                          ;; you need to define it :)
                          false)))
                    settings)
-                   (when (not= <> settings)
-                     (log/debug "Redacting non-user-readable database settings during json encoding.")))))))
+                  (when (not= <> settings)
+                    (log/debug "Redacting non-user-readable database settings during json encoding.")))))))
    json-generator))
 
 ;;; ------------------------------------------------ Serialization ----------------------------------------------------

--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -230,16 +230,11 @@
 (t2/define-before-update :model/Database
   [database]
   (let [database-with-changes                (mi/row-with-changes database)
-        {new-metadata-schedule    :metadata_sync_schedule,
-         new-fieldvalues-schedule :cache_field_values_schedule,
-         new-engine               :engine
+        {new-engine               :engine
          new-settings             :settings} database-with-changes
         {is-sample?               :is_sample
-         old-metadata-schedule    :metadata_sync_schedule
-         old-fieldvalues-schedule :cache_field_values_schedule
          existing-settings        :settings
-         existing-engine          :engine
-         existing-name            :name} (t2/original database)
+         existing-engine          :engine}   (t2/original database)
         new-engine                       (some-> new-engine keyword)]
     (if (and is-sample?
              new-engine
@@ -265,12 +260,6 @@
 
 (t2/define-after-update :model/Database
   [database]
-  #_(log/info
-     (format "%s Database '%s' sync/analyze schedules have changed!" existing-engine existing-name)
-     "\n"
-     (format "Sync metadata was: '%s' is now: '%s'" old-metadata-schedule new-metadata-schedule)
-     "\n"
-     (format "Cache FieldValues was: '%s', is now: '%s'" old-fieldvalues-schedule new-fieldvalues-schedule))
   (check-and-schedule-tasks-for-db! (t2.realize/realize database)))
 
 (t2/define-before-insert :model/Database

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -469,7 +469,7 @@
 (methodical/prefer-method! #'t2.before-insert/before-insert :hook/timestamped? :hook/entity-id)
 
 ;; --- helper fns
-(defn row-with-changes
+(defn changes-with-pk
   "The row merged with the changes in pre-update hooks.
   This is to match the input of pre-update for toucan1 methods"
   [row]

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -471,8 +471,8 @@
 (methodical/prefer-method! #'t2.before-insert/before-insert :hook/timestamped? :hook/entity-id)
 
 ;; --- helper fns
-(defn pre-update-changes
-  "Returns the changes used for pre-update hooks. Not to confused with the changes before the update.
+(defn row-with-changes
+  "The object merged with the changes in pre-update hooks.
   This is to match the input of pre-update for toucan1 methods"
   [row]
   (t2.protocols/with-current row (merge (t2.model/primary-key-values-map row)

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -339,9 +339,7 @@
 
 (def ^{:arglists '([s])} ^:private validate-cron-string
   (let [validator (mc/validator u.cron/CronScheduleString)]
-    (fn [s]
-      (when (validator s)
-        s))))
+    (partial mu/validate-throw validator)))
 
 (def transform-cron-string
   "Transform for encrypted json."

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -470,7 +470,7 @@
 
 ;; --- helper fns
 (defn row-with-changes
-  "The object merged with the changes in pre-update hooks.
+  "The row merged with the changes in pre-update hooks.
   This is to match the input of pre-update for toucan1 methods"
   [row]
   (t2.protocols/with-current row (merge (t2.model/primary-key-values-map row)

--- a/src/metabase/models/interface.clj
+++ b/src/metabase/models/interface.clj
@@ -472,7 +472,7 @@
 
 ;; --- helper fns
 (defn pre-update-changes
-  "Returns the changes used for pre-update hooks.
+  "Returns the changes used for pre-update hooks. Not to confused with the changes before the update.
   This is to match the input of pre-update for toucan1 methods"
   [row]
   (t2.protocols/with-current row (merge (t2.model/primary-key-values-map row)

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -215,7 +215,7 @@
 
 (t2/define-before-update :model/PulseChannel
   [pulse-channel]
-  (validate-email-domains (mi/row-with-changes pulse-channel)))
+  (validate-email-domains (mi/changes-with-pk pulse-channel)))
 
 (defmethod serdes/hash-fields PulseChannel
   [_pulse-channel]

--- a/src/metabase/models/pulse_channel.clj
+++ b/src/metabase/models/pulse_channel.clj
@@ -215,7 +215,7 @@
 
 (t2/define-before-update :model/PulseChannel
   [pulse-channel]
-  (validate-email-domains (mi/pre-update-changes pulse-channel)))
+  (validate-email-domains (mi/row-with-changes pulse-channel)))
 
 (defmethod serdes/hash-fields PulseChannel
   [_pulse-channel]

--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -12,13 +12,13 @@
   "Schema with values for a DB's schedules that can be put directly into the DB."
   [:map
    [:metadata_sync_schedule      {:optional true} u.cron/CronScheduleString]
-   [:cache_field_values_schedule {:optional true} u.cron/CronScheduleString]])
+   [:cache_field_values_schedule {:optional true} [:maybe u.cron/CronScheduleString]]])
 
 (mr/def ::ExpandedSchedulesMap
   (mu/with-api-error-message
    [:map
     {:error/message "Map of expanded schedule maps"}
-    [:cache_field_values {:optional true} u.cron/ScheduleMap]
+    [:cache_field_values {:optional true} [:maybe u.cron/ScheduleMap]]
     [:metadata_sync      {:optional true} u.cron/ScheduleMap]]
    (deferred-tru "value must be a valid map of schedule maps for a DB.")))
 
@@ -70,5 +70,6 @@
 (defn scheduling
   "Adds sync schedule defaults to a map of schedule-maps."
   [{:keys [cache_field_values metadata_sync] :as _schedules}]
-  {:cache_field_values (or cache_field_values (randomly-once-a-day))
-   :metadata_sync      (or metadata_sync (randomly-once-an-hour))})
+  (cond-> {:metadata_sync (or metadata_sync (randomly-once-an-hour))}
+    cache_field_values
+    (assoc :cache_field_values cache_field_values)))

--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -70,6 +70,5 @@
 (defn scheduling
   "Adds sync schedule defaults to a map of schedule-maps."
   [{:keys [cache_field_values metadata_sync] :as _schedules}]
-  (cond-> {:metadata_sync (or metadata_sync (randomly-once-an-hour))}
-    cache_field_values
-    (assoc :cache_field_values cache_field_values)))
+  {:metadata_sync      (or metadata_sync (randomly-once-an-hour))
+   :cache_field_values cache_field_values})

--- a/src/metabase/sync/schedules.clj
+++ b/src/metabase/sync/schedules.clj
@@ -71,4 +71,5 @@
   "Adds sync schedule defaults to a map of schedule-maps."
   [{:keys [cache_field_values metadata_sync] :as _schedules}]
   {:metadata_sync      (or metadata_sync (randomly-once-an-hour))
+   ;; cache_field_values is nullable
    :cache_field_values cache_field_values})

--- a/src/metabase/task.clj
+++ b/src/metabase/task.clj
@@ -181,7 +181,8 @@
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (mu/defn ^:private reschedule-task!
-  [job :- (ms/InstanceOfClass JobDetail) new-trigger :- (ms/InstanceOfClass Trigger)]
+  [job         :- (ms/InstanceOfClass JobDetail)
+   new-trigger :- (ms/InstanceOfClass Trigger)]
   (try
     (when-let [scheduler (scheduler)]
       (when-let [[^Trigger old-trigger] (seq (qs/get-triggers-of-job scheduler (.getKey ^JobDetail job)))]

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -258,7 +258,7 @@
         ;; See https://www.nurkiewicz.com/2012/04/quartz-scheduler-misfire-instructions.html for more info
         (cron/with-misfire-handling-instruction-do-nothing))))))
 
-(defn- update-db-triggers-if-needed!
+(defn- update-db-trigger-if-needed!
   "Replace or remove the existing trigger if the schedule changes, do nothing if schedule is the same."
   [database task-info]
   (let [job                                 (task/job-info (job-key task-info))
@@ -293,7 +293,7 @@
   (if (= perms/audit-db-id (:id database))
     (log/info (u/format-color :red "Not scheduling tasks for audit database"))
     (doseq [task all-tasks]
-      (update-db-triggers-if-needed! database task))))
+      (update-db-trigger-if-needed! database task))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                              TASK INITIALIZATION                                               |

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -279,7 +279,7 @@
      ;; delete the existing trigger
      (nil? new-trigger)
      (do
-      (log/infof "Trigger for \"%s\" of Database \"%s\" has been removed. No new schedule is created."
+      (log/infof "Trigger for \"%s\" of Database \"%s\" has been removed. It will no longer run on a schedule."
                  (:name task-info)
                  (:name database))
       (delete-trigger! database task-info))
@@ -289,11 +289,11 @@
           (nil? existing-trigger-with-same-schedule))
      (do
       (if (delete-trigger! database task-info)
-        (log/infof "Trigger for \"%s\" of Database \"%s\" has been removed. The new schedule is now: \"%s\""
+        (log/infof "Trigger for \"%s\" of Database \"%s\" has been updated. The new schedule is: \"%s\""
                    (:name task-info)
                    (:name database)
                    (cron-schedule database task-info))
-        (log/infof "A trigger for \"%s\" of Database \"%s\" has been screated with schedule: \"%s\""
+        (log/infof "A trigger for \"%s\" of Database \"%s\" has been enabled with schedule: \"%s\""
                    (:name task-info)
                    (:name database)
                    (cron-schedule database task-info)))

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -179,7 +179,7 @@
                task-info :- TaskInfo]
   (triggers/key (format "metabase.task.%s.trigger.%d" (name (:key task-info)) (u/the-id database))))
 
-(mu/defn ^:private cron-schedule :- u.cron/CronScheduleString
+(mu/defn ^:private cron-schedule :- [:maybe u.cron/CronScheduleString]
   "Fetch the appropriate cron schedule string for `database` and `task-info`."
   [database  :- (ms/InstanceOf Database)
    task-info :- TaskInfo]

--- a/src/metabase/task/sync_databases.clj
+++ b/src/metabase/task/sync_databases.clj
@@ -263,6 +263,7 @@
   [database :- (ms/InstanceOf Database)]
   (if (= perms/audit-db-id (:id database))
     (log/info (u/format-color :red "Not scheduling tasks for audit database"))
+    ;; TODO, fix this so fv trigger is optional
     (let [sync-job (task/job-info (job-key sync-analyze-task-info))
           fv-job   (task/job-info (job-key field-values-task-info))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -25,6 +25,7 @@
    [metabase.sync.analyze :as analyze]
    [metabase.sync.field-values :as field-values]
    [metabase.sync.sync-metadata :as sync-metadata]
+   [metabase.task :as task]
    [metabase.task.sync-databases :as task.sync-databases]
    [metabase.test :as mt]
    [metabase.test.data.impl :as data.impl]
@@ -40,7 +41,8 @@
    [toucan2.core :as t2]
    [toucan2.tools.with-temp :as t2.with-temp])
   (:import
-   (java.sql Connection)))
+   (java.sql Connection)
+   (org.quartz TriggerKey)))
 
 (set! *warn-on-reflection* true)
 
@@ -262,19 +264,28 @@
 (def ^:private monthly-schedule {:schedule_type "monthly" :schedule_day "fri" :schedule_frame "last"})
 
 (defn- all-db-sync-triggers-name
+  "Returns the name of trigger for DB.
+  This is all trigger names that a DB SHOULD have."
   [db]
-  (set (map #(.getName (#'task.sync-databases/trigger-key (t2/instance :model/Database db) %))
+  (set (map #(.getName ^TriggerKey (#'task.sync-databases/trigger-key (t2/instance :model/Database db) %))
             @#'task.sync-databases/all-tasks)))
 
 (defn- query-all-db-sync-triggers-name
+  "Find the all triggers for DB \"db\".
+  This is all triger names that a DB HAVE in the scheduler."
   [db]
-  (set (map :trigger_name (t2/query {:select [:trigger_name]
-                                     :from   [:qrtz_triggers]
-                                     :where  [:in :trigger_name (all-db-sync-triggers-name db)]}))))
+  (let [db (t2/instance :model/Database db)]
+    (assert (some? (#'task/scheduler)) "makes sure the scheduler is initialized!")
+    (->> (for [task-info @#'task.sync-databases/all-tasks]
+           (keep #(when (= (.getName ^TriggerKey (#'task.sync-databases/trigger-key db task-info)) (:key %))
+                    (:key %))
+                 (:triggers (task/job-info (#'task.sync-databases/job-key task-info)))))
+         flatten
+         set)))
 
 (defn- sync-and-analyze-trigger-name
   [db]
-  (.getName (#'task.sync-databases/trigger-key db @#'task.sync-databases/sync-analyze-task-info)))
+  (.getName ^TriggerKey (#'task.sync-databases/trigger-key db @#'task.sync-databases/sync-analyze-task-info)))
 
 (defmacro with-test-driver-available!
   [& body]
@@ -283,31 +294,38 @@
                    driver/can-connect? (constantly true)]
        ~@body)))
 
+(defmacro with-db-scheduler-setup
+  [& body]
+  `(mt/with-temp-scheduler
+     (#'task.sync-databases/job-init)
+     ~@body))
+
 (deftest create-db-default-schedule-test
   (testing "POST /api/database"
     (testing "create a db with default scan options"
-      (with-test-driver-available!
-        (let [resp (mt/user-http-request :crowberto :post 200 "database"
-                                         {:name    (mt/random-name)
-                                          :engine  (u/qualified-name ::test-driver)
-                                          :details {:db "my_db"}})
-              db   (t2/select-one :model/Database (:id resp))]
-          (is (malli= [:merge
-                       (into [:map] (m/map-vals (fn [v] [:fn #(= % v)]) (mt/object-defaults Database)))
-                       [:map
-                        [:metadata_sync_schedule #"0 \d{1,2} \* \* \* \? \*"]
-                        [:cache_field_values_schedule #"0 \d{1,2} \d{1,2} \* \* \? \*"]
-                        [:created_at (ms/InstanceOfClass java.time.temporal.Temporal)]
-                        [:engine     [:= ::test-driver]]
-                        [:id         ms/PositiveInt]
-                        [:details    [:fn #(= % {:db "my_db"})]]
-                        [:updated_at (ms/InstanceOfClass java.time.temporal.Temporal)]
-                        [:name       ms/NonBlankString]
-                        [:features   [:= (driver.u/features ::test-driver (mt/db))]]
-                        [:creator_id [:= (mt/user->id :crowberto)]]]]
-                      db))
-          (is (= (all-db-sync-triggers-name db)
-                 (query-all-db-sync-triggers-name db))))))))
+      (with-db-scheduler-setup
+        (with-test-driver-available!
+          (let [resp (mt/user-http-request :crowberto :post 200 "database"
+                                           {:name    (mt/random-name)
+                                            :engine  (u/qualified-name ::test-driver)
+                                            :details {:db "my_db"}})
+                db   (t2/select-one :model/Database (:id resp))]
+            (is (malli= [:merge
+                         (into [:map] (m/map-vals (fn [v] [:fn #(= % v)]) (mt/object-defaults Database)))
+                         [:map
+                          [:metadata_sync_schedule #"0 \d{1,2} \* \* \* \? \*"]
+                          [:cache_field_values_schedule #"0 \d{1,2} \d{1,2} \* \* \? \*"]
+                          [:created_at (ms/InstanceOfClass java.time.temporal.Temporal)]
+                          [:engine     [:= ::test-driver]]
+                          [:id         ms/PositiveInt]
+                          [:details    [:fn #(= % {:db "my_db"})]]
+                          [:updated_at (ms/InstanceOfClass java.time.temporal.Temporal)]
+                          [:name       ms/NonBlankString]
+                          [:features   [:= (driver.u/features ::test-driver (mt/db))]]
+                          [:creator_id [:= (mt/user->id :crowberto)]]]]
+                        db))
+            (is (= (all-db-sync-triggers-name db)
+                   (query-all-db-sync-triggers-name db)))))))))
 
 (deftest create-db-no-full-sync-test
   (testing "POST /api/database"
@@ -324,63 +342,6 @@
         (is (not (:let-user-control-scheduling details)))
         (is (= "daily" (-> cache_field_values_schedule u.cron/cron-string->schedule-map :schedule_type)))
         (is (= "hourly" (-> metadata_sync_schedule u.cron/cron-string->schedule-map :schedule_type)))))))
-
-(deftest create-db-with-manual-schedules-test
-  (testing "POST /api/database"
-    (testing "create a db with scan field values option is \"regularly on a schedule\""
-      (with-test-driver-available!
-        (let [{:keys [details metadata_sync_schedule cache_field_values_schedule] :as db}
-              (mt/user-http-request :crowberto :post 200 "database"
-                                    {:name    (mt/random-name)
-                                     :engine  (u/qualified-name ::test-driver)
-                                     :details   {:let-user-control-scheduling true}
-                                     :schedules {:metadata_sync      monthly-schedule
-                                                 :cache_field_values monthly-schedule}
-                                     :is_on_demand false
-                                     :is_full_sync true})]
-          (is (:let-user-control-scheduling details))
-          (is (= "monthly" (-> cache_field_values_schedule u.cron/cron-string->schedule-map :schedule_type)))
-          (is (= "monthly" (-> metadata_sync_schedule u.cron/cron-string->schedule-map :schedule_type)))
-          (is (= (all-db-sync-triggers-name db)
-                 (query-all-db-sync-triggers-name db))))))))
-
-(deftest create-db-on-demand-scan-field-values-test
-  (testing "POST /api/database"
-    (testing "create a db with scan field values option is \"Only when adding a new filter widget\""
-      (with-test-driver-available!
-        (let [resp (mt/user-http-request :crowberto :post 200 "database"
-                                         {:name         (mt/random-name)
-                                          :engine       (u/qualified-name ::test-driver)
-                                          :details      {:db                          "my_db"
-                                                         :let-user-control-scheduling true}
-                                          :schedules    {:metadata_sync      monthly-schedule
-                                                         :cache_field_values monthly-schedule}
-                                          :is_on_demand true
-                                          :is_full_sync false})
-              db   (t2/select-one :model/Database (:id resp))]
-          (is (some? (:metadata_sync_schedule db)))
-          (is (nil? (:cache_field_values_schedule db)))
-          (is (= #{(sync-and-analyze-trigger-name db)}
-                 (query-all-db-sync-triggers-name db))))))))
-
-(deftest create-db-never-scan-field-values-test
-  (testing "POST /api/database"
-    (testing "create a db with scan field values option is \"Never, I'll do it myself\""
-      (with-test-driver-available!
-        (let [resp (mt/user-http-request :crowberto :post 200 "database"
-                                         {:name         (mt/random-name)
-                                          :engine       (u/qualified-name ::test-driver)
-                                          :details      {:db                          "my_db"
-                                                         :let-user-control-scheduling true}
-                                          :schedules    {:metadata_sync      monthly-schedule
-                                                         :cache_field_values monthly-schedule}
-                                          :is_on_demand false
-                                          :is_full_sync false})
-              db   (t2/select-one :model/Database (:id resp))]
-          (is (some? (:metadata_sync_schedule db)))
-          (is (nil? (:cache_field_values_schedule db)))
-          (is (= #{(sync-and-analyze-trigger-name db)}
-                 (query-all-db-sync-triggers-name db))))))))
 
 (deftest create-db-known-error-connection-test
   (testing "POST /api/database"
@@ -640,77 +601,6 @@
           ;; 4. test the connection was still open at the end of it of the long running process
           (is (true? @connections-stay-open?))
           (tx/destroy-db! driver/*driver* empty-dbdef))))))
-
-(deftest update-db-to-sync-on-custom-schedule-test
-  (with-test-driver-available!
-    (mt/with-temp
-      [:model/Database db {}]
-      (testing "update db setting to never scan should remove scan field values trigger"
-        (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
-                              {:details     {:let-user-control-scheduling true}
-                               :schedules   {:metadata_sync      monthly-schedule
-                                             :cache_field_values monthly-schedule}
-                               :is_full_sync true
-                               :is_on_demand false})
-        (is (= (all-db-sync-triggers-name db)
-               (query-all-db-sync-triggers-name db)))
-        (let [db (t2/select-one :model/Database (:id db))]
-          (is (some? (:metadata_sync_schedule db)))
-          (is (some? (:cache_field_values_schedule db)))
-          (is (= "monthly" (-> (:cache_field_values_schedule db) u.cron/cron-string->schedule-map :schedule_type)))
-          (is (= "monthly" (-> (:metadata_sync_schedule db) u.cron/cron-string->schedule-map :schedule_type))))
-
-        (testing "turn back to default settings should recreate all tasks with randomized schedule"
-          (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
-                                {:details     {:let-user-control-scheduling false}
-                                 :schedules   {:metadata_sync      monthly-schedule
-                                               :cache_field_values monthly-schedule}
-                                 :is_full_sync true
-                                 :is_on_demand false})
-          (is (= (all-db-sync-triggers-name db)
-                 (query-all-db-sync-triggers-name db)))
-          (let [db (t2/select-one :model/Database (:id db))]
-            (is (some? (:metadata_sync_schedule db)))
-            (is (some? (:cache_field_values_schedule db)))
-            ;; make sure the new schedule is randomized, not from the payload
-            (is (not= (-> monthly-schedule u.cron/schedule-map->cron-string)
-                      (:metadata_sync_schedule db)))
-            (is (not= (-> monthly-schedule u.cron/schedule-map->cron-string)
-                      (:cache_field_values_schedule db)))))))))
-
-(deftest update-db-to-never-scan-values-on-demand-test
-  (with-test-driver-available!
-    (mt/with-temp
-      [:model/Database db {}]
-      (testing "update db setting to never scan should remove scan field values trigger"
-        (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
-                              {:details     {:let-user-control-scheduling true}
-                               :schedules   {:metadata_sync      monthly-schedule
-                                             :cache_field_values monthly-schedule}
-                               :is_full_sync false
-                               :is_on_demand false})
-        (is (= #{(sync-and-analyze-trigger-name db)}
-               (query-all-db-sync-triggers-name db)))
-        (let [db (t2/select-one :model/Database (:id db))]
-          (is (some? (:metadata_sync_schedule db)))
-          (is (nil? (:cache_field_values_schedule db))))))))
-
-(deftest update-db-to-scan-field-values-on-demand-test
-  (with-test-driver-available!
-    (testing "update db to scan on demand should remove scan field values trigger"
-      (mt/with-temp
-        [:model/Database db {}]
-        (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
-                              {:details     {:let-user-control-scheduling true}
-                               :schedules   {:metadata_sync      monthly-schedule
-                                             :cache_field_values monthly-schedule}
-                               :is_full_sync false
-                               :is_on_demand true})
-        (is (= #{(sync-and-analyze-trigger-name db)}
-               (query-all-db-sync-triggers-name db)))
-        (let [db (t2/select-one :model/Database (:id db))]
-          (is (some? (:metadata_sync_schedule db)))
-          (is (nil? (:cache_field_values_schedule db))))))))
 
 (deftest fetch-database-metadata-test
   (testing "GET /api/database/:id/metadata"
@@ -1204,61 +1094,165 @@
    :schedule_hour   23
    :schedule_type   "monthly"})
 
-(def ^:private schedule-map-for-hourly
+(def ^:private schedule-map-for-weekly
   {:schedule_minute 0
-   :schedule_day    nil
+   :schedule_day    "fri"
    :schedule_frame  nil
    :schedule_hour   nil
-   :schedule_type   "hourly"})
+   :schedule_type   "weekly"})
 
-(deftest create-new-db-with-custom-schedules-test
-  (testing "Can we create a NEW database and give it custom schedules?"
-    (let [db-name (mt/random-name)]
-      (try (let [db (with-redefs [driver/available? (constantly true)]
-                      (mt/user-http-request :crowberto :post 200 "database"
-                                            {:name      db-name
-                                             :engine    (u/qualified-name ::test-driver)
-                                             :details   {:db "my_db" :let-user-control-scheduling true}
-                                             :schedules {:cache_field_values schedule-map-for-last-friday-at-11pm
-                                                         :metadata_sync      schedule-map-for-hourly}}))]
-             (is (= {:cache_field_values_schedule "0 0 23 ? * 6L *"
-                     :metadata_sync_schedule      "0 0 * * * ? *"}
-                    (into {} (t2/select-one [Database :cache_field_values_schedule :metadata_sync_schedule] :id (u/the-id db))))))
-           (finally (t2/delete! Database :name db-name))))))
+(deftest create-db-with-manual-schedules-test
+  (testing "POST /api/database"
+    (testing "create a db with scan field values option is \"regularly on a schedule\""
+      (with-db-scheduler-setup
+        (with-test-driver-available!
+          (let [{:keys [details] :as db}
+                (mt/user-http-request :crowberto :post 200 "database"
+                                      {:name    (mt/random-name)
+                                       :engine  (u/qualified-name ::test-driver)
+                                       :details   {:let-user-control-scheduling true}
+                                       :schedules {:metadata_sync      schedule-map-for-weekly
+                                                   :cache_field_values schedule-map-for-last-friday-at-11pm}
+                                       :is_on_demand false
+                                       :is_full_sync true})]
+            (is (:let-user-control-scheduling details))
+            (is (= (u.cron/schedule-map->cron-string schedule-map-for-weekly)
+                   (:metadata_sync_schedule db)))
+            (is (= (u.cron/schedule-map->cron-string schedule-map-for-last-friday-at-11pm)
+                   (:cache_field_values_schedule db)))
+            (is (= (all-db-sync-triggers-name db)
+                   (query-all-db-sync-triggers-name db)))))))))
 
-(deftest update-schedules-for-existing-db
-  (let [attempted {:cache_field_values schedule-map-for-last-friday-at-11pm
-                   :metadata_sync      schedule-map-for-hourly}
-        expected  {:cache_field_values_schedule "0 0 23 ? * 6L *"
-                   :metadata_sync_schedule      "0 0 * * * ? *"}]
-    (testing "Can we UPDATE the schedules for an existing database?"
-      (testing "We cannot if we don't mark `:let-user-control-scheduling`"
-        (t2.with-temp/with-temp [Database db {:engine "h2", :details (:details (mt/db))}]
-          (is (=? (select-keys (mt/db) [:cache_field_values_schedule :metadata_sync_schedule])
-                  (api-update-database! 200 db (assoc db :schedules attempted))))
-          (is (not= expected
-                    (into {} (t2/select-one [Database :cache_field_values_schedule :metadata_sync_schedule] :id (u/the-id db)))))))
-      (testing "We can if we mark `:let-user-control-scheduling`"
-        (t2.with-temp/with-temp [Database db {:engine "h2", :details (:details (mt/db))}]
-          (is (=? expected
-                  (api-update-database! 200 db
-                                        (-> (into {} db)
-                                            (assoc :schedules attempted)
-                                            (assoc-in [:details :let-user-control-scheduling] true)))))
-          (is (= expected
-                 (into {} (t2/select-one [Database :cache_field_values_schedule :metadata_sync_schedule] :id (u/the-id db)))))))
-      (testing "if we update back to metabase managed schedules it randomizes for us"
-        (let [original-custom-schedules expected]
-          (t2.with-temp/with-temp [Database db (merge {:engine "h2" :details (assoc (:details (mt/db))
-                                                                                    :let-user-control-scheduling true)}
-                                                      original-custom-schedules)]
-            (is (=? {:id (u/the-id db)}
-                    (api-update-database! 200 db
-                                          (assoc-in db [:details :let-user-control-scheduling] false))))
-            (let [schedules (into {} (t2/select-one [Database :cache_field_values_schedule :metadata_sync_schedule] :id (u/the-id db)))]
-              (is (not= original-custom-schedules schedules))
-              (is (= "hourly" (-> schedules :metadata_sync_schedule u.cron/cron-string->schedule-map :schedule_type)))
-              (is (= "daily" (-> schedules :cache_field_values_schedule u.cron/cron-string->schedule-map :schedule_type))))))))))
+(deftest create-db-never-scan-field-values-test
+  (testing "POST /api/database"
+    (testing "create a db with scan field values option is \"Never, I'll do it myself\""
+      (with-db-scheduler-setup
+        (with-test-driver-available!
+          (let [resp (mt/user-http-request :crowberto :post 200 "database"
+                                           {:name         (mt/random-name)
+                                            :engine       (u/qualified-name ::test-driver)
+                                            :details      {:db                          "my_db"
+                                                           :let-user-control-scheduling true}
+                                            :schedules    {:metadata_sync      schedule-map-for-weekly
+                                                           :cache_field_values schedule-map-for-last-friday-at-11pm}
+                                            :is_on_demand false
+                                            :is_full_sync false})
+                db   (t2/select-one :model/Database (:id resp))]
+            (is (= (u.cron/schedule-map->cron-string schedule-map-for-weekly)
+                   (:metadata_sync_schedule db)))
+            (is (nil? (:cache_field_values_schedule db)))
+            (is (= #{(sync-and-analyze-trigger-name db)}
+                   (query-all-db-sync-triggers-name db)))))))))
+
+(deftest create-db-on-demand-scan-field-values-test
+  (testing "POST /api/database"
+    (testing "create a db with scan field values option is \"Only when adding a new filter widget\""
+      (with-db-scheduler-setup
+        (with-test-driver-available!
+          (let [resp (mt/user-http-request :crowberto :post 200 "database"
+                                           {:name         (mt/random-name)
+                                            :engine       (u/qualified-name ::test-driver)
+                                            :details      {:db                          "my_db"
+                                                           :let-user-control-scheduling true}
+                                            :schedules    {:metadata_sync      schedule-map-for-weekly
+                                                           :cache_field_values schedule-map-for-last-friday-at-11pm}
+                                            :is_on_demand true
+                                            :is_full_sync false})
+                db   (t2/select-one :model/Database (:id resp))]
+            (is (= (u.cron/schedule-map->cron-string schedule-map-for-weekly)
+                   (:metadata_sync_schedule db)))
+            (is (nil? (:cache_field_values_schedule db)))
+            (is (= #{(sync-and-analyze-trigger-name db)}
+                   (query-all-db-sync-triggers-name db)))))))))
+
+(deftest update-db-to-sync-on-custom-schedule-test
+  (with-db-scheduler-setup
+    (with-test-driver-available!
+      (mt/with-temp
+        [:model/Database db {}]
+        (testing "can't update if let-user-control-scheduling is false"
+          (let [db (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
+                                         {:details     {}
+                                          :schedules   {:metadata_sync      schedule-map-for-weekly
+                                                        :cache_field_values schedule-map-for-last-friday-at-11pm}
+                                          :is_full_sync true
+                                          :is_on_demand false})]
+            (is (not= (u.cron/schedule-map->cron-string schedule-map-for-weekly)
+                      (:metadata_sync_schedule db)))
+            (is (not= (u.cron/schedule-map->cron-string schedule-map-for-last-friday-at-11pm)
+                      (:cache_field_values_schedule db)))))
+
+        (testing "update db setting to never scan should remove scan field values trigger"
+          (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
+                                {:details     {:let-user-control-scheduling true}
+                                 :schedules   {:metadata_sync      schedule-map-for-weekly
+                                               :cache_field_values schedule-map-for-last-friday-at-11pm}
+                                 :is_full_sync true
+                                 :is_on_demand false})
+          (is (= (all-db-sync-triggers-name db)
+                 (query-all-db-sync-triggers-name db)))
+          (let [db (t2/select-one :model/Database (:id db))]
+            (is (= (u.cron/schedule-map->cron-string schedule-map-for-weekly)
+                   (:metadata_sync_schedule db)))
+            (is (= (u.cron/schedule-map->cron-string schedule-map-for-last-friday-at-11pm)
+                   (:cache_field_values_schedule db))))
+
+          (testing "turn back to default settings should recreate all tasks with randomized schedule"
+            (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
+                                  {:details     {:let-user-control-scheduling false}
+                                   :schedules   {:metadata_sync      schedule-map-for-weekly
+                                                 :cache_field_values schedule-map-for-last-friday-at-11pm}
+                                   :is_full_sync true
+                                   :is_on_demand false})
+            (is (= (all-db-sync-triggers-name db)
+                   (query-all-db-sync-triggers-name db)))
+            (let [db (t2/select-one :model/Database (:id db))]
+              ;; make sure the new schedule is randomized, not from the payload
+              (is (not= (-> schedule-map-for-weekly u.cron/schedule-map->cron-string)
+                        (:metadata_sync_schedule db)))
+              (is (not= (-> schedule-map-for-last-friday-at-11pm u.cron/schedule-map->cron-string)
+                        (:cache_field_values_schedule db))))))))))
+
+(deftest update-db-to-never-scan-values-on-demand-test
+  (with-db-scheduler-setup
+    (with-test-driver-available!
+      (mt/with-temp
+        [:model/Database db {}]
+        (testing "update db setting to never scan should remove scan field values trigger"
+          (testing "sanity check that it has all triggers to begin with"
+            (is (= (all-db-sync-triggers-name db)
+                   (query-all-db-sync-triggers-name db))))
+          (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
+                                {:details     {:let-user-control-scheduling true}
+                                 :schedules   {:metadata_sync      schedule-map-for-weekly
+                                               :cache_field_values schedule-map-for-last-friday-at-11pm}
+                                 :is_full_sync false
+                                 :is_on_demand false})
+          (is (= #{(sync-and-analyze-trigger-name db)}
+                 (query-all-db-sync-triggers-name db)))
+          (let [db (t2/select-one :model/Database (:id db))]
+            (is (= (u.cron/schedule-map->cron-string schedule-map-for-weekly)
+                   (:metadata_sync_schedule db)))
+            (is (nil? (:cache_field_values_schedule db)))))))))
+
+(deftest update-db-to-scan-field-values-on-demand-test
+  (with-db-scheduler-setup
+    (with-test-driver-available!
+      (testing "update db to scan on demand should remove scan field values trigger"
+        (mt/with-temp
+          [:model/Database db {}]
+          (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
+                                {:details     {:let-user-control-scheduling true}
+                                 :schedules   {:metadata_sync      schedule-map-for-weekly
+                                               :cache_field_values schedule-map-for-last-friday-at-11pm}
+                                 :is_full_sync false
+                                 :is_on_demand true})
+          (is (= #{(sync-and-analyze-trigger-name db)}
+                 (query-all-db-sync-triggers-name db)))
+          (let [db (t2/select-one :model/Database (:id db))]
+            (is (= (u.cron/schedule-map->cron-string schedule-map-for-weekly)
+                   (:metadata_sync_schedule db)))
+            (is (nil? (:cache_field_values_schedule db)))))))))
 
 (deftest fetch-db-with-expanded-schedules
   (testing "If we FETCH a database will it have the correct 'expanded' schedules?"
@@ -1267,7 +1261,7 @@
       (is (= {:cache_field_values_schedule "0 0 23 ? * 6L *"
               :metadata_sync_schedule      "0 0 * * * ? *"
               :schedules                   {:cache_field_values schedule-map-for-last-friday-at-11pm
-                                            :metadata_sync      schedule-map-for-hourly}}
+                                            :metadata_sync      schedule-map-for-weekly}}
              (-> (mt/user-http-request :crowberto :get 200 (format "database/%d" (u/the-id db)))
                  (select-keys [:cache_field_values_schedule :metadata_sync_schedule :schedules])))))))
 

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1256,10 +1256,10 @@
 
 (deftest fetch-db-with-expanded-schedules
   (testing "If we FETCH a database will it have the correct 'expanded' schedules?"
-    (t2.with-temp/with-temp [Database db {:metadata_sync_schedule      "0 0 * * * ? *"
+    (t2.with-temp/with-temp [Database db {:metadata_sync_schedule      "0 0 * ? * 6 *"
                                           :cache_field_values_schedule "0 0 23 ? * 6L *"}]
       (is (= {:cache_field_values_schedule "0 0 23 ? * 6L *"
-              :metadata_sync_schedule      "0 0 * * * ? *"
+              :metadata_sync_schedule      "0 0 * ? * 6 *"
               :schedules                   {:cache_field_values schedule-map-for-last-friday-at-11pm
                                             :metadata_sync      schedule-map-for-weekly}}
              (-> (mt/user-http-request :crowberto :get 200 (format "database/%d" (u/the-id db)))

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -288,14 +288,14 @@
 
 (defn- all-db-sync-triggers-name
   [db]
-  (map #(.getName (#'task.sync-databases/trigger-key db %))
-       @#'task.sync-databases/all-tasks))
+  (set (map #(.getName (#'task.sync-databases/trigger-key db %))
+            @#'task.sync-databases/all-tasks)))
 
 (defn- query-all-db-sync-triggers-name
   [db]
-  (map :trigger_name (t2/query {:select [:trigger_name]
-                                :from   [:qrtz_triggers]
-                                :where  [:in :trigger_name (all-db-sync-triggers-name db)]})))
+  (set (map :trigger_name (t2/query {:select [:trigger_name]
+                                      :from   [:qrtz_triggers]
+                                      :where  [:in :trigger_name (all-db-sync-triggers-name db)]}))))
 
 (defn- sync-and-analyze-trigger-name
   [db]
@@ -651,13 +651,13 @@
           (is (true? @connections-stay-open?))
           (tx/destroy-db! driver/*driver* empty-dbdef))))))
 
-(deftest update-db-to-sync-on-custom-schedule-test
-  (with-test-driver-available!
-    (mt/with-temp
-      [:model/Database db {}]
-      (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
-                            {:details   {:let-user-control-scheduling true}
-                             :schedules {:cache_field_values monthly-schedule}}))))
+#_(deftest update-db-to-sync-on-custom-schedule-test
+    (with-test-driver-available!
+      (mt/with-temp
+        [:model/Database db {}]
+        (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
+                              {:details   {:let-user-control-scheduling true}
+                               :schedules {:cache_field_values monthly-schedule}}))))
 
 (deftest update-db-to-scan-field-values-on-demand-test
   (with-test-driver-available!

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -26,12 +26,12 @@
 
 (defn- db-details []
   (merge
-   (select-keys (mt/db) [:id :timezone :initial_sync_status :cache_field_values_schedule :metadata_sync_schedule])
    (dissoc (mt/object-defaults Database) :details :initial_sync_status :dbms_version)
    {:engine        "h2"
     :name          "test-data"
     :features      (mapv u/qualified-name (driver.u/features :h2 (mt/db)))
-    :timezone      "UTC"}))
+    :timezone      "UTC"}
+   (select-keys (mt/db) [:id :timezone :initial_sync_status :cache_field_values_schedule :metadata_sync_schedule])))
 
 (deftest get-field-test
   (testing "GET /api/field/:id"

--- a/test/metabase/api/field_test.clj
+++ b/test/metabase/api/field_test.clj
@@ -26,7 +26,7 @@
 
 (defn- db-details []
   (merge
-   (select-keys (mt/db) [:id :timezone :initial_sync_status])
+   (select-keys (mt/db) [:id :timezone :initial_sync_status :cache_field_values_schedule :metadata_sync_schedule])
    (dissoc (mt/object-defaults Database) :details :initial_sync_status :dbms_version)
    {:engine        "h2"
     :name          "test-data"

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -33,7 +33,8 @@
 
 (defn- db-details []
   (merge
-   (select-keys (mt/db) [:id :created_at :updated_at :timezone :creator_id :initial_sync_status :dbms_version])
+   (select-keys (mt/db) [:id :created_at :updated_at :timezone :creator_id :initial_sync_status :dbms_version
+                         :cache_field_values_schedule :metadata_sync_schedule])
    {:engine                      "h2"
     :name                        "test-data"
     :is_sample                   false
@@ -43,8 +44,6 @@
     :caveats                     nil
     :points_of_interest          nil
     :features                    (mapv u/qualified-name (driver.u/features :h2 (mt/db)))
-    :cache_field_values_schedule "0 50 0 * * ? *"
-    :metadata_sync_schedule      "0 50 * * * ? *"
     :refingerprint               nil
     :auto_run_queries            true
     :settings                    nil

--- a/test/metabase/models/database_test.clj
+++ b/test/metabase/models/database_test.clj
@@ -75,7 +75,7 @@
                  :key                 (format "metabase.task.sync-and-analyze.trigger.%d" db-id)
                  :misfire-instruction "DO_NOTHING"
                  :may-fire-again?     true
-                 :schedule            "0 50 * * * ? *"
+                 :schedule            (mt/malli=? some?)
                  :final-fire-time     nil
                  :data                {"db-id" db-id}}
                 (trigger-for-db db-id)))

--- a/test/metabase/test/util.clj
+++ b/test/metabase/test/util.clj
@@ -147,10 +147,12 @@
 
    :model/Database
    (fn [_] (default-timestamped
-             {:details   {}
-              :engine    :h2
-              :is_sample false
-              :name      (u.random/random-name)}))
+             {:details                     {}
+              :engine                      :h2
+              :is_sample                   false
+              :name                        (u.random/random-name)
+              :metadata_sync_schedule      "0 50 * * * ? *"
+              :cache_field_values_schedule "0 50 0 * * ? *"}))
 
    :model/Dimension
    (fn [_] (default-timestamped
@@ -619,8 +621,10 @@
 
 (defmacro with-temp-scheduler
   "Execute `body` with a temporary scheduler in place.
+  This does not initialize the all the jobs for performance reasons, so make sure you init it yourself!
 
     (with-temp-scheduler
+      (task.sync-databases/job-init) ;; init the jobs
       (do-something-to-schedule-tasks)
       ;; verify that the right thing happened
       (scheduler-current-tasks))"


### PR DESCRIPTION
First part to fix https://github.com/metabase/metabase/issues/40715

This will fix it so that there will be no background jobs for scanning field values when creating or updating a DB with scan FV options: "Only when adding a new filter" or "Never, I'll do it myself."

I'll have another follow-up to introduce a migration that will remove all the existing scan field values jobs for existing DBs that turn off Scan field values.