### PR TITLE
🚀 🏎️ ⏩Driver tests now take 28 minutes instead of 90 🚀 🏎️ ⏩ 

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -307,7 +307,8 @@
 
   ;; alias for CI-specific options.
   :ci
-  {:jvm-opts ["-Xmx2g"
+  {:jvm-opts ["-Xmx12g"
+              "-Xms12g"
               ;; normally CircleCI sets `CI` as an env var, so this is mostly to replicate that locally. Hawk will not
               ;; print the progress bar in output when this is set. Progress bars aren't very CI friendly
               "-Dci=TRUE"]}


### PR DESCRIPTION
We were setting `-Xmx2g` because CircleCI instances had 4 GB of memory total ~10 years ago, these days GitHub Actions runners have 16 GB of RAM. Let's make use of the extra RAM available to us.

Preliminary results have Postgres driver tests finishing in 28 minutes instead of timing out in 90 minutes. Yay