### PR TITLE
[QP, lib] Add new expression functions for host, domain, subdomain

### DIFF
--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -130,6 +130,24 @@ export const MBQL_CLAUSES: MBQLClauseMap = {
   trim: { displayName: `trim`, type: "string", args: ["string"] },
   rtrim: { displayName: `rtrim`, type: "string", args: ["string"] },
   ltrim: { displayName: `ltrim`, type: "string", args: ["string"] },
+  domain: {
+    displayName: `domain`,
+    type: "string",
+    args: ["string"],
+    requiresFeature: "regex",
+  },
+  subdomain: {
+    displayName: `subdomain`,
+    type: "string",
+    args: ["string"],
+    requiresFeature: "regex",
+  },
+  host: {
+    displayName: `host`,
+    type: "string",
+    args: ["string"],
+    requiresFeature: "regex",
+  },
   // numeric functions
   abs: {
     displayName: `abs`,
@@ -460,6 +478,9 @@ export const EXPRESSION_FUNCTIONS = new Set([
   "rtrim",
   "ltrim",
   "length",
+  "domain",
+  "subdomain",
+  "host",
   // number
   "abs",
   "floor",

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -394,6 +394,45 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     ],
   },
   {
+    name: "host",
+    structure: "host",
+    description: () =>
+      t`Extracts the host (domain name and TLD, eg. "metabase.com" from "status.metabase.com") from a URL or email`,
+    args: [
+      {
+        name: t`urlOrEmail`,
+        description: t`The URL or Email column to extract the host from.`,
+        example: formatIdentifier(t`Email`),
+      },
+    ],
+  },
+  {
+    name: "domain",
+    structure: "domain",
+    description: () =>
+      t`Extracts the domain name (eg. "metabase") from a URL or email`,
+    args: [
+      {
+        name: t`urlOrEmail`,
+        description: t`The URL or Email column to extract domain names from.`,
+        example: formatIdentifier(t`Email`),
+      },
+    ],
+  },
+  {
+    name: "subdomain",
+    structure: "subdomain",
+    description: () =>
+      t`Extracts the first subdomain (eg. "status" from "status.metabase.com", "" from "bbc.co.uk") from a URL. Ignores "www".`,
+    args: [
+      {
+        name: t`url`,
+        description: t`The URL column to extract the subdomain from.`,
+        example: formatIdentifier(t`ProfileImage`),
+      },
+    ],
+  },
+  {
     name: "abs",
     structure: "abs",
     description: () =>

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -380,7 +380,8 @@
 
 (def string-functions
   "Functions that return string values. Should match [[StringExpression]]."
-  #{:substring :trim :rtrim :ltrim :upper :lower :replace :concat :regex-match-first :coalesce :case})
+  #{:substring :trim :rtrim :ltrim :upper :lower :replace :concat :regex-match-first :coalesce :case
+    :host :domain :subdomain})
 
 (def ^:private StringExpression
   "Schema for the definition of an string expression."
@@ -556,6 +557,15 @@
 
 (defclause ^{:requires-features #{:expressions :regex}} regex-match-first
   s StringExpressionArg, pattern :string)
+
+(defclause ^{:requires-features #{:expressions :regex}} host
+  s StringExpressionArg)
+
+(defclause ^{:requires-features #{:expressions :regex}} domain
+  s StringExpressionArg)
+
+(defclause ^{:requires-features #{:expressions :regex}} subdomain
+  s StringExpressionArg)
 
 (defclause ^{:requires-features #{:expressions}} +
   x Addable, y Addable, more (rest Addable))
@@ -863,7 +873,7 @@
           get-hour get-minute get-second))
 
 (mr/def ::StringExpression
-  (one-of substring trim ltrim rtrim replace lower upper concat regex-match-first coalesce case))
+  (one-of substring trim ltrim rtrim replace lower upper concat regex-match-first coalesce case host domain subdomain))
 
 (mr/def ::FieldOrExpressionDef
   "Schema for anything that is accepted as a top-level expression definition, either an arithmetic expression such as a

--- a/src/metabase/legacy_mbql/util.cljc
+++ b/src/metabase/legacy_mbql/util.cljc
@@ -11,8 +11,7 @@
    [metabase.shared.util.i18n :as i18n]
    [metabase.util.log :as log]
    [metabase.util.malli :as mu]
-   #?@(:clj
-       [[metabase.models.dispatch :as models.dispatch]])))
+   #?@(:clj [[metabase.models.dispatch :as models.dispatch]])))
 
 (defn qualified-name
   "Like `name`, but if `x` is a namespace-qualified keyword, returns that a string including the namespace."
@@ -304,12 +303,98 @@
     [:/ x y z & more]
     (recur (into [:/ [:/ x y]] (cons z more)))))
 
+(def ^:private host-regex
+  ;; Extracts the "host" from a URL or an email.
+  ;; By host we mean the main domain name and the TLD, eg. metabase.com, amazon.co.jp, bbc.co.uk.
+  ;; For a URL, this is not the RFC3986 "host", which would include any subdomains and the optional `:3000` port number.
+  ;;
+  ;; For an email, this is generally the part after the @, but it will skip any subdomains:
+  ;;   someone@email.mycompany.net -> mycompany.net
+  ;;
+  ;; Referencing the indexes below:
+  ;; 1.  Positive lookbehind:
+  ;;       Just past one of:
+  ;; 2.      @  from an email or URL userinfo@ prefix
+  ;; 3.      // from a URL scheme
+  ;; 4.      .  from a previous subdomain segment
+  ;; 5.      Start of string
+  ;; 6.  Negative lookahead: don't capture www as part of the domain
+  ;; 7.  Main domain segment
+  ;; 8.  Ending in a dot
+  ;; 9.  Optional short final segment (eg. co in .co.uk)
+  ;; 10. Top-level domain
+  ;; 11. Optional :port, /path, ?query or #hash
+  ;; 12. Anchor to the end
+  ;;1   2 3  4  5 6        7          8 9                     10         11           12
+  #"(?<=@|//|\.|^)(?!www\.)[^@\.:/?#]+\.(?:[^@\.:/?#]{1,3}\.)?[^@\.:/?#]+(?=[:/?#].*$|$)")
+
+(def ^:private domain-regex
+  ;; Deliberately no ^ at the start; there might be several subdomains before this spot.
+  ;; By "short tail" below, I mean a pseudo-TLD nested under a proper TLD. For example, mycompany.co.uk.
+  ;; This can accidentally capture a short domain name, eg. "subdomain.aol.com" -> "subdomain", oops.
+  ;; But there's a load of these, not a short list we can include here, so it's either preprocess the (huge) master list
+  ;; from Mozilla or accept that this regex is a bit best-effort.
+  ;; Referencing the indexes below:
+  ;; 1.  Positive lookbehind:
+  ;;       Just past one of:
+  ;; 2.      @  from an email or URL userinfo@ prefix
+  ;; 3.      // from a URL scheme
+  ;; 4.      .  from a previous subdomain segment
+  ;; 5.      Start of string
+  ;; 6.  Negative lookahead: don't capture www as the domain
+  ;; 7.  One domain segment
+  ;; 8.  Positive lookahead:
+  ;;       Either:
+  ;; 9.      Short final segment (eg. .co.uk)
+  ;; 10.     Top-level domain
+  ;; 11.     Optional :port, /path, ?query or #hash
+  ;; 12.     Anchor to end
+  ;;       Or:
+  ;; 13.     Top-level domain
+  ;; 14.     Optional :port, /path, ?query or #hash
+  ;; 15.     Anchor to end
+  ;;1   2 3  4  5 6        7          (8   9                10         11          12|  13         14           15)
+  #"(?<=@|//|\.|^)(?!www\.)[^@\.:/?#]+(?=\.[^@\.:/?#]{1,3}\.[^@\.:/?#]+(?:[:/?#].*)?$|\.[^@\.:/?#]+(?:[:/?#].*)?$)")
+
+(def ^:private subdomain-regex
+  ;; This grabs the first segment that isn't "www", AND excludes the main domain name.
+  ;; See [[domain-regex]] for more details about how those are matched.
+  ;; Referencing the indexes below:
+  ;; 1.  Positive lookbehind:
+  ;;       Just past one of:
+  ;; 2.      @  from an email or URL userinfo@ prefix
+  ;; 3.      // from a URL scheme
+  ;; 4.      .  from a previous subdomain segment
+  ;; 5.      Start of string
+  ;; 6.  Negative lookahead: don't capture www as the domain
+  ;; 7.  Negative lookahead: don't capture the main domain name or part of the TLD
+  ;;       That would look like:
+  ;; 8.      The next segment we *would* capture as the subdomain
+  ;; 9.      Optional short segment, like "co" in .co.uk
+  ;; 10.     Top-level domain
+  ;; 11.     Optionally more URL things: :port or /path or ?query or #fragment
+  ;; 12.     End of string
+  ;; 13. Match the actual subdomain
+  ;; 14. Positive lookahead: the . after the subdomain, which we want to detect but not capture.
+  ;;1   2 3  4  5 6        7  8           9                    10        11           12 13       14
+  #"(?<=@|//|\.|^)(?!www\.)(?![^\.:/?#]+\.(?:[^\.:/?#]{1,3}\.)?[^\.:/?#]+(?:[:/?#].*)?$)[^\.:/?#]+(?=\.)")
+
+(defn- desugar-host-and-domain [expression]
+  (lib.util.match/replace expression
+    [:host column]
+    (recur [:regex-match-first column (str host-regex)])
+    [:domain column]
+    (recur [:regex-match-first column (str domain-regex)])
+    [:subdomain column]
+    (recur [:regex-match-first column (str subdomain-regex)])))
+
 (mu/defn desugar-expression :- ::mbql.s/FieldOrExpressionDef
   "Rewrite various 'syntactic sugar' expressions like `:/` with more than two args into something simpler for drivers
   to compile."
   [expression :- ::mbql.s/FieldOrExpressionDef]
   (-> expression
-      desugar-divide-with-extra-args))
+      desugar-divide-with-extra-args
+      desugar-host-and-domain))
 
 (defn- maybe-desugar-expression [clause]
   (cond-> clause

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -245,7 +245,7 @@
 (lib.common/defop - [x y & more])
 (lib.common/defop * [x y & more])
 ;; Kondo gets confused
-#_{:clj-kondo/ignore [:unresolved-namespace]}
+#_{:clj-kondo/ignore [:unresolved-namespace :syntax]}
 (lib.common/defop / [x y & more])
 (lib.common/defop case [x y & more])
 (lib.common/defop coalesce [x y & more])
@@ -285,6 +285,9 @@
 (lib.common/defop rtrim [s])
 (lib.common/defop upper [s])
 (lib.common/defop lower [s])
+(lib.common/defop host [s])
+(lib.common/defop domain [s])
+(lib.common/defop subdomain [s])
 
 (mu/defn ^:private expression-metadata :- lib.metadata/ColumnMetadata
   [query                 :- ::lib.schema/query

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -7,6 +7,10 @@
   (mbql-clause/define-tuple-mbql-clause op :- :type/Text
     [:schema [:ref ::expression/string]]))
 
+(doseq [op [:host :domain :subdomain]]
+  (mbql-clause/define-tuple-mbql-clause op :- :type/Text
+    [:schema [:ref ::expression/string]]))
+
 (mbql-clause/define-tuple-mbql-clause :length :- :type/Integer
   [:schema [:ref ::expression/string]])
 

--- a/test/metabase/legacy_mbql/util_test.cljc
+++ b/test/metabase/legacy_mbql/util_test.cljc
@@ -851,3 +851,98 @@
             [:expression "Date" {:temporal-unit :quarter}]
             [:relative-datetime 0 :quarter]]
            (mbql.u/desugar-time-interval [:time-interval [:expression "Date"] :current :quarter]))))
+
+(t/deftest ^:parallel host-regex-on-urls-test
+  (t/are [host url] (= host (re-find @#'mbql.u/host-regex url))
+    "cdbaby.com"      "https://cdbaby.com/some.txt"
+    "fema.gov"        "https://fema.gov/some/path/Vatini?search=foo"
+    "geocities.jp"    "https://www.geocities.jp/some/path/Turbitt?search=foo"
+    "jalbum.net"      "https://jalbum.net/some/path/Kirsz?search=foo"
+    "usa.gov"         "https://usa.gov/some/path/Curdell?search=foo"
+    ;; Oops, this one captures a subdomain because it can't tell va.gov is supposed to be that short.
+    "taxes.va.gov"    "http://taxes.va.gov/some/path/Marritt?search=foo"
+    "gmpg.org"        "http://log.stuff.gmpg.org/some/path/Cambden?search=foo"
+    "hatena.ne.jp"    "http://hatena.ne.jp/"
+    "telegraph.co.uk" "//telegraph.co.uk?foo=bar#tail"
+    "bbc.co.uk"       "bbc.co.uk/some/path?search=foo"
+    "bbc.co.uk"       "news.bbc.co.uk:port"))
+
+(t/deftest ^:parallel host-regex-on-emails-test
+  (t/are [host email] (= host (re-find @#'mbql.u/host-regex email))
+    "metabase.com"      "braden@metabase.com"
+    "homeoffice.gov.uk" "mholmes@homeoffice.gov.uk"
+    "someisp.com"       "john.smith@mail.someisp.com"
+    "amazon.co.uk"      "trk@amazon.co.uk"
+    "hatena.ne.jp"      "takashi@hatena.ne.jp"
+    "hatena.ne.jp"      "takashi@mail.hatena.ne.jp"
+    "ne.jp"             "takashi@www.ne.jp"))
+
+(t/deftest ^:parallel domain-regex-on-urls-test
+  (t/are [domain url] (= domain (re-find @#'mbql.u/domain-regex url))
+    "cdbaby"    "https://cdbaby.com/some.txt"
+    "fema"      "https://fema.gov/some/path/Vatini?search=foo"
+    "geocities" "https://www.geocities.jp/some/path/Turbitt?search=foo"
+    "jalbum"    "https://jalbum.net/some/path/Kirsz?search=foo"
+    "usa"       "https://usa.gov/some/path/Curdell?search=foo"
+    "taxes"     "http://taxes.va.gov/some/path/Marritt?search=foo"
+    "gmpg"      "http://log.stuff.gmpg.org/some/path/Cambden?search=foo"
+    "hatena"    "http://hatena.ne.jp/"
+    "telegraph" "//telegraph.co.uk?foo=bar#tail"
+    "bbc"       "bbc.co.uk/some/path?search=foo"))
+
+(t/deftest ^:parallel domain-regex-on-emails-test
+  (t/are [domain email] (= domain (re-find @#'mbql.u/domain-regex email))
+    "metabase"   "braden@metabase.com"
+    "homeoffice" "mholmes@homeoffice.gov.uk"
+    "someisp"    "john.smith@mail.someisp.com"
+    "amazon"     "trk@amazon.co.uk"
+    "hatena"     "takashi@hatena.ne.jp"
+    "ne"         "takashi@www.ne.jp"))
+
+(t/deftest ^:parallel subdomain-regex-on-urls-test
+  (t/are [subdomain url] (= subdomain (re-find @#'mbql.u/subdomain-regex url))
+       ;; Blanks. "www" doesn't count.
+    nil "cdbaby.com"
+    nil "https://fema.gov"
+    nil "http://www.geocities.jp"
+    nil "usa.gov/some/page.cgi.htm"
+    nil "va.gov"
+
+       ;; Basics - taking the first segment that isn't "www", IF it isn't the domain.
+    "sub"        "sub.jalbum.net"
+    "subdomains" "subdomains.go.here.jalbum.net"
+    "log"        "log.stuff.gmpg.org"
+    "log"        "https://log.stuff.gmpg.org"
+    "log"        "log.stuff.gmpg.org/some/path"
+    "log"        "log.stuff.gmpg.org?search=yes"
+
+       ;; Oops, we miss these! This is the reverse of the problem when picking the domain.
+       ;; We can't tell without maintaining a huge list that va and ne are the real domains, and not the trailing
+       ;; fragments like .co.uk - see below.
+    nil "taxes.va.gov" ; True domain is va, subdomain is taxes.
+    nil "hatena.ne.jp" ; True domain is ne, subdomain is hatena.
+
+       ;; Sometimes the second-last part is a short suffix.
+       ;; Mozilla maintains a huge list of these, but since this has to go into a regex and get passed to the database,
+       ;; we use a best-effort matcher that gets the domain right most of the time.
+    nil         "telegraph.co.uk"
+    nil         "https://telegraph.co.uk"
+    nil         "telegraph.co.uk/some/article.php"
+    "local"     "local.news.telegraph.co.uk"
+    nil         "bbc.co.uk#fragment"
+    "video"     "video.bbc.co.uk"
+       ;; "www" is disregarded as a possible subdomain.
+    nil         "www.usa.gov"
+    nil         "www.dot.va.gov"
+    "licensing" "www.licensing.dot.va.gov"))
+
+(t/deftest ^:parallel desugar-host-and-domain-test
+  (t/is (= [:regex-match-first [:field 1 nil] (str @#'mbql.u/host-regex)]
+           (mbql.u/desugar-expression [:host [:field 1 nil]]))
+        "`host` should desugar to a `regex-match-first` clause with the host regex")
+  (t/is (= [:regex-match-first [:field 1 nil] (str @#'mbql.u/domain-regex)]
+           (mbql.u/desugar-expression [:domain [:field 1 nil]]))
+        "`domain` should desugar to a `regex-match-first` clause with the domain regex")
+  (t/is (= [:regex-match-first [:field 1 nil] (str @#'mbql.u/subdomain-regex)]
+           (mbql.u/desugar-expression [:subdomain [:field 1 nil]]))
+        "`subdomain` should desugar to a `regex-match-first` clause with the subdomain regex"))

--- a/test/metabase/lib/drill_thru/column_extract_test.cljc
+++ b/test/metabase/lib/drill_thru/column_extract_test.cljc
@@ -1,16 +1,14 @@
 (ns metabase.lib.drill-thru.column-extract-test
   "See also [[metabase.query-processor-test.drill-thru-e2e-test/quick-filter-on-bucketed-date-test]]"
   (:require
-   [clojure.test :refer [are deftest testing]]
+   [clojure.test :refer [deftest testing]]
    [medley.core :as m]
    [metabase.lib.core :as lib]
-   [metabase.lib.drill-thru.column-extract :as lib.drill-thru.column-extract]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.drill-thru.test-util.canned :as canned]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
-   [metabase.util :as u]
    #?@(:clj  ([metabase.test :as mt])
        :cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
@@ -30,7 +28,7 @@
   (concat time-extraction-units date-extraction-units))
 
 (deftest ^:parallel column-extract-availability-test
-  (testing "column-extract is available for column clicks on temporal and URL columns"
+  (testing "column-extract is available for column clicks on temporal, URL and Email columns"
     (canned/canned-test
       :drill-thru/column-extract
       (fn [_test-case {:keys [column] :as _context} {:keys [click column-type]}]
@@ -265,22 +263,6 @@
        :expected     {:type        :drill-thru/column-extract
                       :extractions date-extraction-units}})))
 
-(def ^:private url->host-regex
-  #?(:clj  @#'lib.drill-thru.column-extract/url->host-regex
-     :cljs lib.drill-thru.column-extract/url->host-regex))
-
-(def ^:private host->domain-regex
-  #?(:clj  @#'lib.drill-thru.column-extract/host->domain-regex
-     :cljs lib.drill-thru.column-extract/host->domain-regex))
-
-(def ^:private host->subdomain-regex
-  #?(:clj  @#'lib.drill-thru.column-extract/host->subdomain-regex
-     :cljs lib.drill-thru.column-extract/host->subdomain-regex))
-
-(def ^:private email->domain-regex
-  #?(:clj  @#'lib.drill-thru.column-extract/email->domain-regex
-     :cljs lib.drill-thru.column-extract/email->domain-regex))
-
 (def ^:private homepage
   (assoc (meta/field-metadata :people :email)
          :id             9999001
@@ -299,8 +281,13 @@
 
 (deftest ^:parallel column-extract-url->domain-test
   ;; There's no URL columns in the same dataset, but let's pretend there's one called People.HOMEPAGE.
-  (let [mp    (homepage-provider)
-        query (lib/query mp (lib.metadata/table mp (meta/id :people)))]
+  (let [mp       (homepage-provider)
+        query    (lib/query mp (lib.metadata/table mp (meta/id :people)))
+        expected {:type         :drill-thru/column-extract
+                  :display-name "Extract domain, subdomain…"
+                  :extractions  [{:key :domain,    :display-name "Domain"}
+                                 {:key :subdomain, :display-name "Subdomain"}
+                                 {:key :host,      :display-name "Host"}]}]
     (testing "Extracting Domain"
       (lib.drill-thru.tu/test-drill-application
         {:drill-type     :drill-thru/column-extract
@@ -308,16 +295,10 @@
          :query-type     :unaggregated
          :column-name    "HOMEPAGE"
          :custom-query   query
-         :expected       {:type         :drill-thru/column-extract
-                          :display-name "Extract domain, subdomain…"
-                          :extractions  [{:key :domain,    :display-name "Domain"}
-                                         {:key :subdomain, :display-name "Subdomain"}]}
+         :expected       expected
          :drill-args     ["domain"]
-         :expected-query {:stages [{:expressions [[:regex-match-first {:lib/expression-name "Domain"}
-                                                   [:regex-match-first {}
-                                                    [:field {} 9999001]
-                                                    (u/regex->str url->host-regex)]
-                                                   (u/regex->str host->domain-regex)]]}]}}))
+         :expected-query {:stages [{:expressions [[:domain {:lib/expression-name "Domain"}
+                                                   [:field {} 9999001]]]}]}}))
     (testing "Extracting Subdomain"
       (lib.drill-thru.tu/test-drill-application
         {:drill-type     :drill-thru/column-extract
@@ -325,16 +306,21 @@
          :query-type     :unaggregated
          :column-name    "HOMEPAGE"
          :custom-query   query
-         :expected       {:type         :drill-thru/column-extract
-                          :display-name "Extract domain, subdomain…"
-                          :extractions  [{:key :domain,    :display-name "Domain"}
-                                         {:key :subdomain, :display-name "Subdomain"}]}
+         :expected       expected
          :drill-args     ["subdomain"]
-         :expected-query {:stages [{:expressions [[:regex-match-first {:lib/expression-name "Subdomain"}
-                                                   [:regex-match-first {}
-                                                    [:field {} 9999001]
-                                                    (u/regex->str url->host-regex)]
-                                                   (u/regex->str host->subdomain-regex)]]}]}}))))
+         :expected-query {:stages [{:expressions [[:subdomain {:lib/expression-name "Subdomain"}
+                                                   [:field {} 9999001]]]}]}}))
+    (testing "Extracting Host"
+      (lib.drill-thru.tu/test-drill-application
+        {:drill-type     :drill-thru/column-extract
+         :click-type     :header
+         :query-type     :unaggregated
+         :column-name    "HOMEPAGE"
+         :custom-query   query
+         :expected       expected
+         :drill-args     ["host"]
+         :expected-query {:stages [{:expressions [[:host {:lib/expression-name "Host"}
+                                                   [:field {} 9999001]]]}]}}))))
 
 (deftest ^:parallel column-extract-url-requires-regex-test
   (let [query-regex    (lib/query (homepage-provider) (meta/table-metadata :people))
@@ -350,13 +336,11 @@
          :expected       {:type         :drill-thru/column-extract
                           :display-name "Extract domain, subdomain…"
                           :extractions  [{:key :domain,    :display-name "Domain"}
-                                         {:key :subdomain, :display-name "Subdomain"}]}
+                                         {:key :subdomain, :display-name "Subdomain"}
+                                         {:key :host,      :display-name "Host"}]}
          :drill-args     ["subdomain"]
-         :expected-query {:stages [{:expressions [[:regex-match-first {:lib/expression-name "Subdomain"}
-                                                   [:regex-match-first {}
-                                                    [:field {} 9999001]
-                                                    (u/regex->str url->host-regex)]
-                                                   (u/regex->str host->subdomain-regex)]]}]}}))
+         :expected-query {:stages [{:expressions [[:subdomain {:lib/expression-name "Subdomain"}
+                                                   [:field {} 9999001]]]}]}}))
     (testing "when the database does not support :regex URL extraction is not available"
       (lib.drill-thru.tu/test-drill-not-returned
         {:drill-type     :drill-thru/column-extract
@@ -378,11 +362,11 @@
          :custom-query   query-regex
          :expected       {:type         :drill-thru/column-extract
                           :display-name "Extract domain"
-                          :extractions  [{:key :email-domain, :display-name "Domain"}]}
-         :drill-args     ["email-domain"]
-         :expected-query {:stages [{:expressions [[:regex-match-first {:lib/expression-name "Domain"}
-                                                   [:field {} (meta/id :people :email)]
-                                                   (u/regex->str email->domain-regex)]]}]}}))
+                          :extractions  [{:key :domain, :display-name "Domain"}
+                                         {:key :host,   :display-name "Host"}]}
+         :drill-args     ["domain"]
+         :expected-query {:stages [{:expressions [[:domain {:lib/expression-name "Domain"}
+                                                   [:field {} (meta/id :people :email)]]]}]}}))
     (testing "when the database does not support :regex email extraction is not available"
       (lib.drill-thru.tu/test-drill-not-returned
         {:drill-type     :drill-thru/column-extract
@@ -390,85 +374,3 @@
          :query-type     :unaggregated
          :column-name    "EMAIL"
          :custom-query   query-no-regex}))))
