### PR TITLE
Convert `formula.module.css` to CSS modules

### DIFF
--- a/frontend/src/metabase/reference/components/Formula.module.css
+++ b/frontend/src/metabase/reference/components/Formula.module.css
@@ -19,25 +19,25 @@
   composes: p2 from "style";
 }
 
-:global(.formulaDefinition) {
+.formulaDefinition {
   overflow: hidden;
 }
 
-:global(.formulaDefinition-enter) {
+.formulaDefinitionEnter {
   max-height: 0;
 }
 
-:global(.formulaDefinition-enter.formulaDefinition-enter-active) {
+.formulaDefinitionEnter.formulaDefinitionEnterActive {
   /* using 100% max-height breaks the transition */
   max-height: 150px;
   transition: max-height 300ms ease-out;
 }
 
-:global(.formulaDefinition-exit) {
+.formulaDefinitionExit {
   max-height: 150px;
 }
 
-:global(.formulaDefinition-exit.formulaDefinition-exit-active) {
+.formulaDefinitionExit.formulaDefinitionExitActive {
   max-height: 0;
   transition: max-height 300ms ease-out;
 }

--- a/frontend/src/metabase/reference/components/Formula.tsx
+++ b/frontend/src/metabase/reference/components/Formula.tsx
@@ -34,13 +34,18 @@ export const Formula = ({
       {isExpanded && (
         <CSSTransition
           key="formulaDefinition"
-          classNames="formulaDefinition"
+          classNames={{
+            enter: S.formulaDefinitionEnter,
+            enterActive: S.formulaDefinitionEnterActive,
+            exit: S.formulaDefinitionExit,
+            exitActive: S.formulaDefinitionExitActive,
+          }}
           timeout={{
             enter: 300,
             exit: 300,
           }}
         >
-          <div className="formulaDefinition">
+          <div className={S.formulaDefinition}>
             <QueryDefinition
               className={S.formulaDefinitionInner}
               object={entity}


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41347

### Description

Converts the `formula.module.css` file to CSS modules. This file is only used in the `Formula` component, and the only thing that really changes is the CSS transition classes (and one other small change).

I also converted this file to TS, and this PR is stacked on top of that one. Feel free to take a look so I can get both of them in relatively easily.

### How to verify

1. Create a metric and/or segment if you haven't already
2. Go to /reference/metrics and /reference/segment. Click into one of them
3. Click "View the [segment/metric] formula"
4. You should see that the transition to open the formula still works, and that the formula is displayed correctly.

Also tests should still pass