### PR TITLE
Move archived items to the trash

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6793,6 +6793,142 @@ databaseChangeLog:
                   constraints:
                     nullable: true
 
+  - changeSet:
+      id: v50.2024-04-22T14:03:28
+      author: johnswanson
+      comment: Drop foreign key constraint fk_snippet_collection_id
+      rollback:
+        - addForeignKeyConstraint:
+            baseTableName: native_query_snippet
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_snippet_collection_id
+            onDelete: SET NULL
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: native_query_snippet
+            constraintName: fk_snippet_collection_id
+
+  - changeSet:
+      id: v50.2024-04-22T14:03:33
+      author: johnswanson
+      comment: Add foreign key constraint fk_snippet_collection_id with CASCADE delete
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: native_query_snippet
+            constraintName: fk_snippet_collection_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: native_query_snippet
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_snippet_collection_id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v50.2024-04-22T14:04:25
+      author: johnswanson
+      comment: Drop foreign key constraint fk_pulse_collection_id
+      rollback:
+        - addForeignKeyConstraint:
+            baseTableName: pulse
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_pulse_collection_id
+            onDelete: SET NULL
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: pulse
+            constraintName: fk_pulse_collection_id
+
+  - changeSet:
+      id: v50.2024-04-22T14:04:29
+      author: johnswanson
+      comment: Add foreign key constraint fk_pulse_collection_id with CASCADE delete
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: pulse
+            constraintName: fk_pulse_collection_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: pulse
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_pulse_collection_id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v50.2024-04-22T14:05:35
+      author: johnswanson
+      comment: Drop foreign key constraint fk_card_collection_id
+      rollback:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_card_collection_id
+            onDelete: SET NULL
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_card_collection_id
+
+  - changeSet:
+      id: v50.2024-04-22T14:05:40
+      author: johnswanson
+      comment: Add foreign key constraint fk_card_collection_id with CASCADE delete
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: report_card
+            constraintName: fk_card_collection_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_card
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_card_collection_id
+            onDelete: CASCADE
+
+  - changeSet:
+      id: v50.2024-04-22T14:06:29
+      author: johnswanson
+      comment: Drop foreign key constraint fk_dashboard_collection_id
+      rollback:
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboard
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_dashboard_collection_id
+            onDelete: SET NULL
+      changes:
+        - dropForeignKeyConstraint:
+            baseTableName: report_dashboard
+            constraintName: fk_dashboard_collection_id
+
+  - changeSet:
+      id: v50.2024-04-22T14:06:34
+      author: johnswanson
+      comment: Add foreign key constraint fk_dashboard_collection_id with CASCADE delete
+      rollback:
+        - dropForeignKeyConstraint:
+            baseTableName: report_dashboard
+            constraintName: fk_dashboard_collection_id
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: report_dashboard
+            baseColumnNames: collection_id
+            referencedTableName: collection
+            referencedColumnNames: id
+            constraintName: fk_dashboard_collection_id
+            onDelete: CASCADE
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################

--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6794,7 +6794,7 @@ databaseChangeLog:
                     nullable: true
 
   - changeSet:
-      id: v50.2024-04-22T14:03:28
+      id: v50.2024-04-29T14:07:18
       author: johnswanson
       comment: Drop foreign key constraint fk_snippet_collection_id
       rollback:
@@ -6811,7 +6811,7 @@ databaseChangeLog:
             constraintName: fk_snippet_collection_id
 
   - changeSet:
-      id: v50.2024-04-22T14:03:33
+      id: v50.2024-04-29T14:07:24
       author: johnswanson
       comment: Add foreign key constraint fk_snippet_collection_id with CASCADE delete
       rollback:
@@ -6828,7 +6828,7 @@ databaseChangeLog:
             onDelete: CASCADE
 
   - changeSet:
-      id: v50.2024-04-22T14:04:25
+      id: v50.2024-04-29T14:07:33
       author: johnswanson
       comment: Drop foreign key constraint fk_pulse_collection_id
       rollback:
@@ -6845,7 +6845,7 @@ databaseChangeLog:
             constraintName: fk_pulse_collection_id
 
   - changeSet:
-      id: v50.2024-04-22T14:04:29
+      id: v50.2024-04-29T14:07:37
       author: johnswanson
       comment: Add foreign key constraint fk_pulse_collection_id with CASCADE delete
       rollback:
@@ -6862,7 +6862,7 @@ databaseChangeLog:
             onDelete: CASCADE
 
   - changeSet:
-      id: v50.2024-04-22T14:05:35
+      id: v50.2024-04-29T14:07:40
       author: johnswanson
       comment: Drop foreign key constraint fk_card_collection_id
       rollback:
@@ -6879,7 +6879,7 @@ databaseChangeLog:
             constraintName: fk_card_collection_id
 
   - changeSet:
-      id: v50.2024-04-22T14:05:40
+      id: v50.2024-04-29T14:07:47
       author: johnswanson
       comment: Add foreign key constraint fk_card_collection_id with CASCADE delete
       rollback:
@@ -6896,7 +6896,7 @@ databaseChangeLog:
             onDelete: CASCADE
 
   - changeSet:
-      id: v50.2024-04-22T14:06:29
+      id: v50.2024-04-29T14:07:49
       author: johnswanson
       comment: Drop foreign key constraint fk_dashboard_collection_id
       rollback:
@@ -6913,7 +6913,7 @@ databaseChangeLog:
             constraintName: fk_dashboard_collection_id
 
   - changeSet:
