### PR TITLE
Revert "Add BEC team codeowner"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,13 +8,3 @@ enterprise/backend/src/metabase_enterprise/task/truncate_audit_table.clj @noahmo
 enterprise/backend/src/metabase_enterprise/internal_user.clj @noahmoss
 src/metabase/**/*permissions* @noahmoss
 src/metabase/integrations @noahmoss
-
-# BEC team
-src/metabase/sync @qnkhuat @calherries
-src/metabase/sync.clj @qnkhuat @calherries
-src/metabase/search @qnkhuat
-enterprise/backend/src/metabase_enterprise/serialization @piranha
-src/metabase/upload.clj @calherries @crisptrutski
-src/metabase/upload @calherries @crisptrutski
-src/metabase/native_query_analyzer.clj @tsmacdonald
-src/metabase/native_query_analyzer @tsmacdonald


### PR DESCRIPTION
Reverts metabase/metabase#41500

context: https://metaboat.slack.com/archives/C0641E4PB9B/p1713344006240179?thread_ts=1713339524.005789&cid=C0641E4PB9B