### PR TITLE
Fix downgrades for dbs started before the migration split

### DIFF
--- a/resources/migrations/001_update_migrations.yaml
+++ b/resources/migrations/001_update_migrations.yaml
@@ -38,6 +38,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v00.00-000
+      validCheckSum: 8:a59595109e74e7a2678a1b0dfd25f74a
       author: qnkhuat
       comment: Initialze metabase
       preConditions:
@@ -66,6 +67,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-001
+      validCheckSum: 8:da99b71a4ac7eb662f6a95e69585935e
       author: snoe
       comment: Added 0.44.0 - writeback
       # This migration was previously numbered v44.00-012 but ultimately was not shipped with 44.
@@ -120,6 +122,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-002
+      validCheckSum: 8:6da7a6285edb138c404de0eeba209570
       author: snoe
       comment: Added 0.44.0 - writeback
       # This migration was previously numbered v44.00-013 but ultimately was not shipped with 44.
@@ -167,6 +170,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-003
+      validCheckSum: 8:512337d6d4af38016aa79585abbe03a1
       author: snoe
       comment: Added 0.44.0 - writeback
       # This migration was previously numbered v44.00-014 but ultimately was not shipped with 44.
@@ -197,6 +201,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-011
+      validCheckSum: 8:dcf1cda9f20dca4b6ff8101b13b98c4a
       author: snoe
       comment: Added 0.44.0 - writeback
       # This migration was previously numbered v44.00-022 but ultimately was not shipped with 44.
@@ -230,6 +235,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-012
+      validCheckSum: 8:aadf28229f585cff7c4b4c1918e558b2
       author: snoe
       comment: Added 0.44.0 - writeback
       # This migration was previously numbered v44.00-031 but ultimately was not shipped with 44.
@@ -291,6 +297,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-013
+      validCheckSum: 8:26dba276b14255d4346507a1a25d117b
       author: snoe
       comment: Added 0.44.0 - writeback
       # This migration was previously numbered v44.00-032 but ultimately was not shipped with 44.
@@ -322,6 +329,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-022
+      validCheckSum: 8:d46fa24e4d75a11b2e92aecbf39c6ee1
       author: snoe
       comment: Added 0.45.0 - add app container
       changes:
@@ -383,6 +391,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-023
+      validCheckSum: 8:c6c1ff9ca3b62d4cda3a2d782dd86f2f
       author: snoe
       comment: Added 0.45.0 - add app container
       changes:
@@ -396,6 +405,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-025
+      validCheckSum: 8:50a43cea3123ecdb602123825f5a7dbf
       author: metamben
       comment: Added 0.45.0 - mark app pages
       changes:
@@ -412,6 +422,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-026
+      validCheckSum: 8:ae77d4086998911877e3207fcf90c9c7
       author: snoe
       comment: Added 0.45.0 - apps add action_id to report_dashboardcard
       changes:
@@ -426,6 +437,7 @@ databaseChangeLog:
   # FK constraint is added separately because deleteCascade doesn't work in addColumn -- see #14321
   - changeSet:
       id: v45.00-027
+      validCheckSum: 8:40c3c8391c1416a3bce09ca3c7237173
       author: snoe
       comment: Added 0.45.0 - apps add fk for action_id to report_dashboardcard
       changes:
@@ -439,6 +451,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-028
+      validCheckSum: 8:f8f68f80627aeb2ef7f28f2af2b5a31b
       author: camsaul
       comment: Added 0.45.0 -- rename DashboardCard sizeX to size_x. See https://github.com/metabase/metabase/issues/16344
       changes:
@@ -450,6 +463,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-029
+      validCheckSum: 8:579957652133eab3ee023dd911162a1e
       author: camsaul
       comment: Added 0.45.0 -- rename DashboardCard size_y to size_y. See https://github.com/metabase/metabase/issues/16344
       changes:
@@ -461,6 +475,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-030
+      validCheckSum: 8:41eda097feb034c4d01b2dbda74753c8
       author: camsaul
       comment: Added 0.45.0 -- add default value to DashboardCard size_x -- this was previously done by Toucan
       changes:
@@ -471,6 +486,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-031
+      validCheckSum: 8:6416e373e335dc1c12c7571af674dede
       author: camsaul
       comment: Added 0.45.0 -- add default value to DashboardCard size_y -- this was previously done by Toucan
       changes:
@@ -481,6 +497,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-032
+      validCheckSum: 8:d97444fe24a2dca618a2804741335f6d
       author: camsaul
       comment: Added 0.45.0 -- add default value for DashboardCard created_at (Postgres/H2)
       dbms: postgresql,h2
@@ -498,6 +515,7 @@ databaseChangeLog:
     # addDefaultValue with defaultValueComputed doesn't work for MySQL/MariaDB so we have to do this the hard way.
   - changeSet:
       id: v45.00-033
+      validCheckSum: 8:34df79fc79e086ab05bb2fd79bb4e322
       author: camsaul
       comment: Added 0.45.0 -- add default value for DashboardCard created_at (MySQL/MariaDB)
       preConditions:
@@ -514,6 +532,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-034
+      validCheckSum: 8:ba0505a87ef876026759cdcb4e704f41
       author: camsaul
       comment: Added 0.45.0 -- add default value for DashboardCard updated_at (Postgres/H2)
       dbms: postgresql,h2
@@ -530,6 +549,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-035
+      validCheckSum: 8:dcee49781d80d9c4be5ad9dd51975a07
       author: camsaul
       comment: Added 0.45.0 -- add default value for DashboardCard updated_at (MySQL/MariaDB)
       preConditions:
@@ -546,6 +566,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-036
+      validCheckSum: 8:cd4009254bd2c56aaf281082038c1f0b
       author: snoe
       comment: Added 0.45.0 - add model action table
       changes:
@@ -608,8 +629,10 @@ databaseChangeLog:
                   name: visualization_settings
                   type: ${text.type}
                   remarks: Settings for rendering the action
