### PR TITLE
Fix/improve list tags for paginated endpoints

### DIFF
--- a/frontend/src/metabase/api/tags/utils.ts
+++ b/frontend/src/metabase/api/tags/utils.ts
@@ -47,6 +47,10 @@ export function listTag(type: TagType): TagDescription<TagType> {
   return { type, id: "LIST" };
 }
 
+export function partialListTag(type: TagType): TagDescription<TagType> {
+  return { type, id: "PARTIAL-LIST" };
+}
+
 export function idTag(
   type: TagType,
   id: string | number,
@@ -339,7 +343,7 @@ export function provideTableTags(table: Table): TagDescription<TagType>[] {
 }
 
 export function provideTaskListTags(tasks: Task[]): TagDescription<TagType>[] {
-  return [listTag("task"), ...tasks.flatMap(provideTaskTags)];
+  return [partialListTag("task"), ...tasks.flatMap(provideTaskTags)];
 }
 
 export function provideTaskTags(task: Task): TagDescription<TagType>[] {


### PR DESCRIPTION
This PR is a follow-up after #41538.
According to [the documentation](https://redux-toolkit.js.org/rtk-query/usage/pagination#automated-re-fetching-of-paginated-queries), we need to provide a special type of the list tag called `PARTIAL-LIST` if we want the cache to work properly for the paginated endpoints.

This PR introduces new helper called `partialListTag`, and applies it to the `provideTaskListTags`.
Although there are other paginated endpoints, this PR doesn't deal with them now.