### PR TITLE
Fix null characters in JSON breaking CardRevisionAddType for postgres

### DIFF
--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1001,7 +1001,7 @@
   (case (mdb.connection/db-type)
     :postgres
     ;; postgres doesn't allow `\u0000` in text when converting to jsonb, so we need to remove them before we can
-    ;; parse the json. We use negative look ahead to avoid matching `\\u0000` (metabase#40835)
+    ;; parse the json. We use negative look behind to avoid matching `\\u0000` (metabase#40835)
     (t2/query ["UPDATE revision
                SET object = replace(jsonb_set(
                   (regexp_replace(object, '(?<!\\\\)\\\\u0000', '286b707c-e895-4cd3-acfc-569147f54371', 'g'))::jsonb, '{type}',

--- a/src/metabase/db/custom_migrations.clj
+++ b/src/metabase/db/custom_migrations.clj
@@ -1001,15 +1001,15 @@
   (case (mdb.connection/db-type)
     :postgres
     ;; postgres doesn't allow `\u0000` in text when converting to jsonb, so we need to remove them before we can
-    ;; parse the json. We use negative look ahead to make sure we don't match `\\u0000` (metabase#40835)
+    ;; parse the json. We use negative look ahead to avoid matching `\\u0000` (metabase#40835)
     (t2/query ["UPDATE revision
-               SET object = jsonb_set(
-                  (regexp_replace(object, '(?<!\\\\)\\\\u0000', '', 'g'))::jsonb, '{type}',
+               SET object = replace(jsonb_set(
+                  (regexp_replace(object, '(?<!\\\\)\\\\u0000', '286b707c-e895-4cd3-acfc-569147f54371', 'g'))::jsonb, '{type}',
                   to_jsonb(CASE
-                              WHEN ((regexp_replace(object, '(?<!\\\\)\\\\u0000', '', 'g'))::jsonb->>'dataset')::boolean THEN 'model'
+                              WHEN ((regexp_replace(object, '(?<!\\\\)\\\\u0000', '286b707c-e895-4cd3-acfc-569147f54371', 'g'))::jsonb->>'dataset')::boolean THEN 'model'
                               ELSE 'question'
-                           END)::jsonb, true)
-               WHERE model = 'Card' AND ((regexp_replace(object, '(?<!\\\\)\\\\u0000', '', 'g'))::jsonb->>'dataset') IS NOT NULL;"])
+                           END)::jsonb, true)::text, '286b707c-e895-4cd3-acfc-569147f54371', '\\u0000')
+               WHERE model = 'Card' AND ((regexp_replace(object, '(?<!\\\\)\\\\u0000', '286b707c-e895-4cd3-acfc-569147f54371', 'g'))::jsonb->>'dataset') IS NOT NULL;"])
 
     :mysql
     (t2/query ["UPDATE revision

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1600,6 +1600,58 @@
           (is (not (contains? card-revision-object "type")))
           (is (not (contains? model-revision-object "type"))))))))
 
+(deftest card-revision-add-type-null-character-test
+  (testing "CardRevisionAddType migration works even if there's a null character in revision.object (metabase#40835)")
+  (impl/test-migrations "v49.2024-01-22T11:52:00" [migrate!]
+    (let [user-id          (:id (new-instance-with-default :core_user))
+          db-id            (:id (new-instance-with-default :metabase_database))
+          card             (new-instance-with-default :report_card {:dataset false :creator_id user-id :database_id db-id})
+          viz-settings     "{\"table.pivot_column\":\"\u0000ID\"}"
+          new-viz-settings "{\"table.pivot_column\":\"ID\"}"
+          card-revision-id (:id (new-instance-with-default :revision
+                                                           {:object    (json/generate-string
+                                                                        (assoc (dissoc card :type)
+                                                                               :visualization_settings viz-settings))
+                                                            :model     "Card"
+                                                            :model_id  (:id card)
+                                                            :user_id   user-id}))]
+      (testing "sanity check revision object"
+        (let [card-revision-object (t2/select-one-fn (comp json/parse-string :object) :revision card-revision-id)]
+          (testing "doesn't have type"
+            (is (not (contains? card-revision-object "type"))))))
+      (testing "after migration card revisions should have type"
+        (migrate!)
+        (let [card-revision-object  (t2/select-one-fn (comp json/parse-string :object) :revision card-revision-id)]
+          (is (= "question" (get card-revision-object "type")))
+          (testing "original visualization_settings should be preserved"
+            (is (= new-viz-settings
+                   (get card-revision-object "visualization_settings")))))))))
+
+(deftest card-revision-add-type-escaped-null-character-test
+  (testing "CardRevisionAddType migration works even if there's a null character in revision.object #40835")
+  (impl/test-migrations "v49.2024-01-22T11:52:00" [migrate!]
+    (let [user-id          (:id (new-instance-with-default :core_user))
+          db-id            (:id (new-instance-with-default :metabase_database))
+          card             (new-instance-with-default :report_card {:dataset false :creator_id user-id :database_id db-id})
+          viz-settings     "{\"table.pivot_column\":\"\\u0000ID\"}"
+          card-revision-id (:id (new-instance-with-default :revision
+                                                           {:object    (json/generate-string
+                                                                        (assoc (dissoc card :type)
+                                                                               :visualization_settings viz-settings))
+                                                            :model     "Card"
+                                                            :model_id  (:id card)
+                                                            :user_id   user-id}))]
+      (testing "sanity check revision object"
+        (let [card-revision-object (t2/select-one-fn (comp json/parse-string :object) :revision card-revision-id)]
+          (testing "doesn't have type"
+            (is (not (contains? card-revision-object "type"))))))
+      (testing "after migration card revisions should have type"
+        (migrate!)
+        (let [card-revision-object  (t2/select-one-fn (comp json/parse-string :object) :revision card-revision-id)]
+          (testing "original visualization_settings should be preserved"
+            (is (= viz-settings
+                   (get card-revision-object "visualization_settings")))))))))
+
 (deftest delete-scan-field-values-trigger-test
   (testing "We should delete the triggers for DBs that are configured not to scan their field values\n"
     (impl/test-migrations "v49.2024-04-09T10:00:03" [migrate!]

--- a/test/metabase/db/custom_migrations_test.clj
+++ b/test/metabase/db/custom_migrations_test.clj
@@ -1606,8 +1606,7 @@
     (let [user-id          (:id (new-instance-with-default :core_user))
           db-id            (:id (new-instance-with-default :metabase_database))
           card             (new-instance-with-default :report_card {:dataset false :creator_id user-id :database_id db-id})
-          viz-settings     "{\"table.pivot_column\":\"\u0000ID\"}"
-          new-viz-settings "{\"table.pivot_column\":\"ID\"}"
+          viz-settings     "{\"table.pivot_column\":\"\u0000..\\u0000\"}" ; note the escaped and unescaped null characters
           card-revision-id (:id (new-instance-with-default :revision
                                                            {:object    (json/generate-string
                                                                         (assoc (dissoc card :type)
@@ -1623,31 +1622,6 @@
         (migrate!)
         (let [card-revision-object  (t2/select-one-fn (comp json/parse-string :object) :revision card-revision-id)]
           (is (= "question" (get card-revision-object "type")))
-          (testing "original visualization_settings should be preserved"
-            (is (= new-viz-settings
-                   (get card-revision-object "visualization_settings")))))))))
-
-(deftest card-revision-add-type-escaped-null-character-test
-  (testing "CardRevisionAddType migration works even if there's a null character in revision.object #40835")
-  (impl/test-migrations "v49.2024-01-22T11:52:00" [migrate!]
-    (let [user-id          (:id (new-instance-with-default :core_user))
-          db-id            (:id (new-instance-with-default :metabase_database))
-          card             (new-instance-with-default :report_card {:dataset false :creator_id user-id :database_id db-id})
-          viz-settings     "{\"table.pivot_column\":\"\\u0000ID\"}"
-          card-revision-id (:id (new-instance-with-default :revision
-                                                           {:object    (json/generate-string
-                                                                        (assoc (dissoc card :type)
-                                                                               :visualization_settings viz-settings))
-                                                            :model     "Card"
-                                                            :model_id  (:id card)
-                                                            :user_id   user-id}))]
-      (testing "sanity check revision object"
-        (let [card-revision-object (t2/select-one-fn (comp json/parse-string :object) :revision card-revision-id)]
-          (testing "doesn't have type"
-            (is (not (contains? card-revision-object "type"))))))
-      (testing "after migration card revisions should have type"
-        (migrate!)
-        (let [card-revision-object  (t2/select-one-fn (comp json/parse-string :object) :revision card-revision-id)]
           (testing "original visualization_settings should be preserved"
             (is (= viz-settings
                    (get card-revision-object "visualization_settings")))))))))


### PR DESCRIPTION
Fixes the escalation https://github.com/metabase/metabase/issues/40835

### The problem
The `CardRevisionAddType` migration was converting text to JSONB before manipulating it using JSON functions. The text may contain null characters which are not allowed when converting text to JSONB. Here's a relevant resource on JSONB: https://p2d2.cz/files/jsonb-silver-bullet.pdf

### The solution
In the postgres migration, we now:
1. replace `\u0000` with a randomly generated UUID 
2. update the JSONB, as before
3. convert JSONB to text
4. replace the UUID with `\u0000` again