### PR TITLE
[QP, lib] Add expression functions for month, quarter, weekday names

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -678,7 +678,7 @@
   ;;
   ;;    clj -X:dev:ee:ee-dev:test:test/qp
   :test/qp
-  {:exec-args {:only ["test/metadata/driver"
+  {:exec-args {:only ["test/metabase/driver"
                       "test/metabase/query_processor"
                       "test/metabase/query_processor_test"
                       metabase-enterprise.advanced-permissions.models.permissions.block-permissions-test
@@ -690,7 +690,8 @@
   :test/mbql
   {:exec-args {:only ["test/mbql"
                       "test/metabase/lib"
-                      "test/metadata/driver"
+                      "test/metabase/legacy_mbql"
+                      "test/metabase/driver"
                       "test/metabase/query_processor"
                       "test/metabase/query_processor_test"
                       metabase-enterprise.advanced-permissions.models.permissions.block-permissions-test

--- a/frontend/src/metabase-lib/v1/expressions/config.ts
+++ b/frontend/src/metabase-lib/v1/expressions/config.ts
@@ -148,6 +148,21 @@ export const MBQL_CLAUSES: MBQLClauseMap = {
     args: ["string"],
     requiresFeature: "regex",
   },
+  "month-name": {
+    displayName: `monthName`,
+    type: "string",
+    args: ["number"],
+  },
+  "quarter-name": {
+    displayName: `quarterName`,
+    type: "string",
+    args: ["number"],
+  },
+  "day-name": {
+    displayName: `dayName`,
+    type: "string",
+    args: ["number"],
+  },
   // numeric functions
   abs: {
     displayName: `abs`,
@@ -481,6 +496,9 @@ export const EXPRESSION_FUNCTIONS = new Set([
   "domain",
   "subdomain",
   "host",
+  "month-name",
+  "quarter-name",
+  "day-name",
   // number
   "abs",
   "floor",

--- a/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
+++ b/frontend/src/metabase-lib/v1/expressions/helper-text-strings.ts
@@ -433,6 +433,44 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     ],
   },
   {
+    name: "month-name",
+    structure: "monthName",
+    description: () =>
+      t`Returns the localized short name ("Apr") for the given month number (4)`,
+    args: [
+      {
+        name: t`monthNumber`,
+        description: t`Column or expression giving the number of a month in the year, 1 to 12.`,
+        example: formatIdentifier(t`Birthday Month`),
+      },
+    ],
+  },
+  {
+    name: "quarter-name",
+    structure: "quarterName",
+    description: () => t`Returns a string like "Q1", given the quarter number`,
+    args: [
+      {
+        name: t`quarterNumber`,
+        description: t`Column or expression giving the number of a quarter of the year, 1 to 4.`,
+        example: formatIdentifier(t`Fiscal Quarter`),
+      },
+    ],
+  },
+  {
+    name: "day-name",
+    structure: "dayName",
+    description: () =>
+      t`Returns the localized name of a day of the week, given the day's number.`,
+    args: [
+      {
+        name: t`dayNumber`,
+        description: t`Column or expression giving the number of a day of the week, 1 to 7. Which day is 1 is defined in your localization setting; default Sunday.`,
+        example: formatIdentifier(t`Weekday`),
+      },
+    ],
+  },
+  {
     name: "abs",
     structure: "abs",
     description: () =>
@@ -890,7 +928,7 @@ const HELPER_TEXT_STRINGS: HelpTextConfig[] = [
     name: "get-day-of-week",
     structure: "weekday",
     description: () =>
-      t`Takes a datetime and returns an integer (1-7) with the number of the day of the week.`,
+      t`Takes a datetime and returns an integer (1-7) with the number of the day of the week. Which day is 1 is defined in your localization settings.`,
     args: [
       {
         name: t`column`,

--- a/src/metabase/legacy_mbql/schema.cljc
+++ b/src/metabase/legacy_mbql/schema.cljc
@@ -381,7 +381,7 @@
 (def string-functions
   "Functions that return string values. Should match [[StringExpression]]."
   #{:substring :trim :rtrim :ltrim :upper :lower :replace :concat :regex-match-first :coalesce :case
-    :host :domain :subdomain})
+    :host :domain :subdomain :month-name :quarter-name :day-name})
 
 (def ^:private StringExpression
   "Schema for the definition of an string expression."
@@ -566,6 +566,15 @@
 
 (defclause ^{:requires-features #{:expressions :regex}} subdomain
   s StringExpressionArg)
+
+(defclause ^{:requires-features #{:expressions}} month-name
+  n NumericExpressionArg)
+
+(defclause ^{:requires-features #{:expressions}} quarter-name
+  n NumericExpressionArg)
+
+(defclause ^{:requires-features #{:expressions}} day-name
+  n NumericExpressionArg)
 
 (defclause ^{:requires-features #{:expressions}} +
   x Addable, y Addable, more (rest Addable))
@@ -873,7 +882,8 @@
           get-hour get-minute get-second))
 
 (mr/def ::StringExpression
-  (one-of substring trim ltrim rtrim replace lower upper concat regex-match-first coalesce case host domain subdomain))
+  (one-of substring trim ltrim rtrim replace lower upper concat regex-match-first coalesce case host domain subdomain
+          month-name quarter-name day-name))
 
 (mr/def ::FieldOrExpressionDef
   "Schema for anything that is accepted as a top-level expression definition, either an arithmetic expression such as a

--- a/src/metabase/lib/expression.cljc
+++ b/src/metabase/lib/expression.cljc
@@ -288,6 +288,9 @@
 (lib.common/defop host [s])
 (lib.common/defop domain [s])
 (lib.common/defop subdomain [s])
+(lib.common/defop month-name [n])
+(lib.common/defop quarter-name [n])
+(lib.common/defop day-name [n])
 
 (mu/defn ^:private expression-metadata :- lib.metadata/ColumnMetadata
   [query                 :- ::lib.schema/query

--- a/src/metabase/lib/extraction.cljc
+++ b/src/metabase/lib/extraction.cljc
@@ -1,7 +1,6 @@
 (ns metabase.lib.extraction
   (:require
    [metabase.lib.expression :as lib.expression]
-   [metabase.lib.filter :as lib.filter]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.metadata.calculation :as lib.metadata.calculation]
    [metabase.lib.schema :as lib.schema]
@@ -11,7 +10,6 @@
    [metabase.lib.types.isa :as lib.types.isa]
    [metabase.lib.util :as lib.util]
    [metabase.shared.util.i18n :as i18n]
-   [metabase.shared.util.time :as shared.ut]
    [metabase.util.malli :as mu]))
 
 (defn- column-extract-temporal-units [column]
@@ -79,22 +77,14 @@
   [_query _stage-number extraction]
   (dissoc extraction :lib/type :column))
 
-(defn- case-expression
-  "Creates a case expression with a condition for each value of the unit."
-  [expression-fn unit n]
-  (lib.expression/case
-    (for [raw-value (range 1 (inc n))]
-      [(lib.filter/= (expression-fn) raw-value) (shared.ut/format-unit raw-value unit)])
-    ""))
-
 (defn- extraction-expression [column tag]
   (case tag
     ;; Temporal extractions
     :hour-of-day     (lib.expression/get-hour column)
     :day-of-month    (lib.expression/get-day column)
-    :day-of-week     (case-expression #(lib.expression/get-day-of-week column) tag 7)
-    :month-of-year   (case-expression #(lib.expression/get-month column) tag 12)
-    :quarter-of-year (case-expression #(lib.expression/get-quarter column) tag 4)
+    :day-of-week     (lib.expression/day-name (lib.expression/get-day-of-week column))
+    :month-of-year   (lib.expression/month-name (lib.expression/get-month column))
+    :quarter-of-year (lib.expression/quarter-name (lib.expression/get-quarter column))
     :year            (lib.expression/get-year column)
     ;; URLs and emails
     :domain          (lib.expression/domain column)

--- a/src/metabase/lib/schema/expression/string.cljc
+++ b/src/metabase/lib/schema/expression/string.cljc
@@ -11,6 +11,10 @@
   (mbql-clause/define-tuple-mbql-clause op :- :type/Text
     [:schema [:ref ::expression/string]]))
 
+(doseq [op [:month-name :quarter-name :day-name]]
+  (mbql-clause/define-tuple-mbql-clause op :- :type/Text
+    [:schema [:ref ::expression/integer]]))
+
 (mbql-clause/define-tuple-mbql-clause :length :- :type/Integer
   [:schema [:ref ::expression/string]])
 

--- a/src/metabase/shared/util/time.cljc
+++ b/src/metabase/shared/util/time.cljc
@@ -75,9 +75,14 @@
 
 (defn format-unit
   "Formats a temporal-value (iso date/time string, int for hour/minute) given the temporal-bucketing unit.
-   If unit is nil, formats the full date/time"
-  [temporal-value unit]
-  (internal/format-unit temporal-value unit))
+  If unit is nil, formats the full date/time.
+
+  If `locale` is provided, that locale will be used for localizing the formatter. In CLJ this should be a `Locale`. Not
+  supported in CLJS since we have to rely on the browser's locale."
+  ([temporal-value unit]
+   (internal/format-unit temporal-value unit))
+  ([temporal-value unit locale]
+   (internal/format-unit temporal-value unit locale)))
 
 (defn format-diff
   "Formats a time difference between two temporal values.

--- a/test/metabase/lib/drill_thru/column_extract_test.cljc
+++ b/test/metabase/lib/drill_thru/column_extract_test.cljc
@@ -2,15 +2,13 @@
   "See also [[metabase.query-processor-test.drill-thru-e2e-test/quick-filter-on-bucketed-date-test]]"
   (:require
    [clojure.test :refer [deftest testing]]
-   [medley.core :as m]
    [metabase.lib.core :as lib]
    [metabase.lib.drill-thru.test-util :as lib.drill-thru.tu]
    [metabase.lib.drill-thru.test-util.canned :as canned]
    [metabase.lib.metadata :as lib.metadata]
    [metabase.lib.test-metadata :as meta]
    [metabase.lib.test-util :as lib.tu]
-   #?@(:clj  ([metabase.test :as mt])
-       :cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
+   #?@(:cljs ([metabase.test-runner.assert-exprs.approximately-equal]))))
 
 #?(:cljs (comment metabase.test-runner.assert-exprs.approximately-equal/keep-me))
 
@@ -45,16 +43,6 @@
     :expected    {:type        :drill-thru/column-extract
                   :extractions datetime-extraction-units}}))
 
-(defn- case-extraction
-  "Returns `=?` friendly value for a `:case`-based extraction, eg. `:day-of-week`.
-
-  `(case-extraction :get-month \"Month of year\" (meta/id :orders :created-at) [\"Jan\" \"Feb\" ... \"Dec\"])`"
-  [extraction expression-name field-id labels]
-  [:case {:lib/expression-name expression-name}
-   (vec (for [[index label] (m/indexed labels)]
-          [[:= {} [extraction {} [:field {} field-id]] (inc index)] label]))
-   ""])
-
 (deftest ^:parallel apply-column-extract-test-1a-month-of-year
   (testing "column-extract on a regular field without aggregations adds a column in this stage"
     (lib.drill-thru.tu/test-drill-application
@@ -69,9 +57,8 @@
                        :stage-number -1}
       :drill-args     ["month-of-year"]
       :expected-query {:stages [{:expressions
-                                 [(case-extraction :get-month "Month of year" (meta/id :orders :created-at)
-                                                   ["Jan" "Feb" "Mar" "Apr" "May" "Jun"
-                                                    "Jul" "Aug" "Sep" "Oct" "Nov" "Dec"])]}]}})))
+                                 [[:month-name {:lib/expression-name "Month of year"}
+                                   [:get-month {} [:field {} (meta/id :orders :created-at)]]]]}]}})))
 
 (deftest ^:parallel apply-column-extract-test-1b-day-of-week
   (testing "column-extract on a regular field without aggregations adds a column in this stage"
@@ -87,9 +74,8 @@
                        :stage-number -1}
       :drill-args     ["day-of-week"]
       :expected-query {:stages [{:expressions
-                                 [(case-extraction :get-day-of-week "Day of week" (meta/id :orders :created-at)
-                                                   ["Sunday" "Monday" "Tuesday" "Wednesday" "Thursday"
-                                                    "Friday" "Saturday"])]}]}})))
+                                 [[:day-name {:lib/expression-name "Day of week"}
+                                   [:get-day-of-week {} [:field {} (meta/id :orders :created-at)]]]]}]}})))
 
 (deftest ^:parallel apply-column-extract-test-1c-quarter
   (testing "column-extract on a regular field without aggregations adds a column in this stage"
@@ -105,8 +91,8 @@
                        :stage-number -1}
       :drill-args     ["quarter-of-year"]
       :expected-query {:stages [{:expressions
-                                 [(case-extraction :get-quarter "Quarter of year" (meta/id :orders :created-at)
-                                                   ["Q1" "Q2" "Q3" "Q4"])]}]}})))
+                                 [[:quarter-name {:lib/expression-name "Quarter of year"}
+                                   [:get-quarter {} [:field {} (meta/id :orders :created-at)]]]]}]}})))
 
 (deftest ^:parallel apply-column-extract-test-1d-year
   (testing "column-extract on a regular field without aggregations adds a column in this stage"
@@ -198,28 +184,6 @@
          :expected-query {:stages [(get-in query [:stages 0])
                                    {:expressions [[:get-day {:lib/expression-name "Day of month"}
                                                    [:field {} "max"]]]}]}}))))
