### PR TITLE
New default permissions for groups

### DIFF
--- a/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
+++ b/e2e/test/scenarios/permissions/download-permissions.cy.spec.js
@@ -19,7 +19,7 @@ import {
   setTokenFeatures,
 } from "e2e/support/helpers";
 
-const { ALL_USERS_GROUP } = USER_GROUPS;
+const { ALL_USERS_GROUP, COLLECTION_GROUP, DATA_GROUP } = USER_GROUPS;
 
 const {
   PRODUCTS_ID,
@@ -40,6 +40,19 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
     restore();
     cy.signInAsAdmin();
     setTokenFeatures("all");
+    // Restrict downloads for Collection and Data groups before each test so that they don't override All Users
+    cy.updatePermissionsGraph({
+      [COLLECTION_GROUP]: {
+        [SAMPLE_DB_ID]: {
+          download: { schemas: "none" },
+        },
+      },
+      [DATA_GROUP]: {
+        [SAMPLE_DB_ID]: {
+          download: { schemas: "none" },
+        },
+      },
+    });
   });
 
   it("setting downloads permission UI flow should work", () => {
@@ -96,9 +109,9 @@ describeEE("scenarios > admin > permissions > data > downloads", () => {
     // When data permissions are set to `Blocked`, download permissions are automatically revoked
     assertPermissionForItem("All Users", DOWNLOAD_PERMISSION_INDEX, "No");
 
-    // Normal user belongs to both "data" and "collections" groups.
+    // Normal user belongs to both "data" and "collection" groups.
     // They both have restricted downloads so this user shouldn't have the right to download anything.
-    cy.signIn("normal");
+    cy.signInAsNormalUser();
 
     visitQuestion(ORDERS_QUESTION_ID);
 

--- a/e2e/test/scenarios/permissions/view-data/blocked.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data/blocked.cy.spec.js
@@ -60,10 +60,17 @@ describeEE("scenarios > admin > permissions > view data > blocked", () => {
       ],
       // expect that the view data permissions has been automatically droped to query builder only
       ["All Users", "Blocked", "No", "No", "No", "No"],
-      ["collection", "Can view", "No", "No", "No", "No"],
-      ["data", "Can view", "Query builder and native", "No", "No", "No"],
-      ["nosql", "Can view", "Query builder only", "No", "No", "No"],
-      ["readonly", "Can view", "No", "No", "No", "No"],
+      ["collection", "Can view", "No", "1 million rows", "No", "No"],
+      [
+        "data",
+        "Can view",
+        "Query builder and native",
+        "1 million rows",
+        "No",
+        "No",
+      ],
+      ["nosql", "Can view", "Query builder only", "1 million rows", "No", "No"],
+      ["readonly", "Can view", "No", "1 million rows", "No", "No"],
     ]);
   });
 });

--- a/e2e/test/scenarios/permissions/view-data/sandboxed.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/view-data/sandboxed.cy.spec.ts
@@ -74,10 +74,10 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
       ],
       // expect that the view data permissions has been automatically droped to query builder only
       ["All Users", "Sandboxed", "Query builder only", "1 million rows", "No"],
-      ["collection", "Can view", "No", "No", "No"],
-      ["data", "Can view", "Query builder and native", "No", "No"],
-      ["nosql", "Can view", "Query builder only", "No", "No"],
-      ["readonly", "Can view", "No", "No", "No"],
+      ["collection", "Can view", "No", "1 million rows", "No"],
+      ["data", "Can view", "Query builder and native", "1 million rows", "No"],
+      ["nosql", "Can view", "Query builder only", "1 million rows", "No"],
+      ["readonly", "Can view", "No", "1 million rows", "No"],
     ];
     assertPermissionTable(expectedFinalPermissions);
 

--- a/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
+++ b/enterprise/backend/src/metabase_enterprise/advanced_permissions/common.clj
@@ -201,6 +201,8 @@
           (premium-features/enable-sandboxes?)
           (t2/exists? :model/GroupTableAccessPolicy
                       :group_id all-users-group-id
-                      :db_id db-id)))
+                      {:from [[:sandboxes :s]]
+                       :join [[:metabase_table :t] [:= :s.table_id :t.id]]
+                       :where [:= :t.db_id db-id]})))
       :blocked
       :unrestricted)))

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -654,7 +654,7 @@
                                                    :perm_type :perms/download-results
                                                    :db_id db-id
                                                    :group_id all-users-group-id)
