### PR TITLE
Mark the aggregation 'Custom Expression' button as an action

### DIFF
--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -46,6 +46,7 @@ type Section = {
   key: string;
   items: ListItem[];
   icon?: string;
+  type?: string;
 };
 
 function isOperatorListItem(item: ListItem): item is OperatorListItem {
@@ -122,6 +123,7 @@ export function AggregationPicker({
         name: t`Custom Expression`,
         items: [],
         icon: "sum",
+        type: "action",
       });
     }
 


### PR DESCRIPTION

Closes https://github.com/metabase/metabase/issues/41403

### Description

Marks the aggragation  'Custom Expression' button as an action to make the styling consistent.

### How to verify

Describe the steps to verify that the changes are working as expected.


1. New Question → Sample data set → Orders
2. Add an aggregation
3. Scroll down to the Custom Expression item

The button should have a border and a chevron.

### Demo

<img width="460" alt="Screenshot 2024-04-15 at 12 45 12" src="https://github.com/metabase/metabase/assets/1250185/c31511e2-c542-425e-927d-74d86423b5c7">