### PR TITLE
add "Setup embedding" to the admin setup checklist

### DIFF
--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -427,7 +427,7 @@
             (is (= ["Get connected" "Curate your data"]
                    (map :name checklist)))))))
     (testing "setup-embedding"
-            (testing "should be done when a dashboard as been published"
+      (testing "should be done when a dashboard as been published"
         (with-redefs [api.setup/state-for-checklist
                       (constantly
                        (update default-checklist-state
@@ -439,7 +439,7 @@
                       (constantly
                        (update default-checklist-state
                                :configured #(merge %  {:embedding-app-origin true
-                                                       :sso true})))]
+                                                       :sso                  true})))]
           (let [checklist (mt/user-http-request :crowberto :get 200 "setup/admin_checklist")]
             (is (partial= {:completed true} (get-embedding-step checklist))))))
       (testing "should be done when dismissed-done"

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -346,12 +346,12 @@
 (def ^:private default-checklist-state
   {:db-type    :h2
    :hosted?    false
-   :interested-in-embedding false
-   :embedding-homepage-dismissed-as-done false
-   :configured {:email                true
-                :slack                false
-                :sso                  false
-                :embedding-app-origin false}
+   :embedding  {:interested? false
+                :done?       false
+                :app-origin  false}
+   :configured {:email true
+                :slack false
+                :sso   false}
    :counts     {:user  5
                 :card  5
                 :table 5}
@@ -437,16 +437,17 @@
       (testing "should be done when sso and embed-app-origin has been configured"
         (with-redefs [api.setup/state-for-checklist
                       (constantly
-                       (update default-checklist-state
-                               :configured #(merge %  {:embedding-app-origin true
-                                                       :sso                  true})))]
+                       (-> default-checklist-state
+                           (assoc-in [:configured :sso] true)
+                           (assoc-in [:embedding :app-origin] true)))]
           (let [checklist (mt/user-http-request :crowberto :get 200 "setup/admin_checklist")]
-            (is (partial= {:completed true} (get-embedding-step checklist))))))
+            (is (partial= {:completed true}
+                          (get-embedding-step checklist))))))
       (testing "should be done when dismissed-done"
         (with-redefs [api.setup/state-for-checklist
                       (constantly
-                       (merge default-checklist-state
-                              {:embedding-homepage-dismissed-as-done true }))]
+                       (-> default-checklist-state
+                           (assoc-in [:embedding :done?] true)))]
           (let [checklist (mt/user-http-request :crowberto :get 200 "setup/admin_checklist")]
             (is (partial= {:completed true} (get-embedding-step checklist)))))))
 

--- a/test/metabase/api/setup_test.clj
+++ b/test/metabase/api/setup_test.clj
@@ -35,7 +35,7 @@
 (defn- do-with-setup!* [request-body thunk]
   (try
     (mt/discard-setting-changes [site-name site-locale anon-tracking-enabled admin-email]
-                                (thunk))
+      (thunk))
     (finally
       (t2/delete! User :email (get-in request-body [:user :email]))
       (when-let [invited (get-in request-body [:invite :name])]


### PR DESCRIPTION
This is part of the last milestone of [[Epic] Initial homepage experience for embedding admins](https://github.com/metabase/metabase/issues/40005)

It adds a new step in the setup checklist, as by [this design on figma](https://www.figma.com/file/UFay4YjWyUMyl23T1cXzeC/Meet-first-time-embedders-at-the-door-with-a-dashboard?type=design&node-id=1264-41762&mode=design&t=kepstwC5dDtNMEBt-4)
<img width="782" alt="image" src="https://github.com/metabase/metabase/assets/1914270/69b0cedf-9cd8-487a-b152-0a0e99b7959d">

I tried to make the code as coherent as I could to the rest of the files but I had to ask to my friendly local AI how to do some things in clojure so it's possible some things are not very idiomatic.

The list item is set as done if any of the following:
- the embedding homepage has been dismissed as "done"
- a dashboard or a question has been published for static embedding
- sso is configured and the authorized origin has been set (proxy for "interactive embedding is setup")