### PR TITLE
Improve echarts hovers

### DIFF
--- a/frontend/src/metabase/visualizations/components/legend/LegendLayout.jsx
+++ b/frontend/src/metabase/visualizations/components/legend/LegendLayout.jsx
@@ -54,6 +54,7 @@ const LegendLayout = ({
   isReversed,
   canRemoveSeries,
 }) => {
+  const hasDimensions = width != null && height != null;
   const itemHeight = !isFullscreen ? MIN_ITEM_HEIGHT : MIN_ITEM_HEIGHT_LARGE;
   const maxXItems = Math.floor(width / MIN_ITEM_WIDTH);
   const maxYItems = Math.floor(height / itemHeight);
@@ -93,7 +94,7 @@ const LegendLayout = ({
         {isVertical && actionButtons && (
           <LegendActions>{actionButtons}</LegendActions>
         )}
-        <ChartContainer>{children}</ChartContainer>
+        {hasDimensions && <ChartContainer>{children}</ChartContainer>}
       </MainContainer>
     </LegendLayoutRoot>
   );

--- a/frontend/src/metabase/visualizations/echarts/types.ts
+++ b/frontend/src/metabase/visualizations/echarts/types.ts
@@ -10,6 +10,7 @@ export type EChartsSeriesMouseEvent = ElementEvent & {
   seriesId?: string;
   name?: string;
   value: any;
+  seriesType: string;
 };
 
 export type EChartsSeriesBrushEndEvent = EChartsSeriesMouseEvent & {

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -16,10 +16,7 @@ import type {
   EChartsSeriesBrushEndEvent,
   EChartsSeriesMouseEvent,
 } from "metabase/visualizations/echarts/types";
-import type {
-  ClickObject,
-  VisualizationProps,
-} from "metabase/visualizations/types";
+import type { VisualizationProps } from "metabase/visualizations/types";
 import type { EChartsEventHandler } from "metabase/visualizations/types/echarts";
 import {
   canBrush,
@@ -52,7 +49,7 @@ export const useChartEvents = (
     onDeselectTimelineEvents,
     hovered,
   }: VisualizationProps,
-): ClickObject => {
+) => {
   const isBrushing = useRef<boolean>();
 
   const onOpenQuestion = useCallback(
@@ -99,6 +96,16 @@ export const useChartEvents = (
             const eventData = getGoalLineHoverData(settings, event);
 
             onHoverChange?.(eventData);
+            return;
+          }
+
+          const hoveredData = getSeriesHoverData(chartModel, settings, event);
+
+          const isSameDatumHovered =
+            hoveredData?.index === hovered?.index &&
+            hoveredData?.datumIndex === hovered?.datumIndex;
+
+          if (isSameDatumHovered) {
             return;
           }
 
@@ -164,6 +171,7 @@ export const useChartEvents = (
       chartModel,
       onOpenQuestion,
       rawSeries,
+      hovered,
       selectedTimelineEventIds,
       settings,
       timelineEventsModel,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/40532

### Description

Preparation for fixing https://github.com/metabase/metabase/issues/41217
Unfortunately, ECharts API does not provide emphasized/blurred state on axes which means we need to build axes part of the option object considering the `hovered` object. This PR prevents new hovered object creation while hovering the same datum which produces severe lags if we recomute the entire `option` every time `hovered` changes.

Also, this PR fixes a minor hover issue https://github.com/metabase/metabase/issues/40532

And removes a slight lag which hurts performance due to unnecessary rerender:
https://github.com/metabase/metabase/assets/14301985/6720881f-93ba-4d1d-8257-4eabde363971

### How to verify

To verify the `hovered` does not change when hovering the same datum you can
- add useEffect(() => { console.log(hovered) }, [hovered]) to `useChartEvents`
- create a bar chart
- move mouse within a single bar
- ensure there are no logs of the hovered when you move the cursor inside
