### PR TITLE
Remove db portion of mongo connection string

### DIFF
--- a/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
+++ b/modules/drivers/mongo/src/metabase/driver/mongo/connection.clj
@@ -21,7 +21,7 @@
 
 (defn db-details->connection-string
   "Generate connection string from database details."
-  [{:keys [use-conn-uri conn-uri host port dbname additional-options use-srv ssl] :as _db-details}]
+  [{:keys [use-conn-uri conn-uri host port additional-options use-srv ssl] :as _db-details}]
   ;; Connection string docs:
   ;; http://mongodb.github.io/mongo-java-driver/4.11/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html
   (if use-conn-uri
@@ -33,7 +33,6 @@
      host
      (when (and (not use-srv) (some? port)) (str ":" port))
      "/"
-     dbname
      "?connectTimeoutMS=" (driver.u/db-connection-timeout-ms)
      "&serverSelectionTimeoutMS=" (driver.u/db-connection-timeout-ms)
      (when ssl "&ssl=true")

--- a/modules/drivers/mongo/test/metabase/driver/mongo/connection_test.clj
+++ b/modules/drivers/mongo/test/metabase/driver/mongo/connection_test.clj
@@ -38,7 +38,7 @@
                     :use-srv true}]
     (testing "mongo+srv connection string used when :use-srv is thruthy"
       (is (str/includes? (mongo.connection/db-details->connection-string db-details)
-                         "mongodb+srv://test-host.place.com/datadb"))
+                         "mongodb+srv://test-host.place.com/"))
       (let [settings (mongo.connection/db-details->mongo-client-settings db-details)
             ^MongoCredential credential (.getCredential settings)]
         (is (= "test-user" (.getUserName credential)))


### PR DESCRIPTION
Closes #38966

_Probable cause_ of the failure is database name containing non encoded chars.

This PR removes the `<database>` portion of Mongo connection string. Authentication is done against database provided with the credentials. This connection string option sets the _default_ database to login ([docs](https://mongodb.github.io/mongo-java-driver/5.0/apidocs/mongodb-driver-core/com/mongodb/ConnectionString.html)).

Existing tests ensure that we are able to execute queries, do sync, etc. without this option set.

