### PR TITLE
Improve test coverage for describe-fks and describe-fields

### DIFF
--- a/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
+++ b/test/metabase/driver/sql_jdbc/sync/describe_table_test.clj
@@ -49,52 +49,55 @@
                         (mt/normal-drivers-with-feature :nested-field-columns))))))
 
 (deftest ^:parallel describe-table-test
-  (assert (uses-default-describe-table? :h2) "H2 should use the default describe-table implementation")
-  (is (= {:name "VENUES",
-          :fields
-          #{{:name                       "ID"
-             :database-type              "BIGINT"
-             :base-type                  :type/BigInteger
-             :database-position          0
-             :pk?                        true
-             :database-required          false
-             :database-is-auto-increment true :json-unfolding false}
-            {:name                       "NAME"
-             :database-type              "CHARACTER VARYING"
-             :base-type                  :type/Text
-             :database-position          1
-             :database-required          false
-             :database-is-auto-increment false
-             :json-unfolding             false}
-            {:name                       "CATEGORY_ID"
-             :database-type              "INTEGER"
-             :base-type                  :type/Integer
-             :database-position          2
-             :database-required          false
-             :database-is-auto-increment false
-             :json-unfolding             false}
-            {:name                       "LATITUDE"
-             :database-type              "DOUBLE PRECISION"
-             :base-type                  :type/Float
-             :database-position          3
-             :database-required          false
-             :database-is-auto-increment false
-             :json-unfolding             false}
-            {:name                       "LONGITUDE"
-             :database-type              "DOUBLE PRECISION"
-             :base-type                  :type/Float
-             :database-position          4
-             :database-required          false
-             :database-is-auto-increment false
-             :json-unfolding             false}
-            {:name                       "PRICE"
-             :database-type              "INTEGER"
-             :base-type                  :type/Integer
-             :database-position          5
-             :database-required          false
-             :database-is-auto-increment false
-             :json-unfolding             false}}}
-         (driver/describe-table :h2 (mt/id) {:name "VENUES"}))))
+  (mt/test-driver :h2
+    (assert (uses-default-describe-table? :h2)
+            "Make sure H2 uses the default `describe-table` implementation")
+    (is (= {:name "VENUES",
+            :fields
+            #{{:name                       "ID"
+               :database-type              "BIGINT"
+               :base-type                  :type/BigInteger
+               :database-position          0
+               :pk?                        true
+               :database-required          false
+               :database-is-auto-increment true
+               :json-unfolding             false}
+              {:name                       "NAME"
+               :database-type              "CHARACTER VARYING"
+               :base-type                  :type/Text
+               :database-position          1
+               :database-required          false
+               :database-is-auto-increment false
+               :json-unfolding             false}
+              {:name                       "CATEGORY_ID"
+               :database-type              "INTEGER"
+               :base-type                  :type/Integer
+               :database-position          2
+               :database-required          false
+               :database-is-auto-increment false
+               :json-unfolding             false}
+              {:name                       "LATITUDE"
+               :database-type              "DOUBLE PRECISION"
+               :base-type                  :type/Float
+               :database-position          3
+               :database-required          false
+               :database-is-auto-increment false
+               :json-unfolding             false}
+              {:name                       "LONGITUDE"
+               :database-type              "DOUBLE PRECISION"
+               :base-type                  :type/Float
+               :database-position          4
+               :database-required          false
+               :database-is-auto-increment false
+               :json-unfolding             false}
+              {:name                       "PRICE"
+               :database-type              "INTEGER"
+               :base-type                  :type/Integer
+               :database-position          5
+               :database-required          false
+               :database-is-auto-increment false
+               :json-unfolding             false}}}
+           (driver/describe-table :h2 (mt/db) {:name "VENUES"})))))
 
 (deftest describe-auto-increment-on-non-pk-field-test
   (testing "a non-pk field with auto-increment should be have metabase_field.database_is_auto_increment=true"

--- a/test/metabase/driver/sql_jdbc_test.clj
+++ b/test/metabase/driver/sql_jdbc_test.clj
@@ -24,62 +24,6 @@
                          {:name table, :schema "PUBLIC", :description nil}))}
          (driver/describe-database :h2 (mt/db)))))
 
