### PR TITLE
Create example-dashboard-id setting

### DIFF
--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -856,6 +856,6 @@
   :setter     :none
   :getter     (fn []
                 (let [id (setting/get-value-of-type :integer :example-dashboard-id)]
-                  (when (t2/exists? :model/Dashboard id)
+                  (when (and id (t2/exists? :model/Dashboard :id id :archived false))
                     id)))
   :doc        false)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -846,3 +846,12 @@
                   (if-not (pos-int? value)
                     20
                     value))))
+
+;; This is used by the embedding homepage
+(defsetting example-dashboard-id
+  (deferred-tru "The ID of the example dashboard.")
+  :visibility :authenticated
+  :export?    false
+  :type       :integer
+  :setter     :none
+  :doc        false)

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -854,4 +854,8 @@
   :export?    false
   :type       :integer
   :setter     :none
+  :getter     (fn []
+                (let [id (setting/get-value-of-type :integer :example-dashboard-id)]
+                  (when (t2/exists? :model/Dashboard id)
+                    id)))
   :doc        false)

--- a/test/metabase/setup_test.clj
+++ b/test/metabase/setup_test.clj
@@ -54,7 +54,14 @@
       (mdb/setup-db! :create-sample-content? true)
       (is (= 1
              (public-settings/example-dashboard-id)))))
-  (testing "The example-dashboard-id setting should be set if the example content is loaded"
+  (testing "The example-dashboard-id setting should be nil if the example content isn't loaded"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? false)
+      (is (nil? (public-settings/example-dashboard-id)))))
+  (testing "The example-dashboard-id setting should be reset to nil if the example dashboard is archived"
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? true)
+      (is (= 1
+             (public-settings/example-dashboard-id)))
+      (t2/update! :model/Dashboard 1 {:archived true})
       (is (nil? (public-settings/example-dashboard-id))))))

--- a/test/metabase/setup_test.clj
+++ b/test/metabase/setup_test.clj
@@ -5,7 +5,8 @@
    [metabase.db :as mdb]
    [metabase.setup :as setup]
    [metabase.test :as mt]
-   [toucan2.core :as t2]))
+   [toucan2.core :as t2]
+   [metabase.public-settings :as public-settings]))
 
 (deftest has-user-setup-ignores-internal-user-test
   (mt/with-empty-h2-app-db
@@ -46,3 +47,14 @@
       (is (= true
              (setup/has-user-setup)))
       (is (zero? (call-count))))))
+
+(deftest has-example-dashboard-id-setting-test
+  (testing "The example-dashboard-id setting should be set if the example content is loaded"
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? true)
+      (is (= 1
+             (public-settings/example-dashboard-id)))))
+  (testing "The example-dashboard-id setting should be set if the example content is loaded"
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? false)
+      (is (nil? (public-settings/example-dashboard-id))))))

--- a/test/metabase/setup_test.clj
+++ b/test/metabase/setup_test.clj
@@ -3,10 +3,10 @@
    [clojure.test :refer :all]
    [metabase.config :as config]
    [metabase.db :as mdb]
+   [metabase.public-settings :as public-settings]
    [metabase.setup :as setup]
    [metabase.test :as mt]
-   [toucan2.core :as t2]
-   [metabase.public-settings :as public-settings]))
+   [toucan2.core :as t2]))
 
 (deftest has-user-setup-ignores-internal-user-test
   (mt/with-empty-h2-app-db


### PR DESCRIPTION
This PR creates a new setting for embedding to use the dashboard created in https://github.com/metabase/metabase/pull/40753. The setting is called `example-dashboard-id` and stores the ID of the dashboard created with the new sample content.

The setting's value is an integer, and will be `nil` if the sample content was never created.

Important! If the dashboard is deleted, the setting is not updated. Clients need to check the existence of the dashboard.