### PR TITLE
Embedding SDK - Fix table header styles calculation

### DIFF
--- a/enterprise/frontend/src/embedding-sdk/components/private/AppInitializeController.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/AppInitializeController.tsx
@@ -1,7 +1,10 @@
 import type * as React from "react";
 import { t } from "ttag";
 
-import { DEFAULT_FONT } from "embedding-sdk/config";
+import {
+  DEFAULT_FONT,
+  EMBEDDING_SDK_ROOT_ELEMENT_ID,
+} from "embedding-sdk/config";
 import { EmbeddingContext } from "embedding-sdk/context";
 import { useInitData } from "embedding-sdk/hooks";
 import type { SDKConfigType } from "embedding-sdk/types";
@@ -28,7 +31,10 @@ export const AppInitializeController = ({
         isLoggedIn,
       }}
     >
-      <SdkContentWrapper font={config.font ?? DEFAULT_FONT}>
+      <SdkContentWrapper
+        id={EMBEDDING_SDK_ROOT_ELEMENT_ID}
+        font={config.font ?? DEFAULT_FONT}
+      >
         {!isInitialized ? <div>{t`Loading…`}</div> : children}
       </SdkContentWrapper>
     </EmbeddingContext.Provider>

--- a/enterprise/frontend/src/embedding-sdk/components/private/SdkContentWrapper.tsx
+++ b/enterprise/frontend/src/embedding-sdk/components/private/SdkContentWrapper.tsx
@@ -31,4 +31,8 @@ export const SdkContentWrapper = styled.div<{ font: string }>`
 
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  svg {
+    display: inline;
+  }
 `;

--- a/enterprise/frontend/src/embedding-sdk/config.ts
+++ b/enterprise/frontend/src/embedding-sdk/config.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_FONT = "Lato";
+export const EMBEDDING_SDK_ROOT_ELEMENT_ID = "metabase-sdk-root";

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -8,6 +8,7 @@ import { Grid, ScrollSync } from "react-virtualized";
 import { t } from "ttag";
 import _ from "underscore";
 
+import { EMBEDDING_SDK_ROOT_ELEMENT_ID } from "embedding-sdk/config";
 import ExplicitSize from "metabase/components/ExplicitSize";
 import { QueryColumnInfoPopover } from "metabase/components/MetadataInfo/ColumnInfoPopover";
 import Button from "metabase/core/components/Button";
@@ -142,7 +143,14 @@ class TableInteractive extends Component {
     this._div.style.position = "absolute";
     this._div.style.visibility = "hidden";
     this._div.style.zIndex = "-1";
-    document.body.appendChild(this._div);
+
+    if (this.props.isEmbeddingSdk) {
+      document
+        .getElementById(EMBEDDING_SDK_ROOT_ELEMENT_ID)
+        ?.appendChild(this._div);
+    } else {
+      document.body.appendChild(this._div);
+    }
 
     this._measure();
     this._findIDColumn(this.props.data, this.props.isPivoted);

--- a/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
+++ b/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx
@@ -145,9 +145,18 @@ class TableInteractive extends Component {
     this._div.style.zIndex = "-1";
 
     if (this.props.isEmbeddingSdk) {
-      document
-        .getElementById(EMBEDDING_SDK_ROOT_ELEMENT_ID)
-        ?.appendChild(this._div);
+      const rootElement = document.getElementById(
+        EMBEDDING_SDK_ROOT_ELEMENT_ID,
+      );
+
+      if (rootElement) {
+        rootElement.appendChild(this._div);
+      } else {
+        console.warn(
+          // eslint-disable-next-line no-literal-metabase-strings -- not UI string
+          "Failed to find Embedding SDK provider component. Have you forgot to add MetabaseProvider?",
+        );
+      }
     } else {
       document.body.appendChild(this._div);
     }

--- a/jest.tz.unit.conf.json
+++ b/jest.tz.unit.conf.json
@@ -2,8 +2,7 @@
   "moduleNameMapper": {
     "\\.(css|less)$": "<rootDir>/frontend/test/__mocks__/styleMock.js",
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/frontend/test/__mocks__/fileMock.js",
-    "^promise-loader\\?global\\!metabase-lib\\/v1\\/metadata\\/utils\\/ga-metadata$":
-    "<rootDir>/frontend/src/metabase-lib/v1/metadata/utils/ga-metadata.js",
+    "^promise-loader\\?global\\!metabase-lib\\/v1\\/metadata\\/utils\\/ga-metadata$": "<rootDir>/frontend/src/metabase-lib/v1/metadata/utils/ga-metadata.js",
     "^cljs/(.*)$": "<rootDir>/target/cljs_dev/$1",
     "^d3-(.*)$": "<rootDir>/node_modules/d3-$1/dist/d3-$1",
     "react-markdown": "<rootDir>/node_modules/react-markdown/react-markdown.min.js",
@@ -13,7 +12,11 @@
     "<rootDir>/node_modules/(?!rehype-external-links/)"
   ],
   "testMatch": ["<rootDir>/frontend/**/*.tz.unit.spec.{js,ts,jsx,tsx}"],
-  "modulePaths": ["<rootDir>/frontend/test", "<rootDir>/frontend/src"],
+  "modulePaths": [
+    "<rootDir>/frontend/test",
+    "<rootDir>/frontend/src",
+    "<rootDir>/enterprise/frontend/src"
+  ],
   "setupFiles": [
     "<rootDir>/frontend/test/jest-setup.js",
     "<rootDir>/frontend/test/metabase-bootstrap.js",


### PR DESCRIPTION
Relates to https://github.com/metabase/metabase/issues/41095, MS3
Also: https://github.com/metabase/metabase/pull/41106

### Description

This fixes table header styles calculation.

The way how table header cells is calculated described here - https://github.com/metabase/metabase/blob/master/frontend/src/metabase/visualizations/components/TableInteractive/TableInteractive.jsx#L275

We mount a hidden div to **document.body**, render cells, calculate maximum width, and then apply this widths to real content.

The issue is that we apply sdk styles overrides only inside our wrapper component scope, so globally mounted hidden div doesn't have needed svg styles which leads to wrong header cells width.

### How to verify

Run demo, check table header.

### Demo

<table>
<tr>
<th> Before: </th>
<th> After: </th>
</tr>
<tr>
<td>

<img width="400" alt="Screenshot 2024-04-15 at 23 59 21" src="https://github.com/metabase/metabase/assets/7983744/c5be5da7-3669-4fc2-90b5-17df77ed2610">

</td>
<td>

<img width="400" alt="Screenshot 2024-04-15 at 23 55 51" src="https://github.com/metabase/metabase/assets/7983744/f60de2e5-7ce6-4694-826b-3794c8b34d81">



</td>
</tr>
</table>