-(deftest ^:parallel describe-table-test
-  (is (= {:name   "VENUES"
-          :schema "PUBLIC"
-          :fields #{{:name              "ID"
-                     :database-type     "BIGINT"
-                     :base-type         :type/BigInteger
-                     :pk?               true
-                     :database-position 0
-                     :database-required false
-                     :database-is-auto-increment true
-                     :json-unfolding    false}
-                    {:name              "NAME"
-                     :database-type     "CHARACTER VARYING"
-                     :base-type         :type/Text
-                     :database-position 1
-                     :database-required false
-                     :database-is-auto-increment false
-                     :json-unfolding    false}
-                    {:name              "CATEGORY_ID"
-                     :database-type     "INTEGER"
-                     :base-type         :type/Integer
-                     :database-position 2
-                     :database-required false
-                     :database-is-auto-increment false
-                     :json-unfolding    false}
-                    {:name              "LATITUDE"
-                     :database-type     "DOUBLE PRECISION"
-                     :base-type         :type/Float
-                     :database-position 3
-                     :database-required false
-                     :database-is-auto-increment false
-                     :json-unfolding    false}
-                    {:name              "LONGITUDE"
-                     :database-type     "DOUBLE PRECISION"
-                     :base-type         :type/Float
-                     :database-position 4
-                     :database-required false
-                     :database-is-auto-increment false
-                     :json-unfolding    false}
-                    {:name              "PRICE"
-                     :database-type     "INTEGER"
-                     :base-type         :type/Integer
-                     :database-position 5
-                     :database-required false
-                     :database-is-auto-increment false
-                     :json-unfolding    false}}}
-         (driver/describe-table :h2 (mt/db) (t2/select-one Table :id (mt/id :venues))))))
-
-(deftest ^:parallel describe-table-fks-test
-  (is (= #{{:fk-column-name   "CATEGORY_ID"
-            :dest-table       {:name   "CATEGORIES"
-                               :schema "PUBLIC"}
-            :dest-column-name "ID"}}
-         #_{:clj-kondo/ignore [:deprecated-var]}
-         (driver/describe-table-fks :h2 (mt/db) (t2/select-one Table :id (mt/id :venues))))))
-
 (deftest describe-fields-sync-with-composite-pks-test
   (testing "Make sure syncing a table that has a composite pks works"
     (mt/test-driver (mt/normal-drivers-with-feature :describe-fields)

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -224,7 +224,7 @@
                    {:name              (fmt "date")
                     :database-type     string?
                     :database-position 1
-                    :base-type         #(isa? % :type/Date)}
+                    :base-type         #(isa? % :type/Temporal)}
                    {:name              (fmt "count")
                     :database-type     string?
                     :database-position 2

--- a/test/metabase/driver_test.clj
+++ b/test/metabase/driver_test.clj
@@ -217,21 +217,18 @@
       (mt/dataset daily-bird-counts
         (let [table (t2/select-one :model/Table :id (mt/id :bird-count))
               fmt   #(ddl.i/format-name driver/*driver* %)]
-          (is (=? [{:name              (fmt "id"),
-                    :database-type     string?,
-                    :database-position 0,
-                    :base-type         #(isa? % :type/Number),
-                    :json-unfolding    false}
-                   {:name              (fmt "date"),
-                    :database-type     string?,
-                    :database-position 1,
-                    :base-type         #(isa? % :type/Date),
-                    :json-unfolding    false}
-                   {:name              (fmt "count"),
-                    :database-type     string?,
-                    :database-position 2,
-                    :base-type         #(isa? % :type/Number),
-                    :json-unfolding    false}]
+          (is (=? [{:name              (fmt "id")
+                    :database-type     string?
+                    :database-position 0
+                    :base-type         #(isa? % :type/Number)}
+                   {:name              (fmt "date")
+                    :database-type     string?
+                    :database-position 1
+                    :base-type         #(isa? % :type/Date)}
+                   {:name              (fmt "count")
+                    :database-type     string?
+                    :database-position 2
+                    :base-type         #(isa? % :type/Number)}]
                   (describe-fields-for-table (mt/db) table))))))))
 
 (deftest ^:parallel describe-table-fks-test

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -309,44 +309,29 @@
      {:field-name "continent_id", :base-type :type/Integer :fk :continent}]
     [["Ghana" 1]]]])
 
-(deftest sync-fks-and-fields-for-db-test
-  (testing "[[sync-fields/sync-fields!]] and [[sync-fks/sync-fks-for-table!]] should sync fields and fks"
+(deftest sync-fks-and-fields-test
+  (testing (str "[[sync-fields/sync-fields-for-table!]] and [[sync-fks/sync-fks-for-table!]] should sync fields and fks"
+                "in the same way that [[sync-fields/sync-fields!]] and [[sync-fks/sync-fks!]] do")
     (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys)
       (mt/dataset country
         (let [tables (t2/select :model/Table :db_id (mt/id))]
-          ;; 1. delete the fields that were just synced
-          (t2/delete! :model/Field :table_id [:in (map :id tables)])
-          ;; 2. sync the metadata
-          (sync-fields/sync-fields! (mt/db))
-          (sync-fks/sync-fks! (mt/db))
-          (let [continent-id-field (t2/select-one :model/Field :%lower.name "id" :table_id (mt/id :continent))]
-            (is (= #{{:name "name",         :semantic_type nil,      :fk_target_field_id nil}
-                     {:name "id",           :semantic_type :type/PK, :fk_target_field_id nil}
-                     {:name "continent_id", :semantic_type :type/FK, :fk_target_field_id (:id continent-id-field)}}
-                   (set (map #(into {} %)
-                             (t2/select [Field
-                                         [:%lower.name :name]
-                                         :semantic_type
-                                         :fk_target_field_id]
-                                        :table_id [:in (map :id tables)])))))))))))
-
-(deftest sync-fks-and-fields-for-table-test
-  (testing "[[sync-fields/sync-fields-for-table!]] and [[sync-fks/sync-fks-for-table!]] should sync fields and fks"
-    (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys)
-      (mt/dataset country
-        (let [tables (t2/select :model/Table :db_id (mt/id))]
-          ;; 1. delete the fields that were just synced
-          (t2/delete! :model/Field :table_id [:in (map :id tables)])
-          ;; 2. sync the metadata for each table
-          (run! sync-fields/sync-fields-for-table! tables)
-          (run! sync-fks/sync-fks-for-table! tables)
-          (let [continent-id-field (t2/select-one :model/Field :%lower.name "id" :table_id (mt/id :continent))]
-            (is (= #{{:name "name",         :semantic_type nil,      :fk_target_field_id nil}
-                     {:name "id",           :semantic_type :type/PK, :fk_target_field_id nil}
-                     {:name "continent_id", :semantic_type :type/FK, :fk_target_field_id (:id continent-id-field)}}
-                   (set (map #(into {} %)
-                             (t2/select [Field
-                                         [:%lower.name :name]
-                                         :semantic_type
-                                         :fk_target_field_id]
-                                        :table_id [:in (map :id tables)])))))))))))
+          (doseq [sync-fields-and-fks! [(fn []
+                                          (run! sync-fields/sync-fields-for-table! tables)
+                                          (run! sync-fks/sync-fks-for-table! tables))
+                                        (fn []
+                                          (sync-fields/sync-fields! (mt/db))
+                                          (sync-fks/sync-fks! (mt/db)))]]
+            ;; 1. delete the fields that were just synced
+            (t2/delete! :model/Field :table_id [:in (map :id tables)])
+            ;; 2. sync the metadata for each table
+            (sync-fields-and-fks!)
+            (let [continent-id-field (t2/select-one :model/Field :%lower.name "id" :table_id (mt/id :continent))]
+              (is (= #{{:name "name",         :semantic_type nil,      :fk_target_field_id nil}
+                       {:name "id",           :semantic_type :type/PK, :fk_target_field_id nil}
+                       {:name "continent_id", :semantic_type :type/FK, :fk_target_field_id (:id continent-id-field)}}
+                     (set (map #(into {} %)
+                               (t2/select [Field
+                                           [:%lower.name :name]
+                                           :semantic_type
+                                           :fk_target_field_id]
+                                          :table_id [:in (map :id tables)]))))))))))))