+
   - changeSet:
       id: v45.00-037
+      validCheckSum: 8:56f548cc84a53cc6d18302761ee71554
       author: snoe
       comment: Added 0.45.0 - model action
       changes:
@@ -624,6 +647,7 @@ databaseChangeLog:
   # schema migration tests that don't use Toucan, or other manual scripting
   - changeSet:
       id: v45.00-038
+      validCheckSum: 8:c38ddc295206e807c7254581ed9566c3
       author: camsaul
       comment: Added 0.45.0 -- add default value for Database created_at (Postgres/H2)
       dbms: postgresql,h2
@@ -641,6 +665,7 @@ databaseChangeLog:
     # addDefaultValue with defaultValueComputed doesn't work for MySQL/MariaDB so we have to do this the hard way.
   - changeSet:
       id: v45.00-039
+      validCheckSum: 8:2c539d76d3aead7f7366b15333132b30
       author: camsaul
       comment: Added 0.45.0 -- add default value for Database created_at (MySQL/MariaDB)
       preConditions:
@@ -657,6 +682,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-040
+      validCheckSum: 8:00ac7c24cfd3e7ea3a21f21f4e45dbcf
       author: camsaul
       comment: Added 0.45.0 -- add default value for Database updated_at (Postgres/H2)
       dbms: postgresql,h2
@@ -673,6 +699,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-041
+      validCheckSum: 8:82dc368fa3e0163a06929da6e9556fe2
       author: camsaul
       comment: Added 0.45.0 -- add default value for Database updated_at (MySQL/MariaDB)
       preConditions:
@@ -700,6 +727,7 @@ databaseChangeLog:
   # restriction separately; we can use Toucan `pre-insert` to set defaults values when saving things.
   - changeSet:
       id: v45.00-042
+      validCheckSum: 8:d04207471480e335f14094e9a7a5d293
       author: camsaul
       comment: Added 0.45.0 -- add default value for Database with NULL details
       changes:
@@ -710,6 +738,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-043
+      validCheckSum: 8:1d07a5435e51abd0663458d907865a6b
       author: camsaul
       comment: Added 0.45.0 -- make Database details NOT NULL
       changes:
@@ -720,6 +749,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-044
+      validCheckSum: 8:0b23976c5d2248d511ac31b244efef22
       author: metamben
       comment: Added 0.45.0 -- create app permission graph revision table
       changes:
@@ -772,6 +802,7 @@ databaseChangeLog:
   # Add created_at to Collection
   - changeSet:
       id: v45.00-048
+      validCheckSum: 8:0aca8f157f163e62805b7202f8aa202f
       author: camsaul
       comment: Added 0.45.0 -- add created_at to Collection
       changes:
@@ -908,6 +939,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-051
+      validCheckSum: 8:2378c7031da6871dcf1c737bf323d211
       author: qnkhuat
       comment: >-
         Added 0.45.0 - modify type of collection_permission_graph_revision.after from text to ${text.type}
@@ -929,6 +961,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-052
+      validCheckSum: 8:b7343eb9556c3e636b6f8dd70708c0b3
       author: qnkhuat
       comment: >-
         Added 0.45.0 - modify type of collection_permission_graph_revision.before from text to ${text.type}
@@ -950,6 +983,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-053
+      validCheckSum: 8:fa552605d5a587c4fa74e0c6bd358097
       author: qnkhuat
       comment: >-
         Added 0.45.0 - modify type of collection_permission_graph_revision.remark from text to ${text.type}
@@ -971,6 +1005,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-054
+      validCheckSum: 8:60862c4ecf505727e839ac5e94f95528
       author: qnkhuat
       comment: >-
         Added 0.45.0 - modify type of permissions_revision.after from text to ${text.type}
@@ -992,6 +1027,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-055
+      validCheckSum: 8:717f0c266da5768098a2ead6168f3b18
       author: qnkhuat
       comment: >-
         Added 0.45.0 - modify type of permissions_revision.before from text to ${text.type}
@@ -1013,6 +1049,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-056
+      validCheckSum: 8:a1f364d45a922c90b4fac741a22e66b3
       author: qnkhuat
       comment: >-
         Added 0.45.0 - modify type of permissions_revision.remark from text to ${text.type}
@@ -1034,6 +1071,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v45.00-057
+      validCheckSum: 8:650a5b435f8195765a2ab1e3e4bc7b14
       author: qnkhuat
       comment: >-
         Added 0.45.0 - modify type of secret.value from blob to longblob
@@ -1055,6 +1093,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-000
+      validCheckSum: 8:97251413292221e51490e990b6f683f2
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1081,6 +1120,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-001
+      validCheckSum: 8:4a90c7523749aa7e4e4d2ea9dd6db777
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1094,6 +1134,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-002
+      validCheckSum: 8:b2b112f0df413692631b75822f658de1
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1107,6 +1148,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-003
+      validCheckSum: 8:45b8358f31811335aaa93032726a042b
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1120,6 +1162,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-004
+      validCheckSum: 8:0ce8ff05beffc5c72e2348bcec581eee
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1133,6 +1176,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-005
+      validCheckSum: 8:84cf1fbf435c7c3f794c973de4d62fad
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1143,8 +1187,10 @@ databaseChangeLog:
                   name: parameter_mappings
                   remarks: The saved parameter mappings for this action
                   type: ${text.type}
+
   - changeSet:
       id: v46.00-006
