### PR TITLE
Convert `legend.module.css` to CSS modules

### DIFF
--- a/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/pie_chart.cy.spec.js
@@ -65,7 +65,7 @@ function ensurePieChartRendered(rows, totalValue) {
 
     // legend
     rows.forEach((name, i) => {
-      cy.get(".LegendItem").contains(name).should("be.visible");
+      cy.findAllByTestId("legend-item").contains(name).should("be.visible");
     });
   });
 }

--- a/frontend/src/metabase/visualizations/components/Legend.module.css
+++ b/frontend/src/metabase/visualizations/components/Legend.module.css
@@ -2,7 +2,7 @@
 legend item needs to be in the scope in order to control the font size in
 fullscreen dashboard mode
 */
-:global(.LegendItem) {
+.LegendItem {
   font-weight: bold;
   transition: opacity 0.25s linear;
   opacity: 1;
@@ -13,7 +13,7 @@ fullscreen dashboard mode
   margin-bottom: 0.25em;
 }
 
-.LegendItem:global(.muted) {
+.LegendItem.LegendItemMuted {
   opacity: 0.4;
 }
 
@@ -34,6 +34,6 @@ fullscreen dashboard mode
   margin-top: 1em;
 }
 
-.DashCard :global(.LegendItem) {
+.DashCard.LegendItem {
   font-size: 12px;
 }

--- a/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendHorizontal.jsx
@@ -4,14 +4,14 @@ import cx from "classnames";
 import { Component } from "react";
 import ReactDOM from "react-dom";
 
-import styles from "./Legend.module.css";
+import LegendS from "./Legend.module.css";
 import LegendItem from "./LegendItem";
 
 export default class LegendHorizontal extends Component {
   render() {
     const { className, titles, colors, hovered, onHoverChange } = this.props;
     return (
-      <ol className={cx(className, styles.Legend, styles.horizontal)}>
+      <ol className={cx(className, LegendS.Legend, LegendS.horizontal)}>
         {titles.map((title, index) => {
           const isMuted =
             hovered && hovered.index != null && index !== hovered.index;

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -51,6 +51,7 @@ export default class LegendItem extends Component {
 
     return (
       <span
+        data-testid="legend-item"
         className={cx(
           className,
           LegendS.LegendItem,

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -10,6 +10,7 @@ import DashboardS from "metabase/css/dashboard.module.css";
 import EmbedFrameS from "metabase/public/components/EmbedFrame/EmbedFrame.module.css";
 import { Icon } from "metabase/ui";
 
+import LegendS from "./Legend.module.css";
 import { IconContainer } from "./LegendItem.styled";
 
 const propTypes = {
@@ -52,7 +53,8 @@ export default class LegendItem extends Component {
       <span
         className={cx(
           className,
-          "LegendItem",
+          LegendS.LegendItem,
+          { [LegendS.LegendItemMuted]: isMuted },
           CS.noDecoration,
           DashboardS.fullscreenNormalText,
           DashboardS.fullscreenNightText,
@@ -67,7 +69,6 @@ export default class LegendItem extends Component {
         style={{
           overflowX: "hidden",
           flex: "0 1 auto",
-          opacity: isMuted ? 0.4 : 1,
         }}
         onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}

--- a/frontend/src/metabase/visualizations/components/LegendVertical.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendVertical.jsx
@@ -8,7 +8,7 @@ import { t } from "ttag";
 import Tooltip from "metabase/core/components/Tooltip";
 import CS from "metabase/css/core/index.css";
 
-import styles from "./Legend.module.css";
+import LegendS from "./Legend.module.css";
 import LegendItem from "./LegendItem";
 
 export default class LegendVertical extends Component {
@@ -66,7 +66,7 @@ export default class LegendVertical extends Component {
       items = titles;
     }
     return (
-      <ol className={cx(className, styles.Legend, styles.vertical)}>
+      <ol className={cx(className, LegendS.Legend, LegendS.vertical)}>
         {items.map((title, index) => {
           const isMuted =
             hovered && hovered.index != null && index !== hovered.index;
@@ -99,13 +99,13 @@ export default class LegendVertical extends Component {
               {Array.isArray(title) && (
                 <span
                   className={cx(
-                    "LegendItem",
+                    LegendS.LegendItem,
                     CS.flex,
                     CS.alignCenter,
                     CS.flexAlignRight,
                     CS.pl1,
+                    { [LegendS.LegendItemMuted]: isMuted },
                   )}
-                  style={{ opacity: isMuted ? 0.4 : 1 }}
                 >
                   {title[1]}
                 </span>


### PR DESCRIPTION
Closes #41354

### Description

Converts the remaining `legend.module.css` selectors to CSS modules. It looks like it's only used in `LegendItem`, `LegendVertical`, and `LegendHorizontal`. I also made sure that the more complicated selectors still made sense (i.e. the `DashCard` selector, which Denis thankfully already converted).

I did find that the use of two `LegendItem` components made things a little complicated, but I _think_ the components mentioned above are the only ones to use a `LegendItem` class. Let me know if I missed something

### How to verify

From what I understand, this Legend class is used in Pie and Choropleth visualizations. (`ChartWithLegend` uses `LegendVertical` and `LegendHorizontal`, which in turn use `Legend` and `Legend.module.css`). Just ensure that those visualizations work as expected.

(For choropleth, use the People table and use Summarize by `state`. This should give you a map with different colors depending on the number of people in each state.)
