### PR TITLE
Split Data Perms UI - Bug Bash 2

### DIFF
--- a/e2e/support/helpers/e2e-setup-helpers.js
+++ b/e2e/support/helpers/e2e-setup-helpers.js
@@ -3,7 +3,7 @@ export function snapshot(name) {
 }
 
 export function restore(name = "default") {
-  cy.skipOn(name.includes("mongo") && Cypress.env("QA_DB_MONGO") !== true);
+  // cy.skipOn(name.includes("mongo") && Cypress.env("QA_DB_MONGO") !== true);
 
   cy.log("Restore Data Set");
   cy.request("POST", `/api/testing/restore/${name}`);

--- a/e2e/support/helpers/e2e-setup-helpers.js
+++ b/e2e/support/helpers/e2e-setup-helpers.js
@@ -3,7 +3,7 @@ export function snapshot(name) {
 }
 
 export function restore(name = "default") {
-  // cy.skipOn(name.includes("mongo") && Cypress.env("QA_DB_MONGO") !== true);
+  cy.skipOn(name.includes("mongo") && Cypress.env("QA_DB_MONGO") !== true);
 
   cy.log("Restore Data Set");
   cy.request("POST", `/api/testing/restore/${name}`);

--- a/e2e/test/scenarios/permissions/downgrade-ee-to-oss.cy.spec.js
+++ b/e2e/test/scenarios/permissions/downgrade-ee-to-oss.cy.spec.js
@@ -1,0 +1,156 @@
+import { USER_GROUPS } from "e2e/support/cypress_data";
+import {
+  assertPermissionTable,
+  modifyPermission,
+  modal,
+  restore,
+  popover,
+  describeEE,
+  setTokenFeatures,
+  isPermissionDisabled,
+} from "e2e/support/helpers";
+
+const { ALL_USERS_GROUP } = USER_GROUPS;
+
+const EE_DATA_ACCESS_PERMISSION_INDEX = 0;
+const OSS_NATIVE_QUERIES_PERMISSION_INDEX = 0;
+
+describeEE("scenarios > admin > permissions > downgrade ee to oss", () => {
+  beforeEach(() => {
+    restore();
+    cy.signInAsAdmin();
+    setTokenFeatures("all");
+  });
+
+  // we have a case where users may be downgraded for not paying but then will sort out billing and upgrade back to EE again.
+  // we want to make sure that the users can still modify create-queries permissions with view-data values that would
+  // normally disable the input (e.g. blocked, legacy-no-self-service) in EE. when modifying a row like that, we want the
+  // view-data permissions to go up to unrestricted.
+
+  it("should allow users to edit permissions after downgrading EE to OSS", () => {
+    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+
+    modifyPermission(
+      "Sample Database",
+      EE_DATA_ACCESS_PERMISSION_INDEX,
+      "Blocked",
+    );
+    cy.button("Save changes").click();
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.button("Yes").click();
+    });
+
+    setTokenFeatures("none");
+    cy.reload();
+
+    assertPermissionTable([["Sample Database", "No"]]);
+    isPermissionDisabled(OSS_NATIVE_QUERIES_PERMISSION_INDEX, "No", false);
+
+    modifyPermission(
+      "Sample Database",
+      OSS_NATIVE_QUERIES_PERMISSION_INDEX,
+      "Query builder and native",
+    );
+    cy.button("Save changes").click();
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.button("Yes").click();
+    });
+
+    setTokenFeatures("all");
+    cy.reload();
+
+    assertPermissionTable([
+      [
+        "Sample Database",
+        "Can view",
+        "Query builder and native",
+        "No",
+        "No",
+        "No",
+      ],
+    ]);
+  });
+
+  // same context as other test, but also make sure that other rows with EE values are
+  // unmodified if it's possible to keep their EE view-data values behind the scenes.
+  // this will allow users to already have their old EE values when they go to upgrade again.
+  it("should preserve unedited EE values in graph when OSS", () => {
+    // starting as EE, set a EE only value in the graph
+    cy.visit(`/admin/permissions/data/group/${ALL_USERS_GROUP}`);
+
+    modifyPermission(
+      "Sample Database",
+      EE_DATA_ACCESS_PERMISSION_INDEX,
+      "Granular",
+    );
+
+    // set both people and orders tables to sandboxed (an EE only value)
+    [
+      ["Orders", "User ID"],
+      ["People", "ID"],
+    ].forEach(([tableName, colName]) => {
+      modifyPermission(tableName, EE_DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
+
+      cy.findByText("Pick a column").click();
+      popover().within(() => {
+        cy.findByText(colName).click();
+      });
+      cy.findByText("Pick a user attribute").click();
+      popover().within(() => {
+        cy.findByText("attr_uid").click();
+      });
+      cy.button("Save").click();
+    });
+
+    // save changes
+    cy.button("Save changes").click();
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.button("Yes").click();
+    });
+
+    // downgrade to OSS
+    setTokenFeatures("none");
+    cy.reload();
+
+    assertPermissionTable([
+      ["Accounts", "No"],
+      ["Analytic Events", "No"],
+      ["Feedback", "No"],
+      ["Invoices", "No"],
+      ["Orders", "No"],
+      ["People", "No"],
+      ["Products", "No"],
+      ["Reviews", "No"],
+    ]);
+
+    modifyPermission(
+      "Orders",
+      EE_DATA_ACCESS_PERMISSION_INDEX,
+      "Query builder only",
+    );
+
+    cy.button("Save changes").click();
+    modal().within(() => {
+      cy.findByText("Save permissions?");
+      cy.button("Yes").click();
+    });
+
+    // upgrade back to EE
+    setTokenFeatures("all");
+    cy.reload();
+
+    assertPermissionTable([
+      ["Accounts", "Can view", "No", "1 million rows", "No"],
+      ["Analytic Events", "Can view", "No", "1 million rows", "No"],
+      ["Feedback", "Can view", "No", "1 million rows", "No"],
+      ["Invoices", "Can view", "No", "1 million rows", "No"],
+      ["Orders", "Sandboxed", "Query builder only", "1 million rows", "No"],
+      ["People", "Sandboxed", "No", "1 million rows", "No"],
+      ["Products", "Can view", "No", "1 million rows", "No"],
+      ["Reviews", "Can view", "No", "1 million rows", "No"],
+    ]);
+  });
+});

