### PR TITLE
fix missing legend for single series breakout chart

### DIFF
--- a/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
+++ b/frontend/src/metabase/static-viz/components/ComboChart/ComboChart.tsx
@@ -44,7 +44,7 @@ export const ComboChart = ({
     renderingContext,
   );
 
-  const legendItems = getLegendItems(chartModel);
+  const legendItems = getLegendItems(chartModel.seriesModels);
   const isReversed = computedVisualizationSettings["legend.is_reversed"];
   const { height: legendHeight, items: legendLayoutItems } =
     calculateLegendRows({

--- a/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
+++ b/frontend/src/metabase/static-viz/components/ScatterPlot/ScatterPlot.tsx
@@ -38,7 +38,7 @@ export function ScatterPlot({
     renderingContext,
   );
 
-  const legendItems = getLegendItems(chartModel);
+  const legendItems = getLegendItems(chartModel.seriesModels);
   const { height: legendHeight, items: legendLayoutItems } =
     calculateLegendRows({
       items: legendItems,

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/dataset.unit.spec.ts
@@ -1,3 +1,4 @@
+import { createMockSeriesModel } from "__support__/echarts";
 import { checkNumber } from "metabase/lib/types";
 import {
   POSITIVE_STACK_TOTAL_DATA_KEY,
@@ -31,25 +32,10 @@ import {
 } from "./dataset";
 import type {
   ChartDataset,
-  DataKey,
   LegacySeriesSettingsObjectKey,
   NumericAxisScaleTransforms,
-  SeriesModel,
   XAxisModel,
 } from "./types";
-
-const createMockSeriesModel = (
-  dataKey: DataKey,
-  columnIndex: number = 1,
-): SeriesModel => ({
-  dataKey,
-  name: `name for ${dataKey}`,
-  color: "red",
-  legacySeriesSettingsObjectKey: { card: { _seriesKey: dataKey } },
-  vizSettingsKey: dataKey,
-  column: createMockColumn({ name: dataKey }),
-  columnIndex,
-});
 
 const createMockComputedVisualizationSettings = (
   opts: Partial<ComputedVisualizationSettings> = {},
@@ -321,8 +307,8 @@ describe("dataset transform functions", () => {
     ];
 
     const seriesModels = [
-      createMockSeriesModel("series1"),
-      createMockSeriesModel("series2"),
+      createMockSeriesModel({ dataKey: "series1" }),
+      createMockSeriesModel({ dataKey: "series2" }),
     ];
 
     it("should populate dataset with min numeric values for positive and negative stack totals", () => {
@@ -470,7 +456,9 @@ describe("dataset transform functions", () => {
 
   describe("getTransformedDataset", () => {
     const seriesKey = "value";
-    const seriesModels = [createMockSeriesModel("value", 0)];
+    const seriesModels = [
+      createMockSeriesModel({ dataKey: "value", columnIndex: 0 }),
+    ];
 
     it("should sort time-series datasets", () => {
       const dataset = [

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/guards.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/guards.ts
@@ -1,6 +1,8 @@
 import type {
+  BreakoutSeriesModel,
   CategoryXAxisModel,
   NumericXAxisModel,
+  SeriesModel,
   TimeSeriesXAxisModel,
   XAxisModel,
 } from "./types";
@@ -21,4 +23,10 @@ export const isCategoryAxis = (
   axisModel: XAxisModel,
 ): axisModel is CategoryXAxisModel => {
   return axisModel.axisType === "category";
+};
+
+export const isBreakoutSeries = (
+  seriesModel: SeriesModel,
+): seriesModel is BreakoutSeriesModel => {
+  return "breakoutColumn" in seriesModel;
 };

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/legend.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/legend.ts
@@ -1,7 +1,12 @@
-import type { BaseCartesianChartModel } from "./types";
+import { isBreakoutSeries } from "./guards";
+import type { SeriesModel } from "./types";
 
-export const getLegendItems = (chartModel: BaseCartesianChartModel) => {
-  return chartModel.seriesModels.map(seriesModel => ({
+export const getLegendItems = (seriesModels: SeriesModel[]) => {
+  if (seriesModels.length === 1 && !isBreakoutSeries(seriesModels[0])) {
+    return [];
+  }
+
+  return seriesModels.map(seriesModel => ({
     name: seriesModel.name,
     color: seriesModel.color,
   }));

--- a/frontend/src/metabase/visualizations/echarts/cartesian/model/legend.unit.spec.ts
+++ b/frontend/src/metabase/visualizations/echarts/cartesian/model/legend.unit.spec.ts
@@ -1,0 +1,31 @@
+import {
+  createMockBreakoutSeriesModel,
+  createMockSeriesModel,
+} from "__support__/echarts";
+
+import { getLegendItems } from "./legend";
+
+describe("getLegendItems", () => {
+  it("should return an empty array when there is only one series and it is not a breakout series", () => {
+    const legendItems = getLegendItems([createMockSeriesModel()]);
+    expect(legendItems).toEqual([]);
+  });
+
+  it("should return legend items when there are multiple series", () => {
+    const legendItems = getLegendItems([
+      createMockSeriesModel({ name: "Series 1", color: "red" }),
+      createMockSeriesModel({ name: "Series 2", color: "blue" }),
+    ]);
+    expect(legendItems).toStrictEqual([
+      { name: "Series 1", color: "red" },
+      { name: "Series 2", color: "blue" },
+    ]);
+  });
+
+  it("should return legend items when there is a single breakout series", () => {
+    const legendItems = getLegendItems([
+      createMockBreakoutSeriesModel({ name: "breakout series" }),
+    ]);
+    expect(legendItems).toEqual([{ name: "breakout series", color: "red" }]);
+  });
+});

--- a/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
+++ b/frontend/src/metabase/visualizations/visualizations/CartesianChart/CartesianChart.tsx
@@ -56,8 +56,11 @@ function _CartesianChart(props: VisualizationProps) {
   const title = settings["card.title"] || card.name;
   const description = settings["card.description"];
 
-  const legendItems = useMemo(() => getLegendItems(chartModel), [chartModel]);
-  const hasLegend = legendItems.length > 1;
+  const legendItems = useMemo(
+    () => getLegendItems(chartModel.seriesModels),
+    [chartModel],
+  );
+  const hasLegend = legendItems.length > 0;
 
   const handleInit = useCallback((chart: EChartsType) => {
     chartRef.current = chart;

--- a/frontend/test/__support__/echarts.ts
+++ b/frontend/test/__support__/echarts.ts
@@ -1,0 +1,30 @@
+import type {
+  BreakoutSeriesModel,
+  SeriesModel,
+} from "metabase/visualizations/echarts/cartesian/model/types";
+import { createMockColumn } from "metabase-types/api/mocks";
+
+export const createMockSeriesModel = (
+  opts?: Partial<SeriesModel>,
+): SeriesModel => {
+  const dataKey = opts?.dataKey ?? "dataKey";
+  return {
+    dataKey,
+    name: `name for ${dataKey}`,
+    color: "red",
+    legacySeriesSettingsObjectKey: { card: { _seriesKey: dataKey } },
+    vizSettingsKey: dataKey,
+    column: createMockColumn({ name: dataKey }),
+    columnIndex: 1,
+    ...opts,
+  };
+};
+
+export const createMockBreakoutSeriesModel = (
+  opts?: Partial<BreakoutSeriesModel>,
+): BreakoutSeriesModel => ({
+  breakoutColumn: createMockColumn({ name: "breakoutColumn" }),
+  breakoutColumnIndex: 2,
+  breakoutValue: "foo",
+  ...createMockSeriesModel(opts),
+});


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41611

### Description

Fix missing legend when a chart has single series and it is a breakout series.

### How to verify

Describe the steps to verify that the changes are working as expected.

1. New question -> Sample Dataset -> Orders
2. Group by "Created at" and "Product: Category"
3. Add filter Product: Category = Gadget
4. Ensure the legend shows one item

### Demo

<img width="1366" alt="Screenshot 2024-04-18 at 9 15 46 PM" src="https://github.com/metabase/metabase/assets/14301985/791f645f-8096-4e1c-b4ea-7e13d3c7b00a">

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
