### PR TITLE
Cancel statement on completion of `execute-reducible-query`

### DIFF
--- a/src/metabase/driver/sql_jdbc/execute.clj
+++ b/src/metabase/driver/sql_jdbc/execute.clj
@@ -32,7 +32,8 @@
    [metabase.util.malli :as mu]
    [potemkin :as p])
   (:import
-   (java.sql Connection JDBCType PreparedStatement ResultSet ResultSetMetaData Statement Types)
+   (java.sql Connection JDBCType PreparedStatement ResultSet ResultSetMetaData SQLFeatureNotSupportedException
+             Statement Types)
    (java.time Instant LocalDate LocalDateTime LocalTime OffsetDateTime OffsetTime ZonedDateTime)
    (javax.sql DataSource)))
 
@@ -714,14 +715,14 @@
                ;; Following cancels the statment on the dbms side.
                ;; It avoids blocking `.close` call, in case we reduced the results subset eg. by means of
                ;; [[metabase.query-processor.middleware.limit/limit-xform]] middleware, while statment is still
-               ;; in progress.
-               ;; It also handles situation where query is canceled through [[qp.pipeline/*canceled-chan*]].
+               ;; in progress. This problem was encountered on Redshift. For details see the issue #39018.
+               ;; It also handles situation where query is canceled through [[qp.pipeline/*canceled-chan*]] (#41448).
                (finally (try (.cancel stmt)
-                             (catch java.sql.SQLException _
-                               (log/warn "Statement cancelation failed."))
-                             (catch java.sql.SQLFeatureNotSupportedException _
-                               (log/warnf "Statemet's `.cancel` method not supported by `%s` driver."
-                                          (name driver))))))))))))
+                             (catch SQLFeatureNotSupportedException _
+                               (log/warnf "Statemet's `.cancel` method is not supported by the `%s` driver."
+                                          (name driver)))
+                             (catch Throwable _
+                               (log/warn "Statement cancelation failed.")))))))))))
 
 (defn reducible-query
   "Returns a reducible collection of rows as maps from `db` and a given SQL query. This is similar to [[jdbc/reducible-query]] but reuses the


### PR DESCRIPTION
Fixes #39018, #41448

This PR adds call to `.cancel` after `respond` completion in `metabase.driver.sql-jdbc.execute/execute-reducible-query`. 

That ensures statements are not in progress prior to `.close` calls of `with-open` of that function. In case statement was still in progress, the close call would block.

That situation could arise if `limit` (as per `metabase.query-processor.middleware.limit/limit-xform` middleware) takes the necessary results subset before statement has completed.

---

I do not add new tests for the change, as I believe it is overkill to check that query was actually canceled per every driver. That should be guaranteed by java driver implementation. Exception is handled for the case, where the method is not implemented by a java driver.