### PR TITLE
fix static viz webpack config

### DIFF
--- a/webpack.static-viz.config.js
+++ b/webpack.static-viz.config.js
@@ -75,8 +75,9 @@ module.exports = env => {
           ],
         },
         {
-          test: /\.svg$/i,
-          use: "null-loader",
+          test: /\.svg$/,
+          type: "asset/resource",
+          resourceQuery: { not: [/component|source/] },
         },
       ],
     },


### PR DESCRIPTION
### Description

Fixes the webpack config for the static viz bundle which started failing after rebasing on master.

### How to verify

Ensure `yarn build-static-viz` works

