### PR TITLE
Be more consistent with borders and avoid double borders

### DIFF
--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -255,6 +255,7 @@ export function AggregationPicker({
         // disable scrollbars inside the list
         style={{ overflow: "visible" }}
         maxHeight={Infinity}
+        withBorders
       />
     </Root>
   );

--- a/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
+++ b/frontend/src/metabase/common/components/AggregationPicker/AggregationPicker.tsx
@@ -46,6 +46,7 @@ type Section = {
   key: string;
   items: ListItem[];
   icon?: string;
+  type?: string;
 };
 
 function isOperatorListItem(item: ListItem): item is OperatorListItem {
@@ -122,6 +123,7 @@ export function AggregationPicker({
         name: t`Custom Expression`,
         items: [],
         icon: "sum",
+        type: "action",
       });
     }
 

--- a/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
+++ b/frontend/src/metabase/common/components/QueryColumnPicker/QueryColumnPicker.tsx
@@ -203,6 +203,7 @@ export function QueryColumnPicker({
         // Prefer using a11y role selectors
         itemTestId="dimension-list-item"
         globalSearch
+        withBorders
       />
     </DelayGroup>
   );

--- a/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionList.jsx
@@ -100,6 +100,8 @@ export default class AccordionList extends Component {
 
     itemTestId: PropTypes.string,
     "data-testid": PropTypes.string,
+
+    withBorders: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -611,6 +613,7 @@ export default class AccordionList extends Component {
       className,
       sections,
       role,
+      withBorders,
       "data-testid": testId,
     } = this.props;
     const { cursor, scrollToAlignment } = this.state;
@@ -651,6 +654,7 @@ export default class AccordionList extends Component {
               canToggleSections={this.canToggleSections()}
               toggleSection={this.toggleSection}
               hasCursor={this.isRowSelected(rows[index])}
+              withBorders={withBorders}
             />
           ))}
         </AccordionListRoot>
@@ -722,6 +726,7 @@ export default class AccordionList extends Component {
                   sectionIsExpanded={this.isSectionExpanded}
                   canToggleSections={this.canToggleSections()}
                   toggleSection={this.toggleSection}
+                  withBorders={withBorders}
                 />
               )}
             </CellMeasurer>

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -48,6 +48,7 @@ export const AccordionListCell = ({
   getItemStyles,
   searchInputProps,
   hasCursor,
+  withBorders,
 }) => {
   const {
     type,
@@ -326,8 +327,8 @@ export const AccordionListCell = ({
       className={cx(section.className, {
         [ListS.ListSectionExpanded]: sectionIsExpanded(sectionIndex),
         [ListS.ListSectionToggleAble]: canToggleSections,
-        [styles.borderTop]: borderTop,
-        [styles.borderBottom]: borderBottom,
+        [styles.borderTop]: withBorders && borderTop,
+        [styles.borderBottom]: withBorders && borderBottom,
       })}
     >
       {content}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -11,9 +11,9 @@ import CS from "metabase/css/core/index.css";
 import { color } from "metabase/lib/colors";
 import { Icon, Box } from "metabase/ui";
 
+import styles from "./AccordionListCell.module.css";
 import {
   ListCellItem,
-  ListCellHeader,
   FilterContainer,
   Content,
   IconWrapper,
@@ -59,6 +59,9 @@ export const AccordionListCell = ({
     isLastSection,
   } = row;
   let content;
+  let borderTop;
+  let borderBottom;
+
   if (type === "header") {
     if (alwaysExpanded) {
       content = (
@@ -79,11 +82,16 @@ export const AccordionListCell = ({
     } else {
       const icon = renderSectionIcon(section);
       const name = section.name;
+
+      borderTop =
+        section.type === "back" ||
+        section.type === "action" ||
+        section.items?.length > 0;
+      borderBottom = section.type === "back";
+
       content = (
-        <ListCellHeader
+        <div
           data-element-id="list-section-header"
-          borderTop={section.type === "back" || section.items?.length > 0}
-          borderBottom={!isLastSection && section.type === "back"}
           className={cx(
             ListS.ListSectionHeader,
             CS.px2,
@@ -136,16 +144,17 @@ export const AccordionListCell = ({
               />
             </span>
           )}
-        </ListCellHeader>
+        </div>
       );
     }
   } else if (type === "action") {
     const icon = renderSectionIcon(section);
     const name = section.name;
+    borderTop = true;
+    borderBottom = !isLastSection;
+
     content = (
-      <ListCellHeader
-        borderTop
-        borderBottom={!isLastSection}
+      <div
         className={cx(
           "List-section-header",
           CS.px2,
@@ -182,7 +191,7 @@ export const AccordionListCell = ({
         <IconWrapper>
           <Icon name="chevronright" size={12} />
         </IconWrapper>
-      </ListCellHeader>
+      </div>
     );
   } else if (type === "header-hidden") {
     content = <div className={CS.my1} />;
@@ -199,6 +208,7 @@ export const AccordionListCell = ({
       </div>
     );
   } else if (type === "search") {
+    borderBottom = true;
     content = (
       <FilterContainer>
         <ListSearchField
@@ -305,6 +315,8 @@ export const AccordionListCell = ({
       className={cx(section.className, {
         [ListS.ListSectionExpanded]: sectionIsExpanded(sectionIndex),
         [ListS.ListSectionToggleAble]: canToggleSections,
+        [styles.borderTop]: borderTop,
+        [styles.borderBottom]: borderBottom,
       })}
     >
       {content}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -156,7 +156,7 @@ export const AccordionListCell = ({
     content = (
       <div
         className={cx(
-          "List-section-header",
+          ListS.ListSectionHeader,
           CS.px2,
           CS.py2,
           CS.flex,
@@ -176,13 +176,23 @@ export const AccordionListCell = ({
       >
         {icon && (
           <span
-            className={cx(CS.mr1, CS.flex, CS.alignCenter, "List-section-icon")}
+            className={cx(
+              CS.mr1,
+              CS.flex,
+              CS.alignCenter,
+              ListS.ListSectionIcon,
+            )}
           >
             {icon}
           </span>
         )}
         {name && (
-          <h3 className={cx("List-section-title", CS.textWrap)}>{name}</h3>
+          <h3
+            data-element-id="list-section-title"
+            className={cx(ListS.ListSectionTitle, CS.textWrap)}
+          >
+            {name}
+          </h3>
         )}
         {showSpinner(section) && (
           <Box ml="0.5rem">

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.jsx
@@ -162,6 +162,7 @@ export const AccordionListCell = ({
           CS.flex,
           CS.alignCenter,
           CS.hoverParent,
+          styles.action,
           {
             "List-section-header--cursor": hasCursor,
             [CS.cursorPointer]: canToggleSections,

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.module.css
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.module.css
@@ -4,6 +4,10 @@
   .borderBottom + & {
     border-top: none;
   }
+
+  &:first-child {
+    border-top: none;
+  }
 }
 
 .borderBottom {

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.module.css
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.module.css
@@ -1,5 +1,5 @@
 .borderTop {
-  border-top: 1px solid var(--color-bg-medium);
+  border-top: 1px solid var(--color-border);
 
   .borderBottom + & {
     border-top: none;
@@ -11,7 +11,7 @@
 }
 
 .borderBottom {
-  border-bottom: 1px solid var(--color-bg-medium);
+  border-bottom: 1px solid var(--color-border);
 
   &:last-child {
     border-bottom: none;

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.module.css
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.module.css
@@ -10,7 +10,7 @@
   border-bottom: 1px solid var(--color-bg-medium);
 
   &:last-child {
-    border-top: none;
+    border-bottom: none;
   }
 }
 

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.module.css
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.module.css
@@ -13,3 +13,11 @@
     border-top: none;
   }
 }
+
+.action {
+  color: var(--color-text-dark);
+
+  &:hover {
+    color: inherit;
+  }
+}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.module.css
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.module.css
@@ -1,0 +1,15 @@
+.borderTop {
+  border-top: 1px solid var(--color-bg-medium);
+
+  .borderBottom + & {
+    border-top: none;
+  }
+}
+
+.borderBottom {
+  border-bottom: 1px solid var(--color-bg-medium);
+
+  &:last-child {
+    border-top: none;
+  }
+}

--- a/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
+++ b/frontend/src/metabase/core/components/AccordionList/AccordionListCell.styled.tsx
@@ -1,26 +1,10 @@
 import styled from "@emotion/styled";
 
-import { alpha, color } from "metabase/lib/colors";
+import { alpha } from "metabase/lib/colors";
 
 export interface ListCellItemProps {
   isClickable: boolean;
 }
-
-export const ListCellHeader = styled.div<{
-  borderTop?: boolean;
-  borderBottom?: boolean;
-}>`
-  border: none;
-
-  border: 0px solid ${color("bg-medium")};
-
-  border-bottom-width: ${props => (props.borderBottom ? 1 : 0)}px;
-  border-top-width: ${props => (props.borderTop ? 1 : 0)}px;
-
-  li:first-child & {
-    border-top: none;
-  }
-`;
 
 export const ListCellItem = styled.div<ListCellItemProps>`
   border-color: ${props => props.isClickable && alpha("accent2", 0.2)};

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.styled.tsx
@@ -95,6 +95,7 @@ export const EmptyStateContainer = styled.div`
 
 export const TableSearchContainer = styled.div`
   padding: 0.5rem;
+  border-bottom: 1px solid ${color("border")};
 `;
 
 export const TriggerContainer = styled.div`

--- a/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
+++ b/frontend/src/metabase/querying/components/FilterPicker/FilterColumnPicker/FilterColumnPicker.tsx
@@ -128,6 +128,7 @@ export function FilterColumnPicker({
         itemTestId="dimension-list-item"
         searchProp={["name", "displayName"]}
         globalSearch
+        withBorders
       />
     </DelayGroup>
   );


### PR DESCRIPTION
The `AccordionList` component is used in a lot of places, often with ad-hoc ways of creating different sections and headings.

We recently tried adding borders to sections, actions and headers to clarify what content belongs together.

However, due to the inconsistency in how the component gets used, some visual bugs have popped up, like double borders or missing borders.

For example: some components use an empty section to denote an action. We want this action button to receive borders. Other components however render items as sections that should not receive borders. So, without more context it is impossible to correctly assign borders. 



This PR:
- attempts to be more consistent by relying on CSS sibling selectors to avoid double borders from rendering.
- adds missing borders to components that use custom elements in the accordion list
- lock this behaviour behind a prop to reduce the blast radius

### After

<img width="366" alt="Screenshot 2024-04-18 at 11 49 40" src="https://github.com/metabase/metabase/assets/1250185/5ef183ea-0b6f-4e13-ab99-5553f6daf2f1">
<img width="376" alt="Screenshot 2024-04-18 at 11 49 44" src="https://github.com/metabase/metabase/assets/1250185/61268fab-26b8-48a0-8dde-5b6b48e932f8">
<img width="367" alt="Screenshot 2024-04-18 at 11 49 48" src="https://github.com/metabase/metabase/assets/1250185/a4035e9e-722e-46f8-9959-a74ce056539a">
<img width="348" alt="Screenshot 2024-04-18 at 11 49 53" src="https://github.com/metabase/metabase/assets/1250185/b2c3ffb4-5fe0-4414-97ae-7e303af2cb49">


Closes https://github.com/metabase/metabase/issues/41403

