### PR TITLE
Refactor and convert `DataSelector.module.css` to CSS modules

### DIFF
--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.jsx
@@ -46,8 +46,6 @@ import {
 import { SearchResults, getSearchItemTableOrCardId } from "./data-search";
 import SavedEntityPicker from "./saved-entity-picker/SavedEntityPicker";
 
-import "./DataSelector.module.css";
-
 const MIN_SEARCH_LENGTH = 2;
 
 // chooses a data source bucket (datasets / raw data (tables) / saved questions)

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/QuestionDataSelector.jsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/QuestionDataSelector.jsx
@@ -2,6 +2,8 @@
 import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
 import * as Lib from "metabase-lib";
 
+import QuestionDataSelectorS from "./QuestionDataSelector.module.css";
+
 export default function QuestionDataSelector({
   question,
   updateQuestion,
@@ -17,7 +19,7 @@ export default function QuestionDataSelector({
 
   return (
     <DataSourceSelector
-      containerClassName="DataPopoverContainer"
+      containerClassName={QuestionDataSelectorS.DataPopoverContainer}
       hasTableSearch
       databaseQuery={{ saved: true }}
       setSourceTableFn={handleTableChange}

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/QuestionDataSelector.module.css
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/QuestionDataSelector.module.css
@@ -1,4 +1,0 @@
-/* HACK: DataPopover should be below the search box */
-.DataPopoverContainer {
-  z-index: 2;
-}

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/QuestionDataSelector.module.css
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/QuestionDataSelector.module.css
@@ -1,4 +1,4 @@
 /* HACK: DataPopover should be below the search box */
-:global(.DataPopoverContainer) {
+.DataPopoverContainer {
   z-index: 2;
 }

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/QuestionDataSelector.tsx
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/QuestionDataSelector.tsx
@@ -1,15 +1,20 @@
-/* eslint-disable react/prop-types */
+import CS from "metabase/css/core/index.css";
+import type { updateQuestion as updateQuestionAction } from "metabase/query_builder/actions";
 import { DataSourceSelector } from "metabase/query_builder/components/DataSelector";
 import * as Lib from "metabase-lib";
+import type Question from "metabase-lib/v1/Question";
+import type { DatabaseId, TableId } from "metabase-types/api";
 
-import QuestionDataSelectorS from "./QuestionDataSelector.module.css";
-
-export default function QuestionDataSelector({
+export const QuestionDataSelector = ({
   question,
   updateQuestion,
   triggerElement,
-}) {
-  const handleTableChange = (tableId, databaseId) => {
+}: {
+  question: Question;
+  updateQuestion: typeof updateQuestionAction;
+  triggerElement: JSX.Element;
+}) => {
+  const handleTableChange = (tableId: TableId, databaseId: DatabaseId) => {
     const metadata = question.metadata();
     const metadataProvider = Lib.metadataProvider(databaseId, metadata);
     const table = Lib.tableOrCardMetadata(metadataProvider, tableId);
@@ -19,7 +24,7 @@ export default function QuestionDataSelector({
 
   return (
     <DataSourceSelector
-      containerClassName={QuestionDataSelectorS.DataPopoverContainer}
+      containerClassName={CS.z2}
       hasTableSearch
       databaseQuery={{ saved: true }}
       setSourceTableFn={handleTableChange}
@@ -27,4 +32,4 @@ export default function QuestionDataSelector({
       isOpen
     />
   );
-}
+};

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/index.ts
@@ -1,0 +1,1 @@
+export { default as QuestionDataSelector } from "./QuestionDataSelector";

--- a/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/index.ts
+++ b/frontend/src/metabase/query_builder/components/view/QuestionDataSelector/index.ts
@@ -1,1 +1,1 @@
-export { default as QuestionDataSelector } from "./QuestionDataSelector";
+export { QuestionDataSelector } from "./QuestionDataSelector";

--- a/frontend/src/metabase/query_builder/components/view/View/NewQuestionView/NewQuestionView.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NewQuestionView/NewQuestionView.tsx
@@ -4,9 +4,8 @@ import { t } from "ttag";
 import Subhead from "metabase/components/type/Subhead";
 import CS from "metabase/css/core/index.css";
 import type { updateQuestion } from "metabase/query_builder/actions";
+import { QuestionDataSelector } from "metabase/query_builder/components/view/QuestionDataSelector";
 import type Question from "metabase-lib/v1/Question";
-
-import QuestionDataSelector from "../../QuestionDataSelector/QuestionDataSelector";
 
 type Props = {
   question: Question;

--- a/frontend/src/metabase/query_builder/components/view/View/NewQuestionView/NewQuestionView.tsx
+++ b/frontend/src/metabase/query_builder/components/view/View/NewQuestionView/NewQuestionView.tsx
@@ -6,7 +6,7 @@ import CS from "metabase/css/core/index.css";
 import type { updateQuestion } from "metabase/query_builder/actions";
 import type Question from "metabase-lib/v1/Question";
 
-import QuestionDataSelector from "../../QuestionDataSelector";
+import QuestionDataSelector from "../../QuestionDataSelector/QuestionDataSelector";
 
 type Props = {
   question: Question;


### PR DESCRIPTION
Closes #41356 

### Description

This PR refactors `DataSelector.module.css` to more accurately reflect its role within the `QuestionDataSelector` component rather than `DataSelector`, and uses CSS modules instead of a global selector. I also moved the CSS module and the component into its own folder.