### PR TITLE
Note the format_rows changes in the api changelog

### DIFF
--- a/docs/developers-guide/api-changelog.md
+++ b/docs/developers-guide/api-changelog.md
@@ -18,3 +18,20 @@ title: API changelog
 - all endpoints that return data (e.g. exports in JSON, XLSX, CSV, endpoints that end in "/query")
 
    Starting from v49, we respond to the API calls with values formatted according to the instance localization options
+
+# Additions to the API interface
+
+## Metabase 0.49.5
+NOTE: These endpoint changes were added in 0.49.3, and a bug in `GET /api/embed/card/:token/query/:export-format` was fixed in 0.49.5.
+
+- `POST /api/card/:card-id/query/:export-format`
+- `POST /api/:dashboard-id/dashcard/:dashcard-id/card/:card-id/query/:export-format`
+- `POST /api/dataset/:export-format`
+- `GET /api/embed/card/:token/query/:export-format`
+- `GET /api/embed/dashboard/:token/dashcard/:dashcard-id/card/:card-id/:export-format`
+
+    The above endpoints now accept the `format_rows` query parameter. It is an optional boolean parameter that will default to `true` if not included in the request.
+    When `format_rows` is `true`, the export will have formatting applied such that the values match what they appear as in the app.
+    When `format_rows` is `false`, formatting is not applied and exports will behave as they did prior to 0.49.0.
+
+    The value of `format_rows` has no effect when exporting xlsx files.


### PR DESCRIPTION
In 49, export formatting changed, but no option was available to users to retain the old export style (no formatting).

Whether or not this constitutes a breaking API change is a bit of a question.

In 49.3 (plus a fix in 49.5) the `format_rows` query parameter has been added to allow for unformatted downloads/exports.