-      id: v50.2024-04-22T14:06:34
+      id: v50.2024-04-29T14:07:53
       author: johnswanson
       comment: Add foreign key constraint fk_dashboard_collection_id with CASCADE delete
       rollback:

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -501,8 +501,13 @@
                                            [:moderation_reviews :moderator_details])
         card-updates           (cond-> card-updates
                                  (api/column-will-change? :archived card-before-update card-updates)
-                                 (assoc :collection_id (if (:archived card-updates)
-                                                         collection/trash-collection-id
+                                 (assoc :collection_id (cond
+                                                         (:archived card-updates) collection/trash-collection-id
+
+                                                         (api/column-will-change? :collection_id card-before-update card-updates)
+                                                         (:collection_id card-updates)
+
+                                                         :else
                                                          (:trashed_from_collection_id card-before-update))
                                         :trashed_from_collection_id (when (:archived card-updates)
                                                                       (:collection_id card-before-update)))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -500,7 +500,7 @@
   (let [card-before-update     (t2/hydrate (api/write-check Card id)
                                            [:moderation_reviews :moderator_details])
         card-updates           (cond-> card-updates
-                                 (contains? card-updates :archived)
+                                 (api/column-will-change? :archived card-before-update card-updates)
                                  (assoc :collection_id (if (:archived card-updates)
                                                          collection/trash-collection-id
                                                          (:trashed_from_collection_id card-before-update))

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -499,20 +499,7 @@
    collection_preview     [:maybe :boolean]}
   (let [card-before-update     (t2/hydrate (api/write-check Card id)
                                            [:moderation_reviews :moderator_details])
-        card-updates           (cond-> card-updates
-                                 (api/column-will-change? :archived card-before-update card-updates)
-                                 (assoc :collection_id (cond
-                                                         (:archived card-updates) collection/trash-collection-id
-
-                                                         (api/column-will-change? :collection_id card-before-update card-updates)
-                                                         (:collection_id card-updates)
-
-                                                         :else
-                                                         (:trashed_from_collection_id card-before-update))
-                                        :trashed_from_collection_id (when (:archived card-updates)
-                                                                      (:collection_id card-before-update)))
-
-                                 (:type card-updates) (update :type keyword))
+        card-updates           (api/move-on-archive-or-unarchive card-before-update card-updates)
         is-model-after-update? (if (nil? type)
                                  (card/model? card-before-update)
                                  (card/model? card-updates))]

--- a/src/metabase/api/card.clj
+++ b/src/metabase/api/card.clj
@@ -500,6 +500,13 @@
   (let [card-before-update     (t2/hydrate (api/write-check Card id)
                                            [:moderation_reviews :moderator_details])
         card-updates           (cond-> card-updates
+                                 (contains? card-updates :archived)
+                                 (assoc :collection_id (if (:archived card-updates)
+                                                         collection/trash-collection-id
+                                                         (:trashed_from_collection_id card-before-update))
+                                        :trashed_from_collection_id (when (:archived card-updates)
+                                                                      (:collection_id card-before-update)))
+
                                  (:type card-updates) (update :type keyword))
         is-model-after-update? (if (nil? type)
                                  (card/model? card-before-update)

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -82,12 +82,10 @@
 
   To select only personal collections, pass in `personal-only` as `true`.
   This will select only collections where `personal_owner_id` is not `nil`."
-  [{:keys [archived exclude-other-user-collections namespace shallow collection-id personal-only permissions-set]}]
+  [{:keys [exclude-other-user-collections namespace shallow collection-id personal-only permissions-set]}]
   (cond->>
    (t2/select :model/Collection
               {:where [:and
-                       (when (some? archived)
-                         [:= :archived archived])
                        (when shallow
                          (location-from-collection-id-clause collection-id))
                        (when personal-only
@@ -121,8 +119,7 @@
    namespace                      [:maybe ms/NonBlankString]
    personal-only                  [:maybe ms/BooleanValue]}
   (as->
-   (select-collections {:archived                       archived
-                        :exclude-other-user-collections exclude-other-user-collections
+   (select-collections {:exclude-other-user-collections exclude-other-user-collections
                         :namespace                      namespace
                         :shallow                        false
                         :personal-only                  personal-only
@@ -192,9 +189,7 @@
    namespace                      [:maybe ms/NonBlankString]
    shallow                        [:maybe :boolean]
    collection-id                  [:maybe ms/PositiveInt]}
-  (let [archived    (if exclude-archived false nil)
-        collections (select-collections {:archived                       archived
-                                         :exclude-other-user-collections exclude-other-user-collections
+  (let [collections (select-collections {:exclude-other-user-collections exclude-other-user-collections
                                          :namespace                      namespace
                                          :shallow                        shallow
                                          :collection-id                  collection-id
@@ -206,8 +201,7 @@
                                         {:dataset #{}
                                          :card    #{}}
                                         (mdb.query/reducible-query {:select-distinct [:collection_id :type]
-                                                                    :from            [:report_card]
-                                                                    :where           [:= :archived false]}))
+                                                                    :from            [:report_card]}))
             collections-with-details (map collection/personal-collection-with-ui-details collections)]
         (collection/collections->tree collection-type-ids collections-with-details)))))
 
@@ -242,7 +236,6 @@
 
 (def ^:private CollectionChildrenOptions
   [:map
-   [:archived?                     :boolean]
    [:pinned-state {:optional true} [:maybe (into [:enum] (map keyword) valid-pinned-state-values)]]
    ;; when specified, only return results of this type.
    [:models       {:optional true} [:maybe [:set (into [:enum] (map keyword) valid-model-param-values)]]]
@@ -373,7 +366,7 @@
             :moderated_status :icon :personal_owner_id :collection_preview
             :dataset_query :table_id :query_type :is_upload)))
 
-(defn- card-query [dataset? collection {:keys [archived? pinned-state]}]
+(defn- card-query [dataset? collection {:keys [pinned-state]}]
   (-> {:select    (cond->
                     [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
                      :c.dataset_query
@@ -404,7 +397,6 @@
                    [:core_user :u] [:= :u.id :r.user_id]]
        :where     [:and
                    [:= :collection_id (:id collection)]
-                   [:= :archived (boolean archived?)]
                    [:= :c.type (h2x/literal (if dataset? "model" "question"))]]}
       (cond-> dataset?
         (-> (sql.helpers/select :c.table_id :t.is_upload :c.query_type)
@@ -479,7 +471,7 @@
   [_ _ rows]
   (map post-process-card-row rows))
 
-(defn- dashboard-query [collection {:keys [archived? pinned-state]}]
+(defn- dashboard-query [collection {:keys [pinned-state]}]
   (-> {:select    [:d.id :d.name :d.description :d.entity_id :d.collection_position
                    [(h2x/literal "dashboard") :model]
                    [:u.id :last_edit_user]
@@ -494,8 +486,7 @@
                                    [:= :r.model (h2x/literal "Dashboard")]]
                    [:core_user :u] [:= :u.id :r.user_id]]
        :where     [:and
-                   [:= :collection_id (:id collection)]
-                   [:= :archived (boolean archived?)]]}
+                   [:= :collection_id (:id collection)]]}
       (sql.helpers/where (pinned-state->clause pinned-state))))
 
 (defmethod collection-children-query :dashboard
@@ -519,10 +510,9 @@
    [:not= :namespace (u/qualified-name "snippets")]])
 
 (defn- collection-query
-  [collection {:keys [archived? collection-namespace pinned-state]}]
+  [collection {:keys [collection-namespace pinned-state]}]
   (-> (assoc (collection/effective-children-query
               collection
-              [:= :archived archived?]
               (perms/audit-namespace-clause :namespace (u/qualified-name collection-namespace))
               (snippets-collection-filter-clause))
              ;; We get from the effective-children-query a normal set of columns selected:
@@ -562,14 +552,12 @@
                 (mdb.query/reducible-query {:select-distinct [:collection_id :type]
                                             :from            [:report_card]
                                             :where           [:and
-                                                              [:= :archived false]
                                                               [:in :collection_id descendant-collection-ids]]}))
 
         collections-containing-dashboards
         (->> (t2/query {:select-distinct [:collection_id]
                         :from :report_dashboard
                         :where [:and
-                                [:= :archived false]
                                 [:in :collection_id descendant-collection-ids]]})
              (map :collection_id)
              (into #{}))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -86,8 +86,9 @@
   (cond->>
    (t2/select :model/Collection
               {:where [:and
-                       (when (some? archived)
-                         [:= :archived archived])
+                       [:= :archived archived]
+                       (when-not archived
+                         [:not= :id collection/trash-collection-id])
                        (when shallow
                          (location-from-collection-id-clause collection-id))
                        (when personal-only
@@ -122,7 +123,7 @@
    personal-only                  [:maybe ms/BooleanValue]}
   (as->
    (select-collections {:exclude-other-user-collections exclude-other-user-collections
-                        :archived                       archived
+                        :archived                       (boolean archived)
                         :namespace                      namespace
                         :shallow                        false
                         :personal-only                  personal-only
@@ -187,7 +188,7 @@
   TODO: for historical reasons this returns Saved Questions AS 'card' AND Models as 'dataset'; we should fix this at
   some point in the future."
   [archived exclude-other-user-collections namespace shallow collection-id]
-  {archived                       ms/MaybeBooleanValue
+  {archived                       [:maybe :boolean]
    exclude-other-user-collections [:maybe :boolean]
    namespace                      [:maybe ms/NonBlankString]
    shallow                        [:maybe :boolean]
@@ -196,7 +197,7 @@
                                          :namespace                      namespace
                                          :shallow                        shallow
                                          :collection-id                  collection-id
-                                         :archived                       archived
+                                         :archived                       (boolean archived)
                                          :permissions-set                @api/*current-user-permissions-set*})]
     (if shallow
       (shallow-tree-from-collection-id collections)

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1061,7 +1061,7 @@
   archive the collection (archiving means 'moving to the trash' so it makes sense to deal with them together), do the
   appropriate permissions checks and changes."
   [collection-before-update collection-updates]
-  (condp #(contains? %2 %1) collection-updates
+  (condp #(api/column-will-change? %1 collection-before-update %2) collection-updates
     ;; note that archiving includes a move. So if they include `archived` (with or without `parent_id`), that's an
     ;; archive/unarchive. If they only include `parent_id`, that's a move.
     :archived (archive-collection! collection-before-update collection-updates)

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -12,6 +12,7 @@
    [malli.transform :as mtx]
    [medley.core :as m]
    [metabase.api.common :as api]
+   [metabase.config :as config]
    [metabase.db :as mdb]
    [metabase.db.query :as mdb.query]
    [metabase.driver.common.parameters :as params]
@@ -22,13 +23,11 @@
    [metabase.models.collection :as collection :refer [Collection]]
    [metabase.models.collection.graph :as graph]
    [metabase.models.collection.root :as collection.root]
-   [metabase.models.dashboard :refer [Dashboard]]
    [metabase.models.interface :as mi]
-   [metabase.models.native-query-snippet :refer [NativeQuerySnippet]]
    [metabase.models.permissions :as perms]
-   [metabase.models.pulse :as pulse :refer [Pulse]]
+   [metabase.models.pulse :as pulse]
    [metabase.models.revision.last-edit :as last-edit]
-   [metabase.models.timeline :as timeline :refer [Timeline]]
+   [metabase.models.timeline :as timeline]
    [metabase.public-settings.premium-features
     :as premium-features
     :refer [defenterprise]]
@@ -89,10 +88,10 @@
                        (case archived
                          nil nil
                          false [:and
-                                [:not= :id collection/trash-collection-id]
+                                [:not= :id config/trash-collection-id]
                                 [:not :archived]]
                          true [:or
-                               [:= :id collection/trash-collection-id]
+                               [:= :id config/trash-collection-id]
                                :archived])
                        (when shallow
                          (location-from-collection-id-clause collection-id))
@@ -536,8 +535,8 @@
   (-> (assoc (collection/effective-children-query
               collection
               (if archived?
-                [:or [:= :archived true] [:= :id collection/trash-collection-id]]
-                [:and [:= :archived false] [:not= :id collection/trash-collection-id]])
+                [:or [:= :archived true] [:= :id config/trash-collection-id]]
+                [:and [:= :archived false] [:not= :id config/trash-collection-id]])
               (perms/audit-namespace-clause :namespace (u/qualified-name collection-namespace))
               (snippets-collection-filter-clause))
              ;; We get from the effective-children-query a normal set of columns selected:
@@ -649,13 +648,13 @@
 
 (defn- model-name->toucan-model [model-name]
   (case (keyword model-name)
-    :collection Collection
-    :card       Card
-    :dataset    Card
-    :dashboard  Dashboard
-    :pulse      Pulse
-    :snippet    NativeQuerySnippet
-    :timeline   Timeline))
+    :collection :model/Collection
+    :card       :model/Card
+    :dataset    :model/Card
+    :dashboard  :model/Dashboard
+    :pulse      :model/Pulse
+    :snippet    :model/NativeQuerySnippet
+    :timeline   :model/Timeline))
 
 (defn- can-read-in-trash? [collection row]
   (mi/can-write?

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -975,15 +975,22 @@
    authority_level [:maybe collection/AuthorityLevel]}
   (create-collection! body))
 
-;; TODO - I'm not 100% sure it makes sense that moving a Collection requires a special call to `move-collection!`,
-;; while archiving is handled automatically as part of the `pre-update` logic when you change a Collection's
-;; `archived` value. They are both recursive operations; couldn't we just have moving happen automatically when you
-;; change a `:location` as well?
-(defn- move-collection-if-needed!
+(defn- maybe-send-archived-notifications!
+  "When a collection is archived, all of it's cards are also marked as archived, but this is down in the model layer
+  which will not cause the archive notification code to fire. This will delete the relevant alerts and notify the
+  users just as if they had be archived individually via the card API."
+  [& {:keys [collection-before-update collection-updates actor]}]
+  (when (api/column-will-change? :archived collection-before-update collection-updates)
+    (when-let [alerts (seq (pulse/retrieve-alerts-for-cards
+                            {:card-ids (t2/select-pks-set Card :collection_id (u/the-id collection-before-update))}))]
+      (card/delete-alert-and-notify-archived! {:alerts alerts :actor actor}))))
+
+
+(defn- move-collection!
   "If input the `PUT /api/collection/:id` endpoint (`collection-updates`) specify that we should *move* a Collection, do
   appropriate permissions checks and move it (and its descendants)."
   [collection-before-update collection-updates]
-  ;; is a [new] parent_id update specified in the PUT request?
+  ;; sanity check: a [new] parent_id update specified in the PUT request?
   (when (contains? collection-updates :parent_id)
     (let [orig-location (:location collection-before-update)
           new-parent-id (:parent_id collection-updates)
@@ -1000,27 +1007,41 @@
         ;; ok, we're good to move!
         (collection/move-collection! collection-before-update new-location)))))
 
-(defn- check-allowed-to-archive-or-unarchive
-  "If input the `PUT /api/collection/:id` endpoint (`collection-updates`) specify that we should change the `archived`
-  status of a Collection, do appropriate permissions checks. (Actual recurisve (un)archiving logic is handled by
-  Collection's `pre-update`, so we do not need to manually call `collection/archive-collection!` and the like in this
-  namespace.)"
+(defn- archive-collection!
+  "If input to the `PUT /api/collection/:id` endpoint specifies that we should archive a collection, do the appropriate
+  permissions checks and then move it to the trash."
   [collection-before-update collection-updates]
-  (when (api/column-will-change? :archived collection-before-update collection-updates)
-    ;; Check that we have approprate perms
-    (api/check-403
-     (perms/set-has-full-permissions-for-set? @api/*current-user-permissions-set*
-       (collection/perms-for-archiving collection-before-update)))))
+  ;; sanity check
+  (when (contains? collection-updates :archived)
+    (let [new-parent-id (cond
+                          (:archived collection-updates) collection/TRASH_COLLECTION_ID
+                          (contains? collection-updates :parent_id) (:parent_id collection-updates)
+                          (and (= (:location collection-before-update)
+                                  collection/trash-path)
+                               (:trashed_from_location collection-before-update))
+                          (collection/location-path->parent-id
+                           (:trashed_from_location collection-before-update))
+                          :else (throw
+                                 (ex-info (tru "You must specify a new `parent_id` to un-trash to.")
+                                          {:status-code 400})))]
+      (move-collection!
+       collection-before-update
+       (assoc collection-updates :parent_id new-parent-id))
+      (maybe-send-archived-notifications! {:collection-before-update collection-before-update
+                                           :collection-updates       collection-updates
+                                           :actor                    @api/*current-user*}))))
 
-(defn- maybe-send-archived-notifications!
-  "When a collection is archived, all of it's cards are also marked as archived, but this is down in the model layer
-  which will not cause the archive notification code to fire. This will delete the relevant alerts and notify the
-  users just as if they had be archived individually via the card API."
-  [& {:keys [collection-before-update collection-updates actor]}]
-  (when (api/column-will-change? :archived collection-before-update collection-updates)
-    (when-let [alerts (seq (pulse/retrieve-alerts-for-cards
-                            {:card-ids (t2/select-pks-set Card :collection_id (u/the-id collection-before-update))}))]
-      (card/delete-alert-and-notify-archived! {:alerts alerts :actor actor}))))
+(defn- move-or-archive-collection-if-needed!
+  "If input to the `PUT /api/collection/:id` endpoint (`collection-updates`) specifies that we should either move or
+  archive the collection (archiving means 'moving to the trash' so it makes sense to deal with them together), do the
+  appropriate permissions checks and changes."
+  [collection-before-update collection-updates]
+  (condp #(contains? %2 %1) collection-updates
+    ;; note that archiving includes a move. So if they include `archived` (with or without `parent_id`), that's an
+    ;; archive/unarchive. If they only include `parent_id`, that's a move.
+    :archived (archive-collection! collection-before-update collection-updates)
+    :parent_id (move-collection! collection-before-update collection-updates)
+    :no-op))
 
 (api/defendpoint PUT "/:id"
   "Modify an existing Collection, including archiving or unarchiving it, or moving it."
@@ -1033,8 +1054,6 @@
    authority_level [:maybe collection/AuthorityLevel]}
   ;; do we have perms to edit this Collection?
   (let [collection-before-update (api/write-check Collection id)]
-    ;; if we're trying to *archive* the Collection, make sure we're allowed to do that
-    (check-allowed-to-archive-or-unarchive collection-before-update collection-updates)
     ;; if authority_level is changing, make sure we're allowed to do that
     (when (and (contains? collection-updates :authority_level)
                (not= (keyword authority_level) (:authority_level collection-before-update)))
@@ -1042,15 +1061,11 @@
       (api/check-403 api/*is-superuser?*))
     ;; ok, go ahead and update it! Only update keys that were specified in the `body`. But not `parent_id` since
     ;; that's not actually a property of Collection, and since we handle moving a Collection separately below.
-    (let [updates (u/select-keys-when collection-updates :present [:name :description :archived :authority_level])]
+    (let [updates (u/select-keys-when collection-updates :present [:name :description :authority_level])]
       (when (seq updates)
         (t2/update! Collection id updates)))
-    ;; if we're trying to *move* the Collection (instead or as well) go ahead and do that
-    (move-collection-if-needed! collection-before-update collection-updates)
-    ;; if we *did* end up archiving this Collection, we most post a few notifications
-    (maybe-send-archived-notifications! {:collection-before-update collection-before-update
-                                         :collection-updates       collection-updates
-                                         :actor                    @api/*current-user*}))
+    ;; if we're trying to move or archive the Collection, go ahead and do that
+    (move-or-archive-collection-if-needed! collection-before-update collection-updates))
   ;; finally, return the updated object
   (collection-detail (t2/select-one Collection :id id)))
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -943,7 +943,7 @@
   [models exclude_trash archived namespace pinned_state sort_column sort_direction]
   {models         [:maybe Models]
    archived       ms/MaybeBooleanValue
-   exclude_trash  [:maybe ms/BooleanValue]
+   exclude_trash  ms/MaybeBooleanValue
    namespace      [:maybe ms/NonBlankString]
    pinned_state   [:maybe (into [:enum] valid-pinned-state-values)]
    sort_column    [:maybe (into [:enum] valid-sort-columns)]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1005,7 +1005,7 @@
   ;; sanity check
   (when (contains? collection-updates :archived)
     (let [new-parent-id (cond
-                          (:archived collection-updates) collection/TRASH_COLLECTION_ID
+                          (:archived collection-updates) collection/trash-collection-id
                           (contains? collection-updates :parent_id) (:parent_id collection-updates)
                           (and (= (:location collection-before-update)
                                   collection/trash-path)

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1059,7 +1059,10 @@
   "Delete a collection entirely."
   [id]
   {id ms/PositiveInt}
-  (let [collection-before-delete (api/write-check :model/Collection id)]
+  (let [collection-before-delete (t2/select-one :model/Collection :id id)]
+    (api/check-403
+     (perms/set-has-full-permissions-for-set? @api/*current-user-permissions-set*
+                                              (collection/perms-for-archiving collection-before-delete)))
     ;; we can only delete archived collections
     (api/check-400 (:archived collection-before-delete))
     (t2/delete! :model/Collection :id id)))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1034,6 +1034,15 @@
     :parent_id (move-collection! collection-before-update collection-updates)
     :no-op))
 
+(api/defendpoint DELETE "/:id"
+  "Delete a collection entirely."
+  [id]
+  {id ms/PositiveInt}
+  (let [collection-before-delete (api/write-check :model/Collection id)]
+    ;; we can only delete archived collections
+    (api/check-400 (:archived collection-before-delete))
+    (t2/delete! :model/Collection :id id)))
+
 (api/defendpoint PUT "/:id"
   "Modify an existing Collection, including archiving or unarchiving it, or moving it."
   [id, :as {{:keys [name description archived parent_id authority_level], :as collection-updates} :body}]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1093,7 +1093,7 @@
    parent_id       [:maybe ms/PositiveInt]
    authority_level [:maybe collection/AuthorityLevel]}
   ;; do we have perms to edit this Collection?
-  (let [collection-before-update (api/write-check Collection id)]
+  (let [collection-before-update (t2/hydrate (api/write-check Collection id) :parent_id)]
     ;; if authority_level is changing, make sure we're allowed to do that
     (when (and (contains? collection-updates :authority_level)
                (not= (keyword authority_level) (:authority_level collection-before-update)))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -369,6 +369,7 @@
 (defn- card-query [dataset? collection {:keys [pinned-state]}]
   (-> {:select    (cond->
                     [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
+                     :archived
                      :c.dataset_query
                      [(h2x/literal (if dataset? "dataset" "card")) :model]
                      [:u.id :last_edit_user]
@@ -475,6 +476,7 @@
   (-> {:select    [:d.id :d.name :d.description :d.entity_id :d.collection_position
                    [(h2x/literal "dashboard") :model]
                    [:u.id :last_edit_user]
+                   :archived
                    [:u.email :last_edit_email]
                    [:u.first_name :last_edit_first_name]
                    [:u.last_name :last_edit_last_name]
@@ -518,6 +520,7 @@
              ;; We get from the effective-children-query a normal set of columns selected:
              ;; want to make it fit the others to make UNION ALL work
              :select [:id
+                      :archived
                       :name
                       :description
                       :entity_id
@@ -663,7 +666,7 @@
    :model :collection_position :authority_level [:personal_owner_id :integer] :location
    :last_edit_email :last_edit_first_name :last_edit_last_name :moderated_status :icon
    [:last_edit_user :integer] [:last_edit_timestamp :timestamp] [:database_id :integer]
-   :collection_type
+   :collection_type [:archived :boolean]
    ;; for determining whether a model is based on a csv-uploaded table
    [:table_id :integer] [:is_upload :boolean] :query_type])
 

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -1042,7 +1042,7 @@
   permissions checks and then move it to the trash."
   [collection-before-update collection-updates]
   ;; sanity check
-  (when (contains? collection-updates :archived)
+  (when (api/column-will-change? :archived collection-before-update collection-updates)
     (collection/archive-or-unarchive-collection!
      collection-before-update
      (select-keys collection-updates [:parent_id :archived]))

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -383,7 +383,8 @@
   (-> {:select    (cond->
                     [:c.id :c.name :c.description :c.entity_id :c.collection_position :c.display :c.collection_preview
                      :c.trashed_from_collection_id
-                     :archived
+                     ;; sigh. mariadb returns `c.archived` as 0 or 1 because it's a tinyint. This converts it to a boolean.
+                     [[:= :c.archived true] :archived]
                      :c.dataset_query
                      [(h2x/literal (if dataset? "dataset" "card")) :model]
                      [:u.id :last_edit_user]

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -962,11 +962,11 @@
         model-kwds      (visible-model-kwds root-collection model-set)]
     (collection-children
      root-collection
-     {:archived?      (if (nil? archived) false archived)
+     {:archived?      (boolean archived)
       :models         model-kwds
       :pinned-state   (keyword pinned_state)
       :sort-info      [(or (some-> sort_column normalize-sort-choice) :name)
-                          (or (some-> sort_direction normalize-sort-choice) :asc)]})))
+                       (or (some-> sort_direction normalize-sort-choice) :asc)]})))
 
 
 ;;; ----------------------------------------- Creating/Editing a Collection ------------------------------------------
@@ -1020,7 +1020,6 @@
     (when-let [alerts (seq (pulse/retrieve-alerts-for-cards
                             {:card-ids (t2/select-pks-set Card :collection_id (u/the-id collection-before-update))}))]
       (card/delete-alert-and-notify-archived! {:alerts alerts :actor actor}))))
-
 
 (defn- move-collection!
   "If input the `PUT /api/collection/:id` endpoint (`collection-updates`) specify that we should *move* a Collection, do

--- a/src/metabase/api/collection.clj
+++ b/src/metabase/api/collection.clj
@@ -82,10 +82,12 @@
 
   To select only personal collections, pass in `personal-only` as `true`.
   This will select only collections where `personal_owner_id` is not `nil`."
-  [{:keys [exclude-other-user-collections namespace shallow collection-id personal-only permissions-set]}]
+  [{:keys [archived exclude-other-user-collections namespace shallow collection-id personal-only permissions-set]}]
   (cond->>
    (t2/select :model/Collection
               {:where [:and
+                       (when (some? archived)
+                         [:= :archived archived])
                        (when shallow
                          (location-from-collection-id-clause collection-id))
                        (when personal-only
@@ -120,6 +122,7 @@
    personal-only                  [:maybe ms/BooleanValue]}
   (as->
    (select-collections {:exclude-other-user-collections exclude-other-user-collections
+                        :archived                       archived
                         :namespace                      namespace
                         :shallow                        false
                         :personal-only                  personal-only

--- a/src/metabase/api/common.clj
+++ b/src/metabase/api/common.clj
@@ -656,3 +656,23 @@
   (if (sequential? xs)
     (map parse-fn xs)
     [(parse-fn xs)]))
+
+
+;;; ---------------------------------------- MOVING TO TRASH ON ARCHIVE --------------------------------
+
+(defn move-on-archive-or-unarchive
+  "Given a current instance with a `collection_id` and `trashed_from_collection_id` and a set of updates to that
+  instance, return a possibly modified version of the updates reflecting the fact that archiving or unarchiving also
+  moves the instance to/from the Trash."
+  [current-obj obj-updates]
+  (cond-> obj-updates
+    (column-will-change? :archived current-obj obj-updates)
+    (assoc :collection_id (cond
+                            (:archived obj-updates) config/trash-collection-id
+
+                            (column-will-change? :collection_id current-obj obj-updates)
+                            (:collection_id obj-updates)
+
+                            :else (:trashed_from_collection_id current-obj))
+           :trashed_from_collection_id (when (:archived obj-updates)
+                                         (:collection_id current-obj)))))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -706,7 +706,7 @@
                          ;; changing `archived` also means changing the `collection_id` and `trashed_from_collection_id`
                          (contains? dash-updates :archived)
                          (assoc :collection_id (if (:archived dash-updates)
-                                                 collection/TRASH_COLLECTION_ID
+                                                 collection/trash-collection-id
                                                  (:trashed_from_collection_id current-dash))
                                 :trashed_from_collection_id (when (:archived dash-updates)
                                                               (:collection_id current-dash))))]

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -251,7 +251,6 @@
         api/read-check
         hydrate-dashboard-details
         collection.root/hydrate-root-collection
-        api/check-not-archived
         hide-unreadable-cards
         add-query-average-durations)))
 
@@ -702,7 +701,15 @@
           changes-stats              (atom nil)
           ;; tabs are always sent in production as well when dashcards are updated, but there are lots of
           ;; tests that exclude it. so this only checks for dashcards
-          update-dashcards-and-tabs? (contains? dash-updates :dashcards)]
+          update-dashcards-and-tabs? (contains? dash-updates :dashcards)
+          dash-updates (cond-> dash-updates
+                         ;; changing `archived` also means changing the `collection_id` and `trashed_from_collection_id`
+                         (contains? dash-updates :archived)
+                         (assoc :collection_id (if (:archived dash-updates)
+                                                 collection/TRASH_COLLECTION_ID
+                                                 (:trashed_from_collection_id current-dash))
+                                :trashed_from_collection_id (when (:archived dash-updates)
+                                                              (:collection_id current-dash))))]
       (collection/check-allowed-to-change-collection current-dash dash-updates)
       (check-allowed-to-change-embedding current-dash dash-updates)
       (api/check-500

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -704,7 +704,7 @@
           update-dashcards-and-tabs? (contains? dash-updates :dashcards)
           dash-updates (cond-> dash-updates
                          ;; changing `archived` also means changing the `collection_id` and `trashed_from_collection_id`
-                         (contains? dash-updates :archived)
+                         (api/column-will-change? :archived current-dash dash-updates)
                          (assoc :collection_id (if (:archived dash-updates)
                                                  collection/trash-collection-id
                                                  (:trashed_from_collection_id current-dash))

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -705,9 +705,13 @@
           dash-updates (cond-> dash-updates
                          ;; changing `archived` also means changing the `collection_id` and `trashed_from_collection_id`
                          (api/column-will-change? :archived current-dash dash-updates)
-                         (assoc :collection_id (if (:archived dash-updates)
-                                                 collection/trash-collection-id
-                                                 (:trashed_from_collection_id current-dash))
+                         (assoc :collection_id (cond
+                                                 (:archived dash-updates) collection/trash-collection-id
+
+                                                 (api/column-will-change? :collection_id current-dash dash-updates)
+                                                 (:collection_id dash-updates)
+
+                                                 :else (:trashed_from_collection_id current-dash))
                                 :trashed_from_collection_id (when (:archived dash-updates)
                                                               (:collection_id current-dash))))]
       (collection/check-allowed-to-change-collection current-dash dash-updates)

--- a/src/metabase/api/dashboard.clj
+++ b/src/metabase/api/dashboard.clj
@@ -721,7 +721,7 @@
             (when-let [updates (not-empty
                                  (u/select-keys-when
                                    dash-updates
-                                   :present #{:description :position :width :collection_id :collection_position :cache_ttl}
+                                   :present #{:description :position :width :collection_id :collection_position :cache_ttl :trashed_from_collection_id}
                                    :non-nil #{:name :parameters :caveats :points_of_interest :show_in_getting_started :enable_embedding
                                               :embedding_params :archived :auto_apply_filters}))]
               (t2/update! Dashboard id updates)

--- a/src/metabase/api/public.clj
+++ b/src/metabase/api/public.clj
@@ -285,6 +285,7 @@
    card-id     ms/PositiveInt
    parameters  [:maybe ms/JSONString]}
   (validation/check-public-sharing-enabled)
+  (api/check-404 (t2/select-one-pk :model/Card :id card-id :archived false))
   (let [dashboard-id (api/check-404 (t2/select-one-pk Dashboard :public_uuid uuid, :archived false))]
     (process-query-for-dashcard
      :dashboard-id  dashboard-id

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -302,14 +302,16 @@
             (or (contains? current-user-perms "/collection/root/")
                 (contains? current-user-perms "/collection/root/read/"))
 
+            collection-id [:coalesce :model.trashed_from_collection_id :collection_id]
+
             collection-perm-clause
             [:or
-             (when has-root-access? [:= :model.collection_id nil])
+             (when has-root-access? [:= collection-id nil])
              [:and
-              [:not= :model.collection_id nil]
+              [:not= collection-id nil]
               [:or
-               (has-perm-clause "/collection/" :model.collection_id "/")
-               (has-perm-clause "/collection/" :model.collection_id "/read/")]]]]
+               (has-perm-clause "/collection/" collection-id "/")
+               (has-perm-clause "/collection/" collection-id "/read/")]]]]
         (sql.helpers/where
          query
          collection-perm-clause)))))

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -353,18 +353,18 @@
     [(into [:case] case-clauses)]))
 
 (defmulti ^:private check-permissions-for-model
-  {:arglists '([archived? search-result])}
-  (fn [_ search-result] ((comp keyword :model) search-result)))
+  {:arglists '([search-result])}
+  (fn [search-result] ((comp keyword :model) search-result)))
 
 (defmethod check-permissions-for-model :default
-  [archived? instance]
-  (if archived?
+  [instance]
+  (if (:archived instance)
     (mi/can-write? instance)
     ;; We filter what we can (ie. everything that is in a collection) out already when querying
     true))
 
 (defmethod check-permissions-for-model :table
-  [_archived instance]
+  [instance]
   ;; we've already filtered out tables w/o collection permissions in the query itself.
   (and
    (data-perms/user-has-permission-for-table?
@@ -381,7 +381,7 @@
     (:id instance))))
 
 (defmethod check-permissions-for-model :indexed-entity
-  [_archived? instance]
+  [instance]
   (and
    (= :query-builder-and-native
       (data-perms/full-db-permission-for-user api/*current-user-id* :perms/create-queries (:database_id instance)))
@@ -389,20 +389,20 @@
       (data-perms/full-db-permission-for-user api/*current-user-id* :perms/view-data (:database_id instance)))))
 
 (defmethod check-permissions-for-model :metric
-  [archived? instance]
-  (if archived?
+  [instance]
+  (if (:archived instance)
     (mi/can-write? instance)
     (mi/can-read? instance)))
 
 (defmethod check-permissions-for-model :segment
-  [archived? instance]
-  (if archived?
+  [instance]
+  (if (:archived instance)
     (mi/can-write? instance)
     (mi/can-read? instance)))
 
 (defmethod check-permissions-for-model :database
-  [archived? instance]
-  (if archived?
+  [instance]
+  (if (:archived instance)
     (mi/can-write? instance)
     (mi/can-read? instance)))
 
@@ -513,7 +513,7 @@
                             (map #(if (t2/instance-of? :model/Collection %)
                                     (t2/hydrate % :effective_location)
                                     (assoc % :effective_location nil)))
-                            (filter (partial check-permissions-for-model (:archived? search-ctx)))
+                            (filter check-permissions-for-model)
                             ;; MySQL returns `:bookmark` and `:archived` as `1` or `0` so convert those to boolean as
                             ;; needed
                             (map #(update % :bookmark api/bit->boolean))

--- a/src/metabase/api/search.clj
+++ b/src/metabase/api/search.clj
@@ -583,7 +583,7 @@
   (let [models (if (string? models) [models] models)
         ctx    (cond-> {:search-string      search-string
                         :current-user-perms @api/*current-user-permissions-set*
-                        :archived?          (boolean archived)
+                        :archived?          archived
                         :models             models
                         :model-ancestors?   (boolean model-ancestors?)}
                  (some? created-at)                          (assoc :created-at created-at)

--- a/src/metabase/config.clj
+++ b/src/metabase/config.clj
@@ -149,6 +149,10 @@
   "ID of Audit DB which is loaded when running an EE build. ID is placed in OSS code to facilitate permission checks."
   13371337)
 
+(def ^:const trash-collection-id
+  "ID of the Trash collection."
+  13371339)
+
 (def ^:const internal-mb-user-id
   "The user-id of the internal metabase user.
    This is needed in the OSS edition to filter out users for setup/has-user-setup."

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -455,7 +455,7 @@
                                                           :where  [:= :action.model_id model-id]})]
     (t2/delete! :model/Action :id [:in action-ids])))
 
-(defn- pre-update [{archived? :archived, id :id, :as changes}]
+(defn- pre-update [{id :id, :as changes}]
   ;; TODO - don't we need to be doing the same permissions check we do in `pre-insert` if the query gets changed? Or
   ;; does that happen in the `PUT` endpoint? (#40013)
   (u/prog1 changes
@@ -464,9 +464,6 @@
                                   (:dataset_query changes)
                                   (get-in changes [:dataset_query :native]))
                           (t2/select-one [:model/Card :dataset_query :type] :id (u/the-id id)))]
-      ;; if the Card is archived, then remove it from any Dashboards
-      (when archived?
-        (t2/delete! :model/DashboardCard :card_id id))
       ;; if the template tag params for this Card have changed in any way we need to update the FieldValues for
       ;; On-Demand DB Fields
       (when (get-in changes [:dataset_query :native])

--- a/src/metabase/models/card.clj
+++ b/src/metabase/models/card.clj
@@ -850,7 +850,7 @@ saved later when it is ready."
                 ;; `collection_id` and `description` can be `nil` (in order to unset them).
                 ;; Other values should only be modified if they're passed in as non-nil
                 (u/select-keys-when card-updates
-                                    :present #{:collection_id :collection_position :description :cache_ttl}
+                                    :present #{:collection_id :collection_position :description :cache_ttl :trashed_from_collection_id}
                                     :non-nil #{:dataset_query :display :name :visualization_settings :archived
                                                :enable_embedding :type :parameters :parameter_mappings :embedding_params
                                                :result_metadata :collection_preview :verified-result-metadata?})))

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -330,7 +330,7 @@
   ([collection-ids :- VisibleCollections]
    (visible-collection-ids->honeysql-filter-clause :collection_id collection-ids))
 
-  ([collection-id-field :- :keyword
+  ([collection-id-field :- :any
     collection-ids      :- VisibleCollections]
    (if (= collection-ids :all)
      true

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -671,7 +671,6 @@
    (cons (perms/collection-readwrite-path new-parent)
          (perms-for-archiving collection))))
 
-
 (mu/defn ^:private collection->descendant-ids :- [:maybe [:set ms/PositiveInt]]
   [collection :- CollectionWithLocationAndIDOrRoot, & additional-conditions]
   (apply t2/select-pks-set Collection
@@ -780,7 +779,7 @@
     (:personal_owner_id collection)
 
     ;; Try to get the ID of its highest-level ancestor, e.g. if `location` is `/1/2/3/` we would get `1`. Then see if
-    ;; the root-level ancestor is a Personal Collection (Personal Collections can only got in the Root Collection.)
+    ;; the root-level ancestor is a Personal Collection (Personal Collections can only exist in the Root Collection.)
     ;; Note that if the collection is archived, we check this against the `trashed_from_location`.
     (t2/exists? Collection
                 :id                (first (location-path->ids (if (:archived collection)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -58,6 +58,12 @@
   "The fixed location path for the trash collection."
   (format "/%s/" trash-collection-id))
 
+(defn is-trash?
+  "Is this the trash collection?"
+  [collection]
+  (and (not (collection.root/is-root-collection? collection))
+       (= (u/the-id collection) trash-collection-id)))
+
 (defn is-trash-or-descendant?
   "Is this the trash collection, or a descendant of it?"
   [collection]

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -343,7 +343,7 @@
   ([collection-ids :- VisibleCollections]
    (visible-collection-ids->honeysql-filter-clause :collection_id collection-ids))
 
-  ([collection-id-field :- :any
+  ([collection-id-field :- [:or [:vector :keyword] :keyword] ;; `[:vector :keyword]` allows `[:coalesce :option-1 :option-2]`
     collection-ids      :- VisibleCollections]
    (if (= collection-ids :all)
      true

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -693,7 +693,11 @@
                                             :location)
                    :archived will-be-trashed?}
           :where  [:like :location (str orig-children-location "%")]})
-        (doseq [model [:model/Card :model/Dashboard :model/NativeQuerySnippet :model/Pulse]]
+        (doseq [model [:model/Card
+                       :model/Dashboard
+                       :model/NativeQuerySnippet
+                       :model/Pulse
+                       :model/Timeline]]
           (t2/update! model
                       {:collection_id [:in affected-collection-ids]}
                       {:archived will-be-trashed?}))))))
@@ -917,6 +921,14 @@
   [collection]
   ;; Delete all the Children of this Collection
   (t2/delete! Collection :location (children-location collection))
+  (let [affected-collection-ids (cons (u/the-id collection) (collection->descendant-ids collection))]
+    (doseq [model [:model/Card
+                   :model/Dashboard
+                   :model/NativeQuerySnippet
+                   :model/Pulse
+                   :model/Timeline]]
+      (t2/delete! model :collection_id [:in affected-collection-ids])))
+
   ;; You can't delete a Personal Collection! Unless we enable it because we are simultaneously deleting the User
   (when-not *allow-deleting-personal-collections*
     (when (:personal_owner_id collection)

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -678,7 +678,7 @@
     (log/infof "Moving Collection %s and its descendants from %s to %s"
                (u/the-id collection) (:location collection) new-location)
     (let [affected-collection-ids (cons (u/the-id collection)
-                                        (collection->descendant-ids collection, :archived false))]
+                                        (collection->descendant-ids collection))]
       (t2/with-transaction [_conn]
         (t2/update! Collection (u/the-id collection)
                     {:location new-location

--- a/src/metabase/models/collection.clj
+++ b/src/metabase/models/collection.clj
@@ -54,7 +54,7 @@
   []
   (t2/select-one :model/Collection :id trash-collection-id))
 
-(def ^:private trash-path
+(def trash-path
   "The fixed location path for the trash collection."
   (format "/%s/" trash-collection-id))
 
@@ -257,9 +257,12 @@
 
 (mu/defn ^:private parent :- CollectionWithLocationAndIDOrRoot
   "Fetch the parent Collection of `collection`, or the Root Collection special placeholder object if this is a
-  top-level Collection."
+  top-level Collection. Note that the `parent` of a `collection` that's in the trash is the collection it was trashed
+  *from*."
   [collection :- CollectionWithLocationOrRoot]
-  (if-let [new-parent-id (location-path->parent-id (:location collection))]
+  (if-let [new-parent-id (location-path->parent-id (or (when (:archived collection)
+                                                         (:trashed_from_location collection))
+                                                       (:location collection)))]
     (t2/select-one Collection :id new-parent-id)
     root-collection))
 
@@ -655,21 +658,6 @@
    (cons (perms/collection-readwrite-path new-parent)
          (perms-for-archiving collection))))
 
-(mu/defn move-collection!
-  "Move a Collection and all its descendant Collections from its current `location` to a `new-location`."
-  [collection :- CollectionWithLocationAndIDOrRoot, new-location :- LocationPath]
-  (let [orig-children-location (children-location collection)
-        new-children-location  (children-location (assoc collection :location new-location))]
-    ;; first move this Collection
-    (log/infof "Moving Collection %s and its descendants from %s to %s"
-               (u/the-id collection) (:location collection) new-location)
-    (t2/with-transaction [_conn]
-      (t2/update! Collection (u/the-id collection) {:location new-location})
-      ;; we need to update all the descendant collections as well...
-      (t2/query-one
-       {:update :collection
-        :set    {:location [:replace :location orig-children-location new-children-location]}
-        :where  [:like :location (str orig-children-location "%")]}))))
 
 (mu/defn ^:private collection->descendant-ids :- [:maybe [:set ms/PositiveInt]]
   [collection :- CollectionWithLocationAndIDOrRoot, & additional-conditions]
@@ -677,36 +665,38 @@
          :location [:like (str (children-location collection) "%")]
          additional-conditions))
 
-(mu/defn ^:private archive-collection!
-  "Archive a Collection and its descendant Collections and their Cards, Dashboards, and Pulses."
-  [collection :- CollectionWithLocationAndIDOrRoot]
-  (let [affected-collection-ids (cons (u/the-id collection)
-                                      (collection->descendant-ids collection, :archived false))]
-    (t2/with-transaction [_conn]
-      (t2/update! (t2/table-name Collection)
-                  {:id       [:in affected-collection-ids]
-                   :archived false}
-                  {:archived true})
-     (doseq [model '[Card Dashboard NativeQuerySnippet Pulse]]
-       (t2/update! model {:collection_id [:in affected-collection-ids]
-                           :archived      false}
-                    {:archived true})))))
-
-(mu/defn ^:private unarchive-collection!
-  "Unarchive a Collection and its descendant Collections and their Cards, Dashboards, and Pulses."
-  [collection :- CollectionWithLocationAndIDOrRoot]
-  (let [affected-collection-ids (cons (u/the-id collection)
-                                      (collection->descendant-ids collection, :archived true))]
-    (t2/with-transaction [_conn]
-      (t2/update! (t2/table-name Collection)
-               {:id       [:in affected-collection-ids]
-                :archived true}
-               {:archived false})
-      (doseq [model '[Card Dashboard NativeQuerySnippet Pulse]]
-        (t2/update! model {:collection_id [:in affected-collection-ids]
-                           :archived      true}
-                   {:archived false})))))
-
+(mu/defn move-collection!
+  "Move a Collection and all its descendant Collections from its current `location` to a `new-location`."
+  [collection :- CollectionWithLocationAndIDOrRoot, new-location :- LocationPath]
+  (let [orig-children-location (children-location collection)
+        new-children-location  (children-location (assoc collection :location new-location))
+        will-be-trashed? (str/starts-with? new-location trash-path)
+        was-trashed? (str/starts-with? (:location collection) trash-path)]
+    (when (and was-trashed? will-be-trashed?)
+      (throw (ex-info (tru "Collection is already trashed."){})))
+    ;; first move this Collection
+    (log/infof "Moving Collection %s and its descendants from %s to %s"
+               (u/the-id collection) (:location collection) new-location)
+    (let [affected-collection-ids (cons (u/the-id collection)
+                                        (collection->descendant-ids collection, :archived false))]
+      (t2/with-transaction [_conn]
+        (t2/update! Collection (u/the-id collection)
+                    {:location new-location
+                     :trashed_from_location (when will-be-trashed? (:location collection))
+                     :archived will-be-trashed?})
+        ;; we need to update all the descendant collections as well...
+        (t2/query-one
+         {:update :collection
+          :set    {:location [:replace :location orig-children-location new-children-location]
+                   ;; set the `trashed_from_location` to its current location if we're trashing, otherwise `NULL`
+                   :trashed_from_location (when will-be-trashed?
+                                            :location)
+                   :archived will-be-trashed?}
+          :where  [:like :location (str orig-children-location "%")]})
+        (doseq [model [:model/Card :model/Dashboard :model/NativeQuerySnippet :model/Pulse]]
+          (t2/update! model
+                      {:collection_id [:in affected-collection-ids]}
+                      {:archived will-be-trashed?}))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                       Toucan IModel & Perms Method Impls                                       |
@@ -726,11 +716,14 @@
    (or
     ;; If collection has an owner ID we're already done here, we know it's a Personal Collection
     (:personal_owner_id collection)
-    ;; Otherwise try to get the ID of its highest-level ancestor, e.g. if `location` is `/1/2/3/` we would get `1`.
-    ;; Then see if the root-level ancestor is a Personal Collection (Personal Collections can only got in the Root
-    ;; Collection.)
+
+    ;; Try to get the ID of its highest-level ancestor, e.g. if `location` is `/1/2/3/` we would get `1`. Then see if
+    ;; the root-level ancestor is a Personal Collection (Personal Collections can only got in the Root Collection.)
+    ;; Note that if the collection is archived, we check this against the `trashed_from_location`.
     (t2/exists? Collection
-                :id                (first (location-path->ids (:location collection)))
+                :id                (first (location-path->ids (if (:archived collection)
+                                                                (:trashed_from_location collection)
+                                                                (:location collection))))
                 :personal_owner_id [:not= nil]))))
 
 ;;; ----------------------------------------------------- INSERT -----------------------------------------------------
@@ -807,22 +800,6 @@
                             first)]
       (throw
        (ex-info msg {:status-code 400 :errors {k msg}})))))
-
-(mu/defn ^:private maybe-archive-or-unarchive!
-  "If `:archived` specified in the updates map, archive/unarchive as needed."
-  [collection-before-updates :- CollectionWithLocationAndIDOrRoot
-   collection-updates        :- :map]
-  ;; If the updates map contains a value for `:archived`, see if it's actually something different than current value
-  (when (api/column-will-change? :archived collection-before-updates collection-updates)
-    ;; check to make sure we're not trying to change location at the same time
-    (when (api/column-will-change? :location collection-before-updates collection-updates)
-      (throw (ex-info (tru "You cannot move a Collection and archive it at the same time.")
-               {:status-code 400
-                :errors      {:archived (tru "You cannot move a Collection and archive it at the same time.")}})))
-    ;; ok, go ahead and do the archive/unarchive operation
-    ((if (:archived collection-updates)
-       archive-collection!
-       unarchive-collection!) collection-before-updates)))
 
 ;; MOVING COLLECTIONS ACROSS "PERSONAL" BOUNDARIES
 ;;
@@ -922,9 +899,7 @@
     (when (api/column-will-change? :location collection-before-updates collection-updates)
       (update-perms-when-moving-across-personal-boundry! collection-before-updates collection-updates))
     ;; OK, AT THIS POINT THE CHANGES ARE VALIDATED. NOW START ISSUING UPDATES
-    ;; (1) archive or unarchive as appropriate
-    (maybe-archive-or-unarchive! collection-before-updates collection-updates)
-    ;; (2) slugify the collection name in case it's changed in the output; the results of this will get passed along
+    ;; slugify the collection name in case it's changed in the output; the results of this will get passed along
     ;; to Toucan's `update!` impl
     (cond-> collection-updates
       collection-name (assoc :slug (slugify collection-name)))))

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -325,7 +325,6 @@
                    :read  collection-read-path
                    :write collection-readwrite-path)
          collection-id (if (and (contains? this :trashed_from_collection_id)
-                                (contains? this :archived)
                                 (:archived this))
                          (:trashed_from_collection_id this)
                          (:collection_id this))]

--- a/src/metabase/models/permissions.clj
+++ b/src/metabase/models/permissions.clj
@@ -309,7 +309,10 @@
 (mu/defn perms-objects-set-for-parent-collection :- [:set perms.u/PathSchema]
   "Implementation of `perms-objects-set` for models with a `collection_id`, such as Card, Dashboard, or Pulse.
   This simply returns the `perms-objects-set` of the parent Collection (based on `collection_id`) or for the Root
-  Collection if `collection_id` is `nil`."
+  Collection if `collection_id` is `nil`.
+
+  If the model contains an `archived` key and a `trashed_from_collection_id` key, we will check permissions of that
+  collection instead."
   ([this read-or-write]
    (perms-objects-set-for-parent-collection nil this read-or-write))
 
@@ -320,10 +323,15 @@
    ;; based on value of read-or-write determine the approprite function used to calculate the perms path
    (let [path-fn (case read-or-write
                    :read  collection-read-path
-                   :write collection-readwrite-path)]
+                   :write collection-readwrite-path)
+         collection-id (if (and (contains? this :trashed_from_collection_id)
+                                (contains? this :archived)
+                                (:archived this))
+                         (:trashed_from_collection_id this)
+                         (:collection_id this))]
      ;; now pass that function our collection_id if we have one, or if not, pass it an object representing the Root
      ;; Collection
-     #{(path-fn (or (:collection_id this)
+     #{(path-fn (or collection-id
                     {:metabase.models.collection.root/is-root? true
                      :namespace                                collection-namespace}))})))
 

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.core.match :refer [match]]
    [clojure.data :as data]
+   [metabase.models.collection :as collection]
    [metabase.util.i18n :refer [deferred-tru]]
    [toucan2.core :as t2]))
 
@@ -42,24 +43,29 @@
 
     [:archived _ after]
     (if after
-      (deferred-tru "archived {0}" identifier)
-      (deferred-tru "unarchived {0}" identifier))
+      (deferred-tru "trashed {0}" identifier)
+      (deferred-tru "untrashed {0}" identifier))
 
     [:collection_position _ _]
     (deferred-tru "changed pin position")
 
     [:collection_id nil coll-id]
-    (deferred-tru "moved {0} to {1}" identifier (if coll-id
-                                                  (t2/select-one-fn :name 'Collection coll-id)
-                                                  (deferred-tru "Our analytics")))
+    ;; trash/untrash is handled by `archived`
+    (when-not (= coll-id collection/trash-collection-id)
+      (deferred-tru "moved {0} to {1}" identifier (if coll-id
+                                                    (t2/select-one-fn :name 'Collection coll-id)
+                                                    (deferred-tru "Our analytics"))))
 
     [:collection_id (prev-coll-id :guard int?) coll-id]
-    (deferred-tru "moved {0} from {1} to {2}"
-      identifier
-      (t2/select-one-fn :name 'Collection prev-coll-id)
-      (if coll-id
-        (t2/select-one-fn :name 'Collection coll-id)
-        (deferred-tru "Our analytics")))
+    ;; trash/untrash is handled by `archived`
+    (when-not (or (= prev-coll-id collection/trash-collection-id) (= coll-id collection/trash-collection-id))
+      (deferred-tru "moved {0} from {1} to {2}"
+        identifier
+        (t2/select-one-fn :name 'Collection prev-coll-id)
+        (if coll-id
+          (t2/select-one-fn :name 'Collection coll-id)
+          (deferred-tru "Our analytics"))))
+
 
     [:visualization_settings _ _]
     (deferred-tru "changed the visualization settings")

--- a/src/metabase/models/revision/diff.clj
+++ b/src/metabase/models/revision/diff.clj
@@ -2,7 +2,7 @@
   (:require
    [clojure.core.match :refer [match]]
    [clojure.data :as data]
-   [metabase.models.collection :as collection]
+   [metabase.config :as config]
    [metabase.util.i18n :refer [deferred-tru]]
    [toucan2.core :as t2]))
 
@@ -51,14 +51,14 @@
 
     [:collection_id nil coll-id]
     ;; trash/untrash is handled by `archived`
-    (when-not (= coll-id collection/trash-collection-id)
+    (when-not (= coll-id config/trash-collection-id)
       (deferred-tru "moved {0} to {1}" identifier (if coll-id
                                                     (t2/select-one-fn :name 'Collection coll-id)
                                                     (deferred-tru "Our analytics"))))
 
     [:collection_id (prev-coll-id :guard int?) coll-id]
     ;; trash/untrash is handled by `archived`
-    (when-not (or (= prev-coll-id collection/trash-collection-id) (= coll-id collection/trash-collection-id))
+    (when-not (or (= prev-coll-id config/trash-collection-id) (= coll-id config/trash-collection-id))
       (deferred-tru "moved {0} from {1} to {2}"
         identifier
         (t2/select-one-fn :name 'Collection prev-coll-id)

--- a/src/metabase/query_processor/card.clj
+++ b/src/metabase/query_processor/card.clj
@@ -220,7 +220,6 @@
                           :visualization-settings (:visualization_settings card)}
                    (and (= (:type card) :model) (seq (:result_metadata card)))
                    (assoc :metadata/model-metadata (:result_metadata card)))]
-    (api/check-not-archived card)
     (when (seq parameters)
       (validate-card-parameters card-id (mbql.normalize/normalize-fragment [:parameters] parameters)))
     (log/tracef "Running query for Card %d:\n%s" card-id

--- a/src/metabase/search/config.clj
+++ b/src/metabase/search/config.clj
@@ -98,7 +98,7 @@
   (mc/schema
    [:map {:closed true}
     [:search-string                                        [:maybe ms/NonBlankString]]
-    [:archived?                                            :boolean]
+    [:archived?                                            [:maybe :boolean]]
     [:model-ancestors?                                     :boolean]
     [:current-user-perms                                   [:set perms.u/PathSchema]]
     [:models                                               [:set SearchableModel]]

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -39,9 +39,7 @@
 
 (defmethod archived-clause :default
   [model archived?]
-  (if (nil? archived?)
-    true-clause
-    [:= (search.config/column-with-model-alias model :archived) archived?]))
+  [:= (search.config/column-with-model-alias model :archived) archived?])
 
 ;; Databases can't be archived
 (defmethod archived-clause "database"
@@ -52,9 +50,9 @@
 
 (defmethod archived-clause "indexed-entity"
   [_model archived?]
-  (if archived?
-    false-clause
-    true-clause))
+  (if-not archived?
+    true-clause
+    false-clause))
 
 ;; Table has an `:active` flag, but no `:archived` flag; never return inactive Tables
 (defmethod archived-clause "table"
@@ -298,7 +296,7 @@
       (not (str/blank? search-string))
       (sql.helpers/where (search-string-clause-for-model model search-context search-native-query))
 
-      true
+      (some? archived?)
       (sql.helpers/where (archived-clause model archived?))
 
       ;; build optional filters

--- a/src/metabase/search/filter.clj
+++ b/src/metabase/search/filter.clj
@@ -39,7 +39,9 @@
 
 (defmethod archived-clause :default
   [model archived?]
-  [:= (search.config/column-with-model-alias model :archived) archived?])
+  (if (nil? archived?)
+    true-clause
+    [:= (search.config/column-with-model-alias model :archived) archived?]))
 
 ;; Databases can't be archived
 (defmethod archived-clause "database"
@@ -50,9 +52,9 @@
 
 (defmethod archived-clause "indexed-entity"
   [_model archived?]
-  (if-not archived?
-    true-clause
-    false-clause))
+  (if archived?
+    false-clause
+    true-clause))
 
 ;; Table has an `:active` flag, but no `:archived` flag; never return inactive Tables
 (defmethod archived-clause "table"
@@ -296,7 +298,7 @@
       (not (str/blank? search-string))
       (sql.helpers/where (search-string-clause-for-model model search-context search-native-query))
 
-      (some? archived?)
+      true
       (sql.helpers/where (archived-clause model archived?))
 
       ;; build optional filters

--- a/src/metabase/util/malli/schema.clj
+++ b/src/metabase/util/malli/schema.clj
@@ -264,6 +264,14 @@
       (mu/with-api-error-message
        (deferred-tru "value must be a valid boolean string (''true'' or ''false'')."))))
 
+(def MaybeBooleanValue
+  "Same as above, but allows distinguishing between `nil` (the user did not specify a value)
+  and `false` (the user specified `false`)."
+  (-> [:enum {:decode/json (fn [b] (some->> b (contains? #{"true" true})))}
+       "true" "false" true false nil]
+      (mu/with-api-error-message
+       (deferred-tru "value must be a valid boolean string (''true'' or ''false'')."))))
+
 (def ValuesSourceConfig
   "Schema for valid source_options within a Parameter"
   ;; TODO: This should be tighter

--- a/test/metabase/api/bookmark_test.clj
+++ b/test/metabase/api/bookmark_test.clj
@@ -5,7 +5,7 @@
    [metabase.models.bookmark
     :refer [BookmarkOrdering CardBookmark CollectionBookmark DashboardBookmark]]
    [metabase.models.card :refer [Card]]
-   [metabase.models.collection :refer [Collection]]
+   [metabase.models.collection :as collection :refer [Collection]]
    [metabase.models.dashboard :refer [Dashboard]]
    [metabase.models.interface :as mi]
    [metabase.test :as mt]
@@ -77,7 +77,11 @@
 
 (deftest bookmarks-on-archived-items-test
   (testing "POST /api/bookmark/:model/:model-id"
-    (mt/with-temp [Collection archived-collection {:name "Test Collection" :archived true}
+    (collection/ensure-trash-collection-created!)
+    (mt/with-temp [Collection archived-collection {:name "Test Collection"
+                                                   :archived true
+                                                   :location collection/trash-path
+                                                   :trashed_from_location "/"}
                    Card       archived-card {:name "Test Card" :archived true}
                    Dashboard  archived-dashboard {:name "Test Dashboard" :archived true}]
       (bookmark-models (mt/user->id :rasta) archived-collection archived-card archived-dashboard)

--- a/test/metabase/api/card_test.clj
+++ b/test/metabase/api/card_test.clj
@@ -23,6 +23,7 @@
     :refer [Card CardBookmark Collection Dashboard Database ModerationReview
             Pulse PulseCard PulseChannel PulseChannelRecipient Table Timeline
             TimelineEvent]]
+   [metabase.models.collection :as collection]
    [metabase.models.moderation-review :as moderation-review]
    [metabase.models.permissions :as perms]
    [metabase.models.permissions-group :as perms-group]
@@ -275,10 +276,13 @@
 
 (deftest filter-by-archived-test
   (testing "GET /api/card?f=archived"
+    (collection/ensure-trash-collection-created!)
     (mt/with-temp [:model/Card card-1 {:name "Card 1"}
-                   :model/Card card-2 {:name "Card 2", :archived true}
-                   :model/Card card-3 {:name "Card 3", :archived true}]
+                   :model/Card card-2 {:name "Card 2"}
+                   :model/Card card-3 {:name "Card 3"}]
       (with-cards-in-readable-collection [card-1 card-2 card-3]
+        (mt/user-http-request :crowberto :put 200 (format "card/%d" (u/the-id card-2)) {:archived true})
+        (mt/user-http-request :crowberto :put 200 (format "card/%d" (u/the-id card-3)) {:archived true})
         (is (= #{"Card 2" "Card 3"}
                (set (map :name (mt/user-http-request :rasta :get 200 "card", :f :archived))))
             "The set of Card returned with f=archived should be equal to the set of archived cards")))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -2110,12 +2110,12 @@
   (testing "We can optionally request to include the Trash"
     (is (= [{:name "Trash"
              :id collection/trash-collection-id}]
-           (->> (:data (mt/user-http-request :crowberto :get 200 "collection/root/items" :exclude_trash false))
+           (->> (:data (mt/user-http-request :crowberto :get 200 "collection/root/items" :archived true))
                 (filter #(= (:id %) collection/trash-collection-id))
                 (map #(select-keys % [:name :id])))))))
 
 (deftest collection-tree-includes-trash-if-requested
-  (testing "Trash collection is included if requested"
-    (is (some #(= (:id %) collection/trash-collection-id) (mt/user-http-request :crowberto :get 200 "collection/tree" :archived "true"))))
-  (testing "Trash collection is NOT included by default"
-    (is (not (some #(= (:id %) collection/trash-collection-id) (mt/user-http-request :crowberto :get 200 "collection/tree"))))))
+  (testing "Trash collection is included by default"
+    (is (some #(= (:id %) collection/trash-collection-id) (mt/user-http-request :crowberto :get 200 "collection/tree"))))
+  (testing "Trash collection is NOT included if `exclude-archived` is passed"
+    (is (not (some #(= (:id %) collection/trash-collection-id) (mt/user-http-request :crowberto :get 200 "collection/tree" :exclude-archived "true"))))))

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -800,16 +800,16 @@
         (with-some-children-of-collection collection
           (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
           (is (partial= [{:name "Art Collection", :description nil, :model "collection", :entity_id true}]
-                        (items collection/TRASH_COLLECTION_ID)))
+                        (items collection/trash-collection-id)))
           (is (partial= [{:name "Baby Collection", :model "collection" :entity_id true}]
                         (items collection))))))
     (testing "I can untrash something by marking it as not archived"
       (t2.with-temp/with-temp [Collection collection {:name "A"}]
         (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
-        (is (= 1 (count (:data (mt/user-http-request :rasta :get 200 (str "collection/" collection/TRASH_COLLECTION_ID "/items"))))))
+        (is (= 1 (count (:data (mt/user-http-request :rasta :get 200 (str "collection/" collection/trash-collection-id))))))
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived false})
-        (is (zero? (count (:data (mt/user-http-request :rasta :get 200 (str "collection/" collection/TRASH_COLLECTION_ID "/items"))))))))
+        (is (zero? (count (:data (mt/user-http-request :rasta :get 200 (str "collection/" collection/trash-collection-id))))))))
     (testing "I can untrash something to a specific location if desired"
       (t2.with-temp/with-temp [Collection collection-a {:name "A"}
                                Collection collection-b {:name "B" :location (collection/children-location collection-a)}
@@ -818,7 +818,7 @@
         (perms/grant-collection-read-permissions! (perms-group/all-users) collection-b)
         (perms/grant-collection-read-permissions! (perms-group/all-users) destination)
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection-a)) {:archived true})
-        (is (= #{"A"} (set-of-item-names collection/TRASH_COLLECTION_ID)))
+        (is (= #{"A"} (set-of-item-names collection/trash-collection-id)))
         (is (= #{} (set-of-item-names destination)))
         ;; both A and B are marked as `archived`
         (is (:archived (mt/user-http-request :crowberto :get 200 (str "collection/" (u/the-id collection-b)))))
@@ -828,7 +828,7 @@
 
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection-b)) {:archived false :parent_id (u/the-id destination)})
         ;; collection A is still here!
-        (is (= #{"A"} (set-of-item-names collection/TRASH_COLLECTION_ID)))
+        (is (= #{"A"} (set-of-item-names collection/trash-collection-id)))
         ;; collection B got moved correctly
         (is (= #{"B"} (set-of-item-names destination)))
 
@@ -873,7 +873,7 @@
       (doseq [coll [subcollection-a subcollection-b subcollection-c]]
         (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id coll)) {:archived true}))
       (testing "rasta can see the collections in the trash"
-        (is (= #{"sub-A" "sub-C" "sub-B"} (set-of-item-names collection/TRASH_COLLECTION_ID)))))))
+        (is (= #{"sub-A" "sub-C" "sub-B"} (set-of-item-names collection/trash-collection-id)))))))
 
 (deftest collection-items-revision-history-and-ordering-test
   (testing "GET /api/collection/:id/items"

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -795,12 +795,11 @@
                                Collection _ {:name "Baby Collection"
                                              :location (collection/children-location collection)}]
         (perms/grant-collection-read-permissions! (perms-group/all-users) collection)
-        (with-some-children-of-collection collection
-          (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
-          (is (partial= [{:name "Art Collection", :description nil, :model "collection", :entity_id true}]
-                        (get-items :crowberto collection/trash-collection-id)))
-          (is (partial= [{:name "Baby Collection", :model "collection" :entity_id true}]
-                        (get-items :crowberto collection))))))
+        (mt/user-http-request :crowberto :put 200 (str "collection/" (u/the-id collection)) {:archived true})
+        (is (partial= [{:name "Art Collection", :description nil, :model "collection", :entity_id true}]
+                      (get-items :crowberto collection/trash-collection-id)))
+        (is (partial= [{:name "Baby Collection", :model "collection" :entity_id true}]
+                      (get-items :crowberto collection)))))
     (testing "I can untrash something by marking it as not archived"
       (t2.with-temp/with-temp [Collection collection {:name "A"}]
         (perms/grant-collection-read-permissions! (perms-group/all-users) collection)

--- a/test/metabase/api/collection_test.clj
+++ b/test/metabase/api/collection_test.clj
@@ -2099,3 +2099,14 @@
                                        (assoc (graph/graph)
                                               :groups {group-id {default-a :write, currency-a :write}}
                                               :namespace :currency)))))))))
+
+(deftest root-items-excludes-trash-by-default
+  (testing "Trash collection is usually not included"
+    (is (= [] (->> (:data (mt/user-http-request :crowberto :get 200 "collection/root/items"))
+                   (filter #(= (:name %) "Trash"))))))
+  (testing "We can optionally request to include the Trash"
+    (is (= [{:name "Trash"
+             :id collection/trash-collection-id}]
+           (->> (:data (mt/user-http-request :crowberto :get 200 "collection/root/items" :exclude_trash false))
+                (filter #(= (:id %) collection/trash-collection-id))
+                (map #(select-keys % [:name :id])))))))

--- a/test/metabase/api/dashboard_test.clj
+++ b/test/metabase/api/dashboard_test.clj
@@ -284,13 +284,13 @@
 
 (deftest get-dashboards-test
   (mt/with-temp
-    [:model/Dashboard {rasta-dash-id     :id} {:creator_id    (mt/user->id :rasta)}
+    [:model/Dashboard {rasta-dash-id :id} {:creator_id (mt/user->id :rasta)}
      :model/Dashboard {crowberto-dash-id :id
-                       :as crowberto-dash}    {:creator_id    (mt/user->id :crowberto)
-                                               :collection_id (:id (collection/user->personal-collection (mt/user->id :crowberto)))}
-     :model/Dashboard {archived-dash-id  :id} {:archived      true
-                                               :collection_id (:id (collection/user->personal-collection (mt/user->id :crowberto)))
-                                               :creator_id    (mt/user->id :crowberto)}]
+                       :as               crowberto-dash}    {:creator_id    (mt/user->id :crowberto)
+                                                             :collection_id (:id (collection/user->personal-collection (mt/user->id :crowberto)))}
+     :model/Dashboard {archived-dash-id :id} {:archived                   true
+                                              :trashed_from_collection_id (:id (collection/user->personal-collection (mt/user->id :crowberto)))
+                                              :creator_id                 (mt/user->id :crowberto)}]
     (testing "should include creator info and last edited info"
       (revision/push-revision!
        {:entity       :model/Dashboard
@@ -299,16 +299,16 @@
         :is-creation? true
         :object       crowberto-dash})
       (is (=? (merge crowberto-dash
-               {:creator        {:id          (mt/user->id :crowberto)
-                                 :email       "crowberto@metabase.com"
-                                 :first_name  "Crowberto"
-                                 :last_name   "Corv"
-                                 :common_name "Crowberto Corv"}}
-               {:last-edit-info {:id         (mt/user->id :crowberto)
-                                 :first_name "Crowberto"
-                                 :last_name  "Corv"
-                                 :email      "crowberto@metabase.com"
-                                 :timestamp  true}})
+                     {:creator {:id          (mt/user->id :crowberto)
+                                :email       "crowberto@metabase.com"
+                                :first_name  "Crowberto"
+                                :last_name   "Corv"
+                                :common_name "Crowberto Corv"}}
+                     {:last-edit-info {:id         (mt/user->id :crowberto)
+                                       :first_name "Crowberto"
+                                       :last_name  "Corv"
+                                       :email      "crowberto@metabase.com"
+                                       :timestamp  true}})
            (-> (m/find-first #(= (:id %) crowberto-dash-id)
                              (mt/user-http-request :crowberto :get 200 "dashboard" :f "mine"))
                (update-in [:last-edit-info :timestamp] boolean)))))

--- a/test/metabase/models/card_test.clj
+++ b/test/metabase/models/card_test.clj
@@ -73,15 +73,6 @@
                                :model/Dashboard _                      {:parameters [(card-params card-id)]}]
         (is (= 3 (hydrated-count card)))))))
 
-(deftest remove-from-dashboards-when-archiving-test
-  (testing "Test that when somebody archives a Card, it is removed from any Dashboards it belongs to"
-    (t2.with-temp/with-temp [:model/Dashboard     dashboard {}
-                             :model/Card          card      {}
-                             :model/DashboardCard _         {:dashboard_id (u/the-id dashboard), :card_id (u/the-id card)}]
-      (t2/update! :model/Card (u/the-id card) {:archived true})
-      (is (= 0
-             (t2/count :model/DashboardCard :dashboard_id (u/the-id dashboard)))))))
-
 (deftest public-sharing-test
   (testing "test that a Card's :public_uuid comes back if public sharing is enabled..."
     (tu/with-temporary-setting-values [enable-public-sharing true]

--- a/test/metabase/models/collection_test.clj
+++ b/test/metabase/models/collection_test.clj
@@ -95,19 +95,27 @@
                              Collection c2 {:name "my_favorite Cards"}]
       (is (not= (:entity_id c1) (:entity_id c2))))))
 
+(defn- archive-collection! [col]
+  (mt/with-current-user (mt/user->id :crowberto)
+    (collection/archive-or-unarchive-collection! col {:archived true})))
+
+(defn- unarchive-collection! [col]
+  (mt/with-current-user (mt/user->id :crowberto)
+    (collection/archive-or-unarchive-collection! col {:archived false})))
+
 (deftest archive-cards-test
   (testing "check that archiving a Collection archives its Cards as well"
     (t2.with-temp/with-temp [Collection collection {}
                              Card       card       {:collection_id (u/the-id collection)}]
-      (t2/update! Collection (u/the-id collection)
-                  {:archived true})
+      (archive-collection! collection)
       (is (true? (t2/select-one-fn :archived Card :id (u/the-id card))))))
 
   (testing "check that unarchiving a Collection unarchives its Cards as well"
-    (t2.with-temp/with-temp [Collection collection {:archived true}
-                             Card       card       {:collection_id (u/the-id collection), :archived true}]
-      (t2/update! Collection (u/the-id collection)
-                  {:archived false})
+    (t2.with-temp/with-temp [Collection collection {}
+                             Card       card       {:collection_id (u/the-id collection)}]
+      (archive-collection! collection)
+      (is (t2/select-one-fn :archived Card :id (u/the-id card)))
+      (unarchive-collection! (t2/select-one :model/Collection :id (u/the-id collection)))
       (is (false? (t2/select-one-fn :archived Card :id (u/the-id card)))))))
 
 (deftest validate-name-test
@@ -993,7 +1001,7 @@
     ;;           |
     ;;           +-> F -> G
     (with-collection-hierarchy [{:keys [c], :as collections}]
-      (t2/update! Collection (u/the-id c) {:archived true})
+      (archive-collection! c)
       (is (= {"A" {"B" {}}}
              (collection-locations (vals collections) :archived false))))))
 
@@ -1005,8 +1013,8 @@
     ;;           |                            |
     ;;           +-> F -> G                   +-> F -> G
     (with-collection-hierarchy [{:keys [e], :as collections}]
-      (t2/update! Collection (u/the-id e) {:archived true})
-      (t2/update! Collection (u/the-id e) {:archived false})
+      (archive-collection! e)
+      (unarchive-collection! (t2/select-one :model/Collection :id (u/the-id e)))
       (is (= {"A" {"B" {}
                    "C" {"D" {"E" {}}
                         "F" {"G" {}}}}}
@@ -1019,8 +1027,8 @@
     ;;                                        |
     ;;                                        +-> F -> G
     (with-collection-hierarchy [{:keys [c], :as collections}]
-      (t2/update! Collection (u/the-id c) {:archived true})
-      (t2/update! Collection (u/the-id c) {:archived false})
+      (archive-collection! c)
+      (unarchive-collection! (t2/select-one :model/Collection :id (u/the-id c)))
       (is (= {"A" {"B" {}
                    "C" {"D" {"E" {}}
                         "F" {"G" {}}}}}
@@ -1033,7 +1041,7 @@
       (with-collection-hierarchy [{:keys [e], :as _collections} (when (= model NativeQuerySnippet)
                                                                   {:namespace "snippets"})]
         (t2.with-temp/with-temp [model object {:collection_id (u/the-id e)}]
-          (t2/update! Collection (u/the-id e) {:archived true})
+          (archive-collection! e)
           (is (= true
                  (t2/select-one-fn :archived model :id (u/the-id object)))))))
 
@@ -1042,7 +1050,7 @@
       (with-collection-hierarchy [{:keys [c e], :as _collections} (when (= model NativeQuerySnippet)
                                                                     {:namespace "snippets"})]
         (t2.with-temp/with-temp [model object {:collection_id (u/the-id e)}]
-          (t2/update! Collection (u/the-id c) {:archived true})
+          (archive-collection! c)
           (is (= true
                  (t2/select-one-fn :archived model :id (u/the-id object)))))))))
 
@@ -1052,9 +1060,9 @@
       ;; object is in E; unarchiving E should cause object to be unarchived
       (with-collection-hierarchy [{:keys [e], :as _collections} (when (= model NativeQuerySnippet)
                                                                   {:namespace "snippets"})]
-        (t2/update! Collection (u/the-id e) {:archived true})
+        (archive-collection! e)
         (t2.with-temp/with-temp [model object {:collection_id (u/the-id e), :archived true}]
-          (t2/update! Collection (u/the-id e) {:archived false})
+          (unarchive-collection! (t2/select-one :model/Collection :id (u/the-id e)))
           (is (= false
                  (t2/select-one-fn :archived model :id (u/the-id object)))))))
 
@@ -1062,9 +1070,9 @@
       ;; object is in E, a descendant of C; unarchiving C should cause object to be unarchived
       (with-collection-hierarchy [{:keys [c e], :as _collections} (when (= model NativeQuerySnippet)
                                                                     {:namespace "snippets"})]
-        (t2/update! Collection (u/the-id c) {:archived true})
+        (archive-collection! c)
         (t2.with-temp/with-temp [model object {:collection_id (u/the-id e), :archived true}]
-          (t2/update! Collection (u/the-id c) {:archived false})
+          (unarchive-collection! (t2/select-one :model/Collection :id (u/the-id c)))
           (is (= false
                  (t2/select-one-fn :archived model :id (u/the-id object)))))))))
 
@@ -1505,23 +1513,20 @@
            #"Collection does not exist"
            (collection/check-collection-namespace Card Integer/MAX_VALUE))))))
 
-(deftest delete-collection-set-children-collection-id-to-null-test
-  (testing "When deleting a Collection, should change collection_id of Children to nil instead of Cascading"
+(deftest delete-collection-cascades
+  (testing "When deleting a Collection, should delete things that used to be in that collection"
     (t2.with-temp/with-temp [Collection {coll-id :id}      {}
                              Card       {card-id :id}      {:collection_id coll-id}
                              Dashboard  {dashboard-id :id} {:collection_id coll-id}
                              Pulse      {pulse-id :id}     {:collection_id coll-id}]
       (t2/delete! Collection :id coll-id)
-      (is (t2/exists? Card :id card-id)
-          "Card")
-      (is (t2/exists? Dashboard :id dashboard-id)
-          "Dashboard")
-      (is (t2/exists? Pulse :id pulse-id)
-          "Pulse"))
+      (is (not (t2/exists? Card :id card-id)))
+      (is (not (t2/exists? Dashboard :id dashboard-id)))
+      (is (not (t2/exists? Pulse :id pulse-id))))
     (t2.with-temp/with-temp [Collection         {coll-id :id}    {:namespace "snippets"}
                              NativeQuerySnippet {snippet-id :id} {:collection_id coll-id}]
       (t2/delete! Collection :id coll-id)
-      (is (t2/exists? NativeQuerySnippet :id snippet-id)
+      (is (not (t2/exists? NativeQuerySnippet :id snippet-id))
           "Snippet"))))
 
 (deftest collections->tree-test


### PR DESCRIPTION
This PR is probably too big. Hopefully documenting all the changes made here will make it easier to review and digest. So:

## Migration

Tables with a `collection_id` had `ON DELETE SET NULL` on the foreign key. Since we only deleted collections in testing and development, this didn't really affect anything. But now that we are actually deleting collections in production, it's important that nothing accidentally get moved to the root collection, which is what `SET NULL` actually does.

## Moving things to the Trash

When we get an API request to update the `archived` flag on a card, collection, or dashboard, we either move the item *to* the trash (if `archived` is `true`) or *from* the trash (if `archived` is `false`). We set the `trashed_from_collection_id` flag as appropriate, and use it when restoring an item if possible.

## Permissions changes

Because moving something to the trash by itself would have permissions implications (since permissions are based on the parent collection) we need to change the way permissions are enforced for trashed items.

First, we change the definition of `perms-objects-set-for-parent-collection` so that it returns the permission set for the collection the object was *trashed from*, if it is archived.

Second, when listing objects inside the Trash itself, we need to check permissions to make sure the user can actually read the object - usually, of course, if you can read a collection you can read the contents, but this is not true for the trash so we need to check each one. In this case we're actually a little extra restrictive and only return objects the user can *write*. The reasoning here is that you only really want to browse the Trash to see things you could "act on" - unarchive or permanently delete. So there's no reason to show you things you only have read permissions on.

## Collection API changes

Because previously the Collections API expected archived collections to live anywhere, not just in a single tree based in the Trash, I needed to make some changes to some API endpoints.

### /collection/tree

This endpoint still takes an `exclude-archived` parameter, which defaults to `false`. When it's `false`, we return the entire tree including the Trash collection and archived children. When it's `true`, we exclude the Trash collection (and its subtree) from the results.

### /collection/:id/items

Previously, this endpoint took an `archived` parameter, which defaulted to `false`. Thus it would only return non-archived results. This is a problem, because we want the frontend to be able to ask for the contents of the Trash or an archived subcollection without explicitly asking for archived results. We just want to treat these like normal collections.

The change made to support this was to just default `archived` to the `archived` status of the collection itself. If you're asking for the items in an archived collection, you'll only get archived results. If you're asking for the items in a non-archived collection, you'll only get unarchived results.

This is, for normal collections, the same thing as just returning all results. But see the section on namespaced collections for details on why we needed this slightly awkward default.

### /collection/root/items

No change - this endpoint still takes an `archived` parameter. When `archived=true`, we return the Trash collection, as it is in the root collection. Otherwise, we don't.