### PR TITLE
Split Data Perms - Create Queries E2E Tests

### DIFF
--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -1,12 +1,10 @@
 import { SAMPLE_DB_ID, USER_GROUPS } from "e2e/support/cypress_data";
-import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   ORDERS_QUESTION_ID,
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
   restore,
-  popover,
   modal,
   describeEE,
   isOSS,
@@ -21,13 +19,10 @@ import {
   setTokenFeatures,
 } from "e2e/support/helpers";
 
-const { ORDERS_ID } = SAMPLE_DATABASE;
-
 const { ALL_USERS_GROUP, ADMIN_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
 const COLLECTION_ACCESS_PERMISSION_INDEX = 0;
 
-const DATA_ACCESS_PERMISSION_INDEX = 0;
 const NATIVE_QUERIES_PERMISSION_INDEX = 1;
 
 describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
@@ -389,91 +384,6 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
         ]);
       });
 
-      it("allows view and edit permissions", () => {
-        cy.visit("/admin/permissions");
-
-        selectSidebarItem("collection");
-
-        assertPermissionTable([["Sample Database", "Can view", "No"]]);
-
-        // Drill down to tables permissions
-        cy.findByTextEnsureVisible("Sample Database").click();
-
-        assertPermissionTable([
-          ["Accounts", "Can view", "No"],
-          ["Analytic Events", "Can view", "No"],
-          ["Feedback", "Can view", "No"],
-          ["Invoices", "Can view", "No"],
-          ["Orders", "Can view", "No"],
-          ["People", "Can view", "No"],
-          ["Products", "Can view", "No"],
-          ["Reviews", "Can view", "No"],
-        ]);
-
-        // Navigate back
-        selectSidebarItem("collection");
-
-        modifyPermission(
-          "Sample Database",
-          NATIVE_QUERIES_PERMISSION_INDEX,
-          "Query builder and native",
-        );
-
-        assertPermissionTable([
-          ["Sample Database", "Can view", "Query builder and native"],
-        ]);
-
-        // Drill down to tables permissions
-        cy.findByTextEnsureVisible("Sample Database").click();
-
-        assertPermissionTable([
-          ["Accounts", "Can view", "Query builder and native"],
-          ["Analytic Events", "Can view", "Query builder and native"],
-          ["Feedback", "Can view", "Query builder and native"],
-          ["Invoices", "Can view", "Query builder and native"],
-          ["Orders", "Can view", "Query builder and native"],
-          ["People", "Can view", "Query builder and native"],
-          ["Products", "Can view", "Query builder and native"],
-          ["Reviews", "Can view", "Query builder and native"],
-        ]);
-
-        cy.button("Save changes").click();
-
-        modal().within(() => {
-          cy.findByText("Save permissions?");
-          cy.contains(
-            "collection will now be able to read or write native queries for Sample Database.",
-          );
-          cy.button("Yes").click();
-        });
-
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Save changes").should("not.exist");
-
-        assertPermissionTable([
-          ["Accounts", "Can view", "Query builder and native"],
-          ["Analytic Events", "Can view", "Query builder and native"],
-          ["Feedback", "Can view", "Query builder and native"],
-          ["Invoices", "Can view", "Query builder and native"],
-          ["Orders", "Can view", "Query builder and native"],
-          ["People", "Can view", "Query builder and native"],
-          ["Products", "Can view", "Query builder and native"],
-          ["Reviews", "Can view", "Query builder and native"],
-        ]);
-
-        // After saving permissions, user should be able to make further edits without refreshing the page
-        // metabase#37811
-        selectSidebarItem("data");
-
-        modifyPermission(
-          "Sample Database",
-          NATIVE_QUERIES_PERMISSION_INDEX,
-          "No",
-        );
-
-        cy.button("Refresh the page").should("not.exist");
-      });
-
       it("should show a modal when a revision changes while an admin is editing", () => {
         cy.intercept("/api/permissions/graph/group/1").as("graph");
         cy.visit("/admin/permissions");
@@ -500,77 +410,6 @@ describe("scenarios > admin > permissions", { tags: "@OSS" }, () => {
     });
 
     context("database focused view", () => {
-      it("allows view and edit permissions", () => {
-        cy.visit("/admin/permissions/");
-
-        cy.get("label").contains("Databases").click();
-
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Select a database to see group permissions");
-
-        selectSidebarItem("Sample Database");
-
-        assertPermissionTable([
-          ["Administrators", "Can view", "Query builder and native"],
-          ["All Users", "Can view", "No"],
-          ["collection", "Can view", "No"],
-          ["data", "Can view", "Query builder and native"],
-          ["nosql", "Can view", "Query builder only"],
-          ["readonly", "Can view", "No"],
-        ]);
-
-        modifyPermission(
-          "readonly",
-          NATIVE_QUERIES_PERMISSION_INDEX,
-          "Query builder and native",
-        );
-
-        assertPermissionTable([
-          ["Administrators", "Can view", "Query builder and native"],
-          ["All Users", "Can view", "No"],
-          ["collection", "Can view", "No"],
-          ["data", "Can view", "Query builder and native"],
-          ["nosql", "Can view", "Query builder only"],
-          ["readonly", "Can view", "Query builder and native"],
-        ]);
-
-        selectSidebarItem("Orders");
-
-        assertPermissionTable([
-          ["Administrators", "Can view", "Query builder and native"],
-          ["All Users", "Can view", "No"],
-          ["collection", "Can view", "No"],
-          ["data", "Can view", "Query builder and native"],
-          ["nosql", "Can view", "Query builder only"],
-          ["readonly", "Can view", "Query builder and native"],
-        ]);
-
-        // Navigate back
-        cy.get("a").contains("Sample Database").click();
-
-        cy.button("Save changes").click();
-
-        modal().within(() => {
-          cy.findByText("Save permissions?");
-          cy.contains(
-            "readonly will now be able to read or write native queries for Sample Database.",
-          );
-          cy.button("Yes").click();
-        });
-
-        // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-        cy.findByText("Save changes").should("not.exist");
-
-        assertPermissionTable([
-          ["Administrators", "Can view", "Query builder and native"],
-          ["All Users", "Can view", "No"],
-          ["collection", "Can view", "No"],
-          ["data", "Can view", "Query builder and native"],
-          ["nosql", "Can view", "Query builder only"],
-          ["readonly", "Can view", "Query builder and native"],
-        ]);
-      });
-
       it("should show a modal when a revision changes while an admin is editing", () => {
         cy.intercept("/api/permissions/graph/group/1").as("graph");
         cy.visit("/admin/permissions/");
@@ -604,179 +443,6 @@ describeEE("scenarios > admin > permissions", () => {
     restore();
     cy.signInAsAdmin();
     setTokenFeatures("all");
-  });
-
-  it("allows editing sandboxed access in the database focused view", () => {
-    cy.visit(
-      `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}`,
-    );
-
-    modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
-
-    modal().within(() => {
-      cy.findByText("Change access to this database to granular?");
-      cy.button("Change").click();
-    });
-
-    cy.url().should(
-      "include",
-      `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}/segmented/group/${ALL_USERS_GROUP}`,
-    );
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Grant sandboxed access to this table");
-    cy.button("Save").should("be.disabled");
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Pick a column").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("User ID").click();
-
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Pick a user attribute").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("attr_uid").click();
-    cy.button("Save").click();
-
-    assertPermissionTable([
-      [
-        "Administrators",
-        "Can view",
-        "Query builder and native",
-        "1 million rows",
-        "Yes",
-      ],
-      ["All Users", "Sandboxed", "No", "1 million rows", "No"],
-      ["collection", "Can view", "No", "No", "No"],
-      ["data", "Can view", "Query builder and native", "No", "No"],
-      ["nosql", "Can view", "Query builder only", "No", "No"],
-      ["readonly", "Can view", "No", "No", "No"],
-    ]);
-
-    modifyPermission(
-      "All Users",
-      DATA_ACCESS_PERMISSION_INDEX,
-      "Edit sandboxed access",
-    );
-
-    cy.url().should(
-      "include",
-      `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}/segmented/group/${ALL_USERS_GROUP}`,
-    );
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Grant sandboxed access to this table");
-
-    cy.button("Save").click();
-    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-    cy.findByText("Grant sandboxed access to this table").should("not.exist");
-
-    cy.button("Save changes").click();
-
-    assertPermissionTable([
-      [
-        "Administrators",
-        "Can view",
-        "Query builder and native",
-        "1 million rows",
-        "Yes",
-      ],
-      ["All Users", "Sandboxed", "No", "1 million rows", "No"],
-      ["collection", "Can view", "No", "No", "No"],
-      ["data", "Can view", "Query builder and native", "No", "No"],
-      ["nosql", "Can view", "Query builder only", "No", "No"],
-      ["readonly", "Can view", "No", "No", "No"],
-    ]);
-  });
-
-  it("allows editing sandboxed access in the group focused view", () => {
-    cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
-    cy.visit(
-      `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}`,
-    );
-
-    modifyPermission("Orders", DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
-
-    modal().within(() => {
-      cy.findByText("Change access to this database to granular?");
-      cy.button("Change").click();
-    });
-
-    cy.url().should(
-      "include",
-      `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}/schema/PUBLIC/${ORDERS_ID}/segmented`,
-    );
-    modal().within(() => {
-      cy.findByText("Grant sandboxed access to this table");
-      cy.button("Save").should("be.disabled");
-      cy.findByText("Pick a column").click();
-    });
-
-    popover().findByText("User ID").click();
-    modal().findByText("Pick a user attribute").click();
-    popover().findByText("attr_uid").click();
-    modal().button("Save").click();
-
-    assertPermissionTable([
-      ["Accounts", "Can view", "No", "1 million rows", "No"],
-      ["Analytic Events", "Can view", "No", "1 million rows", "No"],
-      ["Feedback", "Can view", "No", "1 million rows", "No"],
-      ["Invoices", "Can view", "No", "1 million rows", "No"],
-      ["Orders", "Sandboxed", "No", "1 million rows", "No"],
-      ["People", "Can view", "No", "1 million rows", "No"],
-      ["Products", "Can view", "No", "1 million rows", "No"],
-      ["Reviews", "Can view", "No", "1 million rows", "No"],
-    ]);
-
-    modifyPermission(
-      "Orders",
-      DATA_ACCESS_PERMISSION_INDEX,
-      "Edit sandboxed access",
-    );
-
-    cy.url().should(
-      "include",
-      `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}/schema/PUBLIC/${ORDERS_ID}/segmented`,
-    );
-
-    modal().findByText("Grant sandboxed access to this table");
-
-    cy.button("Save").click();
-
-    modal().should("not.exist");
-
-    cy.url().should(
-      "include",
-      `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}/schema/PUBLIC`,
-    );
-
-    cy.button("Save changes").click();
-
-    modal().within(() => {
-      cy.findByText("Save permissions?").should("exist");
-      cy.contains(
-        "All Users will be given access to 1 table in Sample Database",
-      ).should("exist");
-      cy.button("Yes").click();
-    });
-
-    cy.wait("@saveGraph");
-
-    // assertions that specifically targets metabase#37774. Should be able to reload with the schema in the URL and not error
-    cy.url().should(
-      "include",
-      `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}/schema/PUBLIC`,
-    );
-    cy.reload();
-
-    assertPermissionTable([
-      ["Accounts", "Can view", "No", "1 million rows", "No"],
-      ["Analytic Events", "Can view", "No", "1 million rows", "No"],
-      ["Feedback", "Can view", "No", "1 million rows", "No"],
-      ["Invoices", "Can view", "No", "1 million rows", "No"],
-      ["Orders", "Sandboxed", "No", "1 million rows", "No"],
-      ["People", "Can view", "No", "1 million rows", "No"],
-      ["Products", "Can view", "No", "1 million rows", "No"],
-      ["Reviews", "Can view", "No", "1 million rows", "No"],
-    ]);
   });
 
   it("Visualization and Settings query builder buttons are not visible for questions that use blocked data sources", () => {

--- a/e2e/test/scenarios/permissions/create-queries/granular.cy.spec.js
+++ b/e2e/test/scenarios/permissions/create-queries/granular.cy.spec.js
@@ -49,7 +49,7 @@ describe("scenarios > admin > permissions > create queries > granular", () => {
     // should allow setting a granular value for one table
     modifyPermission("Orders", NATIVE_QUERIES_PERMISSION_INDEX, "No");
 
-    // should alos remove native permissions for all other tables
+    // should also remove native permissions for all other tables
     assertPermissionTable([
       ["Accounts", "Can view", "Query builder only"],
       ["Analytic Events", "Can view", "Query builder only"],

--- a/e2e/test/scenarios/permissions/create-queries/granular.cy.spec.js
+++ b/e2e/test/scenarios/permissions/create-queries/granular.cy.spec.js
@@ -1,0 +1,96 @@
+import { USER_GROUPS } from "e2e/support/cypress_data";
+import {
+  assertPermissionTable,
+  selectSidebarItem,
+  popover,
+  selectPermissionRow,
+  modal,
+  restore,
+  modifyPermission,
+} from "e2e/support/helpers";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
+
+const NATIVE_QUERIES_PERMISSION_INDEX = 1;
+
+describe("scenarios > admin > permissions > create queries > granular", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow configuring granular permissions in group view", () => {
+    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+
+    modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder and native",
+    );
+
+    // should allow choosing granular option at the db level
+    modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Granular",
+    );
+
+    assertPermissionTable([
+      ["Accounts", "Can view", "Query builder and native"],
+      ["Analytic Events", "Can view", "Query builder and native"],
+      ["Feedback", "Can view", "Query builder and native"],
+      ["Invoices", "Can view", "Query builder and native"],
+      ["Orders", "Can view", "Query builder and native"],
+      ["People", "Can view", "Query builder and native"],
+      ["Products", "Can view", "Query builder and native"],
+      ["Reviews", "Can view", "Query builder and native"],
+    ]);
+
+    // should allow setting a granular value for one table
+    modifyPermission("Orders", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+
+    // should alos remove native permissions for all other tables
+    assertPermissionTable([
+      ["Accounts", "Can view", "Query builder only"],
+      ["Analytic Events", "Can view", "Query builder only"],
+      ["Feedback", "Can view", "Query builder only"],
+      ["Invoices", "Can view", "Query builder only"],
+      ["Orders", "Can view", "No"],
+      ["People", "Can view", "Query builder only"],
+      ["Products", "Can view", "Query builder only"],
+      ["Reviews", "Can view", "Query builder only"],
+    ]);
+
+    // should not allow 'query builder and native' as a granular permissions permission options
+    selectPermissionRow("Orders", NATIVE_QUERIES_PERMISSION_INDEX);
+    popover().should("not.contain", "Query builder and native");
+
+    // should have db set to granular
+    selectSidebarItem("All Users");
+    assertPermissionTable([["Sample Database", "Can view", "Granular"]]);
+
+    // should allow saving
+    cy.intercept("PUT", "/api/permissions/graph").as("saveGraph");
+    cy.button("Save changes").click();
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.button("Yes").click();
+    });
+
+    cy.wait("@saveGraph").then(({ response }) => {
+      expect(response.statusCode).to.equal(200);
+    });
+
+    // should infer value at db level if the tables are all made the same value
+    cy.findByTextEnsureVisible("Sample Database").click();
+    modifyPermission(
+      "Orders",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder only",
+    );
+    selectSidebarItem("All Users");
+    assertPermissionTable([
+      ["Sample Database", "Can view", "Query builder only"],
+    ]);
+  });
+});

--- a/e2e/test/scenarios/permissions/create-queries/no.cy.spec.js
+++ b/e2e/test/scenarios/permissions/create-queries/no.cy.spec.js
@@ -1,0 +1,48 @@
+import {
+  assertPermissionTable,
+  selectSidebarItem,
+  modal,
+  restore,
+  modifyPermission,
+} from "e2e/support/helpers";
+
+const NATIVE_QUERIES_PERMISSION_INDEX = 1;
+
+describe("scenarios > admin > permissions > create queries > no", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow setting create queries to 'no' in group view", () => {
+    cy.visit("/admin/permissions/data");
+
+    selectSidebarItem("data");
+
+    modifyPermission("Sample Database", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+
+    assertPermissionTable([["Sample Database", "Can view", "No"]]);
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.button("Yes").click();
+    });
+
+    assertPermissionTable([["Sample Database", "Can view", "No"]]);
+
+    cy.findByTextEnsureVisible("Sample Database").click();
+
+    assertPermissionTable([
+      ["Accounts", "Can view", "No"],
+      ["Analytic Events", "Can view", "No"],
+      ["Feedback", "Can view", "No"],
+      ["Invoices", "Can view", "No"],
+      ["Orders", "Can view", "No"],
+      ["People", "Can view", "No"],
+      ["Products", "Can view", "No"],
+      ["Reviews", "Can view", "No"],
+    ]);
+  });
+});

--- a/e2e/test/scenarios/permissions/create-queries/query-builder-and-native.cy.spec.js
+++ b/e2e/test/scenarios/permissions/create-queries/query-builder-and-native.cy.spec.js
@@ -1,0 +1,191 @@
+import {
+  restore,
+  modal,
+  assertPermissionTable,
+  modifyPermission,
+  selectPermissionRow,
+  popover,
+  selectSidebarItem,
+} from "e2e/support/helpers";
+
+const NATIVE_QUERIES_PERMISSION_INDEX = 1;
+
+describe("scenarios > admin > permissions > create queries > query builder and native", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow setting create queries to 'query builder and native' in group view", () => {
+    cy.visit("/admin/permissions");
+
+    selectSidebarItem("collection");
+
+    assertPermissionTable([
+      ["Sample Database", "Can view", "No", "No", "No", "No"],
+    ]);
+
+    // Drill down to tables permissions
+    cy.findByTextEnsureVisible("Sample Database").click();
+
+    assertPermissionTable([
+      ["Accounts", "Can view", "No", "No", "No", "No"],
+      ["Analytic Events", "Can view", "No", "No", "No", "No"],
+      ["Feedback", "Can view", "No", "No", "No", "No"],
+      ["Invoices", "Can view", "No", "No", "No", "No"],
+      ["Orders", "Can view", "No", "No", "No", "No"],
+      ["People", "Can view", "No", "No", "No", "No"],
+      ["Products", "Can view", "No", "No", "No", "No"],
+      ["Reviews", "Can view", "No", "No", "No", "No"],
+    ]);
+
+    // Test that query builder and native is not an option when it's not selected at table level
+    selectPermissionRow("Orders", NATIVE_QUERIES_PERMISSION_INDEX);
+    popover().should("not.contain", "Query builder and native");
+
+    // Navigate back
+    selectSidebarItem("collection");
+
+    modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder and native",
+    );
+
+    assertPermissionTable([
+      [
+        "Sample Database",
+        "Can view",
+        "Query builder and native",
+        "No",
+        "No",
+        "No",
+      ],
+    ]);
+
+    // Drill down to tables permissions
+    cy.findByTextEnsureVisible("Sample Database").click();
+
+    const finalTablePermissions = [
+      ["Accounts", "Can view", "Query builder and native", "No", "No", "No"],
+      [
+        "Analytic Events",
+        "Can view",
+        "Query builder and native",
+        "No",
+        "No",
+        "No",
+      ],
+      ["Feedback", "Can view", "Query builder and native", "No", "No", "No"],
+      ["Invoices", "Can view", "Query builder and native", "No", "No", "No"],
+      ["Orders", "Can view", "Query builder and native", "No", "No", "No"],
+      ["People", "Can view", "Query builder and native", "No", "No", "No"],
+      ["Products", "Can view", "Query builder and native", "No", "No", "No"],
+      ["Reviews", "Can view", "Query builder and native", "No", "No", "No"],
+    ];
+
+    assertPermissionTable(finalTablePermissions);
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.contains(
+        "collection will now be able to read or write native queries for Sample Database.",
+      );
+      cy.button("Yes").click();
+    });
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Save changes").should("not.exist");
+
+    assertPermissionTable(finalTablePermissions);
+
+    // After saving permissions, user should be able to make further edits without refreshing the page
+    // metabase#37811
+    selectSidebarItem("data");
+
+    modifyPermission("Sample Database", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+
+    cy.button("Refresh the page").should("not.exist");
+
+    // User should have the option to change permissions back to query builder and native at the database level
+    modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder and native",
+    );
+  });
+
+  it("should allow setting create queries to 'query builder and native' in database view", () => {
+    cy.visit("/admin/permissions/");
+
+    cy.get("label").contains("Databases").click();
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Select a database to see group permissions");
+
+    selectSidebarItem("Sample Database");
+
+    assertPermissionTable([
+      [
+        "Administrators",
+        "Can view",
+        "Query builder and native",
+        "1 million rows",
+        "Yes",
+        "Yes",
+      ],
+      ["All Users", "Can view", "No", "1 million rows", "No", "No"],
+      ["collection", "Can view", "No", "No", "No", "No"],
+      ["data", "Can view", "Query builder and native", "No", "No", "No"],
+      ["nosql", "Can view", "Query builder only", "No", "No", "No"],
+      ["readonly", "Can view", "No", "No", "No", "No"],
+    ]);
+
+    modifyPermission(
+      "readonly",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder and native",
+    );
+
+    const finalPermissions = [
+      [
+        "Administrators",
+        "Can view",
+        "Query builder and native",
+        "1 million rows",
+        "Yes",
+        "Yes",
+      ],
+      ["All Users", "Can view", "No", "1 million rows", "No", "No"],
+      ["collection", "Can view", "No", "No", "No", "No"],
+      ["data", "Can view", "Query builder and native", "No", "No", "No"],
+      ["nosql", "Can view", "Query builder only", "No", "No", "No"],
+      ["readonly", "Can view", "Query builder and native", "No", "No", "No"],
+    ];
+    assertPermissionTable(finalPermissions);
+
+    selectSidebarItem("Orders");
+
+    assertPermissionTable(finalPermissions);
+
+    // Navigate back
+    cy.get("a").contains("Sample Database").click();
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.contains(
+        "readonly will now be able to read or write native queries for Sample Database.",
+      );
+      cy.button("Yes").click();
+    });
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Save changes").should("not.exist");
+
+    assertPermissionTable(finalPermissions);
+  });
+});

