### PR TITLE
Remove -Xmx4g option from :cloverage alias

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -37,7 +37,7 @@
                                                            org.slf4j/slf4j-api]}
   com.draines/postal                        {:mvn/version "2.0.5"}              ; SMTP library
   com.github.seancorfield/honeysql          {:mvn/version "2.6.1126"}           ; Honey SQL 2. SQL generation from Clojure data maps
-  com.github.seancorfield/next.jdbc         {:mvn/version "1.3.925" }           ; Talk to JDBC DBs
+  com.github.seancorfield/next.jdbc         {:mvn/version "1.3.925"}            ; Talk to JDBC DBs
   com.github.steffan-westcott/clj-otel-api  {:mvn/version "0.2.6"}              ; Telemetry library
   com.github.vertical-blank/sql-formatter   {:mvn/version "2.0.4"}              ; Java SQL formatting library https://github.com/vertical-blank/sql-formatter
   com.google.guava/guava                    {:mvn/version "33.1.0-jre"}         ; dep for BigQuery, Spark, and GA. Require here rather than letting different dep versions stomp on each other — see comments on #9697
@@ -529,9 +529,7 @@
                ["metabase\\.driver\\.mysql.*"
                 "metabase\\.driver\\.postgres.*"]}
    ;; different port from `:test` so you can run it at the same time as `:test`.
-   :jvm-opts ["-Dmb.jetty.port=3002"
-              ;; default heap size is 1GB, we were getting OOM on CI so we need to bump this
-              "-Xmx4g"]}
+   :jvm-opts ["-Dmb.jetty.port=3002"]}
 
   ;; clj -T:cljfmt fix '{:paths ["src/metabase/events/view_log.clj"]}'
   :cljfmt


### PR DESCRIPTION
https://github.com/metabase/metabase/pull/41213 bumped the `:ci` alias in deps.edn to set 12g of RAM as both the minimum and maximum heap size. But this is in conflict with the `:cloverage` alias which sets a max heap size of 4g, causing the cloverage job to error on master. I think we can just remove the memory setting from the `:cloverage` alias and use the `:ci` one for both.