### PR TITLE
hide axes on small dashcards

### DIFF
--- a/frontend/src/metabase-types/api/card.ts
+++ b/frontend/src/metabase-types/api/card.ts
@@ -149,7 +149,7 @@ export type VisualizationSettings = {
   // Y-axis
   "graph.y_axis.title_text"?: string;
   "graph.y_axis.scale"?: YAxisScale;
-  "graph.y_axis.axis_enabled"?: true;
+  "graph.y_axis.axis_enabled"?: boolean;
 
   "graph.y_axis.min"?: number;
   "graph.y_axis.max"?: number;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -14,6 +14,7 @@ import { useChartEvents } from "metabase/visualizations/visualizations/Cartesian
 
 import { useChartDebug } from "./use-chart-debug";
 import { useModelsAndOption } from "./use-models-and-option";
+import { getGridSizeAdjustedSettings } from "./utils";
 
 function _CartesianChart(props: VisualizationProps) {
   // The width and height from props reflect the dimensions of the entire container which includes legend,
@@ -22,8 +23,9 @@ function _CartesianChart(props: VisualizationProps) {
 
   const {
     rawSeries,
-    settings,
+    settings: originalSettings,
     card,
+    gridSize,
     width,
     showTitle,
     headerIcon,
@@ -34,10 +36,17 @@ function _CartesianChart(props: VisualizationProps) {
     onChangeCardAndRun,
     onHoverChange,
   } = props;
+
+  const settings = useMemo(
+    () => getGridSizeAdjustedSettings(originalSettings, gridSize),
+    [originalSettings, gridSize],
+  );
+
   const { chartModel, timelineEventsModel, option } = useModelsAndOption({
     ...props,
     width: chartSize.width,
     height: chartSize.height,
+    settings,
   });
   useChartDebug({ isQueryBuilder, rawSeries, option });
 

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -1,0 +1,46 @@
+import type {
+  ComputedVisualizationSettings,
+  VisualizationGridSize,
+} from "metabase/visualizations/types";
+
+const getFidelity = (gridSize?: VisualizationGridSize) => {
+  const fidelity = { x: 0, y: 0 };
+  const size = gridSize || { width: Infinity, height: Infinity };
+  if (size.width >= 5) {
+    fidelity.x = 2;
+  } else if (size.width >= 4) {
+    fidelity.x = 1;
+  }
+  if (size.height >= 5) {
+    fidelity.y = 2;
+  } else if (size.height >= 4) {
+    fidelity.y = 1;
+  }
+
+  return fidelity;
+};
+
+export const getGridSizeAdjustedSettings = (
+  settings: ComputedVisualizationSettings,
+  gridSize?: VisualizationGridSize,
+) => {
+  const fidelity = getFidelity(gridSize);
+  const newSettings = { ...settings };
+
+  // smooth interpolation at smallest x/y fidelity
+  if (fidelity.x === 0 && fidelity.y === 0) {
+    newSettings["line.interpolate"] = "cardinal";
+  }
+
+  // no axis in < 1 fidelity
+  if (fidelity.x < 1 || fidelity.y < 1) {
+    newSettings["graph.y_axis.axis_enabled"] = false;
+  }
+
+  // no labels in < 2 fidelity
+  if (fidelity.x < 2 || fidelity.y < 2) {
+    newSettings["graph.y_axis.labels_enabled"] = false;
+  }
+
+  return newSettings;
+};


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41273

### Description

This PR restores exact logic existed before in `LineAreaBarChart.jsx` which hides axes on small dashcards. It is not ideal and we should [improve](https://metaboat.slack.com/archives/C05NQSWPRMK/p1712338990703189) it later but now we need to at least fix the regression 

### How to verify

Check on small dashcards y-axis title and the axis itself get hidden on small cards

### Demo

Y-axis is enabled but the size of the dashcard overrides this:
<img width="346" alt="Screenshot 2024-04-10 at 10 26 35 PM" src="https://github.com/metabase/metabase/assets/14301985/f44480e9-f51a-4db3-a964-e0d0776a42b3">

