### PR TITLE
Split Data Perm UI - Product Iteration

### DIFF
--- a/e2e/test/scenarios/permissions/create-queries/granular.cy.spec.js
+++ b/e2e/test/scenarios/permissions/create-queries/granular.cy.spec.js
@@ -49,6 +49,11 @@ describe("scenarios > admin > permissions > create queries > granular", () => {
     // should allow setting a granular value for one table
     modifyPermission("Orders", NATIVE_QUERIES_PERMISSION_INDEX, "No");
 
+    modal().within(() => {
+      cy.findByText("Change access to this database to “Granular”?");
+      cy.findByText("Change").click();
+    });
+
     // should also remove native permissions for all other tables
     assertPermissionTable([
       ["Accounts", "Query builder only"],

--- a/e2e/test/scenarios/permissions/create-queries/query-builder-only.cy.spec.js
+++ b/e2e/test/scenarios/permissions/create-queries/query-builder-only.cy.spec.js
@@ -126,6 +126,11 @@ describe("scenarios > admin > permissions > create queries > query builder only"
       "Query builder only",
     );
 
+    modal().within(() => {
+      cy.findByText("Change access to this database to “Granular”?");
+      cy.findByText("Change").click();
+    });
+
     const finalTablePermissions = [
       ["Accounts", "Query builder only"],
       ["Analytic Events", "Query builder only"],

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -798,6 +798,12 @@ describeEE("formatting > sandboxes", () => {
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Sandboxed").click();
       cy.button("Change").click();
+
+      modal().within(() => {
+        cy.findByText("Change access to this database to “Sandboxed”?");
+        cy.button("Change").click();
+      });
+
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText(
         "Use a saved question to create a custom view for this table",

--- a/e2e/test/scenarios/permissions/view-data/granular.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data/granular.cy.spec.js
@@ -168,7 +168,7 @@ function makeOrdersSandboxed() {
   modifyPermission("Orders", DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
 
   modal().within(() => {
-    cy.findByText("Change access to this database to granular?");
+    cy.findByText("Change access to this database to “Granular”?");
     cy.button("Change").click();
   });
 

--- a/e2e/test/scenarios/permissions/view-data/sandboxed.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/view-data/sandboxed.cy.spec.ts
@@ -41,7 +41,12 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
     modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
 
     modal().within(() => {
-      cy.findByText("Change access to this database to granular?");
+      cy.findByText("Change access to this database to “Granular”?");
+      cy.button("Change").click();
+    });
+
+    modal().within(() => {
+      cy.findByText("Change access to this database to “Sandboxed”?");
       cy.button("Change").click();
     });
 
@@ -120,7 +125,12 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
     modifyPermission("Orders", DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
 
     modal().within(() => {
-      cy.findByText("Change access to this database to granular?");
+      cy.findByText("Change access to this database to “Granular”?");
+      cy.button("Change").click();
+    });
+
+    modal().within(() => {
+      cy.findByText("Change access to this database to “Sandboxed”?");
       cy.button("Change").click();
     });
 

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/confirmations.ts
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/confirmations.ts
@@ -1,0 +1,33 @@
+import { t } from "ttag";
+
+import {
+  DataPermissionValue,
+  type EntityId,
+} from "metabase/admin/permissions/types";
+import { hasPermissionValueInGraph } from "metabase/admin/permissions/utils/graph";
+import type { GroupsPermissions } from "metabase-types/api/permissions";
+
+export function getSandboxedTableWarningModal(
+  permissions: GroupsPermissions,
+  groupId: number,
+  entityId: EntityId,
+  value: DataPermissionValue,
+) {
+  // if the user is sandboxing the table while there is create-queries permissions set to
+  // query builder and native for that group's access to the database being modified, we
+  // should prompt them that we will have to remove native access for all tables/schemas
+  if (
+    value === DataPermissionValue.SANDBOXED &&
+    hasPermissionValueInGraph(
+      permissions[groupId][entityId.databaseId],
+      DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+    )
+  ) {
+    return {
+      title: t`Change access to this database to “Sandboxed”?`,
+      message: t`As part of providing sandboxing we will also have to remove this group's native querying permissions from all tables and schemas in this database.`,
+      confirmButtonText: t`Change`,
+      cancelButtonText: t`Cancel`,
+    };
+  }
+}

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/index.js
@@ -15,12 +15,14 @@ import {
   PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES,
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS,
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS,
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_CONFIRMATIONS,
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION,
 } from "metabase/plugins";
 import { hasPremiumFeature } from "metabase-enterprise/settings";
 
 import sandboxingReducer from "./actions";
 import { LoginAttributesWidget } from "./components/LoginAttributesWidget";
+import { getSandboxedTableWarningModal } from "./confirmations";
 import EditSandboxingModal from "./containers/EditSandboxingModal";
 import { getDraftPolicies, hasPolicyChanges } from "./selectors";
 
@@ -77,6 +79,10 @@ if (hasPremiumFeature("sandboxes")) {
     actionCreator: (entityId, groupId, view) =>
       push(getEditSegementedAccessUrl(entityId, groupId, view)),
   });
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_CONFIRMATIONS.push(
+    (permissions, groupId, entityId, newValue) =>
+      getSandboxedTableWarningModal(permissions, groupId, entityId, newValue),
+  );
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION[OPTION_SEGMENTED.value] =
     getEditSegmentedAccessPostAction;
 

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorContent.jsx
@@ -30,6 +30,7 @@ export const permissionEditorContentPropTypes = {
   onAction: PropTypes.func,
   onBreadcrumbsItemSelect: PropTypes.func,
   breadcrumbs: PropTypes.array,
+  warnings: PropTypes.func,
 };
 
 export function PermissionsEditorContent({
@@ -43,6 +44,7 @@ export function PermissionsEditorContent({
   onChange,
   onSelect,
   onAction,
+  warnings: Warnings = () => null,
 }) {
   const [filter, setFilter] = useState("");
   const debouncedFilter = useDebouncedValue(filter, SEARCH_DEBOUNCE_DURATION);
@@ -74,6 +76,8 @@ export function PermissionsEditorContent({
       </Subhead>
 
       {description && <Text>{description}</Text>}
+
+      <Warnings />
 
       <EditorFilterContainer>
         <Input

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
@@ -1,0 +1,41 @@
+import { Link } from "react-router";
+import { t } from "ttag";
+
+import Alert from "metabase/core/components/Alert";
+import { useToggle } from "metabase/hooks/use-toggle";
+import { colors } from "metabase/lib/colors";
+import { Anchor, Text, Box } from "metabase/ui";
+
+export const PermissionsEditorLegacyNoSelfServiceWarning = () => {
+  const [isExpanded, { toggle }] = useToggle(false);
+
+  return (
+    <Box my="md" mr="2.5rem">
+      <Alert icon="warning" variant="warning">
+        <Text fw="bold">
+          {t`The No self-service access level for View data is going away.`}
+          {!isExpanded && (
+            <>
+              {" "}
+              <button onClick={toggle}>
+                <Text fw="bold" color={colors.accent7}>{t`Read more`}</Text>
+              </button>
+            </>
+          )}
+        </Text>
+
+        {isExpanded && (
+          <Text>
+            {t`In a future release, if a group’s View data access for a database (or any of its schemas or tables) is still set to No self-service (deprecated), Metabase will automatically change that group’s View data access for the entire database to Blocked. We’ll be defaulting to Blocked, the least permissive View data access, to prevent any unattended access to data.`}{" "}
+            <Anchor
+              fw="bold"
+              component={Link}
+              to="/admin/settings/embedding-in-other-applications"
+              style={{ color: colors.accent7 }}
+            >{t`Need help? See our docs.`}</Anchor>
+          </Text>
+        )}
+      </Alert>
+    </Box>
+  );
+};

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
@@ -1,17 +1,16 @@
 import { Link } from "react-router";
 import { t } from "ttag";
 
-import Alert from "metabase/core/components/Alert";
 import { useToggle } from "metabase/hooks/use-toggle";
 import { colors } from "metabase/lib/colors";
-import { Anchor, Text, Box } from "metabase/ui";
+import { Icon, Alert, Anchor, Text, Box } from "metabase/ui";
 
 export const PermissionsEditorLegacyNoSelfServiceWarning = () => {
   const [isExpanded, { toggle }] = useToggle(false);
 
   return (
-    <Box my="md" mr="2.5rem">
-      <Alert icon="warning" variant="warning">
+    <Box mt="md" mb="sm" mr="2.5rem">
+      <Alert icon={<Icon name="warning" size={16} />} color="accent5">
         <Text fw="bold">
           {t`The No self-service access level for View data is going away.`}
           {!isExpanded && (

--- a/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
@@ -7,6 +7,8 @@ import { useAsync } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
 
+import { PermissionsEditorLegacyNoSelfServiceWarning } from "metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning";
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { PermissionsApi } from "metabase/services";
 import { Loader, Center } from "metabase/ui";
@@ -151,6 +153,13 @@ function DatabasesPermissionsPage({
           onBreadcrumbsItemSelect={handleBreadcrumbsItemSelect}
           onChange={handlePermissionChange}
           onAction={handleAction}
+          warnings={() => (
+            <>
+              {permissionEditor.deprecatedPermsInGraph.has(
+                DataPermissionValue.LEGACY_NO_SELF_SERVICE,
+              ) && <PermissionsEditorLegacyNoSelfServiceWarning />}
+            </>
+          )}
         />
       )}
 

--- a/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
@@ -7,6 +7,8 @@ import { useAsync } from "react-use";
 import { t } from "ttag";
 import _ from "underscore";
 
+import { PermissionsEditorLegacyNoSelfServiceWarning } from "metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning";
+import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { useSelector, useDispatch } from "metabase/lib/redux";
 import { PermissionsApi } from "metabase/services";
 import { Loader, Center } from "metabase/ui";
@@ -171,6 +173,13 @@ function GroupsPermissionsPage({
           onChange={handlePermissionChange}
           onAction={handleAction}
           onBreadcrumbsItemSelect={handleBreadcrumbsItemSelect}
+          warnings={() => (
+            <>
+              {permissionEditor.deprecatedPermsInGraph.has(
+                DataPermissionValue.LEGACY_NO_SELF_SERVICE,
+              ) && <PermissionsEditorLegacyNoSelfServiceWarning />}
+            </>
+          )}
         />
       )}
 

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -159,7 +159,7 @@ export function getSandboxedTableWarningModal(
     )
   ) {
     return {
-      title: t`Change access to this database to sandboxed?`,
+      title: t`Change access to this database to “Sandboxed”?`,
       message: t`As part of providing sandboxing we will also have to remove this group's native querying permissions from all tables and schemas in this database.`,
       confirmButtonText: t`Change`,
       cancelButtonText: t`Cancel`,

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -8,7 +8,6 @@ import {
 import {
   getFieldsPermission,
   getSchemasPermission,
-  hasPermissionValueInGraph,
 } from "metabase/admin/permissions/utils/graph";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
@@ -136,31 +135,6 @@ export function getControlledDatabaseWarningModal(
     return {
       title: t`Change access to this database to “Granular”?`,
       message: t`Just letting you know that changing the permission setting on this ${entityType} will also update the database permission setting to “Granular” to reflect that some of the database’s ${entityTypePlural} have different permission settings.`,
-      confirmButtonText: t`Change`,
-      cancelButtonText: t`Cancel`,
-    };
-  }
-}
-
-export function getSandboxedTableWarningModal(
-  permissions: GroupsPermissions,
-  groupId: number,
-  entityId: EntityId,
-  value: DataPermissionValue,
-) {
-  // if the user is sandboxing the table while there is create-queries permissions set to
-  // query builder and native for that group's access to the database being modified, we
-  // should prompt them that we will have to remove native access for all tables/schemas
-  if (
-    value === DataPermissionValue.SANDBOXED &&
-    hasPermissionValueInGraph(
-      permissions[groupId][entityId.databaseId],
-      DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
-    )
-  ) {
-    return {
-      title: t`Change access to this database to “Sandboxed”?`,
-      message: t`As part of providing sandboxing we will also have to remove this group's native querying permissions from all tables and schemas in this database.`,
       confirmButtonText: t`Change`,
       cancelButtonText: t`Cancel`,
     };

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -10,6 +10,7 @@ import {
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS,
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS,
   PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_POST_ACTION,
+  PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_CONFIRMATIONS,
   PLUGIN_ADVANCED_PERMISSIONS,
   PLUGIN_FEATURE_LEVEL_PERMISSIONS,
 } from "metabase/plugins";
@@ -29,7 +30,6 @@ import {
   getPermissionWarningModal,
   getControlledDatabaseWarningModal,
   getRevokingAccessToAllTablesWarningModal,
-  getSandboxedTableWarningModal,
   getWillRevokeNativeAccessWarningModal,
 } from "../confirmations";
 
@@ -86,7 +86,9 @@ const buildAccessPermission = (
       groupId,
     ),
     getControlledDatabaseWarningModal(currDbPermissionValue, entityId),
-    getSandboxedTableWarningModal(permissions, groupId, entityId, newValue),
+    ...PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_CONFIRMATIONS.map(confirmation =>
+      confirmation(permissions, groupId, entityId, newValue),
+    ),
     getRevokingAccessToAllTablesWarningModal(
       database,
       permissions,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -29,6 +29,8 @@ import {
   getPermissionWarningModal,
   getControlledDatabaseWarningModal,
   getRevokingAccessToAllTablesWarningModal,
+  getSandboxedTableWarningModal,
+  getWillRevokeNativeAccessWarningModal,
 } from "../confirmations";
 
 const buildAccessPermission = (
@@ -84,6 +86,7 @@ const buildAccessPermission = (
       groupId,
     ),
     getControlledDatabaseWarningModal(currDbPermissionValue, entityId),
+    getSandboxedTableWarningModal(permissions, groupId, entityId, newValue),
     getRevokingAccessToAllTablesWarningModal(
       database,
       permissions,
@@ -165,6 +168,9 @@ const buildNativePermission = (
       DATA_PERMISSION_OPTIONS.queryBuilder,
       DATA_PERMISSION_OPTIONS.no,
     ]),
+    confirmations: () => [
+      getWillRevokeNativeAccessWarningModal(permissions, groupId, entityId),
+    ],
   };
 };
 

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -23,13 +23,14 @@ import type {
   PermissionSectionConfig,
   EntityId,
 } from "../../types";
-import { DataPermission } from "../../types";
+import { DataPermissionValue, DataPermission } from "../../types";
 import {
   getTableEntityId,
   getSchemaEntityId,
   getDatabaseEntityId,
   getPermissionSubject,
 } from "../../utils/data-entity-id";
+import { hasPermissionValueInEntityGraphs } from "../../utils/graph";
 
 import type { EditorBreadcrumb } from "./breadcrumbs";
 import {
@@ -80,7 +81,7 @@ const getRouteParams = (
   };
 };
 
-const getDataPermissions = (state: State) =>
+export const getDataPermissions = (state: State) =>
   state.admin.permissions.dataPermissions;
 
 const getOriginalDataPermissions = (state: State) =>
@@ -280,6 +281,17 @@ export const getDatabasesPermissionEditor = createSelector(
     const breadcrumbs = getDatabasesEditorBreadcrumbs(params, metadata, group);
     const title = t`Permissions for the `;
 
+    const deprecatedPermsInGraph = new Set(
+      _.compact([
+        hasPermissionValueInEntityGraphs(
+          permissions,
+          entities.map((entity: any) => ({ groupId, ...entity.entityId })),
+          DataPermission.VIEW_DATA,
+          DataPermissionValue.LEGACY_NO_SELF_SERVICE,
+        ) && DataPermissionValue.LEGACY_NO_SELF_SERVICE,
+      ]),
+    );
+
     return {
       title,
       breadcrumbs,
@@ -294,6 +306,7 @@ export const getDatabasesPermissionEditor = createSelector(
       filterPlaceholder: getFilterPlaceholder(params, hasSingleSchema),
       columns,
       entities,
+      deprecatedPermsInGraph,
     };
   },
 );
@@ -416,12 +429,27 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
         ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDataColumns(permissionSubject),
       ]);
 
+      const deprecatedPermsInGraph = new Set(
+        _.compact([
+          hasPermissionValueInEntityGraphs(
+            permissions,
+            entities.map((entity: any) => ({
+              groupId: entity.id,
+              ...entity.entityId,
+            })),
+            DataPermission.VIEW_DATA,
+            DataPermissionValue.LEGACY_NO_SELF_SERVICE,
+          ) && DataPermissionValue.LEGACY_NO_SELF_SERVICE,
+        ]),
+      );
+
       return {
         title: t`Permissions for`,
         filterPlaceholder: t`Search for a group`,
         breadcrumbs: getGroupsDataEditorBreadcrumbs(params, metadata),
         columns,
         entities,
+        deprecatedPermsInGraph,
       };
     },
   );

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -24,6 +24,7 @@ import {
   getControlledDatabaseWarningModal,
   getPermissionWarning,
   getPermissionWarningModal,
+  getWillRevokeNativeAccessWarningModal,
 } from "../confirmations";
 
 const buildAccessPermission = (
@@ -150,6 +151,9 @@ const buildNativePermission = (
     postActions: {
       controlled: () => navigateToGranularPermissions(groupId, entityId),
     },
+    confirmations: () => [
+      getWillRevokeNativeAccessWarningModal(permissions, groupId, entityId),
+    ],
   };
 };
 

--- a/frontend/src/metabase/admin/permissions/types.ts
+++ b/frontend/src/metabase/admin/permissions/types.ts
@@ -37,6 +37,8 @@ export type TableEntityId = SchemaEntityId & {
 export type EntityId = DatabaseEntityId &
   Partial<Omit<TableEntityId, "databaseId">>;
 
+export type EntityWithGroupId = EntityId & { groupId: number };
+
 export enum DataPermission {
   VIEW_DATA = "view-data",
   CREATE_QUERIES = "create-queries",

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -87,6 +87,14 @@ export const PLUGIN_ADMIN_PERMISSIONS_DATABASE_ACTIONS = {
 export const PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES = [];
 export const PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES = [];
 export const PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_OPTIONS = [];
+export const PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_CONFIRMATIONS = [] as Array<
+  (
+    _permissions: GroupsPermissions,
+    _groupId: number,
+    _entityId: EntityId,
+    _value: DataPermissionValue,
+  ) => any
+>;
 export const PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_ACTIONS = {
   sandboxed: [],
 };

--- a/frontend/src/metabase/ui/components/feedback/Alert/Alert.stories.mdx
+++ b/frontend/src/metabase/ui/components/feedback/Alert/Alert.stories.mdx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { Canvas, Story, Meta } from "@storybook/addon-docs";
+import { Box, Alert, Icon, Stack, Text, TextInput } from "metabase/ui";
+
+export const args = {
+  icon: <Icon name="warning" />,
+  title: "Bummer!",
+  withCloseButton: false
+};
+
+export const argTypes = {
+  color: {
+    control: { type: "text" },
+  },
+  title: {
+    control: { type: "text" },
+  },
+  withCloseButton: {
+    control: {type: "toggle"}
+  }
+};
+
+<Meta title="Feecback/Alert" component={Alert} args={args} argTypes={argTypes} />
+
+# Alert
+
+Show helpful alerts when things go sideways (or maybe it's a happy alert. It happens)
+
+## Examples
+
+export const DefaultTemplate = args => {
+  return (<Alert {...args}>
+    <Text>The No self-service access level for View data is going away.</Text>
+    <Text>In a future release, if a group’s View data access for a database (or any of its schemas or tables) is still set to No self-service (deprecated), Metabase will automatically change that group’s View data access for the entire database to Blocked. We’ll be defaulting to Blocked, the least permissive View data access, to prevent any unattended access to data. Need help? See our docs.</Text>
+  </Alert>);
+};
+
+export const Default = DefaultTemplate.bind({});
+
+<Canvas>
+  <Story name="Default">{Default}</Story>
+</Canvas>

--- a/frontend/src/metabase/ui/components/feedback/Alert/Alert.styled.tsx
+++ b/frontend/src/metabase/ui/components/feedback/Alert/Alert.styled.tsx
@@ -1,0 +1,22 @@
+import type { MantineThemeOverride } from "@mantine/core";
+
+import { lighten } from "metabase/lib/colors";
+
+export const getAlertOverrides = (): MantineThemeOverride["components"] => ({
+  Alert: {
+    styles: (_theme, params) => {
+      return {
+        wrapper: {
+          alignItems: "center",
+        },
+        root: {
+          backgroundColor: params.color ? lighten(params.color, 0.4) : "none",
+        },
+      };
+    },
+
+    defaultProps: {
+      variant: "outline",
+    },
+  },
+});

--- a/frontend/src/metabase/ui/components/feedback/Alert/index.ts
+++ b/frontend/src/metabase/ui/components/feedback/Alert/index.ts
@@ -1,0 +1,3 @@
+export { Alert } from "@mantine/core";
+export type { AlertProps } from "@mantine/core";
+export { getAlertOverrides } from "./Alert.styled";

--- a/frontend/src/metabase/ui/components/feedback/index.ts
+++ b/frontend/src/metabase/ui/components/feedback/index.ts
@@ -1,1 +1,2 @@
 export * from "./Loader";
+export * from "./Alert";

--- a/frontend/src/metabase/ui/theme.ts
+++ b/frontend/src/metabase/ui/theme.ts
@@ -4,6 +4,7 @@ import { rem } from "@mantine/core";
 import {
   getAccordionOverrides,
   getActionIconOverrides,
+  getAlertOverrides,
   getAnchorOverrides,
   getAutocompleteOverrides,
   getButtonOverrides,
@@ -105,6 +106,7 @@ export const getThemeOverrides = (): MantineThemeOverride => ({
   components: {
     ...getAccordionOverrides(),
     ...getActionIconOverrides(),
+    ...getAlertOverrides(),
     ...getAnchorOverrides(),
     ...getAutocompleteOverrides(),
     ...getButtonOverrides(),

--- a/frontend/src/metabase/ui/utils/colors.ts
+++ b/frontend/src/metabase/ui/utils/colors.ts
@@ -37,6 +37,7 @@ const CUSTOM_COLORS = [
   "success",
   "error",
   "white",
+  "accent5",
 ];
 
 function getColorShades(color: string): ColorShades {


### PR DESCRIPTION
Closes #41221

### Description

Makes three changes:
1. Adds warning above permissions table if a permission in the current view or within a nested entity contains the legacy No self-service (Deprecated)  permission.
2. Adds a warning modal if the user is going to sandbox a table that we will need to remove native query permissions for all other tables/schemas for that group.
3. Adds a warning modal if the user is removing native query permissions for a single tables/schema that all other tables/schemas for that user will also have native query permissions removed.


### How to verify

1. Legacy Deprecation Notice
- Have a permissions graph that has the `legacy-no-self-service` value in it.
- Validate that you see this when the `legacy-no-self-service` value is present in the graph
- Validate it's no longer than if you change the value

2. Sandboxing warning
- Have a database with `Can view` and `Query builder and native` permissions
- Make View data permissions granular
- Change a table to be `Sandboxed`, see that you are properly warned.
- Exit w/o sandboxing
- Change database `Create queries` permissions to `Query builder only`
- Make View data permissions granular
- Change a table to be `Sandboxed`, see that you are not warned.

3. Granular create queries permissions warning
- Have a database with `Can view` and `Query builder and native` permissions
- Make Create queries permissions granular
- Change a table to be `Query builder only` or `No`, see that you are properly warned.

### Demo

1. Legacy Deprecation Notice

<img width="1727" alt="Screenshot 2024-04-12 at 4 43 41 PM" src="https://github.com/metabase/metabase/assets/7104357/c9001906-9ae2-42a0-baca-0e2409bebbce">
<img width="1726" alt="Screenshot 2024-04-12 at 4 43 47 PM" src="https://github.com/metabase/metabase/assets/7104357/69b03cae-7e28-4927-83e5-fec0501e1e34">

2. Sandboxing warning

<img width="1728" alt="Screenshot 2024-04-12 at 4 45 29 PM" src="https://github.com/metabase/metabase/assets/7104357/eaba0218-ce58-403a-8255-de741469eb57">

3. Granular create queries permissions warning

<img width="1728" alt="Screenshot 2024-04-12 at 4 46 28 PM" src="https://github.com/metabase/metabase/assets/7104357/38bcb2aa-a55a-4c4a-b338-de983152d705">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR