### PR TITLE
Fix Dispatch type

### DIFF
--- a/frontend/src/metabase-types/store/state.ts
+++ b/frontend/src/metabase-types/store/state.ts
@@ -36,7 +36,7 @@ export interface State {
   modal: modalName;
 }
 
-export type Dispatch<T = any> = (action: T) => void;
+export type Dispatch<T = any> = (action: T) => unknown | Promise<unknown>;
 
 export type GetState = () => State;
 

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableList/MetadataTableList.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableList/MetadataTableList.tsx
@@ -54,7 +54,7 @@ interface DispatchProps {
   onUpdateTableVisibility: (
     tables: Table[],
     visibility: TableVisibilityType,
-  ) => Promise<void>;
+  ) => Promise<unknown>;
 }
 
 type MetadataTableListProps = OwnProps & TableLoaderProps & DispatchProps;

--- a/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableList/MetadataTableList.tsx
+++ b/frontend/src/metabase/admin/datamodel/metadata/components/MetadataTableList/MetadataTableList.tsx
@@ -210,7 +210,7 @@ interface TableHeaderProps {
   onUpdateTableVisibility: (
     tables: Table[],
     visibility: TableVisibilityType,
-  ) => Promise<void>;
+  ) => Promise<unknown>;
 }
 
 const TableHeader = ({
@@ -260,7 +260,7 @@ interface TableRowProps {
   onUpdateTableVisibility: (
     tables: Table[],
     visibility: TableVisibilityType,
-  ) => Promise<void>;
+  ) => Promise<unknown>;
 }
 
 const TableRow = ({
@@ -314,7 +314,7 @@ interface ToggleVisibilityButtonProps {
   onUpdateTableVisibility: (
     tables: Table[],
     visibility: TableVisibilityType,
-  ) => Promise<void>;
+  ) => Promise<unknown>;
 }
 
 const ToggleVisibilityButton = ({


### PR DESCRIPTION
This PR fixes this warning:
![image](https://github.com/metabase/metabase/assets/6830683/a6f45667-09b4-4601-b250-7e0a95c13d21)

`dispatch` will return an action object or a promise, so it's definitely not `void`.