### PR TITLE
fix: border appearing on night theme if bordered=false

### DIFF
--- a/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
+++ b/frontend/src/metabase/public/components/EmbedFrame/EmbedFrame.module.css
@@ -14,7 +14,7 @@ body {
 
 .ThemeNight.EmbedFrame {
   background-color: var(--color-bg-black);
-  border: 1px solid var(--color-bg-dark);
+  border-color: var(--color-bg-dark);
 }
 
 .ThemeNight .EmbedFrameHeader,


### PR DESCRIPTION

### Description

This was probably made by mistake and never noticed, the night theme is setting not only the border color but also a border width, so the border appears even when #bordered=false.

If people want the border they can add it on the iframe so this shouldn't break anything

[slack thread](https://metaboat.slack.com/archives/C063Q3F1HPF/p1713204621307759)

### How to verify

Make a `#theme=night&bordered=false` dashboard embedding
Notice that without this fix it has a 1px solid border (it's more visible on a dark page)

### Demo
Before:
<img width="574" alt="image" src="https://github.com/metabase/metabase/assets/1914270/90dd66c4-8af9-4472-bb7c-c15b306c1be4">

After:
<img width="426" alt="image" src="https://github.com/metabase/metabase/assets/1914270/40f70702-7283-4659-85c2-9b1fa08fea90">