-                                 (coalesce-most-restrictive :perms/create-queries))]
+                                 (coalesce-most-restrictive :perms/download-results))]
     (set-database-permission! group-or-id db-or-id :perms/view-data view-data-level)
     (set-database-permission! group-or-id db-or-id :perms/create-queries create-queries-level)
     (set-database-permission! group-or-id db-or-id :perms/download-results download-level)

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -7,7 +7,6 @@
    [metabase.api.common :as api]
    [metabase.config :as config]
    [metabase.models.interface :as mi]
-   [metabase.models.permissions-group :as perms-group]
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
@@ -641,21 +640,20 @@
 (defn set-new-group-permissions!
   "Sets permissions for a newly-added group to their appropriate values for a single database. This is generally based
   on the permissions of the All Users group."
-  [group-or-id db-or-id]
+  [group-or-id db-or-id all-users-group-id]
   (let [db-id                (u/the-id db-or-id)
-        all-users-id         (u/the-id (perms-group/all-users))
         view-data-level      (new-group-view-data-permission-level db-id)
         create-queries-level (->> (t2/select-fn-set :value
                                                     [:model/DataPermissions [:perm_value :value]]
                                                     :perm_type :perms/create-queries
                                                     :db_id db-id
-                                                    :group_id all-users-id)
+                                                    :group_id all-users-group-id)
                                   (coalesce-most-restrictive :perms/create-queries))
         download-level      (->> (t2/select-fn-set :value
                                                    [:model/DataPermissions [:perm_value :value]]
                                                    :perm_type :perms/download-results
                                                    :db_id db-id
-                                                   :group_id all-users-id)
+                                                   :group_id all-users-group-id)
                                  (coalesce-most-restrictive :perms/create-queries))]
     (set-database-permission! group-or-id db-or-id :perms/view-data view-data-level)
     (set-database-permission! group-or-id db-or-id :perms/create-queries create-queries-level)

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -643,18 +643,20 @@
   [group-or-id db-or-id all-users-group-id]
   (let [db-id                (u/the-id db-or-id)
         view-data-level      (new-group-view-data-permission-level db-id)
-        create-queries-level (->> (t2/select-fn-set :value
-                                                    [:model/DataPermissions [:perm_value :value]]
-                                                    :perm_type :perms/create-queries
-                                                    :db_id db-id
-                                                    :group_id all-users-group-id)
-                                  (coalesce-most-restrictive :perms/create-queries))
-        download-level      (->> (t2/select-fn-set :value
-                                                   [:model/DataPermissions [:perm_value :value]]
-                                                   :perm_type :perms/download-results
-                                                   :db_id db-id
-                                                   :group_id all-users-group-id)
-                                 (coalesce-most-restrictive :perms/download-results))]
+        create-queries-level (or (->> (t2/select-fn-set :value
+                                                        [:model/DataPermissions [:perm_value :value]]
+                                                        :perm_type :perms/create-queries
+                                                        :db_id db-id
+                                                        :group_id all-users-group-id)
+                                      (coalesce-most-restrictive :perms/create-queries))
+                                 :query-builder-and-native)
+        download-level      (or (->> (t2/select-fn-set :value
+                                                       [:model/DataPermissions [:perm_value :value]]
+                                                       :perm_type :perms/download-results
+                                                       :db_id db-id
+                                                       :group_id all-users-group-id)
+                                     (coalesce-most-restrictive :perms/download-results))
+                                :one-million-rows)]
     (set-database-permission! group-or-id db-or-id :perms/view-data view-data-level)
     (set-database-permission! group-or-id db-or-id :perms/create-queries create-queries-level)
     (set-database-permission! group-or-id db-or-id :perms/download-results download-level)

--- a/src/metabase/models/data_permissions.clj
+++ b/src/metabase/models/data_permissions.clj
@@ -10,7 +10,6 @@
    [metabase.public-settings.premium-features :refer [defenterprise]]
    [metabase.util :as u]
    [metabase.util.i18n :refer [tru]]
-   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [methodical.core :as methodical]
    [toucan2.core :as t2])
@@ -697,9 +696,7 @@
   "Sets permissions for a newly-added database to their appropriate values for a single group. For certain permission
   types, the value computed based on the existing permissions the group has for other databases."
   [group-or-id db-or-id]
