### PR TITLE
Drop clj linting and formatting from pre-commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -469,10 +469,6 @@
     "e2e/test/scenarios/*/{*.(js|ts),!(helpers|shared)/*.(js|ts)}": [
       "node e2e/validate-e2e-test-files.js"
     ],
-    "**/*.{clj,cljc,cljs,bb}": [
-      "clj-kondo --config ./.clj-kondo/config.edn --config-dir ./.clj-kondo --parallel --lint",
-      "./bin/whitespace_lint_staged.sh"
-    ],
     "enterprise/frontend/src/embedding-sdk/README.md": [
       "prettier --write"
     ]


### PR DESCRIPTION
[context](https://metaboat.slack.com/archives/C05MPF0TM3L/p1713462678329479?thread_ts=1712850168.176149&cid=C05MPF0TM3L) 

### Description

It caused problems as lint-staged stashes files and if developer is not familiar with the mechanism, he thinks that his work is lost. To avoid confusion we remove this git hook

### How to verify

if you change any clj file and commit it, no files are stashed and unstashed