+      validCheckSum: 8:df43ef08b76c33c5626dbf9b226717b5
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1158,6 +1204,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-007
+      validCheckSum: 8:6830901cccc14ad22cdfd86bd3a2afe7
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1170,6 +1217,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-008
+      validCheckSum: 8:6e73a8683d1b757c5f9034513ec8a581
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1183,6 +1231,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-009
+      validCheckSum: 8:2b4fd7cee77d5ed8de22fcc2fba158bc
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1196,6 +1245,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-010
+      validCheckSum: 8:77ca03e5a0dbe370461295da1c77cf0f
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1247,6 +1297,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-012
+      validCheckSum: 8:7e4dffe8bbbb740207001ead696a8557
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1341,6 +1392,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-014
+      validCheckSum: 8:585958ee7e90e23a9cc22ebf7e4228cb
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1351,6 +1403,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-015
+      validCheckSum: 8:9b57260e146618caff3f468116031008
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1375,6 +1428,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-016
+      validCheckSum: 8:cb79eef9f483e73b3d9b571f916b8598
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1392,6 +1446,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-017
+      validCheckSum: 8:90525ade34e7bb883bf75cdf8a2b3340
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1411,6 +1466,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-018
+      validCheckSum: 8:cf3c31a975dc86f1def6ee5d11f5f9dc
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1428,6 +1484,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-019
+      validCheckSum: 8:a9f70163707cc7f798bdd0527a55854b
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1448,6 +1505,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-020
+      validCheckSum: 8:2def45c139267d7424e1187764122669
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1458,6 +1516,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-021
+      validCheckSum: 8:52c8107f4bcc6e9889b270e0a4954921
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1468,6 +1527,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-022
+      validCheckSum: 8:52c8107f4bcc6e9889b270e0a4954921
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1478,6 +1538,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-023
+      validCheckSum: 8:33c91db1b039855af8bf1dc8315bd5d2
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1488,6 +1549,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-024
+      validCheckSum: 8:080ff435bae61f324535393d9e78de38
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1498,6 +1560,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-025
+      validCheckSum: 8:60016f3de98c7382602485f13bc4e04f
       author: snoe
       comment: Added 0.46.0 - Unify action representation
       changes:
@@ -1566,6 +1629,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-026
+      validCheckSum: 8:948b9653bfbadeb29c847ef41d053dba
       author: metamben
       comment: Added 0.46.0 -- add field for tracking DBMS versions
       changes:
@@ -1579,6 +1643,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-027
+      validCheckSum: 8:5f7773b797a3c85a99cd35cb60cfd0b3
       author: snoe
       comment: Added 0.46.0 -- add last_used_at to FieldValues
       changes:
@@ -1595,6 +1660,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-028
+      validCheckSum: 8:33cc1a038e926acb7dfd7cf29b4fa545
       author: tsmacdonald
       comment: Added 0.46.0 -- Join table connecting cards to dashboards/cards's parameters that need custom filter values from the card
       changes:
@@ -1652,6 +1718,7 @@ databaseChangeLog:
   # See issue #27054.
   - changeSet:
       id: v46.00-029
+      validCheckSum: 8:96336855a4180eaf51d7be4a97f3b1a4
       author: camsaul
       comment: Make Dimension <=> Field a 1t1 relationship. Drop unique constraint on field_id + name. (1/3)
       changes:
@@ -1666,6 +1733,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-030
+      validCheckSum: 8:e1f67579cb8dc1102445df299636cb7b
       author: camsaul
       comment: Make Dimension <=> Field a 1t1 relationship. Delete duplicate entries. (2/3)
       changes:
@@ -1699,6 +1767,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-031
+      validCheckSum: 8:a9b4c86de880b2bc01e208d8d4d8cf64
       author: camsaul
       comment: Make Dimension <=> Field a 1t1 relationship. Add unique constraint on field_id. (3/3)
       changes:
@@ -1710,6 +1779,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-032
+      validCheckSum: 8:2a7de9726282af199737a334395f1068
       author: tsmacdonald
       comment: Added 0.46.0 -- Unique parameter_card
       changes:
@@ -1720,6 +1790,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-033
+      validCheckSum: 8:25bc5b1a806d4b352d43f5b16e7e6e20
       author: tsmacdonald
       comment: Added 0.46.0 -- parameter_card index on connected object
       changes:
@@ -1732,6 +1803,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-034
+      validCheckSum: 8:5a6b5a2cf7160baec4f81f6675de898c
       author: tsmacdonald
       comment: Added 0.46.0 -- parameter_card index on connected card
       changes:
@@ -1744,6 +1816,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-035
+      validCheckSum: 8:0639e4c0939848b4377792290311f239
       author: tsmacdonald
       comment: Added 0.46.0 - parameter_card.card_id foreign key
       changes:
@@ -1757,6 +1830,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-036
+      validCheckSum: 8:39d440f29a481e9f0915532106079a1a
       author: metamben
       comment: App containers are removed in 0.46.0
       changes:
@@ -1809,6 +1883,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-037
+      validCheckSum: 8:dbbe898501c554e3ee74c6b9ef9c1575
       author: metamben
       comment: App pages are removed in 0.46.0
       changes:
@@ -1829,6 +1904,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-038
+      validCheckSum: 8:220a27bae93423a2c9a76f611f10b87b
       author: metamben
       comment: App containers are removed in 0.46.0
       changes:
@@ -1900,6 +1976,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-039
+      validCheckSum: 8:7ed32de11fbe8565148d8491f908ad05
       author: qnkhuat
       comment: Added 0.46.0 - add entity_id to parameter_card
       changes:
@@ -1916,6 +1993,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-040
+      validCheckSum: 8:7fec881cac598cce34b62c98fcf37563
       author: tsmacdonald
       comment: Added 0.46.0 -- Bump default dashcard size to 4x4
       changes:
@@ -1926,6 +2004,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-041
+      validCheckSum: 8:0214a8d0b94a9eb48aad75b1d50dd279
       author: tsmacdonald
       comment: Added 0.46.0 -- Bump default dashcard size to 4x4
       changes:
@@ -1936,6 +2015,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-042
+      validCheckSum: 8:7b91ad83569565517c43e9f7b9bfa29a
       author: tsmacdonald
       comment: Added 0.46.0 -- index query_execution.executor_id
       changes:
@@ -1948,6 +2028,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-043
+      validCheckSum: 8:d9cab29076035068cfc49fb9570832af
       author: tsmacdonald
       comment: Added 0.46.0 -- index query_execution.context
       changes:
