### PR TITLE
revert dashcard border to put back transparency for transparent embed…

### DIFF
--- a/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
+++ b/frontend/src/metabase/dashboard/components/DashboardGrid.styled.tsx
@@ -2,7 +2,6 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 
 import DashboardS from "metabase/css/dashboard.module.css";
-import { color } from "metabase/lib/colors";
 
 import { FIXED_WIDTH } from "./Dashboard/Dashboard.styled";
 
@@ -36,7 +35,7 @@ export const DashboardCardContainer = styled.div<DashboardCardProps>`
     bottom: 0;
     right: 0;
     border-radius: 8px;
-    box-shadow: 0 0 0 1px ${color("border")};
+    box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.13);
   }
 
   ${props =>


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41393

### Description

A border/shadow was changed in https://github.com/metabase/metabase/pull/36991/, more specifically [this line](https://github.com/metabase/metabase/pull/36991/files#diff-215c69e998ee8317ed7048294524429bc439b581518f6aade1be56d4901a399bL34) sets the dashcards border to a color with 100% alpha.

This makes embeds with the transparent theme on a colored/dark background look a lot different than before (uglier in most cases).

This PR reverts that to address the complaints of some customers.

### How to verify

1. Create a dashboard
2. Do a static embed of it with theme=transparent
3. Notice that if embedded on a page with a dark color it looks better than without this pr

### Demo
Before:

<img width="967" alt="image" src="https://github.com/metabase/metabase/assets/1914270/36b2516c-369d-4ddf-8b9d-d12d6b491dbc">



After:
<img width="982" alt="image" src="https://github.com/metabase/metabase/assets/1914270/93f54325-18b8-4248-91a4-07b84482e355">


I'm not touching the bottom border on the dashboard tabs as as far as I checked that never had transparency.
Customers could complain about it popping up with titled=false and no tabs, making look like there's a top border, but that's been fixed with https://github.com/metabase/metabase/pull/41399
