### PR TITLE
Fix not sending necessary HTTP headers when downloading results

### DIFF
--- a/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
+++ b/e2e/test/scenarios/embedding/interactive-embedding.cy.spec.js
@@ -19,6 +19,7 @@ import {
   createDashboardWithTabs,
   goToTab,
   visitFullAppEmbeddingUrl,
+  getDashboardCardMenu,
 } from "e2e/support/helpers";
 import {
   createMockDashboardCard,
@@ -533,6 +534,33 @@ describeEE("scenarios > embedding > full app", () => {
             },
           }),
         ).to.be.true;
+      });
+    });
+
+    it("should allow downloading question results when logged in via Google SSO (metabase#39848)", () => {
+      const CSRF_TOKEN = "abcdefgh";
+      cy.intercept("GET", "/api/user/current", req => {
+        req.on("response", res => {
+          res.headers["X-Metabase-Anti-CSRF-Token"] = CSRF_TOKEN;
+        });
+      });
+      cy.intercept(
+        "POST",
+        "/api/dashboard/*/dashcard/*/card/*/query/csv?format_rows=true",
+      ).as("CsvDownload");
+      visitDashboardUrl({
+        url: `/dashboard/${ORDERS_DASHBOARD_ID}`,
+      });
+
+      getDashboardCard().realHover();
+      getDashboardCardMenu().click();
+      popover().findByText("Download results").click();
+      popover().findByText(".csv").click();
+
+      cy.wait("@CsvDownload").then(interception => {
+        expect(
+          interception.request.headers["x-metabase-anti-csrf-token"],
+        ).to.equal(CSRF_TOKEN);
       });
     });
   });

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -218,7 +218,7 @@ export class Api extends EventEmitter {
           }
           if (status >= 200 && status <= 299) {
             if (options.transformResponse) {
-              body = options.transformResponse(body, { data });
+              body = options.transformResponse({ body, data });
             }
             resolve(body);
           } else {
@@ -266,6 +266,7 @@ export class Api extends EventEmitter {
 
     return fetch(request)
       .then(response => {
+        const unreadResponse = response.clone();
         return response.text().then(body => {
           if (options.json) {
             try {
@@ -289,7 +290,11 @@ export class Api extends EventEmitter {
 
           if (status >= 200 && status <= 299) {
             if (options.transformResponse) {
-              body = options.transformResponse(body, { data });
+              body = options.transformResponse({
+                body,
+                data,
+                response: unreadResponse,
+              });
             }
             return body;
           } else {

--- a/frontend/src/metabase/lib/api.js
+++ b/frontend/src/metabase/lib/api.js
@@ -17,7 +17,7 @@ const DEFAULT_OPTIONS = {
   json: true,
   hasBody: false,
   noEvent: false,
-  transformResponse: o => o,
+  transformResponse: ({ body }) => body,
   raw: {},
   headers: {},
   retry: false,

--- a/frontend/src/metabase/query_builder/actions/downloading.ts
+++ b/frontend/src/metabase/query_builder/actions/downloading.ts
@@ -145,7 +145,6 @@ const getDatasetParams = ({
 
 export function getDatasetDownloadUrl(url: string, params?: URLSearchParams) {
   url = url.replace(api.basename, ""); // make url relative if it's not
-  url = api.basename + url;
   if (params) {
     url += `?${params.toString()}`;
   }

--- a/frontend/src/metabase/query_builder/actions/downloading.ts
+++ b/frontend/src/metabase/query_builder/actions/downloading.ts
@@ -167,7 +167,7 @@ const getDatasetResponse = ({
 
   if (method === "POST") {
     // BE expects the body to be form-encoded :(
-    const formattedBody = new FormData();
+    const formattedBody = new URLSearchParams();
     if (body != null) {
       for (const key in body) {
         formattedBody.append(key, JSON.stringify(body[key]));

--- a/frontend/src/metabase/query_builder/actions/downloading.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/downloading.unit.spec.ts
@@ -18,7 +18,7 @@ describe("getDatasetResponse", () => {
       const url = "/embed/question/123.xlsx";
 
       expect(downloading.getDatasetDownloadUrl(url)).toBe(
-        `${origin}/embed/question/123.xlsx`,
+        `/embed/question/123.xlsx`,
       );
     });
   });

--- a/frontend/src/metabase/query_builder/actions/downloading.unit.spec.ts
+++ b/frontend/src/metabase/query_builder/actions/downloading.unit.spec.ts
@@ -24,6 +24,11 @@ describe("getDatasetResponse", () => {
   });
 
   describe("subpath deployment", () => {
+    /**
+     * We will assert that the result is a relative path without subpath.
+     * Because this URL will be pass to `frontend/src/metabase/lib/api.js`
+     * which already takes care of the subpath (api.basename)
+     */
     const origin = "http://localhost";
     const subpath = "/mb";
     const originalBasename = api.basename;
@@ -40,7 +45,7 @@ describe("getDatasetResponse", () => {
       const url = `${origin}${subpath}/embed/question/123.xlsx`;
 
       expect(downloading.getDatasetDownloadUrl(url)).toBe(
-        `${origin}${subpath}/embed/question/123.xlsx`,
+        `/embed/question/123.xlsx`,
       );
     });
 
@@ -48,7 +53,7 @@ describe("getDatasetResponse", () => {
       const url = "/embed/question/123.xlsx";
 
       expect(downloading.getDatasetDownloadUrl(url)).toBe(
-        `${origin}${subpath}/embed/question/123.xlsx`,
+        `/embed/question/123.xlsx`,
       );
     });
   });

--- a/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
+++ b/frontend/src/metabase/query_builder/containers/QueryBuilder.unit.spec.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event";
+import type { MockCall } from "fetch-mock";
 import fetchMock from "fetch-mock";
 
 import {
@@ -199,20 +200,15 @@ describe("QueryBuilder", () => {
         await screen.findByRole("button", { name: ".csv" }),
       );
 
-      expect(
-        mockDownloadEndpoint.called((url, options) => {
-          const { body: urlSearchParams } = options;
-          const query =
-            urlSearchParams instanceof URLSearchParams
-              ? JSON.parse(urlSearchParams.get("query") ?? "{}")
-              : {};
-
-          return (
-            url.includes("/api/dataset/csv") &&
-            query?.native.query === "SELECT 1"
-          );
-        }),
-      ).toBe(true);
+      const [url, options] = mockDownloadEndpoint.lastCall() as MockCall;
+      const body = await Promise.resolve(options?.body);
+      const urlSearchParams = new URLSearchParams(body as string);
+      expect(url).toEqual(expect.stringContaining("/api/dataset/csv"));
+      const query =
+        urlSearchParams instanceof URLSearchParams
+          ? JSON.parse(urlSearchParams.get("query") ?? "{}")
+          : {};
+      expect(query?.native.query).toEqual("SELECT 1");
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/39848

Related to https://github.com/metabase/metabase/issues/18823

### Description

This fix the problem where users logged in via Google SSO couldn't download question results. This was because we call `fetch` directly without passing the proper CSRF header which is required when we authenticate with `metabase.EMBEDDED_SESSION` cookie like Google SSO in this case. That is why we got 401 in the response.

### How to verify

1. Follow the repro steps in https://github.com/metabase/metabase/issues/39848

2. Ensure [Fix download full results link for embedded and public questions](https://github.com/metabase/metabase/pull/34659#top) is still working

    To set up subpath. Use https://github.com/WiNloSt/metabase-subpath. The instruction is already in the repo.

### Checklist

- [x] Tests have been added/updated to cover changes in this PR