--- a/e2e/test/scenarios/permissions/create-queries/query-builder-only.cy.spec.js
+++ b/e2e/test/scenarios/permissions/create-queries/query-builder-only.cy.spec.js
@@ -1,0 +1,307 @@
+import {
+  restore,
+  modal,
+  assertPermissionTable,
+  modifyPermission,
+  selectSidebarItem,
+} from "e2e/support/helpers";
+
+const NATIVE_QUERIES_PERMISSION_INDEX = 1;
+
+describe("scenarios > admin > permissions > create queries > query builder only", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+  });
+
+  it("should allow setting create queries to 'query builder only' in group view", () => {
+    cy.visit("/admin/permissions");
+
+    selectSidebarItem("collection");
+
+    assertPermissionTable([["Sample Database", "Can view", "No"]]);
+
+    // Drill down to tables permissions
+    cy.findByTextEnsureVisible("Sample Database").click();
+
+    assertPermissionTable([
+      ["Accounts", "Can view", "No"],
+      ["Analytic Events", "Can view", "No"],
+      ["Feedback", "Can view", "No"],
+      ["Invoices", "Can view", "No"],
+      ["Orders", "Can view", "No"],
+      ["People", "Can view", "No"],
+      ["Products", "Can view", "No"],
+      ["Reviews", "Can view", "No"],
+    ]);
+
+    // Navigate back
+    selectSidebarItem("collection");
+
+    modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder only",
+    );
+
+    assertPermissionTable([
+      ["Sample Database", "Can view", "Query builder only"],
+    ]);
+
+    // Drill down to tables permissions
+    cy.findByTextEnsureVisible("Sample Database").click();
+
+    const finalTablePermissions = [
+      ["Accounts", "Can view", "Query builder only"],
+      ["Analytic Events", "Can view", "Query builder only"],
+      ["Feedback", "Can view", "Query builder only"],
+      ["Invoices", "Can view", "Query builder only"],
+      ["Orders", "Can view", "Query builder only"],
+      ["People", "Can view", "Query builder only"],
+      ["Products", "Can view", "Query builder only"],
+      ["Reviews", "Can view", "Query builder only"],
+    ];
+
+    assertPermissionTable(finalTablePermissions);
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.contains(
+        "collection will now be able to read or write native queries for Sample Database.",
+      );
+      cy.button("Yes").click();
+    });
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Save changes").should("not.exist");
+
+    assertPermissionTable(finalTablePermissions);
+
+    // After saving permissions, user should be able to make further edits without refreshing the page
+    // metabase#37811
+    selectSidebarItem("data");
+
+    modifyPermission("Sample Database", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+
+    cy.button("Refresh the page").should("not.exist");
+
+    // User should have the option to change permissions back to query builder only at the database level
+    modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder only",
+    );
+  });
+
+  it("should set entire database to 'query builder only' if a table is changed to it while db is 'query builder only'", () => {
+    cy.visit("/admin/permissions");
+
+    selectSidebarItem("collection");
+
+    assertPermissionTable([["Sample Database", "Can view", "No"]]);
+
+    modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder and native",
+    );
+
+    // Drill down to tables permissions
+    cy.findByTextEnsureVisible("Sample Database").click();
+
+    assertPermissionTable([
+      ["Accounts", "Can view", "Query builder and native"],
+      ["Analytic Events", "Can view", "Query builder and native"],
+      ["Feedback", "Can view", "Query builder and native"],
+      ["Invoices", "Can view", "Query builder and native"],
+      ["Orders", "Can view", "Query builder and native"],
+      ["People", "Can view", "Query builder and native"],
+      ["Products", "Can view", "Query builder and native"],
+      ["Reviews", "Can view", "Query builder and native"],
+    ]);
+
+    modifyPermission(
+      "Orders",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder only",
+    );
+
+    const finalTablePermissions = [
+      ["Accounts", "Can view", "Query builder only"],
+      ["Analytic Events", "Can view", "Query builder only"],
+      ["Feedback", "Can view", "Query builder only"],
+      ["Invoices", "Can view", "Query builder only"],
+      ["Orders", "Can view", "Query builder only"],
+      ["People", "Can view", "Query builder only"],
+      ["Products", "Can view", "Query builder only"],
+      ["Reviews", "Can view", "Query builder only"],
+    ];
+
+    assertPermissionTable(finalTablePermissions);
+
+    // Navigate back
+    selectSidebarItem("collection");
+    assertPermissionTable([
+      ["Sample Database", "Can view", "Query builder only"],
+    ]);
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.contains(
+        "collection will now be able to read or write native queries for Sample Database.",
+      );
+      cy.button("Yes").click();
+    });
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Save changes").should("not.exist");
+
+    // Drill down to tables permissions
+    cy.findByTextEnsureVisible("Sample Database").click();
+
+    assertPermissionTable(finalTablePermissions);
+  });
+
+  it("should allow setting create queries to 'query builder only' in group view", () => {
+    cy.visit("/admin/permissions");
+
+    selectSidebarItem("collection");
+
+    assertPermissionTable([["Sample Database", "Can view", "No"]]);
+
+    // Drill down to tables permissions
+    cy.findByTextEnsureVisible("Sample Database").click();
+
+    assertPermissionTable([
+      ["Accounts", "Can view", "No"],
+      ["Analytic Events", "Can view", "No"],
+      ["Feedback", "Can view", "No"],
+      ["Invoices", "Can view", "No"],
+      ["Orders", "Can view", "No"],
+      ["People", "Can view", "No"],
+      ["Products", "Can view", "No"],
+      ["Reviews", "Can view", "No"],
+    ]);
+
+    // Navigate back
+    selectSidebarItem("collection");
+
+    modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder only",
+    );
+
+    assertPermissionTable([
+      ["Sample Database", "Can view", "Query builder only"],
+    ]);
+
+    // Drill down to tables permissions
+    cy.findByTextEnsureVisible("Sample Database").click();
+
+    const finalTablePermissions = [
+      ["Accounts", "Can view", "Query builder only"],
+      ["Analytic Events", "Can view", "Query builder only"],
+      ["Feedback", "Can view", "Query builder only"],
+      ["Invoices", "Can view", "Query builder only"],
+      ["Orders", "Can view", "Query builder only"],
+      ["People", "Can view", "Query builder only"],
+      ["Products", "Can view", "Query builder only"],
+      ["Reviews", "Can view", "Query builder only"],
+    ];
+
+    assertPermissionTable(finalTablePermissions);
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.contains(
+        "collection will now be able to read or write native queries for Sample Database.",
+      );
+      cy.button("Yes").click();
+    });
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Save changes").should("not.exist");
+
+    assertPermissionTable(finalTablePermissions);
+
+    // After saving permissions, user should be able to make further edits without refreshing the page
+    // metabase#37811
+    selectSidebarItem("data");
+
+    modifyPermission("Sample Database", NATIVE_QUERIES_PERMISSION_INDEX, "No");
+
+    cy.button("Refresh the page").should("not.exist");
+
+    // User should have the option to change permissions back to query builder only at the database level
+    modifyPermission(
+      "Sample Database",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder only",
+    );
+  });
+
+  it("should allow setting create queries to 'query builder only' in database view", () => {
+    cy.visit("/admin/permissions/");
+
+    cy.get("label").contains("Databases").click();
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Select a database to see group permissions");
+
+    selectSidebarItem("Sample Database");
+
+    assertPermissionTable([
+      ["Administrators", "Can view", "Query builder and native"],
+      ["All Users", "Can view", "No"],
+      ["collection", "Can view", "No"],
+      ["data", "Can view", "Query builder and native"],
+      ["nosql", "Can view", "Query builder only"],
+      ["readonly", "Can view", "No"],
+    ]);
+
+    modifyPermission(
+      "readonly",
+      NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder only",
+    );
+
+    const finalPermissions = [
+      ["Administrators", "Can view", "Query builder and native"],
+      ["All Users", "Can view", "No"],
+      ["collection", "Can view", "No"],
+      ["data", "Can view", "Query builder and native"],
+      ["nosql", "Can view", "Query builder only"],
+      ["readonly", "Can view", "Query builder only"],
+    ];
+    assertPermissionTable(finalPermissions);
+
+    selectSidebarItem("Orders");
+
+    assertPermissionTable(finalPermissions);
+
+    // Navigate back
+    cy.get("a").contains("Sample Database").click();
+
+    cy.button("Save changes").click();
+
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.contains(
+        "readonly will now be able to read or write native queries for Sample Database.",
+      );
+      cy.button("Yes").click();
+    });
+
+    // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
+    cy.findByText("Save changes").should("not.exist");
+
+    assertPermissionTable(finalPermissions);
+  });
+});