@@ -1960,6 +2041,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-045
+      validCheckSum: 8:7a9cabf1c693de8b0c9555f7deb072a4
       author: calherries
       comment: Added 0.46.0 -- add public_uuid to action.
       changes:
@@ -1975,6 +2057,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-051
+      validCheckSum: 8:74e83fc2ee7c1a06a94f07830f361773
       author: calherries
       comment: Added 0.46.0 -- drop defaults for dashcard's position and size
       changes:
@@ -1989,6 +2072,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-052
+      validCheckSum: 8:948c978fcb2d938d272a05b3e56808d1
       author: calherries
       comment: Added 0.46.0 -- drop defaults for dashcard's position and size
       changes:
@@ -2003,6 +2087,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-053
+      validCheckSum: 8:04e092dbffdfda13f28b1e3ea38299a7
       author: calherries
       comment: Added 0.46.0 -- drop defaults for dashcard's position and size
       changes:
@@ -2017,6 +2102,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-054
+      validCheckSum: 8:bc3abf9ab94199aeaebb2be28dea77aa
       author: calherries
       comment: Added 0.46.0 -- drop defaults for dashcard's position and size
       changes:
@@ -2031,6 +2117,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-055
+      validCheckSum: 8:48a516459b84a21e9edbdbfe1bffd671
       author: calherries
       comment: Added 0.46.0 -- add made_public_by_id
       changes:
@@ -2044,6 +2131,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-056
+      validCheckSum: 8:af93ab591b44b5d81d8d8a496600c1bc
       author: calherries
       comment: Added 0.46.0 -- add public_uuid and made_public_by_id to action. public_uuid is indexed
       changes:
@@ -2056,6 +2144,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-057
+      validCheckSum: 8:aff3b0e15dcfc36a4fd97faade0751c0
       author: dpsutton
       comment: Added 0.46.0 -- parameter_card.parameter_id long enough to hold a uuid
       changes:
@@ -2067,6 +2156,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-058
+      validCheckSum: 8:11440c629413c7231e7f156347353761
       author: calherries
       comment: Added 0.46.0 -- add FK constraint for action.made_public_by_id with core_user.id
       changes:
@@ -2080,6 +2170,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-059
+      validCheckSum: 8:6ddec7d622e9200e36bd5e2e2e0a48c2
       author: tsmacdonald
       comment: Added 0.46.0 -- add actions.creator_id
       changes:
@@ -2097,6 +2188,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-060
+      validCheckSum: 8:fc1762a930726afb11131acf3a56312b
       author: tsmacdonald
       comment: Added 0.46.0 -- action.creator_id index
       changes:
@@ -2113,6 +2205,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-061
+      validCheckSum: 8:d57393ae0e96a9b1a0bd7a66597cb485
       author: tsmacdonald
       comment: Added 0.46.0 -- action.creator_id index
       changes:
@@ -2126,6 +2219,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-062
+      validCheckSum: 8:20efdbd79df3c76cbf77318d871a9836
       author: tsmacdonald
       comment: Added 0.46.0 -- add actions.archived
       changes:
@@ -2146,6 +2240,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-064
+      validCheckSum: 8:0ac10ca0d82f1bbe39737eb0a8fdcd7d
       author: noahmoss
       comment: Added 0.46.0 -- rename `group_table_access_policy` to `sandboxes`
       changes:
@@ -2155,6 +2250,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-065
+      validCheckSum: 8:5cbb335952dd1ab7a137d80d6c1ab82e
       author: noahmoss
       comment: Added 0.46.0 -- add `permission_id` to `sandboxes`
       changes:
@@ -2168,6 +2264,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-070
+      validCheckSum: 8:d440a8d0aef0bbfdae24a9c70bd37605
       author: calherries
       comment: Added 0.46.0 - add entity_id column to action
       changes:
@@ -2184,6 +2281,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-074
+      validCheckSum: 8:c1273a3003d82638a0a5413bf2aa6777
       author: metamben
       comment: Added 0.46.0 -- increase precision of updated_at of report_card
       changes:
@@ -2199,6 +2297,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-079
+      validCheckSum: 8:de167f33d3f7670246623466487d2e67
       author: john-metabase
       comment: Added 0.46.0 -- migrates Databases using deprecated and removed presto driver to presto-jdbc
       changes:
@@ -2207,6 +2306,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-080
+      validCheckSum: 8:022a846feb10103f2e9fe4b58cb792d6
       author: noahmoss
       comment: Migrate data permission paths from v1 to v2 (splitting them into separate data and query permissions)
       changes:
@@ -2215,6 +2315,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-084
+      validCheckSum: 8:b4f465ca3be584028e077b907656b804
       author: qnkhuat
       comment: Added 0.46.0 - CASCADE delete for action.model_id
       changes:
@@ -2232,6 +2333,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-085
+      validCheckSum: 8:17fe48c56aa457a6a09775099d44d7a5
       author: qnkhuat
       comment: Added 0.46.0 - CASCADE delete for action.model_id
       changes:
@@ -2245,6 +2347,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-086
+      validCheckSum: 8:677e076d8741275d31a02e97531fd930
       author: calherries
       comment: Added 0.46.0 - Delete the abandonment email task
       changes:
@@ -2253,6 +2356,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-088
+      validCheckSum: 8:ff9defc19920960db55ef71e4d32b4ea
       author: noahmoss
       comment: Added 0.46.5 -- backfill `permission_id` values in `sandboxes`. This is a fixed verison of v46.00-066
                which has been removed, since it had a bug that blocked a customer from upgrading.
@@ -2279,6 +2383,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-089
+      validCheckSum: 8:e0fbd2514cc960cc74106204ac65a3ea
       author: noahmoss
       comment: Added 0.46.5 -- remove orphaned entries in `sandboxes`
       changes:
