### PR TITLE
Bump dompurify in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9640,7 +9640,7 @@ domhandler@^5.0.1, domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-dompurify@^2.5.0:
+dompurify@^2.2.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.5.0.tgz#13b1115d79b9340e6db80b4624653f665885b15f"
   integrity sha512-5RXhAXSCrKTqt9pSbobT9PVRX+oPpENplTZqCiK1l0ya+ZOzwo9kqsGLbYRsAhzIiLCwKEy99XKSSrqnRTLVcw==


### PR DESCRIPTION
Follow-up on #41564

`yarn.lock` was getting changed when running `yarn` locally.
We wanted to map `dompurify@^2.2.0` to `dompurify@^2.5.0`, but accidentally mapping from `dompurify@^2.5.0` to `dompurify@^2.5.0` was pushed in #41564 .