### PR TITLE
Add console.trace() when capturing console error

### DIFF
--- a/frontend/src/metabase/lib/errors/console.js
+++ b/frontend/src/metabase/lib/errors/console.js
@@ -11,5 +11,7 @@ export function captureConsoleErrors() {
     }
     console.errorBuffer.unshift(Array.from(args));
     originalError(...args);
+    // eslint-disable-next-line no-console
+    console.trace();
   };
 }


### PR DESCRIPTION
When capturing calls to `console.error()`, we run the real `console.error()` function inside console.js. But then we don't see the file / line number that gave rise to the error - instead, `console.error()` reports console.js as the file. So let's do `console.trace()` as well, to give devs better information.

(Note that we don't always see a diagnostic screen when a console error is captured - sometimes we see a "You can't see this" screen.)

After:

![image](https://github.com/metabase/metabase/assets/130925/4c0b39c6-c05c-433d-a9c6-77320bffb3d3)
