### PR TITLE
Add table of models to the "Browse models" page

### DIFF
--- a/frontend/src/metabase-types/api/collection.ts
+++ b/frontend/src/metabase-types/api/collection.ts
@@ -59,7 +59,7 @@ export interface Collection {
 
   location: string | null;
   effective_location?: string; // location path containing only those collections that the user has permission to access
-  effective_ancestors?: Collection[];
+  effective_ancestors?: Pick<Collection, "id" | "name">[];
 
   here?: CollectionContentModel[];
   below?: CollectionContentModel[];
@@ -110,6 +110,7 @@ export interface CollectionItem {
   setPinned?: (isPinned: boolean) => void;
   setCollection?: (collection: Pick<Collection, "id">) => void;
   setCollectionPreview?: (isEnabled: boolean) => void;
+  collection_ancestors?: Pick<Collection, "id" | "name">[];
 }
 
 export interface CollectionListQuery {

--- a/frontend/src/metabase-types/api/search.ts
+++ b/frontend/src/metabase-types/api/search.ts
@@ -132,6 +132,7 @@ export type SearchRequest = {
   last_edited_by?: UserId[];
   search_native_query?: boolean | null;
   verified?: boolean | null;
+  model_ancestors?: boolean | null;
 
   // this should be in ListCollectionItemsRequest but legacy code expects them here
   collection?: CollectionId;

--- a/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
+++ b/frontend/src/metabase/admin/performance/components/StrategyForm.tsx
@@ -422,19 +422,9 @@ const MultiplierFieldSubtitle = () => (
   <div>
     {t`To determine how long each cached result should stick around, we take that query's average execution time and multiply that by what you input here. The result is how many seconds the cache should remain valid for.`}{" "}
     <Tooltip
-      events={{
-        hover: true,
-        focus: true,
-        touch: true,
-      }}
+      variant="multiline"
       inline={true}
-      styles={{
-        tooltip: {
-          whiteSpace: "normal",
-        },
-      }}
       label={t`If a query takes on average 120 seconds (2 minutes) to run, and you input 10 for your multiplier, its cache entry will persist for 1,200 seconds (20 minutes).`}
-      maw="20rem"
     >
       <Text tabIndex={0} lh="1" display="inline" c="brand">
         {t`Example`}

--- a/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
@@ -1,23 +1,15 @@
-import {
-  setupSearchEndpoints,
-  setupSettingsEndpoints,
-} from "__support__/server-mocks";
-import userEvent from "@testing-library/user-event";
-
-import userEvent from "@testing-library/user-event";
-
-import {
-  setupSearchEndpoints,
-  setupSettingsEndpoints,
-} from "__support__/server-mocks";
-import { renderWithProviders, screen } from "__support__/ui";
-import { defaultRootCollection } from "metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup";
 import type { SearchResult } from "metabase-types/api";
 import {
   createMockCollection,
-  createMockModelResult,
+  createMockModelResult
 } from "metabase-types/api/mocks";
 import { createMockSetupState } from "metabase-types/store/mocks";
+import { defaultRootCollection } from "metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup";
+import {
+  setupSearchEndpoints,
+  setupSettingsEndpoints
+} from "__support__/server-mocks";
+import { renderWithProviders, screen } from "__support__/ui";
 
 import { BrowseModels } from "./BrowseModels";
 

--- a/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
@@ -13,7 +13,7 @@ import { renderWithProviders, screen } from "__support__/ui";
 
 import { BrowseModels } from "./BrowseModels";
 
-const renderBrowseModels = (modelCount: number) => {
+const setup = (modelCount: number) => {
   const models = mockModels.slice(0, modelCount);
   setupSearchEndpoints(models);
   setupSettingsEndpoints([]);
@@ -209,18 +209,17 @@ const mockModels: SearchResult[] = [
 ].map(model => createMockModelResult(model));
 
 describe("BrowseModels", () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
   it("displays a 'no models' message in the Models tab when no models exist", async () => {
-    renderBrowseModels(0);
+    setup(0);
     expect(await screen.findByText("No models here yet")).toBeInTheDocument();
   });
 
   it("displays the Our Analytics collection if it has a model", async () => {
-    renderBrowseModels(25);
-    await screen.findByText("Alpha");
-    await screen.findByText("Our analytics");
+    setup(25);
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+    expect(
+      await screen.findAllByTestId("path-for-collection: Our analytics"),
+    ).toHaveLength(2);
     expect(await screen.findByText("Model 20")).toBeInTheDocument();
     expect(await screen.findByText("Model 21")).toBeInTheDocument();
     expect(await screen.findByText("Model 22")).toBeInTheDocument();

--- a/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
+++ b/frontend/src/metabase/browse/components/BrowseModels.unit.spec.tsx
@@ -2,6 +2,14 @@ import {
   setupSearchEndpoints,
   setupSettingsEndpoints,
 } from "__support__/server-mocks";
+import userEvent from "@testing-library/user-event";
+
+import userEvent from "@testing-library/user-event";
+
+import {
+  setupSearchEndpoints,
+  setupSettingsEndpoints,
+} from "__support__/server-mocks";
 import { renderWithProviders, screen } from "__support__/ui";
 import { defaultRootCollection } from "metabase/admin/permissions/pages/CollectionPermissionsPage/tests/setup";
 import type { SearchResult } from "metabase-types/api";

--- a/frontend/src/metabase/browse/components/EllipsifiedWithMarkdown.tsx
+++ b/frontend/src/metabase/browse/components/EllipsifiedWithMarkdown.tsx
@@ -1,0 +1,28 @@
+import { Ellipsified } from "metabase/core/components/Ellipsified";
+import Markdown from "metabase/core/components/Markdown";
+
+export const EllipsifiedWithMarkdown = ({
+  shouldMarkdownifyTooltipTarget = false,
+  shouldMarkdownifyTooltip = true,
+  children,
+}: {
+  /** NOTE: If the tooltip target is markdownified,
+   * useIsTruncated won't know whether it has been truncated */
+  shouldMarkdownifyTooltipTarget?: boolean;
+  shouldMarkdownifyTooltip?: boolean;
+  children: string;
+}) => {
+  const tooltip = shouldMarkdownifyTooltip ? (
+    <Markdown disallowHeading unstyleLinks lineClamp={12}>
+      {children}
+    </Markdown>
+  ) : (
+    children
+  );
+  const tooltipTarget = shouldMarkdownifyTooltipTarget ? (
+    <Markdown disallowHeading>{children}</Markdown>
+  ) : (
+    children
+  );
+  return <Ellipsified tooltip={tooltip}>{tooltipTarget}</Ellipsified>;
+};

--- a/frontend/src/metabase/browse/components/ModelExplanationBanner.tsx
+++ b/frontend/src/metabase/browse/components/ModelExplanationBanner.tsx
@@ -1,39 +1,24 @@
-import { useState } from "react";
 import { t } from "ttag";
 
-import { useDispatch, useSelector } from "metabase/lib/redux";
-import { updateUserSetting } from "metabase/redux/settings";
-import { getSetting } from "metabase/selectors/settings";
-import { Flex, Paper, Icon, Text } from "metabase/ui";
+import { useUserSetting } from "metabase/common/hooks";
+import { Flex, Icon, Paper, Text } from "metabase/ui";
 
 import { BannerCloseButton, BannerModelIcon } from "./BrowseModels.styled";
 
 export function ModelExplanationBanner() {
-  const hasDismissedBanner = useSelector(state =>
-    getSetting(state, "dismissed-browse-models-banner"),
+  const [hasDismissedBanner, setHasDismissedBanner] = useUserSetting(
+    "dismissed-browse-models-banner",
   );
-  const dispatch = useDispatch();
-
-  const [shouldShowBanner, setShouldShowBanner] = useState(!hasDismissedBanner);
-
   const dismissBanner = () => {
-    setShouldShowBanner(false);
-    dispatch(
-      updateUserSetting({
-        key: "dismissed-browse-models-banner",
-        value: true,
-      }),
-    );
+    setHasDismissedBanner(true);
   };
 
-  if (!shouldShowBanner) {
+  if (hasDismissedBanner) {
     return null;
   }
 
   return (
     <Paper
-      mt="1rem"
-      mb="-0.5rem"
       p="1rem"
       color="text-dark"
       bg="brand-lighter"
@@ -44,7 +29,7 @@ export function ModelExplanationBanner() {
     >
       <Flex>
         <BannerModelIcon name="model" />
-        <Text size="md" lh="1rem" mr="1rem">
+        <Text size="md" lh="1rem" style={{ marginInlineEnd: "1rem" }}>
           {t`Models help curate data to make it easier to find answers to questions all in one place.`}
         </Text>
         <BannerCloseButton onClick={dismissBanner}>

--- a/frontend/src/metabase/browse/components/ModelsTable.tsx
+++ b/frontend/src/metabase/browse/components/ModelsTable.tsx
@@ -1,0 +1,107 @@
+import { t } from "ttag";
+
+import {
+  ColumnHeader,
+  ItemCell,
+  Table,
+  TableColumn,
+  TBody,
+} from "metabase/components/ItemsTable/BaseItemsTable.styled";
+import { Columns } from "metabase/components/ItemsTable/Columns";
+import type { ResponsiveProps } from "metabase/components/ItemsTable/utils";
+import { color } from "metabase/lib/colors";
+import type { CollectionItem } from "metabase-types/api";
+
+import { getCollectionName } from "../utils";
+
+import { EllipsifiedWithMarkdown } from "./EllipsifiedWithMarkdown";
+
+export interface ModelsTableProps {
+  items: CollectionItem[];
+}
+
+const descriptionProps: ResponsiveProps = {
+  hideAtContainerBreakpoint: "sm",
+  containerName: "ItemsTableContainer",
+};
+
+const collectionProps: ResponsiveProps = {
+  hideAtContainerBreakpoint: "xs",
+  containerName: "ItemsTableContainer",
+};
+
+export const ModelsTable = ({ items }: ModelsTableProps) => {
+  return (
+    <Table>
+      <colgroup>
+        <Columns.Type.Col />
+
+        {/* <col> for Name column */}
+        <TableColumn style={{ width: "10rem" }} />
+
+        {/* <col> for Description column */}
+        <TableColumn {...descriptionProps} />
+
+        {/* <col> for Collection column */}
+        <TableColumn {...collectionProps} />
+
+        <Columns.RightEdge.Col />
+      </colgroup>
+      <thead>
+        <tr>
+          <Columns.Type.Header title="" />
+          <Columns.Name.Header />
+          <ColumnHeader {...descriptionProps}>{t`Description`}</ColumnHeader>
+          <ColumnHeader {...collectionProps}>{t`Collection`}</ColumnHeader>
+          <Columns.RightEdge.Header />
+        </tr>
+      </thead>
+      <TBody>
+        {items.map((item: CollectionItem) => (
+          <TBodyRow item={item} key={`${item.model}-${item.id}`} />
+        ))}
+      </TBody>
+    </Table>
+  );
+};
+
+const TBodyRow = ({ item }: { item: CollectionItem }) => {
+  const icon = item.getIcon();
+  if (item.model === "card") {
+    icon.color = color("text-light");
+  }
+  return (
+    <tr>
+      {/* Type */}
+      <Columns.Type.Cell icon={icon} />
+
+      {/* Name */}
+      <Columns.Name.Cell item={item} includeDescription={false} />
+
+      {/* Description */}
+      <ItemCell {...descriptionProps}>
+        <EllipsifiedWithMarkdown>
+          {item.description || ""}
+        </EllipsifiedWithMarkdown>
+      </ItemCell>
+
+      {/* Collection */}
+      <ItemCell
+        data-testid={`path-for-collection: ${
+          item.collection
+            ? getCollectionName(item.collection)
+            : t`Untitled collection`
+        }`}
+        {...collectionProps}
+      >
+        {item.collection &&
+          item.collection?.effective_ancestors
+            ?.map(collection => getCollectionName(collection))
+            .join(" / ")}
+      </ItemCell>
+
+      {/* Adds a border-radius to the table */}
+      <Columns.RightEdge.Cell />
+    </tr>
+  );
+};

--- a/frontend/src/metabase/components/CollapseSection/CollapseSection.styled.tsx
+++ b/frontend/src/metabase/components/CollapseSection/CollapseSection.styled.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import type { IconName, IconProps } from "metabase/ui";
 import { Icon } from "metabase/ui";
 
-export const HeaderContainer = styled.div<{ role: string; tabIndex?: number }>`
+export const HeaderContainer = styled.div<{ role?: string; tabIndex?: number }>`
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -43,9 +43,8 @@ export const ToggleIcon = styled(
     isExpanded,
     variant,
     size = 12,
-    name: _,
     ...props
-  }: ToggleIconProps & IconProps) => {
+  }: ToggleIconProps & Omit<IconProps, "name">) => {
     const { collapsed, expanded } = ICON_VARIANTS[variant];
     const name = isExpanded ? expanded : collapsed;
     return <Icon name={name as IconName} size={size} {...props} />;

--- a/frontend/src/metabase/components/CollapseSection/CollapseSection.tsx
+++ b/frontend/src/metabase/components/CollapseSection/CollapseSection.tsx
@@ -1,22 +1,8 @@
-import PropTypes from "prop-types";
 import { useCallback, useState } from "react";
 
 import { HeaderContainer, Header, ToggleIcon } from "./CollapseSection.styled";
 
-const propTypes = {
-  children: PropTypes.node,
-  className: PropTypes.string,
-  header: PropTypes.node,
-  headerClass: PropTypes.string,
-  bodyClass: PropTypes.string,
-  initialState: PropTypes.oneOf(["expanded", "collapsed"]),
-  iconVariant: PropTypes.oneOf(["right-down", "up-down"]),
-  iconPosition: PropTypes.oneOf(["left", "right"]),
-  iconSize: PropTypes.number,
-  onToggle: PropTypes.func,
-};
-
-function CollapseSection({
+const CollapseSection = ({
   initialState = "collapsed",
   iconVariant = "right-down",
   iconPosition = "left",
@@ -27,7 +13,18 @@ function CollapseSection({
   bodyClass,
   children,
   onToggle,
-}) {
+}: {
+  children?: React.ReactNode;
+  className?: string;
+  header?: React.ReactNode;
+  headerClass?: string;
+  bodyClass?: string;
+  initialState?: "expanded" | "collapsed";
+  iconVariant?: "right-down" | "up-down";
+  iconPosition?: "left" | "right";
+  iconSize?: number;
+  onToggle?: (nextState: boolean) => void;
+}) => {
   const [isExpanded, setIsExpanded] = useState(initialState === "expanded");
 
   const toggle = useCallback(() => {
@@ -37,7 +34,7 @@ function CollapseSection({
   }, [isExpanded, onToggle]);
 
   const onKeyDown = useCallback(
-    e => {
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.key === "Enter") {
         toggle();
       }
@@ -70,8 +67,7 @@ function CollapseSection({
       </div>
     </div>
   );
-}
+};
 
-CollapseSection.propTypes = propTypes;
-
+// eslint-disable-next-line import/no-default-export -- deprecated usage
 export default CollapseSection;

--- a/frontend/src/metabase/components/ResponsiveContainer/ResponsiveContainer.tsx
+++ b/frontend/src/metabase/components/ResponsiveContainer/ResponsiveContainer.tsx
@@ -1,0 +1,28 @@
+import styled from "@emotion/styled";
+
+import { Box, type BoxProps } from "metabase/ui";
+
+const doNotForwardProps = (...propNamesToBlock: string[]) => ({
+  shouldForwardProp: (propName: string) => !propNamesToBlock.includes(propName),
+});
+
+/** Helps with @container queries in CSS */
+export const ResponsiveContainer = styled(
+  Box,
+  doNotForwardProps("name", "type"),
+)<
+  BoxProps & {
+    name: string;
+    type?: string;
+  }
+>`
+  container-name: ${props => props.name};
+  container-type: ${props => props.type};
+`;
+ResponsiveContainer.defaultProps = { type: "inline-size" };
+
+export const ResponsiveChild = styled(Box, doNotForwardProps("containerName"))<
+  BoxProps & {
+    containerName: string;
+  }
+>``;

--- a/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
+++ b/frontend/src/metabase/core/components/Ellipsified/Ellipsified.styled.tsx
@@ -22,4 +22,8 @@ interface EllipsifiedRootProps {
 
 export const EllipsifiedRoot = styled.div<EllipsifiedRootProps>`
   ${props => ((props.lines ?? 1) > 1 ? clampCss(props) : ellipsifyCss)};
+  // To ellipsify markdown
+  p {
+    ${ellipsifyCss}
+  }
 `;

--- a/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
+++ b/frontend/src/metabase/ui/components/icons/Icon/Icon.tsx
@@ -43,7 +43,7 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
   return tooltip ? <Tooltip label={tooltip}>{icon}</Tooltip> : icon;
 });
 
-/** An icon that does not shrink when the viewport gets narrower **/
+/** An icon that does not shrink when its container is too narrow **/
 export const FixedSizeIcon = styled(Icon)<{ size?: number }>`
   min-width: ${({ size }) => size ?? 16}px;
   min-height: ${({ size }) => size ?? 16}px;

--- a/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.styled.tsx
+++ b/frontend/src/metabase/ui/components/overlays/Tooltip/Tooltip.styled.tsx
@@ -25,5 +25,16 @@ export const getTooltipOverrides = (): MantineThemeOverride["components"] => ({
         padding: "0.6rem 0.75rem",
       },
     }),
+    variants: {
+      multiline: _theme => {
+        return {
+          tooltip: {
+            whiteSpace: "normal",
+            maxWidth: "20rem",
+            overflowWrap: "break-word",
+          },
+        };
+      },
+    },
   },
 });


### PR DESCRIPTION
Adds a table of models to the **Browse models** page.

![image](https://github.com/metabase/metabase/assets/130925/13b4f216-3e72-444e-85fa-07c5ab8af9cf)

Figma: https://www.figma.com/file/hubkgafXKo4wcBeTAbJ4vh/Browsing-Models-Exploration?type=design&node-id=252-22078&mode=design&t=Gmk1MAN7hCTDKM34-4

This PR also removes previously existing tab logic. Previously, the logic for retrieving models and retrieving databases was housed in a high-level component, BrowseApp. I moved the models-related logic into the component that displays the models and the database-related logic into the component that displays the databases.

For now, this table is pretty simple. We'll be iterating on it.