### PR TITLE
React 18 Upgrade - Unit Tests

### DIFF
--- a/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/DatabasesPermissionsPage/DatabasesPermissionsPage.unit.spec.tsx
@@ -13,10 +13,10 @@ import {
   screen,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
+import { delay } from "__support__/utils";
 import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
 import DatabasesPermissionsPage from "metabase/admin/permissions/pages/DatabasePermissionsPage/DatabasesPermissionsPage";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload";
-import { delay } from "metabase/lib/promise";
 import { PLUGIN_ADMIN_PERMISSIONS_TABLE_GROUP_ROUTES } from "metabase/plugins";
 import { createMockGroup } from "metabase-types/api/mocks/group";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";

--- a/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
+++ b/frontend/src/metabase/admin/permissions/test/GroupsPermissionsPage/GroupsPermissionsPage.unit.spec.tsx
@@ -13,10 +13,10 @@ import {
   screen,
   waitForLoaderToBeRemoved,
 } from "__support__/ui";
+import { delay } from "__support__/utils";
 import DataPermissionsPage from "metabase/admin/permissions/pages/DataPermissionsPage/DataPermissionsPage";
 import GroupsPermissionsPage from "metabase/admin/permissions/pages/GroupDataPermissionsPage/GroupsPermissionsPage";
 import { BEFORE_UNLOAD_UNSAVED_MESSAGE } from "metabase/hooks/use-before-unload";
-import { delay } from "metabase/lib/promise";
 import { PLUGIN_ADMIN_PERMISSIONS_TABLE_ROUTES } from "metabase/plugins";
 import { createMockGroup } from "metabase-types/api/mocks/group";
 import { createSampleDatabase } from "metabase-types/api/mocks/presets";

--- a/frontend/src/metabase/api/action.ts
+++ b/frontend/src/metabase/api/action.ts
@@ -1,6 +1,5 @@
 import type { GetActionRequest, WritebackAction } from "metabase-types/api";
 
-//
 import { Api } from "./api";
 import { idTag } from "./tags";
 

--- a/frontend/src/metabase/containers/AdHocQuestionLoader.unit.spec.js
+++ b/frontend/src/metabase/containers/AdHocQuestionLoader.unit.spec.js
@@ -1,7 +1,7 @@
 import { render } from "@testing-library/react";
 
+import { delay } from "__support__/utils";
 import { AdHocQuestionLoader } from "metabase/containers/AdHocQuestionLoader";
-import { delay } from "metabase/lib/promise";
 import Question from "metabase-lib/v1/Question";
 import * as ML_Urls from "metabase-lib/v1/urls";
 
@@ -22,7 +22,7 @@ describe("AdHocQuestionLoader", () => {
     const q = Question.create({ databaseId: 1, tableId: 2 });
     const questionHash = ML_Urls.getUrl(q).match(/(#.*)/)[1];
 
-    await render(
+    render(
       <AdHocQuestionLoader
         questionHash={questionHash}
         loadMetadataForCard={loadMetadataSpy}

--- a/frontend/src/metabase/lib/redux/utils.unit.spec.js
+++ b/frontend/src/metabase/lib/redux/utils.unit.spec.js
@@ -1,4 +1,4 @@
-import { delay } from "metabase/lib/promise";
+import { delay } from "__support__/utils";
 
 import { fetchData, updateData, mergeEntities } from "./utils";
 

--- a/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
+++ b/frontend/src/metabase/query_builder/components/DataSelector/DataSelector.unit.spec.js
@@ -3,7 +3,7 @@ import fetchMock from "fetch-mock";
 
 import { createMockMetadata } from "__support__/metadata";
 import { getIcon, render, renderWithProviders, screen } from "__support__/ui";
-import { delay } from "metabase/lib/promise";
+import { delay } from "__support__/utils";
 import { UnconnectedDataSelector as DataSelector } from "metabase/query_builder/components/DataSelector";
 import {
   createMockDatabase,
@@ -396,7 +396,7 @@ describe("DataSelector", () => {
     expect(screen.getByText("Table in First Schema")).toBeInTheDocument();
   });
 
-  it("should open database picker with correct database selected", async () => {
+  it("should open database picker with correct database selected", () => {
     render(
       <DataSelector
         steps={["DATABASE"]}

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization-themed.unit.spec.tsx
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization-themed.unit.spec.tsx
@@ -1,6 +1,6 @@
 import { renderWithProviders, screen } from "__support__/ui";
+import { delay } from "__support__/utils";
 import { NumberColumn, StringColumn } from "__support__/visualizations";
-import { delay } from "metabase/lib/promise";
 import registerVisualizations from "metabase/visualizations/register";
 import { createMockCard } from "metabase-types/api/mocks";
 

--- a/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.js
+++ b/frontend/src/metabase/visualizations/components/Visualization/Visualization.unit.spec.js
@@ -1,7 +1,7 @@
 import { renderWithProviders, screen } from "__support__/ui";
+import { delay } from "__support__/utils";
 import { NumberColumn, StringColumn } from "__support__/visualizations";
 import { color } from "metabase/lib/colors";
-import { delay } from "metabase/lib/promise";
 import Visualization from "metabase/visualizations/components/Visualization";
 import registerVisualizations from "metabase/visualizations/register";
 import { createMockCard } from "metabase-types/api/mocks";

--- a/frontend/test/__support__/utils.ts
+++ b/frontend/test/__support__/utils.ts
@@ -1,4 +1,12 @@
+import { act } from "./ui";
+
 export const getNextId = (() => {
   let id = 0;
   return () => ++id;
 })();
+
+export async function delay(duration: number) {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, duration));
+  });
+}


### PR DESCRIPTION
Closes #43373

### Description

This PR updates RTL to v15 fixes to gain React 18 support and updates our tests to work with both RTL v15 & React 18.

All backwards compatible changes were already merged / backported in #43375. These changes were the remaining changes that shouldn't be backported.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
