### PR TITLE
migrate caching settings over to the new cache_config table

### DIFF
--- a/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
@@ -70,8 +70,7 @@
               :order-by :ordering
               :limit    [:inline 1]}
         item (t2/select-one :model/CacheConfig :id q)]
-    (when item
-      (:strategy (cache-config/row->config item card)))))
+    (cache-config/card-strategy item card)))
 
 ;;; Strategy execution
 

--- a/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
@@ -1,7 +1,7 @@
 (ns metabase-enterprise.cache.strategies
   (:require
    [java-time.api :as t]
-   [metabase.api.cache :as api.cache]
+   [metabase.models.cache-config :as cache-config]
    [metabase.public-settings.premium-features :refer [defenterprise defenterprise-schema]]
    [metabase.query-processor.middleware.cache-backend.db :as backend.db]
    [metabase.util.cron :as u.cron]
@@ -50,7 +50,7 @@
 
 ;;; Querying DB
 
-(defenterprise-schema granular-cache-strategy :- [:maybe (CacheStrategy)]
+(defenterprise-schema cache-strategy :- [:maybe (CacheStrategy)]
   "Returns the granular cache strategy for a card."
   :feature :cache-granular-controls
   [card dashboard-id]
@@ -71,7 +71,7 @@
               :limit    [:inline 1]}
         item (t2/select-one :model/CacheConfig :id q)]
     (when item
-      (:strategy (api.cache/row->config item card)))))
+      (:strategy (cache-config/row->config item card)))))
 
 ;;; Strategy execution
 

--- a/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
+++ b/enterprise/backend/src/metabase_enterprise/cache/strategies.clj
@@ -1,9 +1,7 @@
 (ns metabase-enterprise.cache.strategies
   (:require
    [java-time.api :as t]
-   [medley.core :as m]
    [metabase.api.cache :as api.cache]
-   [metabase.public-settings :as public-settings]
    [metabase.public-settings.premium-features :refer [defenterprise defenterprise-schema]]
    [metabase.query-processor.middleware.cache-backend.db :as backend.db]
    [metabase.util.cron :as u.cron]
@@ -28,64 +26,52 @@
     [:ttl      [:map {:closed true}
                 [:type [:= :ttl]]
                 [:multiplier ms/PositiveInt]
-                [:min_duration_ms ms/IntGreaterThanOrEqualToZero]]]
+                [:min_duration_ms ms/IntGreaterThanOrEqualToZero]
+                ^:internal
+                [:invalidated-at {:optional true} some?]]]
     [:duration [:map {:closed true}
                 [:type [:= :duration]]
                 [:duration ms/PositiveInt]
-                [:unit [:enum "hours" "minutes" "seconds" "days"]]]]
+                [:unit [:enum "hours" "minutes" "seconds" "days"]]
+                ^:internal
+                [:invalidated-at {:optional true} some?]]]
     [:schedule [:map {:closed true}
                 [:type [:= :schedule]]
                 [:schedule u.cron/CronScheduleString]
                 ^:internal
-                [:invalidated-at [:maybe some?]]]]
+                [:invalidated-at {:optional true} some?]]]
     [:query    [:map {:closed true}
                 [:type [:= :query]]
                 [:field_id int?]
                 [:aggregation [:enum "max" "count"]]
                 [:schedule u.cron/CronScheduleString]
                 ^:internal
-                [:invalidated-at [:maybe some?]]]]]])
+                [:invalidated-at {:optional true} some?]]]]])
 
 ;;; Querying DB
