### PR TITLE
Split Permissions - "Permissions Help" UI Update

### DIFF
--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -500,18 +500,63 @@ describe("scenarios > admin > permissions", () => {
   it("shows permissions help", () => {
     cy.visit("/admin/permissions");
 
-    // Data permissions
+    // Data permissions w/o `legacy-no-self-service` in graph
     cy.get("main").within(() => {
-      cy.findByText("Permission help").as("permissionHelpButton").click();
+      cy.findByText("Permissions help").as("permissionHelpButton").click();
+      cy.get("@permissionHelpButton").should("not.exist");
+    });
+
+    cy.findByLabelText("Permissions help reference").within(() => {
+      cy.findByText("Data permissions");
+
+      cy.findByText("Database 'View data' levels").click();
+      cy.findByTestId("database-view-data-level").should(
+        "not.contain",
+        /No self-service/,
+      );
+      cy.findByText("Database 'View data' levels").click();
+
+      cy.findByText(/Schema or table 'View data' levels/).click();
+      cy.findByTestId("schema-table-level").should(
+        "not.contain",
+        /No self-service/,
+      );
+      cy.findByText(/Schema or table 'View data' levels/).click();
+
+      cy.findByText("'Create queries' levels");
+
+      cy.findByLabelText("Close").click();
+    });
+
+    // Data permissions w/ `legacy-no-self-service` in graph
+    cy.visit("/admin/permissions");
+
+    cy.intercept("GET", `/api/permissions/graph/group/${ALL_USERS_GROUP}`, {
+      statusCode: 200,
+      body: {
+        revision: 1,
+        groups: {
+          1: {
+            1: {
+              "view-data": "legacy-no-self-service",
+              "create-queries": "query-builder-and-native",
+              download: { schemas: "full" },
+            },
+          },
+        },
+      },
+    });
+
+    cy.get("main").within(() => {
+      cy.findByText("Permissions help").as("permissionHelpButton").click();
       cy.get("@permissionHelpButton").should("not.exist");
     });
 
     cy.findByLabelText("Permissions help reference")
       .as("permissionsHelpContent")
       .within(() => {
-        cy.findByText("Data permissions");
-        cy.findByText("Database levels");
-        cy.findByText("Schema and table levels");
+        cy.findByText("Database 'View data' levels").click();
+        cy.findAllByText(/No self-service/);
         cy.findByLabelText("Close").click();
       });
 

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -528,38 +528,6 @@ describe("scenarios > admin > permissions", () => {
       cy.findByLabelText("Close").click();
     });
 
-    // Data permissions w/ `legacy-no-self-service` in graph
-    cy.visit("/admin/permissions");
-
-    cy.intercept("GET", `/api/permissions/graph/group/${ALL_USERS_GROUP}`, {
-      statusCode: 200,
-      body: {
-        revision: 1,
-        groups: {
-          1: {
-            1: {
-              "view-data": "legacy-no-self-service",
-              "create-queries": "query-builder-and-native",
-              download: { schemas: "full" },
-            },
-          },
-        },
-      },
-    });
-
-    cy.get("main").within(() => {
-      cy.findByText("Permissions help").as("permissionHelpButton").click();
-      cy.get("@permissionHelpButton").should("not.exist");
-    });
-
-    cy.findByLabelText("Permissions help reference")
-      .as("permissionsHelpContent")
-      .within(() => {
-        cy.findByText("Database 'View data' levels").click();
-        cy.findAllByText(/No self-service/);
-        cy.findByLabelText("Close").click();
-      });
-
     cy.get("main").within(() => {
       cy.findByText("Collections").click();
       cy.get("@permissionHelpButton").click();

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -509,21 +509,21 @@ describe("scenarios > admin > permissions", () => {
     cy.findByLabelText("Permissions help reference").within(() => {
       cy.findByText("Data permissions");
 
-      cy.findByText("Database 'View data' levels").click();
+      cy.findByText("Database ‘View data’ levels").click();
       cy.findByTestId("database-view-data-level").should(
         "not.contain",
         /No self-service/,
       );
-      cy.findByText("Database 'View data' levels").click();
+      cy.findByText("Database ‘View data’ levels").click();
 
-      cy.findByText(/Schema or table 'View data' levels/).click();
+      cy.findByText(/Schema or table ‘View data’ levels/).click();
       cy.findByTestId("schema-table-level").should(
         "not.contain",
         /No self-service/,
       );
-      cy.findByText(/Schema or table 'View data' levels/).click();
+      cy.findByText(/Schema or table ‘View data’ levels/).click();
 
-      cy.findByText("'Create queries' levels");
+      cy.findByText("‘Create queries’ levels");
 
       cy.findByLabelText("Close").click();
     });
@@ -555,7 +555,7 @@ describe("scenarios > admin > permissions", () => {
     cy.findByLabelText("Permissions help reference")
       .as("permissionsHelpContent")
       .within(() => {
-        cy.findByText("Database 'View data' levels").click();
+        cy.findByText("Database ‘View data’ levels").click();
         cy.findAllByText(/No self-service/);
         cy.findByLabelText("Close").click();
       });

--- a/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/admin-permissions.cy.spec.js
@@ -528,6 +528,38 @@ describe("scenarios > admin > permissions", () => {
       cy.findByLabelText("Close").click();
     });
 
+    // Data permissions w/ `legacy-no-self-service` in graph
+    cy.visit("/admin/permissions");
+
+    cy.intercept("GET", `/api/permissions/graph/group/${ALL_USERS_GROUP}`, {
+      statusCode: 200,
+      body: {
+        revision: 1,
+        groups: {
+          1: {
+            1: {
+              "view-data": "legacy-no-self-service",
+              "create-queries": "query-builder-and-native",
+              download: { schemas: "full" },
+            },
+          },
+        },
+      },
+    });
+
+    cy.get("main").within(() => {
+      cy.findByText("Permissions help").as("permissionHelpButton").click();
+      cy.get("@permissionHelpButton").should("not.exist");
+    });
+
+    cy.findByLabelText("Permissions help reference")
+      .as("permissionsHelpContent")
+      .within(() => {
+        cy.findByText("Database 'View data' levels").click();
+        cy.findAllByText(/No self-service/);
+        cy.findByLabelText("Close").click();
+      });
+
     cy.get("main").within(() => {
       cy.findByText("Collections").click();
       cy.get("@permissionHelpButton").click();

--- a/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/application-permissions.cy.spec.js
@@ -35,7 +35,7 @@ describeEE("scenarios > admin > permissions > application", () => {
   it("shows permissions help", () => {
     cy.visit("/admin/permissions/application");
     cy.get("main").within(() => {
-      cy.findByText("Permission help").as("permissionHelpButton").click();
+      cy.findByText("Permissions help").as("permissionHelpButton").click();
       cy.get("@permissionHelpButton").should("not.exist");
     });
 

--- a/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
+++ b/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
@@ -2,6 +2,7 @@ import { t, jt } from "ttag";
 
 import { PermissionHelpDescription } from "metabase/admin/permissions/components/PermissionHelpDescription";
 import { getLimitedPermissionAvailabilityMessage } from "metabase/admin/permissions/constants/messages";
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
@@ -17,9 +18,18 @@ import {
   Icon,
 } from "metabase/ui";
 
+import { hasPermissionValueInGraph } from "../../utils/graph/data-permissions";
+
 export const DataPermissionsHelp = () => {
   const isAdvancedPermissionsFeatureEnabled = useSelector(
     state => getSetting(state, "token-features").advanced_permissions,
+  );
+
+  const shouldShowLegacyNoSelfServiceInfo = useSelector(state =>
+    hasPermissionValueInGraph(
+      state.admin.permissions.originalDataPermissions,
+      DataPermissionValue.LEGACY_NO_SELF_SERVICE,
+    ),
   );
 
   return (
@@ -62,6 +72,15 @@ export const DataPermissionsHelp = () => {
                 description={t`The group can view data based on the database role you specify with a user attribute (manually or via SSO).`}
               />
 
+              {shouldShowLegacyNoSelfServiceInfo && (
+                <PermissionHelpDescription
+                  icon="eye"
+                  iconColor="accent5"
+                  name={t`No self-service (Deprecated)`}
+                  description={t`The group can't use the query builder or drill through existing questions. They also can't see the data in the Browse data section. They can still view questions based on this data, if they have permissions to the relevant collection. 'Blocked', 'Impersonated' and 'Sandboxed' in another group will override 'No self-service'.`}
+                />
+              )}
+
               <PermissionHelpDescription
                 hasUpgradeNotice={!isAdvancedPermissionsFeatureEnabled}
                 icon="close"
@@ -86,6 +105,15 @@ export const DataPermissionsHelp = () => {
                 name={t`Can view`}
                 description={t`The group can view all data for that schema or table.`}
               />
+
+              {shouldShowLegacyNoSelfServiceInfo && (
+                <PermissionHelpDescription
+                  icon="eye"
+                  iconColor="accent5"
+                  name={t`No self-service (Deprecated)`}
+                  description={t`"No self-service" works like it does for databases, except here it is scoped to individual schemas or tables.`}
+                />
+              )}
 
               <PermissionHelpDescription
                 hasUpgradeNotice={!isAdvancedPermissionsFeatureEnabled}

--- a/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
+++ b/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
@@ -2,7 +2,6 @@ import { t, jt } from "ttag";
 
 import { PermissionHelpDescription } from "metabase/admin/permissions/components/PermissionHelpDescription";
 import { getLimitedPermissionAvailabilityMessage } from "metabase/admin/permissions/constants/messages";
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
@@ -18,18 +17,9 @@ import {
   Icon,
 } from "metabase/ui";
 
-import { hasPermissionValueInGraph } from "../../utils/graph/data-permissions";
-
 export const DataPermissionsHelp = () => {
   const isAdvancedPermissionsFeatureEnabled = useSelector(
     state => getSetting(state, "token-features").advanced_permissions,
-  );
-
-  const shouldShowLegacyNoSelfServiceInfo = useSelector(state =>
-    hasPermissionValueInGraph(
-      state.admin.permissions.originalDataPermissions,
-      DataPermissionValue.LEGACY_NO_SELF_SERVICE,
-    ),
   );
 
   return (
@@ -72,15 +62,6 @@ export const DataPermissionsHelp = () => {
                 description={t`The group can view data based on the database role you specify with a user attribute (manually or via SSO).`}
               />
 
-              {shouldShowLegacyNoSelfServiceInfo && (
-                <PermissionHelpDescription
-                  icon="eye"
-                  iconColor="accent5"
-                  name={t`No self-service (Deprecated)`}
-                  description={t`The group can't use the query builder or drill through existing questions. They also can't see the data in the Browse data section. They can still view questions based on this data, if they have permissions to the relevant collection. 'Blocked', 'Impersonated' and 'Sandboxed' in another group will override 'No self-service'.`}
-                />
-              )}
-
               <PermissionHelpDescription
                 hasUpgradeNotice={!isAdvancedPermissionsFeatureEnabled}
                 icon="close"
@@ -105,15 +86,6 @@ export const DataPermissionsHelp = () => {
                 name={t`Can view`}
                 description={t`The group can view all data for that schema or table.`}
               />
-
-              {shouldShowLegacyNoSelfServiceInfo && (
-                <PermissionHelpDescription
-                  icon="eye"
-                  iconColor="accent5"
-                  name={t`No self-service (Deprecated)`}
-                  description={t`"No self-service" works like it does for databases, except here it is scoped to individual schemas or tables.`}
-                />
-              )}
 
               <PermissionHelpDescription
                 hasUpgradeNotice={!isAdvancedPermissionsFeatureEnabled}

--- a/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
+++ b/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
@@ -47,7 +47,7 @@ export const DataPermissionsHelp = () => {
           value="database-view-data-level"
           data-testid="database-view-data-level"
         >
-          <Accordion.Control>{t`Database 'View data' levels`}</Accordion.Control>
+          <Accordion.Control>{t`Database ‘View data’ levels`}</Accordion.Control>
           <Accordion.Panel>
             <Stack spacing="1rem" py="1rem">
               <PermissionHelpDescription
@@ -77,7 +77,7 @@ export const DataPermissionsHelp = () => {
                   icon="eye"
                   iconColor="accent5"
                   name={t`No self-service (Deprecated)`}
-                  description={t`The group can't use the query builder or drill through existing questions. They also can't see the data in the Browse data section. They can still view questions based on this data, if they have permissions to the relevant collection. 'Blocked', 'Impersonated' and 'Sandboxed' in another group will override 'No self-service'.`}
+                  description={t`The group can't use the query builder or drill through existing questions. They also can't see the data in the Browse data section. They can still view questions based on this data, if they have permissions to the relevant collection. ‘Blocked’, ‘Impersonated’ and ‘Sandboxed’ in another group will override ‘No self-service’.`}
                 />
               )}
 
@@ -96,7 +96,7 @@ export const DataPermissionsHelp = () => {
           value="schema-table-level"
           data-testid="schema-table-level"
         >
-          <Accordion.Control>{t`Schema or table 'View data' levels`}</Accordion.Control>
+          <Accordion.Control>{t`Schema or table ‘View data’ levels`}</Accordion.Control>
           <Accordion.Panel>
             <Stack spacing="1rem" py="1rem">
               <PermissionHelpDescription
@@ -130,7 +130,7 @@ export const DataPermissionsHelp = () => {
           value="create-queries-level"
           data-testid="create-queries-level"
         >
-          <Accordion.Control>{t`'Create queries' levels`}</Accordion.Control>
+          <Accordion.Control>{t`‘Create queries’ levels`}</Accordion.Control>
           <Accordion.Panel>
             <Stack spacing="1rem" py="1rem">
               <PermissionHelpDescription
@@ -185,7 +185,7 @@ export const DataPermissionsHelp = () => {
               <Text>
                 {jt`${(
                   <strong>{t`Manage Database (Pro):`}</strong>
-                )} The group can edit database settings for a given database in the "Database" tab of the Admin settings.`}{" "}
+                )} The group can edit database settings for a given database in the “Database” tab of the Admin settings.`}{" "}
                 {!isAdvancedPermissionsFeatureEnabled &&
                   getLimitedPermissionAvailabilityMessage()}
               </Text>

--- a/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
+++ b/frontend/src/metabase/admin/permissions/components/DataPermissionsHelp/DataPermissionsHelp.tsx
@@ -2,6 +2,7 @@ import { t, jt } from "ttag";
 
 import { PermissionHelpDescription } from "metabase/admin/permissions/components/PermissionHelpDescription";
 import { getLimitedPermissionAvailabilityMessage } from "metabase/admin/permissions/constants/messages";
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 import ExternalLink from "metabase/core/components/ExternalLink";
 import { useSelector } from "metabase/lib/redux";
 import MetabaseSettings from "metabase/lib/settings";
@@ -17,9 +18,18 @@ import {
   Icon,
 } from "metabase/ui";
 
+import { hasPermissionValueInGraph } from "../../utils/graph/data-permissions";
+
 export const DataPermissionsHelp = () => {
   const isAdvancedPermissionsFeatureEnabled = useSelector(
     state => getSetting(state, "token-features").advanced_permissions,
+  );
+
+  const shouldShowLegacyNoSelfServiceInfo = useSelector(state =>
+    hasPermissionValueInGraph(
+      state.admin.permissions.originalDataPermissions,
+      DataPermissionValue.LEGACY_NO_SELF_SERVICE,
+    ),
   );
 
   return (
@@ -33,22 +43,25 @@ export const DataPermissionsHelp = () => {
         chevron={<Icon name="chevrondown" size={12} />}
         defaultValue="database-level"
       >
-        <Accordion.Item value="database-level">
-          <Accordion.Control>{t`Database levels`}</Accordion.Control>
+        <Accordion.Item
+          value="database-view-data-level"
+          data-testid="database-view-data-level"
+        >
+          <Accordion.Control>{t`Database 'View data' levels`}</Accordion.Control>
           <Accordion.Panel>
             <Stack spacing="1rem" py="1rem">
               <PermissionHelpDescription
-                icon="check"
+                icon="eye"
                 iconColor="success"
-                name={t`Unrestricted`}
-                description={t`The group can use the query builder to ask questions of any table in the database.`}
+                name={t`Can view`}
+                description={t`The group can view all data for that database.`}
               />
 
               <PermissionHelpDescription
                 icon="permissions_limited"
                 iconColor="warning"
                 name={t`Granular`}
-                description={t`The group can only use the query builder to ask questions of specific tables.`}
+                description={t`The group can view select schemas and tables. Can be combined with SSO user attributes to create Sandboxes that define what data each person can view.`}
               />
 
               <PermissionHelpDescription
@@ -56,43 +69,51 @@ export const DataPermissionsHelp = () => {
                 icon="database"
                 iconColor="warning"
                 name={t`Impersonated (Pro)`}
-                description={t`Impersonation associates a Metabase group with database-defined roles and their privileges. Metabase queries made by this group will respect the grants given to the database roles. You can use impersonation to give a group access to the native/SQL editor, while restricting the group's access to data based on a specific database role.`}
+                description={t`The group can view data based on the database role you specify with a user attribute (manually or via SSO).`}
               />
 
-              <PermissionHelpDescription
-                icon="eye_crossed_out"
-                iconColor="accent5"
-                name={t`No self-service`}
-                description={t`The group can't use the query builder or drill through existing questions. They also can't see the data in the Browse data section. They can still view questions based on this data, if they have permissions to the relevant collection.`}
-              />
+              {shouldShowLegacyNoSelfServiceInfo && (
+                <PermissionHelpDescription
+                  icon="eye"
+                  iconColor="accent5"
+                  name={t`No self-service (Deprecated)`}
+                  description={t`The group can't use the query builder or drill through existing questions. They also can't see the data in the Browse data section. They can still view questions based on this data, if they have permissions to the relevant collection. 'Blocked', 'Impersonated' and 'Sandboxed' in another group will override 'No self-service'.`}
+                />
+              )}
 
               <PermissionHelpDescription
                 hasUpgradeNotice={!isAdvancedPermissionsFeatureEnabled}
                 icon="close"
                 iconColor="danger"
-                name={t`Block (Pro)`}
-                description={t`The group can't see questions based on this the data, even if they have collection permissions to view the questions. People in a blocked group would need to be in another group with both collection permissions and data permissions in order to view the item.`}
+                name={t`Blocked (Pro)`}
+                description={t`The group cannot view any data from the data source, even if they have collection access to view questions or dashboards that draw from that data.`}
               />
             </Stack>
           </Accordion.Panel>
         </Accordion.Item>
 
-        <Accordion.Item value="schema-table-level">
-          <Accordion.Control>{t`Schema and table levels`}</Accordion.Control>
+        <Accordion.Item
+          value="schema-table-level"
+          data-testid="schema-table-level"
+        >
+          <Accordion.Control>{t`Schema or table 'View data' levels`}</Accordion.Control>
           <Accordion.Panel>
             <Stack spacing="1rem" py="1rem">
               <PermissionHelpDescription
                 icon="check"
                 iconColor="success"
-                name={t`Unrestricted`}
+                name={t`Can view`}
+                description={t`The group can view all data for that schema or table.`}
               />
 
-              <PermissionHelpDescription
-                icon="eye_crossed_out"
-                iconColor="accent5"
-                name={t`No self-service`}
-                description={t`"Unrestricted" and "No self-service permissions" work like they do for databases, except here they're scoped to individual schemas or tables.`}
-              />
+              {shouldShowLegacyNoSelfServiceInfo && (
+                <PermissionHelpDescription
+                  icon="eye"
+                  iconColor="accent5"
+                  name={t`No self-service (Deprecated)`}
+                  description={t`"No self-service" works like it does for databases, except here it is scoped to individual schemas or tables.`}
+                />
+              )}
 
               <PermissionHelpDescription
                 hasUpgradeNotice={!isAdvancedPermissionsFeatureEnabled}
@@ -105,33 +126,66 @@ export const DataPermissionsHelp = () => {
           </Accordion.Panel>
         </Accordion.Item>
 
+        <Accordion.Item
+          value="create-queries-level"
+          data-testid="create-queries-level"
+        >
+          <Accordion.Control>{t`'Create queries' levels`}</Accordion.Control>
+          <Accordion.Panel>
+            <Stack spacing="1rem" py="1rem">
+              <PermissionHelpDescription
+                icon="check"
+                iconColor="success"
+                name={t`Query builder and native`}
+                description={t`The group can use both the query builder and the native code editor to create questions and models.`}
+              />
+
+              <PermissionHelpDescription
+                icon="permissions_limited"
+                iconColor="warning"
+                name={t`Query builder only`}
+                description={t`The group can use the query builder to create questions and models.`}
+              />
+
+              <PermissionHelpDescription
+                icon="permissions_limited"
+                iconColor="warning"
+                name={t`Granular`}
+                description={t`The group can use the query builder to create questions and models for select schemas and tables.`}
+              />
+
+              <PermissionHelpDescription
+                icon="close"
+                iconColor="danger"
+                name={t`No`}
+                description={t`The group cannot create or edit questions, including drill-through.`}
+              />
+            </Stack>
+          </Accordion.Panel>
+        </Accordion.Item>
+
         <Accordion.Item value="others">
           <Accordion.Control>{t`Other data permissions`}</Accordion.Control>
           <Accordion.Panel>
             <Stack spacing="1rem" py="1rem">
               <Text>
                 {jt`${(
-                  <strong>{t`Native query editing:`}</strong>
-                )} Extends the "Unrestricted" data permissions level to include access to the native/SQL editor.`}
-              </Text>
-              <Text>
-                {jt`${(
                   <strong>{t`Download results (Pro):`}</strong>
-                )} Allows the group to download results, and sets the maximum number of rows they can export.`}{" "}
+                )} The group can download results, up to a maximum number of rows that you set.`}{" "}
                 {!isAdvancedPermissionsFeatureEnabled &&
                   getLimitedPermissionAvailabilityMessage()}
               </Text>
               <Text>
                 {jt`${(
                   <strong>{t`Manage Data Model (Pro):`}</strong>
-                )} The group can edit table metadata in the Admin panel.`}{" "}
+                )} The group can edit metadata via the “Table metadata” tab in the Admin settings.`}{" "}
                 {!isAdvancedPermissionsFeatureEnabled &&
                   getLimitedPermissionAvailabilityMessage()}
               </Text>
               <Text>
                 {jt`${(
                   <strong>{t`Manage Database (Pro):`}</strong>
-                )} Grants a group access to the Admin settings page for a given database (i.e., the page at Admin settings > Databases > your database).`}{" "}
+                )} The group can edit database settings for a given database in the "Database" tab of the Admin settings.`}{" "}
                 {!isAdvancedPermissionsFeatureEnabled &&
                   getLimitedPermissionAvailabilityMessage()}
               </Text>

--- a/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsPageLayout/PermissionsPageLayout.tsx
@@ -124,7 +124,7 @@ function PermissionsPageLayout({
             {toolbarRightContent}
             {helpContent && !isHelpReferenceOpen && (
               <ToolbarButton
-                text={t`Permission help`}
+                text={t`Permissions help`}
                 icon="info"
                 onClick={handleToggleHelpReference}
               />

--- a/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
+++ b/frontend/src/metabase/admin/permissions/constants/data-permissions.tsx
@@ -30,7 +30,7 @@ export const DATA_PERMISSION_OPTIONS = {
       </>
     ),
     value: DataPermissionValue.LEGACY_NO_SELF_SERVICE,
-    icon: "eye",
+    icon: "eye_crossed_out",
     iconColor: "accent5",
   },
   no: {

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -188,30 +188,6 @@ export const getFieldsPermission = (
   }
 };
 
-export function hasPermissionValueInGraph(
-  permissions: GroupsPermissions,
-  permissionValue: DataPermissionValue,
-): boolean {
-  function _hasPermissionValueInGraph(permissionsGraphSection: any) {
-    for (const key in permissionsGraphSection) {
-      if (permissionsGraphSection[key] === permissionValue) {
-        return true;
-      } else if (
-        typeof permissionsGraphSection[key] === "object" &&
-        hasPermissionValueInGraph(permissionsGraphSection[key], permissionValue)
-      ) {
-        return true;
-      } else {
-        continue;
-      }
-    }
-
-    return false;
-  }
-
-  return _hasPermissionValueInGraph(permissions);
-}
-
 // Ideally this would live in downgradeNativePermissionsIfNeeded, but originally that function was
 // created to only be called if a view permission was changing. there needs to be some reworking
 // in some of the setter methods to make sure the downgrading will always happen at the appropriate time

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -194,15 +194,16 @@ export function hasPermissionValueInGraph(
 ): boolean {
   function _hasPermissionValueInGraph(permissionsGraphSection: any) {
     for (const key in permissionsGraphSection) {
-      if (permissionsGraphSection[key] === permissionValue) {
+      const isMatch = permissionsGraphSection[key] === permissionValue;
+      if (isMatch) {
         return true;
-      } else if (
+      }
+
+      const isGraphObjWithMatch =
         typeof permissionsGraphSection[key] === "object" &&
-        hasPermissionValueInGraph(permissionsGraphSection[key], permissionValue)
-      ) {
+        _hasPermissionValueInGraph(permissionsGraphSection[key]);
+      if (isGraphObjWithMatch) {
         return true;
-      } else {
-        continue;
       }
     }
 

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -188,6 +188,30 @@ export const getFieldsPermission = (
   }
 };
 
+export function hasPermissionValueInGraph(
+  permissions: GroupsPermissions,
+  permissionValue: DataPermissionValue,
+): boolean {
+  function _hasPermissionValueInGraph(permissionsGraphSection: any) {
+    for (const key in permissionsGraphSection) {
+      if (permissionsGraphSection[key] === permissionValue) {
+        return true;
+      } else if (
+        typeof permissionsGraphSection[key] === "object" &&
+        hasPermissionValueInGraph(permissionsGraphSection[key], permissionValue)
+      ) {
+        return true;
+      } else {
+        continue;
+      }
+    }
+
+    return false;
+  }
+
+  return _hasPermissionValueInGraph(permissions);
+}
+
 // Ideally this would live in downgradeNativePermissionsIfNeeded, but originally that function was
 // created to only be called if a view permission was changing. there needs to be some reworking
 // in some of the setter methods to make sure the downgrading will always happen at the appropriate time


### PR DESCRIPTION
Closes #40852

### Description

Update the items and copy of the `Permissions Help` section to accommodate changes from the split permissions updates.
No self-service description will only show to users if it's currently in their permissions graph.

### How to verify

- Go to permission page in the database or group views.
- Click the permissions help button in the top right hand corner

### Demo

<img width="168" alt="Screenshot 2024-04-10 at 2 17 43 PM" src="https://github.com/metabase/metabase/assets/7104357/8a4d16b6-b2ae-40ff-874f-012a0998c4e2">
<img width="321" alt="Screenshot 2024-04-10 at 2 17 57 PM" src="https://github.com/metabase/metabase/assets/7104357/9f5bb28d-5d19-4dbe-b0fb-0199152efc5b">
<img width="320" alt="Screenshot 2024-04-10 at 2 18 12 PM" src="https://github.com/metabase/metabase/assets/7104357/dfe694b1-edcc-4f06-aa05-64e665a3d6e6">
<img width="322" alt="Screenshot 2024-04-10 at 2 18 23 PM" src="https://github.com/metabase/metabase/assets/7104357/17ea9154-3dde-4e68-a857-1b5b78e1cac3">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