--- a/e2e/test/scenarios/permissions/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/impersonated.cy.spec.js
@@ -1,14 +1,8 @@
 import { USER_GROUPS } from "e2e/support/cypress_data";
 import {
-  assertPermissionTable,
   createTestRoles,
   describeEE,
-  getPermissionRowPermissions,
-  isPermissionDisabled,
-  modal,
-  modifyPermission,
   openNativeEditor,
-  popover,
   restore,
   runNativeQuery,
   setTokenFeatures,
@@ -17,8 +11,6 @@ import {
 const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
 
 const PG_DB_ID = 2;
-const DATA_ACCESS_PERMISSION_INDEX = 0;
-const NATIVE_QUERIES_PERMISSION_INDEX = 1;
 
 describeEE("impersonated permission", () => {
   describe("admins", () => {
@@ -29,370 +21,83 @@ describeEE("impersonated permission", () => {
       setTokenFeatures("all");
     });
 
-    // skipping for now as it's testing UI. We should update this when the UI sets split data perms
-    it.skip("can set impersonated permissions", () => {
-      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+    describe("impersonated users", () => {
+      const setImpersonatedPermission = () => {
+        cy.updatePermissionsGraph(
+          {
+            [ALL_USERS_GROUP]: {
+              1: {
+                "view-data": "unrestricted",
+                "create-queries": "query-builder-and-native",
+              },
+              [PG_DB_ID]: {
+                "view-data": "impersonated",
+                "create-queries": "query-builder-and-native",
+              },
+            },
+            [COLLECTION_GROUP]: {
+              1: { "view-data": "blocked" },
+              [PG_DB_ID]: { "view-data": "blocked" },
+            },
+          },
+          [
+            {
+              db_id: PG_DB_ID,
+              group_id: ALL_USERS_GROUP,
+              attribute: "role",
+            },
+          ],
+        );
+      };
 
-      // Check there is no Impersonated option on H2
-      cy.get("main").findByText("No self-service").click();
-      popover().findByText("Impersonated").should("not.exist");
+      beforeEach(() => {
+        restore("postgres-12");
+        createTestRoles({ type: "postgres" });
+        cy.signInAsAdmin();
+        setTokenFeatures("all");
 
-      // Set impersonated access on Postgres database
-      modifyPermission(
-        "QA Postgres12",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Impersonated",
-      );
+        setImpersonatedPermission();
 
-      selectImpersonatedAttribute("role");
-      saveImpersonationSettings();
-      savePermissions();
+        cy.signInAsImpersonatedUser();
+      });
 
-      assertPermissionTable([
-        [
-          "Sample Database",
-          "No self-service",
-          "No",
-          "1 million rows",
-          "No",
-          "No",
-        ],
-        ["QA Postgres12", "Impersonated", "Yes", "1 million rows", "No", "No"],
-      ]);
+      it("have limited access", () => {
+        cy.visit(`/browse/databases/${PG_DB_ID}`);
 
-      // Checking it shows the right state on the tables level
-      cy.get("main").findByText("QA Postgres12").click();
-
-      assertPermissionTable([
-        ["Accounts", "Impersonated", "Yes", "1 million rows", "No", "No"],
-        [
-          "Analytic Events",
-          "Impersonated",
-          "Yes",
-          "1 million rows",
-          "No",
-          "No",
-        ],
-        ["Feedback", "Impersonated", "Yes", "1 million rows", "No", "No"],
-        ["Invoices", "Impersonated", "Yes", "1 million rows", "No", "No"],
-        ["Orders", "Impersonated", "Yes", "1 million rows", "No", "No"],
-        ["People", "Impersonated", "Yes", "1 million rows", "No", "No"],
-        ["Products", "Impersonated", "Yes", "1 million rows", "No", "No"],
-        ["Reviews", "Impersonated", "Yes", "1 million rows", "No", "No"],
-      ]);
-
-      // Return back to the database view
-      cy.get("main").findByText("All Users group").click();
-
-      // Edit impersonated permission
-      modifyPermission(
-        "QA Postgres12",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Edit Impersonated",
-      );
-
-      selectImpersonatedAttribute("attr_uid");
-      saveImpersonationSettings();
-      savePermissions();
-
-      assertPermissionTable([
-        [
-          "Sample Database",
-          "No self-service",
-          "No",
-          "1 million rows",
-          "No",
-          "No",
-        ],
-        ["QA Postgres12", "Impersonated", "Yes", "1 million rows", "No", "No"],
-      ]);
-
-      // Checking table permissions when the native access is disabled for impersonated users
-      modifyPermission("QA Postgres12", NATIVE_QUERIES_PERMISSION_INDEX, "No");
-      cy.get("main").findByText("QA Postgres12").click();
-
-      cy.get("main")
-        .findByText("Orders")
-        .closest("tr")
-        .within(() => {
-          isPermissionDisabled(
-            DATA_ACCESS_PERMISSION_INDEX,
-            "Impersonated",
-            true,
-          ).click();
-          isPermissionDisabled(NATIVE_QUERIES_PERMISSION_INDEX, "No", true);
-
-          cy.findAllByText("No").eq(0).realHover();
+        // No access through the visual query builder
+        cy.get("main").within(() => {
+          cy.findByText("Reviews").click();
+          cy.findByText("There was a problem with your question");
+          cy.findByText("Show error details").click();
+          cy.findByText("ERROR: permission denied for table reviews");
         });
 
-      // eslint-disable-next-line no-unscoped-text-selectors
-      cy.findByText(
-        'Groups with View data access set to "Blocked" can\'t create queries.',
-      ).should("not.exist");
+        // Has access to allowed tables
+        cy.visit(`/browse/databases/${PG_DB_ID}`);
 
-      // Return back to the database view
-      cy.get("main").findByText("All Users group").click();
+        cy.get("main").findByText("Orders").click();
+        cy.findAllByTestId("header-cell").contains("Subtotal");
 
-      // Change from impersonated permission
-      modifyPermission(
-        "QA Postgres12",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "No self-service",
-      );
-
-      assertPermissionTable([
-        [
-          "Sample Database",
-          "No self-service",
-          "No",
-          "1 million rows",
-          "No",
-          "No",
-        ],
-        [
-          "QA Postgres12",
-          "No self-service",
-          "No",
-          "1 million rows",
-          "No",
-          "No",
-        ],
-      ]);
-    });
-
-    // skipping for now as it's testing UI. We should update this when the UI sets split data perms
-    it.skip("warns when All Users have impersonated access and the target group has no self-service access", () => {
-      cy.visit(`/admin/permissions/data/group/${COLLECTION_GROUP}`);
-
-      modifyPermission(
-        "QA Postgres12",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Impersonated",
-      );
-
-      // Warns that All Users group has greater access
-      cy.findByRole("dialog").within(() => {
-        cy.findByText(
-          'Revoke access even though "All Users" has greater access?',
+        // No access through the native query builder
+        openNativeEditor({ databaseName: "QA Postgres12" }).type(
+          "select * from reviews",
         );
+        runNativeQuery();
 
-        cy.findByText("Revoke access").click();
+        cy.findByTestId("query-builder-main").within(() => {
+          cy.findByText("An error occurred in your query");
+          cy.findByText("ERROR: permission denied for table reviews");
+        });
+
+        // Has access to other tables
+        cy.get("@editor")
+          .type("{selectall}{backspace}", { delay: 50 })
+          .type("select * from orders");
+
+        runNativeQuery();
+
+        cy.findAllByTestId("header-cell").contains("subtotal");
       });
-
-      selectImpersonatedAttribute("role");
-      saveImpersonationSettings();
-      savePermissions();
-
-      getPermissionRowPermissions("QA Postgres12")
-        .eq(DATA_ACCESS_PERMISSION_INDEX)
-        .findByLabelText("warning icon")
-        .realHover();
-
-      popover().findByText(
-        'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
-      );
-    });
-
-    // skipping for now as it's testing UI. We should update this when the UI sets split data perms
-    it.skip("allows switching to the granular access and update table permissions", () => {
-      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
-
-      modifyPermission(
-        "QA Postgres12",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Impersonated",
-      );
-
-      selectImpersonatedAttribute("role");
-      saveImpersonationSettings();
-      savePermissions();
-
-      modifyPermission(
-        "QA Postgres12",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Granular",
-      );
-
-      // Resets table permissions from Impersonated to No self-service
-      assertPermissionTable([
-        ["Accounts", "No self-service", "No", "1 million rows", "No", "No"],
-        [
-          "Analytic Events",
-          "No self-service",
-          "No",
-          "1 million rows",
-          "No",
-          "No",
-        ],
-        ["Feedback", "No self-service", "No", "1 million rows", "No", "No"],
-        ["Invoices", "No self-service", "No", "1 million rows", "No", "No"],
-        ["Orders", "No self-service", "No", "1 million rows", "No", "No"],
-        ["People", "No self-service", "No", "1 million rows", "No", "No"],
-        ["Products", "No self-service", "No", "1 million rows", "No", "No"],
-        ["Reviews", "No self-service", "No", "1 million rows", "No", "No"],
-      ]);
-
-      // Return back to the database view
-      cy.get("main").findByText("All Users group").click();
-
-      // On database level it got reset to No self-service too
-      assertPermissionTable([
-        [
-          "Sample Database",
-          "No self-service",
-          "No",
-          "1 million rows",
-          "No",
-          "No",
-        ],
-        [
-          "QA Postgres12",
-          "No self-service",
-          "No",
-          "1 million rows",
-          "No",
-          "No",
-        ],
-      ]);
-    });
-
-    it("impersonation modal should be positioned behind the page leave confirmation modal", () => {
-      // Try leaving the page
-      cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
-
-      modifyPermission(
-        "QA Postgres12",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Impersonated",
-      );
-
-      selectImpersonatedAttribute("role");
-      saveImpersonationSettings();
-
-      modifyPermission(
-        "QA Postgres12",
-        DATA_ACCESS_PERMISSION_INDEX,
-        "Edit Impersonated",
-      );
-
-      cy.findByRole("dialog").findByText("Edit settings").click();
-
-      // Page leave confirmation should be on top
-      modal()
-        .as("leaveConfirmation")
-        .findByText("Discard your changes?")
-        .should("be.visible");
-
-      // Cancel
-      cy.get("@leaveConfirmation").findByText("Cancel").click();
-
-      // Ensure the impersonation modal is still open
-      cy.findByRole("dialog")
-        .findByText("Map a user attribute to database roles")
-        .should("be.visible");
-
-      // Go to settings
-      cy.findByRole("dialog").findByText("Edit settings").click();
-      cy.get("@leaveConfirmation").findByText("Discard changes").click();
-
-      cy.focused().should("have.attr", "placeholder", "username");
-    });
-  });
-
-  describe("impersonated users", () => {
-    const setImpersonatedPermission = () => {
-      cy.updatePermissionsGraph(
-        {
-          [ALL_USERS_GROUP]: {
-            1: {
-              "view-data": "unrestricted",
-              "create-queries": "query-builder-and-native",
-            },
-            [PG_DB_ID]: {
-              "view-data": "impersonated",
-              "create-queries": "query-builder-and-native",
-            },
-          },
-          [COLLECTION_GROUP]: {
-            1: { "view-data": "blocked" },
-            [PG_DB_ID]: { "view-data": "blocked" },
-          },
-        },
-        [
-          {
-            db_id: PG_DB_ID,
-            group_id: ALL_USERS_GROUP,
-            attribute: "role",
-          },
-        ],
-      );
-    };
-
-    beforeEach(() => {
-      restore("postgres-12");
-      createTestRoles({ type: "postgres" });
-      cy.signInAsAdmin();
-      setTokenFeatures("all");
-
-      setImpersonatedPermission();
-
-      cy.signInAsImpersonatedUser();
-    });
-
-    it("have limited access", () => {
-      cy.visit(`/browse/databases/${PG_DB_ID}`);
-
-      // No access through the visual query builder
-      cy.get("main").within(() => {
-        cy.findByText("Reviews").click();
-        cy.findByText("There was a problem with your question");
-        cy.findByText("Show error details").click();
-        cy.findByText("ERROR: permission denied for table reviews");
-      });
-
-      // Has access to allowed tables
-      cy.visit(`/browse/databases/${PG_DB_ID}`);
-
-      cy.get("main").findByText("Orders").click();
-      cy.findAllByTestId("header-cell").contains("Subtotal");
-
-      // No access through the native query builder
-      openNativeEditor({ databaseName: "QA Postgres12" }).type(
-        "select * from reviews",
-      );
-      runNativeQuery();
-
-      cy.findByTestId("query-builder-main").within(() => {
-        cy.findByText("An error occurred in your query");
-        cy.findByText("ERROR: permission denied for table reviews");
-      });
-
-      // Has access to other tables
-      cy.get("@editor")
-        .type("{selectall}{backspace}", { delay: 50 })
-        .type("select * from orders");
-
-      runNativeQuery();
-
-      cy.findAllByTestId("header-cell").contains("subtotal");
     });
   });
 });
-
-function savePermissions() {
-  cy.findByTestId("edit-bar").button("Save changes").click();
-  cy.findByRole("dialog").findByText("Yes").click();
-  cy.findByTestId("edit-bar").should("not.exist");
-}
-
-function selectImpersonatedAttribute(attribute) {
-  cy.findByRole("dialog").within(() => {
-    cy.findByTestId("select-button").click();
-  });
-
-  popover().findByText(attribute).click();
-}
-
-function saveImpersonationSettings() {
-  cy.findByRole("dialog").findByText("Save").click();
-}

--- a/e2e/test/scenarios/permissions/view-data/impersonated.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data/impersonated.cy.spec.js
@@ -1,0 +1,250 @@
+import { USER_GROUPS } from "e2e/support/cypress_data";
+import {
+  createTestRoles,
+  selectPermissionRow,
+  describeEE,
+  getPermissionRowPermissions,
+  modal,
+  setTokenFeatures,
+  popover,
+  modifyPermission,
+  assertPermissionTable,
+  restore,
+} from "e2e/support/helpers";
+
+const { ALL_USERS_GROUP, COLLECTION_GROUP } = USER_GROUPS;
+
+const DATA_ACCESS_PERMISSION_INDEX = 0;
+
+describeEE("scenarios > admin > permissions > view data > impersonated", () => {
+  beforeEach(() => {
+    restore("postgres-12");
+    createTestRoles({ type: "postgres" });
+    cy.signInAsAdmin();
+    setTokenFeatures("all");
+  });
+
+  it("should allow saving 'impersonated' permissions", () => {
+    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+
+    // Check there is no Impersonated option on H2
+    selectPermissionRow("Sample Database", DATA_ACCESS_PERMISSION_INDEX);
+    popover().should("not.contain", "Impersonated");
+
+    // Set impersonated access on Postgres database
+    modifyPermission(
+      "QA Postgres12",
+      DATA_ACCESS_PERMISSION_INDEX,
+      "Impersonated",
+    );
+
+    selectImpersonatedAttribute("role");
+    saveImpersonationSettings();
+    savePermissions();
+
+    assertPermissionTable([
+      ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
+      [
+        "QA Postgres12",
+        "Impersonated",
+        "Query builder and native",
+        "1 million rows",
+        "No",
+        "No",
+      ],
+    ]);
+
+    // Checking it shows the right state on the tables level
+    cy.get("main").findByText("QA Postgres12").click();
+
+    assertPermissionTable(
+      [
+        "Accounts",
+        "Analytic Events",
+        "Feedback",
+        "Invoices",
+        "Orders",
+        "People",
+        "Products",
+        "Reviews",
+      ].map(tableName => [
+        tableName,
+        "Impersonated",
+        "Query builder and native",
+        "1 million rows",
+        "No",
+        "No",
+      ]),
+    );
+
+    // Return back to the database view
+    cy.get("main").findByText("All Users group").click();
+
+    // Edit impersonated permission
+    modifyPermission(
+      "QA Postgres12",
+      DATA_ACCESS_PERMISSION_INDEX,
+      "Edit Impersonated",
+    );
+
+    selectImpersonatedAttribute("attr_uid");
+    saveImpersonationSettings();
+    savePermissions();
+
+    assertPermissionTable([
+      ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
+      [
+        "QA Postgres12",
+        "Impersonated",
+        "Query builder and native",
+        "1 million rows",
+        "No",
+        "No",
+      ],
+    ]);
+  });
+
+  it("should warns when All Users group has 'impersonated' access and the target group has unrestricted access", () => {
+    cy.visit(`/admin/permissions/data/group/${COLLECTION_GROUP}`);
+
+    modifyPermission(
+      "QA Postgres12",
+      DATA_ACCESS_PERMISSION_INDEX,
+      "Impersonated",
+    );
+
+    // Warns that All Users group has greater access
+    cy.findByRole("dialog").within(() => {
+      cy.findByText(
+        'Revoke access even though "All Users" has greater access?',
+      );
+
+      cy.findByText("Revoke access").click();
+    });
+
+    selectImpersonatedAttribute("role");
+    saveImpersonationSettings();
+    savePermissions();
+
+    getPermissionRowPermissions("QA Postgres12")
+      .eq(DATA_ACCESS_PERMISSION_INDEX)
+      .findByLabelText("warning icon")
+      .realHover();
+
+    popover().findByText(
+      'The "All Users" group has a higher level of access than this, which will override this setting. You should limit or revoke the "All Users" group\'s access to this item.',
+    );
+  });
+
+  it("allows switching to the granular access and update table permissions", () => {
+    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+
+    modifyPermission(
+      "QA Postgres12",
+      DATA_ACCESS_PERMISSION_INDEX,
+      "Impersonated",
+    );
+
+    selectImpersonatedAttribute("role");
+    saveImpersonationSettings();
+    savePermissions();
+
+    modifyPermission("QA Postgres12", DATA_ACCESS_PERMISSION_INDEX, "Granular");
+
+    // Resets table permissions from Impersonated to Can view
+    assertPermissionTable(
+      [
+        "Accounts",
+        "Analytic Events",
+        "Feedback",
+        "Invoices",
+        "Orders",
+        "People",
+        "Products",
+        "Reviews",
+      ].map(tableName => [
+        tableName,
+        "Can view",
+        "Query builder and native",
+        "1 million rows",
+        "No",
+        "No",
+      ]),
+    );
+    // Return back to the database view
+    cy.get("main").findByText("All Users group").click();
+
+    // On database level it got reset to Can view too
+    assertPermissionTable([
+      ["Sample Database", "Can view", "No", "1 million rows", "No", "No"],
+      [
+        "QA Postgres12",
+        "Can view",
+        "Query builder and native",
+        "1 million rows",
+        "No",
+        "No",
+      ],
+    ]);
+  });
+
+  it("impersonation modal should be positioned behind the page leave confirmation modal", () => {
+    // Try leaving the page
+    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+
+    modifyPermission(
+      "QA Postgres12",
+      DATA_ACCESS_PERMISSION_INDEX,
+      "Impersonated",
+    );
+
+    selectImpersonatedAttribute("role");
+    saveImpersonationSettings();
+
+    modifyPermission(
+      "QA Postgres12",
+      DATA_ACCESS_PERMISSION_INDEX,
+      "Edit Impersonated",
+    );
+
+    cy.findByRole("dialog").findByText("Edit settings").click();
+
+    // Page leave confirmation should be on top
+    modal()
+      .as("leaveConfirmation")
+      .findByText("Discard your changes?")
+      .should("be.visible");
+
+    // Cancel
+    cy.get("@leaveConfirmation").findByText("Cancel").click();
+
+    // Ensure the impersonation modal is still open
+    cy.findByRole("dialog")
+      .findByText("Map a user attribute to database roles")
+      .should("be.visible");
+
+    // Go to settings
+    cy.findByRole("dialog").findByText("Edit settings").click();
+    cy.get("@leaveConfirmation").findByText("Discard changes").click();
+
+    cy.focused().should("have.attr", "placeholder", "username");
+  });
+});
+
+function savePermissions() {
+  cy.findByTestId("edit-bar").button("Save changes").click();
+  cy.findByRole("dialog").findByText("Yes").click();
+  cy.findByTestId("edit-bar").should("not.exist");
+}
+
+function selectImpersonatedAttribute(attribute) {
+  cy.findByRole("dialog").within(() => {
+    cy.findByTestId("select-button").click();
+  });
+
+  popover().findByText(attribute).click();
+}
+
+function saveImpersonationSettings() {
+  cy.findByRole("dialog").findByText("Save").click();
+}

--- a/e2e/test/scenarios/permissions/view-data/unrestricted.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data/unrestricted.cy.spec.js
@@ -9,7 +9,7 @@ import {
 
 const DATA_ACCESS_PERMISSION_INDEX = 0;
 
-describeEE("scenarios > admin > permissions > view data > granular", () => {
+describeEE("scenarios > admin > permissions > view data > unrestricted", () => {
   beforeEach(() => {
     restore();
     cy.signInAsAdmin();


### PR DESCRIPTION
### Description

Adds e2e test coverage for `create-queries` permissions. All removes some duplicate sandboxing tests and turns back on impersonated tests.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR