### PR TITLE
Exclude sample content and "Metabase Analytics" content from usage stats (clone)

### DIFF
--- a/enterprise/backend/test/metabase_enterprise/analytics/stats_test.clj
+++ b/enterprise/backend/test/metabase_enterprise/analytics/stats_test.clj
@@ -1,0 +1,31 @@
+(ns metabase-enterprise.analytics.stats-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase-enterprise.audit-db :as audit-db]
+   [metabase.analytics.stats :as stats]
+   [metabase.db :as mdb]
+   [metabase.test :as mt]
+   [toucan2.core :as t2]))
+
+(deftest metabase-analytics-metrics-test
+  (testing "Metabase Analytics doesn't contribute to stats"
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? false)
+      (is (= ::audit-db/installed (audit-db/ensure-audit-db-installed!)))
+      (testing "sense check: Collection, Dashboard, and Cards exist"
+        (is (true? (t2/exists? :model/Collection)))
+        (is (true? (t2/exists? :model/Dashboard)))
+        (is (true? (t2/exists? :model/Card))))
+      (testing "All metrics should be empty"
+        (is (= {:collections 0, :cards_in_collections 0, :cards_not_in_collections 0, :num_cards_per_collection {}}
+               (#'stats/collection-metrics)))
+        (is (= {:questions {}, :public {}, :embedded {}}
+               (#'stats/question-metrics)))
+        (is (= {:dashboards         0
+                :with_params        0
+                :num_dashs_per_user {}
+                :num_cards_per_dash {}
+                :num_dashs_per_card {}
+                :public             {}
+                :embedded           {}}
+               (#'stats/dashboard-metrics)))))))

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6173,6 +6173,22 @@ databaseChangeLog:
                     nullable: true
 
   - changeSet:
+      id: v50.2024-04-09T15:55:19
+      author: calherries
+      comment: Add collection.is_sample column
+      changes:
+        - addColumn:
+            tableName: collection
+            columns:
+              - column:
+                  name: is_sample
+                  type: ${boolean.type}
+                  remarks: "Is the collection part of the sample content?"
+                  constraints:
+                    nullable: false
+                  defaultValue: false
+
+  - changeSet:
       id: v50.2024-04-09T15:55:22
       author: calherries
       comment: Create sample content

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6173,54 +6173,6 @@ databaseChangeLog:
                     nullable: true
 
   - changeSet:
-      id: v50.2024-04-09T15:55:19
-      author: calherries
-      comment: Add collection.is_sample column
-      changes:
-        - addColumn:
-            tableName: collection
-            columns:
-              - column:
-                  name: is_sample
-                  type: ${boolean.type}
-                  remarks: "Is the collection part of the sample content?"
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-
-  - changeSet:
-      id: v50.2024-04-09T15:55:20
-      author: calherries
-      comment: Add report_dashboard.is_sample column
-      changes:
-        - addColumn:
-            tableName: report_dashboard
-            columns:
-              - column:
-                  name: is_sample
-                  type: ${boolean.type}
-                  remarks: "Is the dashboard part of the sample content?"
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-
-  - changeSet:
-      id: v50.2024-04-09T15:55:21
-      author: calherries
-      comment: Add report_card.is_sample column
-      changes:
-        - addColumn:
-            tableName: report_card
-            columns:
-              - column:
-                  name: is_sample
-                  type: ${boolean.type}
-                  remarks: "Is the card part of the sample content?"
-                  constraints:
-                    nullable: false
-                  defaultValue: false
-
-  - changeSet:
       id: v50.2024-04-09T15:55:22
       author: calherries
       comment: Create sample content

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6173,6 +6173,54 @@ databaseChangeLog:
                     nullable: true
 
   - changeSet:
+      id: v50.2024-04-09T15:55:19
+      author: calherries
+      comment: Add collection.is_sample column
+      changes:
+        - addColumn:
+            tableName: collection
+            columns:
+              - column:
+                  name: is_sample
+                  type: ${boolean.type}
+                  remarks: "Is the collection part of the sample content?"
+                  constraints:
+                    nullable: false
+                  defaultValue: false
+
+  - changeSet:
+      id: v50.2024-04-09T15:55:20
+      author: calherries
+      comment: Add report_dashboard.is_sample column
+      changes:
+        - addColumn:
+            tableName: report_dashboard
+            columns:
+              - column:
+                  name: is_sample
+                  type: ${boolean.type}
+                  remarks: "Is the dashboard part of the sample content?"
+                  constraints:
+                    nullable: false
+                  defaultValue: false
+
+  - changeSet:
+      id: v50.2024-04-09T15:55:21
+      author: calherries
+      comment: Add report_card.is_sample column
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: is_sample
+                  type: ${boolean.type}
+                  remarks: "Is the card part of the sample content?"
+                  constraints:
+                    nullable: false
+                  defaultValue: false
+
+  - changeSet:
       id: v50.2024-04-09T15:55:22
       author: calherries
       comment: Create sample content

--- a/resources/sample-content.edn
+++ b/resources/sample-content.edn
@@ -3979,5 +3979,6 @@
    :entity_id "53YGAg4EE6MC76nxx-f5f",
    :location "/",
    :namespace nil,
+   :is_sample true,
    :created_at #t "2024-04-11T12:41:25.429317Z"}),
  :parameter_card ()}

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -179,7 +179,8 @@
   "Get metrics based on questions
   TODO characterize by # executions and avg latency"
   []
-  (let [cards (t2/select [Card :query_type :public_uuid :enable_embedding :embedding_params :dataset_query] :is_sample false)]
+  (let [cards (t2/select [Card :query_type :public_uuid :enable_embedding :embedding_params :dataset_query]
+                         :creator_id [:not= config/internal-mb-user-id])]
     {:questions (merge-count-maps (for [card cards]
                                     (let [native? (= (keyword (:query_type card)) :native)]
                                       {:total       1
@@ -203,11 +204,11 @@
   "Get metrics based on dashboards
   TODO characterize by # of revisions, and created by an admin"
   []
-  (let [dashboards (t2/select [Dashboard :creator_id :public_uuid :parameters :enable_embedding :embedding_params] :is_sample false)
+  (let [dashboards (t2/select [Dashboard :creator_id :public_uuid :parameters :enable_embedding :embedding_params] :creator_id [:not= config/internal-mb-user-id])
         dashcards  (t2/query {:select :dc.*
                               :from [[(t2/table-name DashboardCard) :dc]]
                               :join [[(t2/table-name Dashboard) :d] [:= :d.id :dc.dashboard_id]]
-                              :where [:not :d.is_sample]})]
+                              :where [:not [:= :d.creator_id config/internal-mb-user-id]]})]
     {:dashboards         (count dashboards)
      :with_params        (count (filter (comp seq :parameters) dashboards))
      :num_dashs_per_user (medium-histogram dashboards :creator_id)
@@ -301,8 +302,8 @@
 (defn- collection-metrics
   "Get metrics on Collection usage."
   []
-  (let [collections (t2/select Collection :is_sample false)
-        cards       (t2/select [Card :collection_id] :is_sample false)]
+  (let [collections (t2/select Collection :creator_id [:not= config/internal-mb-user-id])
+        cards       (t2/select [Card :collection_id] :creator_id [:not= config/internal-mb-user-id])]
     {:collections              (count collections)
      :cards_in_collections     (count (filter :collection_id cards))
      :cards_not_in_collections (count (remove :collection_id cards))

--- a/src/metabase/analytics/stats.clj
+++ b/src/metabase/analytics/stats.clj
@@ -302,7 +302,7 @@
 (defn- collection-metrics
   "Get metrics on Collection usage."
   []
-  (let [collections (t2/select Collection :creator_id [:not= config/internal-mb-user-id])
+  (let [collections (t2/select Collection :type [:not= "instance-analytics"] :is_sample false)
         cards       (t2/select [Card :collection_id] :creator_id [:not= config/internal-mb-user-id])]
     {:collections              (count collections)
      :cards_in_collections     (count (filter :collection_id cards))

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1174,9 +1174,9 @@
                                       v))
             table-name->rows      (fn [table-name]
                                     (->> (table-name->raw-rows table-name)
-                                    ;; We sort the rows by id and remove them so that auto-incrementing ids are
-                                    ;; generated in the same order. We can't insert the ids directly in H2 without
-                                    ;; creating sequences for all the generated id columns.
+                                         ;; We sort the rows by id and remove them so that auto-incrementing ids are
+                                         ;; generated in the same order. We can't insert the ids directly in H2 without
+                                         ;; creating sequences for all the generated id columns.
                                          (sort-by :id)
                                          (map (fn [row]
                                                 (dissoc (update-vals row replace-temporals) :id)))))

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1199,11 +1199,7 @@
                                   :report_dashboardcard
                                   :dashboardcard_series]]
                 (when-let [values (seq (table-name->rows table-name))]
-                  (let [values (for [v values]
-                                 (cond-> v
-                                   (contains? #{:collection :report_dashboard :report_card} table-name)
-                                   (assoc :is_sample true)))]
-                    (t2/query {:insert-into table-name :values values}))))
+                  (t2/query {:insert-into table-name :values values})))
               (t2/query {:insert-into :permissions
                          :values      [{:object   (format "/collection/%s/" example-collection-id)
                                         :group_id (:id (t2/query-one {:select :id :from :permissions_group :where [:= :name "All Users"]}))}]})

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1199,7 +1199,11 @@
                                   :report_dashboardcard
                                   :dashboardcard_series]]
                 (when-let [values (seq (table-name->rows table-name))]
-                  (t2/query {:insert-into table-name :values values})))
+                  (let [values (for [v values]
+                                 (cond-> v
+                                   (contains? #{:collection :report_dashboard :report_card} table-name)
+                                   (assoc :is_sample true)))]
+                    (t2/query {:insert-into table-name :values values}))))
               (t2/query {:insert-into :permissions
                          :values      [{:object   (format "/collection/%s/" example-collection-id)
                                         :group_id (:id (t2/query-one {:select :id :from :permissions_group :where [:= :name "All Users"]}))}]})

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -290,10 +290,10 @@
   (testing "Sample content doesn't contribute to stats"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? true)
-      (testing "sense check: Collection, Dashboard, and Cards exist but all have is_sample=true"
-        (is (true? (t2/exists? :model/Collection :is_sample true)))
-        (is (true? (t2/exists? :model/Dashboard :is_sample true)))
-        (is (true? (t2/exists? :model/Card :is_sample true))))
+      (testing "sense check: Collection, Dashboard, and Cards exist"
+        (is (true? (t2/exists? :model/Collection)))
+        (is (true? (t2/exists? :model/Dashboard)))
+        (is (true? (t2/exists? :model/Card))))
       (testing "All metrics should be empty"
         (is (= {:collections 0, :cards_in_collections 0, :cards_not_in_collections 0, :num_cards_per_collection {}}
                (#'stats/collection-metrics)))

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -3,6 +3,7 @@
    [clojure.test :refer :all]
    [java-time.api :as t]
    [metabase.analytics.stats :as stats :refer [anonymous-usage-stats]]
+   [metabase.db :as mdb]
    [metabase.email :as email]
    [metabase.integrations.slack :as slack]
    [metabase.models.card :refer [Card]]
@@ -284,3 +285,25 @@
                                          ["1-5"  [:int {:min 1}]]
                                          ["6-10" [:int {:min 1}]]]]]
                 (#'stats/alert-metrics)))))
+
+(deftest sample-content-metrics-test
+  (testing "Sample content doesn't contribute to stats"
+    (mt/with-temp-empty-app-db [_conn :h2]
+      (mdb/setup-db! :create-sample-content? true)
+      (testing "sense check: Collection, Dashboard, and Cards exist but all have is_sample=true"
+        (is (true? (t2/exists? :model/Collection :is_sample true)))
+        (is (true? (t2/exists? :model/Dashboard :is_sample true)))
+        (is (true? (t2/exists? :model/Card :is_sample true))))
+      (testing "All metrics should be empty"
+        (is (= {:collections 0, :cards_in_collections 0, :cards_not_in_collections 0, :num_cards_per_collection {}}
+               (#'stats/collection-metrics)))
+        (is (= {:questions {}, :public {}, :embedded {}}
+               (#'stats/question-metrics)))
+        (is (= {:dashboards 0,
+                :with_params 0,
+                :num_dashs_per_user {},
+                :num_cards_per_dash {},
+                :num_dashs_per_card {},
+                :public {},
+                :embedded {}}
+               (#'stats/dashboard-metrics)))))))

--- a/test/metabase/analytics/stats_test.clj
+++ b/test/metabase/analytics/stats_test.clj
@@ -299,11 +299,11 @@
                (#'stats/collection-metrics)))
         (is (= {:questions {}, :public {}, :embedded {}}
                (#'stats/question-metrics)))
-        (is (= {:dashboards 0,
-                :with_params 0,
-                :num_dashs_per_user {},
-                :num_cards_per_dash {},
-                :num_dashs_per_card {},
-                :public {},
-                :embedded {}}
+        (is (= {:dashboards         0
+                :with_params        0
+                :num_dashs_per_user {}
+                :num_cards_per_dash {}
+                :num_dashs_per_card {}
+                :public             {}
+                :embedded           {}}
                (#'stats/dashboard-metrics)))))))

--- a/test/metabase/setup_test.clj
+++ b/test/metabase/setup_test.clj
@@ -3,10 +3,14 @@
    [clojure.test :refer :all]
    [metabase.config :as config]
    [metabase.db :as mdb]
+   [metabase.models.interface :as mi]
    [metabase.public-settings :as public-settings]
    [metabase.setup :as setup]
    [metabase.test :as mt]
+   [metabase.test.fixtures :as fixtures]
    [toucan2.core :as t2]))
+
+(use-fixtures :once (fixtures/initialize :test-users))
 
 (deftest has-user-setup-ignores-internal-user-test
   (mt/with-empty-h2-app-db
@@ -49,11 +53,17 @@
       (is (zero? (call-count))))))
 
 (deftest has-example-dashboard-id-setting-test
-  (testing "The example-dashboard-id setting should be set if the example content is loaded"
-    (mt/with-temp-empty-app-db [_conn :h2]
-      (mdb/setup-db! :create-sample-content? true)
+  (mt/with-temp-empty-app-db [_conn :h2]
+    (mdb/setup-db! :create-sample-content? true)
+    (testing "The example-dashboard-id setting should be set if the example content is loaded"
       (is (= 1
-             (public-settings/example-dashboard-id)))))
+             (public-settings/example-dashboard-id))))
+    (testing "Rasta (as a member of 'All Users') should have sufficient privileges to edit the example content"
+      (mt/with-current-user (mt/user->id :rasta)
+        (let [dashboard (t2/select-one :model/Dashboard (public-settings/example-dashboard-id))
+              collection (t2/select-one :model/Collection (:collection_id dashboard))]
+          (mi/can-write? dashboard)
+          (mi/can-write? collection)))))
   (testing "The example-dashboard-id setting should be nil if the example content isn't loaded"
     (mt/with-temp-empty-app-db [_conn :h2]
       (mdb/setup-db! :create-sample-content? false)


### PR DESCRIPTION
Clone of https://github.com/metabase/metabase/pull/41519

Now that we're adding sample content to new instances in https://github.com/metabase/metabase/pull/40753, this PR excludes the content from usage stats. The relevant section of the product doc is [here](https://www.notion.so/metabase/Seed-new-instances-w-an-example-dashboard-18571f9ab18d41f882c39db92de3634d?pvs=4#070cfdadfdfb494cadf4e288a3764fd3):

> When sending [usage stats](https://github.com/metabase/metabase/blob/778e5cdf6554a0b66943cb1291347b032158ef5e/src/metabase/analytics/stats.clj#L422), we should not include this sample content (or the audit v2 content) in any question/dashboards aggregates

It also excludes Metabase Analytics content (behaviour approved [here](https://metaboat.slack.com/archives/C063Q3F1HPF/p1713362797221789?thread_ts=1713202568.295799&cid=C063Q3F1HPF) by Arakaki)

Both changes the same approach: 
1. We now exclude any cards and dashboards that were created by the internal user from the stats. We also exclude any dashcards that belong to a dashboard that was created by the internal user.
2. We exclude any collections that have `is_sample=true` from the stats. This required creating a new `is_sample` column on the `collection` table.