@@ -2289,6 +2394,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v46.00-090
+      validCheckSum: 8:963c0cd3a7bd2858e4dbfd4d4aad95cb
       author: noahmoss
       comment: Add foreign key constraint on sandboxes.permission_id
       preConditions:
@@ -2307,6 +2413,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-001
+      validCheckSum: 8:14bf2732687c04256e9c036ba142aa93
       author: calherries
       comment: Added 0.47.0 -- set base-type to type/JSON for JSON database-types for postgres and mysql
       changes:
@@ -2360,6 +2467,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-002
+      validCheckSum: 8:963690f41f487b122464277c627823f6
       author: calherries
       comment: Added 0.47.0 - Add json_unfolding column to metabase_field
       changes:
@@ -2376,6 +2484,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-003
+      validCheckSum: 8:97bccdf5e9bcdfacd1c315fa1342c167
       author: calherries
       comment: Added 0.47.0 - Populate metabase_field.json_unfolding based on base_type
       changes:
@@ -2388,6 +2497,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-004
+      validCheckSum: 8:58ad79be7de00e413da51fab3c8beea0
       author: qnkhuat
       comment: Added 0.47.0 - Add auto_incremented to metabase_field
       changes:
@@ -2404,6 +2514,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-005
+      validCheckSum: 8:ccf53f27a551fd0799d0103bd65cca99
       author: winlost
       comment: Added 0.47.0 - Add auto_apply_filters to dashboard
       changes:
@@ -2420,6 +2531,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-006
+      validCheckSum: 8:b63ff10d3d121bed42eece1ae3dbb177
       author: qnkhuat
       comment: Added 0.47.0 - Add dashboard_tab table
       changes:
@@ -2480,6 +2592,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-007
+      validCheckSum: 8:e9f7d6b18d65be6fde07c0b5471b8760
       author: qnkhuat
       comment: Added 0.47.0 -- add report_dashboardcard.dashboard_tab_id
       changes:
@@ -2495,6 +2608,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-008
+      validCheckSum: 8:e37c88d202007bd3e6a72b6404d1b0e9
       author: qnkhuat
       comment: Added 0.47.0 -- add report_dashboardcard.dashboard_tab_id fk constraint
       changes:
@@ -2508,6 +2622,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-009
+      validCheckSum: 8:398124b0dd4dd6e117cdc1378152469b
       author: qwef
       comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
       changes:
@@ -2519,6 +2634,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-010
+      validCheckSum: 8:3c4f9fc116fbced18c50952def65b3e0
       author: tsmacdonald
       comment: Added 0.47.0 - Make metabase_table.name long enough for H2 names
       changes:
@@ -2530,6 +2646,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-011
+      validCheckSum: 8:148b982debddfa511cb45b87179b8c46
       author: tsmacdonald
       comment: Added 0.47.0 - Make metabase_table.display_name long enough for H2 names
       changes:
@@ -2541,6 +2658,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-012
+      validCheckSum: 8:bf19ef077bc6bc517c515dd78ca46e3b
       author: qwef
       comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
       changes:
@@ -2560,6 +2678,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-013
+      validCheckSum: 8:044aec6d07049e3c5a45830797189ab0
       author: qwef
       comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
       changes:
@@ -2571,6 +2690,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-014
+      validCheckSum: 8:6a973f3198ad4596ecade95e61b35991
       author: qwef
       comment: Added 0.47.0 - Replace user google_auth and ldap_auth columns with sso_source values
       changes:
@@ -2590,6 +2710,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-015
+      validCheckSum: 8:d2d5eea99db75e656709006b3a7749f0
       author: escherize
       comment: added 0.47.0 - Add is_audit to metabase_database
       changes:
@@ -2606,6 +2727,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-016
+      validCheckSum: 8:62290f0389eb2a17170a9c0351ac8a85
       author: calherres
       comment: Added 0.47.0 - Migrate the report_card.visualization_settings.column_settings field refs from legacy format
       changes:
@@ -2614,6 +2736,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-018
+      validCheckSum: 8:7bacd2f60393eebd3bebcfdb0e952ecd
       author: dpsutton
       comment: Indexed Entities information table
       changes:
@@ -2690,6 +2813,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-019
+      validCheckSum: 8:7a5589d70c80b3ffc99a85722f440a91
       author: dpsutton
       comment: Indexed Entities values table
       changes:
@@ -2719,6 +2843,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-020
+      validCheckSum: 8:d32a4cf7b37f012a7db74628cdde48df
       author: dpsutton
       comment: Add unique constraint on index_id and pk
       changes:
@@ -2733,6 +2858,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-023
+      validCheckSum: 8:5d9e81c3e950afad66cb5e9e823b1f03
       author: dpsutton
       comment: Added 0.47.0 -- model_index index
       changes:
@@ -2745,6 +2871,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-024
+      validCheckSum: 8:3079db8d91e54ff2b41050f7dab27936
       author: dpsutton
       comment: Added 0.47.0 -- model_index foriegn key to report_card
       changes:
@@ -2759,6 +2886,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-025
+      validCheckSum: 8:6889e314a2016c9bc017a358b81ed24e
       author: dpsutton
       comment: Added 0.47.0 -- model_index_value foriegn key to model_index
       changes:
@@ -2773,6 +2901,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-026
+      validCheckSum: 8:acf279edf538ee29a4ea9103d809b3da
       author: noahmoss
       comment: Added 0.47.0 - New table for connection impersonation policies
       changes:
@@ -2814,6 +2943,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-027
+      validCheckSum: 8:c720f3de8feed35e592c0ca9b9975a18
       author: calherries
       comment: Added 0.47.0 - Migrate field_ref in report_card.result_metadata from legacy format
       changes:
@@ -2822,6 +2952,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-028
+      validCheckSum: 8:f38598170766acaaa8fd3b20ef683372
       author: calherries
       comment: Added 0.47.0 - Add join-alias to the report_card.visualization_settings.column_settings field refs
       changes:
