### PR TITLE
add env var to enable css modules classnames linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,11 @@
 /* eslint-disable import/no-commonjs */
+/* eslint-disable no-undef */
+
+// `postcss-modules` lints css modules class names, but it currently crashes
+// eslint on vscode if you use webstorm or want to run the lint for the cli, you
+// can use this flag to enable it. This is set to true in CI
+const shouldLintCssModules =
+  process.env.LINT_CSS_MODULES === "true" || process.env.CI;
 
 module.exports = {
   rules: {
@@ -98,8 +105,12 @@ module.exports = {
       },
     ],
     complexity: ["error", { max: 54 }],
-    "postcss-modules/no-unused-class": "off",
-    "postcss-modules/no-undef-class": "error",
+    ...(shouldLintCssModules
+      ? {
+          "postcss-modules/no-unused-class": "off",
+          "postcss-modules/no-undef-class": "error",
+        }
+      : {}),
   },
   globals: {
     before: true,
@@ -123,7 +134,7 @@ module.exports = {
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:import/typescript",
-    "plugin:postcss-modules/recommended",
+    ...(shouldLintCssModules ? ["plugin:postcss-modules/recommended"] : []),
   ],
   settings: {
     "import/internal-regex": "^metabase/|^metabase-lib/",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -107,7 +107,6 @@ module.exports = {
     complexity: ["error", { max: 54 }],
     ...(shouldLintCssModules
       ? {
-          "postcss-modules/no-unused-class": "off",
           "postcss-modules/no-undef-class": "error",
         }
       : {}),
@@ -125,7 +124,7 @@ module.exports = {
     "jest/globals": true,
   },
   parser: "babel-eslint",
-  plugins: ["react", "no-only-tests"],
+  plugins: ["react", "no-only-tests", "postcss-modules"],
   extends: [
     "eslint:recommended",
     "plugin:react/recommended",
@@ -134,7 +133,6 @@ module.exports = {
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:import/typescript",
-    ...(shouldLintCssModules ? ["plugin:postcss-modules/recommended"] : []),
   ],
   settings: {
     "import/internal-regex": "^metabase/|^metabase-lib/",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,35 +1,37 @@
-{
-  "rules": {
-    "strict": [2, "never"],
+/* eslint-disable import/no-commonjs */
+
+module.exports = {
+  rules: {
+    strict: [2, "never"],
     "no-undef": 2,
     "no-var": 1,
     "no-unused-vars": [
       "error",
       {
-        "vars": "all",
-        "args": "none",
-        "varsIgnorePattern": "^_",
-        "ignoreRestSiblings": true
-      }
+        vars: "all",
+        args: "none",
+        varsIgnorePattern: "^_",
+        ignoreRestSiblings: true,
+      },
     ],
-    "no-empty": [1, { "allowEmptyCatch": true }],
+    "no-empty": [1, { allowEmptyCatch: true }],
     "no-restricted-imports": [
       "error",
       {
-        "paths": [
+        paths: [
           {
-            "name": "moment",
-            "message": "Moment is deprecated, please use dayjs"
+            name: "moment",
+            message: "Moment is deprecated, please use dayjs",
           },
           {
-            "name": "moment-timezone",
-            "message": "Moment is deprecated, please use dayjs"
-          }
-        ]
-      }
+            name: "moment-timezone",
+            message: "Moment is deprecated, please use dayjs",
+          },
+        ],
+      },
     ],
-    "curly": [1, "all"],
-    "eqeqeq": [1, "smart"],
+    curly: [1, "all"],
+    eqeqeq: [1, "smart"],
     "import/no-default-export": 2,
     "import/no-named-as-default": 0,
     "import/no-commonjs": 1,
@@ -37,23 +39,23 @@
       "error",
       {
         "newlines-between": "always",
-        "alphabetize": {
-          "order": "asc",
-          "orderImportKind": "asc",
-          "caseInsensitive": false
+        alphabetize: {
+          order: "asc",
+          orderImportKind: "asc",
+          caseInsensitive: false,
         },
-        "groups": [
+        groups: [
           "builtin",
           "external",
           "internal",
           "parent",
           "sibling",
-          "index"
+          "index",
         ],
-        "warnOnUnassignedImports": false
-      }
+        warnOnUnassignedImports: false,
+      },
     ],
-    "no-console": [2, { "allow": ["warn", "error", "errorBuffer"] }],
+    "no-console": [2, { allow: ["warn", "error", "errorBuffer"] }],
     "react/no-is-mounted": 2,
     "react/prefer-es6-class": 2,
     "react/display-name": 1,
@@ -66,17 +68,17 @@
     "react/no-unescaped-entities": 2,
     "react/jsx-no-target-blank": 2,
     "react/jsx-key": 2,
-    "react/forbid-component-props": [2, { "forbid": ["sx"] }],
+    "react/forbid-component-props": [2, { forbid: ["sx"] }],
     "react-hooks/exhaustive-deps": [
       "warn",
-      { "additionalHooks": "(useSyncedQueryString|useSafeAsyncFunction)" }
+      { additionalHooks: "(useSyncedQueryString|useSafeAsyncFunction)" },
     ],
-    "prefer-const": [1, { "destructuring": "all" }],
+    "prefer-const": [1, { destructuring: "all" }],
     "no-useless-escape": 0,
     "no-only-tests/no-only-tests": [
       "error",
       {
-        "block": [
+        block: [
           "describe",
           "it",
           "context",
@@ -91,62 +93,62 @@
           "When",
           "Then",
           "describeWithSnowplow",
-          "describeEE"
-        ]
-      }
+          "describeEE",
+        ],
+      },
     ],
-    "complexity": ["error", { "max": 54 }]
+    complexity: ["error", { max: 54 }],
   },
-  "globals": {
-    "before": true,
-    "cy": true,
-    "Cypress": true
+  globals: {
+    before: true,
+    cy: true,
+    Cypress: true,
   },
-  "env": {
-    "browser": true,
-    "es6": true,
-    "commonjs": true,
-    "jest": true,
-    "jest/globals": true
+  env: {
+    browser: true,
+    es6: true,
+    commonjs: true,
+    jest: true,
+    "jest/globals": true,
   },
-  "parser": "babel-eslint",
-  "plugins": ["react", "no-only-tests"],
-  "extends": [
+  parser: "babel-eslint",
+  plugins: ["react", "no-only-tests"],
+  extends: [
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:import/typescript"
+    "plugin:import/typescript",
   ],
-  "settings": {
+  settings: {
     "import/internal-regex": "^metabase/|^metabase-lib/",
     "import/resolver": {
-      "webpack": {
-        "typescript": true
-      }
+      webpack: {
+        typescript: true,
+      },
     },
     "import/ignore": ["\\.css$"],
-    "react": {
-      "version": "detect"
-    }
+    react: {
+      version: "detect",
+    },
   },
-  "parserOptions": {
-    "ecmaFeatures": {
-      "legacyDecorators": true
-    }
+  parserOptions: {
+    ecmaFeatures: {
+      legacyDecorators: true,
+    },
   },
-  "overrides": [
+  overrides: [
     {
-      "files": ["*.js", "*.jsx", "*.ts", "*.tsx"],
-      "rules": {
+      files: ["*.js", "*.jsx", "*.ts", "*.tsx"],
+      rules: {
         "no-unconditional-metabase-links-render": "error",
-        "no-literal-metabase-strings": "error"
-      }
+        "no-literal-metabase-strings": "error",
+      },
     },
     {
-      "files": [
+      files: [
         "*.unit.spec.*",
         "frontend/src/metabase/admin/**/*",
         "frontend/src/metabase/setup/**/*",
@@ -154,19 +156,19 @@
         "*.stories.*",
         "e2e/**/*",
         "**/tests/*",
-        "release/**/*"
+        "release/**/*",
       ],
-      "rules": {
+      rules: {
         "no-unconditional-metabase-links-render": "off",
-        "no-literal-metabase-strings": "off"
-      }
+        "no-literal-metabase-strings": "off",
+      },
     },
     {
-      "extends": ["plugin:@typescript-eslint/recommended"],
-      "files": ["*.ts", "*.tsx"],
-      "parser": "@typescript-eslint/parser",
-      "plugins": ["@typescript-eslint"],
-      "rules": {
+      extends: ["plugin:@typescript-eslint/recommended"],
+      files: ["*.ts", "*.tsx"],
+      parser: "@typescript-eslint/parser",
+      plugins: ["@typescript-eslint"],
+      rules: {
         "prefer-rest-params": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/no-inferrable-types": "off",
@@ -176,32 +178,32 @@
         "@typescript-eslint/no-unused-vars": [
           "error",
           {
-            "argsIgnorePattern": "^_",
-            "varsIgnorePattern": "^_",
-            "ignoreRestSiblings": true,
-            "destructuredArrayIgnorePattern": "^_"
-          }
+            argsIgnorePattern: "^_",
+            varsIgnorePattern: "^_",
+            ignoreRestSiblings: true,
+            destructuredArrayIgnorePattern: "^_",
+          },
         ],
         // This was introduced in 6.0.0
-        "@typescript-eslint/no-unsafe-declaration-merging": "off"
-      }
+        "@typescript-eslint/no-unsafe-declaration-merging": "off",
+      },
     },
     {
-      "extends": [
+      extends: [
         "plugin:jest/recommended",
         "plugin:jest-dom/recommended",
-        "plugin:testing-library/react"
+        "plugin:testing-library/react",
       ],
-      "plugins": ["jest", "jest-dom", "testing-library"],
-      "files": [
+      plugins: ["jest", "jest-dom", "testing-library"],
+      files: [
         "*.unit.spec.ts",
         "*.unit.spec.tsx",
         "*.unit.spec.js",
-        "*.unit.spec.jsx"
+        "*.unit.spec.jsx",
       ],
-      "rules": {
-        "jest/valid-title": ["error", { "ignoreTypeOfDescribeName": true }]
-      }
-    }
-  ]
-}
+      rules: {
+        "jest/valid-title": ["error", { ignoreTypeOfDescribeName: true }],
+      },
+    },
+  ],
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -98,6 +98,8 @@ module.exports = {
       },
     ],
     complexity: ["error", { max: 54 }],
+    "postcss-modules/no-unused-class": "off",
+    "postcss-modules/no-undef-class": "error",
   },
   globals: {
     before: true,
@@ -121,6 +123,7 @@ module.exports = {
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:import/typescript",
+    "plugin:postcss-modules/recommended",
   ],
   settings: {
     "import/internal-regex": "^metabase/|^metabase-lib/",
@@ -132,6 +135,9 @@ module.exports = {
     "import/ignore": ["\\.css$"],
     react: {
       version: "detect",
+    },
+    "postcss-modules": {
+      baseDir: "./frontend/src",
     },
   },
   parserOptions: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-undef */
 
 // `postcss-modules` lints css modules class names, but it currently crashes
-// eslint on vscode if you use webstorm or want to run the lint for the cli, you
+// eslint on vscode. If you use webstorm or want to run the lint for the cli, you
 // can use this flag to enable it. This is set to true in CI
 const shouldLintCssModules =
   process.env.LINT_CSS_MODULES === "true" || process.env.CI;

--- a/.github/file-paths.yaml
+++ b/.github/file-paths.yaml
@@ -23,7 +23,7 @@ frontend_sources: &frontend_sources
   - "**/tsconfig*.json"
   - "package.json"
   - "babel.config.json"
-  - ".eslintrc"
+  - ".eslintrc.js"
   - "postcss.config.js"
   - "webpack.config.js"
   - "webpack.embedding-sdk.config.js"

--- a/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageUploadInfoDot.tsx
+++ b/enterprise/frontend/src/metabase-enterprise/whitelabel/components/ImageUploadInfoDot.tsx
@@ -1,7 +1,6 @@
 import { useTheme } from "@emotion/react";
 import { t } from "ttag";
 
-import CS from "metabase/css/core/index.css";
 import { Icon, Stack, Text, HoverCard } from "metabase/ui";
 
 type IllustrationType = "background" | "icon";
@@ -31,11 +30,7 @@ export const ImageUploadInfoDot = ({ type }: CustomFileUploadInfoDot) => {
   return (
     <HoverCard position="top-start">
       <HoverCard.Target>
-        <Icon
-          className={CS.flexShrink}
-          name="info"
-          color={theme.fn.themeColor("text-light")}
-        />
+        <Icon name="info" color={theme.fn.themeColor("text-light")} />
       </HoverCard.Target>
       <HoverCard.Dropdown>
         <Stack p="md" spacing="sm" maw={DESCRIPTIONS_WIDTHS[type]}>

--- a/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.tsx
+++ b/frontend/src/metabase/admin/settings/components/ApiKeys/ManageApiKeys.tsx
@@ -7,7 +7,7 @@ import Breadcrumbs from "metabase/components/Breadcrumbs";
 import LoadingAndErrorWrapper from "metabase/components/LoadingAndErrorWrapper";
 import { Ellipsified } from "metabase/core/components/Ellipsified";
 import AdminS from "metabase/css/admin.module.css";
-import CS from "metabase/css/index.module.css";
+import CS from "metabase/css/core/index.css";
 import { formatDateTimeWithUnit } from "metabase/lib/formatting/date";
 import { Stack, Title, Text, Button, Group, Icon } from "metabase/ui";
 import { getThemeOverrides } from "metabase/ui/theme";

--- a/frontend/src/metabase/css/core/bordered.module.css
+++ b/frontend/src/metabase/css/core/bordered.module.css
@@ -55,7 +55,8 @@
 }
 
 :global(.border-error),
-.border-error {
+.border-error,
+.borderError {
   border-color: var(--color-error) !important;
 }
 

--- a/frontend/src/metabase/css/core/text.module.css
+++ b/frontend/src/metabase/css/core/text.module.css
@@ -59,6 +59,10 @@
   line-height: 1.5em;
 }
 
+.textUnspaced {
+  line-height: normal;
+}
+
 .textSmall {
   font-size: 0.875em;
 }

--- a/frontend/src/metabase/css/core/transitions.module.css
+++ b/frontend/src/metabase/css/core/transitions.module.css
@@ -1,4 +1,5 @@
 :global(.transition-color),
-.transition-color {
+.transition-color,
+.transitionColor {
   transition: color 0.3s linear;
 }

--- a/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
+++ b/frontend/src/metabase/dashboard/hoc/DashboardControls.jsx
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { replace } from "react-router-redux";
 import screenfull from "screenfull";
 
-import CS from "metabase/css/core/spacing.module.css";
+import HideS from "metabase/css/core/hide.module.css";
 import * as MetabaseAnalytics from "metabase/lib/analytics";
 import { parseHashOptions, stringifyHashOptions } from "metabase/lib/browser";
 
@@ -210,9 +210,9 @@ export const DashboardControls = ComposedComponent =>
           );
 
           if (show && nav) {
-            nav.classList.remove(CS.hide);
+            nav.classList.remove(HideS.hide);
           } else if (!show && nav) {
-            nav.classList.add(CS.hide);
+            nav.classList.add(HideS.hide);
           }
         }
       }

--- a/frontend/src/metabase/reference/components/FieldTypeDetail.jsx
+++ b/frontend/src/metabase/reference/components/FieldTypeDetail.jsx
@@ -20,7 +20,7 @@ const FieldTypeDetail = ({
   <div className={cx(D.detail)}>
     <div className={D.detailBody}>
       <div className={D.detailTitle}>
-        <span className={D.detailName}>{t`Field type`}</span>
+        <span>{t`Field type`}</span>
       </div>
       <div className={cx(D.detailSubtitle, { [CS.mt1]: true })}>
         <span>

--- a/frontend/src/metabase/reference/components/FieldsToGroupBy.jsx
+++ b/frontend/src/metabase/reference/components/FieldsToGroupBy.jsx
@@ -31,7 +31,7 @@ class FieldsToGroupBy extends Component {
       <div>
         <div className={D.detailBody}>
           <div className={D.detailTitle}>
-            <span className={D.detailName}>{title}</span>
+            <span>{title}</span>
           </div>
           <div className={S.usefulQuestions}>
             {fields &&

--- a/frontend/src/metabase/reference/components/ReferenceHeader.jsx
+++ b/frontend/src/metabase/reference/components/ReferenceHeader.jsx
@@ -36,9 +36,7 @@ const ReferenceHeader = ({
         </Ellipsified>
 
         {headerLink && (
-          /* TODO: there is only L.headerButton, so either change to
-          L.headerButton or remove */
-          <div key="2" className={cx(CS.flexFull, S.headerButton)}>
+          <div key="2" className={cx(CS.flexFull)}>
             <Link
               to={headerLink}
               className={cx(ButtonsS.Button, ButtonsS.ButtonBorderless, CS.ml3)}

--- a/frontend/src/metabase/reference/components/UsefulQuestions.jsx
+++ b/frontend/src/metabase/reference/components/UsefulQuestions.jsx
@@ -11,7 +11,7 @@ const UsefulQuestions = ({ questions }) => (
   <div className={D.detail}>
     <div className={D.detailBody}>
       <div className={D.detailTitle}>
-        <span className={D.detailName}>{t`Potentially useful questions`}</span>
+        <span>{t`Potentially useful questions`}</span>
       </div>
       <div className={S.usefulQuestions}>
         {questions.map((question, index, questions) => (

--- a/package.json
+++ b/package.json
@@ -238,6 +238,7 @@
     "eslint-plugin-jest": "^27.2.0",
     "eslint-plugin-jest-dom": "^4.0.3",
     "eslint-plugin-no-only-tests": "^2.4.0",
+    "eslint-plugin-postcss-modules": "^2.0.0",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^5.11.0",

--- a/package.json
+++ b/package.json
@@ -365,7 +365,7 @@
     "lint-prettier": "yarn && yarn lint-prettier-pure",
     "lint-prettier-pure": "prettier --check '{frontend,enterprise/frontend,e2e}/**/*.{js,jsx,ts,tsx,css}'",
     "lint-yaml": "yamllint **/*.{yaml,yml} --ignore=node_modules/**/*.{yaml,yml}",
-    "precommit": "lint-staged",
+    "precommit": "lint-staged --shell",
     "preinstall": "echo $npm_execpath | grep -q yarn || echo '\\033[0;33mSorry, npm is not supported. Please use Yarn (https://yarnpkg.com/).\\033[0m'",
     "prepare": "husky install",
     "prettier": "prettier --write '{frontend,enterprise/frontend,e2e}/**/*.{js,jsx,ts,tsx,css}'",
@@ -401,7 +401,7 @@
       "prettier --write"
     ],
     "+(frontend|enterprise/frontend)/**/*.{js,jsx,ts,tsx}": [
-      "eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
+      "LINT_CSS_MODULES=true eslint --rulesdir frontend/lint/eslint-rules --max-warnings 0 --fix",
       "prettier --write",
       "node ./bin/verify-doc-links"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9170,6 +9170,14 @@ dc@2.1.9:
     crossfilter2 "~1.3"
     d3 "^3"
 
+deasync@^0.1.0:
+  version "0.1.29"
+  resolved "https://registry.yarnpkg.com/deasync/-/deasync-0.1.29.tgz#8bbbf9d0b235c561b36edd440b6272f1de6c572c"
+  integrity sha512-EBtfUhVX23CE9GR6m+F8WPeImEE4hR/FW9RkK0PMl9V1t283s0elqsTD8EZjaKX28SY1BW2rYfCgNsAYdpamUw==
+  dependencies:
+    bindings "^1.5.0"
+    node-addon-api "^1.7.1"
+
 debounce@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
@@ -10321,6 +10329,22 @@ eslint-plugin-no-only-tests@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.4.0.tgz#7d565434aa7d16ccc7eea957c391d98f827332ca"
   integrity sha512-azP9PwQYfGtXJjW273nIxQH9Ygr+5/UyeW2wEjYoDtVYPI+WPKwbj0+qcAKYUXFZLRumq4HKkFaoDBAwBoXImQ==
+
+eslint-plugin-postcss-modules@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-postcss-modules/-/eslint-plugin-postcss-modules-2.0.0.tgz#d136d6fb5bd9afa6ac73c22aea85212aa2531806"
+  integrity sha512-82usNIaeAEHKbQOnbSs+H3d9nP6TKD2zBZC/wuedbGMTbF8XGkdxI83kptTE6BcvIWgnLPciVa8voe6zIw4ddw==
+  dependencies:
+    anymatch "^3.0.0"
+    camelcase "^6.0.0"
+    deasync "^0.1.0"
+    icss-utils "^5.1.0"
+    postcss "^8.3.0"
+    postcss-load-config "^3.1.0"
+    postcss-modules-extract-imports "~3.0.0"
+    postcss-modules-local-by-default "^4.0.0"
+    postcss-modules-scope "^3.0.0"
+    postcss-modules-values "^4.0.0"
 
 eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
@@ -14454,6 +14478,11 @@ lilconfig@2.0.6:
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.6.tgz#32a384558bd58af3d4c6e077dd1ad1d397bc69d4"
   integrity sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==
 
+lilconfig@^2.0.5:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
+  integrity sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -16057,6 +16086,11 @@ node-abort-controller@^3.0.1:
   resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
   integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
 
+node-addon-api@^1.7.1:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
+  integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
+
 node-dir@^0.1.10:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
@@ -17325,6 +17359,14 @@ postcss-lab-function@^2.0.1:
     postcss "^7.0.2"
     postcss-values-parser "^2.0.0"
 
+postcss-load-config@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.4.tgz#1ab2571faf84bb078877e1d07905eabe9ebda855"
+  integrity sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==
+  dependencies:
+    lilconfig "^2.0.5"
+    yaml "^1.10.2"
+
 postcss-loader@7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-7.0.2.tgz#b53ff44a26fba3688eee92a048c7f2d4802e23bb"
@@ -17371,7 +17413,7 @@ postcss-modules-extract-imports@^2.0.0:
   dependencies:
     postcss "^7.0.5"
 
-postcss-modules-extract-imports@^3.0.0:
+postcss-modules-extract-imports@^3.0.0, postcss-modules-extract-imports@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz#cda1f047c0ae80c97dbe28c3e76a43b88025741d"
   integrity sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==
@@ -17633,6 +17675,15 @@ postcss@^8.2.15:
     nanoid "^3.1.30"
     picocolors "^1.0.0"
     source-map-js "^0.6.2"
+
+postcss@^8.3.0:
+  version "8.4.38"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.38.tgz#b387d533baf2054288e337066d81c6bee9db9e0e"
+  integrity sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==
+  dependencies:
+    nanoid "^3.3.7"
+    picocolors "^1.0.0"
+    source-map-js "^1.2.0"
 
 postcss@^8.4.33:
   version "8.4.35"
@@ -19893,7 +19944,7 @@ source-list-map@^2.0.0:
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
 
-source-map-js@1.2.0, source-map-js@^0.6.2, source-map-js@^1.0.1, source-map-js@^1.0.2:
+source-map-js@1.2.0, source-map-js@^0.6.2, source-map-js@^1.0.1, source-map-js@^1.0.2, source-map-js@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
@@ -22677,7 +22728,7 @@ yaml-lint@~1.6.0:
     js-yaml "^4.1.0"
     nconf "^0.12.0"
 
-yaml@^1.10.0:
+yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==


### PR DESCRIPTION
⚠️ Please have a look at the [commits](https://github.com/metabase/metabase/pull/41173/commits) to see a nice diff of the eslint file, as in one commit I'm changing it from .eslintrc to .eslintrc.json 

# Description

This is based off https://github.com/metabase/metabase/pull/40628 and adds a ENV to not make it crash vscode (explained later).

As team embedding is working on the css migration, we wanted a way to detect if we were referencing classnames that don't exist. After having tried a few tools @oisincoveney found `eslint-plugin-postcss-modules` to be the most promising and less invasive.

It does slow down eslint a bit though (I suspect it doesn't cache the parsing of index.css, and it parses it every time we import from that), and [it was breaking eslint completely on vscode](https://metaboat.slack.com/archives/C063Q3F1HPF/p1712047392130979?thread_ts=1711971943.265019&cid=C063Q3F1HPF).

To solve that I put the plugin behind a env var to make it "opt in" locally, and always make it run on CI.

It's also enabled on lint-staged, but it's only triggered by js/ts file changes. The reason is that a css change would technically require linting all js/ts files, which would take minutes, which is not something we want to do on a precommit.


# How to verify
- ci should fail and show the css errors on this pr: https://github.com/metabase/metabase/pull/41245
- by default, it should not be enabled in your IDE, so VScode shouldn't crash eslint
- if you want, you can open your IDE setting first the env and it should work
- it should work also if you set the env in .profile and log off/re-login



