### PR TITLE
Add a new migration to clean up deprecated perm types

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -6364,6 +6364,16 @@ databaseChangeLog:
             relativeToChangelogFile: true
       rollback: # no rollback necessary, we're not removing the columns yet
 
+  - changeSet:
+      id: v50.2024-04-19T17:04:04
+      author: noahmoss
+      comment: Clean up deprecated view-data and native-query-editing permissions (again)
+      rollback: # handled by the rollbacks for `v50.2024-02-26T22:15:54` and `v50.2024-02-26T22:15:55`
+      changes:
+        - sql:
+            sql: >
+              DELETE FROM data_permissions where perm_type = 'perms/data-access' OR perm_type = 'perms/native-query-editing';
+
   # >>>>>>>>>> DO NOT ADD NEW MIGRATIONS BELOW THIS LINE! ADD THEM ABOVE <<<<<<<<<<
 
 ########################################################################################################################


### PR DESCRIPTION
This duplicates migration `v50.2024-03-24T19:34:11` which full removes the deprecated `data-access` and `native-query-editing` permission types from the app DB. (By this point in the migrations, they should be fully migrated to `view-data` and `create-queries`).

I'm adding a new one of these migrations because stats got into a strange state after deploying https://github.com/metabase/metabase/pull/41581, where `data-access` permissions were left behind for a single table. This causes the BE to error when trying to fetch the perms graph.

The problematic table is a new app DB table that was also added in a migration, and then synced in stats since the app DB is also a connected data source. I'm still unpacking the sequence of events that led to the `data-access` perms for this table not being removed properly (it may have to do with reverting and then restoring the split data perms migration this week). But in the meantime, we can run the deletion migration again to fix stats. It should be idempotent for all other instances, so there shouldn't be any problem with running this twice.