### PR TITLE
Add curate permissions for "All Users" for example collection

### DIFF
--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1174,9 +1174,9 @@
                                       v))
             table-name->rows      (fn [table-name]
                                     (->> (table-name->raw-rows table-name)
-                                    ;; We sort the rows by id and remove them so that auto-incrementing ids are
-                                    ;; generated in the same order. We can't insert the ids directly in H2 without
-                                    ;; creating sequences for all the generated id columns.
+                                         ;; We sort the rows by id and remove them so that auto-incrementing ids are
+                                         ;; generated in the same order. We can't insert the ids directly in H2 without
+                                         ;; creating sequences for all the generated id columns.
                                          (sort-by :id)
                                          (map (fn [row]
                                                 (dissoc (update-vals row replace-temporals) :id)))))

--- a/test/metabase/setup_test.clj
+++ b/test/metabase/setup_test.clj
@@ -3,10 +3,14 @@
    [clojure.test :refer :all]
    [metabase.config :as config]
    [metabase.db :as mdb]
+   [metabase.models.interface :as mi]
    [metabase.public-settings :as public-settings]
    [metabase.setup :as setup]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :test-users))
 
 (deftest has-user-setup-ignores-internal-user-test
   (mt/with-empty-h2-app-db
@@ -49,11 +53,17 @@
       (is (zero? (call-count))))))
 
 (deftest has-example-dashboard-id-setting-test
-  (testing "The example-dashboard-id setting should be set if the example content is loaded"
-    (mt/with-temp-empty-app-db [_conn :h2]
-      (mdb/setup-db! :create-sample-content? true)
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? true)
+    (testing "The example-dashboard-id setting should be set if the example content is loaded"
       (is (= 1
-             (public-settings/example-dashboard-id)))))
+             (public-settings/example-dashboard-id))))
+    (testing "Rasta (as a member of 'All Users') should have sufficient privileges to edit the example content"
+      (mt/with-current-user (mt/user->id :rasta)
+        (let [dashboard (t2/select-one :model/Dashboard (public-settings/example-dashboard-id))
+              collection (t2/select-one :model/Collection (:collection_id dashboard))]
+          (mi/can-write? dashboard)
+          (mi/can-write? collection)))))
   (testing "The example-dashboard-id setting should be nil if the example content isn't loaded"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? false)


### PR DESCRIPTION
This PR adds "curate" permissions for "All Users" for example collection added in https://github.com/metabase/metabase/pull/40753. Previously only Admins had access. I decided to implement it in Clojure and not by adding more data to `resources/sample-content.edn`, because if we want to export another collection in the future the separation of content and permissions will make that process simpler.

Before: 
<img width="709" alt="image" src="https://github.com/metabase/metabase/assets/39073188/a3a72483-3319-4c8d-84db-c21635a11b46">

After:
![image](https://github.com/metabase/metabase/assets/39073188/25ad1261-9126-48c7-9d5c-293e89405260)