### PR TITLE
Rework view-data migration for efficiency

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -5895,7 +5895,12 @@ databaseChangeLog:
       comment: New `view-data` permission
       changes:
         - sqlFile:
+            dbms: postgresql,h2
             path: permissions/view_data.sql
+            relativeToChangelogFile: true
+        - sqlFile:
+            dbms: mysql,mariadb
+            path: permissions/mysql_view_data.sql
             relativeToChangelogFile: true
       rollback:
         - sqlFile:

--- a/resources/migrations/permissions/mysql_view_data.sql
+++ b/resources/migrations/permissions/mysql_view_data.sql
@@ -28,14 +28,14 @@ SELECT
           SELECT
             group_id,
             db_id,
-            CAST(NULL AS INTEGER) AS table_id
+            CAST(NULL AS UNSIGNED) AS table_id
           FROM
             connection_impersonations
           UNION
           SELECT
             group_id,
             db_id,
-            CAST(NULL AS INTEGER) AS table_id
+            CAST(NULL AS UNSIGNED) AS table_id
           FROM
             data_permissions
           WHERE
@@ -44,7 +44,7 @@ SELECT
           UNION
           SELECT
             group_id,
-            CAST(NULL AS INTEGER) as db_id,
+            CAST(NULL AS UNSIGNED) as db_id,
             table_id
           FROM
             sandboxes
@@ -212,14 +212,13 @@ WHERE
 
 
 -- Remove table-level view-data permissions for groups that have DB-level permissions set
-DELETE FROM data_permissions dp
-USING (
+DELETE dp
+FROM data_permissions dp
+JOIN (
   SELECT group_id, db_id
   FROM data_permissions
   WHERE table_id IS NULL
     AND perm_type = 'perms/view-data'
-) dp2
-WHERE dp.group_id = dp2.group_id
-  AND dp.db_id = dp2.db_id
-  AND dp.table_id IS NOT NULL
+) as dp2 ON dp.group_id = dp2.group_id AND dp.db_id = dp2.db_id
+WHERE dp.table_id IS NOT NULL
   AND dp.perm_type = 'perms/view-data';

--- a/resources/migrations/permissions/view_data.sql
+++ b/resources/migrations/permissions/view_data.sql
@@ -212,14 +212,16 @@ WHERE
 
 
 -- Remove table-level view-data permissions for groups that have DB-level permissions set
-DELETE FROM data_permissions dp
-USING (
-  SELECT group_id, db_id
-  FROM data_permissions
-  WHERE table_id IS NULL
-    AND perm_type = 'perms/view-data'
-) dp2
-WHERE dp.group_id = dp2.group_id
-  AND dp.db_id = dp2.db_id
-  AND dp.table_id IS NOT NULL
-  AND dp.perm_type = 'perms/view-data';
+DELETE FROM data_permissions
+WHERE
+  (group_id, db_id) IN (
+    SELECT
+      group_id,
+      db_id
+    FROM
+      data_permissions
+    WHERE
+      table_id IS NULL
+      AND perm_type = 'perms/view-data'
+  )
+AND table_id IS NOT NULL;

--- a/resources/migrations/permissions/view_data.sql
+++ b/resources/migrations/permissions/view_data.sql
@@ -224,4 +224,5 @@ WHERE
       table_id IS NULL
       AND perm_type = 'perms/view-data'
   )
+AND perm_type = 'perms/view-data'
 AND table_id IS NOT NULL;

--- a/resources/migrations/permissions/view_data.sql
+++ b/resources/migrations/permissions/view_data.sql
@@ -70,6 +70,15 @@ WHERE
 
 
 -- If all tables in a DB have the same view-data permission, insert a DB-level view-data permission instead
+INSERT INTO
+  data_permissions (
+    group_id,
+    perm_type,
+    db_id,
+    schema_name,
+    table_id,
+    perm_value
+  )
 WITH
   ConsistentPermissions AS (
     SELECT
@@ -86,15 +95,6 @@ WITH
       db_id
     HAVING
       COUNT(DISTINCT perm_value) = 1
-  )
-INSERT INTO
-  data_permissions (
-    group_id,
-    perm_type,
-    db_id,
-    schema_name,
-    table_id,
-    perm_value
   )
 SELECT
   cp.group_id,

--- a/resources/migrations/permissions/view_data.sql
+++ b/resources/migrations/permissions/view_data.sql
@@ -211,7 +211,7 @@ WHERE
   );
 
 
--- Remove table-level view-data permissions for groups that have DB-level permissions
+-- Remove table-level view-data permissions for groups that have DB-level permissions set
 DELETE FROM data_permissions
 WHERE
   (group_id, db_id) IN (
@@ -224,4 +224,5 @@ WHERE
       table_id IS NULL
       AND perm_type = 'perms/view-data'
   )
+  AND perm_type = 'perms/view-data'
   AND table_id IS NOT NULL;

--- a/resources/migrations/permissions/view_data.sql
+++ b/resources/migrations/permissions/view_data.sql
@@ -12,113 +12,100 @@ INSERT INTO
     perm_value
   )
 SELECT
-  pg.id AS group_id,
+  dp.group_id,
   'perms/view-data' AS perm_type,
-  mt.db_id AS db_id,
-  mt.schema AS schema_name,
-  mt.id AS table_id,
+  dp.db_id,
+  dp.schema_name,
+  dp.table_id,
   CASE
-    WHEN EXISTS (
-      -- If the table has `no-self-service`, convert it to `legacy-no-self-service`
+    WHEN dp.perm_value = 'no-self-service'
+    AND EXISTS (
       SELECT
         1
       FROM
-        data_permissions dp
+        permissions_group_membership pgm
+        JOIN (
+          SELECT
+            group_id,
+            db_id,
+            CAST(NULL AS INTEGER) AS table_id
+          FROM
+            connection_impersonations
+          UNION
+          SELECT
+            group_id,
+            db_id,
+            CAST(NULL AS INTEGER) AS table_id
+          FROM
+            data_permissions
+          WHERE
+            perm_value = 'block'
+            AND table_id IS NULL
+          UNION
+          SELECT
+            group_id,
+            CAST(NULL AS INTEGER),
+            table_id
+          FROM
+            sandboxes
+        ) AS sp ON pgm.group_id = sp.group_id
       WHERE
-        dp.group_id = pg.id
-        AND dp.db_id = mt.db_id
-        AND dp.table_id = mt.id
-        AND dp.perm_type = 'perms/data-access'
-        AND dp.perm_value = 'no-self-service'
+        pgm.group_id <> dp.group_id
+        AND (
+          sp.db_id IS NULL
+          OR sp.db_id = dp.db_id
+        )
+        AND (
+          sp.table_id IS NULL
+          OR sp.table_id = dp.table_id
+        )
     ) THEN 'legacy-no-self-service'
-    -- Otherwise set the table to `unrestricted`. Sandboxed tables are
-    -- `unrestricted` in `data_permissions`and have the sandbox definition
-    -- stored separately
     ELSE 'unrestricted'
   END AS perm_value
 FROM
-  permissions_group pg
-  CROSS JOIN metabase_table mt
+  data_permissions dp
 WHERE
-  pg.name != 'Administrators'
-  -- Only select group/table combinations where table-level `data-access` perms
-  -- are set AND there is at least one `no-self-service` table in the DB that
-  -- cannot be automatically migrated to `unrestricted`
-  AND EXISTS (
+  dp.perm_type = 'perms/data-access'
+  AND dp.table_id IS NOT NULL;
+
+
+-- If all tables in a DB have the same view-data permission, insert a DB-level view-data permission instead
+WITH
+  ConsistentPermissions AS (
     SELECT
-      1
+      group_id,
+      db_id,
+      MIN(perm_value) AS common_value
     FROM
-      data_permissions dp
+      data_permissions
     WHERE
-      dp.group_id = pg.id
-      AND dp.db_id = mt.db_id
-      AND dp.table_id IS NOT NULL
-      AND dp.perm_type = 'perms/data-access'
-      AND dp.perm_value = 'no-self-service'
+      perm_type = 'perms/view-data'
+      AND table_id IS NOT NULL
+    GROUP BY
+      group_id,
+      db_id
+    HAVING
+      COUNT(DISTINCT perm_value) = 1
   )
-  AND EXISTS (
-    SELECT
-      1
-    FROM
-      permissions_group_membership pgm
-    WHERE
-      pgm.group_id <> pg.id
-      AND pgm.user_id IN (
-        SELECT
-          user_id
-        FROM
-          permissions_group_membership pgm_inner
-        WHERE
-          pgm_inner.group_id = pg.id
-      )
-    AND (
-      EXISTS (
-        -- User in another group with block perms for the DB
-        SELECT
-          1
-        FROM
-          data_permissions dp
-        WHERE
-          dp.group_id = pgm.group_id
-          AND dp.db_id = mt.db_id
-          AND dp.table_id IS NULL
-          AND dp.perm_value = 'block'
-      )
-      OR EXISTS (
-        -- User in another group with impersonation for the DB
-        SELECT
-          1
-        FROM
-          connection_impersonations ci
-        WHERE
-          ci.group_id = pgm.group_id
-          AND ci.db_id = mt.db_id
-      )
-      OR EXISTS (
-        -- User in another group with sandboxing for any table in the DB
-        -- that has `no-self-service` perms
-        SELECT
-          1
-        FROM
-          sandboxes s
-          JOIN metabase_table mt_inner ON mt_inner.id = s.table_id
-        WHERE
-          s.group_id = pgm.group_id
-          AND mt_inner.db_id = mt.db_id
-          AND s.table_id IN (
-            SELECT
-              table_id
-            FROM
-              data_permissions dp_inner
-            WHERE
-              dp_inner.group_id = pg.id
-              AND dp_inner.perm_type = 'perms/data-access'
-              AND dp_inner.perm_value = 'no-self-service'
-              AND dp_inner.table_id IS NOT NULL
-          )
-       )
+INSERT INTO
+  data_permissions (
+    group_id,
+    perm_type,
+    db_id,
+    schema_name,
+    table_id,
+    perm_value
   )
-);
+SELECT
+  cp.group_id,
+  'perms/view-data',
+  cp.db_id,
+  NULL,
+  NULL,
+  cp.common_value
+FROM
+  ConsistentPermissions cp;
+
 
 -- Insert DB-level view data permissions for all groups & DBs that don't have
 -- table-level permissions set.
@@ -222,3 +209,19 @@ WHERE
       AND dp.db_id = md.id
       AND dp.perm_type = 'perms/view-data'
   );
+
+
+-- Remove table-level view-data permissions for groups that have DB-level permissions
+DELETE FROM data_permissions
+WHERE
+  (group_id, db_id) IN (
+    SELECT
+      group_id,
+      db_id
+    FROM
+      data_permissions
+    WHERE
+      table_id IS NULL
+      AND perm_type = 'perms/view-data'
+  )
+  AND table_id IS NOT NULL;


### PR DESCRIPTION
This PR restructures the SQL migration which populates the new `view-data` permission in order to avoid a hot spot which was causing stats to timeout when deploying the migration.

Specifically, when we're detecting whether to set `legacy-no-self-service` for a particular group & table combination, we need to check these conditions:
* If any user in the group is also in another group with:
 * `block` data permissions for the DB
 * a connection impersonation policy for the DB 
 * a sandboxing policy for the table

Previously, this was happening in the `WHERE` clause of a cross-join between the `permissions_group` and `metabase_table`, which turned out to be very inefficient. The cross join itself wasn't a huge problem, which is why earlier testing didn't expose this, but adding these conditions slows it down significantly.

I've restructured this script into several distinct operations:
1. First, we insert a `view-data` permission row for every existing `data-access` row that was set on an individual table. To check whether `legacy-no-self-service` should be set, we join `data_permissions` against a subquery that `UNION`s the relevant columns from `data_permissions`, `sandboxes` and `connection_impersonations`. This is a much faster process.
2. Then, we look for any tables in a DB which are set to all the same values and insert a DB-level row with that value.
3. Then we set DB-level `view-data` permissions for any DBs that previously had DB-level `data-access` permissions. This is unchanged from the previous implementation because it wasn't seeing the same performance issues.
4. Finally, we delete any table-level rows which also have DB-level rows set. (This is necessary as clean-up from step 2)

I've also had to split the `view_data` migration into two versions, one for postgres & h2 and one for mysql & mariadb due to syntax compatibility issues.

**Timing data**
This data is collected from running both the `view_data` and the (unchanged) `create_queries` migrations on a local Postgres app DB populated with a dump of data from stats. tl;dr: I've cut the runtime down from 2 minutes to 3 seconds.

Previous migration:
```
metabase=# \i resources/migrations/permissions/view_data.sql
INSERT 0 0
Time: 129350.615 ms (02:09.351)
INSERT 0 435
Time: 32.590 ms
metabase=# \i resources/migrations/permissions/create_queries.sql
INSERT 0 424
Time: 21.807 ms
INSERT 0 16796
Time: 227.459 ms

```

New migration: 
```
metabase=# \i resources/migrations/permissions/view_data.sql
INSERT 0 16796
Time: 3844.136 ms (00:03.844)
INSERT 0 11
Time: 6.521 ms
INSERT 0 424
Time: 175.322 ms
DELETE 16796
Time: 22.087 ms
metabase=# \i resources/migrations/permissions/create_queries.sql
INSERT 0 424
Time: 21.439 ms
INSERT 0 16796
Time: 218.129 ms

```