### PR TITLE
Convert `rounded.module.css` to CSS modules

### DIFF
--- a/frontend/src/metabase/admin/people/components/GroupsListing.jsx
+++ b/frontend/src/metabase/admin/people/components/GroupsListing.jsx
@@ -152,7 +152,7 @@ function EditingGroupRow({
 }) {
   const textIsValid = group.name && group.name.length;
   return (
-    <tr className={cx(CS.bordered, CS.borderBrand, "rounded")}>
+    <tr className={cx(CS.bordered, CS.borderBrand, CS.rounded)}>
       <td>
         <Input
           className={CS.h3}

--- a/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
+++ b/frontend/src/metabase/admin/settings/components/SettingsUpdatesForm/VersionUpdateNotice/VersionUpdateNotice.jsx
@@ -152,7 +152,7 @@ function HostingCTA() {
       <HostingCTAContent>
         <HostingCTAIconContainer
           className={cx(
-            "circular",
+            CS.circular,
             CS.bgMedium,
             CS.alignCenter,
             CS.justifyCenter,

--- a/frontend/src/metabase/css/core/rounded.module.css
+++ b/frontend/src/metabase/css/core/rounded.module.css
@@ -2,11 +2,10 @@
   --default-border-radius: 8px;
 }
 
-:global(.rounded),
 .rounded {
   border-radius: var(--default-border-radius);
 }
 
-:global(.circular) {
+.circular {
   border-radius: 99px !important;
 }

--- a/frontend/src/metabase/query_builder/components/RunButton.tsx
+++ b/frontend/src/metabase/query_builder/components/RunButton.tsx
@@ -4,6 +4,7 @@ import { forwardRef } from "react";
 import { t } from "ttag";
 
 import Button from "metabase/core/components/Button";
+import CS from "metabase/css/core/index.css";
 import QueryBuilderS from "metabase/css/query_builder.module.css";
 
 interface RunButtonProps {
@@ -45,7 +46,7 @@ const RunButton = forwardRef(function RunButton(
         [QueryBuilderS.RunButtonHidden]: hidden,
         [QueryBuilderS.RunButtonCompact]:
           circular && !props.borderless && compact,
-        circular: circular,
+        [CS.circular]: circular,
       })}
       data-testid="run-button"
       onClick={isRunning ? onCancel : onRun}

--- a/frontend/src/metabase/visualizations/components/LegendItem.jsx
+++ b/frontend/src/metabase/visualizations/components/LegendItem.jsx
@@ -81,7 +81,7 @@ export default class LegendItem extends Component {
         {showDot && (
           <Tooltip tooltip={title} isEnabled={showTooltip && showDotTooltip}>
             <div
-              className={cx(CS.flexNoShrink, CS.inlineBlock, "circular")}
+              className={cx(CS.flexNoShrink, CS.inlineBlock, CS.circular)}
               style={{
                 width: 13,
                 height: 13,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41356

### Description

Converts `rounded.module.css` to CSS modules. It looks like there was only one more instance of the `rounded` class left as a global class, and only two for `circular`. This CSS module finishes the job with those instances