### PR TITLE
fix legend hover does not focus on series, fix area blur style

### DIFF
--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/series.ts
@@ -370,6 +370,7 @@ const buildEChartsLineAreaSeries = (
       lineStyle: {
         opacity: blurOpacity,
       },
+      areaStyle: { opacity: CHART_STYLE.opacity.area },
     },
     z: CHART_STYLE.series.zIndexLineArea,
     id: seriesModel.dataKey,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -190,7 +190,7 @@ export const useChartEvents = (
 
       const { datumIndex: originalDatumIndex, index } = hovered;
       const hoveredSeries = chartModel.seriesModels[index];
-      if (!hoveredSeries || !originalDatumIndex) {
+      if (!hoveredSeries) {
         return;
       }
 
@@ -200,26 +200,30 @@ export const useChartEvents = (
         option?.series as LineSeriesOption[]
       ).findIndex(series => series.id === hoveredSeries.dataKey);
 
-      // (issue #40215)
-      // since some transformed datasets have indexes differing from
-      // the original datasets indexes and ECharts uses the transformedDataset
-      // for rendering, we need to figure out the correct transformedDataset's
-      // index in order to highlight the correct element
-      const transformedDatumIndex = getTransformedDatumIndex(
-        chartModel.transformedDataset,
-        originalDatumIndex,
-      );
+      let dataIndex: number | undefined;
+
+      if (originalDatumIndex != null) {
+        // (issue #40215)
+        // since some transformed datasets have indexes differing from
+        // the original datasets indexes and ECharts uses the transformedDataset
+        // for rendering, we need to figure out the correct transformedDataset's
+        // index in order to highlight the correct element
+        dataIndex = getTransformedDatumIndex(
+          chartModel.transformedDataset,
+          originalDatumIndex,
+        );
+      }
 
       chart.dispatchAction({
         type: "highlight",
-        dataIndex: transformedDatumIndex,
+        dataIndex,
         seriesIndex: eChartsSeriesIndex,
       });
 
       return () => {
         chart.dispatchAction({
           type: "downplay",
-          dataIndex: transformedDatumIndex,
+          dataIndex,
           seriesIndex: eChartsSeriesIndex,
         });
       };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41287

### Description

Fixes legend item hover did not focus on series by making all others blurred.

### How to verify

- Create a chart with multiple series
- Hover legend items for each series
- Ensure the series gets focused

### Demo

<img width="1367" alt="Screenshot 2024-04-10 at 11 26 26 PM" src="https://github.com/metabase/metabase/assets/14301985/f125ecbc-3a90-434a-9685-a482c1f18514">

