### PR TITLE
Fix embed download endpoint

### DIFF
--- a/src/metabase/api/embed.clj
+++ b/src/metabase/api/embed.clj
@@ -406,13 +406,13 @@
 
 (api/defendpoint GET ["/card/:token/query/:export-format", :export-format api.dataset/export-format-regex]
   "Like `GET /api/embed/card/query`, but returns the results as a file in the specified format."
-  [token export-format :as {:keys [query-params format_rows]}]
+  [token export-format format_rows :as {:keys [query-params]}]
   {export-format (into [:enum] api.dataset/export-formats)
    format_rows   [:maybe :boolean]}
   (run-query-for-unsigned-token-async
    (embed/unsign token)
    export-format
-   (m/map-keys keyword query-params)
+   (dissoc (m/map-keys keyword query-params) :format_rows)
    :constraints nil
    :middleware {:process-viz-settings? true
                 :js-int-to-string?     false

--- a/test/metabase/api/embed_test.clj
+++ b/test/metabase/api/embed_test.clj
@@ -1608,7 +1608,8 @@
           output-helper {:csv  (fn [output] (->> output csv/read-csv last))
                          :json (fn [output] (->> output (map (juxt :NUMBER :DATE)) last))}]
       (with-embedding-enabled-and-new-secret-key
-        (t2.with-temp/with-temp [Card {card-id :id} {:display :table :dataset_query q}
+        (t2.with-temp/with-temp [Card {card-id :id} {:enable_embedding true
+                                                     :display :table :dataset_query q}
                                  Dashboard {dashboard-id :id} {:enable_embedding true
                                                                :embedding_params {:name "enabled"}}
                                  DashboardCard {dashcard-id :id} {:dashboard_id dashboard-id
@@ -1618,6 +1619,12 @@
                                                               [:json true ["2,000" "March 26, 2024"]]
                                                               [:json false [2000 "2024-03-26"]]]]
             (testing (format "export_format %s yields expected output for %s exports." apply-formatting? export-format)
+              (is (= expected
+                     (->> (mt/user-http-request
+                           :crowberto :get 200
+                           (format "embed/card/%s/query/%s?format_rows=%s"
+                                   (card-token card-id) (name export-format) apply-formatting?))
+                          ((get output-helper export-format)))))
               (is (= expected
                      (->> (mt/user-http-request
                            :crowberto :get 200


### PR DESCRIPTION
Fixes: #40959 
Fixes: #41240

We have added format_rows as a query parameter. In most endpoints this just works fine.

Here, however, the problem is that we use query parameters to pass parameter values. We run some validation over these provided parameter values (eg. don't allow a user to over ride a 'locked' parameter). Since we have these 2 different use cases for query parameters, the validation was failing on :format_rows, which isn't expected to exist at all.

Here, I dissoc the :format_rows key prior to this validation step, so normal validation can continue.