-
-#?(:clj
-   ;; TODO: This should be possible to run in CLJS if we have a library for setting the locale in JS.
-   ;; Metabase FE has this in frontend/src/metabase/lib/i18n.js but that's loaded after the CLJS.
-   (deftest ^:synchronized apply-column-extract-test-4-i18n-labels
-     (testing "column-extract with custom labels get i18n'd"
-       (mt/with-locale "es"
-         (lib.drill-thru.tu/test-drill-application
-           {:click-type     :header
-            :query-type     :unaggregated
-            :column-name    "CREATED_AT"
-            :drill-type     :drill-thru/column-extract
-            :expected       {:type         :drill-thru/column-extract
-                             :extractions  datetime-extraction-units
-                             ;; Query unchanged
-                             :query        (get-in lib.drill-thru.tu/test-queries ["ORDERS" :unaggregated :query])
-                             :stage-number -1}
-            :drill-args     ["day-of-week"]
-            :expected-query {:stages [{:expressions
-                                       [(case-extraction :get-day-of-week "Day of week" (meta/id :orders :created-at)
-                                                         ["domingo" "lunes" "martes" "miércoles" "jueves"
-                                                          "viernes" "sábado"])]}]}})))))
 
 (deftest ^:parallel column-extract-relevant-units-test-1-time
   (let [ship-time (assoc (meta/field-metadata :orders :created-at)

--- a/test/metabase/query_processor_test/expressions_test.clj
+++ b/test/metabase/query_processor_test/expressions_test.clj
@@ -93,11 +93,11 @@
   (let [priceplusone (if (= driver/*driver* :bigquery-cloud-sdk) "price_plus_1" "Price + 1")
         oneplusone   (if (= driver/*driver* :bigquery-cloud-sdk) "one_plus_one" "1 + 1")
         query        (mt/mbql-query venues
-                                    {:expressions {priceplusone [:+ $price 1]
-                                                   oneplusone   [:+ 1 1]}
-                                     :fields      [$price [:expression oneplusone]]
-                                     :order-by    [[:asc $id]]
-                                     :limit       3})]
+                       {:expressions {priceplusone [:+ $price 1]
+                                      oneplusone   [:+ 1 1]}
+                        :fields      [$price [:expression oneplusone]]
+                        :order-by    [[:asc $id]]
+                        :limit       3})]
     {:priceplusone priceplusone
      :oneplusone   oneplusone
      :query        query}))
@@ -240,14 +240,14 @@
              (calculate-bird-scarcity [:/ 100.0 $count] [:or [:= $count nil] [:!= $count 0]]))))))
 
 (deftest ^:parallel nulls-and-zeroes-test-4
-   (mt/test-drivers
-     (nulls-and-zeroes-test-drivers)
-     (testing
-         "can we handle BOTH NULLS AND ZEROES AT THE SAME TIME????"
-         (is
-          (=
-           [[nil] [nil] [nil] [10.0] [12.5] [20.0] [20.0] [nil] [nil] [nil]]
-           (calculate-bird-scarcity [:/ 100.0 $count]))))))
+  (mt/test-drivers
+    (nulls-and-zeroes-test-drivers)
+    (testing
+     "can we handle BOTH NULLS AND ZEROES AT THE SAME TIME????"
+      (is
+       (=
+        [[nil] [nil] [nil] [10.0] [12.5] [20.0] [20.0] [nil] [nil] [nil]]
+        (calculate-bird-scarcity [:/ 100.0 $count]))))))
 (deftest ^:parallel nulls-and-zeroes-test-5
   (mt/test-drivers (nulls-and-zeroes-test-drivers)
     (testing "can we handle dividing by literal 0?"
@@ -291,7 +291,6 @@
     (testing "can multiplications handle nulls & zeros?"
       (is (= [[nil] [0.0] [0.0] [10.0] [8.0] [5.0] [5.0] [nil] [0.0] [0.0]]
              (calculate-bird-scarcity [:* 1 $count]))))))
-
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                      DATETIME EXTRACTION AND MANIPULATION                                      |
@@ -340,6 +339,78 @@
                         :order-by    [[:asc $name]]})
                      mt/rows))))))))
 
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; |                                                WEEKDAYS                                                        |
+;;; +----------------------------------------------------------------------------------------------------------------+
+;;; Background on weekdays in Metabase:
+;;; - Day 1 inside Metabase is defined by [[metabase.public-settings/start-of-week]]; default `:sunday`.
+;;; - Databases store this differently - 1 to 7, 0 to 6, hard-coded first day, based on the locale, ...
+;;; - Drivers handle that variation, and always expect 1 to 7 where 1 is the `start-of-week` day.
+;;; - Locales differ in what they consider the first day of the week; generally Sunday in the Americas, Monday in
+;;;   Europe, and Saturday in the Arabic-speaking world.
+;;;
+;;; Goals:
+;;; - `[:get-day-of-week "2024-04-19"]` returns numbers 1-7, consistent with the `start-of-week` setting.
+;;; - `[:day-name 4]` understands `4` based on `start-of-week`, and the correct *user* locale name is returned
+;;;   - Even if the user locale and the Metabase setting disagree about which is day 1!
+;;; - Site locale is irrelevant here.
+
+;;; In these tests, we have a series of specific dates from the checkins table that happen to run Monday to Sunday.
+;;; So in the query results:
+;;; - The **order** of the days is fixed, since we're sorting by date ascending.
+;;; - The **day numbers** are based on the `start-of-week` setting.
+;;; - The **day names** are based on the user locale.
+
+(def ^:private weekdays-english
+  ["Monday" "Tuesday" "Wednesday" "Thursday" "Friday" "Saturday" "Sunday"])
+
+(def ^:private weekdays-spanish
+  ["lunes" "martes" "miércoles" "jueves" "viernes" "sábado" "domingo"])
+
+(deftest ^:synchronized weekday-numbers-and-names-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
+    (doseq [first-day                [:sunday :monday :saturday]
+            ;; Adjusting the site locale to get different languages and first day of the week. It should be ignored!
+            site-locale              ["en_US" "es_ES"]
+            ;; For each of two languages and two regions, we check that:
+            ;; 1. the locale's first day of the week is ignored, and
+            ;; 2. the names are correctly translated for the *user* locale.
+            [user-locale exp-names] [;; US uses Sunday=1 in both English and Spanish.
+                                     ["en_US" weekdays-english]
+                                     ["es_US" weekdays-spanish]
+                                                    ;; Europe uses Monday=1 in both English and Spanish.
+                                     ["en_UK" weekdays-english]
+                                     ["es_ES" weekdays-spanish]]]
+      ;; Metabase queries should return weekday numbers based on the *setting*, not the locales.
+      ;; This fixed set of dates from checkins runs Monday to Sunday when sorted ascending by date.
+      (let [known-week  ["2013-02-18"  ; Monday
+                         "2013-02-19"  ; Tuesday
+                         "2013-02-20"  ; Wednesday
+                         "2013-02-21"  ; Thursday
+                         "2013-02-22"  ; Friday
+                         "2013-03-16"  ; Saturday
+                         "2013-03-16"  ; Saturday
+                         "2013-04-28"] ; Sunday
+            ;; The absolute weekdays are fixed above, but the numbering depends on the `start-of-week` setting.
+            exp-numbers (case first-day
+                          :saturday [3 4 5 6 7 1 2]
+                          :sunday   [2 3 4 5 6 7 1]
+                          :monday   [1 2 3 4 5 6 7])]
+        (mt/with-temporary-setting-values [start-of-week first-day
+                                           site-locale   site-locale]
+          (mt/with-user-locale user-locale
+            ;; Fetching [number name date].
+            (let [results (mt/formatted-rows [int str]
+                            (mt/run-mbql-query checkins
+                              {:fields      [[:expression "weekday"] [:expression "name"]]
+                               :expressions {:weekday [:get-day-of-week $date]
+                                             :name    [:day-name [:expression "weekday"]]}
+                               :filter      (into [:= $date] known-week)
+                               :order-by    [[:asc $date]]}))]
+              (testing "weekday numbers disregard site and user locales, and respect `start-of-week` setting"
+                (is (=? exp-numbers (map first results))))
+              (testing "weekday names are correctly translated by *user* locale, though weekday differs across locales"
+                (is (=? exp-names   (map second results)))))))))))
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                     JOINS                                                      |
@@ -363,7 +434,6 @@
                                                   [:field (mt/id :users :id) {:join-alias "users__via__user_id"}]]}]})
                  mt/rows
                  ffirst))))))
-
 
 ;;; +----------------------------------------------------------------------------------------------------------------+
 ;;; |                                                 MISC BUG FIXES                                                 |
@@ -421,10 +491,10 @@
 
 (deftest ^:parallel expression-with-slashes
   (mt/test-drivers (disj
-                     (mt/normal-drivers-with-feature :expressions)
+                    (mt/normal-drivers-with-feature :expressions)
                      ;; Slashes documented as not allowed in BQ
                      ;; https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical
-                     :bigquery-cloud-sdk)
+                    :bigquery-cloud-sdk)
     (testing "Make sure an expression with a / in its name works (#12305)"
       (is (= [[1 "Red Medicine"           4 10.0646 -165.374 3 4.0]
               [2 "Stout Burgers & Beers" 11 34.0996 -118.329 2 3.0]
@@ -439,7 +509,7 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "Can we use aggregations from previous steps in expressions (#12762)"
       (is (= [["20th Century Cafe" 2 2 0]
-              [ "25°" 2 2 0]
+              ["25°" 2 2 0]
               ["33 Taps" 2 2 0]]
              (mt/formatted-rows [str int int int]
                (mt/run-mbql-query venues
@@ -507,9 +577,9 @@
   (mt/test-drivers (mt/normal-drivers-with-feature :expressions)
     (testing "An expression whose name contains weird characters works properly"
       (let [query (mt/mbql-query venues
-                   {:expressions {"Refund Amount (?)" [:* $price -1]}
-                    :limit       1
-                    :order-by    [[:asc $id]]})]
+                    {:expressions {"Refund Amount (?)" [:* $price -1]}
+                     :limit       1
+                     :order-by    [[:asc $id]]})]
         (mt/with-native-query-testing-context query
           (is (= [[1 "Red Medicine" 4 10.0646 -165.374 3 -3]]
                  (mt/formatted-rows [int str int 4.0 4.0 int int]


### PR DESCRIPTION
The new expressions `:month-name`, `:quarter-name` and `:day-name`
return the (user localized) names for these units, given the
corresponding number.

For example, 4 yields `"Apr"`, `"Q4"` or `"Wednesday"` respectively.

The `column-extract` drill uses these new expressions, rather than
generating its own `:case` clauses for them.

Part of the follow-up for Extract Column epic #38964.
