### PR TITLE
docs - Add a missing closing bracket for an example in the documentation

### DIFF
--- a/docs/questions/native-editor/sql-parameters.md
+++ b/docs/questions/native-editor/sql-parameters.md
@@ -305,7 +305,7 @@ FROM
   products
 WHERE
   TRUE
-  [[AND id = {{id}}]
+  [[AND id = {{id}}]]
   [[AND {{category}}]]
 {% endraw %}
 ```


### PR DESCRIPTION
### Description

Simple documentation fix, added a missing closing bracket for the optional parameter query example.
