### PR TITLE
Convert `shadow.module.css` to CSS modules

### DIFF
--- a/frontend/src/metabase/css/core/shadow.module.css
+++ b/frontend/src/metabase/css/core/shadow.module.css
@@ -1,8 +1,3 @@
-:root {
-  --shadow-color: var(--color-shadow);
-}
-
-:global(.shadowed),
 .shadowed {
   box-shadow: 0 2px 2px var(--color-shadow);
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41356

### Description

Converts `shadow.module.css` to CSS modules. It looks like all of the classes were already converted so I just removed the global selector and the unused CSS variable.
