### PR TITLE
Add INFO log for each table being fingerprinted

### DIFF
--- a/src/metabase/sync/analyze/fingerprint.clj
+++ b/src/metabase/sync/analyze/fingerprint.clj
@@ -195,12 +195,14 @@
   "Generate and save fingerprints for all the Fields in `table` that have not been previously analyzed."
   [table :- i/TableInstance]
   (if-let [fields (fields-to-fingerprint table)]
-    (let [stats (sync-util/with-error-handling
-                  (format "Error fingerprinting %s" (sync-util/name-for-logging table))
-                  (fingerprint-table! table fields))]
-      (if (instance? Exception stats)
-        (empty-stats-map 0)
-        stats))
+    (do
+      (log/infof "Fingerprinting %s fields in table %s" (count fields) (sync-util/name-for-logging table))
+      (let [stats (sync-util/with-error-handling
+                    (format "Error fingerprinting %s" (sync-util/name-for-logging table))
+                    (fingerprint-table! table fields))]
+        (if (instance? Exception stats)
+          (empty-stats-map 0)
+          stats)))
     (empty-stats-map 0)))
 
 (def ^:private LogProgressFn


### PR DESCRIPTION
This PR adds INFO-level logs per table being fingerprinted. These logs will help debug performance issues with fingerprinting, because you can correlate issues with specific tables being fingerprinted.

If you add `<Logger name="metabase.sync.analyze.fingerprint" level="INFO"/>` to the log4j2.xml file, you'll get these additional lines in your logs when syncing a table for the first time:
```
[clojure-agent-send-off-pool-7] INFO  metabase.sync.analyze.fingerprint - Fingerprinting 3 fields in table Table 17 ''PUBLIC.USERS''
[clojure-agent-send-off-pool-7] INFO  metabase.sync.analyze.fingerprint - Fingerprinting 12 fields in table Table 18 ''PUBLIC.PEOPLE''
[clojure-agent-send-off-pool-7] INFO  metabase.sync.analyze.fingerprint - Fingerprinting 5 fields in table Table 19 ''PUBLIC.REVIEWS''
[clojure-agent-send-off-pool-7] INFO  metabase.sync.analyze.fingerprint - Fingerprinting 8 fields in table Table 20 ''PUBLIC.ORDERS''
[clojure-agent-send-off-pool-7] INFO  metabase.sync.analyze.fingerprint - Fingerprinting 5 fields in table Table 21 ''PUBLIC.VENUES''
[clojure-agent-send-off-pool-7] INFO  metabase.sync.analyze.fingerprint - Fingerprinting 1 fields in table Table 22 ''PUBLIC.CATEGORIES''
[clojure-agent-send-off-pool-7] INFO  metabase.sync.analyze.fingerprint - Fingerprinting 7 fields in table Table 23 ''PUBLIC.PRODUCTS''
[clojure-agent-send-off-pool-7] INFO  metabase.sync.analyze.fingerprint - Fingerprinting 3 fields in table Table 24 ''PUBLIC.CHECKINS''
```