### PR TITLE
Create the trash collection on startup

### DIFF
--- a/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
+++ b/e2e/test/scenarios/collections/collection-items-listing.cy.spec.js
@@ -26,7 +26,7 @@ describe("scenarios > collection items listing", () => {
   const PAGE_SIZE = 25;
 
   describe("pagination", () => {
-    const SUBCOLLECTIONS = 1;
+    const SUBCOLLECTIONS = 2;
     const ADDED_QUESTIONS = 15;
     const ADDED_DASHBOARDS = 14;
 

--- a/src/metabase/core.clj
+++ b/src/metabase/core.clj
@@ -13,6 +13,7 @@
    [metabase.driver.postgres]
    [metabase.events :as events]
    [metabase.logger :as logger]
+   [metabase.models.collection :as collection]
    [metabase.models.setting :as settings]
    [metabase.plugins :as plugins]
    [metabase.plugins.classloader :as classloader]
@@ -145,6 +146,7 @@
         (sample-data/update-sample-database-if-needed!)))
     (init-status/set-progress! 0.9))
 
+  (collection/ensure-trash-collection-created!)
   (ensure-audit-db-installed!)
   (init-status/set-progress! 0.95)
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -45,18 +45,18 @@
   "Maximum number of characters allowed in a Collection `slug`."
   510)
 
