### PR TITLE
Add color to function helper popover

### DIFF
--- a/frontend/src/metabase/components/Popover/Popover.module.css
+++ b/frontend/src/metabase/components/Popover/Popover.module.css
@@ -53,6 +53,7 @@
 
 :global(.tippy-box[data-theme~="popover"]) {
   font-size: inherit;
+  color: var(--color-text-medium);
   border: 1px solid var(--color-border);
   box-shadow: 0 4px 10px var(--color-shadow);
   background-color: var(--color-bg-white);

--- a/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.styled.tsx
+++ b/frontend/src/metabase/query_builder/components/expressions/ExpressionEditorHelpText/ExpressionEditorHelpText.styled.tsx
@@ -8,6 +8,7 @@ import { Icon } from "metabase/ui";
 export const Container = styled.div`
   padding: 1.25rem 1rem 1.25rem;
 
+  color: ${color("text-dark")};
   font-size: 0.875rem;
   line-height: 1.5rem;
 `;


### PR DESCRIPTION
Closes https://github.com/metabase/metabase/issues/41688

### Description

Adds the missing color property to the function helper popover.

### How to verify

1. Go to New Question → Orders
2. Click on Custom Column → Custom Expression
3. Type case(
4. The popover that shows up should not show white on white text

### Demo

<img width="534" alt="Screenshot 2024-04-22 at 17 47 11" src="https://github.com/metabase/metabase/assets/1250185/bd21eb07-4742-46f7-a6b2-ce5ee4098549">

