### PR TITLE
Disable cypress log to bypass out of memory issue

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -119,6 +119,9 @@ jobs:
       DISPLAY: ""
       CYPRESS_ALL_FEATURES_TOKEN: ${{ secrets.ENTERPRISE_TOKEN }}
       CYPRESS_NO_FEATURES_TOKEN: ${{ secrets.E2E_STARTER_TOKEN }}
+      # disabled because of out of memory issues
+      # probably related to https://github.com/cypress-io/cypress/issues/27415
+      CYPRESS_NO_COMMAND_LOG: 1
       MB_SNOWPLOW_AVAILABLE: true
       MB_SNOWPLOW_URL: "http://localhost:9090" # Snowplow micro
       TERM: xterm


### PR DESCRIPTION
Disable cypress log is a way to fix out of memory issues in chrome accordingly with some comments on the [issue](https://github.com/cypress-io/cypress/issues/27415#issuecomment-2024194520) and my experiments. 

So let's try it for sanity checks to fix out of memory

[example](https://github.com/metabase/metabase/actions/runs/8707123898/job/23881462953)