-
-(defn granular-duration-hours
-  "Returns the granular cache duration (in hours) for a card. On EE, this first checking whether there is a stored value
-   for the card, dashboard, or database (in that order of decreasing preference). Returns nil on OSS."
-  [card dashboard-id]
-  (or (:cache_ttl card)
-      (when dashboard-id
-        (t2/select-one-fn :cache_ttl [:model/Dashboard :cache_ttl] :id dashboard-id))
-      (t2/select-one-fn :cache_ttl [:model/Database :cache_ttl] :id (:database_id card))))
 
 (defenterprise-schema granular-cache-strategy :- [:maybe (CacheStrategy)]
   "Returns the granular cache strategy for a card."
   :feature :cache-granular-controls
   [card dashboard-id]
-  (when (public-settings/enable-query-caching)
-    (let [qs   (for [[i model model-id] [[1 "question"   (:id card)]
-                                         [2 "dashboard"  dashboard-id]
-                                         [3 "database"   (:database_id card)]
-                                         [4 "root"       0]]
-                     :when              model-id]
-                 {:from   [:cache_config]
-                  :select [:id
-                           [[:inline i] :ordering]]
-                  :where  [:and
-                           [:= :model model]
-                           [:= :model_id model-id]]})
-          q    {:from     [[{:union-all qs} :unused_alias]]
-                :select   [:id]
-                :order-by :ordering
-                :limit    1}
-          item (t2/select-one :model/CacheConfig :id q)]
-      (if item
-        (-> (:strategy (api.cache/row->config item))
-            (m/assoc-some :invalidated-at (t/max (:invalidated_at item)
-                                                 (:cache_invalidated_at card))))
-        (when-let [ttl (granular-duration-hours card dashboard-id)]
-          {:type     :duration
-           :duration ttl
-           :unit     "hours"})))))
+  (let [qs   (for [[i model model-id] [[1 "question"   (:id card)]
+                                       [2 "dashboard"  dashboard-id]
+                                       [3 "database"   (:database_id card)]
+                                       [4 "root"       0]]
+                   :when              model-id]
+               {:from   [:cache_config]
+                :select [:id
+                         [[:inline i] :ordering]]
+                :where  [:and
+                         [:= :model [:inline model]]
+                         [:= :model_id model-id]]})
+        q    {:from     [[{:union-all qs} :unused_alias]]
+              :select   [:id]
+              :order-by :ordering
+              :limit    [:inline 1]}
+        item (t2/select-one :model/CacheConfig :id q)]
+    (when item
+      (:strategy (api.cache/row->config item card)))))
 
 ;;; Strategy execution
 

--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -50,7 +50,7 @@
                          :model_id int?
                          :details  {:model     "root"
                                     :model-id  0
-                                    :old-value nil
+                                    ;; no check for old value in case you had something in appdb
                                     :new-value {:strategy "nocache" :config {:name "root"}}}}
                         (last-audit-event)))))
 

--- a/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/cache/cache_test.clj
@@ -113,7 +113,6 @@
                                          :strategy {:type     "schedule"
                                                     :schedule "0/2 * * * * ?"}})))))))))
 
