### PR TITLE
fix combined cards tooltip

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/events.ts
@@ -131,6 +131,7 @@ export const getEventColumnsData = (
   chartModel: BaseCartesianChartModel,
   seriesIndex: number,
   dataIndex: number,
+  hasCombinedCards: boolean,
 ): DataPoint[] => {
   const datum = chartModel.dataset[dataIndex];
 
@@ -155,7 +156,9 @@ export const getEventColumnsData = (
       const col = chartModel.columnByDataKey[dataKey];
       const columnSeriesModel = seriesModelsByDataKey[dataKey];
       const key =
-        columnSeriesModel == null || "breakoutColumn" in columnSeriesModel
+        columnSeriesModel == null ||
+        "breakoutColumn" in columnSeriesModel ||
+        hasCombinedCards
           ? col.display_name
           : columnSeriesModel?.name;
       const displayValue =
@@ -278,6 +281,7 @@ export const getSeriesHoverData = (
   chartModel: BaseCartesianChartModel,
   settings: ComputedVisualizationSettings,
   event: EChartsSeriesMouseEvent,
+  hasCombinedCards: boolean,
 ) => {
   const { dataIndex: echartsDataIndex, seriesId } = event;
   const dataIndex = getDataIndex(
@@ -298,7 +302,12 @@ export const getSeriesHoverData = (
     return;
   }
 
-  const data = getEventColumnsData(chartModel, seriesIndex, dataIndex);
+  const data = getEventColumnsData(
+    chartModel,
+    seriesIndex,
+    dataIndex,
+    hasCombinedCards,
+  );
 
   const stackedTooltipModel =
     settings["graph.tooltip_type"] === "series_comparison"
@@ -384,6 +393,7 @@ export const getSeriesClickData = (
   chartModel: BaseCartesianChartModel,
   settings: ComputedVisualizationSettings,
   event: EChartsSeriesMouseEvent,
+  hasCombinedCards: boolean,
 ): ClickObject | undefined => {
   const { seriesId, dataIndex: echartsDataIndex } = event;
   const dataIndex = getDataIndex(
@@ -399,7 +409,12 @@ export const getSeriesClickData = (
 
   const datum = chartModel.dataset[dataIndex];
 
-  const data = getEventColumnsData(chartModel, seriesIndex, dataIndex);
+  const data = getEventColumnsData(
+    chartModel,
+    seriesIndex,
+    dataIndex,
+    hasCombinedCards,
+  );
   const dimensions = getEventDimensions(
     chartModel,
     datum,

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/use-chart-events.ts
@@ -51,6 +51,7 @@ export const useChartEvents = (
   }: VisualizationProps,
 ) => {
   const isBrushing = useRef<boolean>();
+  const hasCombinedCards = rawSeries.length > 1;
 
   const onOpenQuestion = useCallback(
     (cardId?: CardId) => {
@@ -99,7 +100,12 @@ export const useChartEvents = (
             return;
           }
 
-          const hoveredData = getSeriesHoverData(chartModel, settings, event);
+          const hoveredData = getSeriesHoverData(
+            chartModel,
+            settings,
+            event,
+            hasCombinedCards,
+          );
 
           const isSameDatumHovered =
             hoveredData?.index === hovered?.index &&
@@ -109,13 +115,20 @@ export const useChartEvents = (
             return;
           }
 
-          onHoverChange?.(getSeriesHoverData(chartModel, settings, event));
+          onHoverChange?.(
+            getSeriesHoverData(chartModel, settings, event, hasCombinedCards),
+          );
         },
       },
       {
         eventName: "click",
         handler: (event: EChartsSeriesMouseEvent) => {
-          const clickData = getSeriesClickData(chartModel, settings, event);
+          const clickData = getSeriesClickData(
+            chartModel,
+            settings,
+            event,
+            hasCombinedCards,
+          );
 
           if (timelineEventsModel && event.name === "timeline-event") {
             onOpenTimelines?.();
@@ -182,6 +195,7 @@ export const useChartEvents = (
       onOpenTimelines,
       onSelectTimelineEvents,
       onDeselectTimelineEvents,
+      hasCombinedCards,
     ],
   );
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41215

### Description

We were incorrectly using the series name in the tooltip for charts with combined cards, when we should have been using the column name.

We fix this by passing a boolean `hasCombinedCards` to, `getEventsColumnData`, and if it is true then we use the column name instead of the series name for the tooltip key.

### Demo

Before

![Screenshot 2024-04-16 at 12.06.44 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/cea7e286-1194-4091-82d2-9b618a48cc78.png)

After

![Screenshot 2024-04-16 at 12.01.00 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/9ULpbAzGBtvQRyZEpGvu/9daf0a5a-8af4-4b3e-9652-65c7bc1aeb24.png)

