### PR TITLE
Convert TableInteractive.module.css

### DIFF
--- a/e2e/test/scenarios/admin/datamodel/field.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/field.cy.spec.js
@@ -166,7 +166,7 @@ describe("scenarios > admin > datamodel > field", () => {
 
           cy.log("Make sure custom mapping appears in QB");
           openTable({ database: dbId, table: NUMBER_WITH_NULLS_ID });
-          cy.get(".cellData").should("contain", remappedNullValue);
+          cy.get("[data-testid=cellData]").should("contain", remappedNullValue);
         },
       );
     });

--- a/e2e/test/scenarios/admin/datamodel/field.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/field.cy.spec.js
@@ -166,7 +166,10 @@ describe("scenarios > admin > datamodel > field", () => {
 
           cy.log("Make sure custom mapping appears in QB");
           openTable({ database: dbId, table: NUMBER_WITH_NULLS_ID });
-          cy.get("[data-testid=cellData]").should("contain", remappedNullValue);
+          cy.get("[data-testid=cell-data]").should(
+            "contain",
+            remappedNullValue,
+          );
         },
       );
     });

--- a/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -64,7 +64,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       .first()
       .as("tableHeader")
       .within(() => {
-        cy.get("[data-testid=cellData]")
+        cy.get("[data-testid=cell-data]")
           .eq(1)
           .invoke("text")
           .should("eq", "Revenue");
@@ -74,7 +74,7 @@ describe("scenarios > admin > datamodel > metrics", () => {
       .last()
       .as("tableBody")
       .within(() => {
-        cy.get("[data-testid=cellData]")
+        cy.get("[data-testid=cell-data]")
           .eq(1)
           .invoke("text")
           .should("eq", "50,072.98");

--- a/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
+++ b/e2e/test/scenarios/admin/datamodel/metrics.cy.spec.js
@@ -64,14 +64,20 @@ describe("scenarios > admin > datamodel > metrics", () => {
       .first()
       .as("tableHeader")
       .within(() => {
-        cy.get(".cellData").eq(1).invoke("text").should("eq", "Revenue");
+        cy.get("[data-testid=cellData]")
+          .eq(1)
+          .invoke("text")
+          .should("eq", "Revenue");
       });
 
     cy.get("@table")
       .last()
       .as("tableBody")
       .within(() => {
-        cy.get(".cellData").eq(1).invoke("text").should("eq", "50,072.98");
+        cy.get("[data-testid=cellData]")
+          .eq(1)
+          .invoke("text")
+          .should("eq", "50,072.98");
       });
   });
 

--- a/e2e/test/scenarios/admin/settings/cache.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/cache.cy.spec.js
@@ -98,7 +98,7 @@ function saveQuestion(name) {
 }
 
 function getCellText() {
-  return cy.get(".cellData").eq(-1).invoke("text");
+  return cy.get("[data-testid=cellData]").eq(-1).invoke("text");
 }
 
 function refresh() {

--- a/e2e/test/scenarios/admin/settings/cache.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/cache.cy.spec.js
@@ -98,7 +98,7 @@ function saveQuestion(name) {
 }
 
 function getCellText() {
-  return cy.get("[data-testid=cellData]").eq(-1).invoke("text");
+  return cy.get("[data-testid=cell-data]").eq(-1).invoke("text");
 }
 
 function refresh() {

--- a/e2e/test/scenarios/admin/settings/localization.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/localization.cy.spec.js
@@ -119,7 +119,7 @@ describe("scenarios > admin > localization", () => {
 
     cy.get("@resultTable").within(() => {
       // The third cell in the first row (CREATED_AT_DAY)
-      cy.get("[data-testid=cellData]").eq(2).should("not.contain", "Sunday");
+      cy.get("[data-testid=cell-data]").eq(2).should("not.contain", "Sunday");
     });
   });
 

--- a/e2e/test/scenarios/admin/settings/localization.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/localization.cy.spec.js
@@ -119,7 +119,7 @@ describe("scenarios > admin > localization", () => {
 
     cy.get("@resultTable").within(() => {
       // The third cell in the first row (CREATED_AT_DAY)
-      cy.get(".cellData").eq(2).should("not.contain", "Sunday");
+      cy.get("[data-testid=cellData]").eq(2).should("not.contain", "Sunday");
     });
   });
 

--- a/e2e/test/scenarios/admin/settings/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/settings.cy.spec.js
@@ -171,7 +171,7 @@ describe("scenarios > admin > settings", () => {
     openOrdersTable({ limit: 2 });
 
     cy.findByTextEnsureVisible("Created At");
-    cy.get(".cellData")
+    cy.get("[data-testid=cellData]")
       .should("contain", "Created At")
       .and("contain", "2025/2/11, 21:40");
 
@@ -188,7 +188,7 @@ describe("scenarios > admin > settings", () => {
     openOrdersTable({ limit: 2 });
 
     cy.findByTextEnsureVisible("Created At");
-    cy.get(".cellData").and("contain", "2025/2/11, 9:40 PM");
+    cy.get("[data-testid=cellData]").and("contain", "2025/2/11, 9:40 PM");
   });
 
   it("should show where to display the unit of currency (metabase#table-metadata-missing-38021 and update the formatting", () => {

--- a/e2e/test/scenarios/admin/settings/settings.cy.spec.js
+++ b/e2e/test/scenarios/admin/settings/settings.cy.spec.js
@@ -171,7 +171,7 @@ describe("scenarios > admin > settings", () => {
     openOrdersTable({ limit: 2 });
 
     cy.findByTextEnsureVisible("Created At");
-    cy.get("[data-testid=cellData]")
+    cy.get("[data-testid=cell-data]")
       .should("contain", "Created At")
       .and("contain", "2025/2/11, 21:40");
 
@@ -188,7 +188,7 @@ describe("scenarios > admin > settings", () => {
     openOrdersTable({ limit: 2 });
 
     cy.findByTextEnsureVisible("Created At");
-    cy.get("[data-testid=cellData]").and("contain", "2025/2/11, 9:40 PM");
+    cy.get("[data-testid=cell-data]").and("contain", "2025/2/11, 9:40 PM");
   });
 
   it("should show where to display the unit of currency (metabase#table-metadata-missing-38021 and update the formatting", () => {

--- a/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
@@ -52,7 +52,7 @@ describe("scenarios > binning > correctness > longitude", () => {
     cy.findByText("Done").click();
 
     getTitle("Count by Longitude");
-    cy.get("[data-testid=cellData]")
+    cy.get("[data-testid=cell-data]")
       .should("contain", "Longitude")
       .should("contain", "Count")
       .and("contain", "166.54257260° W")

--- a/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/longitude.cy.spec.js
@@ -52,7 +52,7 @@ describe("scenarios > binning > correctness > longitude", () => {
     cy.findByText("Done").click();
 
     getTitle("Count by Longitude");
-    cy.get(".cellData")
+    cy.get("[data-testid=cellData]")
       .should("contain", "Longitude")
       .should("contain", "Count")
       .and("contain", "166.54257260° W")

--- a/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
@@ -78,8 +78,8 @@ function getTitle(title) {
 }
 
 function assertOnHeaderCells(bucketSize) {
-  cy.get(".cellData").eq(0).contains(`Created At: ${bucketSize}`);
-  cy.get(".cellData").eq(1).contains("Count");
+  cy.get("[data-testid=cellData]").eq(0).contains(`Created At: ${bucketSize}`);
+  cy.get("[data-testid=cellData]").eq(1).contains("Count");
 }
 
 function assertOnTableValues(values) {

--- a/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
+++ b/e2e/test/scenarios/binning/correctness/time-series.cy.spec.js
@@ -78,8 +78,8 @@ function getTitle(title) {
 }
 
 function assertOnHeaderCells(bucketSize) {
-  cy.get("[data-testid=cellData]").eq(0).contains(`Created At: ${bucketSize}`);
-  cy.get("[data-testid=cellData]").eq(1).contains("Count");
+  cy.get("[data-testid=cell-data]").eq(0).contains(`Created At: ${bucketSize}`);
+  cy.get("[data-testid=cell-data]").eq(1).contains("Count");
 }
 
 function assertOnTableValues(values) {

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -44,7 +44,9 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Month").click();
 
-      cy.get(".cellData").should("contain", "April 1958").and("contain", "37");
+      cy.get("[data-testid=cellData]")
+        .should("contain", "April 1958")
+        .and("contain", "37");
     });
 
     it("should work for number", () => {
@@ -109,7 +111,9 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Month").click();
 
-      cy.get(".cellData").should("contain", "April 1958").and("contain", "37");
+      cy.get("[data-testid=cellData]")
+        .should("contain", "April 1958")
+        .and("contain", "37");
     });
 
     it("should work for number", () => {
@@ -161,5 +165,7 @@ function assertQueryBuilderState({ title, mode = null, values } = {}) {
   mode === "notebook" ? visualize() : waitAndAssertOnRequest("@dataset");
 
   cy.findByText(title);
-  cy.get(".cellData").should("contain", firstValue).and("contain", lastValue);
+  cy.get("[data-testid=cellData]")
+    .should("contain", firstValue)
+    .and("contain", lastValue);
 }

--- a/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-implicit-joins.cy.spec.js
@@ -44,7 +44,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Month").click();
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "April 1958")
         .and("contain", "37");
     });
@@ -111,7 +111,7 @@ describe("scenarios > binning > from a saved QB question using implicit joins", 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Month").click();
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "April 1958")
         .and("contain", "37");
     });
@@ -165,7 +165,7 @@ function assertQueryBuilderState({ title, mode = null, values } = {}) {
   mode === "notebook" ? visualize() : waitAndAssertOnRequest("@dataset");
 
   cy.findByText(title);
-  cy.get("[data-testid=cellData]")
+  cy.get("[data-testid=cell-data]")
     .should("contain", firstValue)
     .and("contain", lastValue);
 }

--- a/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
+++ b/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
@@ -45,7 +45,7 @@ describe("issue 23851", () => {
       "have.text",
       "Created At: Day of week is equal to 6",
     );
-    cy.get(".cellData").should("contain", "109.22");
+    cy.get("[data-testid=cellData]").should("contain", "109.22");
     cy.icon("notebook").click();
     getNotebookStep("filter")
       .findByText("Created At: Day of week is equal to 6")

--- a/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
+++ b/e2e/test/scenarios/binning/reproductions/23851-drill-temporal-extraction.cy.spec.js
@@ -45,7 +45,7 @@ describe("issue 23851", () => {
       "have.text",
       "Created At: Day of week is equal to 6",
     );
-    cy.get("[data-testid=cellData]").should("contain", "109.22");
+    cy.get("[data-testid=cell-data]").should("contain", "109.22");
     cy.icon("notebook").click();
     getNotebookStep("filter")
       .findByText("Created At: Day of week is equal to 6")

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -262,7 +262,7 @@ describe("scenarios > question > custom column", () => {
     );
     cy.log("Works in 0.35.3");
     // ID should be "1" but it is picking the product ID and is showing "14"
-    cy.get(".TableInteractive-cellWrapper--firstColumn")
+    cy.get(".test-TableInteractive-cellWrapper--firstColumn")
       .eq(1) // the second cell from the top in the first column (the first one is a header cell)
       .findByText("1");
   });
@@ -473,7 +473,7 @@ describe("scenarios > question > custom column", () => {
       expect(response.body.error).to.not.exist;
     });
 
-    cy.get(".cellData").should("contain", "37.65");
+    cy.get("[data-testid=cellData]").should("contain", "37.65");
     cy.findAllByTestId("header-cell").should("not.contain", CE_NAME);
   });
 

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -473,7 +473,7 @@ describe("scenarios > question > custom column", () => {
       expect(response.body.error).to.not.exist;
     });
 
-    cy.get("[data-testid=cellData]").should("contain", "37.65");
+    cy.get("[data-testid=cell-data]").should("contain", "37.65");
     cy.findAllByTestId("header-cell").should("not.contain", CE_NAME);
   });
 

--- a/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/dashboard-drill.cy.spec.js
@@ -488,7 +488,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
     visitDashboard(ORDERS_DASHBOARD_ID);
     cy.findAllByTestId("column-header").contains("ID").click().click();
 
-    cy.get(".Table-ID").contains(PK_VALUE).first().click();
+    cy.get(".test-Table-ID").contains(PK_VALUE).first().click();
 
     cy.wait("@dataset");
 
@@ -826,7 +826,7 @@ describe("scenarios > dashboard > dashboard drill", () => {
       });
     });
     cy.findByTextEnsureVisible("Quantity");
-    cy.get(".Table-ID")
+    cy.get(".test-Table-ID")
       .first()
       // Mid-point check that this cell actually contains ID = 1
       .contains("1")

--- a/e2e/test/scenarios/dashboard-filters/reproductions/24235-exclude-all-date-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/24235-exclude-all-date-options.cy.spec.js
@@ -57,7 +57,7 @@ describe("issue 24235", () => {
     });
 
     cy.wait("@getCardQuery");
-    cy.get("[data-testid=cellData]").should(
+    cy.get("[data-testid=cell-data]").should(
       "contain",
       "Price, Schultz and Daniel",
     );

--- a/e2e/test/scenarios/dashboard-filters/reproductions/24235-exclude-all-date-options.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/24235-exclude-all-date-options.cy.spec.js
@@ -57,7 +57,10 @@ describe("issue 24235", () => {
     });
 
     cy.wait("@getCardQuery");
-    cy.get(".cellData").should("contain", "Price, Schultz and Daniel");
+    cy.get("[data-testid=cellData]").should(
+      "contain",
+      "Price, Schultz and Daniel",
+    );
   });
 });
 

--- a/e2e/test/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js
@@ -90,7 +90,7 @@ describe("issue 25374", () => {
     cy.findByText(questionDetails.name).click();
     cy.wait("@cardQuery");
 
-    cy.get("[data-testid=cellData]")
+    cy.get("[data-testid=cell-data]")
       .should("contain", "COUNT(*)")
       .and("contain", "3");
 

--- a/e2e/test/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-filters/reproductions/25374-comma-separated-values-not-passed-to-question.cy.spec.js
@@ -90,7 +90,9 @@ describe("issue 25374", () => {
     cy.findByText(questionDetails.name).click();
     cy.wait("@cardQuery");
 
-    cy.get(".cellData").should("contain", "COUNT(*)").and("contain", "3");
+    cy.get("[data-testid=cellData]")
+      .should("contain", "COUNT(*)")
+      .and("contain", "3");
 
     cy.location("search").should("eq", "?num=1%2C2%2C3");
   });

--- a/e2e/test/scenarios/embedding/embedding-downloads-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-downloads-questions.cy.spec.js
@@ -73,7 +73,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
           setFilters: { text: "Foo" },
         });
 
-        cy.get(".cellData").should("have.text", "Foo");
+        cy.get("[data-testid=cellData]").should("have.text", "Foo");
         cy.findByRole("contentinfo").icon("download").click();
 
         popover().within(() => {
@@ -90,7 +90,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
           cy.visit(url + "&hide_download_button=true");
         });
 
-        cy.get(".cellData").should("have.text", "Foo");
+        cy.get("[data-testid=cellData]").should("have.text", "Foo");
         cy.findByRole("contentinfo").icon("download");
       });
     });
@@ -127,7 +127,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
         visitIframe();
 
         filterWidget().type("Foo{enter}");
-        cy.get(".cellData").should("have.text", "Foo");
+        cy.get("[data-testid=cellData]").should("have.text", "Foo");
 
         cy.location("search").should("eq", "?text=Foo");
         cy.location("hash").should("match", /&hide_download_button=true$/);

--- a/e2e/test/scenarios/embedding/embedding-downloads-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-downloads-questions.cy.spec.js
@@ -73,7 +73,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
           setFilters: { text: "Foo" },
         });
 
-        cy.get("[data-testid=cellData]").should("have.text", "Foo");
+        cy.get("[data-testid=cell-data]").should("have.text", "Foo");
         cy.findByRole("contentinfo").icon("download").click();
 
         popover().within(() => {
@@ -90,7 +90,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
           cy.visit(url + "&hide_download_button=true");
         });
 
-        cy.get("[data-testid=cellData]").should("have.text", "Foo");
+        cy.get("[data-testid=cell-data]").should("have.text", "Foo");
         cy.findByRole("contentinfo").icon("download");
       });
     });