-(def ^:const TRASH_COLLECTION_ID
+(def ^:const trash-collection-id
   "The fixed ID of the trash collection."
   13371339)
 
 (defn trash-collection
   "Gets the Trash collection from the database."
   []
-  (t2/select-one :model/Collection :id TRASH_COLLECTION_ID))
+  (t2/select-one :model/Collection :id trash-collection-id))
 
 (def ^:private trash-path
   "The fixed location path for the trash collection."
-  (format "/%s/" TRASH_COLLECTION_ID))
+  (format "/%s/" trash-collection-id))
 
 (defn is-trash-or-descendant?
   "Is this the trash collection, or a descendant of it?"
@@ -67,7 +67,7 @@
   "Creates the trash collection if it does not already exist."
   []
   (when (nil? (trash-collection))
-    (t2/insert! :model/Collection {:id TRASH_COLLECTION_ID
+    (t2/insert! :model/Collection {:id trash-collection-id
                                    :name "Trash"
                                    :type "trash"})))
 

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -45,6 +45,32 @@
   "Maximum number of characters allowed in a Collection `slug`."
   510)
 
+(def ^:const TRASH_COLLECTION_ID
+  "The fixed ID of the trash collection."
+  13371339)
+
+(defn trash-collection
+  "Gets the Trash collection from the database."
+  []
+  (t2/select-one :model/Collection :id TRASH_COLLECTION_ID))
+
+(def ^:private trash-path
+  "The fixed location path for the trash collection."
+  (format "/%s/" TRASH_COLLECTION_ID))
+
+(defn is-trash-or-descendant?
+  "Is this the trash collection, or a descendant of it?"
+  [collection]
+  (str/starts-with? (:location collection) trash-path))
+
+(defn ensure-trash-collection-created!
+  "Creates the trash collection if it does not already exist."
+  []
+  (when (nil? (trash-collection))
+    (t2/insert! :model/Collection {:id TRASH_COLLECTION_ID
+                                   :name "Trash"
+                                   :type "trash"})))
+
 (def Collection
   "Used to be the toucan1 model name defined using [[toucan.models/defmodel]], no2 it's a reference to the toucan2 model name.
   We'll keep this till we replace all the Card symbol in our codebase."

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -67,6 +67,8 @@
         honeysql-form           {:select [[:id :id]]
                                  :from   [:collection]
                                  :where  (into [:and
+                                                ;; Does 'NULL != "trash"'? Postgres says the answer is undefined, aka
+                                                ;; NULL, which... is falsey. :sob:
                                                 [:or [:= :type nil] [:not= :type "trash"]]
                                                 (perms/audit-namespace-clause :namespace (u/qualified-name collection-namespace))
                                                 [:= :personal_owner_id nil]]

--- a/src/metabase/models/collection/graph.clj
+++ b/src/metabase/models/collection/graph.clj
@@ -67,6 +67,7 @@
         honeysql-form           {:select [[:id :id]]
                                  :from   [:collection]
                                  :where  (into [:and
+                                                [:or [:= :type nil] [:not= :type "trash"]]
                                                 (perms/audit-namespace-clause :namespace (u/qualified-name collection-namespace))
                                                 [:= :personal_owner_id nil]]
                                                (for [collection-id personal-collection-ids]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -493,36 +493,49 @@
   (classloader/require 'metabase.models.collection)
   ((resolve 'metabase.models.collection/is-personal-collection-or-descendant-of-one?) collection))
 
-(mu/defn ^:private check-not-personal-collection-or-descendant
-  "Check whether `collection-or-id` refers to a Personal Collection; if so, throw an Exception. This is done because we
-  *should* never be editing granting/etc. permissions for *Personal* Collections to entire Groups! Their owner will
-  get implicit permissions automatically, and of course admins will be able to see them,but a whole group should never
-  be given some sort of access."
+(defn- is-trash-or-descendant? [collection]
+  (classloader/require 'metabase.models.collection)
+  ((resolve 'metabase.models.collection/is-trash-or-descendant?) collection))
+
+(defn- ^:private collection-or-id->collection
+  [collection-or-id]
+  (if (map? collection-or-id)
+    collection-or-id
+    (t2/select-one :model/Collection :id (u/the-id collection-or-id))))
+
+(mu/defn ^:private check-is-modifiable-collection
+  "Check whether `collection-or-id` refers to a collection that can have permissions modified. Personal collections, the
+  Trash, and descendants of those can't have their permissions modified."
   [collection-or-id :- MapOrID]
-  ;; don't apply this check to the Root Collection, because it's never personal
+  ;; skip the whole thing for the root collection, we know it's not a personal collection, trash, or descendant of one
+  ;; of them.
   (when-not (:metabase.models.collection.root/is-root? collection-or-id)
-    ;; ok, once we've confirmed this isn't the Root Collection, see if it's in the DB with a personal_owner_id
-    (let [collection (if (map? collection-or-id)
-                       collection-or-id
-                       (or (t2/select-one 'Collection :id (u/the-id collection-or-id))
-                           (throw (ex-info (tru "Collection does not exist.") {:collection-id (u/the-id collection-or-id)}))))]
+    (let [collection (collection-or-id->collection collection-or-id)]
+      ;; Check whether the collection is the Trash collection or a descendant thereof; if so, throw an Exception. This
+      ;; is done because you can't modify the permissions of things in the Trash, you need to untrash them first.
+      (when (is-trash-or-descendant? collection)
+        (throw (ex-info (tru "You cannot edit permissions for the Trash collection or its descendants.") {})))
+      ;; Check whether the collection is a personal collection or a descendant thereof; if so, throw an Exception.
+      ;; This is done because we *should* never be editing granting/etc. permissions for *Personal* Collections to
+      ;; entire Groups! Their owner will get implicit permissions automatically, and of course admins will be able to
+      ;; see them,but a whole group should never be given some sort of access.
       (when (is-personal-collection-or-descendant-of-one? collection)
-        (throw (Exception. (tru "You cannot edit permissions for a Personal Collection or its descendants.")))))))
+        (throw (ex-info (tru "You cannot edit permissions for a Personal Collection or its descendants.") {}))))))
 
 (mu/defn revoke-collection-permissions!
   "Revoke all access for `group-or-id` to a Collection."
   [group-or-id :- MapOrID collection-or-id :- MapOrID]
-  (check-not-personal-collection-or-descendant collection-or-id)
+  (check-is-modifiable-collection collection-or-id)
   (delete-related-permissions! group-or-id (collection-readwrite-path collection-or-id)))
 
 (mu/defn grant-collection-readwrite-permissions!
   "Grant full access to a Collection, which means a user can view all Cards in the Collection and add/remove Cards."
   [group-or-id :- MapOrID collection-or-id :- MapOrID]
-  (check-not-personal-collection-or-descendant collection-or-id)
+  (check-is-modifiable-collection collection-or-id)
   (grant-permissions! (u/the-id group-or-id) (collection-readwrite-path collection-or-id)))
 
 (mu/defn grant-collection-read-permissions!
   "Grant read access to a Collection, which means a user can view all Cards in the Collection."
   [group-or-id :- MapOrID collection-or-id :- MapOrID]
-  (check-not-personal-collection-or-descendant collection-or-id)
+  (check-is-modifiable-collection collection-or-id)
   (grant-permissions! (u/the-id group-or-id) (collection-read-path collection-or-id)))


### PR DESCRIPTION
The trash collection (and its descendants) can't have its permissions modified.

Note that right now, it's possible to move the Trash collection. I'll fix this when I implement the API for moving things to the Trash.