### PR TITLE
Use dbname from database details instead of stats returned from Mongo

### DIFF
--- a/.github/workflows/drivers.yml
+++ b/.github/workflows/drivers.yml
@@ -281,7 +281,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-4-4-ee'
-        test-args: ":exclude-tags '[:mb/once]'"
+        test-args: ":exclude-tags '[:mb/once :mongo-sharded-cluster-tests]'"
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -327,7 +327,7 @@ jobs:
         uses: ./.github/actions/test-driver
         with:
           junit-name: 'be-tests-mongo-4-4-ee'
-          test-args: ":exclude-tags '[:mb/once]'"
+          test-args: ":exclude-tags '[:mb/once :mongo-sharded-cluster-tests]'"
       - name: Upload Test Results
         uses: ./.github/actions/upload-test-results
         if: always()
@@ -361,7 +361,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-5-0-ee'
-        test-args: ":exclude-tags '[:mb/once]'"
+        test-args: ":exclude-tags '[:mb/once :mongo-sharded-cluster-tests]'"
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -407,7 +407,7 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-5-0-ee'
-        test-args: ":exclude-tags '[:mb/once]'"
+        test-args: ":exclude-tags '[:mb/once :mongo-sharded-cluster-tests]'"
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()
@@ -444,7 +444,39 @@ jobs:
       uses: ./.github/actions/test-driver
       with:
         junit-name: 'be-tests-mongo-latest-ee'
-        test-args: ":exclude-tags '[:mb/once]'"
+        test-args: ":exclude-tags '[:mb/once :mongo-sharded-cluster-tests]'"
+    - name: Upload Test Results
+      uses: ./.github/actions/upload-test-results
+      if: always()
+      with:
+        input-path: ./target/junit/
+        output-name: ${{ github.job }}
+        bucket: ${{ vars.AWS_S3_TEST_RESULTS_BUCKET }}
+        aws-access-key-id: ${{ secrets.AWS_TEST_RESULTS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_TEST_RESULTS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ vars.AWS_REGION }}
+        trunk-api-token: ${{ secrets.TRUNK_API_TOKEN }}
+
+  be-tests-mongo-sharded-cluster-ee:
+    needs: files-changed
+    if: github.event.pull_request.draft == false && needs.files-changed.outputs.backend_all == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    env:
+      CI: 'true'
+      DRIVERS: mongo
+    services:
+      mongodb:
+        image: metabase/mongo-sharded-cluster:6
+        ports:
+          - "27017:17017"
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test MongoDB driver (Sharded cluster)
+      uses: ./.github/actions/test-driver
+      with:
+        junit-name: 'be-tests-mongo-sharded-cluster-ee'
+        test-args: ':only "[metabase.driver.mongo.sharded-cluster-test]"'
     - name: Upload Test Results
       uses: ./.github/actions/upload-test-results
       if: always()

--- a/modules/drivers/mongo/src/metabase/driver/mongo.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo.clj
@@ -49,7 +49,8 @@
   [_ db-details]
   (mongo.connection/with-mongo-client [^MongoClient c db-details]
     (let [db-names (mongo.util/list-database-names c)
-          db (mongo.util/database c (mongo.db/db-name db-details))
+          db-name (mongo.db/db-name db-details)
+          db (mongo.util/database c db-name)
           db-stats (mongo.util/run-command db {:dbStats 1} :keywordize true)]
       (and
        ;; 1. check db.dbStats command completes successfully
@@ -57,7 +58,7 @@
           1.0)
        ;; 2. check the database is actually on the server
        ;; (this is required because (1) is true even if the database doesn't exist)
-       (boolean (some #(= % (:db db-stats)) db-names))))))
+       (boolean (some #(= % db-name) db-names))))))
 
 (defmethod driver/humanize-connection-error-message
   :mongo

--- a/modules/drivers/mongo/test/metabase/driver/mongo/sharded_cluster_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/sharded_cluster_test.clj
@@ -1,0 +1,13 @@
+(ns ^:mongo-sharded-cluster-tests metabase.driver.mongo.sharded-cluster-test
+  (:require
+   [clojure.test :refer :all]
+   [metabase.driver :as driver]
+   [metabase.test :as mt]))
+
+(set! *warn-on-reflection* true)
+
+(deftest ^:synchronized can-connect-test
+  (mt/test-driver
+   :mongo
+   (testing "Mongo driver can connect to a sharded cluster"
+     (is (true? (driver/can-connect? :mongo (mt/db)))))))


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/38013

Linked issue is caused by differences in data returned by `stats` command of Mongo single node and sharded cluster deployments. Specifically, database name from command's result was used for further check. As sharded cluster's result has name stored under a different key, `driver/can-connect? :mongo` behaved incorrectly.

The method in question has database name available in db details. Name from details is used now, to avoid convoluting the code with conditional name extraction based on deployment type.

Apart from that, this PR adds Mongo sharded cluster deployment job, containing just one test at the moment. That test, running against the sharded cluster deployment, without the fix in place would fail.

Approach of testing against sharded cluster was discussed in [this slack thread](https://metaboat.slack.com/archives/C04DN5VRQM6/p1713383985047539).