### PR TITLE
fix incorrect tooltip values

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -154,10 +154,18 @@ export const getEventColumnsData = (
 
       const col = chartModel.columnByDataKey[dataKey];
       const columnSeriesModel = seriesModelsByDataKey[dataKey];
+      const key =
+        columnSeriesModel == null || "breakoutColumn" in columnSeriesModel
+          ? col.display_name
+          : columnSeriesModel?.name;
+      const displayValue =
+        isBreakoutSeries && seriesModel.breakoutColumn === col
+          ? seriesModel.name
+          : value ?? NULL_DISPLAY_VALUE;
 
       return {
-        key: columnSeriesModel?.name ?? col.display_name,
-        value: value ?? NULL_DISPLAY_VALUE,
+        key,
+        value: displayValue,
         col,
       };
     })


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41333

### Description

Fixes tooltip values for breakout series.

### How to verify

- Create a chart with a breakout
- Change one breakout series name to something else
- Hover the series
- Ensure tooltip shows the right key for the y-axis column
- Ensure the breakout column shows the series name as the value

### Demo

Before
<img width="814" alt="Screenshot 2024-04-12 at 6 36 43 PM" src="https://github.com/metabase/metabase/assets/14301985/3089562f-327e-47c6-85e3-50bceadfcedd">

After
<img width="817" alt="Screenshot 2024-04-12 at 6 35 39 PM" src="https://github.com/metabase/metabase/assets/14301985/0e6c7b85-61fb-4282-a8de-1efc117b316a">

### Checklist

- [-] Tests have been added/updated to cover changes in this PR — E2E specs are failing because of this
