### PR TITLE
Remove native dataset from services

### DIFF
--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
@@ -38,7 +38,7 @@ export const PreviewQueryModal = ({
 
   const engine = question.database()?.engine;
   const formattedQuery = formatNativeQuery(data?.query, engine);
-  const formattedError = getResponseErrorMessage(error);
+  const formattedError = error ? getResponseErrorMessage(error) : undefined;
 
   return (
     <NativeQueryPreview

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
@@ -38,16 +38,17 @@ export const PreviewQueryModal = ({
 
   const engine = question.database()?.engine;
   const formattedQuery = formatNativeQuery(data?.query, engine);
+  const formattedError = getResponseErrorMessage(error);
 
   return (
     <NativeQueryPreview
       title={t`Query preview`}
       query={formattedQuery}
-      error={getResponseErrorMessage(error)}
+      error={formattedError}
       isLoading={isFetching}
       onClose={onClose}
     >
-      {error && showMetabaseLinks && (
+      {formattedError && showMetabaseLinks && (
         <ModalExternalLink href={learnUrl}>
           {t`Learn how to debug SQL errors`}
         </ModalExternalLink>

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
@@ -30,7 +30,7 @@ export const PreviewQueryModal = ({
   const payload = {
     ...Lib.toLegacyQuery(sourceQuery),
     parameters,
-    ...{ pretty: false },
+    pretty: false,
   };
   const { data, error, isFetching } = useGetNativeDatasetQuery(payload);
   const learnUrl = getLearnUrl("debugging-sql/sql-syntax");

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
@@ -1,16 +1,19 @@
-import { useCallback } from "react";
 import { t } from "ttag";
 
+import { useGetNativeDatasetQuery } from "metabase/api";
+import { formatNativeQuery } from "metabase/lib/engine";
+import { getResponseErrorMessage } from "metabase/lib/errors";
 import { useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
 import { checkNotNull } from "metabase/lib/types";
 import {
-  getNativeQueryFn,
   getQuestion,
+  getNextRunParameters,
 } from "metabase/query_builder/selectors";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
+import * as Lib from "metabase-lib";
 
-import { NativeQueryPreview, useNativeQuery } from "../NativeQueryPreview";
+import { NativeQueryPreview } from "../NativeQueryPreview";
 
 import { ModalExternalLink } from "./PreviewQueryModal.styled";
 
@@ -22,21 +25,26 @@ export const PreviewQueryModal = ({
   onClose,
 }: PreviewQueryModalProps): JSX.Element => {
   const question = checkNotNull(useSelector(getQuestion));
-  const onLoadQuery = useSelector(getNativeQueryFn);
-  const handleLoadQuery = useCallback(
-    () => onLoadQuery({ pretty: false }),
-    [onLoadQuery],
-  );
-  const { query, error, isLoading } = useNativeQuery(question, handleLoadQuery);
+  const sourceQuery = question.query();
+  const parameters = useSelector(getNextRunParameters);
+  const payload = {
+    ...Lib.toLegacyQuery(sourceQuery),
+    parameters,
+    ...{ pretty: false },
+  };
+  const { data, error, isFetching } = useGetNativeDatasetQuery(payload);
   const learnUrl = MetabaseSettings.learnUrl("debugging-sql/sql-syntax");
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+
+  const engine = question.database()?.engine;
+  const formattedQuery = formatNativeQuery(data?.query, engine);
 
   return (
     <NativeQueryPreview
       title={t`Query preview`}
-      query={query}
-      error={error}
-      isLoading={isLoading}
+      query={formattedQuery}
+      error={getResponseErrorMessage(error)}
+      isLoading={isFetching}
       onClose={onClose}
     >
       {error && showMetabaseLinks && (

--- a/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
+++ b/frontend/src/metabase/query_builder/components/view/PreviewQueryModal/PreviewQueryModal.tsx
@@ -4,12 +4,12 @@ import { useGetNativeDatasetQuery } from "metabase/api";
 import { formatNativeQuery } from "metabase/lib/engine";
 import { getResponseErrorMessage } from "metabase/lib/errors";
 import { useSelector } from "metabase/lib/redux";
-import MetabaseSettings from "metabase/lib/settings";
 import { checkNotNull } from "metabase/lib/types";
 import {
   getQuestion,
   getNextRunParameters,
 } from "metabase/query_builder/selectors";
+import { getLearnUrl } from "metabase/selectors/settings";
 import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import * as Lib from "metabase-lib";
 
@@ -33,7 +33,7 @@ export const PreviewQueryModal = ({
     ...{ pretty: false },
   };
   const { data, error, isFetching } = useGetNativeDatasetQuery(payload);
-  const learnUrl = MetabaseSettings.learnUrl("debugging-sql/sql-syntax");
+  const learnUrl = getLearnUrl("debugging-sql/sql-syntax");
   const showMetabaseLinks = useSelector(getShowMetabaseLinks);
 
   const engine = question.database()?.engine;

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -993,22 +993,6 @@ export const getDataReferenceStack = createSelector(
       : [],
 );
 
-export const getNativeQueryFn = createSelector(
-  [getNextRunDatasetQuery, getNextRunParameters],
-  (datasetQuery, parameters) => {
-    let lastResult = undefined;
-
-    return async (options = {}) => {
-      lastResult ??= await MetabaseApi.native({
-        ...datasetQuery,
-        parameters,
-        ...options,
-      });
-      return lastResult;
-    };
-  },
-);
-
 export const getDashboardId = state => {
   return state.qb.parentDashboard.dashboardId;
 };

--- a/frontend/src/metabase/query_builder/selectors.js
+++ b/frontend/src/metabase/query_builder/selectors.js
@@ -299,8 +299,9 @@ const getNextRunParameterValues = createSelector([getParameters], parameters =>
   ),
 );
 
-const getNextRunParameters = createSelector([getParameters], parameters =>
-  normalizeParameters(parameters),
+export const getNextRunParameters = createSelector(
+  [getParameters],
+  parameters => normalizeParameters(parameters),
 );
 
 export const getQueryBuilderMode = createSelector(

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -329,7 +329,6 @@ export const MetabaseApi = {
   field_remapping: GET("/api/field/:fieldId/remapping/:remappedFieldId"),
   dataset: POST("/api/dataset"),
   dataset_pivot: POST("/api/dataset/pivot"),
-  native: POST("/api/dataset/native"),
 
   // to support audit app  allow the endpoint to be provided in the query
   datasetEndpoint: POST("/api/:endpoint", {


### PR DESCRIPTION
### Description

This PR replaces the last instance of the `MetabaseApi.native` call with the new RTK Query endpoint (introduced in https://github.com/metabase/metabase/pull/40430).

It then removes unused query builder selector, and unused endpoint from MetabaseApi.

### How to verify
```sql
SELECT
  count(*)
FROM
  products
WHERE
  category = {{category}}
```

1. New native question -> Sample Dataset -> paste the query from above
2. An eye icon should appear ("Preview the query")
3. Click on it and you should see the preview modal with an error message (because we're missing a required parameter)
4. Enter a value in the filter "Gizmo"
5. Click on the preview again
6. You should see the preview modal with a query

### Demo
![Kapture 2024-04-30 at 16 40 01](https://github.com/metabase/metabase/assets/31325167/b303b179-68c3-4b8a-95ed-732633bfc03d)

### Checklist
The existing test coverage should suffice.