@@ -127,7 +127,7 @@ describeEE("scenarios > embedding > questions > downloads", () => {
         visitIframe();
 
         filterWidget().type("Foo{enter}");
-        cy.get("[data-testid=cellData]").should("have.text", "Foo");
+        cy.get("[data-testid=cell-data]").should("have.text", "Foo");
 
         cy.location("search").should("eq", "?text=Foo");
         cy.location("hash").should("match", /&hide_download_button=true$/);

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -185,7 +185,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
 
         cy.findByTestId("embed-frame").within(() => {
           cy.findByRole("heading", { name: objectName });
-          cy.get(".cellData").contains("37.65");
+          cy.get("[data-testid=cellData]").contains("37.65");
         });
 
         cy.findByRole("contentinfo").within(() => {

--- a/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-smoketests.cy.spec.js
@@ -185,7 +185,7 @@ describe("scenarios > embedding > smoke tests", { tags: "@OSS" }, () => {
 
         cy.findByTestId("embed-frame").within(() => {
           cy.findByRole("heading", { name: objectName });
-          cy.get("[data-testid=cellData]").contains("37.65");
+          cy.get("[data-testid=cell-data]").contains("37.65");
         });
 
         cy.findByRole("contentinfo").within(() => {

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -274,7 +274,7 @@ describe("scenarios > question > filter", () => {
       { visitQuestion: true },
     );
 
-    cy.get("[data-testid=cellData]").contains("Widget");
+    cy.get("[data-testid=cell-data]").contains("Widget");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 1 row");
   });
@@ -630,7 +630,7 @@ describe("scenarios > question > filter", () => {
       display: "table",
     });
 
-    cy.get("[data-testid=cellData]").contains("Count").click();
+    cy.get("[data-testid=cell-data]").contains("Count").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
     cy.findByPlaceholderText("Enter a number").type("42");
@@ -993,7 +993,7 @@ describe("scenarios > question > filter", () => {
       function assertOnTheResult() {
         // Filter name
         cy.findByTextEnsureVisible(`boolean is ${condition.toLowerCase()}`);
-        cy.get("[data-testid=cellData]").should(
+        cy.get("[data-testid=cell-data]").should(
           "contain",
           integerAssociatedWithCondition,
         );

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -274,7 +274,7 @@ describe("scenarios > question > filter", () => {
       { visitQuestion: true },
     );
 
-    cy.get(".cellData").contains("Widget");
+    cy.get("[data-testid=cellData]").contains("Widget");
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 1 row");
   });
@@ -630,7 +630,7 @@ describe("scenarios > question > filter", () => {
       display: "table",
     });
 
-    cy.get(".cellData").contains("Count").click();
+    cy.get("[data-testid=cellData]").contains("Count").click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Filter by this column").click();
     cy.findByPlaceholderText("Enter a number").type("42");
@@ -993,7 +993,10 @@ describe("scenarios > question > filter", () => {
       function assertOnTheResult() {
         // Filter name
         cy.findByTextEnsureVisible(`boolean is ${condition.toLowerCase()}`);
-        cy.get(".cellData").should("contain", integerAssociatedWithCondition);
+        cy.get("[data-testid=cellData]").should(
+          "contain",
+          integerAssociatedWithCondition,
+        );
       }
     });
   });

--- a/e2e/test/scenarios/filters/view.cy.spec.js
+++ b/e2e/test/scenarios/filters/view.cy.spec.js
@@ -133,7 +133,7 @@ describe("scenarios > question > view", () => {
       });
       cy.findAllByTestId("run-button").last().click();
 
-      cy.get(".TableInteractive-cellWrapper--firstColumn").should(
+      cy.get(".test-TableInteractive-cellWrapper--firstColumn").should(
         "have.length",
         2,
       );

--- a/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
@@ -60,7 +60,7 @@ describe("issue 18630", () => {
     // The query runs and we assert the page is not blank,
     // which was caused by an infinite loop and a stack overflow.
     cy.findByDisplayValue(questionDetails.name);
-    cy.get("[data-testid=cellData]").contains("29494 Anderson Drive");
+    cy.get("[data-testid=cell-data]").contains("29494 Anderson Drive");
     cy.findByTestId("question-row-count").should("have.text", "Showing 3 rows");
   });
 });

--- a/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/18630-field-literals-in-joins.cy.spec.js
@@ -60,7 +60,7 @@ describe("issue 18630", () => {
     // The query runs and we assert the page is not blank,
     // which was caused by an infinite loop and a stack overflow.
     cy.findByDisplayValue(questionDetails.name);
-    cy.get(".cellData").contains("29494 Anderson Drive");
+    cy.get("[data-testid=cellData]").contains("29494 Anderson Drive");
     cy.findByTestId("question-row-count").should("have.text", "Showing 3 rows");
   });
 });

--- a/e2e/test/scenarios/models/models-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/models-metadata.cy.spec.js
@@ -448,10 +448,10 @@ describe("scenarios > models metadata", () => {
 });
 
 function drillFK({ id }) {
-  cy.get(".Table-FK").contains(id).first().click();
+  cy.get(".test-Table-FK").contains(id).first().click();
   popover().findByTextEnsureVisible("View details").click();
 }
 
 function drillDashboardFK({ id }) {
-  cy.get(".Table-FK").contains(id).first().click();
+  cy.get(".test-Table-FK").contains(id).first().click();
 }

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -32,7 +32,7 @@ describe("scenarios > models query editor", () => {
       cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("contain", "109.22");
 
@@ -52,7 +52,7 @@ describe("scenarios > models query editor", () => {
       cy.findByTestId("run-button").click();
       cy.wait("@dataset");
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
 
@@ -64,7 +64,7 @@ describe("scenarios > models query editor", () => {
         .and("not.include", "/query");
       cy.location("hash").should("eq", "");
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
     });
@@ -73,7 +73,7 @@ describe("scenarios > models query editor", () => {
       cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("contain", "109.22");
 
@@ -90,7 +90,7 @@ describe("scenarios > models query editor", () => {
       cy.findByTestId("run-button").click();
       cy.wait("@dataset");
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
 
@@ -103,7 +103,7 @@ describe("scenarios > models query editor", () => {
         .and("not.include", "/query");
       cy.location("hash").should("eq", "");
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("contain", "109.22");
     });
@@ -138,7 +138,7 @@ describe("scenarios > models query editor", () => {
         { visitQuestion: true },
       );
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("contain", "109.22");
 
@@ -155,14 +155,14 @@ describe("scenarios > models query editor", () => {
 
       runNativeQuery();
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
 
       cy.button("Save changes").click();
       cy.wait("@updateCard");
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
     });
@@ -179,7 +179,7 @@ describe("scenarios > models query editor", () => {
         { visitQuestion: true },
       );
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("contain", "109.22");
 
@@ -196,7 +196,7 @@ describe("scenarios > models query editor", () => {
 
       runNativeQuery();
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
 
@@ -204,7 +204,7 @@ describe("scenarios > models query editor", () => {
       modal().button("Discard changes").click();
       cy.wait("@cardQuery");
 
-      cy.get("[data-testid=cellData]")
+      cy.get("[data-testid=cell-data]")
         .should("contain", "37.65")
         .and("contain", "109.22");
     });
@@ -240,14 +240,14 @@ describe("scenarios > models query editor", () => {
       cy.get(".ace_content").type("{backspace}".repeat(" FROM".length));
       runNativeQuery();
 
-      cy.get("[data-testid=cellData]").contains(1);
+      cy.get("[data-testid=cell-data]").contains(1);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Syntax error in SQL/).should("not.exist");
 
       cy.button("Save changes").click();
       cy.wait("@updateCard");
 
-      cy.get("[data-testid=cellData]").contains(1);
+      cy.get("[data-testid=cell-data]").contains(1);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Syntax error in SQL/).should("not.exist");
     });

--- a/e2e/test/scenarios/models/models-query-editor.cy.spec.js
+++ b/e2e/test/scenarios/models/models-query-editor.cy.spec.js
@@ -32,7 +32,9 @@ describe("scenarios > models query editor", () => {
       cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
-      cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
+      cy.get("[data-testid=cellData]")
+        .should("contain", "37.65")
+        .and("contain", "109.22");
 
       openQuestionActions();
 
@@ -50,7 +52,7 @@ describe("scenarios > models query editor", () => {
       cy.findByTestId("run-button").click();
       cy.wait("@dataset");
 
-      cy.get(".cellData")
+      cy.get("[data-testid=cellData]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
 
@@ -62,7 +64,7 @@ describe("scenarios > models query editor", () => {
         .and("not.include", "/query");
       cy.location("hash").should("eq", "");
 
-      cy.get(".cellData")
+      cy.get("[data-testid=cellData]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
     });
@@ -71,7 +73,9 @@ describe("scenarios > models query editor", () => {
       cy.visit(`/model/${ORDERS_QUESTION_ID}`);
       cy.wait("@dataset");
 
-      cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
+      cy.get("[data-testid=cellData]")
+        .should("contain", "37.65")
+        .and("contain", "109.22");
 
       openQuestionActions();
 
@@ -86,7 +90,7 @@ describe("scenarios > models query editor", () => {
       cy.findByTestId("run-button").click();
       cy.wait("@dataset");
 
-      cy.get(".cellData")
+      cy.get("[data-testid=cellData]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
 
@@ -99,7 +103,9 @@ describe("scenarios > models query editor", () => {
         .and("not.include", "/query");
       cy.location("hash").should("eq", "");
 
-      cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
+      cy.get("[data-testid=cellData]")
+        .should("contain", "37.65")
+        .and("contain", "109.22");
     });
 
     it("locks display to table", () => {
@@ -113,7 +119,8 @@ describe("scenarios > models query editor", () => {
       cy.wait("@dataset");
 
       // FE chooses the scalar visualization to display count of rows for regular questions
-      cy.get(".TableInteractive");
+      // TODO (styles): migrate
+      cy.get(".test-TableInteractive");
       cy.findByTestId("scalar-value").should("not.exist");
     });
   });
@@ -131,7 +138,9 @@ describe("scenarios > models query editor", () => {
         { visitQuestion: true },
       );
 
-      cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
+      cy.get("[data-testid=cellData]")
+        .should("contain", "37.65")
+        .and("contain", "109.22");
 
       openQuestionActions();
 
@@ -146,14 +155,14 @@ describe("scenarios > models query editor", () => {
 
       runNativeQuery();
 
-      cy.get(".cellData")
+      cy.get("[data-testid=cellData]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
 
       cy.button("Save changes").click();
       cy.wait("@updateCard");
 
-      cy.get(".cellData")
+      cy.get("[data-testid=cellData]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
     });
@@ -170,7 +179,9 @@ describe("scenarios > models query editor", () => {
         { visitQuestion: true },
       );
 
-      cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
+      cy.get("[data-testid=cellData]")
+        .should("contain", "37.65")
+        .and("contain", "109.22");
 
       openQuestionActions();
 
@@ -185,7 +196,7 @@ describe("scenarios > models query editor", () => {
 
       runNativeQuery();
 
-      cy.get(".cellData")
+      cy.get("[data-testid=cellData]")
         .should("contain", "37.65")
         .and("not.contain", "109.22");
 
@@ -193,7 +204,9 @@ describe("scenarios > models query editor", () => {
       modal().button("Discard changes").click();
       cy.wait("@cardQuery");
 
-      cy.get(".cellData").should("contain", "37.65").and("contain", "109.22");
+      cy.get("[data-testid=cellData]")
+        .should("contain", "37.65")
+        .and("contain", "109.22");
     });
 
     it("handles failing queries", () => {
@@ -227,14 +240,14 @@ describe("scenarios > models query editor", () => {
       cy.get(".ace_content").type("{backspace}".repeat(" FROM".length));
       runNativeQuery();
 
-      cy.get(".cellData").contains(1);
+      cy.get("[data-testid=cellData]").contains(1);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Syntax error in SQL/).should("not.exist");
 
       cy.button("Save changes").click();
       cy.wait("@updateCard");
 
-      cy.get(".cellData").contains(1);
+      cy.get("[data-testid=cellData]").contains(1);
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(/Syntax error in SQL/).should("not.exist");
     });

--- a/e2e/test/scenarios/models/models-revision-history.cy.spec.js
+++ b/e2e/test/scenarios/models/models-revision-history.cy.spec.js
@@ -25,7 +25,7 @@ describe("scenarios > models > revision history", () => {
     cy.wait("@modelQuery" + ORDERS_BY_YEAR_QUESTION_ID);
 
     cy.location("pathname").should("match", /^\/model\/\d+/);
-    cy.get("[data-testid=cellData]");
+    cy.get("[data-testid=cell-data]");
   });
 });
 

--- a/e2e/test/scenarios/models/models-revision-history.cy.spec.js
+++ b/e2e/test/scenarios/models/models-revision-history.cy.spec.js
@@ -25,7 +25,7 @@ describe("scenarios > models > revision history", () => {
     cy.wait("@modelQuery" + ORDERS_BY_YEAR_QUESTION_ID);
 
     cy.location("pathname").should("match", /^\/model\/\d+/);
-    cy.get(".cellData");
+    cy.get("[data-testid=cellData]");
   });
 });
 

--- a/e2e/test/scenarios/models/models.cy.spec.js
+++ b/e2e/test/scenarios/models/models.cy.spec.js
@@ -168,11 +168,13 @@ describe("scenarios > models", () => {
     visitQuestion(ORDERS_BY_YEAR_QUESTION_ID);
 
     cy.get("[data-element-id=line-area-bar-chart]");
-    cy.get(".TableInteractive").should("not.exist");
+    // TODO (styles): migrate
+    cy.get(".test-TableInteractive").should("not.exist");
 
     turnIntoModel();
 
-    cy.get(".TableInteractive");
+    // TODO (styles): migrate
+    cy.get(".test-TableInteractive");
     cy.get("[data-element-id=line-area-bar-chart]").should("not.exist");
   });
 

--- a/e2e/test/scenarios/models/reproductions/19180-native-model-results-disappear.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/19180-native-model-results-disappear.cy.spec.js
@@ -18,7 +18,7 @@ describe("issue 19180", () => {
           cy.visit(`/model/${QUESTION_ID}/query`);
           cy.wait("@cardQuery");
           cy.button("Cancel").click();
-          cy.get(".TableInteractive");
+          cy.get(".test-TableInteractive");
           cy.findByText("Here's where your results will appear").should(
             "not.exist",
           );

--- a/e2e/test/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js
@@ -37,6 +37,6 @@ describe.skip("issue 20624", () => {
     cy.button("Save changes").click();
     cy.wait("@updateCard");
 
-    cy.get(".cellData").should("contain", "Foo");
+    cy.get("[data-testid=cellData]").should("contain", "Foo");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/20624-model-metadata-should-override-column-settings.cy.spec.js
@@ -37,6 +37,6 @@ describe.skip("issue 20624", () => {
     cy.button("Save changes").click();
     cy.wait("@updateCard");
 
-    cy.get("[data-testid=cellData]").should("contain", "Foo");
+    cy.get("[data-testid=cell-data]").should("contain", "Foo");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/22715-remapped-values-override-column-identifier.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/22715-remapped-values-override-column-identifier.cy.spec.js
@@ -66,7 +66,9 @@ describe("filtering based on the remapped column name should result in a correct
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Today").should("not.exist");
 
-    cy.get(".cellData").should("have.length", 4).and("contain", "Created At");
+    cy.get("[data-testid=cellData]")
+      .should("have.length", 4)
+      .and("contain", "Created At");
   });
 
   it("when done through the filter trigger (metabase#22715-2)", () => {
@@ -79,7 +81,9 @@ describe("filtering based on the remapped column name should result in a correct
 
     cy.wait("@dataset");
 
-    cy.get(".cellData").should("have.length", 4).and("contain", "Created At");
+    cy.get("[data-testid=cellData]")
+      .should("have.length", 4)
+      .and("contain", "Created At");
   });
 });
 

--- a/e2e/test/scenarios/models/reproductions/22715-remapped-values-override-column-identifier.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/22715-remapped-values-override-column-identifier.cy.spec.js
@@ -66,7 +66,7 @@ describe("filtering based on the remapped column name should result in a correct
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Today").should("not.exist");
 
-    cy.get("[data-testid=cellData]")
+    cy.get("[data-testid=cell-data]")
       .should("have.length", 4)
       .and("contain", "Created At");
   });
@@ -81,7 +81,7 @@ describe("filtering based on the remapped column name should result in a correct
 
     cy.wait("@dataset");
 
-    cy.get("[data-testid=cellData]")
+    cy.get("[data-testid=cell-data]")
       .should("have.length", 4)
       .and("contain", "Created At");
   });

--- a/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
@@ -94,6 +94,10 @@ describe("issue 29517 - nested question based on native model with remapped valu
   });
 
   it("click behavior to custom destination should work (metabase#29517-2)", () => {
+    cy.intercept("/api/dashboard/*/dashcard/*/card/*/query").as(
+      "dashcardQuery",
+    );
+
     visitDashboard("@dashboardId");
 
     cy
@@ -103,7 +107,10 @@ describe("issue 29517 - nested question based on native model with remapped valu
     cy.wait("@loadTargetDashboard");
 
     cy.location("pathname").should("eq", `/dashboard/${ORDERS_DASHBOARD_ID}`);
-    cy.get("[data-testid=cellData]").contains("37.65");
+
+    cy.wait("@dashcardQuery");
+
+    cy.get("[data-testid=cell-data]").contains("37.65");
   });
 });
 

--- a/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
@@ -103,7 +103,7 @@ describe("issue 29517 - nested question based on native model with remapped valu
     cy.wait("@loadTargetDashboard");
 
     cy.location("pathname").should("eq", `/dashboard/${ORDERS_DASHBOARD_ID}`);
-    cy.get(".cellData").contains("37.65");
+    cy.get("[data-testid=cellData]").contains("37.65");
   });
 });
 

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -48,7 +48,7 @@ describe("issue 29951", { requestTimeout: 10000, viewportWidth: 1600 }, () => {
     dragColumn(0, 100);
     cy.findByTestId("qb-header").button("Refresh").click();
     cy.wait("@dataset");
-    cy.get(".cellData").should("contain", "37.65");
+    cy.get("[data-testid=cellData]").should("contain", "37.65");
     cy.findByTestId("view-footer").should("contain", "Showing 2 rows");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29951-model-editor-results-metadata.cy.spec.js
@@ -48,7 +48,7 @@ describe("issue 29951", { requestTimeout: 10000, viewportWidth: 1600 }, () => {
     dragColumn(0, 100);
     cy.findByTestId("qb-header").button("Refresh").click();
     cy.wait("@dataset");
-    cy.get("[data-testid=cellData]").should("contain", "37.65");
+    cy.get("[data-testid=cell-data]").should("contain", "37.65");
     cy.findByTestId("view-footer").should("contain", "Showing 2 rows");
   });
 });

--- a/e2e/test/scenarios/models/reproductions/35711-metadata-in-models-with-custom-fields.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions/35711-metadata-in-models-with-custom-fields.cy.spec.ts
@@ -72,5 +72,5 @@ function assertNoError() {
   cy.get("main")
     .findByText("There was a problem with your question")
     .should("not.exist");
-  cy.get(".cellData").should("contain", "37.65");
+  cy.get("[data-testid=cellData]").should("contain", "37.65");
 }

--- a/e2e/test/scenarios/models/reproductions/35711-metadata-in-models-with-custom-fields.cy.spec.ts
+++ b/e2e/test/scenarios/models/reproductions/35711-metadata-in-models-with-custom-fields.cy.spec.ts
@@ -72,5 +72,5 @@ function assertNoError() {
   cy.get("main")
     .findByText("There was a problem with your question")
     .should("not.exist");
-  cy.get("[data-testid=cellData]").should("contain", "37.65");
+  cy.get("[data-testid=cell-data]").should("contain", "37.65");
 }

--- a/e2e/test/scenarios/native-filters/reproductions/15163.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/15163.cy.spec.js
@@ -97,7 +97,7 @@ const dashboardDetails = {
       });
 
       cy.get(".ace_content").should("not.be.visible");
-      cy.get(".cellData").should("contain", "51");
+      cy.get("[data-testid=cellData]").should("contain", "51");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 1 row");
     });

--- a/e2e/test/scenarios/native-filters/reproductions/15163.cy.spec.js
+++ b/e2e/test/scenarios/native-filters/reproductions/15163.cy.spec.js
@@ -97,7 +97,7 @@ const dashboardDetails = {
       });
 
       cy.get(".ace_content").should("not.be.visible");
-      cy.get("[data-testid=cellData]").should("contain", "51");
+      cy.get("[data-testid=cell-data]").should("contain", "51");
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Showing 1 row");
     });

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -275,7 +275,7 @@ describe("scenarios > question > native subquery", () => {
     );
 
     visitQuestion("@toplevelQuestionId");
-    cy.get("#main-data-grid [data-testid=cellData]").should("have.text", "41");
+    cy.get("#main-data-grid [data-testid=cell-data]").should("have.text", "41");
   });
 
   it("should be able to reference a nested question (metabase#25988)", () => {
@@ -302,7 +302,7 @@ describe("scenarios > question > native subquery", () => {
 
         runNativeQuery();
 
-        cy.get("[data-testid=cellData]").should("contain", "37.65");
+        cy.get("[data-testid=cell-data]").should("contain", "37.65");
       },
     );
   });
@@ -325,7 +325,7 @@ describe("scenarios > question > native subquery", () => {
 
           runNativeQuery();
 
-          cy.get("[data-testid=cellData]").should("contain", "1");
+          cy.get("[data-testid=cell-data]").should("contain", "1");
         },
       );
     },

--- a/e2e/test/scenarios/native/native_subquery.cy.spec.js
+++ b/e2e/test/scenarios/native/native_subquery.cy.spec.js
@@ -275,7 +275,7 @@ describe("scenarios > question > native subquery", () => {
     );
 
     visitQuestion("@toplevelQuestionId");
-    cy.get("#main-data-grid .cellData").should("have.text", "41");
+    cy.get("#main-data-grid [data-testid=cellData]").should("have.text", "41");
   });
 
   it("should be able to reference a nested question (metabase#25988)", () => {
@@ -302,7 +302,7 @@ describe("scenarios > question > native subquery", () => {
 
         runNativeQuery();
 
-        cy.get(".cellData").should("contain", "37.65");
+        cy.get("[data-testid=cellData]").should("contain", "37.65");
       },
     );
   });
@@ -325,7 +325,7 @@ describe("scenarios > question > native subquery", () => {
 
           runNativeQuery();
 
-          cy.get(".cellData").should("contain", "1");
+          cy.get("[data-testid=cellData]").should("contain", "1");
         },
       );
     },

--- a/e2e/test/scenarios/native/reproductions/20044-no-data-sees-explore-results.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/20044-no-data-sees-explore-results.cy.spec.js
@@ -19,7 +19,7 @@ describe("issue 20044", () => {
 
       visitQuestion(id);
 
-      cy.get("[data-testid=cellData]").contains("1");
+      cy.get("[data-testid=cell-data]").contains("1");
       cy.findByText("Explore results").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/native/reproductions/20044-no-data-sees-explore-results.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/20044-no-data-sees-explore-results.cy.spec.js
@@ -19,7 +19,7 @@ describe("issue 20044", () => {
 
       visitQuestion(id);
 
-      cy.get(".cellData").contains("1");
+      cy.get("[data-testid=cellData]").contains("1");
       cy.findByText("Explore results").should("not.exist");
     });
   });

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -149,7 +149,7 @@ describeEE("formatting > sandboxes", () => {
         visitQuestion("@questionId");
 
         cy.log("Make sure user is initially sandboxed");
-        cy.get(".TableInteractive-cellWrapper--firstColumn").should(
+        cy.get(".test-TableInteractive-cellWrapper--firstColumn").should(
           "have.length",
           11,
         );
@@ -166,7 +166,7 @@ describeEE("formatting > sandboxes", () => {
 
         visualize();
         cy.log("Make sure user is still sandboxed");
-        cy.get(".TableInteractive-cellWrapper--firstColumn").should(
+        cy.get(".test-TableInteractive-cellWrapper--firstColumn").should(
           "have.length",
           7,
         );
@@ -176,8 +176,11 @@ describeEE("formatting > sandboxes", () => {
     describe("table sandboxed on a saved parameterized SQL question", () => {
       it("should show filtered categories", () => {
         openPeopleTable();
-        cy.get(".TableInteractive-headerCellData").should("have.length", 4);
-        cy.get(".TableInteractive-cellWrapper--firstColumn").should(
+        cy.get(".test-TableInteractive-headerCellData").should(
+          "have.length",
+          4,
+        );
+        cy.get(".test-TableInteractive-cellWrapper--firstColumn").should(
           "have.length",
           2,
         );
@@ -612,7 +615,9 @@ describeEE("formatting > sandboxes", () => {
               cy.log(
                 "It should show remapped Display Values instead of Product ID",
               );
-              cy.get(".cellData").contains("Awesome Concrete Shoes").click();
+              cy.get("[data-testid=cellData]")
+                .contains("Awesome Concrete Shoes")
+                .click();
               // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
               cy.findByText(/View details/i).click();
 

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -615,7 +615,7 @@ describeEE("formatting > sandboxes", () => {
               cy.log(
                 "It should show remapped Display Values instead of Product ID",
               );
-              cy.get("[data-testid=cellData]")
+              cy.get("[data-testid=cell-data]")
                 .contains("Awesome Concrete Shoes")
                 .click();
               // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -184,7 +184,7 @@ describe("scenarios > question > nested", () => {
       createNestedQuestion({ baseQuestionDetails, nestedQuestionDetails });
 
       cy.log("Reported failing since v0.35.2");
-      cy.get("[data-testid=cellData]").contains(metric.name);
+      cy.get("[data-testid=cell-data]").contains(metric.name);
     });
   });
 

--- a/e2e/test/scenarios/question/nested.cy.spec.js
+++ b/e2e/test/scenarios/question/nested.cy.spec.js
@@ -184,7 +184,7 @@ describe("scenarios > question > nested", () => {
       createNestedQuestion({ baseQuestionDetails, nestedQuestionDetails });
 
       cy.log("Reported failing since v0.35.2");
-      cy.get(".cellData").contains(metric.name);
+      cy.get("[data-testid=cellData]").contains(metric.name);
     });
   });
 
@@ -465,7 +465,7 @@ describe("scenarios > question > nested", () => {
     cy.wait("@dataset");
 
     // should allow to browse object details when exploring native query results (metabase#16938)
-    cy.get(".Table-ID")
+    cy.get(".test-Table-ID")
       .as("primaryKeys")
       .should("have.length", 5)
       .first()

--- a/e2e/test/scenarios/question/new.cy.spec.js
+++ b/e2e/test/scenarios/question/new.cy.spec.js
@@ -215,16 +215,15 @@ describe("scenarios > question > new", () => {
 
     openOrdersTable();
 
-    cy.get(".TableInteractive-cellWrapper--lastColumn") // Quantity (last in the default order for Sample Database)
+    cy.get(".test-TableInteractive-cellWrapper--lastColumn") // Quantity (last in the default order for Sample Database)
       .eq(1) // first table body cell
       .should("contain", "2") // quantity for order ID#1
       .click();
     cy.wait("@dataset");
 
-    cy.get("#main-data-grid .TableInteractive-cellWrapper--firstColumn").should(
-      "have.length.gt",
-      1,
-    );
+    cy.get(
+      "#main-data-grid .test-TableInteractive-cellWrapper--firstColumn",
+    ).should("have.length.gt", 1);
 
     cy.log(
       "**Reported at v0.34.3 - v0.37.0.2 / probably was always like this**",
@@ -232,19 +231,18 @@ describe("scenarios > question > new", () => {
     cy.log(
       "**It should display the table with all orders with the selected quantity.**",
     );
-    cy.get(".TableInteractive");
+    cy.get(".test-TableInteractive");
 
-    cy.get(".TableInteractive-cellWrapper--firstColumn") // ID (first in the default order for Sample Database)
+    cy.get(".test-TableInteractive-cellWrapper--firstColumn") // ID (first in the default order for Sample Database)
       .eq(1) // first table body cell
       .should("contain", 1)
       .click();
     cy.wait("@dataset");
 
     cy.log("only one row should appear after filtering by ID");
-    cy.get("#main-data-grid .TableInteractive-cellWrapper--firstColumn").should(
-      "have.length",
-      1,
-    );
+    cy.get(
+      "#main-data-grid .test-TableInteractive-cellWrapper--firstColumn",
+    ).should("have.length", 1);
   });
 
   it("should handle ad-hoc question with old syntax (metabase#15372)", () => {

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -245,13 +245,13 @@ describe("converting question to SQL (metabase#12651, metabase#21615, metabase#3
     visitQuestion(ORDERS_QUESTION_ID);
     convertToSql();
     saveSavedQuestion();
-    cy.get("[data-testid=cellData]").should("contain", "37.65");
+    cy.get("[data-testid=cell-data]").should("contain", "37.65");
 
     cy.log(
       "should be possible to `Explore results` after saving a question (metabase#32121)",
     );
     cy.findByTestId("qb-header").findByText("Explore results").click();
-    cy.get("[data-testid=cellData]").should("contain", "37.65");
+    cy.get("[data-testid=cell-data]").should("contain", "37.65");
   });
 
   it("should be possible to save a question based on another question after converting to SQL (metabase#40422)", () => {
@@ -261,7 +261,7 @@ describe("converting question to SQL (metabase#12651, metabase#21615, metabase#3
     );
     convertToSql();
     saveSavedQuestion();
-    cy.get("[data-testid=cellData]").should("contain", "37.65");
+    cy.get("[data-testid=cell-data]").should("contain", "37.65");
   });
 });
 
@@ -299,7 +299,7 @@ describe(
       cy.log("Database and table should be pre-selected (metabase#15946)");
       cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
       cy.findByTestId("selected-table").should("have.text", "Products");
-      cy.get("[data-testid=cellData]").should("contain", "Small Marble Shoes");
+      cy.get("[data-testid=cell-data]").should("contain", "Small Marble Shoes");
 
       cy.log("Nested question");
       cy.log(
@@ -307,7 +307,7 @@ describe(
       );
       saveQuestion("foo");
       cy.findByTestId("qb-header").findByText("Explore results").click();
-      cy.get("[data-testid=cellData]").should("contain", "Small Marble Shoes");
+      cy.get("[data-testid=cell-data]").should("contain", "Small Marble Shoes");
 
       // FIXME: Remove `onlyOn` wrapper block once the issue #38181 is fixed!
       onlyOn(false, () => {
@@ -329,7 +329,7 @@ describe(
         );
         cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
         cy.findByTestId("selected-table").should("have.text", "Products");
-        cy.get("[data-testid=cellData]").should(
+        cy.get("[data-testid=cell-data]").should(
           "contain",
           "Small Marble Shoes",
         );
@@ -359,7 +359,7 @@ describe(
         });
       });
 
-      cy.get("[data-testid=cellData]").should("contain", "Small Marble Shoes");
+      cy.get("[data-testid=cell-data]").should("contain", "Small Marble Shoes");
       openNotebook();
       cy.findByLabelText("View the native query").click();
 
@@ -377,7 +377,7 @@ describe(
       cy.log("Database and table should be pre-selected (metabase#40557)");
       cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
       cy.findByTestId("selected-table").should("have.text", "Products");
-      cy.get("[data-testid=cellData]").should("contain", "Small Marble Shoes");
+      cy.get("[data-testid=cell-data]").should("contain", "Small Marble Shoes");
     });
   },
 );

--- a/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
+++ b/e2e/test/scenarios/question/notebook-native-preview-sidebar.cy.spec.ts
@@ -245,13 +245,13 @@ describe("converting question to SQL (metabase#12651, metabase#21615, metabase#3
     visitQuestion(ORDERS_QUESTION_ID);
     convertToSql();
     saveSavedQuestion();
-    cy.get(".cellData").should("contain", "37.65");
+    cy.get("[data-testid=cellData]").should("contain", "37.65");
 
     cy.log(
       "should be possible to `Explore results` after saving a question (metabase#32121)",
     );
     cy.findByTestId("qb-header").findByText("Explore results").click();
-    cy.get(".cellData").should("contain", "37.65");
+    cy.get("[data-testid=cellData]").should("contain", "37.65");
   });
 
   it("should be possible to save a question based on another question after converting to SQL (metabase#40422)", () => {
@@ -261,7 +261,7 @@ describe("converting question to SQL (metabase#12651, metabase#21615, metabase#3
     );
     convertToSql();
     saveSavedQuestion();
-    cy.get(".cellData").should("contain", "37.65");
+    cy.get("[data-testid=cellData]").should("contain", "37.65");
   });
 });
 
@@ -299,7 +299,7 @@ describe(
       cy.log("Database and table should be pre-selected (metabase#15946)");
       cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
       cy.findByTestId("selected-table").should("have.text", "Products");
-      cy.get(".cellData").should("contain", "Small Marble Shoes");
+      cy.get("[data-testid=cellData]").should("contain", "Small Marble Shoes");
 
       cy.log("Nested question");
       cy.log(
@@ -307,7 +307,7 @@ describe(
       );
       saveQuestion("foo");
       cy.findByTestId("qb-header").findByText("Explore results").click();
-      cy.get(".cellData").should("contain", "Small Marble Shoes");
+      cy.get("[data-testid=cellData]").should("contain", "Small Marble Shoes");
 
       // FIXME: Remove `onlyOn` wrapper block once the issue #38181 is fixed!
       onlyOn(false, () => {
@@ -329,7 +329,10 @@ describe(
         );
         cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
         cy.findByTestId("selected-table").should("have.text", "Products");
-        cy.get(".cellData").should("contain", "Small Marble Shoes");
+        cy.get("[data-testid=cellData]").should(
+          "contain",
+          "Small Marble Shoes",
+        );
       });
     });
 
@@ -356,7 +359,7 @@ describe(
         });
       });
 
-      cy.get(".cellData").should("contain", "Small Marble Shoes");
+      cy.get("[data-testid=cellData]").should("contain", "Small Marble Shoes");
       openNotebook();
       cy.findByLabelText("View the native query").click();
 
@@ -374,7 +377,7 @@ describe(
       cy.log("Database and table should be pre-selected (metabase#40557)");
       cy.findByTestId("selected-database").should("have.text", MONGO_DB_NAME);
       cy.findByTestId("selected-table").should("have.text", "Products");
-      cy.get(".cellData").should("contain", "Small Marble Shoes");
+      cy.get("[data-testid=cellData]").should("contain", "Small Marble Shoes");
     });
   },
 );

--- a/e2e/test/scenarios/question/notebook.cy.spec.js
+++ b/e2e/test/scenarios/question/notebook.cy.spec.js
@@ -840,7 +840,10 @@ describe("scenarios > question > notebook", { tags: "@slow" }, () => {
 });
 
 function assertTableRowCount(expectedCount) {
-  cy.get(".Table-ID:not(.Table-FK)").should("have.length", expectedCount);
+  cy.get(".test-Table-ID:not(.test-Table-FK)").should(
+    "have.length",
+    expectedCount,
+  );
 }
 
 function addSimpleCustomColumn(name) {

--- a/e2e/test/scenarios/question/nulls.cy.spec.js
+++ b/e2e/test/scenarios/question/nulls.cy.spec.js
@@ -147,7 +147,7 @@ describe("scenarios > question > null", () => {
     // Total of "39.72", and the next cell is the `discount` (which is empty)
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("39.72")
-      .closest(".TableInteractive-cellWrapper")
+      .closest(".test-TableInteractive-cellWrapper")
       .next()
       .find("div")
       .should("be.empty")

--- a/e2e/test/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
@@ -46,7 +46,7 @@ describe("issue 13097", { tags: "@mongo" }, () => {
     visualize();
 
     // cy.log("Reported failing on stats ~v0.36.3");
-    cy.get(".cellData")
+    cy.get("[data-testid=cellData]")
       .should("have.length", 4)
       .and("contain", "Distinct values of City")
       .and("contain", "1,966")

--- a/e2e/test/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/13097-mongo-apply-distinct-count-multiple-columns.cy.spec.js
@@ -46,7 +46,7 @@ describe("issue 13097", { tags: "@mongo" }, () => {
     visualize();
 
     // cy.log("Reported failing on stats ~v0.36.3");
-    cy.get("[data-testid=cellData]")
+    cy.get("[data-testid=cell-data]")
       .should("have.length", 4)
       .and("contain", "Distinct values of City")
       .and("contain", "1,966")

--- a/e2e/test/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/13263-postgres-show-row-details-on-pk-click.cy.spec.js
@@ -19,7 +19,7 @@ describe("postgres > user > query", { tags: "@external" }, () => {
   it("should show row details when clicked on its entity key (metabase#13263)", () => {
     // We're clicking on ID: 1 (the first order) => do not change!
     // It is tightly coupled to the assertion ("37.65"), which is "Subtotal" value for that order.
-    cy.get(".Table-ID").eq(0).click();
+    cy.get(".test-Table-ID").eq(0).click();
 
     // Wait until "doing science" spinner disappears (DOM is ready for assertions)
     // TODO: if this proves to be reliable, extract it as a helper function for waiting on DOM to render

--- a/e2e/test/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/18978-18977-nested-question-nodata-user.cy.spec.js
@@ -63,7 +63,7 @@ describe("11914, 18978, 18977", () => {
     assertNoOpenPopover();
 
     // No drills when clicking on a FK
-    cy.get(".Table-FK").contains("123").click();
+    cy.get(".test-Table-FK").contains("123").click();
     assertNoOpenPopover();
 
     assertIsNotAdHoc();

--- a/e2e/test/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
@@ -49,7 +49,7 @@ describe("issue 20627", () => {
 
     visualize();
 
-    cy.get("[data-testid=cellData]")
+    cy.get("[data-testid=cell-data]")
       .should("contain", "Math")
       .and("contain", "Doohickey")
       .and("contain", "3,976");

--- a/e2e/test/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/20627-nested-long-names-wrong-aliases.cy.spec.js
@@ -49,7 +49,7 @@ describe("issue 20627", () => {
 
     visualize();
 
-    cy.get(".cellData")
+    cy.get("[data-testid=cellData]")
       .should("contain", "Math")
       .and("contain", "Doohickey")
       .and("contain", "3,976");

--- a/e2e/test/scenarios/question/reproductions/29082-quick-filter-null.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/29082-quick-filter-null.cy.spec.js
@@ -29,7 +29,7 @@ describe("issue 29082", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 11 rows").should("exist");
 
-    cy.get(".TableInteractive-emptyCell").first().click();
+    cy.get(".test-TableInteractive-emptyCell").first().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("=").click());
     cy.wait("@dataset");
@@ -44,7 +44,7 @@ describe("issue 29082", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Showing 11 rows").should("exist");
 
-    cy.get(".TableInteractive-emptyCell").first().click();
+    cy.get(".test-TableInteractive-emptyCell").first().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     popover().within(() => cy.findByText("≠").click());
     cy.wait("@dataset");

--- a/e2e/test/scenarios/question/reproductions/38354-changing-source-database.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/38354-changing-source-database.cy.spec.js
@@ -42,6 +42,6 @@ describe("issue 38354", { tags: "@external" }, () => {
     cy.findByTestId("query-builder-main")
       .findByText("There was a problem with your question")
       .should("not.exist");
-    cy.get(".cellData").should("contain", "37.65"); // assert visualization renders the data
+    cy.get("[data-testid=cellData]").should("contain", "37.65"); // assert visualization renders the data
   });
 });

--- a/e2e/test/scenarios/question/reproductions/38354-changing-source-database.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/38354-changing-source-database.cy.spec.js
@@ -42,6 +42,6 @@ describe("issue 38354", { tags: "@external" }, () => {
     cy.findByTestId("query-builder-main")
       .findByText("There was a problem with your question")
       .should("not.exist");
-    cy.get("[data-testid=cellData]").should("contain", "37.65"); // assert visualization renders the data
+    cy.get("[data-testid=cell-data]").should("contain", "37.65"); // assert visualization renders the data
   });
 });

--- a/e2e/test/scenarios/question/reproductions/6239-sort-using-cust-exp.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/6239-sort-using-cust-exp.cy.spec.js
@@ -39,12 +39,12 @@ describe("issue 6239", () => {
     // Line chart renders initially. Switch to the table view.
     cy.icon("table2").click();
 
-    cy.get(".cellData")
+    cy.get("[data-testid=cellData]")
       .eq(1)
       .should("contain", "CE")
       .and("have.descendants", ".Icon-chevronup");
 
-    cy.get(".cellData").eq(3).invoke("text").should("eq", "1");
+    cy.get("[data-testid=cellData]").eq(3).invoke("text").should("eq", "1");
 
     // Go back to the notebook editor
     cy.icon("notebook").click();
@@ -56,11 +56,11 @@ describe("issue 6239", () => {
 
     visualize();
 
-    cy.get(".cellData")
+    cy.get("[data-testid=cellData]")
       .eq(1)
       .should("contain", "CE")
       .and("have.descendants", ".Icon-chevrondown");
 
-    cy.get(".cellData").eq(3).invoke("text").should("eq", "584");
+    cy.get("[data-testid=cellData]").eq(3).invoke("text").should("eq", "584");
   });
 });

--- a/e2e/test/scenarios/question/reproductions/6239-sort-using-cust-exp.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/6239-sort-using-cust-exp.cy.spec.js
@@ -39,12 +39,12 @@ describe("issue 6239", () => {
     // Line chart renders initially. Switch to the table view.
     cy.icon("table2").click();
 
-    cy.get("[data-testid=cellData]")
+    cy.get("[data-testid=cell-data]")
       .eq(1)
       .should("contain", "CE")
       .and("have.descendants", ".Icon-chevronup");
 
-    cy.get("[data-testid=cellData]").eq(3).invoke("text").should("eq", "1");
+    cy.get("[data-testid=cell-data]").eq(3).invoke("text").should("eq", "1");
 
     // Go back to the notebook editor
     cy.icon("notebook").click();
@@ -56,11 +56,11 @@ describe("issue 6239", () => {
 
     visualize();
 
-    cy.get("[data-testid=cellData]")
+    cy.get("[data-testid=cell-data]")
       .eq(1)
       .should("contain", "CE")
       .and("have.descendants", ".Icon-chevrondown");
 
-    cy.get("[data-testid=cellData]").eq(3).invoke("text").should("eq", "584");
+    cy.get("[data-testid=cell-data]").eq(3).invoke("text").should("eq", "584");
   });
 });

--- a/e2e/test/scenarios/question/saved.cy.spec.js
+++ b/e2e/test/scenarios/question/saved.cy.spec.js
@@ -246,7 +246,7 @@ describe("scenarios > question > saved", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Tax")
-      .closest(".TableInteractive-headerCellData")
+      .closest(".test-TableInteractive-headerCellData")
       .as("headerCell")
       .then($cell => {
         const originalWidth = $cell[0].getBoundingClientRect().width;

--- a/e2e/test/scenarios/question/settings.cy.spec.js
+++ b/e2e/test/scenarios/question/settings.cy.spec.js
@@ -63,7 +63,7 @@ describe("scenarios > question > settings", () => {
 
       // confirm that the table contains the right columns
       cy.findByTestId("query-visualization-root")
-        .get(".TableInteractive")
+        .get(".test-TableInteractive")
         .as("table");
       cy.get("@table").contains("Product → Category");
       cy.get("@table").contains("Product → Ean");
@@ -251,14 +251,14 @@ describe("scenarios > question > settings", () => {
       cy.findByTestId("viz-settings-button").click(); // open settings sidebar
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Conditional Formatting"); // confirm it's open
-      cy.get(".TableInteractive").findByText("Subtotal").click(); // open subtotal column header actions
+      cy.get(".test-TableInteractive").findByText("Subtotal").click(); // open subtotal column header actions
       popover().icon("gear").click(); // open subtotal column settings
 
       //cy.findByText("Table options").should("not.exist"); // no longer displaying the top level settings
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Separator style"); // shows subtotal column settings
 
-      cy.get(".TableInteractive").findByText("Created At").click(); // open created_at column header actions
+      cy.get(".test-TableInteractive").findByText("Created At").click(); // open created_at column header actions
       popover().icon("gear").click(); // open created_at column settings
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Date style"); // shows created_at column settings

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -248,7 +248,7 @@ describe("scenarios > question > summarize sidebar", () => {
     summarize();
 
     cy.findAllByTestId("header-cell").should("have.length", 4);
-    cy.get(".TableInteractive-headerCellData--sorted").as("sortedCell");
+    cy.get(".test-TableInteractive-headerCellData--sorted").as("sortedCell");
 
     cy.log('At this point only "Sum of Subtotal" should be sorted');
     cy.get("@sortedCell").its("length").should("eq", 1);
@@ -266,7 +266,7 @@ describe("scenarios > question > summarize sidebar", () => {
     removeMetricFromSidebar("Sum of Total");
 
     cy.findAllByTestId("header-cell").should("have.length", 2);
-    cy.get(".cellData").should("contain", 744); // `Count` for year 2022
+    cy.get("[data-testid=cellData]").should("contain", 744); // `Count` for year 2022
   });
 
   // flaky test (#19454)

--- a/e2e/test/scenarios/question/summarization.cy.spec.js
+++ b/e2e/test/scenarios/question/summarization.cy.spec.js
@@ -266,7 +266,7 @@ describe("scenarios > question > summarize sidebar", () => {
     removeMetricFromSidebar("Sum of Total");
 
     cy.findAllByTestId("header-cell").should("have.length", 2);
-    cy.get("[data-testid=cellData]").should("contain", 744); // `Count` for year 2022
+    cy.get("[data-testid=cell-data]").should("contain", 744); // `Count` for year 2022
   });
 
   // flaky test (#19454)

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -66,7 +66,7 @@ describe("scenarios > public > question", () => {
       visitQuestion(id);
 
       // Make sure metadata fully loaded before we continue
-      cy.get(".cellData").contains("Winner");
+      cy.get("[data-testid=cellData]").contains("Winner");
 
       openNewPublicLinkDropdown("card");
 
@@ -83,7 +83,7 @@ describe("scenarios > public > question", () => {
 
       cy.wait("@publicQuery");
       // Name of a city from the expected results
-      cy.get(".cellData").contains("Winner");
+      cy.get("[data-testid=cellData]").contains("Winner");
 
       // Make sure we can download the public question (metabase#21993)
       cy.get("@uuid").then(publicUid => {
@@ -129,7 +129,7 @@ describe("scenarios > public > question", () => {
               filterWidget().contains("Previous 30 Years");
               filterWidget().contains("Affiliate");
 
-              cy.get(".cellData").contains("Winner");
+              cy.get("[data-testid=cellData]").contains("Winner");
             },
           );
         });
@@ -161,7 +161,7 @@ describe("scenarios > public > question", () => {
         cy.signOut();
         cy.signInAsNormalUser().then(() => {
           cy.visit(`/public/question/${uuid}`);
-          cy.get(".cellData").contains("test");
+          cy.get("[data-testid=cellData]").contains("test");
         });
       });
     });
@@ -187,7 +187,7 @@ describe("scenarios > public > question", () => {
           cy.signInAsNormalUser().then(() => {
             cy.visit(`/public/question/${uuid}`);
             // Check the name of the first person in the PEOPLE table
-            cy.get(".cellData").contains("Hudson Borer");
+            cy.get("[data-testid=cellData]").contains("Hudson Borer");
           });
         });
       });

--- a/e2e/test/scenarios/sharing/public-question.cy.spec.js
+++ b/e2e/test/scenarios/sharing/public-question.cy.spec.js
@@ -66,7 +66,7 @@ describe("scenarios > public > question", () => {
       visitQuestion(id);
 
       // Make sure metadata fully loaded before we continue
-      cy.get("[data-testid=cellData]").contains("Winner");
+      cy.get("[data-testid=cell-data]").contains("Winner");
 
       openNewPublicLinkDropdown("card");
 
@@ -83,7 +83,7 @@ describe("scenarios > public > question", () => {
 
       cy.wait("@publicQuery");
       // Name of a city from the expected results
-      cy.get("[data-testid=cellData]").contains("Winner");
+      cy.get("[data-testid=cell-data]").contains("Winner");
 
       // Make sure we can download the public question (metabase#21993)
       cy.get("@uuid").then(publicUid => {
@@ -129,7 +129,7 @@ describe("scenarios > public > question", () => {
               filterWidget().contains("Previous 30 Years");
               filterWidget().contains("Affiliate");
 
-              cy.get("[data-testid=cellData]").contains("Winner");
+              cy.get("[data-testid=cell-data]").contains("Winner");
             },
           );
         });
@@ -161,7 +161,7 @@ describe("scenarios > public > question", () => {
         cy.signOut();
         cy.signInAsNormalUser().then(() => {
           cy.visit(`/public/question/${uuid}`);
-          cy.get("[data-testid=cellData]").contains("test");
+          cy.get("[data-testid=cell-data]").contains("test");
         });
       });
     });
@@ -187,7 +187,7 @@ describe("scenarios > public > question", () => {
           cy.signInAsNormalUser().then(() => {
             cy.visit(`/public/question/${uuid}`);
             // Check the name of the first person in the PEOPLE table
-            cy.get("[data-testid=cellData]").contains("Hudson Borer");
+            cy.get("[data-testid=cell-data]").contains("Hudson Borer");
           });
         });
       });

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -521,7 +521,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     });
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText(/^10 –/)
-      .closest(".TableInteractive-cellWrapper")
+      .closest(".test-TableInteractive-cellWrapper")
       .next()
       .contains("85")
       .click();
@@ -565,7 +565,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.findByText("Distinct values").click();
 
     // there should be 0 distinct values since they are all null
-    cy.get(".TableInteractive-cellWrapper").contains("0");
+    cy.get(".test-TableInteractive-cellWrapper").contains("0");
   });
 
   it("should parse value on click through on the first row of pie chart (metabase#15250)", () => {

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
@@ -20,7 +20,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     });
 
     // Short text cell drills
-    cy.get("[data-testid=cellData]").contains("christ").click();
+    cy.get("[data-testid=cell-data]").contains("christ").click();
     popover().within(() => {
       cy.findByText("Is christ").should("be.visible");
       cy.findByText("Is not christ").should("be.visible");
@@ -28,7 +28,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     });
 
     // Number cell drills
-    cy.get("[data-testid=cellData]").contains("5").first().click();
+    cy.get("[data-testid=cell-data]").contains("5").first().click();
     popover().within(() => {
       cy.findByText(">").should("be.visible");
       cy.findByText("<").should("be.visible");
@@ -37,14 +37,14 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("View details").should("be.visible");
     });
 
-    cy.get("[data-testid=cellData]").contains("Ad perspiciatis quis").click();
+    cy.get("[data-testid=cell-data]").contains("Ad perspiciatis quis").click();
     popover().within(() => {
       cy.findByText("Contains…").should("be.visible");
       cy.findByText("Does not contain…").should("be.visible");
       cy.findByText("View details").should("be.visible");
     });
 
-    cy.get("[data-testid=cellData]").contains("May 15, 20").click();
+    cy.get("[data-testid=cell-data]").contains("May 15, 20").click();
     popover().within(() => {
       cy.findByText("Before").should("be.visible");
       cy.findByText("After").should("be.visible");
@@ -53,7 +53,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("View details").should("be.visible");
     });
 
-    cy.get("[data-testid=cellData]").contains("ID").click({ force: true });
+    cy.get("[data-testid=cell-data]").contains("ID").click({ force: true });
     popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
@@ -63,7 +63,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Distinct values").should("be.visible");
     });
 
-    cy.get("[data-testid=cellData]").contains("Reviewer").click();
+    cy.get("[data-testid=cell-data]").contains("Reviewer").click();
     popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
@@ -74,7 +74,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Distinct values").should("be.visible");
     });
 
-    cy.get("[data-testid=cellData]").contains("Rating").click();
+    cy.get("[data-testid=cell-data]").contains("Rating").click();
     popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
@@ -112,7 +112,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Is not abbey-heidenreich").should("be.visible");
     });
 
-    cy.get("[data-testid=cellData]").contains("1").first().click();
+    cy.get("[data-testid=cell-data]").contains("1").first().click();
     popover().within(() => {
       cy.findByText("See this Review").should("be.visible");
 
@@ -124,7 +124,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("≠").should("be.visible");
     });
 
-    cy.get("[data-testid=cellData]").contains("Reviewer").click();
+    cy.get("[data-testid=cell-data]").contains("Reviewer").click();
     popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
@@ -133,7 +133,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Filter by this column").should("be.visible");
     });
 
-    cy.get("[data-testid=cellData]").contains("Count").click();
+    cy.get("[data-testid=cell-data]").contains("Count").click();
     popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
@@ -158,7 +158,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       { visitQuestion: true },
     );
 
-    cy.get("[data-testid=cellData]").contains("June").first().click();
+    cy.get("[data-testid=cell-data]").contains("June").first().click();
     popover().within(() => {
       cy.findByText("Before").should("be.visible");
       cy.findByText("After").should("be.visible");
@@ -166,7 +166,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Not on").should("be.visible");
     });
 
-    cy.get("[data-testid=cellData]").contains("4").first().click();
+    cy.get("[data-testid=cell-data]").contains("4").first().click();
     popover().within(() => {
       cy.findByText("See this month by week").should("be.visible");
 
@@ -196,7 +196,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       { visitQuestion: true },
     );
 
-    cy.get("[data-testid=cellData]").contains("1").first().click();
+    cy.get("[data-testid=cell-data]").contains("1").first().click();
     popover()
       .findByText("Drill-through doesn’t work on SQL questions.")
       .should("be.visible");

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
@@ -13,14 +13,14 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     openReviewsTable({ limit: 3 });
 
     // FK cell drills
-    cy.get(".Table-FK").findByText("1").first().click();
+    cy.get("[data-tableFK]").findByText("1").first().click();
     popover().within(() => {
       cy.findByText("View this Product's Reviews").should("be.visible");
       cy.findByText("View details").should("be.visible");
     });
 
     // Short text cell drills
-    cy.get(".cellData").contains("christ").click();
+    cy.get("[data-testid=cellData]").contains("christ").click();
     popover().within(() => {
       cy.findByText("Is christ").should("be.visible");
       cy.findByText("Is not christ").should("be.visible");
@@ -28,7 +28,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     });
 
     // Number cell drills
-    cy.get(".cellData").contains("5").first().click();
+    cy.get("[data-testid=cellData]").contains("5").first().click();
     popover().within(() => {
       cy.findByText(">").should("be.visible");
       cy.findByText("<").should("be.visible");
@@ -37,14 +37,14 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("View details").should("be.visible");
     });
 
-    cy.get(".cellData").contains("Ad perspiciatis quis").click();
+    cy.get("[data-testid=cellData]").contains("Ad perspiciatis quis").click();
     popover().within(() => {
       cy.findByText("Contains…").should("be.visible");
       cy.findByText("Does not contain…").should("be.visible");
       cy.findByText("View details").should("be.visible");
     });
 
-    cy.get(".cellData").contains("May 15, 20").click();
+    cy.get("[data-testid=cellData]").contains("May 15, 20").click();
     popover().within(() => {
       cy.findByText("Before").should("be.visible");
       cy.findByText("After").should("be.visible");
@@ -53,7 +53,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("View details").should("be.visible");
     });
 
-    cy.get(".cellData").contains("ID").click({ force: true });
+    cy.get("[data-testid=cellData]").contains("ID").click({ force: true });
     popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
@@ -63,7 +63,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Distinct values").should("be.visible");
     });
 
-    cy.get(".cellData").contains("Reviewer").click();
+    cy.get("[data-testid=cellData]").contains("Reviewer").click();
     popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
@@ -74,7 +74,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Distinct values").should("be.visible");
     });
 
-    cy.get(".cellData").contains("Rating").click();
+    cy.get("[data-testid=cellData]").contains("Rating").click();
     popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
@@ -112,7 +112,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Is not abbey-heidenreich").should("be.visible");
     });
 
-    cy.get(".cellData").contains("1").first().click();
+    cy.get("[data-testid=cellData]").contains("1").first().click();
     popover().within(() => {
       cy.findByText("See this Review").should("be.visible");
 
@@ -124,7 +124,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("≠").should("be.visible");
     });
 
-    cy.get(".cellData").contains("Reviewer").click();
+    cy.get("[data-testid=cellData]").contains("Reviewer").click();
     popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
@@ -133,7 +133,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Filter by this column").should("be.visible");
     });
 
-    cy.get(".cellData").contains("Count").click();
+    cy.get("[data-testid=cellData]").contains("Count").click();
     popover().within(() => {
       cy.icon("arrow_down").should("be.visible");
       cy.icon("arrow_up").should("be.visible");
@@ -158,7 +158,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       { visitQuestion: true },
     );
 
-    cy.get(".cellData").contains("June").first().click();
+    cy.get("[data-testid=cellData]").contains("June").first().click();
     popover().within(() => {
       cy.findByText("Before").should("be.visible");
       cy.findByText("After").should("be.visible");
@@ -166,7 +166,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       cy.findByText("Not on").should("be.visible");
     });
 
-    cy.get(".cellData").contains("4").first().click();
+    cy.get("[data-testid=cellData]").contains("4").first().click();
     popover().within(() => {
       cy.findByText("See this month by week").should("be.visible");
 
@@ -196,7 +196,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
       { visitQuestion: true },
     );
 
-    cy.get(".cellData").contains("1").first().click();
+    cy.get("[data-testid=cellData]").contains("1").first().click();
     popover()
       .findByText("Drill-through doesn’t work on SQL questions.")
       .should("be.visible");

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/table_drills.cy.spec.js
@@ -13,7 +13,7 @@ describe("scenarios > visualizations > drillthroughs > table_drills", () => {
     openReviewsTable({ limit: 3 });
 
     // FK cell drills
-    cy.get("[data-tableFK]").findByText("1").first().click();
+    cy.get(".test-Table-FK").findByText("1").first().click();
     popover().within(() => {
       cy.findByText("View this Product's Reviews").should("be.visible");
       cy.findByText("View details").should("be.visible");

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -108,7 +108,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
 
     cy.log("check click on 1st row");
 
-    cy.get("[data-testid=cellData]").contains("37.65").realHover();
+    cy.get("[data-testid=cell-data]").contains("37.65").realHover();
     cy.findByTestId("detail-shortcut").findByRole("button").click();
 
     cy.findByTestId("object-detail").within(() => {
@@ -118,7 +118,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
 
     cy.log("check click on 3rd row");
 
-    cy.get("[data-testid=cellData]").contains("52.72").realHover();
+    cy.get("[data-testid=cell-data]").contains("52.72").realHover();
     cy.findByTestId("detail-shortcut").findByRole("button").click();
 
     cy.findByTestId("object-detail").within(() => {
@@ -165,7 +165,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
 
     // there should be a hover instead of click
     // but realHover is flaky
-    cy.get("[data-testid=cellData]").contains("4966277046676").click();
+    cy.get("[data-testid=cell-data]").contains("4966277046676").click();
 
     cy.findByTestId("detail-shortcut")
       .findByRole("button")

--- a/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/object_detail.cy.spec.js
@@ -108,7 +108,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
 
     cy.log("check click on 1st row");
 
-    cy.get(".cellData").contains("37.65").realHover();
+    cy.get("[data-testid=cellData]").contains("37.65").realHover();
     cy.findByTestId("detail-shortcut").findByRole("button").click();
 
     cy.findByTestId("object-detail").within(() => {
@@ -118,7 +118,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
 
     cy.log("check click on 3rd row");
 
-    cy.get(".cellData").contains("52.72").realHover();
+    cy.get("[data-testid=cellData]").contains("52.72").realHover();
     cy.findByTestId("detail-shortcut").findByRole("button").click();
 
     cy.findByTestId("object-detail").within(() => {
@@ -165,7 +165,7 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
 
     // there should be a hover instead of click
     // but realHover is flaky
-    cy.get(".cellData").contains("4966277046676").click();
+    cy.get("[data-testid=cellData]").contains("4966277046676").click();
 
     cy.findByTestId("detail-shortcut")
       .findByRole("button")
@@ -383,11 +383,11 @@ describe("scenarios > question > object details", { tags: "@slow" }, () => {
 });
 
 function drillPK({ id }) {
-  cy.get(".Table-ID").contains(id).first().click();
+  cy.get(".test-Table-ID").contains(id).first().click();
 }
 
 function drillFK({ id }) {
-  cy.get(".Table-FK").contains(id).first().click();
+  cy.get(".test-Table-FK").contains(id).first().click();
   popover().findByText("View details").click();
 }
 

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -216,7 +216,7 @@ describe("scenarios > visualizations > table", () => {
         },
       ],
     ].forEach(([column, test]) => {
-      cy.get("[data-testid=cellData]").contains(column).trigger("mouseover");
+      cy.get("[data-testid=cell-data]").contains(column).trigger("mouseover");
 
       // Add a delay here because there can be two popovers active for a very short time.
       cy.wait(250);
@@ -225,7 +225,7 @@ describe("scenarios > visualizations > table", () => {
         test();
       });
 
-      cy.get("[data-testid=cellData]").contains(column).trigger("mouseout");
+      cy.get("[data-testid=cell-data]").contains(column).trigger("mouseout");
     });
 
     summarize();
@@ -234,15 +234,15 @@ describe("scenarios > visualizations > table", () => {
 
     cy.wait("@dataset");
 
-    cy.get("[data-testid=cellData]").contains("Count").trigger("mouseover");
+    cy.get("[data-testid=cell-data]").contains("Count").trigger("mouseover");
     hovercard().within(() => {
       cy.contains("Quantity");
       cy.findByText("No description");
     });
-    cy.get("[data-testid=cellData]").contains("Count").trigger("mouseout");
+    cy.get("[data-testid=cell-data]").contains("Count").trigger("mouseout");
 
     // Make sure new table results loaded with Custom column and Count columns
-    cy.get("[data-testid=cellData]").contains(ccName).trigger("mouseover");
+    cy.get("[data-testid=cell-data]").contains(ccName).trigger("mouseover");
     cy.wait(250);
 
     hovercard().within(() => {
@@ -254,7 +254,7 @@ describe("scenarios > visualizations > table", () => {
   it("should show the field metadata popover for a foreign key field (metabase#19577)", () => {
     openOrdersTable({ limit: 2 });
 
-    cy.get("[data-testid=cellData]")
+    cy.get("[data-testid=cell-data]")
       .contains("Product ID")
       .trigger("mouseover");
 
@@ -285,7 +285,7 @@ describe("scenarios > visualizations > table", () => {
     openNativeEditor().type("select * from products");
     cy.findByTestId("native-query-editor-container").icon("play").click();
 
-    cy.get("[data-testid=cellData]").contains("CATEGORY").realHover();
+    cy.get("[data-testid=cell-data]").contains("CATEGORY").realHover();
 
     hovercard().within(() => {
       cy.contains("No special type");

--- a/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/table.cy.spec.js
@@ -216,7 +216,7 @@ describe("scenarios > visualizations > table", () => {
         },
       ],
     ].forEach(([column, test]) => {
-      cy.get(".cellData").contains(column).trigger("mouseover");
+      cy.get("[data-testid=cellData]").contains(column).trigger("mouseover");
 
       // Add a delay here because there can be two popovers active for a very short time.
       cy.wait(250);
@@ -225,7 +225,7 @@ describe("scenarios > visualizations > table", () => {
         test();
       });
 
-      cy.get(".cellData").contains(column).trigger("mouseout");
+      cy.get("[data-testid=cellData]").contains(column).trigger("mouseout");
     });
 
     summarize();
@@ -234,15 +234,15 @@ describe("scenarios > visualizations > table", () => {
 
     cy.wait("@dataset");
 
-    cy.get(".cellData").contains("Count").trigger("mouseover");
+    cy.get("[data-testid=cellData]").contains("Count").trigger("mouseover");
     hovercard().within(() => {
       cy.contains("Quantity");
       cy.findByText("No description");
     });
-    cy.get(".cellData").contains("Count").trigger("mouseout");
+    cy.get("[data-testid=cellData]").contains("Count").trigger("mouseout");
 
     // Make sure new table results loaded with Custom column and Count columns
-    cy.get(".cellData").contains(ccName).trigger("mouseover");
+    cy.get("[data-testid=cellData]").contains(ccName).trigger("mouseover");
     cy.wait(250);
 
     hovercard().within(() => {
@@ -254,7 +254,9 @@ describe("scenarios > visualizations > table", () => {
   it("should show the field metadata popover for a foreign key field (metabase#19577)", () => {
     openOrdersTable({ limit: 2 });
 
-    cy.get(".cellData").contains("Product ID").trigger("mouseover");
+    cy.get("[data-testid=cellData]")
+      .contains("Product ID")
+      .trigger("mouseover");
 
     hovercard().within(() => {
       cy.contains("Foreign Key");
@@ -283,7 +285,7 @@ describe("scenarios > visualizations > table", () => {
     openNativeEditor().type("select * from products");
     cy.findByTestId("native-query-editor-container").icon("play").click();
 
-    cy.get(".cellData").contains("CATEGORY").realHover();
+    cy.get("[data-testid=cellData]").contains("CATEGORY").realHover();
 
     hovercard().within(() => {
       cy.contains("No special type");

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -8,8 +8,6 @@ import { Grid, ScrollSync } from "react-virtualized";
 import { t } from "ttag";
 import _ from "underscore";
 
-import "./TableInteractive.module.css";
-
 import ExplicitSize from "metabase/components/ExplicitSize";
 import { QueryColumnInfoPopover } from "metabase/components/MetadataInfo/ColumnInfoPopover";
 import Button from "metabase/core/components/Button";
@@ -40,6 +38,7 @@ import { memoizeClass } from "metabase-lib/v1/utils";
 
 import MiniBar from "../MiniBar";
 
+import TableS from "./TableInteractive.module.css";
 import {
   TableDraggable,
   ExpandButton,
@@ -114,19 +113,29 @@ class TableInteractive extends Component {
     isPivoted: false,
     hasMetadataPopovers: true,
     renderTableHeaderWrapper: children => (
-      <div className="cellData">{children}</div>
-    ),
-    renderTableCellWrapper: children => (
-      <div className={cx({ cellData: children != null && children !== "" })}>
+      <div className={TableS.cellData} data-testid="cellData">
         {children}
       </div>
     ),
+    renderTableCellWrapper: children => {
+      const hasChildren = children != null && children !== "";
+      return (
+        <div
+          className={cx({
+            [TableS.cellData]: hasChildren,
+          })}
+          data-testid={hasChildren ? "cellData" : undefined}
+        >
+          {children}
+        </div>
+      );
+    },
   };
 
   UNSAFE_componentWillMount() {
     // for measuring cells:
     this._div = document.createElement("div");
-    this._div.className = "TableInteractive";
+    this._div.className = cx(TableS.TableInteractive, "test-TableInteractive");
     this._div.style.display = "inline-block";
     this._div.style.position = "absolute";
     this._div.style.visibility = "hidden";
@@ -575,20 +584,23 @@ class TableInteractive extends Component {
           backgroundColor,
         }}
         className={cx(
-          "TableInteractive-cellWrapper",
+          TableS.TableInteractiveCellWrapper,
+          "test-TableInteractive-cellWrapper",
           CS.textDark,
           CS.hoverParent,
           CS.hoverVisibility,
           {
-            "TableInteractive-cellWrapper--firstColumn": columnIndex === 0,
-            padLeft: columnIndex === 0 && !showDetailShortcut,
-            "TableInteractive-cellWrapper--lastColumn":
+            [TableS.TableInteractiveCellWrapperFirstColumn]: columnIndex === 0,
+            "test-TableInteractive-cellWrapper--firstColumn": columnIndex === 0,
+            [TableS.padLeft]: columnIndex === 0 && !showDetailShortcut,
+            "test-TableInteractive-cellWrapper--lastColumn":
               columnIndex === cols.length - 1,
-            "TableInteractive-emptyCell": value == null,
+            "test-TableInteractive-emptyCell": value == null,
             [CS.cursorPointer]: isClickable,
             [CS.justifyEnd]: isColumnRightAligned(column),
-            "Table-ID": value != null && isID(column),
-            "Table-FK": value != null && isFK(column),
+            [TableS.TableID]: value != null && isID(column),
+            "test-Table-ID": value != null && isID(column),
+            "test-Table-FK": value != null && isFK(column),
             link: isClickable && isID(column),
           },
         )}
@@ -780,14 +792,21 @@ class TableInteractive extends Component {
               : this.getColumnLeft(style, columnIndex),
           }}
           className={cx(
-            "TableInteractive-cellWrapper TableInteractive-headerCellData",
+            TableS.TableInteractiveCellWrapper,
+            "test-TableInteractive-cellWrapper",
+            TableS.TableInteractiveHeaderCellData,
+            "test-TableInteractive-headerCellData",
             {
-              "TableInteractive-cellWrapper--firstColumn": columnIndex === 0,
-              padLeft: columnIndex === 0 && !showDetailShortcut,
-              "TableInteractive-cellWrapper--lastColumn":
+              [TableS.TableInteractiveCellWrapperFirstColumn]:
+                columnIndex === 0,
+              "test-TableInteractive-cellWrapper--firstColumn":
+                columnIndex === 0,
+              [TableS.padLeft]: columnIndex === 0 && !showDetailShortcut,
+              "test-TableInteractive-cellWrapper--lastColumn":
                 columnIndex === cols.length - 1,
-              "TableInteractive-cellWrapper--active": isDragging,
-              "TableInteractive-headerCellData--sorted": isSorted,
+              [TableS.TableInteractiveHeaderCellDataSorted]: isSorted,
+              "test-TableInteractive-headerCellData--sorted": isSorted,
+              [CS.z1]: isDragging,
               [CS.cursorPointer]: isClickable,
               [CS.justifyEnd]: isRightAligned,
             },
@@ -1005,12 +1024,15 @@ class TableInteractive extends Component {
             }
             return (
               <TableInteractiveRoot
-                className={cx(className, "TableInteractive", CS.relative, {
-                  "TableInteractive--pivot": this.props.isPivoted,
-                  "TableInteractive--ready": this.state.contentWidths,
-                  // no hover if we're dragging a column
-                  "TableInteractive--noHover": this.state.dragColIndex != null,
-                })}
+                className={cx(
+                  className,
+                  TableS.TableInteractive,
+                  "test-TableInteractive",
+                  CS.relative,
+                  {
+                    [TableS.TableInteractivePivot]: this.props.isPivoted,
+                  },
+                )}
                 onMouseEnter={this.handleOnMouseEnter}
                 onMouseLeave={this.handleOnMouseLeave}
                 data-testid="TableInteractive-root"
@@ -1024,7 +1046,7 @@ class TableInteractive extends Component {
                 {!!gutterColumn && (
                   <>
                     <div
-                      className="TableInteractive-header TableInteractive--noHover"
+                      className={TableS.TableInteractiveHeader}
                       style={{
                         position: "absolute",
                         top: 0,
@@ -1036,7 +1058,7 @@ class TableInteractive extends Component {
                     />
                     <div
                       id="gutter-column"
-                      className="TableInteractive-gutter"
+                      className={TableS.TableInteractiveGutter}
                       style={{
                         position: "absolute",
                         top: headerHeight,
@@ -1063,7 +1085,10 @@ class TableInteractive extends Component {
                     overflow: "hidden",
                     paddingRight: getScrollBarSize(),
                   }}
-                  className={cx("TableInteractive-header", CS.scrollHideAll)}
+                  className={cx(
+                    TableS.TableInteractiveHeader,
+                    CS.scrollHideAll,
+                  )}
                   width={width || 0}
                   height={headerHeight}
                   rowCount={1}
@@ -1169,7 +1194,11 @@ export default _.compose(
 
 const DetailShortcut = forwardRef((_props, ref) => (
   <div
-    className={cx("TableInteractive-cellWrapper", CS.cursorPointer)}
+    className={cx(
+      TableS.TableInteractiveCellWrapper,
+      "test-TableInteractive-cellWrapper",
+      CS.cursorPointer,
+    )}
     ref={ref}
     style={{
       position: "absolute",

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -113,7 +113,7 @@ class TableInteractive extends Component {
     isPivoted: false,
     hasMetadataPopovers: true,
     renderTableHeaderWrapper: children => (
-      <div className={TableS.cellData} data-testid="cellData">
+      <div className={TableS.cellData} data-testid="cell-data">
         {children}
       </div>
     ),
@@ -124,7 +124,7 @@ class TableInteractive extends Component {
           className={cx({
             [TableS.cellData]: hasChildren,
           })}
-          data-testid={hasChildren ? "cellData" : undefined}
+          data-testid={hasChildren ? "cell-data" : undefined}
         >
           {children}
         </div>

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.module.css
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.module.css
@@ -1,13 +1,9 @@
-:root {
-  --table-border-radius: 6px;
-}
-
-:global(.TableInteractive) {
+.TableInteractive {
   color: #4f575d;
   overflow: hidden;
 }
 
-:global(.TableInteractive-headerCellData .cellData) {
+.TableInteractiveHeaderCellData .cellData {
   font-weight: 900;
   font-size: 10px;
   border: 1px solid transparent;
@@ -17,27 +13,21 @@
   color: var(--color-brand);
 }
 
-:global(.TableInteractive-headerCellData .cellData:hover) {
+.TableInteractiveHeaderCellData .cellData:hover {
   border: 1px solid transparent;
 }
 
-:global(.TableInteractive-headerCellData .Icon-chevrondown),
-:global(.TableInteractive-headerCellData .Icon-chevronup) {
+.TableInteractiveHeaderCellData :global(.Icon-chevrondown),
+.TableInteractiveHeaderCellData :global(.Icon-chevronup) {
   opacity: 0.5;
 }
 
-:global(.TableInteractive-headerCellData--sorted .Icon-chevrondown),
-:global(.TableInteractive-headerCellData--sorted .Icon-chevronup) {
-  opacity: 1;
-  transition: opacity 0.3s linear;
-}
-
-:global(.TableInteractive-header) {
+.TableInteractiveHeader {
   box-sizing: border-box;
   border-bottom: 1px solid var(--color-border);
 }
 
-:global(.TableInteractive .TableInteractive-cellWrapper) {
+.TableInteractive .TableInteractiveCellWrapper {
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -47,30 +37,20 @@
   border-bottom: 1px solid color-mod(var(--color-border) alpha(-70%));
 }
 
-:global(.TableInteractive .TableInteractive-cellWrapper--active) {
-  z-index: 1;
-}
-
-:global(.TableInteractive .TableInteractive-header),
-:global(.TableInteractive
-    .TableInteractive-header
-    .TableInteractive-cellWrapper),
-:global(.TableInteractive
-    .TableInteractive-header
-    .TableInteractive-cellWrapper:hover) {
+.TableInteractive .TableInteractiveHeader,
+.TableInteractive .TableInteractiveHeader .TableInteractiveCellWrapper,
+.TableInteractive .TableInteractiveHeader .TableInteractiveCellWrapper:hover {
   background-color: var(--color-bg-white);
   background-image: none;
 }
 
-:global(.TableInteractive .TableInteractive-header),
-:global(.TableInteractive
-    .TableInteractive-header
-    .TableInteractive-cellWrapper) {
+.TableInteractive .TableInteractiveHeader,
+.TableInteractive .TableInteractiveHeader .TableInteractiveCellWrapper {
   background-color: var(--color-bg-white);
 }
 
 /* cell overflow ellipsis */
-:global(.TableInteractive .cellData) {
+.TableInteractive .cellData {
   margin: 0 0.75em;
   display: block;
   white-space: nowrap;
@@ -81,28 +61,24 @@
 }
 
 /* pivot */
-:global(.TableInteractive.TableInteractive--pivot
-    .TableInteractive-cellWrapper--firstColumn) {
+.TableInteractive.TableInteractivePivot
+  .TableInteractiveCellWrapperFirstColumn {
   border-right: 1px solid var(--color-border);
 }
 
-:global(.PagingButtons) {
-  border: 1px solid var(--color-border);
-}
-
-:global(.TableInteractive
-    .TableInteractive-header
-    .TableInteractive-cellWrapper.tether-enabled
-    .cellData) {
+.TableInteractive
+  .TableInteractiveHeader
+  .TableInteractiveCellWrapper:global(.tether-enabled)
+  .cellData {
   background-color: transparent;
   color: white !important;
 }
 
-:global(.TableInteractive-cellWrapper:hover) {
+.TableInteractiveCellWrapper:hover {
   background-color: transparent;
 }
 
-:global(.Table-ID .cellData) {
+.TableID .cellData {
   border: 1px solid transparent;
   background-color: transparent;
   padding: 0.25em 0.65em;
@@ -112,26 +88,20 @@
   color: var(--color-brand);
 }
 
-:global(.TableInteractive-ID.TableInteractive-cellWrapper:hover),
-:global(.TableInteractive-ID.TableInteractive-cellWrapper.tether-enabled) {
-  background-color: transparent;
-}
-
-:global(.TableInteractive-ID.TableInteractive-cellWrapper:hover .cellData),
-:global(.TableInteractive-ID.TableInteractive-cellWrapper.tether-enabled
-    .cellData) {
-  background-color: var(--color-brand);
-  color: white;
-}
-
-:global(.TableInteractive-headerCellData--sorted) {
+.TableInteractiveHeaderCellDataSorted {
   color: var(--color-brand);
 }
 
-:global(.TableInteractive-cellWrapper--firstColumn.padLeft) {
+.TableInteractiveHeaderCellDataSorted :global(.Icon-chevrondown),
+.TableInteractiveHeaderCellDataSorted :global(.Icon-chevronup) {
+  opacity: 1;
+  transition: opacity 0.3s linear;
+}
+
+.TableInteractiveCellWrapperFirstColumn.padLeft {
   padding-left: 1.5em;
 }
 
-:global(.TableInteractive-gutter) {
+.TableInteractiveGutter {
   background-color: var(--color-bg-white);
 }

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
@@ -4,8 +4,9 @@ import Draggable from "react-draggable";
 
 import Button from "metabase/core/components/Button";
 import { alpha, color, lighten } from "metabase/lib/colors";
-import TableS from "metabase/visualizations/components/TableInteractive/TableInteractive.module.css";
 import { TableRoot } from "metabase/visualizations/components/TableRoot";
+
+import TableS from "./TableInteractive.module.css";
 
 export const TableInteractiveRoot = styled(TableRoot)`
   .${TableS.TableInteractiveHeaderCellData} .${TableS.cellData} {

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.styled.tsx
@@ -4,18 +4,19 @@ import Draggable from "react-draggable";
 
 import Button from "metabase/core/components/Button";
 import { alpha, color, lighten } from "metabase/lib/colors";
+import TableS from "metabase/visualizations/components/TableInteractive/TableInteractive.module.css";
 import { TableRoot } from "metabase/visualizations/components/TableRoot";
 
 export const TableInteractiveRoot = styled(TableRoot)`
-  .TableInteractive-headerCellData .cellData {
+  .${TableS.TableInteractiveHeaderCellData} .${TableS.cellData} {
     border: 1px solid ${alpha("brand", 0.2)};
   }
 
-  .TableInteractive-headerCellData .cellData:hover {
+  .${TableS.TableInteractiveHeaderCellData} .${TableS.cellData}:hover {
     border: 1px solid ${alpha("brand", 0.56)};
   }
 
-  .TableInteractive-cellWrapper:hover {
+  .${TableS.TableInteractiveCellWrapper}:hover {
     background-color: ${alpha("brand", 0.1)};
   }
 `;

--- a/frontend/src/metabase/visualizations/components/TableRoot/TableRoot.styled.tsx
+++ b/frontend/src/metabase/visualizations/components/TableRoot/TableRoot.styled.tsx
@@ -1,9 +1,10 @@
 import styled from "@emotion/styled";
 
 import { alpha } from "metabase/lib/colors";
+import TableS from "metabase/visualizations/components/TableInteractive/TableInteractive.module.css";
 
 export const TableRoot = styled.div`
-  .Table-ID .cellData {
+  .${TableS.TableID} .${TableS.cellData} {
     border: 1px solid ${alpha("brand", 0.14)};
     background-color: ${alpha("brand", 0.08)};
   }

--- a/frontend/src/metabase/visualizations/components/TableSimple/TableCell.tsx
+++ b/frontend/src/metabase/visualizations/components/TableSimple/TableCell.tsx
@@ -6,6 +6,7 @@ import DashboardS from "metabase/css/dashboard.module.css";
 import { formatValue } from "metabase/lib/formatting";
 import type { OptionsType } from "metabase/lib/formatting/types";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
+import TableS from "metabase/visualizations/components/TableInteractive/TableInteractive.module.css";
 import {
   getTableCellClickedObject,
   getTableClickedObjectRowData,
@@ -175,8 +176,9 @@ export function TableCell({
         DashboardS.fullscreenNightText,
         EmbedFrameS.fullscreenNightText,
         {
-          "Table-ID": value != null && isID(column),
-          "Table-FK": value != null && isFK(column),
+          [TableS.TableID]: value != null && isID(column),
+          "test-Table-ID": value != null && isID(column),
+          "test-Table-FK": value != null && isFK(column),
           link: isClickable && isID(column),
         },
       ),
@@ -190,7 +192,7 @@ export function TableCell({
       isRightAligned={isColumnRightAligned(column)}
     >
       <CellContent
-        className="cellData"
+        className={TableS.cellData}
         isClickable={isClickable}
         onClick={isClickable ? onClick : undefined}
         data-testid="cell-data"


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41258

### Description

This removes most of global css from `frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.module.css`

