### PR TITLE
Remove Metadata schemas in lib.metadata and use the versions in lib.schema.metadata instead

### DIFF
--- a/src/metabase/lib/metadata.cljc
+++ b/src/metabase/lib/metadata.cljc
@@ -9,8 +9,6 @@
    [metabase.shared.util.i18n :as i18n]
    [metabase.util.malli :as mu]))
 
-;;; TODO -- deprecate all the schemas below, and just use the versions in [[lib.schema.metadata]] instead.
-
 ;;; Column vs Field?
 ;;;
 ;;; Lately I've been using `Field` to only mean a something that lives in the application database, i.e. something


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39334

### Description

Originally Malli schemas for MLv2 metadata like `ColumnMetadata` lived in `metabase.lib.metadata`, a while ago we moved them to `metabase.lib.schema.metadata` so they could live with all of the other MLv2 schemas. Now `ColumnMetadata` is a just a def for `::lib.schema.metadata/column`.

### How to verify

Run tests in `metabase.lib.metadata-test`

```sh
clojure -X:dev:test :only metabase.lib.metadata-test
```

EDIT: Addressed in #42070 (we only need to remove the remaining ;TODO commment
