### PR TITLE
Bump dompurify

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9640,10 +9640,10 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^2.2.0:
-  version "2.4.5"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.4.5.tgz#0e89a27601f0bad978f9a924e7a05d5d2cccdd87"
-  integrity sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA==
+dompurify@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.0.tgz#13b1115d79b9340e6db80b4624653f665885b15f"
+  integrity sha512-5RXhAXSCrKTqt9pSbobT9PVRX+oPpENplTZqCiK1l0ya+ZOzwo9kqsGLbYRsAhzIiLCwKEy99XKSSrqnRTLVcw==
 
 domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"


### PR DESCRIPTION
Fix [this alert](https://github.com/metabase/metabase/security/code-scanning/239)

#### How to verify
`dompurify` is an optional dependency for `jspdf` which we used for exporting dashboards to PDF. So testing that dashboards could be exported to PDF should suffice. I tested that it worked on my end.