### PR TITLE
Convert `transitions.module.css` to CSS modules

### DIFF
--- a/frontend/src/metabase/components/LabelIcon/LabelIcon.module.css
+++ b/frontend/src/metabase/components/LabelIcon/LabelIcon.module.css
@@ -6,6 +6,6 @@
 }
 
 .icon {
-  composes: transition-color from "style";
+  composes: transitionColor from "style";
   color: currentColor;
 }

--- a/frontend/src/metabase/css/core/transitions.module.css
+++ b/frontend/src/metabase/css/core/transitions.module.css
@@ -1,5 +1,3 @@
-:global(.transition-color),
-.transition-color,
 .transitionColor {
   transition: color 0.3s linear;
 }


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41356

### Description

Converts `transitions.module.css` to CSS modules. There was only one instance of the `transition-color` class used, so I converted that and removed the global selector.
