### PR TITLE
use css modules instead of inline styles for cursor: default

### DIFF
--- a/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
+++ b/frontend/src/metabase/home/components/EmbedHomepage/EmbedHomepageView.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router";
 import { jt, t } from "ttag";
 
 import ExternalLink from "metabase/core/components/ExternalLink";
+import CS from "metabase/css/core/index.css";
 import {
   Anchor,
   Card,
@@ -49,7 +50,7 @@ export const EmbedHomepageView = (props: EmbedHomepageViewProps) => {
             <Text
               fw="bold"
               color="brand"
-              style={{ cursor: "default" }}
+              className={CS.cursorDefault}
             >{t`Hide these`}</Text>
           </Menu.Target>
           <Menu.Dropdown>


### PR DESCRIPTION
### Description

The original feature was made before that was converted to css modules, so I added this change to the last milestone to not have issues with conflicts etc

Original comment: https://github.com/metabase/metabase/pull/40587#pullrequestreview-1958872374
