### PR TITLE
Missing test case for update scan field values schedule

### DIFF
--- a/src/metabase/models/database.clj
+++ b/src/metabase/models/database.clj
@@ -276,6 +276,8 @@
                  (or
                   ;if there is any changes in user control setting
                   (some? (get-in changes [:details :let-user-control-scheduling]))
+                  ;; if the let user control scheduling is already on, we should always try to re-infer it
+                  (get-in database [:details :let-user-control-scheduling])
                   ;; if there is a changes in schedules, make sure it respects the settings
                   (some some? [(:cache_field_values_schedule changes) (:metadata_sync_schedule changes)]))
                  infer-db-schedules

--- a/test/metabase/api/database_test.clj
+++ b/test/metabase/api/database_test.clj
@@ -1190,7 +1190,7 @@
             (is (not= (u.cron/schedule-map->cron-string schedule-map-for-last-friday-at-11pm)
                       (:cache_field_values_schedule db)))))
 
-        (testing "update db setting to never scan should remove scan field values trigger"
+        (testing "update db setting with a custom trigger should reschedule scan field values"
           (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
                                 {:details     {:let-user-control-scheduling true}
                                  :schedules   {:metadata_sync      schedule-map-for-weekly
@@ -1203,23 +1203,37 @@
             (is (= (u.cron/schedule-map->cron-string schedule-map-for-weekly)
                    (:metadata_sync_schedule db)))
             (is (= (u.cron/schedule-map->cron-string schedule-map-for-last-friday-at-11pm)
-                   (:cache_field_values_schedule db))))
+                   (:cache_field_values_schedule db)))))
 
-          (testing "turn back to default settings should recreate all tasks with randomized schedule"
-            (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
-                                  {:details     {:let-user-control-scheduling false}
-                                   :schedules   {:metadata_sync      schedule-map-for-weekly
-                                                 :cache_field_values schedule-map-for-last-friday-at-11pm}
-                                   :is_full_sync true
-                                   :is_on_demand false})
-            (is (= (all-db-sync-triggers-name db)
-                   (query-all-db-sync-triggers-name db)))
-            (let [db (t2/select-one :model/Database (:id db))]
-              ;; make sure the new schedule is randomized, not from the payload
-              (is (not= (-> schedule-map-for-weekly u.cron/schedule-map->cron-string)
-                        (:metadata_sync_schedule db)))
-              (is (not= (-> schedule-map-for-last-friday-at-11pm u.cron/schedule-map->cron-string)
-                        (:cache_field_values_schedule db))))))))))
+       (testing "update db setting to never scan should remove scan field values trigger"
+         (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
+                               {:details     {:let-user-control-scheduling true}
+                                :schedules   {:metadata_sync      schedule-map-for-weekly
+                                              :cache_field_values schedule-map-for-last-friday-at-11pm}
+                                :is_full_sync false
+                                :is_on_demand false})
+         (is (= #{(sync-and-analyze-trigger-name db)}
+                (query-all-db-sync-triggers-name db)))
+         (let [db (t2/select-one :model/Database (:id db))]
+           (is (= (u.cron/schedule-map->cron-string schedule-map-for-weekly)
+                  (:metadata_sync_schedule db)))
+           (is (nil? (:cache_field_values_schedule db)))))
+
+       (testing "turn back to default settings should recreate all tasks with randomized schedule"
+         (mt/user-http-request :crowberto :put 200 (format "/database/%d" (:id db))
+                               {:details     {:let-user-control-scheduling false}
+                                :schedules   {:metadata_sync      schedule-map-for-weekly
+                                              :cache_field_values schedule-map-for-last-friday-at-11pm}
+                                :is_full_sync true
+                                :is_on_demand false})
+         (is (= (all-db-sync-triggers-name db)
+                (query-all-db-sync-triggers-name db)))
+         (let [db (t2/select-one :model/Database (:id db))]
+           ;; make sure the new schedule is randomized, not from the payload
+           (is (not= (-> schedule-map-for-weekly u.cron/schedule-map->cron-string)
+                     (:metadata_sync_schedule db)))
+           (is (not= (-> schedule-map-for-last-friday-at-11pm u.cron/schedule-map->cron-string)
+                     (:cache_field_values_schedule db)))))))))
 
 (deftest update-db-to-never-scan-values-on-demand-test
   (with-db-scheduler-setup


### PR DESCRIPTION
Follow up of https://github.com/metabase/metabase/pull/41170

This fix a case if you switch from never scan => custom field values scan and it should delete the scan field values trigger