### PR TITLE
Increase timeout for with-dynamic-redefs test

### DIFF
--- a/test/metabase/test/util_test.clj
+++ b/test/metabase/test/util_test.clj
@@ -54,7 +54,8 @@
 (deftest ^:parallel with-dynamic-redefs-test
   (testing "Three threads can independently redefine a regular var"
     (let [n-threads  3
-          thread-id  #(.threadId (Thread/currentThread))
+          ;; Note that .getId is deprecated in favor of .threadId, but that method is only introduced in Java 19
+          thread-id  #(.getId (Thread/currentThread))
           latch      (CountDownLatch. (inc n-threads))
           take-latch #(do
                         (.countDown latch)

--- a/test_config/log4j2-test.xml
+++ b/test_config/log4j2-test.xml
@@ -11,6 +11,7 @@
     <Logger name="liquibase" level="FATAL"/>
     <Logger name="metabase.test.data.interface" level="INFO"/>
     <Logger name="metabase.sync.fetch-metadata" level="ERROR"/>
+    <Logger name="metabase.test.util-test" level="DEBUG" />
 
     <Root level="FATAL">
       <AppenderRef ref="Console"/>


### PR DESCRIPTION
References https://github.com/metabase/metabase/issues/41515

### Description

The test for `with-dynamic-redefs` is hitting its timeout once in a while, and I suspect its just due to thread contention when a large number of tests are run in parallel, and there's a lot of demand on the common thread pool. I doubt that garbage collection is playing a role here given the timeout is already fairly long.

Since `await` will return immediately once its thread is notified after the corresponding `countDown` call, increasing the timeout won't affects runtime for cases when it wouldn't have flaked, so this gives a generous wait time - it's still a bargain compared to rerunning the entire test suite.

In case it still flakes, this adds a bunch of debugging info too.