### PR TITLE
Make sure aggregation references are resolvable

### DIFF
--- a/src/metabase/lib/order_by.cljc
+++ b/src/metabase/lib/order_by.cljc
@@ -108,7 +108,7 @@
           (isa? base-type orderable-base-type))
         lib.schema.expression/orderable-types))
 
-(mu/defn orderable-columns :- [:sequential lib.metadata/ColumnMetadata]
+(mu/defn orderable-columns :- [:maybe [:sequential lib.metadata/ColumnMetadata]]
   "Get column metadata for all the columns you can order by in a given `stage-number` of a `query`. Rules are as
   follows:
 
@@ -156,7 +156,7 @@
                             (comp (map lib.ref/ref)
                                   (keep-indexed (fn [index an-order-by]
                                                   (when-let [col (lib.equality/find-matching-column
-                                                                   query stage-number an-order-by columns)]
+                                                                  query stage-number an-order-by columns)]
                                                     [col index]))))
                             existing-order-bys)]
          (mapv #(let [pos (matching %)]

--- a/src/metabase/lib/util.cljc
+++ b/src/metabase/lib/util.cljc
@@ -549,22 +549,56 @@
 (defn fresh-uuids
   "Recursively replace all the :lib/uuids in `x` with fresh ones. Useful if you need to attach something to a query more
   than once."
-  [x]
-  (cond
-    (sequential? x)
-    (into (empty x) (map fresh-uuids) x)
+  ([x]
+   (fresh-uuids x (constantly nil)))
+  ([x register-fn]
+   (cond
+     (sequential? x)
+     (into (empty x) (map #(fresh-uuids % register-fn)) x)
 
-    (map? x)
-    (into
-     (empty x)
-     (map (fn [[k v]]
-            [k (if (= k :lib/uuid)
-                 (str (random-uuid))
-                 (fresh-uuids v))]))
-     x)
+     (map? x)
+     (into
+      (empty x)
+      (map (fn [[k v]]
+             [k (if (= k :lib/uuid)
+                  (let [new-id (str (random-uuid))]
+                    (register-fn v new-id)
+                    new-id)
+                  (fresh-uuids v register-fn))]))
+      x)
 
-    :else
-    x))
+     :else
+     x)))
+
+(defn- replace-uuid-references
+  [x replacement-map]
+  (let [replacement (find replacement-map x)]
+    (cond
+      replacement
+      (val replacement)
+
+      (sequential? x)
+      (into (empty x) (map #(replace-uuid-references % replacement-map)) x)
+
+      (map? x)
+      (into
+       (empty x)
+       (map (fn [[k v]]
+              [k (cond-> v
+                   (not= k :lib/uuid) (replace-uuid-references replacement-map))]))
+       x)
+
+      :else
+      x)))
+
+(defn fresh-query-instance
+  "Create an copy of `query` with fresh :lib/uuid values making sure that internal
+  uuid references are kept."
+  [query]
+  (let [v-replacement (volatile! (transient {}))
+        almost-query (fresh-uuids query #(vswap! v-replacement assoc! %1 %2))
+        replacement (persistent! @v-replacement)]
+    (replace-uuid-references almost-query replacement)))
 
 (mu/defn normalized-query-type :- [:maybe [:enum #_MLv2 :mbql/query #_legacy :query :native #_audit :internal]]
   "Get the `:lib/type` or `:type` from `query`, even if it is not-yet normalized."

--- a/test/metabase/lib/util_test.cljc
+++ b/test/metabase/lib/util_test.cljc
@@ -4,6 +4,7 @@
    [clojure.string :as str]
    [clojure.test :refer [are deftest is testing]]
    [metabase.lib.core :as lib]
+   [metabase.lib.equality :as lib.equality]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.util :as lib.util]))
 
@@ -357,3 +358,30 @@
             {:lib/uuid "8044c5a1-10ab-4122-8663-aa544074c082"}
             [:field {:lib/uuid "36a2abff-e4ae-4752-b232-4885e08f52ea"} 5]
             "abc"]))))
+
+(deftest ^:parallel fresh-query-instance-test
+  (let [query {:lib/type :mbql/query,
+               :stages
+               [{:lib/type :mbql.stage/mbql,
+                 :breakout
+                 [[:field {:base-type :type/DateTime, :temporal-unit :month,
+                           :lib/uuid "7ec788fb-3eb2-4ed0-88fa-5f6b53a09094"}
+                   38]
+                  [:field {:base-type :type/Text, :source-field 37,
+                           :lib/uuid "65135c9c-fec5-4f51-b111-fadbb6af4522"}
+                   64]],
+                 :aggregation [[:metric {:lib/uuid "aa83c834-9a7c-4d7b-b408-3e17668d5ecc"} 84]],
+                 :order-by
+                 [[:asc
+                   #:lib{:uuid "2712fc42-d13e-4810-9ae9-a126d536376e"}
+                   [:aggregation {:lib/uuid "a1d73928-05db-4cb7-bb05-5123d2dbc261"}
+                    "aa83c834-9a7c-4d7b-b408-3e17668d5ecc"]]],
+                 :source-card 84}],
+               :database 1}
+        fresh-query (lib.util/fresh-query-instance query)
+        aggregation-ref-path [:stages 0 :order-by 0 2 2]]
+    (is (= (get-in fresh-query [:stages 0 :aggregation 0 1 :lib/uuid])
+           (get-in fresh-query aggregation-ref-path)))
+    (is (not= (get-in query       aggregation-ref-path)
+              (get-in fresh-query aggregation-ref-path)))
+    (is (lib.equality/= query fresh-query))))


### PR DESCRIPTION
Part of second step of #37335.

Fixes running queries with order-by referencing an aggregation.