-
-(deftest ^:parallel url->host-regex-test
-  (are [host url] (= host (second (re-find url->host-regex url)))
-       "cdbaby.com"         "https://cdbaby.com/some.txt"
-       "fema.gov"           "https://fema.gov/some/path/Vatini?search=foo"
-       "www.geocities.jp"   "https://www.geocities.jp/some/path/Turbitt?search=foo"
-       "jalbum.net"         "https://jalbum.net/some/path/Kirsz?search=foo"
-       "usa.gov"            "https://usa.gov/some/path/Curdell?search=foo"
-       "taxes.va.gov"       "http://taxes.va.gov/some/path/Marritt?search=foo"
-       "log.stuff.gmpg.org" "http://log.stuff.gmpg.org/some/path/Cambden?search=foo"
-       "hatena.ne.jp"       "http://hatena.ne.jp/"
-       "telegraph.co.uk"    "//telegraph.co.uk?foo=bar#tail"
-       "bbc.co.uk"          "bbc.co.uk/some/path?search=foo"))
-
-(deftest ^:parallel host->domain-regex-test
-  (are [domain host] (= domain (second (re-find host->domain-regex host)))
-       ;; Easy cases: second-last part is the domain.
-       "cdbaby"    "cdbaby.com"
-       "fema"      "fema.gov"
-       "geocities" "www.geocities.jp"
-       "jalbum"    "sub.jalbum.net"
-       "jalbum"    "subdomains.go.here.jalbum.net"
-       "gmpg"      "log.stuff.gmpg.org"
-
-       ;; The second-last part is the domain even if it's short, sometimes.
-       "usa"       "usa.gov"
-       "va"        "va.gov"
-
-       ;; Oops, we picked a subdomain! But see below.
-       "taxes"     "taxes.va.gov" ; True domain is va
-       "hatena"    "hatena.ne.jp" ; True domain is ne
-
-       ;; Sometimes the second-last part is a short suffix.
-       ;; Mozilla maintains a huge list of these, but since this has to go into a regex and get passed to the database,
-       ;; we use a best-effort matcher that gets the domain right most of the time.
-       "telegraph" "telegraph.co.uk"
-       "bbc"       "bbc.co.uk"
-       "dot"       "dot.va.gov"
-
-       ;; "www" is disregarded as a possible subdomain.
-       "usa"       "www.usa.gov"
-       "va"        "www.va.gov"
-       "dot"       "www.dot.va.gov"))
-
-(deftest ^:parallel host->subdomain-regex-test
-  (are [subdomain host] (= subdomain (second (re-find host->subdomain-regex host)))
-       ;; Blanks. "www" doesn't count.
-       nil "cdbaby.com"
-       nil "fema.gov"
-       nil "www.geocities.jp"
-       nil "usa.gov"
-       nil "va.gov"
-
-       ;; Basics - taking the first segment that isn't "www", IF it isn't the domain.
-       "sub"        "sub.jalbum.net"
-       "subdomains" "subdomains.go.here.jalbum.net"
-       "log"        "log.stuff.gmpg.org"
-
-       ;; Oops, we missed those. This is the reverse of the problem when picking the domain.
-       nil "taxes.va.gov" ; True domain is va, subdomain is taxes.
-       nil "hatena.ne.jp" ; True domain is ne, subdomain is hatena.
-
-       ;; Sometimes the second-last part is a short suffix.
-       ;; Mozilla maintains a huge list of these, but since this has to go into a regex and get passed to the database,
-       ;; we use a best-effort matcher that gets the domain right most of the time.
-       nil         "telegraph.co.uk"
-       "local"     "local.news.telegraph.co.uk"
-       nil         "bbc.co.uk"
-       "video"     "video.bbc.co.uk"
-       ;; "www" is disregarded as a possible subdomain, so these are also incorrect.
-       nil         "www.usa.gov"
-       nil         "www.dot.va.gov"
-       "licensing" "www.licensing.dot.va.gov"))
-
-(deftest ^:parallel email->domain-regex-test
-  (are [domain email] (= domain (re-find email->domain-regex email))
-       "metabase"   "braden@metabase.com"
-       "homeoffice" "mholmes@homeoffice.gov.uk"
-       "someisp"    "john.smith@mail.someisp.com"
-       "amazon"     "trk@amazon.co.uk"
-       "hatena"     "takashi@hatena.ne.jp"
-       "ne"         "takashi@www.ne.jp"))


### PR DESCRIPTION
These functions are implemented with hairy regular expressions, and
it's more user-friendly and future-proof to name those functions in MBQL
rather than baking the `regexextract` and regex into the user's query.

It lets us evolve the regexes in the future if we detect a bug, and it
improves the UX since the user sees a meaningful function instead of

    regexextract([My URL Column], "(?<=[@\.])(?!www\.)[^@\.]+(?=\.[^@\.]{1,3}\.[^@\.]+$|\.[^@\.]+$)")

Also refactors the regexes somewhat so that they work for emails as well as URLs, and there's always just one layer of `:regex-match-first`.
Previously this was separated into two steps: URL or email to host, and host to (sub)domain.

Part of the follow-up for Extract Column epic #38964.