@@ -2830,6 +2961,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-029
+      validCheckSum: 8:c7625e5018087e915e547f9318b2b8f5
       author: qnkhuat
       comment: Added 0.47.0 - Stack cards vertically for dashboard with tabs on downgrade
       changes:
@@ -2838,6 +2970,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-030
+      validCheckSum: 8:7919d959008457419a09fd3275d3ed00
       author: escherize
       comment: Added 0.47.0 - Type column for collections for instance-analytics
       changes:
@@ -2896,6 +3029,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-033
+      validCheckSum: 8:c4a38673bf2a702e807a2074c0d0b719
       author: calherries
       comment: Added 0.47.0 - Migrate field refs in visualization_settings.column_settings keys from legacy format
       changes:
@@ -2904,6 +3038,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-034
+      validCheckSum: 8:bb77d686c5c204e480a1da5fcfb518e2
       author: calherries
       comment: Added 0.47.0 - Add join-alias to the visualization_settings.column_settings field refs in card revisions
       changes:
@@ -2912,6 +3047,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-035
+      validCheckSum: 8:aeafa7ff310f799eb3fb2e14640a9e06
       author: calherries
       comment: Added 0.47.0 - Drop foreign key constraint on implicit_action.action_id
       changes:
@@ -2929,6 +3065,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-036
+      validCheckSum: 8:e815729b6ebfd4799743b249409558aa
       author: calherries
       comment: Added 0.47.0 - Set primary key to action_id for implicit_action table
       changes:
@@ -2939,6 +3076,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-037
+      validCheckSum: 8:58c705a18bb3441e3ed5d1167ec64fcb
       author: calherries
       comment: Added 0.47.0 - Add foreign key constraint on implicit_action.action_id
       changes:
@@ -2952,6 +3090,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-043
+      validCheckSum: 8:5e030b73be03e7cd8b19a5a46f9b2a4c
       author: calherres
       comment: Added 0.47.0 - Migrate report_dashboardcard.visualization_settings.column_settings field refs from legacy format
       changes:
@@ -2960,6 +3099,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-044
+      validCheckSum: 8:1828d1bd8e2da6eec14ca61e6c01a56f
       author: calherries
       comment: Added 0.47.0 - Add join-alias to the report_dashboardcard.visualization_settings.column_settings field refs
       changes:
@@ -2968,6 +3108,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-045
+      validCheckSum: 8:d7f479a389877010f5af9dc7ec859b51
       author: calherres
       comment: Added 0.47.0 - Migrate dashboard revision dashboard cards' visualization_settings.column_settings field refs from legacy format
       changes:
@@ -2976,6 +3117,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-046
+      validCheckSum: 8:1e43c8712a5b36809a3c3fa9933a523c
       author: calherries
       comment: Added 0.47.0 - Add join-alias to dashboard revision dashboard cards' visualization_settings.column_settings field refs
       changes:
@@ -2984,6 +3126,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-050
+      validCheckSum: 8:a5d516f2b5ea92f401387646b49a9950
       author: tsmacdonald
       comment: Added 0.47.0 - table.is_upload
       changes:
@@ -3000,6 +3143,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-051
+      validCheckSum: 8:83a8b7ad58b2deb0732e671db51fa608
       author: noahmoss
       comment: Added 0.47.0 - Drop foreign key constraint on connection_impersonations.db_id
       changes:
@@ -3017,6 +3161,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-052
+      validCheckSum: 8:d170bef8f707027360cf08fb55e91452
       author: noahmoss
       comment: Added 0.47.0 - Drop foreign key constraint on connection_impersonations.group_id
       changes:
@@ -3034,6 +3179,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-053
+      validCheckSum: 8:3b52631c2c82b88043b840391c7d9ef0
       author: noahmoss
       comment: Added 0.47.0 -- connection_impersonations index for db_id column
       changes:
@@ -3046,6 +3192,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-054
+      validCheckSum: 8:5404d7e3781f0dfcc984676ea434c842
       author: noahmoss
       comment: Added 0.47.0 -- connection_impersonations index for group_id column
       changes:
@@ -3058,6 +3205,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-055
+      validCheckSum: 8:295c4477995058b93eba2857090eb6f6
       author: noahmoss
       comment: Added 0.47.0 - unique constraint for connection impersonations
       changes:
@@ -3072,6 +3220,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-056
+      validCheckSum: 8:bd965141f770a65982ecebab51a565e9
       author: noahmoss
       comment: Added 0.47.0 - re-add foreign key constraint on connection_impersonations.db_id
       changes:
@@ -3085,6 +3234,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-057
+      validCheckSum: 8:fe79acdba9db58709b6fffbb7aac2844
       author: noahmoss
       comment: Added 0.47.0 - re-add foreign key constraint on connection_impersonations.group_id
       changes:
@@ -3098,6 +3248,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-058
+      validCheckSum: 8:05731b3e62deb09c64b60bc10031d206
       author: qnkhuat
       comment: 'Drop parameter_card.entity_id'
       preConditions:
@@ -3123,6 +3274,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v47.00-059
+      validCheckSum: 8:123cf42eed168444f88418f071d2730f
       author: piranha
       comment: 'Drops not null from dashboard_tab.entity_id since it breaks drop-entity-ids command'
       changes:
@@ -3134,6 +3286,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-001
+      validCheckSum: 8:c38ceb502af7907aed614f17da6c3f80
       author: qnkhuat
       comment: Added 0.47.0 - Migrate database.options to database.settings
       changes:
@@ -3142,6 +3295,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-002
+      validCheckSum: 8:deceb81591f51f2d7253976f247e36cc
       author: qnkhuat
       comment: Added 0.47.0 - drop metabase_database.options
       changes:
@@ -3159,6 +3313,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-003
+      validCheckSum: 8:da33cde0f1f93eed56c0f6d9ac2007df
       author: qnkhuat
       comment: Added 0.48.0 - drop computation_job_result table
       preConditions:
@@ -3172,6 +3327,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-004
+      validCheckSum: 8:d0b1d7cc179c332b7e31f065325b7275
       author: qnkhuat
       comment: Added 0.48.0 - drop computation_job table
       preConditions:
@@ -3185,6 +3341,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-005
+      validCheckSum: 8:a570f2e1d90a302bc207c00e3776eaaf
       author: qnkhuat
       comment: Added 0.48.0 - Add query_execution.action_id
       changes:
@@ -3198,6 +3355,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-006
+      validCheckSum: 8:cf1413241565a186bf98eece35d519bf
       author: qnkhuat
       comment: Added 0.48.0 - Index query_execution.action_id
       changes:
@@ -3210,6 +3368,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-007
+      validCheckSum: 8:15d05ceba05e5b7d25d351fb6ec5b100
       author: qnkhuat
       comment: Added 0.48.0 - Add revision.most_recent
       changes:
@@ -3226,6 +3385,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-008
+      validCheckSum: 8:c0a512701d6dfd5cc1c4a689919be074
       author: qnkhuat
       comment: Set revision.most_recent = true for latest revisions
       changes:
@@ -3256,6 +3416,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-009
+      validCheckSum: 8:dfd90256380263274ea7f5cc0c5ed413
       author: calherries
       comment: Added 0.48.0 - Create table_privileges table
       changes:
@@ -3313,6 +3474,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-010
+      validCheckSum: 8:da6117039b6e0249b710cc3160af982d
       author: qnkhuat
       comment: Remove ON UPDATE for revision.timestamp on mysql, mariadb
       preConditions:
@@ -3327,6 +3489,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-011
+      validCheckSum: 8:65ef87949a7e9555fabaf69069806ee0
       author: qnkhuat
       comment: Index revision.most_recent
       changes:
@@ -3339,6 +3502,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-013
+      validCheckSum: 8:145eb766e2d49e95f31d8a08df8ff776
       author: qnkhuat
       comment: Index unindexed FKs for postgres
       preConditions:
@@ -3382,6 +3546,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-014
+      validCheckSum: 8:b2c1361f1dc14c2390a1dc25a4a86311
       author: calherries
       comment: Added 0.48.0 - Create table_privileges.table_id index
       preConditions:
@@ -3399,6 +3564,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-015
+      validCheckSum: 8:6f58cf60c8048bb39bbf6128058ff85e
       author: calherries
       comment: Added 0.48.0 - Create table_privileges.role index
       changes:
@@ -3412,6 +3578,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-016
+      validCheckSum: 8:ea2cb901edad5cf3a1250bdd2a9b0866
       author: calherries
       comment: Added 0.48.0 - Change the type of collection.slug to varchar(510)
       changes:
@@ -3427,6 +3594,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-018
+      validCheckSum: 8:efae52e7403f39c1458f53e885b4393d
       author: noahmoss
       comment: Add new recent_views table
       changes:
@@ -3471,6 +3639,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-019
+      validCheckSum: 8:c3866a4b7cfbb49d4b626dc2fd750935
       author: nemanjaglumac
       comment: 'Collection color is removed in 0.48.0'
       changes:
@@ -3488,8 +3657,10 @@ databaseChangeLog:
                   constraints:
                     nullable: false
                   defaultValue: '#31698A'
+
   - changeSet:
       id: v48.00-020
+      validCheckSum: 8:2c410019e1834304131ff57278003d35
       author: noahmoss
       comment: Added 0.48.0 - Create recent_views.user_id index
       changes:
@@ -3503,6 +3674,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-021
+      validCheckSum: 8:a1543239e39c70dc9bab3bbc303242b1
       author: piranha
       comment: 'Cards store Metabase version used to create them'
       changes:
@@ -3516,6 +3688,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-022
+      validCheckSum: 8:0f034d06b1ad5336c3c81b0d22cde259
       author: johnswanson
       comment: Migrate migrate-click-through to a custom migration
       preConditions:
@@ -3529,6 +3702,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-023
+      validCheckSum: 8:f18e5e053b508aab0bdd8c4bf1d7de4b
       author: piranha
       comment: Data migration migrate-remove-admin-from-group-mapping-if-needed
       preConditions:
@@ -3542,6 +3716,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-024
+      validCheckSum: 8:fab2a51d73c66cea059d55a6fea8bb2f
       author: piranha
       comment: All data migrations were transferred to custom_migrations!
       changes:
@@ -3592,6 +3767,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-025
+      validCheckSum: 8:a2fa9ab0913b9e4b97dff91f973344d6
       author: piranha
       comment: 'Revisions store Metabase version used to create them'
       changes:
@@ -3605,6 +3781,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-026
+      validCheckSum: 8:7c8330e861c16997780a9b0881144b26
       author: lbrdnk
       comment: Set semantic_type with value type/Number to null (#18754)
       changes:
@@ -3633,6 +3810,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-028
+      validCheckSum: 8:818119252c2e7877bbf46aec40fab160
       author: noahmoss
       comment: Add new audit_log table
       changes:
@@ -3692,6 +3870,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-029
+      validCheckSum: 8:1994760ab0950e7f591c40e887295e1a
       author: noahmoss
       comment: Added 0.48.0 - new view v_audit_log
       changes:
@@ -3713,6 +3892,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-030
+      validCheckSum: 8:965d6479698fe55f2f6799be552b5edb
       author: noahmoss
       comment: Added 0.48.0 - new view v_content
       changes:
@@ -3734,6 +3914,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-031
+      validCheckSum: 8:721bedb0dd362793a1a216cf3e552f3b
       author: noahmoss
       comment: Added 0.48.0 - new view v_dashboardcard
       changes:
@@ -3746,6 +3927,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-032
+      validCheckSum: 8:64d52462def7bb6981a3b6a40d42e67e
       author: noahmoss
       comment: Added 0.48.0 - new view v_group_members
       changes:
@@ -3758,6 +3940,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-033
+      validCheckSum: 8:7ac57373a0fba4bd9613c242702c863d
       author: noahmoss
       comment: Added 0.48.0 - new view v_subscriptions for postgres
       changes:
@@ -3779,6 +3962,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-034
+      validCheckSum: 8:1c268d93ce69eaee11e3ecdf9951449a
       author: noahmoss
       comment: Added 0.48.0 - new view v_users
       changes:
@@ -3800,6 +3984,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-035
+      validCheckSum: 8:c0276764af3e1b4b5b0c4e5fdc979e60
       author: noahmoss
       comment: Added 0.48.0 - new view v_alerts
       changes:
@@ -3821,6 +4006,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-036
+      validCheckSum: 8:8a35e1bdf0738ccac5da8062d6671dd0
       author: noahmoss
       comment: Added 0.48.0 - new view v_databases
       changes:
@@ -3833,6 +4019,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-037
+      validCheckSum: 8:a4b6ebd594b4663a6a888211f36ce6c3
       author: noahmoss
       comment: Added 0.48.0 - new view v_fields
       changes:
@@ -3854,6 +4041,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-038
+      validCheckSum: 8:a24f4bcd3336e79d1c8ef33ab81c0db3
       author: noahmoss
       comment: Added 0.48.0 - new view v_query_log
       changes:
@@ -3875,6 +4063,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-039
+      validCheckSum: 8:b43481a01df86830c4cb1adb8189d400
       author: noahmoss
       comment: Added 0.48.0 - new view v_tables
       changes:
@@ -3896,6 +4085,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-040
+      validCheckSum: 8:b8842eac1c7cba6e997d4d288306e36c
       author: noahmoss
       comment: Added 0.48.0 - new view v_view_log
       changes:
@@ -3917,6 +4107,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-045
+      validCheckSum: 8:874f14ae26d742448d8dd2b47dc8aa3d
       author: qwef
       comment: Added 0.48.0 - add is_sandboxed to query_execution
       changes:
@@ -3932,6 +4123,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-046
+      validCheckSum: 8:4bb11295621890202e066cd15de93a52
       author: noahmoss
       comment: Added 0.48.0 - new indexes to optimize audit v2 queries
       changes:
@@ -3960,6 +4152,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-047
+      validCheckSum: 8:2b18bed0e1ae18dd7b26a0770dac54c0
       author: noahmoss
       comment: Drop foreign key on recent_views so that it can be recreated with onDelete policy
       changes:
@@ -3977,6 +4170,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-048
+      validCheckSum: 8:872e632a8ffa42eb2969f77823e8bfc8
       author: noahmoss
       comment: Add foreign key on recent_views with onDelete CASCADE
       changes:
@@ -3994,6 +4188,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-049
+      validCheckSum: 8:853f2a24c53470bf2d9e85b1246bab7b
       author: noahmoss
       comment: Migrate data from activity to audit_log
       changes:
@@ -4044,6 +4239,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-050
+      validCheckSum: 8:d41d8cd98f00b204e9800998ecf8427e
       author: noahmoss
       comment: Added 0.48.0 - no-op migration to remove audit DB and collection on downgrade
       changes:
@@ -4054,6 +4250,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-051
+      validCheckSum: 8:5f5d1fd5b6153a6613511fd8f765737d
       author: calherries
       comment: Migrate metabase_field when the fk target field is inactive
       changes:
@@ -4080,6 +4277,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-053
+      validCheckSum: 8:8b41162170f6d712871b2ee9221adc1a
       author: johnswanson
       comment: Increase length of `activity.model` to fit longer model names
       changes:
@@ -4091,6 +4289,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-054
+      validCheckSum: 8:d41d8cd98f00b204e9800998ecf8427e
       author: escherize
       comment: Added 0.48.0 - no-op migration to remove Internal Metabase User on downgrade
       changes:
@@ -4099,8 +4298,8 @@ databaseChangeLog:
         - sql: DELETE FROM core_user WHERE id = 13371338;
 
   - changeSet:
-
       id: v48.00-055
+      validCheckSum: 8:fd36092d50982fbf31ce16757c16e47e
       author: noahmoss
       comment: Added 0.48.0 - new view v_tasks
       changes:
@@ -4122,6 +4321,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-056
+      validCheckSum: 8:229e8058cc8309053b344bbfdb042405
       author: noahmoss
       comment: 'Adjust view_log schema for Audit Log v2'
       changes:
@@ -4137,6 +4337,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-057
+      validCheckSum: 8:8e32153df1031ea12005d58ce1674873
       author: noahmoss
       comment: 'Adjust view_log schema for Audit Log v2'
       changes:
@@ -4152,6 +4353,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-059
+      validCheckSum: 8:fd8b5031dbbf69c4588ce2699eb20f33
       author: qwef
       comment: 'Update the namespace of any audit collections that are already loaded'
       changes:
@@ -4161,6 +4363,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-060
+      validCheckSum: 8:a59027f5494811033ce77cd0ba05d6bd
       author: noahmoss
       comment: Added 0.48.0 - task_history.started_at
       changes:
@@ -4173,6 +4376,7 @@ databaseChangeLog:
 
   - changeSet:
       id: v48.00-061
+      validCheckSum: 8:9b9939aad6ca12f7cf4dfa85dae6eb1c
       author: piranha
       comment: 'Adds query_execution.cache_hash -> query_cache.query_hash'
       changes:
@@ -4190,6 +4394,7 @@ databaseChangeLog:
   # in the sql initialization, so we need to recreate one here for new instances running 48+
   - changeSet:
       id: v48.00-067
+      validCheckSum: 8:e7cd8168533c58c865dacf320e819218
       author: qnkhuat
       comment: 'Add unique constraint idx_databasechangelog_id_author_filename'
       preConditions:


### PR DESCRIPTION
resolves https://github.com/metabase/metabase/issues/41641

backport of https://github.com/metabase/metabase/pull/41662

- add validChecksums
- cleanup inconsistent newlines