--- a/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
+++ b/e2e/test/scenarios/permissions/sandboxes.cy.spec.js
@@ -5,6 +5,7 @@ import {
   ORDERS_DASHBOARD_ID,
 } from "e2e/support/cypress_sample_instance_data";
 import {
+  modifyPermission,
   describeEE,
   modal,
   openOrdersTable,
@@ -38,6 +39,8 @@ const {
 } = SAMPLE_DATABASE;
 
 const { DATA_GROUP, COLLECTION_GROUP } = USER_GROUPS;
+
+const DATA_ACCESS_PERMISSION_INDEX = 0;
 
 describeEE("formatting > sandboxes", () => {
   describe("admin", () => {
@@ -791,13 +794,7 @@ describeEE("formatting > sandboxes", () => {
       cy.visit(
         `/admin/permissions/data/database/${SAMPLE_DB_ID}/schema/PUBLIC/table/${ORDERS_ID}`,
       );
-      cy.wait("@tablePermissions");
-      cy.icon("eye")
-        .eq(1) // No better way of doing this, undfortunately (see table above)
-        .click();
-      // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
-      cy.findByText("Sandboxed").click();
-      cy.button("Change").click();
+      modifyPermission("data", DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
 
       modal().within(() => {
         cy.findByText("Change access to this database to “Sandboxed”?");

--- a/e2e/test/scenarios/permissions/view-data/granular.cy.spec.js
+++ b/e2e/test/scenarios/permissions/view-data/granular.cy.spec.js
@@ -167,11 +167,6 @@ describeEE("scenarios > admin > permissions > view data > granular", () => {
 function makeOrdersSandboxed() {
   modifyPermission("Orders", DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
 
-  modal().within(() => {
-    cy.findByText("Change access to this database to “Granular”?");
-    cy.button("Change").click();
-  });
-
   cy.url().should(
     "include",
     `/admin/permissions/data/group/${ALL_USERS_GROUP}/database/${SAMPLE_DB_ID}/schema/PUBLIC/${ORDERS_ID}/segmented`,

--- a/e2e/test/scenarios/permissions/view-data/sandboxed.cy.spec.ts
+++ b/e2e/test/scenarios/permissions/view-data/sandboxed.cy.spec.ts
@@ -41,11 +41,6 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
     modifyPermission("All Users", DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
 
     modal().within(() => {
-      cy.findByText("Change access to this database to “Granular”?");
-      cy.button("Change").click();
-    });
-
-    modal().within(() => {
       cy.findByText("Change access to this database to “Sandboxed”?");
       cy.button("Change").click();
     });
@@ -123,11 +118,6 @@ describeEE("scenarios > admin > permissions > view data > sandboxed", () => {
     cy.get("a").contains("Sample Database").click();
 
     modifyPermission("Orders", DATA_ACCESS_PERMISSION_INDEX, "Sandboxed");
-
-    modal().within(() => {
-      cy.findByText("Change access to this database to “Granular”?");
-      cy.button("Change").click();
-    });
 
     modal().within(() => {
       cy.findByText("Change access to this database to “Sandboxed”?");

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -106,6 +106,13 @@ if (hasPremiumFeature("advanced_permissions")) {
     );
   };
 
+  PLUGIN_ADVANCED_PERMISSIONS.isRestrictivePermission = value => {
+    return value === DataPermissionValue.BLOCKED;
+  };
+
+  PLUGIN_ADVANCED_PERMISSIONS.defaultViewDataPermission =
+    DataPermissionValue.BLOCKED;
+
   PLUGIN_ADMIN_PERMISSIONS_DATABASE_POST_ACTIONS[
     DataPermissionValue.IMPERSONATED
   ] = getImpersonatedPostAction;

--- a/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
+++ b/enterprise/frontend/src/metabase-enterprise/advanced_permissions/index.js
@@ -110,6 +110,8 @@ if (hasPremiumFeature("advanced_permissions")) {
     return value === DataPermissionValue.BLOCKED;
   };
 
+  PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn = true;
+
   PLUGIN_ADVANCED_PERMISSIONS.defaultViewDataPermission =
     DataPermissionValue.BLOCKED;
 

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/actions.js
@@ -80,20 +80,44 @@ const groupTableAccessPolicies = handleActions(
     },
     [UPDATE_DATA_PERMISSION]: {
       next: (state, { payload }) => {
-        if (payload.entityId.tableId === undefined) {
+        if (!payload || !payload.entityId) {
           return state;
         }
 
-        const key = getPolicyKeyFromParams({
-          groupId: payload.groupId,
-          tableId: payload.entityId.tableId,
-        });
+        const { entityId, metadata, groupId } = payload;
 
-        const isSandboxed = key in state;
-        const isUnsandboxing = payload.value !== DataPermissionValue.SANDBOXED;
+        // if user is unsandboxing a specific table,
+        // remove the specific table's sandbox data
+        if (entityId.tableId !== undefined) {
+          const key = getPolicyKeyFromParams({
+            groupId,
+            tableId: entityId.tableId,
+          });
+          const isTableSandboxed = key in state;
+          const isUnsandboxingTable =
+            isTableSandboxed && payload.value !== DataPermissionValue.SANDBOXED;
 
-        if (isSandboxed && isUnsandboxing) {
-          return _.omit(state, key);
+          if (isTableSandboxed && isUnsandboxingTable) {
+            return _.omit(state, key);
+          } else {
+            return state;
+          }
+        }
+
+        if (entityId.databaseId !== null) {
+          const database = metadata.databases?.[entityId.databaseId];
+          const tables = database?.tables ?? [];
+          // filter tables if there's a schema referenced in the entity id
+          const entityTables = tables.filter(
+            table =>
+              !entityId.schemaName || table.schema_name === entityId.schemaName,
+          );
+
+          // delete 0 to N sandboxes present in the state
+          const policyKeys = entityTables.map(table =>
+            getPolicyKeyFromParams({ groupId, tableId: table.id }),
+          );
+          return _.omit(state, policyKeys);
         }
 
         return state;

--- a/enterprise/frontend/src/metabase-enterprise/sandboxes/confirmations.ts
+++ b/enterprise/frontend/src/metabase-enterprise/sandboxes/confirmations.ts
@@ -25,7 +25,7 @@ export function getSandboxedTableWarningModal(
   ) {
     return {
       title: t`Change access to this database to “Sandboxed”?`,
-      message: t`As part of providing sandboxing we will also have to remove this group's native querying permissions from all tables and schemas in this database.`,
+      message: t`This group's native querying permissions will be removed from all tables and schemas in this database.`,
       confirmButtonText: t`Change`,
       cancelButtonText: t`Cancel`,
     };

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
@@ -9,10 +9,10 @@ export const PermissionsEditorLegacyNoSelfServiceWarning = () => {
   const [isExpanded, { toggle }] = useToggle(false);
 
   return (
-    <Box mt="md" mb="sm" mr="2.5rem">
+    <Box mt="md" mb="sm" style={{ marginInlineEnd: "2.5rem" }}>
       <Alert icon={<Icon name="warning" size={16} />} color="accent5">
         <Text fw="bold">
-          {t`The No self-service access level for View data is going away.`}
+          {t`The “No self-service” access level for View data is going away.`}
           {!isExpanded && (
             <>
               {" "}
@@ -25,7 +25,7 @@ export const PermissionsEditorLegacyNoSelfServiceWarning = () => {
 
         {isExpanded && (
           <Text>
-            {t`In a future release, if a group’s View data access for a database (or any of its schemas or tables) is still set to No self-service (deprecated), Metabase will automatically change that group’s View data access for the entire database to Blocked. We’ll be defaulting to Blocked, the least permissive View data access, to prevent any unattended access to data.`}{" "}
+            {t`In a future release, if a group’s View data access for a database (or any of its schemas or tables) is still set to “No self-service (deprecated)”, Metabase will automatically change that group’s View data access for the entire database to “Blocked”. We’ll be defaulting to “Blocked”, the least permissive View data access, to prevent any unintended access to data.`}{" "}
             <Anchor
               fw="bold"
               component={Link}

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import { t } from "ttag";
 
 import { useToggle } from "metabase/hooks/use-toggle";
@@ -28,8 +27,8 @@ export const PermissionsEditorLegacyNoSelfServiceWarning = () => {
             {t`In a future release, if a group’s View data access for a database (or any of its schemas or tables) is still set to “No self-service (deprecated)”, Metabase will automatically change that group’s View data access for the entire database to “Blocked”. We’ll be defaulting to “Blocked”, the least permissive View data access, to prevent any unintended access to data.`}{" "}
             <Anchor
               fw="bold"
-              component={Link}
-              to="/admin/settings/embedding-in-other-applications"
+              target="_blank"
+              to="https://www.metabase.com/docs/latest/permissions/data.html"
               style={{ color: colors.accent7 }}
             >{t`Need help? See our docs.`}</Anchor>
           </Text>

--- a/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
+++ b/frontend/src/metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning.tsx
@@ -28,7 +28,7 @@ export const PermissionsEditorLegacyNoSelfServiceWarning = () => {
             <Anchor
               fw="bold"
               target="_blank"
-              to="https://www.metabase.com/docs/latest/permissions/data.html"
+              href="https://www.metabase.com/docs/latest/permissions/data.html"
               style={{ color: colors.accent7 }}
             >{t`Need help? See our docs.`}</Anchor>
           </Text>

--- a/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
@@ -8,7 +8,6 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { PermissionsEditorLegacyNoSelfServiceWarning } from "metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning";
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { PermissionsApi } from "metabase/services";
 import { Loader, Center } from "metabase/ui";
@@ -155,9 +154,9 @@ function DatabasesPermissionsPage({
           onAction={handleAction}
           warnings={() => (
             <>
-              {permissionEditor.deprecatedPermsInGraph.has(
-                DataPermissionValue.LEGACY_NO_SELF_SERVICE,
-              ) && <PermissionsEditorLegacyNoSelfServiceWarning />}
+              {permissionEditor.hasLegacyNoSelfServiceValueInPermissionGraph && (
+                <PermissionsEditorLegacyNoSelfServiceWarning />
+              )}
             </>
           )}
         />

--- a/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage.jsx
@@ -9,6 +9,7 @@ import _ from "underscore";
 
 import { PermissionsEditorLegacyNoSelfServiceWarning } from "metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning";
 import { useDispatch, useSelector } from "metabase/lib/redux";
+import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 import { PermissionsApi } from "metabase/services";
 import { Loader, Center } from "metabase/ui";
 
@@ -124,6 +125,10 @@ function DatabasesPermissionsPage({
 
   const handleBreadcrumbsItemSelect = item => dispatch(push(item.url));
 
+  const showLegacyNoSelfServiceWarning =
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn &&
+    permissionEditor.hasLegacyNoSelfServiceValueInPermissionGraph;
+
   return (
     <Fragment>
       <PermissionsSidebar
@@ -154,7 +159,7 @@ function DatabasesPermissionsPage({
           onAction={handleAction}
           warnings={() => (
             <>
-              {permissionEditor.hasLegacyNoSelfServiceValueInPermissionGraph && (
+              {showLegacyNoSelfServiceWarning && (
                 <PermissionsEditorLegacyNoSelfServiceWarning />
               )}
             </>

--- a/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
@@ -9,6 +9,7 @@ import _ from "underscore";
 
 import { PermissionsEditorLegacyNoSelfServiceWarning } from "metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning";
 import { useSelector, useDispatch } from "metabase/lib/redux";
+import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 import { PermissionsApi } from "metabase/services";
 import { Loader, Center } from "metabase/ui";
 
@@ -142,6 +143,9 @@ function GroupsPermissionsPage({
   const handleBreadcrumbsItemSelect = item => dispatch(push(item.url));
 
   const showEmptyState = !permissionEditor && !isEditorLoading && !editorError;
+  const showLegacyNoSelfServiceWarning =
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn &&
+    permissionEditor.hasLegacyNoSelfServiceValueInPermissionGraph;
   return (
     <Fragment>
       <PermissionsSidebar
@@ -174,7 +178,7 @@ function GroupsPermissionsPage({
           onBreadcrumbsItemSelect={handleBreadcrumbsItemSelect}
           warnings={() => (
             <>
-              {permissionEditor.hasLegacyNoSelfServiceValueInPermissionGraph && (
+              {showLegacyNoSelfServiceWarning && (
                 <PermissionsEditorLegacyNoSelfServiceWarning />
               )}
             </>

--- a/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
+++ b/frontend/src/metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage.jsx
@@ -8,7 +8,6 @@ import { t } from "ttag";
 import _ from "underscore";
 
 import { PermissionsEditorLegacyNoSelfServiceWarning } from "metabase/admin/permissions/components/PermissionsEditor/PermissionsEditorLegacyWarning";
-import { DataPermissionValue } from "metabase/admin/permissions/types";
 import { useSelector, useDispatch } from "metabase/lib/redux";
 import { PermissionsApi } from "metabase/services";
 import { Loader, Center } from "metabase/ui";
@@ -175,9 +174,9 @@ function GroupsPermissionsPage({
           onBreadcrumbsItemSelect={handleBreadcrumbsItemSelect}
           warnings={() => (
             <>
-              {permissionEditor.deprecatedPermsInGraph.has(
-                DataPermissionValue.LEGACY_NO_SELF_SERVICE,
-              ) && <PermissionsEditorLegacyNoSelfServiceWarning />}
+              {permissionEditor.hasLegacyNoSelfServiceValueInPermissionGraph && (
+                <PermissionsEditorLegacyNoSelfServiceWarning />
+              )}
             </>
           )}
         />

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -163,8 +163,9 @@ export function getWillRevokeNativeAccessWarningModal(
 
     return {
       title: t`Change access to this database to “Granular”?`,
-      message: t`As part of providing granular permissions for this one ${entityType}, we will also have to remove this group's native querying permissions from all tables and schemas in this database.`,
-      confirmButtonText: t`Change`,
+      message: t`As part of providing granular permissions for this one ${entityType}, this group's native querying permissions will also be removed from all tables and schemas in this database.`,
+      confirmButtonText: c("This is a verb, for a confirmation button")
+        .t`Change`,
       cancelButtonText: t`Cancel`,
     };
   }

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -29,12 +29,12 @@ const PERM_LEVELS = [
   DataPermissionValue.UNRESTRICTED,
   DataPermissionValue.FULL,
   DataPermissionValue.IMPERSONATED,
+  DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
+  DataPermissionValue.QUERY_BUILDER,
   DataPermissionValue.CONTROLLED,
   DataPermissionValue.SANDBOXED,
   DataPermissionValue.BLOCKED,
   DataPermissionValue.LEGACY_NO_SELF_SERVICE,
-  DataPermissionValue.QUERY_BUILDER_AND_NATIVE,
-  DataPermissionValue.QUERY_BUILDER,
   DataPermissionValue.LIMITED,
   DataPermissionValue.NO,
   DataPermissionValue.NONE,
@@ -121,21 +121,6 @@ export function getPermissionWarningModal(
         value === DataPermissionValue.CONTROLLED
           ? t`Limit access`
           : t`Revoke access`,
-      cancelButtonText: t`Cancel`,
-    };
-  }
-}
-
-export function getControlledDatabaseWarningModal(
-  currDbPermissionValue: string,
-  entityId: EntityId,
-) {
-  if (currDbPermissionValue !== DataPermissionValue.CONTROLLED) {
-    const [entityType, entityTypePlural] = getEntityTypeFromId(entityId);
-    return {
-      title: t`Change access to this database to “Granular”?`,
-      message: t`Just letting you know that changing the permission setting on this ${entityType} will also update the database permission setting to “Granular” to reflect that some of the database’s ${entityTypePlural} have different permission settings.`,
-      confirmButtonText: t`Change`,
       cancelButtonText: t`Cancel`,
     };
   }

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -1,4 +1,4 @@
-import { t } from "ttag";
+import { t, c } from "ttag";
 import _ from "underscore";
 
 import {

--- a/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/confirmations.ts
@@ -9,6 +9,7 @@ import {
   getFieldsPermission,
   getSchemasPermission,
 } from "metabase/admin/permissions/utils/graph";
+import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type {
   Group,
@@ -179,6 +180,7 @@ export function getRawQueryWarningModal(
   if (
     value === DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
     nativePermission !== DataPermissionValue.QUERY_BUILDER_AND_NATIVE &&
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn &&
     ![
       DataPermissionValue.UNRESTRICTED,
       DataPermissionValue.IMPERSONATED,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -194,9 +194,11 @@ export const buildFieldsPermissions = (
   );
 
   const hasAnyAccessOptions = accessPermission.options.length > 1;
+  const shouldShowViewDataColumn =
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn && hasAnyAccessOptions;
 
   return _.compact([
-    hasAnyAccessOptions && accessPermission,
+    shouldShowViewDataColumn && accessPermission,
     nativePermission,
     ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions(
       entityId,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/fields.ts
@@ -2,7 +2,6 @@ import _ from "underscore";
 
 import { getNativePermissionDisabledTooltip } from "metabase/admin/permissions/selectors/data-permissions/shared";
 import {
-  getSchemasPermission,
   getFieldsPermission,
   getTablesPermission,
 } from "metabase/admin/permissions/utils/graph";
@@ -28,7 +27,6 @@ import {
 import {
   getPermissionWarning,
   getPermissionWarningModal,
-  getControlledDatabaseWarningModal,
   getRevokingAccessToAllTablesWarningModal,
   getWillRevokeNativeAccessWarningModal,
 } from "../confirmations";
@@ -70,13 +68,6 @@ const buildAccessPermission = (
     groupId,
   );
 
-  const currDbPermissionValue = getSchemasPermission(
-    permissions,
-    groupId,
-    entityId,
-    DataPermission.VIEW_DATA,
-  );
-
   const confirmations = (newValue: DataPermissionValue) => [
     getPermissionWarningModal(
       newValue,
@@ -85,7 +76,6 @@ const buildAccessPermission = (
       defaultGroup,
       groupId,
     ),
-    getControlledDatabaseWarningModal(currDbPermissionValue, entityId),
     ...PLUGIN_ADMIN_PERMISSIONS_TABLE_FIELDS_CONFIRMATIONS.map(confirmation =>
       confirmation(permissions, groupId, entityId, newValue),
     ),

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/group-sidebar.unit.spec.ts
@@ -1,5 +1,6 @@
 import { assocIn } from "icepick";
 
+import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 import type { State } from "metabase-types/store";
 
 import { DataPermission, DataPermissionValue } from "../../types";
@@ -50,6 +51,12 @@ describe("getGroupsDataPermissionEditor", () => {
   });
 
   it("returns entities list for permissions editor", () => {
+    const originalPluginValue =
+      PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn;
+
+    // make sure that we're showing the view data column
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn = true;
+
     const entities = getGroupsDataPermissionEditor(stateWithLegacyValues, {
       params: {
         databaseId: 3,
@@ -116,6 +123,8 @@ describe("getGroupsDataPermissionEditor", () => {
         iconColor: "danger",
       },
     ]);
+
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn = originalPluginValue;
   });
 
   it("omits view data options when there is only one view data option", () => {

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -271,9 +271,11 @@ export const getDatabasesPermissionEditor = createSelector(
       hasSingleSchema,
     );
 
+    const showViewDataColumn = hasViewDataOptions(entities);
+
     const columns = _.compact([
       { name: getEditorEntityName(params, hasSingleSchema) },
-      hasViewDataOptions(entities) && { name: t`View data` },
+      showViewDataColumn && { name: t`View data` },
       { name: t`Create queries` },
       ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDataColumns(permissionSubject),
     ]);
@@ -419,9 +421,11 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
 
       const permissionSubject = getPermissionSubject(params);
 
+      const showViewDataColumn = hasViewDataOptions(entities);
+
       const columns = _.compact([
         { name: t`Group name` },
-        hasViewDataOptions(entities) && { name: t`View data` },
+        showViewDataColumn && { name: t`View data` },
         { name: t`Create queries` },
         ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDataColumns(permissionSubject),
       ]);

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/permission-editor.ts
@@ -281,16 +281,13 @@ export const getDatabasesPermissionEditor = createSelector(
     const breadcrumbs = getDatabasesEditorBreadcrumbs(params, metadata, group);
     const title = t`Permissions for the `;
 
-    const deprecatedPermsInGraph = new Set(
-      _.compact([
-        hasPermissionValueInEntityGraphs(
-          permissions,
-          entities.map((entity: any) => ({ groupId, ...entity.entityId })),
-          DataPermission.VIEW_DATA,
-          DataPermissionValue.LEGACY_NO_SELF_SERVICE,
-        ) && DataPermissionValue.LEGACY_NO_SELF_SERVICE,
-      ]),
-    );
+    const hasLegacyNoSelfServiceValueInPermissionGraph =
+      hasPermissionValueInEntityGraphs(
+        permissions,
+        entities.map((entity: any) => ({ groupId, ...entity.entityId })),
+        DataPermission.VIEW_DATA,
+        DataPermissionValue.LEGACY_NO_SELF_SERVICE,
+      );
 
     return {
       title,
@@ -306,7 +303,7 @@ export const getDatabasesPermissionEditor = createSelector(
       filterPlaceholder: getFilterPlaceholder(params, hasSingleSchema),
       columns,
       entities,
-      deprecatedPermsInGraph,
+      hasLegacyNoSelfServiceValueInPermissionGraph,
     };
   },
 );
@@ -429,19 +426,16 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
         ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getDataColumns(permissionSubject),
       ]);
 
-      const deprecatedPermsInGraph = new Set(
-        _.compact([
-          hasPermissionValueInEntityGraphs(
-            permissions,
-            entities.map((entity: any) => ({
-              groupId: entity.id,
-              ...entity.entityId,
-            })),
-            DataPermission.VIEW_DATA,
-            DataPermissionValue.LEGACY_NO_SELF_SERVICE,
-          ) && DataPermissionValue.LEGACY_NO_SELF_SERVICE,
-        ]),
-      );
+      const hasLegacyNoSelfServiceValueInPermissionGraph =
+        hasPermissionValueInEntityGraphs(
+          permissions,
+          entities.map((entity: any) => ({
+            groupId: entity.id,
+            ...entity.entityId,
+          })),
+          DataPermission.VIEW_DATA,
+          DataPermissionValue.LEGACY_NO_SELF_SERVICE,
+        );
 
       return {
         title: t`Permissions for`,
@@ -449,7 +443,7 @@ export const getGroupsDataPermissionEditor: GetGroupsDataPermissionEditorSelecto
         breadcrumbs: getGroupsDataEditorBreadcrumbs(params, metadata),
         columns,
         entities,
-        deprecatedPermsInGraph,
+        hasLegacyNoSelfServiceValueInPermissionGraph,
       };
     },
   );

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/schemas.ts
@@ -211,9 +211,11 @@ export const buildSchemasPermissions = (
   );
 
   const hasAnyAccessOptions = accessPermission.options.length > 1;
+  const shouldShowViewDataColumn =
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn && hasAnyAccessOptions;
 
   return _.compact([
-    hasAnyAccessOptions && accessPermission,
+    shouldShowViewDataColumn && accessPermission,
     nativePermission,
     ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions(
       entityId,

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/shared.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/shared.ts
@@ -4,6 +4,7 @@ import {
   UNABLE_TO_CHANGE_LEGACY_PERMISSIONS,
 } from "metabase/admin/permissions/constants/messages";
 import { isRestrictivePermission } from "metabase/admin/permissions/utils/graph";
+import { PLUGIN_ADVANCED_PERMISSIONS } from "metabase/plugins";
 
 import { DataPermissionValue } from "../../types";
 
@@ -13,6 +14,11 @@ export const getNativePermissionDisabledTooltip = (
 ) => {
   if (isAdmin) {
     return UNABLE_TO_CHANGE_ADMIN_PERMISSIONS;
+  }
+
+  // prevent tooltip from being disabled when the user can't modify the view data column
+  if (!PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn) {
+    return null;
   }
 
   if (accessPermissionValue === DataPermissionValue.LEGACY_NO_SELF_SERVICE) {

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -21,7 +21,6 @@ import {
   DataPermissionType,
 } from "../../types";
 import {
-  getControlledDatabaseWarningModal,
   getPermissionWarning,
   getPermissionWarningModal,
   getWillRevokeNativeAccessWarningModal,
@@ -72,7 +71,6 @@ const buildAccessPermission = (
       defaultGroup,
       groupId,
     ),
-    getControlledDatabaseWarningModal(newValue, entityId),
   ];
 
   const options = PLUGIN_ADVANCED_PERMISSIONS.addSchemaPermissionOptions(

--- a/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
+++ b/frontend/src/metabase/admin/permissions/selectors/data-permissions/tables.ts
@@ -182,8 +182,11 @@ export const buildTablesPermissions = (
 
   const hasAnyAccessOptions = accessPermission.options.length > 1;
 
+  const shouldShowViewDataColumn =
+    PLUGIN_ADVANCED_PERMISSIONS.shouldShowViewDataColumn && hasAnyAccessOptions;
+
   return _.compact([
-    hasAnyAccessOptions && accessPermission,
+    shouldShowViewDataColumn && accessPermission,
     nativePermission,
     ...PLUGIN_FEATURE_LEVEL_PERMISSIONS.getFeatureLevelDataPermissions(
       entityId,

--- a/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
+++ b/frontend/src/metabase/admin/permissions/utils/graph/data-permissions.ts
@@ -1,7 +1,10 @@
 import { getIn, setIn } from "icepick";
 import _ from "underscore";
 
-import { PLUGIN_DATA_PERMISSIONS } from "metabase/plugins";
+import {
+  PLUGIN_DATA_PERMISSIONS,
+  PLUGIN_ADVANCED_PERMISSIONS,
+} from "metabase/plugins";
 import type Database from "metabase-lib/v1/metadata/Database";
 import type Table from "metabase-lib/v1/metadata/Table";
 import type {
@@ -21,7 +24,8 @@ import type {
 import { DataPermission, DataPermissionValue } from "../../types";
 
 export const isRestrictivePermission = (value: DataPermissionValue) =>
-  value === DataPermissionValue.BLOCKED || value === DataPermissionValue.NO;
+  value === DataPermissionValue.NO ||
+  PLUGIN_ADVANCED_PERMISSIONS.isRestrictivePermission(value);
 
 // permission that do not have a nested shemas/native key
 const flatPermissions = new Set([
@@ -45,7 +49,9 @@ function getPermissionPath(
 }
 
 const omittedDefaultValues: Record<DataPermission, DataPermissionValue> = {
-  [DataPermission.VIEW_DATA]: DataPermissionValue.BLOCKED,
+  get [DataPermission.VIEW_DATA]() {
+    return PLUGIN_ADVANCED_PERMISSIONS.defaultViewDataPermission;
+  },
   [DataPermission.CREATE_QUERIES]: DataPermissionValue.NO,
   [DataPermission.DOWNLOAD]: DataPermissionValue.NONE,
   [DataPermission.DATA_MODEL]: DataPermissionValue.NONE,

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -353,6 +353,7 @@ export const PLUGIN_ADVANCED_PERMISSIONS = {
     _subject: "schemas" | "tables" | "fields",
   ) => false,
   isRestrictivePermission: (_value: string) => false,
+  shouldShowViewDataColumn: false,
   defaultViewDataPermission: DataPermissionValue.UNRESTRICTED,
 };
 

--- a/frontend/src/metabase/plugins/index.ts
+++ b/frontend/src/metabase/plugins/index.ts
@@ -4,12 +4,12 @@ import type { AnySchema } from "yup";
 
 import noResultsSource from "assets/img/no_results.svg";
 import { UNABLE_TO_CHANGE_ADMIN_PERMISSIONS } from "metabase/admin/permissions/constants/messages";
-import type {
-  DataPermission,
-  DatabaseEntityId,
-  PermissionSubject,
+import {
+  type DataPermission,
+  type DatabaseEntityId,
+  type PermissionSubject,
   DataPermissionValue,
-  EntityId,
+  type EntityId,
 } from "metabase/admin/permissions/types";
 import type { ADMIN_SETTINGS_SECTIONS } from "metabase/admin/settings/selectors";
 import type {
@@ -352,6 +352,8 @@ export const PLUGIN_ADVANCED_PERMISSIONS = {
     _value: string,
     _subject: "schemas" | "tables" | "fields",
   ) => false,
+  isRestrictivePermission: (_value: string) => false,
+  defaultViewDataPermission: DataPermissionValue.UNRESTRICTED,
 };
 
 export const PLUGIN_FEATURE_LEVEL_PERMISSIONS = {

--- a/frontend/src/metabase/ui/components/feedback/Alert/Alert.stories.mdx
+++ b/frontend/src/metabase/ui/components/feedback/Alert/Alert.stories.mdx
@@ -5,7 +5,7 @@ import { Box, Alert, Icon, Stack, Text, TextInput } from "metabase/ui";
 export const args = {
   icon: <Icon name="warning" />,
   title: "Bummer!",
-  withCloseButton: false
+  withCloseButton: false,
 };
 
 export const argTypes = {
@@ -16,11 +16,16 @@ export const argTypes = {
     control: { type: "text" },
   },
   withCloseButton: {
-    control: {type: "toggle"}
-  }
+    control: { type: "toggle" },
+  },
 };
 
-<Meta title="Feecback/Alert" component={Alert} args={args} argTypes={argTypes} />
+<Meta
+  title="Feedback/Alert"
+  component={Alert}
+  args={args}
+  argTypes={argTypes}
+/>
 
 # Alert
 
@@ -29,10 +34,19 @@ Show helpful alerts when things go sideways (or maybe it's a happy alert. It hap
 ## Examples
 
 export const DefaultTemplate = args => {
-  return (<Alert {...args}>
-    <Text>The No self-service access level for View data is going away.</Text>
-    <Text>In a future release, if a group’s View data access for a database (or any of its schemas or tables) is still set to No self-service (deprecated), Metabase will automatically change that group’s View data access for the entire database to Blocked. We’ll be defaulting to Blocked, the least permissive View data access, to prevent any unattended access to data. Need help? See our docs.</Text>
-  </Alert>);
+  return (
+    <Alert {...args}>
+      <Text>The No self-service access level for View data is going away.</Text>
+      <Text>
+        In a future release, if a group’s View data access for a database (or
+        any of its schemas or tables) is still set to No self-service
+        (deprecated), Metabase will automatically change that group’s View data
+        access for the entire database to Blocked. We’ll be defaulting to
+        Blocked, the least permissive View data access, to prevent any
+        unattended access to data. Need help? See our docs.
+      </Text>
+    </Alert>
+  );
 };
 
 export const Default = DefaultTemplate.bind({});


### PR DESCRIPTION
### Description

Fixes all the issues flagged in our second permissions bug bash. The most notable fixes:
- typos, smart quotes fixes, copy improvements
- link to docs is now correct
- handles downgrading EE to OSS still allowing user to edit values + tries to preserve the EE values as best as possible in case user upgrades again (also e2e tests for this)
- legacy no self-service in one row on OSS was causing the table render create queries values in the view data columns
- fixed OSS schema permissions page still showing view data column w/ no configurable values
- fixed issue where sandboxing a table w/o saving, then modifying the parent schema/database permission value and saving, was still saving the table as sandboxed
- hides legacy no self-service warning in OSS as the user can't migrate the value
- fix controlled create-queries values not getting warning if all users group was more permissive
- removes granular permissions warning for View data column changes

### How to verify

Given the number of changes.. I'm happy to help you repro anything via chat.


### Checklist

- [x] Tests have been added/updated to cover changes in this PR
maybe not exhaustive as they should be... feel free to push back on me here