### PR TITLE
Correct sync error handling in redshift tests

### DIFF
--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -234,7 +234,8 @@
              qual-tbl-nm
              qual-view-nm)
             ;; sync the schema again to pick up the new view (and table, though we aren't checking that)
-            (sync/sync-database! database {:scan :schema})
+            (binding [sync-util/*log-exceptions-and-continue?* false]
+              (sync/sync-database! database {:scan :schema}))
             (is (contains?
                  (t2/select-fn-set :name Table :db_id (u/the-id database)) ; the new view should have been synced
                  view-nm))

--- a/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
+++ b/modules/drivers/redshift/test/metabase/driver/redshift_test.clj
@@ -16,6 +16,7 @@
    [metabase.public-settings :as public-settings]
    [metabase.query-processor :as qp]
    [metabase.sync :as sync]
+   [metabase.sync.util :as sync-util]
    [metabase.test :as mt]
    [metabase.test.data.interface :as tx]
    [metabase.test.data.redshift :as redshift.test]
@@ -262,7 +263,8 @@
                     "CASE WHEN shop_status = 'open' THEN 11387.133 END AS case_when_numeric_inc_nulls "
                     "FROM test_data) WITH NO SCHEMA BINDING;")
                qual-view-nm)
-              (sync/sync-database! database {:scan :schema})
+              (binding [sync-util/*log-exceptions-and-continue?* false]
+                (sync/sync-database! database {:scan :schema}))
               (is (contains?
                    (t2/select-fn-set :name Table :db_id (u/the-id database)) ; the new view should have been synced without errors
                    view-nm))


### PR DESCRIPTION
When the `sync-database!` call in `redshift-lbv-sync-error-test` test fails in CI (usually due to a redshift flake) we don't get a helpful stack trace ([example failure](https://github.com/metabase/metabase/actions/runs/8635699680/job/23674074297#step:3:1169)). We get something like:
```
com.amazon.redshift.util.RedshiftException cannot be cast to class clojure.lang.Associative 
```

And it doesn't actually log any of the information in the exception. That's because our error handling for sync is broken and we're returning an exception here: 
https://github.com/metabase/metabase/blob/df011566c6a9139fae4fb9ea2deb566f8e0020c9/src/metabase/sync/util.clj#L191-L195

Which causes the exception that is logged here:
https://github.com/metabase/metabase/blob/df011566c6a9139fae4fb9ea2deb566f8e0020c9/src/metabase/sync.clj#L52

because we're trying to `assoc` with an exception.

Anyway even if the bug in sync code was fixed, this test should definitely be testing that there were no errors during sync.
So `*log-exceptions-and-continue?*` should be bound to false.