--- a/test/metabase/sync/sync_metadata/fields_test.clj
+++ b/test/metabase/sync/sync_metadata/fields_test.clj
@@ -309,6 +309,27 @@
      {:field-name "continent_id", :base-type :type/Integer :fk :continent}]
     [["Ghana" 1]]]])
 
+(deftest sync-fks-and-fields-for-db-test
+  (testing "[[sync-fields/sync-fields!]] and [[sync-fks/sync-fks-for-table!]] should sync fields and fks"
+    (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys)
+      (mt/dataset country
+        (let [tables (t2/select :model/Table :db_id (mt/id))]
+          ;; 1. delete the fields that were just synced
+          (t2/delete! :model/Field :table_id [:in (map :id tables)])
+          ;; 2. sync the metadata
+          (sync-fields/sync-fields! (mt/db))
+          (sync-fks/sync-fks! (mt/db))
+          (let [continent-id-field (t2/select-one :model/Field :%lower.name "id" :table_id (mt/id :continent))]
+            (is (= #{{:name "name",         :semantic_type nil,      :fk_target_field_id nil}
+                     {:name "id",           :semantic_type :type/PK, :fk_target_field_id nil}
+                     {:name "continent_id", :semantic_type :type/FK, :fk_target_field_id (:id continent-id-field)}}
+                   (set (map #(into {} %)
+                             (t2/select [Field
+                                         [:%lower.name :name]
+                                         :semantic_type
+                                         :fk_target_field_id]
+                                        :table_id [:in (map :id tables)])))))))))))
+
 (deftest sync-fks-and-fields-for-table-test
   (testing "[[sync-fields/sync-fields-for-table!]] and [[sync-fks/sync-fks-for-table!]] should sync fields and fks"
     (mt/test-drivers (mt/normal-drivers-with-feature :foreign-keys)


### PR DESCRIPTION
This PR improves the test coverage around the `describe-fks` and `describe-fields` functions introduced in https://github.com/metabase/metabase/issues/39986

The PR adds these tests:
1. `test/metabase/driver_test.clj` now contains tests for `describe-table`, `describe-fields`, `describe-table-fks` and `describe-fks` that run for every driver. Previously we only had tests for these functions for SQL JDBC drivers that use the default implementations.
2. Extends `sync-fks-and-fields-for-db-test` to test `sync-fields/sync-fields!` and `sync-fields/sync-fks!` for drivers that support foreign keys.