### PR TITLE
Fix `resources/sample-content.edn` (no such file or directory) error running jar

### DIFF
--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1118,7 +1118,7 @@
 (defn- load-edn
   "Loads edn from an EDN file. Parses values tagged with #t into the appropriate `java.time` class"
   [file-name]
-  (with-open [r (io/reader file-name)]
+  (with-open [r (io/reader (io/resource file-name))]
     (edn/read {:readers {'t u.date/parse}} (java.io.PushbackReader. r))))
 
 (defn- no-user?
@@ -1144,7 +1144,7 @@
                (not (config/config-bool :mb-enable-test-endpoints)) ; skip sample content for e2e tests to avoid coupling the tests to the contents
                (no-user?)
                (no-db?))
-      (let [table-name->raw-rows (load-edn "resources/sample-content.edn")
+      (let [table-name->raw-rows (load-edn "sample-content.edn")
             replace-temporals    (fn [v]
                                    (if (isa? (type v) java.time.temporal.Temporal)
                                      :%now


### PR DESCRIPTION
Running the bulit uberjar from `build.sh` currently fails with the following error if you run the jar from outside the project directory:

```
[main] ERROR metabase.core - Metabase Initialization FAILED
liquibase.exception.CommandExecutionException: liquibase.exception.LiquibaseException: liquibase.exception.MigrationFailedException: Migration failed for changeset migrations/001_update_migrations.yaml::v50.2024-04-09T15:55:22::calherries:
     Reason: clojure.lang.ExceptionInfo: resources/sample-content.edn (No such file or directory) {:toucan2/context-trace [["resolve connection" {:toucan2.connection/connectable org.h2.jdbc.JdbcConnection}] ["resolve connection" {:toucan2.connection/connectable nil}]]}
```

This PR fixes the error by specifying the file as a resource rather than using a path relative to the current directory.

I tested the jar already in CI [here](https://github.com/metabase/metabase/actions/runs/8689336483). 