### PR TITLE
add withUndos option to renderWithProviders to render Undos during …

### DIFF
--- a/frontend/test/__support__/ui.tsx
+++ b/frontend/test/__support__/ui.tsx
@@ -13,6 +13,7 @@ import { routerReducer, routerMiddleware } from "react-router-redux";
 import _ from "underscore";
 
 import { Api } from "metabase/api";
+import { UndoListing } from "metabase/containers/UndoListing";
 import mainReducers from "metabase/reducers-main";
 import publicReducers from "metabase/reducers-public";
 import { ThemeProvider } from "metabase/ui";
@@ -32,6 +33,7 @@ export interface RenderWithProvidersOptions {
   storeInitialState?: Partial<State>;
   withRouter?: boolean;
   withDND?: boolean;
+  withUndos?: boolean;
   customReducers?: ReducerObject;
 }
 
@@ -48,6 +50,7 @@ export function renderWithProviders(
     storeInitialState = {},
     withRouter = false,
     withDND = false,
+    withUndos = false,
     customReducers,
     ...options
   }: RenderWithProvidersOptions = {},
@@ -95,6 +98,7 @@ export function renderWithProviders(
       history={history}
       withRouter={withRouter}
       withDND={withDND}
+      withUndos={withUndos}
     />
   );
 
@@ -116,12 +120,14 @@ function Wrapper({
   history,
   withRouter,
   withDND,
+  withUndos,
 }: {
   children: React.ReactElement;
   store: any;
   history?: History;
   withRouter: boolean;
   withDND: boolean;
+  withUndos?: boolean;
 }): JSX.Element {
   return (
     <Provider store={store}>
@@ -130,6 +136,7 @@ function Wrapper({
           <MaybeRouter hasRouter={withRouter} history={history}>
             {children}
           </MaybeRouter>
+          {withUndos && <UndoListing />}
         </ThemeProvider>
       </MaybeDNDProvider>
     </Provider>


### PR DESCRIPTION

### Description

This will allow us to test toast/undos easily in jest tests.

I added it behind a flag to not render the component when we don't need it, even though it's a small component we have a lot of tests

### How to verify

[This test](https://github.com/metabase/metabase/pull/41575/files#diff-bfaa39e7d0397935ebf6b7a70dad5261af7438cd0a8e2ec185094e537f4e05efR211-R213) in a PR with this code should pass