-
 (deftest invalidation-test
   (mt/discard-setting-changes [enable-query-caching]
     (public-settings/enable-query-caching! true)

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6188,6 +6188,25 @@ databaseChangeLog:
         - customChange:
             class: "metabase.db.custom_migrations.BackfillQueryField"
 
+  - changeSet:
+      id: v50.2024-04-12T12:33:09
+      author: piranha
+      comment: 'Copy old cache configurations to cache_config table'
+      changes:
+        - sqlFile:
+            dbms: postgresql
+            path: custom_sql/fill_cache_config.pg.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: custom_sql/fill_cache_config.my.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: h2
+            path: custom_sql/fill_cache_config.h2.sql
+            relativeToChangelogFile: true
+      rollback: # no rollback necessary, we're not removing the columns yet
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/custom_sql/fill_cache_config.h2.sql
+++ b/resources/migrations/custom_sql/fill_cache_config.h2.sql
@@ -1,0 +1,44 @@
+WITH root AS (
+  select 'root' AS model,
+         0      AS model_id,
+         'ttl'  AS strategy,
+         json_object(
+           'multiplier' VALUE coalesce((select ("VALUE"::varchar(15))::int from setting where "KEY" = 'query-caching-ttl-ratio'), 10),
+           'min_duration_ms' VALUE coalesce((select ("VALUE"::varchar(15))::int from setting where "KEY" = 'query-caching-min-ttl'), 60000)
+         ) AS config
+), database AS (
+  select 'database' AS model,
+         id         AS model_id,
+         'duration' AS strategy,
+         json_object('duration' VALUE cache_ttl, 'unit' VALUE 'hours') AS config
+    from metabase_database
+   where cache_ttl is not null
+), dashboard AS (
+  select 'dashboard' AS model,
+         id          AS model_id,
+         'duration'  AS strategy,
+         json_object('duration' VALUE cache_ttl, 'unit' VALUE 'hours') AS config
+    from report_dashboard
+   where cache_ttl is not null
+), card AS (
+  select 'question' AS model,
+         id         AS model_id,
+         'duration' AS strategy,
+         json_object('duration' VALUE cache_ttl, 'unit' VALUE 'hours') AS config
+    from report_card
+   where cache_ttl is not null
+), rows1 AS (
+  SELECT * FROM root UNION ALL
+  SELECT * FROM database UNION ALL
+  SELECT * FROM dashboard UNION ALL
+  SELECT * FROM card
+), rows AS (
+  SELECT * FROM rows1
+   WHERE (SELECT true FROM setting WHERE "KEY" = 'enable-query-caching' AND "VALUE" = 'true')
+)
+    MERGE INTO cache_config AS C
+    USING rows AS R (model, model_id, strategy, config)
+    ON C.model = R.model AND C.model_id = R.model_id
+    WHEN NOT MATCHED THEN
+         INSERT (model, model_id, strategy, config)
+         VALUES (R.model, R.model_id, R.strategy, R.config);

--- a/resources/migrations/custom_sql/fill_cache_config.my.sql
+++ b/resources/migrations/custom_sql/fill_cache_config.my.sql
@@ -1,0 +1,40 @@
+INSERT IGNORE INTO cache_config (model, model_id, strategy, config)
+WITH root AS (
+  select 'root' AS model,
+         0      AS model_id,
+         'ttl'  AS strategy,
+         json_object(
+           'multiplier', coalesce((select cast(`value` as unsigned) from setting where `key` = 'query-caching-ttl-ratio'), 10),
+           'min_duration_ms', coalesce((select cast(`value` as unsigned) from setting where `key` = 'query-caching-min-ttl'), 60000)
+         ) AS config
+), `database` AS (
+  select 'database' AS model,
+         id         AS model_id,
+         'duration' AS strategy,
+         json_object('duration', cache_ttl, 'unit', 'hours') AS config
+    from metabase_database
+   where cache_ttl is not null
+), dashboard AS (
+  select 'dashboard' AS model,
+         id          AS model_id,
+         'duration'  AS strategy,
+         json_object('duration', cache_ttl, 'unit', 'hours') AS config
+    from report_dashboard
+   where cache_ttl is not null
+), card AS (
+  select 'question' AS model,
+         id         AS model_id,
+         'duration' AS strategy,
+         json_object('duration', cache_ttl, 'unit', 'hours') AS config
+    from report_card
+   where cache_ttl is not null
+), rows1 AS (
+  SELECT * FROM root UNION ALL
+  SELECT * FROM `database` UNION ALL
+  SELECT * FROM dashboard UNION ALL
+  SELECT * FROM card
+), `rows` AS (
+  SELECT * FROM rows1
+   WHERE (SELECT true FROM setting WHERE `key` = 'enable-query-caching' AND `value` = 'true')
+)
+    SELECT * FROM `rows`;

--- a/resources/migrations/custom_sql/fill_cache_config.pg.sql
+++ b/resources/migrations/custom_sql/fill_cache_config.pg.sql
@@ -1,0 +1,41 @@
+WITH root AS (
+  select 'root' AS model,
+         0      AS model_id,
+         'ttl'  AS strategy,
+         json_build_object(
+           'multiplier', coalesce((select value::float::int from setting where key = 'query-caching-ttl-ratio'), 10),
+           'min_duration_ms', coalesce((select value::float::int from setting where key = 'query-caching-min-ttl'), 60000)
+         ) AS config
+), database AS (
+  select 'database' AS model,
+         id         AS model_id,
+         'duration' AS strategy,
+         json_build_object('duration', cache_ttl, 'unit', 'hours') AS config
+    from metabase_database
+   where cache_ttl is not null
+), dashboard AS (
+  select 'dashboard' AS model,
+         id          AS model_id,
+         'duration'  AS strategy,
+         json_build_object('duration', cache_ttl, 'unit', 'hours') AS config
+    from report_dashboard
+   where cache_ttl is not null
+), card AS (
+  select 'question' AS model,
+         id         AS model_id,
+         'duration' AS strategy,
+         json_build_object('duration', cache_ttl, 'unit', 'hours') AS config
+    from report_card
+   where cache_ttl is not null
+), rows1 AS (
+  SELECT * FROM root UNION ALL
+  SELECT * FROM database UNION ALL
+  SELECT * FROM dashboard UNION ALL
+  SELECT * FROM card
+), rows AS (
+  SELECT * FROM rows1
+   WHERE (SELECT true FROM setting WHERE key = 'enable-query-caching' AND VALUE = 'true')
+)
+    INSERT INTO cache_config (model, model_id, strategy, config)
+    SELECT * FROM rows
+    ON CONFLICT (model, model_id) DO NOTHING;

--- a/src/metabase/api/cache.clj
+++ b/src/metabase/api/cache.clj
@@ -3,6 +3,7 @@
    [clojure.walk :as walk]
    [compojure.core :refer [GET]]
    [java-time.api :as t]
+   [medley.core :as m]
    [metabase.api.common :as api]
    [metabase.api.common.validation :as validation]
    [metabase.db.query :as mdb.query]
@@ -18,10 +19,13 @@
 
 (defn row->config
   "Transform from how cache config is stored to how it's used/exposed in the API"
-  [row]
+  [row & [card]]
   {:model    (:model row)
    :model_id (:model_id row)
-   :strategy (assoc (:config row) :type (:strategy row))})
+   :strategy (-> (:config row)
+                 (assoc :type (:strategy row))
+                 (m/assoc-some :invalidated-at (t/max (:invalidated_at row)
+                                                      (:cache_invalidated_at card))))})
 
 (defn config->row
   "Transform cache config from API form into db storage from"

--- a/src/metabase/models/cache_config.clj
+++ b/src/metabase/models/cache_config.clj
@@ -28,17 +28,20 @@
   (t2/select-one :model/CacheConfig :model "root" :model_id 0 :strategy :ttl))
 
 (defn row->config
-  "Transform from how cache config is stored to how it's used/exposed in the API.
-
-  Accepts `card` optionally to return proper `:invalidated-at` value."
-  [row & [card]]
+  "Transform from how cache config is stored to how it's used/exposed in the API."
+  [row]
   (when row
     {:model    (:model row)
      :model_id (:model_id row)
      :strategy (-> (:config row)
-                   (assoc :type (:strategy row))
-                   (m/assoc-some :invalidated-at (t/max (:invalidated_at row)
-                                                        (:cache_invalidated_at card))))}))
+                   (assoc :type (:strategy row)))}))
+
+(defn card-strategy
+  "Shapes `row` into strategy for a given `card`."
+  [row card]
+  (some-> (:strategy (row->config row))
+          (m/assoc-some :invalidated-at (t/max (:invalidated_at row)
+                                               (:cache_invalidated_at card)))))
 
 (defn config->row
   "Transform cache config from API form into db storage form."

--- a/src/metabase/public_settings.clj
+++ b/src/metabase/public_settings.clj
@@ -307,7 +307,7 @@
   ;; the results as stored will vary somewhat, since this measurement doesn't include metadata returned with the
   ;; results, and doesn't consider whether the results are compressed, as the `:db` backend does.)
   :type    :integer
-  :default 1000
+  :default 2000
   :audit   :getter
   :setter  (fn [new-value]
              (when (and new-value
@@ -325,24 +325,7 @@
 (defsetting query-caching-max-ttl
   (deferred-tru "The absolute maximum time to keep any cached query results, in seconds.")
   :type    :double
-  :default (* 60.0 60.0 24.0 100.0) ; 100 days
-  :audit   :getter)
-
-;; TODO -- this isn't really a TTL at all. Consider renaming to something like `-min-duration`
-(defsetting query-caching-min-ttl
-  (deferred-tru "{0} will cache all saved questions with an average query execution time longer than this many seconds:"
-                 (application-name-for-setting-descriptions))
-  :type    :double
-  :default 60.0
-  :audit   :getter)
-
-(defsetting query-caching-ttl-ratio
-  (deferred-tru
-   (str "To determine how long each saved question''s cached result should stick around, we take the query''s average "
-        "execution time and multiply that by whatever you input here. So if a query takes on average 2 minutes to run, "
-        "and you input 10 for your multiplier, its cache entry will persist for 20 minutes."))
-  :type    :integer
-  :default 10
+  :default (* 60.0 60.0 24.0 35.0) ; 35 days
   :audit   :getter)
 
 (defsetting notification-link-base-url

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -35,7 +35,7 @@
    database (in that order). In OSS returns root configuration."
   metabase-enterprise.cache.strategies
   [_card _dashboard-id]
-  (cache-config/row->config (cache-config/root-strategy)))
+  (cache-config/card-strategy (cache-config/root-strategy) nil))
 
 (defn- enrich-strategy [strategy query]
   (case (:type strategy)

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -219,8 +219,7 @@
                 (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))))))
 
 (defn- is-cacheable? {:arglists '([query])} [{:keys [cache-strategy]}]
-  (and (public-settings/enable-query-caching)
-       cache-strategy))
+  cache-strategy)
 
 (defn maybe-return-cached-results
   "Middleware for caching results of a query if applicable.

--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -219,7 +219,7 @@
                 (save-results-xform start-time-ns metadata query-hash cache-strategy (rff metadata)))))))))
 
 (defn- is-cacheable? {:arglists '([query])} [{:keys [cache-strategy]}]
-  cache-strategy)
+  (some? cache-strategy))
 
 (defn maybe-return-cached-results
   "Middleware for caching results of a query if applicable.

--- a/test/metabase/db/schema_migrations_test.clj
+++ b/test/metabase/db/schema_migrations_test.clj
@@ -1449,6 +1449,8 @@
                                                                        :parameters "")))
             card (t2/insert-returning-pk! :report_card (-> (mt/with-temp-defaults Card)
                                                            (update :display str)
+                                                           (update :visualization_settings json/generate-string)
+                                                           (update :dataset_query json/generate-string)
                                                            (assoc :cache_ttl 30)))]
 
         (migrate!)
