### PR TITLE
show an error when too many series

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -1,5 +1,5 @@
 import type { EChartsType } from "echarts";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ChartRenderingErrorBoundary } from "metabase/visualizations/components/ChartRenderingErrorBoundary";
 import LegendCaption from "metabase/visualizations/components/legend/LegendCaption";
@@ -14,7 +14,7 @@ import { useChartEvents } from "metabase/visualizations/visualizations/Cartesian
 
 import { useChartDebug } from "./use-chart-debug";
 import { useModelsAndOption } from "./use-models-and-option";
-import { getGridSizeAdjustedSettings } from "./utils";
+import { getGridSizeAdjustedSettings, validateChartModel } from "./utils";
 
 function _CartesianChart(props: VisualizationProps) {
   // The width and height from props reflect the dimensions of the entire container which includes legend,
@@ -58,6 +58,10 @@ function _CartesianChart(props: VisualizationProps) {
 
   const legendItems = useMemo(() => getLegendItems(chartModel), [chartModel]);
   const hasLegend = legendItems.length > 1;
+
+  useEffect(() => {
+    validateChartModel(chartModel);
+  }, [chartModel]);
 
   const handleInit = useCallback((chart: EChartsType) => {
     chartRef.current = chart;

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/utils.ts
@@ -1,3 +1,6 @@
+import { t } from "ttag";
+
+import type { BaseCartesianChartModel } from "metabase/visualizations/echarts/cartesian/model/types";
 import type {
   ComputedVisualizationSettings,
   VisualizationGridSize,
@@ -43,4 +46,14 @@ export const getGridSizeAdjustedSettings = (
   }
 
   return newSettings;
+};
+
+export const MAX_SERIES = 100;
+
+export const validateChartModel = (chartModel: BaseCartesianChartModel) => {
+  if (chartModel.seriesModels.length > MAX_SERIES) {
+    throw new Error(
+      t`This chart type doesn't support more than ${MAX_SERIES} series of data.`,
+    );
+  }
 };


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41609

### Description

Describe the overall approach and the problem being solved.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Products -> 
2. Group by Created At and Title
3. Reorder X-axis columns so that the Title will be used as a breakout dimension since it has >100 values
4. Ensure the chart shows an error. In dev mode it is "A cross-origin error was thrown. React doesn't have access to the actual error object in development. See https://reactjs.org/link/crossorigin-error for more information." — we need to fix this separately. In the console you can see the message is correct.

### Demo

<img width="1725" alt="Screenshot 2024-04-18 at 7 27 43 PM" src="https://github.com/metabase/metabase/assets/14301985/24224c95-a6ff-4148-bbad-3e280a69acd2">

### Checklist

- [-] Tests have been added/updated to cover changes in this PR — covered by e2e specs that caught this
