### PR TITLE
Add most used functions to suggestions when they open

### DIFF
--- a/e2e/support/helpers/e2e-custom-column-helpers.js
+++ b/e2e/support/helpers/e2e-custom-column-helpers.js
@@ -1,3 +1,7 @@
+export function expressionEditorWidget() {
+  return cy.findByTestId("expression-editor").should("exist");
+}
+
 export function enterCustomColumnDetails({ formula, name } = {}) {
   cy.get(".ace_text-input")
     .first()

--- a/e2e/support/helpers/e2e-custom-column-helpers.js
+++ b/e2e/support/helpers/e2e-custom-column-helpers.js
@@ -1,5 +1,5 @@
 export function expressionEditorWidget() {
-  return cy.findByTestId("expression-editor").should("exist");
+  return cy.findByTestId("expression-editor");
 }
 
 export function enterCustomColumnDetails({ formula, name } = {}) {

--- a/e2e/test/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/13751-cc-allow-strings-in-filter.cy.spec.js
@@ -26,13 +26,11 @@ describe("issue 13751", { tags: "@external" }, () => {
 
   it("should allow using strings in filter based on a custom column (metabase#13751)", () => {
     addCustomColumn();
-    popover().within(() => {
-      enterCustomColumnDetails({
-        formula: 'regexextract([State], "^C[A-Z]")',
-      });
-      cy.findByPlaceholderText("Something nice and descriptive").type(CC_NAME);
-      cy.button("Done").click();
+    enterCustomColumnDetails({
+      formula: 'regexextract([State], "^C[A-Z]")',
+      name: CC_NAME,
     });
+    cy.button("Done").click();
 
     getNotebookStep("filter")
       .findByText(/Add filter/)

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -21,6 +21,7 @@ import {
   getNotebookStep,
   queryBuilderMain,
   selectFilterOperator,
+  expressionEditorWidget,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } =
@@ -972,7 +973,7 @@ describe("scenarios > question > filter", () => {
         filter({ mode: "notebook" });
 
         popover().contains("Custom Expression").click();
-        popover().within(() => {
+        expressionEditorWidget().within(() => {
           enterCustomColumnDetails({ formula: `boolean = ${condition}` });
           cy.get("@formula").blur();
 
@@ -1018,7 +1019,7 @@ describe("scenarios > question > filter", () => {
       filter({ mode: "notebook" });
 
       popover().contains("Custom Expression").click();
-      popover().within(() => {
+      expressionEditorWidget().within(() => {
         enterCustomColumnDetails({ formula: "boolean = true" });
         cy.get("@formula").blur();
 
@@ -1035,7 +1036,7 @@ describe("scenarios > question > filter", () => {
       cy.icon("notebook").click();
       summarize({ mode: "notebook" });
       popover().contains("Custom Expression").click();
-      popover().within(() => {
+      expressionEditorWidget().within(() => {
         enterCustomColumnDetails({
           formula: "CountIf(boolean)",
           name: "count if boolean is true",
@@ -1056,7 +1057,7 @@ describe("scenarios > question > filter", () => {
     openReviewsTable({ mode: "notebook" });
     filter({ mode: "notebook" });
 
-    popover().within(() => {
+    expressionEditorWidget().within(() => {
       cy.findByText("Custom Expression").click();
 
       enterCustomColumnDetails({ formula: "floor" });

--- a/e2e/test/scenarios/question/reproductions/17512.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/17512.cy.spec.js
@@ -4,6 +4,8 @@ import {
   popover,
   visualize,
   summarize,
+  expressionEditorWidget,
+  enterCustomColumnDetails,
 } from "e2e/support/helpers";
 
 describe("issue 17512", () => {
@@ -44,18 +46,22 @@ function addSummarizeCustomExpression(formula, name) {
   summarize({ mode: "notebook" });
   popover().contains("Custom Expression").click();
 
-  popover().within(() => {
-    cy.get(".ace_text-input").type(formula).blur();
-    cy.findByPlaceholderText("Something nice and descriptive").type(name);
+  expressionEditorWidget().within(() => {
+    enterCustomColumnDetails({
+      formula,
+      name,
+    });
     cy.button("Done").click();
   });
 }
 
 function addCustomColumn(formula, name) {
   cy.findByText("Custom column").click();
-  popover().within(() => {
-    cy.get(".ace_text-input").type(formula).blur();
-    cy.findByPlaceholderText("Something nice and descriptive").type(name);
+  expressionEditorWidget().within(() => {
+    enterCustomColumnDetails({
+      formula,
+      name,
+    });
     cy.button("Done").click();
   });
 }

--- a/e2e/test/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/18207-string-min-max.cy.spec.js
@@ -6,6 +6,7 @@ import {
   openProductsTable,
   summarize,
   leftSidebar,
+  expressionEditorWidget,
 } from "e2e/support/helpers";
 
 describe("issue 18207", () => {
@@ -70,7 +71,7 @@ describe("issue 18207", () => {
 
   it("should be possible to group by a string expression (metabase#18207)", () => {
     popover().contains("Custom Expression").click();
-    popover().within(() => {
+    expressionEditorWidget().within(() => {
       enterCustomColumnDetails({
         formula: "Max([Vendor])",
         name: "LastVendor",

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -15,6 +15,7 @@ import {
   checkExpressionEditorHelperPopoverPosition,
   rightSidebar,
   interceptIfNotPreviouslyDefined,
+  expressionEditorWidget,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -156,7 +157,7 @@ describe("scenarios > question > summarize sidebar", () => {
     openOrdersTable({ mode: "notebook" });
     summarize({ mode: "notebook" });
     popover().contains("Custom Expression").click();
-    popover().within(() => {
+    expressionEditorWidget().within(() => {
       enterCustomColumnDetails({
         formula: "2 * Max([Total])",
         name: "twice max total",
@@ -178,7 +179,7 @@ describe("scenarios > question > summarize sidebar", () => {
     summarize({ mode: "notebook" });
 
     popover().contains("Custom Expression").click();
-    popover().within(() => {
+    expressionEditorWidget().within(() => {
       enterCustomColumnDetails({
         formula:
           "sum([Total]) / (sum([Product → Price]) * average([Quantity]))",

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -19,6 +19,7 @@ import {
   sidebar,
   moveDnDKitElement,
   selectFilterOperator,
+  expressionEditorWidget,
 } from "e2e/support/helpers";
 
 describe("scenarios > visualizations > table", () => {
@@ -130,7 +131,7 @@ describe("scenarios > visualizations > table", () => {
 
     cy.icon("add_data").click();
 
-    popover().within(() => {
+    expressionEditorWidget().within(() => {
       enterCustomColumnDetails({
         formula: "concat([Name], [Name])",
         name: ccName,

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -560,9 +560,7 @@ export const STANDARD_AGGREGATIONS = new Set([
   "median",
 ]);
 
-// "popular" expressions to suggest initially.
-export const POPULAR_EXPRESSIONS = new Set([
-  // Functions
+export const POPULAR_FUNCTIONS = new Set([
   "case",
   "concat",
   "contains",
@@ -573,8 +571,9 @@ export const POPULAR_EXPRESSIONS = new Set([
   "interval",
   "substring",
   "lower",
+]);
 
-  // Aggregations
+export const POPULAR_AGGREGATIONS = new Set([
   "count",
   "distinct",
   "count-where",
@@ -585,4 +584,10 @@ export const POPULAR_EXPRESSIONS = new Set([
   "sum-where",
   "min",
   "median",
+]);
+
+// "popular" expressions to suggest initially.
+export const POPULAR_EXPRESSIONS = new Set([
+  ...POPULAR_FUNCTIONS,
+  ...POPULAR_AGGREGATIONS,
 ]);

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -560,7 +560,7 @@ export const STANDARD_AGGREGATIONS = new Set([
   "median",
 ]);
 
-export const POPULAR_FUNCTIONS = new Set([
+export const POPULAR_FUNCTIONS = [
   "case",
   "concat",
   "contains",
@@ -571,9 +571,9 @@ export const POPULAR_FUNCTIONS = new Set([
   "interval",
   "substring",
   "lower",
-]);
+];
 
-export const POPULAR_AGGREGATIONS = new Set([
+export const POPULAR_AGGREGATIONS = [
   "count",
   "distinct",
   "count-where",
@@ -584,10 +584,10 @@ export const POPULAR_AGGREGATIONS = new Set([
   "sum-where",
   "min",
   "median",
-]);
+];
 
 // "popular" expressions to suggest initially.
-export const POPULAR_EXPRESSIONS = new Set([
+export const POPULAR_EXPRESSIONS = [
   ...POPULAR_FUNCTIONS,
   ...POPULAR_AGGREGATIONS,
-]);
+];

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -559,3 +559,30 @@ export const STANDARD_AGGREGATIONS = new Set([
   "max",
   "median",
 ]);
+
+// "popular" expressions to suggest initially.
+export const POPULAR_EXPRESSIONS = new Set([
+  // Functions
+  "case",
+  "concat",
+  "contains",
+  "between",
+  "coalesce",
+  "now",
+  "replace",
+  "interval",
+  "substring",
+  "lower",
+
+  // Aggregations
+  "count",
+  "distinct",
+  "count-where",
+  "sum",
+  "avg",
+  "percentile",
+  "share",
+  "sum-where",
+  "min",
+  "median",
+]);

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -566,11 +566,15 @@ export const POPULAR_FUNCTIONS = [
   "contains",
   "between",
   "coalesce",
-  "now",
-  "replace",
+];
+
+export const POPULAR_FILTERS = [
+  "contains",
+  "case",
+  "between",
   "interval",
-  "substring",
-  "lower",
+  "concat",
+  "round",
 ];
 
 export const POPULAR_AGGREGATIONS = [
@@ -579,15 +583,4 @@ export const POPULAR_AGGREGATIONS = [
   "count-where",
   "sum",
   "avg",
-  "percentile",
-  "share",
-  "sum-where",
-  "min",
-  "median",
-];
-
-// "popular" expressions to suggest initially.
-export const POPULAR_EXPRESSIONS = [
-  ...POPULAR_FUNCTIONS,
-  ...POPULAR_AGGREGATIONS,
 ];

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -51,7 +51,7 @@ export const GROUPS = {
 
 export type GroupName = keyof typeof GROUPS;
 
-type SuggestArgs = {
+export type SuggestArgs = {
   source: string;
   query: Lib.Query;
   stageIndex: number;

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -118,6 +118,13 @@ export function suggest({
             return null;
           }
 
+          const isSupported =
+            !database || database?.hasFeature(clause.requiresFeature);
+
+          if (!isSupported) {
+            return null;
+          }
+
           return {
             type: "functions",
             name: clause.displayName,

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -138,7 +138,8 @@ export function suggest({
               : undefined,
           };
         })
-        .filter((suggestion): suggestion is Suggestion => Boolean(suggestion)),
+        .filter((suggestion): suggestion is Suggestion => Boolean(suggestion))
+        .slice(0, 5),
     );
 
     return { suggestions };

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -43,7 +43,7 @@ const suggestionText = (func: MBQLClauseFunctionConfig) => {
   return displayName + suffix;
 };
 
-const GROUPS = {
+export const GROUPS = {
   popular: {
     displayName: t`Most used functions`,
   },

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -44,8 +44,11 @@ const suggestionText = (func: MBQLClauseFunctionConfig) => {
 };
 
 export const GROUPS = {
-  popular: {
+  popularExpressions: {
     displayName: t`Most used functions`,
+  },
+  popularAggregations: {
+    displayName: t`Most used aggregations`,
   },
 } as const;
 
@@ -103,7 +106,7 @@ export function suggest({
     }
 
     suggestions.push(
-      ...Array.from(POPULAR_EXPRESSIONS.keys())
+      ...Array.from(POPULAR_EXPRESSIONS)
         .map((name: string): Suggestion | null => {
           const clause = MBQL_CLAUSES[name];
           if (!clause) {
@@ -132,7 +135,10 @@ export function suggest({
             index: targetOffset,
             icon: "function",
             order: 1,
-            group: "popular",
+            group:
+              startRule === "aggregation"
+                ? "popularAggregations"
+                : "popularExpressions",
             helpText: database
               ? getHelpText(name, database, reportTimezone)
               : undefined,

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -107,7 +107,7 @@ export function suggest({
       }
     }
 
-    let popular = [];
+    let popular: string[] = [];
     if (startRule === "expression") {
       popular = POPULAR_FUNCTIONS;
     }

--- a/frontend/src/metabase-lib/v1/expressions/suggest.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.ts
@@ -106,44 +106,43 @@ export function suggest({
     }
 
     suggestions.push(
-      ...Array.from(POPULAR_EXPRESSIONS)
-        .map((name: string): Suggestion | null => {
-          const clause = MBQL_CLAUSES[name];
-          if (!clause) {
-            return null;
-          }
+      ...POPULAR_EXPRESSIONS.map((name: string): Suggestion | null => {
+        const clause = MBQL_CLAUSES[name];
+        if (!clause) {
+          return null;
+        }
 
-          // only allow aggregation functions when we're aggregating
-          if (
-            (startRule === "aggregation" && clause.type !== "aggregation") ||
-            (startRule !== "aggregation" && clause.type === "aggregation")
-          ) {
-            return null;
-          }
+        // only allow aggregation functions when we're aggregating
+        if (
+          (startRule === "aggregation" && clause.type !== "aggregation") ||
+          (startRule !== "aggregation" && clause.type === "aggregation")
+        ) {
+          return null;
+        }
 
-          const isSupported =
-            !database || database?.hasFeature(clause.requiresFeature);
+        const isSupported =
+          !database || database?.hasFeature(clause.requiresFeature);
 
-          if (!isSupported) {
-            return null;
-          }
+        if (!isSupported) {
+          return null;
+        }
 
-          return {
-            type: "functions",
-            name: clause.displayName,
-            text: suggestionText(clause),
-            index: targetOffset,
-            icon: "function",
-            order: 1,
-            group:
-              startRule === "aggregation"
-                ? "popularAggregations"
-                : "popularExpressions",
-            helpText: database
-              ? getHelpText(name, database, reportTimezone)
-              : undefined,
-          };
-        })
+        return {
+          type: "functions",
+          name: clause.displayName,
+          text: suggestionText(clause),
+          index: targetOffset,
+          icon: "function",
+          order: 1,
+          group:
+            startRule === "aggregation"
+              ? "popularAggregations"
+              : "popularExpressions",
+          helpText: database
+            ? getHelpText(name, database, reportTimezone)
+            : undefined,
+        };
+      })
         .filter((suggestion): suggestion is Suggestion => Boolean(suggestion))
         .slice(0, 5),
     );

--- a/frontend/src/metabase-lib/v1/expressions/suggest.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.unit.spec.ts
@@ -557,6 +557,79 @@ describe("metabase/lib/expression/suggest", () => {
         }),
       ]);
     });
+
+    it("should add suggestions for popular functions when no input is given", () => {
+      expect(
+        suggest_({
+          source: "",
+          ...expressionOpts,
+          query: createQuery({
+            metadata,
+            query: DEFAULT_QUERY,
+          }),
+          stageIndex: -1,
+          metadata,
+          getColumnIcon: () => "icon",
+        }).suggestions,
+      ).toEqual([
+        expect.objectContaining({
+          name: "case",
+          group: "popularExpressions",
+        }),
+        expect.objectContaining({
+          name: "concat",
+          group: "popularExpressions",
+        }),
+        expect.objectContaining({
+          name: "contains",
+          group: "popularExpressions",
+        }),
+        expect.objectContaining({
+          name: "between",
+          group: "popularExpressions",
+        }),
+        expect.objectContaining({
+          name: "coalesce",
+          group: "popularExpressions",
+        }),
+      ]);
+
+      expect(
+        suggest_({
+          source: "",
+          ...expressionOpts,
+          startRule: "aggregation",
+          query: createQuery({
+            metadata,
+            query: DEFAULT_QUERY,
+          }),
+          stageIndex: -1,
+          metadata,
+          getColumnIcon: () => "icon",
+        }).suggestions,
+      ).toEqual([
+        expect.objectContaining({
+          name: "Count",
+          group: "popularAggregations",
+        }),
+        expect.objectContaining({
+          name: "Distinct",
+          group: "popularAggregations",
+        }),
+        expect.objectContaining({
+          name: "CountIf",
+          group: "popularAggregations",
+        }),
+        expect.objectContaining({
+          name: "Sum",
+          group: "popularAggregations",
+        }),
+        expect.objectContaining({
+          name: "Average",
+          group: "popularAggregations",
+        }),
+      ]);
+    });
   });
 });
 

--- a/frontend/src/metabase-lib/v1/expressions/suggest.unit.spec.ts
+++ b/frontend/src/metabase-lib/v1/expressions/suggest.unit.spec.ts
@@ -563,6 +563,7 @@ describe("metabase/lib/expression/suggest", () => {
         suggest_({
           source: "",
           ...expressionOpts,
+          startRule: "expression",
           query: createQuery({
             metadata,
             query: DEFAULT_QUERY,
@@ -590,6 +591,42 @@ describe("metabase/lib/expression/suggest", () => {
         }),
         expect.objectContaining({
           name: "coalesce",
+          group: "popularExpressions",
+        }),
+      ]);
+
+      expect(
+        suggest_({
+          source: "",
+          ...expressionOpts,
+          startRule: "boolean",
+          query: createQuery({
+            metadata,
+            query: DEFAULT_QUERY,
+          }),
+          stageIndex: -1,
+          metadata,
+          getColumnIcon: () => "icon",
+        }).suggestions,
+      ).toEqual([
+        expect.objectContaining({
+          name: "contains",
+          group: "popularExpressions",
+        }),
+        expect.objectContaining({
+          name: "case",
+          group: "popularExpressions",
+        }),
+        expect.objectContaining({
+          name: "between",
+          group: "popularExpressions",
+        }),
+        expect.objectContaining({
+          name: "timeSpan",
+          group: "popularExpressions",
+        }),
+        expect.objectContaining({
+          name: "concat",
           group: "popularExpressions",
         }),
       ]);

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
@@ -11,7 +11,7 @@ import { Icon } from "metabase/ui";
 
 export const ExpressionList = styled.ul`
   min-width: 250px;
-  max-height: 350px;
+  max-height: 300px;
   overflow-y: auto;
 `;
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
@@ -78,3 +78,19 @@ export const PopoverHoverTarget = styled(BasePopoverHoverTarget)`
     visibility: visible;
   }
 `;
+
+export const GroupTitle = styled(ExpressionListItem)`
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: 12px;
+  color: ${color("text-medium")};
+
+  border-top: 1px solid ${color("border")};
+  height: 2rem;
+  display: flex;
+  align-items: center;
+
+  &:first-child {
+    border-top: none;
+  }
+`;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
@@ -7,9 +7,10 @@ import {
   PopoverHoverTarget as BasePopoverHoverTarget,
 } from "metabase/components/MetadataInfo/InfoIcon";
 import { color } from "metabase/lib/colors";
+import { Icon } from "metabase/ui";
 
 export const ExpressionList = styled.ul`
-  min-width: 150px;
+  min-width: 250px;
   max-height: 350px;
   overflow-y: auto;
 `;
@@ -36,6 +37,25 @@ export const ExpressionListItem = styled.li<{ isHighlighted: boolean }>`
   }
 
   ${props => props.isHighlighted && highlighted}
+`;
+
+export const ExpressionListFooter = styled.a`
+  border-top: 1px solid ${color("border")};
+  background: white;
+  height: 2rem;
+  font-weight: bold;
+  color: ${color("text-medium")};
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  padding-left: 0.875rem;
+`;
+
+export const ExternalIcon = styled(Icon)`
+  height: 0.8rem;
+  margin-right: 0.5rem;
 `;
 
 export const SuggestionTitle = styled.span`

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
@@ -41,7 +41,7 @@ export const ExpressionListItem = styled.li<{ isHighlighted: boolean }>`
   ${props => props.isHighlighted && highlighted}
 `;
 
-export const ExpressionListFooter = styled.a`
+export const ExpressionListFooter = styled.a<{ isHighlighted: boolean }>`
   border-top: 1px solid ${color("border")};
   background: white;
   height: 2rem;
@@ -53,6 +53,12 @@ export const ExpressionListFooter = styled.a`
   justify-content: space-between;
 
   padding-left: 0.875rem;
+
+  &:hover {
+    ${highlighted}
+  }
+
+  ${props => props.isHighlighted && highlighted}
 `;
 
 export const ExternalIcon = styled(Icon)`

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
@@ -30,7 +30,9 @@ export const ExpressionListItem = styled.li<{ isHighlighted: boolean }>`
   padding: 0 0.875rem;
   padding-right: 0.5rem;
   cursor: pointer;
-  min-height: 1.625rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
 
   &:hover {
     ${highlighted}
@@ -86,9 +88,6 @@ export const GroupTitle = styled(ExpressionListItem)`
   color: ${color("text-medium")};
 
   border-top: 1px solid ${color("border")};
-  height: 2rem;
-  display: flex;
-  align-items: center;
 
   &:first-child {
     border-top: none;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
@@ -11,8 +11,6 @@ import { Icon } from "metabase/ui";
 
 export const ExpressionList = styled.ul`
   min-width: 250px;
-  max-height: 300px;
-  overflow-y: auto;
 `;
 
 export const SuggestionMatch = styled.span`
@@ -47,6 +45,9 @@ export const ExpressionListFooter = styled.a<{ isHighlighted: boolean }>`
   height: 2rem;
   font-weight: bold;
   color: ${color("text-medium")};
+
+  position: sticky;
+  bottom: 0;
 
   display: flex;
   align-items: center;

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.styled.tsx
@@ -92,6 +92,7 @@ export const GroupTitle = styled(ExpressionListItem)`
   font-weight: bold;
   font-size: 12px;
   color: ${color("text-medium")};
+  pointer-events: none;
 
   border-top: 1px solid ${color("border")};
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -96,8 +96,16 @@ export function ExpressionEditorSuggestions({
               onSuggestionMouseDown={onSuggestionMouseDown}
             />
             <ExpressionEditorSuggestionsListGroup
-              name="popular"
-              suggestions={groups.popular}
+              name="popularAggregations"
+              suggestions={groups.popularAggregations}
+              query={query}
+              stageIndex={stageIndex}
+              highlightedIndex={highlightedIndex}
+              onSuggestionMouseDown={onSuggestionMouseDown}
+            />
+            <ExpressionEditorSuggestionsListGroup
+              name="popularExpressions"
+              suggestions={groups.popularExpressions}
               query={query}
               stageIndex={stageIndex}
               highlightedIndex={highlightedIndex}
@@ -294,7 +302,8 @@ type Groups = {
 function group(suggestions: Suggestion[]): Groups {
   const groups: Groups = {
     _none: [],
-    popular: [],
+    popularAggregations: [],
+    popularExpressions: [],
   };
 
   suggestions.forEach(function (suggestion) {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -62,7 +62,6 @@ export function ExpressionEditorSuggestions({
       radius="xs"
       withinPortal
       zIndex={300}
-      returnFocus
     >
       <Popover.Target>{children}</Popover.Target>
       <Popover.Dropdown>

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -84,10 +84,7 @@ export function ExpressionEditorSuggestions({
       <Popover.Target>{children}</Popover.Target>
       <Popover.Dropdown>
         <DelayGroup>
-          <ExpressionList
-            data-testid="expression-suggestions-list"
-            className={CS.pb1}
-          >
+          <ExpressionList data-testid="expression-suggestions-list">
             <ExpressionEditorSuggestionsListGroup
               suggestions={groups._none}
               query={query}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -104,8 +104,8 @@ function ExpressionEditorSuggestionsListItem({
   onMouseDown: (index: number) => void;
   suggestion: Suggestion;
 }) {
-  const { icon, helpText, name, range = [] } = suggestion;
-  const [start = 0, end = name.length - 1] = range;
+  const { icon, helpText, range = [] } = suggestion;
+  const [start = 0, end = 0] = range;
 
   const { normal, highlighted } = colorForIcon(icon);
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -1,5 +1,11 @@
 import cx from "classnames";
-import { useEffect, useRef, useCallback, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useCallback,
+  type ReactNode,
+  type MouseEvent,
+} from "react";
 import { t } from "ttag";
 import _ from "underscore";
 
@@ -8,6 +14,8 @@ import { Popover as InfoPopover } from "metabase/components/MetadataInfo/Popover
 import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
 import { isObscured } from "metabase/lib/dom";
+import { useSelector } from "metabase/lib/redux";
+import { getShowMetabaseLinks } from "metabase/selectors/whitelabel";
 import { DelayGroup, Icon, type IconName, Popover } from "metabase/ui";
 import type * as Lib from "metabase-lib";
 import type { Suggestion } from "metabase-lib/v1/expressions/suggest";
@@ -16,6 +24,8 @@ import { ExpressionEditorHelpTextContent } from "../ExpressionEditorHelpText";
 
 import {
   ExpressionListItem,
+  ExpressionListFooter,
+  ExternalIcon,
   ExpressionList,
   SuggestionMatch,
   SuggestionTitle,
@@ -23,12 +33,18 @@ import {
   PopoverHoverTarget,
 } from "./ExpressionEditorSuggestions.styled";
 
+const ALL_FUNCTIONS_LINK =
+  "https://www.metabase.com/docs/latest/questions/query-builder/expressions-list#functions";
+const ALL_AGGREGATIONS_LINK =
+  "https://www.metabase.com/docs/latest/questions/query-builder/expressions-list#aggregations";
+
 export function ExpressionEditorSuggestions({
   query,
   stageIndex,
   suggestions = [],
   onSuggestionMouseDown,
   highlightedIndex,
+  startRule,
   children,
 }: {
   query: Lib.Query;
@@ -36,6 +52,7 @@ export function ExpressionEditorSuggestions({
   suggestions?: Suggestion[];
   onSuggestionMouseDown: (index: number) => void;
   highlightedIndex: number;
+  startRule: string;
   children: ReactNode;
 }) {
   return (
@@ -67,6 +84,7 @@ export function ExpressionEditorSuggestions({
             ))}
           </ExpressionList>
         </DelayGroup>
+        <AllFunctionsLink startRule={startRule} />
       </Popover.Dropdown>
     </Popover>
   );
@@ -154,6 +172,32 @@ function ExpressionEditorSuggestionsListItem({
         )}
       </ExpressionListItem>
     </HoverParent>
+  );
+}
+
+function AllFunctionsLink({ startRule }: { startRule: string }) {
+  const showMetabaseLinks = useSelector(getShowMetabaseLinks);
+
+  const allLink =
+    startRule === "aggregation" ? ALL_AGGREGATIONS_LINK : ALL_FUNCTIONS_LINK;
+
+  function handleMouseDownCapture(evt: MouseEvent) {
+    // prevent the dropdown from closing
+    evt.preventDefault();
+  }
+
+  if (!showMetabaseLinks) {
+    return null;
+  }
+
+  return (
+    <ExpressionListFooter
+      target="blank"
+      href={allLink}
+      onMouseDownCapture={handleMouseDownCapture}
+    >
+      {t`View all functions`} <ExternalIcon name="external" />
+    </ExpressionListFooter>
   );
 }
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -305,7 +305,6 @@ function group(suggestions: Suggestion[]): Groups {
 
   suggestions.forEach(function (suggestion) {
     if (suggestion.group) {
-      groups[suggestion.group] ??= [];
       groups[suggestion.group].push(suggestion);
     } else {
       groups._none.push(suggestion);

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -150,7 +150,7 @@ function ExpressionEditorSuggestionsListGroup({
       )}
       {suggestions.map((suggestion: SuggestionWithIndex) => (
         <ExpressionEditorSuggestionsListItem
-          key={`suggesion-${suggestion.index}`}
+          key={`suggestion-${suggestion.index}`}
           query={query}
           stageIndex={stageIndex}
           suggestion={suggestion}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -58,6 +58,8 @@ export function ExpressionEditorSuggestions({
   highlightedIndex: number;
   children: ReactNode;
 }) {
+  const ref = useRef(null);
+
   const withIndex = suggestions.map((suggestion, index) => ({
     ...suggestion,
     index,
@@ -75,6 +77,13 @@ export function ExpressionEditorSuggestions({
 
   const groups = group(items);
 
+  function handleMouseDown(evt: MouseEvent) {
+    if (evt.target === ref.current) {
+      evt.preventDefault();
+      evt.stopPropagation();
+    }
+  }
+
   return (
     <Popover
       position="bottom-start"
@@ -86,7 +95,11 @@ export function ExpressionEditorSuggestions({
       <Popover.Target>{children}</Popover.Target>
       <Popover.Dropdown>
         <DelayGroup>
-          <ExpressionList data-testid="expression-suggestions-list">
+          <ExpressionList
+            data-testid="expression-suggestions-list"
+            ref={ref}
+            onMouseDownCapture={handleMouseDown}
+          >
             <ExpressionEditorSuggestionsListGroup
               suggestions={groups._none}
               query={query}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -44,7 +44,7 @@ type WithIndex<T> = T & {
 export function ExpressionEditorSuggestions({
   query,
   stageIndex,
-  suggestions: _suggestions = [],
+  suggestions = [],
   onSuggestionMouseDown,
   highlightedIndex,
   children,
@@ -56,12 +56,12 @@ export function ExpressionEditorSuggestions({
   highlightedIndex: number;
   children: ReactNode;
 }) {
-  const withIndex = _suggestions.map((suggestion, index) => ({
+  const withIndex = suggestions.map((suggestion, index) => ({
     ...suggestion,
     index,
   }));
 
-  const suggestions = withIndex.filter(
+  const items = withIndex.filter(
     (suggestion): suggestion is WithIndex<Suggestion> =>
       !("footer" in suggestion),
   );
@@ -71,7 +71,7 @@ export function ExpressionEditorSuggestions({
       "footer" in suggestion,
   );
 
-  const groups = group(suggestions);
+  const groups = group(items);
 
   return (
     <Popover

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -262,7 +262,7 @@ function Footer({
 
   return (
     <ExpressionListFooter
-      target="blank"
+      target="_blank"
       href={suggestion.href}
       onMouseDownCapture={handleMouseDownCapture}
       isHighlighted={highlightedIndex === suggestion.index}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -46,6 +46,7 @@ export function ExpressionEditorSuggestions({
   stageIndex,
   suggestions = [],
   onSuggestionMouseDown,
+  open,
   highlightedIndex,
   children,
 }: {
@@ -53,6 +54,7 @@ export function ExpressionEditorSuggestions({
   stageIndex: number;
   suggestions?: (Suggestion | SuggestionFooter)[];
   onSuggestionMouseDown: (index: number) => void;
+  open: boolean;
   highlightedIndex: number;
   children: ReactNode;
 }) {
@@ -76,7 +78,7 @@ export function ExpressionEditorSuggestions({
   return (
     <Popover
       position="bottom-start"
-      opened={suggestions.length > 0}
+      opened={open && suggestions.length > 0}
       radius="xs"
       withinPortal
       zIndex={300}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.tsx
@@ -109,14 +109,14 @@ export function ExpressionEditorSuggestions({
               onSuggestionMouseDown={onSuggestionMouseDown}
             />
           </ExpressionList>
+          {footers.map(suggestion => (
+            <Footer
+              key={suggestion.index}
+              suggestion={suggestion}
+              highlightedIndex={highlightedIndex}
+            />
+          ))}
         </DelayGroup>
-        {footers.map(suggestion => (
-          <Footer
-            key={suggestion.index}
-            suggestion={suggestion}
-            highlightedIndex={highlightedIndex}
-          />
-        ))}
       </Popover.Dropdown>
     </Popover>
   );

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -119,4 +119,14 @@ describe("ExpressionEditorSuggestions", () => {
         ?.endsWith("#aggregations"),
     ).toBe(true);
   });
+
+  test("suggestions should  functions when first opened", async () => {
+    setup({ startRule: "expression" });
+    expect(screen.getByText("Most used functions")).toBeInTheDocument();
+  });
+
+  test("suggestions should not include popular functions when text has been typed", async () => {
+    setup({ source: "[", startRule: "expression" });
+    expect(screen.queryByText("Most used functions")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -63,7 +63,7 @@ function setup({ source = "", startRule }: SetupOpts) {
 }
 
 describe("ExpressionEditorSuggestions", () => {
-  test("suggestions items should show column info icon", async () => {
+  it("should render with the column info icon", async () => {
     setup({ source: "[", startRule: "expression" });
 
     await waitFor(() =>
@@ -87,7 +87,7 @@ describe("ExpressionEditorSuggestions", () => {
     );
   });
 
-  test("suggestions should render correct functions link for expressions", async () => {
+  it("should render correct functions link for expressions", async () => {
     setup({ startRule: "expression" });
     expect(screen.getByText("View all functions")).toBeInTheDocument();
     expect(
@@ -98,7 +98,7 @@ describe("ExpressionEditorSuggestions", () => {
     ).toBe(true);
   });
 
-  test("suggestions should render correct functions link for filters", async () => {
+  it("should render correct functions link for filters", async () => {
     setup({ startRule: "boolean" });
     expect(screen.getByText("View all functions")).toBeInTheDocument();
     expect(
@@ -109,7 +109,7 @@ describe("ExpressionEditorSuggestions", () => {
     ).toBe(true);
   });
 
-  test("suggestions should render correct functions link for aggregations", async () => {
+  it("should render correct functions link for aggregations", async () => {
     setup({ startRule: "aggregation" });
     expect(screen.getByText("View all functions")).toBeInTheDocument();
     expect(
@@ -120,12 +120,12 @@ describe("ExpressionEditorSuggestions", () => {
     ).toBe(true);
   });
 
-  test("suggestions should  functions when first opened", async () => {
+  it("should  functions when first opened", async () => {
     setup({ startRule: "expression" });
     expect(screen.getByText("Most used functions")).toBeInTheDocument();
   });
 
-  test("suggestions should not include popular functions when text has been typed", async () => {
+  it("should not include popular functions when text has been typed", async () => {
     setup({ source: "[", startRule: "expression" });
     expect(screen.queryByText("Most used functions")).not.toBeInTheDocument();
   });

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -19,6 +19,7 @@ type WrapperProps = {
   suggestions?: Suggestion[];
   highlightedIndex: number;
   onSuggestionMouseDown: () => void;
+  startRule: string;
 };
 
 function Wrapper(props: WrapperProps) {
@@ -30,14 +31,15 @@ function Wrapper(props: WrapperProps) {
 }
 
 type SetupOpts = {
-  source: string;
+  source?: string;
+  startRule: string;
 };
 
-function setup(opts: SetupOpts) {
+function setup({ source = "", startRule }: SetupOpts) {
   const query = createQuery({ metadata: METADATA });
   const stageIndex = 0;
   const { suggestions } = suggest({
-    source: opts.source,
+    source,
     query,
     stageIndex,
     metadata: METADATA,
@@ -51,6 +53,7 @@ function setup(opts: SetupOpts) {
     suggestions,
     onSuggestionMouseDown: jest.fn(),
     highlightedIndex: -1,
+    startRule,
   };
 
   const { rerender } = renderWithProviders(<Wrapper {...props} />);
@@ -61,7 +64,7 @@ function setup(opts: SetupOpts) {
 
 describe("ExpressionEditorSuggestions", () => {
   test("suggestions items should show column info icon", async () => {
-    setup({ source: "[" });
+    setup({ source: "[", startRule: "expression" });
 
     await waitFor(() =>
       screen.findAllByTestId("expression-suggestions-list-item"),
@@ -73,7 +76,7 @@ describe("ExpressionEditorSuggestions", () => {
   });
 
   test("suggestions items should show function helptext info icons", async () => {
-    setup({ source: "con" });
+    setup({ source: "con", startRule: "expression" });
 
     await waitFor(() =>
       screen.findAllByTestId("expression-suggestions-list-item"),
@@ -82,5 +85,38 @@ describe("ExpressionEditorSuggestions", () => {
     expect(screen.getAllByLabelText("More info").length).toBeGreaterThanOrEqual(
       1,
     );
+  });
+
+  test("suggestions should render correct functions link for expressions", async () => {
+    setup({ startRule: "expression" });
+    expect(screen.getByText("View all functions")).toBeInTheDocument();
+    expect(
+      screen
+        .getByText("View all functions")
+        .getAttribute("href")
+        ?.endsWith("#functions"),
+    ).toBe(true);
+  });
+
+  test("suggestions should render correct functions link for filters", async () => {
+    setup({ startRule: "boolean" });
+    expect(screen.getByText("View all functions")).toBeInTheDocument();
+    expect(
+      screen
+        .getByText("View all functions")
+        .getAttribute("href")
+        ?.endsWith("#functions"),
+    ).toBe(true);
+  });
+
+  test("suggestions should render correct functions link for aggregations", async () => {
+    setup({ startRule: "aggregation" });
+    expect(screen.getByText("View all functions")).toBeInTheDocument();
+    expect(
+      screen
+        .getByText("View all functions")
+        .getAttribute("href")
+        ?.endsWith("#aggregations"),
+    ).toBe(true);
   });
 });

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -123,10 +123,16 @@ describe("ExpressionEditorSuggestions", () => {
   it("should show functions when first opened", () => {
     setup({ startRule: "expression" });
     expect(screen.getByText("Most used functions")).toBeInTheDocument();
+
+    expect(screen.getByText("case")).toBeInTheDocument();
+    expect(screen.getByText("coalesce")).toBeInTheDocument();
   });
 
   it("should not include popular functions when text has been typed", () => {
     setup({ source: "[", startRule: "expression" });
     expect(screen.queryByText("Most used functions")).not.toBeInTheDocument();
+
+    expect(screen.queryByText("case")).not.toBeInTheDocument();
+    expect(screen.queryByText("coalesce")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -24,7 +24,7 @@ type WrapperProps = {
 
 function Wrapper(props: WrapperProps) {
   return (
-    <ExpressionEditorSuggestions {...props}>
+    <ExpressionEditorSuggestions {...props} open>
       <div>target</div>
     </ExpressionEditorSuggestions>
   );

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -87,7 +87,7 @@ describe("ExpressionEditorSuggestions", () => {
     );
   });
 
-  it("should render correct functions link for expressions", async () => {
+  it("should render correct functions link for expressions", () => {
     setup({ startRule: "expression" });
     expect(screen.getByText("View all functions")).toBeInTheDocument();
     expect(
@@ -98,7 +98,7 @@ describe("ExpressionEditorSuggestions", () => {
     ).toBe(true);
   });
 
-  it("should render correct functions link for filters", async () => {
+  it("should render correct functions link for filters", () => {
     setup({ startRule: "boolean" });
     expect(screen.getByText("View all functions")).toBeInTheDocument();
     expect(
@@ -109,7 +109,7 @@ describe("ExpressionEditorSuggestions", () => {
     ).toBe(true);
   });
 
-  it("should render correct functions link for aggregations", async () => {
+  it("should render correct functions link for aggregations", () => {
     setup({ startRule: "aggregation" });
     expect(screen.getByText("View all functions")).toBeInTheDocument();
     expect(
@@ -120,12 +120,12 @@ describe("ExpressionEditorSuggestions", () => {
     ).toBe(true);
   });
 
-  it("should show functions when first opened", async () => {
+  it("should show functions when first opened", () => {
     setup({ startRule: "expression" });
     expect(screen.getByText("Most used functions")).toBeInTheDocument();
   });
 
-  it("should not include popular functions when text has been typed", async () => {
+  it("should not include popular functions when text has been typed", () => {
     setup({ source: "[", startRule: "expression" });
     expect(screen.queryByText("Most used functions")).not.toBeInTheDocument();
   });

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -120,7 +120,7 @@ describe("ExpressionEditorSuggestions", () => {
     ).toBe(true);
   });
 
-  it("should  functions when first opened", async () => {
+  it("should show functions when first opened", async () => {
     setup({ startRule: "expression" });
     expect(screen.getByText("Most used functions")).toBeInTheDocument();
   });

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorSuggestions/ExpressionEditorSuggestions.unit.spec.tsx
@@ -87,39 +87,6 @@ describe("ExpressionEditorSuggestions", () => {
     );
   });
 
-  it("should render correct functions link for expressions", () => {
-    setup({ startRule: "expression" });
-    expect(screen.getByText("View all functions")).toBeInTheDocument();
-    expect(
-      screen
-        .getByText("View all functions")
-        .getAttribute("href")
-        ?.endsWith("#functions"),
-    ).toBe(true);
-  });
-
-  it("should render correct functions link for filters", () => {
-    setup({ startRule: "boolean" });
-    expect(screen.getByText("View all functions")).toBeInTheDocument();
-    expect(
-      screen
-        .getByText("View all functions")
-        .getAttribute("href")
-        ?.endsWith("#functions"),
-    ).toBe(true);
-  });
-
-  it("should render correct functions link for aggregations", () => {
-    setup({ startRule: "aggregation" });
-    expect(screen.getByText("View all functions")).toBeInTheDocument();
-    expect(
-      screen
-        .getByText("View all functions")
-        .getAttribute("href")
-        ?.endsWith("#aggregations"),
-    ).toBe(true);
-  });
-
   it("should show functions when first opened", () => {
     setup({ startRule: "expression" });
     expect(screen.getByText("Most used functions")).toBeInTheDocument();

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -97,6 +97,9 @@ function transformPropsToState(
     clause,
     query,
     stageIndex,
+    expressionPosition,
+    metadata,
+    reportTimezone,
   } = props;
   const expressionFromClause = clause
     ? Lib.legacyExpressionForExpressionClause(query, stageIndex, clause)
@@ -108,11 +111,23 @@ function transformPropsToState(
     query,
   });
 
+  const { suggestions = [], helpText = null } = suggest({
+    reportTimezone,
+    startRule,
+    source,
+    targetOffset: 0,
+    expressionPosition,
+    query,
+    stageIndex,
+    metadata,
+    getColumnIcon,
+  });
+
   return {
     source,
     highlightedSuggestionIndex: 0,
-    helpText: null,
-    suggestions: [],
+    helpText,
+    suggestions,
     isFocused: false,
     errorMessage: null,
     hasChanges: false,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -568,7 +568,7 @@ class ExpressionEditorTextfield extends React.Component<
   ];
 
   render() {
-    const { width, query, stageIndex } = this.props;
+    const { width, query, stageIndex, startRule } = this.props;
     const {
       source,
       suggestions,
@@ -587,6 +587,7 @@ class ExpressionEditorTextfield extends React.Component<
           suggestions={suggestions}
           onSuggestionMouseDown={this.onSuggestionSelected}
           highlightedIndex={highlightedSuggestionIndex}
+          startRule={startRule}
         >
           <EditorContainer
             isFocused={isFocused}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -66,14 +66,14 @@ function suggestWithFooters(
 
   if (args.showMetabaseLinks) {
     if (args.startRule === "aggregation") {
-      suggestions?.push({
+      suggestions.push({
         footer: true,
         name: t`View all aggregations`,
         icon: "external",
         href: "https://www.metabase.com/docs/latest/questions/query-builder/expressions-list#aggregations",
       });
     } else {
-      suggestions?.push({
+      suggestions.push({
         footer: true,
         name: t`View all functions`,
         icon: "external",

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -347,9 +347,10 @@ class ExpressionEditorTextfield extends React.Component<
         // clicking on the autocomplete
         setTimeout(() => editor.moveCursorTo(row, caretPos));
       } else {
-        const newExpression = source + suggestion.text;
-        this.handleExpressionChange(newExpression);
-        editor.moveCursorTo(row, newExpression.length);
+        const updatedExpression = source + suggestion.text;
+        this.handleExpressionChange(updatedExpression);
+        const caretPos = updatedExpression.length;
+        setTimeout(() => editor.moveCursorTo(row, caretPos));
       }
     }
   };

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -64,7 +64,7 @@ export function suggestWithFooters(
 
   const suggestions: (Suggestion | SuggestionFooter)[] = res.suggestions ?? [];
 
-  if (args.showMetabaseLinks) {
+  if (args.showMetabaseLinks && args.source === "") {
     if (args.startRule === "aggregation") {
       suggestions.push({
         footer: true,

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -57,7 +57,7 @@ type SuggestWithFooters = {
   helpText?: HelpText;
 };
 
-function suggestWithFooters(
+export function suggestWithFooters(
   args: SuggestArgs & { showMetabaseLinks: boolean },
 ): SuggestWithFooters {
   const res = suggest(args);

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -58,14 +58,13 @@ type SuggestWithFooters = {
 };
 
 function suggestWithFooters(
-  args: SuggestArgs,
-  showMetabaseLinks: boolean,
+  args: SuggestArgs & { showMetabaseLinks: boolean },
 ): SuggestWithFooters {
   const res = suggest(args);
 
   const suggestions: (Suggestion | SuggestionFooter)[] = res.suggestions ?? [];
 
-  if (showMetabaseLinks) {
+  if (args.showMetabaseLinks) {
     if (args.startRule === "aggregation") {
       suggestions?.push({
         footer: true,
@@ -162,20 +161,18 @@ function transformPropsToState(
     query,
   });
 
-  const { suggestions = [], helpText = null } = suggestWithFooters(
-    {
-      reportTimezone,
-      startRule,
-      source,
-      targetOffset: 0,
-      expressionPosition,
-      query,
-      stageIndex,
-      metadata,
-      getColumnIcon,
-    },
+  const { suggestions = [], helpText = null } = suggestWithFooters({
+    reportTimezone,
+    startRule,
+    source,
+    targetOffset: 0,
+    expressionPosition,
+    query,
+    stageIndex,
+    metadata,
+    getColumnIcon,
     showMetabaseLinks,
-  );
+  });
 
   return {
     source,
@@ -592,20 +589,18 @@ class ExpressionEditorTextfield extends React.Component<
       showMetabaseLinks,
     } = this.props;
     const { source } = this.state;
-    const { suggestions, helpText } = suggestWithFooters(
-      {
-        reportTimezone,
-        startRule,
-        source,
-        targetOffset: cursor.column,
-        expressionPosition,
-        query,
-        stageIndex,
-        metadata,
-        getColumnIcon,
-      },
+    const { suggestions, helpText } = suggestWithFooters({
+      reportTimezone,
+      startRule,
+      source,
+      targetOffset: cursor.column,
+      expressionPosition,
+      query,
+      stageIndex,
+      metadata,
+      getColumnIcon,
       showMetabaseLinks,
-    );
+    });
 
     this.setState({ helpText: helpText || null });
     if (this.state.isFocused) {

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -315,7 +315,7 @@ class ExpressionEditorTextfield extends React.Component<
 
     if ("footer" in suggestion) {
       // open link in new window
-      window.open(suggestion.href, "tab");
+      window.open(suggestion.href, "_blank");
       return;
     }
 

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -632,7 +632,7 @@ class ExpressionEditorTextfield extends React.Component<
   }
 
   commands: ICommand[] = [
-    // Note: Enter is handled manually (see componentDidUpdate)
+    // Note: Enter is handled manually (see componentDidMount)
     {
       name: "arrowDown",
       bindKey: { win: "Down", mac: "Down" },

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -269,8 +269,11 @@ class ExpressionEditorTextfield extends React.Component<
       const mode = new ExpressionMode() as unknown as Ace.SyntaxMode;
 
       // HACK: manually register the keypress event for the enter key,
-      // since ACE doesn ot seem to call the event handlers in time for
+      // since ACE does not seem to call the event handlers in time for
       // them to do certain things, like window.open.
+      //
+      // Without this hack, popups get blocked since they are not
+      // considered by the browser to be in response to a user action.
       this.textarea()?.addEventListener("keypress", this.handleKeypress);
 
       editor.getSession().setMode(mode);

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.tsx
@@ -685,6 +685,7 @@ class ExpressionEditorTextfield extends React.Component<
           suggestions={suggestions}
           onSuggestionMouseDown={this.onSuggestionSelected}
           highlightedIndex={highlightedSuggestionIndex}
+          open={isFocused}
         >
           <EditorContainer
             isFocused={isFocused}

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/ExpressionEditorTextfield.unit.spec.tsx
@@ -1,0 +1,63 @@
+import { createMockMetadata } from "__support__/metadata";
+import { getColumnIcon } from "metabase/common/utils/columns";
+import { createQuery } from "metabase-lib/test-helpers";
+import { createSampleDatabase } from "metabase-types/api/mocks/presets";
+
+import { suggestWithFooters } from "./ExpressionEditorTextfield";
+
+const METADATA = createMockMetadata({
+  databases: [createSampleDatabase()],
+});
+
+type SetupOpts = {
+  startRule: string;
+};
+
+function setup({ startRule }: SetupOpts) {
+  const query = createQuery({ metadata: METADATA });
+  const stageIndex = 0;
+  const { suggestions } = suggestWithFooters({
+    source: "",
+    query,
+    stageIndex,
+    metadata: METADATA,
+    startRule,
+    getColumnIcon,
+    showMetabaseLinks: true,
+  });
+
+  return suggestions;
+}
+
+describe("suggestWithFooters", () => {
+  it("should return correct functions link for expressions", () => {
+    const suggestions = setup({ startRule: "expression" });
+
+    expect(suggestions.find(suggestion => "footer" in suggestion)).toEqual({
+      footer: true,
+      name: "View all functions",
+      icon: "external",
+      href: "https://www.metabase.com/docs/latest/questions/query-builder/expressions-list#functions",
+    });
+  });
+
+  it("should return correct functions link for filters", () => {
+    const suggestions = setup({ startRule: "boolean" });
+    expect(suggestions.find(suggestion => "footer" in suggestion)).toEqual({
+      footer: true,
+      name: "View all functions",
+      icon: "external",
+      href: "https://www.metabase.com/docs/latest/questions/query-builder/expressions-list#functions",
+    });
+  });
+
+  it("should return correct functions link for aggregations", () => {
+    const suggestions = setup({ startRule: "aggregation" });
+    expect(suggestions.find(suggestion => "footer" in suggestion)).toEqual({
+      footer: true,
+      name: "View all aggregations",
+      icon: "external",
+      href: "https://www.metabase.com/docs/latest/questions/query-builder/expressions-list#aggregations",
+    });
+  });
+});

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/index.ts
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorTextfield/index.ts
@@ -1,1 +1,4 @@
-export { default as ExpressionEditorTextfield } from "./ExpressionEditorTextfield";
+export {
+  default as ExpressionEditorTextfield,
+  type SuggestionFooter,
+} from "./ExpressionEditorTextfield";

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionWidget.tsx
@@ -118,7 +118,7 @@ export const ExpressionWidget = <Clause extends object = Lib.ExpressionClause>(
   };
 
   return (
-    <Container>
+    <Container data-testid="expression-editor">
       {header}
       <ExpressionFieldWrapper>
         <FieldLabel htmlFor="expression-content">


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41237

### Description

Adds the most used functions to the list of suggestions when the expression editor opens.

To accomplish this, this PR:
- adds a list of popular functions
- returns that list when suggestions for the empty string are requested
- adds grouping to the suggestion dropdown
- adds a (permanent) link to all functions in the suggestion dropdown

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question → Sample dataset → Orders
2. Click "Custom Column"
3. The expression editor should open with the dropdown for suggestions opened and showing most popular suggestions. 

### Demo

<img width="554" alt="Screenshot 2024-04-10 at 19 57 24" src="https://github.com/metabase/metabase/assets/1250185/944a3d3d-7abe-41e4-b741-c6fe28b4c4db">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR

### Note

This PR is a follow up of https://github.com/metabase/metabase/pull/41236, so it contains changes from it.