@@ -1479,6 +1481,7 @@
 
       ;; this one to have custom configuration to check they are not copied over
       (t2/insert-returning-pk! :metabase_database (-> (mt/with-temp-defaults Database)
+                                                      (update :details json/generate-string)
                                                       (update :engine str)
                                                       (assoc :cache_ttl 10)))
       (migrate!)

--- a/test/metabase/query_processor/card_test.clj
+++ b/test/metabase/query_processor/card_test.clj
@@ -4,12 +4,10 @@
    [cheshire.core :as json]
    [clojure.test :refer :all]
    [metabase.api.common :as api]
-   [metabase.models :refer [Card Dashboard Database]]
-   [metabase.models.query :as query]
+   [metabase.models :refer [Card]]
    [metabase.query-processor :as qp]
    [metabase.query-processor.card :as qp.card]
    [metabase.test :as mt]
-   [metabase.util :as u]
    [toucan2.tools.with-temp :as t2.with-temp]))
 
 (defn run-query-for-card
@@ -22,50 +20,6 @@
      card-id :api
      :run (fn [query info]
             (qp/process-query (assoc query :info info))))))
-
-(deftest query-cache-strategy-hierarchy-test
-  (mt/with-temporary-setting-values [enable-query-caching true
-                                     query-caching-ttl-ratio 10]
-    (testing "query-magic-ttl converts to seconds correctly"
-      ;; fake average execution time (in millis)
-      (with-redefs [query/average-execution-time-ms (constantly 4000)]
-        (mt/with-temp [Card card {}]
-          (is (=? {:type             :ttl
-                   :multiplier       10
-                   :avg-execution-ms 4000}
-                  (:cache-strategy (#'qp.card/query-for-card card {} {} {})))))))
-    ;; corresponding EE tests in metabase-enterprise.cache.strategies-test
-    (testing "card ttl only, does not take effect on OSS"
-      (mt/with-temp [Card card {:cache_ttl 1337}]
-        (is (=? {:type             :ttl
-                 :multiplier       10
-                 :avg-execution-ms int?}
-                (:cache-strategy (#'qp.card/query-for-card card {} {} {}))))))
-    (testing "dash ttl only, does not take effect on OSS"
-      (mt/with-temp [Database db {}
-                     Dashboard dash {:cache_ttl 1338}
-                     Card card {:database_id (u/the-id db)}]
-        (is (=? {:type             :ttl
-                 :multiplier       10
-                 :avg-execution-ms int?}
-                (:cache-strategy (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
-    (testing "multiple ttl, db ttl does not take effect on OSS"
-      ;; corresponding EE test in metabase-enterprise.cache.strategies-test
-      (mt/with-temp [Database db {:cache_ttl 1337}
-                     Dashboard dash {}
-                     Card card {:database_id (u/the-id db)}]
-        (is (=? {:type             :ttl
-                 :multiplier       10
-                 :avg-execution-ms int?}
-                (:cache-strategy (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))
-    (testing "no ttl, nil result"
-      (mt/with-temp [Database db {}
-                     Dashboard dash {}
-                     Card card {:database_id (u/the-id db)}]
-        (is (=? {:type             :ttl
-                 :multiplier       10
-                 :avg-execution-ms int?}
-                (:cache-strategy (#'qp.card/query-for-card card {} {} {} {:dashboard-id (u/the-id dash)}))))))))
 
 (defn field-filter-query
   "A query with a Field Filter parameter"

--- a/test/metabase/query_processor/middleware/cache_test.clj
+++ b/test/metabase/query_processor/middleware/cache_test.clj
@@ -92,8 +92,7 @@
   (mt/with-open-channels [save-chan  (a/chan 10)
                           purge-chan (a/chan 10)]
     (mt/with-temporary-setting-values [enable-query-caching  true
-                                       query-caching-max-ttl 60
-                                       query-caching-min-ttl 0]
+                                       query-caching-max-ttl 60]
       (binding [cache/*backend* (test-backend save-chan purge-chan)
                 *save-chan*     save-chan
                 *purge-chan*    purge-chan]
@@ -114,11 +113,13 @@
 
 (def ^:private ^:dynamic ^Long *query-execution-delay-ms* 10)
 
+(def ^:private ^:dynamic *query-caching-min-ttl* 1)
+
 (defn ^:private ttl-strategy []
   {:type             :ttl
    :multiplier       60
    :avg-execution-ms 1000
-   :min-duration-ms  (public-settings/query-caching-min-ttl)})
+   :min-duration-ms  *query-caching-min-ttl*})
 
 (defn- test-query [query-kvs]
   (merge {:cache-strategy (ttl-strategy), :lib/type :mbql/query, :stages [{:abc :def}]} query-kvs))
@@ -158,15 +159,13 @@
   (boolean (#'cache/is-cacheable? (merge {:cache-strategy (ttl-strategy), :query :abc} query-kvs))))
 
 (deftest is-cacheable-test
-  (testing "something is-cacheable? if it includes a `:cache-strategy` and the caching setting is enabled"
+  (testing "something is-cacheable? if it includes `:cache-strategy`"
     (with-mock-cache []
-      (doseq [enable-caching? [true false]
-              cache-strategy  [(ttl-strategy) nil]
-              :let            [expected (boolean (and enable-caching? cache-strategy))]]
-        (mt/with-temporary-setting-values [enable-query-caching enable-caching?]
-          (testing (format "cache strategy = %s" (pr-str cache-strategy))
-            (is (= expected
-                   (boolean (#'cache/is-cacheable? {:cache-strategy cache-strategy}))))))))))
+      (doseq [cache-strategy  [(ttl-strategy) nil]
+              :let            [expected (boolean cache-strategy)]]
+        (testing (format "cache strategy = %s" (pr-str cache-strategy))
+          (is (= expected
+                 (boolean (#'cache/is-cacheable? {:cache-strategy cache-strategy})))))))))
 
 (deftest empty-cache-test
   (testing "if there's nothing in the cache, cached results should *not* be returned"
@@ -198,11 +197,10 @@
     (with-mock-cache [save-chan]
       (run-query)
       (mt/wait-for-result save-chan)
-      (mt/with-temporary-setting-values [enable-query-caching false]
-        (is (= false
-               (cacheable?)))
-        (is (= :not-cached
-               (run-query)))))))
+      (is (= false
+             (cacheable? {:cache-strategy nil})))
+      (is (= :not-cached
+             (run-query {:cache-strategy nil}))))))
 
 (deftest max-kb-test
   (testing "check that `query-caching-max-kb` is respected and queries aren't cached if they're past the threshold"
@@ -251,7 +249,7 @@
 (deftest min-ttl-test
   (testing "if the cache takes less than the min TTL to execute, it shouldn't be cached"
     (with-mock-cache [save-chan]
-      (mt/with-temporary-setting-values [query-caching-min-ttl 1000]
+      (binding [*query-caching-min-ttl* 1000]
         (run-query)
         (is (= :metabase.test.util.async/timed-out
                (mt/wait-for-result save-chan)))
@@ -260,7 +258,7 @@
 
   (testing "...but if it takes *longer* than the min TTL, it should be cached"
     (with-mock-cache [save-chan]
-      (mt/with-temporary-setting-values [query-caching-min-ttl 0.1]
+      (binding [*query-caching-min-ttl* 0.1]
         (run-query)
         (mt/wait-for-result save-chan)
         (is (= :cached
@@ -339,8 +337,7 @@
                                                                           (deliver called-promise true))
                     query/save-query-and-update-average-execution-time! (fn [& args]
                                                                           (swap! update-avg-execution-count inc)
-                                                                          (apply save-query-update-avg-time-original args))
-                    public-settings/query-caching-min-ttl               (constantly 0)]
+                                                                          (apply save-query-update-avg-time-original args))]
         (let [query  (assoc (mt/mbql-query venues {:order-by [[:asc $id]] :limit 42})
                             :cache-strategy (assoc (ttl-strategy) :multiplier 5000))
               q-hash (qp.util/query-hash query)]


### PR DESCRIPTION
There are a few parts:

- actual migrations and a test for them; I did them as separate SQL files as this seems the easiest to account for differences in various DBs;
- removal of tests for old `cache_ttl` fields;
- had to adjust middleware.cache tests for the new reality, when there is no 'enable caching' setting;
- adjustments: 
  - a few default settings updated (agreed with Arakaki)
  - any strategy can have `invalidated-at` now (thanks invalidation)
  - had to add root strategy in tests since we won't use old settings to generate default strategy

Haven't removed various usages and checks for `:cache_ttl` and `enable-query-caching` through the tests yet, they'll generate too much churn - I'll do that later as a separate PR.

Resolves #41126