### PR TITLE
Fix invisible user items in search filters

### DIFF
--- a/frontend/src/metabase/search/components/UserListElement/UserListElement.styled.tsx
+++ b/frontend/src/metabase/search/components/UserListElement/UserListElement.styled.tsx
@@ -7,6 +7,8 @@ import { Button } from "metabase/ui";
 export const UserElement = styled(Button)<
   HTMLAttributes<HTMLButtonElement> & ButtonProps
 >`
+  flex-shrink: 0;
+
   &:hover {
     background-color: ${({ theme }) => theme.fn.themeColor("brand-lighter")};
   }


### PR DESCRIPTION
issue report: https://metaboat.slack.com/archives/C064EB1UE5P/p1713460122043189

### Description

![200w](https://github.com/metabase/metabase/assets/30528226/684b5173-ef45-403c-9778-2d047f3ddc97)

On large lists of users in search filters, we were shrinking the user list items to the point of being invisible'

Before | After
----|----
![Screen Shot 2024-04-18 at 12 58 32 PM](https://github.com/metabase/metabase/assets/30528226/87471844-6c22-4333-abc8-49ac96490bfb) | ![Screen Shot 2024-04-18 at 12 57 46 PM](https://github.com/metabase/metabase/assets/30528226/f32abd64-4d64-45ab-a869-e47965f1d32f)

