### PR TITLE
Fix reflection getting Liquibase URL

### DIFF
--- a/src/metabase/db/liquibase.clj
+++ b/src/metabase/db/liquibase.clj
@@ -259,9 +259,9 @@
           (wait-until done? sleep-ms timeout-ms)))))
 
 (defn- liquibase->url [^Liquibase liquibase]
-  ;; Need to this cast to get access to the metadata. We currently only use JDBC app databases.
-  (let [conn ^JdbcConnection (.. liquibase getDatabase getConnection)]
-    (-> conn .getMetaData .getURL)))
+  (let [conn (.. liquibase getDatabase getConnection)]
+    ;; Need to this cast to get access to the metadata. We currently only use JDBC app databases.
+    (.getURL (.getMetaData ^JdbcConnection conn))))
 
 (defn release-concurrent-locks!
   "Release any locks held by this process corresponding to the same database."


### PR DESCRIPTION
### Description

The existing type hint was enough to convince my IDE, but I noticed that we were still getting reflection warnings when compiling from scratch. Just keeping it simple without the chaining macro seems to fix it.