### PR TITLE
add unit tests for #41440

### DIFF
--- a/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.unit.spec.tsx
+++ b/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.unit.spec.tsx
@@ -42,12 +42,41 @@ describe("PublicDashboard", () => {
     expect(screen.getByTestId("embed-frame-header")).toBeInTheDocument();
     expect(screen.queryByText("Tab 1")).not.toBeInTheDocument();
   });
+
+  it("should select the tab from the url", async () => {
+    await setup({ queryString: "?tab=2", numberOfTabs: 3 });
+
+    const secondTab = screen.getByRole("tab", { name: "Tab 2" });
+
+    expect(secondTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("should work with ?tab={tabid}-${tab-name}", async () => {
+    // note: as all slugs this is ignored and we only use the id
+    await setup({
+      queryString: "?tab=2-this-is-the-tab-name",
+      numberOfTabs: 3,
+    });
+
+    const secondTab = screen.getByRole("tab", { name: "Tab 2" });
+
+    expect(secondTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("should default to the first tab if the one passed on the url doesn't exist", async () => {
+    await setup({ queryString: "?tab=1111", numberOfTabs: 3 });
+
+    const firstTab = screen.getByRole("tab", { name: "Tab 1" });
+
+    expect(firstTab).toHaveAttribute("aria-selected", "true");
+  });
 });
 
 async function setup({
   hash,
+  queryString,
   numberOfTabs = 1,
-}: { hash?: string; numberOfTabs?: number } = {}) {
+}: { hash?: string; queryString?: string; numberOfTabs?: number } = {}) {
   const dashboard = createMockDashboard({
     id: 1,
     name: DASHBOARD_TITLE,
@@ -65,7 +94,9 @@ async function setup({
     {
       storeInitialState: createMockState(),
       withRouter: true,
-      initialRoute: `embed/dashboard/${MOCK_TOKEN}${hash ? "#" + hash : ""}`,
+      initialRoute: `embed/dashboard/${MOCK_TOKEN}${
+        queryString ? `?` + queryString : ""
+      }${hash ? "#" + hash : ""}`,
     },
   );
 


### PR DESCRIPTION

### Description

This adds tests for https://github.com/metabase/metabase/issues/41440 which was fixed by https://github.com/metabase/metabase/pull/41399

I'm backporting this as the fix was backported to 49

### How to verify

Tests should be green, 2 of them should fail if you comment out the conditional logic on these lines: https://github.com/metabase/metabase/blob/716a77d484a2a17bcdda66f8865765fe53030d78/frontend/src/metabase/public/containers/PublicDashboard/PublicDashboard.jsx#L186-L188


