### PR TITLE
Remove not flaky tests from flaky group

### DIFF
--- a/e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js
@@ -21,36 +21,32 @@ describe("issue 34382", () => {
     );
   });
 
-  it(
-    "should preserve filter value when navigating between the dashboard and the query builder with auto-apply disabled (metabase#34382)",
-    { tags: "@flaky" },
-    () => {
-      createDashboardWithCards();
-      visitDashboard("@dashboardId");
+  it("should preserve filter value when navigating between the dashboard and the query builder with auto-apply disabled (metabase#34382)", () => {
+    createDashboardWithCards();
+    visitDashboard("@dashboardId");
 
-      addFilterValue("Gizmo");
-      applyFilter();
+    addFilterValue("Gizmo");
+    applyFilter();
 
-      cy.log("Navigate to Products question");
-      getDashboardCard().findByText("Products").click();
+    cy.log("Navigate to Products question");
+    getDashboardCard().findByText("Products").click();
 
-      cy.log("Navigate back to dashboard");
-      queryBuilderHeader()
-        .findByLabelText("Back to Products in a dashboard")
-        .click();
+    cy.log("Navigate back to dashboard");
+    queryBuilderHeader()
+      .findByLabelText("Back to Products in a dashboard")
+      .click();
 
-      cy.location("search").should("eq", "?category=Gizmo");
-      filterWidget().contains("Gizmo");
+    cy.location("search").should("eq", "?category=Gizmo");
+    filterWidget().contains("Gizmo");
 
-      getDashboardCard().within(() => {
-        // only products with category "Gizmo" are filtered
-        cy.findAllByTestId("table-row")
-          .find("td")
-          .eq(3)
-          .should("contain", "Gizmo");
-      });
-    },
-  );
+    getDashboardCard().within(() => {
+      // only products with category "Gizmo" are filtered
+      cy.findAllByTestId("table-row")
+        .find("td")
+        .eq(3)
+        .should("contain", "Gizmo");
+    });
+  });
 });
 
 const createDashboardWithCards = () => {

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js
@@ -25,7 +25,7 @@ describe("scenarios > visualizations > drillthroughs > chart drill", () => {
     cy.signInAsAdmin();
   });
 
-  it("should allow brush date filter", { tags: "@flaky" }, () => {
+  it("should allow brush date filter", () => {
     cy.createQuestion(
       {
         name: "Brush Date Temporal Filter",


### PR DESCRIPTION
### Description

Tests passed stress tests, so it makes sense to remove them from flaky group

[✅  passed](https://github.com/metabase/metabase/actions/runs/8717741910/job/23913555951) - `e2e/test/scenarios/dashboard/reproductions/34382-dashboard-back-navigation-preserve-filters.cy.spec.js`

[✅ passed](https://github.com/metabase/metabase/actions/runs/8717719810/job/23913487774) - `e2e/test/scenarios/visualizations-tabular/drillthroughs/chart_drill.cy.spec.js`