### PR TITLE
Log errors fetching sync metadata

### DIFF
--- a/src/metabase/sync/fetch_metadata.clj
+++ b/src/metabase/sync/fetch_metadata.clj
@@ -7,65 +7,85 @@
    [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
    [metabase.driver.util :as driver.u]
    [metabase.sync.interface :as i]
+   [metabase.util.log :as log]
    [metabase.util.malli :as mu]
    [metabase.util.malli.fn :as mu.fn]))
+
+(defmacro log-if-error
+  "Logs an error message if an exception is thrown while executing the body."
+  {:style/indent 1}
+  [function-name & body]
+  `(try
+     ~@body
+     (catch Throwable e#
+       (log/errorf e# "Error while fetching metdata with '%s'" ~function-name)
+       (throw e#))))
+
+(log/error "Error")
 
 (mu/defn db-metadata :- i/DatabaseMetadata
   "Get basic Metadata about a `database` and its Tables. Doesn't include information about the Fields."
   [database :- i/DatabaseInstance]
-  (driver/describe-database (driver.u/database->driver database) database))
+  (log-if-error "db-metadata"
+    (driver/describe-database (driver.u/database->driver database) database)))
 
 (mu/defn fields-metadata
   "Effectively a wrapper for [[metabase.driver/describe-fields]] that also validates the output against the schema."
   [database :- i/DatabaseInstance & {:as args}]
-  (cond->> (driver/describe-fields (driver.u/database->driver database) database args)
-    ;; This is a workaround for the fact that [[mu/defn]] can't check reducible collections yet
-    (mu.fn/instrument-ns? *ns*)
-    (eduction (map #(mu.fn/validate-output {} i/FieldMetadataEntry %)))))
+  (log-if-error "fields-metadata"
+    (cond->> (driver/describe-fields (driver.u/database->driver database) database args)
+      ;; This is a workaround for the fact that [[mu/defn]] can't check reducible collections yet
+      (mu.fn/instrument-ns? *ns*)
+      (eduction (map #(mu.fn/validate-output {} i/FieldMetadataEntry %))))))
 
 (mu/defn table-fields-metadata :- [:set i/TableMetadataField]
   "Get more detailed information about a `table` belonging to `database`. Includes information about the Fields."
   [database :- i/DatabaseInstance
    table    :- i/TableInstance]
-  (if (driver/database-supports? (driver.u/database->driver database) :describe-fields database)
-    (set (fields-metadata database :table-names [(:name table)] :schema-names [(:schema table)]))
-    (:fields (driver/describe-table (driver.u/database->driver database) database table))))
+  (log-if-error "table-fields-metadata"
+    (if (driver/database-supports? (driver.u/database->driver database) :describe-fields database)
+      (set (fields-metadata database :table-names [(:name table)] :schema-names [(:schema table)]))
+      (:fields (driver/describe-table (driver.u/database->driver database) database table)))))
 
 (mu/defn fk-metadata
   "Effectively a wrapper for [[metabase.driver/describe-fks]] that also validates the output against the schema."
   [database :- i/DatabaseInstance & {:as args}]
-  (cond->> (driver/describe-fks (driver.u/database->driver database) database args)
-    ;; This is a workaround for the fact that [[mu/defn]] can't check reducible collections yet
-    (mu.fn/instrument-ns? *ns*)
-    (eduction (map #(mu.fn/validate-output {} i/FKMetadataEntry %)))))
+  (log-if-error "fk-metadata"
+    (cond->> (driver/describe-fks (driver.u/database->driver database) database args)
+      ;; This is a workaround for the fact that [[mu/defn]] can't check reducible collections yet
+      (mu.fn/instrument-ns? *ns*)
+      (eduction (map #(mu.fn/validate-output {} i/FKMetadataEntry %))))))
 
 (mu/defn table-fk-metadata :- [:maybe [:sequential i/FKMetadataEntry]]
   "Get information about the foreign keys belonging to `table`."
   [database :- i/DatabaseInstance
    table    :- i/TableInstance]
-  (let [driver (driver.u/database->driver database)]
-    (when (driver/database-supports? driver :foreign-keys database)
-      (if (driver/database-supports? driver :describe-fks database)
-        (vec (driver/describe-fks driver database :table-names [(:name table)] :schema-names [(:schema table)]))
-        #_{:clj-kondo/ignore [:deprecated-var]}
-        (vec (for [x (driver/describe-table-fks driver database table)]
-               {:fk-table-name   (:name table)
-                :fk-table-schema (:schema table)
-                :fk-column-name  (:fk-column-name x)
-                :pk-table-name   (:name (:dest-table x))
-                :pk-table-schema (:schema (:dest-table x))
-                :pk-column-name  (:dest-column-name x)}))))))
+  (log-if-error "table-fk-metadata"
+    (let [driver (driver.u/database->driver database)]
+      (when (driver/database-supports? driver :foreign-keys database)
+        (if (driver/database-supports? driver :describe-fks database)
+          (vec (driver/describe-fks driver database :table-names [(:name table)] :schema-names [(:schema table)]))
+          #_{:clj-kondo/ignore [:deprecated-var]}
+          (vec (for [x (driver/describe-table-fks driver database table)]
+                 {:fk-table-name   (:name table)
+                  :fk-table-schema (:schema table)
+                  :fk-column-name  (:fk-column-name x)
+                  :pk-table-name   (:name (:dest-table x))
+                  :pk-table-schema (:schema (:dest-table x))
+                  :pk-column-name  (:dest-column-name x)})))))))
 
 (mu/defn nfc-metadata :- [:maybe [:set i/TableMetadataField]]
   "Get information about the nested field column fields within `table`."
   [database :- i/DatabaseInstance
    table    :- i/TableInstance]
-  (let [driver (driver.u/database->driver database)]
-    (when (driver/database-supports? driver :nested-field-columns database)
-      (sql-jdbc.sync/describe-nested-field-columns driver database table))))
+  (log-if-error "nfc-metadata"
+    (let [driver (driver.u/database->driver database)]
+      (when (driver/database-supports? driver :nested-field-columns database)
+        (sql-jdbc.sync/describe-nested-field-columns driver database table)))))
 
 (mu/defn index-metadata :- [:maybe i/TableIndexMetadata]
   "Get information about the indexes belonging to `table`."
   [database :- i/DatabaseInstance
    table    :- i/TableInstance]
-  (driver/describe-table-indexes (driver.u/database->driver database) database table))
+  (log-if-error "index-metadata"
+    (driver/describe-table-indexes (driver.u/database->driver database) database table)))

--- a/src/metabase/sync/fetch_metadata.clj
+++ b/src/metabase/sync/fetch_metadata.clj
@@ -21,8 +21,6 @@
        (log/errorf e# "Error while fetching metdata with '%s'" ~function-name)
        (throw e#))))
 
-(log/error "Error")
-
 (mu/defn db-metadata :- i/DatabaseMetadata
   "Get basic Metadata about a `database` and its Tables. Doesn't include information about the Fields."
   [database :- i/DatabaseInstance]

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -63,6 +63,10 @@
   [_ _]
   "1.0")
 
+(defmethod driver/describe-database ::test-driver
+  [_ _]
+  {:tables []})
+
 (defn- db-details
   "Return default column values for a database (either the test database, via `(mt/db)`, or optionally passed in)."
   ([]

--- a/test/metabase/api/table_test.clj
+++ b/test/metabase/api/table_test.clj
@@ -412,7 +412,10 @@
 (deftest update-table-sync-test
   (testing "PUT /api/table/:id"
     (testing "Table should get synced when it gets unhidden"
-      (t2.with-temp/with-temp [Table table]
+      (t2.with-temp/with-temp [Database db    {:details (:details (mt/db))}
+                               Table    table (-> (t2/select-one :model/Table (mt/id :venues))
+                                                  (dissoc :id)
+                                                  (assoc :db_id (:id db)))]
         (let [called (atom 0)
               ;; original is private so a var will pick up the redef'd. need contents of var before
               original (var-get #'api.table/sync-unhidden-tables)]

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -10,7 +10,6 @@
     <Logger name="metabase-enterprise" level="FATAL"/>
     <Logger name="liquibase" level="FATAL"/>
     <Logger name="metabase.test.data.interface" level="INFO"/>
-    <Logger name="metabase.test.data.impl.get-or-create" level="ERROR"/>
     <Logger name="metabase.sync.fetch-metadata" level="ERROR"/>
 
     <Root level="FATAL">

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -11,6 +11,7 @@
     <Logger name="liquibase" level="FATAL"/>
     <Logger name="metabase.test.data.interface" level="INFO"/>
     <Logger name="metabase.test.data.impl.get-or-create" level="ERROR"/>
+    <Logger name="metabase.sync.fetch-metadata" level="ERROR"/>
 
     <Root level="FATAL">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
This PR turns on error logging for the `metabase.sync.fetch-metadata` namespace to debug redshift flakes.

https://github.com/metabase/metabase/pull/41022 failed to give any insight into redshift flakes because the stack trace isn't being logged (not sure why). Rather than rely on a stack trace, this PR will help narrow it down by adding logging around each function that we use to fetch data for syncing metadata.

See [this failure](https://github.com/metabase/metabase/actions/runs/8661085895/job/23754004650?pr=41022#step:3:1523) for the current logs. All we get is this:

```
Caused by: com.amazon.redshift.util.RedshiftException: ERROR: relation "2024_04_12_042037a3_49ab_4d07_b91d_60f1d23007e1_schema.ejtaogiukqcpdrjxkvwd" does not exist
	at com.amazon.redshift.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2648) ~[redshift-jdbc42-2.1.0.26.jar:?]
	at com.amazon.redshift.core.v3.QueryExecutorImpl.processResultsOnThread(QueryExecutorImpl.java:2295) ~[redshift-jdbc42-2.1.0.26.jar:?]
	at com.amazon.redshift.core.v3.QueryExecutorImpl.access$000(QueryExecutorImpl.java:82) ~[redshift-jdbc42-2.1.0.26.jar:?]
	at com.amazon.redshift.core.v3.QueryExecutorImpl$RingBufferThread.run(QueryExecutorImpl.java:3128) ~[redshift-jdbc42-2.1.0.26.jar:?]
```