-  (log/errorf "Setting new database permissions for group %d on database %d" group-or-id db-or-id)
   (doseq [[perm-type perm-value] (new-database-permissions group-or-id)]
-    (log/errorf "Setting %s to %s" perm-type perm-value)
     (set-database-permission! group-or-id db-or-id perm-type perm-value)))
 
 (mu/defn set-table-permissions!

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -96,7 +96,7 @@
   [group]
   (t2/with-transaction [_conn]
     (doseq [db-id (t2/select-pks-vec :model/Database)]
-      (data-perms/set-new-group-permissions! group db-id (u/the-id all-users)))))
+      (data-perms/set-new-group-permissions! group db-id (u/the-id (all-users))))))
 
 (t2/define-after-insert :model/PermissionsGroup
   [group]

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -94,14 +94,9 @@
 
 (defn- set-default-permission-values!
   [group]
-  ;; New groups get data access but no query permissions by default, and no other perms
   (t2/with-transaction [_conn]
     (doseq [db-id (t2/select-pks-vec :model/Database)]
-      (data-perms/set-database-permission! group db-id :perms/view-data             :unrestricted)
-      (data-perms/set-database-permission! group db-id :perms/create-queries        :no)
-      (data-perms/set-database-permission! group db-id :perms/download-results      :no)
-      (data-perms/set-database-permission! group db-id :perms/manage-table-metadata :no)
-      (data-perms/set-database-permission! group db-id :perms/manage-database       :no))))
+      (data-perms/set-new-group-permissions! group db-id))))
 
 (t2/define-after-insert :model/PermissionsGroup
   [group]

--- a/src/metabase/models/permissions_group.clj
+++ b/src/metabase/models/permissions_group.clj
@@ -96,7 +96,7 @@
   [group]
   (t2/with-transaction [_conn]
     (doseq [db-id (t2/select-pks-vec :model/Database)]
-      (data-perms/set-new-group-permissions! group db-id))))
+      (data-perms/set-new-group-permissions! group db-id (u/the-id all-users)))))
 
 (t2/define-after-insert :model/PermissionsGroup
   [group]

--- a/test/metabase/api/permissions_test.clj
+++ b/test/metabase/api/permissions_test.clj
@@ -192,13 +192,15 @@
     (testing "make sure we can update the perms graph from the API"
       (testing "Table-specific perms"
         (t2.with-temp/with-temp [PermissionsGroup group]
+          (data-perms/set-database-permission! group (mt/id) :perms/create-queries :no)
           (mt/user-http-request
            :crowberto :put 200 "permissions/graph"
            (assoc-in (data-perms.graph/api-graph)
                      [:groups (u/the-id group) (mt/id) :create-queries]
                      {"PUBLIC" {(mt/id :venues) :query-builder
-                                (mt/id :orders) :no}}))
-          (is (= {(mt/id :venues) :query-builder}
+                                (mt/id :orders) :query-builder}}))
+          (is (= {(mt/id :venues) :query-builder
+                  (mt/id :orders) :query-builder}
                  (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) (mt/id) :create-queries "PUBLIC"]))))))))
 
 (deftest update-perms-graph-perms-for-new-db-test
@@ -213,9 +215,10 @@
                    [:groups (u/the-id group) db-id]
                    {:view-data :unrestricted
                     :create-queries :query-builder}))
-        (is (= {:view-data :unrestricted
-                :create-queries :query-builder}
-               (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) db-id])))))))
+        (is (partial=
+             {:view-data :unrestricted
+              :create-queries :query-builder}
+             (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) db-id])))))))
 
 (deftest update-perms-graph-perms-for-new-db-with-no-tables-test
   (testing "PUT /api/permissions/graph"
@@ -228,9 +231,10 @@
                    [:groups (u/the-id group) db-id]
                    {:view-data :unrestricted
                     :create-queries :query-builder}))
