### PR TITLE
Fix e2e-tests-visualizations-charts-ee

### DIFF
--- a/e2e/support/helpers/e2e-visual-tests-helpers.js
+++ b/e2e/support/helpers/e2e-visual-tests-helpers.js
@@ -57,18 +57,18 @@ export function chartPathsWithFillColors(colors) {
 }
 
 const CIRCLE_PATH = "M1 0A1 1 0 1 1 1 -0.0001";
-export function lineChartCircle() {
+export function cartesianChartCircle() {
   return echartsContainer()
     .find(`path[d="${CIRCLE_PATH}"]`)
     .should("be.visible");
 }
 
-export function lineChartCircleWithColor(color) {
+export function cartesianChartCircleWithColor(color) {
   return echartsContainer()
     .find(`path[d="${CIRCLE_PATH}"][stroke="${color}"]`)
     .should("be.visible");
 }
 
-export function lineChartCircleWithColors(colors) {
-  return colors.map(color => lineChartCircleWithColor(color));
+export function cartesianChartCircleWithColors(colors) {
+  return colors.map(color => cartesianChartCircleWithColor(color));
 }

--- a/e2e/support/helpers/e2e-visual-tests-helpers.js
+++ b/e2e/support/helpers/e2e-visual-tests-helpers.js
@@ -1,5 +1,7 @@
 import { color as getColor } from "metabase/lib/colors";
 import { Icons } from "metabase/ui";
+import { GOAL_LINE_DASH } from "metabase/visualizations/echarts/cartesian/option/goal-line.ts";
+import { TREND_LINE_DASH } from "metabase/visualizations/echarts/cartesian/option/trend-line.ts";
 import {
   setSvgColor,
   svgToDataUri,
@@ -14,11 +16,15 @@ export function echartsContainer() {
 }
 
 export function goalLine() {
-  return echartsContainer().find("path[stroke-dasharray='3,4']");
+  return echartsContainer().find(
+    `path[stroke-dasharray='${GOAL_LINE_DASH.join(",")}']`,
+  );
 }
 
 export function trendLine() {
-  return echartsContainer().find("path[stroke-dasharray='5,5']");
+  return echartsContainer().find(
+    `path[stroke-dasharray='${TREND_LINE_DASH.join(",")}']`,
+  );
 }
 
 export function getXYTransform(element) {

--- a/e2e/support/helpers/e2e-visual-tests-helpers.js
+++ b/e2e/support/helpers/e2e-visual-tests-helpers.js
@@ -13,6 +13,25 @@ export function echartsContainer() {
   return cy.findByTestId("chart-container");
 }
 
+export function goalLine() {
+  return echartsContainer().find("path[stroke-dasharray='3,4']");
+}
+
+export function trendLine() {
+  return echartsContainer().find("path[stroke-dasharray='5,5']");
+}
+
+export function getXYTransform(element) {
+  const transform = element.prop("transform");
+  const {
+    baseVal: [{ matrix }],
+  } = transform;
+
+  const { e: x, f: y } = matrix;
+
+  return { x, y };
+}
+
 export function echartsIcon(name, color = undefined) {
   const iconSvg = setSvgColor(
     Icons[name].source,

--- a/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
+++ b/e2e/test/scenarios/binning/binning-reproductions.cy.spec.js
@@ -13,7 +13,7 @@ import {
   getNotebookStep,
   rightSidebar,
   chartPathWithFillColor,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -179,7 +179,7 @@ describe("binning related reproductions", () => {
     );
 
     visualize();
-    lineChartCircle();
+    cartesianChartCircle();
   });
 
   it("should display date granularity on Summarize when opened from saved question (metabase#10441, metabase#11439)", () => {

--- a/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-explicit-joins.cy.spec.js
@@ -6,7 +6,7 @@ import {
   summarize,
   startNewQuestion,
   echartsContainer,
-  lineChartCircle,
+  cartesianChartCircle,
   chartPathWithFillColor,
 } from "e2e/support/helpers";
 
@@ -227,7 +227,7 @@ describe("scenarios > binning > from a saved QB question with explicit joins", (
         .and("contain", "January 1972")
         .and("contain", "January 2000");
 
-      lineChartCircle();
+      cartesianChartCircle();
 
       // Make sure time series footer works as well
       cy.findByTestId("timeseries-bucket-button").contains("Month").click();
@@ -313,7 +313,7 @@ function assertQueryBuilderState({
   const visualizationSelector = columnType === "time" ? "circle" : "bar";
 
   if (visualizationSelector === "circle") {
-    lineChartCircle();
+    cartesianChartCircle();
   } else {
     chartPathWithFillColor("#509EE3");
   }

--- a/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
+++ b/e2e/test/scenarios/binning/qb-regular-table.cy.spec.js
@@ -6,7 +6,7 @@ import {
   changeBinningForDimension,
   summarize,
   chartPathWithFillColor,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const { ORDERS_ID, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -43,7 +43,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Created At: Quarter");
 
-      lineChartCircle();
+      cartesianChartCircle();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q1 2023");
     });
@@ -92,7 +92,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Created At: Quarter");
 
-      lineChartCircle();
+      cartesianChartCircle();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Q1 2023");
     });
@@ -138,7 +138,7 @@ describe("scenarios > binning > binning options", () => {
 
       getTitle("Count by Created At: Month");
 
-      lineChartCircle();
+      cartesianChartCircle();
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("January 2023");
     });

--- a/e2e/test/scenarios/binning/sql.cy.spec.js
+++ b/e2e/test/scenarios/binning/sql.cy.spec.js
@@ -7,7 +7,7 @@ import {
   summarize,
   openTable,
   visitQuestionAdhoc,
-  lineChartCircle,
+  cartesianChartCircle,
   chartPathWithFillColor,
   echartsContainer,
 } from "e2e/support/helpers";
@@ -72,7 +72,7 @@ describe("scenarios > binning > from a saved sql question", () => {
 
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by CREATED_AT: Year");
-      lineChartCircle();
+      cartesianChartCircle();
     });
 
     it("should work for number", () => {
@@ -139,7 +139,7 @@ describe("scenarios > binning > from a saved sql question", () => {
         assertOnResponse(response);
       });
 
-      lineChartCircle();
+      cartesianChartCircle();
     });
 
     it("should work for number", () => {
@@ -195,7 +195,7 @@ describe("scenarios > binning > from a saved sql question", () => {
       assertOnXYAxisLabels({ xLabel: "CREATED_AT", yLabel: "Count" });
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("Count by CREATED_AT: Month");
-      lineChartCircle();
+      cartesianChartCircle();
 
       // Open a popover with bucket options from the time series footer
       cy.findByTestId("timeseries-bucket-button").contains("Month").click();

--- a/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/custom-column.cy.spec.js
@@ -14,7 +14,7 @@ import {
   getNotebookStep,
   checkExpressionEditorHelperPopoverPosition,
   queryBuilderMain,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -44,7 +44,7 @@ describe("scenarios > question > custom column", () => {
       },
       { visitQuestion: true },
     );
-    lineChartCircle().eq(5).click();
+    cartesianChartCircle().eq(5).click();
     popover()
       .findByText(/Automatic Insights/i)
       .click();
@@ -337,7 +337,7 @@ describe("scenarios > question > custom column", () => {
 
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.contains(`Sum of ${CC_NAME}`);
-    lineChartCircle().should("have.length.of.at.least", 8);
+    cartesianChartCircle().should("have.length.of.at.least", 8);
   });
 
   it("should create custom column after aggregation with 'cum-sum/count' (metabase#13634)", () => {

--- a/e2e/test/scenarios/custom-column/reproductions/13289-cc-post-aggregation-zoom-in.cy.spec.js
+++ b/e2e/test/scenarios/custom-column/reproductions/13289-cc-post-aggregation-zoom-in.cy.spec.js
@@ -5,7 +5,7 @@ import {
   enterCustomColumnDetails,
   visualize,
   summarize,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const CC_NAME = "Math";
@@ -45,7 +45,7 @@ describe("issue 13289", () => {
     visualize();
 
     cy.findByTestId("query-visualization-root").within(() => {
-      lineChartCircle()
+      cartesianChartCircle()
         .eq(5) // random circle in the graph (there is no specific reason for this index)
         .click();
     });

--- a/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/dashboard-cards/click-behavior.cy.spec.js
@@ -15,7 +15,7 @@ import {
   getHeadingCardDetails,
   getLinkCardDetails,
   getTextCardDetails,
-  lineChartCircle,
+  cartesianChartCircle,
   modal,
   openStaticEmbeddingModal,
   popover,
@@ -2127,7 +2127,7 @@ const deserializeCardFromUrl = serialized =>
   JSON.parse(b64hash_to_utf8(serialized));
 
 const clickLineChartPoint = () => {
-  lineChartCircle()
+  cartesianChartCircle()
     .eq(POINT_INDEX)
     /**
      * calling .click() here will result in clicking both

--- a/e2e/test/scenarios/dashboard/reproductions/17879-date-parameter-mapping.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/17879-date-parameter-mapping.cy.spec.js
@@ -1,7 +1,7 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   editDashboard,
-  lineChartCircle,
+  cartesianChartCircle,
   popover,
   restore,
   saveDashboard,
@@ -122,7 +122,7 @@ function setupDashcardAndDrillToQuestion({
     cy.wait("@getCardQuery");
 
     cy.findByTestId("visualization-root").within(() => {
-      lineChartCircle().first().click({ force: true });
+      cartesianChartCircle().first().click({ force: true });
     });
 
     cy.url().should("include", "/question");

--- a/e2e/test/scenarios/dashboard/reproductions/31697-question-xray-segment.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/reproductions/31697-question-xray-segment.cy.spec.js
@@ -1,6 +1,6 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
-  lineChartCircle,
+  cartesianChartCircle,
   popover,
   restore,
   visitQuestion,
@@ -46,7 +46,7 @@ describe("issue 31697", () => {
 
   it("should allow x-rays for questions with segments (metabase#31697)", () => {
     cy.get("@questionId").then(visitQuestion);
-    lineChartCircle().eq(0).click();
+    cartesianChartCircle().eq(0).click();
     popover().findByText("Automatic insights…").click();
     popover().findByText("X-ray").click();
     cy.wait("@xrayDashboard");

--- a/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
+++ b/e2e/test/scenarios/dashboard/x-rays.cy.spec.js
@@ -10,7 +10,7 @@ import {
   popover,
   getDashboardCards,
   saveDashboard,
-  lineChartCircle,
+  cartesianChartCircle,
   chartPathWithFillColor,
 } from "e2e/support/helpers";
 
@@ -77,7 +77,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
 
     cy.intercept("POST", "/api/dataset").as("dataset");
 
-    lineChartCircle()
+    cartesianChartCircle()
       .eq(23) // Random dot
       .click({ force: true });
 
@@ -323,7 +323,7 @@ describe("scenarios > x-rays", { tags: "@slow" }, () => {
         cy.findByRole("tab", { name: "Tab 1" }).click();
         saveDashboard();
 
-        lineChartCircle().eq(0).click({ force: true });
+        cartesianChartCircle().eq(0).click({ force: true });
         popover().findByText("Automatic insights…").click();
         popover().findByText("X-ray").click();
         cy.wait("@dataset", { timeout: 60000 });

--- a/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
+++ b/e2e/test/scenarios/embedding/embedding-questions.cy.spec.js
@@ -7,7 +7,7 @@ import {
   visitIframe,
   openStaticEmbeddingModal,
   echartsContainer,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 import {
@@ -102,7 +102,7 @@ describe("scenarios > embedding > questions", () => {
     echartsContainer().should("contain", "60");
 
     // Check the tooltip for the last point on the line
-    lineChartCircle().last().realHover();
+    cartesianChartCircle().last().realHover();
 
     popover().within(() => {
       testPairedTooltipValues("Created At", "Aug 2022");

--- a/e2e/test/scenarios/filters/filter.cy.spec.js
+++ b/e2e/test/scenarios/filters/filter.cy.spec.js
@@ -22,7 +22,7 @@ import {
   queryBuilderMain,
   selectFilterOperator,
   expressionEditorWidget,
-  lineChartCircleWithColors,
+  cartesianChartCircleWithColors,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } =
@@ -825,7 +825,7 @@ describe("scenarios > question > filter", () => {
     });
 
     assertOnLegendLabels();
-    lineChartCircleWithColors(["#88BF4D", "#509EE3", "#A989C5"]);
+    cartesianChartCircleWithColors(["#88BF4D", "#509EE3", "#A989C5"]);
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Save").click();
     cy.findByTestId("save-question-modal").within(modal => {
@@ -834,7 +834,7 @@ describe("scenarios > question > filter", () => {
     cy.button("Not now").click();
     assertOnLegendLabels();
 
-    lineChartCircleWithColors(["#88BF4D", "#509EE3", "#A989C5"]);
+    cartesianChartCircleWithColors(["#88BF4D", "#509EE3", "#A989C5"]);
 
     function assertOnLegendLabels() {
       cy.findAllByTestId("legend-item")

--- a/e2e/test/scenarios/filters/reproductions/12496-drill-through-filter-date.cy.spec.js
+++ b/e2e/test/scenarios/filters/reproductions/12496-drill-through-filter-date.cy.spec.js
@@ -1,5 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { popover, restore, lineChartCircle } from "e2e/support/helpers";
+import { popover, restore, cartesianChartCircle } from "e2e/support/helpers";
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 describe.skip("issue 12496", () => {
@@ -37,7 +37,7 @@ describe.skip("issue 12496", () => {
   };
   it("should display correct day range in filter pill when drilling into a week", () => {
     setup("week");
-    lineChartCircle().eq(0).click({ force: true });
+    cartesianChartCircle().eq(0).click({ force: true });
     popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 24–30, 2022")
@@ -51,7 +51,7 @@ describe.skip("issue 12496", () => {
   });
   it("should display correct day range in filter pill when drilling into a month", () => {
     setup("month");
-    lineChartCircle().eq(0).click({ force: true });
+    cartesianChartCircle().eq(0).click({ force: true });
     popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 2022")
@@ -65,7 +65,7 @@ describe.skip("issue 12496", () => {
   });
   it("should display correct day range in filter pill when drilling into a hour", () => {
     setup("hour");
-    lineChartCircle().eq(0).click({ force: true });
+    cartesianChartCircle().eq(0).click({ force: true });
     popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 30, 2022, 6:00–59 PM")
@@ -83,7 +83,7 @@ describe.skip("issue 12496", () => {
   });
   it("should display correct minute in filter pill when drilling into a minute", () => {
     setup("minute");
-    lineChartCircle().eq(0).click({ force: true });
+    cartesianChartCircle().eq(0).click({ force: true });
     popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 30, 2022, 6:56 PM")
@@ -96,7 +96,7 @@ describe.skip("issue 12496", () => {
   });
   it("should display correct minute in filter pill when drilling into a day", () => {
     setup("day");
-    lineChartCircle().eq(0).click({ force: true });
+    cartesianChartCircle().eq(0).click({ force: true });
     popover().contains("See this Order").click();
     cy.findByTestId("qb-filters-panel")
       .contains("Created At is April 30, 2022")

--- a/e2e/test/scenarios/joins/reproductions/14793-xrays-joins.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/14793-xrays-joins.cy.spec.js
@@ -6,7 +6,7 @@ import {
   restore,
   visitQuestionAdhoc,
   popover,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const { PRODUCTS, PRODUCTS_ID, REVIEWS, REVIEWS_ID } = SAMPLE_DATABASE;
@@ -51,7 +51,7 @@ describe("issue 14793", () => {
   it("x-rays should work on explicit joins when metric is for the joined table (metabase#14793)", () => {
     visitQuestionAdhoc(QUESTION_DETAILS);
 
-    lineChartCircle().eq(2).click({ force: true });
+    cartesianChartCircle().eq(2).click({ force: true });
 
     popover().findByText("Automatic insights…").click();
     popover().findByText("X-ray").click();

--- a/e2e/test/scenarios/joins/reproductions/27380-dashboard-drops-joined-fields-on-zoom-in.cy.spec.js
+++ b/e2e/test/scenarios/joins/reproductions/27380-dashboard-drops-joined-fields-on-zoom-in.cy.spec.js
@@ -2,7 +2,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   restore,
   visitDashboard,
-  lineChartCircle,
+  cartesianChartCircle,
   echartsContainer,
 } from "e2e/support/helpers";
 
@@ -38,7 +38,7 @@ describe("issue 27380", () => {
     );
 
     // Doesn't really matter which 'circle" we click on the graph
-    lineChartCircle().last().click();
+    cartesianChartCircle().last().click();
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("See this month by week").click();
     cy.wait("@dataset");

--- a/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
+++ b/e2e/test/scenarios/models/reproductions/29517-native-remapped-model-drill-through-click-behavior.cy.spec.js
@@ -6,7 +6,7 @@ import {
   visitQuestion,
   visitDashboard,
   assertQueryBuilderRowCount,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const questionDetails = {
@@ -81,7 +81,7 @@ describe("issue 29517 - nested question based on native model with remapped valu
     visitQuestion("@nestedQuestionId");
 
     // We can click on any circle; this index was chosen randomly
-    lineChartCircle().eq(25).click({ force: true });
+    cartesianChartCircle().eq(25).click({ force: true });
     popover()
       .findByText(/^See these/)
       .click();
@@ -104,7 +104,7 @@ describe("issue 29517 - nested question based on native model with remapped valu
     cy.intercept("GET", `/api/dashboard/${ORDERS_DASHBOARD_ID}`).as(
       "loadTargetDashboard",
     );
-    lineChartCircle().eq(25).click({ force: true });
+    cartesianChartCircle().eq(25).click({ force: true });
     cy.wait("@loadTargetDashboard");
 
     cy.location("pathname").should("eq", `/dashboard/${ORDERS_DASHBOARD_ID}`);

--- a/e2e/test/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js
+++ b/e2e/test/scenarios/native/reproductions/12439-click-on-legend-breaks-ui.cy.spec.js
@@ -3,7 +3,7 @@ import {
   restore,
   visitQuestionAdhoc,
   sidebar,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const nativeQuery = `
@@ -46,7 +46,7 @@ describe("issue 12439", () => {
       cy.findByText("Gizmo").should("be.visible");
       cy.findByText("Doohickey").should("be.visible");
 
-      lineChartCircle();
+      cartesianChartCircle();
     });
 
     // Make sure buttons are clickable

--- a/e2e/test/scenarios/question/nulls.cy.spec.js
+++ b/e2e/test/scenarios/question/nulls.cy.spec.js
@@ -8,7 +8,7 @@ import {
   rightSidebar,
   updateDashboardCards,
   addOrUpdateDashboardCard,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -191,7 +191,7 @@ describe("scenarios > question > null", () => {
         "not.exist",
       );
 
-      lineChartCircle().should("have.length.of.at.least", 40);
+      cartesianChartCircle().should("have.length.of.at.least", 40);
     });
   });
 });

--- a/e2e/test/scenarios/question/reproductions/33079-drill-underlying-records.cy.spec.js
+++ b/e2e/test/scenarios/question/reproductions/33079-drill-underlying-records.cy.spec.js
@@ -1,5 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { popover, restore, lineChartCircle } from "e2e/support/helpers";
+import { popover, restore, cartesianChartCircle } from "e2e/support/helpers";
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
 const questionDetails = {
@@ -24,7 +24,7 @@ describe("issue 33079", () => {
 
   it("underlying records drill should work in a non-English locale (metabase#33079)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
-    lineChartCircle().eq(1).click({ force: true });
+    cartesianChartCircle().eq(1).click({ force: true });
     popover()
       .findByText(/Order/) // See these Orders
       .click();

--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -403,7 +403,7 @@ describe("scenarios > visualizations > bar chart", () => {
     cy.get("[data-testid^=draggable-item]").should("have.length", 0);
   });
 
-  it.skip("should support showing data points with > 10 series (#33725)", () => {
+  it("should support showing data points with > 10 series (#33725)", () => {
     cy.signInAsAdmin();
     const stateFilter = [
       "=",

--- a/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js
@@ -9,6 +9,8 @@ import {
   visitDashboard,
   cypressWaitAll,
   moveDnDKitElement,
+  chartPathWithFillColor,
+  echartsContainer,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PEOPLE, PRODUCTS, PRODUCTS_ID } = SAMPLE_DATABASE;
@@ -81,7 +83,7 @@ describe("scenarios > visualizations > bar chart", () => {
         },
       });
 
-      cy.get(".bar").should("have.length", 5); // there are six bars when null isn't filtered
+      chartPathWithFillColor("#509EE3").should("have.length", 5); // there are six bars when null isn't filtered
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
       cy.findByText("1,800"); // correct data has this on the y-axis
       // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
@@ -112,7 +114,10 @@ describe("scenarios > visualizations > bar chart", () => {
         },
       });
 
-      cy.get(".value-labels").should("contain", "19").and("contain", "20.0M");
+      echartsContainer()
+        .get("text")
+        .should("contain", "19")
+        .and("contain", "20.0M");
     });
   });
 
@@ -168,7 +173,9 @@ describe("scenarios > visualizations > bar chart", () => {
             .findByText(columnName)
             .should("not.exist");
           cy.findAllByTestId("legend-item").should("have.length", 3);
-          cy.findAllByTestId("chart-series").should("have.length", 3);
+          chartPathWithFillColor("#F2A86F").should("be.visible");
+          chartPathWithFillColor("#F9D45C").should("be.visible");
+          chartPathWithFillColor("#88BF4D").should("be.visible");
         });
 
       getDraggableElements()
@@ -185,7 +192,10 @@ describe("scenarios > visualizations > bar chart", () => {
             .findByText(columnName)
             .should("exist");
           cy.findAllByTestId("legend-item").should("have.length", 4);
-          cy.findAllByTestId("chart-series").should("have.length", 4);
+          chartPathWithFillColor("#F2A86F").should("be.visible");
+          chartPathWithFillColor("#F9D45C").should("be.visible");
+          chartPathWithFillColor("#88BF4D").should("be.visible");
+          chartPathWithFillColor("#A989C5").should("be.visible");
         });
 
       cy.findAllByTestId("legend-item").contains("Gadget").click();
@@ -272,7 +282,10 @@ describe("scenarios > visualizations > bar chart", () => {
         },
       });
 
-      cy.get("g.axis.yr").should("be.visible");
+      echartsContainer().within(() => {
+        cy.get("text").contains("Average of Total").should("be.visible");
+        cy.get("text").contains("Min of Total").should("be.visible");
+      });
     });
 
     it("should not split the y-axis when semantic_type, column settings are same and values are not far", () => {
@@ -317,7 +330,10 @@ describe("scenarios > visualizations > bar chart", () => {
         },
       });
 
-      cy.get("g.axis.yr").should("be.visible");
+      echartsContainer().within(() => {
+        cy.get("text").contains("m1").should("not.exist");
+        cy.get("text").contains("m2").should("not.exist");
+      });
     });
   });
 
@@ -387,7 +403,7 @@ describe("scenarios > visualizations > bar chart", () => {
     cy.get("[data-testid^=draggable-item]").should("have.length", 0);
   });
 
-  it("should support showing data points with > 10 series (#33725)", () => {
+  it.skip("should support showing data points with > 10 series (#33725)", () => {
     cy.signInAsAdmin();
     const stateFilter = [
       "=",

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -6,7 +6,7 @@ import {
   saveDashboard,
   addOrUpdateDashboardCard,
   modal,
-  lineChartCircle,
+  cartesianChartCircle,
   chartPathWithFillColor,
 } from "e2e/support/helpers";
 
@@ -48,7 +48,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         ["Custom", "42,156.87"],
       ];
 
-      lineChartCircle().first().trigger("mousemove");
+      cartesianChartCircle().first().trigger("mousemove");
       testTooltipText(originalTooltipText);
 
       openDashCardVisualizationOptions();
@@ -57,7 +57,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       saveDashCardVisualizationOptions();
 
-      lineChartCircle().first().trigger("mousemove");
+      cartesianChartCircle().first().trigger("mousemove");
       testTooltipText(updatedTooltipText);
     });
   });
@@ -169,7 +169,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         ["Custom 2", "3,236"],
       ];
 
-      lineChartCircle().first().trigger("mousemove");
+      cartesianChartCircle().first().trigger("mousemove");
       testTooltipText(originalTooltipText);
 
       openDashCardVisualizationOptions();
@@ -179,7 +179,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       saveDashCardVisualizationOptions();
 
-      lineChartCircle().first().trigger("mousemove");
+      cartesianChartCircle().first().trigger("mousemove");
       testTooltipText(updatedTooltipText);
     });
   });

--- a/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line-bar-tooltips.cy.spec.js
@@ -6,6 +6,8 @@ import {
   saveDashboard,
   addOrUpdateDashboardCard,
   modal,
+  lineChartCircle,
+  chartPathWithFillColor,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -46,9 +48,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         ["Custom", "42,156.87"],
       ];
 
-      const seriesIndex = 0;
-
-      showTooltipForFirstCircleInSeries(seriesIndex);
+      lineChartCircle().first().trigger("mousemove");
       testTooltipText(originalTooltipText);
 
       openDashCardVisualizationOptions();
@@ -57,7 +57,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       saveDashCardVisualizationOptions();
 
-      showTooltipForFirstCircleInSeries(seriesIndex);
+      lineChartCircle().first().trigger("mousemove");
       testTooltipText(updatedTooltipText);
     });
   });
@@ -169,9 +169,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         ["Custom 2", "3,236"],
       ];
 
-      const seriesIndex = 0;
-
-      showTooltipForFirstCircleInSeries(seriesIndex);
+      lineChartCircle().first().trigger("mousemove");
       testTooltipText(originalTooltipText);
 
       openDashCardVisualizationOptions();
@@ -181,7 +179,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       saveDashCardVisualizationOptions();
 
-      showTooltipForFirstCircleInSeries(seriesIndex);
+      lineChartCircle().first().trigger("mousemove");
       testTooltipText(updatedTooltipText);
     });
   });
@@ -319,9 +317,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
         ["Custom", "42,156.87"],
       ];
 
-      const seriesIndex = 0;
-
-      showTooltipForFirstBarInSeries(seriesIndex);
+      chartPathWithFillColor("#88BF4D").first().trigger("mousemove");
       testTooltipText(originalTooltipText);
 
       openDashCardVisualizationOptions();
@@ -330,7 +326,7 @@ describe("scenarios > visualizations > line/bar chart > tooltips", () => {
 
       saveDashCardVisualizationOptions();
 
-      showTooltipForFirstBarInSeries(seriesIndex);
+      chartPathWithFillColor("#88BF4D").first().trigger("mousemove");
       testTooltipText(updatedTooltipText);
     });
   });

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -11,8 +11,8 @@ import {
   modal,
   echartsContainer,
   getXYTransform,
-  lineChartCircleWithColor,
-  lineChartCircle,
+  cartesianChartCircleWithColor,
+  cartesianChartCircle,
   trendLine,
 } from "e2e/support/helpers";
 
@@ -148,7 +148,7 @@ describe("scenarios > visualizations > line chart", () => {
       },
     });
 
-    lineChartCircleWithColor("#509EE3").eq(3).realHover();
+    cartesianChartCircleWithColor("#509EE3").eq(3).realHover();
     popover().within(() => {
       testPairedTooltipValues("Product → Rating", "2.7");
       testPairedTooltipValues("Count", "191");
@@ -217,7 +217,7 @@ describe("scenarios > visualizations > line chart", () => {
       display: "line",
     });
 
-    lineChartCircle().should("have.length", 2);
+    cartesianChartCircle().should("have.length", 2);
   });
 
   it("should show the trend line", () => {

--- a/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js
@@ -9,12 +9,15 @@ import {
   queryBuilderMain,
   addOrUpdateDashboardCard,
   modal,
+  echartsContainer,
+  getXYTransform,
+  lineChartCircleWithColor,
+  lineChartCircle,
+  trendLine,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PRODUCTS_ID, PEOPLE, PEOPLE_ID } =
   SAMPLE_DATABASE;
-
-const Y_AXIS_RIGHT_SELECTOR = ".axis.yr";
 
 const testQuery = {
   type: "query",
@@ -40,9 +43,25 @@ describe("scenarios > visualizations > line chart", () => {
 
     cy.findByTestId("viz-settings-button").click();
     openSeriesSettings("Count");
+
+    echartsContainer()
+      .findByText("Count")
+      .then(label => {
+        const { x, y } = getXYTransform(label);
+        cy.wrap({ x, y }).as("leftAxisLabelPosition");
+      });
+
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Right").click();
-    cy.get(Y_AXIS_RIGHT_SELECTOR);
+    echartsContainer()
+      .findByText("Count")
+      .then(label => {
+        const { x: xRight, y: yRight } = getXYTransform(label);
+        cy.get("@leftAxisLabelPosition").then(({ x: xLeft, y: yLeft }) => {
+          expect(yRight).to.be.eq(yLeft);
+          expect(xRight).to.be.greaterThan(xLeft);
+        });
+      });
   });
 
   it("should be able to format data point values style independently on multi-series chart (metabase#13095)", () => {
@@ -74,7 +93,7 @@ describe("scenarios > visualizations > line chart", () => {
       },
     });
 
-    cy.get(".value-labels").contains("39.75%");
+    echartsContainer().get("text").contains("39.75%");
   });
 
   it("should display an error message when there are more series than the chart supports", () => {
@@ -129,12 +148,7 @@ describe("scenarios > visualizations > line chart", () => {
       },
     });
 
-    cy.findByTestId("query-visualization-root")
-      .findAllByTestId("chart-series")
-      .last()
-      .find(".dot")
-      .eq(3)
-      .trigger("mousemove", { force: true });
+    lineChartCircleWithColor("#509EE3").eq(3).realHover();
     popover().within(() => {
       testPairedTooltipValues("Product → Rating", "2.7");
       testPairedTooltipValues("Count", "191");
@@ -203,7 +217,7 @@ describe("scenarios > visualizations > line chart", () => {
       display: "line",
     });
 
-    cy.get(".sub._0").find("circle").should("have.length", 2);
+    lineChartCircle().should("have.length", 2);
   });
 
   it("should show the trend line", () => {
@@ -233,9 +247,7 @@ describe("scenarios > visualizations > line chart", () => {
       },
     });
 
-    cy.get("[data-element-id=line-area-bar-chart]")
-      .get(".trend")
-      .should("be.visible");
+    trendLine().should("be.visible");
   });
 
   it("should show label for empty value series breakout (metabase#32107)", () => {
@@ -313,10 +325,13 @@ describe("scenarios > visualizations > line chart", () => {
         display: "line",
       });
 
-      cy.get("g.axis.yr").should("be.visible");
+      echartsContainer().within(() => {
+        cy.findByText("Average of Latitude").should("be.visible");
+        cy.findByText("Average of Longitude").should("be.visible");
+      });
     });
 
-    it("should split the y-six when columns are of the same semantic_type but have far values", () => {
+    it("should split the y-axis when columns are of the same semantic_type but have far values", () => {
       visitQuestionAdhoc({
         dataset_query: {
           type: "query",
@@ -335,7 +350,10 @@ describe("scenarios > visualizations > line chart", () => {
         display: "line",
       });
 
-      cy.get("g.axis.yr").should("be.visible");
+      echartsContainer().within(() => {
+        cy.findByText("Sum of Total").should("be.visible");
+        cy.findByText("Min of Total").should("be.visible");
+      });
     });
 
     it("should not split the y-axis when the setting is disabled", () => {
@@ -538,7 +556,8 @@ describe("scenarios > visualizations > line chart", () => {
     }
 
     function assertOnYAxisValues() {
-      cy.get(".y-axis-label")
+      echartsContainer()
+        .get("text")
         .should("contain", RENAMED_FIRST_SERIES)
         .and("contain", RENAMED_SECOND_SERIES);
     }
@@ -576,8 +595,14 @@ describe("scenarios > visualizations > line chart", () => {
     });
 
     it("should display correct axis labels (metabase#12782)", () => {
-      cy.get(".x-axis-label").invoke("text").should("eq", "Created At");
-      cy.get(".y-axis-label").invoke("text").should("eq", "Average of Price");
+      echartsContainer()
+        .get("text")
+        .contains("Created At")
+        .should("be.visible");
+      echartsContainer()
+        .get("text")
+        .contains("Average of Price")
+        .should("be.visible");
     });
   });
 
@@ -611,8 +636,8 @@ describe("scenarios > visualizations > line chart", () => {
       "Quantity is between",
     );
     const X_AXIS_VALUE = 8;
-    cy.get(".CardVisualization").within(() => {
-      cy.get(".x-axis-label").should("have.text", "Quantity");
+    echartsContainer().within(() => {
+      cy.get("text").contains("Quantity").should("be.visible");
       cy.findByText(X_AXIS_VALUE);
     });
   });
@@ -627,5 +652,5 @@ function showTooltipForFirstCircleInSeries(series_index) {
     .as("firstSeries")
     .find("circle")
     .first()
-    .trigger("mousemove", { force: true });
+    .trigger("mousemove");
 }

--- a/e2e/test/scenarios/visualizations-charts/reproductions/13504-post-aggregation-drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/13504-post-aggregation-drill.cy.spec.js
@@ -1,5 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { restore, popover, lineChartCircle } from "e2e/support/helpers";
+import { restore, popover, cartesianChartCircle } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
 
@@ -31,7 +31,7 @@ describe("issue 13504", () => {
   it("should remove post-aggregation filters from a multi-stage query (metabase#13504)", () => {
     cy.createQuestion(questionDetails, { visitQuestion: true });
 
-    lineChartCircle().eq(0).click({ force: true });
+    cartesianChartCircle().eq(0).click({ force: true });
 
     popover().findByText("See these Orders").click();
     cy.wait("@dataset");

--- a/e2e/test/scenarios/visualizations-charts/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/16170-line-mongo-replace-missing-values.cy.spec.js
@@ -3,7 +3,7 @@ import {
   withDatabase,
   popover,
   openSeriesSettings,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const externalDatabaseId = 2;
@@ -42,7 +42,7 @@ describe("issue 16170", { tags: "@mongo" }, () => {
 
       assertOnTheYAxis();
 
-      lineChartCircle().eq(-2).trigger("mousemove", { force: true });
+      cartesianChartCircle().eq(-2).trigger("mousemove", { force: true });
 
       popover().within(() => {
         testPairedTooltipValues("Created At", "2019");

--- a/e2e/test/scenarios/visualizations-charts/reproductions/21452-xhr-on-every-char-for-rename.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/21452-xhr-on-every-char-for-rename.cy.spec.js
@@ -4,7 +4,7 @@ import {
   visitQuestionAdhoc,
   popover,
   openSeriesSettings,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID } = SAMPLE_DATABASE;
@@ -41,7 +41,7 @@ describe("issue 21452", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Done").click();
 
-    lineChartCircle().first().realHover();
+    cartesianChartCircle().first().realHover();
 
     popover().within(() => {
       testPairedTooltipValues("Created At", "2022");

--- a/e2e/test/scenarios/visualizations-charts/reproductions/25007-week-tooltip-native.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/25007-week-tooltip-native.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover, lineChartCircle } from "e2e/support/helpers";
+import { restore, popover, cartesianChartCircle } from "e2e/support/helpers";
 
 const questionDetails = {
   name: "11435",
@@ -29,5 +29,5 @@ describe("issue 25007", () => {
 });
 
 const clickLineDot = ({ index } = {}) => {
-  lineChartCircle().eq(index).click({ force: true });
+  cartesianChartCircle().eq(index).click({ force: true });
 };

--- a/e2e/test/scenarios/visualizations-charts/reproductions/27279-sorting-does-not-apply-to-x-axis.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/27279-sorting-does-not-apply-to-x-axis.cy.spec.js
@@ -1,5 +1,11 @@
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
-import { restore, visitQuestionAdhoc, popover } from "e2e/support/helpers";
+import {
+  restore,
+  visitQuestionAdhoc,
+  popover,
+  echartsContainer,
+  chartPathWithFillColor,
+} from "e2e/support/helpers";
 
 const questionDetails = {
   name: "27279",
@@ -51,18 +57,27 @@ describe("issue 27279", () => {
     const legendItems = ["-3", "-2", "-1", "0"];
     compareValuesInOrder(cy.findAllByTestId("legend-item"), legendItems);
 
-    const xAxisTicks = ["F2021", "V2021", "S2022", "F2022"];
-    compareValuesInOrder(cy.get(".x.axis .tick"), xAxisTicks);
+    // need to add a single space on either side of the text as it is used as padding
+    // in ECharts
+    const xAxisTicks = ["F2021", "V2021", "S2022", "F2022"].map(
+      str => ` ${str} `,
+    );
+    compareValuesInOrder(
+      echartsContainer()
+        .get("text")
+        .contains(/F2021|V2021|S2022|F2022/),
+      xAxisTicks,
+    );
 
     // Extra step, just to be overly cautious
-    cy.get(".bar").first().realHover();
+    chartPathWithFillColor("#98D9D9").realHover();
     popover().within(() => {
       testPairedTooltipValues("K", "F2021");
       testPairedTooltipValues("O", "-3");
       testPairedTooltipValues("Sum of V", "1");
     });
 
-    cy.get(".bar").last().realHover();
+    chartPathWithFillColor("#509EE3").realHover();
     popover().within(() => {
       testPairedTooltipValues("K", "F2022");
       testPairedTooltipValues("O", "0");

--- a/e2e/test/scenarios/visualizations-charts/reproductions/30058-32075-map-visualizations.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/reproductions/30058-32075-map-visualizations.cy.spec.js
@@ -3,6 +3,7 @@ import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
 import {
   addSummaryField,
   addSummaryGroupingField,
+  echartsContainer,
   openNotebook,
   popover,
   removeSummaryGroupingField,
@@ -87,7 +88,7 @@ describe("issue 32075", () => {
     visualize();
 
     cy.get("[data-element-id=pin-map]").should("not.exist");
-    cy.get("[data-element-id=line-area-bar-chart]").should("exist");
+    echartsContainer().should("exist");
   });
 });
 

--- a/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
@@ -4,7 +4,7 @@ import {
   restore,
   visitQuestionAdhoc,
   popover,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
@@ -109,7 +109,7 @@ select 10 as size, 2 as x, 5 as y`,
       },
     });
 
-    lineChartCircle().each(([circle], index) => {
+    cartesianChartCircle().each(([circle], index) => {
       const { width, height } = circle.getBoundingClientRect();
       const TOLERANCE = 0.1;
       expect(width).to.be.greaterThan(0);
@@ -133,7 +133,7 @@ function triggerPopoverForBubble(index = 13) {
     cy.findByLabelText("Switch to visualization").click(); // ... and then back to the scatter visualization (that now seems to be stable enough to make assertions about)
   });
 
-  lineChartCircle()
+  cartesianChartCircle()
     .eq(index) // Random bubble
     .trigger("mousemove");
 }

--- a/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/scatter.cy.spec.js
@@ -1,6 +1,11 @@
 import { SAMPLE_DB_ID } from "e2e/support/cypress_data";
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { restore, visitQuestionAdhoc, popover } from "e2e/support/helpers";
+import {
+  restore,
+  visitQuestionAdhoc,
+  popover,
+  lineChartCircle,
+} from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -104,16 +109,12 @@ select 10 as size, 2 as x, 5 as y`,
       },
     });
 
-    cy.get("circle").each((circle, index) => {
-      cy.wrap(circle)
-        .invoke("attr", "r")
-        .then(r => {
-          const rFloat = +r;
-
-          expect(rFloat).to.be.greaterThan(0);
-
-          cy.wrap(r).as("radius" + index);
-        });
+    lineChartCircle().each(([circle], index) => {
+      const { width, height } = circle.getBoundingClientRect();
+      const TOLERANCE = 0.1;
+      expect(width).to.be.greaterThan(0);
+      expect(height).to.be.within(width - TOLERANCE, width + TOLERANCE);
+      cy.wrap(width).as("radius" + index);
     });
 
     cy.get("@radius0").then(r0 => {
@@ -132,7 +133,7 @@ function triggerPopoverForBubble(index = 13) {
     cy.findByLabelText("Switch to visualization").click(); // ... and then back to the scatter visualization (that now seems to be stable enough to make assertions about)
   });
 
-  cy.get(".bubble")
+  lineChartCircle()
     .eq(index) // Random bubble
     .trigger("mousemove");
 }

--- a/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
@@ -1,5 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { restore, leftSidebar, echartsContainer } from "e2e/support/helpers";
+import { restore, leftSidebar, trendLine } from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -64,8 +64,6 @@ describe("scenarios > question > trendline", () => {
       cy.findByText("Trend line").click();
     });
     // ensure that two trend lines are present
-    echartsContainer()
-      .find("path[stroke-dasharray='5,5']")
-      .should("have.length", 2);
+    trendLine().should("have.length", 2);
   });
 });

--- a/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/trendline.cy.spec.js
@@ -1,5 +1,5 @@
 import { SAMPLE_DATABASE } from "e2e/support/cypress_sample_database";
-import { restore, leftSidebar } from "e2e/support/helpers";
+import { restore, leftSidebar, echartsContainer } from "e2e/support/helpers";
 
 const { ORDERS_ID, ORDERS, PRODUCTS_ID, PRODUCTS } = SAMPLE_DATABASE;
 
@@ -64,6 +64,8 @@ describe("scenarios > question > trendline", () => {
       cy.findByText("Trend line").click();
     });
     // ensure that two trend lines are present
-    cy.get("g.trend path.line").should("have.length", 2);
+    echartsContainer()
+      .find("path[stroke-dasharray='5,5']")
+      .should("have.length", 2);
   });
 });

--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -20,10 +20,8 @@ describe("scenarios > visualizations > waterfall", () => {
   });
 
   function verifyWaterfallRendering(xLabel = null, yLabel = null) {
-    // a waterfall chart is just a stacked bar chart, with 4 bars
-    // (not all of them will be visible at once, but they should exist)
-    chartPathWithFillColor("#88BF4D");
-    chartPathWithFillColor("#4C5773");
+    chartPathWithFillColor("#88BF4D").should("be.visible");
+    chartPathWithFillColor("#4C5773").should("be.visible");
     echartsContainer().get("text").contains("Total");
 
     if (xLabel) {
@@ -215,7 +213,7 @@ describe("scenarios > visualizations > waterfall", () => {
     // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
     cy.findByText("Visualization").click();
     cy.icon("waterfall").click({ force: true });
-    chartPathWithFillColor("#88BF4D");
+    chartPathWithFillColor("#88BF4D").should("be.visible");
   });
 
   it("should display correct values when one of them is 0 (metabase#16246)", () => {

--- a/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-charts/waterfall.cy.spec.js
@@ -233,9 +233,7 @@ describe("scenarios > visualizations > waterfall", () => {
       },
     });
 
-    // paint-order='stroke' targets the waterfall labels only
-    echartsContainer()
-      .get("text[paint-order='stroke']")
+    getWaterfallDataLabels()
       .as("labels")
       .eq(-3)
       .invoke("text")
@@ -261,8 +259,7 @@ describe("scenarios > visualizations > waterfall", () => {
       },
     });
 
-    echartsContainer()
-      .get("text[paint-order='stroke']")
+    getWaterfallDataLabels()
       .as("labels")
       .eq(-3)
       .invoke("text")
@@ -327,3 +324,8 @@ const switchToWaterfallDisplay = () => {
     cy.icon("gear").click();
   });
 };
+
+function getWaterfallDataLabels() {
+  // paint-order='stroke' targets the waterfall labels only
+  return echartsContainer().get("text[paint-order='stroke']");
+}

--- a/e2e/test/scenarios/visualizations-tabular/drillthroughs/dash_drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/drillthroughs/dash_drill.cy.spec.js
@@ -6,7 +6,7 @@ import {
   queryBuilderMain,
   restore,
   visitDashboard,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 
 const { ORDERS, ORDERS_ID, PRODUCTS, PEOPLE, PEOPLE_ID } = SAMPLE_DATABASE;
@@ -129,7 +129,7 @@ describe("scenarios > visualizations > drillthroughs > dash_drill", () => {
       it("should result in a correct query result", () => {
         // eslint-disable-next-line no-unscoped-text-selectors -- deprecated usage
         cy.findByText("Affiliate");
-        lineChartCircle().should("have.length.of.at.least", 100);
+        cartesianChartCircle().should("have.length.of.at.least", 100);
       });
     });
 

--- a/e2e/test/scenarios/visualizations-tabular/reproductions/11435-time-tooltip-native.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/reproductions/11435-time-tooltip-native.cy.spec.js
@@ -1,4 +1,4 @@
-import { restore, popover, lineChartCircle } from "e2e/support/helpers";
+import { restore, popover, cartesianChartCircle } from "e2e/support/helpers";
 
 const questionDetails = {
   name: "11435",
@@ -36,5 +36,5 @@ describe("issue 11435", () => {
 });
 
 const hoverLineDot = ({ index } = {}) => {
-  lineChartCircle().eq(index).realHover();
+  cartesianChartCircle().eq(index).realHover();
 };

--- a/e2e/test/scenarios/visualizations-tabular/reproductions/6010-metric-filter-drill.cy.spec.js
+++ b/e2e/test/scenarios/visualizations-tabular/reproductions/6010-metric-filter-drill.cy.spec.js
@@ -3,7 +3,7 @@ import {
   restore,
   popover,
   visitQuestion,
-  lineChartCircle,
+  cartesianChartCircle,
 } from "e2e/support/helpers";
 import { createMetric as apiCreateMetric } from "e2e/support/helpers/e2e-table-metadata-helpers";
 
@@ -21,7 +21,7 @@ describe("issue 6010", () => {
       .then(({ body: { id } }) => createQuestion(id))
       .then(({ body: { id } }) => visitQuestion(id));
 
-    lineChartCircle().eq(0).click();
+    cartesianChartCircle().eq(0).click();
 
     popover().findByText("See these Orders").click();
     cy.wait("@dataset");

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/goal-line.ts
@@ -10,6 +10,8 @@ import { GOAL_LINE_SERIES_ID, X_AXIS_DATA_KEY } from "../constants/dataset";
 import { CHART_STYLE } from "../constants/style";
 import type { CartesianChartModel, ChartDataset } from "../model/types";
 
+export const GOAL_LINE_DASH = [3, 4];
+
 function getFirstNonNullXValue(dataset: ChartDataset) {
   for (let i = 0; i < dataset.length; i++) {
     const xValue = dataset[i][X_AXIS_DATA_KEY];
@@ -69,7 +71,7 @@ export function getGoalLineSeriesOption(
           lineWidth: 2,
           stroke: renderingContext.getColor("text-medium"),
           color: renderingContext.getColor("text-medium"),
-          lineDash: [3, 4],
+          lineDash: GOAL_LINE_DASH,
         },
       };
 

--- a/frontend/src/metabase/visualizations/echarts/cartesian/option/trend-line.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/option/trend-line.ts
@@ -8,6 +8,8 @@ import type { CartesianChartModel } from "../model/types";
 
 import { getSeriesYAxisIndex } from "./utils";
 
+export const TREND_LINE_DASH = [5, 5];
+
 export function getTrendLinesOption(
   chartModel: CartesianChartModel,
 ): RegisteredSeriesOption["line"][] {
@@ -25,7 +27,7 @@ export function getTrendLinesOption(
       showSymbol: false,
       lineStyle: {
         color: trendSeries.color,
-        type: [5, 5],
+        type: TREND_LINE_DASH,
         width: 2,
       },
       z: CHART_STYLE.trendLine.zIndex,


### PR DESCRIPTION
- Fixes E2E spec e2e-tests-visualizations-charts-ee in https://github.com/metabase/metabase/issues/40930

---
**CI Blockers:**
- `visualization-charts/waterfall.cy.spec.js: "should work with time-series data"`: https://github.com/metabase/metabase/issues/41550
- `e2e/test/scenarios/visualizations-charts/maps.cy.spec.js: "should apply brush filters by dragging map"`: https://github.com/metabase/metabase/issues/41605
- `e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js: "should display an error message when there are more series than the chart supports"`:https://github.com/metabase/metabase/issues/41609
- `e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js: "should be possible to update/change label for an empty row value (metabase#12128)"`: https://github.com/metabase/metabase/issues/41610
- `e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js: "should show label for empty value series breakout (metabase#32107)" and "should not drop the chart legend (metabase#4995)""`: https://github.com/metabase/metabase/issues/41611
- `e2e/test/scenarios/visualizations-charts/line_chart.cy.spec.js: "custom expression names (metabase#16249-1)" and "regular column names (metabase#16249-2)"`: https://github.com/metabase/metabase/issues/41612
- `e2e/test/scenarios/visualizations-charts/bar_chart.cy.spec.js: "supports up to 100 series (metabase#28796)"`:https://github.com/metabase/metabase/issues/41609