### PR TITLE
Preserve the original question name in a "save question" modal

### DIFF
--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -345,8 +345,11 @@ describe("scenarios > question > new", () => {
     cy.findByTestId("save-question-modal").within(() => {
       cy.findByText("Save as new question").click();
 
-      cy.findByDisplayValue(modifiedQuestionName).should("exist");
-      cy.findByDisplayValue(originalDescription).should("exist");
+      cy.findByLabelText("Name").should("have.value", modifiedQuestionName);
+      cy.findByLabelText("Description").should(
+        "have.value",
+        originalDescription,
+      );
     });
   });
 

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -2,6 +2,7 @@ import { SAMPLE_DB_ID, USERS } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_QUESTION_ID,
+  ORDERS_COUNT_QUESTION_ID,
   SECOND_COLLECTION_ID,
   THIRD_COLLECTION_ID,
 } from "e2e/support/cypress_sample_instance_data";
@@ -23,6 +24,7 @@ import {
   modal,
   pickEntity,
   hovercard,
+  visitQuestion,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -320,6 +322,32 @@ describe("scenarios > question > new", () => {
     });
 
     cy.get("header").findByText(NEW_COLLECTION);
+  });
+
+  it("should preserve the original question name (metabase#41196)", () => {
+    const originalQuestionName = "Foo";
+    const modifiedQuestionName = `${originalQuestionName} - Modified`;
+    const originalDescription = "Lorem ipsum dolor sit amet";
+
+    cy.request("PUT", `/api/card/${ORDERS_COUNT_QUESTION_ID}`, {
+      name: originalQuestionName,
+      description: originalDescription,
+    });
+
+    visitQuestion(ORDERS_COUNT_QUESTION_ID);
+    cy.findByDisplayValue(originalQuestionName).should("exist");
+
+    cy.log("Change anything about this question to make it dirty");
+    cy.findByTestId("header-cell").should("have.text", "Count").click();
+    popover().icon("arrow_down").click();
+
+    cy.findByTestId("qb-header-action-panel").button("Save").click();
+    cy.findByTestId("save-question-modal").within(() => {
+      cy.findByText("Save as new question").click();
+
+      cy.findByDisplayValue(modifiedQuestionName).should("exist");
+      cy.findByDisplayValue(originalDescription).should("exist");
+    });
   });
 
   describe("add to a dashboard", () => {

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -115,7 +115,10 @@ export const SaveQuestionModal = ({
 
   const initialValues: FormValues = useMemo(
     () => ({
-      name: question.generateQueryDescription() || "",
+      name:
+        originalQuestion?.displayName() ||
+        question.generateQueryDescription() ||
+        "",
       description: question.description() || "",
       collection_id:
         question.collectionId() === undefined ||

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -115,7 +115,7 @@ export const SaveQuestionModal = ({
 
   const getOriginalNameModification = (originalQuestion: Question | null) =>
     originalQuestion
-      ? originalQuestion?.displayName() + " - " + t`Modified`
+      ? t`${originalQuestion.displayName()}  - Modified`
       : undefined;
 
   const initialValues: FormValues = useMemo(

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -115,7 +115,7 @@ export const SaveQuestionModal = ({
 
   const getOriginalNameModification = (originalQuestion: Question | null) =>
     originalQuestion
-      ? t`${originalQuestion.displayName()}  - Modified`
+      ? t`${originalQuestion.displayName()} - Modified`
       : undefined;
 
   const initialValues: FormValues = useMemo(

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -126,7 +126,8 @@ export const SaveQuestionModal = ({
         // Ad-hoc query
         question.generateQueryDescription() ||
         "",
-      description: question.description() || "",
+      description:
+        originalQuestion?.description() || question.description() || "",
       collection_id:
         question.collectionId() === undefined ||
         isReadonly ||

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.tsx
@@ -113,10 +113,17 @@ export const SaveQuestionModal = ({
     }
   }
 
+  const getOriginalNameModification = (originalQuestion: Question | null) =>
+    originalQuestion
+      ? originalQuestion?.displayName() + " - " + t`Modified`
+      : undefined;
+
   const initialValues: FormValues = useMemo(
     () => ({
       name:
-        originalQuestion?.displayName() ||
+        // Saved question
+        getOriginalNameModification(originalQuestion) ||
+        // Ad-hoc query
         question.generateQueryDescription() ||
         "",
       description: question.description() || "",

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -158,8 +158,6 @@ function getQuestion({
   );
 }
 
-const EXPECTED_DIRTY_SUGGESTED_NAME = "Orders, Count, 1 row";
-
 function getDirtyQuestion(originalQuestion: Question) {
   return originalQuestion
     .setQuery(Lib.limit(originalQuestion.query(), -1, 1))
@@ -358,9 +356,7 @@ describe("SaveQuestionModal", () => {
 
       await userEvent.click(screen.getByText("Save as new question"));
 
-      expect(screen.getByLabelText("Name")).toHaveValue(
-        EXPECTED_DIRTY_SUGGESTED_NAME,
-      );
+      expect(screen.getByLabelText("Name")).toHaveValue(CARD.name);
       expect(screen.getByLabelText("Description")).toHaveValue(
         CARD.description,
       );
@@ -384,7 +380,7 @@ describe("SaveQuestionModal", () => {
 
       const newQuestion = call[0];
       expect(newQuestion.id()).toBeUndefined();
-      expect(newQuestion.displayName()).toBe(EXPECTED_DIRTY_SUGGESTED_NAME);
+      expect(newQuestion.displayName()).toBe(originalQuestion.displayName());
       expect(newQuestion.description()).toBe("Example");
       expect(newQuestion.collectionId()).toBe(null);
     });

--- a/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
+++ b/frontend/src/metabase/containers/SaveQuestionModal/SaveQuestionModal.unit.spec.tsx
@@ -356,7 +356,9 @@ describe("SaveQuestionModal", () => {
 
       await userEvent.click(screen.getByText("Save as new question"));
 
-      expect(screen.getByLabelText("Name")).toHaveValue(CARD.name);
+      expect(screen.getByLabelText("Name")).toHaveValue(
+        `${CARD.name} - Modified`,
+      );
       expect(screen.getByLabelText("Description")).toHaveValue(
         CARD.description,
       );
@@ -380,7 +382,9 @@ describe("SaveQuestionModal", () => {
 
       const newQuestion = call[0];
       expect(newQuestion.id()).toBeUndefined();
-      expect(newQuestion.displayName()).toBe(originalQuestion.displayName());
+      expect(newQuestion.displayName()).toBe(
+        `${originalQuestion.displayName()} - Modified`,
+      );
       expect(newQuestion.description()).toBe("Example");
       expect(newQuestion.collectionId()).toBe(null);
     });


### PR DESCRIPTION
Resolves #41196
Reproduces #41196 

### Description

We're now initializing form values with the name and the description derived from the original question. If, for whatever reason, that question name is not available, we're falling back to auto-generated descriptive question name. And if even that doesn't work, we will leave the `name` field empty for user to populate.

### How to verify

1. Open any saved question (let's say that its name was "Foo")
2. Modify anything about that question (filter, sort, row limit)
3. Click on "Save"
4. Choose "Save as new question"
5. Make sure that the suggested pre-filled name in the form is still "Foo"

Run an associated E2E reproduction.

### Demo
![Kapture 2024-04-09 at 18 40 00](https://github.com/metabase/metabase/assets/31325167/05fe9c99-b077-43ca-8d2c-637bd5729c5e)

### Checklist
- [x] Tests have been added/updated to cover changes in this PR
