### PR TITLE
fix header being rendered (with its border) on dashboard embedded with titled=false and only one tab

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -182,7 +182,10 @@ function EmbedFrame({
     >
       <ContentContainer>
         {hasHeader && (
-          <Header className="EmbedFrame-header" data-testid="embedframe-header">
+          <Header
+            className="EmbedFrame-header"
+            data-testid="embed-frame-header"
+          >
             {finalName && (
               <TitleAndDescriptionContainer>
                 <FixedWidthContainer

--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx
@@ -182,7 +182,7 @@ function EmbedFrame({
     >
       <ContentContainer>
         {hasHeader && (
-          <Header className="EmbedFrame-header">
+          <Header className="EmbedFrame-header" data-testid="embedframe-header">
             {finalName && (
               <TitleAndDescriptionContainer>
                 <FixedWidthContainer

--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.jsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.jsx
@@ -182,7 +182,11 @@ class PublicDashboardInner extends Component {
         actionButtons={
           buttons.length > 0 && <div className={CS.flex}>{buttons}</div>
         }
-        dashboardTabs={<DashboardTabs location={this.props.location} />}
+        dashboardTabs={
+          dashboard?.tabs?.length > 1 && (
+            <DashboardTabs location={this.props.location} />
+          )
+        }
       >
         <LoadingAndErrorWrapper
           className={cx({

--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.unit.spec.tsx
@@ -33,13 +33,13 @@ describe("PublicDashboard", () => {
     await setup({ hash: "titled=false", numberOfTabs: 1 });
 
     expect(screen.queryByText("Tab 1")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("embedframe-header")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("embed-frame-header")).not.toBeInTheDocument();
   });
 
   it("should display the header if title is enabled and there is only one tab", async () => {
     await setup({ numberOfTabs: 1, hash: "titled=true" });
 
-    expect(screen.getByTestId("embedframe-header")).toBeInTheDocument();
+    expect(screen.getByTestId("embed-frame-header")).toBeInTheDocument();
     expect(screen.queryByText("Tab 1")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.unit.spec.tsx
@@ -14,35 +14,51 @@ const MOCK_TOKEN =
   "eyJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6eyJkYXNoYm9hcmQiOjExfSwicGFyYW1zIjp7fSwiaWF0IjoxNzEyNjg0NTA1LCJfZW1iZWRkaW5nX3BhcmFtcyI6e319.WbZTB-cQYh4gjh61ZzoLOcFbJ6j6RlOY3GS4fwzv3W4";
 const DASHBOARD_TITLE = '"My test dash"';
 
-const DASHBOARD_WITH_TABS = createMockDashboard({
-  id: 1,
-  name: DASHBOARD_TITLE,
-  parameters: [],
-  dashcards: [],
-  tabs: [
-    createMockDashboardTab({ id: 1, name: "Tab 1" }),
-    createMockDashboardTab({ id: 2, name: "Tab 2" }),
-  ],
-});
-
 describe("PublicDashboard", () => {
   it("should display dashboard tabs", async () => {
-    await setup();
+    await setup({ numberOfTabs: 2 });
 
     expect(screen.getByText("Tab 1")).toBeInTheDocument();
     expect(screen.getByText("Tab 2")).toBeInTheDocument();
   });
 
   it("should display dashboard tabs if title is disabled (metabase#41195)", async () => {
-    await setup({ hash: "titled=false" });
+    await setup({ hash: "titled=false", numberOfTabs: 2 });
 
     expect(screen.getByText("Tab 1")).toBeInTheDocument();
     expect(screen.getByText("Tab 2")).toBeInTheDocument();
   });
+
+  it("should not display the header if title is disabled and there is only one tab (metabase#41393)", async () => {
+    await setup({ hash: "titled=false", numberOfTabs: 1 });
+
+    expect(screen.queryByText("Tab 1")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("embedframe-header")).not.toBeInTheDocument();
+  });
+
+  it("should display the header if title is enabled and there is only one tab", async () => {
+    await setup({ numberOfTabs: 1, hash: "titled=true" });
+
+    expect(screen.getByTestId("embedframe-header")).toBeInTheDocument();
+    expect(screen.queryByText("Tab 1")).not.toBeInTheDocument();
+  });
 });
 
-async function setup({ hash }: { hash?: string } = {}) {
-  setupEmbedDashboardEndpoints(MOCK_TOKEN, DASHBOARD_WITH_TABS);
+async function setup({
+  hash,
+  numberOfTabs = 1,
+}: { hash?: string; numberOfTabs?: number } = {}) {
+  const dashboard = createMockDashboard({
+    id: 1,
+    name: DASHBOARD_TITLE,
+    parameters: [],
+    dashcards: [],
+    tabs: Array.from({ length: numberOfTabs }, (_, i) =>
+      createMockDashboardTab({ id: i + 1, name: `Tab ${i + 1}` }),
+    ),
+  });
+
+  setupEmbedDashboardEndpoints(MOCK_TOKEN, dashboard);
 
   renderWithProviders(
     <Route path="embed/dashboard/:token" component={PublicDashboard} />,


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41393

### Description

The issue seems to come from the bottom-border on the header, which is rendered even though there's only 1 tab and no title.

`EmbedFrame` is rendering the header only when `Boolean(finalName || dashboardTabs)`
https://github.com/metabase/metabase/blob/97ab5fa41482af0904cb7115f3e96ac7d9d6f921/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.tsx#L168-L168

The issue is that `dashboardTabs` it not the array of the tabs, but a component which is always truthy:
https://github.com/metabase/metabase/blob/2c21fa99a07e8445fbdb61ff6df93de14defe293/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.jsx#L184-L186

I thought about making the component return null if there were no tabs, but I noticed on other places we do the check outside so I did the same here to stay on the safer side:
https://github.com/metabase/metabase/blob/97ab5fa41482af0904cb7115f3e96ac7d9d6f921/frontend/src/metabase/dashboard/containers/AutomaticDashboardApp.jsx#L155-L158

### How to verify

- Make a dashboard with one tab
- do a static embed of it with `#theme=transparent&bordered=false&titled=false`
- notice it renders the header, making look like the dashboard has a top border

This should behave the same for public embeds

### Demo
Before:
<img width="1060" alt="image" src="https://github.com/metabase/metabase/assets/1914270/29dcafb7-e503-4612-a4e8-67f03dfb3819">


After:
<img width="1057" alt="image" src="https://github.com/metabase/metabase/assets/1914270/db160f1e-9592-4483-8788-cde0590320f0">


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
