### PR TITLE
Remove `POST /api/user/:id/send_invite` endpoint

### DIFF
--- a/frontend/src/metabase/entities/users.js
+++ b/frontend/src/metabase/entities/users.js
@@ -14,7 +14,6 @@ export const PASSWORD_RESET_EMAIL =
   "metabase/entities/users/PASSWORD_RESET_EMAIL";
 export const PASSWORD_RESET_MANUAL =
   "metabase/entities/users/RESET_PASSWORD_MANUAL";
-export const RESEND_INVITE = "metabase/entities/users/RESEND_INVITE";
 
 // TODO: It'd be nice to import loadMemberships, but we need to resolve a circular dependency
 function loadMemberships() {
@@ -48,7 +47,6 @@ const Users = createEntity({
     REACTIVATE,
     PASSWORD_RESET_EMAIL,
     PASSWORD_RESET_MANUAL,
-    RESEND_INVITE,
   },
 
   actionDecorators: {
@@ -80,11 +78,6 @@ const Users = createEntity({
   },
 
   objectActions: {
-    resentInvite: async ({ id }) => {
-      MetabaseAnalytics.trackStructEvent("People Admin", "Resent Invite");
-      await UserApi.send_invite({ id });
-      return { type: RESEND_INVITE };
-    },
     resetPasswordEmail: async ({ email }) => {
       MetabaseAnalytics.trackStructEvent(
         "People Admin",

--- a/frontend/src/metabase/services.js
+++ b/frontend/src/metabase/services.js
@@ -448,7 +448,6 @@ export const UserApi = {
   update_qbnewb: PUT("/api/user/:id/modal/qbnewb"),
   delete: DELETE("/api/user/:userId"),
   reactivate: PUT("/api/user/:userId/reactivate"),
-  send_invite: POST("/api/user/:id/send_invite"),
 };
 
 export const UtilApi = {

--- a/src/metabase/api/user.clj
+++ b/src/metabase/api/user.clj
@@ -10,7 +10,6 @@
    [metabase.api.ldap :as api.ldap]
    [metabase.api.session :as api.session]
    [metabase.config :as config]
-   [metabase.email.messages :as messages]
    [metabase.events :as events]
    [metabase.integrations.google :as google]
    [metabase.models.collection :as collection :refer [Collection]]
@@ -534,7 +533,7 @@
   {:success true})
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                  Other Endpoints -- PUT /api/user/:id/qpnewb, POST /api/user/:id/send_invite                   |
+;;; |                                              Other Endpoints                                                   |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 ;; TODO - This could be handled by PUT /api/user/:id, we don't need a separate endpoint
@@ -551,19 +550,6 @@
                               {:modal modal
                                :allowable-modals #{"qbnewb" "datasetnewb"}})))]
     (api/check-500 (pos? (t2/update! User id {:type :personal} {k false}))))
-  {:success true})
-
-(api/defendpoint POST "/:id/send_invite"
-  "Resend the user invite email for a given user."
-  [id]
-  {id ms/PositiveInt}
-  (api/check-superuser)
-  (check-not-internal-user id)
-  (when-let [user (t2/select-one User :id id, :is_active true, :type :personal)]
-    (let [reset-token (user/set-password-reset-token! id)
-          ;; NOTE: the new user join url is just a password reset with an indicator that this is a first time user
-          join-url    (str (user/form-password-reset-url reset-token) "#new")]
-      (messages/send-new-user-email! user @api/*current-user* join-url false)))
   {:success true})
 
 (api/define-routes)

--- a/test/metabase/api/user_test.clj
+++ b/test/metabase/api/user_test.clj
@@ -1204,7 +1204,7 @@
 
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
-;;; |                  Other Endpoints -- PUT /api/user/:id/qpnewb, POST /api/user/:id/send_invite                   |
+;;; |                                              Other Endpoints                                                   |
 ;;; +----------------------------------------------------------------------------------------------------------------+
 
 (deftest update-user-modal-test
@@ -1232,12 +1232,6 @@
                                      (format "user/%d/modal/%s"
                                              (mt/user->id :trashbird)
                                              endpoint))))))))
-
-(deftest send-invite-test
-  (testing "POST /api/user/:id/send_invite"
-    (testing "Check that non-superusers are denied access to resending invites"
-      (is (= "You don't have permissions to do that."
-             (mt/user-http-request :rasta :post 403 (format "user/%d/send_invite" (mt/user->id :crowberto))))))))
 
 (deftest user-activate-deactivate-event-test
   (testing "User Deactivate/Reactivate events via the API are recorded in the audit log"

--- a/test/metabase/db/internal_user_test.clj
+++ b/test/metabase/db/internal_user_test.clj
@@ -30,8 +30,7 @@
                                            [:put "user/:id" 400]
                                            [:put "user/:id/reactivate" 400]
                                            [:delete "user/:id" 400]
-                                           [:put "user/:id/modal/qbnewb" 400]
-                                           [:post "user/:id/send_invite" 400]]]
+                                           [:put "user/:id/modal/qbnewb" 400]]]
       (let [endpoint (str/replace endpoint #":id" (str config/internal-mb-user-id))
             testing-details-string (str/join " " [(u/upper-case-en (name method))
                                                   endpoint


### PR DESCRIPTION
Resolves #41369


> [!important]
> If we want to err on the side of caution I can always remove only the frontend part, while leaving the endpoint intact.
