### PR TITLE
Fix snowflake's delete-old-datasets! for tests

### DIFF
--- a/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
+++ b/modules/drivers/snowflake/test/metabase/test/data/snowflake.clj
@@ -98,9 +98,7 @@
          (loop [acc []]
            (if-not (.next rset)
              acc
-             ;; for whatever dumb reason the Snowflake JDBC driver always returns these as uppercase despite us making
-             ;; them all lower-case
-             (let [catalog (u/lower-case-en (.getString rset "TABLE_CAT"))
+             (let [catalog (.getString rset "TABLE_CAT")
                    acc     (cond-> acc
                              (sql.tu.unique-prefix/old-dataset-name? catalog) (conj catalog))]
                (recur acc)))))))))


### PR DESCRIPTION
This PR fixes the root cause of the problem causing redshift failures in CI ([example](https://github.com/metabase/metabase/actions/runs/8628851832/job/23651827525?pr=41068#step:3:494))

[Slack context](https://metaboat.slack.com/archives/C5XHN8GLW/p1712743631946979)

Previously the `DROP DATABASE ...` statements we were executing in `delete-old-datasets!` were failing because the database name didn't match what was in the database. 

e.g. this is a typical database name being returned from `conn.getCatalogs()`:

`2024_04_08_fb38bcb0_58ff_4a05_a912_87071e9a6218_Default-Schema-Test`

But we would lower-case it before executing DROP DATABASE, like so:

`DROP DATABASE 2024_04_08_fb38bcb0_58ff_4a05_a912_87071e9a6218_default-schema-test`

That would result in the following error:
```
Database '"2024_04_08_fb38bcb0_58ff_4a05_a912_87071e9a6218_default-schema-test"' does not exist or not authorized.
```

It's not clear to me why the database names are being Sentence-Cased but we definitely shouldn't be lower-casing them.