### PR TITLE
Migration to add `trashed_from_*`

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6188,6 +6188,51 @@ databaseChangeLog:
         - customChange:
             class: "metabase.db.custom_migrations.BackfillQueryField"
 
+  - changeSet:
+      id: v50.2024-04-12T13:24:09
+      author: johnswanson
+      comment: Add `collection.trashed_from_location`
+      changes:
+        - addColumn:
+            tableName: collection
+            columns:
+              - column:
+                  name: trashed_from_location
+                  type: ${text.type}
+                  remarks: "The previous location this collection was trashed from"
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v50.2024-04-12T13:43:12
+      author: johnswanson
+      comment: Add `report_card.trashed_from_collection_id`
+      changes:
+        - addColumn:
+            tableName: report_card
+            columns:
+              - column:
+                  name: trashed_from_collection_id
+                  type: int
+                  remarks: "The previous parent collection this card was trashed *from*"
+                  constraints:
+                    nullable: true
+
+  - changeSet:
+      id: v50.2024-04-12T13:43:20
+      author: johnswanson
+      comment: Add `report_dashboard.trashed_from_collection_id`
+      changes:
+        - addColumn:
+            tableName: report_dashboard
+            columns:
+              - column:
+                  name: trashed_from_collection_id
+                  type: int
+                  remarks: "The previous parent collection this dashboard was trashed *from*"
+                  constraints:
+                    nullable: true
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -63,29 +63,30 @@
 
 (def card-defaults
   "The default card params."
-  {:archived               false
-   :collection_id          nil
-   :collection_position    nil
-   :collection_preview     true
-   :dataset_query          {}
-   :type                   "question"
-   :description            nil
-   :display                "scalar"
-   :enable_embedding       false
-   :initially_published_at nil
-   :entity_id              nil
-   :embedding_params       nil
-   :made_public_by_id      nil
-   :parameters             []
-   :parameter_mappings     []
-   :moderation_reviews     ()
-   :public_uuid            nil
-   :query_type             nil
-   :cache_ttl              nil
-   :average_query_time     nil
-   :last_query_start       nil
-   :result_metadata        nil
-   :cache_invalidated_at   nil})
+  {:archived                   false
+   :collection_id              nil
+   :collection_position        nil
+   :collection_preview         true
+   :dataset_query              {}
+   :type                       "question"
+   :description                nil
+   :display                    "scalar"
+   :enable_embedding           false
+   :initially_published_at     nil
+   :entity_id                  nil
+   :embedding_params           nil
+   :made_public_by_id          nil
+   :parameters                 []
+   :parameter_mappings         []
+   :moderation_reviews         ()
+   :public_uuid                nil
+   :query_type                 nil
+   :cache_ttl                  nil
+   :average_query_time         nil
+   :last_query_start           nil
+   :result_metadata            nil
+   :cache_invalidated_at       nil
+   :trashed_from_collection_id nil})
 
 ;; Used in dashboard tests
 (def card-defaults-no-hydrate

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -200,27 +200,28 @@
                                                                    :parameters "abc"})))))
 
 (def ^:private dashboard-defaults
-  {:archived                false
-   :caveats                 nil
-   :collection_id           nil
-   :collection_position     nil
-   :collection              true
-   :created_at              true ; assuming you call dashboard-response on the results
-   :description             nil
-   :embedding_params        nil
-   :enable_embedding        false
-   :initially_published_at  nil
-   :entity_id               true
-   :made_public_by_id       nil
-   :parameters              []
-   :points_of_interest      nil
-   :cache_ttl               nil
-   :position                nil
-   :width                   "fixed"
-   :public_uuid             nil
-   :auto_apply_filters      true
-   :show_in_getting_started false
-   :updated_at              true})
+  {:archived                   false
+   :caveats                    nil
+   :collection_id              nil
+   :collection_position        nil
+   :collection                 true
+   :created_at                 true ; assuming you call dashboard-response on the results
+   :description                nil
+   :embedding_params           nil
+   :enable_embedding           false
+   :initially_published_at     nil
+   :entity_id                  true
+   :made_public_by_id          nil
+   :parameters                 []
+   :points_of_interest         nil
+   :cache_ttl                  nil
+   :position                   nil
+   :width                      "fixed"
+   :public_uuid                nil
+   :auto_apply_filters         true
+   :show_in_getting_started    false
+   :updated_at                 true
+   :trashed_from_collection_id nil})
 
 (deftest create-dashboard-test
   (testing "POST /api/dashboard"

--- a/test/metabase/events/revision_test.clj
+++ b/test/metabase/events/revision_test.clj
@@ -21,39 +21,41 @@
    :creator_id             (mt/user->id :crowberto)})
 
 (defn- card->revision-object [card]
-  {:archived               false
-   :collection_id          nil
-   :collection_position    nil
-   :collection_preview     true
-   :database_id            (mt/id)
-   :dataset_query          (:dataset_query card)
-   :type                   :question
-   :description            nil
-   :display                :table
-   :enable_embedding       false
-   :embedding_params       nil
-   :name                   (:name card)
-   :parameters             []
-   :parameter_mappings     []
-   :cache_ttl              nil
-   :query_type             :query
-   :table_id               (mt/id :categories)
-   :visualization_settings {}})
+  {:archived                   false
+   :collection_id              nil
+   :collection_position        nil
+   :collection_preview         true
+   :database_id                (mt/id)
+   :dataset_query              (:dataset_query card)
+   :type                       :question
+   :description                nil
+   :display                    :table
+   :enable_embedding           false
+   :embedding_params           nil
+   :name                       (:name card)
+   :parameters                 []
+   :parameter_mappings         []
+   :cache_ttl                  nil
+   :query_type                 :query
+   :table_id                   (mt/id :categories)
+   :visualization_settings     {}
+   :trashed_from_collection_id (:trashed_from_collection_id card)})
 
 (defn- dashboard->revision-object [dashboard]
-  {:collection_id       (:collection_id dashboard)
-   :description         nil
-   :cache_ttl           nil
-   :auto_apply_filters  true
-   :name                (:name dashboard)
-   :width               (:width dashboard)
-   :tabs                []
-   :cards               []
-   :archived            false
-   :collection_position nil
-   :enable_embedding    false
-   :embedding_params    nil
-   :parameters          []})
+  {:collection_id              (:collection_id dashboard)
+   :description                nil
+   :cache_ttl                  nil
+   :auto_apply_filters         true
+   :name                       (:name dashboard)
+   :width                      (:width dashboard)
+   :tabs                       []
+   :cards                      []
+   :archived                   false
+   :collection_position        nil
+   :enable_embedding           false
+   :embedding_params           nil
+   :parameters                 []
+   :trashed_from_collection_id (:trashed_from_collection_id dashboard)})
 
 (deftest card-create-test
   (testing :event/card-create

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -839,7 +839,10 @@
                          :table_id :database_id :query_type
                          ;; we don't need a description for made_public_by_id because whenever this field changes
                          ;; public_uuid will change and we have a description for it.
-                         :made_public_by_id} col)
+                         :made_public_by_id
+                         ;; similarly, we don't need a description for `trashed_from_collection_id` because whenever
+                         ;; this field changes `archived` will also change and we have a description for that.
+                         :trashed_from_collection_id} col)
               (testing (format "we should have a revision description for %s" col)
                 (is (some? (u/build-sentence
                             (revision/diff-strings

--- a/test/metabase/models/dashboard_test.clj
+++ b/test/metabase/models/dashboard_test.clj
@@ -36,30 +36,31 @@
                              DashboardCard       {dashcard-id :id} {:dashboard_id dashboard-id, :card_id card-id}
                              DashboardCardSeries _                 {:dashboardcard_id dashcard-id, :card_id series-id-1, :position 0}
                              DashboardCardSeries _                 {:dashboardcard_id dashcard-id, :card_id series-id-2, :position 1}]
-      (is (= {:name                "Test Dashboard"
-              :auto_apply_filters  true
-              :collection_id       nil
-              :description         nil
-              :cache_ttl           nil
-              :cards               [{:size_x                 4
-                                     :size_y                 4
-                                     :row                    0
-                                     :col                    0
-                                     :id                     true
-                                     :card_id                true
-                                     :series                 true
-                                     :dashboard_tab_id       nil
-                                     :action_id              nil
-                                     :parameter_mappings     []
-                                     :visualization_settings {}
-                                     :dashboard_id           dashboard-id}]
-              :tabs                []
-              :archived            false
-              :collection_position nil
-              :enable_embedding    false
-              :embedding_params    nil
-              :parameters          []
-              :width               "fixed"}
+      (is (= {:name                       "Test Dashboard"
+              :trashed_from_collection_id nil
+              :auto_apply_filters         true
+              :collection_id              nil
+              :description                nil
+              :cache_ttl                  nil
+              :cards                      [{:size_x                 4
+                                            :size_y                 4
+                                            :row                    0
+                                            :col                    0
+                                            :id                     true
+                                            :card_id                true
+                                            :series                 true
+                                            :dashboard_tab_id       nil
+                                            :action_id              nil
+                                            :parameter_mappings     []
+                                            :visualization_settings {}
+                                            :dashboard_id           dashboard-id}]
+              :tabs                       []
+              :archived                   false
+              :collection_position        nil
+              :enable_embedding           false
+              :embedding_params           nil
+              :parameters                 []
+              :width                      "fixed"}
              (update (revision/serialize-instance Dashboard (:id dashboard) dashboard)
                      :cards
                      (fn [[{:keys [id card_id series], :as card}]]
@@ -73,20 +74,20 @@
     (t2.with-temp/with-temp [Dashboard           {dashboard-id :id :as dashboard} {:name "Test Dashboard"}
                              :model/DashboardTab {tab-id :id}                     {:dashboard_id dashboard-id :name "Test Tab" :position 0}
                              DashboardCard       {dashcard-id :id}                {:dashboard_id dashboard-id :dashboard_tab_id tab-id}]
-      (is (=? {:name               "Test Dashboard"
-               :auto_apply_filters true
-               :collection_id      nil
-               :description        nil
-               :cache_ttl          nil
-               :cards              [{:size_x           4
-                                     :size_y           4
-                                     :row              0
-                                     :col              0
-                                     :id               dashcard-id
-                                     :dashboard_tab_id tab-id}]
-               :tabs               [{:id      tab-id
-                                     :name    "Test Tab"
-                                     :position 0}]}
+      (is (=? {:name                       "Test Dashboard"
+               :auto_apply_filters         true
+               :collection_id              nil
+               :description                nil
+               :cache_ttl                  nil
+               :cards                      [{:size_x           4
+                                             :size_y           4
+                                             :row              0
+                                             :col              0
+                                             :id               dashcard-id
+                                             :dashboard_tab_id tab-id}]
+               :tabs                       [{:id       tab-id
+                                             :name     "Test Tab"
+                                             :position 0}]}
               (revision/serialize-instance Dashboard (:id dashboard) dashboard))))))
 
 (deftest ^:parallel diff-dashboards-str-test
@@ -242,32 +243,33 @@
 
     (testing "dashboard ---"
       (t2.with-temp/with-temp
-        [:model/Dashboard dashboard {:name               "A Dashboard"
-                                     :description        "An insightful Dashboard"
+        [:model/Dashboard dashboard {:name                "A Dashboard"
+                                     :description         "An insightful Dashboard"
                                      :collection_position 0
                                      :position            10
                                      :cache_ttl           1000
-                                     :parameters          [{:name       "Category Name"
-                                                            :slug       "category_name"
-                                                            :id         "_CATEGORY_NAME_"
-                                                            :type       "category"}]}
+                                     :parameters          [{:name "Category Name"
+                                                            :slug "category_name"
+                                                            :id   "_CATEGORY_NAME_"
+                                                            :type "category"}]}
          Collection       coll      {:name "A collection"}]
         (mt/with-temporary-setting-values [enable-public-sharing true]
           (let [columns    (set/difference (set (keys dashboard)) (set @#'dashboard/excluded-columns-for-dashboard-revision))
                 update-col (fn [col value]
                              (cond
-                               (= col :collection_id)     (:id coll)
-                               (= col :parameters)        (cons {:name "Category ID"
-                                                                 :slug "category_id"
-                                                                 :id   "_CATEGORY_ID_"
-                                                                 :type "number"}
-                                                                value)
-                               (= col :made_public_by_id) (mt/user->id :crowberto)
-                               (= col :embedding_params)  {:category_name "locked"}
-                               (= col :public_uuid)       (str (random-uuid))
-                               (int? value)               (inc value)
-                               (boolean? value)           (not value)
-                               (string? value)            (str value "_changed")))]
+                               (= col :collection_id)              (:id coll)
+                               (= col :parameters)                 (cons {:name "Category ID"
+                                                                          :slug "category_id"
+                                                                          :id   "_CATEGORY_ID_"
+                                                                          :type "number"}
+                                                                         value)
+                               (= col :made_public_by_id)          (mt/user->id :crowberto)
+                               (= col :embedding_params)           {:category_name "locked"}
+                               (= col :public_uuid)                (str (random-uuid))
+                               (= col :trashed_from_collection_id) (:id coll)
+                               (int? value)                        (inc value)
+                               (boolean? value)                    (not value)
+                               (string? value)                     (str value "_changed")))]
             (doseq [col columns]
               (let [before  (select-keys dashboard [col])
                     changes {col (update-col col (get dashboard col))}]
@@ -279,9 +281,10 @@
                 (testing (format "we should track when %s changes" col)
                   (is (= 2 (t2/count Revision :model "Dashboard" :model_id (:id dashboard)))))
 
-                ;; we don't need a description for made_public_by_id because whenever this field changes
-                ;; public_uuid will changes and we had a description for it.
-                (when-not (#{:made_public_by_id} col)
+                ;; we don't need a description for made_public_by_id because whenever this field changes public_uuid
+                ;; will changes and we had a description for it. Same is true for `trashed_from_collection_id` -
+                ;; `archived` will always change with it.
+                (when-not (#{:made_public_by_id :trashed_from_collection_id} col)
                   (testing (format "we should have a revision description for %s" col)
                     (is (some? (u/build-sentence
                                  (revision/diff-strings
@@ -302,15 +305,15 @@
                               :dashboard_id :id)
              update-col (fn [col value]
                           (cond
-                            (= col :action_id)          (:id action)
-                            (= col :card_id)            (:id card)
-                            (= col :dashboard_tab_id)   (:id dashtab)
-                            (= col :parameter_mappings) [{:parameter_id "_CATEGORY_NAME_"
-                                                          :target       [:dimension (mt/$ids $categories.name)]}]
+                            (= col :action_id)              (:id action)
+                            (= col :card_id)                (:id card)
+                            (= col :dashboard_tab_id)       (:id dashtab)
+                            (= col :parameter_mappings)     [{:parameter_id "_CATEGORY_NAME_"
+                                                              :target       [:dimension (mt/$ids $categories.name)]}]
                             (= col :visualization_settings) {:text "now it's a text card"}
-                            (int? value)                (inc value)
-                            (boolean? value)            (not value)
-                            (string? value)             (str value "_changed")))]
+                            (int? value)                    (inc value)
+                            (boolean? value)                (not value)
+                            (string? value)                 (str value "_changed")))]
          (doseq [col columns]
            (clean-revisions-for-dashboard (:id dashboard))
            ;; do the update
@@ -328,8 +331,8 @@
                               :dashboard_id :id)
              update-col (fn [_col value]
                           (cond
-                            (int? value)                (inc value)
-                            (string? value)             (str value "_changed")))]
+                            (int? value)    (inc value)
+                            (string? value) (str value "_changed")))]
          (doseq [col columns]
            (clean-revisions-for-dashboard (:id dashboard))
            ;; do the update
@@ -352,45 +355,47 @@
                                          :id      (= dashcard-id id)
                                          :card_id (= card-id card_id)
                                          :series  (= [series-id-1 series-id-2] series))])
-          empty-dashboard      {:name                "Revert Test"
-                                :description         "something"
-                                :auto_apply_filters  true
-                                :collection_id       nil
-                                :cache_ttl           nil
-                                :cards               []
-                                :tabs                []
-                                :archived            false
-                                :collection_position nil
-                                :enable_embedding    false
-                                :embedding_params    nil
-                                :parameters          []
-                                :width               "fixed"}
+          empty-dashboard      {:name                       "Revert Test"
+                                :trashed_from_collection_id nil
+                                :description                "something"
+                                :auto_apply_filters         true
+                                :collection_id              nil
+                                :cache_ttl                  nil
+                                :cards                      []
+                                :tabs                       []
+                                :archived                   false
+                                :collection_position        nil
+                                :enable_embedding           false
+                                :embedding_params           nil
+                                :parameters                 []
+                                :width                      "fixed"}
           serialized-dashboard (revision/serialize-instance Dashboard (:id dashboard) dashboard)]
       (testing "original state"
-        (is (= {:name                "Test Dashboard"
-                :description         nil
-                :cache_ttl           nil
-                :auto_apply_filters  true
-                :collection_id       nil
-                :cards               [{:size_x                 4
-                                       :size_y                 4
-                                       :row                    0
-                                       :col                    0
-                                       :id                     true
-                                       :card_id                true
-                                       :series                 true
-                                       :dashboard_tab_id       nil
-                                       :action_id              nil
-                                       :parameter_mappings     []
-                                       :visualization_settings {}
-                                       :dashboard_id           dashboard-id}]
-                :tabs                []
-                :archived            false
-                :collection_position nil
-                :enable_embedding    false
-                :embedding_params    nil
-                :parameters          []
-                :width               "fixed"}
+        (is (= {:name                       "Test Dashboard"
+                :trashed_from_collection_id nil
+                :description                nil
+                :cache_ttl                  nil
+                :auto_apply_filters         true
+                :collection_id              nil
+                :cards                      [{:size_x                 4
+                                              :size_y                 4
+                                              :row                    0
+                                              :col                    0
+                                              :id                     true
+                                              :card_id                true
+                                              :series                 true
+                                              :dashboard_tab_id       nil
+                                              :action_id              nil
+                                              :parameter_mappings     []
+                                              :visualization_settings {}
+                                              :dashboard_id           dashboard-id}]
+                :tabs                       []
+                :archived                   false
+                :collection_position        nil
+                :enable_embedding           false
+                :embedding_params           nil
+                :parameters                 []
+                :width                      "fixed"}
                (update serialized-dashboard :cards check-ids))))
       (testing "delete the dashcard and modify the dash attributes"
         (dashboard-card/delete-dashboard-cards! [(:id dashboard-card)])
@@ -404,30 +409,31 @@
                    (revision/serialize-instance Dashboard (:id dashboard) dashboard))))))
       (testing "now do the reversion; state should return to original"
         (revision/revert-to-revision! Dashboard dashboard-id (test.users/user->id :crowberto) serialized-dashboard)
-        (is (= {:name                "Test Dashboard"
-                :description         nil
-                :cache_ttl           nil
-                :auto_apply_filters  true
-                :collection_id       nil
-                :cards               [{:size_x                 4
-                                       :size_y                 4
-                                       :row                    0
-                                       :col                    0
-                                       :id                     false
-                                       :card_id                true
-                                       :series                 true
-                                       :dashboard_tab_id       nil
-                                       :action_id              nil
-                                       :parameter_mappings     []
-                                       :visualization_settings {}
-                                       :dashboard_id           dashboard-id}]
-                :tabs                []
-                :archived            false
-                :collection_position nil
-                :enable_embedding    false
-                :embedding_params    nil
-                :parameters          []
-                :width               "fixed"}
+        (is (= {:name                       "Test Dashboard"
+                :trashed_from_collection_id nil
+                :description                nil
+                :cache_ttl                  nil
+                :auto_apply_filters         true
+                :collection_id              nil
+                :cards                      [{:size_x                 4
+                                              :size_y                 4
+                                              :row                    0
+                                              :col                    0
+                                              :id                     false
+                                              :card_id                true
+                                              :series                 true
+                                              :dashboard_tab_id       nil
+                                              :action_id              nil
+                                              :parameter_mappings     []
+                                              :visualization_settings {}
+                                              :dashboard_id           dashboard-id}]
+                :tabs                       []
+                :archived                   false
+                :collection_position        nil
+                :enable_embedding           false
+                :embedding_params           nil
+                :parameters                 []
+                :width                      "fixed"}
                (update (revision/serialize-instance Dashboard dashboard-id (t2/select-one Dashboard :id dashboard-id))
                        :cards check-ids))))
       (testing "revert back to the empty state"


### PR DESCRIPTION
We want to record where things were trashed *from* for two purposes:

- first, we want to be able to put things back if they're "untrashed".

- second, we want to be able to enforce permissions *as if* something is still in its previous location. That is, if we trash a card or a dashboard from Collection A, the permissions of Collection A should continue to apply to the card or dashboard (e.g. in terms of who can view it).

To achieve this, collections get a `trashed_from_location` (paralleling their `location`) and dashboards/cards get a
`trashed_from_collection_id` (paralleling their `collection_id`).