### PR TITLE
Invalidate model caching when updating upload table

### DIFF
--- a/src/metabase/models/persisted_info.clj
+++ b/src/metabase/models/persisted_info.clj
@@ -123,6 +123,7 @@
   ;; TODO confirm that the corresponding tables will still be cleaned up.
   (t2/update! PersistedInfo
               (merge {:active true} conditions-map)
+              ;; TODO perhaps we should immediately kick off a recalculation of these caches
               {:active false, :state "creating", :state_change_at :%now}))
 
 (defn- create-row

--- a/src/metabase/models/persisted_info.clj
+++ b/src/metabase/models/persisted_info.clj
@@ -117,6 +117,14 @@
   ([conditions-map state]
    (t2/update! PersistedInfo conditions-map {:active false, :state state, :state_change_at :%now})))
 
+(defn invalidate!
+  "Invalidates any caches corresponding to the `conditions-map`. Equivalent to toggling the caching off and on again."
+  [conditions-map]
+  ;; TODO confirm that the corresponding tables will still be cleaned up.
+  (t2/update! PersistedInfo
+              (merge {:active true} conditions-map)
+              {:active false, :state "creating", :state_change_at :%now}))
+
 (defn- create-row
   "Marks PersistedInfo as `creating`, these will at some point be persisted by the PersistRefresh task."
   [user-id card]

--- a/src/metabase/models/persisted_info.clj
+++ b/src/metabase/models/persisted_info.clj
@@ -120,7 +120,7 @@
 (defn invalidate!
   "Invalidates any caches corresponding to the `conditions-map`. Equivalent to toggling the caching off and on again."
   [conditions-map]
-  ;; TODO confirm that the corresponding tables will still be cleaned up.
+  ;; We do not immediately delete the cached table, it will get clobbered during the next refresh cycle.
   (t2/update! PersistedInfo
               (merge {:active true} conditions-map)
               ;; TODO perhaps we should immediately kick off a recalculation of these caches

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -546,7 +546,7 @@
                             (map :id)
                             seq)]
     ;; Ideally we would do all the filtering in the query, but this would not allow us to leverage mlv2.
-    (persisted-info/invalidate! {:id [:in model-ids]})))
+    (persisted-info/invalidate! {:card_id [:in model-ids]})))
 
 (defn- update-with-csv! [database table file & {:keys [replace-rows?]}]
   (try

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -516,11 +516,15 @@
 
 (defn- invalidate-cached-models! [table]
   ;; Find all the models for which this is the "primary table", and there is no meaningful filtering or transformation.
-  (let [model-ids (->> (t2/select [:model/Card :id :dataset_query] :table_id (:id table) :type :model)
-                       (remove (fn [{query :dataset_query}]
-                                 ;; Notably there are no joins or custom columns, which might be expensive.
-                                 (every? #{:source-table :fields :limit} (keys query))))
-                       (map :id))]
+  (when-let [model-ids (->> (t2/select [:model/Card :id :dataset_query]
+                                       :table_id (:id table)
+                                       :type     :model
+                                       :archived false)
+                            (filter (fn [{query :dataset_query}]
+                                      ;; Notably there are no joins or custom columns, which might be expensive.
+                                      (every? #{:source-table :fields :limit} (keys query))))
+                            (map :id)
+                            seq)]
     ;; Ideally we would do all the filtering in the query, but we would need an agnostic way to handle the JSON column.
     (persisted-info/invalidate! {:id [:in model-ids]})))
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -515,10 +515,10 @@
            args)))
 
 (defn- invalidate-cached-models! [table]
-  ;; Find all the models for which this is the "primary table", and there are no joins, filters, transformations, etc.
+  ;; Find all the models for which this is the "primary table", and there is no meaningful filtering or transformation.
   (let [model-ids (->> (t2/select [:model/Card :id :dataset_query] :table_id (:id table) :type :model)
                        (remove (fn [{query :dataset_query}]
-                                 ;; notably there are no joins or expressions
+                                 ;; Notably there are no joins or custom columns, which might be expensive.
                                  (every? #{:source-table :fields :limit} (keys query))))
                        (map :id))]
     ;; Ideally we would do all the filtering in the query, but we would need an agnostic way to handle the JSON column.

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -518,9 +518,10 @@
   (= "query" (name (:query_type model "query"))))
 
 (defn- no-joins?
-  "Returns true if `query` has no joins in it, otherwise false.
-  WARNING: The implementation does not currently detect implicit joins."
+  "Returns true if `query` has no explicit joins in it, otherwise false."
   [query]
+  ;; TODO while it's unlikely (at the time of writing this) that uploaded tables have FKs, we should probably check
+  ;;      for implicit joins as well.
   (->> (range (lib/stage-count query))
        (not-any? (fn [stage-idx]
                    (lib/joins query stage-idx)))))

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -520,10 +520,10 @@
 (defn- no-joins?
   "Returns true if `query` has no joins in it, otherwise false."
   [query]
-  (let [all-joins (mapcat (fn [stage]
-                            (lib/joins query stage))
-                          (range (lib/stage-count query)))]
-    (empty? all-joins)))
+  (->> (range (lib/stage-count query))
+       (mapcat (fn [stage]
+                 (lib/joins query stage)))
+       (empty?)))
 
 (defn- only-table-id
   "For models that depend on only one table, return its id, otherwise return nil. Doesn't support native queries."

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -518,7 +518,8 @@
   (= "query" (name (:query_type model "query"))))
 
 (defn- no-joins?
-  "Returns true if `query` has no joins in it, otherwise false."
+  "Returns true if `query` has no joins in it, otherwise false.
+  WARNING: The implementation does not currently detect implicit joins."
   [query]
   (->> (range (lib/stage-count query))
        (not-any? (fn [stage-idx]

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -521,8 +521,8 @@
   "Returns true if `query` has no joins in it, otherwise false."
   [query]
   (->> (range (lib/stage-count query))
-       (not-any? (fn [stage]
-                   (lib/joins query stage)))))
+       (not-any? (fn [stage-idx]
+                   (lib/joins query stage-idx)))))
 
 (defn- only-table-id
   "For models that depend on only one table, return its id, otherwise return nil. Doesn't support native queries."

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -521,8 +521,8 @@
   "Returns true if `query` has no joins in it, otherwise false."
   [query]
   (->> (range (lib/stage-count query))
-       (every? (fn [stage]
-                 (empty? (lib/joins query stage))))))
+       (not-any? (fn [stage]
+                   (lib/joins query stage)))))
 
 (defn- only-table-id
   "For models that depend on only one table, return its id, otherwise return nil. Doesn't support native queries."

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -753,6 +753,8 @@
                                    set)
         has-uploadable-table? (comp (uploadable-table-ids table-ids) :table_id)]
     (for [model models]
+      ;; NOTE: It is important that this logic is kept in sync with `invalidate-cached-models!`
+      ;; If not, it will mean that the user could modify the table via a given model's page without seeing it update.
       (m/assoc-some model :based_on_upload (when (has-uploadable-table? model)
                                              (only-table-id model))))))
 

--- a/src/metabase/upload.clj
+++ b/src/metabase/upload.clj
@@ -521,9 +521,8 @@
   "Returns true if `query` has no joins in it, otherwise false."
   [query]
   (->> (range (lib/stage-count query))
-       (mapcat (fn [stage]
-                 (lib/joins query stage)))
-       (empty?)))
+       (every? (fn [stage]
+                 (empty? (lib/joins query stage))))))
 
 (defn- only-table-id
   "For models that depend on only one table, return its id, otherwise return nil. Doesn't support native queries."

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1424,6 +1424,7 @@
 (defn- join-mbql [mp base-table join-table]
   (let [base-table-metadata (lib.metadata/table mp (:id base-table))
         join-table-metadata (lib.metadata/table mp (:id join-table))
+        ;; We use the primary keys as the join fields as we know they will exist and have compatible types.
         pk-metadata         (fn [table]
                               (let [field-id (t2/select-one-pk :model/Field
                                                                :table_id (:id table)

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -4,6 +4,7 @@
    [clojure.data.csv :as csv]
    [clojure.java.io :as io]
    [clojure.java.jdbc :as jdbc]
+   [clojure.set :as set]
    [clojure.string :as str]
    [clojure.test :refer :all]
    [flatland.ordered.map :as ordered-map]
@@ -19,7 +20,6 @@
    [metabase.models.data-permissions :as data-perms]
    [metabase.models.interface :as mi]
    [metabase.models.permissions-group :as perms-group]
-   [metabase.models.persisted-info :as persisted-info]
    [metabase.query-processor :as qp]
    [metabase.sync.sync-metadata.tables :as sync-tables]
    [metabase.test :as mt]
@@ -388,11 +388,13 @@
                 (is (not= (:id table-1)
                           (:id table-2)))))))))))
 
-(defn- query-table
-  [table]
-  (qp/process-query {:database (:db_id table)
+(defn- query [db-id source-table]
+  (qp/process-query {:database db-id
                      :type     :query
-                     :query    {:source-table (:id table)}}))
+                     :query    {:source-table source-table}}))
+
+(defn- query-table [table]
+  (query (:db_id table) (:id table)))
 
 (defn- column-names-for-table
   [table]
@@ -403,6 +405,9 @@
 (defn- rows-for-table
   [table]
   (mt/rows (query-table table)))
+
+(defn- rows-for-model [db-id model-id]
+  (mt/rows (query db-id (str "card__" model-id))))
 
 (def ^:private example-files
   {:comma      ["id    ,nulls,string ,bool ,number       ,date      ,datetime"
@@ -1438,8 +1443,11 @@
                                    [(lib/= (lib/ref base-id-metadata)
                                            (lib/ref join-id-metadata))])))))
 
-(deftest ^:mb/once update-invalidate-model-cache-test
-  (mt/test-drivers (mt/normal-drivers-with-feature :uploads)
+(defn- cached-model-ids []
+  (into #{} (map :card_id) (t2/select [:model/PersistedInfo :card_id] :active true)))
+
+(deftest update-invalidate-model-cache-test
+  (mt/test-drivers (mt/normal-drivers-with-feature :uploads :persist-models)
     (doseq [action (actions-to-test driver/*driver*)]
       (testing (action-testing-str action)
         (with-upload-table! [table (create-upload-table!)]
@@ -1450,22 +1458,33 @@
                 other-table (t2/select-one :model/Table other-id)
                 mp          (lib.metadata.jvm/application-database-metadata-provider (:db_id table))]
 
-            (mt/with-temp [:model/Card {question-id         :id} {:table_id table-id, :dataset_query (mbql mp table)}
-                           :model/Card {model-id            :id} {:table_id table-id, :type :model, :dataset_query (mbql mp table)}
-                           :model/Card {complex-model-id    :id} {:table_id table-id, :type :model, :dataset_query (join-mbql mp table other-table)}
-                           :model/Card {_archived-model-id  :id} {:table_id table-id, :type :model, :archived true, :dataset_query (mbql mp table)}
-                           :model/Card {_unrelated-model-id :id} {:table_id other-id, :type :model, :dataset_query (mbql mp other-table)}
-                           :model/Card {_joined-model-id    :id} {:table_id other-id, :type :model, :dataset_query (join-mbql mp other-table table)}]
+            (mt/with-temp [:model/Card {question-id        :id} {:table_id table-id, :dataset_query (mbql mp table)}
+                           :model/Card {model-id           :id} {:table_id table-id, :type :model, :dataset_query (mbql mp table)}
+                           :model/Card {complex-model-id   :id} {:table_id table-id, :type :model, :dataset_query (join-mbql mp table other-table)}
+                           :model/Card {archived-model-id  :id} {:table_id table-id, :type :model, :archived true, :dataset_query (mbql mp table)}
+                           :model/Card {unrelated-model-id :id} {:table_id other-id, :type :model, :dataset_query (mbql mp other-table)}
+                           :model/Card {joined-model-id    :id} {:table_id other-id, :type :model, :dataset_query (join-mbql mp other-table table)}]
 
               (is (= #{question-id model-id complex-model-id}
                      (into #{} (map :id) (t2/select :model/Card :table_id table-id :archived false))))
 
-              (let [captured (atom [])]
-                (mt/with-dynamic-redefs [persisted-info/invalidate! #(swap! captured conj %)]
-                  (update-csv! action {:file file, :table-id (:id table)}))
-                (testing "Active, simple models with this as their primary, have their caches invalidated"
-                  (is (= [{:id [:in [model-id]]}]
-                         @captured)))))
+              (mt/with-persistence-enabled [persist-models!]
+                (persist-models!)
+
+                (let [cached-before (cached-model-ids)
+                      _             (update-csv! action {:file file, :table-id (:id table)})
+                      cached-after  (cached-model-ids)]
+
+                  (testing "The models are cached"
+                    (let [active-model-ids #{model-id complex-model-id unrelated-model-id joined-model-id}]
+                      (is (= active-model-ids (set/intersection cached-before (conj active-model-ids archived-model-id))))))
+                  (testing "The cache is invalidated by the update"
+                    (is (not (contains? cached-after model-id))))
+                  (testing "No unwanted caches were invalidated"
+                    (is (= #{model-id} (set/difference cached-before cached-after))))
+                  (testing "We can see the new row when querying the model"
+                    (is (some (fn [[_ row-name]] (= "Luke Skywalker" row-name))
+                              (rows-for-model (:db_id table) model-id)))))))
 
             (io/delete-file file)))))))
 

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1452,10 +1452,10 @@
 
             (mt/with-temp [:model/Card {question-id         :id} {:table_id table-id, :dataset_query (mbql mp table)}
                            :model/Card {model-id            :id} {:table_id table-id, :type :model, :dataset_query (mbql mp table)}
-                           :model/Card {complex-model-id    :id} {:table_id table-id, :type :model :dataset_query (join-mbql mp table other-table)}
+                           :model/Card {complex-model-id    :id} {:table_id table-id, :type :model, :dataset_query (join-mbql mp table other-table)}
                            :model/Card {_archived-model-id  :id} {:table_id table-id, :type :model, :archived true, :dataset_query (mbql mp table)}
                            :model/Card {_unrelated-model-id :id} {:table_id other-id, :type :model, :dataset_query (mbql mp other-table)}
-                           :model/Card {_joined-model-id    :id} {:table_id other-id, :type :model :dataset_query (join-mbql mp other-table table)}]
+                           :model/Card {_joined-model-id    :id} {:table_id other-id, :type :model, :dataset_query (join-mbql mp other-table table)}]
 
               (is (= #{question-id model-id complex-model-id}
                      (into #{} (map :id) (t2/select :model/Card :table_id table-id :archived false))))

--- a/test/metabase/upload_test.clj
+++ b/test/metabase/upload_test.clj
@@ -1456,7 +1456,6 @@
                            :model/Card {_unrelated-model-id :id} {:table_id other-id, :type :model, :dataset_query (mbql mp other-table)}
                            :model/Card {_joined-model-id    :id} {:table_id other-id, :type :model :dataset_query (join-mbql mp other-table table)}]
 
-
               (is (= #{question-id model-id complex-model-id}
                      (into #{} (map :id) (t2/select :model/Card :table_id table-id :archived false))))
 


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41630

### Description

With this change we "bust" the related model caches when updating an uploaded table, to avoid surprising behavior where the updates are not visible when viewing those models or their derived questions.

We only consider "trivial" models which don't have any calculated columns, joins, filter, etc 

A gotcha with this approach, is that you are still given the option to update the table from models which *do* have all these potentially expensive operations applied, and then the user will still get the confusing experience of seeing their upload succeed, the question refreshing, and the new data still not being present.

You could argue that such non-trivial models should not expose an "upload" option anyway - I was surprised that they do.