-        (is (= {:view-data :unrestricted
-                :create-queries :query-builder}
-               (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) db-id])))))))
+        (is (partial=
+             {:view-data :unrestricted
+              :create-queries :query-builder}
+             (get-in (data-perms.graph/api-graph) [:groups (u/the-id group) db-id])))))))
 
 (deftest update-perms-graph-with-skip-graph-skips-graph-test
   (testing "PUT /api/permissions/graph"

--- a/test/metabase/models/data_permissions/graph_test.clj
+++ b/test/metabase/models/data_permissions/graph_test.clj
@@ -427,6 +427,7 @@
 (deftest graph-set-partial-permissions-for-table-test
   (testing "Test that setting partial permissions for a table retains permissions for other tables -- #3888"
     (mt/with-temp [:model/PermissionsGroup group]
+      (data-perms/set-database-permission! group (mt/id) :perms/create-queries :no)
       (testing "before"
         ;; first, graph permissions only for VENUES
         (data-perms/set-table-permission! group (mt/id :venues) :perms/create-queries :query-builder)

--- a/test/metabase/models/permissions_group_test.clj
+++ b/test/metabase/models/permissions_group_test.clj
@@ -147,15 +147,30 @@
             (is (= #{db-id} (->> graph :groups vals (mapcat keys) set)))))))))
 
 (deftest set-default-permission-values!-test
-  (testing "A new group has no permissions for any DBs by default"
-    (mt/with-temp [:model/Database         {db-id :id}    {}
-                   :model/PermissionsGroup {group-id :id} {}]
-      (is
-       (= {group-id
-           {db-id
-            {:perms/view-data :unrestricted,
-             :perms/create-queries :no,
-             :perms/download-results :no,
-             :perms/manage-table-metadata :no,
-             :perms/manage-database :no}}}
-          (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))
+  (testing "A new group has permissions dynamically set for each DB based on the All Users group"
+    (mt/with-premium-features #{}
+      (mt/with-temp [:model/Database {db-id :id} {}]
+        (mt/with-full-data-perms-for-all-users!
+          (mt/with-temp [:model/PermissionsGroup {group-id :id} {}]
+            (is
+             (= {group-id
+                 {db-id
+                  {:perms/view-data :unrestricted
+                   :perms/create-queries :query-builder-and-native
+                   :perms/download-results :one-million-rows
+                   :perms/manage-table-metadata :no
+                   :perms/manage-database :no}}}
+                (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))
+
+      (mt/with-temp [:model/Database         {db-id :id}    {}]
+        (mt/with-no-data-perms-for-all-users!
+          (mt/with-temp [:model/PermissionsGroup {group-id :id} {}]
+            (is
+             (= {group-id
+                 {db-id
+                  {:perms/view-data :unrestricted
+                   :perms/create-queries :no
+                   :perms/download-results :no
+                   :perms/manage-table-metadata :no
+                   :perms/manage-database :no}}}
+                (data-perms/data-permissions-graph :group-id group-id :db-id db-id)))))))))

--- a/test/metabase/models/table_test.clj
+++ b/test/metabase/models/table_test.clj
@@ -85,60 +85,63 @@
 
 (deftest set-new-table-permissions!-test
   (testing "New permissions are set appropriately for a new table, for all groups"
-    (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
-                   :model/Database         {db-id :id}    {}
-                   :model/Table            {table-id-1 :id} {:db_id  db-id
-                                                             :schema "PUBLIC"}
-                   :model/Table            {table-id-2 :id} {:db_id  db-id
-                                                             :schema "PUBLIC"}]
-      ;; All Users group should have full data access, full download abilities, and full metadata management
-      (let [all-users-group-id (u/the-id (perms-group/all-users))]
-        (is (partial=
-             {all-users-group-id
-              {db-id
-               {:perms/view-data             :unrestricted
-                :perms/create-queries        :query-builder-and-native
-                :perms/download-results      :one-million-rows
-                :perms/manage-table-metadata :no
-                :perms/manage-database       :no}}}
-             (data-perms/data-permissions-graph :group-id all-users-group-id :db-id db-id))))
-
-      ;; Other groups should have no-self-service data access and no download abilities or metadata management
-      (is (partial=
-           {group-id
-            {db-id
-             {:perms/view-data             :unrestricted
-              :perms/create-queries        :no
-              :perms/download-results      :no
-              :perms/manage-table-metadata :no
-              :perms/manage-database       :no}}}
-           (data-perms/data-permissions-graph :group-id group-id :db-id db-id)))
-
-      (testing "A new table has appropriate defaults, when perms are already set granularly for the DB"
-        (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :query-builder)
-        (data-perms/set-table-permission! group-id table-id-1 :perms/view-data :unrestricted)
-        (data-perms/set-table-permission! group-id table-id-1 :perms/download-results :one-million-rows)
-        (data-perms/set-table-permission! group-id table-id-1 :perms/manage-table-metadata :yes)
-        (mt/with-temp [:model/Table {table-id-3 :id} {:db_id  db-id
-                                                      :schema "PUBLIC"}]
+    (mt/with-full-data-perms-for-all-users!
+      (mt/with-temp [:model/PermissionsGroup {group-id :id} {}
+                     :model/Database         {db-id :id}    {}
+                     :model/Table            {table-id-1 :id} {:db_id  db-id
+                                                               :schema "PUBLIC"}
+                     :model/Table            {table-id-2 :id} {:db_id  db-id
+                                                               :schema "PUBLIC"}]
+        ;; Perms for new tables are the same as the DB-level perms, if they exist
+        (let [all-users-group-id (u/the-id (perms-group/all-users))]
           (is (partial=
-               {group-id
+               {all-users-group-id
                 {db-id
                  {:perms/view-data             :unrestricted
-                  :perms/create-queries        {"PUBLIC"
-                                                {table-id-1 :query-builder
-                                                 table-id-2 :no
-                                                 table-id-3 :no}}
-                  :perms/download-results      {"PUBLIC"
-                                                {table-id-1 :one-million-rows
-                                                 table-id-2 :no
-                                                 table-id-3 :no}}
-                  :perms/manage-table-metadata {"PUBLIC"
-                                                {table-id-1 :yes
-                                                 table-id-2 :no
-                                                 table-id-3 :no}}
+                  :perms/create-queries        :query-builder-and-native
+                  :perms/download-results      :one-million-rows
+                  :perms/manage-table-metadata :no
                   :perms/manage-database       :no}}}
-               (data-perms/data-permissions-graph :group-id group-id :db-id db-id))))))))
+               (data-perms/data-permissions-graph :group-id all-users-group-id :db-id db-id))))
+
+        ;; A new group starts with the same perms as All Users
+        (is (partial=
+             {group-id
+              {db-id
+                 {:perms/view-data             :unrestricted
+                  :perms/create-queries        :query-builder-and-native
+                  :perms/download-results      :one-million-rows
+                  :perms/manage-table-metadata :no
+                  :perms/manage-database       :no}}}
+             (data-perms/data-permissions-graph :group-id group-id :db-id db-id)))
+
+        (testing "A new table has appropriate defaults, when perms are already set granularly for the DB"
+          (data-perms/set-table-permission! group-id table-id-1 :perms/create-queries :no)
+          (data-perms/set-table-permission! group-id table-id-1 :perms/download-results :no)
+          (data-perms/set-table-permission! group-id table-id-1 :perms/manage-table-metadata :no)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/create-queries :query-builder)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/download-results :one-million-rows)
+          (data-perms/set-table-permission! group-id table-id-2 :perms/manage-table-metadata :yes)
+          (mt/with-temp [:model/Table {table-id-3 :id} {:db_id  db-id
+                                                        :schema "PUBLIC"}]
+            (is (partial=
+                 {group-id
+                  {db-id
+                   {:perms/view-data             :unrestricted
+                    :perms/create-queries        {"PUBLIC"
+                                                  {table-id-1 :no
+                                                   table-id-2 :query-builder
+                                                   table-id-3 :no}}
+                    :perms/download-results      {"PUBLIC"
+                                                  {table-id-1 :no
+                                                   table-id-2 :one-million-rows
+                                                   table-id-3 :no}}
+                    :perms/manage-table-metadata {"PUBLIC"
+                                                  {table-id-1 :no
+                                                   table-id-2 :yes
+                                                   table-id-3 :no}}
+                    :perms/manage-database       :no}}}
+                 (data-perms/data-permissions-graph :group-id group-id :db-id db-id)))))))))
 
 (deftest cleanup-permissions-after-delete-table-test
   (mt/with-temp


### PR DESCRIPTION
Follow-up to https://github.com/metabase/metabase/pull/40869 

Sets permissions for a new permissions group to be approximately based on the permissions of All Users for each DB. The specific logic is outlined here: https://metaboat.slack.com/archives/C064EB1UE5P/p1712848241031149?thread_ts=1712078853.900079&cid=C064EB1UE5P