### PR TITLE
docs - note on internal metabase account

### DIFF
--- a/docs/people-and-groups/managing.md
+++ b/docs/people-and-groups/managing.md
@@ -115,7 +115,7 @@ This action doesn't affect email distribution lists that are managed outside of 
 
 ## Default user accounts
 
-Metabase includes default user accounts to handle various activities. We're documenting the accounts here so you know they're legitimate accounts and not someone trying to spy on your Metabase. Some things to know about them:
+Metabase includes default user accounts to handle various tasks and activity. We're documenting the accounts here so you know they're legitimate accounts and not someone trying to spy on your Metabase. Some things to know about them:
 
 - Customers are not charged for these accounts.
 - No one can log in to these user accounts.

--- a/docs/people-and-groups/managing.md
+++ b/docs/people-and-groups/managing.md
@@ -115,7 +115,7 @@ This action doesn't affect email distribution lists that are managed outside of 
 
 ## Default user accounts
 
-Metabase includes default user accounts to handle various tasks and activity. We're documenting the accounts here so you know they're legitimate accounts and not someone trying to spy on your Metabase. Some things to know about them:
+Metabase includes default user accounts to handle various tasks. We're documenting these accounts here so you know they're legitimate accounts and not someone trying to spy on your Metabase. Some things to know about them:
 
 - Customers are not charged for these accounts.
 - No one can log in to these user accounts.

--- a/docs/people-and-groups/managing.md
+++ b/docs/people-and-groups/managing.md
@@ -115,7 +115,25 @@ This action doesn't affect email distribution lists that are managed outside of 
 
 ## Default user accounts
 
-Metabase will automatically create a user account called "Metabase Internal" with an email of `internal@metabase.com`. Metabase uses this account to load the [Metabase analytics](../usage-and-performance-tools/usage-analytics.md) collection into your Metabase. Metabase will exclude this Metabase Internal account from the People tab in the Admin settings, so you won't see it show up if you search for it. You may see this `internal@metabase.com` account in the logs, so we're just documenting the account here so that you know it's a legitimate account and not someone trying to spy on your Metabase.
+Metabase includes default user accounts to handle various activities. Metabase will exclude these user accounts from the **Admin settings** > **People** tab, so we're documenting the accounts here so you know they're legitimate accounts and not someone trying to spy on your Metabase.
+
+### Anonymous user account
+
+- ID: 0
+- First name: External
+- Last name: User
+- Email: null
+
+Metabase uses this anonymous user account to log anonymous views, for example views of a [public question or dashboard](../questions/sharing/public-links.md). You'll see this account show up in [usage analytics](../usage-and-performance-tools/usage-analytics.md).
+
+### Metabase internal account
+
+- ID: 13371338
+- First name: Internal
+- Last name: Metabase
+- Email: internal@metabase.com
+
+The [Pro](https://www.metabase.com/pro) and [Enterprise](https://www.metabase.com/enterprise) editions include a user account called "Metabase Internal". Metabase uses this account to load the [Metabase analytics](../usage-and-performance-tools/usage-analytics.md) collection into your Metabase. You may see this `internal@metabase.com` account in the logs.
 
 ## Groups
 

--- a/docs/people-and-groups/managing.md
+++ b/docs/people-and-groups/managing.md
@@ -113,6 +113,10 @@ This action will delete any dashboard subscriptions or alerts the person has cre
 
 This action doesn't affect email distribution lists that are managed outside of Metabase.
 
+## Default user accounts
+
+Metabase will automatically create a user account called "Metabase Internal" with an email of `internal@metabase.com`. Metabase uses this account to load the [Metabase analytics](../usage-and-performance-tools/usage-analytics.md) collection into your Metabase. Metabase will exclude this Metabase Internal account from the People tab in the Admin settings, so you won't see it show up if you search for it. You may see this `internal@metabase.com` account in the logs, so we're just documenting the account here so that you know it's a legitimate account and not someone trying to spy on your Metabase.
+
 ## Groups
 
 To determine [who has access to what](../permissions/start.md), you’ll need to

--- a/docs/people-and-groups/managing.md
+++ b/docs/people-and-groups/managing.md
@@ -115,7 +115,11 @@ This action doesn't affect email distribution lists that are managed outside of 
 
 ## Default user accounts
 
-Metabase includes default user accounts to handle various activities. Metabase will exclude these user accounts from the **Admin settings** > **People** tab, so we're documenting the accounts here so you know they're legitimate accounts and not someone trying to spy on your Metabase.
+Metabase includes default user accounts to handle various activities. We're documenting the accounts here so you know they're legitimate accounts and not someone trying to spy on your Metabase. Some things to know about them:
+
+- Customers are not charged for these accounts.
+- No one can log in to these user accounts.
+- Metabase excludes these user accounts from the **Admin settings** > **People** tab.
 
 ### Anonymous user account
 
@@ -124,7 +128,7 @@ Metabase includes default user accounts to handle various activities. Metabase w
 - Last name: User
 - Email: null
 
-Metabase uses this anonymous user account to log anonymous views, for example views of a [public question or dashboard](../questions/sharing/public-links.md). You'll see this account show up in [usage analytics](../usage-and-performance-tools/usage-analytics.md).
+Metabase uses this anonymous user account to identify anonymous views, for example views of a [public question or dashboard](../questions/sharing/public-links.md). This account is a virtual user: the account doesn't exist in the application database. You'll see this account show up in [usage analytics](../usage-and-performance-tools/usage-analytics.md).
 
 ### Metabase internal account
 
@@ -133,7 +137,7 @@ Metabase uses this anonymous user account to log anonymous views, for example vi
 - Last name: Metabase
 - Email: internal@metabase.com
 
-The [Pro](https://www.metabase.com/pro) and [Enterprise](https://www.metabase.com/enterprise) editions include a user account called "Metabase Internal". Metabase uses this account to load the [Metabase analytics](../usage-and-performance-tools/usage-analytics.md) collection into your Metabase. You may see this `internal@metabase.com` account in the logs.
+Metabase uses this account to load content into Metabase (like the [Metabase analytics](../usage-and-performance-tools/usage-analytics.md) collection). You may see this `internal@metabase.com` account in the logs.
 
 ## Groups
 


### PR DESCRIPTION
Adds note about `internal@metabase.com` and `anonymous` user accounts.

https://github.com/metabase/metabase/issues/38362