### PR TITLE
fix bar min height can be less than 1

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.stories.tsx
@@ -717,6 +717,13 @@ BarStackedSeriesLabelsAutoCompactness.args = {
   renderingContext,
 };
 
+export const BarMinHeightLimit = Template.bind({});
+BarMinHeightLimit.args = {
+  rawSeries: data.barMinHeightLimit as any,
+  dashcardSettings: {},
+  renderingContext,
+};
+
 export const Default = Template.bind({});
 Default.args = {
   rawSeries: data.messedUpAxis as any,

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-min-height-limit.json
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/bar-min-height-limit.json
@@ -1,0 +1,225 @@
+[
+  {
+    "card": {
+      "public_uuid": null,
+      "parameter_usage_count": 0,
+      "created_at": "2024-04-11T00:27:17.204667Z",
+      "parameters": [],
+      "metabase_version": "v0.48.1-SNAPSHOT (04238f7)",
+      "collection": null,
+      "visualization_settings": {
+        "graph.dimensions": ["X"],
+        "graph.series_order_dimension": null,
+        "graph.series_order": null,
+        "graph.metrics": ["Y"]
+      },
+      "collection_preview": true,
+      "entity_id": "xuWz2ZOsTqp7QthPV0bPV",
+      "display": "bar",
+      "parameter_mappings": [],
+      "id": 135,
+      "dataset_query": {
+        "database": 1,
+        "type": "native",
+        "native": {
+          "query": "select 1 x, 100000000 y\nunion all select 2, 100\nunion all select 3, 1",
+          "template-tags": {}
+        }
+      },
+      "cache_ttl": null,
+      "embedding_params": null,
+      "made_public_by_id": null,
+      "updated_at": "2024-04-11T00:27:17.204667Z",
+      "moderation_reviews": [],
+      "creator_id": 1,
+      "average_query_time": null,
+      "type": "question",
+      "dashboard_count": 0,
+      "last_query_start": null,
+      "name": "bar min height",
+      "query_type": "native",
+      "collection_id": null,
+      "enable_embedding": false,
+      "database_id": 1,
+      "can_write": true,
+      "initially_published_at": null,
+      "result_metadata": [
+        {
+          "display_name": "X",
+          "field_ref": [
+            "field",
+            "X",
+            {
+              "base-type": "type/Integer"
+            }
+          ],
+          "name": "X",
+          "base_type": "type/Integer",
+          "effective_type": "type/Integer",
+          "semantic_type": null,
+          "fingerprint": {
+            "global": {
+              "distinct-count": 3,
+              "nil%": 0
+            },
+            "type": {
+              "type/Number": {
+                "min": 1,
+                "q1": 1.25,
+                "q3": 2.75,
+                "max": 3,
+                "sd": 1,
+                "avg": 2
+              }
+            }
+          }
+        },
+        {
+          "display_name": "Y",
+          "field_ref": [
+            "field",
+            "Y",
+            {
+              "base-type": "type/Integer"
+            }
+          ],
+          "name": "Y",
+          "base_type": "type/Integer",
+          "effective_type": "type/Integer",
+          "semantic_type": null,
+          "fingerprint": {
+            "global": {
+              "distinct-count": 3,
+              "nil%": 0
+            },
+            "type": {
+              "type/Number": {
+                "min": 1,
+                "q1": 25.75,
+                "q3": 75000025,
+                "max": 100000000,
+                "sd": 57734997.7627952,
+                "avg": 33333367
+              }
+            }
+          }
+        }
+      ],
+      "table_id": null,
+      "collection_position": null,
+      "archived": false,
+      "description": null,
+      "cache_invalidated_at": null,
+      "displayIsLocked": true
+    },
+    "data": {
+      "rows": [
+        [1, 100000000],
+        [2, 100],
+        [3, 1]
+      ],
+      "cols": [
+        {
+          "display_name": "X",
+          "source": "native",
+          "field_ref": [
+            "field",
+            "X",
+            {
+              "base-type": "type/Integer"
+            }
+          ],
+          "name": "X",
+          "base_type": "type/Integer",
+          "effective_type": "type/Integer"
+        },
+        {
+          "display_name": "Y",
+          "source": "native",
+          "field_ref": [
+            "field",
+            "Y",
+            {
+              "base-type": "type/Integer"
+            }
+          ],
+          "name": "Y",
+          "base_type": "type/Integer",
+          "effective_type": "type/Integer"
+        }
+      ],
+      "native_form": {
+        "params": null,
+        "query": "select 1 x, 100000000 y\nunion all select 2, 100\nunion all select 3, 1"
+      },
+      "format-rows?": true,
+      "results_timezone": "America/Montevideo",
+      "requested_timezone": "Pacific/Guam",
+      "results_metadata": {
+        "columns": [
+          {
+            "display_name": "X",
+            "field_ref": [
+              "field",
+              "X",
+              {
+                "base-type": "type/Integer"
+              }
+            ],
+            "name": "X",
+            "base_type": "type/Integer",
+            "effective_type": "type/Integer",
+            "semantic_type": null,
+            "fingerprint": {
+              "global": {
+                "distinct-count": 3,
+                "nil%": 0
+              },
+              "type": {
+                "type/Number": {
+                  "min": 1,
+                  "q1": 1.25,
+                  "q3": 2.75,
+                  "max": 3,
+                  "sd": 1,
+                  "avg": 2
+                }
+              }
+            }
+          },
+          {
+            "display_name": "Y",
+            "field_ref": [
+              "field",
+              "Y",
+              {
+                "base-type": "type/Integer"
+              }
+            ],
+            "name": "Y",
+            "base_type": "type/Integer",
+            "effective_type": "type/Integer",
+            "semantic_type": null,
+            "fingerprint": {
+              "global": {
+                "distinct-count": 3,
+                "nil%": 0
+              },
+              "type": {
+                "type/Number": {
+                  "min": 1,
+                  "q1": 25.75,
+                  "q3": 75000025,
+                  "max": 100000000,
+                  "sd": 57734997.7627952,
+                  "avg": 33333367
+                }
+              }
+            }
+          }
+        ]
+      },
+      "insights": null
+    }
+  }
+]

--- a/frontend/src/metabase/static-viz/components/ComboChart/stories-data/index.ts
+++ b/frontend/src/metabase/static-viz/components/ComboChart/stories-data/index.ts
@@ -24,6 +24,7 @@ import barHistogramXScale from "./bar-histogram-x-scale.json";
 import barLinearXScale from "./bar-linear-x-scale.json";
 import barLogYScaleStackedNegative from "./bar-log-y-scale-stacked-negative.json";
 import barLogYScaleStacked from "./bar-log-y-scale-stacked.json";
+import barMinHeightLimit from "./bar-min-height-limit.json";
 import barOrdinalXScaleAutoRotatedLabels from "./bar-ordinal-x-scale-auto-rotated-labels.json";
 import barOrdinalXScale from "./bar-ordinal-x-scale.json";
 import barRelativeDatetimeOrdinalScale from "./bar-relative-datetime-ordinal-scale.json";
@@ -110,6 +111,7 @@ export const data = {
   lineFullyNullDimension37902,
   areaFullyNullDimension37902,
   barCorrectWidthWhenTwoYAxes,
+  barMinHeightLimit,
   barLinearXScale,
   barHistogramXScale,
   barHistogramMultiSeries,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/waterfall/option/index.ts
@@ -108,7 +108,7 @@ export const buildEChartsWaterfallSeries = (
 
   const buildLabelOption = () => ({
     ...buildEChartsLabelOptions(
-      seriesModel,
+      seriesModel.dataKey,
       chartModel.yAxisScaleTransforms,
       renderingContext,
       labelFormatter,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41291

### Description

When a bar series have a wide extent so that small values are estimated as less than 1px they can appear invisible which can be misleading. This PR sets min bar height to 1px as it was in the previous implementation.

### How to verify

Check that small values on wide extent are still visible for bar charts:
```
select 1 x, 100000000 y
union all select 2, 100
union all select 3, 1
```

### Demo

Before
<img width="1342" alt="Screenshot 2024-04-10 at 9 32 34 PM" src="https://github.com/metabase/metabase/assets/14301985/9378147a-d83c-4a89-a31c-60a0c040e284">

After
<img width="1338" alt="Screenshot 2024-04-10 at 9 32 16 PM" src="https://github.com/metabase/metabase/assets/14301985/b9638feb-bb2c-4de6-ae0e-e1bc44fff5c8">

Stats
<img width="1359" alt="Screenshot 2024-04-10 at 9 31 58 PM" src="https://github.com/metabase/metabase/assets/14301985/3a8c2b2f-65ce-48b2-aa73-a6bf761bb25a">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
