### PR TITLE
add toast notification after the feedback

### DIFF
--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { t } from "ttag";
 
 import { updateSetting } from "metabase/admin/settings/settings";
 import { useSendProductFeedbackMutation } from "metabase/api/product-feedback";
@@ -6,6 +7,7 @@ import { useSetting } from "metabase/common/hooks";
 import { getPlan } from "metabase/common/utils/plan";
 import { useDispatch, useSelector } from "metabase/lib/redux";
 import { isEEBuild } from "metabase/lib/utils";
+import { addUndo } from "metabase/redux/undo";
 import { getDocsUrl, getSetting } from "metabase/selectors/settings";
 
 import { EmbedHomepageView } from "./EmbedHomepageView";
@@ -82,6 +84,11 @@ export const EmbedHomepage = () => {
       email: email,
       source: "embedding-homepage-dismiss",
     });
+    if (comment || email) {
+      dispatch(
+        addUndo({ message: t`Your feedback was submitted, thank you.` }),
+      );
+    }
   };
 
   return (

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/common.unit.spec.tsx
@@ -176,6 +176,10 @@ describe("EmbedHomepage (OSS)", () => {
       });
 
       await waitForElementToBeRemoved(() => queryFeedbackModal());
+
+      expect(
+        screen.queryByText("Your feedback was submitted, thank you."),
+      ).not.toBeInTheDocument();
     });
 
     it("should send feedback when submitting the modal", async () => {
@@ -203,6 +207,10 @@ describe("EmbedHomepage (OSS)", () => {
       });
 
       await waitForElementToBeRemoved(() => queryFeedbackModal());
+
+      expect(
+        screen.getByText("Your feedback was submitted, thank you."),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/tests/setup.tsx
@@ -49,10 +49,15 @@ export async function setup({
     setupEnterprisePlugins();
   }
 
-  renderWithProviders(<Route path="/" component={EmbedHomepage} />, {
-    storeInitialState: state,
-    withRouter: true,
-  });
+  renderWithProviders(
+    <Route path="/" component={EmbedHomepage} />,
+
+    {
+      storeInitialState: state,
+      withRouter: true,
+      withUndos: true,
+    },
+  );
 }
 
 export const getLastHomepageSettingSettingCall = () =>


### PR DESCRIPTION
Part of milestone 4 of  [[Epic] Initial homepage experience for embedding admins](https://github.com/metabase/metabase/issues/40005)

### Description

Design: https://www.figma.com/file/UFay4YjWyUMyl23T1cXzeC/Meet-first-time-embedders-at-the-door-with-a-dashboard?type=design&node-id=2760-10317&mode=design&t=psYfLAgflNulDma7-4
To see the specs zoom out a bit on figma, but basically it shows up only if you send the feedback (so no when it skips it because both inputs are empty)



