### PR TITLE
[cache] log query hash during calculation of eligibility

### DIFF
--- a/src/metabase/query_processor/middleware/cache.clj
+++ b/src/metabase/query_processor/middleware/cache.clj
@@ -107,7 +107,8 @@
              min-duration-ms (:min-duration-ms strategy 0)
              eligible?       (and @has-rows?
                                   (> duration-ms min-duration-ms))]
-         (log/infof "Query took %s to run; minimum for cache eligibility is %s; %s"
+         (log/infof "Query %s took %s to run; minimum for cache eligibility is %s; %s"
+                    (i/short-hex-hash query-hash)
                     (u/format-milliseconds duration-ms)
                     (u/format-milliseconds min-duration-ms)
                     (if eligible? "eligible" "not eligible"))


### PR DESCRIPTION
It is really hard to find a log about particular query being cached or not, so at least some more logging will help me track it.