### PR TITLE
Convert `width.module.css` to CSS modules

### DIFF
--- a/frontend/src/metabase/components/FieldSet.tsx
+++ b/frontend/src/metabase/components/FieldSet.tsx
@@ -43,7 +43,7 @@ export function FieldSet({
           {required && <span>&nbsp;*</span>}
         </legend>
       )}
-      <div data-testid="field-set-content" className="w-full">
+      <div data-testid="field-set-content" className={CS.wFull}>
         {children}
       </div>
     </fieldset>

--- a/frontend/src/metabase/css/core/width.module.css
+++ b/frontend/src/metabase/css/core/width.module.css
@@ -1,5 +1,3 @@
-:global(.w-full),
-.w-full,
 .wFull {
   width: 100%;
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41356

### Description

Converts `width.module.css` to CSS modules. It looks like there was only one place left with the `w-full` class, so this PR is really small. All of the other instances have already been converted to `.wFull`.